### PR TITLE
fix(qqbot): 补齐 connect() is_reconnect 参数签名 / fix QQAdapter.connect() missing is_reconnect param

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,7 +278,7 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"


### PR DESCRIPTION
## 摘要 / Summary

commit 43b8ba418 (Jun 25) 在 `_connect_adapter_with_timeout()` 中引入了 `is_reconnect` 参数并转发到 `adapter.connect()`。基类 `BasePlatformAdapter.connect()` 和所有其他平台 adapter（telegram, feishu, weixin, dingtalk, wecom 等）都已实现该参数签名，但 **QQAdapter 遗漏了**，导致 QQBot 启动时 TypeError。

commit 43b8ba418 (Jun 25) introduced the `is_reconnect` kwarg in `_connect_adapter_with_timeout()` and forwarded it to `adapter.connect()`. The base class `BasePlatformAdapter.connect()` and every other platform adapter (telegram, feishu, weixin, dingtalk, wecom, etc.) already implement this signature — but **QQAdapter was missed**, causing QQBot to crash on startup with a TypeError.

## 错误 / Error

```
✗ qqbot error: QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'
```

## 修复 / Fix

一行改动：在 `QQAdapter.connect()` 签名中补齐 `*, is_reconnect: bool = False`。

One-line fix: add `*, is_reconnect: bool = False` to `QQAdapter.connect()` signature.

## 影响 / Impact

- QQBot 在所有 0.17.0+ 版本中无法启动（启动后立即断开）
- QQBot cannot start on any 0.17.0+ release (disconnects immediately on boot)