### PR TITLE
computer_use: pluggable per-task backend provider + generic cua-driver spawn_prefix

### DIFF
--- a/agent/computer_use_provider.py
+++ b/agent/computer_use_provider.py
@@ -1,0 +1,132 @@
+"""Computer Use Provider ABC
+==========================
+
+Defines the pluggable-backend interface for computer-use providers that
+supply a per-task :class:`tools.computer_use.backend.ComputerUseBackend`
+(typically a cua-driver instance bound to a per-task display / container).
+
+The default backend (``CuaDriverBackend`` spawned on the host, single
+display) lives in :mod:`tools.computer_use.cua_backend` and is used when no
+provider is configured. A provider is selected via ``computer_use.provider``
+in ``config.yaml``; the active provider services every ``computer_use`` tool
+call by returning a backend bound to the caller's ``task_id``.
+
+This ABC mirrors :class:`agent.browser_provider.BrowserProvider` (PR #25214)
+and :class:`agent.web_search_provider.WebSearchProvider` (PR #25182) — same
+shape, same registration flow. Providers live in their own plugin
+directories (e.g. ``~/.hermes/plugins/computer_use/<name>/``) and
+self-register via :func:`agent.computer_use_registry.register_provider` at
+plugin-discovery time.
+
+Why an ABC and not another core edit: per-thread OS-level keyboard/mouse
+requires running cua-driver against a per-task display that lives somewhere
+the host can't reach directly (a container's ``:1``, a remote VNC, …). Wiring
+that into the singleton backend would special-case one runtime (webtop
+containers) into core. Instead, the core gains one small generic hook —
+"resolve a per-task backend from a registered provider" — and every concrete
+runtime ships as a plugin that implements this ABC. That keeps the core
+footprint minimal and lets third-party runtimes (someone else's product)
+live outside the tree, per AGENTS.md ("widen the generic plugin surface,
+don't special-case it in core"; "third-party products … do NOT land under
+plugins/").
+"""
+
+from __future__ import annotations
+
+import abc
+from typing import TYPE_CHECKING, Any, Dict
+
+if TYPE_CHECKING:  # avoid agent -> tools layering inversion at runtime
+    from tools.computer_use.backend import ComputerUseBackend
+
+
+class ComputerUseProvider(abc.ABC):
+    """Abstract base class for a per-task computer-use backend provider.
+
+    Subclasses must implement :meth:`name`, :meth:`is_available`, and the
+    three lifecycle methods: :meth:`get_backend`, :meth:`close_backend`,
+    :meth:`emergency_cleanup`.
+
+    Contract:
+
+    * :meth:`get_backend` must return a **started** backend (the provider
+      owns ``backend.start()`` and any LRU/cap policy over live backends).
+      It is called on every ``computer_use`` tool dispatch with the current
+      ``task_id``; the provider is expected to return the same backend
+      instance for a given ``task_id`` across calls (stable per-task
+      binding) and to evict/stop backends for evicted tasks.
+    * The returned object must implement the
+      :class:`tools.computer_use.backend.ComputerUseBackend` interface.
+      The return type is string-annotated (``TYPE_CHECKING``) so this
+      ``agent/`` module has no runtime dependency on ``tools/``.
+    """
+
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
+        """Stable short identifier used in the ``computer_use.provider``
+        config key.
+
+        Lowercase, hyphens permitted. Examples: ``webtop-pool``,
+        ``remote-vnc``.
+        """
+
+    @property
+    def display_name(self) -> str:
+        """Human-readable label shown in ``hermes tools``. Defaults to ``name``."""
+        return self.name
+
+    @abc.abstractmethod
+    def is_available(self) -> bool:
+        """Return True when this provider can service calls.
+
+        Typically a cheap check (Docker reachable, container image present,
+        optional Python dep importable). Must NOT make network calls that
+        block — this runs at tool-registration time and on every
+        ``hermes tools`` paint. Mirrors :meth:`BrowserProvider.is_available`.
+        """
+
+    @abc.abstractmethod
+    def get_backend(self, task_id: str) -> "ComputerUseBackend":
+        """Return a started backend bound to ``task_id``.
+
+        The provider owns the per-task backend cache + LRU/cap policy and
+        calls ``backend.start()`` before returning. Repeated calls with the
+        same ``task_id`` must return the same backend instance. When the
+        provider evicts a task (e.g. its container was LRU-reclaimed), it
+        must ``stop()`` that backend.
+
+        May raise ``RuntimeError`` (backend spawn / display setup failure);
+        the dispatcher in :mod:`tools.computer_use.tool` surfaces these to
+        the user as a ``computer_use backend unavailable`` error.
+        """
+
+    @abc.abstractmethod
+    def close_backend(self, task_id: str) -> bool:
+        """Release a task's backend by ``task_id``.
+
+        Returns True on success, False on failure / unknown task. Should not
+        raise — log and return False so the dispatcher's cleanup keeps
+        moving.
+        """
+
+    @abc.abstractmethod
+    def emergency_cleanup(self) -> None:
+        """Best-effort teardown of all live backends during process exit.
+
+        Called from atexit / signal handlers. Must tolerate missing
+        resources, errors, etc. — log and move on. Must not raise.
+        """
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        """Return provider metadata for the ``hermes tools`` picker.
+
+        Default: minimal entry derived from :attr:`display_name`. Override
+        to expose prerequisite prompts, badges, and post-setup hooks.
+        """
+        return {
+            "name": self.display_name,
+            "badge": "",
+            "tag": "",
+            "env_vars": [],
+        }

--- a/agent/computer_use_registry.py
+++ b/agent/computer_use_registry.py
@@ -1,0 +1,148 @@
+"""Computer Use Provider Registry
+================================
+
+Central map of registered computer-use providers. Populated by plugins at
+import-time via :func:`register_provider`; consumed by
+:func:`tools.computer_use.tool._get_active_cu_provider` to route each
+``computer_use`` tool call to a per-task backend supplied by the active
+provider.
+
+Active selection
+----------------
+The active provider is chosen by configuration with this precedence:
+
+1. ``computer_use.provider`` in ``config.yaml`` (explicit override).
+   ``local`` (or the builtin names ``cua`` / ``cua-driver``) short-circuits
+   to ``None`` — the dispatcher uses the legacy host-spawned singleton
+   ``CuaDriverBackend``.
+2. Otherwise ``None`` — the dispatcher falls back to the legacy singleton.
+
+The explicit-config branch (rule 1) intentionally ignores
+:meth:`is_available` so the dispatcher surfaces a typed provider error to
+the user instead of silently falling back to the host singleton. This
+mirrors :func:`agent.browser_registry._resolve` (PR #25214) bit-for-bit:
+a configured-but-unavailable provider is a misconfiguration the user should
+hear about, not a silent mode switch.
+
+There is intentionally NO legacy preference walk here (unlike the browser
+registry): computer_use had no pre-existing auto-detected cloud providers,
+so any provider must be explicitly configured to take effect. Third-party
+plugins added under ``~/.hermes/plugins/computer_use/<vendor>/`` are subject
+to the same explicit-config gate — they never auto-activate.
+
+Note: there is no "capability" split here. Every computer-use provider
+implements the full
+:class:`agent.computer_use_provider.ComputerUseProvider` lifecycle; the
+registry's job is purely selection, not capability routing.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Dict, List, Optional
+
+from agent.computer_use_provider import ComputerUseProvider
+
+logger = logging.getLogger(__name__)
+
+
+_providers: Dict[str, ComputerUseProvider] = {}
+_lock = threading.Lock()
+
+
+# Config values that mean "use the legacy host-spawned singleton, not a
+# registered provider." ``local`` mirrors the browser registry's
+# short-circuit; ``cua`` / ``cua-driver`` / empty cover the names users
+# already use for the builtin backend.
+_LEGACY_SENTINELS = {"", "local", "cua", "cua-driver", "builtin"}
+
+
+def register_provider(provider: ComputerUseProvider) -> None:
+    """Register a computer-use provider.
+
+    Re-registration (same ``name``) overwrites the previous entry and logs
+    a debug message — makes hot-reload scenarios (tests, dev loops) behave
+    predictably. Mirrors :func:`agent.browser_registry.register_provider`.
+    """
+    if not isinstance(provider, ComputerUseProvider):
+        raise TypeError(
+            f"register_provider() expects a ComputerUseProvider instance, "
+            f"got {type(provider).__name__}"
+        )
+    name = provider.name
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError("Computer use provider .name must be a non-empty string")
+    with _lock:
+        existing = _providers.get(name)
+        _providers[name] = provider
+    if existing is not None:
+        logger.debug(
+            "Computer use provider '%s' re-registered (was %r)",
+            name, type(existing).__name__,
+        )
+    else:
+        logger.debug(
+            "Registered computer use provider '%s' (%s)",
+            name, type(provider).__name__,
+        )
+
+
+def list_providers() -> List[ComputerUseProvider]:
+    """Return all registered providers, sorted by name."""
+    with _lock:
+        items = list(_providers.values())
+    return sorted(items, key=lambda p: p.name)
+
+
+def get_provider(name: str) -> Optional[ComputerUseProvider]:
+    """Return the provider registered under *name*, or None."""
+    if not isinstance(name, str):
+        return None
+    with _lock:
+        return _providers.get(name.strip())
+
+
+# ---------------------------------------------------------------------------
+# Active-provider resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve(configured: Optional[str]) -> Optional[ComputerUseProvider]:
+    """Resolve the active computer-use provider.
+
+    Resolution rules (in order):
+
+    1. **Legacy sentinel / unset.** Returns None — the dispatcher uses the
+       host-spawned singleton ``CuaDriverBackend``. Covers ``local``,
+       ``cua``, ``cua-driver``, ``builtin``, and unset.
+    2. **Explicit config wins, ignoring availability.** If ``configured``
+       names a registered provider, return it even if its
+       :meth:`is_available` returns False — the dispatcher will surface a
+       precise provider error instead of silently falling back to the host
+       singleton. Mirrors :func:`agent.browser_registry._resolve`.
+
+    Returns None when no provider is configured (or the value is a legacy
+    sentinel); the dispatcher then falls back to the host singleton.
+    """
+    with _lock:
+        snapshot = dict(_providers)
+
+    if not configured or configured in _LEGACY_SENTINELS:
+        return None
+
+    provider = snapshot.get(configured)
+    if provider is not None:
+        return provider
+    logger.debug(
+        "computer_use provider '%s' configured but not registered; "
+        "falling back to host singleton",
+        configured,
+    )
+    return None
+
+
+def _reset_for_tests() -> None:
+    """Clear the registry. **Test-only.**"""
+    with _lock:
+        _providers.clear()

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -367,6 +367,33 @@ browser:
   inactivity_timeout: 120
 
 # =============================================================================
+# Computer Use (per-task backend provider)
+# =============================================================================
+# By default computer_use spawns cua-driver on the host and drives the host
+# display (singleton backend). For per-thread / per-container isolation (each
+# task_id gets its own display + cua-driver), set ``computer_use.provider`` to
+# a registered provider name and install the matching plugin under
+# ~/.hermes/plugins/computer_use/<name>/. The provider returns a started
+# backend bound to the caller's task_id; the host-DISPLAY gate is bypassed
+# when a provider is available (it supplies its own displays).
+#
+# Built-in / legacy values (no provider, host singleton): "local", "cua",
+# "cua-driver", "builtin", or unset.
+#
+# provider: webtop-pool
+#
+# cua_driver:
+#   # Generic spawn prefix prepended to the cua-driver invocation, letting a
+#   # container or remote runtime own the cua-driver process + display. When
+#   # set, the backend spawns ``[*spawn_prefix, <driver_path>, "mcp"]`` instead
+#   # of resolving cua-driver on the host. A provider typically constructs
+#   # CuaDriverBackend(spawn_prefix=..., driver_path=...) per task; this key
+#   # is documented for standalone use of the host backend against a single
+#   # container.
+#   # spawn_prefix: ["docker", "exec", "-i", "hermes-wt-<slot>", "env", "DISPLAY=:1", "HOME=/config"]
+#   # driver_path: "/config/bin/cua-driver"
+
+# =============================================================================
 # Tool Loop Guardrails
 # =============================================================================
 # Soft warnings are enabled by default. They append guidance to repeated failed

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -797,6 +797,42 @@ class PluginContext:
             self.manifest.name, provider.name,
         )
 
+    # -- computer use provider registration -----------------------------------
+
+    def register_computer_use_provider(self, provider) -> None:
+        """Register a per-task computer-use backend provider.
+
+        ``provider`` must be an instance of
+        :class:`agent.computer_use_provider.ComputerUseProvider`. The
+        ``provider.name`` attribute is what ``computer_use.provider`` in
+        ``config.yaml`` matches against when routing ``computer_use`` tool
+        calls. A provider returns a started
+        :class:`tools.computer_use.backend.ComputerUseBackend` bound to the
+        caller's ``task_id`` (e.g. a per-container cua-driver), so per-thread
+        OS-level keyboard/mouse is isolated without special-casing any one
+        runtime in core.
+
+        Mirrors :meth:`register_browser_provider` exactly — same registration
+        shape, same gating, same logging. The computer_use subsystem's
+        dispatcher (:func:`tools.computer_use.tool._get_active_cu_provider`)
+        consults the registry built up by these calls.
+        """
+        from agent.computer_use_provider import ComputerUseProvider
+        from agent.computer_use_registry import register_provider as _register_cu_provider
+
+        if not isinstance(provider, ComputerUseProvider):
+            logger.warning(
+                "Plugin '%s' tried to register a computer_use provider that "
+                "does not inherit from ComputerUseProvider. Ignoring.",
+                self.manifest.name,
+            )
+            return
+        _register_cu_provider(provider)
+        logger.info(
+            "Plugin '%s' registered computer_use provider: %s",
+            self.manifest.name, provider.name,
+        )
+
     # -- secret source registration -------------------------------------------
 
     def register_secret_source(self, source) -> None:

--- a/tests/computer_use/test_cua_spawn_prefix.py
+++ b/tests/computer_use/test_cua_spawn_prefix.py
@@ -1,0 +1,132 @@
+"""Tests for the generic cua-driver spawn_prefix on CuaDriverBackend.
+
+PR: ``computer_use: pluggable per-task backend provider``.
+
+``spawn_prefix`` lets any container/remote runtime own the cua-driver
+process — core stays runtime-agnostic. These tests pin the two synchronous,
+easily-isolated surfaces that depend on the prefix:
+
+* ``CuaDriverBackend.is_available()`` — True when a prefix is set (the
+  binary lives in-target, not on the host PATH) and falls back to the host
+  binary check otherwise.
+* ``_CuaDriverSession._call_tool_via_cli`` — the CLI-fallback command is
+  wrapped through the prefix and uses the prefix's env; without a prefix
+  the legacy ``[_CUA_DRIVER_CMD, "call", ...]`` shape is preserved.
+
+The async MCP spawn path (``_lifecycle_coro``) is exercised end-to-end in
+the cua-driver integration suite; here we pin the command-shape contract
+that the integration suite depends on.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.computer_use.cua_backend import CuaDriverBackend, _CuaDriverSession, _AsyncBridge
+
+
+def _fake_proc(stdout: str) -> MagicMock:
+    proc = MagicMock()
+    proc.stdout = stdout
+    proc.stderr = ""
+    proc.returncode = 0
+    return proc
+
+
+def test_is_available_true_with_spawn_prefix_even_without_host_binary():
+    # Prefix mode: binary is in-target; host PATH/HERMES_CUA_DRIVER_CMD is N/A.
+    with patch("tools.computer_use.cua_backend.cua_driver_binary_available", return_value=False), \
+         patch("tools.computer_use.cua_backend.sys.platform", "linux"):
+        b = CuaDriverBackend(spawn_prefix=["docker", "exec", "-i", "c1", "env", "DISPLAY=:1"])
+        assert b.is_available() is True
+
+
+def test_is_available_falls_back_to_host_binary_without_prefix():
+    with patch("tools.computer_use.cua_backend.cua_driver_binary_available", return_value=True), \
+         patch("tools.computer_use.cua_backend.sys.platform", "linux"):
+        assert CuaDriverBackend().is_available() is True
+    with patch("tools.computer_use.cua_backend.cua_driver_binary_available", return_value=False), \
+         patch("tools.computer_use.cua_backend.sys.platform", "linux"):
+        assert CuaDriverBackend().is_available() is False
+
+
+def test_is_available_false_on_unsupported_platform_even_with_prefix():
+    # Platform gate still applies in prefix mode — cua-driver itself must
+    # support the host platform's input primitives.
+    with patch("tools.computer_use.cua_backend.sys.platform", "freebsd13"):
+        b = CuaDriverBackend(spawn_prefix=["docker", "exec", "-i", "c1"])
+        assert b.is_available() is False
+
+
+def _make_session(spawn_prefix=None, driver_path=None, spawn_env=None) -> _CuaDriverSession:
+    # _call_tool_via_cli is synchronous and does not touch the bridge loop,
+    # so an un-started bridge is fine.
+    return _CuaDriverSession(
+        _AsyncBridge(),
+        spawn_prefix=spawn_prefix,
+        driver_path=driver_path,
+        spawn_env=spawn_env,
+    )
+
+
+def test_cli_fallback_cmd_wrapped_through_prefix():
+    sess = _make_session(
+        spawn_prefix=["docker", "exec", "-i", "hermes-wt-abc", "env", "DISPLAY=:1", "HOME=/config"],
+        driver_path="/config/bin/cua-driver",
+    )
+    captured = {}
+
+    def fake_run(cmd, **kw):
+        captured["cmd"] = list(cmd)
+        captured["env"] = kw.get("env")
+        return _fake_proc(json.dumps({"tree_markdown": "x", "element_count": 0, "screenshot_png_b64": ""}))
+
+    with patch("subprocess.run", side_effect=fake_run):
+        sess._call_tool_via_cli("get_window_state", {"x": 1}, timeout=15.0)
+    cmd = captured["cmd"]
+    assert cmd[:6] == ["docker", "exec", "-i", "hermes-wt-abc", "env", "DISPLAY=:1"]
+    assert cmd[6] == "HOME=/config"
+    assert cmd[7] == "/config/bin/cua-driver"
+    assert cmd[8:11] == ["call", "get_window_state", json.dumps({"x": 1})]
+    # Prefix mode does NOT route the screenshot through a host temp file
+    # (the in-target driver can't write a host path); screenshot_out_file
+    # must be absent from the call payload.
+    payload = json.loads(cmd[10])
+    assert "screenshot_out_file" not in payload
+
+
+def test_cli_fallback_cmd_legacy_shape_without_prefix():
+    sess = _make_session()
+    captured = {}
+
+    def fake_run(cmd, **kw):
+        captured["cmd"] = list(cmd)
+        return _fake_proc(json.dumps({"tree_markdown": "x", "element_count": 0}))
+
+    with patch("tools.computer_use.cua_backend._CUA_DRIVER_CMD", "cua-driver"), \
+         patch("subprocess.run", side_effect=fake_run):
+        sess._call_tool_via_cli("list_windows", {}, timeout=15.0)
+    cmd = captured["cmd"]
+    assert cmd[0] == "cua-driver"
+    assert cmd[1:4] == ["call", "list_windows", json.dumps({})]
+
+
+def test_cli_fallback_legacy_uses_shot_file_for_get_window_state():
+    # Without a prefix, get_window_state still routes the screenshot through
+    # a host temp file (the optimization the prefix path deliberately skips).
+    sess = _make_session()
+    captured = {}
+
+    def fake_run(cmd, **kw):
+        captured["cmd"] = list(cmd)
+        return _fake_proc(json.dumps({"tree_markdown": "x", "element_count": 0}))
+
+    with patch("tools.computer_use.cua_backend._CUA_DRIVER_CMD", "cua-driver"), \
+         patch("subprocess.run", side_effect=fake_run):
+        sess._call_tool_via_cli("get_window_state", {}, timeout=15.0)
+    payload = json.loads(captured["cmd"][3])
+    assert "screenshot_out_file" in payload
+    assert payload["screenshot_out_file"].startswith("/tmp/")  # mkstemp default dir

--- a/tests/computer_use/test_provider_routing.py
+++ b/tests/computer_use/test_provider_routing.py
@@ -1,0 +1,210 @@
+"""Tests for the computer-use provider registry + tool.py routing hook.
+
+PR: ``computer_use: pluggable per-task backend provider``.
+
+The provider ABC + registry mirror the browser provider surface (PR #25214).
+These tests pin the contract the tool.py dispatcher relies on:
+
+* ``check_computer_use_requirements()`` returns True when an active provider
+  is available, even on a headless host (no DISPLAY) — the provider supplies
+  its own per-task displays.
+* ``_get_backend(task_id)`` delegates to ``provider.get_backend(task_id)``
+  when a provider is active and task_id is supplied; different task_ids get
+  independent backends; the provider owns start().
+* ``reset_backend_for_tests()`` clears the provider cache so tests don't
+  leak the previous test's provider.
+* Legacy mode (no provider configured) falls back to the host singleton.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict
+from unittest.mock import patch
+
+import pytest
+
+from agent.computer_use_provider import ComputerUseProvider
+from agent.computer_use_registry import _reset_for_tests, register_provider
+from tools.computer_use.backend import ComputerUseBackend
+
+
+class _StubBackend(ComputerUseBackend):
+    """Minimal started-backend stub recording the task_id it was minted for."""
+
+    def __init__(self, task_id: str) -> None:
+        self.task_id = task_id
+        self.started = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> None:  # pragma: no cover
+        self.started = False
+
+    def is_available(self) -> bool:
+        return True
+
+    def capture(self, mode="som", app=None):
+        from tools.computer_use.backend import CaptureResult
+        return CaptureResult(mode=mode, width=1024, height=768, png_b64=None,
+                             elements=[], app=app or "", window_title="")
+
+    def click(self, **kw):
+        from tools.computer_use.backend import ActionResult
+        return ActionResult(ok=True, action="click")
+
+    def drag(self, **kw):
+        from tools.computer_use.backend import ActionResult
+        return ActionResult(ok=True, action="drag")
+
+    def scroll(self, **kw):
+        from tools.computer_use.backend import ActionResult
+        return ActionResult(ok=True, action="scroll")
+
+    def type_text(self, text):
+        from tools.computer_use.backend import ActionResult
+        return ActionResult(ok=True, action="type")
+
+    def key(self, keys):
+        from tools.computer_use.backend import ActionResult
+        return ActionResult(ok=True, action="key")
+
+    def list_apps(self):
+        return []
+
+    def focus_app(self, app, raise_window=False):
+        from tools.computer_use.backend import ActionResult
+        return ActionResult(ok=True, action="focus_app")
+
+    def set_value(self, value, element=None):
+        from tools.computer_use.backend import ActionResult
+        return ActionResult(ok=True, action="set_value")
+
+    def wait(self, seconds):
+        from tools.computer_use.backend import ActionResult
+        return ActionResult(ok=True, action="wait")
+
+
+class _StubProvider(ComputerUseProvider):
+    """Records every get_backend call + caches a started backend per task_id.
+
+    Mirrors the real per-task contract: the same task_id returns the same
+    backend instance across calls (stable per-task binding), different
+    task_ids get independent backends. The provider owns start().
+    """
+
+    name = "stub-cu"
+    available = True
+    get_calls: list = []
+    _backends: dict = {}
+
+    def is_available(self) -> bool:
+        return self.available
+
+    def get_backend(self, task_id: str) -> ComputerUseBackend:
+        self.get_calls.append(task_id)
+        b = self._backends.get(task_id)
+        if b is None:
+            b = _StubBackend(task_id)
+            b.start()
+            self._backends[task_id] = b
+        return b
+
+    def close_backend(self, task_id: str) -> bool:
+        return True
+
+    def emergency_cleanup(self) -> None:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry():
+    _reset_for_tests()
+    from tools.computer_use import tool as cu_tool
+    cu_tool.reset_backend_for_tests()
+    _StubProvider.get_calls = []
+    _StubProvider._backends = {}
+    _StubProvider.available = True
+    yield
+    _reset_for_tests()
+    cu_tool.reset_backend_for_tests()
+
+
+def _cfg(provider_value):
+    """Patch load_config to return a computer_use.provider setting."""
+    cfg: Dict = {"computer_use": {"provider": provider_value}} if provider_value is not None else {}
+    return patch("hermes_cli.config.load_config", return_value=cfg)
+
+
+def test_gate_true_on_headless_linux_when_provider_available():
+    # No DISPLAY, no host binary — but an active available provider supplies
+    # its own displays, so the tool is surfaced.
+    register_provider(_StubProvider())
+    from tools.computer_use import tool as cu_tool
+    with patch("tools.computer_use.tool.sys.platform", "linux"), \
+         patch("tools.computer_use.cua_backend.cua_driver_binary_available", return_value=False), \
+         patch.dict(os.environ, {"DISPLAY": ""}, clear=False), \
+         _cfg("stub-cu"):
+        assert cu_tool.check_computer_use_requirements() is True
+
+
+def test_gate_false_when_provider_configured_but_unavailable():
+    register_provider(_StubProvider())
+    _StubProvider.available = False
+    from tools.computer_use import tool as cu_tool
+    with patch("tools.computer_use.tool.sys.platform", "linux"), \
+         patch.dict(os.environ, {"DISPLAY": ""}, clear=False), \
+         _cfg("stub-cu"):
+        # Unavailable provider on a headless host → tool hidden (no thrash).
+        assert cu_tool.check_computer_use_requirements() is False
+
+
+def test_get_backend_routes_per_task_to_provider():
+    register_provider(_StubProvider())
+    from tools.computer_use import tool as cu_tool
+    with _cfg("stub-cu"):
+        b1 = cu_tool._get_backend("task-A")
+        b2 = cu_tool._get_backend("task-B")
+        b1_again = cu_tool._get_backend("task-A")
+    assert isinstance(b1, _StubBackend) and b1.started
+    assert isinstance(b2, _StubBackend) and b2.started
+    assert b1.task_id == "task-A"
+    assert b2.task_id == "task-B"
+    assert b1 is b1_again  # provider returns same instance per task_id
+    assert _StubProvider.get_calls == ["task-A", "task-B", "task-A"]
+
+
+def test_get_backend_without_task_id_uses_legacy_singleton():
+    # No task_id → never consults the provider, even if one is registered.
+    register_provider(_StubProvider())
+    from tools.computer_use import tool as cu_tool
+    with patch.dict(os.environ, {"HERMES_COMPUTER_USE_BACKEND": "noop"}, clear=False), \
+         _cfg("stub-cu"):
+        b = cu_tool._get_backend(None)
+    from tools.computer_use.tool import _NoopBackend
+    assert isinstance(b, _NoopBackend)
+    assert _StubProvider.get_calls == []
+
+
+def test_legacy_provider_value_falls_back_to_singleton():
+    # "local" / "cua" / unset are legacy sentinels → no provider, singleton path.
+    from tools.computer_use import tool as cu_tool
+    for legacy in ("local", "cua", "cua-driver", None):
+        _reset_for_tests()
+        cu_tool.reset_backend_for_tests()
+        with patch.dict(os.environ, {"HERMES_COMPUTER_USE_BACKEND": "noop"}, clear=False), \
+             _cfg(legacy):
+            b = cu_tool._get_backend("task-X")
+        from tools.computer_use.tool import _NoopBackend
+        assert isinstance(b, _NoopBackend), f"legacy={legacy!r} should use singleton"
+
+
+def test_reset_clears_provider_cache():
+    register_provider(_StubProvider())
+    from tools.computer_use import tool as cu_tool
+    with _cfg("stub-cu"):
+        cu_tool._get_active_cu_provider()
+    assert cu_tool._cu_provider_cache  # cached
+    cu_tool.reset_backend_for_tests()
+    assert not cu_tool._cu_provider_cache  # cleared

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -118,11 +118,24 @@ class TestRegistration:
         assert entry.schema["name"] == "computer_use"
 
     def test_check_fn_true_on_linux_when_binary_present(self):
-        # Linux is supported; gated only on the cua-driver binary resolving.
+        # Linux is supported; gated on cua-driver binary resolving AND a
+        # reachable display. A headless gateway (no DISPLAY) must not surface
+        # the tool — cua-driver can't reach an X server there, and exposing it
+        # produces capture/input failures the model thrashes against.
         from tools.computer_use import tool as cu_tool
         with patch("tools.computer_use.tool.sys.platform", "linux"), \
-             patch("tools.computer_use.cua_backend.cua_driver_binary_available", return_value=True):
+             patch("tools.computer_use.cua_backend.cua_driver_binary_available", return_value=True), \
+             patch.dict(os.environ, {"DISPLAY": ":1"}, clear=False):
             assert cu_tool.check_computer_use_requirements() is True
+
+    def test_check_fn_false_on_linux_without_display(self):
+        # Binary present but headless (no DISPLAY) → tool stays hidden so the
+        # model never gets a tool it can't successfully drive.
+        from tools.computer_use import tool as cu_tool
+        with patch("tools.computer_use.tool.sys.platform", "linux"), \
+             patch("tools.computer_use.cua_backend.cua_driver_binary_available", return_value=True), \
+             patch.dict(os.environ, {"DISPLAY": ""}, clear=False):
+            assert cu_tool.check_computer_use_requirements() is False
 
     def test_check_fn_false_on_linux_without_binary(self):
         from tools.computer_use import tool as cu_tool

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -624,8 +624,17 @@ class _CuaDriverSession:
     session object, never the surrounding contexts.
     """
 
-    def __init__(self, bridge: _AsyncBridge) -> None:
+    def __init__(
+        self,
+        bridge: _AsyncBridge,
+        spawn_prefix: Optional[List[str]] = None,
+        spawn_env: Optional[Dict[str, str]] = None,
+        driver_path: Optional[str] = None,
+    ) -> None:
         self._bridge = bridge
+        self._spawn_prefix = list(spawn_prefix) if spawn_prefix else None
+        self._spawn_env = spawn_env
+        self._driver_path = driver_path or "cua-driver"
         self._session = None
         self._lock = threading.Lock()
         self._started = False
@@ -671,21 +680,36 @@ class _CuaDriverSession:
         self._startup_phase = "binary-check"
 
         try:
-            if not cua_driver_binary_available():
-                raise RuntimeError(cua_driver_install_hint())
+            if self._spawn_prefix:
+                # Container / remote runtime: spawn cua-driver through the
+                # prefix (e.g. ``docker exec -i <c> env DISPLAY=:1
+                # /config/bin/cua-driver mcp``). The binary lives in-target,
+                # not on the host, so skip the host binary check and host
+                # manifest discovery (manifest would run on the host binary
+                # and describe the wrong invocation).
+                command = self._spawn_prefix[0]
+                args = list(self._spawn_prefix[1:]) + [self._driver_path, "mcp"]
+                child_env = self._spawn_env
+                if child_env is None:
+                    child_env = cua_driver_child_env()
+                child_env = _sanitize_subprocess_env(child_env)
+            else:
+                if not cua_driver_binary_available():
+                    raise RuntimeError(cua_driver_install_hint())
 
-            # Surface 8: ask cua-driver itself which subcommand spawns
-            # the MCP server, instead of hardcoding ["mcp"]. Falls back
-            # transparently for older drivers / any discovery failure.
-            self._startup_phase = "manifest-discovery"
-            command, args = _resolve_mcp_invocation(_CUA_DRIVER_CMD)
+                # Surface 8: ask cua-driver itself which subcommand spawns
+                # the MCP server, instead of hardcoding ["mcp"]. Falls back
+                # transparently for older drivers / any discovery failure.
+                self._startup_phase = "manifest-discovery"
+                command, args = _resolve_mcp_invocation(_CUA_DRIVER_CMD)
+                child_env = _sanitize_subprocess_env(cua_driver_child_env())
             _t_manifest = _time.monotonic()
             params = StdioServerParameters(
                 command=command,
                 args=args,
                 # Apply the telemetry policy first (default: disabled), then
                 # sanitize Hermes-managed secrets out of the child env.
-                env=_sanitize_subprocess_env(cua_driver_child_env()),
+                env=child_env,
             )
 
             async with stdio_client(params) as (read, write):
@@ -980,12 +1004,31 @@ class _CuaDriverSession:
 
         call_args = dict(args)
         shot_file: Optional[str] = None
-        if name == "get_window_state" and "screenshot_out_file" not in call_args:
+        # spawn_prefix generalization (per-task provider). getattr keeps the
+        # legacy no-prefix path identical even for a session constructed via
+        # object.__new__ (the env-sanitization tests bypass __init__).
+        spawn_prefix = getattr(self, "_spawn_prefix", None)
+        driver_path = getattr(self, "_driver_path", None) or "cua-driver"
+        spawn_env = getattr(self, "_spawn_env", None)
+        # The screenshot-to-file optimization routes the PNG through a host
+        # temp file the daemon writes and we read back. When spawning
+        # through a prefix (container/remote) the in-target cua-driver
+        # cannot write to a host path, so skip the indirection and accept
+        # the inline base64 blob over the spawned pipe. The MCP stdio path
+        # is the primary transport in prefix mode; this CLI fallback is
+        # rarely hit there, and the action data still comes through.
+        use_shot_file = name == "get_window_state" and "screenshot_out_file" not in call_args
+        if use_shot_file and not spawn_prefix:
             fd, shot_file = _tempfile.mkstemp(prefix="cua_shot_", suffix=".png")
             os.close(fd)
             call_args["screenshot_out_file"] = shot_file
 
-        cmd = [_CUA_DRIVER_CMD, "call", name, json.dumps(call_args)]
+        if spawn_prefix:
+            cmd = list(spawn_prefix) + [driver_path, "call", name, json.dumps(call_args)]
+            cli_env = spawn_env if spawn_env is not None else cua_driver_child_env()
+        else:
+            cmd = [_CUA_DRIVER_CMD, "call", name, json.dumps(call_args)]
+            cli_env = cua_driver_child_env()
         attempts = 4
         backoff = 0.5
         parsed: Any = None
@@ -995,7 +1038,7 @@ class _CuaDriverSession:
                 try:
                     proc = _subprocess.run(
                         cmd, capture_output=True, text=True, timeout=max(15.0, timeout),
-                        env=_sanitize_subprocess_env(cua_driver_child_env()),
+                        env=_sanitize_subprocess_env(cli_env),
                     )
                 except Exception as e:  # pragma: no cover - subprocess spawn failure
                     raise RuntimeError(f"cua-driver CLI fallback for {name} failed to spawn: {e}") from e
@@ -1268,11 +1311,32 @@ def _ingest_windows(raw_windows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 class CuaDriverBackend(ComputerUseBackend):
-    """Default computer-use backend. Cross-platform via cua-driver MCP."""
+    """Default computer-use backend. Cross-platform via cua-driver MCP.
 
-    def __init__(self) -> None:
+    By default the backend spawns ``cua-driver mcp`` on the host and drives
+    the host display. When ``spawn_prefix`` is given, the backend instead
+    spawns ``[*spawn_prefix, driver_path, "mcp"]`` — letting a container or
+    remote runtime own the cua-driver process and the display it connects
+    to (e.g. ``["docker","exec","-i",container,"env","DISPLAY=:1",
+    "HOME=/config"]`` with ``driver_path="/config/bin/cua-driver"``). The
+    MCP stdio bridge works unchanged over the spawned pipe. This is the
+    generic hook a per-task ComputerUseProvider uses to bind cua-driver to
+    a per-task display without special-casing any one runtime in core.
+    """
+
+    def __init__(
+        self,
+        spawn_prefix: Optional[List[str]] = None,
+        spawn_env: Optional[Dict[str, str]] = None,
+        driver_path: Optional[str] = None,
+    ) -> None:
         self._bridge = _AsyncBridge()
-        self._session = _CuaDriverSession(self._bridge)
+        self._session = _CuaDriverSession(
+            self._bridge,
+            spawn_prefix=spawn_prefix,
+            spawn_env=spawn_env,
+            driver_path=driver_path,
+        )
         # Sticky context — updated by capture(), used by action tools.
         self._active_pid: Optional[int] = None
         self._active_window_id: Optional[int] = None
@@ -1363,6 +1427,11 @@ class CuaDriverBackend(ComputerUseBackend):
         # other Unix-likes haven't been exercised end-to-end.
         if sys.platform not in ("darwin", "win32", "linux"):
             return False
+        # When spawned through a prefix (container/remote), the cua-driver
+        # binary lives in-target, not on the host PATH — the provider that
+        # constructed us guarantees it, so the host binary check is N/A.
+        if self._session._spawn_prefix:
+            return True
         return cua_driver_binary_available()
 
     def _clear_active_target(self) -> None:

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -987,11 +987,25 @@ def check_computer_use_requirements() -> bool:
     upstream. Linux users see specific blocked checks via
     `hermes computer-use doctor` if their session is incomplete (e.g. no
     DISPLAY set).
+
+    On Linux the gateway process is typically headless (no ``DISPLAY``); the
+    cua-driver backend cannot reach an X server without one, so exposing the
+    tool in that state produces capture/input failures that the model then
+    thrashes against. Require a non-empty ``DISPLAY`` on Linux in addition to
+    the binary, so the tool is only surfaced when a display is actually
+    reachable. (A future per-task computer-use provider can override this by
+    registering as available; see ``computer_use.provider``.)
     """
     if sys.platform not in ("darwin", "win32", "linux"):
         return False
     from tools.computer_use.cua_backend import cua_driver_binary_available
-    return cua_driver_binary_available()
+    if not cua_driver_binary_available():
+        return False
+    # Headless Linux has no display for cua-driver to drive; don't surface the
+    # tool until a display exists (or a provider supplies one per-task).
+    if sys.platform == "linux" and not os.environ.get("DISPLAY", "").strip():
+        return False
+    return True
 
 
 def get_computer_use_schema() -> Dict[str, Any]:

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -150,9 +150,62 @@ _approval_lock = threading.Lock()
 _session_auto_approve: Dict[str, bool] = {}
 _always_allow: Dict[str, set] = {}
 
+# Per-process cache of the resolved computer-use provider. None (before first
+# resolution) or a ComputerUseProvider / None result. Re-resolved only when
+# reset by reset_backend_for_tests(); config is not re-read per tool call.
+_cu_provider_lock = threading.Lock()
+_cu_provider_cache: list = []  # [ComputerUseProvider | None] once resolved
 
-def _get_backend() -> ComputerUseBackend:
+
+def _get_active_cu_provider():
+    """Return the active registered ComputerUseProvider, or None for legacy.
+
+    Reads ``computer_use.provider`` from config.yaml once per process and
+    resolves it through :mod:`agent.computer_use_registry`. None (or a
+    legacy sentinel like ``local``/``cua``) means "use the host-spawned
+    singleton backend". A configured-but-unregistered name also returns None
+    (the registry logs it) so the dispatcher falls back to the singleton
+    rather than raising at gate time.
+    """
+    with _cu_provider_lock:
+        if _cu_provider_cache:
+            return _cu_provider_cache[0]
+        configured = None
+        try:
+            from hermes_cli.config import load_config
+            cfg = load_config() or {}
+            cu = cfg.get("computer_use") or {}
+            configured = cu.get("provider")
+        except Exception as exc:  # noqa: BLE001 - fail open to singleton
+            logger.debug("computer_use: provider config read failed: %s", exc)
+            configured = None
+        from agent.computer_use_registry import _resolve
+        provider = _resolve(configured if isinstance(configured, str) else None)
+        _cu_provider_cache.append(provider)
+        return provider
+
+
+def _get_backend(task_id: Optional[str] = None) -> ComputerUseBackend:
+    """Return a computer-use backend for ``task_id`` (or the host singleton).
+
+    When a provider is active and ``task_id`` is supplied, delegate to
+    ``provider.get_backend(task_id)`` — the provider owns the per-task
+    backend cache, LRU/cap, and ``start()``. Otherwise fall back to the
+    legacy process-global singleton spawned on the host display.
+    """
     global _backend
+    if task_id:
+        provider = _get_active_cu_provider()
+        if provider is not None:
+            try:
+                if not provider.is_available():
+                    raise RuntimeError(
+                        f"computer_use provider {provider.name!r} is not available"
+                    )
+            except Exception:
+                # Let get_backend raise the precise spawn/setup error.
+                pass
+            return provider.get_backend(task_id)
     with _backend_lock:
         if _backend is None:
             backend_name = os.environ.get("HERMES_COMPUTER_USE_BACKEND", "cua").lower()
@@ -176,7 +229,8 @@ def _get_backend() -> ComputerUseBackend:
 
 
 def reset_backend_for_tests() -> None:  # pragma: no cover
-    """Test helper — tear down the cached backend and per-session state."""
+    """Test helper — tear down the cached backend, provider cache, and
+    per-session state."""
     global _backend
     with _backend_lock:
         if _backend is not None:
@@ -185,6 +239,8 @@ def reset_backend_for_tests() -> None:  # pragma: no cover
             except Exception:
                 pass
         _backend = None
+    with _cu_provider_lock:
+        _cu_provider_cache.clear()
     with _approval_lock:
         _session_auto_approve.clear()
         _always_allow.clear()
@@ -294,9 +350,11 @@ def handle_computer_use(args: Dict[str, Any], **kwargs) -> Any:
         if err is not None:
             return err
 
-    # Dispatch to backend.
+    # Dispatch to backend. task_id routes to a per-task provider backend
+    # when one is configured (e.g. per-container cua-driver); otherwise the
+    # host singleton is used.
     try:
-        backend = _get_backend()
+        backend = _get_backend(kwargs.get("task_id"))
     except Exception as e:
         return json.dumps({
             "error": f"computer_use backend unavailable: {e}",
@@ -998,6 +1056,16 @@ def check_computer_use_requirements() -> bool:
     """
     if sys.platform not in ("darwin", "win32", "linux"):
         return False
+    # A registered, available computer-use provider supplies its own
+    # per-task displays (e.g. per-container cua-driver), so the host-DISPLAY
+    # heuristic below does not apply — surface the tool even on a headless
+    # host when a provider is ready.
+    provider = _get_active_cu_provider()
+    if provider is not None:
+        try:
+            return bool(provider.is_available())
+        except Exception:  # noqa: BLE001 - treat buggy provider as unavailable
+            return False
     from tools.computer_use.cua_backend import cua_driver_binary_available
     if not cua_driver_binary_available():
         return False


### PR DESCRIPTION
## What

The `computer_use` backend is a process-global singleton spawned on the host display. Per-thread / per-container isolation (each `task_id` gets its own display + cua-driver — e.g. a webtop container pool or a remote VNC) requires routing `task_id` to a backend bound to that task's display. Wiring any one runtime into the singleton would special-case a third-party product in core (linuxserver/webtop, trycua/cua-driver) — rejected by AGENTS.md ("plugins that touch core files"; "third-party products do NOT land under plugins/").

Instead, widen the generic plugin surface minimally and let every concrete runtime ship as a plugin.

## Changes

- **`agent/computer_use_provider.py`** — `ComputerUseProvider` ABC (`name`, `is_available`, `get_backend(task_id) -> ComputerUseBackend`, `close_backend`, `emergency_cleanup`). Mirrors `agent.browser_provider.BrowserProvider` (PR #25214) and `agent.web_search_provider.WebSearchProvider` (PR #25182). Return type string-annotated under `TYPE_CHECKING` so `agent/` has no runtime dependency on `tools/`.
- **`agent/computer_use_registry.py`** — `register_provider` / `list_providers` / `_resolve`, mirroring `agent.browser_registry`. Active provider selected via `computer_use.provider` in `config.yaml` (explicit config wins; legacy sentinels `local`/`cua`/`cua-driver`/`builtin`/unset → host singleton). No legacy auto-detect walk (computer_use had no pre-existing cloud providers).
- **`hermes_cli/plugins.py`** — `PluginContext.register_computer_use_provider()` so a plugin's `register(ctx)` can populate the registry (mirrors `register_browser_provider`).
- **`tools/computer_use/tool.py`** — `_get_active_cu_provider()` reads config once (cached, reset by `reset_backend_for_tests`); `_get_backend(task_id=None)` delegates to `provider.get_backend(task_id)` when a provider is active and `task_id` is supplied (provider owns per-task cache + LRU + `start()`), else the legacy host singleton. `check_computer_use_requirements()` returns True when an active provider is available (it supplies its own displays, so the host-DISPLAY heuristic doesn't apply), else the host heuristic. `handle_computer_use` passes `kwargs.get("task_id")`.
- **`tools/computer_use/cua_backend.py`** — `CuaDriverBackend(spawn_prefix=None, spawn_env=None, driver_path=None)` generic spawn hook. When `spawn_prefix` is set, the backend spawns `[*spawn_prefix, driver_path, "mcp"]` (e.g. `["docker","exec","-i",container,"env","DISPLAY=:1","/config/bin/cua-driver","mcp"]`) instead of resolving cua-driver on the host, skips host manifest discovery + host binary check (the binary is in-target), and `is_available()` returns True. The CLI fallback wraps through the prefix too and skips the screenshot-to-file optimization (a host temp file is unreachable from an in-target driver). The MCP stdio bridge works unchanged over the spawned pipe. `getattr` keeps the legacy no-prefix path identical for sessions constructed via `object.__new__` (the env-sanitization tests bypass `__init__`).
- **`cli-config.yaml.example`** — documents `computer_use.provider` and `computer_use.cua_driver.spawn_prefix` / `driver_path`.

## Non-speculative

A concrete consumer ships separately as a standalone plugin repo — `hermes-webtop-pool` (github.com/jarrelscy/hermes-webtop-pool) — that registers a `ComputerUseProvider` returning per-container `CuaDriverBackend(spawn_prefix=["docker","exec",...])`. Per AGENTS.md the third-party runtime (linuxserver/webtop image + trycua/cua binary) lives outside the core tree; this PR only adds the generic surface the plugin implements against.

## Tests

- `tests/computer_use/test_provider_routing.py` — stub provider: gate True on headless+provider, False when provider unavailable, per-task routing (same task_id → same backend, different task_ids → independent), legacy fallback, cache reset.
- `tests/computer_use/test_cua_spawn_prefix.py` — `is_available` with/without prefix, CLI cmd shape wrapped vs legacy, screenshot-file optimization skipped in prefix mode.
- Existing cua env/telemetry/spawn-sanitization tests unchanged.

## Stacking

This branch is stacked on #61310 ("computer_use: require a display on Linux before exposing the tool") — the host-DISPLAY heuristic from that bugfix is the provider-unavailable fallback in `check_computer_use_requirements`. The diff currently shows both commits; once PR 1 merges, GitHub auto-drops that commit from this PR's diff. **Merge PR 1 first**, then this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)