### PR TITLE
fix(openviking): write remembered memories under user namespace

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -3240,9 +3240,9 @@ class OpenVikingMemoryProvider(MemoryProvider):
         )
 
     def _build_memory_uri(self, subdir: str) -> str:
-        """Build a viking:// memory URI under the configured peer namespace."""
+        """Build a viking:// memory URI under the configured user namespace."""
         slug = uuid.uuid4().hex[:12]
-        return f"viking://user/peers/{self._agent}/memories/{subdir}/mem_{slug}.md"
+        return f"viking://user/{self._user}/memories/{subdir}/mem_{slug}.md"
 
     def on_memory_write(
         self,

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -1356,8 +1356,9 @@ class TestOpenVikingBrowse:
 class TestOpenVikingMemoryUriBuilder:
     """Regression tests for _build_memory_uri — fixes #36969.
 
-    OpenViking's current memory layout stores peer-scoped memories under
-    viking://user/peers/{peer_id}/...
+    OpenViking user memories live under the configured user namespace. The
+    agent/peer ID is request actor identity, not the storage namespace for
+    viking_remember files.
     """
 
     def _make_provider(self, user="alice", agent="coder"):
@@ -1366,19 +1367,52 @@ class TestOpenVikingMemoryUriBuilder:
         p._agent = agent
         return p
 
-    def test_uri_layout_includes_peer_segment(self):
-        """URI must contain /peers/{peer_id}/ between user and memories."""
+    def test_uri_layout_uses_configured_user_namespace(self):
+        """URI must use /user/{user}/memories, not /user/peers/{agent}/memories."""
         p = self._make_provider(user="alice", agent="coder")
         uri = p._build_memory_uri("preferences")
-        assert uri.startswith("viking://user/peers/coder/memories/preferences/mem_")
+        assert uri.startswith("viking://user/alice/memories/preferences/mem_")
+        assert "/peers/" not in uri
         assert uri.endswith(".md")
 
-    def test_uri_uses_configured_peer_not_default(self):
-        """_agent value is the OpenViking actor peer ID, not hardcoded to 'hermes'."""
+    def test_uri_ignores_actor_peer_for_storage_namespace(self):
+        """_agent is the OpenViking actor peer ID, not the memory storage namespace."""
         p = self._make_provider(user="alice", agent="research-bot")
         uri = p._build_memory_uri("entities")
-        assert "/peers/research-bot/" in uri
+        assert uri.startswith("viking://user/alice/memories/entities/mem_")
+        assert "/peers/research-bot/" not in uri
         assert "/peers/hermes/" not in uri
+
+    def test_tool_remember_posts_user_scoped_memory_uri(self):
+        """viking_remember must write memory context, not peer-scoped resources."""
+
+        class FakeClient:
+            def __init__(self):
+                self.calls = []
+
+            def post(self, path, payload=None, **kwargs):
+                self.calls.append((path, payload or {}))
+                return {"result": {"written_bytes": 12}}
+
+        p = self._make_provider(user="alice", agent="research-bot")
+        p._client = FakeClient()
+
+        result = json.loads(p._tool_remember({"content": "remember this", "category": "event"}))
+
+        assert result["status"] == "stored"
+        assert p._client.calls == [
+            (
+                "/api/v1/content/write",
+                {
+                    "uri": p._client.calls[0][1]["uri"],
+                    "content": "remember this",
+                    "mode": "create",
+                },
+            )
+        ]
+        uri = p._client.calls[0][1]["uri"]
+        assert uri.startswith("viking://user/alice/memories/events/mem_")
+        assert "/peers/" not in uri
 
     def test_uri_slug_is_twelve_hex_chars_and_unique(self):
         """Slug must be 12 hex chars and differ between calls."""


### PR DESCRIPTION
## Summary

Fix `viking_remember` / built-in memory mirroring to create OpenViking memory files under the configured user namespace:

- before: `viking://user/peers/{agent}/memories/...`
- after: `viking://user/{user}/memories/...`

The agent/peer ID remains request actor identity; it should not replace the configured user namespace for user memory storage.

## Motivation

`_build_memory_uri()` currently ignores `OPENVIKING_USER` / `self._user` and builds paths under `viking://user/peers/{agent}/...`. On current OpenViking layouts, user memories are stored under `viking://user/{user}/memories/...`; the peer-scoped path can be rejected or classified outside the memory context. That makes explicit durable writes fail even while search/read/health checks are working.

This is separate from #54972, which adjusts the default search scope. This PR fixes the write-side URI construction used by `viking_remember` and memory mirroring.

## Changes

- Change `_build_memory_uri()` to use `self._user` in the URI path.
- Update URI-builder regression tests to assert user-scoped memory paths and no `/peers/` segment.
- Add a `viking_remember` regression test proving `/api/v1/content/write` receives a user-scoped memory URI with `mode: create`.

## Tests

- `python -m pytest tests/openviking_plugin/test_openviking.py -q`
- `python -m py_compile plugins/memory/openviking/__init__.py tests/openviking_plugin/test_openviking.py`
- `git diff --check`
