### PR TITLE
fix(dashboard): force fresh PTY spawn when resume target changes

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -160,6 +160,13 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reconnectAttemptRef = useRef(0);
   const forceFreshPtyRef = useRef(false);
+  // Tracks the previous ?resume= query param so the PTY WS effect can detect
+  // when the user picks a different session from the sidebar / Sessions page.
+  // When the target changes, force a fresh PTY spawn so _resolve_chat_argv
+  // injects the correct HERMES_TUI_RESUME into the child environment;
+  // without this the keep-alive PTY (same ?attach= token) is reattached
+  // as-is with stale env vars and loads the wrong session's history.
+  const prevResumeParamRef = useRef<string | null>(null);
   // NS-504: when the agent process exits cleanly (the user typed `/exit`, or
   // started a new session that ended the current PTY child), the PTY socket
   // closes with a normal code. Before this fix the terminal just printed
@@ -684,8 +691,19 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     let unmounting = false;
     let onDataDisposable: { dispose(): void } | null = null;
     let onResizeDisposable: { dispose(): void } | null = null;
-    const forceFresh = forceFreshPtyRef.current;
+    let forceFresh = forceFreshPtyRef.current;
     forceFreshPtyRef.current = false;
+    // When the ?resume= target changes (user picks a different session from the
+    // sidebar or the Sessions page), force a fresh PTY spawn so the backend
+    // injects HERMES_TUI_RESUME into the child process environment. Without this
+    // the keep-alive PTY (same ?attach= token) is reattached as-is with stale
+    // env vars and continues showing the previous session instead of loading
+    // the newly selected session's history.
+    const resumeChanged = resumeParam !== prevResumeParamRef.current;
+    if (resumeChanged && !forceFresh) {
+      forceFresh = true;
+    }
+    prevResumeParamRef.current = resumeParam;
     const scheduleReconnect = (code: number) => {
       if (reconnectTimerRef.current) {
         return;


### PR DESCRIPTION
## Summary

When the user picks a different session from the ChatSessionList sidebar or the Sessions page's play button, the embedded TUI was not loading the newly selected session's history. Instead it continued showing the previous session (or a fresh/empty one), making the "Resume in Chat" feature unusable for switching between conversations.

## Root Cause

The keep-alive PTY mechanism (introduced in v0.18.0) reattaches to the existing live PTY process when the same `?attach=` token is used. In this case `_resolve_chat_argv()` is **never called**, so `HERMES_TUI_RESUME` stays at its original value and the TUI never receives the new session id.

Specifically, `PtySessionRegistry.attach_or_spawn()` at `web_server.py` returns the existing session when the attach token matches, bypassing the spawn path that would set the correct env var.

## Fix

Track the previous `?resume=` query param value with a `useRef`. When it changes between effect runs (user navigated to a different session), set `forceFresh = true` so the new WebSocket connection sends `fresh=1`, forcing the backend to spawn a fresh PTY with the correct `HERMES_TUI_RESUME`.

**Before:** URL changed to `/chat?resume=X` but the keep-alive PTY was reattached with stale env vars, loading the wrong session.

**After:** Resume target change triggers `fresh=1` → new PTY spawned with `HERMES_TUI_RESUME=X` → `session.resume` RPC loads the correct history.

## Related

Fixes #19085 — dashboard Sessions → Chat resume does not reliably load the selected historical session.
