### PR TITLE
fix(credential-pool): deduplicate same-key entries for custom providers

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2318,25 +2318,124 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
                 # Check if this model's base_url matches our custom provider
                 matched_key = get_custom_provider_pool_key(model_base_url)
                 if matched_key == pool_key:
-                    source = "model_config"
-                    if not _is_suppressed(pool_key, source):
-                        active_sources.add(source)
-                        changed |= _upsert_entry(
-                            entries,
-                            pool_key,
-                            source,
-                            {
-                                "source": source,
-                                "auth_type": AUTH_TYPE_API_KEY,
-                                "access_token": model_api_key,
-                                "base_url": model_base_url,
-                                "label": "model_config",
-                            },
-                        )
+                    # Skip seeding a duplicate entry when the same API key is
+                    # already present from the custom_providers config entry.
+                    # Without this, a standard setup (where custom_providers
+                    # and model.api_key point at the same key+URL) creates two
+                    # pool entries for one credential.  When that key hits a
+                    # 402/429, the first entry is marked exhausted, the pool
+                    # "rotates" to the second (identical) entry, which also
+                    # fails, and the user sees "all keys exhausted" despite
+                    # having only one key.  Compare by access_token value,
+                    # falling back to secret_fingerprint for entries loaded
+                    # from disk where the raw key was sanitized away.
+                    def _matches_existing(e: PooledCredential) -> bool:
+                        e_token = getattr(e, "access_token", "") or ""
+                        if e_token and e_token == model_api_key:
+                            return True
+                        # Disk-sanitized entries have empty access_token but
+                        # a secret_fingerprint — compute the fingerprint of
+                        # the candidate key and compare.
+                        e_fp = getattr(e, "secret_fingerprint", "") or ""
+                        if e_fp:
+                            from agent.credential_persistence import _fingerprint_value
+                            candidate_fp = _fingerprint_value(model_api_key)
+                            if candidate_fp and candidate_fp == e_fp:
+                                return True
+                        return False
+
+                    _already_seeded = any(_matches_existing(e) for e in entries)
+                    if not _already_seeded:
+                        source = "model_config"
+                        if not _is_suppressed(pool_key, source):
+                            active_sources.add(source)
+                            changed |= _upsert_entry(
+                                entries,
+                                pool_key,
+                                source,
+                                {
+                                    "source": source,
+                                    "auth_type": AUTH_TYPE_API_KEY,
+                                    "access_token": model_api_key,
+                                    "base_url": model_base_url,
+                                    "label": "model_config",
+                                },
+                            )
     except Exception:
         pass
 
     return changed, active_sources
+
+
+def _dedup_custom_pool_entries(entries: List[PooledCredential]) -> bool:
+    """Remove custom-pool entries that share the same API key.
+
+    When two entries have the same ``access_token`` or the same
+    ``secret_fingerprint`` (the on-disk hash when the raw key was sanitized
+    away), they are the same credential seeded from different sources.  Keeping
+    duplicates makes the pool appear to have N keys when it really has 1, and
+    exhausting that one key marks all N entries exhausted — the user sees "all
+    keys exhausted" despite only owning a single key.
+
+    Keeps the first entry per fingerprint.  If any duplicate is marked
+    exhausted/dead, propagates that status to the survivor so a known-bad key
+    doesn't silently revive after dedup.
+    """
+    if len(entries) <= 1:
+        return False
+
+    def _entry_key(entry: PooledCredential) -> str:
+        # Prefer the raw access_token when available (in-memory, pre-sanitize).
+        # Fall back to secret_fingerprint for entries loaded from disk where
+        # the raw key was stripped by sanitize_borrowed_credential_payload.
+        token = getattr(entry, "access_token", "") or ""
+        if token:
+            return f"token:{token}"
+        fp = getattr(entry, "secret_fingerprint", "") or ""
+        if fp:
+            return f"fp:{fp}"
+        # No comparable identity — never dedup entries we can't identify.
+        return f"id:{entry.id}"
+
+    seen: Dict[str, int] = {}
+    kept: List[PooledCredential] = []
+    removed_count = 0
+    for entry in entries:
+        key = _entry_key(entry)
+        if key not in seen:
+            seen[key] = len(kept)
+            kept.append(entry)
+        else:
+            survivor_idx = seen[key]
+            survivor = kept[survivor_idx]
+            # Propagate exhaustion status from the duplicate to the survivor.
+            # If the survivor is healthy but the duplicate is exhausted, the
+            # key is genuinely exhausted — marking the survivor healthy would
+            # send requests to a known-bad key.
+            if (
+                survivor.last_status not in {STATUS_EXHAUSTED, STATUS_DEAD}
+                and entry.last_status in {STATUS_EXHAUSTED, STATUS_DEAD}
+            ):
+                kept[survivor_idx] = replace(
+                    survivor,
+                    last_status=entry.last_status,
+                    last_status_at=entry.last_status_at,
+                    last_error_code=entry.last_error_code,
+                    last_error_reason=entry.last_error_reason,
+                    last_error_message=entry.last_error_message,
+                    last_error_reset_at=entry.last_error_reset_at,
+                )
+            removed_count += 1
+    if removed_count:
+        entries[:] = kept
+        logger.info(
+            "credential pool: removed %d duplicate %s entr%s (same API key "
+            "seeded from multiple sources)",
+            removed_count,
+            kept[0].provider if kept else "custom",
+            "y" if removed_count == 1 else "ies",
+        )
+    return removed_count > 0
 
 
 def load_pool(provider: str) -> CredentialPool:
@@ -2358,6 +2457,12 @@ def load_pool(provider: str) -> CredentialPool:
         # Custom endpoint pool — seed from custom_providers config and model config
         custom_changed, custom_sources = _seed_custom_pool(provider, entries)
         changed = raw_needs_sanitization or custom_changed
+        # Deduplicate BEFORE pruning: when two borrowed entries share the same
+        # key, pruning removes the one not in active_sources — but without
+        # dedup first, the exhaustion status on the pruned entry is lost and
+        # the surviving entry can silently revive a known-bad key.  Dedup
+        # merges that status into the survivor first.
+        changed |= _dedup_custom_pool_entries(entries)
         changed |= _prune_stale_seeded_entries(entries, custom_sources)
     else:
         singleton_changed, singleton_sources = _seed_from_singletons(provider, entries)

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2041,6 +2041,266 @@ def test_custom_endpoint_pool_seeds_from_model_config(tmp_path, monkeypatch):
     assert model_entries[0].access_token == "sk-model-key"
 
 
+def test_custom_endpoint_pool_no_duplicate_same_key(tmp_path, monkeypatch):
+    """When custom_providers and model.api_key point to the same key+URL,
+    the pool must contain ONE entry, not two.
+
+    Without dedup, both entries exhaust together on a single 402/429,
+    making the pool look empty ("all keys exhausted") when the user has
+    only one key.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1})
+
+    import yaml
+    same_key = "sk-shared-key-123"
+    config_path = tmp_path / "hermes" / "config.yaml"
+    config_path.write_text(yaml.dump({
+        "custom_providers": [
+            {
+                "name": "Together.ai",
+                "base_url": "https://api.together.ai/v1",
+                "api_key": same_key,
+            }
+        ],
+        "model": {
+            "provider": "custom",
+            "base_url": "https://api.together.ai/v1",
+            "api_key": same_key,
+        },
+    }))
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("custom:together.ai")
+    assert pool.has_credentials()
+    entries = pool.entries()
+    assert len(entries) == 1, (
+        f"Expected 1 entry for one key, got {len(entries)}: "
+        f"{[(e.source, e.access_token) for e in entries]}"
+    )
+
+
+def test_custom_pool_dedup_propagates_exhaustion(tmp_path, monkeypatch):
+    """When load_pool encounters pre-existing duplicate entries (from before
+    the dedup fix) where one is exhausted, the survivor inherits the
+    exhausted status so a known-bad key doesn't silently revive.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+
+    # Write auth.json with two entries that share the same fingerprint but
+    # have different exhaustion status.  Both are seeded from sources that
+    # will be active in the config below so they survive pruning.
+    _same_fp = "sha256:abc123def456"
+    _write_auth_store(tmp_path, {
+        "version": 1,
+        "credential_pool": {
+            "custom:together.ai": [
+                {
+                    "id": "entry1",
+                    "source": "config:Together.ai",
+                    "auth_type": "api_key",
+                    "access_token": "",
+                    "base_url": "https://api.together.ai/v1",
+                    "label": "Together.ai",
+                    "priority": 0,
+                    "secret_fingerprint": _same_fp,
+                    "last_status": "exhausted",
+                    "last_status_at": 1700000000.0,
+                    "last_error_code": 402,
+                    "last_error_reason": "billing_error",
+                    "last_error_message": "out of credits",
+                },
+                {
+                    "id": "entry2",
+                    "source": "model_config",
+                    "auth_type": "api_key",
+                    "access_token": "",
+                    "base_url": "https://api.together.ai/v1",
+                    "label": "model_config",
+                    "priority": 1,
+                    "secret_fingerprint": _same_fp,
+                    "last_status": None,
+                    "last_status_at": None,
+                    "last_error_code": None,
+                },
+            ],
+        },
+    })
+
+    # Config WITH matching api_key so both sources survive pruning.
+    # The config entry re-seeds with the raw key; model_config is also
+    # active because model.api_key is set.  But the _seed_custom_pool
+    # dedup prevents creating a NEW model_config entry since the same key
+    # is already present from config.
+    import yaml
+    same_key = "sk-shared-key"
+    config_path = tmp_path / "hermes" / "config.yaml"
+    config_path.write_text(yaml.dump({
+        "custom_providers": [
+            {
+                "name": "Together.ai",
+                "base_url": "https://api.together.ai/v1",
+                "api_key": same_key,
+            }
+        ],
+        "model": {
+            "provider": "custom",
+            "base_url": "https://api.together.ai/v1",
+            "api_key": same_key,
+        },
+    }))
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("custom:together.ai")
+    entries = pool.entries()
+    assert len(entries) == 1, f"Expected 1 entry after dedup, got {len(entries)}"
+    survivor = entries[0]
+    assert survivor.last_status == "exhausted", (
+        f"Survivor should inherit exhausted status, got {survivor.last_status}"
+    )
+
+
+def test_custom_endpoint_pool_different_keys_not_deduped(tmp_path, monkeypatch):
+    """When custom_providers and model.api_key have DIFFERENT keys for the
+    same endpoint, both entries must survive — this is a legitimate multi-key
+    setup for load distribution or failover.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1})
+
+    import yaml
+    config_path = tmp_path / "hermes" / "config.yaml"
+    config_path.write_text(yaml.dump({
+        "custom_providers": [
+            {
+                "name": "Together.ai",
+                "base_url": "https://api.together.ai/v1",
+                "api_key": "sk-key-A",
+            }
+        ],
+        "model": {
+            "provider": "custom",
+            "base_url": "https://api.together.ai/v1",
+            "api_key": "sk-key-B",
+        },
+    }))
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("custom:together.ai")
+    entries = pool.entries()
+    assert len(entries) == 2, (
+        f"Expected 2 entries for different keys, got {len(entries)}"
+    )
+    tokens = {e.access_token for e in entries}
+    assert tokens == {"sk-key-A", "sk-key-B"}, f"Unexpected tokens: {tokens}"
+
+
+def test_custom_pool_dedup_manual_entries_same_key(tmp_path, monkeypatch):
+    """Two manually-added entries with the same API key are deduplicated.
+    Manual entries can't be pruned (they're not borrowed sources), so the
+    runtime _dedup_custom_pool_entries is the only mechanism that catches them.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    same_key = "sk-manual-duplicate"
+    _write_auth_store(tmp_path, {
+        "version": 1,
+        "credential_pool": {
+            "custom:together.ai": [
+                {
+                    "id": "man1",
+                    "source": "manual",
+                    "auth_type": "api_key",
+                    "access_token": same_key,
+                    "base_url": "https://api.together.ai/v1",
+                    "label": "key-1",
+                    "priority": 0,
+                },
+                {
+                    "id": "man2",
+                    "source": "manual",
+                    "auth_type": "api_key",
+                    "access_token": same_key,
+                    "base_url": "https://api.together.ai/v1",
+                    "label": "key-2",
+                    "priority": 1,
+                },
+            ],
+        },
+    })
+
+    # Config without api_key so seeding doesn't interfere
+    import yaml
+    config_path = tmp_path / "hermes" / "config.yaml"
+    config_path.write_text(yaml.dump({
+        "custom_providers": [
+            {
+                "name": "Together.ai",
+                "base_url": "https://api.together.ai/v1",
+            }
+        ],
+    }))
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("custom:together.ai")
+    entries = pool.entries()
+    assert len(entries) == 1, (
+        f"Expected 1 entry after manual dedup, got {len(entries)}"
+    )
+
+
+def test_custom_pool_dedup_preserves_different_keys_with_manual(tmp_path, monkeypatch):
+    """Two manually-added entries with DIFFERENT keys must NOT be deduped."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {
+        "version": 1,
+        "credential_pool": {
+            "custom:together.ai": [
+                {
+                    "id": "man1",
+                    "source": "manual",
+                    "auth_type": "api_key",
+                    "access_token": "sk-key-X",
+                    "base_url": "https://api.together.ai/v1",
+                    "label": "key-X",
+                    "priority": 0,
+                },
+                {
+                    "id": "man2",
+                    "source": "manual",
+                    "auth_type": "api_key",
+                    "access_token": "sk-key-Y",
+                    "base_url": "https://api.together.ai/v1",
+                    "label": "key-Y",
+                    "priority": 1,
+                },
+            ],
+        },
+    })
+
+    import yaml
+    config_path = tmp_path / "hermes" / "config.yaml"
+    config_path.write_text(yaml.dump({
+        "custom_providers": [
+            {
+                "name": "Together.ai",
+                "base_url": "https://api.together.ai/v1",
+            }
+        ],
+    }))
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("custom:together.ai")
+    entries = pool.entries()
+    assert len(entries) == 2, (
+        f"Expected 2 entries for different manual keys, got {len(entries)}"
+    )
+
+
 def test_custom_pool_does_not_break_existing_providers(tmp_path, monkeypatch):
     """Existing registry providers work exactly as before with custom pool support."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))


### PR DESCRIPTION
## Problem

When a custom provider is configured, the credential pool is seeded from **two independent paths** that both read the same API key:

1. `custom_providers` config entry → pool source `config:<name>`
2. `model.api_key` when `model.provider == "custom"` → pool source `model_config`

In a standard setup both point to the same key+URL, creating **two pool entries for one credential**. When that key hits a 402/429:
- Entry #1 is marked exhausted → pool "rotates" to entry #2
- Entry #2 has the same key → also fails → marked exhausted
- User sees **"all keys exhausted"** despite having only one key

This was confirmed in the reporter's `auth.json`:
```
custom:hyper.charm.land (2 entries):
  [0] source=config:Hyper.charm.land  status=exhausted  code=402  fingerprint=sha256:70a09c402df9b0c0
  [1] source=model_config             status=exhausted  code=402  fingerprint=sha256:70a09c402df9b0c0
```
Both entries: same fingerprint, same error, same key — phantom exhaustion.

## Fix

Three-layer defense in `agent/credential_pool.py`:

### 1. Prevent duplicate seeding (`_seed_custom_pool`)
Before creating a `model_config` entry, check if the same API key already exists from the config entry. Compares by `access_token` value, falling back to `secret_fingerprint` for disk-sanitized entries (where the raw key was stripped by `sanitize_borrowed_credential_payload`).

### 2. Runtime dedup (`_dedup_custom_pool_entries`, new function)
Catches duplicates from **any** source — including manually-added entries (`hermes auth add`) which can't be pruned because they're owned sources. Identifies duplicates by `access_token` or `secret_fingerprint`. When a duplicate is exhausted/dead, **propagates that status to the survivor** so a known-bad key doesn't silently revive after dedup.

### 3. Correct ordering in `load_pool`
Dedup runs **before** pruning. When two borrowed entries share the same key, pruning removes the one not in `active_sources` — but without dedup first, the exhaustion status on the pruned entry is lost and the surviving entry can silently revive a known-bad key.

## Tests

Six regression tests in `tests/agent/test_credential_pool.py`:

| Test | What it covers |
|------|---------------|
| `test_custom_endpoint_pool_no_duplicate_same_key` | Same key from config + model_config → 1 entry |
| `test_custom_endpoint_pool_different_keys_not_deduped` | Different keys → 2 entries preserved |
| `test_custom_pool_dedup_propagates_exhaustion` | Pre-existing duplicates on disk: survivor inherits exhaustion |
| `test_custom_pool_dedup_manual_entries_same_key` | Manual entries with same key → deduped (can't be pruned) |
| `test_custom_pool_dedup_preserves_different_keys_with_manual` | Manual entries with different keys → preserved |
| *(existing)* `test_custom_endpoint_pool_seeds_from_model_config` | Different keys still seed from model_config |

All 90 tests in `test_credential_pool.py` pass, plus 30 related tests across `test_custom_pool_mismatch_guard.py`, `test_credential_pool_routing.py`, `test_fallback_credential_isolation.py`, `test_credential_pool_interrupt.py`, and `test_switch_model_pool_reload_52727.py`.