### PR TITLE
feat(config): model_router skeleton — schema parser + validator

### DIFF
--- a/hermes_cli/model_router.py
+++ b/hermes_cli/model_router.py
@@ -1,0 +1,163 @@
+"""Skeleton for the agent-level model router (#61371).
+
+The actual routing logic is intentionally NOT implemented here — this
+module reads ``model_router`` from config.yaml, validates the schema,
+and exposes a single ``resolve_router_config()`` / ``is_router_enabled()``
+so the agent loop can probe whether the user opted into router-based
+selection. The actual per-task classifier and switch-model integration
+are tracked in #61371; until they land, callers receive a logger.info()
+"router enabled but no dispatch yet" message and fall back to the
+existing single-provider path.
+
+The router schema mirrors the example in #61371:
+
+    model_router:
+      enabled: true
+      local:
+        provider: ollama
+        model: llama3.2-3b
+        for_tasks: [read_only, shell_commands]
+      cloud:
+        provider: nous
+        model: anthropic/claude-sonnet-4.6
+        for_tasks: [debugging, code_review, log_analysis]
+
+Validation enforces the schema strictly so a malformed config fails at
+load time rather than producing silent fallbacks later. The
+for_tasks-list-per-bucket structure is not yet mapped to real prompt
+classifiers — that decision lands in the follow-up PR.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Mapping
+
+logger = logging.getLogger(__name__)
+
+# Known top-level task-type labels the router advertises as a vocabulary.
+# Buckets that name labels outside this set are rejected at config-load
+# time so users find out about typos immediately rather than silently
+# losing the routing rule at dispatch.
+KNOWN_TASK_LABELS: frozenset[str] = frozenset(
+    {
+        "read_only",
+        "shell_commands",
+        "debugging",
+        "code_review",
+        "log_analysis",
+        # Future buckets land here as the per-task classifier lands.
+    }
+)
+
+
+class ModelRouterConfigError(ValueError):
+    """Raised when the ``model_router`` block in config.yaml is malformed.
+
+    Mirrors the fail-fast parse-error contract the rest of config.py
+    uses — never let a malformed router config pass through to dispatch.
+    """
+
+
+def is_router_enabled(config: Mapping[str, Any] | None) -> bool:
+    """Return True iff the user opted into the model router.
+
+    Defensive against missing/None/empty config dicts. Default is False
+    so this skeleton is a no-op for everyone who hasn't added the
+    ``model_router`` block to their config.yaml yet — preserving the
+    existing single-provider behavior (#61371 acceptance criterion).
+    """
+    if not config:
+        return False
+    block = config.get("model_router")
+    if not isinstance(block, Mapping):
+        return False
+    return bool(block.get("enabled", False))
+
+
+def _validate_bucket(name: str, bucket: Any) -> dict[str, Any]:
+    """Validate one bucket (e.g. ``local`` / ``cloud``) of the router config.
+
+    Returns a normalized dict of (provider, model, for_tasks) so the
+    downstream dispatcher and tests can rely on a stable shape.
+    """
+    if not isinstance(bucket, Mapping):
+        raise ModelRouterConfigError(
+            f"model_router.{name} must be a mapping with provider/model/"
+            "for_tasks; got {type(bucket).__name__}"
+        )
+
+    for required in ("provider", "model"):
+        value = bucket.get(required)
+        if not isinstance(value, str) or not value.strip():
+            raise ModelRouterConfigError(
+                f"model_router.{name}.{required} must be a non-empty string"
+            )
+
+    for_tasks = bucket.get("for_tasks", [])
+    if isinstance(for_tasks, str):
+        # Allow the comma-joined shorthand the issue body uses — split it.
+        for_tasks = [t.strip() for t in for_tasks.split(",") if t.strip()]
+    if not isinstance(for_tasks, list) or not all(
+        isinstance(t, str) and t.strip() for t in for_tasks
+    ):
+        raise ModelRouterConfigError(
+            f"model_router.{name}.for_tasks must be a list of non-empty "
+            "strings (or a comma-joined string)"
+        )
+
+    unknown = sorted(set(for_tasks) - KNOWN_TASK_LABELS)
+    if unknown:
+        raise ModelRouterConfigError(
+            f"model_router.{name}.for_tasks contains labels that aren't in "
+            f"the known vocabulary yet: {unknown}. Add them to "
+            "KNOWN_TASK_LABELS in model_router.py once the per-task "
+            "classifier lands (#61371)."
+        )
+
+    return {
+        "provider": bucket["provider"].strip(),
+        "model": bucket["model"].strip(),
+        "for_tasks": list(for_tasks),
+    }
+
+
+def resolve_router_config(config: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Parse + validate the model's router block.
+
+    Returns a normalized dict, or the disabled-shape ``{"enabled": False}``
+    when the user hasn't opted in. Raises :class:`ModelRouterConfigError`
+    on malformed schema.
+
+    Calling this in the agent loop is a no-op for routing *today* — it
+    only validates + logs. Real dispatch lands in the follow-up PR.
+    """
+    if not is_router_enabled(config):
+        return {"enabled": False, "buckets": {}, "default_task_label": None}
+
+    block = config["model_router"]  # type: ignore[index]  # already validated
+    buckets: dict[str, dict[str, Any]] = {}
+    for name in ("local", "cloud"):
+        if name in block:
+            buckets[name] = _validate_bucket(name, block[name])
+
+    if not buckets:
+        raise ModelRouterConfigError(
+            "model_router.enabled is true but neither a 'local' nor a "
+            "'cloud' bucket is defined — at least one routing target "
+            "must be configured (#61371)"
+        )
+
+    logger.info(
+        "model_router: enabled with buckets=%s — routing dispatch is "
+        "not implemented yet (skeleton PR for #61371). Falling back to "
+        "the legacy single-provider path until the per-task classifier "
+        "ships in the follow-up.",
+        sorted(buckets.keys()),
+    )
+
+    return {
+        "enabled": True,
+        "buckets": buckets,
+        "default_task_label": None,  # set by classifier; tracked in #61371
+    }

--- a/tests/hermes_cli/test_model_router.py
+++ b/tests/hermes_cli/test_model_router.py
@@ -1,0 +1,232 @@
+"""Skeleton tests for #61371 model_router.
+
+The actual routing dispatch lands in a follow-up PR. These tests pin
+the parser/validator behavior so future schema drift is caught early:
+default-off (no config or no `enabled: true`), the example block from
+the issue body parses AND normalizes correctly, malformed buckets
+fail-fast at load time, unknown task labels are rejected, and
+comma-joined for_tasks shorthand parses.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from hermes_cli.model_router import (
+    KNOWN_TASK_LABELS,
+    ModelRouterConfigError,
+    is_router_enabled,
+    resolve_router_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# default-off contract — never silently route
+# ---------------------------------------------------------------------------
+
+
+class TestRouterIsOffByDefault:
+    """#61371 acceptance criterion: existing single-provider behavior
+    is preserved until the user explicitly opts in.
+    """
+
+    def test_none_config_yields_disabled(self):
+        assert is_router_enabled(None) is False
+
+    def test_empty_config_yields_disabled(self):
+        assert is_router_enabled({}) is False
+
+    def test_no_model_router_block_yields_disabled(self):
+        assert is_router_enabled({"agent": {"max_turns": 90}}) is False
+
+    def test_resolve_returns_disabled_shape(self):
+        resolved = resolve_router_config({})
+        assert resolved == {
+            "enabled": False,
+            "buckets": {},
+            "default_task_label": None,
+        }
+
+    def test_explicit_enabled_false_stays_disabled(self):
+        config = {"model_router": {"enabled": False, "local": {}}}
+        assert is_router_enabled(config) is False
+
+
+# ---------------------------------------------------------------------------
+# the example block from issue #61371 parses + normalizes correctly
+# ---------------------------------------------------------------------------
+
+
+class TestRouterExampleBlockParses:
+    def test_local_and_cloud_buckets_normalize(self):
+        config = {
+            "model_router": {
+                "enabled": True,
+                "local": {
+                    "provider": "ollama",
+                    "model": "llama3.2-3b",
+                    "for_tasks": ["read_only", "shell_commands"],
+                },
+                "cloud": {
+                    "provider": "nous",
+                    "model": "anthropic/claude-sonnet-4.6",
+                    "for_tasks": ["debugging", "code_review", "log_analysis"],
+                },
+            }
+        }
+        resolved = resolve_router_config(config)
+        assert resolved["enabled"] is True
+        assert set(resolved["buckets"].keys()) == {"local", "cloud"}
+        assert resolved["buckets"]["local"]["provider"] == "ollama"
+        assert resolved["buckets"]["local"]["model"] == "llama3.2-3b"
+        assert resolved["buckets"]["local"]["for_tasks"] == [
+            "read_only",
+            "shell_commands",
+        ]
+        assert resolved["buckets"]["cloud"]["provider"] == "nous"
+        assert resolved["buckets"]["cloud"]["model"] == "anthropic/claude-sonnet-4.6"
+
+
+# ---------------------------------------------------------------------------
+# fail-fast validation
+# ---------------------------------------------------------------------------
+
+
+class TestRouterFailFastValidation:
+    def test_bucket_must_be_a_mapping(self):
+        config = {"model_router": {"enabled": True, "local": "not-a-dict"}}
+        with pytest.raises(ModelRouterConfigError, match="must be a mapping"):
+            resolve_router_config(config)
+
+    def test_provider_required_and_nonempty(self):
+        config = {
+            "model_router": {
+                "enabled": True,
+                "local": {"model": "llama3.2-3b", "for_tasks": ["read_only"]},
+            }
+        }
+        with pytest.raises(ModelRouterConfigError, match="provider"):
+            resolve_router_config(config)
+
+    def test_provider_must_be_string_not_number(self):
+        config = {
+            "model_router": {
+                "enabled": True,
+                "local": {
+                    "provider": 42,
+                    "model": "llama3.2-3b",
+                    "for_tasks": ["read_only"],
+                },
+            }
+        }
+        with pytest.raises(ModelRouterConfigError, match="provider"):
+            resolve_router_config(config)
+
+    def test_for_tasks_string_is_split_on_comma(self):
+        # Comma-joined shorthand accepted; colon-joined typo still rejected
+        # as an unknown label so users find out at config-load, not dispatch.
+        config = {
+            "model_router": {
+                "enabled": True,
+                "local": {
+                    "provider": "ollama",
+                    "model": "llama3.2-3b",
+                    "for_tasks": "read_only, shell_commands",
+                },
+            }
+        }
+        resolved = resolve_router_config(config)
+        assert resolved["buckets"]["local"]["for_tasks"] == [
+            "read_only",
+            "shell_commands",
+        ]
+
+    def test_non_list_non_string_for_tasks_rejected(self):
+        config = {
+            "model_router": {
+                "enabled": True,
+                "local": {
+                    "provider": "ollama",
+                    "model": "llama3.2-3b",
+                    "for_tasks": 42,
+                },
+            }
+        }
+        with pytest.raises(ModelRouterConfigError, match="for_tasks"):
+            resolve_router_config(config)
+
+    def test_unknown_task_labels_rejected(self):
+        config = {
+            "model_router": {
+                "enabled": True,
+                "local": {
+                    "provider": "ollama",
+                    "model": "llama3.2-3b",
+                    "for_tasks": ["read_only", "totally-unknown-label"],
+                },
+            }
+        }
+        with pytest.raises(ModelRouterConfigError, match="known vocabulary"):
+            resolve_router_config(config)
+
+    def test_enabled_but_no_buckets_is_rejected(self):
+        config = {"model_router": {"enabled": True}}
+        with pytest.raises(ModelRouterConfigError, match="at least one routing target"):
+            resolve_router_config(config)
+
+
+# ---------------------------------------------------------------------------
+# known-label registry drift guards
+# ---------------------------------------------------------------------------
+
+
+class TestKnownTaskLabels:
+    def test_vocabulary_includes_issue_example(self):
+        """The issue body lists five example labels — they must all live
+        in the known-vocabulary set, otherwise the example YAML fails
+        the schema guard above.
+        """
+        for label in (
+            "read_only",
+            "shell_commands",
+            "debugging",
+            "code_review",
+            "log_analysis",
+        ):
+            assert label in KNOWN_TASK_LABELS
+
+
+# ---------------------------------------------------------------------------
+# skeleton observability — the runtime logs a "not yet wired" notice so
+# operators don't lose visibility when they enable the router skeleton.
+# ---------------------------------------------------------------------------
+
+
+class TestRouterSkeletonsLogs:
+    def test_resolving_enabled_router_emits_info(self, caplog):
+        config = {
+            "model_router": {
+                "enabled": True,
+                "local": {
+                    "provider": "ollama",
+                    "model": "llama3.2-3b",
+                    "for_tasks": ["read_only"],
+                },
+            }
+        }
+        with caplog.at_level(logging.INFO, logger="hermes_cli.model_router"):
+            resolve_router_config(config)
+        assert any(
+            "model_router" in rec.message and "skeleton" in rec.message.lower()
+            for rec in caplog.records
+        ), "skeleton must surface a runtime-visible 'not yet wired' log"
+
+    def test_disabled_router_does_not_emit_info(self, caplog):
+        with caplog.at_level(logging.INFO, logger="hermes_cli.model_router"):
+            resolve_router_config({})
+        # Disabled router is silent — no spam for users who haven't opted in.
+        assert not any(
+            "model_router" in rec.message for rec in caplog.records
+        )


### PR DESCRIPTION
## Summary

`#61371` is an agent-level model router feature request: route different task types to different model:provider pairs. The full implementation needs a task classifier, per-bucket `switch_model()` integration, and observe/metrics wiring — easy 500-1000+ LOC across ~20 files.

This PR is the **skeleton** only:

- `hermes_cli/model_router.py` (new): schema parser + validator for the `model_router` block the issue body sketches. Public surface = ``is_router_enabled(config)``, ``resolve_router_config(config)``, ``ModelRouterConfigError``, and ``KNOWN_TASK_LABELS``. Default-off: existing single-provider behavior is preserved for every user who hasn't added the block (#61371 acceptance criterion).

- `tests/hermes_cli/test_model_router.py` (new): 16 regression tests covering default-off, example-block parsing, fail-fast validation, comma shorthand, unknown-label rejection, and skeleton observability (INFO log when enabled, silent when disabled).

The dispatcher — task-type classifier + per-bucket switch_model glue + provider pool integration — is **intentionally out of scope** here. This PR establishes the schema surface and the failure-mode ergonomics so the follow-up PR doesn't have to rename public APIs.

## Why a skeleton and not the full feature

`AGENTS.md`: 'every model tool we add is sent on every API call, so the bar for a *core* tool is high.' A model-router dispatcher is more invasive than adding a tool — it changes per-turn behavior on every session, in every gateway path, with non-obvious cost and routing-rule semantics. Building it as one mega-PR is hard to review; landing the schema surface as a no-dispatch skeleton keeps the dispatcher design discussion open in the follow-up PR without blocking #61371 from making any forward progress.

## Changes

- `hermes_cli/model_router.py` (new): ~150 LOC of parser + validator.
- `tests/hermes_cli/test_model_router.py` (new): 16 regression tests.

## How to Test

```
pytest tests/hermes_cli/test_model_router.py -xvs  # 16/16
pytest tests/hermes_cli/test_model_router.py tests/hermes_cli/test_env_loader.py  # 22/22 sibling suite green
```

## Checklist

- [x] Tests pass — 16/16 new + 6/6 sibling test_env_loader.py.
- [x] Follows Conventional Commits (`feat(config): …`).
- [x] Cross-platform impact: pure Python, no platform-sensitive code.
- [x] profile-safe paths used (no path involvement).
- [x] .env not used — schema lives in `config.yaml` per the issue.

## Risk & Impact

**Low.** Pure additive: a new module + tests, no existing call sites touched. The module becomes meaningful once a future PR calls `resolve_router_config()` from the agent loop. Until then, the package import + class definition are the only side effects, and those don't change runtime behavior outside of importing the module.

Type: Feature (skeleton).
Refs: #61371