### PR TITLE
fix: keep review-required kanban reblocks out of triage

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -132,9 +132,15 @@ VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 # spirit (default 2) but counts a different signal: manual unblock recurrences,
 # not dispatcher spawn/crash/timeout failures.
 BLOCK_RECURRENCE_LIMIT = 2
+REVIEW_REQUIRED_REASON_PREFIX = "review-required:"
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 _IS_WINDOWS = sys.platform == "win32"
+
+
+def _is_review_required_reason(reason: Optional[str]) -> bool:
+    """Return True when ``reason`` is the canonical review handoff marker."""
+    return bool(reason and reason.lstrip().lower().startswith(REVIEW_REQUIRED_REASON_PREFIX))
 
 
 def _fire_kanban_lifecycle_hook(event: str, task_id: str, **fields: Any) -> None:
@@ -4562,9 +4568,11 @@ def block_task(
       "Type 1"). Lands in ``blocked`` for a human. BUT: each time such a task
       is re-blocked for the SAME kind after having been unblocked, the
       unblock-loop counter (``block_recurrences``) increments. When it reaches
-      :data:`BLOCK_RECURRENCE_LIMIT`, the task is routed to ``triage`` instead
-      of ``blocked`` — breaking the cron-unblock ↔ worker-re-block loop and
-      forcing a human-in-the-loop triage decision.
+      :data:`BLOCK_RECURRENCE_LIMIT`, the task is usually routed to ``triage``
+      instead of ``blocked`` — breaking the cron-unblock ↔ worker-re-block loop
+      and forcing a human-in-the-loop triage decision. Canonical
+      ``review-required:`` handoffs are the carve-out: they stay ``blocked`` so
+      the review lane can service the same card.
 
     * ``transient`` — treated like a generic block for routing, but a worker
       can use it to signal "this might clear on its own"; it still participates
@@ -4649,7 +4657,7 @@ def block_task(
         same_cause = prev_kind == kind
         recurrences = prev_recurrences + 1 if same_cause else 1
 
-        if recurrences >= BLOCK_RECURRENCE_LIMIT:
+        if recurrences >= BLOCK_RECURRENCE_LIMIT and not _is_review_required_reason(reason):
             # Loop detected — stop letting the unblocker spin this task. Route
             # to triage for a human-in-the-loop decision instead of blocked.
             cur = conn.execute(

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -91,6 +91,25 @@ def test_same_cause_reblock_routes_to_triage(kanban_home: Path) -> None:
         assert t.block_recurrences == 2
 
 
+def test_same_cause_review_required_reblock_stays_blocked(kanban_home: Path) -> None:
+    """Review-required rework is a governed handoff, not a triage loop."""
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        kb.block_task(conn, tid, reason="review-required: needs human eyes", kind="needs_input")
+        kb.unblock_task(conn, tid)
+        _make_running_again(conn, tid)
+        kb.block_task(conn, tid, reason="review-required: still needs human eyes", kind="needs_input")
+        t = kb.get_task(conn, tid)
+        assert t is not None
+        assert t.status == "blocked"
+        assert t.block_recurrences == 2
+        blocked_events = [e for e in kb.list_events(conn, tid) if e.kind == "blocked"]
+        assert blocked_events, "expected a blocked event for review-required handoff"
+        payload = blocked_events[-1].payload or {}
+        assert payload.get("recurrences") == 2
+        assert not [e for e in kb.list_events(conn, tid) if e.kind == "block_loop_detected"]
+
+
 def test_untyped_block_loop_also_protected(kanban_home: Path) -> None:
     """Legacy un-typed blocks (kind=None) still trip the breaker."""
     with kb.connect_closing() as conn:

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -99,6 +99,42 @@ def test_worker_block_on_child_with_done_parents_is_still_sticky(kanban_home: Pa
         assert kb.get_task(conn, child).status == "blocked"
 
 
+def test_review_required_reblock_stays_sticky_and_out_of_triage(kanban_home: Path) -> None:
+    """A second canonical review-required handoff must still park the same
+    card in ``blocked`` so review routing can service it; triage would make it
+    an auto-decompose candidate again."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="needs review twice")
+        kb.claim_task(conn, tid)
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        kb.block_task(
+            conn, tid,
+            reason="review-required: first pass",
+            kind="needs_input",
+            expected_run_id=task.current_run_id,
+        )
+        assert kb.unblock_task(conn, tid)
+        assert kb.claim_task(conn, tid) is not None
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        kb.block_task(
+            conn, tid,
+            reason="review-required: second pass",
+            kind="needs_input",
+            expected_run_id=task.current_run_id,
+        )
+
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked"
+        assert task.block_recurrences == 2
+        assert kb.recompute_ready(conn) == 0
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked"
+
+
 # ---------------------------------------------------------------------------
 # Circuit-breaker blocks still auto-recover (preserve #40c1decb3 intent)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- keep canonical `review-required:` re-blocks in `blocked` even when `block_recurrences` reaches the generic loop limit
- preserve existing triage escalation and `block_loop_detected` emission for non-review same-cause re-blocks
- add regressions proving review-required rework stays blocked/sticky and never becomes a triage auto-decompose candidate

## Before
A second same-kind re-block always routed the task to `triage`. That incorrectly treated governed `review-required:` rework the same as a generic unblock/re-block storm, which made the auto-decomposer fan the card back out into new child swarms.

## After
When the recurring block reason carries the canonical `review-required:` marker, the task stays `blocked` with `block_recurrences=2` and emits the normal `blocked` handoff instead of `block_loop_detected`. Non-review recurrence still routes to `triage` unchanged.

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_block_kinds.py tests/hermes_cli/test_kanban_blocked_sticky.py`
- `venv/bin/python -m pytest tests/hermes_cli/test_kanban_block_kinds.py tests/hermes_cli/test_kanban_blocked_sticky.py -q`

## Upstream research artifact
- `/Users/alimai/.hermes/audits/review-required-block-loop-20260709/upstream-research.md`