### PR TITLE
fix(cli): use time.monotonic() for per-prompt elapsed timer to prevent clock jumps

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4509,7 +4509,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         """
         if prompt_start_time is None and prompt_duration == 0.0:
             return "⏲ 0s"
-        elapsed = time.time() - prompt_start_time if prompt_start_time is not None else prompt_duration
+        # Use time.monotonic() for elapsed calculation to stay immune to
+        # system clock adjustments (NTP sync, DST transitions).  The per‑turn
+        # start timestamp is also recorded with time.monotonic().
+        elapsed = time.monotonic() - prompt_start_time if prompt_start_time is not None else prompt_duration
         elapsed = max(0.0, elapsed)
 
         days = int(elapsed // 86400)
@@ -12394,7 +12397,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # exits the main thread and daemon threads are reaped automatically).
             # Start per-prompt elapsed timer — frozen after the agent thread
             # finishes; reset on the next turn.
-            self._prompt_start_time = time.time()
+            # Use time.monotonic() so the elapsed timer is immune to system clock
+            # adjustments (NTP sync, DST transitions, VM suspend/resume).
+            self._prompt_start_time = time.monotonic()
             self._prompt_duration = 0.0
             agent_thread = threading.Thread(target=run_agent, daemon=True)
             agent_thread.start()
@@ -12487,8 +12492,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
             # Freeze per-prompt elapsed timer once the agent thread has
             # exited (or been abandoned as a daemon after interrupt).
+            # Uses time.monotonic() — consistent with _prompt_start_time.
             if self._prompt_start_time is not None:
-                self._prompt_duration = max(0.0, time.time() - self._prompt_start_time)
+                self._prompt_duration = max(0.0, time.monotonic() - self._prompt_start_time)
                 self._prompt_start_time = None
             # Record when this agent loop finished so the status bar can show
             # idle time since the last final response.
@@ -15139,7 +15145,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 if not self._app:
                     time.sleep(0.1)
                     continue
-                if self._command_running:
+                if self._command_running or getattr(self, "_agent_running", False):
                     self._invalidate(min_interval=0.1)
                     time.sleep(0.1)
                 else:

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -678,3 +678,37 @@ class TestIdleSinceLastTurn:
         cli_obj._prompt_duration = 7.0
         text = cli_obj._build_status_bar_text(width=160)
         assert "✓ 42s" in text
+
+    def test_prompt_elapsed_uses_monotonic_clock_not_wall_clock(self):
+        """_format_prompt_elapsed must derive elapsed from time.monotonic(),
+        not time.time(), so the per-prompt timer is immune to system clock
+        adjustments (NTP sync, DST transitions, VM suspend/resume).
+        
+        Pin monotonic and wall clocks to different values and assert the
+        formatted output matches the monotonic delta — not the wall-clock
+        delta."""
+        cli_obj = _make_cli()
+
+        # Pin: monotonic clock at 500.0, wall clock at an unrelated epoch value.
+        with patch.object(cli_mod.time, "monotonic", return_value=500.0), \
+             patch.object(cli_mod.time, "time", return_value=1_700_000_000.0):
+            # Live turn: _prompt_start_time uses monotonic epoch.
+            cli_obj._prompt_start_time = 400.0
+            cli_obj._prompt_duration = 0.0
+            live = HermesCLI._format_prompt_elapsed(
+                cli_obj._prompt_start_time, cli_obj._prompt_duration, live=True
+            )
+            # Should show 100s (500.0 - 400.0), NOT the wall-clock delta.
+            assert live == "⏱ 1m 40s", f"expected ⏱ 1m 40s, got {live!r}"
+
+            # Frozen turn: uses pre-recorded _prompt_duration.
+            cli_obj._prompt_start_time = None
+            cli_obj._prompt_duration = 42.5
+            frozen = HermesCLI._format_prompt_elapsed(
+                cli_obj._prompt_start_time, cli_obj._prompt_duration, live=False
+            )
+            assert frozen == "⏲ 42s", f"expected ⏲ 42s, got {frozen!r}"
+
+    def test_prompt_elapsed_zero_on_fresh_start(self):
+        """Before any turn completes, the timer shows ⏲ 0s."""
+        assert HermesCLI._format_prompt_elapsed(None, 0.0, live=False) == "⏲ 0s"


### PR DESCRIPTION
## What does this PR do?

Fixes the per-prompt elapsed timer (the `⏱ 524s` display in the status bar) to use `time.monotonic()` instead of `time.time()`, making it immune to system clock adjustments (NTP sync, DST transitions, VM suspend/resume).

## Root Cause

The status bar per-prompt timer used `time.time()` across three code paths:
- **Start** (line 12319): `self._prompt_start_time = time.time()`
- **Freeze** (line 12413): `time.time() - self._prompt_start_time`
- **Render** (line 4499): `time.time() - prompt_start_time`

All other CLI timers (`_render_spinner_text` tool timer, `_invalidate` throttle) already use `time.monotonic()`. This inconsistency meant the `⏱` timer was the only one affected by system clock stepping — when the clock jumped, the displayed elapsed time jumped by the same delta (sometimes tens of seconds at a time, accumulating to hundreds over long sessions).

## Changes Made

1. **cli.py:12319** — `_prompt_start_time` now recorded with `time.monotonic()`
2. **cli.py:12413** — freeze `_prompt_duration` with `time.monotonic()`
3. **cli.py:4499** — `_format_prompt_elapsed` computes elapsed with `time.monotonic()`
4. **cli.py:15062** — `spinner_loop` now invalidates during agent execution (redundant source for status bar refresh)

## How to Test

```bash
python -m pytest tests/cli/test_cli_status_bar.py -v
```

Two new tests added:
- `test_prompt_elapsed_uses_monotonic_clock_not_wall_clock` — verifies monotonic clock is used by pinning monotonic and wall clocks to diverging values
- `test_prompt_elapsed_zero_on_fresh_start` — edge case coverage

## Type of Change

- [x] Bug fix