### PR TITLE
fix(desktop): preserve node-pty helper path in unpacked app

### DIFF
--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -13,17 +13,39 @@ import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve, join } from 'node:path'
 import {
+  chmodSync,
   cpSync,
   existsSync,
   mkdirSync,
+  readFileSync,
   readdirSync,
-  rmSync
+  rmSync,
+  writeFileSync
 } from 'node:fs'
 import { isMain } from './utils.mjs'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const projectRoot = resolve(here, '..')
 const require = createRequire(import.meta.url)
+
+function ensureExecutable(filePath) {
+  if (process.platform === 'win32') return
+  chmodSync(filePath, 0o755)
+}
+
+function patchUnixTerminalAsarPath(destRoot) {
+  const filePath = join(destRoot, 'lib', 'unixTerminal.js')
+  if (!existsSync(filePath)) return
+
+  const source = readFileSync(filePath, 'utf8')
+  const patched = source.replace(
+    "helperPath = helperPath.replace('app.asar', 'app.asar.unpacked');",
+    "helperPath = helperPath.replace(/app\\.asar(?!\\.unpacked)/, 'app.asar.unpacked');"
+  )
+  if (patched !== source) {
+    writeFileSync(filePath, patched)
+  }
+}
 
 /**
  * Locate node-pty's package root via real module resolution, so this
@@ -72,7 +94,11 @@ function copyBuildRelease(srcDir, destDir) {
       continue
     }
     if (entry.name === 'spawn-helper' || /\.(node|dll|exe)$/.test(entry.name)) {
-      cpSync(join(srcDir, entry.name), join(destDir, entry.name))
+      const destFile = join(destDir, entry.name)
+      cpSync(join(srcDir, entry.name), destFile)
+      if (entry.name === 'spawn-helper') {
+        ensureExecutable(destFile)
+      }
     }
   }
 }
@@ -90,6 +116,7 @@ export function stageNodePty({ platform = process.platform, arch = process.arch 
 
   // lib/**/*.js — the JS surface node-pty's `main` points into.
   copyGlobByExt(join(srcRoot, 'lib'), join(destRoot, 'lib'), ['.js'])
+  patchUnixTerminalAsarPath(destRoot)
 
   // build/Release/* — present when node-pty was compiled locally
   // (e.g. no prebuild available for this Electron ABI/platform combo).
@@ -114,7 +141,9 @@ export function stageNodePty({ platform = process.platform, arch = process.arch 
         continue
       }
       if (entry.name === 'spawn-helper') {
-        cpSync(join(prebuildDir, entry.name), join(destPrebuild, entry.name))
+        const destFile = join(destPrebuild, entry.name)
+        cpSync(join(prebuildDir, entry.name), destFile)
+        ensureExecutable(destFile)
       }
     }
   } else {

--- a/apps/desktop/scripts/test-desktop.mjs
+++ b/apps/desktop/scripts/test-desktop.mjs
@@ -101,7 +101,8 @@ function expectedNativeDepPaths() {
     packageJson: path.join(root, 'package.json'),
     prebuildsDir,
     buildReleaseDir,
-    libIndex: path.join(root, 'lib', 'index.js')
+    libIndex: path.join(root, 'lib', 'index.js'),
+    unixTerminal: path.join(root, 'lib', 'unixTerminal.js')
   }
 }
 
@@ -332,6 +333,9 @@ function validateBundle() {
   if (!exists(native.libIndex)) {
     die(`Missing node-pty lib/index.js in app.asar.unpacked: ${native.libIndex}`)
   }
+  if (!exists(native.unixTerminal)) {
+    die(`Missing node-pty lib/unixTerminal.js in app.asar.unpacked: ${native.unixTerminal}`)
+  }
   // The native binary lands in prebuilds/<platform>-<arch>/ (downloaded prebuild)
   // OR build/Release/ (compiled from source). stage-native-deps.mjs copies
   // whichever is present, so accept either.
@@ -356,6 +360,13 @@ function validateBundle() {
       .find(exists)
     if (!spawnHelper) {
       die(`Missing node-pty spawn-helper (required on darwin) in: ${nativeBinaryDirs.join(', ')}`)
+    }
+    if ((fs.statSync(spawnHelper).mode & 0o111) === 0) {
+      die(`node-pty spawn-helper is not executable: ${spawnHelper}`)
+    }
+    const unixTerminalSource = fs.readFileSync(native.unixTerminal, 'utf8')
+    if (!unixTerminalSource.includes('/app\\.asar(?!\\.unpacked)/')) {
+      die(`node-pty unixTerminal.js can double-unpack app.asar paths: ${native.unixTerminal}`)
     }
   }
 


### PR DESCRIPTION
## Summary
- patch staged node-pty unixTerminal.js so app.asar paths are only rewritten when they are not already app.asar.unpacked
- preserve executable permissions for Darwin spawn-helper when staging node-pty native payloads
- extend desktop bundle validation to catch non-executable spawn-helper and app.asar.unpacked.unpacked regressions

Fixes #61389

## Testing
- node --check apps/desktop/scripts/stage-native-deps.mjs
- node --check apps/desktop/scripts/test-desktop.mjs
- git diff --check
- npm run pack (in the original working tree with dependencies)
- HERMES_DESKTOP_SKIP_BUILD=1 npm run test:desktop:fresh (in the original working tree with dependencies)
- ELECTRON_RUN_AS_NODE=1 release/mac-arm64/Hermes.app/Contents/MacOS/Hermes -e '<packaged node-pty spawn smoke test>'
