### PR TITLE
fix(desktop): recover session for file attachments

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -973,6 +973,57 @@ describe('usePromptActions file attachment sync', () => {
       params: { session_id: RUNTIME_SESSION_ID, text: '@file:data/report.txt\n\nsummarize' }
     })
   })
+
+  it('resumes the stored session and retries once when file.attach reports "session not found"', async () => {
+    $connection.set({ mode: 'local' } as never)
+
+    const storedSessionId = 'stored-db-xyz789'
+    const recoveredSessionId = 'rt-recovered-456'
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    let attachAttempts = 0
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'file.attach') {
+        attachAttempts += 1
+
+        if (attachAttempts === 1) {
+          throw new Error('session not found')
+        }
+
+        return { attached: true, ref_text: '@file:data/report.txt', uploaded: false } as never
+      }
+
+      if (method === 'session.resume') {
+        return { session_id: recoveredSessionId } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        storedSessionId={storedSessionId}
+      />
+    )
+
+    const ok = await handle!.submitText('summarize', { attachments: [fileAttachment()] })
+
+    expect(ok).toBe(true)
+    expect(calls.map(c => c.method)).toEqual(['file.attach', 'session.resume', 'file.attach', 'prompt.submit'])
+    expect(calls[0]?.params).toMatchObject({ session_id: RUNTIME_SESSION_ID })
+    expect(calls[1]?.params).toEqual({ session_id: storedSessionId, source: 'desktop' })
+    expect(calls[2]?.params).toMatchObject({ session_id: recoveredSessionId })
+    expect(calls[3]).toEqual({
+      method: 'prompt.submit',
+      params: { session_id: recoveredSessionId, text: '@file:data/report.txt\n\nsummarize' }
+    })
+  })
 })
 
 describe('usePromptActions eager-upload races', () => {
@@ -1239,7 +1290,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
 
     expect(ok).toBe(true)
     expect(calls.map(c => c.method)).toEqual(['prompt.submit', 'session.resume', 'prompt.submit'])
-    expect(calls[1]?.params).toEqual({ session_id: STORED_SESSION_ID })
+    expect(calls[1]?.params).toEqual({ session_id: STORED_SESSION_ID, source: 'desktop' })
     expect(calls[2]?.params).toEqual({
       session_id: RECOVERED_SESSION_ID,
       text: 'message during starved loop'

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -69,9 +69,14 @@ interface HandoffResult {
  */
 export async function uploadComposerAttachment(
   attachment: ComposerAttachment,
-  opts: { remote: boolean; requestGateway: GatewayRequest; sessionId: string }
+  opts: {
+    recoverSession?: (sessionId: string) => Promise<null | string>
+    remote: boolean
+    requestGateway: GatewayRequest
+    sessionId: string
+  }
 ): Promise<ComposerAttachment> {
-  const { remote, requestGateway, sessionId } = opts
+  const { recoverSession, remote, requestGateway, sessionId } = opts
   const path = attachment.path ?? ''
   const label = attachment.label || pathLabel(path)
 
@@ -133,12 +138,29 @@ export async function uploadComposerAttachment(
     }
   }
 
-  const result = await requestGateway<FileAttachResponse>('file.attach', {
-    name: label,
-    path,
-    session_id: sessionId,
-    ...(dataUrl ? { data_url: dataUrl } : {})
-  })
+  const attachFile = (attachSessionId: string) =>
+    requestGateway<FileAttachResponse>('file.attach', {
+      name: label,
+      path,
+      session_id: attachSessionId,
+      ...(dataUrl ? { data_url: dataUrl } : {})
+    })
+
+  let attachedSessionId = sessionId
+  let result: FileAttachResponse
+
+  try {
+    result = await attachFile(attachedSessionId)
+  } catch (err) {
+    const recoveredSessionId = isSessionNotFoundError(err) ? await recoverSession?.(sessionId) : null
+
+    if (!recoveredSessionId) {
+      throw err
+    }
+
+    attachedSessionId = recoveredSessionId
+    result = await attachFile(attachedSessionId)
+  }
 
   if (!result.attached || !result.ref_text) {
     throw new Error(result.message || `Could not attach ${label}`)
@@ -146,7 +168,7 @@ export async function uploadComposerAttachment(
 
   return {
     ...attachment,
-    attachedSessionId: sessionId,
+    attachedSessionId,
     refText: result.ref_text,
     uploadState: undefined
   }
@@ -198,6 +220,28 @@ export function usePromptActions({
 }: PromptActionsOptions) {
   const { t } = useI18n()
   const copy = t.desktop
+
+  const recoverSessionForAttachment = useCallback(
+    async () => {
+      if (!selectedStoredSessionIdRef.current) {
+        return null
+      }
+
+      const resumed = await requestGateway<{ session_id: string }>('session.resume', {
+        session_id: selectedStoredSessionIdRef.current,
+        source: 'desktop'
+      })
+
+      const recoveredId = resumed?.session_id || null
+
+      if (recoveredId) {
+        activeSessionIdRef.current = recoveredId
+      }
+
+      return recoveredId
+    },
+    [activeSessionIdRef, requestGateway, selectedStoredSessionIdRef]
+  )
 
   const appendSessionTextMessage = useCallback(
     (sessionId: string, role: ChatMessage['role'], text: string) => {
@@ -270,7 +314,12 @@ export function usePromptActions({
         }
 
         if (attachment.kind === 'image' || attachment.kind === 'file') {
-          const nextAttachment = await uploadComposerAttachment(attachment, { remote, requestGateway, sessionId })
+          const nextAttachment = await uploadComposerAttachment(attachment, {
+            recoverSession: recoverSessionForAttachment,
+            remote,
+            requestGateway,
+            sessionId
+          })
 
           // Update-only: never resurrect a chip the user removed mid-upload.
           if (updateComposerAttachments) {
@@ -287,7 +336,7 @@ export function usePromptActions({
 
       return synced
     },
-    [requestGateway]
+    [recoverSessionForAttachment, requestGateway]
   )
 
   // Stage a freshly dropped file as soon as it lands (when a session already
@@ -309,7 +358,14 @@ export function usePromptActions({
       try {
         // Update-only: if the user removed the chip while this was uploading,
         // don't resurrect it — just drop the staged result on the floor.
-        updateComposerAttachment(await uploadComposerAttachment(attachment, { remote, requestGateway, sessionId }))
+        updateComposerAttachment(
+          await uploadComposerAttachment(attachment, {
+            recoverSession: recoverSessionForAttachment,
+            remote,
+            requestGateway,
+            sessionId
+          })
+        )
       } catch (err) {
         // Leave the chip in place so submit-time sync can retry (or the user can
         // remove it) and flag the card; also toast so a hard failure (unreadable
@@ -318,7 +374,7 @@ export function usePromptActions({
         notifyError(err, copy.dropFiles)
       }
     },
-    [copy.dropFiles, requestGateway]
+    [copy.dropFiles, recoverSessionForAttachment, requestGateway]
   )
 
   const composerAttachments = useStore($composerAttachments)

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -206,7 +206,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       setAwaitingResponse(true)
       clearNotifications()
 
-      let sessionId: null | string = activeSessionId
+      let sessionId: null | string = activeSessionIdRef.current || activeSessionId
 
       if (sessionId) {
         seedOptimistic(sessionId)
@@ -265,9 +265,18 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       }
 
       try {
+        sessionId = activeSessionIdRef.current || sessionId
+
         const syncedAttachments = await syncAttachmentsForSubmit(sessionId, attachments, {
           updateComposerAttachments: usingComposerAttachments
         })
+
+        const recoveredAttachmentSessionId =
+          activeSessionIdRef.current && activeSessionIdRef.current !== sessionId ? activeSessionIdRef.current : null
+
+        if (recoveredAttachmentSessionId) {
+          sessionId = recoveredAttachmentSessionId
+        }
 
         // Rewrite the optimistic message + prompt text with the synced refs so
         // the gateway receives @file: paths that resolve in its workspace.


### PR DESCRIPTION
## Summary
- retry desktop file.attach once after resuming the selected stored session on "session not found"
- keep subsequent prompt.submit on the recovered runtime session
- add regression coverage for file attachment session recovery

Closes #61285

## Tests
- npm --prefix apps/desktop run test:ui -- src/app/session/hooks/use-prompt-actions/index.test.tsx
- npm --prefix apps/desktop run typecheck
- npm --prefix apps/desktop run lint