### PR TITLE
fix: surface Bedrock in explicit-only model pickers when AWS env credentials are set

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1510,6 +1510,23 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
             if has_usable_secret(os.getenv(env_var, "")):
                 return True
 
+    # AWS SDK providers (Bedrock) have auth_type="aws_sdk" and empty
+    # api_key_env_vars, so the loop above never sees them. A user who sets
+    # AWS_BEARER_TOKEN_BEDROCK (or an access-key pair) in .env has configured
+    # the provider exactly as explicitly as pasting ANTHROPIC_API_KEY —
+    # without this check the desktop picker's explicit_only filter hides
+    # Bedrock even though list_authenticated_providers builds its row.
+    # Only check explicit env credentials here (NOT boto3's full chain):
+    # ambient sources like EC2 IMDS / SSO profiles must not auto-surface.
+    if pconfig and pconfig.auth_type == "aws_sdk":
+        if has_usable_secret(os.getenv("AWS_BEARER_TOKEN_BEDROCK", "")):
+            return True
+        if (
+            has_usable_secret(os.getenv("AWS_ACCESS_KEY_ID", ""))
+            and has_usable_secret(os.getenv("AWS_SECRET_ACCESS_KEY", ""))
+        ):
+            return True
+
     # 4. Check persisted credential-pool entries that came from EXPLICIT flows
     # the user initiated inside Hermes (manual add / device-code / PKCE), plus
     # env-backed pool entries. This intentionally excludes ambient borrowed

--- a/tests/hermes_cli/test_auth_provider_gate.py
+++ b/tests/hermes_cli/test_auth_provider_gate.py
@@ -171,3 +171,94 @@ def test_env_pool_entry_counts_when_var_still_resolves(tmp_path, monkeypatch):
 
     from hermes_cli.auth import is_provider_explicitly_configured
     assert is_provider_explicitly_configured("deepseek") is True
+
+
+# ─── aws_sdk providers (Bedrock) ─────────────────────────────────────────
+#
+# Bedrock is registered with auth_type="aws_sdk" and an empty
+# api_key_env_vars tuple, so the api_key env-var loop never sees it.
+# Setting AWS_BEARER_TOKEN_BEDROCK (or an access-key pair) in .env is
+# exactly as explicit as pasting ANTHROPIC_API_KEY, and must count —
+# otherwise the desktop picker's explicit_only filter hides Bedrock even
+# though list_authenticated_providers builds a full row for it.
+#
+# Ambient AWS credential sources (SSO profiles, EC2 IMDS, container
+# credentials) must NOT count: aws_sdk detection here is env-var only,
+# never boto3's full chain.
+
+
+@pytest.fixture()
+def _clean_aws_env(monkeypatch):
+    """Strip AWS env vars so developer/CI AWS credentials don't leak in."""
+    for key in (
+        "AWS_BEARER_TOKEN_BEDROCK",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "AWS_PROFILE",
+        "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+        "AWS_WEB_IDENTITY_TOKEN_FILE",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_bedrock_not_explicit_without_aws_env(tmp_path, monkeypatch, _clean_aws_env):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    (tmp_path / "hermes").mkdir(parents=True, exist_ok=True)
+
+    from hermes_cli.auth import is_provider_explicitly_configured
+    assert is_provider_explicitly_configured("bedrock") is False
+
+
+def test_bedrock_bearer_token_counts_as_explicit(tmp_path, monkeypatch, _clean_aws_env):
+    """AWS_BEARER_TOKEN_BEDROCK is Bedrock-specific — the user set it for
+    exactly this provider, so it gates like a provider API key."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    (tmp_path / "hermes").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "ABSKexample-bearer-token-value")
+
+    from hermes_cli.auth import is_provider_explicitly_configured
+    assert is_provider_explicitly_configured("bedrock") is True
+
+
+def test_bedrock_access_key_pair_counts_as_explicit(tmp_path, monkeypatch, _clean_aws_env):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    (tmp_path / "hermes").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAEXAMPLE1234567890")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "examplesecretexamplesecretexample0000000")
+
+    from hermes_cli.auth import is_provider_explicitly_configured
+    assert is_provider_explicitly_configured("bedrock") is True
+
+
+def test_bedrock_access_key_without_secret_is_not_explicit(tmp_path, monkeypatch, _clean_aws_env):
+    """A lone AWS_ACCESS_KEY_ID can't authenticate anything — require the pair."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    (tmp_path / "hermes").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAEXAMPLE1234567890")
+
+    from hermes_cli.auth import is_provider_explicitly_configured
+    assert is_provider_explicitly_configured("bedrock") is False
+
+
+def test_bedrock_ambient_aws_profile_is_not_explicit(tmp_path, monkeypatch, _clean_aws_env):
+    """AWS_PROFILE is ambient machine state (SSO / shared credentials file),
+    not an explicit Hermes provider choice — same principle as gh_cli-seeded
+    Copilot pool entries (#56974)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    (tmp_path / "hermes").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("AWS_PROFILE", "default")
+
+    from hermes_cli.auth import is_provider_explicitly_configured
+    assert is_provider_explicitly_configured("bedrock") is False
+
+
+def test_aws_env_does_not_leak_into_other_providers(tmp_path, monkeypatch, _clean_aws_env):
+    """The aws_sdk env check must key on the provider's auth_type, not fire
+    for every provider whenever AWS credentials happen to be present."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    (tmp_path / "hermes").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "ABSKexample-bearer-token-value")
+
+    from hermes_cli.auth import is_provider_explicitly_configured
+    assert is_provider_explicitly_configured("anthropic") is False


### PR DESCRIPTION
## Summary

`is_provider_explicitly_configured()` (`hermes_cli/auth.py`) gates which providers appear in explicit-only model pickers (the desktop chat picker's `explicit_only=True` path from #56974). Its env-var check only runs for providers with `auth_type="api_key"` — but Bedrock is registered with `auth_type="aws_sdk"` and an empty `api_key_env_vars` tuple, so a user who pastes `AWS_BEARER_TOKEN_BEDROCK` (or an `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` pair) into `.env` is never counted as having explicitly configured Bedrock.

## Symptom

With `AWS_BEARER_TOKEN_BEDROCK` set, the desktop model picker never shows the Bedrock provider — even after a full app restart, and even though the backend has discovered credentials and built a complete row for it. Reproduced on current `main`:

```python
build_models_payload(ctx, explicit_only=False)
# providers: ['moa', 'nous', 'bedrock', ...]   <- row exists, 132 models discovered

build_models_payload(ctx, explicit_only=True)
# providers: ['nous', ...]                     <- bedrock silently filtered out
```

The row is built by `list_authenticated_providers` (whose `_has_fast_aws_sdk_signal()` correctly recognizes `AWS_BEARER_TOKEN_BEDROCK`), then dropped by `_filter_explicit_provider_rows` → `is_provider_explicitly_configured("bedrock")` → `False`.

## Fix

Add an `aws_sdk` branch to the env-var check: setting Bedrock env credentials is exactly as explicit a user action as pasting `ANTHROPIC_API_KEY`, so it must gate the same way.

Deliberately **env-var-only** — this does NOT consult boto3's full credential chain, so ambient machine state still never auto-surfaces a provider, consistent with the gate's purpose (#56974):

- `AWS_BEARER_TOKEN_BEDROCK` → explicit (Bedrock-specific by definition)
- `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` pair → explicit
- lone `AWS_ACCESS_KEY_ID` (no secret) → not explicit (can't authenticate anything)
- `AWS_PROFILE` / SSO / EC2 IMDS / container credentials → not explicit (ambient, same principle as gh_cli-seeded Copilot pool entries)

The branch keys on the provider's registered `auth_type`, so AWS env vars don't leak "explicit" status into unrelated providers.

## Tests

Six behavior-contract cases added to `tests/hermes_cli/test_auth_provider_gate.py`, following the file's existing real-import + temp `HERMES_HOME` pattern (no mocks of the function under test):

- `test_bedrock_not_explicit_without_aws_env` — baseline
- `test_bedrock_bearer_token_counts_as_explicit`
- `test_bedrock_access_key_pair_counts_as_explicit`
- `test_bedrock_access_key_without_secret_is_not_explicit`
- `test_bedrock_ambient_aws_profile_is_not_explicit`
- `test_aws_env_does_not_leak_into_other_providers`

All 16 tests in the file pass, plus the full `test_inventory.py` suite (55 total). Also ran `test_provider_precedence.py`, `test_bedrock_model_picker.py`, `test_api_key_providers.py` — 233 passed; the single failure (`test_eu_region_from_botocore_profile_yields_eu_models`) is pre-existing on unmodified `main` (verified via `git stash`) and unrelated (region routing vs. this gate).

## E2E validation

On the affected machine (macOS, desktop app, `AWS_BEARER_TOKEN_BEDROCK` in `.env`): before the patch `explicit_only=True` returned `['nous', 'nvidia', 'openrouter', 'gemini']`; after, `['nous', 'bedrock', 'nvidia', 'openrouter', 'gemini']`, and the Bedrock row (132 models) renders in the desktop picker.
