### PR TITLE
fix(model_metadata): avoid str(tools) token estimate stalls

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2439,5 +2439,71 @@ def estimate_request_tokens_rough(
     if messages:
         total += estimate_messages_tokens_rough(messages)
     if tools:
-        total += (len(str(tools)) + 3) // 4
+        total += _estimate_tools_tokens_rough(tools)
     return total
+
+
+# NOTE: tool schemas can be large. Avoid repeated `str(tools)` conversions,
+# which are CPU-heavy and can stall GUI event loops under GIL pressure.
+_TOOLS_TOKENS_CACHE: dict[int, Tuple[int, str, str, int]] = {}
+
+
+def _tool_name_for_cache(tool: Any) -> str:
+    if not isinstance(tool, dict):
+        return ""
+    fn = tool.get("function")
+    if isinstance(fn, dict):
+        name = fn.get("name")
+        if isinstance(name, str):
+            return name
+    name = tool.get("name")
+    return name if isinstance(name, str) else ""
+
+
+def _estimate_tools_tokens_rough(tools: List[Dict[str, Any]]) -> int:
+    if not tools:
+        return 0
+
+    # Cache by list identity. Tools are rebuilt rarely (toolset changes),
+    # but token estimates are requested frequently (preflight, compaction).
+    key = id(tools)
+    n = len(tools)
+    first = _tool_name_for_cache(tools[0]) if n else ""
+    last = _tool_name_for_cache(tools[-1]) if n else ""
+
+    cached = _TOOLS_TOKENS_CACHE.get(key)
+    if cached is not None:
+        cached_n, cached_first, cached_last, cached_tokens = cached
+        if cached_n == n and cached_first == first and cached_last == last:
+            return cached_tokens
+
+    # Fast, stable rough estimate: sum lengths of the major schema fields.
+    # This avoids the pathological `str(tools)` path while still scaling with
+    # schema size (descriptions + parameters dominate).
+    total_chars = 0
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        fn = tool.get("function")
+        if isinstance(fn, dict):
+            name = fn.get("name") or ""
+            desc = fn.get("description") or ""
+            params = fn.get("parameters") or {}
+        else:
+            name = tool.get("name") or ""
+            desc = tool.get("description") or ""
+            params = tool.get("parameters") or {}
+
+        if isinstance(name, str):
+            total_chars += len(name)
+        if isinstance(desc, str):
+            total_chars += len(desc)
+        # Parameters can be nested; JSON is closer to over-the-wire size than repr().
+        try:
+            total_chars += len(json.dumps(params, ensure_ascii=False, separators=(",", ":")))
+        except Exception:
+            total_chars += len(str(params))
+
+    tokens = (total_chars + 3) // 4
+    _TOOLS_TOKENS_CACHE[key] = (n, first, last, tokens)
+    return tokens

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2445,7 +2445,13 @@ def estimate_request_tokens_rough(
 
 # NOTE: tool schemas can be large. Avoid repeated `str(tools)` conversions,
 # which are CPU-heavy and can stall GUI event loops under GIL pressure.
+#
+# Keyed by ``id(tools)``. A long-lived gateway/desktop backend builds many
+# transient tool lists over its lifetime, so the cache is bounded and evicts
+# oldest-first (insertion-ordered dict) once it exceeds the cap. The cap is
+# generous relative to how rarely toolsets are rebuilt within a process.
 _TOOLS_TOKENS_CACHE: dict[int, Tuple[int, str, str, int]] = {}
+_TOOLS_TOKENS_CACHE_MAX = 256
 
 
 def _tool_name_for_cache(tool: Any) -> str:
@@ -2505,5 +2511,10 @@ def _estimate_tools_tokens_rough(tools: List[Dict[str, Any]]) -> int:
             total_chars += len(str(params))
 
     tokens = (total_chars + 3) // 4
+    # Bound the cache: drop the oldest entry when the cap is exceeded so a
+    # long-running process can't accumulate an unbounded number of stale
+    # ``id(tools)`` entries (id values are recycled after GC anyway).
+    if len(_TOOLS_TOKENS_CACHE) >= _TOOLS_TOKENS_CACHE_MAX:
+        _TOOLS_TOKENS_CACHE.pop(next(iter(_TOOLS_TOKENS_CACHE)), None)
     _TOOLS_TOKENS_CACHE[key] = (n, first, last, tokens)
     return tokens

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -142,6 +142,32 @@ class TestEstimateRequestTokensRough:
             estimate_request_tokens_rough(messages, system_prompt="x" * 8, tools=tools)
             assert dumps.call_count == 1
 
+    def test_tools_cache_is_bounded(self):
+        # A long-lived process builds many transient tool lists; the cache must
+        # not grow without bound. Feed more distinct lists than the cap and
+        # confirm the cache never exceeds it.
+        import agent.model_metadata as mm
+
+        mm._TOOLS_TOKENS_CACHE.clear()
+        cap = mm._TOOLS_TOKENS_CACHE_MAX
+        # Keep references so ids are not recycled mid-loop, forcing distinct keys.
+        held = []
+        for i in range(cap + 50):
+            tools = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": f"tool_{i}",
+                        "description": "d",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ]
+            held.append(tools)
+            mm._estimate_tools_tokens_rough(tools)
+            assert len(mm._TOOLS_TOKENS_CACHE) <= cap
+        assert len(mm._TOOLS_TOKENS_CACHE) == cap
+
 
 # =========================================================================
 # Default context lengths

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -30,6 +30,7 @@ from agent.model_metadata import (
     save_context_length,
     fetch_model_metadata,
     _MODEL_CACHE_TTL,
+    estimate_request_tokens_rough,
 )
 
 
@@ -118,6 +119,28 @@ class TestEstimateMessagesTokensRough:
         ]}
         result = estimate_messages_tokens_rough([msg])
         assert result < 5000
+
+
+class TestEstimateRequestTokensRough:
+    def test_caches_tools_estimate(self):
+        messages = [{"role": "user", "content": "hello"}]
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "terminal",
+                    "description": "Run a command",
+                    "parameters": {"type": "object", "properties": {"command": {"type": "string"}}},
+                },
+            }
+        ]
+
+        # json.dumps is used for params sizing; ensure the tools estimate is cached
+        # so repeated calls don't keep re-serializing the same schema list.
+        with patch("agent.model_metadata.json.dumps", wraps=__import__("json").dumps) as dumps:
+            estimate_request_tokens_rough(messages, system_prompt="x" * 8, tools=tools)
+            estimate_request_tokens_rough(messages, system_prompt="x" * 8, tools=tools)
+            assert dumps.call_count == 1
 
 
 # =========================================================================


### PR DESCRIPTION
## Summary
Repeated token estimates on large toolsets no longer stall the desktop backend's event loop.

`estimate_request_tokens_rough()` stringified the entire tool-schema list (`len(str(tools))`) on every call. With 50+ tools enabled and preflight/compaction estimating repeatedly on the same conversation, that CPU work ran on the backend event loop and stalled the "Summarizing thread" UI under GIL pressure. This replaces `str(tools)` with a bounded per-field schema walk plus a per-list memoization cache, so repeated estimates on a stable tool list are O(1).

Salvage of #61029 by @infinitycrew39 — original commits cherry-picked with authorship preserved, plus one follow-up commit from us bounding the cache.

## Changes
- `agent/model_metadata.py`: `_estimate_tools_tokens_rough()` sums `name + description + compact-JSON(parameters)` per tool instead of `str(tools)`; memoized in `_TOOLS_TOKENS_CACHE` keyed by `id(tools)` with an `(n, first_name, last_name)` guard.
- `agent/model_metadata.py` (follow-up): cache is bounded at 256 entries with oldest-first eviction so a long-lived process can't accumulate unbounded stale `id()` entries.
- `tests/agent/test_model_metadata.py`: regression test that repeated estimates don't re-serialize the same schema list, plus a test that the cache stays bounded.

## Validation
| | Before | After |
|---|---|---|
| `str(tools)` per call (60 tools) | ~263 µs | ~258 µs (cache miss) / ~0.25 µs (cache hit, 1048×) |
| cache size after 5000 distinct lists | n/a | ≤ 256 (bounded) |
| `tests/agent/test_model_metadata.py` | — | 119 passed |

The change is estimation-only — it does not alter the request sent to any provider, touch prompt caching, or affect message alternation. The new estimate runs ~14–16% lower than the old `repr()`-based count (the old one counted quote/brace/wrapper characters); the new value is closer to actual wire size and still only gates the authoritative `should_compress` decision.

Closes #61029.
