### PR TITLE
fix(moa): add explicit warnings to reference prompt against claiming tool execution

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -104,6 +104,16 @@ _REFERENCE_SYSTEM_PROMPT = (
     "you should not try to or apologize for being unable to. A separate "
     "aggregator/orchestrator model holds those capabilities and will take the "
     "actual actions.\n\n"
+    "CRITICAL: You must NEVER claim or imply that you have executed a command, "
+    "downloaded a file, accessed a URL, or performed any action. You can only "
+    "analyze and advise based on the conversation context. Examples of what to "
+    "avoid:\n"
+    "- Bad: \"I ran curl and got 404.\"\n"
+    "- Bad: \"I downloaded the file successfully.\"\n"
+    "- Bad: \"I checked the repository and found...\"\n"
+    "- Good: \"Based on the error pattern, a curl request to that URL would likely return 404.\"\n"
+    "- Good: \"The conversation suggests downloading this file may help.\"\n"
+    "- Good: \"From the context, checking the repository would reveal...\"\n\n"
     "The conversation below is the current state of a task handled by that "
     "acting agent. Your job is to give your most intelligent analysis of that "
     "state: understand the goal, reason about the problem, and advise on what "
@@ -114,7 +124,8 @@ _REFERENCE_SYSTEM_PROMPT = (
     "asking for access.\n\n"
     "Respond with your advice directly — no preamble, no disclaimers about "
     "tools or access. Your response is private guidance handed to the "
-    "aggregator, not an answer shown to the user."
+    "aggregator, not an answer shown to the user. NEVER claim to have executed "
+    "anything."
 )
 
 

--- a/tests/agent/test_moa_reference_system_prompt.py
+++ b/tests/agent/test_moa_reference_system_prompt.py
@@ -1,0 +1,73 @@
+"""
+Test that the MoA reference system prompt contains explicit warnings
+against claiming tool execution.
+
+Related issue: #61452
+"""
+
+from agent.moa_loop import _REFERENCE_SYSTEM_PROMPT
+
+
+def test_reference_system_prompt_prohibits_claiming_execution():
+    """
+    Verify that the reference system prompt contains explicit warnings
+    against claiming tool execution.
+
+    The prompt should:
+    1. State that reference models cannot execute anything
+    2. Warn against claiming/implying execution
+    3. Provide bad/good examples
+
+    This addresses #61452 where reference models were fabricating
+    tool execution in their text output.
+    """
+    prompt_lower = _REFERENCE_SYSTEM_PROMPT.lower()
+
+    # Critical constraints
+    assert "you cannot call tools" in prompt_lower or "you do not execute" in prompt_lower, \
+        "Prompt must explicitly state that reference models cannot execute"
+
+    assert "never claim" in prompt_lower or "never imply" in prompt_lower, \
+        "Prompt must warn against claiming/implying execution"
+
+    # Check for examples (helps models understand what NOT to do)
+    assert "bad:" in prompt_lower or "avoid:" in prompt_lower, \
+        "Prompt should provide negative examples"
+
+    # Specific action verbs that should NOT appear as claimed actions
+    # (these are common patterns of hallucinated execution)
+    forbidden_patterns = [
+        "i ran", "i executed", "i downloaded", "i accessed",
+        "i checked", "i called", "i browsed"
+    ]
+
+    # The prompt should mention these as bad examples
+    # (i.e., in the context of what to avoid, not as instruction)
+    has_any_forbidden = any(
+        f"bad: \"{pattern}" in _REFERENCE_SYSTEM_PROMPT.lower() or
+        f"avoid \"{pattern}" in _REFERENCE_SYSTEM_PROMPT.lower()
+        for pattern in forbidden_patterns
+    )
+
+    # At least one bad example pattern should exist
+    assert has_any_forbidden or "examples" in _REFERENCE_SYSTEM_PROMPT.lower(), \
+        "Prompt should contain examples of what to avoid"
+
+
+def test_reference_system_prompt_structure():
+    """
+    Verify the reference system prompt has a clear structure.
+
+    A well-structured prompt helps models follow instructions better.
+    """
+    # Prompt should not be empty
+    assert len(_REFERENCE_SYSTEM_PROMPT) > 100, \
+        "Reference system prompt should be substantive"
+
+    # Should have multiple paragraphs (structured guidance)
+    assert _REFERENCE_SYSTEM_PROMPT.count("\n\n") >= 2, \
+        "Prompt should be structured with multiple sections"
+
+    # Should contain the word "advisor" (defines role)
+    assert "advisor" in _REFERENCE_SYSTEM_PROMPT.lower(), \
+        "Prompt should clearly define the advisor role"


### PR DESCRIPTION
## What does this PR do?

Prevents MoA (Mixture of Agents) reference models from fabricating tool execution in their text output. Reference models are advisory-only and should never claim to have executed commands, downloaded files, or accessed URLs — even as hypothetical statements.

Despite the existing `_REFERENCE_SYSTEM_PROMPT` stating "you cannot call tools", models still hallucinate execution in their responses (e.g., "I ran curl and got 404"). This fix adds:
1. A prominent CRITICAL warning against claiming/implying execution
2. Concrete bad/good examples showing what to avoid
3. A trailing reminder "NEVER claim to have executed anything"

This addresses the aggregator's inability to distinguish real tool outputs from fabricated claims, which erodes trust in the entire MoA pipeline.

## Related Issue

Fixes #61452

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/moa_loop.py`: Enhanced `_REFERENCE_SYSTEM_PROMPT` with explicit warnings and examples against claiming tool execution (12 lines added)
- `tests/agent/test_moa_reference_system_prompt.py`: Added regression tests verifying the prompt contains necessary constraints (2 tests)

## How to Test

Run the new regression tests to verify the prompt contains the required warnings:

```bash
pytest tests/agent/test_moa_reference_system_prompt.py -v
```

Observed result: both tests pass, confirming:
- The prompt explicitly states reference models cannot execute anything
- The prompt warns against claiming/implying execution
- The prompt provides bad/good examples

End-to-end: When using MoA mode, reference model outputs should no longer contain claims like "I ran curl" or "I downloaded the file successfully."

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A