### PR TITLE
feat(whatsapp): opt-in inline slash commands in owner-reply DMs

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1851,6 +1851,95 @@ def coerce_plaintext_gateway_command(event: "MessageEvent") -> None:
         return
 
 
+# --- Inline slash-command promotion for the WhatsApp owner-reply flow (opt-in) ---
+#
+# Hermes recognizes slash commands only at the START of a message
+# (MessageEvent.is_command == text.startswith("/")). In the WhatsApp "owner
+# reply" flow (fromOwner, 1:1) the owner often types a command in the MIDDLE of
+# a sentence addressed to a contact. When WHATSAPP_INLINE_COMMANDS is enabled we
+# find the FIRST *isolated* token that resolves to a KNOWN gateway command
+# (built-in OR plugin-registered) and rewrite event.text so it starts with that
+# command. Everything downstream (access checks, command:<name> hooks, the
+# if/elif router, get_command_args' dash-fix) is reused verbatim.
+#
+# Safety:
+#   * Opt-in. Default OFF => byte-identical behavior to stock Hermes.
+#   * WhatsApp + 1:1 + fromOwner only. Groups and other platforms untouched.
+#   * Only rewrites when the token resolves to a real command => "see
+#     /home/user/x", a URL, or "/unknownword" never trigger.
+#   * The token must be ISOLATED (start-or-whitespace before, whitespace-or-end
+#     after) so "/status" inside "http://h/status" is never matched.
+#   * Command names never contain "/" (regex charclass excludes it), matching
+#     MessageEvent.get_command's path rejection.
+
+# Keep in sync with plugins/platforms/whatsapp/adapter.py:_OWNER_REPLY_PREFIX.
+# base.py must not import from the WhatsApp plugin (layering/cycle), so we copy
+# the literal here; test_whatsapp_inline_commands asserts they stay equal.
+_OWNER_REPLY_PREFIX = "[owner reply] "
+
+# An ISOLATED slash-command token. (?:^|(?<=\s)) = at string start or right
+# after whitespace; (?=\s|$) = followed by whitespace or end. The "@bot" mention
+# suffix (dropped, as get_command does) is consumed so it stays out of the args.
+_INLINE_COMMAND_TOKEN = re.compile(r"(?:^|(?<=\s))/([A-Za-z0-9][A-Za-z0-9_-]*)(?:@\S+)?(?=\s|$)")
+
+
+def _inline_commands_enabled() -> bool:
+    return os.getenv("WHATSAPP_INLINE_COMMANDS", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def coerce_inline_owner_command(event: "MessageEvent") -> None:
+    """Promote a known inline slash command to the front of a WhatsApp owner-reply.
+
+    Opt-in via WHATSAPP_INLINE_COMMANDS. No-op unless the event is a WhatsApp
+    1:1 owner-reply TEXT message containing a *known* isolated slash command.
+    Mutates event.text in place (mirrors coerce_plaintext_gateway_command) and,
+    when it rewrites, drops the "[owner reply] " marker so get_command() sees the
+    slash at index 0 (the marker's signal lives on in metadata).
+    """
+    try:
+        if event is None or event.message_type != MessageType.TEXT:
+            return
+        if not _inline_commands_enabled():
+            return
+        source = getattr(event, "source", None)
+        platform = getattr(source, "platform", None)
+        # Platform gate: WhatsApp only (compare by value to tolerate dynamic members).
+        if getattr(platform, "value", platform) != Platform.WHATSAPP.value:
+            return
+        if getattr(source, "chat_type", None) != "dm":
+            return
+        metadata = getattr(event, "metadata", None) or {}
+        # Strict identity: only the exact boolean True (set by the adapter for a
+        # genuine fromOwner event) qualifies. A truthy non-bool (e.g. the string
+        # "false") must NOT slip a non-owner through this privilege gate.
+        if metadata.get("whatsapp_from_owner") is not True:
+            return
+        # Lazy import (base.py already imports hermes_cli.commands lazily elsewhere;
+        # avoids import cycles and forcing plugin discovery at module import).
+        try:
+            from hermes_cli.commands import is_gateway_known_command
+        except Exception:
+            return  # registry unavailable -> safest is no rewrite
+        text = event.text or ""
+        # Remove the owner-reply marker (if present) so we scan the real body.
+        body = text[len(_OWNER_REPLY_PREFIX):] if text.startswith(_OWNER_REPLY_PREFIX) else text
+        # Scan the ORIGINAL body (no dash-normalization) so match spans line up.
+        # Promote the FIRST isolated token whose name is a known command — even
+        # if it is already at the start (that path still drops the prefix).
+        for m in _INLINE_COMMAND_TOKEN.finditer(body):
+            name = m.group(1).lower()
+            if not is_gateway_known_command(name):
+                continue
+            before = body[:m.start()].strip()
+            after = body[m.end():].strip()
+            remainder = " ".join(p for p in (before, after) if p)
+            event.text = (f"/{name} {remainder}").rstrip()
+            return
+        return  # no known inline command: leave event.text untouched
+    except Exception:
+        return
+
+
 @dataclass
 class SendResult:
     """Result of sending a message."""
@@ -4594,6 +4683,7 @@ class BasePlatformAdapter(ABC):
             return
 
         coerce_plaintext_gateway_command(event)
+        coerce_inline_owner_command(event)
 
         # Rewrite ``event.source.thread_id`` via the installed recovery hook
         # (Telegram DM topic mode) so the session key, guard checks, and

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1280,15 +1280,48 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
         )
 
+    def _can_batch_text_events(self, existing: MessageEvent, event: MessageEvent) -> bool:
+        """Only batch chunks with the same owner-reply attribution.
+
+        The merged batch keeps the FIRST chunk's metadata/source, and in a DM
+        the batch key is chat-scoped — so without this boundary an owner-typed
+        chunk and a contact chunk arriving inside the same debounce window
+        would merge, and the combined text would inherit
+        ``whatsapp_from_owner`` from whichever chunk came first. That would
+        let a contact's text ride under the owner marker (or silently drop
+        the owner's own marker). Mirrors the sender-attribution rule of
+        ``_can_merge_text_debounce_events`` in gateway/platforms/base.py.
+        """
+        existing_owner = (getattr(existing, "metadata", None) or {}).get(
+            "whatsapp_from_owner"
+        ) is True
+        event_owner = (getattr(event, "metadata", None) or {}).get(
+            "whatsapp_from_owner"
+        ) is True
+        return existing_owner == event_owner
+
     def _enqueue_text_event(self, event: MessageEvent) -> None:
         """Buffer a text event and reset the flush timer.
 
         When WhatsApp delivers rapid-fire messages (e.g. forwarded
         batches), this concatenates them and waits for a short quiet
-        period before dispatching the combined message.
+        period before dispatching the combined message. Chunks with a
+        different owner-reply attribution never merge: the buffered burst
+        is dispatched as-is and the new chunk starts a fresh batch (see
+        ``_can_batch_text_events``).
         """
         key = self._text_batch_key(event)
         existing = self._pending_text_batches.get(key)
+        if existing is not None and not self._can_batch_text_events(existing, event):
+            # Preserve sender attribution: dispatch the buffered burst now;
+            # the new sender starts a fresh debounce batch.
+            prior_task = self._pending_text_batch_tasks.pop(key, None)
+            if prior_task and not prior_task.done():
+                prior_task.cancel()
+            flushed = self._pending_text_batches.pop(key, None)
+            if flushed is not None:
+                asyncio.create_task(self.handle_message(flushed))
+            existing = None
         chunk_len = len(event.text or "")
         if existing is None:
             event._last_chunk_len = chunk_len  # type: ignore[attr-defined]
@@ -1728,6 +1761,8 @@ def _apply_yaml_config(yaml_cfg: dict, whatsapp_cfg: dict) -> dict | None:
         os.environ["WHATSAPP_FREE_RESPONSE_CHATS"] = str(frc)
     if "dm_policy" in whatsapp_cfg and not os.getenv("WHATSAPP_DM_POLICY"):
         os.environ["WHATSAPP_DM_POLICY"] = str(whatsapp_cfg["dm_policy"]).lower()
+    if "inline_commands" in whatsapp_cfg and not os.getenv("WHATSAPP_INLINE_COMMANDS"):
+        os.environ["WHATSAPP_INLINE_COMMANDS"] = str(whatsapp_cfg["inline_commands"]).lower()
     af = whatsapp_cfg.get("allow_from")
     if af is not None and not os.getenv("WHATSAPP_ALLOWED_USERS"):
         if isinstance(af, list):

--- a/tests/gateway/test_whatsapp_inline_commands.py
+++ b/tests/gateway/test_whatsapp_inline_commands.py
@@ -1,0 +1,347 @@
+"""Tests for the opt-in inline slash-command promotion in the WhatsApp
+owner-reply flow.
+
+Exercises ``coerce_inline_owner_command`` in isolation — no gateway/adapter —
+by constructing a ``MessageEvent`` + ``SessionSource`` directly. Uses a real
+built-in gateway command (``/status``) so the tests do not depend on any plugin
+being loaded. JIDs are fictitious (upstream fixture style).
+"""
+
+import pathlib
+import re
+
+import pytest
+
+from gateway.platforms.base import (
+    coerce_inline_owner_command,
+    MessageEvent,
+    MessageType,
+)
+from gateway.session import SessionSource
+from gateway.config import Platform
+
+
+def _owner_dm_event(text, from_owner=True, chat_type="dm", platform=Platform.WHATSAPP):
+    src = SessionSource(
+        platform=platform,
+        chat_id="6281234567890@s.whatsapp.net",
+        chat_type=chat_type,
+        user_id="6281234567890@s.whatsapp.net",
+    )
+    md = {"whatsapp_from_owner": True} if from_owner else {}
+    return MessageEvent(text=text, message_type=MessageType.TEXT, source=src, metadata=md)
+
+
+@pytest.fixture(autouse=True)
+def _flag_on(monkeypatch):
+    monkeypatch.setenv("WHATSAPP_INLINE_COMMANDS", "true")
+    yield
+
+
+# A known command in the middle of an owner DM is promoted to the front.
+def test_inline_command_promoted_in_owner_dm():
+    event = _owner_dm_event("please run /status now")
+    coerce_inline_owner_command(event)
+    assert event.text == "/status please run now"
+    assert event.get_command() == "status"
+
+
+# The "[owner reply] " marker is stripped before scanning and absent after rewrite.
+def test_inline_respects_owner_reply_prefix():
+    event = _owner_dm_event("[owner reply] hey /status thanks")
+    coerce_inline_owner_command(event)
+    assert event.text == "/status hey thanks"
+    assert "[owner reply]" not in event.text
+    assert event.get_command() == "status"
+
+
+# A command already at the start (after the marker) still sheds the marker.
+def test_command_at_start_after_prefix_drops_prefix():
+    event = _owner_dm_event("[owner reply] /status foo")
+    coerce_inline_owner_command(event)
+    assert event.text == "/status foo"
+    assert event.get_command() == "status"
+
+    # variant without the prefix -> unchanged text, still a command
+    event2 = _owner_dm_event("/status foo")
+    coerce_inline_owner_command(event2)
+    assert event2.text == "/status foo"
+    assert event2.get_command() == "status"
+
+
+# Flag off (the default): byte-identical no-op.
+def test_flag_off_is_identity(monkeypatch):
+    monkeypatch.delenv("WHATSAPP_INLINE_COMMANDS", raising=False)
+    event = _owner_dm_event("please run /status now")
+    coerce_inline_owner_command(event)
+    assert event.text == "please run /status now"
+    assert event.get_command() is None
+
+
+# A path-like token has an internal "/" and never matches.
+def test_path_like_token_not_promoted():
+    event = _owner_dm_event("see /home/user/notes for details")
+    coerce_inline_owner_command(event)
+    assert event.text == "see /home/user/notes for details"
+    assert event.get_command() is None
+
+
+# A command name embedded in a URL is not an isolated token.
+def test_url_not_treated_as_command():
+    event = _owner_dm_event("check http://example.com/status please")
+    coerce_inline_owner_command(event)
+    assert event.text == "check http://example.com/status please"
+    assert event.get_command() is None
+
+
+# Span-based matching: a URL occurrence must not shadow the real command.
+def test_url_then_real_command_promotes_real():
+    event = _owner_dm_event("see http://ex.com/status then /status now")
+    coerce_inline_owner_command(event)
+    assert event.text == "/status see http://ex.com/status then now"
+    assert event.get_command() == "status"
+
+
+# The first KNOWN command wins; an unknown slash word before it does not block.
+def test_unknown_then_known_promotes_known():
+    event = _owner_dm_event("/banana please /status now")
+    coerce_inline_owner_command(event)
+    assert event.text == "/status /banana please now"
+    assert event.get_command() == "status"
+
+
+# A path-like token before a known command does not block promotion.
+def test_path_then_known_promotes_known():
+    event = _owner_dm_event("/home/user please /status now")
+    coerce_inline_owner_command(event)
+    assert event.text == "/status /home/user please now"
+    assert event.get_command() == "status"
+
+
+# Unknown slash words alone are never promoted.
+def test_unknown_slash_word_not_promoted():
+    event = _owner_dm_event("talk about /banana today")
+    coerce_inline_owner_command(event)
+    assert event.text == "talk about /banana today"
+    assert event.get_command() is None
+
+
+# The "@bot" mention suffix is dropped and kept out of the args.
+def test_mention_suffix_stripped():
+    event = _owner_dm_event("hey /status@somebot ok")
+    coerce_inline_owner_command(event)
+    assert event.text == "/status hey ok"
+    assert event.get_command() == "status"
+
+
+# Command at the end: empty remainder, no trailing space.
+def test_command_at_end_empty_remainder():
+    event = _owner_dm_event("please /status")
+    coerce_inline_owner_command(event)
+    assert event.text == "/status please"
+    assert event.get_command() == "status"
+
+    # command alone -> empty remainder, no trailing space
+    event2 = _owner_dm_event("/status")
+    coerce_inline_owner_command(event2)
+    assert event2.text == "/status"
+    assert event2.get_command() == "status"
+
+
+# Group chats are out of scope.
+def test_group_not_affected():
+    event = _owner_dm_event("run /status", chat_type="group")
+    coerce_inline_owner_command(event)
+    assert event.text == "run /status"
+    assert event.get_command() is None
+
+
+# Non-WhatsApp platforms are out of scope.
+def test_non_whatsapp_not_affected():
+    event = _owner_dm_event("run /status", platform=Platform.TELEGRAM)
+    coerce_inline_owner_command(event)
+    assert event.text == "run /status"
+    assert event.get_command() is None
+
+
+# Events without the owner marker are untouched.
+def test_not_from_owner_not_affected():
+    event = _owner_dm_event("run /status", from_owner=False)
+    coerce_inline_owner_command(event)
+    assert event.text == "run /status"
+    assert event.get_command() is None
+
+
+# Strict boolean gate: a truthy NON-bool marker must NOT qualify as owner.
+def test_truthy_non_bool_owner_marker_rejected():
+    for marker in ("false", "0", 1, "yes"):
+        event = MessageEvent(
+            text="run /status",
+            message_type=MessageType.TEXT,
+            source=SessionSource(
+                platform=Platform.WHATSAPP,
+                chat_id="6281234567890@s.whatsapp.net",
+                chat_type="dm",
+                user_id="6281234567890@s.whatsapp.net",
+            ),
+            metadata={"whatsapp_from_owner": marker},
+        )
+        coerce_inline_owner_command(event)
+        assert event.text == "run /status", f"marker {marker!r} must not qualify"
+        assert event.get_command() is None
+
+
+# iOS en/em-dash auto-correction: args are normalized downstream.
+def test_endash_normalized_in_args():
+    # iOS auto-corrects "-" to en/em dash. We do NOT normalize before the scan
+    # (offsets stay intact); get_command_args() re-applies the dash-fix so args
+    # come out with a real ASCII dash.
+    event = _owner_dm_event("do /status —v")
+    coerce_inline_owner_command(event)
+    assert event.get_command() == "status"
+    assert "-v" in event.get_command_args()
+
+
+# Static extraction — does not import the adapter module (no import side effects).
+def test_owner_reply_prefix_constant_in_sync():
+    from gateway.platforms.base import _OWNER_REPLY_PREFIX as base_prefix
+
+    adapter_src = (
+        pathlib.Path(__file__).resolve().parents[2]
+        / "plugins" / "platforms" / "whatsapp" / "adapter.py"
+    ).read_text(encoding="utf-8")
+    m = re.search(r'_OWNER_REPLY_PREFIX\s*=\s*(["\'])(.*?)\1', adapter_src)
+    assert m, "could not locate _OWNER_REPLY_PREFIX in adapter.py"
+    assert m.group(2) == base_prefix
+
+
+# YAML config propagation with env-var precedence.
+def test_yaml_inline_commands_env_and_precedence(monkeypatch):
+    from plugins.platforms.whatsapp.adapter import _apply_yaml_config
+
+    # env clean -> YAML populates the env var (bool -> "true")
+    monkeypatch.delenv("WHATSAPP_INLINE_COMMANDS", raising=False)
+    _apply_yaml_config({}, {"inline_commands": True})
+    assert __import__("os").environ["WHATSAPP_INLINE_COMMANDS"] == "true"
+
+    # env already set -> env wins over YAML
+    monkeypatch.setenv("WHATSAPP_INLINE_COMMANDS", "false")
+    _apply_yaml_config({}, {"inline_commands": True})
+    assert __import__("os").environ["WHATSAPP_INLINE_COMMANDS"] == "false"
+
+
+# ── Text-batching sender boundary (owner-reply vs contact) ─────────────────
+#
+# The adapter's rapid-fire text batching is keyed by session (chat-scoped in a
+# DM) and the merged event keeps the FIRST chunk's metadata/source. Without a
+# sender boundary, an owner chunk and a contact chunk landing in the same
+# debounce window would merge, so the combined text would inherit
+# ``whatsapp_from_owner`` from whichever arrived first — letting a contact's
+# inline command run under the owner marker, or losing the owner's own marker.
+# These tests pin the boundary: batches never mix owner-reply and contact text.
+
+import asyncio
+
+from unittest.mock import AsyncMock
+
+from gateway.config import PlatformConfig
+
+
+def _batch_adapter():
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    adapter = object.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+    adapter.config = PlatformConfig(enabled=True, extra={})
+    adapter._pending_text_batches = {}
+    adapter._pending_text_batch_tasks = {}
+    adapter._text_batch_delay_seconds = 0.01
+    adapter._text_batch_split_delay_seconds = 0.01
+    adapter.handle_message = AsyncMock()
+    return adapter
+
+
+def _dm_text_event(text, from_owner):
+    src = SessionSource(
+        platform=Platform.WHATSAPP,
+        chat_id="6281234567890@s.whatsapp.net",
+        chat_type="dm",
+        user_id=(
+            "15551230000@s.whatsapp.net"
+            if from_owner
+            else "6281234567890@s.whatsapp.net"
+        ),
+    )
+    md = {"whatsapp_from_owner": True} if from_owner else {}
+    return MessageEvent(text=text, message_type=MessageType.TEXT, source=src, metadata=md)
+
+
+# Owner-attribution boundary predicate: same marker batches, mixed never does.
+def test_can_batch_text_events_owner_boundary():
+    adapter = _batch_adapter()
+    owner_a = _dm_text_event("a", from_owner=True)
+    owner_b = _dm_text_event("b", from_owner=True)
+    contact_a = _dm_text_event("c", from_owner=False)
+    contact_b = _dm_text_event("d", from_owner=False)
+    assert adapter._can_batch_text_events(owner_a, owner_b) is True
+    assert adapter._can_batch_text_events(contact_a, contact_b) is True
+    assert adapter._can_batch_text_events(owner_a, contact_a) is False
+    assert adapter._can_batch_text_events(contact_a, owner_a) is False
+
+
+# Contact chunk first, owner chunk second: two separate dispatches; the
+# contact's inline command never gains the owner marker.
+@pytest.mark.asyncio
+async def test_batch_contact_then_owner_not_merged():
+    adapter = _batch_adapter()
+    adapter._enqueue_text_event(_dm_text_event("hey /status now", from_owner=False))
+    adapter._enqueue_text_event(_dm_text_event("[owner reply] ok", from_owner=True))
+    await asyncio.sleep(0.05)
+
+    events = [c.args[0] for c in adapter.handle_message.await_args_list]
+    assert len(events) == 2, "owner and contact chunks must not merge"
+    contact_event = events[0]
+    assert (contact_event.metadata or {}).get("whatsapp_from_owner") is not True
+    assert "/status" in contact_event.text
+    coerce_inline_owner_command(contact_event)
+    assert contact_event.get_command() is None
+
+
+# Owner chunk first, contact chunk second: the contact's text must not ride
+# into the owner-attributed event (no privilege leak into promoted args).
+@pytest.mark.asyncio
+async def test_batch_owner_then_contact_no_privilege_leak():
+    adapter = _batch_adapter()
+    adapter._enqueue_text_event(
+        _dm_text_event("[owner reply] look at this", from_owner=True)
+    )
+    adapter._enqueue_text_event(_dm_text_event("please run /status", from_owner=False))
+    await asyncio.sleep(0.05)
+
+    events = [c.args[0] for c in adapter.handle_message.await_args_list]
+    assert len(events) == 2, "owner and contact chunks must not merge"
+    owner_event, contact_event = events
+    assert (owner_event.metadata or {}).get("whatsapp_from_owner") is True
+    assert "/status" not in owner_event.text
+    coerce_inline_owner_command(owner_event)
+    assert owner_event.get_command() is None
+    coerce_inline_owner_command(contact_event)
+    assert contact_event.get_command() is None
+
+
+# Owner-only multi-chunk burst still merges and the inline command works on
+# the combined text.
+@pytest.mark.asyncio
+async def test_batch_owner_multichunk_still_merges_and_promotes():
+    adapter = _batch_adapter()
+    adapter._enqueue_text_event(_dm_text_event("[owner reply] hang on", from_owner=True))
+    adapter._enqueue_text_event(
+        _dm_text_event("[owner reply] /status please", from_owner=True)
+    )
+    await asyncio.sleep(0.05)
+
+    assert adapter.handle_message.await_count == 1, "same-owner chunks must merge"
+    merged = adapter.handle_message.await_args_list[0].args[0]
+    assert (merged.metadata or {}).get("whatsapp_from_owner") is True
+    coerce_inline_owner_command(merged)
+    assert merged.get_command() == "status"


### PR DESCRIPTION
# feat(whatsapp): opt-in inline slash commands in owner-reply DMs

## Motivation

Hermes recognizes slash commands only at the **start** of a message
(`MessageEvent.is_command == text.startswith("/")`). In the WhatsApp
owner-reply flow (`fromOwner`, 1:1) the owner frequently types a command
mid-sentence while talking to a contact — e.g. `"hang on, /status for me"`.
Today that command is not recognized and falls through to the model as plain
text.

This change adds an **opt-in** promotion of a *known* inline slash command to
the front of the message, reusing the existing dispatch pipeline unchanged.

## Scope

**WhatsApp 1:1 owner-reply only.** Group inline commands are intentionally out
of scope for this change: groups already accept a leading `/` via the intake
gate, and extending mid-message parsing to groups is left for a follow-up.

## Design

Mirrors the existing `coerce_plaintext_gateway_command` precedent — a small
rewrite helper called from `BasePlatformAdapter.handle_message`, before
dispatch. When enabled and the event is a WhatsApp 1:1 `fromOwner` text
message, it does a span-based scan (`re.finditer`) for the first **isolated**
slash token (`(?:^|(?<=\s))/name(?=\s|$)`), validates the name against
`is_gateway_known_command` (built-in **and** plugin-registered commands), and
rewrites `event.text` so the command is at index 0. Everything downstream
(access checks, `command:<name>` hooks, the if/elif router,
`get_command_args`' dash normalization) is reused verbatim.

Because the token must be isolated and must resolve to a real command, a path
like `see /home/user/x` or a URL like `http://host/status` never triggers.

The WhatsApp adapter's rapid-fire text batching also gains an
**owner-attribution boundary**: chunks whose `whatsapp_from_owner` attribution
differs never merge — the buffered burst is dispatched as-is and the new chunk
starts a fresh batch. The batch key is chat-scoped in a DM and the merged
event keeps the *first* chunk's metadata, so without this boundary a contact
chunk arriving inside the owner's debounce window would ride under the owner
marker (or drop it) — a privilege-boundary violation once inline commands are
enabled. This mirrors the sender-attribution rule
`_can_merge_text_debounce_events` already enforces for the busy-text debounce
in `gateway/platforms/base.py`.

## Opt-in / backward compatibility

Gated by `WHATSAPP_INLINE_COMMANDS` (env var, or `whatsapp.inline_commands` in
YAML config). **Default OFF ⇒ byte-identical behavior** to stock Hermes.

- No change to `is_command` / `get_command`.
- No other platform affected (explicit WhatsApp platform gate).
- No bridge (Node) change — the flag is read in Python.

## Tests

New `tests/gateway/test_whatsapp_inline_commands.py` exercises
`coerce_inline_owner_command` in isolation (constructs `MessageEvent` +
`SessionSource` directly, no gateway/adapter), covering:

- inline command promotion in an owner DM;
- owner-reply `[owner reply]` prefix drop on promotion;
- command already at the start (still drops the prefix);
- flag-off identity (byte-identical, no rewrite);
- path-like token and URL rejection;
- unknown slash word not promoted;
- first *known* command among several tokens;
- `@bot` mention-suffix stripping;
- command at end of message (empty remainder, no trailing space);
- group / non-WhatsApp / non-owner exclusion;
- iOS en/em-dash argument normalization;
- YAML → env propagation with env precedence;
- a static guard that the duplicated `_OWNER_REPLY_PREFIX` constant stays in
  sync between `base.py` and the WhatsApp adapter;
- the text-batching owner-attribution boundary: mixed owner/contact bursts
  dispatch separately in both orders (no privilege leak, no lost owner
  marker), while owner-only multi-chunk bursts still merge and promote.

(The twin `coerce_plaintext_gateway_command` had no upstream test; this change
adds coverage for the pattern.)

## Known limitations

The scan does not distinguish quoted or pasted text from prose: an owner
message that quotes or pastes a line containing a known command (e.g. a pasted
`> /status` line) will be promoted and executed. The false positive is limited
to the owner's own messages — the strict boolean `whatsapp_from_owner` gate
means third-party text can never trigger a command — and the whole feature is
opt-in (default OFF). A quoting/code-block parsing convention felt like a
project-level decision, so this change deliberately does not impose one;
happy to add it here if maintainers have a preferred convention.

## Security

No PII. The helper only rewrites when a real command token is present, reuses
`get_command`'s path-rejection semantics, and is fully behind an opt-in flag.
