### PR TITLE
fix(tui): honor quit delete for live sessions

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import os
 import subprocess
@@ -3761,6 +3762,292 @@ def test_session_close_releases_resume_lock_before_slow_teardown(monkeypatch):
 
     assert not thread.is_alive()
     assert response["result"] == {"closed": True}
+
+
+def _session_close_delete_result(session_id: str = "live-sid") -> dict:
+    resp = server.handle_request({
+        "id": "close-delete",
+        "method": "session.close",
+        "params": {"session_id": session_id, "delete": True},
+    })
+    assert resp is not None
+    return resp["result"]
+
+
+def _close_live_session_with_delete(
+    session: dict, session_id: str = "live-sid"
+) -> dict:
+    server._sessions[session_id] = session
+    try:
+        return _session_close_delete_result(session_id)
+    finally:
+        server._sessions.pop(session_id, None)
+
+
+def test_session_close_delete_uses_durable_id_and_profile_store(monkeypatch, tmp_path):
+    calls: dict = {}
+    profile_home = tmp_path / "profile"
+
+    class _DB:
+        def get_session(self, sid):
+            calls["looked_up"] = sid
+            return {"source": "tui"}
+
+        def delete_session(self, sid, sessions_dir=None):
+            calls["deleted"] = (sid, sessions_dir)
+            return True
+
+    db = _DB()
+    profiles = []
+
+    def _profile_db(session):
+        profiles.append(session.get("profile_home"))
+        return contextlib.nullcontext(db)
+
+    monkeypatch.setattr(server, "_session_db", _profile_db)
+    monkeypatch.setattr(
+        server,
+        "_teardown_session",
+        lambda _session, *, end_reason="tui_close": calls.setdefault(
+            "end_reason", end_reason
+        ),
+    )
+    result = _close_live_session_with_delete(
+        _session(
+            agent=types.SimpleNamespace(session_id="compressed-tip"),
+            session_key="stale-parent",
+            profile_home=str(profile_home),
+        )
+    )
+
+    assert result == {
+        "closed": True,
+        "deleted": True,
+        "deleted_session_id": "compressed-tip",
+    }
+    assert calls["looked_up"] == "compressed-tip"
+    assert calls["deleted"] == ("compressed-tip", profile_home / "sessions")
+    assert profiles == [str(profile_home), str(profile_home)]
+    assert calls["end_reason"] == "tui_delete"
+    assert "live-sid" not in server._sessions
+
+
+def test_session_close_delete_refuses_gateway_owned_source(monkeypatch):
+    calls: dict = {}
+    ended = []
+
+    class _DB:
+        def get_session(self, sid):
+            return {"source": "telegram"}
+
+        def end_session(self, sid, end_reason):
+            ended.append((sid, end_reason))
+
+        def delete_session(self, *args, **kwargs):
+            raise AssertionError("gateway-owned history must not be deleted")
+
+    db = _DB()
+    monkeypatch.setattr(
+        server, "_session_db", lambda _session: contextlib.nullcontext(db)
+    )
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *args: None)
+    real_teardown = server._teardown_session
+
+    def _recording_teardown(session, *, end_reason="tui_close"):
+        calls["end_reason"] = end_reason
+        real_teardown(session, end_reason=end_reason)
+
+    monkeypatch.setattr(server, "_teardown_session", _recording_teardown)
+    session = _session(session_key="telegram-session")
+    session["agent"] = None
+    result = _close_live_session_with_delete(session)
+
+    assert result["closed"] is True
+    assert result["deleted"] is False
+    assert result["deleted_session_id"] == "telegram-session"
+    assert "gateway-owned" in result["delete_error"]
+    assert calls["end_reason"] == "tui_close"
+    assert ended == []
+
+
+def test_session_close_delete_fails_closed_when_ownership_unknown(monkeypatch):
+    calls: dict = {}
+
+    class _DB:
+        def get_session(self, sid):
+            raise RuntimeError("temporary read error")
+
+        def delete_session(self, *args, **kwargs):
+            raise AssertionError("unknown ownership must block deletion")
+
+    monkeypatch.setattr(
+        server, "_session_db", lambda _session: contextlib.nullcontext(_DB())
+    )
+    monkeypatch.setattr(
+        server,
+        "_teardown_session",
+        lambda _session, *, end_reason="tui_close": calls.setdefault(
+            "end_reason", end_reason
+        ),
+    )
+    result = _close_live_session_with_delete(_session(session_key="stored-session"))
+
+    assert result["closed"] is True
+    assert result["deleted"] is False
+    assert "cannot verify session ownership" in result["delete_error"]
+    assert calls["end_reason"] == "tui_close"
+
+
+def test_session_close_delete_fails_closed_when_profile_db_is_unavailable(
+    monkeypatch,
+):
+    calls: dict = {}
+    monkeypatch.setattr(
+        server, "_session_db", lambda _session: contextlib.nullcontext(None)
+    )
+    monkeypatch.setattr(
+        server,
+        "_teardown_session",
+        lambda _session, *, end_reason="tui_close": calls.setdefault(
+            "end_reason", end_reason
+        ),
+    )
+    result = _close_live_session_with_delete(_session(session_key="stored-session"))
+
+    assert result["closed"] is True
+    assert result["deleted"] is False
+    assert "state.db unavailable" in result["delete_error"]
+    assert calls["end_reason"] == "tui_close"
+
+
+def test_session_close_delete_never_uses_runtime_sid_as_delete_key(monkeypatch):
+    calls: dict = {}
+
+    def _unexpected_db(_session):
+        raise AssertionError("DB must not be opened without a durable session id")
+
+    monkeypatch.setattr(server, "_session_db", _unexpected_db)
+    monkeypatch.setattr(
+        server,
+        "_teardown_session",
+        lambda _session, *, end_reason="tui_close": calls.setdefault(
+            "end_reason", end_reason
+        ),
+    )
+    result = _close_live_session_with_delete(
+        _session(agent=types.SimpleNamespace(), session_key="")
+    )
+
+    assert result == {
+        "closed": True,
+        "deleted": False,
+        "delete_error": "no durable session id available for deletion",
+    }
+    assert calls["end_reason"] == "tui_close"
+
+
+@pytest.mark.parametrize(
+    ("delete_outcome", "expected_error"),
+    [
+        (False, "session not found for deletion"),
+        (RuntimeError("read-only filesystem"), "delete failed: read-only filesystem"),
+    ],
+    ids=["not-found", "exception"],
+)
+def test_session_close_delete_reports_failure_after_close(
+    monkeypatch, delete_outcome, expected_error
+):
+    calls: dict = {}
+
+    class _DB:
+        def get_session(self, sid):
+            return {"source": "tui"}
+
+        def delete_session(self, sid, sessions_dir=None):
+            if isinstance(delete_outcome, Exception):
+                raise delete_outcome
+            return delete_outcome
+
+    monkeypatch.setattr(
+        server, "_session_db", lambda _session: contextlib.nullcontext(_DB())
+    )
+    monkeypatch.setattr(
+        server,
+        "_teardown_session",
+        lambda _session, *, end_reason="tui_close": calls.setdefault(
+            "end_reason", end_reason
+        ),
+    )
+    result = _close_live_session_with_delete(_session(session_key="stored-session"))
+
+    assert result == {
+        "closed": True,
+        "deleted": False,
+        "deleted_session_id": "stored-session",
+        "delete_error": expected_error,
+    }
+    assert calls["end_reason"] == "tui_delete"
+
+
+def test_session_close_delete_missing_live_session_does_not_open_db(monkeypatch):
+    def _unexpected_db(_session):
+        raise AssertionError("DB must not be opened without a live session")
+
+    monkeypatch.setattr(server, "_session_db", _unexpected_db)
+    assert _session_close_delete_result("missing") == {
+        "closed": False,
+        "deleted": False,
+    }
+
+
+def test_session_close_delete_releases_resume_lock_before_profile_db_work(
+    monkeypatch,
+):
+    db_started = threading.Event()
+    release_db = threading.Event()
+    response: dict = {}
+
+    class _DB:
+        def get_session(self, sid):
+            return {"source": "tui"}
+
+        def delete_session(self, sid, sessions_dir=None):
+            return True
+
+    @contextlib.contextmanager
+    def _slow_session_db(_session):
+        db_started.set()
+        assert release_db.wait(timeout=2.0)
+        yield _DB()
+
+    monkeypatch.setattr(server, "_session_db", _slow_session_db)
+    monkeypatch.setattr(server, "_teardown_session", lambda *args, **kwargs: None)
+    server._sessions["slow-delete"] = _session(session_key="stored-session")
+
+    def _close():
+        response.update(_session_close_delete_result("slow-delete"))
+
+    thread = threading.Thread(target=_close)
+    thread.start()
+    acquired = False
+    try:
+        assert db_started.wait(timeout=1.0)
+        assert "slow-delete" not in server._sessions
+        acquired = server._session_resume_lock.acquire(timeout=0.2)
+        assert acquired, "delete DB work kept the global resume lock held"
+    finally:
+        if acquired:
+            server._session_resume_lock.release()
+        release_db.set()
+        thread.join(timeout=2.0)
+        server._sessions.pop("slow-delete", None)
+
+    assert not thread.is_alive()
+    assert response == {
+        "closed": True,
+        "deleted": True,
+        "deleted_session_id": "stored-session",
+    }
 
 
 def test_ws_orphan_reap_closes_worker_when_session_stays_detached(monkeypatch):

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -2753,8 +2753,11 @@ def _(rid, params: dict) -> dict:
     # keep every unrelated session.resume waiting behind it.
     with _session_resume_lock:
         session = _pop_session_by_id(sid)
-    closed = _teardown_popped_session(session, end_reason="tui_close")
-    return _ok(rid, {"closed": closed})
+    if is_truthy_value(params.get("delete", False)):
+        result = _teardown_popped_session_and_delete(session)
+    else:
+        result = {"closed": _teardown_popped_session(session, end_reason="tui_close")}
+    return _ok(rid, result)
 
 
 @method("session.branch")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -912,6 +912,88 @@ def _teardown_popped_session(
     return True
 
 
+def _teardown_popped_session_and_delete(session: dict | None) -> dict:
+    """Close a claimed live session and delete its durable local history.
+
+    The caller must pop the session before entering this helper. That atomic
+    claim makes concurrent close/reaper attempts no-ops while all DB reads,
+    plugin finalization, and file deletion remain outside the global resume
+    lock. Deletion uses the session's profile-scoped store and fails closed
+    unless durable lifecycle ownership can be verified.
+    """
+    if session is None:
+        return {"closed": False, "deleted": False}
+
+    runtime_sid = str(session.get("_sid") or "")
+    delete_id = _session_lookup_key(session, fallback="")
+    if not delete_id or delete_id == runtime_sid:
+        _teardown_popped_session(session, end_reason="tui_close")
+        return {
+            "closed": True,
+            "deleted": False,
+            "delete_error": "no durable session id available for deletion",
+        }
+
+    ownership_error = ""
+    gateway_owned = False
+    try:
+        with _session_db(session) as db:
+            if db is None:
+                ownership_error = "state.db unavailable for session profile"
+            else:
+                row = db.get_session(delete_id) or {}
+                source = str(row.get("source") or "")
+                gateway_owned = _is_gateway_owned_source(source)
+    except Exception as exc:
+        ownership_error = f"cannot verify session ownership: {exc}"
+
+    if ownership_error or gateway_owned:
+        _teardown_popped_session(session, end_reason="tui_close")
+        return {
+            "closed": True,
+            "deleted": False,
+            "deleted_session_id": delete_id,
+            "delete_error": ownership_error
+            or "session is gateway-owned; the TUI is a viewer and cannot delete it",
+        }
+
+    # Ownership is known-local. Finalize before deleting so pending messages and
+    # lifecycle hooks run while the durable row still exists.
+    _teardown_popped_session(session, end_reason="tui_delete")
+    profile_home = session.get("profile_home")
+    sessions_dir = (
+        Path(profile_home) / "sessions"
+        if profile_home
+        else get_hermes_home() / "sessions"
+    )
+    try:
+        with _session_db(session) as db:
+            if db is None:
+                return {
+                    "closed": True,
+                    "deleted": False,
+                    "deleted_session_id": delete_id,
+                    "delete_error": "state.db unavailable for session profile",
+                }
+            deleted = bool(db.delete_session(delete_id, sessions_dir=sessions_dir))
+    except Exception as exc:
+        return {
+            "closed": True,
+            "deleted": False,
+            "deleted_session_id": delete_id,
+            "delete_error": f"delete failed: {exc}",
+        }
+
+    result = {
+        "closed": True,
+        "deleted": deleted,
+        "deleted_session_id": delete_id,
+    }
+    if not deleted:
+        result["delete_error"] = "session not found for deletion"
+    return result
+
+
 def _close_session_by_id(
     sid: str,
     *,

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -115,20 +115,107 @@ describe('createSlashHandler', () => {
     expect(ctx.composer.openEditor).toHaveBeenCalledTimes(1)
   })
 
-  it('exits locally for /quit', () => {
+  it('exits locally for bare /quit without closing through the gateway', () => {
     const ctx = buildCtx()
 
     expect(createSlashHandler(ctx)('/quit')).toBe(true)
     expect(ctx.session.die).toHaveBeenCalledTimes(1)
+    expect(ctx.gateway.rpc).not.toHaveBeenCalled()
     expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
   })
 
-  it('keeps hosted dashboard chat alive for /exit', () => {
+  it('waits for session.close(delete=true) before exiting for /quit --delete', async () => {
+    patchUiState({ sid: 'sid-abc' })
+    const rpc = vi.fn(() => Promise.resolve({ deleted: true, deleted_session_id: 'stored-abc' }))
+    const ctx = buildCtx({ gateway: { ...buildGateway(), rpc } })
+
+    expect(createSlashHandler(ctx)('/quit --delete')).toBe(true)
+    expect(rpc).toHaveBeenCalledWith('session.close', { delete: true, session_id: 'sid-abc' })
+    expect(ctx.session.die).not.toHaveBeenCalled()
+
+    await vi.waitFor(() => {
+      expect(ctx.transcript.sys).toHaveBeenCalledWith('session stored-abc deleted')
+      expect(ctx.session.die).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('supports /exit -d as an alias for deleting before exit', async () => {
+    patchUiState({ sid: 'sid-abc' })
+    const rpc = vi.fn(() => Promise.resolve({ deleted: true, deleted_session_id: 'stored-abc' }))
+    const ctx = buildCtx({ gateway: { ...buildGateway(), rpc } })
+
+    expect(createSlashHandler(ctx)('/exit -d')).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(rpc).toHaveBeenCalledWith('session.close', { delete: true, session_id: 'sid-abc' })
+      expect(ctx.session.die).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('warns and exits when /quit --delete closes but cannot delete', async () => {
+    patchUiState({ sid: 'sid-abc' })
+    const rpc = vi.fn(() => Promise.resolve({ closed: true, deleted: false, delete_error: 'session not found' }))
+    const ctx = buildCtx({ gateway: { ...buildGateway(), rpc } })
+
+    expect(createSlashHandler(ctx)('/quit --delete')).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(ctx.transcript.sys).toHaveBeenCalledWith('warning: session not found')
+      expect(ctx.session.die).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('keeps the TUI open when /quit --delete cannot reach the gateway', async () => {
+    patchUiState({ sid: 'sid-abc' })
+    const rpc = vi.fn(() => Promise.reject(new Error('gateway unavailable')))
+    const ctx = buildCtx({ gateway: { ...buildGateway(), rpc } })
+
+    expect(createSlashHandler(ctx)('/quit --delete')).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(ctx.transcript.sys).toHaveBeenCalledWith('error: gateway unavailable')
+    })
+    expect(ctx.session.die).not.toHaveBeenCalled()
+  })
+
+  it('rejects unknown /quit arguments without exiting', () => {
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/quit later')).toBe(true)
+    expect(ctx.session.die).not.toHaveBeenCalled()
+    expect(ctx.gateway.rpc).not.toHaveBeenCalled()
+    expect(ctx.transcript.sys).toHaveBeenCalledWith(
+      '✗ Unknown argument: later. Use /quit --delete to also remove session history.'
+    )
+  })
+
+  it('exits with a warning when /quit --delete has no active session', () => {
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/quit --delete')).toBe(true)
+    expect(ctx.gateway.rpc).not.toHaveBeenCalled()
+    expect(ctx.transcript.sys).toHaveBeenCalledWith('warning: no active session to delete; exiting')
+    expect(ctx.session.die).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps hosted dashboard chat alive for bare /exit', () => {
     envState.dashboardTuiMode = true
     const ctx = buildCtx()
 
     expect(createSlashHandler(ctx)('/exit')).toBe(true)
     expect(ctx.session.die).not.toHaveBeenCalled()
+    expect(ctx.gateway.rpc).not.toHaveBeenCalled()
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
+    expect(ctx.transcript.sys).toHaveBeenCalledWith(DASHBOARD_EXIT_DISABLED_MESSAGE)
+  })
+
+  it('keeps hosted dashboard chat alive for /exit --delete', () => {
+    envState.dashboardTuiMode = true
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/exit --delete')).toBe(true)
+    expect(ctx.session.die).not.toHaveBeenCalled()
+    expect(ctx.gateway.rpc).not.toHaveBeenCalled()
     expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
     expect(ctx.transcript.sys).toHaveBeenCalledWith(DASHBOARD_EXIT_DISABLED_MESSAGE)
   })

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -7,6 +7,7 @@ import { isSectionName, nextDetailsMode, parseDetailsMode, SECTION_NAMES } from 
 import type {
   ConfigGetValueResponse,
   ConfigSetResponse,
+  SessionCloseResponse,
   SessionSaveResponse,
   SessionStatusResponse,
   SessionSteerResponse,
@@ -126,9 +127,9 @@ export const coreCommands: SlashCommand[] = [
 
   {
     aliases: ['exit'],
-    help: 'exit hermes',
+    help: 'exit hermes; --delete removes session history',
     name: 'quit',
-    run: (_arg, ctx) => {
+    run: (arg, ctx, cmd) => {
       // In the hosted dashboard chat there is no in-page restart path after
       // the PTY child exits, so quitting bricks the tab until a refresh. The
       // keyboard idle-exit (Ctrl+C / Ctrl+D) and SIGINT handling already refuse
@@ -142,7 +143,51 @@ export const coreCommands: SlashCommand[] = [
         return
       }
 
-      ctx.session.die()
+      const trimmed = arg.trim()
+
+      if (!trimmed) {
+        ctx.session.die()
+
+        return
+      }
+
+      const flag = trimmed.toLowerCase()
+      const usageCommand = cmd.trim().split(/\s+/, 1)[0] || '/quit'
+
+      if (flag !== '--delete' && flag !== '-d') {
+        ctx.transcript.sys(
+          `✗ Unknown argument: ${trimmed}. Use ${usageCommand} --delete to also remove session history.`
+        )
+
+        return
+      }
+
+      if (!ctx.sid) {
+        ctx.transcript.sys('warning: no active session to delete; exiting')
+        ctx.session.die()
+
+        return
+      }
+
+      void ctx.gateway
+        .rpc<SessionCloseResponse>('session.close', { delete: true, session_id: ctx.sid })
+        .then(r => {
+          if (ctx.stale()) {
+            return
+          }
+
+          if (r?.deleted) {
+            ctx.transcript.sys(r.deleted_session_id ? `session ${r.deleted_session_id} deleted` : 'session deleted')
+          } else {
+            const detail =
+              r?.delete_error || (r?.closed === false ? 'session already closed' : 'session was not deleted')
+
+            ctx.transcript.sys(`warning: ${detail}`)
+          }
+
+          ctx.session.die()
+        })
+        .catch(ctx.guardedErr)
     }
   },
 

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -307,6 +307,9 @@ export interface SessionBranchResponse {
 
 export interface SessionCloseResponse {
   closed?: boolean
+  delete_error?: string
+  deleted?: boolean
+  deleted_session_id?: string
   ok?: boolean
 }
 


### PR DESCRIPTION
## Summary

- honor `/quit --delete` and `/exit -d` in the Ink TUI instead of treating them like bare `/quit`
- extend `session.close` with an optional delete path that closes the claimed live session, resolves the durable SessionDB id, and removes persisted local history
- port the behavior to the current split gateway architecture (`methods_session.py` + shared lifecycle helpers)

## Why

The classic CLI already supports `/quit --delete` / `/exit --delete`, but the Ink TUI handles `/quit` and `/exit` as local core commands. It previously ignored all arguments, so `/quit --delete` exited without deleting the stored session.

## Behavior

- bare `/quit` and `/exit` keep their existing immediate-exit behavior
- `/quit --delete` and `/exit -d` wait for `session.close({ delete: true })` before exiting
- RPC failure leaves the TUI open instead of reporting a false success
- hosted dashboard mode continues to reject both exit and delete requests
- unknown arguments are rejected with usage guidance

## Lifecycle and safety

- prefer the agent's durable `session_id` after compression, with `session_key` as fallback; never use the runtime sid as a deletion key
- refuse deletion for gateway-owned sessions
- fail closed when ownership cannot be verified or the profile database is unavailable
- finalize a confirmed local session before deleting its durable row and transcript files
- use the live session's profile-scoped `state.db` and `sessions/` directory
- hold the global resume lock only for the atomic claim/pop; ownership lookup, plugin finalization, and file deletion run outside it

## Validation

- backend delete regressions: **9 passed**
- slash-handler tests: **85 passed**
- existing CLI exit/delete contract: **7 passed**
- gateway test file excluding one reproduced clean-main wake-event isolation failure: **539 passed, 1 deselected**
- full TUI suite excluding one reproduced clean-main palette assertion: **1548 passed, 5 skipped**
- TypeScript typecheck: passed
- ESLint: 0 errors (1 pre-existing warning in an untouched file)
- production build: passed
- Ruff, `py_compile`, Prettier, and `git diff --check`: passed

The two excluded tests were reproduced in an isolated clean-main worktree before exclusion. Later upstream commits did not touch the affected gateway/TUI paths.
