### PR TITLE
fix(gateway): remove feishu from port-binding platform set (fixes #52563)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1391,7 +1391,6 @@ _PORT_BINDING_PLATFORM_VALUES = frozenset({
     "webhook",
     "api_server",
     "msgraph_webhook",
-    "feishu",
     "wecom_callback",
     "bluebubbles",
     "sms",


### PR DESCRIPTION
## Summary

Feishu in websocket mode (default, `FEISHU_CONNECTION_MODE=websocket`) does **not** bind a local HTTP port — each bot app establishes its own outbound WebSocket connection. However, `_PORT_BINDING_PLATFORM_VALUES` in `gateway/run.py` included `"feishu"`, causing `MultiplexConfigError` for every secondary Feishu profile when `gateway.multiplex_profiles` is on.

## Fix

Remove `"feishu"` from `_PORT_BINDING_PLATFORM_VALUES`.

The same-credential conflict detection at line 8567 (`_adapter_credential_fingerprint`) already prevents duplicate Feishu polling across profiles, so removing the blanket port-binding classification is safe.

## Verification

- [x] One-line deletion, no behavior change for single-profile setups
- [x] Multiplexed Feishu profiles (websocket mode) will no longer be rejected
- [x] Same-credential detection still catches real duplicates