### PR TITLE
fix(computer-use): preserve minus/plus key when parsing key combos

### DIFF
--- a/tests/tools/test_cua_key_combo.py
+++ b/tests/tools/test_cua_key_combo.py
@@ -1,0 +1,32 @@
+"""Regression tests for cua_backend._parse_key_combo.
+
+A trailing '+'/'-' is the key being pressed, not a combo separator. re.split
+on '[+\\-]' would otherwise consume it, leaving key=None so key() reports
+"Could not parse key" and the keypress never happens (e.g. zoom-out 'cmd+-').
+"""
+
+from tools.computer_use.cua_backend import _parse_key_combo
+
+
+def test_minus_key_with_modifier_is_preserved():
+    # macOS/Chrome zoom-out; '-' is the key, not a separator.
+    assert _parse_key_combo("cmd+-") == ("-", ["cmd"])
+    assert _parse_key_combo("ctrl+-") == ("-", ["ctrl"])
+
+
+def test_plus_key_with_modifier_is_preserved():
+    # Zoom-in; the trailing '+' is the key.
+    assert _parse_key_combo("ctrl++") == ("+", ["ctrl"])
+
+
+def test_bare_minus_and_plus_are_preserved():
+    assert _parse_key_combo("-") == ("-", [])
+    assert _parse_key_combo("+") == ("+", [])
+
+
+def test_existing_combos_unaffected():
+    # Normal '+'-combined combos still parse.
+    assert _parse_key_combo("cmd+s") == ("s", ["cmd"])
+    assert _parse_key_combo("ctrl+alt+t") == ("t", ["ctrl", "option"])
+    # Emacs-style '-' separators still resolve to (key, modifiers).
+    assert _parse_key_combo("ctrl-c") == ("c", ["ctrl"])

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -477,7 +477,13 @@ def _parse_key_combo(keys: str) -> Tuple[Optional[str], List[str]]:
 
     parts = [p.strip().lower() for p in re.split(r'[+\-]', keys) if p.strip()]
     modifiers = []
-    key = None
+    # A trailing '+' or '-' is the key being pressed, not a combo separator
+    # (e.g. 'cmd+-'/'ctrl+-' zoom-out, 'ctrl++' zoom-in, bare '-'). re.split
+    # consumes it as a delimiter and would otherwise drop it, leaving key=None
+    # so key() reports "Could not parse key". Seed it here; a real non-modifier
+    # token in the loop still wins.
+    stripped = keys.strip()
+    key = stripped[-1] if stripped and stripped[-1] in "+-" else None
     for part in parts:
         normalized = KEY_ALIASES.get(part, part)
         if normalized in MODIFIER_NAMES:


### PR DESCRIPTION
## What does this PR do?

Fixes a dropped-key bug in the computer-use key parser (`tools/computer_use/cua_backend.py`). `_parse_key_combo` splits the combo string on `[+\-]`, treating `-` purely as a separator. When `-` (or a trailing `+`) is the **key** being pressed, `re.split` consumes it as a delimiter and it is dropped:

```
_parse_key_combo('cmd+-')  -> re.split -> ['cmd', '', ''] -> ['cmd'] -> key=None, modifiers=['cmd']
_parse_key_combo('-')      -> ['', '']  -> [] -> key=None
_parse_key_combo('ctrl++') -> ['ctrl','',''] -> ['ctrl'] -> key=None
```

`key()` then hits `if not key_name:` and returns `ActionResult(ok=False, … "Could not parse key from '…'.")` — the keypress never happens. This makes whole categories of presses **unreachable**: zoom-out `cmd+-` / `ctrl+-`, zoom-in `ctrl++`, and a bare `-`.

The fix seeds the key from a trailing `+`/`-` before scanning the parts (a real non-modifier token in the loop still wins). The literal `-`/`+` char is the correct token: it matches how single-character keys are already sent, the schema documents `+` as the combiner with single-char key examples (`'cmd+s'`), and the higher-level permission canonicalizer `_canon_key_combo` already treats `-` as a literal key rather than a separator. Existing `+`- and `-`-separated combos (`cmd+s`, `ctrl+alt+t`, emacs-style `ctrl-c`) are unaffected.

This is a focused, single-function correctness fix independent of the stale #15328 (idle since 2026-04-28), which touches this area only as part of a large integration rewrite.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/computer_use/cua_backend.py`: in `_parse_key_combo`, preserve a trailing `+`/`-` as the pressed key instead of letting `re.split` drop it.
- `tests/tools/test_cua_key_combo.py`: new regression tests for `cmd+-`, `ctrl+-`, `ctrl++`, bare `-`/`+`, plus guards that `cmd+s`, `ctrl+alt+t`, and `ctrl-c` still parse as before.

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/tools/test_cua_key_combo.py -v`
2. Fail-before / pass-after: reverting only the production hunk makes the minus/plus cases return `(None, …)` (the pre-fix "Could not parse key" path); with the fix they return `('-', ['cmd'])`, `('+', ['ctrl'])`, etc.
3. Full computer-use area is green: `pytest tests/tools/test_computer_use*.py tests/computer_use/ tests/tools/test_cua_key_combo.py -q` → 258 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A