### PR TITLE
feat: add automatic reasoning effort resolution

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8585,6 +8585,13 @@ def _build_call_kwargs(
     task: Optional[str] = None,
 ) -> dict:
     """Build kwargs for .chat.completions.create() with model/provider adjustments."""
+    # ``auto`` is an internal request policy, never a provider wire value.
+    # Resolve it here, at the shared auxiliary boundary, so direct auxiliary
+    # calls, MoA advisors, retries, and fallback routes all project the same
+    # concrete effort from the messages belonging to this request.
+    from hermes_constants import resolve_auto_reasoning_config
+
+    reasoning_config = resolve_auto_reasoning_config(reasoning_config, messages)
     kwargs: Dict[str, Any] = {
         "model": model,
         "messages": messages,

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8592,6 +8592,12 @@ def _build_call_kwargs(
     from hermes_constants import resolve_auto_reasoning_config
 
     reasoning_config = resolve_auto_reasoning_config(reasoning_config, messages)
+    extra_body = dict(extra_body or {})
+    extra_reasoning = extra_body.get("reasoning")
+    if isinstance(extra_reasoning, dict):
+        extra_body["reasoning"] = resolve_auto_reasoning_config(
+            extra_reasoning, messages
+        )
     kwargs: Dict[str, Any] = {
         "model": model,
         "messages": messages,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -665,7 +665,10 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
 def build_api_kwargs(agent, api_messages: list) -> dict:
     """Build the keyword arguments dict for the active API mode."""
+    from hermes_constants import resolve_auto_reasoning_config
+
     tools_for_api = agent.tools
+    reasoning_config = resolve_auto_reasoning_config(agent.reasoning_config, api_messages)
 
     if agent.api_mode == "anthropic_messages":
         _transport = agent._get_transport()
@@ -680,7 +683,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             messages=anthropic_messages,
             tools=tools_for_api,
             max_tokens=ephemeral_out if ephemeral_out is not None else agent.max_tokens,
-            reasoning_config=agent.reasoning_config,
+            reasoning_config=reasoning_config,
             is_oauth=agent._is_anthropic_oauth,
             preserve_dots=agent._anthropic_preserve_dots(),
             context_length=ctx_len,
@@ -756,7 +759,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             model=agent.model,
             messages=_msgs_for_codex,
             tools=tools_for_api,
-            reasoning_config=agent.reasoning_config,
+            reasoning_config=reasoning_config,
             session_id=getattr(agent, "session_id", None),
             max_tokens=agent.max_tokens,
             timeout=agent._resolved_api_call_timeout(),
@@ -874,7 +877,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             max_tokens=agent.max_tokens,
             ephemeral_max_output_tokens=_ephemeral_out,
             max_tokens_param_fn=agent._max_tokens_param,
-            reasoning_config=agent.reasoning_config,
+            reasoning_config=reasoning_config,
             request_overrides=agent.request_overrides,
             session_id=getattr(agent, "session_id", None),
             provider_profile=_profile,
@@ -906,7 +909,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         max_tokens=agent.max_tokens,
         ephemeral_max_output_tokens=_ephemeral_out,
         max_tokens_param_fn=agent._max_tokens_param,
-        reasoning_config=agent.reasoning_config,
+        reasoning_config=reasoning_config,
         request_overrides=agent.request_overrides,
         session_id=getattr(agent, "session_id", None),
         model_lower=(agent.model or "").lower(),
@@ -1659,9 +1662,16 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             agent._resolve_lmstudio_summary_reasoning_effort()
             if _is_lmstudio_summary else None
         )
+        try:
+            from hermes_constants import resolve_auto_reasoning_config
+            summary_reasoning_config = resolve_auto_reasoning_config(
+                agent.reasoning_config, api_messages
+            )
+        except Exception:
+            summary_reasoning_config = agent.reasoning_config
         if not _is_lmstudio_summary and agent._supports_reasoning_extra_body():
-            if agent.reasoning_config is not None:
-                summary_extra_body["reasoning"] = agent.reasoning_config
+            if summary_reasoning_config is not None:
+                summary_extra_body["reasoning"] = summary_reasoning_config
             else:
                 summary_extra_body["reasoning"] = {
                     "enabled": True,
@@ -1734,7 +1744,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             if agent.api_mode == "anthropic_messages":
                 _tsum = agent._get_transport()
                 _ant_kw = _tsum.build_kwargs(model=agent.model, messages=api_messages, tools=None,
-                               max_tokens=agent.max_tokens, reasoning_config=agent.reasoning_config,
+                               max_tokens=agent.max_tokens, reasoning_config=summary_reasoning_config,
                                is_oauth=agent._is_anthropic_oauth,
                                preserve_dots=agent._anthropic_preserve_dots())
                 summary_response = agent._anthropic_messages_create(_ant_kw)
@@ -1765,7 +1775,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 _tretry = agent._get_transport()
                 _ant_kw2 = _tretry.build_kwargs(model=agent.model, messages=api_messages, tools=None,
                                 is_oauth=agent._is_anthropic_oauth,
-                                max_tokens=agent.max_tokens, reasoning_config=agent.reasoning_config,
+                                max_tokens=agent.max_tokens, reasoning_config=summary_reasoning_config,
                                 preserve_dots=agent._anthropic_preserve_dots())
                 retry_response = agent._anthropic_messages_create(_ant_kw2)
                 _retry_result = _tretry.normalize_response(retry_response, strip_tool_prefix=agent._is_anthropic_oauth)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1824,8 +1824,14 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
 def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = None) -> dict:
     """Build the keyword arguments dict for the active API mode."""
+    from hermes_constants import resolve_auto_reasoning_config
+
     if tools_for_api is None:
         tools_for_api = agent.tools
+    reasoning_config = resolve_auto_reasoning_config(
+        agent.reasoning_config,
+        api_messages,
+    )
 
     if agent.api_mode == "anthropic_messages":
         _transport = agent._get_transport()
@@ -1840,7 +1846,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             messages=anthropic_messages,
             tools=tools_for_api,
             max_tokens=ephemeral_out if ephemeral_out is not None else agent.max_tokens,
-            reasoning_config=agent.reasoning_config,
+            reasoning_config=reasoning_config,
             is_oauth=agent._is_anthropic_oauth,
             preserve_dots=agent._anthropic_preserve_dots(),
             context_length=ctx_len,
@@ -1939,7 +1945,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             model=agent.model,
             messages=_msgs_for_codex,
             tools=tools_for_api,
-            reasoning_config=agent.reasoning_config,
+            reasoning_config=reasoning_config,
             session_id=getattr(agent, "session_id", None),
             cache_scope_id=_cache_scope_id,
             base_url=agent.base_url,
@@ -1950,7 +1956,10 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             is_github_responses=is_github_responses,
             is_codex_backend=is_codex_backend,
             is_xai_responses=is_xai_responses,
-            github_reasoning_extra=agent._github_models_reasoning_extra_body() if is_github_responses else None,
+            github_reasoning_extra=(
+                agent._github_models_reasoning_extra_body(reasoning_config)
+                if is_github_responses else None
+            ),
             replay_encrypted_reasoning=bool(
                 getattr(agent, "_codex_reasoning_replay_enabled", True)
             ),
@@ -2048,7 +2057,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             max_tokens=agent.max_tokens,
             ephemeral_max_output_tokens=_ephemeral_out,
             max_tokens_param_fn=agent._max_tokens_param,
-            reasoning_config=agent.reasoning_config,
+            reasoning_config=reasoning_config,
             request_overrides=agent.request_overrides,
             session_id=getattr(agent, "session_id", None),
             cache_scope_id=_cache_scope_id,
@@ -2081,7 +2090,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
         max_tokens=agent.max_tokens,
         ephemeral_max_output_tokens=_ephemeral_out,
         max_tokens_param_fn=agent._max_tokens_param,
-        reasoning_config=agent.reasoning_config,
+        reasoning_config=reasoning_config,
         request_overrides=agent.request_overrides,
         session_id=getattr(agent, "session_id", None),
         cache_scope_id=_cache_scope_id,
@@ -2104,7 +2113,10 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
         fixed_temperature=_fixed_temp,
         omit_temperature=_omit_temp,
         supports_reasoning=agent._supports_reasoning_extra_body(),
-        github_reasoning_extra=agent._github_models_reasoning_extra_body() if _is_gh else None,
+        github_reasoning_extra=(
+            agent._github_models_reasoning_extra_body(reasoning_config)
+            if _is_gh else None
+        ),
         lmstudio_reasoning_options=agent._lmstudio_reasoning_options_cached() if _is_lmstudio else None,
         anthropic_max_output=_ant_max,
         provider_name=agent.provider,
@@ -2880,6 +2892,12 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     from agent.context_compressor import MAX_ITERATIONS_SUMMARY_REQUEST
 
     summary_request = MAX_ITERATIONS_SUMMARY_REQUEST
+    from hermes_constants import resolve_auto_reasoning_config
+
+    summary_reasoning_config = resolve_auto_reasoning_config(
+        agent.reasoning_config,
+        messages,
+    )
     append_message(messages, {"role": "user", "content": summary_request})
 
     try:
@@ -2981,12 +2999,12 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             and agent._supports_reasoning_extra_body()
         )
         _lm_reasoning_effort: str | None = (
-            agent._resolve_lmstudio_summary_reasoning_effort()
+            agent._resolve_lmstudio_summary_reasoning_effort(summary_reasoning_config)
             if _is_lmstudio_summary else None
         )
         if not _is_lmstudio_summary and agent._supports_reasoning_extra_body():
-            if agent.reasoning_config is not None:
-                summary_extra_body["reasoning"] = agent.reasoning_config
+            if summary_reasoning_config is not None:
+                summary_extra_body["reasoning"] = summary_reasoning_config
             else:
                 summary_extra_body["reasoning"] = {
                     "enabled": True,
@@ -3029,7 +3047,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                         provider_preferences=provider_preferences or None,
                         model=agent.model,
                         base_url=agent.base_url,
-                        reasoning_config=agent.reasoning_config,
+                        reasoning_config=summary_reasoning_config,
                     )
             except Exception:
                 pass
@@ -3073,7 +3091,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                     messages=api_messages,
                     tools=None,
                     max_tokens=agent.max_tokens,
-                    reasoning_config=agent.reasoning_config,
+                    reasoning_config=summary_reasoning_config,
                     is_oauth=agent._is_anthropic_oauth,
                     preserve_dots=agent._anthropic_preserve_dots(),
                     base_url=getattr(agent, "_anthropic_base_url", None),
@@ -3126,7 +3144,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                     tools=None,
                     is_oauth=agent._is_anthropic_oauth,
                     max_tokens=agent.max_tokens,
-                    reasoning_config=agent.reasoning_config,
+                    reasoning_config=summary_reasoning_config,
                     preserve_dots=agent._anthropic_preserve_dots(),
                     base_url=getattr(agent, "_anthropic_base_url", None),
                 )

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1822,16 +1822,22 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
 
 
-def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = None) -> dict:
+def build_api_kwargs(
+    agent,
+    api_messages: list,
+    tools_for_api: list | None = None,
+    reasoning_config: dict | None = None,
+) -> dict:
     """Build the keyword arguments dict for the active API mode."""
     from hermes_constants import resolve_auto_reasoning_config
 
     if tools_for_api is None:
         tools_for_api = agent.tools
-    reasoning_config = resolve_auto_reasoning_config(
-        agent.reasoning_config,
-        api_messages,
-    )
+    if reasoning_config is None:
+        reasoning_config = resolve_auto_reasoning_config(
+            agent.reasoning_config,
+            api_messages,
+        )
 
     if agent.api_mode == "anthropic_messages":
         _transport = agent._get_transport()
@@ -3015,7 +3021,10 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             summary_extra_body["tags"] = _portal_tags()
 
         if agent.api_mode == "codex_responses":
-            codex_kwargs = agent._build_api_kwargs(api_messages)
+            codex_kwargs = agent._build_api_kwargs(
+                api_messages,
+                reasoning_config=summary_reasoning_config,
+            )
             codex_kwargs.pop("tools", None)
             summary_response = agent._run_codex_stream(codex_kwargs)
             _ct_sum = agent._get_transport()
@@ -3130,7 +3139,10 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         else:
             # Retry summary generation
             if agent.api_mode == "codex_responses":
-                codex_kwargs = agent._build_api_kwargs(api_messages)
+                codex_kwargs = agent._build_api_kwargs(
+                    api_messages,
+                    reasoning_config=summary_reasoning_config,
+                )
                 codex_kwargs.pop("tools", None)
                 retry_response = agent._run_codex_stream(codex_kwargs)
                 _ct_retry = agent._get_transport()

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1055,7 +1055,8 @@ agent:
   
   # Reasoning effort level (OpenRouter and Nous Portal)
   # Controls how much "thinking" the model does before responding.
-  # Options: "xhigh" (max), "high", "medium", "low", "minimal", "none" (disable)
+  # "auto" deterministically selects low/medium/high from the latest user message.
+  # Options: "auto", "xhigh" (max), "high", "medium", "low", "minimal", "none" (disable)
   reasoning_effort: "medium"
   
   # Per-model reasoning effort overrides (optional dict)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4786,7 +4786,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     def _load_reasoning_config() -> dict | None:
         """Load reasoning effort from config.yaml.
 
-        Reads agent.reasoning_effort from config.yaml. Valid: "none",
+        Reads agent.reasoning_effort from config.yaml. Valid: "none", "auto",
         "minimal", "low", "medium", "high", "xhigh". Returns None to use
         default (medium).
         """

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3625,7 +3625,12 @@ class GatewaySlashCommandsMixin:
                 "value": "none",
                 "label": t("gateway.reasoning.choice_none"),
                 "is_current": current_effort == "none",
-            }
+            },
+            {
+                "value": "auto",
+                "label": "auto",
+                "is_current": current_effort == "auto",
+            },
         ]
         for level in VALID_REASONING_EFFORTS:
             choices.append(

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2493,7 +2493,7 @@ class CLICommandsMixin:
             full_state = "full" if getattr(self, "reasoning_full", False) else "clamped to 10 lines"
             _cprint(f"  {_ACCENT}Reasoning effort:  {level}{_RST}")
             _cprint(f"  {_ACCENT}Reasoning display: {display_state} ({full_state}){_RST}")
-            _cprint(f"  {_DIM}Usage: /reasoning <none|minimal|low|medium|high|xhigh|show|hide|full|clamp>{_RST}")
+            _cprint(f"  {_DIM}Usage: /reasoning <none|auto|minimal|low|medium|high|xhigh|show|hide|full|clamp>{_RST}")
             return
 
         arg = parts[1].strip().lower()
@@ -2534,7 +2534,7 @@ class CLICommandsMixin:
         parsed = _parse_reasoning_config(arg)
         if parsed is None:
             _cprint(f"  {_DIM}(._.) Unknown argument: {arg}{_RST}")
-            _cprint(f"  {_DIM}Valid levels: none, minimal, low, medium, high, xhigh{_RST}")
+            _cprint(f"  {_DIM}Valid levels: none, auto, minimal, low, medium, high, xhigh{_RST}")
             _cprint(f"  {_DIM}Display:      show, hide{_RST}")
             return
 

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -3506,7 +3506,7 @@ class CLICommandsMixin:
 
         Usage:
             /reasoning              Show current effort level and display state
-            /reasoning <level>      Set effort for this session only (none, minimal, low, medium, high, xhigh, max, ultra)
+            /reasoning <level>      Set effort for this session only (none, auto, minimal, low, medium, high, xhigh, max, ultra)
             /reasoning <level> --global  Persist reasoning effort to config.yaml
             /reasoning show|on      Show model thinking/reasoning in output
             /reasoning hide|off     Hide model thinking/reasoning from output
@@ -3529,7 +3529,7 @@ class CLICommandsMixin:
             full_state = "full" if getattr(self, "reasoning_full", False) else "clamped to 10 lines"
             _cprint(f"  {_ACCENT}Reasoning effort:  {level}{_RST}")
             _cprint(f"  {_ACCENT}Reasoning display: {display_state} ({full_state}){_RST}")
-            _cprint(f"  {_DIM}Usage: /reasoning <none|minimal|low|medium|high|xhigh|max|ultra|show|hide|full|clamp> [--global]{_RST}")
+            _cprint(f"  {_DIM}Usage: /reasoning <none|auto|minimal|low|medium|high|xhigh|max|ultra|show|hide|full|clamp> [--global]{_RST}")
             return
 
         arg = parts[1].strip().lower()
@@ -3580,7 +3580,7 @@ class CLICommandsMixin:
         parsed = _parse_reasoning_config(arg)
         if parsed is None:
             _cprint(f"  {_DIM}(._.) Unknown argument: {arg}{_RST}")
-            _cprint(f"  {_DIM}Valid levels: none, minimal, low, medium, high, xhigh, max, ultra{_RST}")
+            _cprint(f"  {_DIM}Valid levels: none, auto, minimal, low, medium, high, xhigh, max, ultra{_RST}")
             _cprint(f"  {_DIM}Display:      show, hide{_RST}")
             _cprint(f"  {_DIM}Scope:        session-scoped by default, --global to persist{_RST}")
             return

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -280,7 +280,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                subcommands=("manual", "smart", "off")),
     CommandDef("reasoning", "Manage reasoning effort and display", "Configuration",
                args_hint="[level|show|hide|full|clamp] [--global]",
-               subcommands=("none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra", "show", "hide", "on", "off", "full", "clamp", "--global")),
+               subcommands=("none", "auto", "minimal", "low", "medium", "high", "xhigh", "max", "ultra", "show", "hide", "on", "off", "full", "clamp", "--global")),
     CommandDef("fast", "Toggle fast mode — OpenAI Priority Processing / Anthropic Fast Mode (Normal/Fast)", "Configuration",
                args_hint="[normal|fast|status] [--global]",
                subcommands=("normal", "fast", "status", "on", "off", "--global")),

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -797,7 +797,7 @@ VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh", "max")
 def parse_reasoning_effort(effort) -> dict | None:
     """Parse a reasoning effort level into a config dict.
 
-    Valid levels: "none", "minimal", "low", "medium", "high", "xhigh", "max".
+    Valid levels: "none", "auto", "minimal", "low", "medium", "high", "xhigh", "max".
     Returns None when the input is empty or unrecognized (caller uses default).
     Returns {"enabled": False} for "none" (aliases: "false", "disabled", and
     YAML boolean False — users write ``reasoning_effort: false``/``off``/``no``
@@ -815,9 +815,63 @@ def parse_reasoning_effort(effort) -> dict | None:
     effort = effort.strip().lower()
     if effort in {"none", "false", "disabled"}:
         return {"enabled": False}
-    if effort in VALID_REASONING_EFFORTS:
+    if effort == "auto" or effort in VALID_REASONING_EFFORTS:
         return {"enabled": True, "effort": effort}
     return None
+
+
+def _latest_user_text(messages) -> str:
+    for msg in reversed(messages or []):
+        if not isinstance(msg, dict) or msg.get("role") != "user":
+            continue
+        content = msg.get("content", "")
+        if isinstance(content, str):
+            return content.lower()
+        if isinstance(content, list):
+            parts = []
+            for item in content:
+                if isinstance(item, dict):
+                    parts.append(str(item.get("text") or item.get("content") or ""))
+                else:
+                    parts.append(str(item))
+            return " ".join(parts).lower()
+        return str(content).lower()
+    return ""
+
+
+def resolve_auto_reasoning_config(reasoning_config: dict | None, messages) -> dict | None:
+    """Resolve {effort: auto} to a concrete effort for this request.
+
+    Uses deterministic local heuristics only; no extra model call and no system
+    prompt mutation, so prompt caching remains stable.
+    """
+    if not isinstance(reasoning_config, dict):
+        return reasoning_config
+    if reasoning_config.get("enabled") is False:
+        return reasoning_config
+    if str(reasoning_config.get("effort") or "").strip().lower() != "auto":
+        return reasoning_config
+
+    text = _latest_user_text(messages)
+    high_markers = (
+        "root cause", "security", "audit", "auth", "credential", "secret",
+        "production", "prod", "architecture", "architekt", "refactor",
+        "debug", "traceback", "failing test", "test failure", "performance",
+        "incident", "migration", "database", "payment", "gateway", "systemd",
+    )
+    medium_markers = (
+        "implement", "build", "code", "patch", "change", "modify", "config",
+        "configure", "setup", "install", "design", "compare", "research",
+        "plan", "workflow", "automation", "test", "fix", "pakeit", "padaryk",
+    )
+
+    if any(marker in text for marker in high_markers):
+        effort = "high"
+    elif len(text) > 500 or any(marker in text for marker in medium_markers):
+        effort = "medium"
+    else:
+        effort = "low"
+    return {"enabled": True, "effort": effort}
 
 
 def is_termux() -> bool:

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1160,8 +1160,8 @@ VALID_REASONING_EFFORTS = (
 def parse_reasoning_effort(effort) -> dict | None:
     """Parse a reasoning effort level into a config dict.
 
-    Valid levels: "none", "minimal", "low", "medium", "high", "xhigh", "max",
-    "ultra".
+    Valid levels: "none", "auto", "minimal", "low", "medium", "high", "xhigh",
+    "max", "ultra".
     Returns None when the input is empty or unrecognized (caller uses default).
     Returns {"enabled": False} for "none" (aliases: "false", "disabled", and
     YAML boolean False — users write ``reasoning_effort: false``/``off``/``no``
@@ -1179,9 +1179,67 @@ def parse_reasoning_effort(effort) -> dict | None:
     effort = effort.strip().lower()
     if effort in {"none", "false", "disabled"}:
         return {"enabled": False}
-    if effort in VALID_REASONING_EFFORTS:
+    if effort == "auto" or effort in VALID_REASONING_EFFORTS:
         return {"enabled": True, "effort": effort}
     return None
+
+
+def _latest_user_text(messages) -> str:
+    """Return lowercase text from the latest user message."""
+    for message in reversed(messages or []):
+        if not isinstance(message, dict) or message.get("role") != "user":
+            continue
+        content = message.get("content", "")
+        if isinstance(content, str):
+            return content.lower()
+        if isinstance(content, list):
+            parts = []
+            for item in content:
+                if isinstance(item, dict):
+                    parts.append(str(item.get("text") or item.get("content") or ""))
+                else:
+                    parts.append(str(item))
+            return " ".join(parts).lower()
+        return str(content).lower()
+    return ""
+
+
+def resolve_auto_reasoning_config(
+    reasoning_config: dict | None,
+    messages,
+) -> dict | None:
+    """Resolve ``effort: auto`` deterministically for one request.
+
+    Resolution reads only the latest user turn and never mutates conversation
+    history or the agent's configured value, preserving prompt-cache stability.
+    """
+    if not isinstance(reasoning_config, dict):
+        return reasoning_config
+    if reasoning_config.get("enabled") is False:
+        return reasoning_config
+    if str(reasoning_config.get("effort") or "").strip().lower() != "auto":
+        return reasoning_config
+
+    text = _latest_user_text(messages)
+    high_markers = (
+        "root cause", "security", "audit", "auth", "credential", "secret",
+        "production", "prod", "architecture", "refactor", "debug", "traceback",
+        "failing test", "test failure", "performance", "incident", "migration",
+        "database", "payment", "gateway", "systemd",
+    )
+    medium_markers = (
+        "implement", "build", "code", "patch", "change", "modify", "config",
+        "configure", "setup", "install", "design", "compare", "research", "plan",
+        "workflow", "automation", "test", "fix",
+    )
+
+    if any(marker in text for marker in high_markers):
+        effort = "high"
+    elif len(text) > 500 or any(marker in text for marker in medium_markers):
+        effort = "medium"
+    else:
+        effort = "low"
+    return {"enabled": True, "effort": effort}
 
 
 def _canonical_model_variants(model: str) -> list[str]:

--- a/run_agent.py
+++ b/run_agent.py
@@ -7621,10 +7621,20 @@ class AIAgent:
                     content[-1]["cache_control"] = {"type": "ephemeral"}
                 break
 
-    def _build_api_kwargs(self, api_messages: list, tools_for_api: Optional[list] = None) -> dict:
+    def _build_api_kwargs(
+        self,
+        api_messages: list,
+        tools_for_api: Optional[list] = None,
+        reasoning_config: Optional[dict] = None,
+    ) -> dict:
         """Forwarder — see ``agent.chat_completion_helpers.build_api_kwargs``."""
         from agent.chat_completion_helpers import build_api_kwargs
-        return build_api_kwargs(self, api_messages, tools_for_api=tools_for_api)
+        return build_api_kwargs(
+            self,
+            api_messages,
+            tools_for_api=tools_for_api,
+            reasoning_config=reasoning_config,
+        )
 
     def _supports_reasoning_extra_body(self) -> bool:
         """Return True when reasoning extra_body is safe to send for this route/model.

--- a/run_agent.py
+++ b/run_agent.py
@@ -7766,7 +7766,10 @@ class AIAgent:
         cache[key] = (supported, _time.monotonic())
         return bool(supported)
 
-    def _resolve_lmstudio_summary_reasoning_effort(self) -> Optional[str]:
+    def _resolve_lmstudio_summary_reasoning_effort(
+        self,
+        reasoning_config: Optional[dict] = None,
+    ) -> Optional[str]:
         """Resolve a safe top-level ``reasoning_effort`` for LM Studio.
 
         The iteration-limit summary path calls ``chat.completions.create()``
@@ -7774,12 +7777,19 @@ class AIAgent:
         can't drift on effort resolution and clamping.
         """
         from agent.lmstudio_reasoning import resolve_lmstudio_effort
+        effective_config = (
+            getattr(self, "reasoning_config", None)
+            if reasoning_config is None else reasoning_config
+        )
         return resolve_lmstudio_effort(
-            self.reasoning_config,
+            effective_config,
             self._lmstudio_reasoning_options_cached(),
         )
 
-    def _github_models_reasoning_extra_body(self) -> dict | None:
+    def _github_models_reasoning_extra_body(
+        self,
+        reasoning_config: Optional[dict] = None,
+    ) -> dict | None:
         """Format reasoning payload for GitHub Models/OpenAI-compatible routes."""
         try:
             from hermes_cli.models import github_model_reasoning_efforts
@@ -7790,11 +7800,15 @@ class AIAgent:
         if not supported_efforts:
             return None
 
-        if self.reasoning_config and isinstance(self.reasoning_config, dict):
-            if self.reasoning_config.get("enabled") is False:
+        effective_config = (
+            getattr(self, "reasoning_config", None)
+            if reasoning_config is None else reasoning_config
+        )
+        if effective_config and isinstance(effective_config, dict):
+            if effective_config.get("enabled") is False:
                 return None
             requested_effort = str(
-                self.reasoning_config.get("effort", "medium")
+                effective_config.get("effort", "medium")
             ).strip().lower()
         else:
             requested_effort = "medium"

--- a/tests/agent/test_auto_reasoning_transport.py
+++ b/tests/agent/test_auto_reasoning_transport.py
@@ -1,0 +1,110 @@
+import types
+from unittest.mock import patch
+
+from agent.chat_completion_helpers import build_api_kwargs, handle_max_iterations
+
+
+class _CapturingTransport:
+    def __init__(self):
+        self.kwargs = None
+
+    def build_kwargs(self, **kwargs):
+        self.kwargs = kwargs
+        return kwargs
+
+
+class _GitHubResponsesAgent:
+    tools = []
+    api_mode = "codex_responses"
+    model = "gpt-5.4"
+    base_url = "https://models.github.ai/inference"
+    provider = "github-models"
+    _base_url_hostname = "models.github.ai"
+    _base_url_lower = base_url.lower()
+    reasoning_config = {"enabled": True, "effort": "auto"}
+    session_id = "session-auto"
+    max_tokens = 4096
+    request_overrides = {}
+    _codex_reasoning_replay_enabled = True
+    codex_responses_native_compaction = False
+
+    def __init__(self):
+        self.transport = _CapturingTransport()
+
+    def _get_transport(self):
+        return self.transport
+
+    def _prepare_messages_for_non_vision_model(self, messages):
+        return messages
+
+    def _resolved_api_call_timeout(self):
+        return 30
+
+    def _github_models_reasoning_extra_body(self, reasoning_config=None):
+        config = self.reasoning_config if reasoning_config is None else reasoning_config
+        return {"effort": config["effort"]}
+
+
+def test_github_responses_transport_uses_resolved_auto_reasoning_config():
+    agent = _GitHubResponsesAgent()
+
+    build_api_kwargs(
+        agent,
+        [{"role": "user", "content": "debug this production security incident"}],
+    )
+
+    assert agent.transport.kwargs is not None
+    assert agent.transport.kwargs["reasoning_config"] == {
+        "enabled": True,
+        "effort": "high",
+    }
+    assert agent.transport.kwargs["github_reasoning_extra"] == {"effort": "high"}
+
+
+def test_lmstudio_iteration_summary_uses_resolved_auto_reasoning_config():
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="lm-studio",
+        provider="lmstudio",
+        model="reasoning-model",
+        base_url="http://localhost:1234/v1",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        reasoning_config={"enabled": True, "effort": "auto"},
+    )
+    setattr(agent, "_cached_system_prompt", "SYS")
+
+    captured = {}
+
+    class _Completions:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return "RAW-RESPONSE"
+
+    client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(completions=_Completions())
+    )
+    transport = types.SimpleNamespace(
+        normalize_response=lambda _response: types.SimpleNamespace(content="SUMMARY")
+    )
+    messages = [
+        {"role": "user", "content": "debug this production security incident"},
+        {"role": "assistant", "content": "working"},
+    ]
+
+    with (
+        patch.object(agent, "_ensure_primary_openai_client", return_value=client),
+        patch.object(agent, "_get_transport", return_value=transport),
+        patch.object(agent, "_supports_reasoning_extra_body", return_value=True),
+        patch.object(
+            agent,
+            "_lmstudio_reasoning_options_cached",
+            return_value=["low", "medium", "high"],
+        ),
+    ):
+        result = handle_max_iterations(agent, messages, 5)
+
+    assert result == "SUMMARY"
+    assert captured["reasoning_effort"] == "high"

--- a/tests/agent/test_auto_reasoning_transport.py
+++ b/tests/agent/test_auto_reasoning_transport.py
@@ -108,3 +108,68 @@ def test_lmstudio_iteration_summary_uses_resolved_auto_reasoning_config():
 
     assert result == "SUMMARY"
     assert captured["reasoning_effort"] == "high"
+
+
+def _codex_summary_agent():
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="test-codex-key",
+        provider="openai-codex",
+        model="gpt-5.4",
+        base_url="https://chatgpt.com/backend-api/codex",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        reasoning_config={"enabled": True, "effort": "auto"},
+    )
+    agent._cached_system_prompt = "SYS"
+    return agent
+
+
+class _CodexSummaryTransport:
+    def __init__(self):
+        self.calls = []
+
+    def build_kwargs(self, **kwargs):
+        self.calls.append(kwargs)
+        return kwargs
+
+    def normalize_response(self, response):
+        return types.SimpleNamespace(content=response)
+
+
+def test_codex_iteration_summary_initial_call_preserves_pre_synthetic_auto_resolution():
+    agent = _codex_summary_agent()
+    transport = _CodexSummaryTransport()
+    messages = [{"role": "user", "content": "debug this production security incident"}]
+
+    with (
+        patch.object(agent, "_run_codex_stream", return_value="SUMMARY"),
+        patch.object(agent, "_get_transport", return_value=transport),
+    ):
+        result = handle_max_iterations(agent, messages, 5)
+
+    assert result == "SUMMARY"
+    assert [call["reasoning_config"] for call in transport.calls] == [
+        {"enabled": True, "effort": "high"}
+    ]
+
+
+def test_codex_iteration_summary_retry_preserves_pre_synthetic_auto_resolution():
+    agent = _codex_summary_agent()
+    transport = _CodexSummaryTransport()
+    responses = iter(["", "SUMMARY"])
+    messages = [{"role": "user", "content": "debug this production security incident"}]
+
+    with (
+        patch.object(agent, "_run_codex_stream", side_effect=lambda _kwargs: next(responses)),
+        patch.object(agent, "_get_transport", return_value=transport),
+    ):
+        result = handle_max_iterations(agent, messages, 5)
+
+    assert result == "SUMMARY"
+    assert [call["reasoning_config"] for call in transport.calls] == [
+        {"enabled": True, "effort": "high"},
+        {"enabled": True, "effort": "high"},
+    ]

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -465,6 +465,25 @@ class TestBuildCallKwargsMaxTokens:
         assert "max_tokens" not in kw3
 
 
+def test_moa_reference_resolves_auto_before_auxiliary_wire_projection():
+    """MoA advisor requests must never project the internal ``auto`` sentinel."""
+    kwargs = _build_call_kwargs(
+        provider="custom",
+        model="reasoning-model",
+        messages=[
+            {
+                "role": "user",
+                "content": "debug this production security incident",
+            }
+        ],
+        reasoning_config={"enabled": True, "effort": "auto"},
+        task="moa_reference",
+    )
+
+    assert kwargs["reasoning_effort"] == "high"
+    assert "auto" not in repr(kwargs)
+
+
 
 
 class TestNousTagsScoping:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -20,6 +20,7 @@ from agent.auxiliary_client import (
     call_llm,
     async_call_llm,
     _build_call_kwargs,
+    _get_task_extra_body,
     _read_codex_access_token,
     _get_provider_chain,
     _is_payment_error,
@@ -484,6 +485,52 @@ def test_moa_reference_resolves_auto_before_auxiliary_wire_projection():
     assert "auto" not in repr(kwargs)
 
 
+def test_explicit_extra_body_auto_is_resolved_before_wire_projection():
+    kwargs = _build_call_kwargs(
+        provider="openrouter",
+        model="reasoning-model",
+        messages=[{"role": "user", "content": "debug this production security incident"}],
+        extra_body={"reasoning": {"enabled": True, "effort": "auto"}},
+        task="compression",
+    )
+
+    assert kwargs["extra_body"]["reasoning"]["effort"] == "high"
+    assert "auto" not in repr(kwargs)
+
+
+def test_task_reasoning_effort_auto_is_resolved_before_wire_projection(monkeypatch):
+    import agent.auxiliary_client as aux
+
+    monkeypatch.setattr(
+        aux,
+        "_get_auxiliary_task_config",
+        lambda task: {"reasoning_effort": "auto"} if task == "compression" else {},
+    )
+    extra_body = _get_task_extra_body("compression")
+    kwargs = _build_call_kwargs(
+        provider="openrouter",
+        model="reasoning-model",
+        messages=[{"role": "user", "content": "debug this production security incident"}],
+        extra_body=extra_body,
+        task="compression",
+    )
+
+    assert kwargs["extra_body"]["reasoning"]["effort"] == "high"
+    assert "auto" not in repr(kwargs)
+
+
+def test_moa_slot_resolution_cannot_coexist_with_task_extra_body_auto():
+    kwargs = _build_call_kwargs(
+        provider="custom",
+        model="reasoning-model",
+        messages=[{"role": "user", "content": "debug this production security incident"}],
+        reasoning_config={"enabled": True, "effort": "high"},
+        extra_body={"reasoning": {"enabled": True, "effort": "auto"}},
+        task="moa_reference",
+    )
+
+    assert kwargs["reasoning_effort"] == "high"
+    assert "auto" not in repr(kwargs)
 
 
 class TestNousTagsScoping:

--- a/tests/cli/test_reasoning_command.py
+++ b/tests/cli/test_reasoning_command.py
@@ -103,6 +103,19 @@ class TestHandleReasoningCommand(unittest.TestCase):
         self.assertEqual(stub.reasoning_config, {"enabled": True, "effort": "high"})
         self.assertIsNone(stub.agent)
 
+    def test_builtin_reasoning_help_surfaces_include_auto(self):
+        from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+        stub = self._make_cli(reasoning_config={"enabled": True, "effort": "medium"})
+        output = []
+        with patch("cli._cprint", side_effect=output.append):
+            CLICommandsMixin._handle_reasoning_command(stub, "/reasoning")
+            CLICommandsMixin._handle_reasoning_command(stub, "/reasoning turbo")
+
+        help_lines = [line for line in output if "Usage:" in line or "Valid levels:" in line]
+        self.assertEqual(len(help_lines), 2)
+        self.assertTrue(all("auto" in line for line in help_lines))
+
 
 
     def test_new_session_clears_session_reasoning_override(self):

--- a/tests/gateway/test_choice_picker.py
+++ b/tests/gateway/test_choice_picker.py
@@ -81,10 +81,11 @@ class TestReasoningChoicePicker:
         assert len(adapter.calls) == 1
         call = adapter.calls[0]
         values = [c["value"] for c in call["choices"]]
-        # Full canonical ladder + none + subcommands, in order
+        # Auto is a runtime policy, not part of the static provider effort ladder.
         from hermes_constants import VALID_REASONING_EFFORTS
         assert values[0] == "none"
-        assert values[1:1 + len(VALID_REASONING_EFFORTS)] == list(VALID_REASONING_EFFORTS)
+        assert values[1] == "auto"
+        assert values[2:2 + len(VALID_REASONING_EFFORTS)] == list(VALID_REASONING_EFFORTS)
         assert values[-3:] == ["reset", "show", "hide"]
 
 

--- a/tests/gateway/test_reasoning_command.py
+++ b/tests/gateway/test_reasoning_command.py
@@ -95,6 +95,30 @@ class TestReasoningCommand:
 
 
     @pytest.mark.asyncio
+    async def test_handle_reasoning_command_accepts_auto_through_shared_parser(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "agent:\n  reasoning_effort: medium\n", encoding="utf-8"
+        )
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+        event = _make_event("/reasoning auto")
+        session_key = runner._session_key_for_source(event.source)
+
+        result = await runner._handle_reasoning_command(event)
+
+        assert runner._session_reasoning_overrides[session_key] == {
+            "enabled": True,
+            "effort": "auto",
+        }
+        assert result is not None
+        assert "auto" in result
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("effort", ["max", "ultra"])
     async def test_handle_reasoning_command_accepts_extended_efforts(
         self, tmp_path, monkeypatch, effort

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -393,6 +393,9 @@ class TestSubcommands:
         assert "/skills" in SUBCOMMANDS
         assert "install" in SUBCOMMANDS["/skills"]
 
+    def test_reasoning_subcommands_include_auto(self):
+        assert "auto" in SUBCOMMANDS["/reasoning"]
+
 
     def test_commands_without_subcommands_not_in_dict(self):
         """Plain commands should not appear in SUBCOMMANDS."""

--- a/tests/test_auto_reasoning_effort.py
+++ b/tests/test_auto_reasoning_effort.py
@@ -1,0 +1,32 @@
+from hermes_constants import parse_reasoning_effort, resolve_auto_reasoning_config
+
+
+def test_parse_reasoning_effort_accepts_auto_marker():
+    assert parse_reasoning_effort("auto") == {"enabled": True, "effort": "auto"}
+
+
+def test_auto_reasoning_uses_low_for_simple_status_question():
+    cfg = {"enabled": True, "effort": "auto"}
+    messages = [{"role": "user", "content": "koks effort nustatytas default profiliui?"}]
+
+    assert resolve_auto_reasoning_config(cfg, messages) == {"enabled": True, "effort": "low"}
+
+
+def test_auto_reasoning_uses_medium_for_design_and_config_changes():
+    cfg = {"enabled": True, "effort": "auto"}
+    messages = [{"role": "user", "content": "noriu auto effort pakeitimo Hermes confige"}]
+
+    assert resolve_auto_reasoning_config(cfg, messages) == {"enabled": True, "effort": "medium"}
+
+
+def test_auto_reasoning_uses_high_for_debug_security_and_architecture():
+    cfg = {"enabled": True, "effort": "auto"}
+    messages = [{"role": "user", "content": "padaryk root cause debugging security architekturos sprendimui"}]
+
+    assert resolve_auto_reasoning_config(cfg, messages) == {"enabled": True, "effort": "high"}
+
+
+def test_auto_reasoning_leaves_explicit_effort_unchanged():
+    cfg = {"enabled": True, "effort": "medium"}
+
+    assert resolve_auto_reasoning_config(cfg, []) is cfg

--- a/tests/test_auto_reasoning_effort.py
+++ b/tests/test_auto_reasoning_effort.py
@@ -1,8 +1,16 @@
-from hermes_constants import parse_reasoning_effort, resolve_auto_reasoning_config
+from hermes_constants import (
+    VALID_REASONING_EFFORTS,
+    parse_reasoning_effort,
+    resolve_auto_reasoning_config,
+)
 
 
 def test_parse_reasoning_effort_accepts_auto_marker():
     assert parse_reasoning_effort("auto") == {"enabled": True, "effort": "auto"}
+
+
+def test_auto_policy_is_not_added_to_static_provider_effort_ladder():
+    assert "auto" not in VALID_REASONING_EFFORTS
 
 
 def test_auto_reasoning_uses_low_for_simple_status_question():

--- a/tests/test_auto_reasoning_effort.py
+++ b/tests/test_auto_reasoning_effort.py
@@ -7,21 +7,32 @@ def test_parse_reasoning_effort_accepts_auto_marker():
 
 def test_auto_reasoning_uses_low_for_simple_status_question():
     cfg = {"enabled": True, "effort": "auto"}
-    messages = [{"role": "user", "content": "koks effort nustatytas default profiliui?"}]
+    messages = [{"role": "user", "content": "what effort is active?"}]
 
     assert resolve_auto_reasoning_config(cfg, messages) == {"enabled": True, "effort": "low"}
 
 
 def test_auto_reasoning_uses_medium_for_design_and_config_changes():
     cfg = {"enabled": True, "effort": "auto"}
-    messages = [{"role": "user", "content": "noriu auto effort pakeitimo Hermes confige"}]
+    messages = [{"role": "user", "content": "implement an automatic effort config change"}]
 
     assert resolve_auto_reasoning_config(cfg, messages) == {"enabled": True, "effort": "medium"}
 
 
 def test_auto_reasoning_uses_high_for_debug_security_and_architecture():
     cfg = {"enabled": True, "effort": "auto"}
-    messages = [{"role": "user", "content": "padaryk root cause debugging security architekturos sprendimui"}]
+    messages = [{"role": "user", "content": "find the root cause of this security architecture failure"}]
+
+    assert resolve_auto_reasoning_config(cfg, messages) == {"enabled": True, "effort": "high"}
+
+
+def test_auto_reasoning_reads_structured_latest_user_content():
+    cfg = {"enabled": True, "effort": "auto"}
+    messages = [
+        {"role": "user", "content": "old simple question"},
+        {"role": "assistant", "content": "answer"},
+        {"role": "user", "content": [{"type": "text", "text": "debug this failing test"}]},
+    ]
 
     assert resolve_auto_reasoning_config(cfg, messages) == {"enabled": True, "effort": "high"}
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1578,10 +1578,12 @@ Control how much "thinking" the model does before responding:
 
 ```yaml
 agent:
-  reasoning_effort: ""   # empty = medium. Options: none, minimal, low, medium, high, xhigh, max, ultra
+  reasoning_effort: ""   # empty = medium. Options: auto, none, minimal, low, medium, high, xhigh, max, ultra
 ```
 
 When unset (default), reasoning effort defaults to "medium" — a balanced level that works well for most tasks. Setting a value overrides it — higher reasoning effort gives better results on complex tasks at the cost of more tokens and latency.
+
+Set `reasoning_effort: "auto"` to choose an effort for each request from the latest user message. Hermes uses `low` for simple prompts, `medium` for implementation, configuration, and planning work, and `high` for debugging, security, production, and architecture tasks. Resolution is deterministic, does not modify conversation history or the configured value, and the selected provider can still clamp the result to an effort level it supports.
 
 :::note Adaptive-thinking models (Claude 4.6+, Fable/Mythos-class) over OpenRouter
 These models use *adaptive* thinking and don't accept the usual `reasoning.effort`
@@ -1609,6 +1611,7 @@ You can also change the reasoning effort at runtime with the `/reasoning` comman
 
 ```
 /reasoning                # Show current effort level and display state
+/reasoning auto           # Select low, medium, or high for each request
 /reasoning high           # Set reasoning effort to high (this session only)
 /reasoning high --global  # Set effort and persist to config.yaml
 /reasoning none           # Disable reasoning (this session only)


### PR DESCRIPTION
## Summary
- allow `reasoning_effort: auto` to parse as a first-class marker
- resolve `auto` per request with deterministic local heuristics (`low` / `medium` / `high`)
- apply the resolved concrete reasoning config across OpenAI-compatible, Anthropic, Codex, and max-iteration summary paths
- update `/reasoning` help text and gateway config docs

## Why
Users can keep a stable config while avoiding one fixed reasoning level for every task. The resolver is local-only and does not mutate prompts or tools, so prompt caching remains stable.

## Tests
- `python -m pytest tests/test_auto_reasoning_effort.py -q`
- `ruff check agent/chat_completion_helpers.py gateway/run.py hermes_cli/cli_commands_mixin.py hermes_constants.py tests/test_auto_reasoning_effort.py`
