### PR TITLE
fix(mcp): proactively reconnect on transport-exception breaker trip

### DIFF
--- a/tests/tools/test_mcp_circuit_breaker.py
+++ b/tests/tools/test_mcp_circuit_breaker.py
@@ -267,6 +267,44 @@ def test_half_open_probe_on_dead_session_requests_reconnect(monkeypatch, tmp_pat
         _cleanup(mcp_tool, "srv")
 
 
+def test_transport_exception_signals_reconnect_on_breaker_trip(monkeypatch, tmp_path):
+    """When a transport exception trips the breaker, the handler must
+    proactively signal reconnect — even when the session object still exists.
+
+    Without this, a broken pipe or stale connection causes every half-open
+    probe after cooldown to hit the same dead transport, re-trip the breaker,
+    and leave the server permanently unreachable for the session.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    async def _call_tool_transport_error(*a, **kw):
+        raise ConnectionError("broken pipe")
+
+    server = _install_stub_server(mcp_tool, "srv", _call_tool_transport_error)
+    mcp_tool._ensure_mcp_loop()
+
+    try:
+        reconnect_calls_before = server._reconnect_event.set_calls
+        handler = _make_tool_handler("srv", "tool1", 10.0)
+
+        # Call enough times to trip the breaker (threshold=3). Each call hits
+        # the transport exception path, which bumps the count and — on the
+        # trip — signals reconnect.
+        for _ in range(mcp_tool._CIRCUIT_BREAKER_THRESHOLD):
+            handler({})
+
+        # The reconnect signal must have been delivered when the breaker tripped.
+        reconnect_calls_after = server._reconnect_event.set_calls
+        assert reconnect_calls_after > reconnect_calls_before, (
+            "breaker trip from transport exception must signal reconnect"
+        )
+    finally:
+        _cleanup(mcp_tool, "srv")
+
+
 def test_half_open_dead_session_recovers_after_reconnect(monkeypatch, tmp_path):
     """Once the transport comes back (session repopulated + breaker reset by
     the run loop), the next call must go straight through — proving the wedge

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4029,6 +4029,15 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 return recovered
 
             _bump_server_error(server_name)
+
+            # If the breaker just tripped, proactively signal reconnect. The
+            # session object may still exist while the underlying transport is
+            # dead (stale HTTP, broken pipe). Without this, every half-open
+            # probe after cooldown hits the same dead transport, re-trips the
+            # breaker, and the server stays unreachable for the session.
+            if _server_error_counts.get(server_name, 0) >= _CIRCUIT_BREAKER_THRESHOLD:
+                _signal_reconnect(server)
+
             logger.error(
                 "MCP tool %s/%s call failed: %s",
                 server_name, tool_name, exc,


### PR DESCRIPTION
## What

When a transport-level exception (timeout, broken pipe, connection drop) trips the circuit breaker, the handler now proactively signals reconnect instead of waiting for the session to go `None`.

## Why

The existing half-open recovery only fires when `session is None` (dead stdio subprocess that has been parked). But a transport can be broken while the session object still exists — a stale HTTP connection, a half-closed pipe, or a wedged SSE stream where the session object is alive but the underlying transport is dead.

Without this fix, every half-open probe after cooldown hits the same broken transport, re-trips the breaker, and the server stays permanently unreachable for the rest of the session. The failure count climbs 3→4→5→…→N with no recovery path — the user must start a new session to regain access to the MCP server.

This was observed in production: a single 30s timeout on a Sentry MCP write tripped the breaker, and the session never recovered because all subsequent probes hit the same stale pipe. The count climbed to 10+ over 30 minutes.

## How to test

```bash
pytest tests/tools/test_mcp_circuit_breaker.py -v
```

New regression test: `test_transport_exception_signals_reconnect_on_breaker_trip` — calls a tool that raises `ConnectionError` enough times to trip the breaker, then asserts `_reconnect_event.set()` was called. All 8 existing tests still pass.

## Changes

- `tools/mcp_tool.py`: after `_bump_server_error`, if the count has reached the threshold, call `_signal_reconnect(server)` so the run loop rebuilds the transport before the next half-open probe
- `tests/tools/test_mcp_circuit_breaker.py`: regression test

## Relationship to #61555

This is the second of two independent fixes for MCP circuit breaker recovery. PR #61555 stops semantic errors from tripping the breaker; this PR ensures real transport failures actually recover. Both are standalone and can be merged independently.