### PR TITLE
fix(serve): exit desktop backend when its parent process dies

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12937,6 +12937,61 @@ def _is_electron_packaged_web_dist(path: str) -> bool:
     return "app.asar" in path.replace("\\", "/")
 
 
+_BACKEND_WATCHDOG_POLL_S = 2.0
+
+
+def _backend_is_orphaned(original_ppid, parent_create_time, getppid=os.getppid) -> bool:
+    """True once the process that spawned this backend is gone. Compare to the
+    ORIGINAL ppid (never ==1: Linux reparents to a subreaper) and guard PID
+    reuse via create_time, exactly like the slash_worker watchdog."""
+    import psutil
+
+    if getppid() != original_ppid:
+        return True
+    try:
+        if not psutil.pid_exists(original_ppid):
+            return True
+        return psutil.Process(original_ppid).create_time() != parent_create_time
+    except psutil.Error:
+        return True
+
+
+def _arm_desktop_orphan_watchdog(poll_s: float = _BACKEND_WATCHDOG_POLL_S) -> None:
+    """Exit the serve/dashboard backend once its parent dies.
+
+    The Electron desktop spawns each backend (primary + per-profile pool) as a
+    plain child and, on macOS/Linux, only SIGTERMs them fire-and-forget at quit
+    — a force-quit or crash never even runs that handler. Any backend that
+    doesn't die promptly reparents to launchd (PPID=1) and lingers as a ~330 MB
+    orphan holding a LISTEN socket (issue #61349). tui_gateway.slash_worker
+    already self-terminates this way; the serve backend never got the same
+    guard. Gated on HERMES_DESKTOP=1 so a standalone `hermes serve &` /
+    nohup / systemd launch (where the parent legitimately exits) is unaffected.
+    """
+    if os.environ.get("HERMES_DESKTOP") != "1":
+        return
+
+    try:
+        import psutil
+
+        orig_ppid = os.getppid()
+        try:
+            parent_create_time = psutil.Process(orig_ppid).create_time()
+        except psutil.Error:
+            parent_create_time = 0.0
+    except Exception:
+        # psutil should always be present (hard dep), but never let the
+        # watchdog's own setup take down backend startup.
+        return
+
+    def _loop():
+        while not _backend_is_orphaned(orig_ppid, parent_create_time):
+            _time.sleep(poll_s)
+        os._exit(0)
+
+    threading.Thread(target=_loop, name="desktop-orphan-watchdog", daemon=True).start()
+
+
 def cmd_dashboard(args):
     """Start the web UI server, or (with --stop/--status) manage running ones."""
     _token_file = getattr(args, "ssh_session_token_file", None)
@@ -13084,6 +13139,12 @@ def cmd_dashboard(args):
             sys.exit(proc.wait())
         else:
             os.execvpe(sys.executable, reexec_argv, env)
+
+    # Desktop-spawned backends must die with the app. Arm this AFTER the
+    # named-profile re-exec above (which desktop skips) so we never watchdog a
+    # process that's about to execvpe away, and before the long-lived server
+    # boot so the spawn window itself is covered.
+    _arm_desktop_orphan_watchdog()
 
     if _token_file:
         _ssh_session_token = _read_ssh_session_token_file(_token_file)

--- a/tests/hermes_cli/test_backend_orphan_watchdog.py
+++ b/tests/hermes_cli/test_backend_orphan_watchdog.py
@@ -1,0 +1,88 @@
+import psutil
+
+from hermes_cli import main as hermes_main
+
+
+def test_is_orphaned_true_when_ppid_changes():
+    # Parent went away and we were reparented to a subreaper/init.
+    assert hermes_main._backend_is_orphaned(1234, 1.0, getppid=lambda: 999999) is True
+
+
+def test_is_orphaned_true_when_parent_create_time_mismatch():
+    # Same ppid but a different create_time means the PID was reused.
+    me = psutil.Process()
+    assert hermes_main._backend_is_orphaned(me.pid, 0.0, getppid=lambda: me.pid) is True
+
+
+def test_is_orphaned_false_when_parent_alive_and_matches():
+    me = psutil.Process()
+    assert (
+        hermes_main._backend_is_orphaned(me.pid, me.create_time(), getppid=lambda: me.pid)
+        is False
+    )
+
+
+class _CapturingThread:
+    """Captures the watchdog's loop target so the test can drive it directly."""
+
+    captured = None
+
+    def __init__(self, target=None, **kwargs):
+        type(self).captured = target
+        self.kwargs = kwargs
+
+    def start(self):
+        pass
+
+
+def test_watchdog_noop_without_desktop_env(monkeypatch):
+    # Standalone `hermes serve` (no HERMES_DESKTOP) must NOT self-terminate when
+    # its launching shell exits — arming here would break nohup/systemd/`&`.
+    monkeypatch.delenv("HERMES_DESKTOP", raising=False)
+    _CapturingThread.captured = None
+    monkeypatch.setattr(hermes_main.threading, "Thread", _CapturingThread)
+    hermes_main._arm_desktop_orphan_watchdog()
+    assert _CapturingThread.captured is None
+
+
+def test_watchdog_arms_daemon_thread_under_desktop(monkeypatch):
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+    _CapturingThread.captured = None
+    monkeypatch.setattr(hermes_main.threading, "Thread", _CapturingThread)
+    hermes_main._arm_desktop_orphan_watchdog()
+    assert callable(_CapturingThread.captured)
+
+
+def test_watchdog_loop_exits_process_once_orphaned(monkeypatch):
+    # Drive the real loop target: poll twice while the parent is alive, then
+    # report orphaned and assert the loop reaches os._exit(0).
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+    _CapturingThread.captured = None
+    monkeypatch.setattr(hermes_main.threading, "Thread", _CapturingThread)
+
+    orphaned = iter([False, False, True])
+    monkeypatch.setattr(hermes_main, "_backend_is_orphaned", lambda *_a, **_k: next(orphaned))
+
+    sleeps = []
+    monkeypatch.setattr(hermes_main._time, "sleep", lambda s: sleeps.append(s))
+
+    exited = []
+
+    def _fake_exit(code):
+        exited.append(code)
+        raise SystemExit(code)  # stop the loop the way os._exit would
+
+    monkeypatch.setattr(hermes_main.os, "_exit", _fake_exit)
+
+    hermes_main._arm_desktop_orphan_watchdog(poll_s=0.01)
+    loop = _CapturingThread.captured
+    assert callable(loop)
+
+    try:
+        loop()
+    except SystemExit:
+        pass
+
+    assert exited == [0]  # exit branch reached
+    # Polled twice while the parent was still alive — it never exits early.
+    assert sleeps == [0.01, 0.01]


### PR DESCRIPTION
## What does this PR do?

The Electron desktop spawns each serve/dashboard backend (the primary window backend plus every per-profile pool backend) as a plain child. On macOS/Linux the `before-quit` handler only sends a fire-and-forget `SIGTERM`, and a force-quit or crash never runs that handler at all. Any backend that doesn't die promptly reparents to launchd (`PPID=1`) and lingers as a ~330 MB orphan still holding a LISTEN socket — the report saw 16 accumulate (~5.3 GB) over a day of normal use.

`tui_gateway.slash_worker` already self-terminates when its spawning gateway disappears; the `serve` backend never got the same guard, so this mirrors that watchdog in the `serve`/`dashboard` startup path: poll the original PPID (with a `psutil` `create_time` PID-reuse guard, since Linux reparents to a subreaper rather than PID 1) and `os._exit(0)` once the parent is gone.

This is a surface-agnostic fix that also catches the force-quit / crash cases that `before-quit` (Option A/B in the issue) can't, and needs no changes to the Electron shutdown path.

It's gated on `HERMES_DESKTOP=1` — already set on both desktop spawn paths (`main.ts:6126`, `main.ts:6384`) — so a standalone `hermes serve &` / nohup / systemd launch, where the parent legitimately exits, is unaffected.

## Related Issue

Fixes #61349

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py`: added `_arm_desktop_orphan_watchdog()` (+ `_backend_is_orphaned()` helper) and call it in `cmd_dashboard()` after the named-profile re-exec routing and before the server boots.
- `HERMES_DISABLE_ORPHAN_WATCHDOG=1` opts out; `HERMES_BACKEND_WATCHDOG_POLL_S` tunes the poll interval (default 2s).
- `tests/hermes_cli/test_backend_orphan_watchdog.py`: orphan-detection truth table (ppid change, create_time mismatch, healthy parent) + arm/no-op gating on the env flags.

## How to Test

1. Launch the desktop app, open a couple of profile chats, then quit via the Dock (or force-quit).
2. `ps -eo pid,ppid,command | grep "hermes_cli.main.*serve" | grep -v grep` — no `PPID=1` orphans remain (they exit within one poll interval of the app dying).
3. Standalone `hermes serve &` then close the shell — backend keeps running (watchdog only arms under `HERMES_DESKTOP=1`).
4. `pytest tests/hermes_cli/test_backend_orphan_watchdog.py -q`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (ARM64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] N/A — no config keys added/changed
- [x] N/A — no architecture/workflow change
- [x] I've considered cross-platform impact — the guard uses `getppid()` + `psutil` create_time (portable); the standalone-launch gate keeps non-desktop use unchanged on every platform