### PR TITLE
fix(mcp): semantic tool errors must not trip circuit breaker

### DIFF
--- a/tests/tools/test_mcp_circuit_breaker.py
+++ b/tests/tools/test_mcp_circuit_breaker.py
@@ -221,6 +221,55 @@ def test_circuit_breaker_reopens_on_probe_failure(monkeypatch, tmp_path):
         _cleanup(mcp_tool, "srv")
 
 
+def test_tool_level_error_does_not_trip_breaker(monkeypatch, tmp_path):
+    """Semantic tool errors must not advance the transport breaker.
+
+    A tool-level error payload (validation, not-found, gated action) is a
+    sign the transport is healthy — the request reached the server and the
+    server produced a response. The breaker must reset on any call that
+    completes without a transport-level exception.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    call_count = {"n": 0}
+
+    async def _call_tool_returns_semantic_error(*a, **kw):
+        call_count["n"] += 1
+        result = MagicMock()
+        result.isError = True
+        block = MagicMock()
+        block.text = "Error: validation failed"
+        result.content = [block]
+        result.structuredContent = None
+        return result
+
+    _install_stub_server(mcp_tool, "srv", _call_tool_returns_semantic_error)
+    mcp_tool._ensure_mcp_loop()
+
+    try:
+        mcp_tool._server_error_counts["srv"] = mcp_tool._CIRCUIT_BREAKER_THRESHOLD - 1
+        handler = _make_tool_handler("srv", "tool1", 10.0)
+
+        result = handler({})
+        parsed = json.loads(result)
+        assert "error" in parsed, parsed
+        assert call_count["n"] == 1
+        # Transport completed → breaker must reset to 0, not stay at threshold-1.
+        assert mcp_tool._server_error_counts.get("srv", 0) == 0
+
+        # A second call must also go through (breaker closed, not tripped).
+        result = handler({})
+        parsed = json.loads(result)
+        assert "error" in parsed, parsed
+        assert call_count["n"] == 2, "tool-level error should not trip breaker"
+        assert mcp_tool._server_error_counts.get("srv", 0) == 0
+    finally:
+        _cleanup(mcp_tool, "srv")
+
+
 def test_half_open_probe_on_dead_session_requests_reconnect(monkeypatch, tmp_path):
     """A half-open probe against a server with no live session must request
     a transport reconnect and return a clean error — NOT write into a dead

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3995,15 +3995,11 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
 
         try:
             result = _call_once()
-            # Check if the MCP tool itself returned an error
-            try:
-                parsed = json.loads(result)
-                if "error" in parsed:
-                    _bump_server_error(server_name)
-                else:
-                    _reset_server_error(server_name)  # success — reset
-            except (json.JSONDecodeError, TypeError):
-                _reset_server_error(server_name)  # non-JSON = success
+            # The call completed without a transport-level exception, so the
+            # server is reachable. Whether the tool itself returned an error
+            # payload (validation, not-found, gated action) or a success
+            # result, the transport is healthy — reset the breaker (#10447).
+            _reset_server_error(server_name)
             return result
         except InterruptedError:
             return _interrupted_call_result()


### PR DESCRIPTION
## What

The MCP circuit breaker was counting **tool-level error payloads** as transport failures. After 3 consecutive tool-level errors, the breaker opens and blocks ALL tools from that MCP server for 60 seconds — even though the transport itself is perfectly healthy.

## Why

Tool-level errors are semantic responses: the request reached the server and the server produced a valid response. They include:

- Validation errors (wrong arguments, missing fields)
- Not-found / permission-denied
- Gated actions (e.g. an MCP gateway holding destructive calls for confirmation, returning an error payload with a token)

Counting these as transport failures causes a cascading outage: an MCP gateway that holds destructive calls for human confirmation returns an error payload on every held call. After 3 held calls, the entire server becomes unreachable for the session. Half-open probes after cooldown trigger more held calls, so the breaker never recovers — the server is permanently offline for the rest of the session.

## How to test

```bash
pytest tests/tools/test_mcp_circuit_breaker.py -v
```

New regression test: `test_tool_level_error_does_not_trip_breaker` — sets the error count to `THRESHOLD - 1`, calls a tool that returns `isError=True`, and asserts the count resets to 0 (not tripped). All 8 existing tests still pass.

## Changes

- `tools/mcp_tool.py`: any call that completes without a transport-level exception resets the breaker. The entire `json.loads` result-parsing block is removed — if `_call_once()` returned without raising, the transport is healthy. Period. Only transport-level exceptions in the `except Exception` path advance the failure count.
- `tests/tools/test_mcp_circuit_breaker.py`: regression test