### PR TITLE
computer_use: require a display on Linux before exposing the tool

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -118,11 +118,24 @@ class TestRegistration:
         assert entry.schema["name"] == "computer_use"
 
     def test_check_fn_true_on_linux_when_binary_present(self):
-        # Linux is supported; gated only on the cua-driver binary resolving.
+        # Linux is supported; gated on cua-driver binary resolving AND a
+        # reachable display. A headless gateway (no DISPLAY) must not surface
+        # the tool — cua-driver can't reach an X server there, and exposing it
+        # produces capture/input failures the model thrashes against.
         from tools.computer_use import tool as cu_tool
         with patch("tools.computer_use.tool.sys.platform", "linux"), \
-             patch("tools.computer_use.cua_backend.cua_driver_binary_available", return_value=True):
+             patch("tools.computer_use.cua_backend.cua_driver_binary_available", return_value=True), \
+             patch.dict(os.environ, {"DISPLAY": ":1"}, clear=False):
             assert cu_tool.check_computer_use_requirements() is True
+
+    def test_check_fn_false_on_linux_without_display(self):
+        # Binary present but headless (no DISPLAY) → tool stays hidden so the
+        # model never gets a tool it can't successfully drive.
+        from tools.computer_use import tool as cu_tool
+        with patch("tools.computer_use.tool.sys.platform", "linux"), \
+             patch("tools.computer_use.cua_backend.cua_driver_binary_available", return_value=True), \
+             patch.dict(os.environ, {"DISPLAY": ""}, clear=False):
+            assert cu_tool.check_computer_use_requirements() is False
 
     def test_check_fn_false_on_linux_without_binary(self):
         from tools.computer_use import tool as cu_tool

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -987,11 +987,25 @@ def check_computer_use_requirements() -> bool:
     upstream. Linux users see specific blocked checks via
     `hermes computer-use doctor` if their session is incomplete (e.g. no
     DISPLAY set).
+
+    On Linux the gateway process is typically headless (no ``DISPLAY``); the
+    cua-driver backend cannot reach an X server without one, so exposing the
+    tool in that state produces capture/input failures that the model then
+    thrashes against. Require a non-empty ``DISPLAY`` on Linux in addition to
+    the binary, so the tool is only surfaced when a display is actually
+    reachable. (A future per-task computer-use provider can override this by
+    registering as available; see ``computer_use.provider``.)
     """
     if sys.platform not in ("darwin", "win32", "linux"):
         return False
     from tools.computer_use.cua_backend import cua_driver_binary_available
-    return cua_driver_binary_available()
+    if not cua_driver_binary_available():
+        return False
+    # Headless Linux has no display for cua-driver to drive; don't surface the
+    # tool until a display exists (or a provider supplies one per-task).
+    if sys.platform == "linux" and not os.environ.get("DISPLAY", "").strip():
+        return False
+    return True
 
 
 def get_computer_use_schema() -> Dict[str, Any]:


### PR DESCRIPTION
## What

`check_computer_use_requirements()` currently returns `True` on Linux whenever the cua-driver binary resolves, with no regard for whether an X server is actually reachable. A headless gateway (the common Linux deployment: no `DISPLAY`, cua-driver present) thus surfaces `computer_use` to the model, which then drives it into capture/input failures and thrashes across `computer_use`/`terminal`/`skill` calls trying to recover.

The docstring already hints at this ("no DISPLAY set" -> `hermes computer-use doctor` reports blocked checks) but the gate never enforced it.

## Change

Tighten the Linux branch to also require a non-empty `DISPLAY`, so the tool is only surfaced when cua-driver can actually reach a display. macOS/Windows unchanged.

```python
if sys.platform == "linux" and not os.environ.get("DISPLAY", "").strip():
    return False
```

This is a standalone bugfix — no env vars, no plugin dependency, no new surface. A future per-task `computer_use.provider` can override this by registering as available (a headless host with a container-supplied display still gets the tool); that hook lands in a separate stacked PR.

## Why not just the binary check

The binary check was added when Linux support landed, but the gateway process is headless by default on Linux servers — cua-driver's `doctor` reports `ax_capability: X11 not reachable` + `screen_capture_capability: fail` there. Exposing a tool the model can't successfully drive is worse than hiding it: the model burns a turn, gets an error blob, and retries against other tools. Tightening the gate to "binary AND display" matches the reality the doctor already reports.

## Tests

Updated `test_check_fn_true_on_linux_when_binary_present` to set `DISPLAY=:1` (the gate now requires it) and added `test_check_fn_false_on_linux_without_display` proving the headless case hides the tool. Binary-absent and unsupported-platform tests unchanged.

## Scope

Single-file core change (`tools/computer_use/tool.py`) + one test. No config, no env vars, no plugin surface. Stacks cleanly under the pluggable provider PR (the host heuristic is the provider-unavailable fallback there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)