### PR TITLE
fix(browser-connect): support Obscura as a CDP browser candidate

### DIFF
--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -41,6 +41,10 @@ _WINDOWS_INSTALL_PARTS = tuple(parts for _, group in _WINDOWS_BROWSER_GROUPS for
 
 _LINUX_BROWSER_GROUPS = (
     (
+        ("obscura",),
+        ("/usr/local/bin/obscura", "/usr/bin/obscura"),
+    ),
+    (
         ("google-chrome", "google-chrome-stable"),
         ("/opt/google/chrome/chrome", "/usr/bin/google-chrome", "/usr/bin/google-chrome-stable"),
     ),
@@ -138,6 +142,18 @@ def _chrome_debug_args(port: int) -> list[str]:
     ]
 
 
+def _browser_debug_argv(candidate: str, port: int) -> list[str]:
+    """Return argv for launching a CDP-compatible debug server.
+
+    Chromium-family browsers expose CDP via ``--remote-debugging-port``.
+    Obscura is a lightweight Rust headless browser with a CDP server and uses
+    ``obscura serve --port <port>`` instead.
+    """
+    if os.path.basename(candidate).lower() == "obscura":
+        return [candidate, "serve", "--port", str(port)]
+    return [candidate, *_chrome_debug_args(port)]
+
+
 def is_browser_debug_ready(url: str, timeout: float = 1.0) -> bool:
     """Return True when ``url`` exposes a reachable Chrome DevTools endpoint."""
     import socket
@@ -179,7 +195,7 @@ def manual_chrome_debug_command(port: int = DEFAULT_BROWSER_CDP_PORT, system: st
     candidates = get_chrome_debug_candidates(system)
 
     if candidates:
-        argv = [candidates[0], *_chrome_debug_args(port)]
+        argv = _browser_debug_argv(candidates[0], port)
         return subprocess.list2cmdline(argv) if system == "Windows" else shlex.join(argv)
 
     if system == "Darwin":
@@ -308,7 +324,7 @@ def launch_chrome_debug(
         try:
             with open(stderr_path, "wb") as stderr_file:
                 proc = subprocess.Popen(
-                    [candidate, *_chrome_debug_args(port)],
+                    _browser_debug_argv(candidate, port),
                     stdout=subprocess.DEVNULL,
                     stderr=stderr_file,
                     **_detach_kwargs(system),

--- a/tests/hermes_cli/test_browser_connect_obscura.py
+++ b/tests/hermes_cli/test_browser_connect_obscura.py
@@ -1,0 +1,113 @@
+"""Tests for Obscura browser support in hermes_cli.browser_connect.
+
+Obscura is a lightweight Rust headless browser that exposes a Chrome DevTools
+Protocol server via `obscura serve --port <N>`, unlike Chromium-family browsers
+which use `--remote-debugging-port`. These tests guard the `_browser_debug_argv`
+dispatch helper and the obscura entry in `_LINUX_BROWSER_GROUPS`.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from hermes_cli.browser_connect import (
+    _browser_debug_argv,
+    get_chrome_debug_candidates,
+)
+
+
+class TestBrowserDebugArgv:
+    """_browser_debug_argv dispatches per-binary."""
+
+    def test_obscura_returns_serve_argv(self):
+        """Obscura uses `obscura serve --port <N>` instead of --remote-debugging-port."""
+        argv = _browser_debug_argv("/usr/local/bin/obscura", 9222)
+        assert argv == ["/usr/local/bin/obscura", "serve", "--port", "9222"]
+
+    def test_obscura_case_insensitive(self):
+        """Binary name matching is case-insensitive."""
+        argv = _browser_debug_argv("/x/OBsCuRa", 9222)
+        assert argv == ["/x/OBsCuRa", "serve", "--port", "9222"]
+
+    def test_chrome_returns_remote_debugging_argv(self):
+        """Chromium-family browsers use --remote-debugging-port."""
+        argv = _browser_debug_argv("/usr/bin/google-chrome", 9222)
+        assert argv[0] == "/usr/bin/google-chrome"
+        assert any("--remote-debugging-port=9222" in arg for arg in argv)
+        assert any("--user-data-dir=" in arg for arg in argv)
+        assert "--no-first-run" in argv
+        assert "--no-default-browser-check" in argv
+
+    def test_chromium_returns_remote_debugging_argv(self):
+        """Chromium also uses --remote-debugging-port."""
+        argv = _browser_debug_argv("/usr/bin/chromium", 9222)
+        assert argv[0] == "/usr/bin/chromium"
+        assert "--remote-debugging-port=9222" in argv
+
+    def test_brave_returns_remote_debugging_argv(self):
+        """Brave also uses --remote-debugging-port."""
+        argv = _browser_debug_argv("/usr/bin/brave-browser", 9222)
+        assert argv[0] == "/usr/bin/brave-browser"
+        assert "--remote-debugging-port=9222" in argv
+
+
+class TestObscuraInLinuxCandidates:
+    """get_chrome_debug_candidates includes obscura when available."""
+
+    def test_obscura_included_when_which_resolves(self, monkeypatch):
+        """When shutil.which('obscura') finds it, obscura is in candidates."""
+        def fake_which(name):
+            if name == "obscura":
+                return "/home/user/.local/bin/obscura"
+            return None
+
+        monkeypatch.setattr(shutil, "which", fake_which)
+        # Mock os.path.isfile to return True for the which-resolved path
+        import os
+        original_isfile = os.path.isfile
+        def fake_isfile(path):
+            if path == "/home/user/.local/bin/obscura":
+                return True
+            return original_isfile(path)
+        monkeypatch.setattr(os.path, "isfile", fake_isfile)
+
+        candidates = get_chrome_debug_candidates("Linux")
+        assert "/home/user/.local/bin/obscura" in candidates
+
+    def test_obscura_not_included_when_which_fails(self, monkeypatch):
+        """When shutil.which('obscura') returns None, obscura is not in candidates."""
+        def fake_which(name):
+            return None
+
+        monkeypatch.setattr(shutil, "which", fake_which)
+        # Mock os.path.isfile to return False for all obscura paths
+        import os
+        original_isfile = os.path.isfile
+        def fake_isfile(path):
+            if "obscura" in path:
+                return False
+            return original_isfile(path)
+        monkeypatch.setattr(os.path, "isfile", fake_isfile)
+
+        candidates = get_chrome_debug_candidates("Linux")
+        assert not any("obscura" in c for c in candidates)
+
+    def test_obscura_static_paths_included_when_present(self, monkeypatch):
+        """Static paths like /usr/local/bin/obscura are included when they exist."""
+        def fake_which(name):
+            return None
+
+        monkeypatch.setattr(shutil, "which", fake_which)
+        # Mock os.path.isfile to return True for /usr/local/bin/obscura
+        import os
+        original_isfile = os.path.isfile
+        def fake_isfile(path):
+            if path == "/usr/local/bin/obscura":
+                return True
+            return original_isfile(path)
+        monkeypatch.setattr(os.path, "isfile", fake_isfile)
+
+        candidates = get_chrome_debug_candidates("Linux")
+        assert "/usr/local/bin/obscura" in candidates


### PR DESCRIPTION
## Summary

Add Obscura (a lightweight Rust headless browser that exposes a Chrome DevTools Protocol server) as a recognized CDP browser candidate in `hermes_cli/browser_connect.py`.

Upstream has zero Obscura support — `get_chrome_debug_candidates()` and the launch paths only know about Chromium-family binaries that use `--remote-debugging-port`. Obscura uses a different argv shape: `obscura serve --port <N>`.

## Changes

1. **`_LINUX_BROWSER_GROUPS`** — new `("obscura",)` entry with generalized paths (`/usr/local/bin/obscura`, `/usr/bin/obscura`) plus `shutil.which("obscura")` resolution for `~/.local/bin` installs.

2. **`_browser_debug_argv(candidate, port)`** — new dispatch helper:
   - If `os.path.basename(candidate).lower() == "obscura"`: returns `[candidate, "serve", "--port", str(port)]`
   - Otherwise: returns `[candidate, *_chrome_debug_args(port)]` (the existing Chromium argv)

3. **Call-site updates** — `manual_chrome_debug_command()` (~line 197) and the `subprocess.Popen` in `launch_chrome_debug()` (~line 326) now route through the helper instead of inlining `[candidate, *_chrome_debug_args(port)]`.

## Rationale

A single dispatch helper keeps the per-binary argv logic in one place. Adding the next non-Chromium CDP browser (if any) becomes a one-line branch inside the helper, not a scattered change across two call sites.

## Test Plan

- [x] `tests/hermes_cli/test_browser_connect_obscura.py` added (8 tests)
- [x] `_browser_debug_argv("/usr/local/bin/obscura", 9222)` returns the serve argv
- [x] Case-insensitive dispatch: `_browser_debug_argv("/x/OBsCuRa", 9222)` still routes to serve
- [x] Chromium/Brave still get `--remote-debugging-port=` argv
- [x] `get_chrome_debug_candidates("Linux")` includes obscura when `shutil.which` resolves, excludes it when it doesn't
- [x] Static paths (`/usr/local/bin/obscura`) included when `os.path.isfile` is true
- [x] Existing browser tests still green: `test_graphical_browser_detection.py`, `test_dashboard_browser_safe_imports.py`

Full run: **19 passed in 0.52s**

```
pytest tests/hermes_cli/test_browser_connect_obscura.py \
       tests/hermes_cli/test_graphical_browser_detection.py \
       tests/hermes_cli/test_dashboard_browser_safe_imports.py -v
```
