### PR TITLE
fix(auth): tolerate unsupported auth directory fsync

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -27,6 +27,7 @@ import ssl
 import stat
 import sys
 import base64
+import errno
 import hashlib
 import subprocess
 import threading
@@ -1158,6 +1159,16 @@ def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = N
         if dir_fd is not None:
             try:
                 os.fsync(dir_fd)
+            except OSError as exc:
+                # Some mounted filesystems reject directory fsync even though
+                # the auth file has already been fsynced and replaced.
+                if exc.errno not in (errno.EBADF, errno.EINVAL):
+                    raise
+                logger.debug(
+                    "auth store directory fsync unsupported for %s: %s",
+                    auth_file.parent,
+                    exc,
+                )
             finally:
                 os.close(dir_fd)
     finally:

--- a/tests/hermes_cli/test_auth_toctou_file_modes.py
+++ b/tests/hermes_cli/test_auth_toctou_file_modes.py
@@ -18,6 +18,7 @@ enforcement does not exist on Windows.
 
 from __future__ import annotations
 
+import errno
 import json
 import os
 import stat
@@ -67,6 +68,59 @@ def test_save_auth_store_writes_0o600_with_0o700_parent(tmp_path, monkeypatch):
     # Content survived the rewrite
     data = json.loads(auth_path.read_text())
     assert data["providers"]["openai-codex"]["tokens"]["access_token"] == "secret-x"
+
+
+@pytest.mark.parametrize("fsync_errno", [errno.EBADF, errno.EINVAL])
+def test_save_auth_store_tolerates_unsupported_directory_fsync(
+    tmp_path, monkeypatch, fsync_errno
+):
+    """Unsupported directory fsync errors must not fail auth persistence."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from hermes_cli import auth as auth_mod
+
+    real_fsync = os.fsync
+
+    def virtiofs_like_fsync(fd: int) -> None:
+        if stat.S_ISDIR(os.fstat(fd).st_mode):
+            raise OSError(fsync_errno, os.strerror(fsync_errno))
+        real_fsync(fd)
+
+    monkeypatch.setattr(auth_mod.os, "fsync", virtiofs_like_fsync)
+
+    auth_path = auth_mod._save_auth_store(
+        {
+            "version": auth_mod.AUTH_STORE_VERSION,
+            "providers": {"openai-codex": {"tokens": {"access_token": "secret-x"}}},
+        }
+    )
+
+    assert auth_path.exists()
+    data = json.loads(auth_path.read_text())
+    assert data["providers"]["openai-codex"]["tokens"]["access_token"] == "secret-x"
+
+
+def test_save_auth_store_reraises_unexpected_directory_fsync_error(tmp_path, monkeypatch):
+    """Only known unsupported-directory-fsync errors are downgraded."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from hermes_cli import auth as auth_mod
+
+    real_fsync = os.fsync
+
+    def failing_dir_fsync(fd: int) -> None:
+        if stat.S_ISDIR(os.fstat(fd).st_mode):
+            raise OSError(errno.EIO, "Input/output error")
+        real_fsync(fd)
+
+    monkeypatch.setattr(auth_mod.os, "fsync", failing_dir_fsync)
+
+    with pytest.raises(OSError) as excinfo:
+        auth_mod._save_auth_store(
+            {"version": auth_mod.AUTH_STORE_VERSION, "providers": {}}
+        )
+
+    assert excinfo.value.errno == errno.EIO
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes auth credential persistence on mounted filesystems that reject directory `fsync()` with `EBADF` or `EINVAL`.

Hermes already writes the auth store through a temp file, flushes and fsyncs the file, then atomically replaces `auth.json`. The final parent-directory fsync is a durability best-effort step; on filesystems such as virtiofs it can fail even after the credential file was written successfully. This PR downgrades only those unsupported directory-fsync errors while continuing to raise unexpected I/O failures.

## Related Issue

No issue exists. I can create it if needed. This is an issue I experienced and fixed immediately.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/auth.py`: treat `EBADF` and `EINVAL` from parent-directory `os.fsync(dir_fd)` as non-fatal after the auth file has already been fsynced and atomically replaced.
- `tests/hermes_cli/test_auth_toctou_file_modes.py`: add regression coverage for unsupported directory fsync errors, and verify unexpected errors like `EIO` still raise.

## How to Test

1. Run `./scripts/run_tests.sh tests/hermes_cli/test_auth_toctou_file_modes.py`.
2. Verify the unsupported directory fsync regression cases pass for `EBADF` and `EINVAL`.
3. Verify the unexpected `EIO` case still raises.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass - 
    - `pytest tests/hermes_cli/test_auth_toctou_file_modes.py -q` passed: 7 passed.
    - Full default suite attempted in a fresh Docker container with the canonical runner: `scripts/run_tests.sh -j 4`.
        - Result: 45,757 passed, 61 failed across 21 unrelated files.
        - The auth persistence tests passed in the full run.
        - The remaining failures appear environment/cache related in the Docker test environment, including root permission behavior, missing `systemctl`/Chromium, service/voice detection, mtime cache invalidation, and stale intra-file temp-dir state.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS local checkout, targeted test file

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Cross-platform impact considered: Windows is unaffected because directory-open failures were already skipped; POSIX mounted filesystems that reject directory fsync with EBADF/EINVAL now keep auth persistence working while unexpected I/O errors still raise.
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Targeted validation:

`./scripts/run_tests.sh tests/hermes_cli/test_auth_toctou_file_modes.py`

Result: `7 tests passed, 0 failed`.