### PR TITLE
feat(feishu): support group chat allowlist

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -330,6 +330,7 @@ class GatewayAuthorizationMixin:
             chat_allowlist_env = {
                 Platform.TELEGRAM: "TELEGRAM_GROUP_ALLOWED_CHATS",
                 Platform.QQBOT: "QQ_GROUP_ALLOWED_USERS",
+                Platform.FEISHU: "FEISHU_GROUP_ALLOWED_CHATS",
             }.get(source.platform, "")
             if chat_allowlist_env:
                 raw_chat_allowlist = os.getenv(chat_allowlist_env, "").strip()
@@ -388,6 +389,7 @@ class GatewayAuthorizationMixin:
         platform_group_chat_env_map = {
             Platform.TELEGRAM: "TELEGRAM_GROUP_ALLOWED_CHATS",
             Platform.QQBOT: "QQ_GROUP_ALLOWED_USERS",
+            Platform.FEISHU: "FEISHU_GROUP_ALLOWED_CHATS",
         }
         platform_allow_all_map = {
             Platform.TELEGRAM: "TELEGRAM_ALLOW_ALL_USERS",
@@ -697,6 +699,7 @@ class GatewayAuthorizationMixin:
                     "TELEGRAM_GROUP_ALLOWED_CHATS",
                 ),
                 Platform.QQBOT: ("QQ_GROUP_ALLOWED_USERS",),
+                Platform.FEISHU: ("FEISHU_GROUP_ALLOWED_CHATS",),
             }
             if os.getenv(platform_env_map.get(platform, ""), "").strip():
                 return "ignore"

--- a/plugins/platforms/feishu/plugin.yaml
+++ b/plugins/platforms/feishu/plugin.yaml
@@ -30,6 +30,10 @@ optional_env:
     description: "Comma-separated Feishu user IDs allowed to talk to the bot"
     prompt: "Allowed users (comma-separated)"
     password: false
+  - name: FEISHU_GROUP_ALLOWED_CHATS
+    description: "Comma-separated Feishu group chat IDs whose members may talk to the bot in those groups only"
+    prompt: "Allowed group chats (comma-separated chat IDs)"
+    password: false
   - name: FEISHU_ALLOW_ALL_USERS
     description: "Allow any Feishu user to trigger the bot (dev only)"
     prompt: "Allow all users? (true/false)"

--- a/tests/gateway/test_feishu_bot_auth_bypass.py
+++ b/tests/gateway/test_feishu_bot_auth_bypass.py
@@ -21,6 +21,7 @@ def _isolate_feishu_env(monkeypatch):
         "FEISHU_ALLOW_BOTS",
         "FEISHU_ALLOWED_USERS",
         "FEISHU_ALLOW_ALL_USERS",
+        "FEISHU_GROUP_ALLOWED_CHATS",
         "TELEGRAM_ALLOW_BOTS",
         "GATEWAY_ALLOW_ALL_USERS",
         "GATEWAY_ALLOWED_USERS",
@@ -97,6 +98,39 @@ def test_feishu_human_still_checked_against_allowlist_when_bot_policy_set(monkey
 
     assert runner._is_user_authorized(_make_feishu_human_source("ou_stranger")) is False
     assert runner._is_user_authorized(_make_feishu_human_source("ou_human")) is True
+
+
+def test_feishu_group_allowed_chats_authorizes_only_that_group(monkeypatch):
+    runner = _make_bare_runner()
+    monkeypatch.setenv("FEISHU_GROUP_ALLOWED_CHATS", "oc_1")
+
+    assert runner._is_user_authorized(_make_feishu_human_source("ou_anyone")) is True
+
+    other_group = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_2",
+        chat_type="group",
+        user_id="ou_anyone",
+        user_name="Human",
+        is_bot=False,
+    )
+    assert runner._is_user_authorized(other_group) is False
+
+    dm = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_dm",
+        chat_type="dm",
+        user_id="ou_anyone",
+        user_name="Human",
+    )
+    assert runner._is_user_authorized(dm) is False
+
+
+def test_feishu_group_allowed_chats_supports_wildcard(monkeypatch):
+    runner = _make_bare_runner()
+    monkeypatch.setenv("FEISHU_GROUP_ALLOWED_CHATS", "*")
+
+    assert runner._is_user_authorized(_make_feishu_human_source("ou_anyone")) is True
 
 
 def test_feishu_bot_bypass_does_not_leak_to_other_platforms(monkeypatch):

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -375,6 +375,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `FEISHU_ENCRYPT_KEY` | Optional encryption key for webhook mode |
 | `FEISHU_VERIFICATION_TOKEN` | Optional verification token for webhook mode |
 | `FEISHU_ALLOWED_USERS` | Comma-separated Feishu user IDs allowed to message the bot |
+| `FEISHU_GROUP_ALLOWED_CHATS` | Comma-separated Feishu group chat IDs whose members may use Hermes only inside those groups |
 | `FEISHU_ALLOW_BOTS` | `none` (default) / `mentions` / `all` — accept inbound messages from other bots. See [bot-to-bot messaging](../user-guide/messaging/feishu.md#bot-to-bot-messaging) |
 | `FEISHU_REQUIRE_MENTION` | `true` (default) / `false` — whether group messages must @mention the bot. Override per-chat via `group_rules.<chat_id>.require_mention`. |
 | `FEISHU_HOME_CHANNEL` | Feishu chat ID for cron delivery and notifications |

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -151,6 +151,7 @@ FEISHU_CONNECTION_MODE=websocket
 
 # Optional but strongly recommended
 FEISHU_ALLOWED_USERS=ou_xxx,ou_yyy
+FEISHU_GROUP_ALLOWED_CHATS=oc_xxx
 FEISHU_HOME_CHANNEL=oc_xxx
 ```
 
@@ -185,6 +186,13 @@ For production use, set an allowlist of Feishu Open IDs:
 
 ```bash
 FEISHU_ALLOWED_USERS=ou_xxx,ou_yyy
+```
+
+To allow everyone in a specific group chat without granting DM access or access
+from other groups, allow the group chat ID instead:
+
+```bash
+FEISHU_GROUP_ALLOWED_CHATS=oc_xxx,oc_yyy
 ```
 
 If you leave the allowlist empty, anyone who can reach the bot may be able to use it. In group chats, the allowlist is checked against the sender's open_id before the message is processed.
@@ -545,6 +553,7 @@ Inbound messages are deduplicated using message IDs with a 24-hour TTL. The dedu
 | `FEISHU_DOMAIN` | — | `feishu` | `feishu` (China) or `lark` (international) |
 | `FEISHU_CONNECTION_MODE` | — | `websocket` | `websocket` or `webhook` |
 | `FEISHU_ALLOWED_USERS` | — | _(empty)_ | Comma-separated open_id list for user allowlist |
+| `FEISHU_GROUP_ALLOWED_CHATS` | — | _(empty)_ | Comma-separated group chat IDs whose members may use Hermes only inside those groups |
 | `FEISHU_ALLOW_BOTS` | — | `none` | Accept messages from other bots: `none`, `mentions`, or `all` |
 | `FEISHU_REQUIRE_MENTION` | — | `true` | Whether group messages must @mention the bot |
 | `FEISHU_HOME_CHANNEL` | — | — | Chat ID for cron/notification output |


### PR DESCRIPTION
## Summary

Adds a Feishu/Lark group chat allowlist environment variable, `FEISHU_GROUP_ALLOWED_CHATS`, so operators can authorize all members of specific group chats without granting those users DM access or access from other groups.

## Details

- Extends gateway authorization to recognize `FEISHU_GROUP_ALLOWED_CHATS` for group chat-scoped access.
- Includes wildcard support through the existing group chat allowlist behavior.
- Adds the env var to the Feishu plugin metadata and docs.
- Adds regression coverage for matching group, non-matching group, DM, and wildcard behavior.

## Validation

- `/home/will/.hermes/hermes-agent/.venv/bin/python -m pytest tests/gateway/test_feishu_bot_auth_bypass.py -q` passed: 8 tests.
- `/home/will/.hermes/hermes-agent/.venv/bin/python -m py_compile gateway/authz_mixin.py` passed.
- `git diff --check` passed.

Note: `scripts/run_tests.sh` in the temporary worktree selected `/home/will/.hermes/hermes-agent/venv`, which does not have `pytest`; the validation above used the repo's working `.venv` interpreter explicitly while running from this branch's worktree.