### PR TITLE
fix(gateway): query systemd timeout in owning scope

### DIFF
--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -342,12 +342,18 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
 
     # Try to identify our unit name and ask systemctl for its config.
     unit_name: Optional[str] = None
+    systemd_scope: Optional[str] = None
     try:
         # /proc/self/cgroup gives us "0::/user.slice/.../hermes-gateway.service"
         with open("/proc/self/cgroup", encoding="utf-8") as fh:
             for line in fh:
                 # systemd cgroup line ends with the unit name
                 if ".service" in line:
+                    cgroup_path = line.strip().split(":", 2)[-1]
+                    if cgroup_path.startswith("/system.slice/"):
+                        systemd_scope = "system"
+                    elif cgroup_path.startswith("/user.slice/"):
+                        systemd_scope = "user"
                     parts = line.strip().split("/")
                     for p in reversed(parts):
                         if p.endswith(".service"):
@@ -360,11 +366,19 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
     if not unit_name:
         return None
 
-    # Query systemctl for TimeoutStopUSec.  Use --user OR system depending
-    # on which manager actually owns the unit.  Try user first since
-    # that's the common case for hermes.
+    # Query systemctl for TimeoutStopUSec.  Use the manager identified by
+    # /proc/self/cgroup when possible: systemctl --user can return exit 0 plus
+    # a default TimeoutStopUSec for unknown units, so probing it first causes
+    # false stale-unit warnings for system-scope services (#61003).
     timeout_us: Optional[int] = None
-    for flag in (["--user"], []):
+    if systemd_scope == "system":
+        scope_flags = ([],)
+    elif systemd_scope == "user":
+        scope_flags = (["--user"],)
+    else:
+        scope_flags = (["--user"], [])
+
+    for flag in scope_flags:
         try:
             result = subprocess.run(
                 ["systemctl", *flag, "show", unit_name, "--property=TimeoutStopUSec"],

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import signal
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -248,3 +249,52 @@ class TestCheckSystemdTimingAlignment:
         # for whatever unit pytest IS in.  Both are valid; we just ensure
         # the function doesn't raise.
         assert result is None or isinstance(result, dict)
+
+    def test_system_scope_cgroup_skips_phantom_user_unit(self, monkeypatch):
+        """A system-scope unit must not trust systemctl --user's default row.
+
+        systemctl --user show can return success plus TimeoutStopUSec=90s even
+        for an unknown user unit. If /proc/self/cgroup says this process is in
+        /system.slice, the check should query the system manager directly.
+        """
+        monkeypatch.setenv("INVOCATION_ID", "abc")
+
+        cgroup = "0::/system.slice/hermes-gateway-duke.service\n"
+        real_open = open
+
+        def fake_open(path, *args, **kwargs):
+            if path == "/proc/self/cgroup":
+                from io import StringIO
+
+                return StringIO(cgroup)
+            return real_open(path, *args, **kwargs)
+
+        calls = []
+
+        def fake_run(cmd, **_kwargs):
+            calls.append(cmd)
+            if "--user" in cmd:
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout="TimeoutStopUSec=1min 30s\n", stderr=""
+                )
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="TimeoutStopUSec=4min\n", stderr=""
+            )
+
+        monkeypatch.setattr("builtins.open", fake_open)
+        monkeypatch.setattr(sf.subprocess, "run", fake_run)
+
+        result = sf.check_systemd_timing_alignment(180.0)
+
+        assert result is not None
+        assert result["unit"] == "hermes-gateway-duke.service"
+        assert result["timeout_stop_sec"] == 240.0
+        assert result["mismatch"] is False
+        assert calls == [
+            [
+                "systemctl",
+                "show",
+                "hermes-gateway-duke.service",
+                "--property=TimeoutStopUSec",
+            ]
+        ]


### PR DESCRIPTION
## Summary

Fixes #61003.

`check_systemd_timing_alignment()` currently probes `systemctl --user show` before the system manager. On system-scope gateway units, `systemctl --user show <missing-unit>` can still return success with the default `TimeoutStopUSec=1min 30s`, so Hermes reports a stale-unit warning even when the real system unit has a sufficient timeout.

This change records the manager scope while reading `/proc/self/cgroup`:

- `/system.slice/...service` queries system `systemctl show` only
- `/user.slice/...service` queries `systemctl --user show` only
- unknown cgroup shapes keep the previous fallback order

## Tests

Added regression coverage for a system-scope cgroup where the user manager would return the phantom 90s timeout but the system manager reports 4min.

```bash
uv run --extra dev python -m pytest tests/gateway/test_shutdown_forensics.py -q
uv run --extra dev python -m ruff check gateway/shutdown_forensics.py tests/gateway/test_shutdown_forensics.py
git diff --check
```
