### PR TITLE
docs(irc): recommend self-hosted server examples

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4296,7 +4296,7 @@ OPTIONAL_ENV_VARS = {
         "category": "messaging",
     },
     "IRC_SERVER": {
-        "description": "IRC server hostname (e.g. irc.libera.chat)",
+        "description": "IRC server hostname (e.g. localhost for a self-hosted ircd)",
         "prompt": "IRC server",
         "url": None,
         "password": False,

--- a/plugins/platforms/irc/adapter.py
+++ b/plugins/platforms/irc/adapter.py
@@ -12,7 +12,7 @@ Configuration in config.yaml::
         irc:
           enabled: true
           extra:
-            server: irc.libera.chat
+            server: localhost
             port: 6697
             nickname: hermes-bot
             channel: "#hermes"
@@ -559,11 +559,11 @@ def interactive_setup() -> None:
         if not prompt_yes_no("Reconfigure IRC?", False):
             return
 
-    print_info("Connect Hermes to an IRC network. Uses Python stdlib — no extra packages needed.")
-    print_info("   Works with Libera.Chat, OFTC, your own ZNC/InspIRCd, etc.")
+    print_info("Connect Hermes to an IRC server. Uses Python stdlib — no extra packages needed.")
+    print_info("   Recommended: a local/self-hosted ircd such as Ergo, InspIRCd, or ZNC.")
     print()
 
-    server = prompt("IRC server hostname (e.g. irc.libera.chat)", default=existing_server or "")
+    server = prompt("IRC server hostname (e.g. localhost)", default=existing_server or "")
     if not server:
         print_warning("Server is required — skipping IRC setup")
         return

--- a/plugins/platforms/irc/plugin.yaml
+++ b/plugins/platforms/irc/plugin.yaml
@@ -12,7 +12,7 @@ author: Nous Research
 # platform-plugin env var injector in ``hermes_cli/config.py``.
 requires_env:
   - name: IRC_SERVER
-    description: "IRC server hostname (e.g. irc.libera.chat)"
+    description: "IRC server hostname (e.g. localhost for a self-hosted ircd)"
     prompt: "IRC server"
     password: false
   - name: IRC_CHANNEL

--- a/tests/gateway/test_irc_recommendations.py
+++ b/tests/gateway/test_irc_recommendations.py
@@ -1,0 +1,25 @@
+"""Regression tests for IRC setup recommendations."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_irc_user_facing_examples_do_not_recommend_libera():
+    """Hermes should not steer agentic IRC users toward Libera.Chat."""
+    user_facing_paths = [
+        "plugins/platforms/irc/adapter.py",
+        "plugins/platforms/irc/plugin.yaml",
+        "hermes_cli/config.py",
+        "website/docs/user-guide/messaging/irc.md",
+        "website/docs/reference/environment-variables.md",
+    ]
+
+    offenders = []
+    for rel_path in user_facing_paths:
+        text = (REPO_ROOT / rel_path).read_text(encoding="utf-8")
+        if "irc.libera.chat" in text or "Libera.Chat" in text:
+            offenders.append(rel_path)
+
+    assert offenders == []

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -591,7 +591,7 @@ Connect Hermes to an IRC server. No external dependencies. See [the IRC messagin
 
 | Variable | Description |
 |----------|-------------|
-| `IRC_SERVER` | IRC server hostname (e.g. `irc.libera.chat`). Required. |
+| `IRC_SERVER` | IRC server hostname (e.g. `localhost` for a self-hosted ircd). Required. |
 | `IRC_CHANNEL` | Channel(s) to join (e.g. `#hermes`); comma-separate for multiple. Required. |
 | `IRC_NICKNAME` | Bot nickname (default: `hermes-bot`). Required. |
 | `IRC_PORT` | Server port (default: `6697` with TLS, `6667` without). |

--- a/website/docs/user-guide/messaging/irc.md
+++ b/website/docs/user-guide/messaging/irc.md
@@ -1,6 +1,6 @@
 # IRC
 
-The IRC adapter connects Hermes to any IRC server and relays messages between an IRC channel (or direct messages) and the agent. It speaks the IRC protocol over Python's stdlib `asyncio` — **no external dependencies, no SDK, no daemon**. It works with public networks like [Libera.Chat](https://libera.chat/) and any self-hosted ircd.
+The IRC adapter connects Hermes to any IRC server and relays messages between an IRC channel (or direct messages) and the agent. It speaks the IRC protocol over Python's stdlib `asyncio` — **no external dependencies, no SDK, no daemon**. For agentic use, prefer a local or self-hosted ircd where you control the network policy.
 
 IRC is plain text: there is no voice, image, file, thread, reaction, typing, or streaming support — replies are sent as `PRIVMSG` lines, with long messages split to fit the IRC line limit.
 
@@ -8,7 +8,7 @@ IRC is plain text: there is no voice, image, file, thread, reaction, typing, or 
 
 ## Prerequisites
 
-- An IRC server to connect to (e.g. `irc.libera.chat`)
+- An IRC server to connect to (e.g. `localhost` for a self-hosted ircd)
 - A channel to join (e.g. `#hermes`) — comma-separate to join several
 - A nickname for the bot (default: `hermes-bot`)
 - Optional: a registered nick + NickServ password if your network requires identification
@@ -25,7 +25,7 @@ gateway:
     irc:
       enabled: true
       extra:
-        server: irc.libera.chat
+        server: localhost
         port: 6697
         nickname: hermes-bot
         channel: "#hermes"
@@ -40,7 +40,7 @@ gateway:
 
 | Variable | Required | Description |
 |----------|:--------:|-------------|
-| `IRC_SERVER` | ✅ | IRC server hostname (e.g. `irc.libera.chat`) |
+| `IRC_SERVER` | ✅ | IRC server hostname (e.g. `localhost` for a self-hosted ircd) |
 | `IRC_CHANNEL` | ✅ | Channel(s) to join — comma-separate for multiple |
 | `IRC_NICKNAME` | ✅ | Bot nickname (default: `hermes-bot`) |
 | `IRC_PORT` | — | Server port (default: `6697` with TLS, `6667` without) |


### PR DESCRIPTION
## Summary
- replace Libera.Chat IRC setup examples with localhost/self-hosted ircd examples
- update setup prompt and env metadata to recommend a local/self-hosted IRC server
- add a regression test that keeps user-facing IRC recommendations from pointing back to Libera.Chat

Fixes #61181

## Tests
- `uv run --extra dev python -m pytest tests/gateway/test_irc_recommendations.py tests/gateway/test_irc_adapter.py tests/hermes_cli/test_setup_irc.py -q`
- `uv run --extra dev python -m ruff check plugins/platforms/irc/adapter.py hermes_cli/config.py tests/gateway/test_irc_recommendations.py`
- `git diff --check`