### PR TITLE
feat: increase statusbar text size and add Codex-inspired colorful theme

### DIFF
--- a/apps/desktop/src/app/shell/statusbar-controls.tsx
+++ b/apps/desktop/src/app/shell/statusbar-controls.tsx
@@ -8,7 +8,7 @@ import { cn } from '@/lib/utils'
 // Shared chrome styling for interactive statusbar items (button / link / menu
 // trigger). The 'text' variant intentionally omits hover/transition/disabled.
 const STATUSBAR_ACTION_CLASS =
-  'inline-flex h-full items-center gap-1 rounded-none px-1.5 text-[0.6875rem] text-(--ui-text-tertiary) transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground disabled:cursor-default disabled:opacity-45'
+  'inline-flex h-full items-center gap-1.5 rounded-none px-2 text-xs text-(--ui-text-tertiary) transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground disabled:cursor-default disabled:opacity-45'
 
 export interface StatusbarMenuItem {
   id: string
@@ -61,7 +61,7 @@ export function StatusbarControls({ className, leftItems = [], items = [], ...pr
   return (
     <footer
       className={cn(
-        'flex h-5 shrink-0 items-stretch justify-between gap-2 border-t border-(--ui-stroke-tertiary) bg-(--ui-sidebar-surface-background) px-1 py-0 text-(--ui-text-tertiary) [-webkit-app-region:no-drag]',
+        'flex h-6 shrink-0 items-stretch justify-between gap-2 border-t border-(--ui-stroke-tertiary) bg-(--ui-sidebar-surface-background) px-1.5 py-0 text-(--ui-text-tertiary) [-webkit-app-region:no-drag]',
         className
       )}
       data-slot="statusbar"
@@ -96,7 +96,7 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
     <>
       {item.icon}
       {item.label && <span className="truncate">{item.label}</span>}
-      {item.detail && <span className="truncate text-muted-foreground/80">{item.detail}</span>}
+      {item.detail && <span className="truncate text-muted-foreground">{item.detail}</span>}
     </>
   )
 
@@ -179,7 +179,7 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
       <Tip label={item.title}>
         <div
           className={cn(
-            'inline-flex h-full items-center gap-1 px-1.5 text-[0.6875rem] text-(--ui-text-tertiary)',
+            'inline-flex h-full items-center gap-1.5 px-2 text-xs text-(--ui-text-tertiary)',
             item.className
           )}
         >

--- a/apps/desktop/src/themes/presets.ts
+++ b/apps/desktop/src/themes/presets.ts
@@ -277,13 +277,80 @@ export const slateTheme: DesktopTheme = {
   }
 }
 
+/** Vibrant purple-blue with colorful accents — inspired by Codex and modern AI tools. */
+export const codexTheme: DesktopTheme = {
+  name: 'codex',
+  label: 'Codex',
+  description: 'Vibrant purple-blue with colorful accents',
+  colors: {
+    background: '#F5F3FF',
+    foreground: '#1E1B2E',
+    card: '#FFFFFF',
+    cardForeground: '#1E1B2E',
+    muted: '#EDE9FE',
+    mutedForeground: '#6B6590',
+    popover: '#FFFFFF',
+    popoverForeground: '#1E1B2E',
+    primary: '#7C3AED',
+    primaryForeground: '#FFFFFF',
+    secondary: '#EDE9FE',
+    secondaryForeground: '#3B2F6B',
+    accent: '#DDD6FE',
+    accentForeground: '#4C1D95',
+    border: '#DDD6FE',
+    input: '#E9E5F5',
+    ring: '#7C3AED',
+    midground: '#7C3AED',
+    composerRing: '#7C3AED',
+    destructive: '#DC2626',
+    destructiveForeground: '#FFFFFF',
+    sidebarBackground: '#EDE9FE',
+    sidebarBorder: '#DDD6FE',
+    userBubble: '#EDE9FE',
+    userBubbleBorder: '#C4B5FD'
+  },
+  darkColors: {
+    background: '#0F0A1E',
+    foreground: '#E8E0F0',
+    card: '#1A1230',
+    cardForeground: '#E8E0F0',
+    muted: '#231A3E',
+    mutedForeground: '#9585C0',
+    popover: '#1E1538',
+    popoverForeground: '#E8E0F0',
+    primary: '#A78BFA',
+    primaryForeground: '#0F0A1E',
+    secondary: '#2D2252',
+    secondaryForeground: '#C4B5FD',
+    accent: '#3B2F6B',
+    accentForeground: '#DDD6FE',
+    border: '#3D2F72',
+    input: '#2D2252',
+    ring: '#A78BFA',
+    midground: '#7C3AED',
+    composerRing: '#A78BFA',
+    destructive: '#F87171',
+    destructiveForeground: '#0F0A1E',
+    sidebarBackground: '#0A0718',
+    sidebarBorder: '#2D2252',
+    userBubble: '#1E1538',
+    userBubbleBorder: '#4C1D95'
+  },
+  typography: {
+    fontSans: SYSTEM_SANS,
+    fontMono: `"JetBrains Mono", ${SYSTEM_MONO}`,
+    fontUrl: 'https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap'
+  }
+}
+
 export const BUILTIN_THEMES: Record<string, DesktopTheme> = {
   nous: nousTheme,
   midnight: midnightTheme,
   ember: emberTheme,
   mono: monoTheme,
   cyberpunk: cyberpunkTheme,
-  slate: slateTheme
+  slate: slateTheme,
+  codex: codexTheme
 }
 
 export const BUILTIN_THEME_LIST = Object.values(BUILTIN_THEMES)


### PR DESCRIPTION
## Summary

Two small UX improvements for the Hermes Desktop app, based on user feedback:

### 1. Larger statusbar text
- Text size: `0.6875rem` (11px) → `text-xs` (12px)
- Height: `h-5` (20px) → `h-6` (24px)
- Wider padding (`px-1` → `px-1.5` / `px-2`) and spacing (`gap-1` → `gap-1.5`)
- Detail text now uses full `text-muted-foreground` opacity instead of `/80`

**Before**: statusbar text at 11px was hard to read, cramped layout
**After**: 12px text with more breathing room while staying compact

### 2. New "Codex" theme (vibrant purple-blue)
Adds a new built-in theme inspired by modern AI tools like OpenAI Codex:
- **Light mode**: soft lavender backgrounds with vivid purple accents (#7C3AED)
- **Dark mode**: deep indigo-purple with brighter lavender accents (#A78BFA)
- JetBrains Mono for code rendering
- Fully integrated — auto-appears in Appearance settings, no other code needed

The new theme joins the existing lineup as `codex`, visible in the theme picker dropdown alongside Nous, Midnight, Ember, Mono, Cyberpunk, and Slate.

## Screenshots

> *Needs screenshots from a build — the theme definition follows the same `DesktopTheme` interface as all existing themes.*

## Testing

- [ ] Theme appears in Appearance settings → themes dropdown
- [ ] Both light and dark mode render correctly
- [ ] Statusbar text is larger and more readable
- [ ] No regressions in existing themes

## Related

- Closes user request: status bar text too small, UI too black-and-white