### PR TITLE
docs(readme): add Paperclip adapter to Community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ scripts/run_tests.sh
 - 🐛 [Issues](https://github.com/NousResearch/hermes-agent/issues)
 - 🔌 [computer-use-linux](https://github.com/avifenesh/computer-use-linux) — Linux desktop-control MCP server for Hermes and other MCP hosts, with AT-SPI accessibility trees, Wayland/X11 input, screenshots, and compositor window targeting.
 - 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Community WeChat bridge: Run Hermes Agent and OpenClaw on the same WeChat account.
+- 🔌 [Paperclip adapter](https://github.com/paperclipai/hermes-paperclip-adapter) — Run Hermes Agent as a managed employee in a Paperclip company: shared task board, comment-driven wakes, and 8 model providers out of the box. [Setup guide](https://docs.paperclip.ing/reference/adapters/hermes/).
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Adds the **Paperclip adapter** to the Community list in `README.md`. Paperclip lets people run Hermes Agent as a managed "employee" — Hermes picks up tasks from a shared board, wakes on comments, and reports back — so Hermes reaches users who want a hosted/managed way to operate it. This is a docs-only, one-line link addition.

## Related Issue

N/A — community/ecosystem link addition (same shape as the existing `computer-use-linux` and `HermesClaw` entries).

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `README.md`: one entry under **## Community** linking the standalone adapter repo (`paperclipai/hermes-paperclip-adapter`) and its setup guide.

## How to Test

1. Open `README.md` and view the **Community** section.
2. Confirm the new bullet renders and both links resolve:
   - Adapter repo: https://github.com/paperclipai/hermes-paperclip-adapter
   - Setup guide: https://docs.paperclip.ing/reference/adapters/hermes/

## Placement rationale

Per `CONTRIBUTING.md` → *Third-Party Product Integrations: Ship as a Standalone Plugin*, the integration lives in its own repo and does **not** add any code under `plugins/` or elsewhere in this tree. This PR only lists it in the Community section, matching precedent (`HermesClaw`, `computer-use-linux`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`docs(readme):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this addition (single-line docs change)
- [x] Tests: N/A — docs-only change, no code paths touched
- [x] Added tests: N/A — docs-only
- [x] Platform: N/A — docs-only

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README) — this PR is the doc update
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (docs-only)
