### PR TITLE
fix(kanban): judge_goal 4-value unpack — fix orchestrator crash (#61490)

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -620,8 +620,9 @@ def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
 
     # Mock the judge to reject the completion. The gate only runs when a
     # judge is reachable, so force the availability probe True as well.
-    def mock_judge_goal(goal, last_response, *, timeout=30.0, subgoals=None):
-        return "continue", "missing verification evidence", False
+    def mock_judge_goal(goal, last_response, *, timeout=30.0, subgoals=None,
+                         background_processes=None, contract=None):
+        return "continue", "missing verification evidence", False, None
 
     monkeypatch.setattr("tools.kanban_tools.judge_goal", mock_judge_goal)
     monkeypatch.setattr("tools.kanban_tools._goal_judge_available", lambda: True)

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -602,7 +602,7 @@ def _handle_complete(args: dict, **kw) -> str:
                 verdict = "done"
                 reason = ""
                 try:
-                    verdict, reason, _ = judge_goal(
+                    verdict, reason, _, _ = judge_goal(
                         goal=f"{task.title}\n\n{task.body or ''}".strip(),
                         last_response=(summary or result or "").strip(),
                     )


### PR DESCRIPTION
## Summary

`judge_goal()` returns `(verdict, reason, parse_failed, wait_directive)` — a 4-tuple — since the contract/subgoal/background_process extensions landed. `kanban_tools.py:605` (goal-mode completion gate) used a 3-value unpack (`verdict, reason, _ = judge_goal(...)`) and crashed the orchestrator with `ValueError: too many values to unpack (expected 3)`.

Fixed to 4-value unpack (`_, _` for unused). Also updated the existing mock in `test_kanban_tools.py` to return 4 values matching the real signature.

## Changes

- `tools/kanban_tools.py:605`: `verdict, reason, _, _ = judge_goal(...)` (was `verdict, reason, _`)
- `tests/tools/test_kanban_tools.py`: `mock_judge_goal` updated — 4-value return with `background_processes`/`contract` kwargs

## How to Test

```bash
pytest tests/tools/test_kanban_tools.py -x -q
# ✅ 97/97 passed
```

## Checklist

- [x] Tests pass — 97/97
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cross-platform impact: None (no platform primitives)
- [x] profile-safe paths: not applicable
- [x] .env not used

## Risk & Impact

**Low.** Single-line unpack fix — judge_goal's actual return type was already documented as 4-tuple. No behavioral change beyond unpacking the extra value that was already being returned. Mock updated to match real signature.

**Type:** Bug fix
**Closes:** #61490