### PR TITLE
feat(providers): add Meta Model API (Muse Spark) provider plugin

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -54,6 +54,7 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "arcee",
     "gmi",
     "tencent-tokenhub",
+    "meta-ai",
     "custom", "local",
     # Common aliases
     "google", "google-gemini", "google-ai-studio",
@@ -68,6 +69,10 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "xai", "x-ai", "x.ai", "grok",
     "nvidia", "nim", "nvidia-nim", "nemotron",
     "qwen-portal", "novita-ai", "novitaai",
+    # Meta Model API (Muse Spark) — provider prefix + user-facing aliases
+    # so `meta:muse-spark-1.1` / `muse:muse-spark-1.1` / etc. strip correctly
+    # for cache lookups and server queries.
+    "meta", "muse", "model-api", "llama-api",
 })
 
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -264,7 +264,10 @@ DEFAULT_CONTEXT_LENGTHS = {
     "deepseek-chat": 1_000_000,
     "deepseek-reasoner": 1_000_000,
     "deepseek": 128000,
-    # Meta
+    # Meta — Muse Spark (Model API) ships with a 1M context window.
+    # Longer key before the generic "llama" Meta catch-all so muse-spark-*
+    # model IDs resolve correctly via longest-substring matching.
+    "muse-spark": 1_048_576,
     "llama": 131072,
     # Qwen — specific model families before the catch-all.
     # Official docs: https://help.aliyun.com/zh/model-studio/developer-reference/

--- a/plugins/model-providers/meta-ai/__init__.py
+++ b/plugins/model-providers/meta-ai/__init__.py
@@ -1,26 +1,66 @@
 """Meta Model API (Muse Spark) provider profile.
 
-Meta's OpenAI-compatible ``/v1/chat/completions`` endpoint supports
-top-level ``reasoning_effort`` with values ``minimal``, ``low``,
-``medium``, ``high``, and ``xhigh``.
+Meta Model API is OpenAI-compatible and serves Muse Spark 1.1 with:
 
-This profile maps Hermes's ``max`` → ``xhigh``.  When reasoning is
-explicitly disabled (``enabled: false``) or effort is ``none``, the
-profile emits ``reasoning_effort=minimal`` — Meta returns HTTP 400 for
-``none``, so that value must never appear on the wire.  Empty / missing
-effort omits the field so the model uses its default.
+- Base URL: https://api.meta.ai/v1
+- Auth: MODEL_API_KEY (alias META_API_KEY, META_MODEL_API_KEY), format LLM|...
+- Context window: 1,048,576 tokens (no long-context premium)
+- Input modalities: text, image, video, PDF; Output: text
+- Pricing: $1.25 input / $0.15 cached input / $4.25 output per 1M tokens
+- Features: parallel tool calling, structured output (response_format json_schema),
+  prompt caching (automatic prefix, reports cached_tokens), search grounding
+  (built-in web_search), file handling via file_id, token counting
+
+Reasoning:
+- Muse Spark is a reasoning model that always reasons internally.
+- Control depth via top-level ``reasoning_effort`` on Chat Completions:
+  minimal, low, medium, high, xhigh. On Responses API it's nested as
+  reasoning.effort.
+- ``none`` disables reasoning and Muse Spark does NOT support it: HTTP 400.
+  Hermes never emits ``none`` — map disabled/``none`` → ``minimal``.
+- ``max`` is not a Meta value (it is Hermes/Ollama shorthand). Map → ``xhigh``.
+- Reasoning tokens count toward max_tokens / max_output_tokens and are billed.
+- When omitted, model reasons at a model-determined level.
+
+Ref: https://dev.meta.ai/docs/features/reasoning/
+     https://dev.meta.ai/docs/getting-started/models/
+     https://dev.meta.ai/docs/getting-started/pricing-rate-limits/
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from providers import register_provider
 from providers.base import ProviderProfile
 
 
+@dataclass
 class MetaAiProfile(ProviderProfile):
-    """Meta Model API — top-level reasoning_effort (never emit none)."""
+    """Meta Model API — vision + tool calling + structured output + reasoning.
+
+    Implements Meta's reasoning_effort contract:
+
+    - Chat Completions: top-level ``reasoning_effort``
+    - Responses API: nested ``reasoning.effort`` (handled via extra_body fallback)
+    - Valid values: minimal, low, medium, high, xhigh — NEVER none (400)
+    - Hermes extras: ``max`` → xhigh
+
+    When reasoning is disabled (``enabled: false``) or effort is ``none``,
+    emit ``minimal`` so request stays valid at lowest thinking tier.
+    Empty / missing effort omits field so model uses its default.
+
+    Vision: Muse Spark accepts image, video and PDF in user messages.
+    Hermes sets ``supports_vision=True`` so native image routing is used
+    (user-role images, tool-result multipart) instead of text fallback.
+    Per https://dev.meta.ai/docs/getting-started/models/ and
+    https://dev.meta.ai/docs/features/image-understanding/
+    """
+
+    # Override dataclass default for vision — must be dataclass field, not
+    # plain class attribute, so ProviderProfile dataclass machinery picks it up.
+    supports_vision: bool = True
 
     def build_api_kwargs_extras(
         self,
@@ -28,45 +68,66 @@ class MetaAiProfile(ProviderProfile):
         reasoning_config: dict | None = None,
         **ctx: Any,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
-        """Emit top-level ``reasoning_effort`` for Meta Model API.
+        """Emit Meta-compatible reasoning_effort.
 
-        The ``supports_reasoning`` flag passed by the transport is
-        deliberately ignored — this profile always handles reasoning
-        when ``reasoning_config`` is present.
+        The ``supports_reasoning`` flag from transport is intentionally ignored
+        — this profile always handles reasoning when config is present.
+
+        Returns (extra_body, top_level) where:
+        - top_level: for Chat Completions (reasoning_effort)
+        - extra_body: for Responses API fallback (reasoning.effort) if needed
+          by a custom api_mode override.
         """
         top_level: dict[str, Any] = {}
+        extra_body: dict[str, Any] = {}
 
-        if reasoning_config and isinstance(reasoning_config, dict):
-            enabled = reasoning_config.get("enabled", True)
-            if enabled is False:
-                # Meta rejects reasoning_effort=none with HTTP 400.
-                # Map disabled → minimal (lowest valid thinking tier).
-                top_level["reasoning_effort"] = "minimal"
-                return {}, top_level
+        if not reasoning_config or not isinstance(reasoning_config, dict):
+            return extra_body, top_level
 
-            effort = (reasoning_config.get("effort") or "").strip().lower()
-            if not effort:
-                # No explicit effort — let the model decide
-                return {}, {}
-            if effort == "none":
-                # NEVER emit none — Meta returns HTTP 400
-                top_level["reasoning_effort"] = "minimal"
-            elif effort in ("max", "xhigh"):
-                top_level["reasoning_effort"] = "xhigh"
-            elif effort in ("minimal", "low", "medium", "high"):
-                top_level["reasoning_effort"] = effort
-            else:
-                # Unknown value — forward as-is, let the API decide
-                top_level["reasoning_effort"] = effort
+        enabled = reasoning_config.get("enabled", True)
+        if enabled is False:
+            # Meta rejects reasoning_effort=none with HTTP 400.
+            # Map disabled → minimal (lowest valid tier).
+            top_level["reasoning_effort"] = "minimal"
+            # Also cover Responses API mode if user forces it via config.
+            extra_body["reasoning"] = {"effort": "minimal"}
+            return extra_body, top_level
 
-        return {}, top_level
+        effort = (reasoning_config.get("effort") or "").strip().lower()
+        if not effort:
+            # No explicit effort — let model decide (still reasons internally)
+            return {}, {}
+
+        # Normalize Hermes / generic values to Meta's valid set
+        if effort == "none":
+            # NEVER emit none — Meta returns HTTP 400 for Spark
+            mapped = "minimal"
+        elif effort in ("max", "xhigh"):
+            mapped = "xhigh"
+        elif effort in ("minimal", "low", "medium", "high"):
+            mapped = effort
+        else:
+            # Unknown value — forward as-is to allow future values,
+            # but guard against the only known invalid: none already handled.
+            mapped = effort
+
+        top_level["reasoning_effort"] = mapped
+        # Defensive: if caller uses Responses api_mode, also expose nested form.
+        # Hermes transport merges both; the non-applicable one is ignored.
+        # Only emit extra_body when api_mode hints at Responses to avoid
+        # polluting Chat Completions calls with both forms.
+        api_mode = (ctx.get("api_mode") or "").strip().lower()
+        if api_mode == "codex_responses" or ctx.get("is_responses_api"):
+            extra_body["reasoning"] = {"effort": mapped}
+
+        return extra_body, top_level
 
 
 meta_ai = MetaAiProfile(
     name="meta-ai",
     aliases=("meta", "muse", "llama-api", "model-api"),
     display_name="Meta Model API",
-    description="Meta Model API — Muse Spark (OpenAI-compatible)",
+    description="Meta Model API — Muse Spark (1M context, vision, tools, reasoning)",
     signup_url="https://dev.meta.ai/",
     env_vars=(
         "MODEL_API_KEY",
@@ -77,8 +138,11 @@ meta_ai = MetaAiProfile(
     base_url="https://api.meta.ai/v1",
     auth_type="api_key",
     api_mode="chat_completions",
+    supports_vision=True,
     # Muse Spark spends completion budget on hidden reasoning_tokens first;
     # low caps (e.g. 32–128) finish with empty content. Cap high like NVIDIA NIM.
+    # See https://dev.meta.ai/docs/features/reasoning/ :
+    # "Reasoning tokens count toward your output-token budget"
     default_max_tokens=16384,
     default_aux_model="muse-spark-1.1",
     fallback_models=("muse-spark-1.1",),

--- a/plugins/model-providers/meta-ai/__init__.py
+++ b/plugins/model-providers/meta-ai/__init__.py
@@ -1,0 +1,84 @@
+"""Meta Model API (Muse Spark) provider profile.
+
+Meta's OpenAI-compatible ``/v1/chat/completions`` endpoint supports
+top-level ``reasoning_effort`` with values ``minimal``, ``low``,
+``medium``, ``high``, and ``xhigh``.
+
+This profile maps Hermes's ``max`` → ``xhigh``.  When reasoning is
+explicitly disabled (``enabled: false``) or effort is ``none``, the
+profile emits ``reasoning_effort=minimal`` — Meta returns HTTP 400 for
+``none``, so that value must never appear on the wire.  Empty / missing
+effort omits the field so the model uses its default.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class MetaAiProfile(ProviderProfile):
+    """Meta Model API — top-level reasoning_effort (never emit none)."""
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        **ctx: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Emit top-level ``reasoning_effort`` for Meta Model API.
+
+        The ``supports_reasoning`` flag passed by the transport is
+        deliberately ignored — this profile always handles reasoning
+        when ``reasoning_config`` is present.
+        """
+        top_level: dict[str, Any] = {}
+
+        if reasoning_config and isinstance(reasoning_config, dict):
+            enabled = reasoning_config.get("enabled", True)
+            if enabled is False:
+                # Meta rejects reasoning_effort=none with HTTP 400.
+                # Map disabled → minimal (lowest valid thinking tier).
+                top_level["reasoning_effort"] = "minimal"
+                return {}, top_level
+
+            effort = (reasoning_config.get("effort") or "").strip().lower()
+            if not effort:
+                # No explicit effort — let the model decide
+                return {}, {}
+            if effort == "none":
+                # NEVER emit none — Meta returns HTTP 400
+                top_level["reasoning_effort"] = "minimal"
+            elif effort in ("max", "xhigh"):
+                top_level["reasoning_effort"] = "xhigh"
+            elif effort in ("minimal", "low", "medium", "high"):
+                top_level["reasoning_effort"] = effort
+            else:
+                # Unknown value — forward as-is, let the API decide
+                top_level["reasoning_effort"] = effort
+
+        return {}, top_level
+
+
+meta_ai = MetaAiProfile(
+    name="meta-ai",
+    aliases=("meta", "muse", "llama-api", "model-api"),
+    display_name="Meta Model API",
+    description="Meta Model API — Muse Spark (OpenAI-compatible)",
+    signup_url="https://dev.meta.ai/",
+    env_vars=(
+        "MODEL_API_KEY",
+        "META_API_KEY",
+        "META_MODEL_API_KEY",
+        "META_BASE_URL",
+    ),
+    base_url="https://api.meta.ai/v1",
+    auth_type="api_key",
+    api_mode="chat_completions",
+    default_aux_model="muse-spark-1.1",
+    fallback_models=("muse-spark-1.1",),
+)
+
+register_provider(meta_ai)

--- a/plugins/model-providers/meta-ai/__init__.py
+++ b/plugins/model-providers/meta-ai/__init__.py
@@ -77,6 +77,9 @@ meta_ai = MetaAiProfile(
     base_url="https://api.meta.ai/v1",
     auth_type="api_key",
     api_mode="chat_completions",
+    # Muse Spark spends completion budget on hidden reasoning_tokens first;
+    # low caps (e.g. 32–128) finish with empty content. Cap high like NVIDIA NIM.
+    default_max_tokens=16384,
     default_aux_model="muse-spark-1.1",
     fallback_models=("muse-spark-1.1",),
 )

--- a/plugins/model-providers/meta-ai/plugin.yaml
+++ b/plugins/model-providers/meta-ai/plugin.yaml
@@ -1,0 +1,5 @@
+name: meta-ai-provider
+kind: model-provider
+version: 1.0.0
+description: Meta Model API — Muse Spark (OpenAI-compatible)
+author: Nous Research

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -41,6 +41,7 @@ class TestProviderRegistry:
         ("minimax-cn", "MiniMax (China)", "api_key"),
         ("kilocode", "Kilo Code", "api_key"),
         ("gmi", "GMI Cloud", "api_key"),
+        ("meta-ai", "Meta Model API", "api_key"),
     ])
     def test_provider_registered(self, provider_id, name, auth_type):
         assert provider_id in PROVIDER_REGISTRY
@@ -105,6 +106,15 @@ class TestProviderRegistry:
         assert pconfig.api_key_env_vars == ("GMI_API_KEY",)
         assert pconfig.base_url_env_var == "GMI_BASE_URL"
 
+    def test_meta_ai_env_vars(self):
+        pconfig = PROVIDER_REGISTRY["meta-ai"]
+        assert pconfig.api_key_env_vars == (
+            "MODEL_API_KEY",
+            "META_API_KEY",
+            "META_MODEL_API_KEY",
+        )
+        assert pconfig.base_url_env_var == "META_BASE_URL"
+
     def test_huggingface_env_vars(self):
         pconfig = PROVIDER_REGISTRY["huggingface"]
         assert pconfig.api_key_env_vars == ("HF_TOKEN",)
@@ -120,6 +130,7 @@ class TestProviderRegistry:
         assert PROVIDER_REGISTRY["minimax-cn"].inference_base_url == "https://api.minimaxi.com/anthropic"
         assert PROVIDER_REGISTRY["kilocode"].inference_base_url == "https://api.kilo.ai/api/gateway"
         assert PROVIDER_REGISTRY["gmi"].inference_base_url == "https://api.gmi-serving.com/v1"
+        assert PROVIDER_REGISTRY["meta-ai"].inference_base_url == "https://api.meta.ai/v1"
         assert PROVIDER_REGISTRY["huggingface"].inference_base_url == "https://router.huggingface.co/v1"
 
     def test_oauth_providers_unchanged(self):
@@ -143,6 +154,7 @@ PROVIDER_ENV_VARS = (
     "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY",
     "KILOCODE_API_KEY", "KILOCODE_BASE_URL",
     "GMI_API_KEY", "GMI_BASE_URL",
+    "MODEL_API_KEY", "META_API_KEY", "META_MODEL_API_KEY", "META_BASE_URL",
     "DASHSCOPE_API_KEY", "OPENCODE_ZEN_API_KEY", "OPENCODE_GO_API_KEY",
     "NOUS_API_KEY", "GITHUB_TOKEN", "GH_TOKEN",
     "OPENAI_BASE_URL", "HERMES_COPILOT_ACP_COMMAND", "COPILOT_CLI_PATH",
@@ -177,6 +189,21 @@ class TestResolveProvider:
 
     def test_explicit_gmi(self):
         assert resolve_provider("gmi") == "gmi"
+
+    def test_explicit_meta_ai(self):
+        assert resolve_provider("meta-ai") == "meta-ai"
+
+    def test_alias_meta(self):
+        assert resolve_provider("meta") == "meta-ai"
+
+    def test_alias_muse(self):
+        assert resolve_provider("muse") == "meta-ai"
+
+    def test_alias_llama_api(self):
+        assert resolve_provider("llama-api") == "meta-ai"
+
+    def test_alias_model_api(self):
+        assert resolve_provider("model-api") == "meta-ai"
 
     def test_alias_glm(self):
         assert resolve_provider("glm") == "zai"

--- a/tests/hermes_cli/test_meta_ai_provider.py
+++ b/tests/hermes_cli/test_meta_ai_provider.py
@@ -23,7 +23,11 @@ from hermes_cli.models import (
     _PROVIDER_LABELS,
     provider_model_ids,
 )
-from agent.model_metadata import get_model_context_length
+from agent.model_metadata import (
+    get_model_context_length,
+    _PROVIDER_PREFIXES,
+    _strip_provider_prefix,
+)
 
 
 _META_ENV = (
@@ -65,6 +69,20 @@ class TestMetaAiAliases:
             "META_MODEL_API_KEY",
         )
         assert pconfig.base_url_env_var == "META_BASE_URL"
+
+
+class TestMetaAiProviderPrefixes:
+    """provider:model strings like meta:muse-spark-1.1 must strip correctly."""
+
+    def test_prefixes_include_meta_variants(self):
+        for prefix in ("meta-ai", "meta", "muse", "model-api", "llama-api"):
+            assert prefix in _PROVIDER_PREFIXES, f"{prefix} missing from _PROVIDER_PREFIXES"
+
+    def test_strip_meta_prefix(self):
+        assert _strip_provider_prefix("meta:muse-spark-1.1") == "muse-spark-1.1"
+        assert _strip_provider_prefix("meta-ai:muse-spark-1.1") == "muse-spark-1.1"
+        assert _strip_provider_prefix("muse:muse-spark-1.1") == "muse-spark-1.1"
+        assert _strip_provider_prefix("model-api:muse-spark-1.1") == "muse-spark-1.1"
 
 
 class TestMetaAiConfigRegistry:
@@ -212,3 +230,27 @@ class TestMetaAiModelMetadata:
             )
 
         assert result == 1_048_576
+
+    def test_muse_spark_variants_resolve(self):
+        """All muse-spark ID forms should resolve to 1M via substring matching."""
+        with patch(
+            "agent.model_metadata.get_cached_context_length",
+            return_value=None,
+        ), patch(
+            "agent.model_metadata.fetch_endpoint_model_metadata",
+            return_value={},
+        ), patch(
+            "agent.models_dev.lookup_models_dev_context",
+            return_value=None,
+        ), patch(
+            "agent.model_metadata.fetch_model_metadata",
+            return_value={},
+        ):
+            for model_id in ("muse-spark-1.1", "muse-spark-1.0", "muse-spark"):
+                result = get_model_context_length(
+                    model_id,
+                    base_url="https://api.meta.ai/v1",
+                    api_key="meta-test-key",
+                    provider="meta-ai",
+                )
+                assert result == 1_048_576, f"{model_id} should be 1M"

--- a/tests/hermes_cli/test_meta_ai_provider.py
+++ b/tests/hermes_cli/test_meta_ai_provider.py
@@ -1,0 +1,214 @@
+"""Focused tests for Meta Model API (Muse Spark) first-class provider wiring."""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import patch
+
+import pytest
+
+if "dotenv" not in sys.modules:
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    sys.modules["dotenv"] = fake_dotenv
+
+from hermes_cli.auth import (
+    PROVIDER_REGISTRY,
+    resolve_api_key_provider_credentials,
+    resolve_provider,
+)
+from hermes_cli.models import (
+    CANONICAL_PROVIDERS,
+    _PROVIDER_LABELS,
+    provider_model_ids,
+)
+from agent.model_metadata import get_model_context_length
+
+
+_META_ENV = (
+    "MODEL_API_KEY",
+    "META_API_KEY",
+    "META_MODEL_API_KEY",
+    "META_BASE_URL",
+    "OPENROUTER_API_KEY",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GOOGLE_API_KEY",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_provider_env(monkeypatch):
+    for key in _META_ENV:
+        monkeypatch.delenv(key, raising=False)
+
+
+class TestMetaAiAliases:
+    @pytest.mark.parametrize(
+        "alias",
+        ["meta-ai", "meta", "muse", "llama-api", "model-api"],
+    )
+    def test_alias_resolves(self, alias, monkeypatch):
+        monkeypatch.setenv("MODEL_API_KEY", "meta-test-key")
+        assert resolve_provider(alias) == "meta-ai"
+
+    def test_provider_registry_entry(self):
+        assert "meta-ai" in PROVIDER_REGISTRY
+        pconfig = PROVIDER_REGISTRY["meta-ai"]
+        assert pconfig.name == "Meta Model API"
+        assert pconfig.auth_type == "api_key"
+        assert pconfig.inference_base_url == "https://api.meta.ai/v1"
+        assert pconfig.api_key_env_vars == (
+            "MODEL_API_KEY",
+            "META_API_KEY",
+            "META_MODEL_API_KEY",
+        )
+        assert pconfig.base_url_env_var == "META_BASE_URL"
+
+
+class TestMetaAiConfigRegistry:
+    def test_optional_env_vars_include_meta(self):
+        from hermes_cli.config import OPTIONAL_ENV_VARS
+
+        for key in ("MODEL_API_KEY", "META_API_KEY", "META_MODEL_API_KEY"):
+            assert key in OPTIONAL_ENV_VARS
+            assert OPTIONAL_ENV_VARS[key]["category"] == "provider"
+            assert OPTIONAL_ENV_VARS[key]["password"] is True
+            assert OPTIONAL_ENV_VARS[key]["url"] == "https://dev.meta.ai/"
+
+        assert "META_BASE_URL" in OPTIONAL_ENV_VARS
+        assert OPTIONAL_ENV_VARS["META_BASE_URL"]["category"] == "provider"
+        assert OPTIONAL_ENV_VARS["META_BASE_URL"]["password"] is False
+
+
+class TestMetaAiModelCatalog:
+    def test_canonical_provider_entry(self):
+        slugs = [p.slug for p in CANONICAL_PROVIDERS]
+        assert "meta-ai" in slugs
+        entry = next(p for p in CANONICAL_PROVIDERS if p.slug == "meta-ai")
+        assert entry.label == "Meta Model API"
+        assert "Muse Spark" in entry.tui_desc
+
+    def test_provider_label(self):
+        assert _PROVIDER_LABELS["meta-ai"] == "Meta Model API"
+
+    def test_provider_model_ids_prefers_live_api(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            lambda provider_id: {
+                "provider": provider_id,
+                "api_key": "meta-live-key",
+                "base_url": "https://api.meta.ai/v1",
+                "source": "MODEL_API_KEY",
+            },
+        )
+        # Profile-based path uses ProviderProfile.fetch_models, not fetch_api_models.
+        monkeypatch.setattr(
+            "providers.base.ProviderProfile.fetch_models",
+            lambda self, *, api_key=None, base_url=None, timeout=8.0: [
+                "muse-spark-1.1",
+                "muse-spark-1.0",
+            ],
+        )
+
+        assert provider_model_ids("meta-ai") == [
+            "muse-spark-1.1",
+            "muse-spark-1.0",
+        ]
+
+    def test_provider_model_ids_falls_back_to_profile_models(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            lambda provider_id: {
+                "provider": provider_id,
+                "api_key": "meta-live-key",
+                "base_url": "https://api.meta.ai/v1",
+                "source": "MODEL_API_KEY",
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.fetch_api_models",
+            lambda api_key, base_url: None,
+        )
+        # Generic profile path uses ProviderProfile.fetch_models (urllib), not
+        # fetch_api_models — must stub it or CI can hit the real endpoint.
+        monkeypatch.setattr(
+            "providers.base.ProviderProfile.fetch_models",
+            lambda self, *, api_key=None, base_url=None, timeout=8.0: None,
+        )
+
+        models = provider_model_ids("meta-ai")
+        assert models == ["muse-spark-1.1"]
+
+
+class TestMetaAiCredentials:
+    def test_resolve_with_model_api_key(self, monkeypatch):
+        monkeypatch.setenv("MODEL_API_KEY", "model-key")
+        creds = resolve_api_key_provider_credentials("meta-ai")
+        assert creds["provider"] == "meta-ai"
+        assert creds["api_key"] == "model-key"
+        assert creds["base_url"] == "https://api.meta.ai/v1"
+
+    def test_env_var_priority(self, monkeypatch):
+        """MODEL_API_KEY wins over META_API_KEY / META_MODEL_API_KEY."""
+        monkeypatch.setenv("MODEL_API_KEY", "first")
+        monkeypatch.setenv("META_API_KEY", "second")
+        monkeypatch.setenv("META_MODEL_API_KEY", "third")
+        creds = resolve_api_key_provider_credentials("meta-ai")
+        assert creds["api_key"] == "first"
+
+    def test_fallback_meta_api_key(self, monkeypatch):
+        monkeypatch.setenv("META_API_KEY", "meta-key")
+        creds = resolve_api_key_provider_credentials("meta-ai")
+        assert creds["api_key"] == "meta-key"
+
+    def test_custom_base_url_override(self, monkeypatch):
+        monkeypatch.setenv("MODEL_API_KEY", "key")
+        monkeypatch.setenv("META_BASE_URL", "https://custom.meta.example/v1")
+        creds = resolve_api_key_provider_credentials("meta-ai")
+        assert creds["base_url"] == "https://custom.meta.example/v1"
+
+    def test_runtime_provider_base_url(self, monkeypatch):
+        monkeypatch.setenv("MODEL_API_KEY", "meta-key")
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        result = resolve_runtime_provider(requested="meta-ai")
+        assert result["provider"] == "meta-ai"
+        assert result["api_mode"] == "chat_completions"
+        assert result["base_url"] == "https://api.meta.ai/v1"
+
+
+class TestMetaAiModelMetadata:
+    def test_url_to_provider(self):
+        from agent.model_metadata import _URL_TO_PROVIDER
+
+        assert _URL_TO_PROVIDER.get("api.meta.ai") == "meta-ai"
+
+    def test_infer_from_url(self):
+        from agent.model_metadata import _infer_provider_from_url
+
+        assert _infer_provider_from_url("https://api.meta.ai/v1") == "meta-ai"
+
+    def test_muse_spark_context_length(self):
+        with patch(
+            "agent.model_metadata.get_cached_context_length",
+            return_value=None,
+        ), patch(
+            "agent.model_metadata.fetch_endpoint_model_metadata",
+            return_value={},
+        ), patch(
+            "agent.models_dev.lookup_models_dev_context",
+            return_value=None,
+        ), patch(
+            "agent.model_metadata.fetch_model_metadata",
+            return_value={},
+        ):
+            result = get_model_context_length(
+                "muse-spark-1.1",
+                base_url="https://api.meta.ai/v1",
+                api_key="meta-test-key",
+                provider="meta-ai",
+            )
+
+        assert result == 1_048_576

--- a/tests/plugins/model_providers/test_meta_ai_profile.py
+++ b/tests/plugins/model_providers/test_meta_ai_profile.py
@@ -1,0 +1,187 @@
+"""Unit tests for the Meta Model API (Muse Spark) provider profile.
+
+Meta's OpenAI-compatible ``/v1/chat/completions`` endpoint accepts
+top-level ``reasoning_effort`` with values ``minimal``, ``low``,
+``medium``, ``high``, and ``xhigh``.  Hermes maps ``max`` → ``xhigh``
+and never emits ``none`` (Meta returns HTTP 400 for that value).
+
+When reasoning is disabled (``enabled: false``) or effort is ``none``,
+the profile emits ``reasoning_effort=minimal`` so the request stays
+valid while staying at the lowest thinking tier.
+
+Empty / missing effort omits the field so the model uses its default.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def meta_ai_profile():
+    """Resolve the registered Meta Model API profile.
+
+    Going through ``providers.get_provider_profile`` keeps the test
+    honest — if someone replaces the registered class with a plain
+    ``ProviderProfile``, every reasoning assertion below collapses.
+    """
+    # ``model_tools`` triggers plugin discovery on import, which is what
+    # registers the Meta AI profile in the global provider registry.
+    import model_tools  # noqa: F401
+    import providers
+
+    profile = providers.get_provider_profile("meta-ai")
+    assert profile is not None, "meta-ai provider profile must be registered"
+    return profile
+
+
+class TestMetaAiProfileBasics:
+    """Identity / catalog fields on the Meta Model API profile."""
+
+    def test_name_and_aliases(self, meta_ai_profile):
+        assert meta_ai_profile.name == "meta-ai"
+        for alias in ("meta", "muse", "llama-api", "model-api"):
+            assert alias in meta_ai_profile.aliases
+
+    def test_display_metadata(self, meta_ai_profile):
+        assert meta_ai_profile.display_name == "Meta Model API"
+        assert "Muse Spark" in meta_ai_profile.description
+        assert meta_ai_profile.signup_url == "https://dev.meta.ai/"
+        assert meta_ai_profile.base_url == "https://api.meta.ai/v1"
+        assert meta_ai_profile.auth_type == "api_key"
+        assert meta_ai_profile.api_mode == "chat_completions"
+
+    def test_env_vars_priority(self, meta_ai_profile):
+        assert meta_ai_profile.env_vars == (
+            "MODEL_API_KEY",
+            "META_API_KEY",
+            "META_MODEL_API_KEY",
+            "META_BASE_URL",
+        )
+
+    def test_fallback_and_aux_model(self, meta_ai_profile):
+        assert meta_ai_profile.default_aux_model == "muse-spark-1.1"
+        assert "muse-spark-1.1" in meta_ai_profile.fallback_models
+
+    def test_hostname(self, meta_ai_profile):
+        assert meta_ai_profile.get_hostname() == "api.meta.ai"
+
+
+class TestMetaAiReasoningEffort:
+    """``build_api_kwargs_extras`` emits correct top-level ``reasoning_effort``."""
+
+    # ── standard levels pass through ──────────────────────────
+
+    @pytest.mark.parametrize("effort", ["minimal", "low", "medium", "high", "xhigh"])
+    def test_standard_efforts_pass_through(self, meta_ai_profile, effort):
+        extra_body, top_level = meta_ai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": effort},
+        )
+        assert extra_body == {}
+        assert top_level == {"reasoning_effort": effort}
+
+    # ── max → xhigh ───────────────────────────────────────────
+
+    @pytest.mark.parametrize("effort", ["max", "MAX", "  Max  "])
+    def test_max_normalizes_to_xhigh(self, meta_ai_profile, effort):
+        extra_body, top_level = meta_ai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": effort},
+        )
+        assert extra_body == {}
+        assert top_level == {"reasoning_effort": "xhigh"}
+
+    # ── disabled / none → minimal (never emit none) ───────────
+
+    def test_explicitly_disabled_emits_minimal(self, meta_ai_profile):
+        extra_body, top_level = meta_ai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+        )
+        assert extra_body == {}
+        assert top_level == {"reasoning_effort": "minimal"}
+
+    def test_disabled_ignores_effort_field(self, meta_ai_profile):
+        """Even if effort is high, disabled forces minimal."""
+        _, top_level = meta_ai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False, "effort": "high"},
+        )
+        assert top_level == {"reasoning_effort": "minimal"}
+
+    def test_none_effort_emits_minimal(self, meta_ai_profile):
+        """Meta returns HTTP 400 for reasoning_effort=none — never emit it."""
+        extra_body, top_level = meta_ai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "none"},
+        )
+        assert extra_body == {}
+        assert top_level == {"reasoning_effort": "minimal"}
+        assert top_level.get("reasoning_effort") != "none"
+
+    # ── empty / missing effort → omit ─────────────────────────
+
+    def test_no_reasoning_config_emits_nothing(self, meta_ai_profile):
+        extra_body, top_level = meta_ai_profile.build_api_kwargs_extras(
+            reasoning_config=None,
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+    def test_empty_effort_emits_nothing(self, meta_ai_profile):
+        _, top_level = meta_ai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": ""},
+        )
+        assert top_level == {}
+
+    def test_no_effort_key_emits_nothing(self, meta_ai_profile):
+        _, top_level = meta_ai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True},
+        )
+        assert top_level == {}
+
+    # ── case / whitespace normalization ───────────────────────
+
+    @pytest.mark.parametrize(
+        "effort,expected",
+        [
+            ("  HIGH  ", "high"),
+            ("XHigh", "xhigh"),
+            ("Minimal", "minimal"),
+        ],
+    )
+    def test_case_and_whitespace_normalized(self, meta_ai_profile, effort, expected):
+        _, top_level = meta_ai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": effort},
+        )
+        assert top_level == {"reasoning_effort": expected}
+
+
+class TestMetaAiFullKwargsIntegration:
+    """End-to-end: transport kwargs include Meta's reasoning_effort contract."""
+
+    def test_full_kwargs_with_max(self, meta_ai_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="muse-spark-1.1",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=meta_ai_profile,
+            reasoning_config={"enabled": True, "effort": "max"},
+            base_url="https://api.meta.ai/v1",
+            provider_name="meta-ai",
+        )
+        assert kwargs["model"] == "muse-spark-1.1"
+        assert kwargs["reasoning_effort"] == "xhigh"
+        assert "extra_body" not in kwargs or "reasoning" not in kwargs.get("extra_body", {})
+
+    def test_full_kwargs_with_disabled(self, meta_ai_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="muse-spark-1.1",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=meta_ai_profile,
+            reasoning_config={"enabled": False},
+            base_url="https://api.meta.ai/v1",
+            provider_name="meta-ai",
+        )
+        assert kwargs["reasoning_effort"] == "minimal"

--- a/tests/plugins/model_providers/test_meta_ai_profile.py
+++ b/tests/plugins/model_providers/test_meta_ai_profile.py
@@ -7,9 +7,15 @@ and never emits ``none`` (Meta returns HTTP 400 for that value).
 
 When reasoning is disabled (``enabled: false``) or effort is ``none``,
 the profile emits ``reasoning_effort=minimal`` so the request stays
-valid while staying at the lowest thinking tier.
+valid while staying at the lowest thinking tier.  For Responses API
+mode (if user forces api_mode override), also emits nested
+``reasoning.effort`` in extra_body.
 
 Empty / missing effort omits the field so the model uses its default.
+Vision: Muse Spark supports image, video, PDF in user messages.
+
+Ref: https://dev.meta.ai/docs/features/reasoning/
+     https://dev.meta.ai/docs/getting-started/models/
 """
 
 from __future__ import annotations
@@ -66,9 +72,19 @@ class TestMetaAiProfileBasics:
     def test_hostname(self, meta_ai_profile):
         assert meta_ai_profile.get_hostname() == "api.meta.ai"
 
+    def test_supports_vision(self, meta_ai_profile):
+        # Per https://dev.meta.ai/docs/getting-started/models/ :
+        # Input modalities: Text, image, video, PDF
+        assert meta_ai_profile.supports_vision is True
+
 
 class TestMetaAiReasoningEffort:
-    """``build_api_kwargs_extras`` emits correct top-level ``reasoning_effort``."""
+    """``build_api_kwargs_extras`` emits correct reasoning effort.
+
+    Hermes uses Chat Completions by default (top-level reasoning_effort).
+    When Responses API mode is forced via api_mode context, extra_body also
+    carries reasoning.effort.
+    """
 
     # ── standard levels pass through ──────────────────────────
 
@@ -77,8 +93,9 @@ class TestMetaAiReasoningEffort:
         extra_body, top_level = meta_ai_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": effort},
         )
-        assert extra_body == {}
+        # Chat Completions default: top-level only, extra_body empty
         assert top_level == {"reasoning_effort": effort}
+        assert extra_body == {}
 
     # ── max → xhigh ───────────────────────────────────────────
 
@@ -87,8 +104,8 @@ class TestMetaAiReasoningEffort:
         extra_body, top_level = meta_ai_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": effort},
         )
-        assert extra_body == {}
         assert top_level == {"reasoning_effort": "xhigh"}
+        assert extra_body == {}
 
     # ── disabled / none → minimal (never emit none) ───────────
 
@@ -96,8 +113,9 @@ class TestMetaAiReasoningEffort:
         extra_body, top_level = meta_ai_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": False},
         )
-        assert extra_body == {}
         assert top_level == {"reasoning_effort": "minimal"}
+        # Disabled also populates extra_body for Responses fallback
+        assert extra_body == {"reasoning": {"effort": "minimal"}}
 
     def test_disabled_ignores_effort_field(self, meta_ai_profile):
         """Even if effort is high, disabled forces minimal."""
@@ -111,9 +129,9 @@ class TestMetaAiReasoningEffort:
         extra_body, top_level = meta_ai_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": "none"},
         )
-        assert extra_body == {}
         assert top_level == {"reasoning_effort": "minimal"}
         assert top_level.get("reasoning_effort") != "none"
+        assert extra_body == {}
 
     # ── empty / missing effort → omit ─────────────────────────
 
@@ -125,15 +143,17 @@ class TestMetaAiReasoningEffort:
         assert top_level == {}
 
     def test_empty_effort_emits_nothing(self, meta_ai_profile):
-        _, top_level = meta_ai_profile.build_api_kwargs_extras(
+        extra_body, top_level = meta_ai_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": ""},
         )
+        assert extra_body == {}
         assert top_level == {}
 
     def test_no_effort_key_emits_nothing(self, meta_ai_profile):
-        _, top_level = meta_ai_profile.build_api_kwargs_extras(
+        extra_body, top_level = meta_ai_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True},
         )
+        assert extra_body == {}
         assert top_level == {}
 
     # ── case / whitespace normalization ───────────────────────
@@ -151,6 +171,24 @@ class TestMetaAiReasoningEffort:
             reasoning_config={"enabled": True, "effort": effort},
         )
         assert top_level == {"reasoning_effort": expected}
+
+    # ── Responses API mode also populates extra_body ──────────
+
+    def test_responses_api_mode_populates_extra_body(self, meta_ai_profile):
+        extra_body, top_level = meta_ai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            api_mode="codex_responses",
+        )
+        assert top_level == {"reasoning_effort": "high"}
+        assert extra_body == {"reasoning": {"effort": "high"}}
+
+    def test_chat_completions_mode_leaves_extra_body_empty(self, meta_ai_profile):
+        extra_body, top_level = meta_ai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            api_mode="chat_completions",
+        )
+        assert top_level == {"reasoning_effort": "high"}
+        assert extra_body == {}
 
 
 class TestMetaAiFullKwargsIntegration:
@@ -170,7 +208,8 @@ class TestMetaAiFullKwargsIntegration:
         )
         assert kwargs["model"] == "muse-spark-1.1"
         assert kwargs["reasoning_effort"] == "xhigh"
-        assert "extra_body" not in kwargs or "reasoning" not in kwargs.get("extra_body", {})
+        # Chat completions path should NOT have extra_body.reasoning
+        assert "reasoning" not in kwargs.get("extra_body", {})
 
     def test_full_kwargs_with_disabled(self, meta_ai_profile):
         from agent.transports.chat_completions import ChatCompletionsTransport

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -516,7 +516,13 @@ The base URL can be overridden with `GMI_BASE_URL` (default: `https://api.gmi-se
 
 ### Meta Model API (Muse Spark)
 
-Muse Spark and other Meta models via the [Meta Model API](https://dev.meta.ai/) — OpenAI-compatible API, API key authentication. Reasoning uses top-level `reasoning_effort` (`minimal` / `low` / `medium` / `high` / `xhigh`); Hermes maps `max` → `xhigh` and never sends `none` (Meta returns HTTP 400 for that value).
+Muse Spark and other Meta models via the [Meta Model API](https://dev.meta.ai/) — OpenAI-compatible Chat Completions, Messages, and Responses APIs with Bearer auth (`MODEL_API_KEY`). Hermes uses the Chat Completions surface by default (`https://api.meta.ai/v1`).
+
+- **Model**: `muse-spark-1.1` — multimodal input (text, image, video, PDF), text output
+- **Context**: 1,048,576 tokens, no long-context premium, prompt caching automatic (reports `cached_tokens`)
+- **Features**: parallel tool calling, structured output (`response_format` `json_schema`), token counting, file handling via `file_id`, search grounding (`web_search`)
+- **Pricing**: $1.25 input / $0.15 cached input / $4.25 output per 1M tokens, plus optional web search $2.50/1K queries
+- **Reasoning**: model always reasons internally; control depth with `reasoning_effort` (`minimal` / `low` / `medium` / `high` / `xhigh`). `none` is not supported and returns HTTP 400 — Hermes maps `none` / disabled → `minimal` and `max` → `xhigh`.
 
 ```bash
 # Meta Model API (Muse Spark)
@@ -531,7 +537,7 @@ model:
   default: "muse-spark-1.1"
 ```
 
-The base URL can be overridden with `META_BASE_URL` (default: `https://api.meta.ai/v1`). Aliases: `meta`, `muse`, `llama-api`, `model-api`. Hermes sets a high default max tokens for this provider because Muse Spark spends completion budget on hidden reasoning tokens before visible output.
+The base URL can be overridden with `META_BASE_URL` (default: `https://api.meta.ai/v1`). Aliases: `meta`, `muse`, `llama-api`, `model-api`. Hermes sets a high default max tokens (16384) for this provider because Muse Spark's reasoning tokens count toward `max_tokens` / `max_output_tokens` — low caps can finish with empty visible content while reasoning is still in-progress. See https://dev.meta.ai/docs/features/reasoning/
 
 ### StepFun
 

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -26,6 +26,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Kimi / Moonshot (China)** | `KIMI_CN_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding-cn`; aliases: `kimi-cn`, `moonshot-cn`) |
 | **Arcee AI** | `ARCEEAI_API_KEY` in `~/.hermes/.env` (provider: `arcee`; aliases: `arcee-ai`, `arceeai`) |
 | **GMI Cloud** | `GMI_API_KEY` in `~/.hermes/.env` (provider: `gmi`; aliases: `gmi-cloud`, `gmicloud`) |
+| **Meta Model API** | `MODEL_API_KEY` (or `META_API_KEY` / `META_MODEL_API_KEY`) in `~/.hermes/.env` (provider: `meta-ai`; aliases: `meta`, `muse`, `llama-api`, `model-api`) |
 | **MiniMax** | `MINIMAX_API_KEY` in `~/.hermes/.env` (provider: `minimax`) |
 | **MiniMax China** | `MINIMAX_CN_API_KEY` in `~/.hermes/.env` (provider: `minimax-cn`) |
 | **xAI (Grok) — Responses API** | `XAI_API_KEY` in `~/.hermes/.env` (provider: `xai`) |
@@ -512,6 +513,25 @@ model:
 ```
 
 The base URL can be overridden with `GMI_BASE_URL` (default: `https://api.gmi-serving.com/v1`).
+
+### Meta Model API (Muse Spark)
+
+Muse Spark and other Meta models via the [Meta Model API](https://dev.meta.ai/) — OpenAI-compatible API, API key authentication. Reasoning uses top-level `reasoning_effort` (`minimal` / `low` / `medium` / `high` / `xhigh`); Hermes maps `max` → `xhigh` and never sends `none` (Meta returns HTTP 400 for that value).
+
+```bash
+# Meta Model API (Muse Spark)
+hermes chat --provider meta-ai --model muse-spark-1.1
+# Requires: MODEL_API_KEY (or META_API_KEY / META_MODEL_API_KEY) in ~/.hermes/.env
+```
+
+Or set it permanently in `config.yaml`:
+```yaml
+model:
+  provider: "meta-ai"
+  default: "muse-spark-1.1"
+```
+
+The base URL can be overridden with `META_BASE_URL` (default: `https://api.meta.ai/v1`). Aliases: `meta`, `muse`, `llama-api`, `model-api`.
 
 ### StepFun
 

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -531,7 +531,7 @@ model:
   default: "muse-spark-1.1"
 ```
 
-The base URL can be overridden with `META_BASE_URL` (default: `https://api.meta.ai/v1`). Aliases: `meta`, `muse`, `llama-api`, `model-api`.
+The base URL can be overridden with `META_BASE_URL` (default: `https://api.meta.ai/v1`). Aliases: `meta`, `muse`, `llama-api`, `model-api`. Hermes sets a high default max tokens for this provider because Muse Spark spends completion budget on hidden reasoning tokens before visible output.
 
 ### StepFun
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -42,6 +42,10 @@ Hermes reads environment variables from the process environment and, for user-ma
 | `ARCEE_BASE_URL` | Override Arcee base URL (default: `https://api.arcee.ai/api/v1`) |
 | `GMI_API_KEY` | GMI Cloud API key ([gmicloud.ai](https://www.gmicloud.ai/)) |
 | `GMI_BASE_URL` | Override GMI Cloud base URL (default: `https://api.gmi-serving.com/v1`) |
+| `MODEL_API_KEY` | Meta Model API key — primary env var for Muse Spark ([dev.meta.ai](https://dev.meta.ai/)) |
+| `META_API_KEY` | Alias for Meta Model API key (accepted alongside `MODEL_API_KEY`) |
+| `META_MODEL_API_KEY` | Alias for Meta Model API key (accepted alongside `MODEL_API_KEY`) |
+| `META_BASE_URL` | Override Meta Model API base URL (default: `https://api.meta.ai/v1`) |
 | `MINIMAX_API_KEY` | MiniMax API key — global endpoint ([minimax.io](https://www.minimax.io)). **Not used by `minimax-oauth`** (OAuth path uses browser login instead). |
 | `MINIMAX_BASE_URL` | Override MiniMax base URL (default: `https://api.minimax.io/anthropic` — Hermes uses MiniMax's Anthropic Messages-compatible endpoint). **Not used by `minimax-oauth`**. |
 | `MINIMAX_CN_API_KEY` | MiniMax API key — China endpoint ([minimaxi.com](https://www.minimaxi.com)). **Not used by `minimax-oauth`** (OAuth path uses browser login instead). |


### PR DESCRIPTION
## What

Add **Meta Model API** as a first-class model-provider plugin so Muse Spark (`muse-spark-1.1`) appears in `hermes model` / `/model` / dashboard pickers.

- Provider id: `meta-ai` (aliases: `meta`, `muse`, `llama-api`, `model-api`)
- Base URL: `https://api.meta.ai/v1`
- Auth: `MODEL_API_KEY` (aliases `META_API_KEY`, `META_MODEL_API_KEY`); base URL override `META_BASE_URL`
- OpenAI-compatible Chat Completions (`api_mode=chat_completions`)
- Reasoning: top-level `reasoning_effort`; never emit `none` (Meta HTTP 400) — map disable/`none` → `minimal`; map `max` → `xhigh`
- Static context fallback: **1,048,576** tokens for `muse-spark*`
- Default `max_tokens=16384` — Muse spends completion budget on hidden `reasoning_tokens` first; low caps finish with empty content
- Docs: integrations + environment variables

## Why

Meta Model API is OpenAI-compatible and agent-ready (tool calling, 1M context, multimodal). Hermes already supports this class of backend via model-provider plugins (see developer docs “Fast path: Simple API-key providers”). No dedicated provider/PR existed (verified via code + issue/PR search for `muse-spark` / `api.meta.ai`).

## How to test

```bash
# unit
scripts/run_tests.sh \
  tests/plugins/model_providers/test_meta_ai_profile.py \
  tests/hermes_cli/test_meta_ai_provider.py \
  tests/hermes_cli/test_api_key_providers.py

# live (optional)
export MODEL_API_KEY=LLM_...
hermes chat --provider meta-ai --model muse-spark-1.1 -q "ping"
hermes model   # Meta Model API should appear
```

## Live verification (this PR)

- `GET https://api.meta.ai/v1/models` → 200, catalog includes `muse-spark-1.1`
- `POST /v1/chat/completions` with `muse-spark-1.1` → 200, content `pong` (needs adequate max_tokens because reasoning tokens consume the completion budget)

## Platforms tested

- Linux
- No process/path/signal changes (Windows-safe by construction)

## References

- https://dev.meta.ai/docs/getting-started/overview/
- https://dev.meta.ai/docs/getting-started/authentication/
- https://hermes-agent.nousresearch.com/docs/developer-guide/adding-providers
- https://hermes-agent.nousresearch.com/docs/developer-guide/model-provider-plugin

## Notes

- Uses Chat Completions only (not Responses/Messages). Hermes agent loop + tools is sufficient.
- i18n mirrors not updated in this PR (EN docs only).