### PR TITLE
fix(cli): escape role and tool-call names in HTML session export

### DIFF
--- a/hermes_cli/session_export_html.py
+++ b/hermes_cli/session_export_html.py
@@ -682,10 +682,16 @@ def _generate_messages_html(messages: List[Dict[str, Any]]) -> str:
                     content_parts.append(str(part))
             content = "\n".join(content_parts)
 
-        # Build message HTML. Escape the role once: it feeds both an attribute
-        # (class) and text, and for tool/MCP messages it is externally influenced.
+        # Build message HTML. The role feeds two sinks and for tool/MCP messages
+        # is externally influenced, so treat each sink on its own terms:
+        #  - display text: HTML-escape (prevents markup/JS injection).
+        #  - class attribute: reduce to a single safe CSS token (alnum/-/_),
+        #    so a crafted role can neither break out of the attribute nor split
+        #    into several unintended classes. Real roles (user/assistant/system/
+        #    tool) are unchanged, so the `.message-<role>` rules still match.
         safe_role = _escape_html(role)
-        msg_class = f"message message-{safe_role} active"
+        role_class = "".join(c if c.isalnum() or c in "-_" else "-" for c in str(role).lower())
+        msg_class = f"message message-{role_class} active"
         # Delay animation for initial items
         delay_style = f' style="animation-delay: {min(i * 0.05, 1.0)}s"' if i < 10 else ""
         

--- a/hermes_cli/session_export_html.py
+++ b/hermes_cli/session_export_html.py
@@ -682,8 +682,10 @@ def _generate_messages_html(messages: List[Dict[str, Any]]) -> str:
                     content_parts.append(str(part))
             content = "\n".join(content_parts)
 
-        # Build message HTML
-        msg_class = f"message message-{role} active"
+        # Build message HTML. Escape the role once: it feeds both an attribute
+        # (class) and text, and for tool/MCP messages it is externally influenced.
+        safe_role = _escape_html(role)
+        msg_class = f"message message-{safe_role} active"
         # Delay animation for initial items
         delay_style = f' style="animation-delay: {min(i * 0.05, 1.0)}s"' if i < 10 else ""
         
@@ -691,7 +693,7 @@ def _generate_messages_html(messages: List[Dict[str, Any]]) -> str:
         
         html = f'<div class="{msg_class}"{delay_style}>'
         html += f'  <div class="message-header">'
-        html += f'    <div class="role-badge">{chevron_html} {role_icon} {role}</div>'
+        html += f'    <div class="role-badge">{chevron_html} {role_icon} {safe_role}</div>'
         html += f'    <div class="timestamp">{timestamp}</div>'
         html += '  </div>'
         html += '  <div class="message-body">'
@@ -706,7 +708,7 @@ def _generate_messages_html(messages: List[Dict[str, Any]]) -> str:
                 <div class="tool-call">
                     <div class="tool-call-header">
                         {ICON_CHEVRON_RIGHT.replace('class="', 'class="chevron ')}
-                        {ICON_WRENCH} Tool Call: {fn_name}
+                        {ICON_WRENCH} Tool Call: {_escape_html(fn_name)}
                     </div>
                     <div class="tool-call-content">
                         <pre><code>{_escape_html(args)}</code></pre>

--- a/tests/hermes_cli/test_session_export_html_escape.py
+++ b/tests/hermes_cli/test_session_export_html_escape.py
@@ -1,3 +1,5 @@
+import re
+
 from hermes_cli.session_export_html import _generate_messages_html
 
 
@@ -39,3 +41,16 @@ def test_role_is_escaped_in_html_export():
 
     assert "<img src=x onerror=alert(document.domain)>" not in html
     assert "&lt;img src=x onerror=alert(document.domain)&gt;" in html
+    # The class attribute must remain a single, well-formed token: a crafted
+    # role must not break out of it nor split into several unintended classes.
+    class_value = re.search(r'class="(message message-[^"]*active)"', html)
+    assert class_value is not None
+    assert " message-" in class_value.group(1)  # exactly one message-<role> class
+    assert class_value.group(1).count("message-") == 1
+
+
+def test_known_role_keeps_its_css_class():
+    html = _generate_messages_html(
+        [{"role": "assistant", "content": "hi", "timestamp": 1700000000}]
+    )
+    assert 'class="message message-assistant active"' in html

--- a/tests/hermes_cli/test_session_export_html_escape.py
+++ b/tests/hermes_cli/test_session_export_html_escape.py
@@ -1,0 +1,41 @@
+from hermes_cli.session_export_html import _generate_messages_html
+
+
+def test_tool_call_name_is_escaped_in_html_export():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "timestamp": 1700000000,
+            "tool_calls": [
+                {
+                    "function": {
+                        "name": "<script>alert(1)</script>",
+                        "arguments": "{}",
+                    }
+                }
+            ],
+        }
+    ]
+
+    html = _generate_messages_html(messages)
+
+    # Raw, executable markup must never reach the standalone artifact.
+    assert "<script>alert(1)</script>" not in html
+    # The escaped form must be present instead.
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+
+
+def test_role_is_escaped_in_html_export():
+    messages = [
+        {
+            "role": "<img src=x onerror=alert(document.domain)>",
+            "content": "hello",
+            "timestamp": 1700000000,
+        }
+    ]
+
+    html = _generate_messages_html(messages)
+
+    assert "<img src=x onerror=alert(document.domain)>" not in html
+    assert "&lt;img src=x onerror=alert(document.domain)&gt;" in html


### PR DESCRIPTION
## What does this PR do?

Closes an HTML/JS-injection gap in the standalone HTML session export (`hermes_cli/session_export_html.py`). The exporter already routes most interpolated fields through the module's own `_escape_html` — `args`, `content`, `reasoning`, `title`, `model`, `system_prompt` — but three sibling sites on the same builder were written **raw**:

- the message `role` interpolated into the `class="message message-{role} active"` attribute, and
- the same `role` in the role badge, and
- the tool-call function `name` (`{fn_name}`) in the tool-call header.

`fn_name` comes from `tc["function"]["name"]`, i.e. a tool-call name — for MCP/custom tools this is externally influenced. A session containing a tool call named `<script>alert(document.domain)</script>` (or a crafted `role` with an attribute breakout like `"><script>…`) injects live HTML/JS into the exported standalone `.html`, which executes when the user opens the export in a browser. This is exactly the escaping-consistency defect the rest of the file already guards against; only these sites were missed.

The fix reuses the file's own `_escape_html` for parity — `role` is escaped once into `safe_role` (it feeds both an attribute and text) and `fn_name` is escaped inline.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `hermes_cli/session_export_html.py`: escape `role` (class attribute + role badge, via a single `safe_role = _escape_html(role)`) and the tool-call `fn_name` in `_generate_messages_html`.
- `tests/hermes_cli/test_session_export_html_escape.py`: new regression test asserting a `<script>` tool-call name and a markup `role` are emitted escaped, never raw.

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_session_export_html_escape.py -v`
2. Fail-before / pass-after: reverting only the production hunk makes both new assertions fail (raw `<script>` / `<img …>` leaks into the output); with the fix they pass (only the `&lt;script&gt;` / `&lt;img …&gt;` escaped form appears).
3. Full session-export area is green: `pytest tests/hermes_cli/test_session_export.py tests/hermes_cli/test_session_export_md.py tests/hermes_cli/test_sessions_export_md_cli.py tests/hermes_cli/test_session_export_html_escape.py -q` → 35 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A