### PR TITLE
fix(desktop): disable FontationsFontBackend on macOS 26 to prevent emoji SIGBUS crash

### DIFF
--- a/apps/desktop/electron/emoji-font-workaround.test.ts
+++ b/apps/desktop/electron/emoji-font-workaround.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { fontationsWorkaround, MACOS_TAHOE_DARWIN_MAJOR } from './emoji-font-workaround'
+
+test('Tahoe (Darwin 25) disables FontationsFontBackend', () => {
+  const result = fontationsWorkaround(MACOS_TAHOE_DARWIN_MAJOR)
+  assert.ok(result, 'workaround must apply on Tahoe')
+  assert.equal(result.switch, 'disable-features')
+  assert.equal(result.value, 'FontationsFontBackend')
+})
+
+test('post-Tahoe (Darwin 26+) still disables FontationsFontBackend', () => {
+  const result = fontationsWorkaround(MACOS_TAHOE_DARWIN_MAJOR + 1)
+  assert.ok(result, 'workaround must apply on future macOS too')
+  assert.equal(result.value, 'FontationsFontBackend')
+})
+
+test('pre-Tahoe (Darwin 24) does not disable FontationsFontBackend', () => {
+  assert.equal(fontationsWorkaround(MACOS_TAHOE_DARWIN_MAJOR - 1), null)
+})
+
+test('non-macOS (darwinMajor 0) does not disable FontationsFontBackend', () => {
+  assert.equal(fontationsWorkaround(0), null)
+})
+
+test('MACOS_TAHOE_DARWIN_MAJOR is 25', () => {
+  assert.equal(MACOS_TAHOE_DARWIN_MAJOR, 25)
+})

--- a/apps/desktop/electron/emoji-font-workaround.ts
+++ b/apps/desktop/electron/emoji-font-workaround.ts
@@ -1,0 +1,28 @@
+import { MACOS_TAHOE_DARWIN_MAJOR } from './titlebar-overlay-width'
+
+export { MACOS_TAHOE_DARWIN_MAJOR }
+
+/**
+ * Chromium command-line switches to disable FontationsFontBackend on macOS
+ * Tahoe (Darwin ≥ 25). Returns the switch name and value when the workaround
+ * is needed, or `null` on unaffected platforms.
+ *
+ * Background: macOS 26's Apple Color Emoji.ttc ships a corrupt sbix PNG that
+ * SIGBUS-crashes Apple's ImageIO when Chromium's Fontations (Rust) font
+ * backend routes bitmap extraction through NSImage/NSPasteboard → ImageIO.
+ * Disabling FontationsFontBackend forces Chromium onto the older
+ * SkTypeface/CoreText path that decodes sbix PNGs through Skia's own libpng,
+ * bypassing the broken ImageIO codepath entirely.
+ *
+ * @param darwinMajor  Darwin kernel major (e.g. 25 for Tahoe). Pass 0 for
+ *                     non-macOS platforms.
+ * @returns `{ switch: string, value: string }` when the workaround applies,
+ *          or `null` otherwise.
+ */
+export function fontationsWorkaround(darwinMajor: number): { switch: string; value: string } | null {
+  if (darwinMajor >= MACOS_TAHOE_DARWIN_MAJOR) {
+    return { switch: 'disable-features', value: 'FontationsFontBackend' }
+  }
+
+  return null
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -104,6 +104,7 @@ import {
   SESSION_WINDOW_MIN_HEIGHT,
   SESSION_WINDOW_MIN_WIDTH
 } from './session-windows'
+import { fontationsWorkaround } from './emoji-font-workaround'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
 import { resolveBehindCount, shouldCountCommits } from './update-count'
 import { readLiveUpdateMarker, writeUpdateMarker } from './update-marker'
@@ -201,21 +202,11 @@ app.commandLine.appendSwitch('disable-renderer-backgrounding')
 app.commandLine.appendSwitch('disable-backgrounding-occluded-windows')
 app.commandLine.appendSwitch('disable-background-timer-throttling')
 
-// macOS 26 (Tahoe): the shipped Apple Color Emoji.ttc (21.4d3e1) has at least
-// one glyph whose embedded sbix PNG SIGBUS-crashes Apple's ImageIO
-// (PNGReadPlugin::InitializePluginData dereferences a corrupt function
-// pointer 0x0BAD4007). Chromium's Fontations (Rust) font backend triggers it
-// because fontations_ffi routes sbix bitmap extraction through
-// NSImage/NSPasteboard → ImageIO. The CSS @font-face alias (styles.css) only
-// covers the renderer's web-content font resolution — the browser process has
-// its own font pipeline that resolves system fonts directly, so the crash
-// fires on CrBrowserMain before CSS can intervene.
-//
-// Disabling FontationsFontBackend makes Chromium fall back to the older
-// SkTypeface/CoreText path that decodes sbix PNGs through Skia's own libpng
-// codec, bypassing the broken ImageIO path entirely.
-if (DARWIN_MAJOR >= 25) {
-  app.commandLine.appendSwitch('disable-features', 'FontationsFontBackend')
+// macOS 26 (Tahoe) emoji SIGBUS workaround — see emoji-font-workaround.ts.
+const emojiWorkaround = fontationsWorkaround(DARWIN_MAJOR)
+
+if (emojiWorkaround) {
+  app.commandLine.appendSwitch(emojiWorkaround.switch, emojiWorkaround.value)
   console.log('[hermes] macOS Tahoe detected; disabling FontationsFontBackend to work around Apple Color Emoji ImageIO crash')
 }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -201,6 +201,24 @@ app.commandLine.appendSwitch('disable-renderer-backgrounding')
 app.commandLine.appendSwitch('disable-backgrounding-occluded-windows')
 app.commandLine.appendSwitch('disable-background-timer-throttling')
 
+// macOS 26 (Tahoe): the shipped Apple Color Emoji.ttc (21.4d3e1) has at least
+// one glyph whose embedded sbix PNG SIGBUS-crashes Apple's ImageIO
+// (PNGReadPlugin::InitializePluginData dereferences a corrupt function
+// pointer 0x0BAD4007). Chromium's Fontations (Rust) font backend triggers it
+// because fontations_ffi routes sbix bitmap extraction through
+// NSImage/NSPasteboard → ImageIO. The CSS @font-face alias (styles.css) only
+// covers the renderer's web-content font resolution — the browser process has
+// its own font pipeline that resolves system fonts directly, so the crash
+// fires on CrBrowserMain before CSS can intervene.
+//
+// Disabling FontationsFontBackend makes Chromium fall back to the older
+// SkTypeface/CoreText path that decodes sbix PNGs through Skia's own libpng
+// codec, bypassing the broken ImageIO path entirely.
+if (DARWIN_MAJOR >= 25) {
+  app.commandLine.appendSwitch('disable-features', 'FontationsFontBackend')
+  console.log('[hermes] macOS Tahoe detected; disabling FontationsFontBackend to work around Apple Color Emoji ImageIO crash')
+}
+
 const SOURCE_REPO_ROOT = path.resolve(APP_ROOT, '../..')
 
 // Build-time install stamp -- the git ref this .exe was built against.

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -17,6 +17,33 @@
   src: url('../../../node_modules/@nous-research/ui/dist/fonts/Collapse-Bold.woff2') format('woff2');
 }
 
+/* Noto Color Emoji — bundled emoji font (OFL-1.1). Workaround for a macOS 26
+   (Tahoe) system bug: the shipped Apple Color Emoji.ttc (21.4d3e1) contains at
+   least one glyph whose embedded sbix PNG SIGBUS-crashes ImageIO
+   (PNGReadPlugin::InitializePluginData) the moment CoreText rasterizes it,
+   killing the Electron renderer at first paint. We bundle Noto and ALIAS the
+   'Apple Color Emoji' family name to the same file below, so no code path —
+   ours or a third-party component's explicit reference — ever touches the
+   broken system font. See CTFontDrawGlyphs repro: glyph #136 of
+   /System/Library/Fonts/Apple Color Emoji.ttc bus-errors natively. */
+@font-face {
+  font-family: 'Noto Color Emoji';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('./fonts/NotoColorEmoji.woff2') format('woff2');
+}
+/* Alias: intercept explicit 'Apple Color Emoji' references and serve the
+   bundled Noto file instead of the (crashing) system font. Document-level
+   @font-face wins over local system families of the same name in Chromium. */
+@font-face {
+  font-family: 'Apple Color Emoji';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('./fonts/NotoColorEmoji.woff2') format('woff2');
+}
+
 /* JetBrains Mono — bundled terminal font (Apache-2.0) so bold/italic share the
    regular face's metrics instead of squeezing against a system fallback. */
 @font-face {
@@ -313,15 +340,15 @@
 
     --dt-font-sans:
       'Segoe WPC', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'SF Pro Text', system-ui, sans-serif,
-      'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji', emoji;
+      'Noto Color Emoji', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', emoji;
     /* Key caps always use the native UI face — never theme typography overrides. */
     --dt-font-kbd: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', system-ui, sans-serif;
     /* JetBrains Mono first — the face we bundle (@font-face above) and the
        terminal's primary — so code/diff match the terminal on every platform
        instead of drifting to a system Cascadia Code where it's installed. */
     --dt-font-mono:
-      'JetBrains Mono', 'Cascadia Code', 'SF Mono', ui-monospace, Menlo, Consolas, monospace, 'Apple Color Emoji',
-      'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji', emoji;
+      'JetBrains Mono', 'Cascadia Code', 'SF Mono', ui-monospace, Menlo, Consolas, monospace, 'Noto Color Emoji',
+      'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', emoji;
     --dt-base-size: 1rem;
     --dt-line-height: 1.5;
     --dt-letter-spacing: 0;

--- a/apps/desktop/src/themes/presets.ts
+++ b/apps/desktop/src/themes/presets.ts
@@ -9,7 +9,10 @@ import type { DesktopTheme, DesktopThemeTypography } from './types'
 // text/mono fonts carry emoji glyphs, so without this emoji render as tofu
 // boxes on platforms whose default text font lacks them (e.g. Linux/#40364).
 // Covers macOS, Windows, Linux, plus the `emoji` generic for anything else.
-export const EMOJI_FALLBACK = '"Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji", emoji'
+// 'Noto Color Emoji' leads: we bundle it via @font-face (styles.css) and alias
+// 'Apple Color Emoji' to the same file — the macOS 26 system emoji font has a
+// glyph whose sbix PNG crashes ImageIO/the renderer (SIGBUS at first paint).
+export const EMOJI_FALLBACK = '"Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", emoji'
 
 const SYSTEM_SANS =
   '"Segoe WPC", "Segoe UI", -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display", system-ui, sans-serif, ' +


### PR DESCRIPTION
## Problem

On macOS 26 (Tahoe, verified on 26.5.1 and 26.5.2), the shipped Apple Color Emoji font (`.ttc` v21.4d3e1) has at least one glyph whose embedded `sbix` PNG crashes Apple's ImageIO framework (`SIGBUS` in `PNGReadPlugin::InitializePluginData` — dereferences a corrupt function pointer `0x0BAD4007`).

The first commit bundles Noto Color Emoji and adds CSS `@font-face` aliases. That fixes the **renderer's** web-content font resolution, but the crash fires on **`CrBrowserMain`** through Chromium's `fontations_ffi` → `NSImage/NSPasteboard` → ImageIO pipeline — a path CSS cannot intercept.

### Crash stack (abbreviated)
```
Thread 0 Crashed:: CrBrowserMain
0  ???                    0xbad4007
1  ImageIO                PNGReadPlugin::InitializePluginData + 824
…
7  ImageIO                CGImageDestinationAddImageFromSource + 1164
8  AppKit                 -[_NSPboardImageTypeConverter _convertImageData:toDataOfType:]
…
12 AppKit                 -[NSImage initWithPasteboard:]
13 Electron Framework     fontations_ffi$cxxbridge1$font_ref_is_valid + 2273704
```

## Fix (two commits)

1. **CSS defense-in-depth** — bundle Noto Color Emoji, alias `Apple Color Emoji` via `@font-face`, reorder emoji fallback stacks. Prevents the renderer's web-content font resolution from touching the broken system font.

2. **Chromium-level fix** — add `app.commandLine.appendSwitch('disable-features', 'FontationsFontBackend')` gated on `DARWIN_MAJOR >= 25`. This makes Chromium fall back to the older SkTypeface/CoreText path that decodes `sbix` PNGs through Skia's own libpng codec, bypassing Apple's broken ImageIO entirely. This is the fix that actually prevents the browser-process crash.

## Testing

- Built and packaged the desktop app on macOS 26.5.2 (Mac14,6 / arm64)
- Confirmed the app launches and stays alive (previously SIGBUS-crashed within ~43s)
- All 53 existing Electron unit tests pass

---

[Warp conversation](https://app.warp.dev/conversation/80531d20-c0b3-49f8-aa7f-c0aea7566850)

Co-Authored-By: Oz <oz-agent@warp.dev>