### PR TITLE
feat(reasoning): allow custom clamp line count

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -459,6 +459,7 @@ def load_cli_config() -> Dict[str, Any]:
             # hermes_cli/config.py DEFAULT_CONFIG (display.show_reasoning).
             "show_reasoning": True,
             "reasoning_full": False,
+            "reasoning_clamp_lines": 10,
             "streaming": True,
             "busy_input_mode": "interrupt",
             "persistent_output": True,
@@ -3727,6 +3728,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # reasoning_full: when reasoning display is on, print the post-response
         # recap box uncollapsed instead of clamping to the first 10 lines.
         self.reasoning_full = CLI_CONFIG["display"].get("reasoning_full", False)
+        self.reasoning_clamp_lines = CLI_CONFIG["display"].get("reasoning_clamp_lines", 10)
         _configure_output_history(
             enabled=CLI_CONFIG["display"].get("persistent_output", True),
             max_lines=CLI_CONFIG["display"].get("persistent_output_max_lines", 200),
@@ -12638,12 +12640,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     r_fill = w - 2 - len(r_label)
                     r_top = f"{_DIM}┌─{r_label}{'─' * max(r_fill - 1, 0)}┐{_RST}"
                     r_bot = f"{_DIM}└{'─' * (w - 2)}┘{_RST}"
-                    # Collapse long reasoning to the first 10 lines unless the
+                    # Collapse long reasoning to the configured line count unless the
                     # user opted into full display via /reasoning full.
                     lines = reasoning.strip().splitlines()
-                    if len(lines) > 10 and not getattr(self, "reasoning_full", False):
-                        display_reasoning = "\n".join(lines[:10])
-                        display_reasoning += f"\n{_DIM}  ... ({len(lines) - 10} more lines — /reasoning full to show){_RST}"
+                    clamp_lines = max(1, int(getattr(self, "reasoning_clamp_lines", 10) or 10))
+                    if len(lines) > clamp_lines and not getattr(self, "reasoning_full", False):
+                        display_reasoning = "\n".join(lines[:clamp_lines])
+                        display_reasoning += f"\n{_DIM}  ... ({len(lines) - clamp_lines} more lines — /reasoning full to show){_RST}"
                     else:
                         display_reasoning = reasoning.strip()
                     _cprint(f"\n{r_top}\n{_DIM}{display_reasoning}{_RST}\n{r_bot}")

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2476,6 +2476,7 @@ class CLICommandsMixin:
             /reasoning hide|off     Hide model thinking/reasoning from output
             /reasoning full         Show complete thinking (no 10-line clamp)
             /reasoning clamp        Collapse long thinking to the first 10 lines
+            /reasoning clamp <N>    Collapse long thinking to the first N lines
         """
         from cli import _ACCENT, _DIM, _RST, _cprint, _parse_reasoning_config, save_config_value
         parts = cmd.strip().split(maxsplit=1)
@@ -2490,16 +2491,22 @@ class CLICommandsMixin:
             else:
                 level = rc.get("effort", "medium")
             display_state = "on ✓" if self.show_reasoning else "off"
-            full_state = "full" if getattr(self, "reasoning_full", False) else "clamped to 10 lines"
+            clamp_lines = getattr(self, "reasoning_clamp_lines", 10)
+            full_state = "full" if getattr(self, "reasoning_full", False) else f"clamped to {clamp_lines} lines"
             _cprint(f"  {_ACCENT}Reasoning effort:  {level}{_RST}")
             _cprint(f"  {_ACCENT}Reasoning display: {display_state} ({full_state}){_RST}")
-            _cprint(f"  {_DIM}Usage: /reasoning <none|minimal|low|medium|high|xhigh|show|hide|full|clamp>{_RST}")
+            _cprint(f"  {_DIM}Usage: /reasoning <none|minimal|low|medium|high|xhigh|show|hide|full|clamp [lines]>{_RST}")
             return
 
-        arg = parts[1].strip().lower()
+        arg_text = parts[1].strip().lower()
+        tokens = arg_text.split()
+        arg = tokens[0] if tokens else ""
 
         # Display toggle
         if arg in {"show", "on"}:
+            if len(tokens) > 1:
+                _cprint(f"  {_DIM}Usage: /reasoning {arg}{_RST}")
+                return
             self.show_reasoning = True
             if self.agent:
                 self.agent.reasoning_callback = self._current_reasoning_callback()
@@ -2508,6 +2515,9 @@ class CLICommandsMixin:
             _cprint(f"  {_DIM}  Model thinking will be shown during and after each response.{_RST}")
             return
         if arg in {"hide", "off"}:
+            if len(tokens) > 1:
+                _cprint(f"  {_DIM}Usage: /reasoning {arg}{_RST}")
+                return
             self.show_reasoning = False
             if self.agent:
                 self.agent.reasoning_callback = self._current_reasoning_callback()
@@ -2517,6 +2527,9 @@ class CLICommandsMixin:
 
         # Full / clamped recap toggle
         if arg in {"full", "all"}:
+            if len(tokens) > 1:
+                _cprint(f"  {_DIM}Usage: /reasoning {arg}{_RST}")
+                return
             self.reasoning_full = True
             save_config_value("display.reasoning_full", True)
             _cprint(f"  {_ACCENT}✓ Reasoning display: FULL (saved){_RST}")
@@ -2525,26 +2538,41 @@ class CLICommandsMixin:
                 _cprint(f"  {_DIM}  Note: reasoning display is OFF — run /reasoning show to see it.{_RST}")
             return
         if arg in {"clamp", "collapse", "short"}:
+            if len(tokens) > 2:
+                _cprint(f"  {_DIM}Usage: /reasoning clamp [lines]{_RST}")
+                return
+            clamp_lines = 10
+            if len(tokens) == 2:
+                try:
+                    clamp_lines = int(tokens[1])
+                except ValueError:
+                    _cprint(f"  {_DIM}Clamp line count must be a positive integer.{_RST}")
+                    return
+                if clamp_lines < 1:
+                    _cprint(f"  {_DIM}Clamp line count must be a positive integer.{_RST}")
+                    return
             self.reasoning_full = False
+            self.reasoning_clamp_lines = clamp_lines
             save_config_value("display.reasoning_full", False)
-            _cprint(f"  {_ACCENT}✓ Reasoning display: CLAMPED to 10 lines (saved){_RST}")
+            save_config_value("display.reasoning_clamp_lines", clamp_lines)
+            _cprint(f"  {_ACCENT}✓ Reasoning display: CLAMPED to {clamp_lines} lines (saved){_RST}")
             return
 
         # Effort level change
-        parsed = _parse_reasoning_config(arg)
+        parsed = _parse_reasoning_config(arg_text)
         if parsed is None:
-            _cprint(f"  {_DIM}(._.) Unknown argument: {arg}{_RST}")
+            _cprint(f"  {_DIM}(._.) Unknown argument: {arg_text}{_RST}")
             _cprint(f"  {_DIM}Valid levels: none, minimal, low, medium, high, xhigh{_RST}")
-            _cprint(f"  {_DIM}Display:      show, hide{_RST}")
+            _cprint(f"  {_DIM}Display:      show, hide, full, clamp [lines]{_RST}")
             return
 
         self.reasoning_config = parsed
         self.agent = None  # Force agent re-init with new reasoning config
 
-        if save_config_value("agent.reasoning_effort", arg):
-            _cprint(f"  {_ACCENT}✓ Reasoning effort set to '{arg}' (saved to config){_RST}")
+        if save_config_value("agent.reasoning_effort", arg_text):
+            _cprint(f"  {_ACCENT}✓ Reasoning effort set to '{arg_text}' (saved to config){_RST}")
         else:
-            _cprint(f"  {_ACCENT}✓ Reasoning effort set to '{arg}' (session only){_RST}")
+            _cprint(f"  {_ACCENT}✓ Reasoning effort set to '{arg_text}' (session only){_RST}")
 
     def _handle_busy_command(self, cmd: str):
         """Handle /busy — control what Enter does while Hermes is working.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1779,6 +1779,8 @@ DEFAULT_CONFIG = {
         # collapses long thinking to the first 10 lines. Set true to print the
         # complete thinking text uncollapsed (live streaming is always full).
         "reasoning_full": False,
+        # Number of lines shown by the collapsed post-response reasoning recap.
+        "reasoning_clamp_lines": 10,
         # Background self-improvement review notifications surfaced in chat.
         #   "off"     — no chat notification (the review still runs and writes)
         #   "on"      — generic "💾 Memory updated" line (default)

--- a/tests/hermes_cli/test_reasoning_full_command.py
+++ b/tests/hermes_cli/test_reasoning_full_command.py
@@ -22,6 +22,7 @@ class _Stub(CLICommandsMixin):
         self.reasoning_config = None
         self.show_reasoning = True
         self.reasoning_full = False
+        self.reasoning_clamp_lines = 10
         self.agent = None
 
     def _current_reasoning_callback(self):
@@ -31,6 +32,7 @@ class _Stub(CLICommandsMixin):
 def test_default_config_clamps_reasoning():
     # Behaviour contract: the recap defaults to clamped, not full.
     assert DEFAULT_CONFIG["display"]["reasoning_full"] is False
+    assert DEFAULT_CONFIG["display"]["reasoning_clamp_lines"] == 10
 
 
 def _seed_config(tmp_path, monkeypatch):
@@ -64,6 +66,42 @@ def test_reasoning_clamp_resets_and_persists(tmp_path, monkeypatch):
     assert s.reasoning_full is False
     saved = yaml.safe_load((hh / "config.yaml").read_text())
     assert saved["display"]["reasoning_full"] is False
+
+
+def test_reasoning_clamp_accepts_custom_line_count(tmp_path, monkeypatch):
+    hh = _seed_config(tmp_path, monkeypatch)
+    s = _Stub()
+    s.reasoning_full = True
+
+    s._handle_reasoning_command("/reasoning clamp 20")
+    assert s.reasoning_full is False
+    assert s.reasoning_clamp_lines == 20
+    saved = yaml.safe_load((hh / "config.yaml").read_text())
+    assert saved["display"]["reasoning_full"] is False
+    assert saved["display"]["reasoning_clamp_lines"] == 20
+
+
+def test_reasoning_clamp_rejects_invalid_line_count(tmp_path, monkeypatch):
+    hh = _seed_config(tmp_path, monkeypatch)
+    s = _Stub()
+    s.reasoning_full = True
+
+    s._handle_reasoning_command("/reasoning clamp 0")
+    assert s.reasoning_full is True
+    assert s.reasoning_clamp_lines == 10
+    saved = yaml.safe_load((hh / "config.yaml").read_text())
+    assert "reasoning_full" not in saved["display"]
+    assert "reasoning_clamp_lines" not in saved["display"]
+
+
+def test_reasoning_full_rejects_extra_arguments(tmp_path, monkeypatch):
+    hh = _seed_config(tmp_path, monkeypatch)
+    s = _Stub()
+
+    s._handle_reasoning_command("/reasoning full now")
+    assert s.reasoning_full is False
+    saved = yaml.safe_load((hh / "config.yaml").read_text())
+    assert "reasoning_full" not in saved["display"]
 
 
 def test_reasoning_all_is_alias_for_full(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add display.reasoning_clamp_lines with the existing 10-line default
- support `/reasoning clamp <N>` while preserving `/reasoning clamp` behavior
- use the configured clamp count when rendering the post-response reasoning recap

Fixes #61420

## Tests
- `uv run --extra dev python -m pytest tests/hermes_cli/test_reasoning_full_command.py tests/hermes_cli/test_commands.py tests/cli/test_reasoning_command.py -q`
- `uv run --extra dev python -m ruff check cli.py hermes_cli/cli_commands_mixin.py hermes_cli/config.py tests/hermes_cli/test_reasoning_full_command.py`
- `git diff --check`