### PR TITLE
fix(hermes): heal managed Node when npm/npx sibling is missing

### DIFF
--- a/contributors/emails/seraphine@Seraphines-Mac-Studio.local
+++ b/contributors/emails/seraphine@Seraphines-Mac-Studio.local
@@ -1,0 +1,2 @@
+Bartok9
+# Seraphine Mac Studio local email on Bartok9 PR tips (per-PR attribution; Teknium/Daniel 2026-08-01)

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -480,17 +480,28 @@ def find_hermes_node_executable(command: str) -> str | None:
     """Return a Hermes-managed Node/npm executable path, healing broken trees."""
     names = _candidate_node_command_names(command)
     broken_present = False
+    found_present = False
     for directory in iter_hermes_node_dirs():
         for name in names:
             candidate = directory / name
             if candidate.is_file() and (
                 sys.platform == "win32" or os.access(candidate, os.X_OK)
             ):
+                found_present = True
                 resolved = str(candidate)
                 if node_tool_runnable(resolved):
                     return resolved
                 broken_present = True
-    if broken_present and heal_hermes_managed_node():
+    # Heal when the requested tool is present-but-broken, OR entirely missing
+    # while the managed tree is otherwise present (a sibling tool such as
+    # ``node`` survives). A self-update clobber (``npm i -g npm``), partial
+    # symlink cleanup, or interrupted zip extraction can delete ``npm``/``npx``
+    # while leaving ``node`` behind — both are partial-tree states that
+    # heal_hermes_managed_node() repairs by redownloading the full tarball.
+    needs_heal = broken_present or (
+        not found_present and hermes_managed_node_tree_present()
+    )
+    if needs_heal and heal_hermes_managed_node():
         for directory in iter_hermes_node_dirs():
             for name in names:
                 candidate = directory / name

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -589,11 +589,14 @@ def _managed_node_tree_outdated(home: Path | None = None) -> bool:
 def find_hermes_node_executable(command: str) -> str | None:
     """Return a Hermes-managed Node/npm executable path, healing broken trees.
 
-    Outdated trees (node major below ``_HERMES_NODE_TARGET_MAJOR``) heal the
-    same way broken ones do — the once-per-process heal redownloads the target
-    major, upgrading existing users on next launch rather than next reinstall.
-    When the heal fails (offline, download error), an outdated-but-runnable
-    tree is still returned: old Node beats no Node.
+    Heals when the requested tool is present-but-broken, entirely missing while
+    the managed tree is otherwise present (a sibling such as ``node`` survives),
+    or outdated (node major below ``_HERMES_NODE_TARGET_MAJOR``). The
+    once-per-process heal redownloads the target major — upgrading existing
+    users on next launch rather than next reinstall, and restoring npm/npx
+    deleted by a self-update clobber, partial symlink cleanup, or interrupted
+    zip extraction. When the heal fails (offline, download error), an
+    outdated-but-runnable tree is still returned: old Node beats no Node.
     """
     names = _candidate_node_command_names(command)
 
@@ -612,8 +615,10 @@ def find_hermes_node_executable(command: str) -> str | None:
         return None, broken
 
     resolved, broken_present = _first_runnable()
-    needs_heal = broken_present or (
-        resolved is not None and _managed_node_tree_outdated()
+    needs_heal = (
+        broken_present
+        or (resolved is None and hermes_managed_node_tree_present())
+        or (resolved is not None and _managed_node_tree_outdated())
     )
     if needs_heal and heal_hermes_managed_node():
         healed, _ = _first_runnable()

--- a/scripts/lib/node-bootstrap.sh
+++ b/scripts/lib/node-bootstrap.sh
@@ -236,16 +236,25 @@ _nb_install_bundled_node() {
 _nb_managed_tool_broken() {
     local tool="$1"
     local probe
+    local found=1
     for probe in \
         "$HERMES_HOME/node/bin/$tool" \
         "$HERMES_HOME/node/${tool}.exe" \
         "$HERMES_HOME/node/$tool"; do
         if [ -x "$probe" ] || [ -f "$probe" ]; then
+            found=0
             if ! "$probe" --version >/dev/null 2>&1; then
                 return 0
             fi
         fi
     done
+    # A managed Node tree with an entirely absent sibling (e.g. npm/npx
+    # missing while node is healthy) is also repair-worthy: redownloading
+    # the pinned tarball restores the missing tool. Only treat absence as
+    # broken when the managed tree exists, so this stays a no-op otherwise.
+    if [ "$found" -ne 0 ] && [ -d "$HERMES_HOME/node" ]; then
+        return 0
+    fi
     return 1
 }
 

--- a/scripts/lib/node-bootstrap.sh
+++ b/scripts/lib/node-bootstrap.sh
@@ -332,16 +332,25 @@ _nb_install_bundled_node() {
 _nb_managed_tool_broken() {
     local tool="$1"
     local probe
+    local found=1
     for probe in \
         "$HERMES_HOME/node/bin/$tool" \
         "$HERMES_HOME/node/${tool}.exe" \
         "$HERMES_HOME/node/$tool"; do
         if [ -x "$probe" ] || [ -f "$probe" ]; then
+            found=0
             if ! "$probe" --version >/dev/null 2>&1; then
                 return 0
             fi
         fi
     done
+    # A managed Node tree with an entirely absent sibling (e.g. npm/npx
+    # missing while node is healthy) is also repair-worthy: redownloading
+    # the pinned tarball restores the missing tool. Only treat absence as
+    # broken when the managed tree exists, so this stays a no-op otherwise.
+    if [ "$found" -ne 0 ] && [ -d "$HERMES_HOME/node" ]; then
+        return 0
+    fi
     return 1
 }
 

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -195,6 +195,36 @@ class TestNodeToolRunnable:
         assert resolved == str(broken_npm)
         assert resolved != str(system_bin / "npm")
 
+    def test_missing_managed_npm_heals_when_node_still_runs(self, tmp_path, monkeypatch):
+        """npm entirely absent while node survives must heal (not PATH-fall back)."""
+        profile_home = tmp_path / "profiles" / "assistant"
+        managed_bin = profile_home / "node" / "bin"
+        managed_bin.mkdir(parents=True)
+        self._stub(managed_bin, "node", "#!/bin/sh\necho '22.0.0'\nexit 0\n")
+        # Intentionally no managed npm/npx — the partial-tree case this heals.
+        heal_called = {"value": False}
+        healed_npm = managed_bin / "npm"
+
+        system_bin = tmp_path / "system-bin"
+        system_bin.mkdir()
+        self._stub(system_bin, "npm", "#!/bin/sh\necho '11.10.0'\nexit 0\n")
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        monkeypatch.setenv("PATH", str(system_bin))
+        monkeypatch.setattr(hermes_constants, "_managed_node_heal_attempted", False)
+
+        def _heal():
+            heal_called["value"] = True
+            healed_npm.write_text("#!/bin/sh\necho '22.0.0'\nexit 0\n")
+            healed_npm.chmod(0o755)
+            return True
+
+        monkeypatch.setattr(hermes_constants, "heal_hermes_managed_node", _heal)
+
+        resolved = find_node_executable("npm")
+        assert heal_called["value"] is True
+        assert resolved == str(healed_npm)
+        assert resolved != str(system_bin / "npm")
 
     def test_broken_managed_npm_returns_none_when_heal_fails(self, tmp_path, monkeypatch):
         profile_home = tmp_path / "profiles" / "assistant"

--- a/tests/test_install_sh_node_global_prefix.py
+++ b/tests/test_install_sh_node_global_prefix.py
@@ -56,3 +56,44 @@ def test_node_bootstrap_redirects_bundled_npm_global_prefix_to_link_dir() -> Non
     assert "heal_managed_node()" in text
     assert "_nb_managed_tool_broken" in text
     assert "for tool in node npm npx" in text
+
+
+def _run_predicate(hermes_home: Path, tool: str) -> int:
+    """Source node-bootstrap.sh and invoke _nb_managed_tool_broken for tool.
+
+    Returns the predicate's exit status (0 == broken/heal-worthy)."""
+    import subprocess
+
+    script = (
+        f'HERMES_HOME={hermes_home!s}; '
+        f'. "{NODE_BOOTSTRAP}"; '
+        f'_nb_managed_tool_broken "{tool}"'
+    )
+    return subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+    ).returncode
+
+
+def test_absent_managed_sibling_is_heal_worthy(tmp_path: Path) -> None:
+    """A managed Node tree with node present but npm/npx entirely absent must
+    be treated as broken so heal_managed_node() redownloads the pinned tarball.
+    Previously the predicate only reported broken when a present probe failed
+    --version, so a fully missing sibling slipped through to a PATH fallback."""
+    node_dir = tmp_path / "node" / "bin"
+    node_dir.mkdir(parents=True)
+    node_bin = node_dir / "node"
+    node_bin.write_text('#!/bin/sh\necho v20.0.0\n')
+    node_bin.chmod(0o755)
+
+    # node itself is present and runnable -> not broken.
+    assert _run_predicate(tmp_path, "node") != 0
+    # npm/npx are entirely absent from an existing managed tree -> heal-worthy.
+    assert _run_predicate(tmp_path, "npm") == 0
+    assert _run_predicate(tmp_path, "npx") == 0
+
+
+def test_absent_sibling_without_managed_tree_is_not_heal_worthy(tmp_path: Path) -> None:
+    """Absence must stay a no-op when there is no managed Node tree at all, so
+    systems relying on PATH-provided node/npm are not forced into a download."""
+    assert _run_predicate(tmp_path, "npm") != 0


### PR DESCRIPTION
## Summary

- Salvage of #53232 by @briandevans (closed idle, not rejected).
- `find_hermes_node_executable` now heals not only present-but-broken managed tools, but also **missing** managed `npm`/`npx` when the managed node tree is otherwise present.
- Avoids silently preferring PATH npm after partial tree damage (self-update clobber / interrupted extract).

## Motivation

Managed node healing already recovered broken binary files. If `npm`/`npx` was deleted while `node` remained, heal never ran and resolution fell through to whatever system tool was on PATH — version skew and “it works on PATH but not managed” failures.

## Verification

- `python3 -m pytest tests/test_hermes_constants.py -k "managed_npm_heals" -q` — 3 passed
- New regression: `test_missing_managed_npm_heals_when_node_still_runs`
- Existing broken-present heal coverage retained.

## Notes

- Cap-safe salvage.
- Credit: @briandevans / closed PR #53232.