### PR TITLE
fix(agent): repair MCP tool names with dropped mcp__server__ prefix

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2380,6 +2380,39 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
         if c and c in agent.valid_tool_names:
             return c
 
+    # MCP tool prefix repair: some models (notably GLM) emit MCP tool
+    # names without the full ``mcp__<server>__`` prefix — e.g.
+    # ``list_memory_projects`` instead of
+    # ``mcp__basic_memory__list_memory_projects``.  Two sub-cases:
+    #
+    # 1. Bare suffix — model dropped the entire prefix:
+    #    ``list_memory_projects`` → ``mcp__basic_memory__list_memory_projects``
+    # 2. Partial prefix — model kept ``server__tool`` but dropped ``mcp__``:
+    #    ``basic_memory__list_memory_projects`` → same full name
+    #
+    # For case 1 we only attempt when the emitted name has no ``__``
+    # (otherwise it might be a partially-correct prefix for fuzzy match).
+    # For case 2 a simple ``mcp__`` prepend is unambiguous.
+    #
+    # When multiple MCP servers expose the same bare tool name, we skip
+    # repair (can't determine which server the model meant) and let the
+    # fuzzy matcher / error-retry path handle it.
+    if "__" not in lowered:
+        mcp_matches: list[str] = []
+        for vn in agent.valid_tool_names:
+            if not vn.startswith("mcp__"):
+                continue
+            parts = vn.split("__", 2)
+            if len(parts) == 3 and parts[2] in (lowered, normalized):
+                mcp_matches.append(vn)
+        if len(mcp_matches) == 1:
+            return mcp_matches[0]
+    else:
+        # Case 2: model emitted ``server__tool`` — try prepending ``mcp__``.
+        mcp_prefixed = f"mcp__{lowered}"
+        if mcp_prefixed in agent.valid_tool_names:
+            return mcp_prefixed
+
     # Fuzzy match as last resort.
     matches = get_close_matches(lowered, agent.valid_tool_names, n=1, cutoff=0.7)
     if matches:

--- a/tests/run_agent/test_repair_tool_call_name.py
+++ b/tests/run_agent/test_repair_tool_call_name.py
@@ -186,3 +186,71 @@ class TestVolcEngineXmlPollution:
         # rest of the pipeline (fuzzy match at 0.7 cutoff) can still
         # recover the obvious target.
         assert repair('"terminal"') == "terminal"
+
+
+class TestMcpPrefixRepair:
+    """Models (notably GLM) sometimes emit MCP tool names without the
+    full ``mcp__<server>__`` prefix, e.g. ``list_memory_projects``
+    instead of ``mcp__basic_memory__list_memory_projects``. The repair
+    routine must map the bare suffix back to the full MCP tool name.
+
+    Covers two sub-cases:
+    - Bare suffix (no ``__``): ``list_memory_projects``
+    - Partial prefix (has ``__`` but missing ``mcp__``): ``basic_memory__list_memory_projects``
+    """
+
+    MCP_VALID = {
+        "todo",
+        "web_search",
+        "mcp__basic_memory__list_memory_projects",
+        "mcp__basic_memory__write_note",
+        "mcp__zotero__search_items",
+        "mcp__zotero__add_by_doi",
+    }
+
+    @pytest.fixture
+    def mcp_repair(self):
+        from run_agent import AIAgent
+        stub = SimpleNamespace(valid_tool_names=self.MCP_VALID)
+        return AIAgent._repair_tool_call.__get__(stub, AIAgent)
+
+    # --- Case 1: bare suffix (model dropped entire mcp__server__ prefix) ---
+
+    def test_bare_suffix_matches_mcp_tool(self, mcp_repair):
+        assert mcp_repair("list_memory_projects") == "mcp__basic_memory__list_memory_projects"
+
+    def test_bare_suffix_different_server(self, mcp_repair):
+        assert mcp_repair("search_items") == "mcp__zotero__search_items"
+
+    def test_bare_suffix_with_underscores_in_name(self, mcp_repair):
+        assert mcp_repair("add_by_doi") == "mcp__zotero__add_by_doi"
+
+    def test_non_mcp_tool_unaffected(self, mcp_repair):
+        assert mcp_repair("todo") == "todo"
+
+    def test_unknown_bare_name_returns_none(self, mcp_repair):
+        assert mcp_repair("nonexistent_mcp_tool") is None
+
+    # --- Case 2: partial prefix (model kept server__tool, dropped mcp__) ---
+
+    def test_partial_prefix_prepends_mcp(self, mcp_repair):
+        assert mcp_repair("basic_memory__list_memory_projects") == "mcp__basic_memory__list_memory_projects"
+
+    def test_partial_prefix_different_server(self, mcp_repair):
+        assert mcp_repair("zotero__search_items") == "mcp__zotero__search_items"
+
+    def test_partial_prefix_unknown_returns_none(self, mcp_repair):
+        assert mcp_repair("unknown_server__no_such_tool") is None
+
+    # --- Ambiguity guard: same bare suffix on two servers ---
+
+    def test_ambiguous_bare_suffix_skips_repair(self):
+        """When two MCP servers expose the same tool suffix, repair must
+        skip (return None) rather than guessing non-deterministically."""
+        from run_agent import AIAgent
+        ambiguous = SimpleNamespace(valid_tool_names={
+            "mcp__server_a__search",
+            "mcp__server_b__search",
+        })
+        repair = AIAgent._repair_tool_call.__get__(ambiguous, AIAgent)
+        assert repair("search") is None


### PR DESCRIPTION
## What

Models (notably GLM) sometimes emit MCP tool names without the full `mcp__<server>__` prefix — e.g. `list_memory_projects` instead of `mcp__basic_memory__list_memory_projects`. The existing `_repair_tool_call` pipeline (case-folding, CamelCase, suffix stripping, fuzzy match at 0.7 cutoff) cannot map the bare suffix back to the full prefixed name. The call fails with "Unknown tool", the agent burns 3 retries, then aborts with `Model generated invalid tool call: list_memory_projects`.

## Root cause

After #52750 (merged 2026-07-05) adopted the `mcp__server__tool` double-underscore naming convention, the repair pipeline has no strategy to bridge a bare tool suffix to its full `mcp__server__tool` registered name. The fuzzy matcher scores `list_memory_projects` vs `mcp__basic_memory__list_memory_projects` well below the 0.7 cutoff.

Prior PRs #21696, #37100, #33359 all target the **old single-underscore** `mcp_` format and do not apply to the new convention. #21696 also modifies `run_agent.py` (the pre-refactor location of `_repair_tool_call`), which would conflict with the current `agent/agent_runtime_helpers.py` location.

## Fix

Add two repair paths in `repair_tool_call()` before the fuzzy-match fallback:

**Case 1 — bare suffix** (no `__` in emitted name): scan registered `mcp__` tools and match on the tool-suffix portion (`parts[2]` after splitting on `__`). Skip when ambiguous (multiple servers expose the same suffix) to avoid non-deterministic routing.

**Case 2 — partial prefix** (`__` in emitted name but missing `mcp__`): prepend `mcp__` and check for an exact match. Handles `basic_memory__list_memory_projects` → `mcp__basic_memory__list_memory_projects`.

Both paths only resolve on exact matches — they cannot mis-route non-MCP tools.

## How to reproduce

1. Configure any MCP server (e.g. `basic_memory`) with tools registered as `mcp__basic_memory__list_memory_projects`
2. Use a model that drops the prefix (observed with GLM-5.2-heavy, also reported with other models in #21696)
3. Model calls `list_memory_projects` → `Tool 'list_memory_projects' does not exist` → 3 retries → session aborts

## Tests

9 new tests in `TestMcpPrefixRepair`:

| Test | Covers |
|------|--------|
| `test_bare_suffix_matches_mcp_tool` | Case 1: `list_memory_projects` → full name |
| `test_bare_suffix_different_server` | Case 1 with different server |
| `test_bare_suffix_with_underscores_in_name` | Case 1 with multi-word suffix |
| `test_non_mcp_tool_unaffected` | Non-MCP tools still work |
| `test_unknown_bare_name_returns_none` | Unknown bare name → None |
| `test_partial_prefix_prepends_mcp` | Case 2: `server__tool` → `mcp__server__tool` |
| `test_partial_prefix_different_server` | Case 2 with different server |
| `test_partial_prefix_unknown_returns_none` | Unknown partial prefix → None |
| `test_ambiguous_bare_suffix_skips_repair` | Two servers, same suffix → None (no guess) |

All 38 tests in `test_repair_tool_call_name.py` pass.

```bash
scripts/run_tests.sh tests/run_agent/test_repair_tool_call_name.py
```

## Related

- #52750 — introduced the `mcp__server__tool` naming convention
- #21696 — repairs dropped `mcp_` prefix (old single-underscore format, pre-#52750)
- #37100 — strips shared `mcp_<server>_` prefix before fuzzy match (old format)
- #33359 — normalises duplicated `mcp_` prefixes (old format)
- Issue #37171 — duplicated `mcp_` prefix fuzzy match failures

## Platform

Tested on macOS 26.5 / Python 3.11.