### PR TITLE
fix(desktop): extend remote cwd boot timeout

### DIFF
--- a/apps/desktop/src/lib/desktop-fs.test.ts
+++ b/apps/desktop/src/lib/desktop-fs.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { STARTUP_REQUEST_TIMEOUT_MS } from '@/hermes'
 import { $connection } from '@/store/session'
 
 import {
@@ -105,7 +106,7 @@ describe('desktop filesystem facade', () => {
     expect(api).toHaveBeenCalledWith({ path: '/api/fs/read-text?path=%2Fhome%2Fuser%2Fproject%2Fa%20b.txt' })
     expect(api).toHaveBeenCalledWith({ path: '/api/fs/read-data-url?path=%2Fhome%2Fuser%2Fproject%2Fa%20b.txt' })
     expect(api).toHaveBeenCalledWith({ path: '/api/fs/git-root?path=%2Fhome%2Fuser%2Fproject' })
-    expect(api).toHaveBeenCalledWith({ path: '/api/fs/default-cwd' })
+    expect(api).toHaveBeenCalledWith({ path: '/api/fs/default-cwd', profile: undefined, timeoutMs: STARTUP_REQUEST_TIMEOUT_MS })
     expect(readDir).not.toHaveBeenCalled()
     expect(readFileText).not.toHaveBeenCalled()
     expect(readFileDataUrl).not.toHaveBeenCalled()
@@ -119,7 +120,11 @@ describe('desktop filesystem facade', () => {
     await desktopDefaultCwd()
 
     expect(api).toHaveBeenCalledWith({ path: '/api/fs/list?path=%2Fsrv%2Fproject', profile: 'remote-docker' })
-    expect(api).toHaveBeenCalledWith({ path: '/api/fs/default-cwd', profile: 'remote-docker' })
+    expect(api).toHaveBeenCalledWith({
+      path: '/api/fs/default-cwd',
+      profile: 'remote-docker',
+      timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
+    })
   })
 
   it('routes file diffs through backend git in remote mode', async () => {

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -4,6 +4,7 @@ import type {
   HermesReadFileTextResult,
   HermesSelectPathsOptions
 } from '@/global'
+import { STARTUP_REQUEST_TIMEOUT_MS } from '@/hermes'
 import { $connection } from '@/store/session'
 
 export interface DesktopFsRemotePicker {
@@ -119,7 +120,11 @@ export async function desktopDefaultCwd(): Promise<{ branch: string; cwd: string
     return null
   }
 
-  return remoteFsApi<{ branch: string; cwd: string }>('/api/fs/default-cwd')
+  return bridge().api<{ branch: string; cwd: string }>({
+    path: '/api/fs/default-cwd',
+    profile: desktopFsProfile(),
+    timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
+  })
 }
 
 // Reveal a path in the OS file manager (Finder / Explorer / Files). Local only.


### PR DESCRIPTION
What changed and why

Per the reporter's clarification on July 9, 2026, the remote desktop path can still fail after `Remote Hermes backend is ready` with a renderer-side `hermes:api` timeout on current `main`. The desktop boot burst had already been widened for config/model/profile calls, but the remote `desktopDefaultCwd()` probe still used the Electron bridge's default 15s timeout. This PR moves that remote `/api/fs/default-cwd` request onto `STARTUP_REQUEST_TIMEOUT_MS`, so the post-connect boot path does not fail early on the leftover short timeout.

How to test

1. Run `npm --workspace apps/desktop exec -- vitest run src/lib/desktop-fs.test.ts src/hermes.test.ts`.
2. Launch Hermes Desktop against a remote gateway that is reachable but slow enough to exercise the post-connect startup burst.
3. Verify that after `Remote Hermes backend is ready`, the renderer can complete the remote default-CWD probe without tripping the old 15s `hermes:api` timeout.

What platforms tested on

- Not fully verified in this worker environment: the targeted Vitest command timed out locally without producing output.

Fixes #38061

<!-- autocontrib:worker-id=issue-followup-08077dd9 kind=pr-open -->