### PR TITLE
fix(tools): unpack all 4 judge_goal() return values in kanban complete gate

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -620,8 +620,11 @@ def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
 
     # Mock the judge to reject the completion. The gate only runs when a
     # judge is reachable, so force the availability probe True as well.
+    # Matches the real judge_goal signature (verdict, reason, parse_failed,
+    # wait_directive) — a 3-tuple stub here would mask a call-site unpack
+    # bug (see test_complete_goal_mode_call_site_matches_judge_goal_arity below).
     def mock_judge_goal(goal, last_response, *, timeout=30.0, subgoals=None):
-        return "continue", "missing verification evidence", False
+        return "continue", "missing verification evidence", False, None
 
     monkeypatch.setattr("tools.kanban_tools.judge_goal", mock_judge_goal)
     monkeypatch.setattr("tools.kanban_tools._goal_judge_available", lambda: True)
@@ -641,6 +644,56 @@ def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
         assert task.status == "running"  # Should still be running, not done
     finally:
         conn2.close()
+
+
+def test_complete_goal_mode_call_site_matches_judge_goal_arity(monkeypatch, tmp_path, caplog):
+    """Regression for #61490: the L605 call site must unpack exactly as many
+    values as the real (unmocked) judge_goal returns. A stale 3-value unpack
+    against the 4-value real signature raises ValueError, which the local
+    except silently swallows as a fail-open — masking a real "continue"
+    verdict as "done" and letting incomplete work through.
+
+    Uses the real judge_goal (not a stub) via the guaranteed-deterministic
+    empty-response early return, so this can't be fooled by a mock that
+    happens to match the buggy arity."""
+    from pathlib import Path as _Path
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "test-worker")
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        goal_task_id = kb.create_task(
+            conn, title="goal-mode-arity-test", assignee="test-worker",
+            body="Must achieve X with verified evidence.", goal_mode=True
+        )
+        kb.claim_task(conn, goal_task_id)
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", goal_task_id)
+
+    # judge_goal is intentionally left unmocked. A whitespace-only summary
+    # passes the "provide at least one of summary/result" precheck (it's
+    # truthy) but strips down to last_response="", which judge_goal
+    # short-circuits deterministically to ("continue", "empty response
+    # (nothing to evaluate)", False, None) with no auxiliary client call
+    # involved.
+    monkeypatch.setattr("tools.kanban_tools._goal_judge_available", lambda: True)
+
+    out = kt._handle_complete({"summary": "   "})
+    d = json.loads(out)
+
+    assert "goal judge check failed" not in caplog.text
+    assert "error" in d
+    assert "empty response (nothing to evaluate)" in d["error"]
 
 
 def test_complete_goal_mode_allows_when_judge_unavailable(monkeypatch, tmp_path):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -602,7 +602,7 @@ def _handle_complete(args: dict, **kw) -> str:
                 verdict = "done"
                 reason = ""
                 try:
-                    verdict, reason, _ = judge_goal(
+                    verdict, reason, _parse_failed, _wait = judge_goal(
                         goal=f"{task.title}\n\n{task.body or ''}".strip(),
                         last_response=(summary or result or "").strip(),
                     )


### PR DESCRIPTION
## What does this PR do?

Fixes the goal-mode completion gate in `tools/kanban_tools.py::_handle_complete` (L605), which unpacks only 3 values from `judge_goal()` while the function returns 4: `(verdict, reason, parse_failed, wait_directive)`. Every call raises `ValueError: too many values to unpack (expected 3)`, which the surrounding `except Exception` catches and logs as a warning — silently falling back to the pre-`try` default `verdict = "done"`. That means the anti-bypass judge gate (added for #38367, to stop workers from calling `kanban_complete` before their acceptance criteria are met) currently never actually evaluates anything; it always lets completion through.

Other call sites in `hermes_cli/goals.py` (L1444, L1698) already unpack all 4 values correctly — this one call site was missed.

## Related Issue

Fixes #61490

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/kanban_tools.py`: unpack `judge_goal()`'s 4 return values (`verdict, reason, _parse_failed, _wait`) instead of 3, matching the real signature and the other call sites in `goals.py`.
- `tests/tools/test_kanban_tools.py`:
  - Fixed `test_complete_goal_mode_rejected_by_judge`'s `mock_judge_goal` stub to return a 4-tuple — the previous 3-tuple stub matched the buggy call-site arity and masked the bug instead of catching it.
  - Added `test_complete_goal_mode_call_site_matches_judge_goal_arity`, which calls the *real* (unmocked) `judge_goal` via its deterministic empty-response early-return path, so the regression can't be hidden again by a mock that happens to match a future arity drift.

## How to Test

1. `hermes kanban create "test" --assignee <worker> --goal` — pre-fix, any goal-mode `kanban_complete` call unconditionally succeeds regardless of whether the work is actually done (the judge gate is a no-op due to the crash).
2. `pytest tests/tools/test_kanban_tools.py -k goal_mode -v` — all 8 tests pass with the fix; reverting just the `tools/kanban_tools.py` change reproduces the original `ValueError: too many values to unpack (expected 3)` and fails both judge-gate tests.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/tools/test_kanban_tools.py -q` and `pytest tests/hermes_cli/test_goals.py -q` — all relevant tests pass (unrelated pre-existing failures in both files come from missing `python-dotenv` in this sandbox's venv and a live-system-guard `os.kill` check, both present on a clean `origin/main` checkout with none of this PR's changes applied — confirmed via `git stash`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin), Python 3.11.3

### Documentation & Housekeeping

- [x] N/A — no docs, config keys, or tool schemas changed

## AI Disclosure

This bug was identified and fixed with AI assistance.