### PR TITLE
fix(cli): show reset-specific message for /reset

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8621,7 +8621,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 cmd_original=cmd_original,
             ) is None:
                 return True  # confirmation cancelled — command handled, keep REPL alive
-            self.new_session(title=title)
+            # /reset is an alias of /new (same session rotation). Keep the
+            # shared path but use reset-specific user-facing copy (#61422).
+            if _base_word == "reset":
+                self.new_session(title=title, silent=True)
+                print("Your session has been reset.")
+            else:
+                self.new_session(title=title)
         elif canonical == "resume":
             self._handle_resume_command(cmd_original)
         elif canonical == "sessions":

--- a/tests/cli/test_cli_new_session.py
+++ b/tests/cli/test_cli_new_session.py
@@ -175,6 +175,35 @@ def test_new_command_creates_real_fresh_session_and_resets_agent_state(tmp_path)
     cli.agent._invalidate_system_prompt.assert_called_once()
 
 
+def test_reset_command_rotates_session_and_prints_reset_message(tmp_path, capsys):
+    """/reset shares the /new session path but uses reset-specific copy (#61422)."""
+    cli = _prepare_cli_with_active_session(tmp_path)
+    old_session_id = cli.session_id
+
+    cli.process_command("/reset")
+
+    assert cli.session_id != old_session_id
+    old_session = cli._session_db.get_session(old_session_id)
+    assert old_session is not None
+    assert old_session["end_reason"] == "new_session"
+    assert cli._session_db.get_session(cli.session_id) is not None
+
+    out = capsys.readouterr().out
+    assert "Your session has been reset." in out
+    assert "New session started" not in out
+
+
+def test_new_command_still_prints_new_session_message(tmp_path, capsys):
+    """/new keeps the existing new-session success wording (#61422)."""
+    cli = _prepare_cli_with_active_session(tmp_path)
+
+    cli.process_command("/new")
+
+    out = capsys.readouterr().out
+    assert "New session started!" in out
+    assert "Your session has been reset." not in out
+
+
 def test_new_session_queues_boundary_commit_with_snapshot(tmp_path):
     """/new hands the OLD session's history + ids to the memory manager's
     serialized boundary task instead of blocking on extraction inline."""

--- a/tests/cli/test_destructive_slash_inline_skip_e2e.py
+++ b/tests/cli/test_destructive_slash_inline_skip_e2e.py
@@ -51,7 +51,7 @@ def _make_cli_stub():
     return self_, new_session_calls
 
 
-def test_reset_now_invokes_new_session_without_modal():
+def test_reset_now_invokes_new_session_without_modal(capsys):
     """``/reset now`` runs ``new_session`` and never touches the modal."""
     self_, calls = _make_cli_stub()
 
@@ -64,6 +64,27 @@ def test_reset_now_invokes_new_session_without_modal():
     assert calls, "new_session was never invoked"
     # The /new branch passes title=None when there's no non-skip remainder.
     assert calls[0]["title"] is None
+    # /reset shares the session path with /new but uses reset-specific copy.
+    assert calls[0]["silent"] is True
+    out = capsys.readouterr().out
+    assert "Your session has been reset." in out
+    assert "New session started" not in out
+
+
+def test_new_now_does_not_print_reset_message(capsys):
+    """``/new now`` must not emit the /reset success string (#61422)."""
+    self_, calls = _make_cli_stub()
+
+    with patch(
+        "cli.load_cli_config",
+        return_value={"approvals": {"destructive_slash_confirm": True}},
+    ):
+        self_.process_command("/new now")
+
+    assert calls, "new_session was never invoked"
+    assert calls[0].get("silent", False) is False
+    out = capsys.readouterr().out
+    assert "Your session has been reset." not in out
 
 
 def test_new_yes_with_title_preserves_title():


### PR DESCRIPTION
## Summary

CLI `/reset` is registered as an alias of `/new` and correctly shares the session-rotation path, but it previously printed the `/new` success text (`New session started!`).

This keeps `/reset` as an alias (least-invasive) and only changes the CLI user-facing success message when the originally typed command was `reset`:

- `/reset` → `Your session has been reset.`
- `/new` → unchanged `New session started!` wording

No gateway, registry, or session-rotation behavior changes.

Fixes #61422

## Verification

- Code path: `process_command()` resolves aliases via `resolve_command()`, keeps `_base_word` from the typed command, and for `canonical == "new"` with `_base_word == "reset"` calls `new_session(..., silent=True)` then prints `Your session has been reset.`
- `/new` still calls `new_session(title=title)` with the existing success print inside `new_session()`.
- Fix is intentionally minimal and only changes CLI user-facing text for `/reset`.

## Tests

```bash
scripts/run_tests.sh tests/cli/test_destructive_slash_inline_skip_e2e.py -q
scripts/run_tests.sh tests/cli/test_cli_new_session.py -q
scripts/run_tests.sh tests/cli/test_cli_new_session.py tests/cli/test_destructive_slash_inline_skip_e2e.py tests/cli/test_destructive_slash_confirm.py -q
```

All passed (33 tests across the three files).

Added/updated coverage:

1. `/reset` invokes the session reset path (session id rotates; old session ends with `new_session`)
2. `/reset` prints `Your session has been reset.`
3. `/new` still prints `New session started!`