### PR TITLE
fix(qqbot): accept gateway reconnect flag

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,7 +278,7 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -182,7 +182,7 @@ class TestVoiceAttachmentSSRFProtection:
             adapter = QQAdapter(_make_config(app_id="a", client_secret="b"))
             adapter._ensure_token = mock.AsyncMock(side_effect=RuntimeError("stop after client creation"))
 
-            connected = asyncio.run(adapter.connect())
+            connected = asyncio.run(adapter.connect(is_reconnect=True))
 
         assert connected is False
         assert async_client_cls.call_count == 1


### PR DESCRIPTION
## Summary
- Update QQBot adapter connect signature to accept the gateway reconnect flag.
- Cover the gateway contract by invoking QQBot connect with `is_reconnect=True` in the existing redirect-guard test.

## Why
`GatewayRunner._connect_adapter_with_timeout()` now forwards `is_reconnect` to all platform adapters so reconnects can preserve server-side queues. QQBot overrode `connect()` with the old no-kwarg signature, causing configured QQBot gateways to fail with `QQAdapter.connect() got an unexpected keyword argument is_reconnect` on startup/reconnect.

## Tests
- `scripts/run_tests.sh tests/gateway/test_qqbot.py -q`
- `scripts/run_tests.sh tests/gateway/test_platform_reconnect.py tests/gateway/relay/test_relay_adapter.py -q`
- `.venv/bin/python -m ruff check gateway/platforms/qqbot/adapter.py tests/gateway/test_qqbot.py`