### PR TITLE
feat(cli): accept --max-turns on the oneshot/-z path

### DIFF
--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -153,6 +153,18 @@ def build_top_level_parser():
         default=None,
         help="Comma-separated toolsets to enable for this invocation. Applies to -z/--oneshot and --tui.",
     )
+    # Accepted at the top level so it can pair with -z/--oneshot without the
+    # `chat` subcommand (mirrors `hermes chat --max-turns`). The chat subparser
+    # sets its --max-turns default to argparse.SUPPRESS so `hermes --max-turns N
+    # chat` — the flag placed before the subcommand — is not clobbered back to
+    # the default. Callers read it via getattr(args, "max_turns", None).
+    parser.add_argument(
+        "--max-turns",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Maximum tool-calling iterations for this invocation. Applies to -z/--oneshot (default: 90).",
+    )
     parser.add_argument(
         "--resume",
         "-r",
@@ -353,7 +365,11 @@ def build_top_level_parser():
     chat_parser.add_argument(
         "--max-turns",
         type=int,
-        default=None,
+        # SUPPRESS (not None) so `hermes --max-turns N chat` — the flag placed
+        # before the subcommand and parsed by the top-level parser — is not
+        # clobbered back to the default by this subparser. Absence therefore
+        # reads as None via getattr(args, "max_turns", None), same as before.
+        default=argparse.SUPPRESS,
         metavar="N",
         help="Maximum tool-calling iterations per conversation turn (default: 90, or agent.max_turns in config)",
     )

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12516,6 +12516,7 @@ def _try_termux_fast_cli_launch() -> bool:
                 provider=getattr(args, "provider", None),
                 toolsets=getattr(args, "toolsets", None),
                 usage_file=getattr(args, "usage_file", None),
+                max_turns=getattr(args, "max_turns", None),
             )
         )
 
@@ -14613,6 +14614,7 @@ def main():
                 provider=getattr(args, "provider", None),
                 toolsets=getattr(args, "toolsets", None),
                 usage_file=getattr(args, "usage_file", None),
+                max_turns=getattr(args, "max_turns", None),
             )
         )
 

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -166,6 +166,7 @@ def run_oneshot(
     provider: Optional[str] = None,
     toolsets: object = None,
     usage_file: Optional[str] = None,
+    max_turns: Optional[int] = None,
 ) -> int:
     """Execute a single prompt and print only the final content block.
 
@@ -232,6 +233,7 @@ def run_oneshot(
                     provider=provider,
                     toolsets=explicit_toolsets,
                     use_config_toolsets=use_config_toolsets,
+                    max_turns=max_turns,
                 )
             except BaseException as exc:  # noqa: BLE001
                 # Capture anything that escapes the agent (including OSError
@@ -300,6 +302,7 @@ def _run_agent(
     provider: Optional[str] = None,
     toolsets: object = None,
     use_config_toolsets: bool = True,
+    max_turns: Optional[int] = None,
 ) -> tuple[str, dict]:
     """Build an AIAgent exactly like a normal CLI chat turn would, then
     run a single conversation.  Returns ``(final_response, run_result)``."""
@@ -384,6 +387,10 @@ def _run_agent(
     # honour the same merge semantics as interactive CLI and gateway sessions.
     _fb = get_fallback_chain(cfg)
 
+    # An explicit --max-turns caps this run's tool-calling iterations; when unset
+    # we pass nothing so AIAgent keeps its own default (max_iterations=90).
+    _max_iter = {"max_iterations": max_turns} if max_turns is not None else {}
+
     agent = AIAgent(
         api_key=runtime.get("api_key"),
         base_url=runtime.get("base_url"),
@@ -394,6 +401,7 @@ def _run_agent(
         quiet_mode=True,
         platform="cli",
         session_db=session_db,
+        **_max_iter,
         credential_pool=runtime.get("credential_pool"),
         fallback_model=_fb or None,
         # Interactive callbacks are intentionally NOT wired beyond this

--- a/tests/hermes_cli/test_oneshot_max_turns.py
+++ b/tests/hermes_cli/test_oneshot_max_turns.py
@@ -1,0 +1,47 @@
+"""Tests for ``--max-turns`` on the oneshot (``-z``) path.
+
+The flag already existed on ``hermes chat``; these cover accepting it at the top
+level (so it pairs with ``-z/--oneshot``) and threading it through to the agent.
+"""
+
+from unittest.mock import patch
+
+from hermes_cli._parser import build_top_level_parser
+
+
+class TestOneshotMaxTurnsParsing:
+    def test_max_turns_pairs_with_oneshot(self):
+        args = build_top_level_parser().parse_args(["-z", "hi", "--max-turns", "5"])
+        assert args.max_turns == 5
+
+    def test_absent_max_turns_reads_as_none(self):
+        args = build_top_level_parser().parse_args(["-z", "hi"])
+        assert getattr(args, "max_turns", None) is None
+
+    def test_top_level_flag_survives_chat_subcommand(self):
+        # `hermes --max-turns 7 chat`: the chat subparser's --max-turns default is
+        # argparse.SUPPRESS, so the top-level value must NOT be clobbered back.
+        args = build_top_level_parser().parse_args(["--max-turns", "7", "chat"])
+        assert args.max_turns == 7
+
+
+class TestOneshotMaxTurnsThreading:
+    def test_run_oneshot_forwards_max_turns_to_agent(self):
+        from hermes_cli import oneshot
+
+        with patch.object(oneshot, "_write_usage_file"), patch.object(
+            oneshot, "_run_agent", return_value=("ok", {})
+        ) as run_agent:
+            oneshot.run_oneshot("hello", max_turns=5)
+
+        assert run_agent.call_args.kwargs.get("max_turns") == 5
+
+    def test_run_oneshot_forwards_none_when_unset(self):
+        from hermes_cli import oneshot
+
+        with patch.object(oneshot, "_write_usage_file"), patch.object(
+            oneshot, "_run_agent", return_value=("ok", {})
+        ) as run_agent:
+            oneshot.run_oneshot("hello")
+
+        assert run_agent.call_args.kwargs.get("max_turns") is None


### PR DESCRIPTION
## What
`--max-turns` currently only works under `hermes chat`. This registers it at the top level so it also applies to the oneshot path (`-z`/`--oneshot`), threading the value into `AIAgent(max_iterations=...)`.

## Why
Non-interactive / scripted `hermes -z` runs have no way to cap tool-calling iterations, so a single invocation can loop up to the default (90) with no override. Accepting `--max-turns` on oneshot lets callers bound iterations per invocation — useful for cost/latency control in pipelines, CI, and subprocess/gateway use.

## Details
- `_parser.py`: add a top-level `--max-turns`; set the `chat` subparser's `--max-turns` default to `argparse.SUPPRESS` so `hermes --max-turns N chat` (flag placed before the subcommand, parsed by the top-level parser) isn't clobbered back to the default. Absence still reads as `None` via `getattr(args, "max_turns", None)`.
- `oneshot.py`: thread `max_turns` through `run_oneshot` → `_run_agent`; pass `max_iterations=max_turns` to `AIAgent` only when a value is given (otherwise the built-in default is left untouched).
- `main.py`: forward `getattr(args, "max_turns", None)` at both oneshot call sites.

## Tests
`tests/hermes_cli/test_oneshot_max_turns.py`: the flag pairs with `-z`, reads as `None` when absent, survives the `chat` subcommand, and `run_oneshot` forwards it to the agent.

No behavior change when `--max-turns` is not passed.
