### PR TITLE
fix(skills): persist only platform delta of disabled skills

### DIFF
--- a/contributors/emails/seraphine@Seraphines-Mac-Studio.local
+++ b/contributors/emails/seraphine@Seraphines-Mac-Studio.local
@@ -1,0 +1,2 @@
+Bartok9
+# Seraphine Mac Studio local email on Bartok9 PR tips (per-PR attribution; Teknium/Daniel 2026-08-01)

--- a/hermes_cli/skills_config.py
+++ b/hermes_cli/skills_config.py
@@ -62,13 +62,25 @@ def get_disabled_skills(config: dict, platform: Optional[str] = None) -> Set[str
 
 
 def save_disabled_skills(config: dict, disabled: Set[str], platform: Optional[str] = None):
-    """Persist disabled skill names to config."""
+    """Persist disabled skill names to config.
+
+    ``platform_disabled[platform]`` is an *override* list that is unioned
+    with the global ``disabled`` list on read (see
+    :func:`get_disabled_skills`), so it must store only the platform-specific
+    delta. Callers (``skills_command``) pass the effective (unioned) set they
+    read back, so globally-disabled skills are subtracted before writing —
+    otherwise every global disable would be copied into the platform list and
+    stay pinned there even after the user re-enables it globally.
+    """
     config.setdefault("skills", {})
     if platform is None:
         config["skills"]["disabled"] = sorted(disabled)
     else:
+        global_disabled = set(config["skills"].get("disabled", []) or [])
         config["skills"].setdefault("platform_disabled", {})
-        config["skills"]["platform_disabled"][platform] = sorted(disabled)
+        config["skills"]["platform_disabled"][platform] = sorted(
+            set(disabled) - global_disabled
+        )
     save_config(config)
 
 

--- a/tests/hermes_cli/test_skills_config.py
+++ b/tests/hermes_cli/test_skills_config.py
@@ -36,6 +36,30 @@ class TestSaveDisabledSkills:
         assert config["skills"]["disabled"] == ["skill-a", "skill-z"]
         mock_save.assert_called_once()
 
+    @patch("hermes_cli.skills_config.save_config")
+    def test_platform_save_excludes_global_disabled(self, mock_save):
+        from hermes_cli.skills_config import save_disabled_skills
+        # skills_command reads the UNION (global | platform) and passes it back
+        # here. Only the platform-specific delta may be persisted — the global
+        # disable must NOT be copied into the platform_disabled list, or it
+        # stays pinned there even after a later global re-enable.
+        config = {"skills": {"disabled": ["global-skill"]}}
+        save_disabled_skills(config, {"global-skill", "tg-skill"}, platform="telegram")
+        assert config["skills"]["platform_disabled"]["telegram"] == ["tg-skill"]
+
+    @patch("hermes_cli.skills_config.save_config")
+    def test_platform_re_enable_after_global_reenable(self, mock_save):
+        from hermes_cli.skills_config import get_disabled_skills, save_disabled_skills
+        # Disable a skill globally, then configure telegram (which reads the
+        # union and saves it back).
+        config = {"skills": {"disabled": ["global-skill"]}}
+        union = get_disabled_skills(config, platform="telegram")  # {"global-skill"}
+        save_disabled_skills(config, union, platform="telegram")
+        # Now re-enable the skill globally. Because the platform list only holds
+        # its delta (empty here), the effective telegram set clears too.
+        config["skills"]["disabled"] = []
+        assert get_disabled_skills(config, platform="telegram") == set()
+
 
 # ---------------------------------------------------------------------------
 # _is_skill_disabled


### PR DESCRIPTION
## Summary

- Salvage of #57026 by @briandevans (closed idle, not rejected).
- `save_disabled_skills(..., platform=...)` now persists only the platform-specific delta after subtracting the global `skills.disabled` set.
- Prevents global disables from being pinned into `platform_disabled` when `hermes skills` reads the union and writes it back.

## Motivation

`get_disabled_skills(config, platform)` returns the **union** of global + platform lists. `skills_command` then saves that effective set via `save_disabled_skills`. Before this fix, the full union was written into `platform_disabled[platform]`, so re-enabling a skill **globally** left it still disabled on that platform forever.

## Verification

- `python3 -m pytest tests/hermes_cli/test_skills_config.py -k "save or platform" -q` — 18 passed
- Added:
  - `test_platform_save_excludes_global_disabled`
  - `test_platform_re_enable_after_global_reenable`
- Manual logic: global `{global-skill}` + telegram save of union → platform list is `[]`; clearing global returns empty effective set for telegram.

## Notes

- Cap-safe salvage (does not count as first-mover).
- No public issue filed; original work credited to @briandevans / #57026.