### PR TITLE
fix(telegram): add voice/audio retry branches to caption parse-mode fallback

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1393,6 +1393,14 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                                 last_msg = await bot.send_video(
                                     chat_id=int_chat_id, video=f, **media_kwargs
                                 )
+                            elif ext in _VOICE_EXTS and is_voice:
+                                last_msg = await bot.send_voice(
+                                    chat_id=int_chat_id, voice=f, **media_kwargs
+                                )
+                            elif ext in _TELEGRAM_SEND_AUDIO_EXTS:
+                                last_msg = await bot.send_audio(
+                                    chat_id=int_chat_id, audio=f, **media_kwargs
+                                )
                             else:
                                 last_msg = await bot.send_document(
                                     chat_id=int_chat_id, document=f, **media_kwargs


### PR DESCRIPTION
## Summary

Add missing `send_voice` and `send_audio` retry branches to the caption parse-mode fallback handler in `_send_telegram`.

## Problem

The caption parse-mode failure retry handler (lines 1388–1399) only handles image, video, and document types. When a voice note (`.ogg`/`.opus`) or audio note (`.mp3`/`.m4a`) with a MarkdownV2 caption fails to parse, the retry falls through to `bot.send_document` instead of re-sending as voice/audio — corrupting the media type on retry.

## Fix

Added the two missing `elif` branches (`_VOICE_EXTS` → `send_voice`, `_TELEGRAM_SEND_AUDIO_EXTS` → `send_audio`) to mirror the original media dispatch logic. 8-line diff, zero behavior change for non-audio paths.

## Testing
- Syntax check passed (py_compile)
- Behavior verified