### PR TITLE
fix(ntfy): replay cached messages on reconnect

### DIFF
--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -180,6 +180,7 @@ class NtfyAdapter(BasePlatformAdapter):
 
         # Message deduplication: msg_id -> timestamp
         self._seen_messages: Dict[str, float] = {}
+        self._last_seen_id: Optional[str] = None
 
     # -- Connection lifecycle -----------------------------------------------
 
@@ -239,6 +240,8 @@ class NtfyAdapter(BasePlatformAdapter):
         """Open an HTTP streaming connection and dispatch events."""
         # poll=false keeps a persistent streaming connection alive with keepalive events
         params = {"poll": "false"}
+        if self._last_seen_id:
+            params["since"] = self._last_seen_id
         async with self._http_client.stream(
             "GET",
             url,
@@ -311,6 +314,8 @@ class NtfyAdapter(BasePlatformAdapter):
         if self._is_duplicate(msg_id):
             logger.debug("[%s] Duplicate message %s, skipping", self.name, msg_id)
             return
+        if event.get("id"):
+            self._last_seen_id = event["id"]
 
         # Echo-loop prevention: skip messages tagged by this adapter.
         tags = event.get("tags") or []

--- a/tests/gateway/test_ntfy_plugin.py
+++ b/tests/gateway/test_ntfy_plugin.py
@@ -158,6 +158,7 @@ class TestNtfyAdapterInit:
         assert adapter._stream_task is None
         assert adapter._http_client is None
         assert adapter._seen_messages == {}
+        assert adapter._last_seen_id is None
 
 
 # ---------------------------------------------------------------------------
@@ -1000,6 +1001,52 @@ class TestFatalErrorPropagation:
         assert adapter._fatal_error_code == "ntfy_topic_not_found"
         assert "missing-topic" in adapter._fatal_error_message
         assert adapter._fatal_error_retryable is False
+
+
+class TestStreamReplayCursor:
+    """The ntfy stream must request cached messages after reconnecting."""
+
+    def test_consume_stream_passes_since_after_message_seen(self):
+        adapter = NtfyAdapter(PlatformConfig(enabled=True, extra={"topic": "t"}))
+        adapter._last_seen_id = "ntfy-msg-1"
+        adapter._running = True
+        adapter._http_client = MagicMock()
+
+        class _Response:
+            status_code = 200
+
+            def raise_for_status(self):
+                return None
+
+            async def aiter_lines(self):
+                if False:
+                    yield ""
+
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=_Response())
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+        adapter._http_client.stream = MagicMock(return_value=mock_cm)
+
+        fake_httpx = MagicMock()
+        fake_httpx.Timeout = MagicMock()
+        with patch.object(_ntfy, "httpx", fake_httpx):
+            _run(adapter._consume_stream("https://ntfy.example/t/json", {}))
+
+        params = adapter._http_client.stream.call_args.kwargs["params"]
+        assert params == {"poll": "false", "since": "ntfy-msg-1"}
+
+    def test_on_message_records_last_seen_id_after_dedup_accepts(self):
+        adapter = NtfyAdapter(PlatformConfig(enabled=True, extra={"topic": "t"}))
+        adapter.handle_message = AsyncMock()
+
+        _run(adapter._on_message({
+            "event": "message",
+            "id": "ntfy-msg-2",
+            "topic": "t",
+            "message": "hello",
+        }))
+
+        assert adapter._last_seen_id == "ntfy-msg-2"
 
 
 class TestTruncateHelper:


### PR DESCRIPTION
## What does this PR do?

Fixes #61436.

The ntfy adapter now tracks the last accepted ntfy message id and includes it as `since=<id>` when opening the next `/json?poll=false` stream. This lets ntfy replay cached messages published during a reconnect gap instead of silently dropping them.

The cursor is updated only after the adapter accepts a non-duplicate message id, so the existing dedup window still handles overlap from messages received immediately before disconnect.

## Changes Made

- `plugins/platforms/ntfy/adapter.py`
  - Add `_last_seen_id` state.
  - Pass `since` on stream reconnect when a cursor exists.
  - Update the cursor after dedup accepts a message id.
- `tests/gateway/test_ntfy_plugin.py`
  - Cover initial cursor state.
  - Cover `since` request params.
  - Cover cursor advancement after message acceptance.

## Verification

- Red test confirmed before implementation:
  - `uv run --extra dev pytest tests/gateway/test_ntfy_plugin.py -q -k 'initial_state or StreamReplayCursor'` failed with missing `_last_seen_id` and missing `since` param.
- After fix:
  - `uv run --extra dev pytest tests/gateway/test_ntfy_plugin.py -q` → 84 passed.
  - `uv run --extra dev ruff check plugins/platforms/ntfy/adapter.py tests/gateway/test_ntfy_plugin.py` → passed.
  - `git diff --check` → passed.
