### PR TITLE
fix(desktop): preserve mono fallback for Latin Extended code

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -318,10 +318,13 @@
     --dt-font-kbd: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', system-ui, sans-serif;
     /* JetBrains Mono first — the face we bundle (@font-face above) and the
        terminal's primary — so code/diff match the terminal on every platform
-       instead of drifting to a system Cascadia Code where it's installed. */
+       instead of drifting to a system Cascadia Code where it's installed. The
+       extra Linux mono fallbacks preserve Latin Extended glyphs as monospace
+       when a theme display font does not cover them. */
     --dt-font-mono:
-      'JetBrains Mono', 'Cascadia Code', 'SF Mono', ui-monospace, Menlo, Consolas, monospace, 'Apple Color Emoji',
-      'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji', emoji;
+      'JetBrains Mono', 'Cascadia Code', 'Cascadia Mono', 'DejaVu Sans Mono', 'Liberation Mono', 'Noto Sans Mono',
+      'Noto Mono', 'SF Mono', ui-monospace, Menlo, Consolas, monospace, 'Apple Color Emoji', 'Segoe UI Emoji',
+      'Segoe UI Symbol', 'Noto Color Emoji', emoji;
     --dt-base-size: 1rem;
     --dt-line-height: 1.5;
     --dt-letter-spacing: 0;

--- a/apps/desktop/src/themes/presets.test.ts
+++ b/apps/desktop/src/themes/presets.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { BUILTIN_THEME_LIST, DEFAULT_TYPOGRAPHY, EMOJI_FALLBACK } from './presets'
+import { BUILTIN_THEME_LIST, DEFAULT_TYPOGRAPHY, EMOJI_FALLBACK, nousTheme } from './presets'
 
 // #40364: none of the UI text/mono fonts carry emoji glyphs, so every font
 // stack must end with a color-emoji fallback or emoji render as tofu on
@@ -29,5 +29,38 @@ describe('theme typography emoji fallback (#40364)', () => {
     expect(EMOJI_FALLBACK).toContain('Apple Color Emoji')
     expect(EMOJI_FALLBACK).toContain('Segoe UI Emoji')
     expect(EMOJI_FALLBACK).toContain('Noto Color Emoji')
+  })
+})
+
+describe('theme typography Latin Extended fallback (#61392)', () => {
+  const monoStacks: Array<[string, string]> = [
+    ['DEFAULT_TYPOGRAPHY.fontMono', DEFAULT_TYPOGRAPHY.fontMono],
+    ...BUILTIN_THEME_LIST.map(theme => [
+      `${theme.name}.effectiveFontMono`,
+      theme.typography?.fontMono ?? nousTheme.typography?.fontMono ?? DEFAULT_TYPOGRAPHY.fontMono
+    ] as [string, string])
+  ]
+
+  it.each(monoStacks)('%s falls back to bundled JetBrains Mono before generic fonts', (_label, stack) => {
+    const jetbrains = stack.indexOf('JetBrains Mono')
+
+    expect(jetbrains).toBeGreaterThanOrEqual(0)
+
+    const genericIndexes = [
+      stack.indexOf('ui-monospace'),
+      stack.indexOf('monospace'),
+      stack.indexOf('Apple Color Emoji'),
+      stack.indexOf('Segoe UI Emoji'),
+      stack.indexOf('Noto Color Emoji')
+    ].filter(index => index >= 0)
+
+    expect(genericIndexes.length).toBeGreaterThan(0)
+    expect(jetbrains).toBeLessThan(Math.min(...genericIndexes))
+  })
+
+  it('default stack includes common Linux monospace glyph fallbacks', () => {
+    expect(DEFAULT_TYPOGRAPHY.fontMono).toContain('DejaVu Sans Mono')
+    expect(DEFAULT_TYPOGRAPHY.fontMono).toContain('Liberation Mono')
+    expect(DEFAULT_TYPOGRAPHY.fontMono).toContain('Noto Sans Mono')
   })
 })

--- a/apps/desktop/src/themes/presets.ts
+++ b/apps/desktop/src/themes/presets.ts
@@ -15,8 +15,15 @@ const SYSTEM_SANS =
   '"Segoe WPC", "Segoe UI", -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display", system-ui, sans-serif, ' +
   EMOJI_FALLBACK
 
+// Keep the bundled JetBrains Mono first in every mono fallback chain. Several
+// theme display fonts (Courier Prime, IBM Plex Mono) do not cover Vietnamese /
+// Latin Extended glyphs; falling directly to platform UI fonts makes code
+// blocks visibly non-monospace. JetBrains Mono is bundled with the app and
+// covers those glyphs, while the Linux fallbacks catch distros without it.
 const SYSTEM_MONO =
-  '"Cascadia Code", "JetBrains Mono", "SF Mono", ui-monospace, Menlo, Monaco, Consolas, monospace, ' + EMOJI_FALLBACK
+  '"JetBrains Mono", "Cascadia Code", "Cascadia Mono", "DejaVu Sans Mono", "Liberation Mono", "Noto Sans Mono", ' +
+  '"Noto Mono", "SF Mono", ui-monospace, Menlo, Monaco, Consolas, monospace, ' +
+  EMOJI_FALLBACK
 
 export const DEFAULT_TYPOGRAPHY: DesktopThemeTypography = { fontSans: SYSTEM_SANS, fontMono: SYSTEM_MONO }
 
@@ -236,8 +243,8 @@ export const cyberpunkTheme: DesktopTheme = {
     userBubbleBorder: '#004800'
   },
   typography: {
-    fontMono: `"Courier New", Courier, monospace, ${EMOJI_FALLBACK}`,
-    fontSans: `"Courier New", Courier, monospace, ${EMOJI_FALLBACK}`
+    fontMono: `"Courier New", Courier, ${SYSTEM_MONO}`,
+    fontSans: `"Courier New", Courier, ${SYSTEM_MONO}`
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes desktop code block font fallback for Vietnamese / Latin Extended glyphs. Some themes start their mono stack with Google-hosted display fonts such as Courier Prime or IBM Plex Mono; when those fonts do not contain Vietnamese glyphs, code can fall through to non-monospace system rendering. This keeps the bundled JetBrains Mono and common glyph-complete Linux monospace faces ahead of generic fallbacks.

## Related Issue

Fixes #61392

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Updated `apps/desktop/src/themes/presets.ts` so theme mono stacks fall back through bundled `JetBrains Mono` and glyph-complete monospace fonts before generic/system fallbacks.
- Synced the default CSS `--dt-font-mono` fallback in `apps/desktop/src/styles.css`.
- Added regression coverage in `apps/desktop/src/themes/presets.test.ts` for the effective built-in theme mono stacks.

## How to Test

1. Run `cd apps/desktop && npm run test:ui -- src/themes/presets.test.ts`.
2. Run `cd apps/desktop && npx eslint src/themes/presets.ts src/themes/presets.test.ts`.
3. Render a desktop code block containing Vietnamese diacritics with mono/ember themes and inspect the computed code font stack; the glyph fallback should remain monospace before generic fallback fonts.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS local worktree targeted desktop tests

### Documentation & Housekeeping

- [x] Documentation update N/A
- [x] `cli-config.yaml.example` update N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update N/A
- [x] Cross-platform impact considered: keeps Windows/macOS/Linux monospace fallbacks before generic fonts
- [x] Tool descriptions/schemas update N/A

## Screenshots / Logs

Validation run locally:

```text
npm run test:ui -- src/themes/presets.test.ts
Test Files  1 passed (1)
Tests       18 passed (18)

npx eslint src/themes/presets.ts src/themes/presets.test.ts
passed

git diff --check
passed
```
