### PR TITLE
fix(telegram): strip TOOLCALL markup from reply preview text

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8330,7 +8330,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         reply_to_text = None
 
         # Strip TOOLCALL markup leaked from bot replies (#61217)
-        if reply_to_text:
+        if isinstance(reply_to_text, str) and reply_to_text:
             reply_to_text = _TOOLCALL_RE.sub('', reply_to_text).strip()
 
         # Per-channel/topic ephemeral prompt

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -21,6 +21,9 @@ from typing import Dict, List, Optional, Set, Any
 
 logger = logging.getLogger(__name__)
 
+# Regex to strip TOOLCALL markup from reply text (#61217)
+_TOOLCALL_RE = re.compile(r'<TOOLCALL>.*?</TOOLCALL>', re.DOTALL)
+
 
 def _redact_telegram_error_text(error: object) -> str:
     """Redact secrets from Telegram transport errors before logging or returning them."""
@@ -8325,6 +8328,10 @@ class TelegramAdapter(BasePlatformAdapter):
                         )
                     except Exception:
                         reply_to_text = None
+
+        # Strip TOOLCALL markup leaked from bot replies (#61217)
+        if reply_to_text:
+            reply_to_text = _TOOLCALL_RE.sub('', reply_to_text).strip()
 
         # Per-channel/topic ephemeral prompt
         from gateway.platforms.base import resolve_channel_prompt


### PR DESCRIPTION
Fixes #61217

When the bot sends a reply to a message that contained tool call markup, the raw TOOLCALL text leaked into Telegram's reply preview UI. Users saw internal markup like:



The fix strips TOOLCALL blocks from reply_to_text after extraction.