### PR TITLE
fix(auth): degrade on exhausted Nous tool gateway OAuth

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -774,6 +774,7 @@ def _normalize_lmstudio_runtime_base_url(base_url: str) -> str:
 # Such failures are transient and re-authenticating cannot resolve them, so
 # they must be kept distinct from missing/expired-credential errors.
 CODEX_RATE_LIMITED_CODE = "codex_rate_limited"
+NOUS_OAUTH_EXHAUSTED_CODE = "nous_oauth_exhausted"
 
 
 class AuthError(RuntimeError):
@@ -804,7 +805,7 @@ def is_rate_limited_auth_error(error: Exception) -> bool:
     return (
         isinstance(error, AuthError)
         and not error.relogin_required
-        and error.code == CODEX_RATE_LIMITED_CODE
+        and error.code in {CODEX_RATE_LIMITED_CODE, NOUS_OAUTH_EXHAUSTED_CODE}
     )
 
 
@@ -5473,6 +5474,156 @@ def _quarantine_nous_pool_entries(
     return removed
 
 
+def _pool_timestamp_seconds(value: Any) -> Optional[float]:
+    if value is None or value == "":
+        return None
+    if isinstance(value, (int, float)):
+        numeric = float(value)
+        if numeric <= 0:
+            return None
+        return numeric / 1000.0 if numeric > 1_000_000_000_000 else numeric
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return None
+        try:
+            numeric = float(raw)
+        except ValueError:
+            numeric = None
+        if numeric is not None:
+            return numeric / 1000.0 if numeric > 1_000_000_000_000 else numeric
+        try:
+            return datetime.fromisoformat(raw.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            return None
+    return None
+
+
+def _pool_exhausted_ttl_seconds(error_code: Any) -> int:
+    try:
+        code = int(error_code)
+    except (TypeError, ValueError):
+        code = None
+    if code == 401:
+        return 5 * 60
+    return 60 * 60
+
+
+def _nous_pool_entry_exhausted_until(entry: Dict[str, Any]) -> Optional[float]:
+    reset_at = _pool_timestamp_seconds(entry.get("last_error_reset_at"))
+    if reset_at is not None:
+        return reset_at
+    status_at = _pool_timestamp_seconds(entry.get("last_status_at"))
+    if status_at is None:
+        return None
+    return status_at + _pool_exhausted_ttl_seconds(entry.get("last_error_code"))
+
+
+def _is_nous_device_code_pool_source(source: Any) -> bool:
+    """Match only the pool row mirrored from ``providers.nous``.
+
+    Manual device-code rows are independent accounts and cannot gate refresh
+    of the singleton provider state used by the managed Tool Gateway.
+    """
+    normalized = str(source or "").strip().lower()
+    return normalized == NOUS_DEVICE_CODE_SOURCE
+
+
+def _nous_provider_access_needs_refresh(state: Optional[Dict[str, Any]]) -> bool:
+    if not isinstance(state, dict) or not state:
+        return True
+    access_token = state.get("access_token")
+    if not isinstance(access_token, str) or not access_token.strip():
+        return True
+    return _is_expiring(state.get("expires_at"), ACCESS_TOKEN_REFRESH_SKEW_SECONDS)
+
+
+def _nous_oauth_exhaustion_cooldown_from_store(
+    auth_store: Dict[str, Any],
+    *,
+    state: Optional[Dict[str, Any]] = None,
+    now: Optional[float] = None,
+) -> Optional[Dict[str, Any]]:
+    """Return active Nous device-code cooldown details when refresh would retry."""
+    provider_state = state if state is not None else _load_provider_state(auth_store, "nous")
+    if not _nous_provider_access_needs_refresh(provider_state):
+        return None
+
+    pool = auth_store.get("credential_pool")
+    if not isinstance(pool, dict):
+        return None
+    entries = pool.get("nous")
+    if not isinstance(entries, list):
+        return None
+
+    current_time = time.time() if now is None else now
+    active: list[tuple[float, Dict[str, Any]]] = []
+    for raw_entry in entries:
+        if not isinstance(raw_entry, dict):
+            continue
+        if not _is_nous_device_code_pool_source(raw_entry.get("source")):
+            continue
+        if raw_entry.get("last_status") != "exhausted":
+            continue
+        exhausted_until = _nous_pool_entry_exhausted_until(raw_entry)
+        if exhausted_until is None or exhausted_until <= current_time:
+            continue
+        active.append((exhausted_until, raw_entry))
+
+    if not active:
+        return None
+
+    retry_at, entry = min(active, key=lambda item: item[0])
+    remaining = max(1, int(retry_at - current_time + 0.999))
+    return {
+        "provider": "nous",
+        "code": NOUS_OAUTH_EXHAUSTED_CODE,
+        "retry_at": retry_at,
+        "remaining_seconds": remaining,
+        "label": entry.get("label") or entry.get("id") or "device_code",
+        "source": entry.get("source"),
+        "status_code": entry.get("last_error_code"),
+        "reason": entry.get("last_error_reason"),
+        "message": entry.get("last_error_message"),
+    }
+
+
+def get_nous_oauth_exhaustion_cooldown() -> Optional[Dict[str, Any]]:
+    """Return active Nous Portal device-code cooldown details without network IO."""
+    try:
+        with _auth_store_lock():
+            auth_store = _load_auth_store()
+            return _nous_oauth_exhaustion_cooldown_from_store(auth_store)
+    except Exception:
+        return None
+
+
+def _format_duration_short(seconds: Any) -> str:
+    try:
+        remaining = max(0, int(seconds))
+    except (TypeError, ValueError):
+        return "the cooldown"
+    minutes, secs = divmod(remaining, 60)
+    hours, minutes = divmod(minutes, 60)
+    if hours:
+        return f"{hours}h {minutes}m"
+    if minutes:
+        return f"{minutes}m {secs}s"
+    return f"{secs}s"
+
+
+def format_nous_oauth_exhaustion_message(
+    cooldown: Optional[Dict[str, Any]] = None,
+) -> str:
+    """User-visible message for a Nous OAuth cooldown snapshot."""
+    details = cooldown or get_nous_oauth_exhaustion_cooldown() or {}
+    retry = _format_duration_short(details.get("remaining_seconds"))
+    return (
+        f"Nous Portal OAuth exhausted (retry in ~{retry}). "
+        "Tool gateway unavailable until token refreshes."
+    )
+
+
 def _try_import_shared_nous_state(
     *,
     timeout_seconds: float = 15.0,
@@ -5723,7 +5874,17 @@ def resolve_nous_access_token(
             merged_shared = _merge_shared_nous_oauth_state(state)
             access_token = state.get("access_token")
             refresh_token = state.get("refresh_token")
+            cooldown = _nous_oauth_exhaustion_cooldown_from_store(
+                auth_store,
+                state=state,
+            )
             if not isinstance(access_token, str) or not access_token:
+                if cooldown is not None:
+                    raise AuthError(
+                        format_nous_oauth_exhaustion_message(cooldown),
+                        provider="nous",
+                        code=NOUS_OAUTH_EXHAUSTED_CODE,
+                    )
                 raise AuthError(
                     "No access token found for Nous Portal login.",
                     provider="nous",
@@ -5734,6 +5895,13 @@ def resolve_nous_access_token(
                 if merged_shared:
                     _save_provider_state_to_source(auth_store, "nous", state, state_source_path)
                 return access_token
+
+            if cooldown is not None:
+                raise AuthError(
+                    format_nous_oauth_exhaustion_message(cooldown),
+                    provider="nous",
+                    code=NOUS_OAUTH_EXHAUSTED_CODE,
+                )
 
             if not isinstance(refresh_token, str) or not refresh_token:
                 raise AuthError(

--- a/hermes_cli/nous_account.py
+++ b/hermes_cli/nous_account.py
@@ -538,7 +538,12 @@ def _select_nous_pool_entry() -> Optional[Any]:
     pool = load_pool("nous")
     if not pool or not pool.has_credentials():
         return None
-    entries = list(pool.entries())
+    peek = getattr(pool, "peek", None)
+    if callable(peek):
+        entry = peek()
+        entries = [entry] if entry is not None else []
+    else:
+        entries = list(pool.entries())
     if not entries:
         return None
 

--- a/tests/hermes_cli/test_auth_nous_provider.py
+++ b/tests/hermes_cli/test_auth_nous_provider.py
@@ -455,6 +455,106 @@ def test_get_nous_auth_status_empty_returns_not_logged_in(tmp_path, monkeypatch)
 
 
 
+def test_resolve_nous_access_token_respects_device_code_exhaustion_cooldown(
+    tmp_path,
+    monkeypatch,
+):
+    from agent.credential_pool import load_pool
+    from hermes_cli import auth as auth_mod
+
+    hermes_home = tmp_path / "hermes"
+    _setup_nous_auth(
+        hermes_home,
+        access_token="access-old",
+        refresh_token="refresh-old",
+        expires_at="2020-01-01T00:00:00+00:00",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    pool = load_pool("nous")
+    assert pool.entries(), "expected providers.nous to seed credential_pool.nous"
+
+    payload = json.loads((hermes_home / "auth.json").read_text())
+    pool_entry = payload["credential_pool"]["nous"][0]
+    pool_entry.update({
+        "last_status": "exhausted",
+        "last_status_at": time.time(),
+        "last_error_code": 429,
+        "last_error_reason": "rate_limit",
+    })
+    (hermes_home / "auth.json").write_text(json.dumps(payload))
+
+    refresh_calls: list[str] = []
+
+    def _unexpected_refresh(*, client, portal_base_url, client_id, refresh_token):
+        refresh_calls.append(refresh_token)
+        raise AssertionError("refresh should not run during cooldown")
+
+    monkeypatch.setattr(auth_mod, "_refresh_access_token", _unexpected_refresh)
+
+    with pytest.raises(AuthError) as exc:
+        auth_mod.resolve_nous_access_token()
+
+    assert exc.value.code == auth_mod.NOUS_OAUTH_EXHAUSTED_CODE
+    assert exc.value.relogin_required is False
+    assert "Nous Portal OAuth exhausted" in str(exc.value)
+    assert refresh_calls == []
+
+
+@pytest.mark.parametrize(
+    "manual_source",
+    ["manual:device_code", "manual:dashboard_device_code"],
+)
+def test_unrelated_manual_exhaustion_does_not_block_singleton_refresh(
+    tmp_path,
+    monkeypatch,
+    manual_source,
+):
+    from agent.credential_pool import load_pool
+    from hermes_cli import auth as auth_mod
+
+    hermes_home = tmp_path / "hermes"
+    _setup_nous_auth(
+        hermes_home,
+        access_token="access-old",
+        refresh_token="refresh-singleton",
+        expires_at="2020-01-01T00:00:00+00:00",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    load_pool("nous")
+
+    payload = json.loads((hermes_home / "auth.json").read_text())
+    payload["credential_pool"]["nous"].append({
+        "id": "independent-manual-account",
+        "source": manual_source,
+        "auth_type": "oauth",
+        "access_token": "manual-access",
+        "refresh_token": "manual-refresh",
+        "last_status": "exhausted",
+        "last_status_at": time.time(),
+        "last_error_code": 429,
+    })
+    (hermes_home / "auth.json").write_text(json.dumps(payload))
+
+    refreshed_access = _invoke_jwt(seconds=3600)
+    refresh_calls = []
+
+    def _refresh(*, client, portal_base_url, client_id, refresh_token):
+        refresh_calls.append(refresh_token)
+        return {
+            "access_token": refreshed_access,
+            "refresh_token": "refresh-rotated",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+            "scope": "inference:invoke",
+        }
+
+    monkeypatch.setattr(auth_mod, "_refresh_access_token", _refresh)
+
+    assert auth_mod.resolve_nous_access_token() == refreshed_access
+    assert refresh_calls == ["refresh-singleton"]
+
+
 # =============================================================================
 # _login_nous: "Skip (keep current)" must preserve prior provider + model
 # =============================================================================

--- a/tests/tools/test_tool_backend_helpers.py
+++ b/tests/tools/test_tool_backend_helpers.py
@@ -11,6 +11,9 @@ Tests cover:
 
 from __future__ import annotations
 
+import json
+import logging
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -55,6 +58,56 @@ class TestManagedNousToolsEnabled:
             _raise_import,
         )
         assert managed_nous_tools_enabled() is False
+
+    def test_exhausted_nous_device_code_degrades_without_account_lookup(
+        self,
+        tmp_path,
+        monkeypatch,
+        caplog,
+    ):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        (hermes_home / "auth.json").write_text(json.dumps({
+            "version": 1,
+            "providers": {
+                "nous": {
+                    "access_token": "expired-token",
+                    "expires_at": "2020-01-01T00:00:00+00:00",
+                    "refresh_token": "refresh-token",
+                },
+            },
+            "credential_pool": {
+                "nous": [
+                    {
+                        "id": "dev001",
+                        "label": "device-code",
+                        "auth_type": "oauth",
+                        "source": "device_code",
+                        "access_token": "expired-token",
+                        "refresh_token": "refresh-token",
+                        "last_status": "exhausted",
+                        "last_status_at": time.time(),
+                        "last_error_code": 429,
+                        "last_error_reason": "rate_limit",
+                    }
+                ]
+            },
+        }))
+
+        def _unexpected_account_lookup(*_args, **_kwargs):
+            raise AssertionError("account lookup should not run during cooldown")
+
+        monkeypatch.setattr(
+            "hermes_cli.nous_account.get_nous_portal_account_info",
+            _unexpected_account_lookup,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="tools.tool_backend_helpers"):
+            assert managed_nous_tools_enabled() is False
+
+        assert "Nous Portal OAuth exhausted" in caplog.text
+        assert "Tool gateway unavailable" in caplog.text
 
 
 class TestNousToolGatewayUnavailableMessage:

--- a/tools/tool_backend_helpers.py
+++ b/tools/tool_backend_helpers.py
@@ -31,6 +31,16 @@ def managed_nous_tools_enabled(*, force_fresh: bool = False) -> bool:
     reflect a just-purchased subscription, credits, or pool grant immediately.
     """
     try:
+        from hermes_cli.auth import (
+            format_nous_oauth_exhaustion_message,
+            get_nous_oauth_exhaustion_cooldown,
+        )
+
+        cooldown = get_nous_oauth_exhaustion_cooldown()
+        if cooldown is not None:
+            logger.warning("%s", format_nous_oauth_exhaustion_message(cooldown))
+            return False
+
         from hermes_cli.nous_account import get_nous_portal_account_info
 
         if force_fresh:


### PR DESCRIPTION
## Summary

Fixes #61270.

When the Nous Portal device-code credential is already marked `exhausted`, gateway startup/tool availability checks should not retry the Portal refresh path and stall startup. This PR adds a network-free cooldown snapshot for Nous device-code pool entries and uses it to degrade the managed Tool Gateway quickly with a user-visible warning:

`Nous Portal OAuth exhausted (retry in ~N). Tool gateway unavailable until token refreshes.`

Changes:
- Add `get_nous_oauth_exhaustion_cooldown()` / formatter in `hermes_cli.auth` to inspect local auth state and cooldown metadata without network I/O.
- Make `resolve_nous_access_token()` raise a non-relogin, retry-later `AuthError` before attempting refresh when the cached token needs refresh and the device-code row is still cooling down.
- Make `managed_nous_tools_enabled()` log the warning and return `False`, so startup can continue without Portal tools.
- Make the Nous account snapshot path prefer the pool's availability-aware `peek()` when available, so exhausted rows are not selected for account gating.

## Duplicate / preflight notes

- Exact open PR search for `#61270` was empty before starting and before pushing.
- Distinctive phrase searches for `Nous Portal OAuth exhausted` and `tool gateway unavailable until token refreshes` were empty before PR creation.
- Broad preflight keyword warnings were manually inspected; nearby open PRs cover shared-store token recovery, homelab startup warnings, generic startup readiness, or unrelated OAuth providers, not this Portal device-code exhaustion startup degradation path.

## Validation

```text
uv run --extra dev pytest tests/tools/test_tool_backend_helpers.py tests/hermes_cli/test_auth_nous_provider.py -q
# 120 passed

uv run --extra dev pytest tests/hermes_cli/test_nous_account.py -q
# 24 passed

uv run --extra dev pytest tests/tools/test_managed_tool_gateway.py -q
# 6 passed

uv run python -m py_compile hermes_cli/auth.py hermes_cli/nous_account.py tools/tool_backend_helpers.py

git diff --check

gitleaks git --log-opts='origin/main..HEAD' --redact .
# no leaks found

gitleaks git --log-opts='origin/main..fork/agent/nous-oauth-exhausted-gateway' --redact .
# no leaks found
```
