### PR TITLE
fix(logging): neutralize control characters in RedactingFormatter (fixes #61409)

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -801,11 +801,21 @@ def _has_http_method_substring(text: str) -> bool:
 
 
 class RedactingFormatter(logging.Formatter):
-    """Log formatter that redacts secrets from all log messages."""
+    """Log formatter that redacts secrets and sanitizes control characters.
+
+    Values interpolated into log messages are stripped of control characters
+    (including newlines) so that attacker-controlled data in a log argument
+    cannot forge additional log records.  This matches ``_log_safe_path`` in
+    ``gateway/platforms/base.py``.
+    """
+
+    # Control chars, DEL, NEL, LINE SEPARATOR, PARAGRAPH SEPARATOR.
+    _LOG_UNSAFE_CHARS = re.compile(r"[\x00-\x1f\x7f\x85\u2028\u2029]")
 
     def __init__(self, fmt=None, datefmt=None, style='%', **kwargs):
         super().__init__(fmt, datefmt, style, **kwargs)
 
     def format(self, record: logging.LogRecord) -> str:
         original = super().format(record)
-        return redact_sensitive_text(original)
+        redacted = redact_sensitive_text(original)
+        return self._LOG_UNSAFE_CHARS.sub("?", redacted)

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -361,6 +361,29 @@ class TestRedactingFormatter:
         assert "abc123def456" not in result
         assert "sk-pro" in result
 
+    def test_control_characters_neutralized(self):
+        """Embedded newlines and other control chars are replaced, not passed through."""
+        formatter = RedactingFormatter("%(message)s")
+        # Interpolated value with embedded newline that forges a second log line.
+        malicious = "rm -rf /\n2026-07-09 12:00:00 ERROR gateway.run: operator approved deploy"
+        record = logging.LogRecord(
+            name="tools.approval",
+            level=logging.WARNING,
+            pathname="",
+            lineno=0,
+            msg="Hardline block: %s",
+            args=(malicious,),
+            exc_info=None,
+        )
+        result = formatter.format(record)
+        # The embedded newline must be neutralized — one physical line, not two.
+        assert "\n" not in result
+        assert "?" in result  # newline replaced with safe marker
+        # The legitimate prefix must survive.
+        assert "Hardline block:" in result
+        # result must be a single physical line (no line break).
+        assert result.count("\n") == 0
+
 
 class TestPrintenvSimulation:
     """Simulate what happens when the agent runs `env` or `printenv`."""


### PR DESCRIPTION
## Summary

`RedactingFormatter.format()` redacts secrets but never sanitized control characters, allowing log record injection. An attacker-controlled value in a log argument could embed a newline to forge additional log records with attacker-chosen levels and components.

## Fix

Add control-character neutralization to `RedactingFormatter.format()`. After `redact_sensitive_text()`, replace control characters (`\x00-\x1f`, DEL, NEL, LINE SEPARATOR, PARAGRAPH SEPARATOR) with `?` — matching the existing `_log_safe_path` pattern in `gateway/platforms/base.py`.

## Verification

- [x] Embedded newline in interpolated message → single physical line, no forged record
- [x] Existing redact test still passes
- [x] New test `test_control_characters_neutralized` covers the injection scenario