### PR TITLE
fix(agent): centralize bounded model fallback

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -161,6 +161,21 @@ def _ra():
     return run_agent
 
 
+def _should_activate_bounded_fallback(classified, retry_count: int) -> bool:
+    """Return whether this classified failure should enter the fallback chain.
+
+    The error classifier is the source of truth for deterministic provider
+    failures that should degrade to a configured fallback model/provider.  Keep
+    the loop-level exception here narrow: transport failures get one retry
+    window before failover because many are transient socket/backend blips.
+    """
+    if classified.reason in {FailoverReason.timeout, FailoverReason.overloaded}:
+        return retry_count >= 2
+    if classified.should_compress:
+        return False
+    return bool(classified.should_fallback)
+
+
 def _nous_entitlement_message(capability: str) -> str:
     try:
         from hermes_cli.nous_account import (
@@ -3159,9 +3174,9 @@ def run_conversation(
                 )
                 if _is_zai_coding_overload:
                     max_retries = max(max_retries, zai_coding_overload_retry_ceiling())
-                _should_fallback = (
-                    is_rate_limited
-                    or (_is_transport_failure and retry_count >= 2)
+                _should_fallback = _should_activate_bounded_fallback(
+                    classified,
+                    retry_count,
                 )
                 if _should_fallback and agent._fallback_index < len(agent._fallback_chain):
                     # Don't eagerly fallback if credential pool rotation may
@@ -3173,8 +3188,12 @@ def run_conversation(
                     # etc.) is throttling OpenRouter, so always fall back to a
                     # different model regardless of pool state.
                     _is_upstream = classified.reason == FailoverReason.upstream_rate_limit
+                    _pool_recovery_reason = classified.reason in {
+                        FailoverReason.rate_limit,
+                        FailoverReason.billing,
+                    }
                     pool_may_recover = (
-                        False if _is_upstream
+                        False if _is_upstream or not _pool_recovery_reason
                         else _ra()._pool_may_recover_from_rate_limit(
                             agent._credential_pool,
                         )
@@ -3196,8 +3215,17 @@ def run_conversation(
                             agent._buffer_status(
                                 "⚠️ Provider unreachable — switching to fallback provider..."
                             )
+                        elif classified.reason == FailoverReason.model_not_found:
+                            agent._buffer_status(
+                                "⚠️ Model is unavailable — switching to fallback provider..."
+                            )
+                        elif classified.is_auth:
+                            agent._buffer_status(
+                                "🔐 Authentication failed and could not be refreshed — "
+                                "switching to fallback provider..."
+                            )
                         else:
-                            agent._buffer_status("⚠️ Rate limited — switching to fallback provider...")
+                            agent._buffer_status("⚠️ Provider rejected the request — switching to fallback provider...")
                         if agent._try_activate_fallback(reason=classified.reason):
                             active_system_prompt = _sync_failover_system_message(
                                 agent, api_messages, active_system_prompt)

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -173,6 +173,10 @@ _USAGE_LIMIT_PATTERNS = [
     "quota",
     "limit exceeded",
     "key limit exceeded",
+    "session limit",
+    "session usage limit",
+    "session budget",
+    "resource exhausted",
 ]
 
 # Patterns confirming usage limit is transient (not billing)
@@ -1267,6 +1271,7 @@ def _classify_by_error_code(
             FailoverReason.rate_limit,
             retryable=True,
             should_rotate_credential=True,
+            should_fallback=True,
         )
 
     if code_lower in {

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1007,6 +1007,7 @@ class TestClassifyApiError:
         )
         result = classify_api_error(e)
         assert result.reason == FailoverReason.rate_limit
+        assert result.should_fallback is True
 
     def test_error_code_model_not_found(self):
         e = MockAPIError(
@@ -1087,6 +1088,7 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.billing
         assert result.retryable is False
         assert result.should_rotate_credential is True
+        assert result.should_fallback is True
 
     def test_message_quota_with_reset_window_is_rate_limit(self):
         """'quota' + 'resets at' with no status code → rate_limit."""
@@ -1094,6 +1096,7 @@ class TestClassifyApiError:
         result = classify_api_error(e)
         assert result.reason == FailoverReason.rate_limit
         assert result.retryable is True
+        assert result.should_fallback is True
 
     def test_message_limit_exceeded_with_wait_is_rate_limit(self):
         """'limit exceeded' + 'wait' with no status code → rate_limit."""
@@ -1101,6 +1104,21 @@ class TestClassifyApiError:
         result = classify_api_error(e)
         assert result.reason == FailoverReason.rate_limit
         assert result.retryable is True
+        assert result.should_fallback is True
+
+    def test_message_session_limit_without_status_falls_back_as_billing(self):
+        """Autonomous workers can receive session-limit failures without HTTP metadata."""
+        e = Exception("you have reached your session usage limit for this account")
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    def test_message_resource_exhausted_without_status_falls_back(self):
+        e = Exception("RESOURCE_EXHAUSTED: weekly GPU session budget exhausted")
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.billing
+        assert result.should_fallback is True
 
     # ── Unknown / fallback ──
 
@@ -2046,4 +2064,3 @@ class Test408RequestTimeout:
         assert result.reason == FailoverReason.timeout
         assert result.retryable is True
         assert result.should_compress is False
-

--- a/tests/run_agent/test_bounded_fallback_gate.py
+++ b/tests/run_agent/test_bounded_fallback_gate.py
@@ -1,0 +1,48 @@
+"""Tests for the main-agent bounded provider/model fallback gate."""
+
+from agent.conversation_loop import _should_activate_bounded_fallback
+from agent.error_classifier import ClassifiedError, FailoverReason
+
+
+def test_classifier_fallback_contract_triggers_immediate_gate_for_dead_model():
+    classified = ClassifiedError(
+        reason=FailoverReason.model_not_found,
+        retryable=False,
+        should_fallback=True,
+    )
+
+    assert _should_activate_bounded_fallback(classified, retry_count=0) is True
+
+
+def test_classifier_fallback_contract_triggers_immediate_gate_for_quota():
+    classified = ClassifiedError(
+        reason=FailoverReason.billing,
+        retryable=False,
+        should_rotate_credential=True,
+        should_fallback=True,
+    )
+
+    assert _should_activate_bounded_fallback(classified, retry_count=0) is True
+
+
+def test_transport_failures_get_retry_window_before_fallback():
+    classified = ClassifiedError(
+        reason=FailoverReason.timeout,
+        retryable=True,
+        should_fallback=False,
+    )
+
+    assert _should_activate_bounded_fallback(classified, retry_count=0) is False
+    assert _should_activate_bounded_fallback(classified, retry_count=1) is False
+    assert _should_activate_bounded_fallback(classified, retry_count=2) is True
+
+
+def test_compression_recovery_does_not_enter_provider_fallback_gate():
+    classified = ClassifiedError(
+        reason=FailoverReason.context_overflow,
+        retryable=True,
+        should_compress=True,
+        should_fallback=True,
+    )
+
+    assert _should_activate_bounded_fallback(classified, retry_count=0) is False


### PR DESCRIPTION
Main-agent fallback activation now follows the centralized error classifier, so invalid model IDs and quota/session-limit failures enter the configured bounded fallback chain consistently across foreground and worker contexts.

## What does this PR do?

Centralizes the main agent's bounded fallback gate around `ClassifiedError.should_fallback`, while preserving the existing retry window for transient transport failures and compression recovery for context errors.

## Related Issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Shared root cause

- The error classifier already describes which provider/model failures should fall back, but the conversation loop duplicated a narrower fallback predicate for only rate-limit/billing/upstream and delayed transport cases. That left newly classified hard failures dependent on scattered later branches, and message-only session/resource exhaustion variants were not consistently marked as fallback-capable.
- The fix makes the loop consult one bounded fallback helper backed by `should_fallback`, keeps transport fallback delayed until after the retry window, and prevents credential-pool recovery from blocking deterministic non-rate failures like `model_not_found`.

## How this fixes each issue

- #40066: OpenRouter invalid-model responses classify as `model_not_found` with `should_fallback=True`, so the main loop now enters the fallback chain through the centralized gate instead of relying on the generic non-retryable abort path.
- #59002: quota/session exhaustion variants such as `resource_exhausted`, `session usage limit`, and `session budget` now classify as fallback-capable, so autonomous jobs with configured fallback providers can degrade to the next approved model/provider.

## Changes Made

- `agent/error_classifier.py`: recognizes message-only session/resource exhaustion patterns and marks structured rate-limit error codes as fallback-capable.
- `agent/conversation_loop.py`: adds `_should_activate_bounded_fallback()` and uses it for the eager fallback decision while keeping compression and transient transport behavior bounded.
- `tests/agent/test_error_classifier.py` and `tests/run_agent/test_bounded_fallback_gate.py`: cover quota/session classification and the main-agent fallback gate.

## How to Test

1. `/opt/homebrew/bin/timeout -k 30 480 pytest tests/agent/test_error_classifier.py tests/run_agent/test_bounded_fallback_gate.py -q --timeout=60`
2. `BASE=$(git merge-base origin/main HEAD); CHANGED_PY=$( { git diff --name-only --diff-filter=d "$BASE"; git ls-files --others --exclude-standard; } | grep -E '\.pyi?$' | sort -u ); [ -n "$CHANGED_PY" ] && printf '%s\n' "$CHANGED_PY" | xargs ruff check`
3. `python scripts/check-windows-footguns.py agent/conversation_loop.py agent/error_classifier.py tests/agent/test_error_classifier.py tests/run_agent/test_bounded_fallback_gate.py`

Attempted the required full suite: `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh`. It aborted during collection before project tests ran because this environment lacks `fastapi`/`uvicorn`, and the lazy dependency install is blocked by Homebrew Python's externally managed environment policy.

## What platforms tested on

- macOS on darwin-arm64 (local)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS on darwin-arm64

### Documentation & Housekeeping

- [x] Documentation update N/A
- [x] `cli-config.yaml.example` update N/A
- [x] Architecture docs update N/A
- [x] Cross-platform impact considered
- [x] Tool descriptions/schemas update N/A

## Screenshots / Logs

N/A

---
_This coordinated PR bundles a fix that spans several issues. Happy to split it back into focused per-issue PRs if you'd prefer to review them separately._

Refs #40066
Refs #59002

<!-- autocontrib:worker-id=pr-spanning-1a86136b kind=pr-open -->