### PR TITLE
fix(wecom): decode URL-encoded filenames before caching documents

### DIFF
--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -835,7 +835,7 @@ class WeComAdapter(BasePlatformAdapter):
             if match:
                 return match.group(1)
 
-        name = Path(urlparse(url).path).name or "document"
+        name = unquote(Path(urlparse(url).path).name) or "document"
         if "." not in name:
             ext = mimetypes.guess_extension(content_type) or ".bin"
             name = f"{name}{ext}"

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -833,7 +833,7 @@ class WeComAdapter(BasePlatformAdapter):
         if content_disposition:
             match = re.search(r'filename="?([^";]+)"?', content_disposition)
             if match:
-                return match.group(1)
+                return unquote(match.group(1))
 
         name = unquote(Path(urlparse(url).path).name) or "document"
         if "." not in name:

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -393,6 +393,26 @@ class TestMediaHelpers:
 
         assert decrypted == plaintext
 
+    def test_guess_filename_decodes_content_disposition(self):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        result = WeComAdapter._guess_filename(
+            "https://example.com/file",
+            'attachment; filename="%E6%B5%8B%E8%AF%95%E6%96%87%E4%BB%B6.pdf"',
+            "application/pdf",
+        )
+        assert result == "测试文件.pdf"
+
+    def test_guess_filename_decodes_url_path(self):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        result = WeComAdapter._guess_filename(
+            "https://example.com/%E6%B5%8B%E8%AF%95%E6%96%87%E4%BB%B6.pdf",
+            None,
+            "application/pdf",
+        )
+        assert result == "测试文件.pdf"
+
     @pytest.mark.asyncio
     async def test_load_outbound_media_rejects_placeholder_path(self):
         from plugins.platforms.wecom.adapter import WeComAdapter


### PR DESCRIPTION
Fixes #61211

When a WeCom user sends a file with a Chinese filename, the URL contains percent-encoded characters. `_guess_filename()` used `Path().name` without decoding them, causing file cache failures with `FileNotFoundError`.

The fix applies `unquote()` to the filename, mirroring the same pattern already used in `_resolve_cached_destination()` (line 1161 of the same file).