### PR TITLE
fix(desktop): reset voice state on session switch

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -20,6 +20,7 @@ import type { ChatBarProps } from '../types'
 import { useAutoSpeakReplies } from './use-auto-speak-replies'
 import { useVoiceConversation } from './use-voice-conversation'
 import { useVoiceRecorder } from './use-voice-recorder'
+import { useEndVoiceOnSessionSwitch, useStopVoicePlaybackOnUnmount } from './use-voice-session-reset'
 
 interface UseComposerVoiceArgs {
   busy: boolean
@@ -66,7 +67,12 @@ export function useComposerVoice({
   const ownsWakeIndicatorRef = useRef(false)
   const voiceStartRequest = useStore($voiceConversationStartRequest)
 
-  const { dictate, voiceActivityState, voiceStatus } = useVoiceRecorder({
+  const {
+    cancel: cancelDictation,
+    dictate,
+    voiceActivityState,
+    voiceStatus
+  } = useVoiceRecorder({
     focusInput,
     maxRecordingSeconds,
     onTranscript: insertText,
@@ -151,6 +157,20 @@ export function useComposerVoice({
     // to finish releasing the capture device (see wakePauseBarrierRef).
     beforeMicOpen: () => wakePauseBarrierRef.current ?? undefined
   })
+
+  const endVoiceRef = useRef(conversation.end)
+  const cancelDictationRef = useRef(cancelDictation)
+  endVoiceRef.current = conversation.end
+  cancelDictationRef.current = cancelDictation
+
+  const resetVoiceForSessionSwitch = useCallback(() => {
+    setVoiceConversationActive(false)
+    cancelDictationRef.current()
+    void endVoiceRef.current()
+  }, [])
+
+  useEndVoiceOnSessionSwitch(sessionId, resetVoiceForSessionSwitch)
+  useStopVoicePlaybackOnUnmount()
 
   // eslint-disable-next-line no-restricted-syntax -- ownership token used only by unmount cleanup
   useEffect(() => {

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.ts
@@ -106,11 +106,18 @@ export function useVoiceRecorder({
     }
   }
 
+  const cancel = () => {
+    clearTimers()
+    handle.cancel()
+    setElapsedSeconds(0)
+    setVoiceStatus('idle')
+  }
+
   const voiceActivityState: VoiceActivityState = {
     elapsedSeconds,
     level,
     status: voiceStatus
   }
 
-  return { dictate, voiceActivityState, voiceStatus }
+  return { cancel, dictate, voiceActivityState, voiceStatus }
 }

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-session-reset.test.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-session-reset.test.ts
@@ -1,0 +1,172 @@
+import { cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { stopVoicePlayback } from '@/lib/voice-playback'
+
+import { useComposerVoice } from './use-composer-voice'
+import { useEndVoiceOnSessionSwitch, useStopVoicePlaybackOnUnmount } from './use-voice-session-reset'
+
+const voiceMocks = vi.hoisted(() => ({
+  conversation: { end: vi.fn(), status: 'idle' },
+  recorder: {
+    cancel: vi.fn(),
+    dictate: vi.fn(),
+    voiceActivityState: { elapsedSeconds: 3, level: 0.5, status: 'recording' },
+    voiceStatus: 'recording'
+  }
+}))
+
+vi.mock('@/lib/voice-playback', () => ({
+  stopVoicePlayback: vi.fn()
+}))
+
+vi.mock('@nanostores/react', () => ({ useStore: () => null }))
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      assistant: { thread: { readAloudFailed: '' } },
+      notifications: { voice: { sayStopToEnd: () => '' } },
+      settings: { config: { autosaveFailed: '' } }
+    }
+  })
+}))
+vi.mock('@/lib/chat-messages', () => ({ chatMessageText: () => '', collectUnspokenTurnSpeech: () => [] }))
+vi.mock('@/lib/haptics', () => ({ triggerHaptic: vi.fn() }))
+vi.mock('@/lib/wake-indicator', () => ({ clearWakeIndicator: vi.fn(), syncWakeIndicatorWithVoice: () => false }))
+vi.mock('@/store/composer', () => ({ $voiceConversationStartRequest: {}, takeVoiceConversationStart: () => false }))
+vi.mock('@/store/composer-input-history', () => ({ resetBrowseState: vi.fn() }))
+vi.mock('@/store/gateway', () => ({ $gateway: { get: () => null } }))
+vi.mock('@/store/notifications', () => ({ notify: vi.fn(), notifyError: vi.fn() }))
+vi.mock('@/store/voice-prefs', () => ({
+  $autoSpeakReplies: { get: () => false },
+  $voiceStopPhrase: { get: () => null },
+  setAutoSpeakReplies: vi.fn()
+}))
+vi.mock('@/store/wake-word', () => ({ resumeWakeAfterVoice: vi.fn() }))
+vi.mock('../focus', () => ({ onComposerVoiceToggleRequest: () => () => undefined }))
+vi.mock('../scope', () => ({ useComposerScope: () => ({ $messages: { get: () => [] } }) }))
+vi.mock('./use-auto-speak-replies', () => ({ useAutoSpeakReplies: vi.fn() }))
+vi.mock('./use-voice-conversation', () => ({ useVoiceConversation: () => voiceMocks.conversation }))
+vi.mock('./use-voice-recorder', () => ({ useVoiceRecorder: () => voiceMocks.recorder }))
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+function setup(initial: string | null | undefined) {
+  const onSwitch = vi.fn()
+  const view = renderHook(({ id }: { id: string | null | undefined }) => useEndVoiceOnSessionSwitch(id, onSwitch), {
+    initialProps: { id: initial }
+  })
+
+  return { onSwitch, ...view }
+}
+
+describe('useEndVoiceOnSessionSwitch', () => {
+  it('does not fire on initial mount', () => {
+    const { onSwitch } = setup('session-a')
+
+    expect(onSwitch).not.toHaveBeenCalled()
+  })
+
+  it('does not fire when the session id is unchanged', () => {
+    const { onSwitch, rerender } = setup('session-a')
+
+    rerender({ id: 'session-a' })
+    rerender({ id: 'session-a' })
+
+    expect(onSwitch).not.toHaveBeenCalled()
+  })
+
+  it('fires once for each switch between real sessions', () => {
+    const { onSwitch, rerender } = setup('session-a')
+
+    rerender({ id: 'session-b' })
+    rerender({ id: 'session-c' })
+    rerender({ id: 'session-a' })
+
+    expect(onSwitch).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not fire on the first no-session to session persist', () => {
+    const { onSwitch, rerender } = setup(null)
+
+    rerender({ id: 'session-a' })
+
+    expect(onSwitch).not.toHaveBeenCalled()
+  })
+
+  it('treats undefined and null as the same no-session state', () => {
+    const { onSwitch, rerender } = setup(undefined)
+
+    rerender({ id: null })
+    rerender({ id: 'session-a' })
+
+    expect(onSwitch).not.toHaveBeenCalled()
+  })
+
+  it('fires when leaving a session', () => {
+    const { onSwitch, rerender } = setup('session-a')
+
+    rerender({ id: null })
+
+    expect(onSwitch).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses the latest switch callback', () => {
+    const first = vi.fn()
+    const second = vi.fn()
+    const { rerender } = renderHook(
+      ({ id, cb }: { cb: () => void; id: string | null }) => useEndVoiceOnSessionSwitch(id, cb),
+      { initialProps: { cb: first, id: 'session-a' as string | null } }
+    )
+
+    rerender({ cb: second, id: 'session-b' })
+
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useStopVoicePlaybackOnUnmount', () => {
+  it('does not stop playback while mounted', () => {
+    renderHook(() => useStopVoicePlaybackOnUnmount())
+
+    expect(stopVoicePlayback).not.toHaveBeenCalled()
+  })
+
+  it('stops global voice playback on unmount', () => {
+    const { unmount } = renderHook(() => useStopVoicePlaybackOnUnmount())
+
+    unmount()
+
+    expect(stopVoicePlayback).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useComposerVoice session switches', () => {
+  it('cancels active dictation and ends the voice conversation', () => {
+    const { rerender } = renderHook(
+      ({ sessionId }: { sessionId: string }) =>
+        useComposerVoice({
+          busy: false,
+          clearDraft: vi.fn(),
+          disabled: false,
+          focusInput: vi.fn(),
+          insertText: vi.fn(),
+          maxRecordingSeconds: 60,
+          onSubmit: vi.fn(),
+          onTranscribeAudio: vi.fn(),
+          sessionId,
+          target: 'main'
+        }),
+      { initialProps: { sessionId: 'session-a' } }
+    )
+
+    rerender({ sessionId: 'session-b' })
+
+    expect(voiceMocks.recorder.cancel).toHaveBeenCalledTimes(1)
+    expect(voiceMocks.conversation.end).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-session-reset.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-session-reset.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from 'react'
+
+import { stopVoicePlayback } from '@/lib/voice-playback'
+
+export function useEndVoiceOnSessionSwitch(sessionId: string | null | undefined, onSwitch: () => void) {
+  const lastSessionIdRef = useRef(sessionId)
+
+  useEffect(() => {
+    const previousSessionId = lastSessionIdRef.current ?? null
+    const currentSessionId = sessionId ?? null
+    lastSessionIdRef.current = sessionId
+
+    if (previousSessionId === currentSessionId || (previousSessionId === null && currentSessionId !== null)) {
+      return
+    }
+
+    onSwitch()
+  }, [onSwitch, sessionId])
+}
+
+export function useStopVoicePlaybackOnUnmount() {
+  useEffect(
+    () => () => {
+      stopVoicePlayback()
+    },
+    []
+  )
+}


### PR DESCRIPTION
## What does this PR do?

Resets Desktop composer voice state at the same session boundary that scopes the foreground transcript, so session switches cannot carry listening/read-aloud status into the newly selected chat.

## Shared root cause

- Desktop has a shared foreground chat/composer surface, while several state sources are session keyed by runtime id. The transcript cache already rejects background-session view writes in `useSessionStateCache`, but composer voice state still lived in component/module state and survived warm switches or cold unmount/remount paths.
- This wires a session switch reset into `useComposerVoice`: warm switches disable the active voice conversation and call the conversation teardown, while cold unmounts stop the module-level voice playback singleton.
- This folds in the voice-session reset approach from #46279 by @harjothkhara, adapted to the current extracted `useComposerVoice` structure.

## How this fixes each issue

- #45738: prevents composer-adjacent voice playback/status rows such as `Preparing audio` or `Speaking` from remaining visible after switching to a different selected session; transcript isolation remains covered by the existing active-session cache guard.
- #46194: prevents queued/follow-up voice state from leaking across a busy session switch by ending the old session's listening/playback state before the new session renders.

## Supersedes

Supersedes #46279

## Related Issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Added `useEndVoiceOnSessionSwitch` and `useStopVoicePlaybackOnUnmount` for Desktop composer voice session-boundary cleanup.
- Wired the reset into `useComposerVoice` so warm switches call the current conversation teardown and cold unmounts stop global playback.
- Added hook tests for initial mount, real session switches, no-session transitions, latest callback usage, and unmount playback cleanup.

## How to Test

1. Start a Desktop voice/read-aloud flow in session A until the composer shows listening, `Preparing audio`, or `Speaking`.
2. Switch to session B from the sidebar while that voice state is active.
3. Verify session B shows only its own chat/composer state and does not inherit session A's voice status.

Local checks:
- `npx prettier --write apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts apps/desktop/src/app/chat/composer/hooks/use-voice-session-reset.ts apps/desktop/src/app/chat/composer/hooks/use-voice-session-reset.test.ts` passed.
- `git diff --check` passed.
- `python scripts/check-windows-footguns.py apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts apps/desktop/src/app/chat/composer/hooks/use-voice-session-reset.ts apps/desktop/src/app/chat/composer/hooks/use-voice-session-reset.test.ts` passed with no Python files scanned.
- `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh` was run and aborted during collection because this sandbox lacks `fastapi`/`uvicorn`; the lazy installer is blocked by Homebrew's externally managed Python.
- `npm --workspace apps/desktop run test:ui -- --run apps/desktop/src/app/chat/composer/hooks/use-voice-session-reset.test.ts` could not start because `vitest` is missing. A bounded `npm ci --ignore-scripts --workspace apps/desktop --include-workspace-root=false` attempt failed on `getaddrinfo ENOTFOUND registry.npmjs.org`, and changed-file ESLint failed for the same network-restricted dependency resolution reason.

## What platforms tested on

- macOS on darwin-arm64 (local)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass (attempted; blocked by missing local Python dashboard deps)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS on darwin-arm64

### Documentation & Housekeeping

- [x] Documentation N/A
- [x] `cli-config.yaml.example` N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` N/A
- [x] Cross-platform impact considered
- [x] Tool descriptions/schemas N/A

## Screenshots / Logs

N/A

---
_This coordinated PR bundles a fix that spans several issues. Happy to split it back into focused per-issue PRs if you'd prefer to review them separately._

Refs #45738
Refs #46194

<!-- autocontrib:worker-id=pr-spanning-b895372c kind=pr-open -->