### PR TITLE
Handle KeyboardInterrupt in single-query chat

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -16264,8 +16264,14 @@ def main(
                 # Surface security advisories before the agent runs — short
                 # banner, doesn't depend on the welcome banner being shown.
                 cli._show_security_advisories()
-                cli.chat(query, images=single_query_images or None)
-                cli._print_exit_summary(clear_screen=False)
+                try:
+                    cli.chat(query, images=single_query_images or None)
+                except KeyboardInterrupt:
+                    _emit_interrupted_session_end(cli, reason="keyboard_interrupt")
+                    cli._print_exit_summary(clear_screen=False)
+                    sys.exit(130)
+                else:
+                    cli._print_exit_summary(clear_screen=False)
         finally:
             _finalize_single_query(cli)
         return

--- a/tests/cli/test_single_query_session_finalize.py
+++ b/tests/cli/test_single_query_session_finalize.py
@@ -200,6 +200,68 @@ def test_human_single_query_main_finalizes_after_query(monkeypatch):
     ]
 
 
+def test_human_single_query_main_handles_keyboard_interrupt(monkeypatch):
+    calls = []
+
+    import cli as cli_mod
+
+    class _Console:
+        def print(self, *_args, **_kwargs):
+            calls.append("query-label")
+
+    class FakeCLI:
+        def __init__(self, **_kwargs):
+            self.console = _Console()
+            self.session_id = "interrupted-session"
+            self.agent = SimpleNamespace(
+                session_id="interrupted-session",
+                platform="cli",
+            )
+
+        def _claim_active_session(self, surface, *, stderr=False):
+            calls.append(("claim", surface, stderr))
+            return True
+
+        def _show_security_advisories(self):
+            calls.append("advisories")
+
+        def chat(self, query, images=None):
+            calls.append(("chat", query, images))
+            raise KeyboardInterrupt
+
+        def _print_exit_summary(self, clear_screen=True):
+            calls.append(("summary", clear_screen))
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        cli_mod,
+        "_emit_interrupted_session_end",
+        lambda fake_cli, *, reason: calls.append(
+            ("interrupted", fake_cli.session_id, reason)
+        ),
+    )
+    monkeypatch.setattr(
+        cli_mod,
+        "_finalize_single_query",
+        lambda fake_cli: calls.append(("finalize", fake_cli.session_id)),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_mod.main(query="hello", quiet=False, toolsets="terminal")
+
+    assert exc_info.value.code == 130
+    assert calls == [
+        ("claim", "cli", False),
+        "query-label",
+        "advisories",
+        ("chat", "hello", None),
+        ("interrupted", "interrupted-session", "keyboard_interrupt"),
+        ("summary", False),
+        ("finalize", "interrupted-session"),
+    ]
+
+
 def test_quiet_single_query_main_finalizes_while_preserving_exit_code(monkeypatch):
     calls = []
 


### PR DESCRIPTION
## Summary

Handle `KeyboardInterrupt` in the human-facing single-query `hermes chat -q` path.

The single-query signal handler intentionally raises `KeyboardInterrupt`, but the non-quiet `-q` wrapper called `cli.chat(...)` without catching it. If the signal lands while the main thread is blocked in `queue.Queue.get()`, Python prints a raw traceback instead of exiting cleanly.

Fixes #61508.

## Changes

- Catch `KeyboardInterrupt` around the non-quiet single-query `cli.chat(...)` call.
- Emit the interrupted session-end hook, matching quiet mode behavior.
- Print the normal single-query exit summary without clearing the screen.
- Exit with status 130 while preserving the existing `_finalize_single_query(cli)` cleanup path.

## Verification

- `python3 -m py_compile cli.py`
