### PR TITLE
fix(agent): allow /plan skill to stop after writing plan (#61207)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -321,7 +321,7 @@ TASK_COMPLETION_GUIDANCE = (
     "# Finishing the job\n"
     "When the user asks you to build, run, or verify something, the deliverable is "
     "a working artifact backed by real tool output — not a description of one. "
-    "Do not stop after writing a stub, a plan, or a single command. Keep working "
+    "Do not stop after writing a stub or a single command. Keep working "
     "until you have actually exercised the code or produced the requested result, "
     "then report what real execution returned.\n"
     "If a tool, install, or network call fails and blocks the real path, say so "


### PR DESCRIPTION
## Summary

Fixes #61207 — `/plan` doesn't write a plan file anymore.

## Root cause

The system prompt instructs the agent:

> "Do not stop after writing a stub, **a plan**, or a single command. Keep working until you have actually exercised the code or produced the requested result, and report what real execution returned."

The `/plan` skill tells the agent:

> "Do not implement code. Do not edit project files except the plan markdown file. Your deliverable is a markdown plan saved inside the active workspace under `.hermes/plans/`."

These instructions directly conflict. When the user invokes `/plan`, the model prioritizes the system prompt's "keep working" directive over the skill's "write a plan and stop" instruction. The result: the agent writes the plan but keeps running indefinitely, never stopping to return control to the user.

## Fix

Remove "a plan" from the keep-working guidance in `TASK_COMPLETION_GUIDANCE`:

**Before:** `"Do not stop after writing a stub, a plan, or a single command. Keep working ..."`
**After:** `"Do not stop after writing a stub or a single command. Keep working ..."`

This resolves the direct contradiction. When `/plan` is invoked, the skill's instruction to write a plan and stop is no longer overridden. The "keep working" directive still applies to stubs and single commands as intended.

## Verification

1. `hermes` → `/plan Write a simple REST API`
2. The agent writes a plan to `.hermes/plans/YYYY-MM-DD_HHMMSS-<slug>.md`
3. The agent stops after writing the plan (or asks for clarification if underspecified)
4. The agent does not start implementing code

