### PR TITLE
fix(desktop): handle branch switch in non-git projects

### DIFF
--- a/apps/desktop/electron/git-worktree-ops.test.ts
+++ b/apps/desktop/electron/git-worktree-ops.test.ts
@@ -92,6 +92,19 @@ test('switchBranch: switches a normal checkout branch', async () => {
   }
 })
 
+test('switchBranch: reports a friendly error for non-git project folders', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-non-git-switch-'))
+
+  try {
+    await assert.rejects(
+      () => switchBranch(dir, '2026-notes', 'git'),
+      /This project folder is not a git repository/
+    )
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('listBranches: lists locals and flags the checked-out branch', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-branches-'))
 

--- a/apps/desktop/electron/git-worktree-ops.ts
+++ b/apps/desktop/electron/git-worktree-ops.ts
@@ -332,6 +332,23 @@ async function switchBranch(repoPath, branch, gitBin) {
     throw new Error('Branch name is required.')
   }
 
+  try {
+    const inside = (await runGit(gitBin, ['rev-parse', '--is-inside-work-tree'], resolved)).trim()
+
+    if (inside !== 'true') {
+      throw new Error('This project folder is not a git repository.')
+    }
+  } catch (err) {
+    const caught = err as { message?: unknown; stderr?: unknown }
+    const detail = `${String(caught.stderr || '')}\n${String(caught.message || '')}`
+
+    if (/not a git repository/i.test(detail)) {
+      throw new Error('This project folder is not a git repository.')
+    }
+
+    throw err
+  }
+
   await runGit(gitBin, ['switch', target], resolved)
 
   return { branch: target }


### PR DESCRIPTION
Summary
- Add a non-git preflight to the desktop branch-switch IPC path so plain project folders surface a friendly error instead of raw `git switch` stderr.
- Cover the non-git project case in the Electron git worktree ops tests.

Root Cause
- `switchBranch()` sanitized the requested branch name and invoked `git switch` directly, even when the project path was a plain folder outside any Git worktree.
- That let the raw `fatal: not a git repository` error bubble up to the desktop UI when a non-git project exposed a branch-switch action.

Tests
- `tsx --test electron/git-worktree-ops.test.ts` passes 13 tests.
- `git diff --check origin/main...HEAD`

Refs #61362