### PR TITLE
fix(hindsight): queue async retain tool calls

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1717,10 +1717,26 @@ class HindsightMemoryProvider(MemoryProvider):
                 item.pop("retain_async", None)
                 logger.debug("Tool hindsight_retain: bank=%s, content_len=%d, context=%s",
                              self._bank_id, len(content), context)
-                self._run_hindsight_operation(
-                    lambda client: client.aretain_batch(bank_id=self._bank_id, items=[item])
-                )
-                logger.debug("Tool hindsight_retain: success")
+                bank_id = self._bank_id
+                retain_async_flag = self._retain_async
+
+                def _do_retain() -> None:
+                    self._run_hindsight_operation(
+                        lambda client: client.aretain_batch(
+                            bank_id=bank_id,
+                            items=[item],
+                            retain_async=retain_async_flag,
+                        )
+                    )
+
+                if retain_async_flag:
+                    self._ensure_writer()
+                    self._register_atexit()
+                    self._retain_queue.put(_do_retain)
+                    logger.debug("Tool hindsight_retain: queued async retain")
+                else:
+                    _do_retain()
+                    logger.debug("Tool hindsight_retain: success")
                 return json.dumps({"result": "Memory stored successfully."})
             except Exception as e:
                 logger.warning("hindsight_retain failed: %s", e, exc_info=True)

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -637,8 +637,18 @@ class TestPostSetup:
 # ---------------------------------------------------------------------------
 
 
+def _drain_one_retain_job(provider):
+    """Run one queued retain job synchronously for payload assertions."""
+    job = provider._retain_queue.get_nowait()
+    try:
+        job()
+    finally:
+        provider._retain_queue.task_done()
+
+
 class TestToolHandlers:
-    def test_retain_success(self, provider):
+    def test_retain_success(self, provider_with_config):
+        provider = provider_with_config(retain_async=False)
         result = json.loads(provider.handle_tool_call(
             "hindsight_retain", {"content": "user likes dark mode"}
         ))
@@ -646,20 +656,44 @@ class TestToolHandlers:
         provider._client.aretain_batch.assert_called_once()
         call_kwargs = provider._client.aretain_batch.call_args.kwargs
         assert call_kwargs["bank_id"] == "test-bank"
+        assert call_kwargs["retain_async"] is False
         item = call_kwargs["items"][0]
         assert item["content"] == "user likes dark mode"
         # bank_id/retain_async are call-level args, never item keys.
         assert "bank_id" not in item
         assert "retain_async" not in item
 
+    def test_retain_async_queues_work_without_blocking(self, provider, monkeypatch):
+        monkeypatch.setattr(provider, "_ensure_writer", lambda: None)
+        monkeypatch.setattr(provider, "_register_atexit", lambda: None)
+
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_retain", {"content": "user likes dark mode"}
+        ))
+
+        assert result["result"] == "Memory stored successfully."
+        provider._client.aretain_batch.assert_not_called()
+        assert provider._retain_queue.qsize() == 1
+
+        _drain_one_retain_job(provider)
+
+        provider._client.aretain_batch.assert_called_once()
+        call_kwargs = provider._client.aretain_batch.call_args.kwargs
+        assert call_kwargs["bank_id"] == "test-bank"
+        assert call_kwargs["retain_async"] is True
+        item = call_kwargs["items"][0]
+        assert item["content"] == "user likes dark mode"
+        assert "bank_id" not in item
+        assert "retain_async" not in item
+
     def test_retain_with_tags(self, provider_with_config):
-        p = provider_with_config(retain_tags=["pref", "ui"])
+        p = provider_with_config(retain_tags=["pref", "ui"], retain_async=False)
         p.handle_tool_call("hindsight_retain", {"content": "likes dark mode"})
         item = p._client.aretain_batch.call_args.kwargs["items"][0]
         assert item["tags"] == ["pref", "ui"]
 
     def test_retain_merges_per_call_tags_with_config_tags(self, provider_with_config):
-        p = provider_with_config(retain_tags=["pref", "ui"])
+        p = provider_with_config(retain_tags=["pref", "ui"], retain_async=False)
         p.handle_tool_call(
             "hindsight_retain",
             {"content": "likes dark mode", "tags": ["client:x", "ui"]},
@@ -667,18 +701,20 @@ class TestToolHandlers:
         item = p._client.aretain_batch.call_args.kwargs["items"][0]
         assert item["tags"] == ["pref", "ui", "client:x"]
 
-    def test_retain_without_tags(self, provider):
+    def test_retain_without_tags(self, provider_with_config):
+        provider = provider_with_config(retain_async=False)
         provider.handle_tool_call("hindsight_retain", {"content": "hello"})
         item = provider._client.aretain_batch.call_args.kwargs["items"][0]
         assert "tags" not in item
 
     def test_retain_passes_observation_scopes(self, provider_with_config):
-        p = provider_with_config(observation_scopes="per_tag")
+        p = provider_with_config(observation_scopes="per_tag", retain_async=False)
         p.handle_tool_call("hindsight_retain", {"content": "likes dark mode"})
         item = p._client.aretain_batch.call_args.kwargs["items"][0]
         assert item["observation_scopes"] == "per_tag"
 
-    def test_retain_omits_observation_scopes_by_default(self, provider):
+    def test_retain_omits_observation_scopes_by_default(self, provider_with_config):
+        provider = provider_with_config(retain_async=False)
         provider.handle_tool_call("hindsight_retain", {"content": "hello"})
         item = provider._client.aretain_batch.call_args.kwargs["items"][0]
         assert "observation_scopes" not in item
@@ -746,7 +782,8 @@ class TestToolHandlers:
         ))
         assert "error" in result
 
-    def test_retain_error_handling(self, provider):
+    def test_retain_error_handling(self, provider_with_config):
+        provider = provider_with_config(retain_async=False)
         provider._client.aretain_batch.side_effect = RuntimeError("connection failed")
         result = json.loads(provider.handle_tool_call(
             "hindsight_retain", {"content": "test"}


### PR DESCRIPTION
## Summary

Fixes #61442.

`hindsight_retain` already strips `retain_async` from the item payload because Hindsight expects it as a call-level argument, but the tool path never passed the config value to `aretain_batch`. It also always called `_run_hindsight_operation()` inline, so the default async config still blocked the agent loop on the retain request.

This change makes the tool path match the existing `sync_turn()` retain pattern:

- when `retain_async` is true, enqueue the retain on the existing Hindsight writer queue and return immediately
- pass `retain_async` as a call-level argument to `aretain_batch`
- keep `retain_async: false` as a synchronous path, preserving direct error reporting for configured synchronous retains

## Tests

```bash
uv run --extra dev python -m pytest tests/plugins/memory/test_hindsight_provider.py -q
uv run --extra dev python -m ruff check plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py
git diff --check
```
