### PR TITLE
fix(desktop): bump electron node-headers sha256 to match pinned electron.version

### DIFF
--- a/nix/desktop.nix
+++ b/nix/desktop.nix
@@ -28,7 +28,10 @@ let
 
   electronHeaders = pkgs.fetchurl {
     url = "https://artifacts.electronjs.org/headers/dist/v${electron.version}/node-v${electron.version}-headers.tar.gz";
-    sha256 = "sha256-zi/QMwRZ0+FwE9XTE+DiSIeJXAwxmLKEaBWD5W3pMOI=";
+    # Pinned to the current nixpkgs electron (41.9.1). This hash tracks
+    # electron.version and must be bumped alongside every nixpkgs electron
+    # bump — see #61443.
+    sha256 = "sha256-zOl8rx6woWh7aeRUOlkTMviKc/EAQQX6nr/MxAx1ZPI=";
   };
 
   # node-pty ships no Electron-tagged prebuild we can trust to match this


### PR DESCRIPTION
## What does this PR do?

`electronHeaders` in `nix/desktop.nix` fetches from a URL templated off `electron.version`, but its `sha256` was hardcoded to a prior electron release. `nixpkgs-nixos-unstable` now resolves `electron` to `41.9.1`, so the URL and the pinned hash have desynced and the fixed-output derivation fails with a hash mismatch — `nix build .#desktop` is broken.

This only surfaces at Nix build time; the networked Docker / `npm ci` paths are unaffected, which is why it merged green in the first place. The reported hash mismatch error includes the actual sha256 Nix computed for the 41.9.1 tarball (`got:` line), so this bump uses that first-party value rather than a guess.

## Related Issue

Fixes #61443

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `nix/desktop.nix`: bump `electronHeaders.sha256` from the stale pinned-electron-version hash to the hash Nix reported for the current `electron.version` (41.9.1), with a comment noting it needs to move in lockstep with `electron.version` going forward.

## How to Test

1. `nix build .#desktop` on current `main` fails with:
   ```
   error: hash mismatch in fixed-output derivation 'node-v41.9.1-headers.tar.gz.drv':
     specified: sha256-zi/QMwRZ0+FwE9XTE+DiSIeJXAwxmLKEaBWD5W3pMOI=
          got:  sha256-zOl8rx6woWh7aeRUOlkTMviKc/EAQQX6nr/MxAx1ZPI=
   ```
2. With this PR's `sha256` value, the fixed-output derivation matches and the build proceeds past the `electronHeaders` fetch.

I don't have a local Nix toolchain in this environment to run `nix build .#desktop` myself, so I can't attach a green build log — the fix is the exact `got:` value from the issue's own Nix error trace, not a derived/guessed one. Flagging this so a maintainer or reviewer with Nix available can do the final confirm; happy to iterate if the value needs adjusting for a different platform's tarball.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs (by issue number and by file/mechanism) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, this is a Nix-only data value change with no Python test surface, and I don't have a local Nix toolchain to run `nix build` in this environment (see note above)
- [ ] I've added tests for my changes — N/A, no pytest-testable surface for this change; the issue notes #53202 extends the offline nix-build CI guard to `.#desktop`, which is what will catch this class going forward
- [x] I've tested on my platform: macOS 15 (Darwin) — verified via `git show origin/main:nix/desktop.nix` that the current hash/URL mismatch matches the issue description exactly; did not run `nix build` (no local Nix)

### Documentation & Housekeeping

- [x] N/A — no docs, config keys, or tool schemas changed

## AI Disclosure

This bug was identified and fixed with AI assistance.