### PR TITLE
Fix MCP task cancellation after event loop shutdown

### DIFF
--- a/tests/tools/test_mcp_cancelled_error_propagation.py
+++ b/tests/tools/test_mcp_cancelled_error_propagation.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 import asyncio
 from unittest.mock import patch
 
+import pytest
+
 
 
 async def _hanging_run(self, cfg):
@@ -28,6 +30,47 @@ async def _hanging_run(self, cfg):
 
 
 class TestCancelledErrorPropagation:
+    def test_cancel_task_if_loop_open_skips_closed_owning_loop(self):
+        """Closed-loop cleanup must not call ``Task.cancel()``.
+
+        ``Task.cancel()`` schedules cancellation with ``loop.call_soon()``; if
+        coroutine finalization runs after the MCP loop is closed, that raises
+        ``RuntimeError("Event loop is closed")``. The helper should detect the
+        closed owning loop and return False without raising.
+        """
+        from tools.mcp_tool import MCPServerTask
+
+        loop = asyncio.new_event_loop()
+        task = loop.create_task(asyncio.sleep(3600))
+        task._log_destroy_pending = False
+
+        try:
+            loop.close()
+
+            assert task.done() is False
+            assert task.get_loop().is_closed() is True
+            assert MCPServerTask._cancel_task_if_loop_open(task) is False
+        finally:
+            task.get_coro().close()
+
+    def test_cancel_task_if_loop_open_preserves_live_loop_cancellation(self):
+        """Open-loop tasks should still receive ordinary cancellation."""
+        from tools.mcp_tool import MCPServerTask
+
+        loop = asyncio.new_event_loop()
+        task = loop.create_task(asyncio.sleep(3600))
+        task._log_destroy_pending = False
+
+        try:
+            assert MCPServerTask._cancel_task_if_loop_open(task) is True
+            with pytest.raises(asyncio.CancelledError):
+                loop.run_until_complete(task)
+            assert task.cancelled() is True
+        finally:
+            if not task.done():
+                task.get_coro().close()
+            loop.close()
+
     def test_cancelled_error_is_not_swallowed_by_except_exception(self):
         """CancelledError raised inside the transport call must re-raise
         so the reconnect loop terminates cleanly on cancel — not stay wedged."""

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1659,6 +1659,31 @@ class MCPServerTask:
         self._recycled_reason = reason
         self.session = None
 
+    @staticmethod
+    def _cancel_task_if_loop_open(task: asyncio.Task) -> bool:
+        """Cancel a task unless its owning loop is already closed.
+
+        Coroutine finalization can run after the MCP loop has been closed.
+        Calling Task.cancel() in that state schedules onto the dead loop and
+        raises RuntimeError("Event loop is closed"), which is only shutdown
+        noise for these lifecycle waiters.
+        """
+        if task.done():
+            return False
+        try:
+            loop = task.get_loop()
+        except RuntimeError:
+            return False
+        if loop.is_closed():
+            return False
+        try:
+            task.cancel()
+            return True
+        except RuntimeError as exc:
+            if "Event loop is closed" in str(exc):
+                return False
+            raise
+
     # ----- Dynamic tool discovery (notifications/tools/list_changed) -----
 
     async def _refresh_tools_task(self):
@@ -1949,8 +1974,7 @@ class MCPServerTask:
                         break
         finally:
             for t in (shutdown_task, reconnect_task):
-                if not t.done():
-                    t.cancel()
+                if self._cancel_task_if_loop_open(t):
                     try:
                         await t
                     except (asyncio.CancelledError, Exception):
@@ -1993,8 +2017,7 @@ class MCPServerTask:
             )
         finally:
             for t in (shutdown_task, reconnect_task):
-                if not t.done():
-                    t.cancel()
+                if self._cancel_task_if_loop_open(t):
                     try:
                         await t
                     except (asyncio.CancelledError, Exception):
@@ -2889,8 +2912,8 @@ class MCPServerTask:
             # owner to reap it (#59349). Propagate the cancellation so the
             # transport context managers unwind and their finally blocks
             # release the child process / FDs.
-            if self._task and not self._task.done():
-                self._task.cancel()
+            if self._task:
+                self._cancel_task_if_loop_open(self._task)
             raise
         if self._error:
             raise self._error
@@ -2912,14 +2935,14 @@ class MCPServerTask:
                     "MCP server '%s' shutdown timed out, cancelling task",
                     self.name,
                 )
-                self._task.cancel()
-                try:
-                    await self._task
-                except asyncio.CancelledError:
-                    pass
+                if self._cancel_task_if_loop_open(self._task):
+                    try:
+                        await self._task
+                    except asyncio.CancelledError:
+                        pass
         if self._pending_refresh_tasks:
             for task in list(self._pending_refresh_tasks):
-                task.cancel()
+                self._cancel_task_if_loop_open(task)
             await asyncio.gather(*self._pending_refresh_tasks, return_exceptions=True)
             self._pending_refresh_tasks.clear()
         self._deregister_tools()
@@ -2952,8 +2975,7 @@ class MCPServerTask:
             )
         finally:
             for task in (shutdown_task, reconnect_task):
-                if not task.done():
-                    task.cancel()
+                if self._cancel_task_if_loop_open(task):
                     try:
                         await task
                     except (asyncio.CancelledError, Exception):


### PR DESCRIPTION
## Summary

This fixes a shutdown/finalization race in `MCPServerTask` where lifecycle waiter tasks can be cancelled after the MCP event loop has already closed.

`asyncio.Task.cancel()` schedules cancellation on the task's owning loop. If coroutine finalization runs after the loop is closed, raw `task.cancel()` can raise `RuntimeError("Event loop is closed")`, producing noisy `Exception ignored in: <coroutine object MCPServerTask.run ...>` traces during shutdown.

Fixes #60197.

Related: #60032, #60104.

## Changes

- Add `MCPServerTask._cancel_task_if_loop_open()`.
- Use it in lifecycle waiter cleanup paths.
- Use it for timeout/pending-refresh task cancellation during MCP shutdown.
- Preserve normal cancellation behavior when the task loop is still open.

## Verification

- `python3 -m py_compile tools/mcp_tool.py`
- Focused closed-loop check confirms `_cancel_task_if_loop_open()` returns `False` instead of raising when a task's owning loop is already closed.
