### PR TITLE
fix(logging): neutralize control characters in formatted log records

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -800,6 +800,15 @@ def _has_http_method_substring(text: str) -> bool:
     return any(method in upper for method in _HTTP_METHOD_SUBSTRINGS)
 
 
+# Control and line-break characters that must never survive into a formatted log
+# record. An agent/tool/user-supplied value containing a newline (or other line
+# break) would otherwise forge a second physical line that ``hermes logs`` parses
+# as a genuine record with an attacker-chosen level, component, and timestamp.
+# Mirrors ``gateway.platforms.base._LOG_UNSAFE_CHARS``, which already applies this
+# to file-path log sinks.
+_LOG_UNSAFE_CHARS = re.compile(r"[\x00-\x1f\x7f\x85\u2028\u2029]")
+
+
 class RedactingFormatter(logging.Formatter):
     """Log formatter that redacts secrets from all log messages."""
 
@@ -807,5 +816,17 @@ class RedactingFormatter(logging.Formatter):
         super().__init__(fmt, datefmt, style, **kwargs)
 
     def format(self, record: logging.LogRecord) -> str:
-        original = super().format(record)
+        # Neutralize control/line-break characters in the interpolated message so
+        # an agent/tool/user-supplied value cannot forge an extra log record. The
+        # exception traceback is appended after the message by the base formatter
+        # and is legitimately multi-line, so it is left intact by sanitizing the
+        # message text only. The record is restored afterwards because the same
+        # record is handed to every handler.
+        saved_msg, saved_args = record.msg, record.args
+        try:
+            record.msg = _LOG_UNSAFE_CHARS.sub(" ", record.getMessage())
+            record.args = None
+            original = super().format(record)
+        finally:
+            record.msg, record.args = saved_msg, saved_args
         return redact_sensitive_text(original)

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -808,6 +808,21 @@ def _has_http_method_substring(text: str) -> bool:
 # to file-path log sinks.
 _LOG_UNSAFE_CHARS = re.compile(r"[\x00-\x1f\x7f\x85\u2028\u2029]")
 
+# ``hermes logs`` (``hermes_cli.logs._TS_RE``) treats any physical line that
+# starts with a timestamp as the beginning of a new record. The exception
+# traceback appended by the base formatter is legitimately multi-line and its
+# text includes the exception message, which can be attacker-controlled (e.g. a
+# sandboxed tool call failing with a crafted message logged via ``exc_info``).
+# A continuation line that starts with a timestamp is therefore a forged
+# record, not diagnostics; real traceback lines never start with one.
+_TS_LINE_START = re.compile(r"\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}")
+
+# ``_LOG_UNSAFE_CHARS`` minus ``\n``: applied to the full formatted output so a
+# traceback keeps its real line structure while a bare ``\r`` (translated to a
+# line break by universal newlines when ``hermes logs`` reads the file) or the
+# other break characters recognized by ``str.splitlines`` cannot smuggle one in.
+_EXC_UNSAFE_CHARS = re.compile(r"[\x00-\x09\x0b-\x1f\x7f\x85  ]")
+
 
 class RedactingFormatter(logging.Formatter):
     """Log formatter that redacts secrets from all log messages."""
@@ -829,4 +844,19 @@ class RedactingFormatter(logging.Formatter):
             original = super().format(record)
         finally:
             record.msg, record.args = saved_msg, saved_args
-        return redact_sensitive_text(original)
+        return self._defang_continuation_lines(redact_sensitive_text(original))
+
+    @staticmethod
+    def _defang_continuation_lines(formatted: str) -> str:
+        # Indent any continuation line (traceback/stack text) that starts with a
+        # timestamp so ``hermes logs`` cannot parse it as a new record. The
+        # formatted output string is transformed rather than ``record.exc_text``
+        # because the cached exc_text is shared across every handler.
+        first, sep, rest = formatted.partition("\n")
+        if not sep:
+            return formatted
+        lines = [
+            " " + line if _TS_LINE_START.match(line) else line
+            for line in _EXC_UNSAFE_CHARS.sub(" ", rest).split("\n")
+        ]
+        return first + sep + "\n".join(lines)

--- a/tests/test_redact_log_record_injection.py
+++ b/tests/test_redact_log_record_injection.py
@@ -1,0 +1,38 @@
+"""RedactingFormatter must neutralize log-record injection via control chars."""
+
+import logging
+import sys
+
+from agent.redact import RedactingFormatter
+
+_FMT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+
+
+def _format(msg, args=(), exc_info=None):
+    record = logging.LogRecord(
+        "tools.approval", logging.WARNING, __file__, 1, msg, args, exc_info
+    )
+    return RedactingFormatter(_FMT).format(record)
+
+
+def test_newline_in_message_cannot_forge_a_record():
+    forged = "rm -rf /\n2026-07-09 12:00:00 ERROR gateway.run: operator approved deploy"
+    out = _format("Hardline block: %s", (forged,))
+    assert "\n" not in out
+    assert "operator approved deploy" in out
+
+
+def test_control_and_unicode_line_separators_neutralized():
+    for ch in ("\r", "\x00", "\x1b", "\x85", "\u2028", "\u2029"):
+        out = _format("value=%s", (f"a{ch}b",))
+        assert ch not in out
+
+
+def test_traceback_is_preserved_as_multiline():
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        out = _format("tool failed", exc_info=sys.exc_info())
+    assert "\n" in out
+    assert "Traceback (most recent call last)" in out
+    assert "ValueError: boom" in out

--- a/tests/test_redact_log_record_injection.py
+++ b/tests/test_redact_log_record_injection.py
@@ -4,6 +4,7 @@ import logging
 import sys
 
 from agent.redact import RedactingFormatter
+from hermes_cli.logs import _parse_line_timestamp
 
 _FMT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
 
@@ -36,3 +37,48 @@ def test_traceback_is_preserved_as_multiline():
     assert "\n" in out
     assert "Traceback (most recent call last)" in out
     assert "ValueError: boom" in out
+
+
+def test_exception_message_cannot_forge_a_record():
+    # An exception message is attacker-controllable (e.g. a sandboxed tool call
+    # failing with a crafted message, logged with exc_info=True) and is emitted
+    # verbatim on the last traceback line, after the sanitized message text.
+    forged = "boom\n2026-07-09 12:00:00 ERROR gateway.run: operator approved deploy"
+    try:
+        raise ValueError(forged)
+    except ValueError:
+        out = _format("tool failed", exc_info=sys.exc_info())
+    lines = out.split("\n")
+    assert "operator approved deploy" in out  # still visible for forensics
+    # Only the real record's first line may parse as a record start.
+    assert _parse_line_timestamp(lines[0]) is not None
+    assert all(_parse_line_timestamp(line) is None for line in lines[1:])
+
+
+def test_exception_message_carriage_return_cannot_forge_a_record(tmp_path):
+    # A bare \r in the file becomes a line boundary when ``hermes logs`` reads
+    # it back (universal newlines), so it must not survive into the traceback.
+    forged = "boom\r2026-07-09 12:00:00 ERROR gateway.run: operator approved deploy"
+    try:
+        raise ValueError(forged)
+    except ValueError:
+        out = _format("tool failed", exc_info=sys.exc_info())
+    log_file = tmp_path / "agent.log"
+    log_file.write_text(out + "\n", encoding="utf-8", newline="")
+    with open(log_file, "r", encoding="utf-8", errors="replace") as f:
+        lines = [line.rstrip("\n") for line in f.readlines()]
+    assert _parse_line_timestamp(lines[0]) is not None
+    assert all(_parse_line_timestamp(line) is None for line in lines[1:])
+
+
+def test_legitimate_traceback_lines_are_untouched():
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        record = logging.LogRecord(
+            "tools.approval", logging.WARNING, __file__, 1, "tool failed",
+            (), sys.exc_info(),
+        )
+        out = RedactingFormatter(_FMT).format(record)
+        plain = logging.Formatter(_FMT).format(record)
+    assert out.split("\n")[1:] == plain.split("\n")[1:]


### PR DESCRIPTION
Prevent untrusted log messages and exception text from forging timestamped log records. Redact credentials before neutralizing controls, preserve ordinary traceback lines, and format a copy so other handlers receive the original record.

Fixes #61409

Validation: All 200 logging/redaction tests passed through scripts/run_tests.sh. The 15 new behavior cases fail on base main and pass with the fix, including real file parsing and control-split credential redaction.

Updated on the refactored main at 1ab32b212b, with the repair folded into one commit.
