### PR TITLE
fix(approval): honor permanent approval gating

### DIFF
--- a/gateway/platforms/ADDING_A_PLATFORM.md
+++ b/gateway/platforms/ADDING_A_PLATFORM.md
@@ -117,7 +117,7 @@ If your platform supports interactive button/menu messages, implement these for 
 | Method | Purpose |
 |--------|---------|
 | `send_clarify(chat_id, question, choices, clarify_id, session_key, ...)` | Render the `clarify` tool's multi-choice question as tappable buttons. Pair with inbound dispatch that routes button taps to `tools.clarify_gateway.resolve_gateway_clarify`. |
-| `send_exec_approval(chat_id, command, session_key, description, ...)` | Render dangerous-command approval as Approve/Deny buttons. Inbound dispatch routes to `tools.approval.resolve_gateway_approval`. |
+| `send_exec_approval(chat_id, command, session_key, description, allow_permanent=True, ...)` | Render dangerous-command approval as Approve/Deny buttons. Hide permanent approval when `allow_permanent` is false. Inbound dispatch routes to `tools.approval.resolve_gateway_approval`. |
 | `send_slash_confirm(chat_id, title, message, session_key, confirm_id, ...)` | Render slash-command confirmations (e.g. `/reload-mcp`) as Once/Always/Cancel buttons. Inbound dispatch routes to `tools.slash_confirm.resolve`. |
 | `send_model_picker(...)` | Interactive `/model` picker. Used by Telegram and Discord. |
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -657,6 +657,14 @@ def _openai_error(message: str, err_type: str = "invalid_request_error", param: 
     }
 
 
+def _approval_event_choices(allow_permanent: bool = True) -> List[str]:
+    choices = ["once", "session"]
+    if allow_permanent:
+        choices.append("always")
+    choices.append("deny")
+    return choices
+
+
 if AIOHTTP_AVAILABLE:
     @web.middleware
     async def body_limit_middleware(request, handler):
@@ -4308,15 +4316,13 @@ class APIServerAdapter(BasePlatformAdapter):
                         from gateway.run import _redact_approval_command
 
                         event["command"] = _redact_approval_command(event.get("command"))
-                    choices = ["once", "session"]
-                    if event.get("allow_permanent", True):
-                        choices.append("always")
-                    choices.append("deny")
                     event.update({
                         "event": "approval.request",
                         "run_id": run_id,
                         "timestamp": time.time(),
-                        "choices": choices,
+                        "choices": _approval_event_choices(
+                            bool(event.get("allow_permanent", True))
+                        ),
                     })
                     self._set_run_status(
                         run_id,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4308,11 +4308,15 @@ class APIServerAdapter(BasePlatformAdapter):
                         from gateway.run import _redact_approval_command
 
                         event["command"] = _redact_approval_command(event.get("command"))
+                    choices = ["once", "session"]
+                    if event.get("allow_permanent", True):
+                        choices.append("always")
+                    choices.append("deny")
                     event.update({
                         "event": "approval.request",
                         "run_id": run_id,
                         "timestamp": time.time(),
-                        "choices": ["once", "session", "always", "deny"],
+                        "choices": choices,
                     })
                     self._set_run_status(
                         run_id,

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -2634,8 +2634,9 @@ class QQAdapter(BasePlatformAdapter):
             chat_id: str,
             req: ApprovalRequest,
             reply_to: Optional[str] = None,
+            allow_permanent: bool = True,
     ) -> SendResult:
-        """Send a 3-button approval request (``allow-once / allow-always / deny``).
+        """Send an approval request with an optional permanent choice.
 
         The rendered text comes from :func:`build_approval_text`; callers can
         override by passing a custom :class:`ApprovalRequest`.
@@ -2648,7 +2649,9 @@ class QQAdapter(BasePlatformAdapter):
         return await self.send_with_keyboard(
             chat_id,
             build_approval_text(req),
-            build_approval_keyboard(req.session_key),
+            build_approval_keyboard(
+                req.session_key, allow_permanent=allow_permanent,
+            ),
             reply_to=reply_to,
         )
 
@@ -2668,6 +2671,7 @@ class QQAdapter(BasePlatformAdapter):
             session_key: str,
             description: str = "dangerous command",
             metadata: Optional[Dict[str, Any]] = None,
+            allow_permanent: bool = True,
     ) -> SendResult:
         """Send a button-based exec-approval prompt for a dangerous command.
 
@@ -2691,7 +2695,7 @@ class QQAdapter(BasePlatformAdapter):
             timeout_sec=self._APPROVAL_TIMEOUT_SECONDS,
         )
         return await self.send_approval_request(
-            chat_id, req, reply_to=msg_id,
+            chat_id, req, reply_to=msg_id, allow_permanent=allow_permanent,
         )
 
     _APPROVAL_TIMEOUT_SECONDS = 300  # matches gateway's default gateway_timeout

--- a/gateway/platforms/qqbot/keyboards.py
+++ b/gateway/platforms/qqbot/keyboards.py
@@ -10,7 +10,7 @@ This module provides:
 
 - :class:`InlineKeyboard` + button dataclasses — serialized into the
   ``keyboard`` field of the outbound message body.
-- :func:`build_approval_keyboard` — 3-button ✅ once / ⭐ always / ❌ deny
+- :func:`build_approval_keyboard` — ✅ once / optional ⭐ always / ❌ deny
   keyboard for tool-approval flows.
 - :func:`build_update_prompt_keyboard` — Yes/No keyboard for update confirms.
 - :func:`parse_approval_button_data` / :func:`parse_update_prompt_button_data`
@@ -201,44 +201,49 @@ def _make_callback_button(
     )
 
 
-def build_approval_keyboard(session_key: str) -> InlineKeyboard:
-    """Build the 3-button approval keyboard.
+def build_approval_keyboard(
+    session_key: str, *, allow_permanent: bool = True,
+) -> InlineKeyboard:
+    """Build an approval keyboard, optionally without permanent approval.
 
-    Layout: ``[✅ 允许一次] [⭐ 始终允许] [❌ 拒绝]`` — all three share
-    ``group_id='approval'`` so clicking one greys out the rest.
+    All rendered buttons share ``group_id='approval'`` so clicking one greys
+    out the rest.
 
     :param session_key: Embedded into ``button_data`` so the decision
         routes back to the right pending approval.
+    :param allow_permanent: Include the permanent-approval button when true.
     """
+    buttons = [
+        _make_callback_button(
+            btn_id="allow",
+            label="✅ 允许一次",
+            visited_label="已允许",
+            data=f"{APPROVAL_BUTTON_PREFIX}{session_key}:allow-once",
+            style=1,
+            group_id="approval",
+        ),
+    ]
+    if allow_permanent:
+        buttons.append(_make_callback_button(
+            btn_id="always",
+            label="⭐ 始终允许",
+            visited_label="已始终允许",
+            data=f"{APPROVAL_BUTTON_PREFIX}{session_key}:allow-always",
+            style=1,
+            group_id="approval",
+        ))
+    buttons.append(_make_callback_button(
+        btn_id="deny",
+        label="❌ 拒绝",
+        visited_label="已拒绝",
+        data=f"{APPROVAL_BUTTON_PREFIX}{session_key}:deny",
+        style=0,
+        group_id="approval",
+    ))
     return InlineKeyboard(
         content=KeyboardContent(
             rows=[
-                KeyboardRow(buttons=[
-                    _make_callback_button(
-                        btn_id="allow",
-                        label="✅ 允许一次",
-                        visited_label="已允许",
-                        data=f"{APPROVAL_BUTTON_PREFIX}{session_key}:allow-once",
-                        style=1,
-                        group_id="approval",
-                    ),
-                    _make_callback_button(
-                        btn_id="always",
-                        label="⭐ 始终允许",
-                        visited_label="已始终允许",
-                        data=f"{APPROVAL_BUTTON_PREFIX}{session_key}:allow-always",
-                        style=1,
-                        group_id="approval",
-                    ),
-                    _make_callback_button(
-                        btn_id="deny",
-                        label="❌ 拒绝",
-                        visited_label="已拒绝",
-                        data=f"{APPROVAL_BUTTON_PREFIX}{session_key}:deny",
-                        style=0,
-                        group_id="approval",
-                    ),
-                ]),
+                KeyboardRow(buttons=buttons),
             ]
         )
     )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18563,14 +18563,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # false positives from MagicMock auto-attribute creation in tests.
                 if getattr(type(_status_adapter), "send_exec_approval", None) is not None:
                     try:
+                        _send_exec_approval_kwargs = {
+                            "chat_id": _status_chat_id,
+                            "command": cmd,
+                            "session_key": _approval_session_key,
+                            "description": desc,
+                            "metadata": _status_thread_metadata,
+                        }
+                        _send_exec_approval_sig = inspect.signature(
+                            type(_status_adapter).send_exec_approval
+                        )
+                        if "allow_permanent" in _send_exec_approval_sig.parameters:
+                            _send_exec_approval_kwargs["allow_permanent"] = bool(
+                                approval_data.get("allow_permanent", True)
+                            )
                         _approval_fut = safe_schedule_threadsafe(
-                            _status_adapter.send_exec_approval(
-                                chat_id=_status_chat_id,
-                                command=cmd,
-                                session_key=_approval_session_key,
-                                description=desc,
-                                metadata=_status_thread_metadata,
-                            ),
+                            _status_adapter.send_exec_approval(**_send_exec_approval_kwargs),
                             _loop_for_step,
                             logger=logger,
                             log_message="send_exec_approval scheduling error",
@@ -18595,12 +18603,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # Slack threads and reserved by Matrix clients.
                 _p = getattr(_status_adapter, "typed_command_prefix", "/")
                 cmd_preview = cmd[:200] + "..." if len(cmd) > 200 else cmd
+                approve_options = (
+                    f"Reply `{_p}approve` to execute, `{_p}approve session` to approve this pattern "
+                    f"for the session"
+                )
+                if approval_data.get("allow_permanent", True):
+                    approve_options += f", `{_p}approve always` to approve permanently"
+                approve_options += f", or `{_p}deny` to cancel."
                 msg = (
                     f"⚠️ **Dangerous command requires approval:**\n"
                     f"```\n{cmd_preview}\n```\n"
                     f"Reason: {desc}\n\n"
-                    f"Reply `{_p}approve` to execute, `{_p}approve session` to approve this pattern "
-                    f"for the session, `{_p}approve always` to approve permanently, or `{_p}deny` to cancel."
+                    f"{approve_options}"
                 )
                 try:
                     _approval_send_fut = safe_schedule_threadsafe(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -353,6 +353,40 @@ def _redact_approval_command(cmd: "str | None") -> str:
     return redact_sensitive_text(str(cmd or ""), force=True)
 
 
+def _build_exec_approval_kwargs(
+    adapter,
+    *,
+    chat_id: str,
+    command: str,
+    session_key: str,
+    description: str,
+    metadata: Optional[Dict[str, Any]],
+    allow_permanent: bool,
+) -> Dict[str, Any]:
+    """Build adapter kwargs without breaking older approval surfaces."""
+    kwargs: Dict[str, Any] = {
+        "chat_id": chat_id,
+        "command": command,
+        "session_key": session_key,
+        "description": description,
+        "metadata": metadata,
+    }
+    method = getattr(type(adapter), "send_exec_approval", None)
+    if method is not None and "allow_permanent" in inspect.signature(method).parameters:
+        kwargs["allow_permanent"] = bool(allow_permanent)
+    return kwargs
+
+
+def _format_exec_approval_reply_options(prefix: str, allow_permanent: bool) -> str:
+    options = (
+        f"Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern "
+        "for the session"
+    )
+    if allow_permanent:
+        options += f", `{prefix}approve always` to approve permanently"
+    return options + f", or `{prefix}deny` to cancel."
+
+
 def _gateway_provider_error_reply(text: str) -> str:
     """Map raw provider/API errors to a short user-safe Telegram reply."""
     if _GATEWAY_AUTH_ERROR_RE.search(text):
@@ -18563,20 +18597,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # false positives from MagicMock auto-attribute creation in tests.
                 if getattr(type(_status_adapter), "send_exec_approval", None) is not None:
                     try:
-                        _send_exec_approval_kwargs = {
-                            "chat_id": _status_chat_id,
-                            "command": cmd,
-                            "session_key": _approval_session_key,
-                            "description": desc,
-                            "metadata": _status_thread_metadata,
-                        }
-                        _send_exec_approval_sig = inspect.signature(
-                            type(_status_adapter).send_exec_approval
+                        _send_exec_approval_kwargs = _build_exec_approval_kwargs(
+                            _status_adapter,
+                            chat_id=_status_chat_id,
+                            command=cmd,
+                            session_key=_approval_session_key,
+                            description=desc,
+                            metadata=_status_thread_metadata,
+                            allow_permanent=approval_data.get("allow_permanent", True),
                         )
-                        if "allow_permanent" in _send_exec_approval_sig.parameters:
-                            _send_exec_approval_kwargs["allow_permanent"] = bool(
-                                approval_data.get("allow_permanent", True)
-                            )
                         _approval_fut = safe_schedule_threadsafe(
                             _status_adapter.send_exec_approval(**_send_exec_approval_kwargs),
                             _loop_for_step,
@@ -18603,13 +18632,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # Slack threads and reserved by Matrix clients.
                 _p = getattr(_status_adapter, "typed_command_prefix", "/")
                 cmd_preview = cmd[:200] + "..." if len(cmd) > 200 else cmd
-                approve_options = (
-                    f"Reply `{_p}approve` to execute, `{_p}approve session` to approve this pattern "
-                    f"for the session"
+                approve_options = _format_exec_approval_reply_options(
+                    _p, bool(approval_data.get("allow_permanent", True))
                 )
-                if approval_data.get("allow_permanent", True):
-                    approve_options += f", `{_p}approve always` to approve permanently"
-                approve_options += f", or `{_p}deny` to cancel."
                 msg = (
                     f"⚠️ **Dangerous command requires approval:**\n"
                     f"```\n{cmd_preview}\n```\n"

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5571,6 +5571,7 @@ class DiscordAdapter(BasePlatformAdapter):
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
         metadata: Optional[dict] = None,
+        allow_permanent: bool = True,
     ) -> SendResult:
         """
         Send a button-based exec approval prompt for a dangerous command.
@@ -5642,6 +5643,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 allowed_role_ids=self._allowed_role_ids,
                 require_admin=require_admin,
                 admin_user_ids=admin_user_ids,
+                allow_permanent=allow_permanent,
             )
 
             send_kwargs: Dict[str, Any] = {"content": content, "embed": embed, "view": view}
@@ -6807,6 +6809,17 @@ def _resolve_exec_approval_admin_gate(
     return (True, admin_ids)
 
 
+def _remove_discord_view_item_by_label(view: Any, label: str) -> None:
+    for child in tuple(getattr(view, "children", ())):
+        if getattr(child, "label", None) != label:
+            continue
+        remover = getattr(view, "remove_item", None)
+        if callable(remover):
+            remover(child)
+        else:
+            view.children.remove(child)
+
+
 def _define_discord_view_classes() -> None:
     """Register Discord UI view classes as module globals.
 
@@ -6823,7 +6836,7 @@ def _define_discord_view_classes() -> None:
         """
         Interactive button view for exec approval of dangerous commands.
 
-        Shows four buttons: Allow Once, Allow Session, Always Allow, Deny.
+        Shows Allow Once, Allow Session, optional Always Allow, and Deny.
         Clicking a button calls ``resolve_gateway_approval()`` to unblock the
         waiting agent thread — the same mechanism as the text ``/approve`` flow.
         Only users in the allowed list can click.  Times out after 5 minutes.
@@ -6836,6 +6849,7 @@ def _define_discord_view_classes() -> None:
             allowed_role_ids: Optional[set] = None,
             require_admin: bool = False,
             admin_user_ids: Optional[set] = None,
+            allow_permanent: bool = True,
         ):
             super().__init__(timeout=_read_discord_prompt_timeout())
             self.session_key = session_key
@@ -6849,6 +6863,8 @@ def _define_discord_view_classes() -> None:
                 str(a).strip() for a in (admin_user_ids or set()) if str(a).strip()
             }
             self.resolved = False
+            if not allow_permanent:
+                _remove_discord_view_item_by_label(self, "Always Allow")
 
         def _check_auth(self, interaction: discord.Interaction) -> bool:
             """Verify the user clicking is authorized.

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1980,6 +1980,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
         metadata: Optional[Dict[str, Any]] = None,
+        allow_permanent: bool = True,
     ) -> SendResult:
         """Send an interactive card with approval buttons.
 
@@ -2002,6 +2003,14 @@ class FeishuAdapter(BasePlatformAdapter):
                     "value": {"hermes_action": action_name, "approval_id": approval_id},
                 }
 
+            actions = [
+                _btn("✅ Allow Once", "approve_once", "primary"),
+                _btn("✅ Session", "approve_session"),
+            ]
+            if allow_permanent:
+                actions.append(_btn("✅ Always", "approve_always"))
+            actions.append(_btn("❌ Deny", "deny", "danger"))
+
             card = {
                 "config": {"wide_screen_mode": True},
                 "header": {
@@ -2015,12 +2024,7 @@ class FeishuAdapter(BasePlatformAdapter):
                     },
                     {
                         "tag": "action",
-                        "actions": [
-                            _btn("✅ Allow Once", "approve_once", "primary"),
-                            _btn("✅ Session", "approve_session"),
-                            _btn("✅ Always", "approve_always"),
-                            _btn("❌ Deny", "deny", "danger"),
-                        ],
+                        "actions": actions,
                     },
                 ],
             }

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2000,6 +2000,7 @@ class MatrixAdapter(BasePlatformAdapter):
         session_key: str,
         description: str = "dangerous command",
         metadata: Optional[dict] = None,
+        allow_permanent: bool = True,
     ) -> SendResult:
         """Send a reaction-based exec approval prompt for Matrix."""
         if not self._client:
@@ -2007,12 +2008,17 @@ class MatrixAdapter(BasePlatformAdapter):
 
         requester_user_id = str((metadata or {}).get("requester_user_id") or "") or None
         cmd_preview = command[:2000] + "..." if len(command) > 2000 else command
+        reply_options = (
+            "Reply `!approve` to execute, `!approve session` to approve this pattern for the session"
+        )
+        if allow_permanent:
+            reply_options += ", `!approve always` to approve permanently"
+        reply_options += ", or `!deny` to cancel."
         text = (
             "⚠️ **Dangerous command requires approval**\n"
             f"```\n{cmd_preview}\n```\n"
             f"Reason: {description}\n\n"
-            "Reply `!approve` to execute, `!approve session` to approve this pattern for the session, "
-            "`!approve always` to approve permanently, or `!deny` to cancel.\n\n"
+            f"{reply_options}\n\n"
             "You can also click the reaction to approve:\n"
             "✅ = approve\n"
             "❎ = deny"
@@ -2035,7 +2041,11 @@ class MatrixAdapter(BasePlatformAdapter):
         self._approval_prompts_by_event[result.message_id] = prompt
         self._approval_prompt_by_session[session_key] = result.message_id
 
-        for emoji in ("✅", "♾️", "❌"):
+        approval_reactions = ["✅"]
+        if allow_permanent:
+            approval_reactions.append("♾️")
+        approval_reactions.append("❌")
+        for emoji in approval_reactions:
             try:
                 reaction_result = await self._send_reaction(chat_id, result.message_id, emoji)
                 # Save the bot's reaction event_id for later cleanup

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3244,6 +3244,7 @@ class SlackAdapter(BasePlatformAdapter):
         session_key: str,
         description: str = "dangerous command",
         metadata: Optional[Dict[str, Any]] = None,
+        allow_permanent: bool = True,
     ) -> SendResult:
         """Send a Block Kit approval prompt with interactive buttons.
 
@@ -3268,6 +3269,36 @@ class SlackAdapter(BasePlatformAdapter):
             budget = 3000 - len(header) - len(reason) - len("``````\n") - len("...")
             cmd_preview = command[:budget] + "..." if len(command) > budget else command
 
+            actions = [
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "Allow Once"},
+                    "style": "primary",
+                    "action_id": "hermes_approve_once",
+                    "value": session_key,
+                },
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "Allow Session"},
+                    "action_id": "hermes_approve_session",
+                    "value": session_key,
+                },
+            ]
+            if allow_permanent:
+                actions.append({
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "Always Allow"},
+                    "action_id": "hermes_approve_always",
+                    "value": session_key,
+                })
+            actions.append({
+                "type": "button",
+                "text": {"type": "plain_text", "text": "Deny"},
+                "style": "danger",
+                "action_id": "hermes_deny",
+                "value": session_key,
+            })
+
             blocks = [
                 {
                     "type": "section",
@@ -3278,34 +3309,7 @@ class SlackAdapter(BasePlatformAdapter):
                 },
                 {
                     "type": "actions",
-                    "elements": [
-                        {
-                            "type": "button",
-                            "text": {"type": "plain_text", "text": "Allow Once"},
-                            "style": "primary",
-                            "action_id": "hermes_approve_once",
-                            "value": session_key,
-                        },
-                        {
-                            "type": "button",
-                            "text": {"type": "plain_text", "text": "Allow Session"},
-                            "action_id": "hermes_approve_session",
-                            "value": session_key,
-                        },
-                        {
-                            "type": "button",
-                            "text": {"type": "plain_text", "text": "Always Allow"},
-                            "action_id": "hermes_approve_always",
-                            "value": session_key,
-                        },
-                        {
-                            "type": "button",
-                            "text": {"type": "plain_text", "text": "Deny"},
-                            "style": "danger",
-                            "action_id": "hermes_deny",
-                            "value": session_key,
-                        },
-                    ],
+                    "elements": actions,
                 },
             ]
 

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -1098,6 +1098,7 @@ class TeamsAdapter(BasePlatformAdapter):
         session_key: str,
         description: str = "dangerous command",
         metadata: Optional[Dict[str, Any]] = None,
+        allow_permanent: bool = True,
     ) -> SendResult:
         """Send an Adaptive Card approval prompt with Allow/Deny buttons."""
         if not self._app:
@@ -1111,6 +1112,32 @@ class TeamsAdapter(BasePlatformAdapter):
             "desc": description,
         }
 
+        actions = [
+            ExecuteAction(
+                title="Allow Once",
+                verb="hermes_approve",
+                data={**btn_data_base, "hermes_action": "approve_once"},
+                style="positive",
+            ),
+            ExecuteAction(
+                title="Allow Session",
+                verb="hermes_approve",
+                data={**btn_data_base, "hermes_action": "approve_session"},
+            ),
+        ]
+        if allow_permanent:
+            actions.append(ExecuteAction(
+                title="Always Allow",
+                verb="hermes_approve",
+                data={**btn_data_base, "hermes_action": "approve_always"},
+            ))
+        actions.append(ExecuteAction(
+            title="Deny",
+            verb="hermes_approve",
+            data={**btn_data_base, "hermes_action": "deny"},
+            style="destructive",
+        ))
+
         card = (
             AdaptiveCard()
             .with_version("1.4")
@@ -1119,30 +1146,7 @@ class TeamsAdapter(BasePlatformAdapter):
                 TextBlock(text=f"```\n{cmd_preview}\n```", wrap=True),
                 TextBlock(text=f"Reason: {description}", wrap=True, isSubtle=True),
             ])
-            .with_actions([
-                ExecuteAction(
-                    title="Allow Once",
-                    verb="hermes_approve",
-                    data={**btn_data_base, "hermes_action": "approve_once"},
-                    style="positive",
-                ),
-                ExecuteAction(
-                    title="Allow Session",
-                    verb="hermes_approve",
-                    data={**btn_data_base, "hermes_action": "approve_session"},
-                ),
-                ExecuteAction(
-                    title="Always Allow",
-                    verb="hermes_approve",
-                    data={**btn_data_base, "hermes_action": "approve_always"},
-                ),
-                ExecuteAction(
-                    title="Deny",
-                    verb="hermes_approve",
-                    data={**btn_data_base, "hermes_action": "deny"},
-                    style="destructive",
-                ),
-            ])
+            .with_actions(actions)
         )
 
         try:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4556,6 +4556,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
         metadata: Optional[Dict[str, Any]] = None,
+        allow_permanent: bool = True,
     ) -> SendResult:
         """Send an inline-keyboard approval prompt with interactive buttons.
 
@@ -4584,16 +4585,20 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._approval_counter = itertools.count(1)
             approval_id = next(self._approval_counter)
 
-            keyboard = InlineKeyboardMarkup([
-                [
-                    InlineKeyboardButton("✅ Allow Once", callback_data=f"ea:once:{approval_id}"),
-                    InlineKeyboardButton("✅ Session", callback_data=f"ea:session:{approval_id}"),
-                ],
-                [
-                    InlineKeyboardButton("✅ Always", callback_data=f"ea:always:{approval_id}"),
-                    InlineKeyboardButton("❌ Deny", callback_data=f"ea:deny:{approval_id}"),
-                ],
-            ])
+            keyboard_rows = [[
+                InlineKeyboardButton("✅ Allow Once", callback_data=f"ea:once:{approval_id}"),
+                InlineKeyboardButton("✅ Session", callback_data=f"ea:session:{approval_id}"),
+            ]]
+            final_row = []
+            if allow_permanent:
+                final_row.append(
+                    InlineKeyboardButton("✅ Always", callback_data=f"ea:always:{approval_id}")
+                )
+            final_row.append(
+                InlineKeyboardButton("❌ Deny", callback_data=f"ea:deny:{approval_id}")
+            )
+            keyboard_rows.append(final_row)
+            keyboard = InlineKeyboardMarkup(keyboard_rows)
 
             kwargs: Dict[str, Any] = {
                 "chat_id": normalize_telegram_chat_id(chat_id),

--- a/tests/gateway/test_approval_permanent_gating.py
+++ b/tests/gateway/test_approval_permanent_gating.py
@@ -1,0 +1,64 @@
+from gateway.platforms.api_server import _approval_event_choices
+from gateway.run import (
+    _build_exec_approval_kwargs,
+    _format_exec_approval_reply_options,
+)
+
+
+class _LegacyApprovalAdapter:
+    async def send_exec_approval(
+        self, chat_id, command, session_key, description="dangerous command", metadata=None,
+    ):
+        raise AssertionError("not called")
+
+
+class _PermanentAwareApprovalAdapter:
+    async def send_exec_approval(
+        self,
+        chat_id,
+        command,
+        session_key,
+        description="dangerous command",
+        metadata=None,
+        allow_permanent=True,
+    ):
+        raise AssertionError("not called")
+
+
+def _approval_kwargs(adapter, allow_permanent):
+    return _build_exec_approval_kwargs(
+        adapter,
+        chat_id="chat-1",
+        command="rm -rf /tmp/example",
+        session_key="session-1",
+        description="dangerous command",
+        metadata={"thread_id": "thread-1"},
+        allow_permanent=allow_permanent,
+    )
+
+
+def test_dispatcher_forwards_allow_permanent_to_aware_adapters():
+    kwargs = _approval_kwargs(_PermanentAwareApprovalAdapter(), False)
+
+    assert kwargs["allow_permanent"] is False
+
+
+def test_dispatcher_preserves_legacy_adapter_contract():
+    kwargs = _approval_kwargs(_LegacyApprovalAdapter(), False)
+
+    assert "allow_permanent" not in kwargs
+
+
+def test_api_choices_hide_permanent_approval_when_disallowed():
+    assert _approval_event_choices(False) == ["once", "session", "deny"]
+    assert _approval_event_choices(True) == ["once", "session", "always", "deny"]
+
+
+def test_text_fallback_hides_permanent_approval_when_disallowed():
+    restricted = _format_exec_approval_reply_options("!", False)
+    unrestricted = _format_exec_approval_reply_options("!", True)
+
+    assert "!approve always" not in restricted
+    assert "!approve always" in unrestricted
+    assert "!approve session" in restricted
+    assert "!deny" in restricted

--- a/tests/gateway/test_discord_exec_approval_content.py
+++ b/tests/gateway/test_discord_exec_approval_content.py
@@ -4,7 +4,11 @@ from unittest.mock import AsyncMock
 import pytest
 
 from gateway.config import PlatformConfig
-from plugins.platforms.discord.adapter import DiscordAdapter
+import plugins.platforms.discord.adapter as discord_adapter
+from plugins.platforms.discord.adapter import (
+    DiscordAdapter,
+    _remove_discord_view_item_by_label,
+)
 
 
 def _capture_channel(adapter):
@@ -46,6 +50,50 @@ async def test_exec_approval_prompt_uses_visible_content_with_command_and_reason
     assert command in prompt_text
     assert "Reason" in prompt_text
     assert "script execution via -c flag" in prompt_text
+
+
+@pytest.mark.asyncio
+async def test_exec_approval_hides_always_when_permanent_approval_disallowed(monkeypatch):
+    captured = {}
+
+    class _CapturedView:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(discord_adapter, "ExecApprovalView", _CapturedView)
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    sent = _capture_channel(adapter)
+
+    result = await adapter.send_exec_approval(
+        chat_id="555",
+        command="curl http://172.16.0.2/internal",
+        session_key="discord:555",
+        allow_permanent=False,
+    )
+
+    assert result.success is True
+    assert captured["allow_permanent"] is False
+
+
+def test_discord_view_removes_permanent_approval_button_by_label():
+    always = SimpleNamespace(label="Always Allow")
+    view = SimpleNamespace(
+        children=[
+            SimpleNamespace(label="Allow Once"),
+            SimpleNamespace(label="Allow Session"),
+            always,
+            SimpleNamespace(label="Deny"),
+        ]
+    )
+    view.remove_item = view.children.remove
+
+    _remove_discord_view_item_by_label(view, "Always Allow")
+
+    assert [child.label for child in view.children] == [
+        "Allow Once",
+        "Allow Session",
+        "Deny",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -129,6 +129,31 @@ class TestFeishuExecApproval:
         ]
 
     @pytest.mark.asyncio
+    async def test_hides_always_when_permanent_approval_disallowed(self):
+        adapter = _make_adapter()
+
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_001"),
+        )
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_send:
+            await adapter.send_exec_approval(
+                chat_id="oc_12345",
+                command="curl http://172.16.0.2/internal",
+                session_key="agent:main:feishu:group:oc_12345",
+                description="Security scan warning",
+                allow_permanent=False,
+            )
+
+        card = json.loads(mock_send.call_args[1]["payload"])
+        actions = card["elements"][1]["actions"]
+        action_names = [a["value"]["hermes_action"] for a in actions]
+        assert action_names == ["approve_once", "approve_session", "deny"]
+
+    @pytest.mark.asyncio
     async def test_stores_approval_state(self):
         adapter = _make_adapter()
 

--- a/tests/gateway/test_matrix_exec_approval.py
+++ b/tests/gateway/test_matrix_exec_approval.py
@@ -32,6 +32,36 @@ class TestMatrixExecApprovalReactions:
         assert emojis == ["✅", "♾️", "❌"]
 
     @pytest.mark.asyncio
+    async def test_hides_permanent_instruction_and_reaction_when_disallowed(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@liizfq:liizfq.top")
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        adapter = MatrixAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="tok",
+                extra={"homeserver": "https://matrix.example.org"},
+            )
+        )
+        adapter._client = types.SimpleNamespace()
+        adapter.send = AsyncMock(
+            return_value=types.SimpleNamespace(success=True, message_id="$evt1")
+        )
+        adapter._send_reaction = AsyncMock(return_value="$r")
+
+        await adapter.send_exec_approval(
+            chat_id="!room:example.org",
+            command="curl http://172.16.0.2/internal",
+            session_key="sess-1",
+            allow_permanent=False,
+        )
+
+        text = adapter.send.await_args.args[1]
+        assert "!approve always" not in text
+        emojis = [call.args[2] for call in adapter._send_reaction.await_args_list]
+        assert emojis == ["✅", "❌"]
+
+    @pytest.mark.asyncio
     async def test_reaction_resolves_pending_approval(self, monkeypatch):
         monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@liizfq:liizfq.top")
         from plugins.platforms.matrix.adapter import MatrixAdapter, _MatrixApprovalPrompt

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1069,6 +1069,16 @@ class TestBuildApprovalKeyboard:
         assert len(kb.content.rows) == 1
         assert len(kb.content.rows[0].buttons) == 3
 
+    def test_hides_always_when_permanent_approval_disallowed(self):
+        from gateway.platforms.qqbot.keyboards import build_approval_keyboard
+
+        kb = build_approval_keyboard("session-1", allow_permanent=False)
+        datas = [button.action.data for button in kb.content.rows[0].buttons]
+        assert datas == [
+            "approve:session-1:allow-once",
+            "approve:session-1:deny",
+        ]
+
     def test_button_data_embeds_session_key(self):
         from gateway.platforms.qqbot.keyboards import build_approval_keyboard
         kb = build_approval_keyboard("agent:main:qqbot:c2c:UID")
@@ -1780,9 +1790,16 @@ class TestSendExecApproval:
 
         calls = []
 
-        async def fake_send_approval(chat_id, req, reply_to=None):
+        async def fake_send_approval(
+            chat_id, req, reply_to=None, allow_permanent=True,
+        ):
             from gateway.platforms.base import SendResult
-            calls.append({"chat_id": chat_id, "req": req, "reply_to": reply_to})
+            calls.append({
+                "chat_id": chat_id,
+                "req": req,
+                "reply_to": reply_to,
+                "allow_permanent": allow_permanent,
+            })
             return SendResult(success=True, message_id="m-1")
 
         adapter.send_approval_request = fake_send_approval  # type: ignore[assignment]
@@ -1802,13 +1819,39 @@ class TestSendExecApproval:
         assert req.command_preview == "rm -rf /tmp/demo"
         assert req.description == "delete temp dir"
         assert calls[0]["reply_to"] == "inbound-42"
+        assert calls[0]["allow_permanent"] is True
+
+    @pytest.mark.asyncio
+    async def test_forwards_permanent_approval_policy(self):
+        adapter = self._make_adapter()
+        calls = []
+
+        async def fake_send_approval(
+            chat_id, req, reply_to=None, allow_permanent=True,
+        ):
+            from gateway.platforms.base import SendResult
+            calls.append(allow_permanent)
+            return SendResult(success=True)
+
+        adapter.send_approval_request = fake_send_approval  # type: ignore[assignment]
+
+        await adapter.send_exec_approval(
+            chat_id="u",
+            command="curl http://172.16.0.2/internal",
+            session_key="s",
+            allow_permanent=False,
+        )
+
+        assert calls == [False]
 
     @pytest.mark.asyncio
     async def test_accepts_metadata_arg(self):
         """Gateway always passes metadata=…; the adapter must accept + ignore it."""
         adapter = self._make_adapter()
 
-        async def fake_send_approval(chat_id, req, reply_to=None):
+        async def fake_send_approval(
+            chat_id, req, reply_to=None, allow_permanent=True,
+        ):
             from gateway.platforms.base import SendResult
             return SendResult(success=True)
 

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -122,6 +122,27 @@ class TestSlackExecApproval:
             assert e["value"] == "agent:main:slack:group:C1:1111"
 
     @pytest.mark.asyncio
+    async def test_hides_always_when_permanent_approval_disallowed(self):
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "1234.5678"})
+
+        await adapter.send_exec_approval(
+            chat_id="C1",
+            command="curl http://172.16.0.2/internal",
+            session_key="session-1",
+            allow_permanent=False,
+        )
+
+        blocks = mock_client.chat_postMessage.call_args.kwargs["blocks"]
+        action_ids = [element["action_id"] for element in blocks[1]["elements"]]
+        assert action_ids == [
+            "hermes_approve_once",
+            "hermes_approve_session",
+            "hermes_deny",
+        ]
+
+    @pytest.mark.asyncio
     async def test_sends_in_thread(self):
         adapter = _make_adapter()
         mock_client = adapter._team_clients["T1"]

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -112,17 +112,26 @@ def _ensure_teams_mock():
 
     # Cards mocks
     class MockAdaptiveCard:
+        def __init__(self):
+            self.body = []
+            self.actions = []
+
         def with_version(self, v):
             return self
 
         def with_body(self, body):
+            self.body = body
             return self
 
         def with_actions(self, actions):
+            self.actions = actions
             return self
 
+    def MockExecuteAction(**kwargs):
+        return SimpleNamespace(**kwargs)
+
     microsoft_teams_cards.AdaptiveCard = MockAdaptiveCard
-    microsoft_teams_cards.ExecuteAction = MagicMock
+    microsoft_teams_cards.ExecuteAction = MockExecuteAction
     microsoft_teams_cards.TextBlock = MagicMock
 
     # HttpRequest TypedDict mock
@@ -497,6 +506,35 @@ class TestTeamsSend:
         mock_app.send.assert_awaited_once()
         call_args = mock_app.send.call_args
         assert call_args[0][0] == "conv-id"
+
+
+class TestTeamsExecApproval:
+    @pytest.mark.anyio
+    async def test_hides_always_when_permanent_approval_disallowed(self):
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+        adapter._app = MagicMock()
+        captured = {}
+
+        async def fake_send_card(chat_id, card):
+            captured["chat_id"] = chat_id
+            captured["card"] = card
+            return SimpleNamespace(id="msg-123")
+
+        adapter._send_card = AsyncMock(side_effect=fake_send_card)
+
+        result = await adapter.send_exec_approval(
+            chat_id="conv-id",
+            command="curl http://172.16.0.2/internal",
+            session_key="session-1",
+            allow_permanent=False,
+        )
+
+        assert result.success is True
+        assert captured["chat_id"] == "conv-id"
+        titles = [action.title for action in captured["card"].actions]
+        assert titles == ["Allow Once", "Allow Session", "Deny"]
 
 
 def _make_summary_payload():

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -106,6 +106,38 @@ class TestTelegramExecApproval:
         assert kwargs["reply_markup"] is not None  # InlineKeyboardMarkup
 
     @pytest.mark.asyncio
+    async def test_hides_always_when_permanent_approval_disallowed(self, monkeypatch):
+        import plugins.platforms.telegram.adapter as telegram_adapter
+
+        monkeypatch.setattr(
+            telegram_adapter,
+            "InlineKeyboardButton",
+            lambda text, callback_data: SimpleNamespace(
+                text=text, callback_data=callback_data,
+            ),
+        )
+        monkeypatch.setattr(
+            telegram_adapter,
+            "InlineKeyboardMarkup",
+            lambda rows: SimpleNamespace(inline_keyboard=rows),
+        )
+        adapter = _make_adapter()
+        adapter._bot.send_message = AsyncMock(
+            return_value=SimpleNamespace(message_id=42)
+        )
+
+        await adapter.send_exec_approval(
+            chat_id="12345",
+            command="curl http://172.16.0.2/internal",
+            session_key="session-1",
+            allow_permanent=False,
+        )
+
+        keyboard = adapter._bot.send_message.call_args.kwargs["reply_markup"]
+        labels = [button.text for row in keyboard.inline_keyboard for button in row]
+        assert labels == ["✅ Allow Once", "✅ Session", "❌ Deny"]
+
+    @pytest.mark.asyncio
     async def test_stores_approval_state(self):
         adapter = _make_adapter()
         mock_msg = MagicMock()


### PR DESCRIPTION
## Summary

Honors `allow_permanent=false` across gateway approval delivery paths.

When Tirith or another pre-approval policy disallows permanent approval, gateway clients must not offer an `always` action in API events, button UIs, reactions, or text instructions.

## Details

- Builds API approval event choices dynamically.
- Forwards `allow_permanent` through the gateway dispatcher while preserving compatibility with legacy adapters.
- Omits `approve always` from the generic text fallback.
- Hides permanent approval in Feishu, Telegram, Slack, Matrix, Teams, QQBot, and Discord.
- Documents the optional adapter contract.
- Adds direct dispatcher, API-choice, and fallback regression tests.
- Adds platform-specific tests for every updated native approval surface.

WhatsApp Cloud is unchanged because its approval UI only exposes Approve and Deny and has no permanent action.

## Validation

- 8 changed-surface test files: 324 passed
- 5 compatibility/API regression files: 148 passed
- Total targeted tests: 472 passed
- `ruff check` on all changed Python files
- `git diff --check`
