### PR TITLE
fix(send_message): fall back to Telegram env token

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -878,6 +878,39 @@ class TestSendToPlatformChunking:
         assert bot.send_message.await_count >= 2
         assert max(send_lengths) <= 4096
 
+    def test_telegram_send_uses_env_token_when_config_token_is_empty(self, monkeypatch):
+        bot = MagicMock()
+        bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=1))
+        bot.send_photo = AsyncMock()
+        bot.send_video = AsyncMock()
+        bot.send_voice = AsyncMock()
+        bot.send_audio = AsyncMock()
+        bot.send_document = AsyncMock()
+        tokens = []
+        parse_mode = SimpleNamespace(MARKDOWN_V2="MarkdownV2", HTML="HTML")
+        constants_mod = SimpleNamespace(ParseMode=parse_mode)
+        telegram_mod = SimpleNamespace(
+            Bot=lambda token, **_kwargs: tokens.append(token) or bot,
+            MessageEntity=lambda **_kw: SimpleNamespace(**_kw),
+            constants=constants_mod,
+        )
+        monkeypatch.setitem(sys.modules, "telegram", telegram_mod)
+        monkeypatch.setitem(sys.modules, "telegram.constants", constants_mod)
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "env-token")
+
+        result = asyncio.run(
+            _send_to_platform(
+                Platform.TELEGRAM,
+                SimpleNamespace(enabled=True, token="", extra={}),
+                "123",
+                "hello",
+            )
+        )
+
+        assert result["success"] is True
+        assert tokens == ["env-token"]
+        bot.send_message.assert_awaited_once()
+
     def test_telegram_media_attaches_after_long_text_chunks(self, tmp_path, monkeypatch):
         """Long text is split into multiple chunks, then media is attached."""
         image_path = tmp_path / "photo.png"

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -848,8 +848,10 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     # after all text chunks.
     if platform == Platform.TELEGRAM:
         disable_link_previews = bool(getattr(pconfig, "extra", {}) and pconfig.extra.get("disable_link_previews"))
+        token = getattr(pconfig, "token", None) or os.getenv("TELEGRAM_BOT_TOKEN", "")
+
         return await _send_telegram(
-            pconfig.token,
+            token,
             chat_id,
             message,
             media_files=media_files,


### PR DESCRIPTION
## Summary
- use TELEGRAM_BOT_TOKEN as a fallback when send_message has an empty Telegram platform token
- add regression coverage for env-only Telegram send_message delivery

Closes #61467

## Tests
- uv run --extra dev --extra messaging pytest tests/tools/test_send_message_tool.py
- uv run --extra dev ruff check tools/send_message_tool.py tests/tools/test_send_message_tool.py