### PR TITLE
fix(memory): preserve entry content on substring replace

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -319,12 +319,23 @@ class TestMemoryStoreAdd:
 
 
 class TestMemoryStoreReplace:
-    def test_replace_entry(self, store):
+    def test_replace_substring_within_entry(self, store):
+        """Replace only the matched substring, preserving the rest (issue #59184)."""
         store.add("memory", "Python 3.11 project")
-        result = store.replace("memory", "3.11", "Python 3.12 project")
+        result = store.replace("memory", "3.11", "3.12")
         assert result["success"] is True
         assert "Python 3.12 project" in store.memory_entries
-        assert "Python 3.11 project" not in store.memory_entries
+
+    def test_replace_preserves_surrounding_content(self, store):
+        """Composite entry: replacing one section must not discard others."""
+        composite = "## Hermes\nSome text\n## Search\nOld search\n## Git\nGit text"
+        store.add("memory", composite)
+        result = store.replace("memory", "## Search\nOld search", "## Search\nNew search")
+        assert result["success"] is True
+        full = "\n".join(store.memory_entries)
+        assert "## Search\nNew search" in full
+        assert "## Hermes\nSome text" in full
+        assert "## Git\nGit text" in full
 
     def test_replace_no_match(self, store):
         store.add("memory", "fact A")

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -431,7 +431,7 @@ class MemoryStore:
 
             # Check that replacement doesn't blow the budget
             test_entries = entries.copy()
-            test_entries[idx] = new_content
+            test_entries[idx] = test_entries[idx].replace(old_text, new_content, 1)
             new_total = len(ENTRY_DELIMITER.join(test_entries))
 
             if new_total > limit:
@@ -448,7 +448,11 @@ class MemoryStore:
                     "usage": f"{current:,}/{limit:,}",
                 })
 
-            entries[idx] = new_content
+            # Replace only the matched substring within the entry,
+            # preserving the rest of the entry content.  The previous
+            # code did `entries[idx] = new_content` which discarded
+            # everything outside the match (issue #59184).
+            entries[idx] = entries[idx].replace(old_text, new_content, 1)
             self._set_entries(target, entries)
             self.save_to_disk(target)
 


### PR DESCRIPTION
## Summary

Fixes issue #59184 — `memory replace` discards content outside the matched substring.

### Problem

When `replace` was called with `old_text` matching a substring of a composite memory entry, the entire entry was overwritten with `new_content`, discarding everything outside the match:

```
Entry: "## Hermes
Text
## Search
Old
## Git
Text"
replace(old="## Search
Old", new="## Search
New")
Result: "## Search
New"  ← Hermes and Git sections LOST
```

### Fix

Changed `entries[idx] = new_content` to `entries[idx].replace(old_text, new_content, 1)` in both the actual replacement and the budget-check paths. Now only the matched substring is replaced:

```
Result: "## Hermes
Text
## Search
New
## Git
Text"  ✓
```

### Tests

- Updated `test_replace_substring_within_entry` to verify substring replacement
- Added `test_replace_preserves_surrounding_content` for composite entries
- All 86 tests in `test_memory_tool.py` pass

Closes #59184