### PR TITLE
feat(cli): add bell_on_approval config for terminal bell on command approval prompts

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1175,6 +1175,13 @@ display:
   #   false: Silent (default)
   bell_on_complete: false
 
+  # Ring the terminal bell when a command is waiting for approval, so a user
+  # who stepped away knows the agent is blocked on a prompt (not just on task
+  # completion).
+  #   null (default): inherit bell_on_complete
+  #   true/false:     control the approval bell independently
+  bell_on_approval: null
+
   # Show model reasoning/thinking before each response.
   # When enabled, a dim box shows the model's thought process above the response.
   # Toggle at runtime with /reasoning show or /reasoning hide.

--- a/cli.py
+++ b/cli.py
@@ -3722,6 +3722,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self.resume_display = CLI_CONFIG["display"].get("resume_display", "full")
         # bell_on_complete: play terminal bell (\a) when agent finishes a response
         self.bell_on_complete = CLI_CONFIG["display"].get("bell_on_complete", False)
+        # bell_on_approval: ring the terminal bell when a command is waiting for
+        # approval. Defaults to bell_on_complete so users who enabled the bell
+        # also get alerted when the agent blocks on a prompt.
+        _bell_approval = CLI_CONFIG["display"].get("bell_on_approval", None)
+        self.bell_on_approval = (
+            self.bell_on_complete if _bell_approval is None else bool(_bell_approval)
+        )
         # show_reasoning: display model thinking/reasoning before the response
         self.show_reasoning = CLI_CONFIG["display"].get("show_reasoning", True)
         # reasoning_full: when reasoning display is on, print the post-response
@@ -11703,6 +11710,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 "response_queue": response_queue,
             }
             self._approval_deadline = _time.monotonic() + timeout
+
+            # Ring the terminal bell so a user who stepped away knows the agent
+            # is blocked waiting for approval (not just on task completion).
+            if getattr(self, "bell_on_approval", False):
+                try:
+                    sys.stdout.write("\a")
+                    sys.stdout.flush()
+                except Exception:
+                    pass
 
             # Modal prompt — paint immediately, bypassing the throttle/resize
             # guard. A throttled paint here can be silently dropped (250ms

--- a/cli.py
+++ b/cli.py
@@ -3723,11 +3723,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # bell_on_complete: play terminal bell (\a) when agent finishes a response
         self.bell_on_complete = CLI_CONFIG["display"].get("bell_on_complete", False)
         # bell_on_approval: ring the terminal bell when a command is waiting for
-        # approval. Defaults to bell_on_complete so users who enabled the bell
+        # approval. null inherits bell_on_complete so users who enabled the bell
         # also get alerted when the agent blocks on a prompt.
-        _bell_approval = CLI_CONFIG["display"].get("bell_on_approval", None)
-        self.bell_on_approval = (
-            self.bell_on_complete if _bell_approval is None else bool(_bell_approval)
+        self.bell_on_approval = self._resolve_bell_on_approval(
+            CLI_CONFIG["display"].get("bell_on_approval", None), self.bell_on_complete
         )
         # show_reasoning: display model thinking/reasoning before the response
         self.show_reasoning = CLI_CONFIG["display"].get("show_reasoning", True)
@@ -11680,6 +11679,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self._paint_now()
         _cprint(f"\n{_DIM}  ⏱ Timeout — continuing without sudo{_RST}")
         return ""
+
+    @staticmethod
+    def _resolve_bell_on_approval(configured, bell_on_complete: bool) -> bool:
+        """null inherits bell_on_complete; an explicit true/false overrides it."""
+        return bool(bell_on_complete) if configured is None else bool(configured)
 
     def _approval_callback(self, command: str, description: str,
                            *, allow_permanent: bool = True) -> str:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1770,6 +1770,9 @@ DEFAULT_CONFIG = {
         # dashboard. Set false to suppress the hint.
         "tui_agents_nudge": True,
         "bell_on_complete": False,
+        # Ring the terminal bell when a command is waiting for approval.
+        # null => inherit bell_on_complete; set true/false to control separately.
+        "bell_on_approval": None,
         # Stream the model's reasoning/thinking live before the response.
         # Default ON: on thinking models the reasoning phase can run tens of
         # seconds, and with this off the user stares at a spinner the whole

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -118,6 +118,78 @@ class TestCliApprovalUi:
         thread.join(timeout=2)
         assert result["value"] == "deny"
 
+    def test_bell_on_approval_inherits_bell_on_complete_when_null(self):
+        assert HermesCLI._resolve_bell_on_approval(None, True) is True
+        assert HermesCLI._resolve_bell_on_approval(None, False) is False
+
+    def test_bell_on_approval_explicit_overrides_inheritance(self):
+        # explicit false wins even when bell_on_complete is on
+        assert HermesCLI._resolve_bell_on_approval(False, True) is False
+        # explicit true wins even when bell_on_complete is off
+        assert HermesCLI._resolve_bell_on_approval(True, False) is True
+
+    def test_approval_rings_bell_before_paint(self):
+        cli = _make_cli_stub()
+        cli.bell_on_approval = True
+        calls = []
+
+        cli._paint_now = MagicMock(side_effect=lambda: calls.append("paint"))
+        cli._approval_choices = MagicMock(return_value=["once", "deny"])
+        cli._persist_prompt_summary = MagicMock()
+
+        fake_stdout = MagicMock()
+        fake_stdout.write.side_effect = lambda s: calls.append(("write", s))
+
+        result = {}
+
+        def _run_callback():
+            with patch.object(cli_module.sys, "stdout", fake_stdout):
+                result["value"] = cli._approval_callback("rm -rf /tmp/x", "cleanup")
+
+        thread = threading.Thread(target=_run_callback, daemon=True)
+        thread.start()
+
+        deadline = time.time() + 2
+        while cli._approval_state is None and time.time() < deadline:
+            time.sleep(0.01)
+
+        assert cli._approval_state is not None
+        cli._approval_state["response_queue"].put("deny")
+        thread.join(timeout=2)
+
+        assert ("write", "\a") in calls
+        # bell must be written before the first paint
+        assert calls.index(("write", "\a")) < calls.index("paint")
+
+    def test_approval_no_bell_when_disabled(self):
+        cli = _make_cli_stub()
+        cli.bell_on_approval = False
+        writes = []
+
+        cli._paint_now = MagicMock()
+        cli._approval_choices = MagicMock(return_value=["once", "deny"])
+        cli._persist_prompt_summary = MagicMock()
+
+        fake_stdout = MagicMock()
+        fake_stdout.write.side_effect = lambda s: writes.append(s)
+
+        def _run_callback():
+            with patch.object(cli_module.sys, "stdout", fake_stdout):
+                cli._approval_callback("rm -rf /tmp/x", "cleanup")
+
+        thread = threading.Thread(target=_run_callback, daemon=True)
+        thread.start()
+
+        deadline = time.time() + 2
+        while cli._approval_state is None and time.time() < deadline:
+            time.sleep(0.01)
+
+        assert cli._approval_state is not None
+        cli._approval_state["response_queue"].put("deny")
+        thread.join(timeout=2)
+
+        assert "\a" not in writes
+
     def test_handle_approval_selection_view_expands_in_place(self):
         cli = _make_cli_stub()
         cli._approval_state = {

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1420,6 +1420,7 @@ display:
   compact: false          # Compact output mode (less whitespace)
   resume_display: full    # full (show previous messages on resume) | minimal (one-liner only)
   bell_on_complete: false # Play terminal bell when agent finishes (great for long tasks)
+  bell_on_approval: null  # Ring the bell when blocked on an approval prompt; null inherits bell_on_complete, true/false overrides
   show_reasoning: false   # Show model reasoning/thinking above each response (toggle with /reasoning show|hide)
   streaming: false        # Stream tokens to terminal as they arrive (real-time output)
   show_cost: false        # Show estimated $ cost in the CLI status bar


### PR DESCRIPTION
## What does this PR do?

Rings the terminal bell (\a) when a dangerous command is waiting for approval, so users who step away know the agent is blocked on input (not just on task completion). Defaults to inheriting bell_on_complete for unified behavior.

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
- Add display.bell_on_approval config (defaults to null = inherit bell_on_complete)
- Ring bell in _approval_callback before painting the prompt
- Backwards compatible: existing users who enabled bell_on_complete also get approval alerts


## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- cli.py: read display.bell_on_approval in init; ring bell in _approval_callback before _paint_now()
- hermes_cli/config.py: register display.bell_on_approval in DEFAULT_CONFIG (default None)

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Enable the bell: hermes config set display.bell_on_complete true (approval bell inherits this), or set display.bell_on_approval: true independently
2. Start a new hermes session (config is read at startup)
3. Trigger a dangerous command approval prompt (e.g. rm -rf /tmp/nonexistent) — the terminal bell should ring when the approval panel appears
4. Confirm the bell also rings on task completion as before

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->
Terminal bell rings when approval panel appears:
    $ hermes config set display.bell_on_complete true
    ✓ Set display.bell_on_complete = True
    
    In session, triggering rm -rf:
    → bell rings on approval panel pop-up  ← NEW
    → bell rings on task completion← existing
