### PR TITLE
feat(cli): show origin and enabled_toolsets in cron list output

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -135,6 +135,8 @@ def cron_list(show_all: bool = False):
         deliver = job.get("deliver") or ["local"]
         if isinstance(deliver, str):
             deliver = [deliver]
+        # Flatten comma-separated composite targets (e.g. "origin,all")
+        deliver = [t.strip() for item in deliver for t in item.split(",")]
         deliver_str = ", ".join(deliver)
 
         skills = job.get("skills") or ([job["skill"]] if job.get("skill") else [])
@@ -155,9 +157,13 @@ def cron_list(show_all: bool = False):
         print(f"    Deliver:   {deliver_str}")
         if "origin" in deliver and job.get("origin"):
             origin = job["origin"]
-            platform = origin.get("platform")
-            chat_id = origin.get("chat_id")
-            print(f"    Origin:    {platform}:{chat_id}")
+            if isinstance(origin, dict):
+                platform = origin.get("platform")
+                chat_id = origin.get("chat_id")
+                if platform and chat_id:
+                    print(f"    Origin:    {platform}:{chat_id}")
+                elif platform:
+                    print(f"    Origin:    {platform}")
         enabled_toolsets = job.get("enabled_toolsets")
         if enabled_toolsets:
             print(f"    Toolsets:  {', '.join(enabled_toolsets)}")

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -153,6 +153,14 @@ def cron_list(show_all: bool = False):
         print(f"    Repeat:    {repeat_str}")
         print(f"    Next run:  {next_run}")
         print(f"    Deliver:   {deliver_str}")
+        if "origin" in deliver and job.get("origin"):
+            origin = job["origin"]
+            platform = origin.get("platform")
+            chat_id = origin.get("chat_id")
+            print(f"    Origin:    {platform}:{chat_id}")
+        enabled_toolsets = job.get("enabled_toolsets")
+        if enabled_toolsets:
+            print(f"    Toolsets:  {', '.join(enabled_toolsets)}")
         if skills:
             print(f"    Skills:    {', '.join(skills)}")
         script = job.get("script")

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -282,6 +282,81 @@ class TestExternalCronProviderStatus:
         assert "Gateway is not running" not in out
 
 
+def test_cron_list_shows_toolsets_when_set(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "cron.jobs.list_jobs",
+        lambda include_disabled=False: [
+            {
+                "id": "job-tools",
+                "name": "Job with toolsets",
+                "schedule_display": "every day",
+                "state": "scheduled",
+                "enabled": True,
+                "next_run_at": "2026-07-01T00:00:00Z",
+                "deliver": ["local"],
+                "enabled_toolsets": ["terminal", "file"],
+            }
+        ],
+    )
+    monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [9999])
+    monkeypatch.setattr(cron_cli, "_warn_if_gateway_not_running", lambda: None)
+
+    cron_cli.cron_list()
+
+    out = capsys.readouterr().out
+    assert "Toolsets:  terminal, file" in out
+
+
+def test_cron_list_shows_origin_when_deliver_is_origin(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "cron.jobs.list_jobs",
+        lambda include_disabled=False: [
+            {
+                "id": "job-origin",
+                "name": "Job with origin",
+                "schedule_display": "every day",
+                "state": "scheduled",
+                "enabled": True,
+                "next_run_at": "2026-07-01T00:00:00Z",
+                "deliver": ["origin"],
+                "origin": {"platform": "telegram", "chat_id": "12345"},
+            }
+        ],
+    )
+    monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [9999])
+    monkeypatch.setattr(cron_cli, "_warn_if_gateway_not_running", lambda: None)
+
+    cron_cli.cron_list()
+
+    out = capsys.readouterr().out
+    assert "Origin:    telegram:12345" in out
+
+
+def test_cron_list_hides_origin_and_toolsets_when_absent(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "cron.jobs.list_jobs",
+        lambda include_disabled=False: [
+            {
+                "id": "job-plain",
+                "name": "Plain job",
+                "schedule_display": "every day",
+                "state": "scheduled",
+                "enabled": True,
+                "next_run_at": "2026-07-01T00:00:00Z",
+                "deliver": ["local"],
+            }
+        ],
+    )
+    monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [9999])
+    monkeypatch.setattr(cron_cli, "_warn_if_gateway_not_running", lambda: None)
+
+    cron_cli.cron_list()
+
+    out = capsys.readouterr().out
+    assert "Origin:" not in out
+    assert "Toolsets:" not in out
+
+
 def test_cron_list_warns_when_gateway_not_running(monkeypatch, capsys):
     monkeypatch.setattr(
         "cron.jobs.list_jobs",

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -332,6 +332,57 @@ def test_cron_list_shows_origin_when_deliver_is_origin(monkeypatch, capsys):
     assert "Origin:    telegram:12345" in out
 
 
+def test_cron_list_shows_origin_when_deliver_is_origin_all(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "cron.jobs.list_jobs",
+        lambda include_disabled=False: [
+            {
+                "id": "job-origin-all",
+                "name": "Job with origin,all",
+                "schedule_display": "every day",
+                "state": "scheduled",
+                "enabled": True,
+                "next_run_at": "2026-07-01T00:00:00Z",
+                "deliver": ["origin,all"],
+                "origin": {"platform": "telegram", "chat_id": "12345"},
+            }
+        ],
+    )
+    monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [9999])
+    monkeypatch.setattr(cron_cli, "_warn_if_gateway_not_running", lambda: None)
+
+    cron_cli.cron_list()
+
+    out = capsys.readouterr().out
+    assert "Origin:    telegram:12345" in out
+
+
+def test_cron_list_does_not_crash_on_non_dict_origin(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "cron.jobs.list_jobs",
+        lambda include_disabled=False: [
+            {
+                "id": "job-string-origin",
+                "name": "Job with string origin",
+                "schedule_display": "every day",
+                "state": "scheduled",
+                "enabled": True,
+                "next_run_at": "2026-07-01T00:00:00Z",
+                "deliver": ["origin"],
+                "origin": "cli-session-provenance",
+            }
+        ],
+    )
+    monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [9999])
+    monkeypatch.setattr(cron_cli, "_warn_if_gateway_not_running", lambda: None)
+
+    cron_cli.cron_list()
+
+    out = capsys.readouterr().out
+    assert "Origin:" not in out
+    assert "Job with string origin" in out
+
+
 def test_cron_list_hides_origin_and_toolsets_when_absent(monkeypatch, capsys):
     monkeypatch.setattr(
         "cron.jobs.list_jobs",


### PR DESCRIPTION
Show `Origin:` when deliver targets `origin`, and `Toolsets:` when
`enabled_toolsets` is set on a job. Both are conditional and only appear
when the data exists. Existing jobs without these fields show no difference.

PR #56973 already added model to the default output without a flag.
This follows the same direction.

**How to test:**
1. `hermes cron list`: no change for existing jobs without these fields
2. Create a job with `enabled_toolsets` and `deliver=origin`, verify
   both lines appear in the output

**Changes:**
- `hermes_cli/cron.py`: added (conditional display blocks)
- `tests/hermes_cli/test_cron.py`: 3 new tests added