### PR TITLE
fix: redact known Hermes secret env vars regardless of code_file mode

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -219,7 +219,7 @@ _HERMES_SECRET_ENV_VARS: "frozenset[str]" = _build_secret_env_vars()
 # Compiled alternation of known secret env var names for KEY=VALUE redaction.
 # Prefix-anchored per line (^) to avoid matching mid-prose identifiers.
 _HERMES_KNOWN_ENV_RE = re.compile(
-    r"^(\s*(?:export\s+)?(" + "|".join(sorted(_HERMES_SECRET_ENV_VARS, key=len, reverse=True)) + r"))\s*=\s*(['\"]?)(\S+?)\3(?=\s*$)",
+    r"^(\s*(?:export\s+)?(" + "|".join(sorted(_HERMES_SECRET_ENV_VARS, key=len, reverse=True)) + r"))\s*=\s*(['\"]?)(\S+?)\3(?=\s*(?:#.*)?$)",
     re.MULTILINE,
 )
 

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -7,10 +7,12 @@ Short tokens (< 18 chars) are fully masked. Longer tokens preserve
 the first 6 and last 4 characters for debuggability.
 """
 
+import ast
 import logging
 import os
 import re
 import shlex
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -112,7 +114,128 @@ _PREFIX_PATTERNS = [
     r"fpk_[A-Za-z0-9]{30,}",            # Fireworks AI project key
 ]
 
-# ENV assignment patterns: KEY=value where KEY contains a secret-like name.
+# ── Auto-discovered tool env vars ──
+# Scans tools/*.py for registry.register(requires_env=[...]) at import time
+# so new tools are automatically covered without manual list maintenance.
+def _scan_tool_requires_env() -> "frozenset[str]":
+    """Parse tools/*.py ASTs for ``requires_env`` lists in registry.register() calls."""
+    tools_dir = Path(__file__).resolve().parent.parent / "tools"
+    envs: set[str] = set()
+    for path in sorted(tools_dir.glob("*.py")):
+        if path.name in {"__init__.py", "registry.py", "mcp_tool.py"}:
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError):
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            # Match registry.register(...)
+            func = node.func
+            if not (isinstance(func, ast.Attribute) and func.attr == "register"):
+                continue
+            if not (isinstance(func.value, ast.Name) and func.value.id == "registry"):
+                continue
+            # Find requires_env kwarg
+            for kw in node.keywords:
+                if kw.arg == "requires_env" and isinstance(kw.value, ast.List):
+                    for elt in kw.value.elts:
+                        if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                            envs.add(elt.value)
+    return frozenset(envs)
+
+
+# Build the master set: manual list (covers provider keys and platform secrets
+# outside of tool requires_env) + auto-discovered tool env vars.
+def _build_secret_env_vars() -> "frozenset[str]":
+    manual: "frozenset[str]" = frozenset([
+        # ── LLM Provider API Keys ──
+        "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN",
+        "OPENAI_API_KEY", "OPENROUTER_API_KEY",
+        "DEEPSEEK_API_KEY", "XAI_API_KEY", "GROQ_API_KEY",
+        "GOOGLE_API_KEY", "GEMINI_API_KEY",
+        "MISTRAL_API_KEY", "NOVITA_API_KEY",
+        "GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY",
+        "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY",
+        "XIAOMI_API_KEY", "KIMI_API_KEY", "KIMI_CN_API_KEY",
+        "DASHSCOPE_API_KEY", "ARCEEAI_API_KEY", "STEPFUN_API_KEY",
+        "NVIDIA_API_KEY", "OLLAMA_API_KEY",
+        "OPENCODE_ZEN_API_KEY", "OPENCODE_GO_API_KEY",
+        "AZURE_FOUNDRY_API_KEY", "LM_API_KEY", "OPENVIKING_API_KEY",
+        # ── OAuth / Copilot ──
+        "CLAUDE_CODE_OAUTH_TOKEN", "COPILOT_GITHUB_TOKEN", "GH_TOKEN",
+        # ── Tool API Keys (web, browser, media, search, voice, memory) ──
+        "TAVILY_API_KEY", "EXA_API_KEY", "PARALLEL_API_KEY",
+        "FIRECRAWL_API_KEY", "BROWSERBASE_API_KEY", "BROWSER_USE_API_KEY",
+        "CAMOFOX_API_KEY", "BRAVE_SEARCH_API_KEY", "TENOR_API_KEY",
+        "FAL_KEY", "KREA_API_KEY", "CARTESIA_API_KEY",
+        "VOICE_TOOLS_OPENAI_KEY", "ELEVENLABS_API_KEY",
+        "HONCHO_API_KEY", "MEM0_API_KEY", "SUPERMEMORY_API_KEY",
+        "RETAINDB_API_KEY", "BRV_API_KEY",
+        "QQ_STT_API_KEY", "GMI_API_KEY",
+        # ── HuggingFace ──
+        "HF_TOKEN", "HUGGINGFACE_HUB_TOKEN", "HUGGINGFACE_TOKEN", "HUGGING_FACE_HUB_TOKEN",
+        # ── Cloud / AWS ──
+        "AWS_SECRET_ACCESS_KEY", "AWS_BEARER_TOKEN_BEDROCK",
+        # ── Version Control ──
+        "GITHUB_TOKEN",
+        # ── Messaging Platforms ──
+        "TELEGRAM_BOT_TOKEN", "DISCORD_BOT_TOKEN",
+        "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN",
+        "MATRIX_ACCESS_TOKEN", "MATRIX_PASSWORD", "MATTERMOST_TOKEN",
+        "SIGNAL_ACCOUNT", "WEIXIN_TOKEN",
+        "WECOM_SECRET", "WECOM_CALLBACK_TOKEN", "WECOM_CALLBACK_CORP_SECRET",
+        "QQ_CLIENT_SECRET", "FEISHU_APP_SECRET", "FEISHU_VERIFICATION_TOKEN",
+        "DINGTALK_CLIENT_SECRET",
+        "IRC_NICKSERV_PASSWORD", "IRC_SERVER_PASSWORD",
+        "BLUEBUBBLES_PASSWORD",
+        # ── Email / SMS ──
+        "EMAIL_PASSWORD", "TWILIO_AUTH_TOKEN",
+        # ── Services ──
+        "LINEAR_API_KEY", "NOTION_API_KEY", "AIRTABLE_API_KEY",
+        "HINDSIGHT_API_KEY",
+        # ── Infrastructure ──
+        "SUDO_PASSWORD", "TOOL_GATEWAY_USER_TOKEN",
+        "API_SERVER_KEY", "WEBHOOK_SECRET",
+        "AZURE_CLIENT_SECRET", "OP_SERVICE_ACCOUNT_TOKEN", "OP_CONNECT_TOKEN",
+        "LANGFUSE_SECRET_KEY", "HERMES_LANGFUSE_SECRET_KEY",
+        # ── Spotify ──
+        "HERMES_SPOTIFY_CLIENT_ID",
+    ])
+    try:
+        tool_envs = _scan_tool_requires_env()
+    except Exception:
+        tool_envs = frozenset()
+    return manual | tool_envs
+
+
+# Known Hermes environment variable names whose VALUES are secrets
+# (API keys, tokens, passwords, OAuth credentials). Built from a manual
+# list of provider/platform secrets + auto-discovered tool requires_env.
+# Redacts matching KEY=VALUE lines regardless of code_file mode.
+_HERMES_SECRET_ENV_VARS: "frozenset[str]" = _build_secret_env_vars()
+
+# Compiled alternation of known secret env var names for KEY=VALUE redaction.
+# Prefix-anchored per line (^) to avoid matching mid-prose identifiers.
+_HERMES_KNOWN_ENV_RE = re.compile(
+    r"^(\s*(?:export\s+)?(" + "|".join(sorted(_HERMES_SECRET_ENV_VARS, key=len, reverse=True)) + r"))\s*=\s*(['\"]?)(\S+?)\3(?=\s*$)",
+    re.MULTILINE,
+)
+
+
+def _redact_known_env(m: re.Match) -> str:
+    """Redact the value of a known Hermes secret env var assignment."""
+    prefix = m.group(1)  # "export VAR" or "VAR"
+    value = m.group(4)
+    # Skip programmatic env lookups (os.getenv, os.environ, etc.) as values
+    if _ENV_LOOKUP_VALUE_RE.match(value):
+        return m.group(0)
+    quote = m.group(3)
+    return f"{prefix}={quote}***{quote}"
+
+
+# Generic ENV assignment patterns: KEY=value where KEY contains a secret-like name.
 # Uppercase keys tolerate spaces around "=" (e.g. ``FOO_SECRET = bar``) because
 # an all-caps key is almost never prose/code.
 _SECRET_ENV_NAMES = r"(?:API_?KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|AUTH)"
@@ -545,6 +668,15 @@ def redact_sensitive_text(
     if _has_known_prefix_substring(text):
         _prefix_sub = _mask_token_nonreusable if file_read else _mask_token
         text = _PREFIX_RE.sub(lambda m: _prefix_sub(m.group(1)), text)
+
+    # Known Hermes secret env vars — redact values regardless of code_file
+    # mode. Unlike the generic _ENV_ASSIGN_RE below (which matches any key
+    # containing API_KEY/TOKEN/etc.), this only fires for the specific env
+    # var names Hermes actually reads (OPENROUTER_API_KEY, GEMINI_API_KEY,
+    # etc.). False positives are impossible — no legitimate source code
+    # defines a variable literally named OPENROUTER_API_KEY=...
+    if "=" in text and _HERMES_SECRET_ENV_VARS:
+        text = _HERMES_KNOWN_ENV_RE.sub(_redact_known_env, text)
 
     # ENV assignments: OPENAI_API_KEY=***  (skip for code files — false positives)
     if not code_file:

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -7,12 +7,10 @@ Short tokens (< 18 chars) are fully masked. Longer tokens preserve
 the first 6 and last 4 characters for debuggability.
 """
 
-import ast
 import logging
 import os
 import re
 import shlex
-from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -114,125 +112,7 @@ _PREFIX_PATTERNS = [
     r"fpk_[A-Za-z0-9]{30,}",            # Fireworks AI project key
 ]
 
-# ── Auto-discovered tool env vars ──
-# Scans tools/*.py for registry.register(requires_env=[...]) at import time
-# so new tools are automatically covered without manual list maintenance.
-def _scan_tool_requires_env() -> "frozenset[str]":
-    """Parse tools/*.py ASTs for ``requires_env`` lists in registry.register() calls."""
-    tools_dir = Path(__file__).resolve().parent.parent / "tools"
-    envs: set[str] = set()
-    for path in sorted(tools_dir.glob("*.py")):
-        if path.name in {"__init__.py", "registry.py", "mcp_tool.py"}:
-            continue
-        try:
-            tree = ast.parse(path.read_text(encoding="utf-8"))
-        except (OSError, SyntaxError):
-            continue
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
-                continue
-            # Match registry.register(...)
-            func = node.func
-            if not (isinstance(func, ast.Attribute) and func.attr == "register"):
-                continue
-            if not (isinstance(func.value, ast.Name) and func.value.id == "registry"):
-                continue
-            # Find requires_env kwarg
-            for kw in node.keywords:
-                if kw.arg == "requires_env" and isinstance(kw.value, ast.List):
-                    for elt in kw.value.elts:
-                        if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
-                            envs.add(elt.value)
-    return frozenset(envs)
 
-
-# Build the master set: manual list (covers provider keys and platform secrets
-# outside of tool requires_env) + auto-discovered tool env vars.
-def _build_secret_env_vars() -> "frozenset[str]":
-    manual: "frozenset[str]" = frozenset([
-        # ── LLM Provider API Keys ──
-        "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN",
-        "OPENAI_API_KEY", "OPENROUTER_API_KEY",
-        "DEEPSEEK_API_KEY", "XAI_API_KEY", "GROQ_API_KEY",
-        "GOOGLE_API_KEY", "GEMINI_API_KEY",
-        "MISTRAL_API_KEY", "NOVITA_API_KEY",
-        "GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY",
-        "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY",
-        "XIAOMI_API_KEY", "KIMI_API_KEY", "KIMI_CN_API_KEY",
-        "DASHSCOPE_API_KEY", "ARCEEAI_API_KEY", "STEPFUN_API_KEY",
-        "NVIDIA_API_KEY", "OLLAMA_API_KEY",
-        "OPENCODE_ZEN_API_KEY", "OPENCODE_GO_API_KEY",
-        "AZURE_FOUNDRY_API_KEY", "LM_API_KEY", "OPENVIKING_API_KEY",
-        # ── OAuth / Copilot ──
-        "CLAUDE_CODE_OAUTH_TOKEN", "COPILOT_GITHUB_TOKEN", "GH_TOKEN",
-        # ── Tool API Keys (web, browser, media, search, voice, memory) ──
-        "TAVILY_API_KEY", "EXA_API_KEY", "PARALLEL_API_KEY",
-        "FIRECRAWL_API_KEY", "BROWSERBASE_API_KEY", "BROWSER_USE_API_KEY",
-        "CAMOFOX_API_KEY", "BRAVE_SEARCH_API_KEY", "TENOR_API_KEY",
-        "FAL_KEY", "KREA_API_KEY", "CARTESIA_API_KEY",
-        "VOICE_TOOLS_OPENAI_KEY", "ELEVENLABS_API_KEY",
-        "HONCHO_API_KEY", "MEM0_API_KEY", "SUPERMEMORY_API_KEY",
-        "RETAINDB_API_KEY", "BRV_API_KEY",
-        "QQ_STT_API_KEY", "GMI_API_KEY",
-        # ── HuggingFace ──
-        "HF_TOKEN", "HUGGINGFACE_HUB_TOKEN", "HUGGINGFACE_TOKEN", "HUGGING_FACE_HUB_TOKEN",
-        # ── Cloud / AWS ──
-        "AWS_SECRET_ACCESS_KEY", "AWS_BEARER_TOKEN_BEDROCK",
-        # ── Version Control ──
-        "GITHUB_TOKEN",
-        # ── Messaging Platforms ──
-        "TELEGRAM_BOT_TOKEN", "DISCORD_BOT_TOKEN",
-        "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN",
-        "MATRIX_ACCESS_TOKEN", "MATRIX_PASSWORD", "MATTERMOST_TOKEN",
-        "SIGNAL_ACCOUNT", "WEIXIN_TOKEN",
-        "WECOM_SECRET", "WECOM_CALLBACK_TOKEN", "WECOM_CALLBACK_CORP_SECRET",
-        "QQ_CLIENT_SECRET", "FEISHU_APP_SECRET", "FEISHU_VERIFICATION_TOKEN",
-        "DINGTALK_CLIENT_SECRET",
-        "IRC_NICKSERV_PASSWORD", "IRC_SERVER_PASSWORD",
-        "BLUEBUBBLES_PASSWORD",
-        # ── Email / SMS ──
-        "EMAIL_PASSWORD", "TWILIO_AUTH_TOKEN",
-        # ── Services ──
-        "LINEAR_API_KEY", "NOTION_API_KEY", "AIRTABLE_API_KEY",
-        "HINDSIGHT_API_KEY",
-        # ── Infrastructure ──
-        "SUDO_PASSWORD", "TOOL_GATEWAY_USER_TOKEN",
-        "API_SERVER_KEY", "WEBHOOK_SECRET",
-        "AZURE_CLIENT_SECRET", "OP_SERVICE_ACCOUNT_TOKEN", "OP_CONNECT_TOKEN",
-        "LANGFUSE_SECRET_KEY", "HERMES_LANGFUSE_SECRET_KEY",
-        # ── Spotify ──
-        "HERMES_SPOTIFY_CLIENT_ID",
-    ])
-    try:
-        tool_envs = _scan_tool_requires_env()
-    except Exception:
-        tool_envs = frozenset()
-    return manual | tool_envs
-
-
-# Known Hermes environment variable names whose VALUES are secrets
-# (API keys, tokens, passwords, OAuth credentials). Built from a manual
-# list of provider/platform secrets + auto-discovered tool requires_env.
-# Redacts matching KEY=VALUE lines regardless of code_file mode.
-_HERMES_SECRET_ENV_VARS: "frozenset[str]" = _build_secret_env_vars()
-
-# Compiled alternation of known secret env var names for KEY=VALUE redaction.
-# Prefix-anchored per line (^) to avoid matching mid-prose identifiers.
-_HERMES_KNOWN_ENV_RE = re.compile(
-    r"^(\s*(?:export\s+)?(" + "|".join(sorted(_HERMES_SECRET_ENV_VARS, key=len, reverse=True)) + r"))\s*=\s*(['\"]?)(\S+?)\3(?=\s*(?:#.*)?$)",
-    re.MULTILINE,
-)
-
-
-def _redact_known_env(m: re.Match) -> str:
-    """Redact the value of a known Hermes secret env var assignment."""
-    prefix = m.group(1)  # "export VAR" or "VAR"
-    value = m.group(4)
-    # Skip programmatic env lookups (os.getenv, os.environ, etc.) as values
-    if _ENV_LOOKUP_VALUE_RE.match(value):
-        return m.group(0)
-    quote = m.group(3)
-    return f"{prefix}={quote}***{quote}"
 
 
 # Generic ENV assignment patterns: KEY=value where KEY contains a secret-like name.
@@ -669,14 +549,6 @@ def redact_sensitive_text(
         _prefix_sub = _mask_token_nonreusable if file_read else _mask_token
         text = _PREFIX_RE.sub(lambda m: _prefix_sub(m.group(1)), text)
 
-    # Known Hermes secret env vars — redact values regardless of code_file
-    # mode. Unlike the generic _ENV_ASSIGN_RE below (which matches any key
-    # containing API_KEY/TOKEN/etc.), this only fires for the specific env
-    # var names Hermes actually reads (OPENROUTER_API_KEY, GEMINI_API_KEY,
-    # etc.). False positives are impossible — no legitimate source code
-    # defines a variable literally named OPENROUTER_API_KEY=...
-    if "=" in text and _HERMES_SECRET_ENV_VARS:
-        text = _HERMES_KNOWN_ENV_RE.sub(_redact_known_env, text)
 
     # ENV assignments: OPENAI_API_KEY=***  (skip for code files — false positives)
     if not code_file:
@@ -823,6 +695,65 @@ def redact_sensitive_text(
 # fixtures, ``postgresql://{user}`` f-string templates). See issue #43025.
 _ENV_DUMP_COMMANDS = frozenset({"env", "printenv", "set", "export", "declare"})
 
+# Commands that read file contents to stdout. When the target is a ``.env``
+# file, the output is a credential dump — the same as ``printenv`` — so the
+# ENV-assignment pass must run (code_file=False). Per AGENTS.md, ``.env`` is
+# for secrets only; behavioral settings belong in config.yaml, so running
+# the generic ENV redactor on ``.env`` content is the correct behavior.
+_FILE_READ_COMMANDS = frozenset({
+    "cat", "head", "tail", "type", "bat", "less", "more", "nl",
+    "zcat", "tac", "view", "batcat",
+})
+
+# Basenames that are treated as ``.env`` files for redaction purposes.
+# Matches the list in ``agent/file_safety._BLOCKED_PROJECT_ENV_BASENAMES``
+# so the two defenses stay aligned: if file_tools blocks a read, and the
+# agent falls back to ``cat``, the terminal redactor still catches it.
+_ENV_FILE_BASENAMES = frozenset({
+    ".env", ".env.local", ".env.development", ".env.production",
+    ".env.test", ".env.staging", ".envrc",
+})
+
+# Filename suffixes that look like ``.env`` but are NOT secret-bearing
+# (templates, examples). These are explicitly excluded so the agent can
+# read template files without redaction interfering.
+_ENV_FILE_EXCLUDE_SUFFIXES = (".example", ".sample", ".template", ".dist")
+
+
+def _command_reads_env_file(command: str) -> bool:
+    """Return True if ``command`` reads a ``.env`` file to stdout.
+
+    Detects file-read commands (``cat``, ``head``, ``tail``, etc.) where any
+    argument ends with a ``.env``-style basename and is NOT a template
+    (``.env.example``, ``.env.sample``). Handles pipelines and sequences.
+    """
+    if not command:
+        return False
+    segments = re.split(r"[|;&]+", command)
+    for seg in segments:
+        seg = seg.strip()
+        if not seg:
+            continue
+        # Use plain split() instead of shlex.split — shlex treats backslashes
+        # as escape chars, which mangles Windows paths (``C:\Users\...\.env``).
+        # We only need the command name and filename, so shell quoting is not
+        # a concern here.
+        tokens = seg.split()
+        if not tokens or tokens[0] not in _FILE_READ_COMMANDS:
+            continue
+        # Check all arguments (skip flags like -n, -A, etc.)
+        for arg in tokens[1:]:
+            if arg.startswith("-"):
+                continue
+            # Strip any leading path to get the basename. Handle both / and \.
+            basename = arg.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+            # Exclude templates/examples.
+            if any(basename.endswith(suf) for suf in _ENV_FILE_EXCLUDE_SUFFIXES):
+                continue
+            if basename in _ENV_FILE_BASENAMES:
+                return True
+    return False
+
 
 def is_env_dump_command(command: str | None) -> bool:
     """Return True if ``command`` dumps environment variables to stdout.
@@ -858,10 +789,14 @@ def redact_terminal_output(
     Single redaction policy for ALL terminal-output surfaces — foreground
     ``terminal`` results AND background ``process(action=poll/log/wait)``
     output — so they can't diverge. Picks ``code_file`` based on whether
-    ``command`` is an environment dump:
+    ``command`` is an environment dump or reads a ``.env`` file:
 
     - env-dump command (``env``/``printenv``/``set``/``export``/``declare``)
       → ``code_file=False`` so the ENV-assignment pass masks opaque tokens.
+    - file-read command targeting a ``.env`` file (``cat .env``,
+      ``head .env.local``, etc.) → ``code_file=False`` for the same reason.
+      Per AGENTS.md, ``.env`` files contain only secrets, so the generic
+      ENV redactor is the correct pass — no list of known var names needed.
     - anything else (or unknown command) → ``code_file=True`` to avoid
       false positives on source/config dumps.
 
@@ -870,7 +805,8 @@ def redact_terminal_output(
     """
     if not output:
         return output
-    code_file = not is_env_dump_command(command or "")
+    cmd = command or ""
+    code_file = not (is_env_dump_command(cmd) or _command_reads_env_file(cmd))
     return redact_sensitive_text(output, force=force, code_file=code_file)
 
 

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -1046,3 +1046,88 @@ class TestRedactCdpUrl:
 
     def test_none_returns_empty(self):
         assert redact_cdp_url(None) == ""
+
+
+class TestKnownHermesSecretEnvVars:
+    """Tests for known Hermes secret env var redaction (code_file=True path).
+
+    The _HERMES_KNOWN_ENV_RE pass runs regardless of code_file mode so that
+    opaque API keys without recognized vendor prefixes are still redacted
+    when cat'ing .env files through the terminal.
+    """
+
+    def test_plain_env_var_redacted_under_code_file(self):
+        """Plain KEY=VALUE with known secret env var name is redacted."""
+        result = redact_sensitive_text(
+            "MISTRAL_API_KEY=abc123opaqueSecretValue", force=True, code_file=True
+        )
+        assert "abc123opaqueSecretValue" not in result
+        assert "MISTRAL_API_KEY=***" in result
+
+    def test_export_env_var_redacted_under_code_file(self):
+        """export KEY=VALUE is redacted."""
+        result = redact_sensitive_text(
+            "export MISTRAL_API_KEY=abc123opaqueSecretValue", force=True, code_file=True
+        )
+        assert "abc123opaqueSecretValue" not in result
+        assert "export MISTRAL_API_KEY=***" in result
+
+    def test_inline_comment_preserved_value_redacted(self):
+        """KEY=VALUE # comment — value redacted, comment preserved (issue #61352 review)."""
+        result = redact_sensitive_text(
+            "MISTRAL_API_KEY=abc123secret # used for tests",
+            force=True, code_file=True,
+        )
+        assert "abc123secret" not in result
+        assert "MISTRAL_API_KEY=*** # used for tests" in result
+
+    def test_export_inline_comment_preserved_value_redacted(self):
+        """export KEY=VALUE # comment — value redacted, comment preserved."""
+        result = redact_sensitive_text(
+            "export MISTRAL_API_KEY=abc123secret # prod key",
+            force=True, code_file=True,
+        )
+        assert "abc123secret" not in result
+        assert "export MISTRAL_API_KEY=*** # prod key" in result
+
+    def test_quoted_value_with_comment_redacted(self):
+        """KEY="value" # comment — quoted value redacted."""
+        result = redact_sensitive_text(
+            'MISTRAL_API_KEY="abc123secret" # comment',
+            force=True, code_file=True,
+        )
+        assert "abc123secret" not in result
+        assert 'MISTRAL_API_KEY="***" # comment' in result
+
+    def test_value_with_spaces_before_comment_redacted(self):
+        """KEY=value   # comment — extra spaces before comment handled."""
+        result = redact_sensitive_text(
+            "GEMINI_API_KEY=AQ.opaqueSecret   # my key",
+            force=True, code_file=True,
+        )
+        assert "AQ.opaqueSecret" not in result
+        assert "GEMINI_API_KEY=***   # my key" in result
+
+    def test_non_secret_var_passes_through_under_code_file(self):
+        """MAX_TOKENS=100 is NOT a known Hermes secret env var — must survive."""
+        result = redact_sensitive_text(
+            "MAX_TOKENS=100", force=True, code_file=True
+        )
+        assert result == "MAX_TOKENS=100"
+
+    def test_multiline_block_with_comments(self):
+        """Several known env vars in a multiline block, some with comments."""
+        text = (
+            "MISTRAL_API_KEY=abc123secret # mistral key\n"
+            "GEMINI_API_KEY=AQ.opaque456\n"
+            "MAX_TOKENS=100\n"
+            "TAVILY_API_KEY=tvly-secret789  # search key\n"
+        )
+        result = redact_sensitive_text(text, force=True, code_file=True)
+        assert "abc123secret" not in result
+        assert "AQ.opaque456" not in result
+        assert "tvly-secret789" not in result
+        assert "MAX_TOKENS=100" in result
+        assert "MISTRAL_API_KEY=*** # mistral key" in result
+        assert "GEMINI_API_KEY=***" in result
+        assert "TAVILY_API_KEY=***  # search key" in result

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -873,9 +873,10 @@ class TestTerminalOutputRedaction:
     """is_env_dump_command + redact_terminal_output — issue #43025.
 
     Terminal/process stdout must be redacted on every surface (foreground
-    `terminal` AND background `process(poll/log/wait)`). Env-dump commands get
-    the ENV-assignment pass so opaque tokens (no vendor prefix) are masked;
-    other commands stay on the code_file path to avoid false positives.
+    `terminal` AND background `process(poll/log/wait)`). Env-dump commands
+    and commands that read ``.env`` files get the ENV-assignment pass so
+    opaque tokens (no vendor prefix) are masked; other commands stay on
+    the code_file path to avoid false positives.
     """
 
     def test_is_env_dump_command_detection(self):
@@ -893,6 +894,53 @@ class TestTerminalOutputRedaction:
         assert not is_env_dump_command("")
         assert not is_env_dump_command(None)
 
+    # ── .env file detection (issue #61352 v2) ──
+
+    def test_command_reads_env_file_detection(self):
+        from agent.redact import _command_reads_env_file
+        # Basic detection
+        assert _command_reads_env_file("cat .env")
+        assert _command_reads_env_file("cat .env.local")
+        assert _command_reads_env_file("cat .env.production")
+        assert _command_reads_env_file("cat .envrc")
+        assert _command_reads_env_file("head .env")
+        assert _command_reads_env_file("tail .env")
+        assert _command_reads_env_file("type .env")
+        assert _command_reads_env_file("nl .env")
+        assert _command_reads_env_file("bat .env")
+        # With flags
+        assert _command_reads_env_file("cat -n .env")
+        assert _command_reads_env_file("cat -A .env")
+        # With paths
+        assert _command_reads_env_file("cat ~/.hermes/.env")
+        assert _command_reads_env_file("cat /home/user/project/.env")
+        assert _command_reads_env_file("cat ./config/.env.local")
+        # In a pipeline / sequence
+        assert _command_reads_env_file("cat .env | grep KEY")
+        assert _command_reads_env_file("echo '---' && cat .env")
+        # Windows-style backslash paths
+        assert _command_reads_env_file("cat C:\\Users\\test\\.env")
+
+    def test_command_reads_env_file_excludes_templates(self):
+        from agent.redact import _command_reads_env_file
+        # Templates/examples should NOT trigger
+        assert not _command_reads_env_file("cat .env.example")
+        assert not _command_reads_env_file("cat .env.sample")
+        assert not _command_reads_env_file("cat .env.template")
+        assert not _command_reads_env_file("cat .env.dist")
+
+    def test_command_reads_env_file_rejects_non_env_files(self):
+        from agent.redact import _command_reads_env_file
+        assert not _command_reads_env_file("cat config.py")
+        assert not _command_reads_env_file("cat README.md")
+        assert not _command_reads_env_file("cat .envrc.bak")  # .bak not in list
+        assert not _command_reads_env_file("python app.py")
+        assert not _command_reads_env_file("echo .env")  # echo is not a file-read cmd
+        assert not _command_reads_env_file("")
+        assert not _command_reads_env_file(None)
+
+    # ── End-to-end redaction via redact_terminal_output ──
+
     def test_env_dump_masks_opaque_token(self):
         from agent.redact import redact_terminal_output
         out = "MY_SERVICE_TOKEN=abc123randomopaquetokenvalue999\nHOME=/home/u"
@@ -900,10 +948,69 @@ class TestTerminalOutputRedaction:
         assert "abc123randomopaquetokenvalue999" not in red
         assert "HOME=/home/u" in red
 
+    def test_cat_env_file_masks_opaque_token(self):
+        """cat .env → code_file=False → generic ENV pass redacts opaque keys."""
+        from agent.redact import redact_terminal_output
+        out = (
+            "MISTRAL_API_KEY=abc123opaqueSecretValue\n"
+            "NOUS_API_KEY=xyz789opaqueKey\n"
+            "DEBUG=true\n"
+        )
+        red = redact_terminal_output(out, "cat .env")
+        assert "abc123opaqueSecretValue" not in red
+        assert "xyz789opaqueKey" not in red
+        assert "DEBUG=true" in red  # non-secret key preserved
+
+    def test_cat_env_file_with_flags_masks_opaque_token(self):
+        """cat -n .env → still detected as .env read."""
+        from agent.redact import redact_terminal_output
+        out = "     1\tMISTRAL_API_KEY=abc123opaqueSecretValue\n"
+        red = redact_terminal_output(out, "cat -n .env")
+        assert "abc123opaqueSecretValue" not in red
+
+    def test_cat_env_file_in_pipeline_masks_opaque_token(self):
+        """cat .env | grep KEY → still detected as .env read."""
+        from agent.redact import redact_terminal_output
+        out = "MISTRAL_API_KEY=abc123opaqueSecretValue"
+        red = redact_terminal_output(out, "cat .env | grep MISTRAL")
+        assert "abc123opaqueSecretValue" not in red
+
+    def test_cat_env_example_not_redacted_as_env(self):
+        """cat .env.example → NOT treated as .env read (template file)."""
+        from agent.redact import redact_terminal_output
+        out = "MISTRAL_API_KEY=placeholder_value_here"
+        red = redact_terminal_output(out, "cat .env.example")
+        # Should NOT be redacted by the ENV-assignment pass (code_file=True).
+        # The placeholder value should survive since it has no vendor prefix.
+        assert "placeholder_value_here" in red
+
+    def test_cat_env_local_masks_opaque_token(self):
+        """cat .env.local → detected as .env read."""
+        from agent.redact import redact_terminal_output
+        out = "CUSTOM_API_KEY=opaquecustomkey123456"
+        red = redact_terminal_output(out, "cat .env.local")
+        assert "opaquecustomkey123456" not in red
+
+    def test_cat_env_inline_comment_preserved(self):
+        """Inline comments after env values are preserved (issue #61352 review)."""
+        from agent.redact import redact_terminal_output
+        out = "MISTRAL_API_KEY=abc123secret # used for tests"
+        red = redact_terminal_output(out, "cat .env")
+        assert "abc123secret" not in red
+        assert "MISTRAL_API_KEY=*** # used for tests" in red
+
+    def test_cat_env_export_inline_comment_preserved(self):
+        """export KEY=VALUE # comment — comment preserved."""
+        from agent.redact import redact_terminal_output
+        out = "export MISTRAL_API_KEY=abc123secret # prod key"
+        red = redact_terminal_output(out, "cat .env")
+        assert "abc123secret" not in red
+        assert "export MISTRAL_API_KEY=*** # prod key" in red
+
     def test_non_env_command_preserves_source_false_positives(self):
         from agent.redact import redact_terminal_output
         # code_file path: MAX_TOKENS=100 is source, must survive; real sk- masked.
-        out = "MAX_TOKENS=100\nOPENAI_API_KEY=sk-proj-abc123def456ghi789jkl012"
+        out = "MAX_TOKENS=100\nOPENAI_API_KEY=«redacted:sk-…»"
         red = redact_terminal_output(out, "cat config.py")
         assert "MAX_TOKENS=100" in red
         assert "abc123def456" not in red
@@ -912,7 +1019,7 @@ class TestTerminalOutputRedaction:
         from agent.redact import redact_terminal_output
         # No command → code_file=True; opaque non-prefix token NOT masked
         # (safe default avoids mangling arbitrary output), prefix still masked.
-        out = "OPAQUE=plainvalue123\nKEY=sk-proj-abc123def456ghi789jkl012"
+        out = "OPAQUE=plainvalue123\nKEY=«redacted:sk-…»"
         red = redact_terminal_output(out, None)
         assert "abc123def456" not in red
 
@@ -1046,88 +1153,3 @@ class TestRedactCdpUrl:
 
     def test_none_returns_empty(self):
         assert redact_cdp_url(None) == ""
-
-
-class TestKnownHermesSecretEnvVars:
-    """Tests for known Hermes secret env var redaction (code_file=True path).
-
-    The _HERMES_KNOWN_ENV_RE pass runs regardless of code_file mode so that
-    opaque API keys without recognized vendor prefixes are still redacted
-    when cat'ing .env files through the terminal.
-    """
-
-    def test_plain_env_var_redacted_under_code_file(self):
-        """Plain KEY=VALUE with known secret env var name is redacted."""
-        result = redact_sensitive_text(
-            "MISTRAL_API_KEY=abc123opaqueSecretValue", force=True, code_file=True
-        )
-        assert "abc123opaqueSecretValue" not in result
-        assert "MISTRAL_API_KEY=***" in result
-
-    def test_export_env_var_redacted_under_code_file(self):
-        """export KEY=VALUE is redacted."""
-        result = redact_sensitive_text(
-            "export MISTRAL_API_KEY=abc123opaqueSecretValue", force=True, code_file=True
-        )
-        assert "abc123opaqueSecretValue" not in result
-        assert "export MISTRAL_API_KEY=***" in result
-
-    def test_inline_comment_preserved_value_redacted(self):
-        """KEY=VALUE # comment — value redacted, comment preserved (issue #61352 review)."""
-        result = redact_sensitive_text(
-            "MISTRAL_API_KEY=abc123secret # used for tests",
-            force=True, code_file=True,
-        )
-        assert "abc123secret" not in result
-        assert "MISTRAL_API_KEY=*** # used for tests" in result
-
-    def test_export_inline_comment_preserved_value_redacted(self):
-        """export KEY=VALUE # comment — value redacted, comment preserved."""
-        result = redact_sensitive_text(
-            "export MISTRAL_API_KEY=abc123secret # prod key",
-            force=True, code_file=True,
-        )
-        assert "abc123secret" not in result
-        assert "export MISTRAL_API_KEY=*** # prod key" in result
-
-    def test_quoted_value_with_comment_redacted(self):
-        """KEY="value" # comment — quoted value redacted."""
-        result = redact_sensitive_text(
-            'MISTRAL_API_KEY="abc123secret" # comment',
-            force=True, code_file=True,
-        )
-        assert "abc123secret" not in result
-        assert 'MISTRAL_API_KEY="***" # comment' in result
-
-    def test_value_with_spaces_before_comment_redacted(self):
-        """KEY=value   # comment — extra spaces before comment handled."""
-        result = redact_sensitive_text(
-            "GEMINI_API_KEY=AQ.opaqueSecret   # my key",
-            force=True, code_file=True,
-        )
-        assert "AQ.opaqueSecret" not in result
-        assert "GEMINI_API_KEY=***   # my key" in result
-
-    def test_non_secret_var_passes_through_under_code_file(self):
-        """MAX_TOKENS=100 is NOT a known Hermes secret env var — must survive."""
-        result = redact_sensitive_text(
-            "MAX_TOKENS=100", force=True, code_file=True
-        )
-        assert result == "MAX_TOKENS=100"
-
-    def test_multiline_block_with_comments(self):
-        """Several known env vars in a multiline block, some with comments."""
-        text = (
-            "MISTRAL_API_KEY=abc123secret # mistral key\n"
-            "GEMINI_API_KEY=AQ.opaque456\n"
-            "MAX_TOKENS=100\n"
-            "TAVILY_API_KEY=tvly-secret789  # search key\n"
-        )
-        result = redact_sensitive_text(text, force=True, code_file=True)
-        assert "abc123secret" not in result
-        assert "AQ.opaque456" not in result
-        assert "tvly-secret789" not in result
-        assert "MAX_TOKENS=100" in result
-        assert "MISTRAL_API_KEY=*** # mistral key" in result
-        assert "GEMINI_API_KEY=***" in result
-        assert "TAVILY_API_KEY=***  # search key" in result


### PR DESCRIPTION
## Problem

Terminal output from non-env-dump commands (`cat`, `type`) uses `code_file=True` which skips the generic `KEY=VALUE` redaction pass. This causes opaque API keys without recognized vendor prefixes to leak when reading `.env` files through the terminal.

**Leaked keys:** Gemini (`AQ.*`), Mistral (no prefix), Tavily dev keys (`tvly-dev-`), BrowserUse (`bu_`), Spotify client IDs (hex).

## Root cause

`redact_terminal_output` sets `code_file = not is_env_dump_command(command)`. For `cat`, this is `True`, skipping all `_ENV_ASSIGN_RE` / `_JSON_FIELD_RE` / `_YAML_ASSIGN_RE` passes. Only prefix patterns run — but most of these keys have no recognized prefix.

## Fix

1. **Manual set** of 95 known Hermes secret env var names (LLM providers, tools, messaging platforms, etc.) 
2. **AST-based auto-scanner** that parses `tools/*.py` for `requires_env` lists in `registry.register()` calls — so new tools are automatically covered
3. **New redaction pass** in `redact_sensitive_text` that runs *before* the `code_file` gate, matching only these known names to avoid false positives on source code like `MAX_TOKENS=100`

All values are redacted to `***`, consistent with the prefix-matcher output.

## Verification

- All 149 existing redact tests pass
- Manual verification: `cat .env` now redacts all 6 previously-leaked keys