### PR TITLE
fix(agent): match Windows drive-letter paths in extract_image_refs

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -63,10 +63,12 @@ _IMAGE_EXTS = (
 _IMAGE_EXT_PATTERN = "|".join(e.lstrip(".") for e in _IMAGE_EXTS)
 
 # Absolute / home-relative local image path. Matches the same shape gateway's
-# extract_local_files() uses: anchors to ``~/`` or ``/``, ignores matches inside
-# URLs (the ``(?<![/:\w.])`` lookbehind), and case-insensitive on the extension.
+# extract_local_files() uses: anchors to ``~/``, ``/``, or a Windows
+# drive-letter root (``X:\`` / ``X:/`` — #34632), ignores matches inside URLs
+# (the ``(?<![/:\w.])`` lookbehind), and case-insensitive on the extension.
 _LOCAL_IMAGE_PATH_RE = re.compile(
-    r"(?<![/:\w.])(?:~/|/)(?:[\w.\-]+/)*[\w.\-]+\.(?:" + _IMAGE_EXT_PATTERN + r")\b",
+    r"(?<![/:\w.])(?:~/|/|[A-Za-z]:[/\\])(?:[\w.\-]+[/\\])*[\w.\-]+\.(?:"
+    + _IMAGE_EXT_PATTERN + r")\b",
     re.IGNORECASE,
 )
 
@@ -84,9 +86,10 @@ def extract_image_refs(text: str) -> Tuple[List[str], List[str]]:
 
     Returns ``(local_paths, urls)``:
 
-      * ``local_paths`` — absolute (``/``) or home-relative (``~/``) paths
-        whose suffix is an image extension AND whose expanded form exists
-        on disk as a file. Order-preserving, deduplicated.
+      * ``local_paths`` — absolute (``/`` or ``X:\\``), or home-relative
+        (``~/``) paths whose suffix is an image extension AND whose
+        expanded form exists on disk as a file. Returned expanded and
+        normalized (``os.path.normpath``). Order-preserving, deduplicated.
       * ``urls`` — ``http(s)://…`` URLs whose path ends in an image
         extension (a ``?query`` is allowed after the extension).
         Order-preserving, deduplicated.
@@ -119,7 +122,10 @@ def extract_image_refs(text: str) -> Tuple[List[str], List[str]]:
         if _in_code(match.start()):
             continue
         raw = match.group(0)
-        expanded = os.path.expanduser(raw)
+        # normpath gives every hit the platform's native separators, so
+        # ``C:\x\a.png`` and ``C:/x/a.png`` in the same body dedupe to one
+        # attachment (expanduser also leaves a foreign ``/`` after ``~``).
+        expanded = os.path.normpath(os.path.expanduser(raw))
         try:
             if not os.path.isfile(expanded):
                 continue

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -537,8 +537,10 @@ class TestExtractImageRefs:
         assert urls == []
 
     def test_finds_home_relative_path(self, tmp_path: Path, monkeypatch):
-        # Simulate ~/foo.png by pointing HOME at tmp_path and creating the file
+        # Simulate ~/foo.png by pointing HOME at tmp_path and creating the file.
+        # Windows expanduser() prefers USERPROFILE over HOME; POSIX uses HOME.
         monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
         img = tmp_path / "foo.png"
         img.write_bytes(_png_bytes())
         paths, urls = extract_image_refs("see ~/foo.png please")
@@ -637,6 +639,56 @@ class TestExtractImageRefs:
         body = f"see {img}"
         paths, urls = extract_image_refs(body)
         assert paths == [str(img)]
+
+    def test_mixed_separator_duplicates_collapse(self, tmp_path: Path):
+        # On Windows the same file cited with ``\`` and ``/`` separators must
+        # dedupe to a single attachment (paths are normalized before dedupe).
+        # On POSIX both spellings are identical, so this degrades to the
+        # plain dedupe case.
+        img = tmp_path / "one.png"
+        img.write_bytes(_png_bytes())
+        native = str(img)
+        forward = native.replace("\\", "/")
+        body = f"see {native} and also {forward}"
+        paths, urls = extract_image_refs(body)
+        assert paths == [native]
+        assert urls == []
+
+
+class TestLocalImagePathRegexWindowsShapes:
+    """Pattern-level coverage for Windows path shapes (#34632 parity with
+    gateway's ``extract_local_files``). Runs on every platform — no file on
+    disk is needed to assert what the regex does and doesn't match."""
+
+    def _matches(self, text: str) -> list:
+        from agent.image_routing import _LOCAL_IMAGE_PATH_RE
+        return [m.group(0) for m in _LOCAL_IMAGE_PATH_RE.finditer(text)]
+
+    def test_backslash_drive_path_matches(self):
+        assert self._matches(r"see C:\Users\kotsu\shot.png ok") == [r"C:\Users\kotsu\shot.png"]
+
+    def test_forward_slash_drive_path_matches(self):
+        assert self._matches("see C:/Users/kotsu/shot.png ok") == ["C:/Users/kotsu/shot.png"]
+
+    def test_lowercase_drive_letter_matches(self):
+        assert self._matches(r"see d:\pics\a.jpeg ok") == [r"d:\pics\a.jpeg"]
+
+    def test_drive_root_file_matches(self):
+        assert self._matches(r"at D:\report.png end") == [r"D:\report.png"]
+
+    def test_relative_windows_path_ignored(self):
+        # No drive letter, no leading separator → not an absolute path.
+        assert self._matches(r"see Users\kotsu\shot.png ok") == []
+
+    def test_drive_letter_without_separator_ignored(self):
+        assert self._matches("see C:file.png ok") == []
+
+    def test_unix_shapes_still_match(self):
+        assert self._matches("see /tmp/a.png and ~/b.jpg ok") == ["/tmp/a.png", "~/b.jpg"]
+
+    def test_url_path_portion_still_ignored(self):
+        # The lookbehind must keep rejecting the path-portion of URLs.
+        assert self._matches("https://example.com/some/dir/image.png") == []
 
 
 # ─── build_native_content_parts with URLs ────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

Fixes a native-Windows product bug in `agent/image_routing.py::extract_image_refs`: the local-path regex (`_LOCAL_IMAGE_PATH_RE`) only anchored on `~/` or `/` with forward-slash separators, so Windows absolute paths (`C:\Users\...\shot.png`, `C:/...`) could never match. User-visible effect: kanban task-body image enrichment (`cli.py`) silently attached nothing on native Windows — pasting a screenshot path into a task body worked on POSIX and was a no-op on Windows. 12 tests fail on native Windows because of this (7 in `tests/agent/test_image_routing.py::TestExtractImageRefs`, 5 in `tests/hermes_cli/test_kanban_worker_image_extraction.py`).

The regex documents itself as matching "the same shape gateway's extract_local_files() uses" — but the gateway pattern was extended for Windows drive-letter paths in #34632 and this one was missed. This PR applies the exact same shape: `(?:~/|/|[A-Za-z]:[/\])` anchor with `[/\]` segment separators.

Two adjacent fixes ride along:

1. Returned paths are now normalized (`os.path.normpath` after `expanduser`) so the same file cited as `C:\x\a.png` and `C:/x/a.png` dedupes to one attachment, and tilde expansion on Windows doesn't leave a foreign `/` in the result. On POSIX this is lexical-identity for the shapes the regex emits — behavior unchanged.
2. `test_finds_home_relative_path` monkeypatched only `HOME`, which `ntpath.expanduser` ignores (Python ≥3.8 uses `USERPROFILE`). It now sets both — same idiom as `tests/tools/test_vision_tools.py`.

## Related Issue

Fixes #61568

Continues the native-Windows series: #57016, #57181 (fixes #57145), #57182 (fixes #57147), #57885 (fixes #57883). Windows-path parity with #34632.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/image_routing.py`: `_LOCAL_IMAGE_PATH_RE` gains the #34632 drive-letter alternation and `[/\]` separators; expanded paths are `normpath`-normalized before the `isfile` check and dedupe; docstring/comments updated
- `tests/agent/test_image_routing.py`:
  - `test_finds_home_relative_path` sets `USERPROFILE` alongside `HOME`
  - new `test_mixed_separator_duplicates_collapse` (native-separator + forward-slash spellings of one file → one attachment)
  - new `TestLocalImagePathRegexWindowsShapes` — pattern-level coverage that runs on every platform (backslash drive path, forward-slash drive path, lowercase drive, drive-root file, relative path and `C:file.png` non-matches, Unix shapes still match, URL path-portion still rejected via the lookbehind) — same approach as `tests/gateway/test_run_tool_media_re.py`

## How to Test

1. On native Windows, before this change: `python -m pytest tests/agent/test_image_routing.py tests/hermes_cli/test_kanban_worker_image_extraction.py -q` → **12 failed** (`assert [] == ['C:\...\real.jpg']`)
2. After this change, same command → **115 passed, 1 skipped**
3. On POSIX: the new pattern-level tests exercise the Windows shapes without needing files on disk; existing behavior is unchanged (anchor alternation only adds drive-letter roots; `normpath` is identity for the matched shapes)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (both affected files green natively on Windows; note below on pre-existing unrelated flakes)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (native, Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring + regex comments updated in place
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — that is the point of this PR; POSIX behavior unchanged
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before (main @ daedf4f62, native Windows):

```
FAILED tests/agent/test_image_routing.py::TestExtractImageRefs::test_finds_absolute_path
FAILED tests/agent/test_image_routing.py::TestExtractImageRefs::test_finds_home_relative_path
FAILED tests/agent/test_image_routing.py::TestExtractImageRefs::test_dedupes_paths_and_urls
FAILED tests/agent/test_image_routing.py::TestExtractImageRefs::test_ignores_paths_in_fenced_code_block
FAILED tests/agent/test_image_routing.py::TestExtractImageRefs::test_ignores_paths_in_inline_code
FAILED tests/agent/test_image_routing.py::TestExtractImageRefs::test_mixed_paths_and_urls
FAILED tests/agent/test_image_routing.py::TestExtractImageRefs::test_case_insensitive_extension
FAILED tests/hermes_cli/test_kanban_worker_image_extraction.py::TestExtractFromTaskBody::test_local_path_in_body_round_trips
FAILED tests/hermes_cli/test_kanban_worker_image_extraction.py::TestExtractFromTaskBody::test_mixed_path_and_url_in_body
FAILED tests/hermes_cli/test_kanban_worker_image_extraction.py::TestBuildPartsFromTaskBody::test_local_path_becomes_native_image_part
FAILED tests/hermes_cli/test_kanban_worker_image_extraction.py::TestBuildPartsFromTaskBody::test_body_with_both_yields_two_image_parts
FAILED tests/hermes_cli/test_kanban_worker_image_extraction.py::TestBuildPartsFromTaskBody::test_code_block_example_is_not_attached
12 failed, ...
```

After:

```
115 passed, 1 skipped in 3.75s
```

Note: when `test_image_routing.py` runs together with the other vision-routing test files, `TestDecideImageInputMode` / `TestLookupSupportsVisionOverride` show order-dependent flaky failures **on clean main as well** (verified A/B, varying membership run to run) — pre-existing and unrelated to this change; flagged in #61568 and I'll file separately once isolated.
