### PR TITLE
fix(banner): use 'version' not 'commit' when update count may come from PyPI

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -357,6 +357,12 @@ def check_for_updates() -> Optional[int]:
             repo_dir = hermes_home / "hermes-agent"
         if not (repo_dir / ".git").exists():
             behind = check_via_pypi()
+            # PyPI returns 1 for any newer version — not a true count.
+            # Normalise to UPDATE_AVAILABLE_NO_COUNT so renderers use
+            # generic "update available" wording instead of presenting
+            # an uncomputed value as a precise count (#35857).
+            if behind == 1:
+                behind = UPDATE_AVAILABLE_NO_COUNT
         else:
             behind = _check_via_local_git(repo_dir)
 
@@ -856,9 +862,11 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
         if behind is not None and behind != 0:
             from hermes_cli.config import get_managed_update_command, recommended_update_command
             if behind > 0:
-                commits_word = "commit" if behind == 1 else "commits"
+                # Use "version" not "commit" — the count may come from PyPI
+                # (1 = one version behind), not from git commit math (#35857).
+                word = "version" if behind == 1 else "versions"
                 right_lines.append(
-                    f"[bold yellow]⚠ {behind} {commits_word} behind[/]"
+                    f"[bold yellow]⚠ {behind} {word} behind[/]"
                     f"[dim yellow] — run [bold]{recommended_update_command()}[/bold] to update[/]"
                 )
             else:

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -308,9 +308,50 @@ def test_check_for_updates_non_docker_still_checks(tmp_path, monkeypatch):
          patch("hermes_cli.banner.check_via_pypi", return_value=1) as mock_pypi:
         result = banner.check_for_updates()
 
-    assert result == 1
+    assert result == banner.UPDATE_AVAILABLE_NO_COUNT
     mock_pypi.assert_called_once()
     mock_run.assert_not_called()
+
+
+def test_check_for_updates_pypi_up_to_date_returns_zero(tmp_path, monkeypatch):
+    """When PyPI reports up-to-date, check_for_updates() returns 0 — not -1."""
+    import hermes_cli.banner as banner
+
+    fake_banner = tmp_path / "hermes_cli" / "banner.py"
+    fake_banner.parent.mkdir(parents=True, exist_ok=True)
+    fake_banner.touch()
+    monkeypatch.setattr(banner, "__file__", str(fake_banner))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+
+    with patch("hermes_cli.config.detect_install_method", return_value="pip"), \
+         patch("hermes_cli.banner.subprocess.run") as mock_run, \
+         patch("hermes_cli.banner.check_via_pypi", return_value=0) as mock_pypi:
+        result = banner.check_for_updates()
+
+    assert result == 0
+    mock_pypi.assert_called_once()
+    mock_run.assert_not_called()
+
+
+def test_check_for_updates_pypi_none_passthrough(tmp_path, monkeypatch):
+    """When PyPI check fails (returns None), propagate None — don't normalise."""
+    import hermes_cli.banner as banner
+
+    fake_banner = tmp_path / "hermes_cli" / "banner.py"
+    fake_banner.parent.mkdir(parents=True, exist_ok=True)
+    fake_banner.touch()
+    monkeypatch.setattr(banner, "__file__", str(fake_banner))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+
+    with patch("hermes_cli.config.detect_install_method", return_value="pip"), \
+         patch("hermes_cli.banner.subprocess.run") as mock_run, \
+         patch("hermes_cli.banner.check_via_pypi", return_value=None) as mock_pypi:
+        result = banner.check_for_updates()
+
+    assert result is None
+    mock_pypi.assert_called_once()
 
 
 def test_prefetch_non_blocking():

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -396,21 +396,38 @@ export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
           <Text color={t.color.muted}>/help for commands</Text>
         </Text>
 
-        {typeof info.update_behind === 'number' && info.update_behind > 0 && (
-          <Text bold color={t.color.warn}>
-            ! {info.update_behind} {info.update_behind === 1 ? 'commit' : 'commits'} behind
-            <Text bold={false} color={t.color.warn} dimColor>
-              {' '}
-              - run{' '}
-            </Text>
+        {typeof info.update_behind === 'number' && info.update_behind !== 0 && (
+          info.update_behind > 0 ? (
             <Text bold color={t.color.warn}>
-              {info.update_command || 'hermes update'}
+              ! {info.update_behind} {info.update_behind === 1 ? 'commit' : 'commits'} behind
+              <Text bold={false} color={t.color.warn} dimColor>
+                {' '}
+                - run{' '}
+              </Text>
+              <Text bold color={t.color.warn}>
+                {info.update_command || 'hermes update'}
+              </Text>
+              <Text bold={false} color={t.color.warn} dimColor>
+                {' '}
+                to update
+              </Text>
             </Text>
-            <Text bold={false} color={t.color.warn} dimColor>
-              {' '}
-              to update
+          ) : (
+            <Text bold color={t.color.warn}>
+              ! update available
+              <Text bold={false} color={t.color.warn} dimColor>
+                {' '}
+                - run{' '}
+              </Text>
+              <Text bold color={t.color.warn}>
+                {info.update_command || 'hermes update'}
+              </Text>
+              <Text bold={false} color={t.color.warn} dimColor>
+                {' '}
+                to update
+              </Text>
             </Text>
-          </Text>
+          )
         )}
       </Box>
     </Box>


### PR DESCRIPTION
Fixes #35857

In Docker without git history, check_via_pypi() returns 1 for 'one version behind'. The banner rendered this as '1 commit behind' — misleading because no git commits were counted.

Replace with neutral 'version'/'versions' wording.