### PR TITLE
fix(mem0): prevent Qdrant lock on re-init + add multilingual-e5 embedding dims

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -363,6 +363,12 @@ class Mem0MemoryProvider(MemoryProvider):
             _rr.lower() in ("true", "1", "yes") if isinstance(_rr, str) else bool(_rr)
         )
         self._channel = kwargs.get("platform") or "cli"
+        # Reuse existing backend when already initialized — a single
+        # provider instance must share one Qdrant connection across
+        # sessions. User-level isolation is handled by mem0's own
+        # user_id filters on search/add, not by per-session backends.
+        if self._backend is not None:
+            return
         self._backend = self._create_backend()
         if self._backend and not self._atexit_registered:
             atexit.register(self._shutdown_backend)

--- a/plugins/memory/mem0/_oss_providers.py
+++ b/plugins/memory/mem0/_oss_providers.py
@@ -57,6 +57,7 @@ KNOWN_DIMS: dict[str, int] = {
     "text-embedding-3-large": 3072,
     "text-embedding-ada-002": 1536,
     "nomic-embed-text": 768,
+    "intfloat/multilingual-e5-large": 1024,
 }
 
 


### PR DESCRIPTION
## Problem

mem0 OSS plugin with Qdrant local storage fails in two scenarios:

### 1. Lock contention on repeated initialize() calls

`initialize()` is called multiple times during session startup. Each call unconditionally invoked `_create_backend()`, which constructed a new `QdrantClient` pointing at the same on-disk path. Qdrant local mode enforces single-process exclusive access, so the second client fails.

### 2. Embedding dimension mismatch

When using `fastembed` with `intfloat/multilingual-e5-large` (1024 dims), freshly created Qdrant collections default to 1536 dimensions because the model is absent from `KNOWN_DIMS`. This causes `shapes not aligned` errors on search.

## Root Cause

1. **Lock**: `Mem0MemoryProvider` is a module-level singleton, but `initialize()` rebuilds the backend unconditionally — creating multiple `QdrantClient` instances on the same path.
2. **Dims**: `intfloat/multilingual-e5-large` is a commonly used embedding model for Chinese/English mixed workloads, but was absent from the `KNOWN_DIMS` lookup table.

## Fix

### Commit 1: Reuse existing backend (`__init__.py`, +6 lines)

```python
if self._backend is not None:
    return
```

After the first `initialize()` call, `self._backend` holds a valid `OSSBackend`. Subsequent calls return early — no new client, no lock contention. User-level isolation is already guaranteed by mem0's `user_id` filters.

### Commit 2: Add multilingual-e5 to KNOWN_DIMS (`_oss_providers.py`, +1 line)

```python
"intfloat/multilingual-e5-large": 1024,
```

The existing `_recreate_collection_if_dims_changed()` logic handles stale collections automatically.

## Testing

- Existing tests: **122/122 mem0 tests pass**
- Manual verification on Windows 10: 6 consecutive `mem0_search` + `mem0_add` calls, zero errors; restart cycle clean
- No conflicts with existing PR #58714 (touches different files)

## Related

- Fixes: #58705
- Complements: #58714 (which fixes a third lock scenario in `_recreate_collection_if_dims_changed`)

## Affected files

| File | Change |
|------|--------|
| `plugins/memory/mem0/__init__.py` | +6 lines: backend reuse guard |
| `plugins/memory/mem0/_oss_providers.py` | +1 line: dims entry |