### PR TITLE
fix(compression): persist summary failure breaker

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1827,6 +1827,11 @@ def init_agent(
             max_tokens=agent.max_tokens,
         )
     _bind_session_state = getattr(agent.context_compressor, "bind_session_state", None)
+    if hasattr(agent.context_compressor, "notice_callback"):
+        try:
+            agent.context_compressor.notice_callback = agent._emit_notice
+        except Exception:
+            pass
     if callable(_bind_session_state):
         try:
             _bind_session_state(session_db=session_db, session_id=agent.session_id)

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -214,6 +214,8 @@ _IMAGE_TOKEN_ESTIMATE = 1600
 # for tail-cut decisions.
 _IMAGE_CHAR_EQUIVALENT = _IMAGE_TOKEN_ESTIMATE * _CHARS_PER_TOKEN
 _SUMMARY_FAILURE_COOLDOWN_SECONDS = 600
+_SUMMARY_FAILURE_CIRCUIT_BREAKER_THRESHOLD = 3
+_SUMMARY_FAILURE_CIRCUIT_BREAKER_SECONDS = 300
 
 # Hard ceiling for the deterministic summary-failure handoff.  The fallback is
 # only meant to preserve continuity anchors from the dropped window, not to
@@ -737,6 +739,9 @@ class ContextCompressor(ContextEngine):
         self._last_compression_savings_pct = 100.0
         self._ineffective_compression_count = 0
         self._summary_failure_cooldown_until = 0.0  # transient errors must not block a fresh session
+        self._summary_failure_count = 0
+        self._summary_failure_breaker_until = 0.0
+        self._summary_breaker_notice_emitted = False
         self._last_summary_error = None
         self._last_compress_aborted = False
         self.last_real_prompt_tokens = 0
@@ -772,6 +777,9 @@ class ContextCompressor(ContextEngine):
         self._last_compression_savings_pct = 100.0
         self._ineffective_compression_count = 0
         self._summary_failure_cooldown_until = 0.0
+        self._summary_failure_count = 0
+        self._summary_failure_breaker_until = 0.0
+        self._summary_breaker_notice_emitted = False
         self._last_compress_aborted = False
         self._context_probed = False
         self._context_probe_persistable = False
@@ -785,8 +793,36 @@ class ContextCompressor(ContextEngine):
         self._session_db = session_db
         self._session_id = session_id or ""
         self._summary_failure_cooldown_until = 0.0
+        self._summary_failure_count = 0
+        self._summary_failure_breaker_until = 0.0
+        self._summary_breaker_notice_emitted = False
         self._last_summary_error = None
         self.get_active_compression_failure_cooldown()
+        self._load_compression_summary_failure_state()
+
+    def _load_compression_summary_failure_state(self) -> Optional[Dict[str, Any]]:
+        """Load the durable summary-failure breaker mirror for the bound session."""
+        session_db = getattr(self, "_session_db", None)
+        session_id = getattr(self, "_session_id", "")
+        if not session_db or not session_id:
+            return None
+        getter = getattr(session_db, "get_compression_summary_failure_state", None)
+        if getter is None:
+            return None
+        try:
+            state = getter(session_id)
+        except sqlite3.Error as exc:
+            logger.debug("compression summary failure state lookup failed: %s", exc)
+            return None
+        except Exception:
+            return None
+        if not state:
+            return None
+        self._summary_failure_count = int(state.get("failure_count") or 0)
+        remaining = float(state.get("breaker_remaining_seconds") or 0.0)
+        self._summary_failure_breaker_until = time.monotonic() + remaining if remaining > 0 else 0.0
+        self._summary_breaker_notice_emitted = remaining > 0
+        return state
 
     def on_session_start(self, session_id: str, **kwargs) -> None:
         """Bind session-scoped compression state for a new or resumed session."""
@@ -835,6 +871,45 @@ class ContextCompressor(ContextEngine):
             "error": self._last_summary_error,
         }
 
+    def _emit_summary_breaker_open_warning(
+        self,
+        *,
+        failure_count: int,
+        breaker_seconds: float,
+        error: Optional[str],
+    ) -> None:
+        """Log and notify once when the consecutive summary-failure breaker opens."""
+        if self._summary_breaker_notice_emitted:
+            return
+        self._summary_breaker_notice_emitted = True
+        logger.warning(
+            "Compression summary circuit breaker opened after %d consecutive failures; "
+            "auto-compression paused for %.0fs. Last error: %s",
+            failure_count,
+            breaker_seconds,
+            error or "unknown",
+        )
+        callback = getattr(self, "notice_callback", None)
+        if not callback:
+            return
+        try:
+            from agent.credits_tracker import AgentNotice
+
+            callback(
+                AgentNotice(
+                    text=(
+                        "⚠ Context summary circuit breaker opened. "
+                        f"Auto-compression paused after {failure_count} consecutive "
+                        "summary failures; use /compress to retry manually."
+                    ),
+                    level="warn",
+                    kind="ephemeral",
+                    key="compression.summary_breaker.open",
+                )
+            )
+        except Exception:
+            logger.debug("compression breaker notice callback failed", exc_info=True)
+
     def _record_compression_failure_cooldown(
         self,
         cooldown_seconds: float,
@@ -846,21 +921,62 @@ class ContextCompressor(ContextEngine):
 
         session_db = getattr(self, "_session_db", None)
         session_id = getattr(self, "_session_id", "")
-        if not session_db or not session_id:
+        state: Optional[Dict[str, Any]] = None
+        if session_db and session_id:
+            recorder = getattr(session_db, "record_compression_summary_failure", None)
+            if recorder is not None:
+                try:
+                    state = recorder(
+                        session_id,
+                        transient_cooldown_until=cooldown_until,
+                        error=error,
+                        breaker_threshold=_SUMMARY_FAILURE_CIRCUIT_BREAKER_THRESHOLD,
+                        breaker_cooldown_seconds=_SUMMARY_FAILURE_CIRCUIT_BREAKER_SECONDS,
+                    )
+                except sqlite3.Error as exc:
+                    logger.debug("compression summary failure persist failed: %s", exc)
+                except Exception as exc:
+                    logger.debug("compression summary failure persist failed (non-sqlite): %s", exc)
+            else:
+                recorder = getattr(session_db, "record_compression_failure_cooldown", None)
+                if recorder is not None:
+                    try:
+                        recorder(session_id, cooldown_until, error)
+                    except sqlite3.Error as exc:
+                        logger.debug("compression failure cooldown persist failed: %s", exc)
+                    except Exception as exc:
+                        logger.debug("compression failure cooldown persist failed (non-sqlite): %s", exc)
+
+        if state:
+            self._summary_failure_count = int(state.get("failure_count") or 0)
+            remaining = float(state.get("breaker_remaining_seconds") or 0.0)
+            self._summary_failure_breaker_until = time.monotonic() + remaining if remaining > 0 else 0.0
+            if state.get("breaker_opened"):
+                self._emit_summary_breaker_open_warning(
+                    failure_count=self._summary_failure_count,
+                    breaker_seconds=remaining,
+                    error=error,
+                )
             return
 
-        recorder = getattr(session_db, "record_compression_failure_cooldown", None)
-        if recorder is None:
-            return
-        try:
-            recorder(session_id, cooldown_until, error)
-        except sqlite3.Error as exc:
-            logger.debug("compression failure cooldown persist failed: %s", exc)
-        except Exception as exc:
-            logger.debug("compression failure cooldown persist failed (non-sqlite): %s", exc)
+        # Fallback for tests/plugins that host the compressor without SessionDB:
+        # keep a local mirror so the breaker still prevents same-instance loops.
+        self._summary_failure_count += 1
+        if self._summary_failure_count >= _SUMMARY_FAILURE_CIRCUIT_BREAKER_THRESHOLD:
+            self._summary_failure_breaker_until = (
+                time.monotonic() + _SUMMARY_FAILURE_CIRCUIT_BREAKER_SECONDS
+            )
+            self._emit_summary_breaker_open_warning(
+                failure_count=self._summary_failure_count,
+                breaker_seconds=_SUMMARY_FAILURE_CIRCUIT_BREAKER_SECONDS,
+                error=error,
+            )
 
     def _clear_compression_failure_cooldown(self) -> None:
         self._summary_failure_cooldown_until = 0.0
+        self._summary_failure_count = 0
+        self._summary_failure_breaker_until = 0.0
+        self._summary_breaker_notice_emitted = False
         self._last_summary_error = None
 
         session_db = getattr(self, "_session_db", None)
@@ -869,14 +985,22 @@ class ContextCompressor(ContextEngine):
             return
 
         clearer = getattr(session_db, "clear_compression_failure_cooldown", None)
-        if clearer is None:
+        if clearer is not None:
+            try:
+                clearer(session_id)
+            except sqlite3.Error as exc:
+                logger.debug("compression failure cooldown clear failed: %s", exc)
+            except Exception as exc:
+                logger.debug("compression failure cooldown clear failed (non-sqlite): %s", exc)
+        breaker_clearer = getattr(session_db, "clear_compression_summary_failures", None)
+        if breaker_clearer is None:
             return
         try:
-            clearer(session_id)
+            breaker_clearer(session_id)
         except sqlite3.Error as exc:
-            logger.debug("compression failure cooldown clear failed: %s", exc)
+            logger.debug("compression summary failure clear failed: %s", exc)
         except Exception as exc:
-            logger.debug("compression failure cooldown clear failed (non-sqlite): %s", exc)
+            logger.debug("compression summary failure clear failed (non-sqlite): %s", exc)
 
     def update_model(
         self,
@@ -944,6 +1068,9 @@ class ContextCompressor(ContextEngine):
         self.last_compression_rough_tokens = 0
         self.awaiting_real_usage_after_compression = False
         self._ineffective_compression_count = 0
+        self._summary_failure_count = 0
+        self._summary_failure_breaker_until = 0.0
+        self._summary_breaker_notice_emitted = False
 
     # When the MINIMUM_CONTEXT_LENGTH floor meets/exceeds a small context
     # window, compacting at the percentage (50% → 32K of a 64K window) wastes
@@ -1132,6 +1259,10 @@ class ContextCompressor(ContextEngine):
         self._last_compression_savings_pct: float = 100.0
         self._ineffective_compression_count: int = 0
         self._summary_failure_cooldown_until: float = 0.0
+        self._summary_failure_count: int = 0
+        self._summary_failure_breaker_until: float = 0.0
+        self._summary_breaker_notice_emitted: bool = False
+        self.notice_callback = None
         self._last_summary_error: Optional[str] = None
         # When summary generation fails and a static fallback is inserted,
         # record how many turns were unrecoverably dropped so callers
@@ -1249,6 +1380,16 @@ class ContextCompressor(ContextEngine):
                     "Compression deferred — summary LLM in cooldown for %.0fs more",
                     _cooldown_remaining,
                 )
+            return False
+        # Distinct from the transient retry cooldown: after repeated persisted
+        # summary failures, pause automatic compression long enough for the lane
+        # to surface the spiral rather than silently retrying every turn.
+        _breaker_remaining = self._summary_failure_breaker_until - time.monotonic()
+        if _breaker_remaining > 0:
+            logger.warning(
+                "Compression skipped — summary circuit breaker active for %.0fs more",
+                _breaker_remaining,
+            )
             return False
         # Anti-thrashing: back off if recent compressions were ineffective
         if self._ineffective_compression_count >= 2:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18258,6 +18258,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     return
                 if not line:
                     return
+                notice_key = str(getattr(notice, "key", "") or "")
+                if notice_key == "compression.summary_breaker.open":
+                    try:
+                        from cron.scheduler import _get_home_target_chat_id, _get_home_target_thread_id
+
+                        platform_name = source.platform.value if source.platform else ""
+                        home_chat_id = _get_home_target_chat_id(platform_name)
+                        if home_chat_id:
+                            home_thread_id = _get_home_target_thread_id(platform_name)
+                            metadata = (
+                                {"thread_id": home_thread_id}
+                                if home_thread_id
+                                else None
+                            )
+                            safe_schedule_threadsafe(
+                                _status_adapter.send(home_chat_id, line, metadata=metadata),
+                                _loop_for_step,
+                                logger=logger,
+                                log_message="compression breaker home notice scheduling error",
+                            )
+                            return
+                    except Exception:
+                        logger.debug("compression breaker home notice resolution failed", exc_info=True)
                 safe_schedule_threadsafe(
                     self._deliver_platform_notice(source, line),
                     _loop_for_step,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -738,8 +738,14 @@ CREATE TABLE IF NOT EXISTS sessions (
     handoff_state TEXT,
     handoff_platform TEXT,
     handoff_error TEXT,
+    -- Compression failure state is split deliberately: cooldown/error are the
+    -- short-lived retry backoff for one failed summary call, while the summary
+    -- failure count/breaker columns are the durable per-session consecutive-
+    -- failure circuit breaker shared across compressor instances.
     compression_failure_cooldown_until REAL,
     compression_failure_error TEXT,
+    compression_summary_failure_count INTEGER NOT NULL DEFAULT 0,
+    compression_summary_failure_breaker_until REAL,
     rewind_count INTEGER NOT NULL DEFAULT 0,
     archived INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
@@ -2175,6 +2181,144 @@ class SessionDB:
         except sqlite3.Error as exc:
             logger.warning(
                 "clear_compression_failure_cooldown(%s) failed: %s",
+                session_id, exc,
+            )
+
+    def record_compression_summary_failure(
+        self,
+        session_id: str,
+        *,
+        transient_cooldown_until: float,
+        error: Optional[str] = None,
+        breaker_threshold: int = 3,
+        breaker_cooldown_seconds: float = 300.0,
+    ) -> Dict[str, Any]:
+        """Atomically increment the durable per-session summary failure streak.
+
+        This is the cross-instance circuit-breaker authority.  Compressor-local
+        counters are only mirrors; gateway resumes, background forks, and fresh
+        ``SessionDB`` / ``ContextCompressor`` instances must converge through this
+        single write path.
+        """
+        if not session_id:
+            return {
+                "failure_count": 0,
+                "breaker_until": None,
+                "breaker_remaining_seconds": 0.0,
+                "breaker_opened": False,
+                "error": error,
+            }
+
+        threshold = max(1, int(breaker_threshold or 1))
+        cooldown_seconds = max(0.0, float(breaker_cooldown_seconds or 0.0))
+        now = time.time()
+        result: Dict[str, Any] = {
+            "failure_count": 0,
+            "breaker_until": None,
+            "breaker_remaining_seconds": 0.0,
+            "breaker_opened": False,
+            "error": error,
+        }
+
+        def _do(conn):
+            row = conn.execute(
+                "SELECT compression_summary_failure_count, "
+                "compression_summary_failure_breaker_until "
+                "FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            if row is None:
+                return
+            old_count = int(row[0] or 0)
+            old_breaker_until = row[1]
+            old_breaker_until = float(old_breaker_until) if old_breaker_until is not None else None
+            new_count = old_count + 1
+            breaker_until = old_breaker_until
+            breaker_opened = False
+            if new_count >= threshold:
+                candidate_until = now + cooldown_seconds
+                breaker_until = max(float(breaker_until or 0.0), candidate_until)
+                breaker_opened = old_count < threshold or float(old_breaker_until or 0.0) <= now
+
+            conn.execute(
+                "UPDATE sessions SET "
+                "compression_failure_cooldown_until = ?, "
+                "compression_failure_error = ?, "
+                "compression_summary_failure_count = ?, "
+                "compression_summary_failure_breaker_until = ? "
+                "WHERE id = ?",
+                (
+                    transient_cooldown_until,
+                    error,
+                    new_count,
+                    breaker_until,
+                    session_id,
+                ),
+            )
+            result.update(
+                {
+                    "failure_count": new_count,
+                    "breaker_until": breaker_until,
+                    "breaker_remaining_seconds": max(0.0, float(breaker_until or 0.0) - now),
+                    "breaker_opened": breaker_opened,
+                    "error": error,
+                }
+            )
+
+        try:
+            self._execute_write(_do)
+        except sqlite3.Error as exc:
+            logger.warning(
+                "record_compression_summary_failure(%s) failed: %s",
+                session_id, exc,
+            )
+        return result
+
+    def get_compression_summary_failure_state(
+        self,
+        session_id: str,
+    ) -> Optional[Dict[str, Any]]:
+        """Return the persisted summary-failure streak and breaker state."""
+        if not session_id:
+            return None
+        now = time.time()
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT compression_summary_failure_count, "
+                "compression_summary_failure_breaker_until, compression_failure_error "
+                "FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        failure_count = int(row["compression_summary_failure_count"] or 0)
+        breaker_until = row["compression_summary_failure_breaker_until"]
+        breaker_until = float(breaker_until) if breaker_until is not None else None
+        remaining = max(0.0, float(breaker_until or 0.0) - now)
+        return {
+            "failure_count": failure_count,
+            "breaker_until": breaker_until,
+            "breaker_remaining_seconds": remaining,
+            "error": row["compression_failure_error"],
+        }
+
+    def clear_compression_summary_failures(self, session_id: str) -> None:
+        """Reset the durable consecutive summary-failure breaker for a session."""
+        if not session_id:
+            return
+
+        def _do(conn):
+            conn.execute(
+                "UPDATE sessions SET compression_summary_failure_count = 0, "
+                "compression_summary_failure_breaker_until = NULL WHERE id = ?",
+                (session_id,),
+            )
+
+        try:
+            self._execute_write(_do)
+        except sqlite3.Error as exc:
+            logger.warning(
+                "clear_compression_summary_failures(%s) failed: %s",
                 session_id, exc,
             )
     # ──────────────────────────────────────────────────────────────────────

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2,6 +2,7 @@
 
 import pytest
 import time
+import logging
 from unittest.mock import patch, MagicMock
 
 from agent.context_compressor import (
@@ -44,6 +45,58 @@ class TestShouldCompress:
         assert compressor.should_compress(prompt_tokens=90000) is True
         assert compressor.should_compress(prompt_tokens=50000) is False
 
+    def test_active_summary_breaker_blocks_auto_compression(self, compressor):
+        compressor._summary_failure_breaker_until = time.monotonic() + 60.0
+
+        assert compressor.should_compress(prompt_tokens=90000) is False
+
+
+class TestCompressionFailureBreakerWarnings:
+    def test_breaker_open_emits_warning_and_notice_once_at_threshold(self, compressor, caplog):
+        notices = []
+        compressor.notice_callback = notices.append
+
+        with caplog.at_level(logging.WARNING, logger="agent.context_compressor"):
+            compressor._record_compression_failure_cooldown(1.0, "timeout-1")
+            compressor._record_compression_failure_cooldown(1.0, "timeout-2")
+
+        assert "summary circuit breaker opened" not in caplog.text
+        assert notices == []
+
+        with caplog.at_level(logging.WARNING, logger="agent.context_compressor"):
+            compressor._record_compression_failure_cooldown(1.0, "timeout-3")
+
+        assert "summary circuit breaker opened after 3 consecutive failures" in caplog.text
+        assert len(notices) == 1
+        assert notices[0].level == "warn"
+        assert notices[0].key == "compression.summary_breaker.open"
+        assert "Auto-compression paused" in notices[0].text
+
+        caplog.clear()
+        compressor._record_compression_failure_cooldown(1.0, "timeout-4")
+        assert "summary circuit breaker opened" not in caplog.text
+        assert len(notices) == 1
+
+    def test_persisted_breaker_open_emits_warning_and_notice(self, compressor, tmp_path, caplog):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("s1", "cli")
+        compressor.bind_session_state(db, "s1")
+        notices = []
+        compressor.notice_callback = notices.append
+
+        with caplog.at_level(logging.WARNING, logger="agent.context_compressor"):
+            compressor._record_compression_failure_cooldown(1.0, "timeout-1")
+            compressor._record_compression_failure_cooldown(1.0, "timeout-2")
+            compressor._record_compression_failure_cooldown(1.0, "timeout-3")
+
+        state = db.get_compression_summary_failure_state("s1")
+        assert state is not None
+        assert state["failure_count"] == 3
+        assert state["breaker_remaining_seconds"] > 0
+        assert "summary circuit breaker opened after 3 consecutive failures" in caplog.text
+        assert len(notices) == 1
+
+        db.close()
 
 
 class TestUpdateFromResponse:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -5339,6 +5339,67 @@ def test_expired_compression_failure_cooldown_is_ignored(db):
     assert db.get_compression_failure_cooldown("s1") is None
 
 
+def test_compression_summary_failure_breaker_opens_at_threshold(db, monkeypatch):
+    db.create_session("s1", "cli")
+    monkeypatch.setattr(hermes_state.time, "time", lambda: 1000.0)
+
+    first = db.record_compression_summary_failure(
+        "s1",
+        transient_cooldown_until=1010.0,
+        error="timeout-1",
+        breaker_threshold=3,
+        breaker_cooldown_seconds=300.0,
+    )
+    second = db.record_compression_summary_failure(
+        "s1",
+        transient_cooldown_until=1020.0,
+        error="timeout-2",
+        breaker_threshold=3,
+        breaker_cooldown_seconds=300.0,
+    )
+    third = db.record_compression_summary_failure(
+        "s1",
+        transient_cooldown_until=1030.0,
+        error="timeout-3",
+        breaker_threshold=3,
+        breaker_cooldown_seconds=300.0,
+    )
+
+    assert first["failure_count"] == 1
+    assert first["breaker_opened"] is False
+    assert second["failure_count"] == 2
+    assert second["breaker_opened"] is False
+    assert third["failure_count"] == 3
+    assert third["breaker_opened"] is True
+    assert third["breaker_until"] == 1300.0
+
+    state = db.get_compression_summary_failure_state("s1")
+    assert state["failure_count"] == 3
+    assert state["breaker_until"] == 1300.0
+    assert state["breaker_remaining_seconds"] == 300.0
+    assert state["error"] == "timeout-3"
+
+
+def test_clear_compression_summary_failures_resets_breaker(db, monkeypatch):
+    db.create_session("s1", "cli")
+    monkeypatch.setattr(hermes_state.time, "time", lambda: 2000.0)
+
+    db.record_compression_summary_failure(
+        "s1",
+        transient_cooldown_until=2010.0,
+        error="timeout",
+        breaker_threshold=1,
+        breaker_cooldown_seconds=120.0,
+    )
+
+    db.clear_compression_summary_failures("s1")
+
+    state = db.get_compression_summary_failure_state("s1")
+    assert state["failure_count"] == 0
+    assert state["breaker_until"] is None
+    assert state["breaker_remaining_seconds"] == 0.0
+
+
 def test_refresh_compression_lock_requires_holder_and_preserves_reclaimability(db, monkeypatch):
     db.create_session("s1", "cli")
 


### PR DESCRIPTION
## Summary
- Persist consecutive compression summary failures per session in `SessionDB` so fresh compressors/gateway workers inherit the breaker state instead of resetting in memory.
- Keep the existing transient compression retry cooldown separate from the durable summary-failure circuit breaker.
- Surface a one-shot breaker-open notice through the agent/gateway notice spine.

## Implementation notes
- Adds durable session fields for `compression_summary_failure_count` and `compression_summary_failure_breaker_until` via the existing column reconciliation path.
- Adds atomic `SessionDB` helpers to record, read, and clear summary-failure breaker state.
- Updates `ContextCompressor` to load persisted breaker state on bind and to fall back to in-memory tracking only when no DB is bound.
- Adds coverage for active breaker suppression, one-shot notices, persisted breaker inheritance, threshold/open behavior, and reset behavior.

## Verification
- `git diff origin/main --check` — passed.
- `python -m py_compile agent/context_compressor.py hermes_state.py agent/agent_init.py gateway/run.py` — passed.
- `scripts/run_tests.sh tests/test_hermes_state.py tests/test_hermes_state_compression_locks.py tests/agent/test_context_compressor.py tests/agent/test_context_compressor_*.py tests/agent/test_compression_*.py tests/agent/test_compressor_*.py tests/run_agent/test_compression_*.py tests/run_agent/test_compressor_fallback_update.py tests/run_agent/test_notice_spine.py tests/gateway/test_compression_*.py -v --tb=short` — 718 passed, 3 timed out in `tests/gateway/test_compression_failure_session_sync.py` during the parallel run.
- Direct rerun: `python -m pytest tests/gateway/test_compression_failure_session_sync.py -v --tb=short` — 3 passed in 0.54s.

## Reviewer focus / risks
- `gateway/run.py` lazy-imports home-target helpers from `cron.scheduler` only on the notice-delivery path; please confirm the dependency direction is acceptable.
- `SessionDB.record_compression_summary_failure()` updates both transient cooldown fields and durable breaker fields in one write; please confirm this matches the intended final-summary-failure semantics.
- Breaker threshold/duration are constants (`threshold=3`, `breaker pause=300s`) and are not config-exposed in this PR.
- Schema changes are through `SessionDB._reconcile_columns()` only; no manual DB migration is expected.
