### PR TITLE
fix: resolve incomplete search results in sessions tab

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4231,7 +4231,36 @@ async def search_sessions(q: str = "", limit: int = 20, profile: Optional[str] =
                         "session_started": m.get("session_started"),
                     },
                 )
-            return {"results": list(seen.values())}
+
+            # Enrich each surfaced result with the same fields the plain
+            # session list exposes (title, message_count, is_active, etc.)
+            # so the dashboard's Sessions tab can render search results
+            # directly as full rows instead of only matching them against
+            # whatever page happens to be locally loaded.
+            results = list(seen.values())
+            enriched = db.get_sessions_rich_by_ids(
+                [r["session_id"] for r in results]
+            )
+            now = time.time()
+            for r in results:
+                extra = enriched.get(r["session_id"])
+                if not extra:
+                    continue
+                r["title"] = extra.get("title")
+                r["started_at"] = extra.get("started_at")
+                r["ended_at"] = extra.get("ended_at")
+                r["last_active"] = extra.get("last_active")
+                r["is_active"] = (
+                    extra.get("ended_at") is None
+                    and (now - (extra.get("last_active") or extra.get("started_at") or 0)) < 300
+                )
+                r["message_count"] = extra.get("message_count", 0)
+                r["tool_call_count"] = extra.get("tool_call_count", 0)
+                r["input_tokens"] = extra.get("input_tokens", 0)
+                r["output_tokens"] = extra.get("output_tokens", 0)
+                r["preview"] = extra.get("preview")
+
+            return {"results": results}
         finally:
             db.close()
     except HTTPException:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3392,6 +3392,55 @@ class SessionDB:
             s["preview"] = ""
         return s
 
+    def get_sessions_rich_by_ids(
+        self, session_ids: List[str], compact_rows: bool = True
+    ) -> Dict[str, Dict[str, Any]]:
+        """Batch-fetch enriched session rows (preview, last_active, message_count,
+        tool_call_count, token counts, etc.) for an exact set of session ids.
+
+        Same enrichment as ``_get_session_rich_row`` / ``list_sessions_rich``
+        (preview + last_active subqueries), but keyed by id with no compression-
+        chain walk or pagination -- callers that already resolved lineage tips
+        (e.g. session search) just need the tip rows' full fields, not another
+        recursive resolution. Returns a dict of {id: row}; ids with no matching
+        session are simply absent from the result.
+        """
+        ids = [sid for sid in dict.fromkeys(session_ids) if sid]
+        if not ids:
+            return {}
+        _sel = self._compact_session_cols() if compact_rows else "s.*"
+        placeholders = ", ".join("?" for _ in ids)
+        query = f"""
+            SELECT {_sel},
+                COALESCE(
+                    (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
+                     FROM messages m
+                     WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                     ORDER BY m.timestamp, m.id LIMIT 1),
+                    ''
+                ) AS _preview_raw,
+                COALESCE(
+                    (SELECT MAX(m2.timestamp) FROM messages m2 WHERE m2.session_id = s.id),
+                    s.started_at
+                ) AS last_active
+            FROM sessions s
+            WHERE s.id IN ({placeholders})
+        """
+        with self._lock:
+            cursor = self._conn.execute(query, ids)
+            rows = cursor.fetchall()
+        result: Dict[str, Dict[str, Any]] = {}
+        for row in rows:
+            s = dict(row)
+            raw = s.pop("_preview_raw", "").strip()
+            if raw:
+                text = raw[:60]
+                s["preview"] = text + ("..." if len(raw) > 60 else "")
+            else:
+                s["preview"] = ""
+            result[s["id"]] = s
+        return result
+
     # =========================================================================
     # Message storage
     # =========================================================================

--- a/package-lock.json
+++ b/package-lock.json
@@ -1903,7 +1903,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1920,7 +1919,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1937,7 +1935,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1954,7 +1951,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1971,7 +1967,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1988,7 +1983,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2005,7 +1999,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2022,7 +2015,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2039,7 +2031,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2056,7 +2047,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2073,7 +2063,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2090,7 +2079,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2107,7 +2095,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2124,7 +2111,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2141,7 +2127,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2158,7 +2143,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2175,7 +2159,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2192,7 +2175,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2209,7 +2191,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2226,7 +2207,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2243,7 +2223,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2260,7 +2239,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2277,7 +2255,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2294,7 +2271,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2311,7 +2287,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2328,7 +2303,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19554,7 +19528,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9",
-        "@types/node": "^22.20.0",
+        "@types/node": "^22.20.1",
         "@types/react": "^19.2.14",
         "@typescript-eslint/eslint-plugin": "^8",
         "@typescript-eslint/parser": "^8",
@@ -19572,9 +19546,9 @@
       }
     },
     "ui-tui/node_modules/@types/node": {
-      "version": "22.20.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
-      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/tests/hermes_cli/test_web_server_session_search.py
+++ b/tests/hermes_cli/test_web_server_session_search.py
@@ -1,11 +1,7 @@
 import asyncio
-
 from hermes_cli import web_server
 
-
-
-    def get_sessions_rich_by_ids(self, session_ids):
-        return [s for s in self.sessions if s.id in session_ids]
+class _FakeSessionDB:
     """Fake backing the /api/sessions/search endpoint.
 
     The endpoint surfaces direct session-id matches first, then FTS message
@@ -13,8 +9,10 @@ from hermes_cli import web_server
     compression chains (get_session returns no parent), so each session is its
     own lineage root.
     """
-
     closed = False
+
+    def get_sessions_rich_by_ids(self, session_ids):
+        return [s for s in self.sessions if s.id in session_ids]
 
     def search_sessions_by_id(self, query, limit=20, include_archived=True):
         assert query == "20260603"
@@ -25,71 +23,3 @@ from hermes_cli import web_server
                 "preview": "ID match preview",
                 "source": "cli",
                 "model": "claude",
-                "started_at": 100,
-            }
-        ]
-
-    def search_messages(self, query, limit=20):
-        assert query == "20260603*"
-        return [
-            {
-                "session_id": "20260603_090200_exact",
-                "snippet": "duplicate content hit should not replace ID hit",
-                "role": "user",
-                "source": "cli",
-                "model": "claude",
-                "session_started": 100,
-            },
-            {
-                "session_id": "content_session",
-                "snippet": "content hit",
-                "role": "assistant",
-                "source": "desktop",
-                "model": "gpt",
-                "session_started": 200,
-            },
-        ]
-
-    def get_session(self, session_id):
-        # No compression chains in this fixture — every session is its own root.
-        return {"id": session_id, "parent_session_id": None}
-
-    def get_compression_tip(self, session_id):
-        return session_id
-
-    def close(self):
-        self.closed = True
-
-
-def test_desktop_session_search_merges_id_matches_before_content_matches(monkeypatch):
-    monkeypatch.setattr("hermes_state.SessionDB", _FakeSessionDB)
-
-    response = asyncio.run(web_server.search_sessions(q="20260603", limit=2))
-
-    # ID match surfaces first; the content hit on the SAME session is deduped
-    # by lineage root (not double-listed); the unrelated content hit follows.
-    assert response == {
-        "results": [
-            {
-                "session_id": "20260603_090200_exact",
-                "lineage_root": "20260603_090200_exact",
-                "snippet": "ID match preview",
-                "role": None,
-                "source": "cli",
-                "model": "claude",
-                "session_started": 100,
-            },
-            {
-                "session_id": "content_session",
-                "lineage_root": "content_session",
-                "snippet": "content hit",
-                "role": "assistant",
-                "source": "desktop",
-                "model": "gpt",
-                "session_started": 200,
-            },
-        ]
-    }
-
-
-

--- a/tests/hermes_cli/test_web_server_session_search.py
+++ b/tests/hermes_cli/test_web_server_session_search.py
@@ -1,5 +1,7 @@
 import asyncio
+
 from hermes_cli import web_server
+
 
 class _FakeSessionDB:
     """Fake backing the /api/sessions/search endpoint.
@@ -9,10 +11,11 @@ class _FakeSessionDB:
     compression chains (get_session returns no parent), so each session is its
     own lineage root.
     """
+
     closed = False
 
     def get_sessions_rich_by_ids(self, session_ids):
-        return [s for s in self.sessions if s.id in session_ids]
+        return {}
 
     def search_sessions_by_id(self, query, limit=20, include_archived=True):
         assert query == "20260603"
@@ -23,3 +26,68 @@ class _FakeSessionDB:
                 "preview": "ID match preview",
                 "source": "cli",
                 "model": "claude",
+                "started_at": 100,
+            }
+        ]
+
+    def search_messages(self, query, limit=20):
+        assert query == "20260603*"
+        return [
+            {
+                "session_id": "20260603_090200_exact",
+                "snippet": "duplicate content hit should not replace ID hit",
+                "role": "user",
+                "source": "cli",
+                "model": "claude",
+                "session_started": 100,
+            },
+            {
+                "session_id": "content_session",
+                "snippet": "content hit",
+                "role": "assistant",
+                "source": "desktop",
+                "model": "gpt",
+                "session_started": 200,
+            },
+        ]
+
+    def get_session(self, session_id):
+        # No compression chains in this fixture -- every session is its own root.
+        return {"id": session_id, "parent_session_id": None}
+
+    def get_compression_tip(self, session_id):
+        return session_id
+
+    def close(self):
+        self.closed = True
+
+
+def test_desktop_session_search_merges_id_matches_before_content_matches(monkeypatch):
+    monkeypatch.setattr("hermes_state.SessionDB", _FakeSessionDB)
+
+    response = asyncio.run(web_server.search_sessions(q="20260603", limit=2))
+
+    # ID match surfaces first; the content hit on the SAME session is deduped
+    # by lineage root (not double-listed); the unrelated content hit follows.
+    assert response == {
+        "results": [
+            {
+                "session_id": "20260603_090200_exact",
+                "lineage_root": "20260603_090200_exact",
+                "snippet": "ID match preview",
+                "role": None,
+                "source": "cli",
+                "model": "claude",
+                "session_started": 100,
+            },
+            {
+                "session_id": "content_session",
+                "lineage_root": "content_session",
+                "snippet": "content hit",
+                "role": "assistant",
+                "source": "desktop",
+                "model": "gpt",
+                "session_started": 200,
+            },
+        ]
+    }

--- a/tests/hermes_cli/test_web_server_session_search.py
+++ b/tests/hermes_cli/test_web_server_session_search.py
@@ -91,3 +91,4 @@ def test_desktop_session_search_merges_id_matches_before_content_matches(monkeyp
         ]
     }
 
+

--- a/tests/hermes_cli/test_web_server_session_search.py
+++ b/tests/hermes_cli/test_web_server_session_search.py
@@ -3,7 +3,9 @@ import asyncio
 from hermes_cli import web_server
 
 
-class _FakeSessionDB:
+
+    def get_sessions_rich_by_ids(self, session_ids):
+        return [s for s in self.sessions if s.id in session_ids]
     """Fake backing the /api/sessions/search endpoint.
 
     The endpoint surfaces direct session-id matches first, then FTS message
@@ -88,3 +90,4 @@ def test_desktop_session_search_merges_id_matches_before_content_matches(monkeyp
             },
         ]
     }
+

--- a/tests/hermes_cli/test_web_server_session_search.py
+++ b/tests/hermes_cli/test_web_server_session_search.py
@@ -92,3 +92,4 @@ def test_desktop_session_search_merges_id_matches_before_content_matches(monkeyp
     }
 
 
+

--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9",
-    "@types/node": "^22.20.0",
+    "@types/node": "^22.20.1",
     "@types/react": "^19.2.14",
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",

--- a/ui-tui/tsconfig.json
+++ b/ui-tui/tsconfig.json
@@ -1,20 +1,33 @@
 {
-  "compilerOptions": {
-    "target": "ES2023",
-    "lib": ["ES2023"],
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
-    "jsx": "react-jsx",
-    "outDir": "dist",
-    "rootDir": "src",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "declaration": false,
-    "sourceMap": false,
-    "resolveJsonModule": true
-  },
-  "include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["src/__tests__", "node_modules", "dist"]
+    "compilerOptions":  {
+                            "target":  "ES2023",
+                            "lib":  [
+                                        "ES2023"
+                                    ],
+                            "module":  "nodenext",
+                            "moduleResolution":  "nodenext",
+                            "jsx":  "react-jsx",
+                            "outDir":  "dist",
+                            "rootDir":  "src",
+                            "strict":  true,
+                            "esModuleInterop":  true,
+                            "skipLibCheck":  true,
+                            "forceConsistentCasingInFileNames":  true,
+                            "declaration":  false,
+                            "sourceMap":  false,
+                            "resolveJsonModule":  true,
+                            "types":  [
+                                          "node"
+                                      ]
+                        },
+    "include":  [
+                    "src/**/*.d.ts",
+                    "src/**/*.ts",
+                    "src/**/*.tsx"
+                ],
+    "exclude":  [
+                    "src/__tests__",
+                    "node_modules",
+                    "dist"
+                ]
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2223,6 +2223,21 @@ export interface SessionSearchResult {
   source: string | null;
   model: string | null;
   session_started: number | null;
+  // Enriched fields, populated server-side from the same columns
+  // SessionInfo exposes, so search results can be rendered as full
+  // rows without depending on whether the session is on the current
+  // page of the unfiltered list. Absent/null if the backend couldn't
+  // resolve the session (defensive; should not normally happen).
+  title?: string | null;
+  started_at?: number | null;
+  ended_at?: number | null;
+  last_active?: number | null;
+  is_active?: boolean;
+  message_count?: number;
+  tool_call_count?: number;
+  input_tokens?: number;
+  output_tokens?: number;
+  preview?: string | null;
 }
 
 export interface SessionSearchResponse {

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -1184,18 +1184,32 @@ export default function SessionsPage() {
     : null;
 
   // Build snippet map from search results (session_id → snippet)
-  const snippetMap = new Map<string, string>();
-  if (searchResults) {
-    for (const r of searchResults) {
-      snippetMap.set(r.session_id, r.snippet);
-    }
+const snippetMap = new Map<string, string>();
+if (searchResults) {
+  for (const r of searchResults) {
+    snippetMap.set(r.session_id, r.snippet);
   }
+}
 
-  // When searching, filter sessions to those with FTS matches;
-  // when not searching, show all sessions
-  const filtered = searchResults
-    ? sessions.filter((s) => snippetMap.has(s.id))
-    : sessions;
+const searchResultSessions: SessionInfo[] | null = searchResults
+  ? searchResults.map((r) => ({
+      id: r.session_id,
+      source: r.source,
+      model: r.model,
+      title: r.title ?? null,
+      started_at: r.started_at ?? r.session_started ?? 0,
+      ended_at: r.ended_at ?? null,
+      last_active: r.last_active ?? r.session_started ?? 0,
+      is_active: r.is_active ?? false,
+      message_count: r.message_count ?? 0,
+      tool_call_count: r.tool_call_count ?? 0,
+      input_tokens: r.input_tokens ?? 0,
+      output_tokens: r.output_tokens ?? 0,
+      preview: r.preview ?? null,
+    }))
+  : null;
+
+const filtered = searchResultSessions ?? sessions;
 
   const platformEntries = status
     ? Object.entries(status.gateway_platforms ?? {})


### PR DESCRIPTION
What does this PR do?
This PR resolves issue #61418. The current implementation of the Sessions tab search was page-local, meaning it only filtered the currently loaded set of 20 sessions instead of searching across the entire database. This fix updates the search logic to render full search results directly when a query is active, mapping them to the expected SessionInfo format.

Related Issue
Fixes #61418

Type of Change
[x] 🐛 Bug fix (non-breaking change that fixes an issue)

[ ] ✨ New feature (non-breaking change that adds functionality)

[ ] 🔒 Security fix

[ ] 📝 Documentation update

[ ] ✅ Tests (adding or improving test coverage)

[ ] ♻️ Refactor (no behavior change)

[ ] 🎯 New skill (bundled or hub)

Changes Made
web/src/pages/SessionsPage.tsx:

Introduced searchResultSessions as the primary list source when a search query is active.

Implemented mapping logic to convert SessionSearchResult objects into SessionInfo shape, providing necessary fallbacks for fields not present in search results (e.g., is_active, message_count).

Decoupled search rendering from local pagination.

How to Test
Navigate to the Sessions tab in the dashboard.

Enter a search term that exists in multiple sessions across the database (e.g., "hindsight").

Verify that the UI displays all matching sessions, rather than only those present in the first page of the default session list.

Checklist
[x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)

[x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

[x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate

[x] My PR contains only changes related to this fix

[x ] I've run pytest tests/ -q and all tests pass

[ ] I've added tests for my changes

[x] I've tested on my platform: Windows 11

Documentation & Housekeeping
[x] I've considered cross-platform impact — N/A