### PR TITLE
fix(photon): do not retry shared-line 'Target not allowed' outbound rejections (#51897)

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -104,6 +104,21 @@ _PHOTON_RETRYABLE_PATTERNS = (
     "upstream_unavailable",
 )
 
+# Permanent, non-actionable rejections. Unlike the patterns above these will
+# NEVER succeed on retry — re-hammering the same target just floods the logs
+# (and Photon's abuse controls) with the same error. The free/shared-line
+# "Target not allowed" rejection (#51897) is the canonical case: a shared
+# Photon line pool cannot originate outbound sends to an arbitrary target,
+# so the send is rejected at the upstream and must be surfaced, not retried.
+_PHOTON_FATAL_PATTERNS = (
+    "target not allowed",
+    "not allowed for this project",
+    "shared line",
+    "free tier",
+    "outbound not permitted",
+    "forbidden target",
+)
+
 # Minimum seconds between typing-indicator calls for the same chat.
 # iMessage is a personal channel — suppressing rapid repeats reduces
 # upstream gRPC pressure during Photon overflow events.
@@ -1398,6 +1413,19 @@ class PhotonAdapter(BasePlatformAdapter):
         lowered = error.lower()
         return any(pat in lowered for pat in _PHOTON_RETRYABLE_PATTERNS)
 
+    @staticmethod
+    def _is_fatal_error(error: Optional[str]) -> bool:
+        """Permanent upstream rejection — never worth retrying.
+
+        Retrying (or downgrading to plain text) only re-hammers the same
+        rejected target. The shared-line / free-tier ``Target not allowed``
+        rejection falls here (#51897).
+        """
+        if not error:
+            return False
+        lowered = error.lower()
+        return any(pat in lowered for pat in _PHOTON_FATAL_PATTERNS)
+
     async def _send_with_retry(
         self,
         chat_id: str,
@@ -1424,6 +1452,13 @@ class PhotonAdapter(BasePlatformAdapter):
             return result
 
         error_str = result.error or ""
+        if self._is_fatal_error(error_str):
+            # Permanent upstream rejection (e.g. shared-line free tier
+            # "Target not allowed"). Retrying or downgrading to plain text
+            # only re-hammers the same rejected target — surface it once.
+            logger.error("[photon] Outbound send permanently rejected: %s", error_str)
+            return result
+
         is_network = result.retryable or self._is_retryable_error(error_str)
         if not is_network and self._is_timeout_error(error_str):
             return result
@@ -1703,7 +1738,18 @@ async def _standalone_send(
                     return {"error": f"sidecar returned {resp.status_code}: {resp.text[:200]}"}
                 data = resp.json() or {}
                 if not data.get("ok"):
-                    return {"error": data.get("error") or "sidecar reported failure"}
+                    err = data.get("error") or "sidecar reported failure"
+                    lowered = str(err).lower()
+                    if any(pat in lowered for pat in _PHOTON_FATAL_PATTERNS):
+                        return {
+                            "error": (
+                                f"{err}. This Photon line cannot originate "
+                                "outbound sends (shared/free-tier line pool — "
+                                "see Photon docs). Use a different delivery "
+                                "channel such as Discord for cron output."
+                            )
+                        }
+                    return {"error": err}
                 last_message_id = data.get("messageId")
 
             # 2. Each attachment as a separate /send-attachment call.
@@ -1731,7 +1777,18 @@ async def _standalone_send(
                     return {"error": f"sidecar returned {resp.status_code}: {resp.text[:200]}"}
                 data = resp.json() or {}
                 if not data.get("ok"):
-                    return {"error": data.get("error") or "sidecar reported failure"}
+                    err = data.get("error") or "sidecar reported failure"
+                    lowered = str(err).lower()
+                    if any(pat in lowered for pat in _PHOTON_FATAL_PATTERNS):
+                        return {
+                            "error": (
+                                f"{err}. This Photon line cannot originate "
+                                "outbound sends (shared/free-tier line pool — "
+                                "see Photon docs). Use a different delivery "
+                                "channel such as Discord for cron output."
+                            )
+                        }
+                    return {"error": err}
                 last_message_id = data.get("messageId") or last_message_id
 
         return {"success": True, "message_id": last_message_id}

--- a/tests/plugins/platforms/photon/test_shared_line_outbound.py
+++ b/tests/plugins/platforms/photon/test_shared_line_outbound.py
@@ -1,0 +1,100 @@
+"""Photon adapter handling of permanent shared-line / free-tier rejections.
+
+Covers issue #51897: Photon's free shared-line pool rejects outbound sends
+initiated by Hermes (e.g. cron-delivered messages) with a
+`Target not allowed for this project` error. This is a permanent, non-
+actionable rejection — the adapter must NOT retry or downgrade to plain
+text (which would re-hammer the same rejected target); it must surface the
+failure once and return a clear explanation.
+
+No Node sidecar is spawned and no ports are bound.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.photon.adapter import PhotonAdapter
+
+
+def _make_adapter(monkeypatch: pytest.MonkeyPatch) -> PhotonAdapter:
+    monkeypatch.setenv("PHOTON_PROJECT_ID", "test-project-id")
+    monkeypatch.setenv("PHOTON_PROJECT_SECRET", "test-project-secret")
+    cfg = PlatformConfig(enabled=True, token="", extra={})
+    return PhotonAdapter(cfg)
+
+
+# -- Fatal (shared-line) classification --------------------------------------
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        "AuthenticationError: [spectrum-imessage] Target not allowed for this project",
+        "TARGET NOT ALLOWED FOR THIS PROJECT",  # case-insensitive
+        "shared line cannot originate outbound sends",
+        "outbound not permitted on free tier",
+    ],
+)
+def test_shared_line_rejection_classified_fatal(error: str) -> None:
+    assert PhotonAdapter._is_fatal_error(error) is True
+
+
+def test_transient_error_not_classified_fatal() -> None:
+    # A genuine transient failure must NOT be treated as a permanent block.
+    assert PhotonAdapter._is_fatal_error("reset reason: overflow") is False
+    assert PhotonAdapter._is_fatal_error(None) is False
+
+
+# -- Send path short-circuits without retry/downgrade -----------------------
+
+@pytest.mark.asyncio
+async def test_send_skips_retry_on_shared_line_rejection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+
+    # First (and only) sidecar call returns the permanent rejection.
+    calls: list[str] = []
+
+    async def _fake_sidecar_send(space_id: str, text: str):
+        calls.append(text)
+        from gateway.platforms.base import SendResult
+
+        return SendResult(success=False, error="Target not allowed for this project")
+
+    monkeypatch.setattr(adapter, "_sidecar_send", _fake_sidecar_send)
+
+    result = await adapter._send_with_retry(chat_id="chat-1", content="hello")
+
+    # Exactly one attempt — no retry loop, no plain-text downgrade.
+    assert len(calls) == 1
+    assert result.success is False
+    assert "target not allowed" in (result.error or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_send_retries_on_transient_error_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+
+    # Overflow first, success on the retry — proves transient errors still
+    # exercise the backoff path (regression guard for #50185).
+    calls: list[str] = []
+
+    async def _fake_sidecar_send(space_id: str, text: str):
+        calls.append(text)
+        from gateway.platforms.base import SendResult
+
+        if len(calls) == 1:
+            return SendResult(success=False, error="reset reason: overflow", retryable=True)
+        return SendResult(success=True, message_id="msg-1")
+
+    monkeypatch.setattr(adapter, "_sidecar_send", _fake_sidecar_send)
+
+    result = await adapter._send_with_retry(chat_id="chat-1", content="hello")
+
+    assert len(calls) == 2
+    assert result.success is True

--- a/website/docs/user-guide/messaging/photon.md
+++ b/website/docs/user-guide/messaging/photon.md
@@ -20,6 +20,16 @@ your first iMessage from Hermes — just a phone number we can bind to
 your account.
 :::
 
+:::warning Outbound sends require a paid tier
+The free shared-line pool can **receive and reply within an active
+conversation**, but Photon rejects **outbound sends initiated by Hermes**
+(e.g. cron-delivered messages) from shared lines with a
+`Target not allowed for this project` error. This is a Photon platform
+limitation, not a Hermes bug. If you need Hermes to originate messages
+(cron deliveries, proactive alerts), use the **paid Business tier** for a
+dedicated sending number, or deliver over another channel (Discord, etc.).
+:::
+
 ## Architecture
 
 Photon is a **persistent-connection** channel, like Discord or Slack —


### PR DESCRIPTION
Fixes #51897

## Description
Photon's free shared-line pool rejects outbound sends initiated by Hermes (e.g. cron-delivered messages) with `Target not allowed for this project`. This is a permanent upstream rejection, not a transient fault — yet `_send_with_retry` (and `_standalone_send`) logged the error, retried the same rejected target through its backoff loop, then downgraded to plain text and retried again, never recognizing the failure as final.

This PR:
- Adds `_PHOTON_FATAL_PATTERNS` + a `_is_fatal_error()` classifier for permanent rejections (shared-line / free-tier `Target not allowed`, `not allowed for this project`, etc.).
- Short-circuits `_send_with_retry` on a fatal error: no retry loop, no plain-text downgrade — the failure is surfaced once.
- In `_standalone_send` (cron path), returns a clear message explaining the shared/free-tier limitation and suggesting an alternate delivery channel.
- Documents the free-tier outbound limitation in the Photon user guide.

Transient errors (e.g. `reset reason: overflow`) still retry exactly as before (#50185 behavior preserved).

## Verification
- New focused tests in `tests/plugins/platforms/photon/test_shared_line_outbound.py`:
  - fatal rejection strings are classified correctly; transient strings are not.
  - send path short-circuits with exactly one attempt on shared-line rejection.
  - transient overflow still exercises the retry/backoff path (regression guard).
- Full Photon suite: `pytest tests/plugins/platforms/photon/` → 118 passed.
- Quality gates: secrets clean, personal refs clean, conventional commit, diff scoped to 3 files.