### PR TITLE
fix(agent): reapply provider headers after model switch (#61099)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1925,6 +1925,11 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             _sm_timeout = get_provider_request_timeout(agent.provider, agent.model)
             if _sm_timeout is not None:
                 agent._client_kwargs["timeout"] = _sm_timeout
+            # Reapply provider-specific headers (e.g. OpenRouter HTTP-Referer,
+            # X-Title) that were lost when _client_kwargs was rebuilt from
+            # scratch.  Without this, model switches clear attribution headers
+            # and OpenRouter logs show "Unknown" for subsequent requests.
+            agent._apply_client_headers_for_base_url(effective_base)
             agent.client = agent._create_openai_client(
                 dict(agent._client_kwargs),
                 reason="switch_model",


### PR DESCRIPTION
## Summary

`switch_model()` in `agent/agent_runtime_helpers.py` rebuilds `_client_kwargs` from scratch (only `api_key` + `base_url`) but does not call `_apply_client_headers_for_base_url()`. This drops provider-specific HTTP headers like OpenRouter's `HTTP-Referer` and `X-Title`, causing subsequent requests to show "Unknown" in OpenRouter dashboard logs.

Fixes #61099

## Root Cause

In `switch_model()` (line ~1903), `_client_kwargs` is rebuilt:
```python
agent._client_kwargs = {
    "api_key": effective_key,
    "base_url": effective_base,
}
```

But `_apply_client_headers_for_base_url(effective_base)` is never called, so headers like:
```python
{"HTTP-Referer": "https://hermes-agent.nousresearch.com", "X-Title": "Hermes Agent"}
```
are lost. The client is then created without attribution headers.

During initial agent setup (`__init__`), `_apply_client_headers_for_base_url` IS called. But after any `/model` switch, the headers are gone.

## Fix

Add `agent._apply_client_headers_for_base_url(effective_base)` after rebuilding `_client_kwargs` and before `_create_openai_client()`.

## Impact

- Affects all providers that use URL-based attribution (OpenRouter, NVIDIA NIM, Copilot, Kimi)
- After a model switch, all subsequent requests lose provider-specific headers
- OpenRouter dashboard shows "Unknown" instead of "Hermes Agent"
