### PR TITLE
fix(telegram): preserve user_id/user_name on triggered group messages in observe mode

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -7107,7 +7107,11 @@ class TelegramAdapter(BasePlatformAdapter):
         allowed = self._telegram_observe_allowed_chats()
         if not allowed or chat_id_str not in allowed:
             return event
-        shared_source = self._telegram_group_observe_shared_source(event.source)
+        shared_source = dataclasses.replace(
+            self._telegram_group_observe_shared_source(event.source),
+            user_id=event.source.user_id,
+            user_name=event.source.user_name,
+        )
         observe_prompt = self._telegram_group_observe_channel_prompt()
         channel_prompt = f"{event.channel_prompt}\n\n{observe_prompt}" if event.channel_prompt else observe_prompt
         if event.message_type == MessageType.COMMAND:

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -215,8 +215,9 @@ def test_observed_group_context_uses_shared_source_and_prompt_for_later_mentions
 
         assert event.source.chat_id == "-100"
         assert event.source.chat_type == "group"
-        assert event.source.user_id is None
-        assert event.source.user_name is None
+        # Triggered messages preserve user_id/user_name for auth checks
+        assert event.source.user_id == "222"
+        assert event.source.user_name == "Bob Example"
         assert event.text == "[Bob Example|222]\nwhat did Alice say?"
         assert "Existing topic prompt" in event.channel_prompt
         assert "observed Telegram group context" in event.channel_prompt
@@ -343,7 +344,8 @@ def test_observed_group_context_preserves_slash_command_text_for_dispatch():
 
     assert attributed.text == "/new@hermes_bot"
     assert attributed.get_command() == "new"
-    assert attributed.source.user_id is None
+    # Triggered messages preserve user_id for auth checks
+    assert attributed.source.user_id == "111"
     assert "observed Telegram group context" in attributed.channel_prompt
 
 
@@ -1080,7 +1082,8 @@ def test_triggered_location_message_uses_shared_session_in_observe_mode():
 
         adapter.handle_message.assert_awaited_once()
         event = adapter.handle_message.call_args[0][0]
-        assert event.source.user_id is None
+        # Triggered messages preserve user_id for auth checks
+        assert event.source.user_id == "111"
         assert "[Alice Example|111]" in event.text
 
     asyncio.run(_run())
@@ -1135,7 +1138,8 @@ def test_triggered_voice_message_uses_shared_session_in_observe_mode():
 
         adapter.handle_message.assert_awaited_once()
         event = adapter.handle_message.call_args[0][0]
-        assert event.source.user_id is None
+        # Triggered messages preserve user_id for auth checks
+        assert event.source.user_id == "111"
         assert "[Alice Example|111]" in event.text
 
     asyncio.run(_run())


### PR DESCRIPTION
## What does this PR do?

When `observe_unmentioned_group_messages: true` is combined with `require_mention: true` in a Telegram group, @mentions of the bot were silently dropped and never responded to.

**Root cause:** The `_apply_telegram_group_observe_attribution` function unconditionally replaced the event source with a "shared source" that set `user_id=None, user_name=None`. This caused the auth check at `run.py:7975` to fail for triggered messages (@mentions, replies, commands), preventing session creation and agent dispatch.

**Fix:** Preserve `user_id` and `user_name` on the shared source for triggered messages while keeping `user_id=None` for observed (unmentioned) messages. This aligns with the documented behavior that "@botname mention, reply to the bot, or configured mention pattern can use that observed context."

The fix ensures that:
1. **Triggered messages** (@mentions, replies, commands) retain sender identity for auth checks → bot responds
2. **Observed messages** (unmentioned chatter) still use shared source with `user_id=None` → stored in shared session context
3. Both types use the same session_id for shared context

## Related Issue

Fixes #61308

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/telegram/adapter.py`: Modified `_apply_telegram_group_observe_attribution` to preserve `user_id` and `user_name` on the shared source for triggered messages
- `tests/gateway/test_telegram_group_gating.py`: Updated 4 test assertions to reflect the new behavior (triggered messages preserve user_id for auth checks)

## How to Test

1. **Manual test** (requires Telegram group):
   - Configure a Telegram group with `require_mention: true` and `observe_unmentioned_group_messages: true`
   - Send an @mention to the bot
   - **Before fix:** Bot silently ignores the @mention
   - **After fix:** Bot responds to the @mention normally

2. **Automated test:**
   - Run `pytest tests/gateway/test_telegram_group_gating.py -v`
   - All 51 tests pass, including updated tests for triggered messages

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (4 test assertions updated to verify the fix)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A (behavior aligns with existing docs)
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (platform-agnostic fix, applies to all platforms)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A