### PR TITLE
fix(gateway): respect explicit Feishu enabled:false in config.yaml (fixes #47804)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1871,10 +1871,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     feishu_app_id = getenv("FEISHU_APP_ID")
     feishu_app_secret = getenv("FEISHU_APP_SECRET")
     if feishu_app_id and feishu_app_secret:
-        if Platform.FEISHU not in config.platforms:
-            config.platforms[Platform.FEISHU] = PlatformConfig()
-        config.platforms[Platform.FEISHU].enabled = True
-        config.platforms[Platform.FEISHU].extra.update({
+        feishu_config = _enable_from_env(Platform.FEISHU)
+        feishu_config.extra.update({
             "app_id": feishu_app_id,
             "app_secret": feishu_app_secret,
             "domain": getenv("FEISHU_DOMAIN", "feishu"),

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -2334,10 +2334,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     feishu_app_id = getenv("FEISHU_APP_ID")
     feishu_app_secret = getenv("FEISHU_APP_SECRET")
     if feishu_app_id and feishu_app_secret:
-        if Platform.FEISHU not in config.platforms:
-            config.platforms[Platform.FEISHU] = PlatformConfig()
-        config.platforms[Platform.FEISHU].enabled = True
-        config.platforms[Platform.FEISHU].extra.update({
+        feishu_config = _enable_from_env(Platform.FEISHU)
+        feishu_config.extra.update({
             "app_id": feishu_app_id,
             "app_secret": feishu_app_secret,
             "domain": getenv("FEISHU_DOMAIN", "feishu"),

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -90,6 +90,116 @@ class TestConfigEnvOverrides(unittest.TestCase):
 
         self.assertIn(Platform.FEISHU, config.get_connected_platforms())
 
+    @patch.dict(os.environ, {}, clear=True)
+    def test_explicit_feishu_disabled_wins_over_env_credentials(self):
+        """YAML enabled: false must keep Feishu disabled even with credentials set."""
+        from gateway.config import load_gateway_config, Platform
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hermes_home = Path(tmpdir) / ".hermes"
+            hermes_home.mkdir()
+            (hermes_home / "config.yaml").write_text(
+                "platforms:\n"
+                "  feishu:\n"
+                "    enabled: false\n",
+                encoding="utf-8",
+            )
+            os.environ["HERMES_HOME"] = str(hermes_home)
+            os.environ["FEISHU_APP_ID"] = "cli_xxx"
+            os.environ["FEISHU_APP_SECRET"] = "secret_xxx"
+            try:
+                config = load_gateway_config()
+                feishu_cfg = config.platforms[Platform.FEISHU]
+                self.assertFalse(feishu_cfg.enabled)
+                self.assertEqual(feishu_cfg.extra["app_id"], "cli_xxx")
+            finally:
+                os.environ.pop("HERMES_HOME", None)
+                os.environ.pop("FEISHU_APP_ID", None)
+                os.environ.pop("FEISHU_APP_SECRET", None)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_env_credentials_auto_enable_feishu_when_not_explicitly_disabled(self):
+        """Without config.yaml, env credentials should auto-enable Feishu."""
+        from gateway.config import load_gateway_config, Platform
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hermes_home = Path(tmpdir) / ".hermes"
+            hermes_home.mkdir()
+            os.environ["HERMES_HOME"] = str(hermes_home)
+            os.environ["FEISHU_APP_ID"] = "cli_xxx"
+            os.environ["FEISHU_APP_SECRET"] = "secret_xxx"
+            try:
+                config = load_gateway_config()
+                self.assertIn(Platform.FEISHU, config.platforms)
+                self.assertTrue(config.platforms[Platform.FEISHU].enabled)
+            finally:
+                os.environ.pop("HERMES_HOME", None)
+                os.environ.pop("FEISHU_APP_ID", None)
+                os.environ.pop("FEISHU_APP_SECRET", None)
+
+
+# Regression tests following the slack_mention pattern (pytest fixtures).
+# These exercise the real load_gateway_config() path, not just _apply_env_overrides().
+
+
+def test_explicit_feishu_disabled_wins_over_env_credentials_regression(
+    monkeypatch, tmp_path
+):
+    """YAML platforms.feishu.enabled: false must keep Feishu disabled even with credentials."""
+    from gateway.config import load_gateway_config, Platform
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "platforms:\n"
+        "  feishu:\n"
+        "    enabled: false\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("FEISHU_APP_ID", "cli_xxx")
+    monkeypatch.setenv("FEISHU_APP_SECRET", "secret_xxx")
+
+    config = load_gateway_config()
+
+    feishu_cfg = config.platforms[Platform.FEISHU]
+    assert feishu_cfg.enabled is False
+    assert feishu_cfg.extra["app_id"] == "cli_xxx"
+    assert feishu_cfg.extra["app_secret"] == "secret_xxx"
+
+
+def test_env_credentials_auto_enable_feishu_regression(monkeypatch, tmp_path):
+    """Without config.yaml, env credentials should auto-enable Feishu."""
+    from gateway.config import load_gateway_config, Platform
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("FEISHU_APP_ID", "cli_xxx")
+    monkeypatch.setenv("FEISHU_APP_SECRET", "secret_xxx")
+
+    config = load_gateway_config()
+
+    assert Platform.FEISHU in config.platforms
+    assert config.platforms[Platform.FEISHU].enabled is True
+    assert config.platforms[Platform.FEISHU].extra["app_id"] == "cli_xxx"
+
+
+def test_feishu_absent_from_platforms_when_no_credentials(monkeypatch, tmp_path):
+    """Feishu should not appear in platforms when no credentials are set."""
+    from gateway.config import load_gateway_config, Platform
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    config = load_gateway_config()
+
+    assert Platform.FEISHU not in config.platforms
+
 
 class TestFeishuMessageNormalization(unittest.TestCase):
     def test_normalize_merge_forward_preserves_summary_lines(self):

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -64,6 +64,115 @@ class TestConfigEnvOverrides(unittest.TestCase):
         self.assertEqual(config.platforms[Platform.FEISHU].extra["app_id"], "cli_xxx")
         self.assertEqual(config.platforms[Platform.FEISHU].extra["connection_mode"], "websocket")
 
+    @patch.dict(os.environ, {}, clear=True)
+    def test_explicit_feishu_disabled_wins_over_env_credentials(self):
+        """YAML enabled: false must keep Feishu disabled even with credentials set."""
+        from gateway.config import load_gateway_config, Platform
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hermes_home = Path(tmpdir) / ".hermes"
+            hermes_home.mkdir()
+            (hermes_home / "config.yaml").write_text(
+                "platforms:\n"
+                "  feishu:\n"
+                "    enabled: false\n",
+                encoding="utf-8",
+            )
+            os.environ["HERMES_HOME"] = str(hermes_home)
+            os.environ["FEISHU_APP_ID"] = "cli_xxx"
+            os.environ["FEISHU_APP_SECRET"] = "secret_xxx"
+            try:
+                config = load_gateway_config()
+                feishu_cfg = config.platforms[Platform.FEISHU]
+                self.assertFalse(feishu_cfg.enabled)
+                self.assertEqual(feishu_cfg.extra["app_id"], "cli_xxx")
+            finally:
+                os.environ.pop("HERMES_HOME", None)
+                os.environ.pop("FEISHU_APP_ID", None)
+                os.environ.pop("FEISHU_APP_SECRET", None)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_env_credentials_auto_enable_feishu_when_not_explicitly_disabled(self):
+        """Without config.yaml, env credentials should auto-enable Feishu."""
+        from gateway.config import load_gateway_config, Platform
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hermes_home = Path(tmpdir) / ".hermes"
+            hermes_home.mkdir()
+            os.environ["HERMES_HOME"] = str(hermes_home)
+            os.environ["FEISHU_APP_ID"] = "cli_xxx"
+            os.environ["FEISHU_APP_SECRET"] = "secret_xxx"
+            try:
+                config = load_gateway_config()
+                self.assertIn(Platform.FEISHU, config.platforms)
+                self.assertTrue(config.platforms[Platform.FEISHU].enabled)
+            finally:
+                os.environ.pop("HERMES_HOME", None)
+                os.environ.pop("FEISHU_APP_ID", None)
+                os.environ.pop("FEISHU_APP_SECRET", None)
+
+
+# Regression tests following the slack_mention pattern (pytest fixtures).
+# These exercise the real load_gateway_config() path, not just _apply_env_overrides().
+
+
+def test_explicit_feishu_disabled_wins_over_env_credentials_regression(
+    monkeypatch, tmp_path
+):
+    """YAML platforms.feishu.enabled: false must keep Feishu disabled even with credentials."""
+    from gateway.config import load_gateway_config, Platform
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "platforms:\n"
+        "  feishu:\n"
+        "    enabled: false\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("FEISHU_APP_ID", "cli_xxx")
+    monkeypatch.setenv("FEISHU_APP_SECRET", "secret_xxx")
+
+    config = load_gateway_config()
+
+    feishu_cfg = config.platforms[Platform.FEISHU]
+    assert feishu_cfg.enabled is False
+    assert feishu_cfg.extra["app_id"] == "cli_xxx"
+    assert feishu_cfg.extra["app_secret"] == "secret_xxx"
+
+
+def test_env_credentials_auto_enable_feishu_regression(monkeypatch, tmp_path):
+    """Without config.yaml, env credentials should auto-enable Feishu."""
+    from gateway.config import load_gateway_config, Platform
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("FEISHU_APP_ID", "cli_xxx")
+    monkeypatch.setenv("FEISHU_APP_SECRET", "secret_xxx")
+
+    config = load_gateway_config()
+
+    assert Platform.FEISHU in config.platforms
+    assert config.platforms[Platform.FEISHU].enabled is True
+    assert config.platforms[Platform.FEISHU].extra["app_id"] == "cli_xxx"
+
+
+def test_feishu_absent_from_platforms_when_no_credentials(monkeypatch, tmp_path):
+    """Feishu should not appear in platforms when no credentials are set."""
+    from gateway.config import load_gateway_config, Platform
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    config = load_gateway_config()
+
+    assert Platform.FEISHU not in config.platforms
 
 class TestFeishuMessageNormalization(unittest.TestCase):
 


### PR DESCRIPTION
## Summary

`_apply_env_overrides()` unconditionally set `Feishu.enabled = True` when `FEISHU_APP_ID` and `FEISHU_APP_SECRET` env vars were present, ignoring explicit `enabled: false` in `config.yaml`. This broke multi-profile setups where a secondary profile inherits the default profile's env vars but must keep Feishu disabled.

## Root Cause

At `gateway/config.py` L1859, the Feishu path did a blind `config.platforms[Platform.FEISHU].enabled = True` with no check for `_enabled_explicit`, unlike every other platform (Slack/DingTalk/WeCom/etc.) which respects explicit `enabled: false`.

## Fix

Add the same `_enabled_explicit` check that Slack uses at L1596:

- If the user explicitly set `enabled: false` in `config.yaml`, the env-var auto-enable is skipped
- If the config is absent or has `enabled` unset, env vars still auto-enable as before

This matches the established pattern in the codebase.

## Verification

- [x] Multi-profile with env-inherited Feishu creds + explicit `enabled: false` → Feishu stays disabled
- [x] Single-profile with env vars but no `enabled` in config → Feishu still auto-enables (no regression)
- [x] Lint passes