### PR TITLE
fix(kanban): unpack 4-tuple from judge_goal in completion gate

### DIFF
--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -296,3 +296,55 @@ def test_loop_stops_if_task_reclaimed(monkeypatch):
         first_response="x",
     )
     assert res["outcome"] == "stopped"
+
+
+# ---------------------------------------------------------------------------
+# kanban_complete pre-completion judge gate (Issue #61490)
+# ---------------------------------------------------------------------------
+def test_complete_goal_gate_unpacks_four_tuple(monkeypatch, kanban_home):
+    """kanban_complete's judge gate must unpack judge_goal's 4-tuple.
+
+    Regression test for #61490: the gate used ``verdict, reason, _ = judge_goal(...)``
+    (3-value unpack) while judge_goal returns
+    ``(verdict, reason, parse_failed, wait_directive)`` (4 values), raising
+    ``ValueError: too many values to unpack (expected 3)`` in --goal mode.
+    The orchestrator crashed on this and auto-blocked the task after 2 fails.
+    """
+    import tools.kanban_tools as kt
+
+    # Make the judge reachable so the gate is enforced.
+    monkeypatch.setattr(kt, "_goal_judge_available", lambda: True)
+
+    # Return the real 4-tuple contract judge_goal uses.
+    def _fake_judge(goal, last_response, **_kw):
+        return "done", "acceptance met", False, None
+
+    monkeypatch.setattr(kt, "judge_goal", _fake_judge)
+
+    # Goal-mode task + worker context so _enforce_worker_task_ownership passes.
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="goal task",
+            assignee="worker",
+            goal_mode=True,
+        )
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+
+    # Must NOT raise ValueError; a "done" verdict lets completion proceed.
+    out = kt._handle_complete(
+        {"task_id": tid, "summary": "all acceptance criteria met"}
+    )
+    assert "rejected by judge" not in out
+    # The task should actually complete (no tool_error string returned).
+    assert out is None or "Goal completion" not in out
+
+    # And a non-"done" verdict must still reject completion via the gate.
+    def _fake_judge_reject(goal, last_response, **_kw):
+        return "continue", "not done yet", False, None
+
+    monkeypatch.setattr(kt, "judge_goal", _fake_judge_reject)
+    out2 = kt._handle_complete(
+        {"task_id": tid, "summary": "still working"}
+    )
+    assert "rejected by judge" in out2

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -602,7 +602,7 @@ def _handle_complete(args: dict, **kw) -> str:
                 verdict = "done"
                 reason = ""
                 try:
-                    verdict, reason, _ = judge_goal(
+                    verdict, reason, _parse_failed, _wait = judge_goal(
                         goal=f"{task.title}\n\n{task.body or ''}".strip(),
                         last_response=(summary or result or "").strip(),
                     )


### PR DESCRIPTION
## Summary

Fixes a crash in Kanban `--goal` mode: `kanban_tools.py`'nin pre-completion goal judge gate'i `judge_goal(...)`'ı 3 değerle unpack ediyordu (`verdict, reason, _ = judge_goal(...)`), ancak `judge_goal` (`hermes_cli/goals.py`) 4'lü bir tuple döndürüyor. `--goal` modunda bu `ValueError: too many values to unpack (expected 3)` hatasına yol açıyor, orchestrator sonraki goal-loop turlarında çöküyor ve görev 2 ardışık crash sonrası otomatik olarak bloklanıyordu.

---

## Root Cause

Gate'in unpack arity'si, `wait_directive` (4. dönüş değeri) eklendiğinde `judge_goal`'ün imzasıyla senkronize kalmadı. Diğer üç çağrı noktası (`goals.py` L1444, L1698) zaten dört değeri de unpack ediyordu; sadece kanban completion gate atlanmıştı.

---

## Fix

Diğer çağrı noktalarıyla tutarlı olacak şekilde dört değer de unpack edildi: `verdict, reason, _parse_failed, _wait = judge_goal(...)`. Fazladan gelen iki değer bilinçli olarak kullanılmıyor — gate yalnızca `verdict` üzerinden karar veriyor. Exception fırlatıldığında mevcut fail-open davranışı korunuyor. Crash yapmayan yollarda herhangi bir davranış değişikliği yok.

---

## Changes

**`tools/kanban_tools.py`** (L605)
- `verdict, reason, _ = judge_goal(...)` → `verdict, reason, _parse_failed, _wait = judge_goal(...)`

**`tests/hermes_cli/test_kanban_goal_mode.py`**
- Added `test_complete_goal_gate_unpacks_four_tuple` regression test

---

## How to Test

1. `hermes kanban create "test" --assignee orchestrator --goal --goal-max-turns 40`
2. `hermes kanban dispatch` → orchestrator spawns, runs goal loop
3. **Before fix:** `ValueError: too many values to unpack (expected 3)` on the judge gate → orchestrator crashes → auto-block after 2 failures.
4. **After fix:** goal loop runs without the unpack crash.

**Regression test (verified):** `test_complete_goal_gate_unpacks_four_tuple` monkeypatches `judge_goal` to return the real 4-tuple and asserts both the `done` (completion proceeds) and `continue` (rejected by judge) paths work. Confirmed to fail against the old 3-tuple code and pass with the fix.

PYTHONPATH=. python3 -m pytest tests/hermes_cli/test_kanban_goal_mode.py -o "addopts=" -v
# 13 passed

---

## Checklist

- [x] Follows Contributing Guide and Conventional Commits
- [x] No duplicate PRs — searched, none reference #61490
- [x] Changes scoped to this fix only
- [x] Tests run — test_kanban_goal_mode.py, 13 passed
- [x] Regression test added
- [x] Tested on: Linux (WSL2) / Python 3.12

---

## Risk & Impact

**Low.** Single-line unpack fix, matching the pattern already used at the other three call sites in `goals.py`. Fail-open exception behavior is unchanged; no behavior change on non-crashing paths.

**Type:** 🐛 Bug fix
**Fixes:** #61490