### PR TITLE
test(gateway): mock systemd preflight in service-refresh tests for non-systemd hosts (salvage #15435)

### DIFF
--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -68,6 +68,10 @@ class TestSystemdServiceRefresh:
 
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
         monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
+        # Bypass systemd availability checks — this test targets unit-file
+        # refresh logic, not D-Bus reachability (fails on macOS/WSL/Docker).
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda **kw: None)
+        monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
 
         calls = []
 
@@ -91,6 +95,10 @@ class TestSystemdServiceRefresh:
 
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
         monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
+        # Bypass systemd availability checks — this test targets unit-file
+        # refresh logic, not D-Bus reachability (fails on macOS/WSL/Docker).
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda **kw: None)
+        monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
 
         calls = []
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)


### PR DESCRIPTION
## What this does

Salvages #15435 (@Tranquil-Flow) onto current `main`.

`TestSystemdServiceRefresh::test_systemd_start_refreshes_outdated_unit` and
`test_systemd_restart_refreshes_outdated_unit` call `systemd_start()` /
`systemd_restart()`, which run the `_preflight_user_systemd()` D-Bus
reachability check. On hosts without a reachable `systemctl --user` session
(macOS, WSL, Docker, CI runners without linger) that check raises
`UserSystemdUnavailableError` and the tests fail — even though they target the
unit-file *refresh* logic, not D-Bus reachability.

This mocks `_preflight_user_systemd` and `_select_systemd_scope` in those two
tests so they exercise the refresh path deterministically on any platform.

## Verification

Full `tests/hermes_cli/test_gateway_service.py` run on macOS:
- **Before:** 6 failed / 182 passed
- **After:** 4 failed / 184 passed

The two target tests now pass. The 4 remaining failures
(`TestGatewaySystemServiceRouting::test_systemd_restart_*`) share the same
underlying D-Bus-preflight cause but are out of scope for this PR — they can be
addressed as a focused follow-up.

Test-only change (+8 lines, one file); no production code touched. `ruff` clean.

## Credit

Salvages #15435 by @Tranquil-Flow (cherry-picked with authorship preserved).
Can be closed in favor of this PR. Fixes #15187.
