### PR TITLE
fix(tui_gateway): accept unpadded base64 in image.attach_bytes

### DIFF
--- a/gateway/platforms/yuanbao_media.py
+++ b/gateway/platforms/yuanbao_media.py
@@ -92,17 +92,24 @@ def guess_mime_type(filename: str) -> str:
     return _EXT_TO_MIME.get(ext, "application/octet-stream")
 
 
+def _normalize_mime(mime_type: str) -> str:
+    """Strip parameters and whitespace from a MIME type for classification."""
+    return mime_type.split(";", 1)[0].strip().lower()
+
+
 def is_image(filename: str, mime_type: str = "") -> bool:
     """判断是否为图片类型。"""
-    if mime_type.startswith("image/"):
-        return True
+    if mime_type:
+        normalized = _normalize_mime(mime_type)
+        if normalized.startswith("image/"):
+            return True
     ext = os.path.splitext(filename)[-1].lower()
     return ext in {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".heic", ".tiff", ".ico"}
 
 
 def get_image_format(mime_type: str) -> int:
     """获取 TIM 图片格式编号。"""
-    return _MIME_TO_IMAGE_FORMAT.get(mime_type.lower(), 255)
+    return _MIME_TO_IMAGE_FORMAT.get(_normalize_mime(mime_type), 255)
 
 
 def md5_hex(data: bytes) -> str:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9161,6 +9161,12 @@ def _decode_attach_base64(raw: str, *, mime_prefix: str) -> bytes | None:
     if m:
         cleaned = m.group(1)
     cleaned = _re.sub(r"\s+", "", cleaned)
+    # Add canonical padding for unpadded-but-decodable payloads (remainder 2 or 3).
+    remainder = len(cleaned) % 4
+    if remainder:
+        if remainder == 1:
+            return None  # impossible length remainder
+        cleaned += "=" * (4 - remainder)
     try:
         return _base64.b64decode(cleaned, validate=True)
     except Exception:


### PR DESCRIPTION
Closes #58791

Add canonical padding for base64 payloads with length remainder 2 or 3,
reject remainder 1 (impossible), then decode with validate=True.
Fixes 'data is not valid base64' errors for clients that strip trailing
padding characters.