### PR TITLE
fix(tools): normalize disabled_toolsets from YAML to prevent silent toolset config loss (#61264)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3877,6 +3877,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # Parse and validate toolsets
         self.enabled_toolsets = toolsets
         self.disabled_toolsets = CLI_CONFIG["agent"].get("disabled_toolsets") or []
+        # Guard against YAML type confusion: a quoted YAML string like
+        # '["hermes-cli", "web"]' parses as a literal string, not an array.
+        # Iterating a string yields individual characters, silently dropping
+        # every toolset name. Normalize to list. (#61264)
+        if isinstance(self.disabled_toolsets, str):
+            import json
+            try:
+                parsed = json.loads(self.disabled_toolsets)
+                self.disabled_toolsets = parsed if isinstance(parsed, list) else []
+            except (json.JSONDecodeError, TypeError):
+                self.disabled_toolsets = []
 
         if toolsets and "all" not in toolsets and "*" not in toolsets:
             # Validate each toolset — MCP server names are resolved via

--- a/hermes_cli/prompt_size.py
+++ b/hermes_cli/prompt_size.py
@@ -43,7 +43,18 @@ def _build_inspection_agent(platform: str) -> Any:
     # Resolve platform-specific toolsets the same way the gateway does.
     enabled_toolsets = sorted(_get_platform_tools(cfg, platform))
     agent_cfg = cfg.get("agent") or {}
-    disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
+    disabled_toolsets_raw = agent_cfg.get("disabled_toolsets")
+    # Guard against YAML type confusion — a quoted YAML string like
+    # '["hermes-cli", "web"]' parses as a literal string, not an array.
+    # See #61264.
+    if isinstance(disabled_toolsets_raw, str):
+        import json
+        try:
+            parsed = json.loads(disabled_toolsets_raw)
+            disabled_toolsets_raw = parsed if isinstance(parsed, list) else None
+        except (json.JSONDecodeError, TypeError):
+            disabled_toolsets_raw = None
+    disabled_toolsets = disabled_toolsets_raw or None
 
     return AIAgent(
         model=model,

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1897,7 +1897,19 @@ def _get_platform_tools(
     # platforms without per-platform toolset configuration.  This runs
     # last so it overrides everything above.
     agent_cfg = config.get("agent") or {}
-    disabled_toolsets = agent_cfg.get("disabled_toolsets") or []
+    disabled_toolsets_raw = agent_cfg.get("disabled_toolsets") or []
+    # Guard against YAML type confusion — a quoted YAML string like
+    # '["hermes-cli", "web"]' parses as a literal string, not an array.
+    # Iterating a string yields individual characters, silently dropping
+    # every toolset name. Normalize to list. (#61264)
+    if isinstance(disabled_toolsets_raw, str):
+        import json
+        try:
+            parsed = json.loads(disabled_toolsets_raw)
+            disabled_toolsets_raw = parsed if isinstance(parsed, list) else []
+        except (json.JSONDecodeError, TypeError):
+            disabled_toolsets_raw = []
+    disabled_toolsets = disabled_toolsets_raw or []
     if disabled_toolsets:
         disabled_set = {str(ts) for ts in disabled_toolsets}
         enabled_toolsets -= disabled_set


### PR DESCRIPTION
## Summary

Fixes #61264 and addresses the root cause of #61265.

## The Bug

When `agent.disabled_toolsets` in `config.yaml` is written as a YAML-quoted string like:

```yaml
disabled_toolsets: '["hermes-cli", "web"]'
```

instead of a proper YAML array:

```yaml
disabled_toolsets: [hermes-cli, web]
```

it parses as a Python string `'["hermes-cli", "web"]'`. All three code paths that read this value then attempt `for toolset_name in disabled_toolsets`, which iterates over **individual characters** — `[`, `"`, `h`, `e`, `r`, ... — never matching any real toolset name. The result: **every toolset remains enabled** and the **full 50+ tool schema set** is sent to the LLM on every API call.

This is a key contributor to both reported issues:
- **#61264** — NVIDIA NIM closes the connection because Hermes sends an enormous request (~6K tokens of context + 50 tool schemas) that the endpoint's limits reject
- **#61265** — Local OpenAI-compatible models stall for minutes processing excessively large prompts with repeated tool definitions

## Fix

Add YAML-type-confusion guards in all three code paths that read `disabled_toolsets` from config:

1. **`cli.py`** (line 3879) — CLI mode agent init
2. **`hermes_cli/tools_config.py`** (line 1900) — Platform tools resolution
3. **`hermes_cli/prompt_size.py`** (line 46) — Prompt size inspection agent

Each guard detects a string value, attempts `json.loads()` to recover the intended array, and falls back to an empty list on failure.

## Impact

Without this fix, any user who has configured `disabled_toolsets` (common for users who want to reduce token usage with local models) may have the setting silently ignored if their YAML was quoted — sending all tool schemas on every request and causing oversized prompts.

## Verification

1. Set `agent.disabled_toolsets: '["web", "browser"]'` in `config.yaml` (quoted string)
2. Without fix: all tool schemas still sent to LLM
3. With fix: "web" and "browser" tools are excluded from the schema list

