### PR TITLE
fix(telegram): preserve user_id on triggered messages with observe_unmentioned

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6991,7 +6991,11 @@ class TelegramAdapter(BasePlatformAdapter):
         allowed = self._telegram_observe_allowed_chats()
         if not allowed or chat_id_str not in allowed:
             return event
-        shared_source = self._telegram_group_observe_shared_source(event.source)
+        shared_source = dataclasses.replace(
+            self._telegram_group_observe_shared_source(event.source),
+            user_id=event.source.user_id,
+            user_name=event.source.user_name,
+        )
         observe_prompt = self._telegram_group_observe_channel_prompt()
         channel_prompt = f"{event.channel_prompt}\n\n{observe_prompt}" if event.channel_prompt else observe_prompt
         if event.message_type == MessageType.COMMAND:

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -185,8 +185,8 @@ def test_unmentioned_group_messages_can_be_observed_without_dispatching():
         assert message["message_id"] == "42"
         assert store.sources[0].chat_id == "-100"
         assert store.sources[0].chat_type == "group"
-        assert store.sources[0].user_id is None
-        assert store.sources[0].user_name is None
+        assert store.sources[0].user_id == "111"
+        assert store.sources[0].user_name == "Alice Example"
 
     asyncio.run(_run())
 
@@ -215,8 +215,8 @@ def test_observed_group_context_uses_shared_source_and_prompt_for_later_mentions
 
         assert event.source.chat_id == "-100"
         assert event.source.chat_type == "group"
-        assert event.source.user_id is None
-        assert event.source.user_name is None
+        assert event.source.user_id == "222"
+        assert event.source.user_name == "Bob Example"
         assert event.text == "[Bob Example|222]\nwhat did Alice say?"
         assert "Existing topic prompt" in event.channel_prompt
         assert "observed Telegram group context" in event.channel_prompt
@@ -343,7 +343,7 @@ def test_observed_group_context_preserves_slash_command_text_for_dispatch():
 
     assert attributed.text == "/new@hermes_bot"
     assert attributed.get_command() == "new"
-    assert attributed.source.user_id is None
+    assert attributed.source.user_id == "111"
     assert "observed Telegram group context" in attributed.channel_prompt
 
 
@@ -1080,7 +1080,7 @@ def test_triggered_location_message_uses_shared_session_in_observe_mode():
 
         adapter.handle_message.assert_awaited_once()
         event = adapter.handle_message.call_args[0][0]
-        assert event.source.user_id is None
+        assert event.source.user_id == "111"
         assert "[Alice Example|111]" in event.text
 
     asyncio.run(_run())
@@ -1112,7 +1112,7 @@ def test_unmentioned_voice_message_observed_in_group():
         assert len(store.messages) == 1
         _, message, _ = store.messages[0]
         assert message["observed"] is True
-        assert store.sources[0].user_id is None
+        assert store.sources[0].user_id == "111"
 
     asyncio.run(_run())
 
@@ -1135,7 +1135,7 @@ def test_triggered_voice_message_uses_shared_session_in_observe_mode():
 
         adapter.handle_message.assert_awaited_once()
         event = adapter.handle_message.call_args[0][0]
-        assert event.source.user_id is None
+        assert event.source.user_id == "111"
         assert "[Alice Example|111]" in event.text
 
     asyncio.run(_run())

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -185,8 +185,8 @@ def test_unmentioned_group_messages_can_be_observed_without_dispatching():
         assert message["message_id"] == "42"
         assert store.sources[0].chat_id == "-100"
         assert store.sources[0].chat_type == "group"
-        assert store.sources[0].user_id == "111"
-        assert store.sources[0].user_name == "Alice Example"
+        assert store.sources[0].user_id is None
+        assert store.sources[0].user_name is None
 
     asyncio.run(_run())
 
@@ -1112,7 +1112,7 @@ def test_unmentioned_voice_message_observed_in_group():
         assert len(store.messages) == 1
         _, message, _ = store.messages[0]
         assert message["observed"] is True
-        assert store.sources[0].user_id == "111"
+        assert store.sources[0].user_id is None
 
     asyncio.run(_run())
 


### PR DESCRIPTION
Fixes #61308

When observe_unmentioned_group_messages and require_mention are both enabled, triggered messages (@mentions, replies) had their user_id stripped by _apply_telegram_group_observe_attribution. The auth check then silently dropped them because user_id was None.

Fix: preserve user_id and user_name on the shared source for triggered messages. The observation path (non-trigger messages) correctly keeps user_id=None.