### PR TITLE
fix(dashboard): validate HERMES_WEB_DIST before startup (#17845 follow-through)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12092,6 +12092,10 @@ def cmd_dashboard(args):
             print("  Pre-build first:  npm install --workspace web && npm run build -w web")
             print("  Or unset HERMES_WEB_DIST to build and use the default web UI dist.")
             sys.exit(1)
+        # Write the expanded path back: web_server reads HERMES_WEB_DIST raw
+        # at import (no expanduser), so a validated "~/dist" would otherwise
+        # pass here and still 404 there.
+        os.environ["HERMES_WEB_DIST"] = str(_dist_root)
         print(f"→ Using web dist from HERMES_WEB_DIST: {_dist_root}")
 
     # Discover and load plugins so any DashboardAuthProvider plugin

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12080,6 +12080,19 @@ def cmd_dashboard(args):
             print("  Or drop --skip-build to build automatically.")
             sys.exit(1)
         print(f"→ Skipping web UI build (--skip-build); using dist at {_dist_root}")
+    else:
+        # HERMES_WEB_DIST is set without --skip-build: the build is skipped
+        # (the env var points at a caller-managed dist), so validate it the
+        # same way the --skip-build branch does — otherwise the server starts
+        # and serves 404s with no obvious cause (same failure mode as #23817,
+        # via the env-var path).
+        _dist_root = Path(os.environ["HERMES_WEB_DIST"]).expanduser()
+        if not (_dist_root / "index.html").exists():
+            print(f"✗ HERMES_WEB_DIST is set but no web dist found at: {_dist_root}")
+            print("  Pre-build first:  npm install --workspace web && npm run build -w web")
+            print("  Or unset HERMES_WEB_DIST to build and use the default web UI dist.")
+            sys.exit(1)
+        print(f"→ Using web dist from HERMES_WEB_DIST: {_dist_root}")
 
     # Discover and load plugins so any DashboardAuthProvider plugin
     # (e.g. plugins/dashboard_auth/nous) registers BEFORE start_server's

--- a/tests/hermes_cli/test_dashboard_web_dist_validation.py
+++ b/tests/hermes_cli/test_dashboard_web_dist_validation.py
@@ -111,3 +111,26 @@ def test_env_dist_with_index_starts_server(main_mod, monkeypatch, tmp_path):
 
     assert len(started) == 1
     assert builds == []
+
+
+def test_env_dist_tilde_expanded_for_web_server(main_mod, monkeypatch, tmp_path):
+    """A '~/...' HERMES_WEB_DIST must be written back expanded so
+    web_server's raw os.environ read serves the validated path."""
+    _wire_common(main_mod, monkeypatch)
+    home = tmp_path / "home"
+    dist = home / "mydist"
+    dist.mkdir(parents=True)
+    (dist / "index.html").write_text("<html></html>", encoding="utf-8")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("HERMES_WEB_DIST", "~/mydist")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.web_server",
+        types.SimpleNamespace(start_server=lambda **k: None),
+    )
+
+    main_mod.cmd_dashboard(_args())
+
+    import os
+    assert os.environ["HERMES_WEB_DIST"] == str(dist)

--- a/tests/hermes_cli/test_dashboard_web_dist_validation.py
+++ b/tests/hermes_cli/test_dashboard_web_dist_validation.py
@@ -1,0 +1,113 @@
+"""Regression tests: `hermes dashboard` validates HERMES_WEB_DIST before serving.
+
+A custom HERMES_WEB_DIST without --skip-build previously skipped BOTH the
+build and any validation, so the server started and served 404s with no
+obvious cause (same failure mode as issue #23817, reached via the env-var
+path instead of --skip-build). The env-var branch must now fail fast when
+the dist has no index.html, and proceed when it does.
+
+Design credit: PR #17845 (@Caelier).
+"""
+
+import sys
+import types
+
+import pytest
+
+
+@pytest.fixture()
+def main_mod():
+    import hermes_cli.main as main
+    return main
+
+
+def _args(**over):
+    base = {
+        "host": "127.0.0.1",
+        "port": 0,
+        "no_open": True,
+        "open_profile": None,
+        "skip_build": False,
+        "headless_backend": False,
+        "tui": False,
+    }
+    base.update(over)
+    return types.SimpleNamespace(**base)
+
+
+def _wire_common(main_mod, monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name", lambda: "default"
+    )
+    monkeypatch.setattr(main_mod, "_sync_bundled_skills_quietly", lambda: None)
+    monkeypatch.setitem(sys.modules, "fastapi", types.SimpleNamespace())
+    monkeypatch.setitem(sys.modules, "uvicorn", types.SimpleNamespace())
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_logging",
+        types.SimpleNamespace(setup_logging=lambda **_k: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(discover_plugins=lambda: None),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.mcp_startup.start_background_mcp_discovery",
+        lambda **_k: None,
+    )
+
+
+def test_env_dist_without_index_exits(main_mod, monkeypatch, tmp_path, capsys):
+    """HERMES_WEB_DIST pointing at a dist with no index.html must exit 1,
+    not start a server that 404s."""
+    _wire_common(main_mod, monkeypatch)
+    empty_dist = tmp_path / "empty_dist"
+    empty_dist.mkdir()
+    monkeypatch.setenv("HERMES_WEB_DIST", str(empty_dist))
+
+    started = []
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.web_server",
+        types.SimpleNamespace(start_server=lambda **k: started.append(k)),
+    )
+    builds = []
+    monkeypatch.setattr(
+        main_mod, "_build_web_ui", lambda *a, **k: builds.append(a) or True
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod.cmd_dashboard(_args())
+
+    assert exc.value.code == 1
+    assert started == []
+    assert builds == []  # env var set -> build skipped, validation is the gate
+    out = capsys.readouterr().out
+    assert "HERMES_WEB_DIST" in out and str(empty_dist) in out
+
+
+def test_env_dist_with_index_starts_server(main_mod, monkeypatch, tmp_path):
+    """A valid HERMES_WEB_DIST (has index.html) proceeds to start_server
+    without building."""
+    _wire_common(main_mod, monkeypatch)
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "index.html").write_text("<html></html>", encoding="utf-8")
+    monkeypatch.setenv("HERMES_WEB_DIST", str(dist))
+
+    started = []
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.web_server",
+        types.SimpleNamespace(start_server=lambda **k: started.append(k)),
+    )
+    builds = []
+    monkeypatch.setattr(
+        main_mod, "_build_web_ui", lambda *a, **k: builds.append(a) or True
+    )
+
+    main_mod.cmd_dashboard(_args())
+
+    assert len(started) == 1
+    assert builds == []


### PR DESCRIPTION
## Summary
`hermes dashboard` with a custom `HERMES_WEB_DIST` now fails fast with actionable guidance when the dist is missing/incomplete, instead of starting a server that 404s on every static route with no obvious cause.

Root cause: the build gate had branches for "no env var → build" and "--skip-build → validate (#23817)", but `HERMES_WEB_DIST` set *without* `--skip-build` fell through both — build skipped AND no validation.

## Changes
- `hermes_cli/main.py`: add the missing else-branch — validate `index.html` exists in the env-var dist, exit 1 with pre-build/unset guidance when absent, proceed without building when present.
- `tests/hermes_cli/test_dashboard_web_dist_validation.py`: 2 regression tests (invalid dist exits 1 + never calls `_build_web_ui`; valid dist reaches `start_server` without building). Mutation-verified: the exit-1 test fails on main's fall-through version.

## Validation
| | Before | After |
|---|---|---|
| `HERMES_WEB_DIST=/empty hermes dashboard` | server starts, SPA 404s silently | exit 1: "no web dist found at ..." |
| valid `HERMES_WEB_DIST` | serves | serves (unchanged, no build) |

Real-subprocess E2E: `hermes dashboard` with an empty dist exits 1 with the message; targeted suites green (test_dashboard_unified_launch + new file, 11 passed). ruff clean.

Blast-radius note: the modern desktop app spawns `hermes serve` (headless branch, `HERMES_SERVE_HEADLESS=1`) and never reaches this gate. Legacy runtimes routed through `dashboard --no-open` with a bad `resolveWebDist()` fallback previously produced an unusable 404 window; they now fail fast with the guidance line captured in the desktop's backend log — strictly better diagnosability for the same broken state.

## Credit
- @Caelier — #17845 originally proposed validating the web UI dist at dashboard startup. The `--skip-build` half of that scope has since landed via the #23817 fix on a rewritten `cmd_dashboard`; this fresh commit covers the remaining env-var path (a cherry-pick would conflict with the headless/skip-build restructuring that postdates the PR).

Supersedes #17845 — can be closed in favor of this.
