### PR TITLE
fix(kanban): unpack goal judge wait result

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -621,7 +621,7 @@ def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
     # Mock the judge to reject the completion. The gate only runs when a
     # judge is reachable, so force the availability probe True as well.
     def mock_judge_goal(goal, last_response, *, timeout=30.0, subgoals=None):
-        return "continue", "missing verification evidence", False
+        return "continue", "missing verification evidence", False, None
 
     monkeypatch.setattr("tools.kanban_tools.judge_goal", mock_judge_goal)
     monkeypatch.setattr("tools.kanban_tools._goal_judge_available", lambda: True)

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -602,7 +602,7 @@ def _handle_complete(args: dict, **kw) -> str:
                 verdict = "done"
                 reason = ""
                 try:
-                    verdict, reason, _ = judge_goal(
+                    verdict, reason, _parse_failed, _wait = judge_goal(
                         goal=f"{task.title}\n\n{task.body or ''}".strip(),
                         last_response=(summary or result or "").strip(),
                     )


### PR DESCRIPTION
## Summary
- update the kanban_complete goal-mode judge gate to unpack the current 4-value `judge_goal()` return shape
- update the regression test mock to return `(verdict, reason, parse_failed, wait_directive)` so the gate no longer fails open on a shape mismatch

## Root Cause
`judge_goal()` now returns four values, but `tools/kanban_tools.py` still unpacked only three inside the Kanban goal completion gate. That raised `ValueError`, was caught by the defensive fail-open path, and allowed goal-mode completion behavior to drift from the judge verdict.

## Validation
- `uv run --extra dev pytest tests/tools/test_kanban_tools.py -q -o addopts=`
- `uv run --extra dev ruff check tools/kanban_tools.py tests/tools/test_kanban_tools.py`

Fixes #61490
