### PR TITLE
fix(agent): switch_model resets codex reasoning replay flag for xai-oauth/codex

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1178,6 +1178,9 @@ def restore_primary_runtime(agent) -> bool:
             "use_native_cache_layout",
             agent.api_mode == "anthropic_messages" and agent.provider == "anthropic",
         )
+        agent._codex_reasoning_replay_enabled = rt.get(
+            "codex_reasoning_replay_enabled", True
+        )
 
         # ── Rebuild client for the primary provider ──
         if agent.api_mode == "anthropic_messages":
@@ -1797,6 +1800,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             "_anthropic_base_url",
             "_is_anthropic_oauth",
             "_config_context_length",
+            "_codex_reasoning_replay_enabled",
         )
     }
     # _client_kwargs is a dict — snapshot a shallow copy so mutating the
@@ -1824,6 +1828,13 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         if base_url:
             agent.base_url = base_url
         agent.api_mode = api_mode
+        # Reset Codex reasoning replay flag when (re)entering codex_responses mode
+        # (xai-oauth, openai-codex etc). Leaving codex mode or switching providers
+        # can leave stale encrypted_content from previous issuer, causing
+        # invalid_encrypted_content 400s on next codex turn. Ensure replay is
+        # enabled for the new codex context (history items will be filtered
+        # by issuer guard at send time if needed).
+        agent._codex_reasoning_replay_enabled = (api_mode == "codex_responses")
         # Invalidate transport cache — new api_mode may need a different transport
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
@@ -2028,6 +2039,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         "client_kwargs": dict(agent._client_kwargs),
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,
+        "codex_reasoning_replay_enabled": getattr(agent, "_codex_reasoning_replay_enabled", True),
         "compressor_model": getattr(_cc, "model", agent.model) if _cc else agent.model,
         "compressor_base_url": getattr(_cc, "base_url", agent.base_url) if _cc else agent.base_url,
         "compressor_api_key": getattr(_cc, "api_key", "") if _cc else "",

--- a/tests/run_agent/test_switch_model_rollback.py
+++ b/tests/run_agent/test_switch_model_rollback.py
@@ -228,6 +228,67 @@ def test_switch_model_resets_codex_reasoning_replay_flag():
         )
 
     assert agent._codex_reasoning_replay_enabled is True
+
+
+def test_restore_primary_runtime_restores_codex_reasoning_replay_flag():
+    """The switch snapshot must survive fallback activation/restoration.
+
+    A Codex-mode model switch updates ``_primary_runtime`` so future turns
+    restore that runtime after a transient fallback. If the replay flag is not
+    stored there, fallback restoration can resurrect the stale non-codex flag
+    even though the primary runtime is codex_responses.
+    """
+    from agent.agent_runtime_helpers import restore_primary_runtime
+
+    class _Compressor:
+        model = "grok-4"
+        base_url = "https://api.x.ai/v1"
+        api_key = "xai-key"
+        provider = "xai-oauth"
+        api_mode = "codex_responses"
+        context_length = 128_000
+        threshold_tokens = 96_000
+
+        def update_model(self, **kwargs):
+            self.updated = kwargs
+
+    agent = _make_agent_openrouter()
+    agent.context_compressor = _Compressor()
+    agent._transport_cache = {"old": object()}
+    agent._rate_limited_until = 0
+    agent._credential_pool = None
+    agent._create_openai_client = lambda *_a, **_kw: MagicMock(name="CodexClient")
+
+    with patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None):
+        agent.switch_model(
+            new_model="grok-4",
+            new_provider="xai-oauth",
+            api_key="xai-key",
+            base_url="https://api.x.ai/v1",
+            api_mode="codex_responses",
+        )
+
+    assert agent._primary_runtime["api_mode"] == "codex_responses"
+    assert agent._primary_runtime["codex_reasoning_replay_enabled"] is True
+
+    # Simulate a fallback turn perturbing live runtime state before the next
+    # turn restores the primary runtime.
+    agent._fallback_activated = True
+    agent.model = "fallback-model"
+    agent.provider = "openrouter"
+    agent.base_url = "https://openrouter.ai/api/v1"
+    agent.api_mode = "chat_completions"
+    agent._codex_reasoning_replay_enabled = False
+
+    with (
+        patch("agent.chat_completion_helpers._reset_stale_streak"),
+        patch("agent.chat_completion_helpers.rewrite_prompt_model_identity"),
+    ):
+        assert restore_primary_runtime(agent) is True
+
+    assert agent.api_mode == "codex_responses"
+    assert agent.provider == "xai-oauth"
+    assert agent._codex_reasoning_replay_enabled is True
     assert agent.api_mode == "codex_responses"
 
     # Now switch away to non-codex

--- a/tests/run_agent/test_switch_model_rollback.py
+++ b/tests/run_agent/test_switch_model_rollback.py
@@ -46,6 +46,7 @@ def _make_agent_openrouter():
     agent._fallback_chain = []
     agent._fallback_model = None
     agent._config_context_length = None
+    agent._codex_reasoning_replay_enabled = True
 
     return agent
 
@@ -73,6 +74,7 @@ def _make_agent_anthropic():
     agent._fallback_chain = []
     agent._fallback_model = None
     agent._config_context_length = None
+    agent._codex_reasoning_replay_enabled = True
 
     return agent
 
@@ -202,3 +204,49 @@ def test_successful_switch_still_works_after_rollback_refactor():
     assert agent.provider == "openrouter"
     assert agent.api_key == "or-key-new"
     assert agent.client is new_client
+
+
+def test_switch_model_resets_codex_reasoning_replay_flag():
+    """When switching into codex_responses (xai-oauth, openai-codex), the
+    replay flag must be (re)enabled so Grok/xAI cross-turn reasoning works.
+    Switching away should not leave stale state for future codex use.
+    """
+    agent = _make_agent_openrouter()
+    agent._codex_reasoning_replay_enabled = False  # simulate previous disable
+
+    new_client = MagicMock()
+    agent._create_openai_client = lambda *_a, **_kw: new_client
+
+    with patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None):
+        # Switch to xai-oauth / codex
+        agent.switch_model(
+            new_model="grok-4",
+            new_provider="xai-oauth",
+            api_key="xai-key",
+            base_url="https://api.x.ai/v1",
+            api_mode="codex_responses",
+        )
+
+    assert agent._codex_reasoning_replay_enabled is True
+    assert agent.api_mode == "codex_responses"
+
+    # Now switch away to non-codex
+    agent._create_openai_client = lambda *_a, **_kw: MagicMock()
+    agent.switch_model(
+        new_model="claude-sonnet-4-5",
+        new_provider="anthropic",
+        api_key="sk-ant",
+        base_url="https://api.anthropic.com",
+        api_mode="anthropic_messages",
+    )
+
+    # Flag is now irrelevant (not codex), but switching back should re-enable
+    agent.switch_model(
+        new_model="grok-4",
+        new_provider="xai-oauth",
+        api_key="xai-key2",
+        base_url="https://api.x.ai/v1",
+        api_mode="codex_responses",
+    )
+
+    assert agent._codex_reasoning_replay_enabled is True


### PR DESCRIPTION
## Problem

When using `xai-oauth` (Grok) or other `codex_responses` providers, the agent maintains a `_codex_reasoning_replay_enabled` flag and stores `codex_reasoning_items` (containing `encrypted_content`) in conversation history.

`switch_model()` updates `api_mode`, `provider`, `base_url`, client, etc., but never touches the Codex reasoning replay flag or cleans the history items. The flag is only initialized to `True` in `agent_init.py` and is not stored in `_primary_runtime`.

As a result:
- After any `invalid_encrypted_content` error (or switch away from codex), the flag stays `False`.
- Switching back to Grok/xai-oauth (or any codex provider) leaves replay permanently disabled.
- Stale items from a previous codex issuer can still be replayed, causing 400s and unwanted fallbacks.

This breaks Grok's cross-turn reasoning coherence after model switches — a very common operation in long-lived sessions.

## Root Cause

- The flag and codex history items are treated as "ephemeral" but are actually session-persistent state.
- `switch_model` and `_primary_runtime` snapshot/restore paths completely ignore `_codex_reasoning_replay_enabled`.
- No reset or cleanup happens when `api_mode` changes to/from `"codex_responses"`.

## Fix

- Add `_codex_reasoning_replay_enabled` to the pre-swap snapshot (for rollback safety).
- After swapping `api_mode`, explicitly set the flag: `True` only when the new mode is `codex_responses`.
- Store the flag in `_primary_runtime`.
- Restore the flag in `restore_primary_runtime`.
- Added regression test covering switch-to-codex, switch-away, and switch-back.

The existing per-item foreign-issuer guard in the adapter will still drop incompatible items at send time.

## Test

- Added `test_switch_model_resets_codex_reasoning_replay_flag` in `tests/run_agent/test_switch_model_rollback.py`.
- Verifies flag is correctly enabled when entering codex mode and the round-trip (to non-codex and back) works.
- Existing switch_model rollback and happy-path tests continue to pass.