### PR TITLE
fix(cli): add /whoami handler to CLICommandsMixin

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8354,6 +8354,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             return False
         elif canonical == "help":
             self.show_help()
+        elif canonical == "whoami":
+            self._handle_whoami_command()
         elif canonical == "profile":
             self._handle_profile_command()
         elif canonical == "tools":

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -502,6 +502,15 @@ class CLICommandsMixin:
         self.new_session()
         _cprint(f"{_DIM}Session reset. New tool configuration is active.{_RST}")
 
+    def _handle_whoami_command(self):
+        """Handle /whoami — show slash command access info."""
+        from hermes_cli.commands import COMMAND_REGISTRY
+        print()
+        print("  CLI session — all slash commands are available locally:")
+        for cmd in sorted(COMMAND_REGISTRY, key=lambda c: c.name):
+            print(f"    /{cmd.name:<20} {cmd.description}")
+        print()
+
     def _handle_profile_command(self):
         """Display active profile name and home directory."""
         from hermes_constants import display_hermes_home


### PR DESCRIPTION
Fixes #35892

/whoami was registered in COMMAND_REGISTRY but had no handler in the CLI/TUI path. The command showed in autocomplete but printed "Unknown command" when executed.

Add _handle_whoami_command to CLICommandsMixin that lists available slash commands.