### PR TITLE
fix(agent): warn when reasoning_effort has no THINKING_BUDGET entry (fixes #61334)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2641,7 +2641,14 @@ def build_anthropic_kwargs(
     if reasoning_config and isinstance(reasoning_config, dict) and not _is_kimi_coding:
         if reasoning_config.get("enabled") is not False and "haiku" not in model.lower():
             effort = str(reasoning_config.get("effort", "medium")).lower()
-            budget = THINKING_BUDGET.get(effort, 8000)
+            if effort not in THINKING_BUDGET:
+                logger.warning(
+                    "reasoning_effort=%r has no entry in THINKING_BUDGET for "
+                    "this provider transport; falling back to 'medium' "
+                    "budget (%d tokens)",
+                    effort, THINKING_BUDGET["medium"],
+                )
+            budget = THINKING_BUDGET.get(effort, THINKING_BUDGET["medium"])
             if _supports_adaptive_thinking(model):
                 kwargs["thinking"] = {
                     "type": "adaptive",

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1710,6 +1710,37 @@ class TestBuildAnthropicKwargs:
 # ---------------------------------------------------------------------------
 
 
+    def test_unmapped_effort_warns_and_falls_back_to_medium(self, caplog):
+        """minimal/max have no THINKING_BUDGET entry on the manual
+        (non-adaptive) path; this must be visible via a warning, not
+        silently treated the same as medium."""
+        import logging
+        with caplog.at_level(logging.WARNING):
+            kwargs = build_anthropic_kwargs(
+                model="minimax-m2",
+                messages=[{"role": "user", "content": "hi"}],
+                tools=None,
+                max_tokens=4096,
+                reasoning_config={"effort": "minimal"},
+            )
+        assert kwargs["thinking"]["budget_tokens"] == 8000
+        assert any("THINKING_BUDGET" in r.message for r in caplog.records)
+
+    def test_mapped_effort_does_not_warn(self, caplog):
+        """Sanity check: a properly-mapped effort level should NOT warn."""
+        import logging
+        with caplog.at_level(logging.WARNING):
+            kwargs = build_anthropic_kwargs(
+                model="minimax-m2",
+                messages=[{"role": "user", "content": "hi"}],
+                tools=None,
+                max_tokens=4096,
+                reasoning_config={"effort": "high"},
+            )
+        assert kwargs["thinking"]["budget_tokens"] == 16000
+        assert not any("THINKING_BUDGET" in r.message for r in caplog.records)
+
+
 class TestGetAnthropicMaxOutput:
     def test_opus_4_6(self):
         from agent.anthropic_adapter import _get_anthropic_max_output


### PR DESCRIPTION
## What does this PR do?

`reasoning_effort: minimal` and `reasoning_effort: max` had no entry in `THINKING_BUDGET` on the manual (non-adaptive) thinking path used by Anthropic-Messages-compatible providers (MiniMax, Qwen3, GLM, Kimi-coding, etc). Both silently fell back to the `medium` budget (8000 tokens) — `minimal` got no cost savings, and `max` got less budget than `xhigh`, with no warning either way.

This adds a warning log via the existing module logger when `reasoning_effort` has no matching `THINKING_BUDGET` entry, before falling back to medium. This is Option 2 from the linked issue: no behavior change, just visibility. Adaptive-thinking models (Claude 4.6+) are unaffected — they use a separate `ADAPTIVE_EFFORT_MAP` path on a different code branch.

## Related Issue

Fixes #61334

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/anthropic_adapter.py`: log a warning in `build_anthropic_kwargs()` when `reasoning_effort` has no `THINKING_BUDGET` entry, and fall back to `THINKING_BUDGET["medium"]` explicitly instead of a hardcoded `8000`
- `tests/agent/test_anthropic_adapter.py`: add `test_unmapped_effort_warns_and_falls_back_to_medium` and `test_mapped_effort_does_not_warn` to `TestBuildAnthropicKwargs`

## How to Test

1. Run the added tests: `pytest tests/agent/test_anthropic_adapter.py -k "unmapped_effort or mapped_effort_does_not_warn" -v`
2. Or reproduce manually:
```python
   import logging
   logging.basicConfig(level=logging.WARNING)
   from agent.anthropic_adapter import build_anthropic_kwargs

   build_anthropic_kwargs(
       model="minimax-m2",
       messages=[{"role": "user", "content": "hi"}],
       tools=None,
       max_tokens=4096,
       reasoning_config={"effort": "minimal"},
   )
```
3. Confirm a `WARNING` is logged mentioning `THINKING_BUDGET`, and that `kwargs["thinking"]["budget_tokens"]` still resolves to 8000 (medium) as a safe fallback.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing docs affected, this is a logging-only fix)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure Python logging, no OS-dependent behavior)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool schema changes)

## Screenshots / Logs

Example warning output when `reasoning_effort: minimal` is used on a non-adaptive model:
WARNING:agent.anthropic_adapter:reasoning_effort='minimal' has no entry in THINKING_BUDGET for this provider transport; falling back to 'medium' budget (8000 tokens)
Full test suite: 174 passed, 1 skipped (pre-existing skip, unrelated to this change).