### PR TITLE
fix(feishu): use ReplyMessage instead of CreateMessage for thread delivery

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4621,17 +4621,18 @@ class FeishuAdapter(BasePlatformAdapter):
             return await self._run_blocking(self._client.im.v1.message.reply, request)
 
         # For topic/thread messages that fell back from reply→create, use
-        # thread_id as receive_id so the message lands in the topic instead of
-        # the main chat.
+        # ReplyMessage with reply_in_thread. CreateMessage does not accept
+        # receive_id_type=thread_id — Feishu returns 99992402 (#61000).
         _thread_id = (metadata or {}).get("thread_id")
         if _thread_id:
-            body = self._build_create_message_body(
-                receive_id=_thread_id,
-                msg_type=msg_type,
+            body = self._build_reply_message_body(
                 content=payload,
+                msg_type=msg_type,
+                reply_in_thread=True,
                 uuid_value=str(uuid.uuid4()),
             )
-            request = self._build_create_message_request("thread_id", body)
+            request = self._build_reply_message_request(_thread_id, body)
+            return await self._run_blocking(self._client.im.v1.message.reply, request)
         else:
             receive_id = chat_id
             receive_id_type = "chat_id"

--- a/tests/gateway/test_stream_consumer_thread_routing.py
+++ b/tests/gateway/test_stream_consumer_thread_routing.py
@@ -218,23 +218,19 @@ class TestFeishuFallbackThreadRouting:
         # Verify message.reply was called (not message.create)
         mock_client.im.v1.message.reply.assert_called_once()
 
-        # The reply request should have the thread_id as receive_id
+        # The reply request should have the thread_id as message_id
         call_args = mock_client.im.v1.message.reply.call_args[0][0]
-        # Lark SDK builder exposes .body; the in-tree fallback exposes .request_body.
+        # message_id on the reply request is the thread_id
+        msg_id = getattr(call_args, "message_id", None)
+        assert msg_id == "omt_topic_abc", (
+            f"Expected message_id='omt_topic_abc', got '{msg_id}'"
+        )
+        # The request body should have reply_in_thread=True
         body = getattr(call_args, "body", None) or getattr(call_args, "request_body", None)
         assert body is not None, "request has neither .body nor .request_body"
-        # receive_id should be the thread_id
-        receive_id = getattr(body, "receive_id", None)
-        if receive_id is None and isinstance(body, str):
-            import json as _json
-            receive_id = _json.loads(body).get("receive_id")
-        assert receive_id == "omt_topic_abc", (
-            f"Expected receive_id='omt_topic_abc', got '{receive_id}'"
-        )
-        # And receive_id_type must be 'thread_id', not 'chat_id'
-        receive_id_type = getattr(call_args, "receive_id_type", None)
-        assert receive_id_type == "thread_id", (
-            f"Expected receive_id_type='thread_id', got '{receive_id_type}'"
+        reply_in_thread = getattr(body, "reply_in_thread", None)
+        assert reply_in_thread is True, (
+            f"Expected reply_in_thread=True, got '{reply_in_thread}'"
         )
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_stream_consumer_thread_routing.py
+++ b/tests/gateway/test_stream_consumer_thread_routing.py
@@ -178,8 +178,8 @@ class TestFeishuFallbackThreadRouting:
 
     @pytest.mark.asyncio
     async def test_create_uses_thread_id_when_available(self):
-        """When reply_to=None and metadata has thread_id, message.create
-        should use receive_id_type='thread_id'."""
+        """When reply_to=None and metadata has thread_id, message.reply
+        with reply_in_thread=True should be used instead of message.create."""
         from plugins.platforms.feishu.adapter import FeishuAdapter
 
         # We test the _send_raw_message method directly by mocking the client
@@ -187,16 +187,16 @@ class TestFeishuFallbackThreadRouting:
 
         # Set up the real _send_raw_message logic manually
         mock_client = MagicMock()
-        mock_create_response = SimpleNamespace(
+        mock_reply_response = SimpleNamespace(
             success=lambda: True,
             data=SimpleNamespace(message_id="new_msg_1"),
         )
-        mock_client.im.v1.message.create = MagicMock(return_value=mock_create_response)
+        mock_client.im.v1.message.reply = MagicMock(return_value=mock_reply_response)
 
         # Use the real implementation path
         adapter._client = mock_client
-        adapter._build_create_message_body = FeishuAdapter._build_create_message_body
-        adapter._build_create_message_request = FeishuAdapter._build_create_message_request
+        adapter._build_reply_message_body = FeishuAdapter._build_reply_message_body
+        adapter._build_reply_message_request = FeishuAdapter._build_reply_message_request
         # _send_raw_message routes blocking SDK calls through _run_blocking
         # (adapter-owned executor). On a MagicMock(spec=...) that method is
         # auto-mocked and would swallow the real call, so wire a passthrough.
@@ -215,17 +215,15 @@ class TestFeishuFallbackThreadRouting:
             metadata={"thread_id": "omt_topic_abc"},
         )
 
-        # Verify message.create was called (not message.reply)
-        mock_client.im.v1.message.create.assert_called_once()
+        # Verify message.reply was called (not message.create)
+        mock_client.im.v1.message.reply.assert_called_once()
 
-        # The request should have receive_id_type="thread_id"
-        call_args = mock_client.im.v1.message.create.call_args[0][0]
+        # The reply request should have the thread_id as receive_id
+        call_args = mock_client.im.v1.message.reply.call_args[0][0]
         # Lark SDK builder exposes .body; the in-tree fallback exposes .request_body.
-        # The contributor's branch had the lark SDK installed, the test environment
-        # may not — handle both shapes.
         body = getattr(call_args, "body", None) or getattr(call_args, "request_body", None)
         assert body is not None, "request has neither .body nor .request_body"
-        # receive_id should be the thread_id, not the chat_id
+        # receive_id should be the thread_id
         receive_id = getattr(body, "receive_id", None)
         if receive_id is None and isinstance(body, str):
             import json as _json


### PR DESCRIPTION
Fixes #61000

Feishu does not accept receive_id_type=thread_id in CreateMessage — returns error 99992402. When sending a message to a thread (topic) without a specific reply target, use ReplyMessage with reply_in_thread=True instead.

The previous code also had a bug where the CreateMessage request was built but never actually sent because the code fell through to the else block and built a second request.