### PR TITLE
fix(feishu): preserve topic reply anchors across gateway sends

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -65,8 +65,13 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
     thread_id = getattr(source, "thread_id", None)
     if thread_id is None:
         return None
+    platform = _platform_name(getattr(source, "platform", None))
     metadata = {"thread_id": thread_id}
-    if _platform_name(getattr(source, "platform", None)) == "telegram" and getattr(source, "chat_type", None) == "dm":
+    if platform == "feishu":
+        anchor = reply_to_message_id or getattr(source, "message_id", None)
+        if anchor is not None:
+            metadata["reply_to_message_id"] = str(anchor)
+    if platform == "telegram" and getattr(source, "chat_type", None) == "dm":
         metadata["telegram_dm_topic_reply_fallback"] = True
         tid = str(thread_id)
         if tid and tid not in {"", "1"}:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14382,6 +14382,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if thread_id is None:
             return None
         metadata: Dict[str, Any] = {"thread_id": thread_id}
+        if platform == Platform.FEISHU and reply_to_message_id is not None:
+            metadata["reply_to_message_id"] = str(reply_to_message_id)
         if self._is_telegram_dm_topic_target(
             platform,
             chat_id,
@@ -15328,7 +15330,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # interrupts feel identical to fresh voice messages.
             if successful_transcripts and self._should_echo_stt_transcripts():
                 echo_adapter = self._adapter_for_source(source)
-                echo_meta = {"thread_id": source.thread_id} if source.thread_id else None
+                echo_meta = self._thread_metadata_for_target(
+                    source.platform,
+                    source.chat_id,
+                    source.thread_id,
+                    reply_to_message_id=self._reply_anchor_for_event(event),
+                )
                 if echo_adapter:
                     for tx in successful_transcripts:
                         try:
@@ -15683,13 +15690,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         f"Here's the final output:\n{new_output}]"
                     )
                     adapter = None
+                    target_platform = None
                     for p, a in self.adapters.items():
                         if p.value == platform_name:
                             adapter = a
+                            target_platform = p
                             break
                     if adapter and chat_id:
                         try:
-                            send_meta = {"thread_id": thread_id} if thread_id else None
+                            send_meta = self._thread_metadata_for_target(
+                                target_platform,
+                                chat_id,
+                                thread_id or None,
+                                reply_to_message_id=message_id,
+                            )
                             await adapter.send(
                                 chat_id,
                                 message_text,
@@ -15713,13 +15727,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     f"New output:\n{new_output}]"
                 )
                 adapter = None
+                target_platform = None
                 for p, a in self.adapters.items():
                     if p.value == platform_name:
                         adapter = a
+                        target_platform = p
                         break
                 if adapter and chat_id:
                     try:
-                        send_meta = {"thread_id": thread_id} if thread_id else None
+                        send_meta = self._thread_metadata_for_target(
+                            target_platform,
+                            chat_id,
+                            thread_id or None,
+                            reply_to_message_id=message_id,
+                        )
                         await adapter.send(
                             chat_id,
                             message_text,
@@ -19303,7 +19324,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                         )
                                         pending_text = _enriched
                                         if _transcripts and self._should_echo_stt_transcripts():
-                                            _echo_meta = {"thread_id": source.thread_id} if source.thread_id else None
+                                            _echo_meta = self._thread_metadata_for_target(
+                                                source.platform,
+                                                source.chat_id,
+                                                source.thread_id,
+                                                reply_to_message_id=self._reply_anchor_for_event(_peek_event),
+                                            )
                                             for _tx in _transcripts:
                                                 try:
                                                     await _adapter.send(
@@ -19725,7 +19751,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             )
                             pending = _enriched or None
                             if _transcripts and self._should_echo_stt_transcripts():
-                                _echo_meta = {"thread_id": source.thread_id} if source.thread_id else None
+                                _echo_meta = self._thread_metadata_for_target(
+                                    source.platform,
+                                    source.chat_id,
+                                    source.thread_id,
+                                    reply_to_message_id=self._reply_anchor_for_event(pending_event),
+                                )
                                 for _tx in _transcripts:
                                     try:
                                         await adapter.send(
@@ -19920,6 +19951,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         return result
                     next_message_id = self._reply_anchor_for_event(pending_event)
                     next_channel_prompt = getattr(pending_event, "channel_prompt", None)
+                    if (
+                        next_source.platform == Platform.FEISHU
+                        and next_source.message_id
+                    ):
+                        # In-band queued turns stay in this handler task, so
+                        # refresh both durable and task-local reply anchors.
+                        await self.async_session_store.update_session(
+                            next_session_key,
+                            source=next_source,
+                        )
+                        self._set_session_env(
+                            SessionContext(
+                                source=next_source,
+                                connected_platforms=[],
+                                home_channels={},
+                                session_key=next_session_key,
+                                session_id=session_id,
+                            )
+                        )
 
                 # Restart typing indicator so the user sees activity while
                 # the follow-up turn runs.  The outer _process_message_background

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1804,6 +1804,10 @@ class SessionStore:
             if slot.error is not None:
                 raise slot.error
             assert slot.result is not None
+            # The routing result is shared, but each Feishu delivery carries
+            # its own asynchronous reply anchor.
+            if source.platform == Platform.FEISHU and source.message_id:
+                self.update_session(slot.result.session_key, source=source)
             return slot.result
 
         try:
@@ -1920,6 +1924,12 @@ class SessionStore:
                 elif entry.session_id != _stale_session_id:
                     # Another thread handled this entry during our lock-free
                     # window.  Treat as healthy -- bump updated_at and save.
+                    if (
+                        source.platform == Platform.FEISHU
+                        and source.message_id
+                        and entry.origin is not None
+                    ):
+                        entry.origin.message_id = source.message_id
                     entry.updated_at = now
                     _needs_save = True
                 else:
@@ -1933,6 +1943,12 @@ class SessionStore:
                         entry = None
                         _needs_recover = True
                     else:
+                        if (
+                            source.platform == Platform.FEISHU
+                            and source.message_id
+                            and entry.origin is not None
+                        ):
+                            entry.origin.message_id = source.message_id
                         entry.updated_at = now
                         _needs_save = True
             else:
@@ -2022,8 +2038,9 @@ class SessionStore:
         self,
         session_key: str,
         last_prompt_tokens: int = None,
+        source: Optional[SessionSource] = None,
     ) -> None:
-        """Update lightweight session metadata after an interaction."""
+        """Update interaction metadata and the latest Feishu reply anchor."""
         with self._lock:
             self._ensure_loaded_locked()
 
@@ -2032,6 +2049,13 @@ class SessionStore:
                 entry.updated_at = _now()
                 if last_prompt_tokens is not None:
                     entry.last_prompt_tokens = last_prompt_tokens
+                if (
+                    source is not None
+                    and source.platform == Platform.FEISHU
+                    and source.message_id
+                    and entry.origin is not None
+                ):
+                    entry.origin.message_id = source.message_id
                 self._save()
                 self._record_gateway_session_peer(
                     entry.session_id,

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -356,6 +356,17 @@ class _FeishuBotIdentity:
 
 
 @dataclass(frozen=True)
+class _FeishuLocalErrorResponse:
+    """Represent a local routing failure using the Feishu SDK response contract."""
+
+    code: str
+    msg: str
+
+    def success(self) -> bool:
+        return False
+
+
+@dataclass(frozen=True)
 class FeishuPostParseResult:
     text_content: str
     image_keys: List[str] = field(default_factory=list)
@@ -2225,6 +2236,13 @@ class FeishuAdapter(BasePlatformAdapter):
         """Send a local image file to Feishu."""
         if not self._client:
             return SendResult(success=False, error="Not connected")
+        thread_error = self._thread_anchor_error_response(
+            chat_id=chat_id,
+            reply_to=reply_to,
+            metadata=metadata,
+        )
+        if thread_error:
+            return self._finalize_send_result(thread_error, "image send failed")
         if not os.path.exists(image_path):
             return SendResult(success=False, error=f"Image file not found: {image_path}")
 
@@ -3288,6 +3306,7 @@ class FeishuAdapter(BasePlatformAdapter):
             thread_id=thread_id,
             user_id_alt=sender_profile["user_id_alt"],
             is_bot=is_bot,
+            message_id=message_id,
         )
         normalized = MessageEvent(
             text=text,
@@ -3362,6 +3381,8 @@ class FeishuAdapter(BasePlatformAdapter):
         existing.timestamp = event.timestamp
         if event.message_id:
             existing.message_id = event.message_id
+            if existing.source is not None:
+                existing.source.message_id = event.message_id
         self._schedule_media_batch_flush(key)
 
     def _schedule_media_batch_flush(self, key: str) -> None:
@@ -3675,6 +3696,8 @@ class FeishuAdapter(BasePlatformAdapter):
         existing.timestamp = event.timestamp
         if event.message_id:
             existing.message_id = event.message_id
+            if existing.source is not None:
+                existing.source.message_id = event.message_id
         self._pending_text_batch_counts[key] = next_count
         self._schedule_text_batch_flush(key)
 
@@ -4521,6 +4544,27 @@ class FeishuAdapter(BasePlatformAdapter):
     # Outbound payload construction and send pipeline
     # =========================================================================
 
+    @staticmethod
+    def _thread_anchor_error_response(
+        *,
+        chat_id: str,
+        reply_to: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+    ) -> Optional[_FeishuLocalErrorResponse]:
+        thread_id = (metadata or {}).get("thread_id")
+        reply_anchor = reply_to or (metadata or {}).get("reply_to_message_id")
+        if not thread_id or reply_anchor:
+            return None
+        logger.error(
+            "[Feishu] Cannot send message in thread %s for chat %s: missing reply_to_message_id",
+            thread_id,
+            chat_id,
+        )
+        return _FeishuLocalErrorResponse(
+            code="thread_anchor_required",
+            msg=f"Feishu thread {thread_id} requires reply_to_message_id",
+        )
+
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
         # Feishu post-type 'md' elements do not render markdown tables; sending
         # table content as post causes the message to appear blank on the client.
@@ -4546,6 +4590,13 @@ class FeishuAdapter(BasePlatformAdapter):
     ) -> SendResult:
         if not self._client:
             return SendResult(success=False, error="Not connected")
+        thread_error = self._thread_anchor_error_response(
+            chat_id=chat_id,
+            reply_to=reply_to,
+            metadata=metadata,
+        )
+        if thread_error:
+            return self._finalize_send_result(thread_error, "file send failed")
         if not os.path.exists(file_path):
             return SendResult(success=False, error=f"File not found: {file_path}")
 
@@ -4606,6 +4657,14 @@ class FeishuAdapter(BasePlatformAdapter):
         reply_to: Optional[str],
         metadata: Optional[Dict[str, Any]],
     ) -> Any:
+        thread_error = self._thread_anchor_error_response(
+            chat_id=chat_id,
+            reply_to=reply_to,
+            metadata=metadata,
+        )
+        if thread_error:
+            return thread_error
+
         effective_reply_to = reply_to
         if not effective_reply_to and metadata and metadata.get("thread_id"):
             effective_reply_to = metadata.get("reply_to_message_id")
@@ -4620,34 +4679,22 @@ class FeishuAdapter(BasePlatformAdapter):
             request = self._build_reply_message_request(effective_reply_to, body)
             return await self._run_blocking(self._client.im.v1.message.reply, request)
 
-        # For topic/thread messages that fell back from reply→create, use
-        # thread_id as receive_id so the message lands in the topic instead of
-        # the main chat.
-        _thread_id = (metadata or {}).get("thread_id")
-        if _thread_id:
-            body = self._build_create_message_body(
-                receive_id=_thread_id,
-                msg_type=msg_type,
-                content=payload,
-                uuid_value=str(uuid.uuid4()),
-            )
-            request = self._build_create_message_request("thread_id", body)
-        else:
-            receive_id = chat_id
-            receive_id_type = "chat_id"
-            if chat_id.startswith("feishu_user_id:"):
-                receive_id = chat_id.split(":", 1)[1]
-                receive_id_type = "user_id"
-            elif chat_id.startswith("ou_"):
-                receive_id_type = "open_id"
+        # Default path: create a new message in the chat.
+        receive_id = chat_id
+        receive_id_type = "chat_id"
+        if chat_id.startswith("feishu_user_id:"):
+            receive_id = chat_id.split(":", 1)[1]
+            receive_id_type = "user_id"
+        elif chat_id.startswith("ou_"):
+            receive_id_type = "open_id"
 
-            body = self._build_create_message_body(
-                receive_id=receive_id,
-                msg_type=msg_type,
-                content=payload,
-                uuid_value=str(uuid.uuid4()),
-            )
-            request = self._build_create_message_request(receive_id_type, body)
+        body = self._build_create_message_body(
+            receive_id=receive_id,
+            msg_type=msg_type,
+            content=payload,
+            uuid_value=str(uuid.uuid4()),
+        )
+        request = self._build_create_message_request(receive_id_type, body)
         return await self._run_blocking(self._client.im.v1.message.create, request)
 
     @staticmethod

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -227,6 +227,58 @@ async def test_thread_id_passed_to_send(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("sessions", "expected_fragment"),
+    [
+        (
+            [SimpleNamespace(output_buffer="building...\n", exited=False, exit_code=None), None],
+            "is still running",
+        ),
+        (
+            [SimpleNamespace(output_buffer="done\n", exited=True, exit_code=0)],
+            "finished with exit code 0",
+        ),
+    ],
+)
+async def test_feishu_topic_watcher_delivery_uses_triggering_message_anchor(
+    monkeypatch, tmp_path, sessions, expected_fragment
+):
+    """Periodic and final watcher sends must reply inside the originating topic."""
+    import tools.process_registry as pr_module
+
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters.pop(Platform.TELEGRAM)
+    runner.adapters[Platform.FEISHU] = adapter
+    watcher = {
+        "session_id": "proc_feishu_topic",
+        "check_interval": 0,
+        "platform": "feishu",
+        "chat_id": "oc_chat",
+        "thread_id": "omt-topic",
+        "message_id": "om-trigger",
+    }
+
+    await runner._run_process_watcher(watcher)
+
+    matching_calls = [
+        call
+        for call in adapter.send.await_args_list
+        if expected_fragment in call.args[1]
+    ]
+    assert len(matching_calls) == 1
+    assert matching_calls[0].kwargs["metadata"] == {
+        "thread_id": "omt-topic",
+        "reply_to_message_id": "om-trigger",
+    }
+
+
+@pytest.mark.asyncio
 async def test_no_thread_id_sends_no_metadata(monkeypatch, tmp_path):
     """When thread_id is empty, metadata should be None (general topic)."""
     import tools.process_registry as pr_module

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1776,14 +1776,16 @@ class TestAdapterBehavior(unittest.TestCase):
 
         adapter = FeishuAdapter(PlatformConfig())
         adapter.handle_message = AsyncMock()
-        source = SessionSource(
-            platform=adapter.platform,
-            chat_id="oc_chat",
-            chat_name="Feishu DM",
-            chat_type="dm",
-            user_id="ou_user",
-            user_name="张三",
-        )
+        def source(message_id):
+            return SessionSource(
+                platform=adapter.platform,
+                chat_id="oc_chat",
+                chat_name="Feishu DM",
+                chat_type="dm",
+                user_id="ou_user",
+                user_name="张三",
+                message_id=message_id,
+            )
 
         async def _sleep(_delay):
             return None
@@ -1791,10 +1793,10 @@ class TestAdapterBehavior(unittest.TestCase):
         async def _run() -> None:
             with patch("plugins.platforms.feishu.adapter.asyncio.sleep", side_effect=_sleep):
                 await adapter._dispatch_inbound_event(
-                    MessageEvent(text="A", message_type=MessageType.TEXT, source=source, message_id="om_1")
+                    MessageEvent(text="A", message_type=MessageType.TEXT, source=source("om_1"), message_id="om_1")
                 )
                 await adapter._dispatch_inbound_event(
-                    MessageEvent(text="B", message_type=MessageType.TEXT, source=source, message_id="om_2")
+                    MessageEvent(text="B", message_type=MessageType.TEXT, source=source("om_2"), message_id="om_2")
                 )
                 pending = list(adapter._pending_text_batch_tasks.values())
                 self.assertEqual(len(pending), 1)
@@ -1806,6 +1808,8 @@ class TestAdapterBehavior(unittest.TestCase):
         event = adapter.handle_message.await_args.args[0]
         self.assertEqual(event.text, "A\nB")
         self.assertEqual(event.message_type, MessageType.TEXT)
+        self.assertEqual(event.message_id, "om_2")
+        self.assertEqual(event.source.message_id, "om_2")
 
     @patch.dict(
         os.environ,
@@ -1822,14 +1826,16 @@ class TestAdapterBehavior(unittest.TestCase):
 
         adapter = FeishuAdapter(PlatformConfig())
         adapter.handle_message = AsyncMock()
-        source = SessionSource(
-            platform=adapter.platform,
-            chat_id="oc_chat",
-            chat_name="Feishu DM",
-            chat_type="dm",
-            user_id="ou_user",
-            user_name="张三",
-        )
+        def source(message_id):
+            return SessionSource(
+                platform=adapter.platform,
+                chat_id="oc_chat",
+                chat_name="Feishu DM",
+                chat_type="dm",
+                user_id="ou_user",
+                user_name="张三",
+                message_id=message_id,
+            )
 
         async def _sleep(_delay):
             return None
@@ -1837,13 +1843,13 @@ class TestAdapterBehavior(unittest.TestCase):
         async def _run() -> None:
             with patch("plugins.platforms.feishu.adapter.asyncio.sleep", side_effect=_sleep):
                 await adapter._dispatch_inbound_event(
-                    MessageEvent(text="A", message_type=MessageType.TEXT, source=source, message_id="om_1")
+                    MessageEvent(text="A", message_type=MessageType.TEXT, source=source("om_1"), message_id="om_1")
                 )
                 await adapter._dispatch_inbound_event(
-                    MessageEvent(text="B", message_type=MessageType.TEXT, source=source, message_id="om_2")
+                    MessageEvent(text="B", message_type=MessageType.TEXT, source=source("om_2"), message_id="om_2")
                 )
                 await adapter._dispatch_inbound_event(
-                    MessageEvent(text="C", message_type=MessageType.TEXT, source=source, message_id="om_3")
+                    MessageEvent(text="C", message_type=MessageType.TEXT, source=source("om_3"), message_id="om_3")
                 )
                 pending = list(adapter._pending_text_batch_tasks.values())
                 self.assertEqual(len(pending), 1)
@@ -1856,6 +1862,8 @@ class TestAdapterBehavior(unittest.TestCase):
         second = adapter.handle_message.await_args_list[1].args[0]
         self.assertEqual(first.text, "A\nB")
         self.assertEqual(second.text, "C")
+        self.assertEqual(first.source.message_id, "om_2")
+        self.assertEqual(second.source.message_id, "om_3")
 
     @patch.dict(os.environ, {}, clear=True)
     def test_media_batch_merges_rapid_photo_messages(self):
@@ -1866,14 +1874,16 @@ class TestAdapterBehavior(unittest.TestCase):
 
         adapter = FeishuAdapter(PlatformConfig())
         adapter.handle_message = AsyncMock()
-        source = SessionSource(
-            platform=adapter.platform,
-            chat_id="oc_chat",
-            chat_name="Feishu DM",
-            chat_type="dm",
-            user_id="ou_user",
-            user_name="张三",
-        )
+        def source(message_id):
+            return SessionSource(
+                platform=adapter.platform,
+                chat_id="oc_chat",
+                chat_name="Feishu DM",
+                chat_type="dm",
+                user_id="ou_user",
+                user_name="张三",
+                message_id=message_id,
+            )
 
         async def _sleep(_delay):
             return None
@@ -1884,7 +1894,7 @@ class TestAdapterBehavior(unittest.TestCase):
                     MessageEvent(
                         text="第一张",
                         message_type=MessageType.PHOTO,
-                        source=source,
+                        source=source("om_p1"),
                         message_id="om_p1",
                         media_urls=["/tmp/a.png"],
                         media_types=["image/png"],
@@ -1894,7 +1904,7 @@ class TestAdapterBehavior(unittest.TestCase):
                     MessageEvent(
                         text="第二张",
                         message_type=MessageType.PHOTO,
-                        source=source,
+                        source=source("om_p2"),
                         message_id="om_p2",
                         media_urls=["/tmp/b.png"],
                         media_types=["image/png"],
@@ -1911,6 +1921,8 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(event.media_urls, ["/tmp/a.png", "/tmp/b.png"])
         self.assertIn("第一张", event.text)
         self.assertIn("第二张", event.text)
+        self.assertEqual(event.message_id, "om_p2")
+        self.assertEqual(event.source.message_id, "om_p2")
 
     @patch.dict(os.environ, {}, clear=True)
     def test_send_image_downloads_then_uses_native_image_send(self):
@@ -2104,6 +2116,93 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(event.reply_to_message_id, "om_parent")
         self.assertEqual(event.reply_to_text, "父消息内容")
 
+    def test_feishu_thread_metadata_carries_reply_anchor(self):
+        from gateway.config import Platform
+        from gateway.platforms.base import _thread_metadata_for_source
+
+        source = SimpleNamespace(
+            platform=Platform.FEISHU,
+            chat_type="group",
+            thread_id="omt-thread",
+            message_id=None,
+        )
+
+        self.assertEqual(
+            _thread_metadata_for_source(source, "om-trigger"),
+            {
+                "thread_id": "omt-thread",
+                "reply_to_message_id": "om-trigger",
+            },
+        )
+
+    def test_gateway_runner_thread_metadata_carries_feishu_anchor_only_for_feishu(self):
+        from gateway.config import Platform
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+
+        self.assertEqual(
+            runner._thread_metadata_for_target(
+                Platform.FEISHU,
+                "oc_chat",
+                "omt-thread",
+                reply_to_message_id="om-trigger",
+            ),
+            {
+                "thread_id": "omt-thread",
+                "reply_to_message_id": "om-trigger",
+            },
+        )
+        self.assertEqual(
+            runner._thread_metadata_for_target(
+                Platform.DISCORD,
+                "discord-channel",
+                "discord-thread",
+                reply_to_message_id="discord-message",
+            ),
+            {"thread_id": "discord-thread"},
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_inbound_message_id_persists_as_feishu_reply_anchor(self):
+        from gateway.config import PlatformConfig
+        from gateway.session import SessionSource
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_chat", "name": "Feishu Topic", "type": "group"}
+        )
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "ou_user", "user_name": "张三", "user_id_alt": None}
+        )
+        message = SimpleNamespace(
+            chat_id="oc_chat",
+            thread_id="omt-thread",
+            parent_id="om-parent",
+            upper_message_id=None,
+            message_type="text",
+            content='{"text":"topic message"}',
+            message_id="om-trigger",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_user", user_id=None, union_id=None),
+                is_bot=False,
+                chat_type="group",
+                message_id="om-trigger",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        self.assertEqual(event.source.message_id, "om-trigger")
+        restored = SessionSource.from_dict(event.source.to_dict())
+        self.assertEqual(restored.message_id, "om-trigger")
+
     @patch.dict(os.environ, {}, clear=True)
     def test_send_replies_in_thread_when_thread_metadata_present(self):
         from gateway.config import PlatformConfig
@@ -2183,6 +2282,144 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertTrue(result.success)
         self.assertEqual(captured["request"].message_id, "om_trigger")
         self.assertTrue(captured["request"].request_body.reply_in_thread)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_thread_without_reply_anchor_fails_closed(self):
+        """A thread-only send must fail without calling any message API."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        calls = []
+
+        class _MessageAPI:
+            def list(self, request):
+                calls.append("list")
+                return SimpleNamespace(success=lambda: False, code=9999, msg="unsupported")
+
+            def reply(self, request):
+                calls.append("reply")
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_sent"),
+                )
+
+            def create(self, request):
+                calls.append("create")
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_sent"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="thread reply",
+                    metadata={"thread_id": "omt-thread"},
+                )
+            )
+
+        self.assertFalse(result.success)
+        self.assertIn("requires reply_to_message_id", result.error)
+        self.assertEqual(calls, [])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_thread_without_reply_anchor_skips_file_upload(self):
+        """Reject an unanchored thread file before creating an orphan upload."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        calls = []
+
+        class _FileAPI:
+            def create(self, request):
+                calls.append("file.create")
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(file_key="file_key"),
+                )
+
+        class _MessageAPI:
+            def reply(self, request):
+                calls.append("message.reply")
+                return SimpleNamespace(success=lambda: True)
+
+            def create(self, request):
+                calls.append("message.create")
+                return SimpleNamespace(success=lambda: True)
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(file=_FileAPI(), message=_MessageAPI())
+            )
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf") as temp_file:
+            result = asyncio.run(
+                adapter.send_document(
+                    chat_id="oc_chat",
+                    file_path=temp_file.name,
+                    metadata={"thread_id": "omt-thread"},
+                )
+            )
+
+        self.assertFalse(result.success)
+        self.assertIn("requires reply_to_message_id", result.error)
+        self.assertEqual(calls, [])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_thread_without_reply_anchor_skips_image_upload(self):
+        """Reject an unanchored thread image before creating an orphan upload."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        calls = []
+
+        class _ImageAPI:
+            def create(self, request):
+                calls.append("image.create")
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(image_key="image_key"),
+                )
+
+        class _MessageAPI:
+            def reply(self, request):
+                calls.append("message.reply")
+                return SimpleNamespace(success=lambda: True)
+
+            def create(self, request):
+                calls.append("message.create")
+                return SimpleNamespace(success=lambda: True)
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(image=_ImageAPI(), message=_MessageAPI())
+            )
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".png") as temp_file:
+            result = asyncio.run(
+                adapter.send_image_file(
+                    chat_id="oc_chat",
+                    image_path=temp_file.name,
+                    metadata={"thread_id": "omt-thread"},
+                )
+            )
+
+        self.assertFalse(result.success)
+        self.assertIn("requires reply_to_message_id", result.error)
+        self.assertEqual(calls, [])
 
     @patch.dict(os.environ, {}, clear=True)
     def test_send_retries_transient_failure(self):

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -3,16 +3,18 @@
 import asyncio
 import importlib
 import sys
+import threading
 import time
 import types
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
 import gateway.platforms.base as base_platform
-from gateway.config import Platform, PlatformConfig, StreamingConfig
+from gateway.config import GatewayConfig, Platform, PlatformConfig, StreamingConfig
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
-from gateway.session import SessionSource
+from gateway.session import SessionSource, SessionStore
 
 
 class ProgressCaptureAdapter(BasePlatformAdapter):
@@ -245,6 +247,74 @@ class DelayedInterimAgent:
         }
 
 
+class InterruptibleVoiceAgent:
+    """Wait for the gateway monitor to deliver a pending voice interrupt."""
+
+    def __init__(self, **kwargs):
+        self.tools = []
+        self._interrupt_requested = False
+        self._interrupted = threading.Event()
+
+    @property
+    def is_interrupted(self):
+        return self._interrupt_requested
+
+    def interrupt(self, _message=None):
+        self._interrupt_requested = True
+        self._interrupted.set()
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        assert self._interrupted.wait(timeout=3), "voice interrupt was not delivered"
+        return {
+            "final_response": "",
+            "messages": [],
+            "api_calls": 1,
+            "interrupted": True,
+            "interrupt_message": None,
+        }
+
+
+class ImmediateVoiceAgent:
+    """Complete immediately so a queued voice event enters the drain path."""
+
+    def __init__(self, **kwargs):
+        self.tools = []
+        self._interrupt_requested = False
+
+    @property
+    def is_interrupted(self):
+        return self._interrupt_requested
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class ContextRecordingVoiceAgent(ImmediateVoiceAgent):
+    """Record the reply anchor visible to tools on each queued turn."""
+
+    observed_message_ids = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        from gateway.session_context import get_session_env
+
+        self.observed_message_ids.append(
+            get_session_env("HERMES_SESSION_MESSAGE_ID", "")
+        )
+        return super().run_conversation(message, conversation_history, task_id)
+
+
+class InterruptEchoCaptureAdapter(ProgressCaptureAdapter):
+    """Expose the event to the monitor, then consume it before post-run drain."""
+
+    def get_pending_message(self, session_key):
+        self._pending_messages.pop(session_key, None)
+        return None
+
+
 def _make_runner(adapter):
     gateway_run = importlib.import_module("gateway.run")
     GatewayRunner = gateway_run.GatewayRunner
@@ -260,7 +330,11 @@ def _make_runner(adapter):
     runner._session_db = None
     runner._running_agents = {}
     runner._session_run_generation = {}
-    runner.session_store = SimpleNamespace(_entries={}, _save=lambda: None)
+    runner.session_store = SimpleNamespace(
+        _entries={},
+        _save=lambda: None,
+        update_session=lambda *args, **kwargs: None,
+    )
     runner.hooks = SimpleNamespace(loaded_hooks=False)
     runner.config = SimpleNamespace(
         thread_sessions_per_user=False,
@@ -268,6 +342,183 @@ def _make_runner(adapter):
         stt_enabled=False,
     )
     return runner
+
+
+def _feishu_voice_event(message_id="om-current-event"):
+    event_source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_chat",
+        chat_type="group",
+        thread_id="omt-topic",
+        message_id=message_id,
+    )
+    return MessageEvent(
+        text="",
+        message_type=MessageType.VOICE,
+        source=event_source,
+        message_id=message_id,
+        media_urls=["/tmp/voice.ogg"],
+        media_types=["audio/ogg"],
+    )
+
+
+def _install_voice_agent(monkeypatch, tmp_path, agent_cls):
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = agent_cls
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+    monkeypatch.setattr(
+        "tools.transcription_tools.transcribe_audio",
+        lambda _path: {
+            "success": True,
+            "transcript": "current voice transcript",
+            "provider": "local_command",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_feishu_voice_interrupt_echo_uses_current_event_anchor(monkeypatch, tmp_path):
+    """The interrupt monitor must anchor its echo to the pending event, not the old turn."""
+    _install_voice_agent(monkeypatch, tmp_path, InterruptibleVoiceAgent)
+    adapter = InterruptEchoCaptureAdapter(platform=Platform.FEISHU)
+    runner = _make_runner(adapter)
+    runner.config.stt_enabled = True
+    runner._has_setup_skill = lambda: False
+
+    old_source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_chat",
+        chat_type="group",
+        thread_id="omt-topic",
+        message_id="om-old-source",
+    )
+    session_key = "agent:main:feishu:group:oc_chat:omt-topic"
+    adapter._pending_messages[session_key] = _feishu_voice_event()
+    adapter._active_sessions[session_key] = asyncio.Event()
+    adapter._active_sessions[session_key].set()
+
+    await runner._run_agent(
+        message="old turn",
+        context_prompt="",
+        history=[],
+        source=old_source,
+        session_id="sess-feishu-voice-interrupt",
+        session_key=session_key,
+        event_message_id="om-old-source",
+    )
+
+    echoes = [call for call in adapter.sent if call["content"].startswith("🎙️")]
+    assert len(echoes) == 1
+    assert echoes[0]["metadata"] == {
+        "thread_id": "omt-topic",
+        "reply_to_message_id": "om-current-event",
+    }
+
+
+@pytest.mark.asyncio
+async def test_feishu_voice_drain_echo_uses_current_event_anchor(monkeypatch, tmp_path):
+    """A queued voice echo after normal completion must use that queued event's anchor."""
+    _install_voice_agent(monkeypatch, tmp_path, ImmediateVoiceAgent)
+    adapter = ProgressCaptureAdapter(platform=Platform.FEISHU)
+    runner = _make_runner(adapter)
+    runner.config.stt_enabled = True
+    runner._has_setup_skill = lambda: False
+    runner._prepare_inbound_message_text = AsyncMock(return_value="current voice transcript")
+
+    old_source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_chat",
+        chat_type="group",
+        thread_id="omt-topic",
+        message_id="om-old-source",
+    )
+    session_key = "agent:main:feishu:group:oc_chat:omt-topic"
+    adapter._pending_messages[session_key] = _feishu_voice_event()
+
+    await runner._run_agent(
+        message="old turn",
+        context_prompt="",
+        history=[],
+        source=old_source,
+        session_id="sess-feishu-voice-drain",
+        session_key=session_key,
+        event_message_id="om-old-source",
+    )
+
+    echoes = [call for call in adapter.sent if call["content"].startswith("🎙️")]
+    assert len(echoes) == 1
+    assert echoes[0]["metadata"] == {
+        "thread_id": "omt-topic",
+        "reply_to_message_id": "om-current-event",
+    }
+
+
+@pytest.mark.asyncio
+async def test_feishu_queued_turn_refreshes_persisted_and_tool_anchor(
+    monkeypatch, tmp_path
+):
+    """The queued turn must replace the prior turn's persisted/tool anchor."""
+    import hermes_state
+    from gateway.session_context import clear_session_vars, set_session_vars
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    ContextRecordingVoiceAgent.observed_message_ids = []
+    _install_voice_agent(monkeypatch, tmp_path, ContextRecordingVoiceAgent)
+    adapter = ProgressCaptureAdapter(platform=Platform.FEISHU)
+    runner = _make_runner(adapter)
+    runner.config.stt_enabled = True
+    runner._has_setup_skill = lambda: False
+    runner._prepare_inbound_message_text = AsyncMock(
+        return_value="current voice transcript"
+    )
+
+    old_source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_chat",
+        chat_type="group",
+        thread_id="omt-topic",
+        message_id="om-old-source",
+    )
+    store = SessionStore(tmp_path / "sessions", GatewayConfig())
+    entry = store.get_or_create_session(old_source)
+    runner.session_store = store
+    session_key = entry.session_key
+    adapter._pending_messages[session_key] = _feishu_voice_event()
+
+    tokens = set_session_vars(
+        platform="feishu",
+        chat_id="oc_chat",
+        thread_id="omt-topic",
+        session_key=session_key,
+        message_id="om-old-source",
+    )
+    try:
+        await runner._run_agent(
+            message="old turn",
+            context_prompt="",
+            history=[],
+            source=old_source,
+            session_id=entry.session_id,
+            session_key=session_key,
+            event_message_id="om-old-source",
+        )
+    finally:
+        clear_session_vars(tokens)
+
+    assert ContextRecordingVoiceAgent.observed_message_ids == [
+        "om-old-source",
+        "om-current-event",
+    ]
+    assert store._entries[session_key].origin.message_id == "om-current-event"
+    store._db.close()
 
 
 @pytest.mark.asyncio
@@ -486,7 +737,10 @@ async def test_run_agent_feishu_progress_replies_inside_existing_thread(monkeypa
     assert result["final_response"] == "done"
     assert adapter.sent
     assert adapter.sent[0]["reply_to"] == "om_triggering_user_message"
-    assert adapter.sent[0]["metadata"] == {"thread_id": "topic_17585"}
+    assert adapter.sent[0]["metadata"] == {
+        "thread_id": "topic_17585",
+        "reply_to_message_id": "om_triggering_user_message",
+    }
     assert adapter.edits
     assert adapter.edits[0]["message_id"] == "progress-1"
 

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1,5 +1,7 @@
 """Tests for gateway session management."""
 import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
 import pytest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
@@ -1664,6 +1666,166 @@ class TestGatewaySessionDbRecovery:
         assert reset.session_id != entry.session_id
         assert reset.was_auto_reset is True
         assert reset.auto_reset_reason == "idle"
+
+
+class TestFeishuSessionAnchorRefresh:
+    @pytest.fixture(autouse=True)
+    def _isolated_db(self, tmp_path, monkeypatch):
+        import hermes_state
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+
+    @staticmethod
+    def _topic_source(
+        platform, message_id, *, chat_name="Original chat", user_name="Alice"
+    ):
+        return SessionSource(
+            platform=platform,
+            chat_id="chat-1",
+            chat_name=chat_name,
+            chat_type="group",
+            user_id="user-1",
+            user_name=user_name,
+            thread_id="topic-1",
+            message_id=message_id,
+        )
+
+    @pytest.mark.parametrize("initial_message_id", [None, "old-message"])
+    def test_existing_topic_refreshes_only_message_id_and_persists(
+        self, tmp_path, initial_message_id
+    ):
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        original = self._topic_source(Platform.FEISHU, initial_message_id)
+        entry = store.get_or_create_session(original)
+        original_origin = entry.origin
+        original_data = original.to_dict()
+
+        inbound = self._topic_source(
+            Platform.FEISHU,
+            "new-message",
+            chat_name="Renamed chat",
+            user_name="Different user name",
+        )
+        refreshed = store.get_or_create_session(inbound)
+
+        assert refreshed.session_id == entry.session_id
+        assert refreshed.origin is original_origin
+        assert refreshed.origin.to_dict() == {
+            **original_data,
+            "message_id": "new-message",
+        }
+
+        store._db.close()
+        restarted = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        restarted._ensure_loaded()
+        persisted = restarted._entries[entry.session_key]
+        assert persisted.origin.to_dict() == refreshed.origin.to_dict()
+        restarted._db.close()
+
+    def test_empty_inbound_message_id_does_not_clear_feishu_anchor(self, tmp_path):
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        original = self._topic_source(Platform.FEISHU, "old-message")
+        entry = store.get_or_create_session(original)
+
+        refreshed = store.get_or_create_session(
+            self._topic_source(Platform.FEISHU, None)
+        )
+
+        assert refreshed.origin is entry.origin
+        assert refreshed.origin.message_id == "old-message"
+        store._db.close()
+
+    def test_concurrent_session_replacement_receives_current_feishu_anchor(
+        self, tmp_path, monkeypatch
+    ):
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        entry = store.get_or_create_session(
+            self._topic_source(Platform.FEISHU, "old-message")
+        )
+
+        def replace_session_during_stale_check(_session_id):
+            entry.session_id = "replacement-session"
+            return False
+
+        monkeypatch.setattr(
+            store, "_is_session_ended_in_db", replace_session_during_stale_check
+        )
+
+        refreshed = store.get_or_create_session(
+            self._topic_source(Platform.FEISHU, "new-message")
+        )
+
+        assert refreshed is entry
+        assert refreshed.session_id == "replacement-session"
+        assert refreshed.origin.message_id == "new-message"
+        store._db.close()
+
+    def test_single_flight_waiter_persists_its_feishu_anchor(
+        self, tmp_path, monkeypatch
+    ):
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        owner_entered = threading.Event()
+        release_owner = threading.Event()
+        original_impl = store._get_or_create_session_impl
+
+        def blocked_impl(source, force_new=False):
+            if source.message_id == "first-message":
+                owner_entered.set()
+                assert release_owner.wait(timeout=5)
+            return original_impl(source, force_new=force_new)
+
+        monkeypatch.setattr(store, "_get_or_create_session_impl", blocked_impl)
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            first = executor.submit(
+                store.get_or_create_session,
+                self._topic_source(Platform.FEISHU, "first-message"),
+            )
+            assert owner_entered.wait(timeout=5)
+            second = executor.submit(
+                store.get_or_create_session,
+                self._topic_source(Platform.FEISHU, "second-message"),
+            )
+            release_owner.set()
+            first_entry = first.result(timeout=5)
+            second_entry = second.result(timeout=5)
+
+        assert second_entry is first_entry
+        assert second_entry.origin.message_id == "second-message"
+
+        store._db.close()
+        restarted = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        restarted._ensure_loaded()
+        assert (
+            restarted._entries[first_entry.session_key].origin.message_id
+            == "second-message"
+        )
+        restarted._db.close()
+
+    def test_non_feishu_origin_remains_unchanged(self, tmp_path):
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        original = self._topic_source(Platform.TELEGRAM, "old-message")
+        entry = store.get_or_create_session(original)
+        original_origin = entry.origin
+        original_data = original.to_dict()
+
+        refreshed = store.get_or_create_session(
+            self._topic_source(
+                Platform.TELEGRAM,
+                "new-message",
+                chat_name="Renamed chat",
+                user_name="Different user name",
+            )
+        )
+
+        assert refreshed.origin is original_origin
+        assert refreshed.origin.to_dict() == original_data
+
+        store._db.close()
+        restarted = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        restarted._ensure_loaded()
+        assert restarted._entries[entry.session_key].origin.to_dict() == original_data
+        restarted._db.close()
 
 
 class TestGatewayRoutingTable:

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -185,3 +185,66 @@ async def test_prepare_inbound_message_text_transcribes_queued_voice_event():
     # Success path: the transcript passes through as a plain quoted line, with
     # no "voice message" meta-commentary that the LLM would echo back.
     assert "queued voice transcript" in result
+
+
+@pytest.mark.asyncio
+async def test_dequeue_pending_voice_echo_uses_current_feishu_event_anchor():
+    """Queued voice echoes must not reuse the source message from the prior turn."""
+    from types import SimpleNamespace
+
+    from gateway.run import GatewayRunner
+
+    old_source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_chat",
+        chat_type="group",
+        thread_id="omt-topic",
+        message_id="om-old-source",
+    )
+    current_source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_chat",
+        chat_type="group",
+        thread_id="omt-topic",
+        message_id="om-current-event",
+    )
+    event = MessageEvent(
+        text="",
+        message_type=MessageType.VOICE,
+        source=current_source,
+        message_id="om-current-event",
+        media_urls=["/tmp/queued-voice.ogg"],
+        media_types=["audio/ogg"],
+    )
+    adapter = SimpleNamespace(
+        get_pending_message=lambda _session_key: event,
+        send=AsyncMock(),
+    )
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner.adapters = {Platform.FEISHU: adapter}
+    runner._has_setup_skill = lambda: False
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={
+            "success": True,
+            "transcript": "queued voice transcript",
+            "provider": "local_command",
+        },
+    ):
+        result = await runner._dequeue_pending_with_transcription(
+            adapter,
+            "agent:main:feishu:group:oc_chat:omt-topic",
+            old_source,
+        )
+
+    assert "queued voice transcript" in result
+    adapter.send.assert_awaited_once_with(
+        "oc_chat",
+        '🎙️ "queued voice transcript"',
+        metadata={
+            "thread_id": "omt-topic",
+            "reply_to_message_id": "om-current-event",
+        },
+    )


### PR DESCRIPTION
## Problem

Feishu topic replies could fall back to `message.create` in the parent chat when only a thread id was available. The Feishu message-list API does not support resolving a topic root with `container_id_type="thread"`, so a thread-root lookup is not a valid solution.

## Solution

- propagate the triggering Feishu `message_id` as `reply_to_message_id` through gateway metadata and persisted session origins
- send anchored topic messages with `message.reply(..., reply_in_thread=True)`
- fail closed when a topic send has no reply anchor, instead of creating a parent-chat message
- validate topic anchors before image or file uploads
- preserve the current event anchor for process-watcher notifications and queued or interrupted voice transcript echoes

No new Feishu API permission, root lookup, fallback-to-parent-chat behavior, configuration, or dependency is introduced. The PR does not add Kanban, cron, or update-delivery persistence contracts.

## Tests

- Feishu adapter reply, fail-closed, and media-upload coverage
- gateway metadata propagation
- session origin persistence and existing-session anchor refresh
- process-watcher and queued/interrupted voice echo routing
- Telegram and non-Feishu regression coverage

Local verification with `scripts/run_tests.sh`: **552 passed, 0 failed** across 8 related test files.
