### PR TITLE
fix(cli,tui): skip unreliable COLORFGBG in Zed terminal (#61536)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2081,6 +2081,21 @@ _FALSE_RE = re.compile(r"^(0|false|off|no|n)$")
 _LIGHT_DEFAULT_TERM_PROGRAMS = frozenset()  # Apple_Terminal doesn't reliably indicate; require explicit
 
 
+def _is_zed_terminal() -> bool:
+    """Return True when the process runs inside Zed's integrated terminal.
+
+    Zed inherits COLORFGBG from the shell that launched it, so the value
+    reflects the *launching* terminal's background rather than Zed's actual
+    theme.  When we detect Zed, the COLORFGBG signal is unreliable and should
+    be skipped so detection falls through to OSC 11 or the dark default.
+    """
+    return (
+        (os.environ.get("TERM_PROGRAM") or "").strip().lower() == "zed"
+        or (os.environ.get("ZED_TERM") or "").strip().lower()
+        in {"1", "true", "yes", "on"}
+    )
+
+
 def _luminance_from_hex(hex_str: str) -> float | None:
     s = (hex_str or "").strip().lstrip("#")
     if len(s) == 3:
@@ -2201,8 +2216,10 @@ def _detect_light_mode() -> bool:
             _LIGHT_MODE_CACHE = result
             return result
         # 4. COLORFGBG (xterm/Konsole/urxvt)
+        # Skip in Zed's terminal — Zed inherits COLORFGBG from the launching
+        # shell, so the value reflects the parent terminal, not Zed's theme.
         cfgbg = (os.environ.get("COLORFGBG") or "").strip()
-        if cfgbg:
+        if cfgbg and not _is_zed_terminal():
             last = cfgbg.split(";")[-1] if ";" in cfgbg else cfgbg
             if last.isdigit():
                 bg = int(last)

--- a/tests/cli/test_cli_light_mode.py
+++ b/tests/cli/test_cli_light_mode.py
@@ -75,6 +75,50 @@ class TestLightModeDetection:
         assert cli_mod._detect_light_mode() is True
 
 
+class TestZedTerminalGuard:
+    """Zed inherits COLORFGBG from the parent shell.  When TERM_PROGRAM=zed
+    or ZED_TERM is set, COLORFGBG must be skipped so detection falls through
+    to the dark default (or explicit override).
+    """
+
+    def test_zed_term_program_skips_light_colorfgbg(self, cli_mod, monkeypatch):
+        monkeypatch.delenv("HERMES_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_TUI_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_TUI_THEME", raising=False)
+        monkeypatch.delenv("HERMES_TUI_BACKGROUND", raising=False)
+        monkeypatch.setenv("TERM_PROGRAM", "zed")
+        monkeypatch.setenv("COLORFGBG", "0;15")
+        assert cli_mod._detect_light_mode() is False
+
+    def test_zed_term_env_skips_light_colorfgbg(self, cli_mod, monkeypatch):
+        monkeypatch.delenv("HERMES_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_TUI_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_TUI_THEME", raising=False)
+        monkeypatch.delenv("HERMES_TUI_BACKGROUND", raising=False)
+        monkeypatch.setenv("ZED_TERM", "true")
+        monkeypatch.setenv("COLORFGBG", "0;15")
+        assert cli_mod._detect_light_mode() is False
+
+    def test_zed_with_explicit_override_still_wins(self, cli_mod, monkeypatch):
+        """Explicit user overrides (HERMES_TUI_THEME=light, etc.) must still
+        win even when Zed is detected — the guard only disables COLORFGBG."""
+        monkeypatch.setenv("TERM_PROGRAM", "zed")
+        monkeypatch.setenv("COLORFGBG", "0;15")
+        monkeypatch.setenv("HERMES_TUI_THEME", "light")
+        assert cli_mod._detect_light_mode() is True
+
+    def test_non_zed_colorfgbg_unchanged(self, cli_mod, monkeypatch):
+        """Without Zed markers, COLORFGBG=0;15 still detects light."""
+        monkeypatch.delenv("HERMES_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_TUI_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_TUI_THEME", raising=False)
+        monkeypatch.delenv("HERMES_TUI_BACKGROUND", raising=False)
+        monkeypatch.delenv("TERM_PROGRAM", raising=False)
+        monkeypatch.delenv("ZED_TERM", raising=False)
+        monkeypatch.setenv("COLORFGBG", "0;15")
+        assert cli_mod._detect_light_mode() is True
+
+
 class TestOsc11Probe:
     """The OSC 11 background probe must never run where its reply can leak
     into prompt_toolkit's input (a late BEL-terminated reply reads as Ctrl+G

--- a/ui-tui/src/__tests__/theme.test.ts
+++ b/ui-tui/src/__tests__/theme.test.ts
@@ -180,6 +180,23 @@ describe('detectLightMode', () => {
     // Dark COLORFGBG must beat the allow-list.
     expect(detectLightMode({ COLORFGBG: '15;0', TERM_PROGRAM: 'Apple_Terminal' }, allowList)).toBe(false)
   })
+
+  it('skips COLORFGBG inside Zed terminal via TERM_PROGRAM=zed', async () => {
+    const { detectLightMode } = await importThemeWithCleanEnv()
+
+    // Zed with COLORFGBG=0;15 should fall through to dark default.
+    expect(detectLightMode({ TERM_PROGRAM: 'zed', COLORFGBG: '0;15' })).toBe(false)
+    // Non-Zed still uses COLORFGBG.
+    expect(detectLightMode({ COLORFGBG: '0;15' })).toBe(true)
+  })
+
+  it('skips COLORFGBG inside Zed terminal via ZED_TERM=true', async () => {
+    const { detectLightMode } = await importThemeWithCleanEnv()
+
+    expect(detectLightMode({ ZED_TERM: 'true', COLORFGBG: '0;15' })).toBe(false)
+    // Explicit override still wins over the Zed guard.
+    expect(detectLightMode({ ZED_TERM: 'true', COLORFGBG: '0;15', HERMES_TUI_THEME: 'light' })).toBe(true)
+  })
 })
 
 describe('fromSkin', () => {

--- a/ui-tui/src/theme.ts
+++ b/ui-tui/src/theme.ts
@@ -443,7 +443,14 @@ export function detectLightMode(
 
   const colorfgbg = (env.COLORFGBG ?? '').trim()
 
-  if (colorfgbg) {
+  // Zed inherits COLORFGBG from the launching shell, so the value
+  // reflects the parent terminal's background, not Zed's actual theme.
+  // When TERM_PROGRAM=zed or ZED_TERM is truthy, skip COLORFGBG.
+  const isZed =
+    (env.TERM_PROGRAM ?? '').toLowerCase() === 'zed' ||
+    /^(1|true|yes|on)$/i.test((env.ZED_TERM ?? '').trim())
+
+  if (colorfgbg && !isZed) {
     // Validate as a decimal integer before coercing — `Number('')` is 0,
     // so a malformed `COLORFGBG='15;'` would otherwise look like an
     // authoritative dark slot and incorrectly block the TERM_PROGRAM


### PR DESCRIPTION
## Problem

When Hermes runs inside Zed's integrated terminal using a dark Zed theme, the default skin renders with light-mode remapped colors even though the terminal background is dark.

Zed inherits `COLORFGBG` from the shell that launched it, so a value like `COLORFGBG=0;15` reflects the *launching* terminal's background rather than Zed's actual integrated-terminal theme. Hermes' light/dark detector trusts `COLORFGBG` as authoritative and incorrectly detects light mode.

## Solution

Add a Zed-terminal guard to both the Python and TypeScript light/dark detection paths. When `TERM_PROGRAM=zed` or `ZED_TERM` is truthy, the `COLORFGBG` signal is treated as unreliable and skipped, so detection falls through to the dark default (or explicit user overrides like `HERMES_TUI_THEME=dark`).

**Python side** (`cli.py`):
- Add `_is_zed_terminal()` helper
- Guard the `COLORFGBG` branch in `_detect_light_mode()`

**TypeScript side** (`ui-tui/src/theme.ts`):
- Add `isZed` check in `detectLightMode()` before the `COLORFGBG` branch

## Testing

- **Python**: 4 new test cases in `TestZedTerminalGuard` covering `TERM_PROGRAM=zed`, `ZED_TERM=true`, explicit override still winning, and non-Zed behavior unchanged
- **TypeScript**: 2 new test cases in `theme.test.ts` covering both `TERM_PROGRAM=zed` and `ZED_TERM=true` with `COLORFGBG=0;15`

All 24 Python and 31 TypeScript theme tests pass (0 regressions).

Fixes #61536