### PR TITLE
fix(memory): tolerate delimiter-adjacent whitespace

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -782,6 +782,21 @@ class TestExternalDriftGuard:
         result = store.replace("memory", "Entry two", "Entry two replaced.")
         assert result["success"] is True
 
+    def test_delimiter_adjacent_whitespace_does_not_trigger_drift(self, store):
+        """Blank lines around § are cosmetic because entries are stripped."""
+        path = store._path_for("memory")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("First entry.\n\n§\nSecond entry.\n", encoding="utf-8")
+        store.load_from_disk()
+
+        result = store.replace("memory", "Second entry", "Second entry updated.")
+
+        assert result["success"] is True
+        assert "drift_backup" not in result
+        assert path.read_text(encoding="utf-8") == (
+            "First entry.\n§\nSecond entry updated."
+        )
+
     def test_error_message_points_at_remediation(self, store):
         """The error string must reference the backup AND remediation steps."""
         store.add("memory", "Initial.")

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -705,12 +705,8 @@ class MemoryStore:
         """Return a backup-path string if on-disk content shows external drift.
 
         The memory file is supposed to be a list of small entries the tool
-        wrote, joined by §. Detect drift via two signals:
-
-        1. Round-trip mismatch — re-parsing and re-serializing the file
-           doesn't produce identical bytes (rare; would catch oddly-encoded
-           delimiters).
-        2. Entry-size overflow — any single parsed entry exceeds the
+        wrote, joined by §. Detect drift via entry-size overflow: any single
+        parsed entry exceeds the
            store's whole-file char limit. The tool budgets the ENTIRE store
            against that limit; no single tool-written entry can exceed it.
            When we see one entry larger than the limit, an external writer
@@ -718,6 +714,11 @@ class MemoryStore:
            free-form content into what the tool will treat as one entry.
            Flushing would then truncate that entry to the model's new
            content, discarding the appended bytes — issue #26045.
+
+        Formatting-only differences around the delimiter are intentionally not
+        drift. _read_file() already strips each parsed entry, so blank lines
+        next to § would be normalized by any successful write without losing
+        parsed content (#61523).
 
         Returns the absolute path of the .bak file when drift was found and
         backed up; returns None when the file looks tool-shaped.
@@ -736,12 +737,10 @@ class MemoryStore:
             return None
 
         parsed = [e.strip() for e in raw.split(ENTRY_DELIMITER) if e.strip()]
-        roundtrip = ENTRY_DELIMITER.join(parsed)
-
         char_limit = self._char_limit(target)
         max_entry_len = max((len(e) for e in parsed), default=0)
 
-        drift_detected = (raw.strip() != roundtrip) or (max_entry_len > char_limit)
+        drift_detected = max_entry_len > char_limit
         if not drift_detected:
             return None
 
@@ -1146,7 +1145,5 @@ registry.register(
     check_fn=check_memory_requirements,
     emoji="🧠",
 )
-
-
 
 


### PR DESCRIPTION
## Summary

Fixes #61523.

The memory drift guard compared raw file bytes against the parser's normalized serialization. Since `_read_file()` strips each parsed entry, cosmetic whitespace next to `§` delimiters could never survive parsing, but it still caused `replace`/`remove` to hard-lock all writes with a drift backup.

This change keeps the guard focused on the data-loss case it can uniquely protect: a parsed entry larger than the target store's full char limit. Formatting-only whitespace around delimiters is allowed and will be normalized by the next successful memory write.

## Tests

Added a regression test for a `MEMORY.md` containing the same parsed entries as canonical output, but with a blank line before `§`; `replace` now succeeds and rewrites the file in canonical delimiter form.

```bash
uv run --extra dev python -m pytest tests/tools/test_memory_tool.py -q
uv run --extra dev python -m ruff check tools/memory_tool.py tests/tools/test_memory_tool.py
git diff --check
```
