### PR TITLE
fix: keep Telegram long chunks rendering consistent

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3286,7 +3286,8 @@ class TelegramAdapter(BasePlatformAdapter):
             chunks = self.truncate_message(
                 formatted, self.MAX_MESSAGE_LENGTH, len_fn=utf16_len,
             )
-            if len(chunks) > 1:
+            multi_chunk_legacy_plain = len(chunks) > 1
+            if multi_chunk_legacy_plain:
                 # truncate_message appends a raw " (1/2)" suffix. Escape the
                 # MarkdownV2-special parentheses so Telegram doesn't reject the
                 # chunk and fall back to plain text.
@@ -3296,6 +3297,15 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
                     for chunk in chunks
                 ]
+                # Telegram can reject MarkdownV2 for only one chunk (for
+                # example when a split cuts through a code span/fence or leaves
+                # a reserved character in a bad context).  Once some chunks are
+                # already sent we cannot atomically roll them back, so sending a
+                # multi-part legacy response as mixed MarkdownV2/plain text
+                # produces the confusing UX reported by users: one long chunk is
+                # raw/unrendered while the next continuation is rendered.  Keep
+                # the whole legacy multi-chunk delivery visually consistent.
+                chunks = [_strip_mdv2(chunk) for chunk in chunks]
             
             message_ids = []
             thread_id = self._metadata_thread_id(metadata)
@@ -3363,33 +3373,44 @@ class TelegramAdapter(BasePlatformAdapter):
                 msg = None
                 for _send_attempt in range(3):
                     try:
-                        # Try Markdown first, fall back to plain text if it fails
-                        try:
+                        if multi_chunk_legacy_plain:
                             msg = await self._bot.send_message(
                                 chat_id=normalize_telegram_chat_id(chat_id),
                                 text=chunk,
-                                parse_mode=ParseMode.MARKDOWN_V2,
+                                parse_mode=None,
                                 reply_to_message_id=reply_to_id,
                                 **thread_kwargs,
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),
                             )
-                        except Exception as md_error:
-                            # Markdown parsing failed, try plain text
-                            if "parse" in str(md_error).lower() or "markdown" in str(md_error).lower():
-                                logger.warning("[%s] MarkdownV2 parse failed, falling back to plain text: %s", self.name, md_error)
-                                plain_chunk = _strip_mdv2(chunk)
+                        else:
+                            # Try Markdown first, fall back to plain text if it fails
+                            try:
                                 msg = await self._bot.send_message(
                                     chat_id=normalize_telegram_chat_id(chat_id),
-                                    text=plain_chunk,
-                                    parse_mode=None,
+                                    text=chunk,
+                                    parse_mode=ParseMode.MARKDOWN_V2,
                                     reply_to_message_id=reply_to_id,
                                     **thread_kwargs,
                                     **self._link_preview_kwargs(),
                                     **self._notification_kwargs(metadata),
                                 )
-                            else:
-                                raise
+                            except Exception as md_error:
+                                # Markdown parsing failed, try plain text
+                                if "parse" in str(md_error).lower() or "markdown" in str(md_error).lower():
+                                    logger.warning("[%s] MarkdownV2 parse failed, falling back to plain text: %s", self.name, md_error)
+                                    plain_chunk = _strip_mdv2(chunk)
+                                    msg = await self._bot.send_message(
+                                        chat_id=normalize_telegram_chat_id(chat_id),
+                                        text=plain_chunk,
+                                        parse_mode=None,
+                                        reply_to_message_id=reply_to_id,
+                                        **thread_kwargs,
+                                        **self._link_preview_kwargs(),
+                                        **self._notification_kwargs(metadata),
+                                    )
+                                else:
+                                    raise
                         break  # success
                     except _NetErr as send_err:
                         # BadRequest is a subclass of NetworkError in
@@ -3810,6 +3831,7 @@ class TelegramAdapter(BasePlatformAdapter):
         chunks = self.truncate_message(
             content, self.MAX_MESSAGE_LENGTH, len_fn=utf16_len,
         )
+        multi_chunk_legacy_plain = finalize and len(chunks) > 1
         if len(chunks) <= 1:
             # Defensive: shouldn't happen given the caller's pre-flight, but
             # if truncate_message returned a single chunk just edit normally.
@@ -3818,7 +3840,13 @@ class TelegramAdapter(BasePlatformAdapter):
         # Step 1 — edit the existing message with the first chunk.
         first_chunk = chunks[0]
         try:
-            if finalize:
+            if multi_chunk_legacy_plain:
+                await self._bot.edit_message_text(
+                    chat_id=normalize_telegram_chat_id(chat_id),
+                    message_id=int(message_id),
+                    text=_strip_mdv2(first_chunk),
+                )
+            elif finalize:
                 # Use format_message + parse_mode for the final chunk;
                 # mirror edit_message's main happy-path.
                 formatted = _separate_chunk_indicator_from_fence(
@@ -3881,7 +3909,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 metadata,
                 reply_to_message_id=reply_to_id,
             )
-            for use_markdown in (True, False) if finalize else (False,):
+            markdown_attempts = (
+                (False,)
+                if multi_chunk_legacy_plain
+                else ((True, False) if finalize else (False,))
+            )
+            for use_markdown in markdown_attempts:
                 try:
                     if use_markdown:
                         text = _separate_chunk_indicator_from_fence(

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gateway.config import PlatformConfig
+from gateway.config import Platform, PlatformConfig
 
 
 # ---------------------------------------------------------------------------
@@ -843,16 +843,16 @@ class TestFormatMessageTables:
 
 
 @pytest.mark.asyncio
-async def test_send_escapes_chunk_indicator_for_markdownv2(adapter):
+async def test_send_keeps_plain_chunk_indicators_for_multi_chunk_legacy(adapter):
     adapter.MAX_MESSAGE_LENGTH = 80
     adapter._bot = MagicMock()
 
-    sent_texts = []
+    sent_calls = []
 
     async def _fake_send_message(**kwargs):
-        sent_texts.append(kwargs["text"])
+        sent_calls.append(kwargs)
         msg = MagicMock()
-        msg.message_id = len(sent_texts)
+        msg.message_id = len(sent_calls)
         return msg
 
     adapter._bot.send_message = AsyncMock(side_effect=_fake_send_message)
@@ -861,9 +861,37 @@ async def test_send_escapes_chunk_indicator_for_markdownv2(adapter):
     result = await adapter.send("123", content)
 
     assert result.success is True
-    assert len(sent_texts) > 1
-    assert re.search(r" \\\([0-9]+/[0-9]+\\\)$", sent_texts[0])
-    assert re.search(r" \\\([0-9]+/[0-9]+\\\)$", sent_texts[-1])
+    assert len(sent_calls) > 1
+    assert re.search(r" \([0-9]+/[0-9]+\)$", sent_calls[0]["text"])
+    assert re.search(r" \([0-9]+/[0-9]+\)$", sent_calls[-1]["text"])
+    assert all(call.get("parse_mode") is None for call in sent_calls)
+
+
+@pytest.mark.asyncio
+async def test_long_legacy_send_uses_consistent_plain_chunks(adapter):
+    """Multi-chunk legacy sends must not mix raw/plain and rendered chunks.
+
+    If Telegram rejects MarkdownV2 for one chunk, previously only that chunk
+    fell back to plain text while later continuations still rendered as
+    MarkdownV2.  The user-visible result looked like duplicate/inconsistent
+    long-text delivery.  Keep all chunks on the same plain-text path.
+    """
+    adapter.MAX_MESSAGE_LENGTH = 80
+    adapter._bot = MagicMock()
+    adapter._rich_messages_enabled = False
+    adapter._bot.send_message = AsyncMock(
+        side_effect=[SimpleNamespace(message_id=i) for i in range(1, 20)]
+    )
+
+    content = ("**bold** chunk content " * 12).strip()
+    result = await adapter.send("123", content, metadata={"expect_edits": True})
+
+    assert result.success is True
+    assert adapter._bot.send_message.await_count > 1
+    for call in adapter._bot.send_message.await_args_list:
+        assert call.kwargs.get("parse_mode") is None
+        assert "**" not in call.kwargs["text"]
+        assert "\\(" not in call.kwargs["text"]
 
 
 # =========================================================================
@@ -1041,6 +1069,8 @@ def _guest_test_adapter(*, guest_mode=True, require_mention=True, allowed_chats=
     )
     adapter = object.__new__(TelegramAdapter)
     adapter.config = config
+    object.__setattr__(adapter, "_platform", Platform.TELEGRAM)
+    object.__setattr__(adapter, "platform", Platform.TELEGRAM)
     adapter._bot = SimpleNamespace(id=999, username="hermes_bot")
     adapter._mention_patterns = adapter._compile_mention_patterns()
     # PR db50af910 added a TELEGRAM_ALLOWED_USERS allowlist gate to


### PR DESCRIPTION
## Summary
- keep legacy multi-chunk Telegram sends on a consistent plain-text path instead of mixing MarkdownV2 and plain fallback chunks
- apply the same consistency to finalized overflow split continuations
- add regression coverage for long legacy sends and update the test helper setup

## Why
Telegram can reject MarkdownV2 for only one chunk of a long response (for example around split markdown/code/table boundaries). Previously that single chunk fell back to plain text while following chunks still rendered as MarkdownV2, producing a confusing user-visible mix that can look like duplicated rendered/unrendered long text.

## Tests
- `.venv/bin/python -m pytest tests/gateway/test_telegram_format.py tests/gateway/test_telegram_overflow_partial.py -q`
