### PR TITLE
fix(desktop): add Noto Sans Mono to monospace font stack for Vietnamese/non-Latin script support

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -320,8 +320,8 @@
        terminal's primary — so code/diff match the terminal on every platform
        instead of drifting to a system Cascadia Code where it's installed. */
     --dt-font-mono:
-      'JetBrains Mono', 'Cascadia Code', 'SF Mono', ui-monospace, Menlo, Consolas, monospace, 'Apple Color Emoji',
-      'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji', emoji;
+      'JetBrains Mono', 'Cascadia Code', 'SF Mono', ui-monospace, Menlo, Consolas, monospace, 'Noto Sans Mono',
+      'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji', emoji;
     --dt-base-size: 1rem;
     --dt-line-height: 1.5;
     --dt-letter-spacing: 0;

--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -21,6 +21,13 @@ import { BUILTIN_THEME_LIST, BUILTIN_THEMES, DEFAULT_SKIN_NAME, DEFAULT_TYPOGRAP
 import type { DesktopTheme, DesktopThemeColors } from './types'
 import { $userThemes, resolveTheme } from './user-themes'
 
+// Font with near-complete Unicode coverage loaded as a web font fallback so
+// non-Latin scripts (Vietnamese, Cyrillic, etc.) render inside monospace
+// metrics instead of falling through to a proportional system face.  See
+// #61392.
+const NOTO_SANS_MONO_FONT_URL =
+  'https://fonts.googleapis.com/css2?family=Noto+Sans+Mono:wght@400;700&display=swap'
+
 // Legacy global skin (pre per-profile themes). Still the inheritance fallback
 // for any profile without its own assignment, so single-profile users and old
 // installs are unaffected.
@@ -253,6 +260,18 @@ function applyTheme(theme: DesktopTheme, mode: 'light' | 'dark') {
     link.dataset.hermesThemeFont = 'true'
     document.head.appendChild(link)
     INJECTED_FONT_URLS.add(typo.fontUrl)
+  }
+
+  // Load Noto Sans Mono as a fallback monospace font for scripts the theme's
+  // primary mono face doesn't cover (e.g. Vietnamese diacritics).  Loaded
+  // once per session — see #61392.
+  if (!INJECTED_FONT_URLS.has(NOTO_SANS_MONO_FONT_URL)) {
+    const link = document.createElement('link')
+    link.rel = 'stylesheet'
+    link.href = NOTO_SANS_MONO_FONT_URL
+    link.dataset.hermesThemeFont = 'true'
+    document.head.appendChild(link)
+    INJECTED_FONT_URLS.add(NOTO_SANS_MONO_FONT_URL)
   }
 }
 

--- a/apps/desktop/src/themes/presets.ts
+++ b/apps/desktop/src/themes/presets.ts
@@ -16,7 +16,7 @@ const SYSTEM_SANS =
   EMOJI_FALLBACK
 
 const SYSTEM_MONO =
-  '"Cascadia Code", "JetBrains Mono", "SF Mono", ui-monospace, Menlo, Monaco, Consolas, monospace, ' + EMOJI_FALLBACK
+  '"Cascadia Code", "JetBrains Mono", "SF Mono", ui-monospace, Menlo, Monaco, Consolas, monospace, "Noto Sans Mono", ' + EMOJI_FALLBACK
 
 export const DEFAULT_TYPOGRAPHY: DesktopThemeTypography = { fontSans: SYSTEM_SANS, fontMono: SYSTEM_MONO }
 

--- a/web/src/themes/fonts.ts
+++ b/web/src/themes/fonts.ts
@@ -23,7 +23,7 @@
 const SYSTEM_SANS =
   'system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif';
 const SYSTEM_MONO =
-  'ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace';
+  'ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace, "Noto Sans Mono"';
 const SYSTEM_SERIF =
   'Georgia, Cambria, "Times New Roman", Times, serif';
 

--- a/web/src/themes/presets.ts
+++ b/web/src/themes/presets.ts
@@ -19,7 +19,7 @@ import type { DashboardTheme, ThemeTypography, ThemeLayout } from "./types";
 const SYSTEM_SANS =
   'system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif';
 const SYSTEM_MONO =
-  'ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace';
+  'ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace, "Noto Sans Mono"';
 
 const DEFAULT_TYPOGRAPHY: ThemeTypography = {
   fontSans: SYSTEM_SANS,


### PR DESCRIPTION
Fixes #61392

## Problem

Code blocks containing Vietnamese characters (ư, ơ, đ, ắ, ễ, ệ, ỗ, ự, etc.) render misaligned because the theme's primary monospace fonts (Courier Prime, JetBrains Mono, IBM Plex Mono, DM Mono) lack these glyphs. The browser falls through to a proportional system/emoji font, breaking monospace alignment inside code blocks.

## Root Cause

The `SYSTEM_MONO` font stack in both desktop and web theme presets had no font with comprehensive non-Latin coverage before the emoji fallback. On Windows 11, the system `monospace` and `ui-monospace` maps to fonts that either lack Vietnamese glyphs or are proportional.

## Fix

1. **Add `"Noto Sans Mono"` to `SYSTEM_MONO`** in both desktop and web theme presets — provides a monospace fallback with near-complete Unicode coverage
2. **Add to desktop CSS `--dt-font-mono` stack** — ensures the theme-independent default stack also benefits
3. **Load Noto Sans Mono from Google Fonts** unconditionally in the desktop theme context (`context.tsx`) — makes the font available on-demand without requiring local installation, loaded once per session via the existing `INJECTED_FONT_URLS` dedup mechanism

## Noto Sans Mono

Noto Sans Mono from Google Fonts covers Latin Extended Additional (U+1E00–U+1EFF) including all Vietnamese diacritics, Cyrillic, Greek, IPA Extensions, and many other scripts — making it a robust fallback that keeps characters inside monospace metrics when the primary theme font lacks coverage.