### PR TITLE
fix(telegram): improve local video delivery metadata

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -10,12 +10,14 @@ Uses python-telegram-bot library for:
 import asyncio
 import dataclasses
 import faulthandler
+import hashlib
 import inspect
 import json
 import logging
 import os
 import html as _html
 import re
+import subprocess
 import threading
 import time
 from contextvars import ContextVar
@@ -262,6 +264,7 @@ from gateway.platforms.base import (
     cache_audio_from_bytes,
     cache_video_from_bytes,
     cache_document_from_bytes,
+    get_video_cache_dir,
     resolve_proxy_url,
     SUPPORTED_VIDEO_TYPES,
     SUPPORTED_DOCUMENT_TYPES,
@@ -362,6 +365,138 @@ def _probe_voice_duration_seconds(path: str) -> Optional[int]:
         pass
 
     return None
+
+
+
+def _probe_video_metadata(video_path: str) -> Dict[str, int]:
+    """Best-effort Telegram sendVideo metadata from ffprobe.
+
+    Telegram clients render large Bot API videos more reliably when sendVideo
+    includes the same fields native clients usually provide: dimensions,
+    duration, and ``supports_streaming``.  If ffprobe is unavailable or the file
+    is malformed we silently fall back to Telegram's own probing.
+    """
+    try:
+        completed = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-show_entries",
+                "stream=width,height,duration:format=duration",
+                "-of",
+                "json",
+                video_path,
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        data = json.loads(completed.stdout or "{}")
+    except Exception:
+        logger.debug("[Telegram] Failed to probe video metadata for %s", video_path, exc_info=True)
+        return {}
+
+    streams = data.get("streams") or []
+    stream = streams[0] if streams and isinstance(streams[0], dict) else {}
+    fmt = data.get("format") if isinstance(data.get("format"), dict) else {}
+    out: Dict[str, int] = {}
+    for src_key, dst_key in (("width", "width"), ("height", "height")):
+        try:
+            value = int(float(stream.get(src_key)))
+        except (TypeError, ValueError):
+            continue
+        if value > 0:
+            out[dst_key] = value
+    duration_raw = stream.get("duration") or fmt.get("duration")
+    try:
+        duration = int(round(float(duration_raw)))
+    except (TypeError, ValueError):
+        duration = 0
+    if duration > 0:
+        out["duration"] = duration
+    return out
+
+
+_TELEGRAM_VIDEO_THUMB_MAX_BYTES = 200 * 1024
+
+
+def _valid_telegram_video_thumbnail(path: _Path) -> bool:
+    """Return True when a generated thumbnail fits Telegram's hard limits."""
+    try:
+        return 0 < path.stat().st_size <= _TELEGRAM_VIDEO_THUMB_MAX_BYTES
+    except OSError:
+        return False
+
+
+def _looks_like_telegram_thumbnail_error(error: Exception) -> bool:
+    """Best-effort check for Telegram rejecting only the video thumbnail."""
+    text = str(error).lower()
+    return any(
+        marker in text
+        for marker in (
+            "thumbnail",
+            "thumb",
+            "photo_invalid_dimensions",
+            "image_process_failed",
+        )
+    )
+
+
+def _ensure_video_thumbnail(video_path: str) -> Optional[str]:
+    """Create/cache a JPEG thumbnail for Telegram sendVideo.
+
+    Telegram accepts thumbnails under 200 kB and within 320x320.  Generating one
+    avoids all-black first-frame previews common with slide/screencast videos
+    and helps clients show a real video card instead of a black download tile.
+    """
+    try:
+        src = _Path(video_path)
+        if not src.exists():
+            return None
+        stat = src.stat()
+        digest = hashlib.sha1(
+            f"{src.resolve()}:{stat.st_size}:{stat.st_mtime_ns}".encode("utf-8", "replace")
+        ).hexdigest()[:16]
+        thumb = get_video_cache_dir() / f"telegram-thumb-{digest}.jpg"
+        if thumb.exists():
+            if _valid_telegram_video_thumbnail(thumb):
+                return str(thumb)
+            thumb.unlink(missing_ok=True)
+
+        # Seek a little into the file to avoid intentionally/accidentally black
+        # opening frames.  force_original_aspect_ratio=decrease fits both
+        # landscape and portrait frames inside Telegram's 320x320 thumbnail box.
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-ss",
+                "3",
+                "-i",
+                video_path,
+                "-frames:v",
+                "1",
+                "-vf",
+                "scale=320:320:force_original_aspect_ratio=decrease",
+                "-q:v",
+                "5",
+                str(thumb),
+            ],
+            check=True,
+            capture_output=True,
+            timeout=30,
+        )
+        if _valid_telegram_video_thumbnail(thumb):
+            return str(thumb)
+        thumb.unlink(missing_ok=True)
+    except Exception:
+        logger.debug("[Telegram] Failed to create video thumbnail for %s", video_path, exc_info=True)
+    return None
+
 
 
 def check_telegram_requirements() -> bool:
@@ -6805,22 +6940,94 @@ class TelegramAdapter(BasePlatformAdapter):
                 reply_to_message_id=reply_to_id,
                 reply_to_mode=self._reply_to_mode
             )
-            with open(video_path, "rb") as f:
-                msg = await self._send_with_dm_topic_reply_anchor_retry(
-                    self._bot.send_video,
-                    {
-                        "chat_id": normalize_telegram_chat_id(chat_id),
-                        "video": f,
-                        "caption": caption[:1024] if caption else None,
-                        "reply_to_message_id": reply_to_id,
-                        **thread_kwargs,
-                        **self._notification_kwargs(metadata),
-                    },
-                    metadata,
-                    reply_to_id,
-                    "video",
-                    reset_media=lambda: f.seek(0),
-                )
+            video_metadata, thumbnail_path = await asyncio.gather(
+                asyncio.to_thread(_probe_video_metadata, video_path),
+                asyncio.to_thread(_ensure_video_thumbnail, video_path),
+            )
+            send_kwargs = {
+                "chat_id": normalize_telegram_chat_id(chat_id),
+                "caption": caption[:1024] if caption else None,
+                "reply_to_message_id": reply_to_id,
+                "supports_streaming": True,
+                **video_metadata,
+                **thread_kwargs,
+                **self._notification_kwargs(metadata),
+            }
+
+            if self.config.extra.get("local_mode"):
+                # Local Bot API can read server-side paths directly. Passing the
+                # path preserves file metadata and avoids a huge multipart stream
+                # through the gateway process.
+                send_kwargs["video"] = video_path
+                if thumbnail_path:
+                    send_kwargs["thumbnail"] = thumbnail_path
+                try:
+                    msg = await self._send_with_dm_topic_reply_anchor_retry(
+                        self._bot.send_video,
+                        send_kwargs,
+                        metadata,
+                        reply_to_id,
+                        "video",
+                        reset_media=None,
+                    )
+                except Exception as send_err:
+                    if not thumbnail_path or not _looks_like_telegram_thumbnail_error(send_err):
+                        raise
+                    logger.warning(
+                        "[%s] Telegram rejected video thumbnail, retrying without it: %s",
+                        self.name,
+                        _redact_telegram_error_text(send_err),
+                    )
+                    retry_kwargs = dict(send_kwargs)
+                    retry_kwargs.pop("thumbnail", None)
+                    msg = await self._send_with_dm_topic_reply_anchor_retry(
+                        self._bot.send_video,
+                        retry_kwargs,
+                        metadata,
+                        reply_to_id,
+                        "video",
+                        reset_media=None,
+                    )
+            else:
+                with open(video_path, "rb") as f:
+                    thumb_file = open(thumbnail_path, "rb") if thumbnail_path else None
+                    try:
+                        send_kwargs["video"] = f
+                        if thumb_file is not None:
+                            send_kwargs["thumbnail"] = thumb_file
+                        try:
+                            msg = await self._send_with_dm_topic_reply_anchor_retry(
+                                self._bot.send_video,
+                                send_kwargs,
+                                metadata,
+                                reply_to_id,
+                                "video",
+                                reset_media=lambda: (f.seek(0), thumb_file and thumb_file.seek(0)),
+                            )
+                        except Exception as send_err:
+                            if thumb_file is None or not _looks_like_telegram_thumbnail_error(send_err):
+                                raise
+                            logger.warning(
+                                "[%s] Telegram rejected video thumbnail, retrying without it: %s",
+                                self.name,
+                                _redact_telegram_error_text(send_err),
+                            )
+                            thumb_file.close()
+                            thumb_file = None
+                            f.seek(0)
+                            retry_kwargs = dict(send_kwargs)
+                            retry_kwargs.pop("thumbnail", None)
+                            msg = await self._send_with_dm_topic_reply_anchor_retry(
+                                self._bot.send_video,
+                                retry_kwargs,
+                                metadata,
+                                reply_to_id,
+                                "video",
+                                reset_media=lambda: f.seek(0),
+                            )
+                    finally:
+                        if thumb_file is not None:
+                            thumb_file.close()
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
             logger.warning(

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9,12 +9,15 @@ Uses python-telegram-bot library for:
 
 import asyncio
 import dataclasses
+import faulthandler
+import hashlib
 import inspect
 import json
 import logging
 import os
 import html as _html
 import re
+import subprocess
 import threading
 import time
 from contextvars import ContextVar
@@ -199,6 +202,7 @@ from gateway.platforms.base import (
     cache_audio_from_bytes,
     cache_video_from_bytes,
     cache_document_from_bytes,
+    get_video_cache_dir,
     resolve_proxy_url,
     SUPPORTED_VIDEO_TYPES,
     SUPPORTED_DOCUMENT_TYPES,
@@ -330,6 +334,136 @@ def telegram_deps_present() -> bool:
     and runs from ``create_adapter()`` when this returns False (#79812).
     """
     return TELEGRAM_AVAILABLE
+
+
+def _probe_video_metadata(video_path: str) -> Dict[str, int]:
+    """Best-effort Telegram sendVideo metadata from ffprobe.
+
+    Telegram clients render large Bot API videos more reliably when sendVideo
+    includes the same fields native clients usually provide: dimensions,
+    duration, and ``supports_streaming``.  If ffprobe is unavailable or the file
+    is malformed we silently fall back to Telegram's own probing.
+    """
+    try:
+        completed = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-show_entries",
+                "stream=width,height,duration:format=duration",
+                "-of",
+                "json",
+                video_path,
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        data = json.loads(completed.stdout or "{}")
+    except Exception:
+        logger.debug("[Telegram] Failed to probe video metadata for %s", video_path, exc_info=True)
+        return {}
+
+    streams = data.get("streams") or []
+    stream = streams[0] if streams and isinstance(streams[0], dict) else {}
+    fmt = data.get("format") if isinstance(data.get("format"), dict) else {}
+    out: Dict[str, int] = {}
+    for src_key, dst_key in (("width", "width"), ("height", "height")):
+        try:
+            value = int(float(stream.get(src_key)))
+        except (TypeError, ValueError):
+            continue
+        if value > 0:
+            out[dst_key] = value
+    duration_raw = stream.get("duration") or fmt.get("duration")
+    try:
+        duration = int(round(float(duration_raw)))
+    except (TypeError, ValueError):
+        duration = 0
+    if duration > 0:
+        out["duration"] = duration
+    return out
+
+
+_TELEGRAM_VIDEO_THUMB_MAX_BYTES = 200 * 1024
+
+
+def _valid_telegram_video_thumbnail(path: _Path) -> bool:
+    """Return True when a generated thumbnail fits Telegram's hard limits."""
+    try:
+        return 0 < path.stat().st_size <= _TELEGRAM_VIDEO_THUMB_MAX_BYTES
+    except OSError:
+        return False
+
+
+def _looks_like_telegram_thumbnail_error(error: Exception) -> bool:
+    """Best-effort check for Telegram rejecting only the video thumbnail."""
+    text = str(error).lower()
+    return any(
+        marker in text
+        for marker in (
+            "thumbnail",
+            "thumb",
+            "photo_invalid_dimensions",
+            "image_process_failed",
+        )
+    )
+
+
+def _ensure_video_thumbnail(video_path: str) -> Optional[str]:
+    """Create/cache a JPEG thumbnail for Telegram sendVideo.
+
+    Telegram accepts thumbnails under 200 kB and within 320x320.  Generating one
+    avoids all-black first-frame previews common with slide/screencast videos
+    and helps clients show a real video card instead of a black download tile.
+    """
+    try:
+        src = _Path(video_path)
+        if not src.exists():
+            return None
+        stat = src.stat()
+        digest = hashlib.sha1(
+            f"{src.resolve()}:{stat.st_size}:{stat.st_mtime_ns}".encode("utf-8", "replace")
+        ).hexdigest()[:16]
+        thumb = get_video_cache_dir() / f"telegram-thumb-{digest}.jpg"
+        if thumb.exists():
+            if _valid_telegram_video_thumbnail(thumb):
+                return str(thumb)
+            thumb.unlink(missing_ok=True)
+
+        # Seek a little into the file to avoid intentionally/accidentally black
+        # opening frames.  force_original_aspect_ratio=decrease fits both
+        # landscape and portrait frames inside Telegram's 320x320 thumbnail box.
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-ss",
+                "3",
+                "-i",
+                video_path,
+                "-frames:v",
+                "1",
+                "-vf",
+                "scale=320:320:force_original_aspect_ratio=decrease",
+                "-q:v",
+                "5",
+                str(thumb),
+            ],
+            check=True,
+            capture_output=True,
+            timeout=30,
+        )
+        if _valid_telegram_video_thumbnail(thumb):
+            return str(thumb)
+        thumb.unlink(missing_ok=True)
+    except Exception:
+        logger.debug("[Telegram] Failed to create video thumbnail for %s", video_path, exc_info=True)
+    return None
 
 
 def check_telegram_requirements() -> bool:
@@ -8101,23 +8235,68 @@ class TelegramAdapter(BasePlatformAdapter):
                 reply_to_message_id=reply_to_id,
                 reply_to_mode=self._reply_to_mode
             )
-            with open(video_path, "rb") as f:
-                msg = await self._send_with_dm_topic_reply_anchor_retry(
-                    self._bot.send_video,
-                    {
-                        "chat_id": normalize_telegram_chat_id(chat_id),
-                        "video": f,
-                        "caption": caption[:1024] if caption else None,
-                        "reply_to_message_id": reply_to_id,
-                        "read_timeout": _MEDIA_SEND_READ_TIMEOUT,
-                        **thread_kwargs,
-                        **self._notification_kwargs(metadata),
-                    },
-                    metadata,
-                    reply_to_id,
-                    "video",
-                    reset_media=lambda: f.seek(0),
-                )
+            video_metadata, thumbnail_path = await asyncio.gather(
+                asyncio.to_thread(_probe_video_metadata, video_path),
+                asyncio.to_thread(_ensure_video_thumbnail, video_path),
+            )
+            send_kwargs = {
+                "chat_id": normalize_telegram_chat_id(chat_id),
+                "caption": caption[:1024] if caption else None,
+                "reply_to_message_id": reply_to_id,
+                "read_timeout": _MEDIA_SEND_READ_TIMEOUT,
+                "supports_streaming": True,
+                **video_metadata,
+                **thread_kwargs,
+                **self._notification_kwargs(metadata),
+            }
+
+            if self.config.extra.get("local_mode"):
+                send_kwargs["video"] = video_path
+                if thumbnail_path:
+                    send_kwargs["thumbnail"] = thumbnail_path
+                try:
+                    msg = await self._send_with_dm_topic_reply_anchor_retry(
+                        self._bot.send_video, send_kwargs, metadata, reply_to_id,
+                        "video", reset_media=None,
+                    )
+                except Exception as send_err:
+                    if not thumbnail_path or not _looks_like_telegram_thumbnail_error(send_err):
+                        raise
+                    retry_kwargs = dict(send_kwargs)
+                    retry_kwargs.pop("thumbnail", None)
+                    msg = await self._send_with_dm_topic_reply_anchor_retry(
+                        self._bot.send_video, retry_kwargs, metadata, reply_to_id,
+                        "video", reset_media=None,
+                    )
+            else:
+                with open(video_path, "rb") as f:
+                    thumb_file = open(thumbnail_path, "rb") if thumbnail_path else None
+                    try:
+                        send_kwargs["video"] = f
+                        if thumb_file is not None:
+                            send_kwargs["thumbnail"] = thumb_file
+                        try:
+                            msg = await self._send_with_dm_topic_reply_anchor_retry(
+                                self._bot.send_video, send_kwargs, metadata, reply_to_id,
+                                "video",
+                                reset_media=lambda: (f.seek(0), thumb_file and thumb_file.seek(0)),
+                            )
+                        except Exception as send_err:
+                            if thumb_file is None or not _looks_like_telegram_thumbnail_error(send_err):
+                                raise
+                            thumb_file.close()
+                            thumb_file = None
+                            f.seek(0)
+                            retry_kwargs = dict(send_kwargs)
+                            retry_kwargs.pop("thumbnail", None)
+                            msg = await self._send_with_dm_topic_reply_anchor_retry(
+                                self._bot.send_video, retry_kwargs, metadata, reply_to_id,
+                                "video", reset_media=lambda: f.seek(0),
+                            )
+                    finally:
+                        if thumb_file is not None:
+                            thumb_file.close()
+
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
             logger.warning(

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -51,7 +51,11 @@ def _ensure_telegram_mock():
 _ensure_telegram_mock()
 
 # Now we can safely import
-from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+from plugins.platforms.telegram.adapter import (  # noqa: E402
+    TelegramAdapter,
+    _TELEGRAM_VIDEO_THUMB_MAX_BYTES,
+    _ensure_video_thumbnail,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -919,6 +923,126 @@ class TestSendVideo:
         assert result.success is True
         assert result.message_id == "200"
         connected_adapter._bot.send_video.assert_called_once()
+        call_kwargs = connected_adapter._bot.send_video.call_args[1]
+        assert call_kwargs["supports_streaming"] is True
+        assert getattr(call_kwargs["video"], "name", None) == str(test_file)
+
+    @pytest.mark.asyncio
+    async def test_send_video_local_mode_passes_path_and_metadata(self, connected_adapter, tmp_path, monkeypatch):
+        test_file = tmp_path / "clip.mp4"
+        test_file.write_bytes(b"\x00\x00\x00\x1c" + b"ftyp" + b"\x00" * 100)
+        thumb = tmp_path / "thumb.jpg"
+        thumb.write_bytes(b"jpeg")
+        connected_adapter.config.extra["local_mode"] = True
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter._probe_video_metadata",
+            lambda path: {"width": 1920, "height": 1080, "duration": 42},
+        )
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter._ensure_video_thumbnail",
+            lambda path: str(thumb),
+        )
+
+        mock_msg = MagicMock()
+        mock_msg.message_id = 202
+        connected_adapter._bot.send_video = AsyncMock(return_value=mock_msg)
+
+        result = await connected_adapter.send_video(
+            chat_id="12345",
+            video_path=str(test_file),
+            caption="Check this out",
+        )
+
+        assert result.success is True
+        call_kwargs = connected_adapter._bot.send_video.call_args[1]
+        assert call_kwargs["video"] == str(test_file)
+        assert call_kwargs["thumbnail"] == str(thumb)
+        assert call_kwargs["supports_streaming"] is True
+        assert call_kwargs["width"] == 1920
+        assert call_kwargs["height"] == 1080
+        assert call_kwargs["duration"] == 42
+
+    @pytest.mark.asyncio
+    async def test_send_video_retries_without_rejected_thumbnail(self, connected_adapter, tmp_path, monkeypatch):
+        test_file = tmp_path / "clip.mp4"
+        test_file.write_bytes(b"\x00\x00\x00\x1c" + b"ftyp" + b"\x00" * 100)
+        thumb = tmp_path / "thumb.jpg"
+        thumb.write_bytes(b"jpeg")
+        connected_adapter.config.extra["local_mode"] = True
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter._probe_video_metadata",
+            lambda path: {"width": 1920, "height": 1080, "duration": 42},
+        )
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter._ensure_video_thumbnail",
+            lambda path: str(thumb),
+        )
+
+        mock_msg = MagicMock()
+        mock_msg.message_id = 203
+        connected_adapter._bot.send_video = AsyncMock(
+            side_effect=[Exception("Bad Request: wrong thumbnail"), mock_msg]
+        )
+
+        result = await connected_adapter.send_video(
+            chat_id="12345",
+            video_path=str(test_file),
+        )
+
+        assert result.success is True
+        assert connected_adapter._bot.send_video.await_count == 2
+        first_call = connected_adapter._bot.send_video.await_args_list[0].kwargs
+        second_call = connected_adapter._bot.send_video.await_args_list[1].kwargs
+        assert first_call["thumbnail"] == str(thumb)
+        assert "thumbnail" not in second_call
+        assert second_call["video"] == str(test_file)
+        assert second_call["supports_streaming"] is True
+
+    def test_ensure_video_thumbnail_fits_portrait_and_size_limit(self, tmp_path, monkeypatch):
+        video = tmp_path / "portrait.mp4"
+        video.write_bytes(b"fake video")
+        cache_dir = tmp_path / "cache"
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.get_video_cache_dir",
+            lambda: cache_dir,
+        )
+
+        def fake_run(cmd, check, capture_output, timeout):
+            assert "scale=320:320:force_original_aspect_ratio=decrease" in cmd
+            out = tmp_path / cmd[-1]
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_bytes(b"jpeg")
+            return MagicMock()
+
+        monkeypatch.setattr("plugins.platforms.telegram.adapter.subprocess.run", fake_run)
+
+        thumb = _ensure_video_thumbnail(str(video))
+
+        assert thumb is not None
+        assert os.path.exists(thumb)
+        assert os.path.getsize(thumb) <= _TELEGRAM_VIDEO_THUMB_MAX_BYTES
+
+    def test_ensure_video_thumbnail_drops_oversized_output(self, tmp_path, monkeypatch):
+        video = tmp_path / "clip.mp4"
+        video.write_bytes(b"fake video")
+        cache_dir = tmp_path / "cache"
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.get_video_cache_dir",
+            lambda: cache_dir,
+        )
+
+        def fake_run(cmd, check, capture_output, timeout):
+            out = tmp_path / cmd[-1]
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_bytes(b"x" * (_TELEGRAM_VIDEO_THUMB_MAX_BYTES + 1))
+            return MagicMock()
+
+        monkeypatch.setattr("plugins.platforms.telegram.adapter.subprocess.run", fake_run)
+
+        thumb = _ensure_video_thumbnail(str(video))
+
+        assert thumb is None
+        assert not any(cache_dir.glob("telegram-thumb-*.jpg"))
 
     @pytest.mark.asyncio
     async def test_send_video_file_not_found(self, connected_adapter):

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -927,6 +927,73 @@ class TestSendVideo:
         assert call_kwargs["supports_streaming"] is True
         assert getattr(call_kwargs["video"], "name", None) == str(test_file)
 
+
+    @pytest.mark.asyncio
+    async def test_send_video_multipart_forwards_metadata_and_thumbnail(
+        self, connected_adapter, tmp_path, monkeypatch
+    ):
+        """Default (non-local_mode) path must forward probe metadata + open thumbnail."""
+        test_file = tmp_path / "clip.mp4"
+        test_file.write_bytes(b"\x00\x00\x00\x1c" + b"ftyp" + b"\x00" * 100)
+        thumb = tmp_path / "thumb.jpg"
+        thumb.write_bytes(b"jpeg-thumb")
+        assert not connected_adapter.config.extra.get("local_mode")
+
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter._probe_video_metadata",
+            lambda path: {"width": 1280, "height": 720, "duration": 15},
+        )
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter._ensure_video_thumbnail",
+            lambda path: str(thumb),
+        )
+
+        captured: dict = {}
+
+        async def capture_send_video(**kwargs):
+            video = kwargs["video"]
+            thumbnail = kwargs["thumbnail"]
+            captured["video_name"] = getattr(video, "name", None)
+            captured["thumbnail_name"] = getattr(thumbnail, "name", None)
+            captured["video_closed"] = getattr(video, "closed", None)
+            captured["thumbnail_closed"] = getattr(thumbnail, "closed", None)
+            captured["video_readable"] = video.read(4)
+            video.seek(0)
+            captured["thumbnail_readable"] = thumbnail.read(4)
+            thumbnail.seek(0)
+            captured["kwargs"] = {
+                key: kwargs[key]
+                for key in ("width", "height", "duration", "supports_streaming", "caption")
+            }
+            mock_msg = MagicMock()
+            mock_msg.message_id = 204
+            return mock_msg
+
+        connected_adapter._bot.send_video = AsyncMock(side_effect=capture_send_video)
+
+        result = await connected_adapter.send_video(
+            chat_id="12345",
+            video_path=str(test_file),
+            caption="Multipart clip",
+        )
+
+        assert result.success is True
+        assert result.message_id == "204"
+        connected_adapter._bot.send_video.assert_called_once()
+        assert captured["video_name"] == str(test_file)
+        assert captured["thumbnail_name"] == str(thumb)
+        assert captured["video_closed"] is False
+        assert captured["thumbnail_closed"] is False
+        assert captured["video_readable"] == b"\x00\x00\x00\x1c"
+        assert captured["thumbnail_readable"] == b"jpeg"
+        assert captured["kwargs"] == {
+            "width": 1280,
+            "height": 720,
+            "duration": 15,
+            "supports_streaming": True,
+            "caption": "Multipart clip",
+        }
+
     @pytest.mark.asyncio
     async def test_send_video_local_mode_passes_path_and_metadata(self, connected_adapter, tmp_path, monkeypatch):
         test_file = tmp_path / "clip.mp4"

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -28,7 +28,11 @@ from gateway.platforms.base import (
 # Mock the telegram package if it's not installed
 # ---------------------------------------------------------------------------
 # Now we can safely import
-from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+from plugins.platforms.telegram.adapter import (  # noqa: E402
+    TelegramAdapter,
+    _TELEGRAM_VIDEO_THUMB_MAX_BYTES,
+    _ensure_video_thumbnail,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -521,6 +525,126 @@ class TestSendVideo:
         assert result.success is True
         assert result.message_id == "200"
         connected_adapter._bot.send_video.assert_called_once()
+        call_kwargs = connected_adapter._bot.send_video.call_args[1]
+        assert call_kwargs["supports_streaming"] is True
+        assert getattr(call_kwargs["video"], "name", None) == str(test_file)
+
+    @pytest.mark.asyncio
+    async def test_send_video_local_mode_passes_path_and_metadata(self, connected_adapter, tmp_path, monkeypatch):
+        test_file = tmp_path / "clip.mp4"
+        test_file.write_bytes(b"\x00\x00\x00\x1c" + b"ftyp" + b"\x00" * 100)
+        thumb = tmp_path / "thumb.jpg"
+        thumb.write_bytes(b"jpeg")
+        connected_adapter.config.extra["local_mode"] = True
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter._probe_video_metadata",
+            lambda path: {"width": 1920, "height": 1080, "duration": 42},
+        )
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter._ensure_video_thumbnail",
+            lambda path: str(thumb),
+        )
+
+        mock_msg = MagicMock()
+        mock_msg.message_id = 202
+        connected_adapter._bot.send_video = AsyncMock(return_value=mock_msg)
+
+        result = await connected_adapter.send_video(
+            chat_id="12345",
+            video_path=str(test_file),
+            caption="Check this out",
+        )
+
+        assert result.success is True
+        call_kwargs = connected_adapter._bot.send_video.call_args[1]
+        assert call_kwargs["video"] == str(test_file)
+        assert call_kwargs["thumbnail"] == str(thumb)
+        assert call_kwargs["supports_streaming"] is True
+        assert call_kwargs["width"] == 1920
+        assert call_kwargs["height"] == 1080
+        assert call_kwargs["duration"] == 42
+
+    @pytest.mark.asyncio
+    async def test_send_video_retries_without_rejected_thumbnail(self, connected_adapter, tmp_path, monkeypatch):
+        test_file = tmp_path / "clip.mp4"
+        test_file.write_bytes(b"\x00\x00\x00\x1c" + b"ftyp" + b"\x00" * 100)
+        thumb = tmp_path / "thumb.jpg"
+        thumb.write_bytes(b"jpeg")
+        connected_adapter.config.extra["local_mode"] = True
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter._probe_video_metadata",
+            lambda path: {"width": 1920, "height": 1080, "duration": 42},
+        )
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter._ensure_video_thumbnail",
+            lambda path: str(thumb),
+        )
+
+        mock_msg = MagicMock()
+        mock_msg.message_id = 203
+        connected_adapter._bot.send_video = AsyncMock(
+            side_effect=[Exception("Bad Request: wrong thumbnail"), mock_msg]
+        )
+
+        result = await connected_adapter.send_video(
+            chat_id="12345",
+            video_path=str(test_file),
+        )
+
+        assert result.success is True
+        assert connected_adapter._bot.send_video.await_count == 2
+        first_call = connected_adapter._bot.send_video.await_args_list[0].kwargs
+        second_call = connected_adapter._bot.send_video.await_args_list[1].kwargs
+        assert first_call["thumbnail"] == str(thumb)
+        assert "thumbnail" not in second_call
+        assert second_call["video"] == str(test_file)
+        assert second_call["supports_streaming"] is True
+
+    def test_ensure_video_thumbnail_fits_portrait_and_size_limit(self, tmp_path, monkeypatch):
+        video = tmp_path / "portrait.mp4"
+        video.write_bytes(b"fake video")
+        cache_dir = tmp_path / "cache"
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.get_video_cache_dir",
+            lambda: cache_dir,
+        )
+
+        def fake_run(cmd, check, capture_output, timeout):
+            assert "scale=320:320:force_original_aspect_ratio=decrease" in cmd
+            out = tmp_path / cmd[-1]
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_bytes(b"jpeg")
+            return MagicMock()
+
+        monkeypatch.setattr("plugins.platforms.telegram.adapter.subprocess.run", fake_run)
+
+        thumb = _ensure_video_thumbnail(str(video))
+
+        assert thumb is not None
+        assert os.path.exists(thumb)
+        assert os.path.getsize(thumb) <= _TELEGRAM_VIDEO_THUMB_MAX_BYTES
+
+    def test_ensure_video_thumbnail_drops_oversized_output(self, tmp_path, monkeypatch):
+        video = tmp_path / "clip.mp4"
+        video.write_bytes(b"fake video")
+        cache_dir = tmp_path / "cache"
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.get_video_cache_dir",
+            lambda: cache_dir,
+        )
+
+        def fake_run(cmd, check, capture_output, timeout):
+            out = tmp_path / cmd[-1]
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_bytes(b"x" * (_TELEGRAM_VIDEO_THUMB_MAX_BYTES + 1))
+            return MagicMock()
+
+        monkeypatch.setattr("plugins.platforms.telegram.adapter.subprocess.run", fake_run)
+
+        thumb = _ensure_video_thumbnail(str(video))
+
+        assert thumb is None
+        assert not any(cache_dir.glob("telegram-thumb-*.jpg"))
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -529,6 +529,73 @@ class TestSendVideo:
         assert call_kwargs["supports_streaming"] is True
         assert getattr(call_kwargs["video"], "name", None) == str(test_file)
 
+
+    @pytest.mark.asyncio
+    async def test_send_video_multipart_forwards_metadata_and_thumbnail(
+        self, connected_adapter, tmp_path, monkeypatch
+    ):
+        """Default (non-local_mode) path must forward probe metadata + open thumbnail."""
+        test_file = tmp_path / "clip.mp4"
+        test_file.write_bytes(b"\x00\x00\x00\x1c" + b"ftyp" + b"\x00" * 100)
+        thumb = tmp_path / "thumb.jpg"
+        thumb.write_bytes(b"jpeg-thumb")
+        assert not connected_adapter.config.extra.get("local_mode")
+
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter._probe_video_metadata",
+            lambda path: {"width": 1280, "height": 720, "duration": 15},
+        )
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter._ensure_video_thumbnail",
+            lambda path: str(thumb),
+        )
+
+        captured: dict = {}
+
+        async def capture_send_video(**kwargs):
+            video = kwargs["video"]
+            thumbnail = kwargs["thumbnail"]
+            captured["video_name"] = getattr(video, "name", None)
+            captured["thumbnail_name"] = getattr(thumbnail, "name", None)
+            captured["video_closed"] = getattr(video, "closed", None)
+            captured["thumbnail_closed"] = getattr(thumbnail, "closed", None)
+            captured["video_readable"] = video.read(4)
+            video.seek(0)
+            captured["thumbnail_readable"] = thumbnail.read(4)
+            thumbnail.seek(0)
+            captured["kwargs"] = {
+                key: kwargs[key]
+                for key in ("width", "height", "duration", "supports_streaming", "caption")
+            }
+            mock_msg = MagicMock()
+            mock_msg.message_id = 204
+            return mock_msg
+
+        connected_adapter._bot.send_video = AsyncMock(side_effect=capture_send_video)
+
+        result = await connected_adapter.send_video(
+            chat_id="12345",
+            video_path=str(test_file),
+            caption="Multipart clip",
+        )
+
+        assert result.success is True
+        assert result.message_id == "204"
+        connected_adapter._bot.send_video.assert_called_once()
+        assert captured["video_name"] == str(test_file)
+        assert captured["thumbnail_name"] == str(thumb)
+        assert captured["video_closed"] is False
+        assert captured["thumbnail_closed"] is False
+        assert captured["video_readable"] == b"\x00\x00\x00\x1c"
+        assert captured["thumbnail_readable"] == b"jpeg"
+        assert captured["kwargs"] == {
+            "width": 1280,
+            "height": 720,
+            "duration": 15,
+            "supports_streaming": True,
+            "caption": "Multipart clip",
+        }
+
     @pytest.mark.asyncio
     async def test_send_video_local_mode_passes_path_and_metadata(self, connected_adapter, tmp_path, monkeypatch):
         test_file = tmp_path / "clip.mp4"


### PR DESCRIPTION
## What does this PR do?

Fixes Telegram video delivery so MP4 attachments are sent with the metadata Telegram clients expect for playable video cards.

`TelegramAdapter.send_video()` now:

- probes duration, width, and height with `ffprobe`
- generates/caches a small JPEG thumbnail with `ffmpeg`
- constrains thumbnails to Telegram's 320x320 / 200 KB limits
- retries `sendVideo` without the thumbnail if Telegram rejects only the thumbnail
- runs probing/thumbnail generation off the async event loop via `asyncio.to_thread`
- passes `supports_streaming=True`
- passes local filesystem paths directly when Telegram local Bot API mode is enabled

This avoids large valid MP4s being accepted by Telegram but rendered in clients as black/empty `00:00` download tiles.

## Related Issue

Fixes #61569

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/telegram/adapter.py`
  - add best-effort video metadata probing for `sendVideo`
  - add cached thumbnail generation for outgoing videos
  - enforce Telegram thumbnail size/dimension constraints
  - retry without thumbnail on thumbnail-specific Telegram errors
  - send local-mode videos by path with metadata/thumbnail
  - keep the old file-object upload path for non-local Bot API mode
- `tests/gateway/test_telegram_documents.py`
  - assert `supports_streaming` is passed for video sends
  - add local-mode coverage for path, thumbnail, duration, width, and height kwargs
  - add thumbnail rejection retry coverage
  - add thumbnail constraint/oversize tests

## How to Test

1. `python3 -m pytest tests/gateway/test_telegram_documents.py::TestSendVideo -q -o 'addopts='`
2. `python3 -m pytest tests/gateway/test_telegram_documents.py -q -o 'addopts='`
3. `python3 -m pytest tests/gateway/test_telegram_max_doc_bytes.py tests/gateway/test_telegram_send_path_health.py -q -o 'addopts='`

Latest local results after review fixes:

```text
TestSendVideo: 9 passed
test_telegram_documents.py: 48 passed
test_telegram_max_doc_bytes.py + test_telegram_send_path_health.py: 7 passed
```

Manual smoke test from my Telegram local Bot API setup returned a normal video object with metadata and thumbnail:

```text
{'message_id': 41624, 'video_duration': 1057, 'width': 1920, 'height': 1080, 'file_size': 88052635, 'thumb': True}
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Direct local Bot API smoke result:

```text
{'message_id': 41624, 'video_duration': 1057, 'width': 1920, 'height': 1080, 'file_size': 88052635, 'thumb': True}
```
