### PR TITLE
fix(dashboard): key keep-alive PTY on resume+profile, not just tab token (#61284)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15393,9 +15393,12 @@ async def pty_ws(ws: WebSocket) -> None:
         return
 
     # Keep-alive path: the PTY outlives this socket; reattach by token.
+    # Key on attach_token + resume + profile so switching to a different
+    # session spawns a distinct PTY instead of reusing the old one (#61284).
+    registry_key = "\0".join((attach_token, resume or "", profile or ""))
     try:
         session, _created = await PTY_REGISTRY.attach_or_spawn(
-            attach_token, spawn=_spawn
+            registry_key, spawn=_spawn
         )
     except PtyUnavailableError as exc:
         await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
@@ -15443,7 +15446,7 @@ async def pty_ws(ws: WebSocket) -> None:
     finally:
         # Detach only — the PTY keeps running for a reattach; the registry
         # reaper closes it after the TTL (or immediately on process exit).
-        PTY_REGISTRY.detach(attach_token, ws)
+        PTY_REGISTRY.detach(registry_key, ws)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #61284 — Dashboard "Silent WebSocket" on Session Switch.

## Root cause

The keep-alive PTY registry (`PtySessionRegistry`) was keyed only on the per-tab `attach_token`, which is stable across session switches. When the user selects a different chat session:

1. The same `attach_token` is sent
2. `attach_or_spawn()` finds the existing PTY running session A and reattaches
3. The freshly-resolved argv carrying `--resume B` is never spawned
4. The dashboard shows the previous session's terminal

The `code=1005 / messages=1` log line in the issue is benign teardown of the superseded socket, not the root cause.

## Fix

Fold `resume` (which session to resume) and `profile` into the registry key using NUL-byte concatenation:

- Same `attach_token` + same `resume` → reattach (browser refresh preserves keep-alive)
- Same `attach_token` + different `resume` → spawn new PTY (session switch)
- `profile` is also included for the same latent bug with profile switching

```python
registry_key = "\0".join((attach_token, resume or "", profile or ""))
```

The detach call is updated to use the same compound key.

## Verification

1. Open dashboard, switch between 3+ chat sessions — each switch should show the correct session's terminal
2. Refresh the browser while viewing session B — keep-alive reattaches to session B
3. The old session A's PTY lingers to the reaper TTL, so switching back reattaches to A's live agent
4. Bounded by the existing `max_sessions` + reaper

