### PR TITLE
fix(gateway): enable linger on systemd user-service repair path (salvage #12989)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3166,6 +3166,8 @@ def systemd_install(
             if enable_on_startup:
                 _run_systemctl(["enable", get_service_name()], system=system, check=True, timeout=30)
             print(f"✓ {_service_scope_label(system).capitalize()} service definition updated")
+            if not system:
+                _ensure_linger_enabled()
             return
         print(f"Service already installed at: {unit_path}")
         print("Use --force to reinstall")

--- a/tests/hermes_cli/test_gateway_linger.py
+++ b/tests/hermes_cli/test_gateway_linger.py
@@ -194,7 +194,12 @@ def test_systemd_install_repair_path_system_scope_skips_linger(monkeypatch, tmp_
     gateway.systemd_install(force=False, system=True)
 
     assert helper_calls == []
-    assert [cmd for cmd, _ in calls] == [
-        ["systemctl", "daemon-reload"],
-        ["systemctl", "enable", gateway.get_service_name()],
-    ]
+    # System scope: no `systemctl --user` anywhere, and the repair still runs
+    # daemon-reload + enable. Assert the behavior contract rather than an exact
+    # call sequence — refresh_systemd_unit_if_needed legitimately emits an
+    # extra `systemctl show ... --property Environment` (HERMES_HOME sync) that
+    # is an internal of the refresh path, not part of this test's contract.
+    systemctl_cmds = [cmd for cmd, _ in calls if cmd and cmd[0] == "systemctl"]
+    assert all("--user" not in cmd for cmd in systemctl_cmds)
+    assert ["systemctl", "daemon-reload"] in systemctl_cmds
+    assert ["systemctl", "enable", gateway.get_service_name()] in systemctl_cmds

--- a/tests/hermes_cli/test_gateway_linger.py
+++ b/tests/hermes_cli/test_gateway_linger.py
@@ -132,3 +132,69 @@ def test_systemd_install_calls_linger_helper(monkeypatch, tmp_path, capsys):
     ]
     assert helper_calls == [True]
     assert "User service installed and enabled" in out
+
+
+def test_systemd_install_repair_path_calls_linger_helper(monkeypatch, tmp_path):
+    # The repair branch used to early-return before the linger helper ran, so
+    # upgrades on headless hosts left the service dead after the user logged
+    # out. Pin that repair now behaves like fresh-install on user scope.
+    unit_path = tmp_path / "hermes-gateway.service"
+    unit_path.write_text("old unit\n", encoding="utf-8")
+
+    monkeypatch.setattr(gateway, "get_systemd_unit_path", lambda system=False: unit_path)
+    monkeypatch.setattr(gateway, "systemd_unit_is_current", lambda system=False: False)
+    monkeypatch.setattr(
+        gateway, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n"
+    )
+
+    calls = []
+
+    def fake_run(cmd, check=False, **kwargs):
+        calls.append((cmd, check))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    helper_calls = []
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+    monkeypatch.setattr(gateway, "_ensure_linger_enabled", lambda: helper_calls.append(True))
+
+    gateway.systemd_install(force=False)
+
+    assert unit_path.read_text(encoding="utf-8") == "new unit\n"
+    assert [cmd for cmd, _ in calls] == [
+        ["systemctl", "--user", "daemon-reload"],
+        ["systemctl", "--user", "enable", gateway.get_service_name()],
+    ]
+    assert helper_calls == [True]
+
+
+def test_systemd_install_repair_path_system_scope_skips_linger(monkeypatch, tmp_path):
+    # Linger is a per-user-session concept; system-scope units run under PID 1
+    # and must never touch it. Guards against mirroring the user-scope fix in
+    # the wrong branch of systemd_install().
+    unit_path = tmp_path / "hermes-gateway.service"
+    unit_path.write_text("old unit\n", encoding="utf-8")
+
+    monkeypatch.setattr(gateway, "get_systemd_unit_path", lambda system=False: unit_path)
+    monkeypatch.setattr(gateway, "systemd_unit_is_current", lambda system=False: False)
+    monkeypatch.setattr(
+        gateway, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n"
+    )
+    monkeypatch.setattr(gateway, "_require_root_for_system_service", lambda _action: None)
+
+    calls = []
+
+    def fake_run(cmd, check=False, **kwargs):
+        calls.append((cmd, check))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    helper_calls = []
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+    monkeypatch.setattr(gateway, "_ensure_linger_enabled", lambda: helper_calls.append(True))
+
+    gateway.systemd_install(force=False, system=True)
+
+    assert helper_calls == []
+    assert [cmd for cmd, _ in calls] == [
+        ["systemctl", "daemon-reload"],
+        ["systemctl", "enable", gateway.get_service_name()],
+    ]


### PR DESCRIPTION
## What this does

Salvages #12989 (@season179) onto current `main`. Closes #12863.

`systemd_install()` has a **repair branch**: when an outdated unit already
exists (`hermes gateway install` without `--force`), it refreshes the unit,
re-enables it, and `return`s early — **before** reaching the
`_ensure_linger_enabled()` call that the fresh-install path runs. On a headless
host (SSH, no seat), that means an upgrade that repairs the unit leaves linger
disabled, so the user gateway dies when the session logs out.

The fix adds `_ensure_linger_enabled()` to the repair branch, guarded by
`if not system` (linger is a per-user-session concept; system-scope units run
under PID 1 and must never touch it).

## Verification

- Premise confirmed live on current `main`: the repair branch early-returns
  before linger.
- `tests/hermes_cli/test_gateway_linger.py`: 8/8 pass.
- Mutation-verified the guard test has teeth: removing the fix makes
  `test_systemd_install_repair_path_calls_linger_helper` fail (`[] == [True]`).
- The remaining `test_gateway_service.py` macOS failures are pre-existing D-Bus
  preflight failures unrelated to this change (addressed separately by #61384).

## Commits

1. @season179's fix, cherry-picked with authorship preserved.
2. A follow-up (mine): the salvaged system-scope guard test asserted an exact
   `systemctl` call sequence that broke because `refresh_systemd_unit_if_needed`
   grew a `systemctl show … --property Environment` (HERMES_HOME sync) step
   since the PR was authored. Replaced it with a behavior-contract assertion
   (no `systemctl --user` on system scope; daemon-reload + enable both run;
   linger not called) — the linger-not-called invariant is unchanged.

## Credit

Salvages #12989 by @season179 (authorship preserved). Can be closed in favor of
this PR.
