### PR TITLE
feat(desktop): improve chat readability and tray behavior

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -3,6 +3,7 @@ const {
   BrowserWindow,
   Menu,
   Notification,
+  Tray,
   clipboard,
   dialog,
   ipcMain,
@@ -429,6 +430,12 @@ const APP_ICON_PATHS = [
   path.join(APP_ROOT, 'dist', 'apple-touch-icon.png'),
   path.join(unpackedPathFor(APP_ROOT), 'dist', 'apple-touch-icon.png')
 ]
+const TRAY_ICON_PATHS = [
+  process.resourcesPath ? path.join(process.resourcesPath, 'icon.ico') : null,
+  path.join(APP_ROOT, 'assets', 'icon.ico'),
+  path.join(APP_ROOT, '..', 'assets', 'icon.ico'),
+  ...APP_ICON_PATHS
+].filter(Boolean)
 
 let rendererTitleBarTheme = null
 const terminalSessions = new Map()
@@ -772,6 +779,9 @@ function registerMediaProtocol() {
 }
 
 let mainWindow = null
+let tray = null
+let isQuitting = false
+let hasShownTrayHint = false
 let hermesProcess = null
 let connectionPromise = null
 // Additional per-profile backends, keyed by profile name. The PRIMARY backend
@@ -3351,6 +3361,56 @@ function fetchJson(url, token, options = {}) {
   })
 }
 
+function isLoopbackUrl(url) {
+  try {
+    const parsed = new URL(url)
+    return parsed.hostname === '127.0.0.1' || parsed.hostname === 'localhost' || parsed.hostname === '::1'
+  } catch {
+    return false
+  }
+}
+
+function isTransientBackendReadError(error) {
+  const code = typeof error?.code === 'string' ? error.code : ''
+  const message = String(error?.message || '')
+  return (
+    code === 'ECONNRESET' ||
+    code === 'ECONNREFUSED' ||
+    code === 'EPIPE' ||
+    /ECONNRESET|ECONNREFUSED|socket hang up/i.test(message)
+  )
+}
+
+function isRetryableApiRequest(url, options = {}) {
+  const method = String(options.method || 'GET').toUpperCase()
+  return isLoopbackUrl(url) && (method === 'GET' || method === 'HEAD')
+}
+
+async function fetchJsonWithStartupRetry(url, token, options = {}) {
+  if (!isRetryableApiRequest(url, options)) {
+    return fetchJson(url, token, options)
+  }
+
+  const delays = [250, 500, 1_000, 2_000]
+  let lastError = null
+  for (let attempt = 0; attempt <= delays.length; attempt += 1) {
+    try {
+      return await fetchJson(url, token, options)
+    } catch (error) {
+      lastError = error
+      if (!isTransientBackendReadError(error) || attempt >= delays.length) {
+        throw error
+      }
+      rememberLog(
+        `[api] transient local backend ${error.code || error.message}; retrying ${url} in ${delays[attempt]}ms`
+      )
+      await new Promise(resolve => setTimeout(resolve, delays[attempt]))
+    }
+  }
+
+  throw lastError
+}
+
 function fetchPublicJson(url, options = {}) {
   // Credential-free JSON GET/POST for public gateway endpoints
   // (``/api/status``, ``/api/auth/providers``). Unlike ``fetchJson`` it sends
@@ -3994,6 +4054,77 @@ function registerPowerResumeListeners() {
 
 function getAppIconPath() {
   return APP_ICON_PATHS.find(fileExists)
+}
+
+function getTrayIconPath() {
+  return TRAY_ICON_PATHS.find(fileExists) || getAppIconPath()
+}
+
+function showMainWindow() {
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    createWindow()
+    return
+  }
+  focusWindow(mainWindow)
+}
+
+function hideMainWindowToTray() {
+  if (!mainWindow || mainWindow.isDestroyed()) return
+  schedulePersistWindowState.flush()
+  closePetOverlay()
+  mainWindow.hide()
+  if (!hasShownTrayHint) {
+    hasShownTrayHint = true
+    try {
+      if (Notification.isSupported()) {
+        new Notification({
+          title: APP_NAME,
+          body: 'Hermes is still running in the system tray. Right-click the tray icon to quit.'
+        }).show()
+      }
+    } catch {
+      // Best-effort hint only.
+    }
+  }
+}
+
+function quitFromTray() {
+  isQuitting = true
+  app.quit()
+}
+
+function buildTrayMenu() {
+  return Menu.buildFromTemplate([
+    {
+      label: `Open ${APP_NAME}`,
+      click: showMainWindow
+    },
+    {
+      label: 'Hide Window',
+      enabled: Boolean(mainWindow && !mainWindow.isDestroyed() && mainWindow.isVisible()),
+      click: hideMainWindowToTray
+    },
+    { type: 'separator' },
+    {
+      label: `Quit ${APP_NAME}`,
+      click: quitFromTray
+    }
+  ])
+}
+
+function ensureTray() {
+  if (tray || IS_MAC) return tray
+
+  const iconPath = getTrayIconPath()
+  const icon = iconPath ? nativeImage.createFromPath(iconPath) : nativeImage.createEmpty()
+  tray = new Tray(icon)
+  tray.setToolTip(APP_NAME)
+  tray.setContextMenu(buildTrayMenu())
+  tray.on('click', showMainWindow)
+  tray.on('double-click', showMainWindow)
+  tray.on('right-click', () => tray?.setContextMenu(buildTrayMenu()))
+
+  return tray
 }
 
 function sendOpenUpdatesRequested() {
@@ -6030,7 +6161,13 @@ function createWindow() {
   mainWindow.on('moved', schedulePersistWindowState)
   mainWindow.on('maximize', schedulePersistWindowState)
   mainWindow.on('unmaximize', schedulePersistWindowState)
-  mainWindow.on('close', () => schedulePersistWindowState.flush())
+  mainWindow.on('close', event => {
+    schedulePersistWindowState.flush()
+    if (!IS_MAC && !isQuitting && !isQuittingForHandoff) {
+      event.preventDefault()
+      hideMainWindowToTray()
+    }
+  })
 
   // The overlay rides the main window — closing the app's primary window must
   // tear it down too (otherwise it strands as an orphan that blocks
@@ -6575,7 +6712,7 @@ ipcMain.handle('hermes:api', async (_event, request) => {
       timeoutMs
     })
   }
-  return fetchJson(url, connection.token, {
+  return fetchJsonWithStartupRetry(url, connection.token, {
     method: request?.method,
     body: request?.body,
     timeoutMs
@@ -7545,8 +7682,7 @@ function handleDeepLink(url) {
     return
   }
   try {
-    if (mainWindow.isMinimized()) mainWindow.restore()
-    mainWindow.focus()
+    focusWindow(mainWindow)
     mainWindow.webContents.send('hermes:deep-link', payload)
     rememberLog(`[deeplink] delivered ${kind}/${name}`)
   } catch (err) {
@@ -7594,8 +7730,7 @@ if (!_gotSingleInstanceLock) {
     const url = _extractDeepLink(argv)
     if (url) handleDeepLink(url)
     else if (mainWindow) {
-      if (mainWindow.isMinimized()) mainWindow.restore()
-      mainWindow.focus()
+      showMainWindow()
     }
   })
 }
@@ -7620,6 +7755,7 @@ app.whenReady().then(() => {
   ensureWslWindowsFonts()
   configureSpellChecker()
   registerPowerResumeListeners()
+  ensureTray()
   createWindow()
 
   // Win/Linux cold start: the launching hermes:// URL is in our own argv.
@@ -7662,6 +7798,12 @@ function configureSpellChecker() {
 }
 
 app.on('before-quit', () => {
+  isQuitting = true
+  if (tray) {
+    tray.destroy()
+    tray = null
+  }
+
   // The always-on-top overlay isn't a "real" app window; close it so a stray
   // pet can't keep the process alive or float over a quit app.
   closePetOverlay()

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -14,7 +14,11 @@ import {
   messageContentText,
   pickPrimaryPreviewTarget
 } from '@/components/assistant-ui/thread/content'
-import { MESSAGE_PARTS_COMPONENTS } from '@/components/assistant-ui/thread/message-parts'
+import {
+  MESSAGE_RESPONSE_PARTS_COMPONENTS,
+  MESSAGE_TRACE_PARTS_COMPONENTS,
+  ProcessTraceDisclosure
+} from '@/components/assistant-ui/thread/message-parts'
 import { StreamStallIndicator } from '@/components/assistant-ui/thread/status'
 import { formatMessageTimestamp } from '@/components/assistant-ui/thread/timestamp'
 import { TooltipIconButton } from '@/components/assistant-ui/tooltip-icon-button'
@@ -102,7 +106,10 @@ export const AssistantMessage: FC<{
         data-slot="aui_assistant-message-content"
       >
         {/* Todos render in the composer status stack now, not inline. */}
-        <MessagePrimitive.Parts components={MESSAGE_PARTS_COMPONENTS} />
+        <ProcessTraceDisclosure hasVisibleText={hasVisibleText}>
+          <MessagePrimitive.Parts components={MESSAGE_TRACE_PARTS_COMPONENTS} />
+        </ProcessTraceDisclosure>
+        <MessagePrimitive.Parts components={MESSAGE_RESPONSE_PARTS_COMPONENTS} />
         {isRunning && <StreamStallIndicator />}
         {previewTargets.length > 0 && (
           <div className="mt-3 flex flex-wrap gap-2">

--- a/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
@@ -1,5 +1,5 @@
 import { type ToolCallMessagePartProps, useAuiState } from '@assistant-ui/react'
-import { type ComponentProps, type FC, type ReactNode, useEffect, useRef, useState } from 'react'
+import { type ComponentProps, type FC, type ReactNode, useEffect, useMemo, useRef, useState } from 'react'
 
 import { ClarifyTool } from '@/components/assistant-ui/clarify-tool'
 import { MarkdownText, MarkdownTextContent } from '@/components/assistant-ui/markdown-text'
@@ -18,6 +18,126 @@ const ImageGenerateTool: FC<ToolCallMessagePartProps> = ({ args, result }) => {
   return (
     <div className="mt-1.5">
       <GeneratedImage aspectRatio={aspectRatio} result={result} />
+    </div>
+  )
+}
+
+const NullPart: FC = () => null
+
+type TracePart = {
+  isError?: boolean
+  result?: unknown
+  status?: { type?: string }
+  text?: string
+  type?: string
+}
+
+function resultFlag(result: unknown, key: string): unknown {
+  if (!result || typeof result !== 'object') {
+    return undefined
+  }
+
+  return (result as Record<string, unknown>)[key]
+}
+
+function traceSummary(parts: readonly TracePart[]) {
+  let reasoning = 0
+  let tools = 0
+  let failed = 0
+  let running = 0
+
+  for (const part of parts) {
+    if (part.type === 'reasoning') {
+      if (typeof part.text === 'string' && part.text.trim()) {
+        reasoning += 1
+      }
+
+      if (part.status?.type && part.status.type !== 'complete') {
+        running += 1
+      }
+
+      continue
+    }
+
+    if (part.type !== 'tool-call') {
+      continue
+    }
+
+    tools += 1
+
+    if (part.result === undefined) {
+      running += 1
+    }
+
+    if (part.isError || resultFlag(part.result, 'success') === false || resultFlag(part.result, 'error')) {
+      failed += 1
+    }
+  }
+
+  return `${failed}:${reasoning}:${running}:${tools}:${reasoning + tools}`
+}
+
+function parseTraceSummary(signature: string) {
+  const [failed = 0, reasoning = 0, running = 0, tools = 0, total = 0] = signature.split(':').map(Number)
+
+  return { failed, reasoning, running, tools, total }
+}
+
+export const ProcessTraceDisclosure: FC<{
+  children: ReactNode
+  hasVisibleText: boolean
+}> = ({ children, hasVisibleText }) => {
+  const { t } = useI18n()
+  const messageRunning = useAuiState(s => s.message.status?.type === 'running')
+  const summarySignature = useAuiState(s => traceSummary(s.message.parts as TracePart[]))
+  const summary = useMemo(() => parseTraceSummary(summarySignature), [summarySignature])
+  const [userOpen, setUserOpen] = useState<boolean | null>(null)
+  const defaultOpen = messageRunning || !hasVisibleText
+  const open = userOpen ?? defaultOpen
+
+  useEffect(() => {
+    if (messageRunning) {
+      setUserOpen(null)
+    }
+  }, [messageRunning])
+
+  const summaryText = useMemo(() => {
+    const parts = [t.assistant.thread.processTraceStepCount(summary.total)]
+
+    if (summary.failed > 0) {
+      parts.push(t.assistant.thread.processTraceErrorCount(summary.failed))
+    } else if (summary.running > 0) {
+      parts.push(t.assistant.thread.processTraceRunning)
+    }
+
+    return parts.join(' · ')
+  }, [summary.failed, summary.running, summary.total, t.assistant.thread])
+
+  if (summary.total === 0) {
+    return null
+  }
+
+  return (
+    <div
+      className="mb-1.5 text-[length:var(--conversation-tool-font-size)] text-(--ui-text-tertiary)"
+      data-slot="process-trace-disclosure"
+    >
+      <DisclosureRow onToggle={() => setUserOpen(!open)} open={open}>
+        <span className="flex min-w-0 items-baseline gap-1.5">
+          <span
+            className={cn(
+              'font-medium leading-(--conversation-line-height) text-(--ui-text-secondary)',
+              messageRunning && 'shimmer text-foreground/55'
+            )}
+          >
+            {t.assistant.thread.processTrace}
+          </span>
+          <span className="text-[length:var(--conversation-caption-font-size)] leading-(--conversation-caption-line-height) text-(--ui-text-tertiary)">
+            {summaryText}
+          </span>
+        </span>
+      </DisclosureRow>
+      {open && <div className="mt-0.5 grid min-w-0 max-w-full gap-(--tool-row-gap) pb-1 pl-0.5">{children}</div>}
     </div>
   )
 }
@@ -189,7 +309,7 @@ const ReasoningTextPart: FC<{ text: string; status?: { type: string } }> = ({ te
   )
 }
 
-// Module-level constant so the `components` prop on `MessagePrimitive.Parts`
+// Module-level constants so the `components` prop on `MessagePrimitive.Parts`
 // has a stable identity across renders. Without this every AssistantMessage
 // render would create a fresh `components` object, invalidating the memo on
 // `MessagePrimitivePartByIndex` and forcing every tool/reasoning child to
@@ -202,4 +322,20 @@ export const MESSAGE_PARTS_COMPONENTS = {
   Text: MarkdownText,
   ToolGroup: ToolGroupSlot,
   tools: { Fallback: ChainToolFallback }
+} as const
+
+export const MESSAGE_TRACE_PARTS_COMPONENTS = {
+  Reasoning: ReasoningTextPart,
+  ReasoningGroup: ReasoningAccordionGroup,
+  Text: NullPart,
+  ToolGroup: ToolGroupSlot,
+  tools: { Fallback: ChainToolFallback }
+} as const
+
+export const MESSAGE_RESPONSE_PARTS_COMPONENTS = {
+  Reasoning: NullPart,
+  ReasoningGroup: NullPart,
+  Text: MarkdownText,
+  ToolGroup: NullPart,
+  tools: { Fallback: NullPart }
 } as const

--- a/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
@@ -11,7 +11,7 @@ import {
   type TimelineSourceMessage
 } from './timeline-data'
 
-const MIN_ENTRIES = 4
+const MIN_ENTRIES = 2
 const VIEWPORT = '[data-slot="aui_thread-viewport"]'
 const HOVER_CLOSE_MS = 140
 
@@ -23,6 +23,8 @@ const ROW_CLASS =
 // the dropdown/select/dialog menus. We only own layout + the border/radius here.
 const POPOVER_SHELL =
   'absolute right-full top-1/2 z-50 max-h-[min(22rem,calc(100vh-8rem))] w-80 max-w-[min(20rem,calc(100vw-2rem))] -translate-y-1/2 overflow-x-hidden overflow-y-auto overscroll-contain rounded-lg border p-1 text-popover-foreground transition-[opacity,transform] duration-100 ease-out group-hover/timeline:transition-none'
+
+const cssEscape = (value: string) => globalThis.CSS?.escape?.(value) ?? value.replace(/[^a-zA-Z0-9_-]/g, '\\$&')
 
 function userPromptText(content: unknown): string {
   if (typeof content === 'string') {
@@ -103,7 +105,7 @@ function jumpScroll(viewport: HTMLElement, top: number, duration = 170): void {
 
 function scrollToPrompt(id: string) {
   const viewport = document.querySelector<HTMLElement>(VIEWPORT)
-  const node = viewport?.querySelector<HTMLElement>(`[data-message-id="${CSS.escape(id)}"]`)
+  const node = viewport?.querySelector<HTMLElement>(`[data-message-id="${cssEscape(id)}"]`)
 
   if (!viewport || !node) {
     return
@@ -115,7 +117,7 @@ function scrollToPrompt(id: string) {
   jumpScroll(viewport, Math.max(0, top))
 }
 
-/** Right-edge prompt rail — hover previews, click to jump. ≥4 user turns only. */
+/** Right-edge prompt rail — hover previews, click to jump. ≥2 user turns only. */
 export const ThreadTimeline: FC = () => {
   const sourceSignature = useAuiState(s => {
     const rows: TimelineSourceMessage[] = []
@@ -190,7 +192,7 @@ export const ThreadTimeline: FC = () => {
       const top = viewport.getBoundingClientRect().top
 
       const offsets = entries.map(entry => {
-        const node = viewport.querySelector<HTMLElement>(`[data-message-id="${CSS.escape(entry.id)}"]`)
+        const node = viewport.querySelector<HTMLElement>(`[data-message-id="${cssEscape(entry.id)}"]`)
 
         return node ? node.getBoundingClientRect().top - top : null
       })

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -30,7 +30,7 @@ export function StickyHumanMessageContainer({
     // while attachments below it scroll away.
     <>
       <div
-        className="group/user-message sticky z-40 -mx-4 flex w-[calc(100%+2rem)] min-w-0 max-w-none flex-col items-stretch gap-0 self-end overflow-visible bg-(--ui-chat-surface-background) px-4 pb-(--conversation-turn-gap) pt-1"
+        className="group/user-message sticky z-40 -mx-4 flex w-[calc(100%+2rem)] min-w-0 max-w-none flex-col items-end gap-0 self-end overflow-visible bg-(--ui-chat-surface-background) px-4 pb-(--conversation-turn-gap) pt-1"
         data-message-id={messageId}
         data-role="user"
         data-slot="aui_user-message-root"
@@ -220,7 +220,7 @@ export const UserMessage: FC<{
   const bubbleClassName = cn(
     USER_BUBBLE_BASE_CLASS,
     'cursor-pointer pr-9 text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground/95 transition-colors',
-    'border-(--ui-stroke-tertiary) hover:border-(--ui-stroke-secondary)'
+    'border-(--dt-user-bubble-border) hover:border-(--theme-primary)'
   )
 
   const bubbleContent = hasBody && (
@@ -255,7 +255,7 @@ export const UserMessage: FC<{
         }
         messageId={messageId}
       >
-        <ActionBarPrimitive.Root className="relative w-full max-w-full" data-slot="aui_user-bubble-actions">
+        <ActionBarPrimitive.Root className="relative w-full max-w-[min(76%,42rem)]" data-slot="aui_user-bubble-actions">
           <div className="human-message-with-todos-wrapper flex w-full flex-col gap-0">
             <div className="relative w-full">
               {readOnly ? (

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2223,6 +2223,10 @@ export const en: Translations = {
           ? 'Will resume when the background task finishes'
           : `Will resume when ${count} background tasks finish`,
       thinking: 'Thinking',
+      processTrace: 'Process trace',
+      processTraceRunning: 'running',
+      processTraceStepCount: count => `${count} ${count === 1 ? 'step' : 'steps'}`,
+      processTraceErrorCount: count => `${count} ${count === 1 ? 'error' : 'errors'}`,
       today: time => `Today, ${time}`,
       yesterday: time => `Yesterday, ${time}`,
       copy: 'Copy',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2202,6 +2202,10 @@ export const ja = defineLocale({
           ? 'バックグラウンドタスクの完了後に再開します'
           : `${count} 件のバックグラウンドタスクの完了後に再開します`,
       thinking: '考え中',
+      processTrace: 'プロセス記録',
+      processTraceRunning: '実行中',
+      processTraceStepCount: count => `${count} ステップ`,
+      processTraceErrorCount: count => `${count} エラー`,
       today: time => `今日 ${time}`,
       yesterday: time => `昨日 ${time}`,
       copy: 'コピー',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1858,6 +1858,10 @@ export interface Translations {
       loadingResponse: string
       resumeWhenBackgroundDone: (count: number) => string
       thinking: string
+      processTrace: string
+      processTraceRunning: string
+      processTraceStepCount: (count: number) => string
+      processTraceErrorCount: (count: number) => string
       today: (time: string) => string
       yesterday: (time: string) => string
       copy: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2135,6 +2135,10 @@ export const zhHant = defineLocale({
       resumeWhenBackgroundDone: count =>
         count === 1 ? '背景工作完成後將自動繼續' : `${count} 個背景工作完成後將自動繼續`,
       thinking: '思考中',
+      processTrace: '過程記錄',
+      processTraceRunning: '執行中',
+      processTraceStepCount: count => `${count} 步`,
+      processTraceErrorCount: count => `${count} 個錯誤`,
       today: time => `今天，${time}`,
       yesterday: time => `昨天，${time}`,
       copy: '複製',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2387,6 +2387,10 @@ export const zh: Translations = {
       resumeWhenBackgroundDone: count =>
         count === 1 ? '后台任务完成后将自动继续' : `${count} 个后台任务完成后将自动继续`,
       thinking: '思考中',
+      processTrace: '过程记录',
+      processTraceRunning: '运行中',
+      processTraceStepCount: count => `${count} 步`,
+      processTraceErrorCount: count => `${count} 个错误`,
       today: time => `今天，${time}`,
       yesterday: time => `昨天，${time}`,
       copy: '复制',

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -308,8 +308,8 @@
     --dt-destructive-foreground: #ffffff;
     --dt-sidebar-bg: var(--ui-bg-sidebar);
     --dt-sidebar-border: var(--ui-stroke-secondary);
-    --dt-user-bubble: var(--ui-chat-bubble-background);
-    --dt-user-bubble-border: var(--ui-stroke-tertiary);
+    --dt-user-bubble: color-mix(in srgb, #2563eb 18%, var(--ui-chat-bubble-background));
+    --dt-user-bubble-border: color-mix(in srgb, #60a5fa 46%, var(--ui-stroke-secondary));
 
     --dt-font-sans:
       'Segoe WPC', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'SF Pro Text', system-ui, sans-serif,


### PR DESCRIPTION
## Summary
- show the conversation timeline after 2 user prompts instead of 4
- render user messages as narrower right-aligned blue bubbles
- collapse completed assistant tool/reasoning traces into a process trace disclosure while keeping running traces visible
- keep the Windows desktop app resident in the system tray when the main window close button is clicked, with tray actions for open/hide/quit

## Verification
- node --check apps/desktop/electron/main.cjs
- git diff --check
- npm --prefix apps/desktop run typecheck
- npm --prefix apps/desktop run build
- node --test apps/desktop/electron/window-state.test.cjs apps/desktop/electron/session-windows.test.cjs apps/desktop/electron/titlebar-overlay-width.test.cjs apps/desktop/electron/windows-child-process.test.cjs
- npm --prefix apps/desktop run builder -- --dir --config.directories.output=release-patched

## Notes
- opened as draft for maintainer review because this bundles several desktop UX improvements
