### PR TITLE
fix: Desktop hooks registration gap and diagnostics improvements

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -502,6 +502,6 @@ def finalize_turn(
             platform=getattr(agent, "platform", None) or "",
         )
     except Exception as exc:
-        logger.warning("on_session_end hook failed: %s", exc)
+        logger.warning("on_session_end hook failed: %s", exc, exc_info=True)
 
     return result

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1909,6 +1909,12 @@ class PluginManager:
         """
         kwargs.setdefault("telemetry_schema_version", OBSERVER_SCHEMA_VERSION)
         callbacks = self._hooks.get(hook_name, [])
+        # Governance: log callback count at DEBUG level for diagnostics
+        if callbacks:
+            logger.debug(
+                "invoke_hook(%s): %d callback(s) registered, firing...",
+                hook_name, len(callbacks),
+            )
         results: List[Any] = []
         for cb in callbacks:
             try:
@@ -2151,6 +2157,11 @@ def _get_pre_tool_call_directive_details(
         api_request_id=api_request_id,
         middleware_trace=list(middleware_trace or []),
     )
+    if hook_results:
+        logger.debug(
+            "pre_tool_call hook returned %d result(s) for tool=%s",
+            len(hook_results), tool_name,
+        )
 
     for result in hook_results:
         if not isinstance(result, dict):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2034,6 +2034,9 @@ def _run_single_child(
 
         duration = round(time.monotonic() - child_start, 2)
 
+        # Guard: result may be a list (e.g. from background-review re-dispatch)
+        if not isinstance(result, dict):
+            result = {"final_response": str(result)[:500], "completed": False, "interrupted": False, "api_calls": 0}
         summary = result.get("final_response") or ""
         completed = result.get("completed", False)
         interrupted = result.get("interrupted", False)
@@ -2714,6 +2717,13 @@ def delegate_task(
                     if isinstance(_child_index, int) and 0 <= _child_index < len(children)
                     else None
                 )
+                # Governance hook: subagent_stop fires here
+                logger.debug(
+                    "Firing subagent_stop hook: child_session=%s status=%s role=%s",
+                    getattr(_child_agent, "session_id", None),
+                    entry.get("status"),
+                    child_role,
+                )
                 _invoke_hook(
                     "subagent_stop",
                     parent_session_id=_parent_session_id,
@@ -2724,8 +2734,12 @@ def delegate_task(
                     child_status=entry.get("status"),
                     duration_ms=int((entry.get("duration_seconds") or 0) * 1000),
                 )
+                logger.debug(
+                    "subagent_stop hook completed: child_session=%s",
+                    getattr(_child_agent, "session_id", None),
+                )
             except Exception:
-                logger.debug("subagent_stop hook invocation failed", exc_info=True)
+                logger.warning("subagent_stop hook invocation failed", exc_info=True)
 
         # Fold the aggregated child cost into the parent's session total.  This is
         # additive — each delegate_task call contributes its own children — so

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4374,6 +4374,17 @@ def _make_agent(
 ):
     from run_agent import AIAgent
 
+    # discover_plugins() is not triggered by lazy imports in the dashboard/
+    # desktop WebSocket path the way it is for the CLI and slash_worker paths.
+    # Call it explicitly here so plugin hooks fire for every agent created by
+    # the desktop GUI.  discover_plugins() is idempotent (no-ops after the
+    # first call per process), so this is safe.
+    try:
+        from hermes_cli.plugins import discover_plugins
+        discover_plugins()
+    except Exception:
+        pass
+
     # MCP tool discovery runs in a background daemon thread at startup so a
     # dead server can't freeze the shell.  The agent snapshots its tool list
     # once here and never re-reads it, so briefly wait for in-flight discovery


### PR DESCRIPTION
## Problem

When running Hermes in Desktop GUI mode, shell hooks configured in `config.yaml` are not registered because:

1. **Desktop WebSocket path** (`tui_gateway/server.py:_make_agent`) never calls `discover_plugins()`, so Python plugins — including any that register shell hooks — are never loaded for agents created via the desktop GUI.

2. **Lack of diagnostics**: When hooks fire (or fail), there's no visibility at INFO level — useful diagnostic information is locked behind DEBUG logging.

3. **Crash risk**: `delegate_task` can crash with `'list' object has no attribute 'get'` when background-review re-dispatches results.

## Changes

### 1. `tui_gateway/server.py` — Ensure plugin discovery in Desktop path

```python
# discover_plugins() is not triggered by lazy imports in the dashboard/
# desktop WebSocket path the way it is for the CLI and slash_worker paths.
# Call it explicitly here so plugin hooks fire for every agent created by
# the desktop GUI.
try:
    from hermes_cli.plugins import discover_plugins
    discover_plugins()
except Exception:
    pass
```

`discover_plugins()` is idempotent — no-ops after the first call per process, so this is safe.

### 2. `tools/delegate_tool.py` — Crash guard + diagnostic logging

- **isinstance guard**: Protects against `'list' object has no attribute 'get'` when `result` is unexpectedly a list (observed with background-review re-dispatch).
- **Log level promotion**: Subagent_stop hook failure escalated from `logger.debug` to `logger.warning` so it's visible in default INFO-level logs.

### 3. `hermes_cli/plugins.py` — Hook execution diagnostics

Logs callback counts at DEBUG level when hooks fire, e.g.:
```
invoke_hook(subagent_stop): 1 callback(s) registered, firing...
```

### 4. `agent/turn_finalizer.py` — Better error diagnostics

Includes `exc_info=True` when `on_session_end` hook fails, so the full traceback is available for debugging.

## Testing

- Shell hooks (pre_tool_call, subagent_stop, on_session_end) verified to fire in Desktop GUI mode after these changes.
- Verified with user-installed governance Python plugin (loaded via `discover_plugins`) calling `register_from_config()`.
- Tested delegate_task with various result shapes — isinstance guard prevents crash.

## Related

This addresses the same gap that required downstream users to patch `hermes_cli/main.py` (cmd_dashboard), `tui_gateway/entry.py`, and `cli.py` with manual `register_from_config()` calls. With `discover_plugins()` called in `_make_agent`, user Python plugins can handle shell-hook registration themselves — no source patches needed.