### PR TITLE
docs: normalize Python example spacing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -347,12 +347,10 @@ Tools self-register with the central registry. Each tool file co-locates its sch
 import json
 from tools.registry import registry
 
-
 def my_tool(param1: str, param2: int = 10, **kwargs) -> str:
     """Handler. Returns a string result (often JSON)."""
     result = do_work(param1, param2)
     return json.dumps(result)
-
 
 MY_TOOL_SCHEMA = {
     "type": "function",
@@ -370,11 +368,9 @@ MY_TOOL_SCHEMA = {
     },
 }
 
-
 def _check_requirements() -> bool:
     """Return True if this tool's dependencies are available."""
     return True
-
 
 registry.register(
     name="my_tool",

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -239,7 +239,6 @@ logger = logging.getLogger("hooks.boot-md")
 
 BOOT_FILE = Path.home() / ".hermes" / "BOOT.md"
 
-
 def _build_prompt(content: str) -> str:
     return (
         "You are running a startup boot checklist. Follow the instructions "
@@ -253,7 +252,6 @@ def _build_prompt(content: str) -> str:
         "If nothing needs attention and there is nothing to report, reply "
         "with ONLY: [SILENT]"
     )
-
 
 def _run_boot_agent(content: str) -> None:
     """Spawn a one-shot agent and execute the checklist.
@@ -282,7 +280,6 @@ def _run_boot_agent(content: str) -> None:
             logger.info("boot-md completed (nothing to report)")
     except Exception as e:
         logger.error("boot-md agent failed: %s", e)
-
 
 async def handle(event_type: str, context: dict) -> None:
     if not BOOT_FILE.exists():


### PR DESCRIPTION
## Summary
- Remove extra blank lines from Python snippets in CONTRIBUTING.md
- Align the hooks documentation example with the same formatted style

## Test Plan
- git diff --check
- verified changed Markdown code fences are balanced