### PR TITLE
feat(plugins): add register_telegram_handler plugin API (mirrors Slack)

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1042,6 +1042,65 @@ class PluginContext:
 
     # -- auxiliary task registration ---------------------------------------
 
+    def register_telegram_handler(
+        self,
+        handler: Any,
+        group: int = 0,
+    ) -> None:
+        """Register a python-telegram-bot handler from a plugin.
+
+        Hermes' Telegram adapter wires registered handlers into its PTB
+        ``Application`` at connect time, so plugins can react to updates the
+        built-in handlers don't cover — message reactions, edited messages,
+        custom commands, chat-member changes, etc. This mirrors
+        :meth:`register_slack_action_handler` for the Slack adapter.
+
+        Args:
+            handler: A ``telegram.ext.BaseHandler`` instance (e.g.
+                ``MessageHandler``, ``TypeHandler``, ``CommandHandler``,
+                ``CallbackQueryHandler``) exactly as
+                ``Application.add_handler`` accepts.
+            group: PTB handler group. Handlers are organised in groups; 0 or
+                1 handler per group is used per update. Use a non-zero group
+                (e.g. ``1``) to run alongside the built-ins in group 0
+                without displacing them. Defaults to ``0``.
+
+        Raises:
+            ValueError: if ``handler`` is not a BaseHandler instance.
+
+        Example::
+
+            from telegram import Update
+            from telegram.ext import TypeHandler
+
+            async def _on_reaction(update, context):
+                if update.message_reaction:
+                    ...  # e.g. render a table image fallback
+
+            ctx.register_telegram_handler(
+                TypeHandler(Update, _on_reaction), group=1
+            )
+        """
+        # Duck-type to avoid importing python-telegram-bot in environments
+        # that don't use Telegram (it is an optional dependency).
+        if not (
+            callable(getattr(handler, "check_update", None))
+            and callable(getattr(handler, "handle", None))
+        ):
+            raise ValueError(
+                "register_telegram_handler expects a telegram.ext.BaseHandler "
+                "instance (needs check_update/handle)."
+            )
+        self._manager._telegram_handlers.append(
+            (handler, group, self.manifest.name)
+        )
+        logger.debug(
+            "Plugin %s registered Telegram handler: %s (group=%s)",
+            self.manifest.name,
+            type(handler).__name__,
+            group,
+        )
+
     def register_auxiliary_task(
         self,
         key: str,
@@ -1269,6 +1328,10 @@ class PluginManager:
         # ``re.Pattern``, or a constraint dict); ``callback`` is an async
         # function with the slack_bolt signature ``(ack, body, action)``.
         self._slack_action_handlers: List[tuple] = []
+        # Plugin-registered python-telegram-bot handlers; the Telegram adapter
+        # wires them into its PTB Application at connect time. Each entry is a
+        # ``(handler, group, plugin_name)`` tuple.
+        self._telegram_handlers: List[tuple] = []
 
     # -----------------------------------------------------------------------
     # Public
@@ -1298,6 +1361,7 @@ class PluginManager:
             self._plugin_skills.clear()
             self._aux_tasks.clear()
             self._slack_action_handlers.clear()
+            self._telegram_handlers.clear()
             self._context_engine = None
         # Set the flag up front as a re-entrancy guard (a plugin's register()
         # can transitively trigger discovery again), but reset it if the sweep
@@ -1970,6 +2034,18 @@ class PluginManager:
         :meth:`PluginContext.register_slack_action_handler`.
         """
         return list(self._slack_action_handlers)
+
+    def get_telegram_handlers(self) -> List[tuple]:
+        """Return the list of plugin-registered python-telegram-bot handlers.
+
+        Each entry is a ``(handler, group, plugin_name)`` tuple. Consumed by
+        the Telegram adapter at connect time to wire the handlers into its PTB
+        ``Application`` via ``Application.add_handler``.
+
+        Plugins register handlers via
+        :meth:`PluginContext.register_telegram_handler`.
+        """
+        return list(self._telegram_handlers)
 
     # -----------------------------------------------------------------------
     # Introspection

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1082,14 +1082,16 @@ class PluginContext:
             )
         """
         # Duck-type to avoid importing python-telegram-bot in environments
-        # that don't use Telegram (it is an optional dependency).
+        # that don't use Telegram (it is an optional dependency). PTB v22's
+        # BaseHandler contract is check_update() + handle_update(); it has no
+        # `handle` attribute, so a real MessageHandler/TypeHandler must pass.
         if not (
             callable(getattr(handler, "check_update", None))
-            and callable(getattr(handler, "handle", None))
+            and callable(getattr(handler, "handle_update", None))
         ):
             raise ValueError(
                 "register_telegram_handler expects a telegram.ext.BaseHandler "
-                "instance (needs check_update/handle)."
+                "instance (needs check_update/handle_update)."
             )
         self._manager._telegram_handlers.append(
             (handler, group, self.manifest.name)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1042,65 +1042,59 @@ class PluginContext:
 
     # -- auxiliary task registration ---------------------------------------
 
-    def register_telegram_handler(
-        self,
-        handler: Any,
-        group: int = 0,
-    ) -> None:
-        """Register a python-telegram-bot handler from a plugin.
+    def register_telegram_handler(self, factory: Callable) -> None:
+        """Register a python-telegram-bot handler factory from a plugin.
 
-        Hermes' Telegram adapter wires registered handlers into its PTB
-        ``Application`` at connect time, so plugins can react to updates the
-        built-in handlers don't cover — message reactions, edited messages,
-        custom commands, chat-member changes, etc. This mirrors
-        :meth:`register_slack_action_handler` for the Slack adapter.
+        Hermes' Telegram adapter invokes registered factories at ``connect()``
+        time, right after the PTB ``Application`` is built and **before** the
+        core handlers are added. The factory receives ``(application, adapter)``
+        and wires its own handlers::
+
+            def _wire(application, adapter):
+                from telegram.ext import CallbackQueryHandler
+
+                application.add_handler(
+                    CallbackQueryHandler(_on_button, pattern=r"^myplugin:")
+                )
+
+            ctx.register_telegram_handler(_wire)
+
+        Notes:
+
+        * The factory is called lazily at connect time, so plugins may import
+          ``telegram`` / ``telegram.ext`` inside the factory body — the
+          plugin's ``register()`` still works when PTB is not installed.
+        * PTB dispatches only the *first* matching handler within a group.
+          Because plugin factories run before the core handlers, a
+          pattern-scoped handler (e.g. ``CallbackQueryHandler`` with
+          ``pattern=r"^myplugin:"``) takes precedence for its own updates
+          while everything else falls through to the core handlers unchanged.
+          Always scope callback handlers with ``pattern=`` — an unscoped one
+          would swallow the core button flows (approvals, model picker).
+        * ``adapter`` is the ``TelegramAdapter`` instance (``adapter.config``);
+          treat it as read-only. Reach the bot handle via ``application.bot``
+          (PTB), not ``adapter.bot``.
+        * Exceptions raised by the factory are caught and logged by the
+          adapter — a broken plugin cannot prevent Telegram from connecting.
 
         Args:
-            handler: A ``telegram.ext.BaseHandler`` instance (e.g.
-                ``MessageHandler``, ``TypeHandler``, ``CommandHandler``,
-                ``CallbackQueryHandler``) exactly as
-                ``Application.add_handler`` accepts.
-            group: PTB handler group. Handlers are organised in groups; 0 or
-                1 handler per group is used per update. Use a non-zero group
-                (e.g. ``1``) to run alongside the built-ins in group 0
-                without displacing them. Defaults to ``0``.
+            factory: Callable receiving ``(application, adapter)``.
 
         Raises:
-            ValueError: if ``handler`` is not a BaseHandler instance.
-
-        Example::
-
-            from telegram import Update
-            from telegram.ext import TypeHandler
-
-            async def _on_reaction(update, context):
-                if update.message_reaction:
-                    ...  # e.g. render a table image fallback
-
-            ctx.register_telegram_handler(
-                TypeHandler(Update, _on_reaction), group=1
-            )
+            ValueError: if ``factory`` is not callable.
         """
-        # Duck-type to avoid importing python-telegram-bot in environments
-        # that don't use Telegram (it is an optional dependency). PTB v22's
-        # BaseHandler contract is check_update() + handle_update(); it has no
-        # `handle` attribute, so a real MessageHandler/TypeHandler must pass.
-        if not (
-            callable(getattr(handler, "check_update", None))
-            and callable(getattr(handler, "handle_update", None))
-        ):
+        if not callable(factory):
             raise ValueError(
-                "register_telegram_handler expects a telegram.ext.BaseHandler "
-                "instance (needs check_update/handle_update)."
+                f"Plugin '{self.manifest.name}' tried to register a Telegram "
+                f"handler factory with a non-callable factory."
             )
-        self._manager._telegram_handlers.append(
-            (handler, group, self.manifest.name)
+        self._manager._telegram_handler_factories.append(
+            (factory, self.manifest.name)
         )
         logger.debug(
-            "Plugin %s registered Telegram handler: %s (group=%s)",
+            "Plugin %s registered Telegram handler factory: %s",
             self.manifest.name,
-            type(handler).__name__,
-            group,
+            getattr(factory, "__name__", repr(factory)),
         )
 
     def register_auxiliary_task(
@@ -1330,10 +1324,12 @@ class PluginManager:
         # ``re.Pattern``, or a constraint dict); ``callback`` is an async
         # function with the slack_bolt signature ``(ack, body, action)``.
         self._slack_action_handlers: List[tuple] = []
-        # Plugin-registered python-telegram-bot handlers; the Telegram adapter
-        # wires them into its PTB Application at connect time. Each entry is a
-        # ``(handler, group, plugin_name)`` tuple.
-        self._telegram_handlers: List[tuple] = []
+        # Telegram handler factories registered by plugins. Each entry is
+        # (factory, plugin_name); the Telegram adapter invokes factories at
+        # connect() time with (application, adapter) so plugins can wire
+        # their own PTB handlers (pattern-scoped CallbackQueryHandler, etc.)
+        # before the core handlers are added.
+        self._telegram_handler_factories: List[tuple] = []
 
     # -----------------------------------------------------------------------
     # Public
@@ -1363,7 +1359,7 @@ class PluginManager:
             self._plugin_skills.clear()
             self._aux_tasks.clear()
             self._slack_action_handlers.clear()
-            self._telegram_handlers.clear()
+            self._telegram_handler_factories.clear()
             self._context_engine = None
         # Set the flag up front as a re-entrancy guard (a plugin's register()
         # can transitively trigger discovery again), but reset it if the sweep
@@ -2037,17 +2033,18 @@ class PluginManager:
         """
         return list(self._slack_action_handlers)
 
-    def get_telegram_handlers(self) -> List[tuple]:
-        """Return the list of plugin-registered python-telegram-bot handlers.
+    def get_telegram_handler_factories(self) -> List[tuple]:
+        """Return the list of plugin-registered Telegram handler factories.
 
-        Each entry is a ``(handler, group, plugin_name)`` tuple. Consumed by
-        the Telegram adapter at connect time to wire the handlers into its PTB
-        ``Application`` via ``Application.add_handler``.
+        Each entry is a ``(factory, plugin_name)`` tuple. Consumed by the
+        Telegram adapter at connect time; each factory is invoked with
+        ``(application, adapter)`` so plugins can wire their own PTB handlers
+        before the core handlers are added.
 
-        Plugins register handlers via
+        Plugins register factories via
         :meth:`PluginContext.register_telegram_handler`.
         """
-        return list(self._telegram_handlers)
+        return list(self._telegram_handler_factories)
 
     # -----------------------------------------------------------------------
     # Introspection

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2931,65 +2931,59 @@ class PluginContext:
 
     # -- auxiliary task registration ---------------------------------------
 
-    def register_telegram_handler(
-        self,
-        handler: Any,
-        group: int = 0,
-    ) -> None:
-        """Register a python-telegram-bot handler from a plugin.
+    def register_telegram_handler(self, factory: Callable) -> None:
+        """Register a python-telegram-bot handler factory from a plugin.
 
-        Hermes' Telegram adapter wires registered handlers into its PTB
-        ``Application`` at connect time, so plugins can react to updates the
-        built-in handlers don't cover — message reactions, edited messages,
-        custom commands, chat-member changes, etc. This mirrors
-        :meth:`register_slack_action_handler` for the Slack adapter.
+        Hermes' Telegram adapter invokes registered factories at ``connect()``
+        time, right after the PTB ``Application`` is built and **before** the
+        core handlers are added. The factory receives ``(application, adapter)``
+        and wires its own handlers::
+
+            def _wire(application, adapter):
+                from telegram.ext import CallbackQueryHandler
+
+                application.add_handler(
+                    CallbackQueryHandler(_on_button, pattern=r"^myplugin:")
+                )
+
+            ctx.register_telegram_handler(_wire)
+
+        Notes:
+
+        * The factory is called lazily at connect time, so plugins may import
+          ``telegram`` / ``telegram.ext`` inside the factory body — the
+          plugin's ``register()`` still works when PTB is not installed.
+        * PTB dispatches only the *first* matching handler within a group.
+          Because plugin factories run before the core handlers, a
+          pattern-scoped handler (e.g. ``CallbackQueryHandler`` with
+          ``pattern=r"^myplugin:"``) takes precedence for its own updates
+          while everything else falls through to the core handlers unchanged.
+          Always scope callback handlers with ``pattern=`` — an unscoped one
+          would swallow the core button flows (approvals, model picker).
+        * ``adapter`` is the ``TelegramAdapter`` instance (``adapter.config``);
+          treat it as read-only. Reach the bot handle via ``application.bot``
+          (PTB), not ``adapter.bot``.
+        * Exceptions raised by the factory are caught and logged by the
+          adapter — a broken plugin cannot prevent Telegram from connecting.
 
         Args:
-            handler: A ``telegram.ext.BaseHandler`` instance (e.g.
-                ``MessageHandler``, ``TypeHandler``, ``CommandHandler``,
-                ``CallbackQueryHandler``) exactly as
-                ``Application.add_handler`` accepts.
-            group: PTB handler group. Handlers are organised in groups; 0 or
-                1 handler per group is used per update. Use a non-zero group
-                (e.g. ``1``) to run alongside the built-ins in group 0
-                without displacing them. Defaults to ``0``.
+            factory: Callable receiving ``(application, adapter)``.
 
         Raises:
-            ValueError: if ``handler`` is not a BaseHandler instance.
-
-        Example::
-
-            from telegram import Update
-            from telegram.ext import TypeHandler
-
-            async def _on_reaction(update, context):
-                if update.message_reaction:
-                    ...  # e.g. render a table image fallback
-
-            ctx.register_telegram_handler(
-                TypeHandler(Update, _on_reaction), group=1
-            )
+            ValueError: if ``factory`` is not callable.
         """
-        # Duck-type to avoid importing python-telegram-bot in environments
-        # that don't use Telegram (it is an optional dependency). PTB v22's
-        # BaseHandler contract is check_update() + handle_update(); it has no
-        # `handle` attribute, so a real MessageHandler/TypeHandler must pass.
-        if not (
-            callable(getattr(handler, "check_update", None))
-            and callable(getattr(handler, "handle_update", None))
-        ):
+        if not callable(factory):
             raise ValueError(
-                "register_telegram_handler expects a telegram.ext.BaseHandler "
-                "instance (needs check_update/handle_update)."
+                f"Plugin '{self.manifest.name}' tried to register a Telegram "
+                f"handler factory with a non-callable factory."
             )
-        self._manager._telegram_handlers.append(
-            (handler, group, self.manifest.name)
+        self._manager._telegram_handler_factories.append(
+            (factory, self.manifest.name)
         )
         logger.debug(
-            "Plugin %s registered Telegram handler: %s (group=%s)",
+            "Plugin %s registered Telegram handler factory: %s",
             self.manifest.name,
-            type(handler).__name__,
-            group,
+            getattr(factory, "__name__", repr(factory)),
         )
 
     @_serialized_replacement
@@ -3498,10 +3492,12 @@ class PluginManager:
         # ``re.Pattern``, or a constraint dict); ``callback`` is an async
         # function with the slack_bolt signature ``(ack, body, action)``.
         self._slack_action_handlers: List[tuple] = []
-        # Plugin-registered python-telegram-bot handlers; the Telegram adapter
-        # wires them into its PTB Application at connect time. Each entry is a
-        # ``(handler, group, plugin_name)`` tuple.
-        self._telegram_handlers: List[tuple] = []
+        # Telegram handler factories registered by plugins. Each entry is
+        # (factory, plugin_name); the Telegram adapter invokes factories at
+        # connect() time with (application, adapter) so plugins can wire
+        # their own PTB handlers (pattern-scoped CallbackQueryHandler, etc.)
+        # before the core handlers are added.
+        self._telegram_handler_factories: List[tuple] = []
         # Registration handles are kept both per plugin (ownership lookup) and
         # globally (reverse-order teardown for overrides spanning plugins).
         #
@@ -3790,7 +3786,7 @@ class PluginManager:
             self._system_prompt_sections.clear()
             self._approval_transports.clear()
             self._slack_action_handlers.clear()
-            self._telegram_handlers.clear()
+            self._telegram_handler_factories.clear()
             self._predeclared_modules.clear()
             self._predeclared_tools.clear()
             self._context_engine = None
@@ -5517,17 +5513,18 @@ class PluginManager:
         """
         return list(self._slack_action_handlers)
 
-    def get_telegram_handlers(self) -> List[tuple]:
-        """Return the list of plugin-registered python-telegram-bot handlers.
+    def get_telegram_handler_factories(self) -> List[tuple]:
+        """Return the list of plugin-registered Telegram handler factories.
 
-        Each entry is a ``(handler, group, plugin_name)`` tuple. Consumed by
-        the Telegram adapter at connect time to wire the handlers into its PTB
-        ``Application`` via ``Application.add_handler``.
+        Each entry is a ``(factory, plugin_name)`` tuple. Consumed by the
+        Telegram adapter at connect time; each factory is invoked with
+        ``(application, adapter)`` so plugins can wire their own PTB handlers
+        before the core handlers are added.
 
-        Plugins register handlers via
+        Plugins register factories via
         :meth:`PluginContext.register_telegram_handler`.
         """
-        return list(self._telegram_handlers)
+        return list(self._telegram_handler_factories)
 
     # -----------------------------------------------------------------------
     # Introspection

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2971,14 +2971,16 @@ class PluginContext:
             )
         """
         # Duck-type to avoid importing python-telegram-bot in environments
-        # that don't use Telegram (it is an optional dependency).
+        # that don't use Telegram (it is an optional dependency). PTB v22's
+        # BaseHandler contract is check_update() + handle_update(); it has no
+        # `handle` attribute, so a real MessageHandler/TypeHandler must pass.
         if not (
             callable(getattr(handler, "check_update", None))
-            and callable(getattr(handler, "handle", None))
+            and callable(getattr(handler, "handle_update", None))
         ):
             raise ValueError(
                 "register_telegram_handler expects a telegram.ext.BaseHandler "
-                "instance (needs check_update/handle)."
+                "instance (needs check_update/handle_update)."
             )
         self._manager._telegram_handlers.append(
             (handler, group, self.manifest.name)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2936,9 +2936,9 @@ class PluginContext:
     def register_telegram_handler(self, factory: Callable) -> PluginRegistration:
         """Register a python-telegram-bot handler factory from a plugin.
 
-        Hermes' Telegram adapter invokes registered factories at ``connect()``
-        time, right after the PTB ``Application`` is built and **before** the
-        core handlers are added. The factory receives ``(application, adapter)``
+        Hermes' Telegram adapter invokes registered factories whenever it
+        (re)builds its PTB ``Application``, always **before** the core
+        handlers are added. The factory receives ``(application, adapter)``
         and wires its own handlers::
 
             def _wire(application, adapter):
@@ -2952,32 +2952,56 @@ class PluginContext:
 
         Notes:
 
-        * The factory is called lazily at connect time, so plugins may import
-          ``telegram`` / ``telegram.ext`` inside the factory body — the
-          plugin's ``register()`` still works when PTB is not installed.
+        * The factory must be a plain synchronous callable. It runs from
+          synchronous wiring code, so an ``async def`` factory is rejected
+          at registration time (its coroutine could never be awaited
+          there). The *callbacks* a factory registers may of course be
+          async, which is the normal PTB pattern.
+        * The factory is called lazily at (re)build time, so plugins may
+          import ``telegram`` / ``telegram.ext`` inside the factory body;
+          the plugin's ``register()`` still works when PTB is not
+          installed. The adapter rebuilds the Application on transient
+          init failures, so a factory can run more than once per connect:
+          keep it idempotent (limit side effects to wiring the
+          application it is given).
         * PTB dispatches only the *first* matching handler within a group.
           Because plugin factories run before the core handlers, a
           pattern-scoped handler (e.g. ``CallbackQueryHandler`` with
           ``pattern=r"^myplugin:"``) takes precedence for its own updates
-          while everything else falls through to the core handlers unchanged.
-          Always scope callback handlers with ``pattern=`` — an unscoped one
-          would swallow the core button flows (approvals, model picker).
-        * ``adapter`` is the ``TelegramAdapter`` instance (``adapter.config``);
-          treat it as read-only. Reach the bot handle via ``application.bot``
-          (PTB), not ``adapter.bot``.
+          while everything else falls through to the core handlers
+          unchanged. Always scope callback handlers with ``pattern=``; an
+          unscoped one would swallow the core button flows (approvals,
+          model picker), and the adapter logs a warning when a factory
+          adds a group-0 handler that could shadow the core set.
+        * ``adapter`` is the ``TelegramAdapter`` instance
+          (``adapter.config``); treat it as read-only. Reach the bot
+          handle via ``application.bot`` (PTB), not ``adapter.bot``.
         * Exceptions raised by the factory are caught and logged by the
-          adapter — a broken plugin cannot prevent Telegram from connecting.
+          adapter; a broken plugin cannot prevent Telegram from
+          connecting.
+        * The returned :class:`PluginRegistration` dequeues the factory
+          when disposed, so a reloaded plugin's stale factory is not
+          invoked on later connects. It does not unwire handlers the
+          factory already added to a running Application.
 
         Args:
-            factory: Callable receiving ``(application, adapter)``.
+            factory: Synchronous callable receiving ``(application, adapter)``.
 
         Raises:
-            ValueError: if ``factory`` is not callable.
+            ValueError: if ``factory`` is not callable, or is a coroutine
+                function (``async def``).
         """
         if not callable(factory):
             raise ValueError(
                 f"Plugin '{self.manifest.name}' tried to register a Telegram "
                 f"handler factory with a non-callable factory."
+            )
+        if inspect.iscoroutinefunction(factory):
+            raise ValueError(
+                f"Plugin '{self.manifest.name}' tried to register an async "
+                f"Telegram handler factory. Factories run from synchronous "
+                f"wiring code; register a sync factory and pass async "
+                f"callbacks to application.add_handler()."
             )
         entry = (factory, self.manifest.name)
         self._manager._telegram_handler_factories.append(entry)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2931,7 +2931,9 @@ class PluginContext:
 
     # -- auxiliary task registration ---------------------------------------
 
-    def register_telegram_handler(self, factory: Callable) -> None:
+    # -- telegram handler registration -------------------------------------
+
+    def register_telegram_handler(self, factory: Callable) -> PluginRegistration:
         """Register a python-telegram-bot handler factory from a plugin.
 
         Hermes' Telegram adapter invokes registered factories at ``connect()``
@@ -2977,14 +2979,21 @@ class PluginContext:
                 f"Plugin '{self.manifest.name}' tried to register a Telegram "
                 f"handler factory with a non-callable factory."
             )
-        self._manager._telegram_handler_factories.append(
-            (factory, self.manifest.name)
+        entry = (factory, self.manifest.name)
+        self._manager._telegram_handler_factories.append(entry)
+        handle = self._track(
+            "telegram_handler",
+            getattr(factory, "__name__", repr(factory)),
+            lambda: self._manager._remove_identity(
+                self._manager._telegram_handler_factories, entry
+            ),
         )
         logger.debug(
             "Plugin %s registered Telegram handler factory: %s",
             self.manifest.name,
             getattr(factory, "__name__", repr(factory)),
         )
+        return handle
 
     @_serialized_replacement
     def register_auxiliary_task(
@@ -3493,10 +3502,8 @@ class PluginManager:
         # function with the slack_bolt signature ``(ack, body, action)``.
         self._slack_action_handlers: List[tuple] = []
         # Telegram handler factories registered by plugins. Each entry is
-        # (factory, plugin_name); the Telegram adapter invokes factories at
-        # connect() time with (application, adapter) so plugins can wire
-        # their own PTB handlers (pattern-scoped CallbackQueryHandler, etc.)
-        # before the core handlers are added.
+        # (factory, plugin_name); the Telegram adapter invokes the factories
+        # at connect() time.
         self._telegram_handler_factories: List[tuple] = []
         # Registration handles are kept both per plugin (ownership lookup) and
         # globally (reverse-order teardown for overrides spanning plugins).
@@ -5517,9 +5524,7 @@ class PluginManager:
         """Return the list of plugin-registered Telegram handler factories.
 
         Each entry is a ``(factory, plugin_name)`` tuple. Consumed by the
-        Telegram adapter at connect time; each factory is invoked with
-        ``(application, adapter)`` so plugins can wire their own PTB handlers
-        before the core handlers are added.
+        Telegram adapter at connect time.
 
         Plugins register factories via
         :meth:`PluginContext.register_telegram_handler`.

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2931,6 +2931,65 @@ class PluginContext:
 
     # -- auxiliary task registration ---------------------------------------
 
+    def register_telegram_handler(
+        self,
+        handler: Any,
+        group: int = 0,
+    ) -> None:
+        """Register a python-telegram-bot handler from a plugin.
+
+        Hermes' Telegram adapter wires registered handlers into its PTB
+        ``Application`` at connect time, so plugins can react to updates the
+        built-in handlers don't cover — message reactions, edited messages,
+        custom commands, chat-member changes, etc. This mirrors
+        :meth:`register_slack_action_handler` for the Slack adapter.
+
+        Args:
+            handler: A ``telegram.ext.BaseHandler`` instance (e.g.
+                ``MessageHandler``, ``TypeHandler``, ``CommandHandler``,
+                ``CallbackQueryHandler``) exactly as
+                ``Application.add_handler`` accepts.
+            group: PTB handler group. Handlers are organised in groups; 0 or
+                1 handler per group is used per update. Use a non-zero group
+                (e.g. ``1``) to run alongside the built-ins in group 0
+                without displacing them. Defaults to ``0``.
+
+        Raises:
+            ValueError: if ``handler`` is not a BaseHandler instance.
+
+        Example::
+
+            from telegram import Update
+            from telegram.ext import TypeHandler
+
+            async def _on_reaction(update, context):
+                if update.message_reaction:
+                    ...  # e.g. render a table image fallback
+
+            ctx.register_telegram_handler(
+                TypeHandler(Update, _on_reaction), group=1
+            )
+        """
+        # Duck-type to avoid importing python-telegram-bot in environments
+        # that don't use Telegram (it is an optional dependency).
+        if not (
+            callable(getattr(handler, "check_update", None))
+            and callable(getattr(handler, "handle", None))
+        ):
+            raise ValueError(
+                "register_telegram_handler expects a telegram.ext.BaseHandler "
+                "instance (needs check_update/handle)."
+            )
+        self._manager._telegram_handlers.append(
+            (handler, group, self.manifest.name)
+        )
+        logger.debug(
+            "Plugin %s registered Telegram handler: %s (group=%s)",
+            self.manifest.name,
+            type(handler).__name__,
+            group,
+        )
+
     @_serialized_replacement
     def register_auxiliary_task(
         self,
@@ -3437,6 +3496,10 @@ class PluginManager:
         # ``re.Pattern``, or a constraint dict); ``callback`` is an async
         # function with the slack_bolt signature ``(ack, body, action)``.
         self._slack_action_handlers: List[tuple] = []
+        # Plugin-registered python-telegram-bot handlers; the Telegram adapter
+        # wires them into its PTB Application at connect time. Each entry is a
+        # ``(handler, group, plugin_name)`` tuple.
+        self._telegram_handlers: List[tuple] = []
         # Registration handles are kept both per plugin (ownership lookup) and
         # globally (reverse-order teardown for overrides spanning plugins).
         #
@@ -3725,6 +3788,7 @@ class PluginManager:
             self._system_prompt_sections.clear()
             self._approval_transports.clear()
             self._slack_action_handlers.clear()
+            self._telegram_handlers.clear()
             self._predeclared_modules.clear()
             self._predeclared_tools.clear()
             self._context_engine = None
@@ -5450,6 +5514,18 @@ class PluginManager:
         :meth:`PluginContext.register_slack_action_handler`.
         """
         return list(self._slack_action_handlers)
+
+    def get_telegram_handlers(self) -> List[tuple]:
+        """Return the list of plugin-registered python-telegram-bot handlers.
+
+        Each entry is a ``(handler, group, plugin_name)`` tuple. Consumed by
+        the Telegram adapter at connect time to wire the handlers into its PTB
+        ``Application`` via ``Application.add_handler``.
+
+        Plugins register handlers via
+        :meth:`PluginContext.register_telegram_handler`.
+        """
+        return list(self._telegram_handlers)
 
     # -----------------------------------------------------------------------
     # Introspection

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2981,6 +2981,34 @@ class TelegramAdapter(BasePlatformAdapter):
             if self._post_connect_task is asyncio.current_task():
                 self._post_connect_task = None
 
+    def _wire_plugin_handlers(self) -> None:
+        """Wire plugin-registered PTB handlers into the Application at connect.
+
+        Consumes ``PluginManager.get_telegram_handlers()`` (populated by
+        ``ctx.register_telegram_handler``) and registers each on the PTB
+        Application with its requested group. The plugin-manager load and each
+        per-handler ``add_handler`` are isolated so one bad plugin cannot block
+        Telegram connect — mirrors how the Slack adapter consumes
+        ``get_slack_action_handlers``.
+        """
+        try:
+            from hermes_cli.plugins import get_plugin_manager
+            tg_handlers = get_plugin_manager().get_telegram_handlers()
+        except Exception as tg_load_exc:
+            logger.warning(
+                "[%s] could not load plugin Telegram handlers: %s",
+                self.name, tg_load_exc,
+            )
+            tg_handlers = []
+        for tg_h, tg_g, tg_pname in tg_handlers:
+            try:
+                self._app.add_handler(tg_h, group=tg_g)
+            except Exception as tg_reject_exc:
+                logger.warning(
+                    "[%s] plugin Telegram handler from %s rejected: %s",
+                    self.name, tg_pname, tg_reject_exc,
+                )
+
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Connect to Telegram via polling or webhook.
 
@@ -3189,25 +3217,8 @@ class TelegramAdapter(BasePlatformAdapter):
             # Handle inline keyboard button callbacks (update prompts)
             self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
             # Wire plugin-registered python-telegram-bot handlers (plugins call
-            # ctx.register_telegram_handler). Mirrors how the Slack adapter
-            # consumes ctx.register_slack_action_handler at connect time.
-            try:
-                from hermes_cli.plugins import get_plugin_manager
-                tg_handlers = get_plugin_manager().get_telegram_handlers()
-            except Exception as tg_load_exc:
-                logger.warning(
-                    "[%s] could not load plugin Telegram handlers: %s",
-                    self.name, tg_load_exc,
-                )
-                tg_handlers = []
-            for tg_h, tg_g, tg_pname in tg_handlers:
-                try:
-                    self._app.add_handler(tg_h, group=tg_g)
-                except Exception as tg_reject_exc:
-                    logger.warning(
-                        "[%s] plugin Telegram handler from %s rejected: %s",
-                        self.name, tg_pname, tg_reject_exc,
-                    )
+            # ctx.register_telegram_handler) into the Application.
+            self._wire_plugin_handlers()
             
             # Start polling — retry initialize() for transient TLS resets.
             # Each attempt is capped by _init_timeout so a single unreachable

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3188,6 +3188,26 @@ class TelegramAdapter(BasePlatformAdapter):
             ))
             # Handle inline keyboard button callbacks (update prompts)
             self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
+            # Wire plugin-registered python-telegram-bot handlers (plugins call
+            # ctx.register_telegram_handler). Mirrors how the Slack adapter
+            # consumes ctx.register_slack_action_handler at connect time.
+            try:
+                from hermes_cli.plugins import get_plugin_manager
+                tg_handlers = get_plugin_manager().get_telegram_handlers()
+            except Exception as tg_load_exc:
+                logger.warning(
+                    "[%s] could not load plugin Telegram handlers: %s",
+                    self.name, tg_load_exc,
+                )
+                tg_handlers = []
+            for tg_h, tg_g, tg_pname in tg_handlers:
+                try:
+                    self._app.add_handler(tg_h, group=tg_g)
+                except Exception as tg_reject_exc:
+                    logger.warning(
+                        "[%s] plugin Telegram handler from %s rejected: %s",
+                        self.name, tg_pname, tg_reject_exc,
+                    )
             
             # Start polling — retry initialize() for transient TLS resets.
             # Each attempt is capped by _init_timeout so a single unreachable

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2982,31 +2982,40 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._post_connect_task = None
 
     def _wire_plugin_handlers(self) -> None:
-        """Wire plugin-registered PTB handlers into the Application at connect.
+        """Invoke plugin-registered Telegram handler factories at connect.
 
-        Consumes ``PluginManager.get_telegram_handlers()`` (populated by
-        ``ctx.register_telegram_handler``) and registers each on the PTB
-        Application with its requested group. The plugin-manager load and each
-        per-handler ``add_handler`` are isolated so one bad plugin cannot block
-        Telegram connect — mirrors how the Slack adapter consumes
-        ``get_slack_action_handlers``.
+        Plugins call ``ctx.register_telegram_handler(factory)`` at register()
+        time; the manager queues the factories and this method invokes each
+        with ``(application, adapter)`` right after the PTB Application is
+        built and BEFORE the core handlers are added. PTB dispatches only the
+        first matching handler per group, so plugin handlers registered first
+        take precedence for the updates they scope to (e.g. a
+        ``CallbackQueryHandler`` with a ``pattern=`` prefix) while everything
+        else falls through to the core handlers.
+
+        Each factory is isolated so a misbehaving plugin can't prevent
+        Telegram from connecting.
         """
         try:
             from hermes_cli.plugins import get_plugin_manager
-            tg_handlers = get_plugin_manager().get_telegram_handlers()
+            factories = get_plugin_manager().get_telegram_handler_factories()
         except Exception as tg_load_exc:
             logger.warning(
-                "[%s] could not load plugin Telegram handlers: %s",
+                "[%s] Could not load plugin Telegram handler factories: %s",
                 self.name, tg_load_exc,
             )
-            tg_handlers = []
-        for tg_h, tg_g, tg_pname in tg_handlers:
+            return
+        for factory, plugin_name in factories:
             try:
-                self._app.add_handler(tg_h, group=tg_g)
-            except Exception as tg_reject_exc:
-                logger.warning(
-                    "[%s] plugin Telegram handler from %s rejected: %s",
-                    self.name, tg_pname, tg_reject_exc,
+                factory(self._app, self)
+                logger.info(
+                    "[%s] Wired Telegram handlers from plugin '%s'",
+                    self.name, plugin_name,
+                )
+            except Exception as tg_factory_exc:
+                logger.error(
+                    "[%s] Plugin '%s' Telegram handler factory raised: %s",
+                    self.name, plugin_name, tg_factory_exc, exc_info=True,
                 )
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
@@ -3196,6 +3205,10 @@ class TelegramAdapter(BasePlatformAdapter):
             builder = builder.request(request).get_updates_request(get_updates_request)
             self._app = builder.build()
             self._bot = self._app.bot
+
+            # Wire plugin-provided PTB handlers BEFORE the core handlers are
+            # added — see _wire_plugin_handlers for precedence + isolation.
+            self._wire_plugin_handlers()
             
             # Register handlers
             self._app.add_handler(TelegramMessageHandler(
@@ -3216,9 +3229,6 @@ class TelegramAdapter(BasePlatformAdapter):
             ))
             # Handle inline keyboard button callbacks (update prompts)
             self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
-            # Wire plugin-registered python-telegram-bot handlers (plugins call
-            # ctx.register_telegram_handler) into the Application.
-            self._wire_plugin_handlers()
             
             # Start polling — retry initialize() for transient TLS resets.
             # Each attempt is capped by _init_timeout so a single unreachable

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4227,6 +4227,34 @@ class TelegramAdapter(BasePlatformAdapter):
         # it observes alongside, never displaces, the core handlers.
         app.add_handler(TypeHandler(Update, self._on_platform_update), group=99)
 
+    def _wire_plugin_handlers(self) -> None:
+        """Wire plugin-registered PTB handlers into the Application at connect.
+
+        Consumes ``PluginManager.get_telegram_handlers()`` (populated by
+        ``ctx.register_telegram_handler``) and registers each on the PTB
+        Application with its requested group. The plugin-manager load and each
+        per-handler ``add_handler`` are isolated so one bad plugin cannot block
+        Telegram connect — mirrors how the Slack adapter consumes
+        ``get_slack_action_handlers``.
+        """
+        try:
+            from hermes_cli.plugins import get_plugin_manager
+            tg_handlers = get_plugin_manager().get_telegram_handlers()
+        except Exception as tg_load_exc:
+            logger.warning(
+                "[%s] could not load plugin Telegram handlers: %s",
+                self.name, tg_load_exc,
+            )
+            tg_handlers = []
+        for tg_h, tg_g, tg_pname in tg_handlers:
+            try:
+                self._app.add_handler(tg_h, group=tg_g)
+            except Exception as tg_reject_exc:
+                logger.warning(
+                    "[%s] plugin Telegram handler from %s rejected: %s",
+                    self.name, tg_pname, tg_reject_exc,
+                )
+
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Connect to Telegram via polling or webhook.
 
@@ -4471,25 +4499,8 @@ class TelegramAdapter(BasePlatformAdapter):
             # Register handlers via the single registration site (#64176).
             self._register_handlers(self._app)
             # Wire plugin-registered python-telegram-bot handlers (plugins call
-            # ctx.register_telegram_handler). Mirrors how the Slack adapter
-            # consumes ctx.register_slack_action_handler at connect time.
-            try:
-                from hermes_cli.plugins import get_plugin_manager
-                tg_handlers = get_plugin_manager().get_telegram_handlers()
-            except Exception as tg_load_exc:
-                logger.warning(
-                    "[%s] could not load plugin Telegram handlers: %s",
-                    self.name, tg_load_exc,
-                )
-                tg_handlers = []
-            for tg_h, tg_g, tg_pname in tg_handlers:
-                try:
-                    self._app.add_handler(tg_h, group=tg_g)
-                except Exception as tg_reject_exc:
-                    logger.warning(
-                        "[%s] plugin Telegram handler from %s rejected: %s",
-                        self.name, tg_pname, tg_reject_exc,
-                    )
+            # ctx.register_telegram_handler) into the Application.
+            self._wire_plugin_handlers()
             
             # Start polling — retry initialize() for transient TLS resets.
             # Each attempt is capped by _init_timeout so a single unreachable

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4470,6 +4470,26 @@ class TelegramAdapter(BasePlatformAdapter):
             
             # Register handlers via the single registration site (#64176).
             self._register_handlers(self._app)
+            # Wire plugin-registered python-telegram-bot handlers (plugins call
+            # ctx.register_telegram_handler). Mirrors how the Slack adapter
+            # consumes ctx.register_slack_action_handler at connect time.
+            try:
+                from hermes_cli.plugins import get_plugin_manager
+                tg_handlers = get_plugin_manager().get_telegram_handlers()
+            except Exception as tg_load_exc:
+                logger.warning(
+                    "[%s] could not load plugin Telegram handlers: %s",
+                    self.name, tg_load_exc,
+                )
+                tg_handlers = []
+            for tg_h, tg_g, tg_pname in tg_handlers:
+                try:
+                    self._app.add_handler(tg_h, group=tg_g)
+                except Exception as tg_reject_exc:
+                    logger.warning(
+                        "[%s] plugin Telegram handler from %s rejected: %s",
+                        self.name, tg_pname, tg_reject_exc,
+                    )
             
             # Start polling — retry initialize() for transient TLS resets.
             # Each attempt is capped by _init_timeout so a single unreachable

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4202,9 +4202,11 @@ class TelegramAdapter(BasePlatformAdapter):
 
         Single source of truth for handler registration. Both initial connect
         and the transient-initialization rebuild path call this method, keeping
-        the ``gateway_platform_event`` observer (group 99) in lockstep with the
-        core handlers.
+        plugin factories, the ``gateway_platform_event`` observer (group 99),
+        and the core handlers in lockstep. Plugin factories run first so their
+        scoped handlers take PTB's first-match precedence over the core set.
         """
+        self._wire_plugin_handlers(app)
         app.add_handler(TelegramMessageHandler(
             filters.TEXT & ~filters.COMMAND,
             self._handle_text_message
@@ -4227,17 +4229,18 @@ class TelegramAdapter(BasePlatformAdapter):
         # it observes alongside, never displaces, the core handlers.
         app.add_handler(TypeHandler(Update, self._on_platform_update), group=99)
 
-    def _wire_plugin_handlers(self) -> None:
-        """Invoke plugin-registered Telegram handler factories at connect.
+    def _wire_plugin_handlers(self, app) -> None:
+        """Invoke plugin-registered Telegram handler factories.
 
         Plugins call ``ctx.register_telegram_handler(factory)`` at register()
         time; the manager queues the factories and this method invokes each
-        with ``(application, adapter)`` right after the PTB Application is
-        built and BEFORE the core handlers are added. PTB dispatches only the
-        first matching handler per group, so plugin handlers registered first
-        take precedence for the updates they scope to (e.g. a
-        ``CallbackQueryHandler`` with a ``pattern=`` prefix) while everything
-        else falls through to the core handlers.
+        with ``(application, adapter)``. Called as the first step of
+        :meth:`_register_handlers`, so plugin handlers are registered BEFORE
+        the core handlers. PTB dispatches only the first matching handler per
+        group, so plugin handlers registered first take precedence for the
+        updates they scope to (e.g. a ``CallbackQueryHandler`` with a
+        ``pattern=`` prefix) while everything else falls through to the core
+        handlers.
 
         Each factory is isolated so a misbehaving plugin can't prevent
         Telegram from connecting.
@@ -4253,7 +4256,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         for factory, plugin_name in factories:
             try:
-                factory(self._app, self)
+                factory(app, self)
                 logger.info(
                     "[%s] Wired Telegram handlers from plugin '%s'",
                     self.name, plugin_name,
@@ -4505,11 +4508,9 @@ class TelegramAdapter(BasePlatformAdapter):
             self._app = builder.build()
             self._bot = self._app.bot
 
-            # Wire plugin-provided PTB handlers BEFORE the core handlers are
-            # added — see _wire_plugin_handlers for precedence + isolation.
-            self._wire_plugin_handlers()
-
             # Register handlers via the single registration site (#64176).
+            # Plugin factories, core handlers, and the observer are wired
+            # there in precedence order.
             self._register_handlers(self._app)
             
             # Start polling — retry initialize() for transient TLS resets.
@@ -4625,11 +4626,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         self._app = builder.build()
                         self._bot = self._app.bot
                         # Keep plugin, core, and observer handlers in lockstep
-                        # after a transient-init rebuild (#64176): the rebuilt
-                        # Application needs the plugin factories re-invoked too,
-                        # or plugin handlers silently vanish while the core
-                        # handlers survive.
-                        self._wire_plugin_handlers()
+                        # after a transient-init rebuild (#64176).
                         self._register_handlers(self._app)
                         # Best-effort discard the old app's resources
                         try:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4228,31 +4228,40 @@ class TelegramAdapter(BasePlatformAdapter):
         app.add_handler(TypeHandler(Update, self._on_platform_update), group=99)
 
     def _wire_plugin_handlers(self) -> None:
-        """Wire plugin-registered PTB handlers into the Application at connect.
+        """Invoke plugin-registered Telegram handler factories at connect.
 
-        Consumes ``PluginManager.get_telegram_handlers()`` (populated by
-        ``ctx.register_telegram_handler``) and registers each on the PTB
-        Application with its requested group. The plugin-manager load and each
-        per-handler ``add_handler`` are isolated so one bad plugin cannot block
-        Telegram connect — mirrors how the Slack adapter consumes
-        ``get_slack_action_handlers``.
+        Plugins call ``ctx.register_telegram_handler(factory)`` at register()
+        time; the manager queues the factories and this method invokes each
+        with ``(application, adapter)`` right after the PTB Application is
+        built and BEFORE the core handlers are added. PTB dispatches only the
+        first matching handler per group, so plugin handlers registered first
+        take precedence for the updates they scope to (e.g. a
+        ``CallbackQueryHandler`` with a ``pattern=`` prefix) while everything
+        else falls through to the core handlers.
+
+        Each factory is isolated so a misbehaving plugin can't prevent
+        Telegram from connecting.
         """
         try:
             from hermes_cli.plugins import get_plugin_manager
-            tg_handlers = get_plugin_manager().get_telegram_handlers()
+            factories = get_plugin_manager().get_telegram_handler_factories()
         except Exception as tg_load_exc:
             logger.warning(
-                "[%s] could not load plugin Telegram handlers: %s",
+                "[%s] Could not load plugin Telegram handler factories: %s",
                 self.name, tg_load_exc,
             )
-            tg_handlers = []
-        for tg_h, tg_g, tg_pname in tg_handlers:
+            return
+        for factory, plugin_name in factories:
             try:
-                self._app.add_handler(tg_h, group=tg_g)
-            except Exception as tg_reject_exc:
-                logger.warning(
-                    "[%s] plugin Telegram handler from %s rejected: %s",
-                    self.name, tg_pname, tg_reject_exc,
+                factory(self._app, self)
+                logger.info(
+                    "[%s] Wired Telegram handlers from plugin '%s'",
+                    self.name, plugin_name,
+                )
+            except Exception as tg_factory_exc:
+                logger.error(
+                    "[%s] Plugin '%s' Telegram handler factory raised: %s",
+                    self.name, plugin_name, tg_factory_exc, exc_info=True,
                 )
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
@@ -4495,12 +4504,13 @@ class TelegramAdapter(BasePlatformAdapter):
             builder = builder.request(request).get_updates_request(get_updates_request)
             self._app = builder.build()
             self._bot = self._app.bot
-            
+
+            # Wire plugin-provided PTB handlers BEFORE the core handlers are
+            # added — see _wire_plugin_handlers for precedence + isolation.
+            self._wire_plugin_handlers()
+
             # Register handlers via the single registration site (#64176).
             self._register_handlers(self._app)
-            # Wire plugin-registered python-telegram-bot handlers (plugins call
-            # ctx.register_telegram_handler) into the Application.
-            self._wire_plugin_handlers()
             
             # Start polling — retry initialize() for transient TLS resets.
             # Each attempt is capped by _init_timeout so a single unreachable
@@ -4614,8 +4624,12 @@ class TelegramAdapter(BasePlatformAdapter):
                         old_app = self._app
                         self._app = builder.build()
                         self._bot = self._app.bot
-                        # Keep core and observer handlers in lockstep after a
-                        # transient-init rebuild (#64176).
+                        # Keep plugin, core, and observer handlers in lockstep
+                        # after a transient-init rebuild (#64176): the rebuilt
+                        # Application needs the plugin factories re-invoked too,
+                        # or plugin handlers silently vanish while the core
+                        # handlers survive.
+                        self._wire_plugin_handlers()
                         self._register_handlers(self._app)
                         # Best-effort discard the old app's resources
                         try:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4240,10 +4240,14 @@ class TelegramAdapter(BasePlatformAdapter):
         group, so plugin handlers registered first take precedence for the
         updates they scope to (e.g. a ``CallbackQueryHandler`` with a
         ``pattern=`` prefix) while everything else falls through to the core
-        handlers.
+        handlers. Factories may be re-invoked when the Application is
+        rebuilt after transient init failures, so they must stay
+        idempotent; async factories are rejected at registration time.
 
         Each factory is isolated so a misbehaving plugin can't prevent
-        Telegram from connecting.
+        Telegram from connecting. Factories that add group-0 handlers are
+        flagged: group 0 is shared with the core handlers and an unscoped
+        handler there can silently shadow the core button/text flows.
         """
         try:
             from hermes_cli.plugins import get_plugin_manager
@@ -4256,7 +4260,30 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         for factory, plugin_name in factories:
             try:
-                factory(app, self)
+                group0_before = self._group_zero_handlers(app)
+                wired = factory(app, self)
+                if inspect.iscoroutine(wired):
+                    # A sync-callable factory that returns a coroutine
+                    # (e.g. a lambda delegating to an async def) did no
+                    # wiring; close the coroutine so it can't linger as a
+                    # never-awaited RuntimeWarning.
+                    wired.close()
+                    logger.error(
+                        "[%s] Plugin '%s' Telegram handler factory returned "
+                        "a coroutine; wiring is synchronous and the "
+                        "coroutine was discarded. Register a sync factory.",
+                        self.name, plugin_name,
+                    )
+                    continue
+                added_group0 = self._new_group_zero_handlers(app, group0_before)
+                if added_group0:
+                    logger.warning(
+                        "[%s] Plugin '%s' added %d group-0 handler(s) that "
+                        "may shadow the core handlers: PTB dispatches only "
+                        "the first match per group. Scope callback handlers "
+                        "with pattern= or register in a non-zero group.",
+                        self.name, plugin_name, len(added_group0),
+                    )
                 logger.info(
                     "[%s] Wired Telegram handlers from plugin '%s'",
                     self.name, plugin_name,
@@ -4266,6 +4293,26 @@ class TelegramAdapter(BasePlatformAdapter):
                     "[%s] Plugin '%s' Telegram handler factory raised: %s",
                     self.name, plugin_name, tg_factory_exc, exc_info=True,
                 )
+
+    @staticmethod
+    def _group_zero_handlers(app) -> Optional[list]:
+        """Snapshot the live group-0 handler list, or None when the app's
+        handler map cannot be inspected (mock apps in tests)."""
+        try:
+            return list(app.handlers.get(0, []))
+        except Exception:
+            return None
+
+    @staticmethod
+    def _new_group_zero_handlers(app, before) -> list:
+        """Return handlers added to group 0 since the ``before`` snapshot."""
+        if before is None:
+            return []
+        try:
+            current = app.handlers.get(0, [])
+        except Exception:
+            return []
+        return [h for h in current if not any(h is b for b in before)]
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Connect to Telegram via polling or webhook.

--- a/tests/gateway/test_telegram_plugin_handlers.py
+++ b/tests/gateway/test_telegram_plugin_handlers.py
@@ -36,9 +36,11 @@ from hermes_cli.plugins import (  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
-# A minimal BaseHandler stand-in. The real telegram.ext.BaseHandler has
-# check_update() + handle(); we duck-type on exactly those so the test does
-# not require python-telegram-bot to be installed.
+# A minimal BaseHandler stand-in. The real telegram.ext.BaseHandler (PTB v22,
+# pinned in pyproject.toml) exposes check_update() + handle_update() and has
+# NO `handle` attribute. We mirror that contract exactly so the test exercises
+# what a real MessageHandler/TypeHandler instance looks like — this is what
+# caught (and now guards against) the earlier `handle`-attr validation bug.
 # ---------------------------------------------------------------------------
 
 class _FakeHandler:
@@ -50,9 +52,6 @@ class _FakeHandler:
 
     async def handle_update(self, *a, **kw):  # pragma: no cover
         ...
-
-    # register_telegram_handler duck-types on check_update + handle
-    handle = handle_update
 
 
 class _NotAHandler:
@@ -94,6 +93,22 @@ class TestRegisterTelegramHandlerAPI:
         h = _FakeHandler()
         ctx.register_telegram_handler(h, group=1)
         assert mgr.get_telegram_handlers()[0][1] == 1
+
+    def test_accepts_real_ptb_v22_contract(self):
+        """Regression: PTB v22 BaseHandler has check_update/handle_update, no `handle`.
+
+        A real MessageHandler/TypeHandler instance carries no ``handle``
+        attribute, so the validator must key on ``handle_update`` — not
+        ``handle``. An earlier version required ``handle`` and silently
+        rejected every real PTB handler; this pins the correct contract.
+        """
+        mgr, ctx = _make_ctx()
+        h = _FakeHandler("reaction")
+        assert not hasattr(h, "handle"), "fake must mirror real PTB (no handle attr)"
+
+        # Must not raise — a real PTB handler would have failed the old check.
+        ctx.register_telegram_handler(h)
+        assert mgr.get_telegram_handlers()[0][0] is h
 
     def test_non_handler_raises(self):
         """A non-BaseHandler object must be rejected, not silently stored."""

--- a/tests/gateway/test_telegram_plugin_handlers.py
+++ b/tests/gateway/test_telegram_plugin_handlers.py
@@ -1,0 +1,154 @@
+"""Tests for plugin-registered python-telegram-bot handlers.
+
+Covers the new plugin API that mirrors ``register_slack_action_handler``:
+* ``PluginContext.register_telegram_handler`` validation + queuing
+* ``PluginManager.get_telegram_handlers`` accessor
+* the ``(handler, group, plugin_name)`` tuple shape the Telegram adapter
+  consumes at connect time
+
+(The adapter-side ``connect()`` wiring — ``for h, g, _ in
+get_telegram_handlers(): app.add_handler(h, group=g)`` — is an 8-line mirror
+of the Slack adapter's action-handler wiring; its defensive load/reject
+behaviour matches the pattern covered by
+``test_slack_plugin_action_handlers.py``.)
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Ensure the repo root is importable when this test runs directly
+# ---------------------------------------------------------------------------
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+from hermes_cli.plugins import (  # noqa: E402
+    PluginContext,
+    PluginManager,
+    PluginManifest,
+)
+
+
+# ---------------------------------------------------------------------------
+# A minimal BaseHandler stand-in. The real telegram.ext.BaseHandler has
+# check_update() + handle(); we duck-type on exactly those so the test does
+# not require python-telegram-bot to be installed.
+# ---------------------------------------------------------------------------
+
+class _FakeHandler:
+    def __init__(self, name: str = "fake"):
+        self.name = name
+
+    async def check_update(self, update):  # pragma: no cover - never dispatched
+        return False
+
+    async def handle_update(self, *a, **kw):  # pragma: no cover
+        ...
+
+    # register_telegram_handler duck-types on check_update + handle
+    handle = handle_update
+
+
+class _NotAHandler:
+    """Something a plugin might mistakenly register."""
+    pass
+
+
+def _make_ctx(name: str = "test_plugin") -> tuple[PluginManager, PluginContext]:
+    """Build a fresh PluginManager + PluginContext bound to it."""
+    mgr = PluginManager()
+    manifest = PluginManifest(name=name, version="0.1.0", description="test")
+    ctx = PluginContext(manifest=manifest, manager=mgr)
+    return mgr, ctx
+
+
+# ---------------------------------------------------------------------------
+# PluginContext.register_telegram_handler — input validation + queuing
+# ---------------------------------------------------------------------------
+
+class TestRegisterTelegramHandlerAPI:
+    """Behaviour of ctx.register_telegram_handler()."""
+
+    def test_basehandler_is_queued_with_default_group(self):
+        mgr, ctx = _make_ctx()
+        h = _FakeHandler("reaction")
+
+        ctx.register_telegram_handler(h)
+
+        handlers = mgr.get_telegram_handlers()
+        assert len(handlers) == 1
+        handler, group, plugin_name = handlers[0]
+        assert handler is h
+        assert group == 0
+        assert plugin_name == "test_plugin"
+
+    def test_explicit_group_is_recorded(self):
+        """Plugins use group=1 to run alongside built-ins without displacing them."""
+        mgr, ctx = _make_ctx()
+        h = _FakeHandler()
+        ctx.register_telegram_handler(h, group=1)
+        assert mgr.get_telegram_handlers()[0][1] == 1
+
+    def test_non_handler_raises(self):
+        """A non-BaseHandler object must be rejected, not silently stored."""
+        _mgr, ctx = _make_ctx()
+        with pytest.raises(ValueError, match="BaseHandler"):
+            ctx.register_telegram_handler(_NotAHandler())  # type: ignore[arg-type]
+
+    def test_none_handler_raises(self):
+        _mgr, ctx = _make_ctx()
+        with pytest.raises(ValueError, match="BaseHandler"):
+            ctx.register_telegram_handler(None)  # type: ignore[arg-type]
+
+    def test_get_telegram_handlers_returns_copy(self):
+        """The accessor returns a copy so callers can't mutate plugin state."""
+        mgr, ctx = _make_ctx()
+        ctx.register_telegram_handler(_FakeHandler())
+
+        handlers = mgr.get_telegram_handlers()
+        handlers.clear()
+        assert len(mgr.get_telegram_handlers()) == 1
+
+    def test_multiple_plugins_each_recorded(self):
+        mgr = PluginManager()
+        ctx_a = PluginContext(
+            manifest=PluginManifest(name="plug_a", version="0", description=""),
+            manager=mgr,
+        )
+        ctx_b = PluginContext(
+            manifest=PluginManifest(name="plug_b", version="0", description=""),
+            manager=mgr,
+        )
+        ctx_a.register_telegram_handler(_FakeHandler("a"), group=1)
+        ctx_b.register_telegram_handler(_FakeHandler("b"), group=1)
+
+        handlers = mgr.get_telegram_handlers()
+        assert {h[2] for h in handlers} == {"plug_a", "plug_b"}
+        # Registration order preserved (PTB group ordering is significant).
+        assert [h[0].name for h in handlers] == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# Contract the Telegram adapter relies on at connect time
+# ---------------------------------------------------------------------------
+
+class TestTelegramHandlerContract:
+    """The shape get_telegram_handlers() yields is exactly what connect() unpacks."""
+
+    def test_tuple_is_handler_group_pluginname(self):
+        mgr, ctx = _make_ctx()
+        h = _FakeHandler()
+        ctx.register_telegram_handler(h, group=2)
+
+        entry = mgr.get_telegram_handlers()[0]
+        assert len(entry) == 3
+        handler, group, plugin_name = entry  # unpacks like the adapter loop
+        assert handler is h
+        assert group == 2
+        assert isinstance(plugin_name, str)

--- a/tests/gateway/test_telegram_plugin_handlers.py
+++ b/tests/gateway/test_telegram_plugin_handlers.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -167,3 +169,108 @@ class TestTelegramHandlerContract:
         assert handler is h
         assert group == 2
         assert isinstance(plugin_name, str)
+
+
+# ---------------------------------------------------------------------------
+# TelegramAdapter connect-path wiring
+# ---------------------------------------------------------------------------
+# Exercises TelegramAdapter._wire_plugin_handlers() — the connect-time code
+# path that consumes get_telegram_handlers() and calls Application.add_handler.
+# python-telegram-bot is an optional dep, so mock the telegram package the same
+# way tests/gateway/test_telegram_network_reconnect.py does.
+
+def _ensure_telegram_mock() -> None:
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    telegram_mod = MagicMock()
+    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    telegram_mod.constants.ChatType.GROUP = "group"
+    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
+    telegram_mod.constants.ChatType.CHANNEL = "channel"
+    telegram_mod.constants.ChatType.PRIVATE = "private"
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, telegram_mod)
+
+
+_ensure_telegram_mock()
+
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+
+
+class _RecordingApp:
+    """Stand-in PTB Application that records add_handler(handler, group=...)."""
+
+    def __init__(self, raise_on: tuple = ()):
+        self.added: list = []  # list of (handler, group)
+        self._raise_on = set(raise_on)
+
+    def add_handler(self, handler, group=None):
+        if getattr(handler, "name", None) in self._raise_on:
+            raise RuntimeError("PTB rejected handler")
+        self.added.append((handler, group))
+
+
+class TestTelegramAdapterPluginHandlerWiring:
+    """_wire_plugin_handlers() (the connect path) registers handlers on the app."""
+
+    def _adapter(self, app) -> TelegramAdapter:
+        # object.__new__ skips the heavy __init__. _wire_plugin_handlers only
+        # needs self._app and self.name; `name` is a read-only property over
+        # self.platform (Platform.TELEGRAM.value.title() -> "Telegram"), so set
+        # a stand-in platform rather than the property itself.
+        a = object.__new__(TelegramAdapter)
+        a.platform = SimpleNamespace(value="telegram")
+        a._app = app
+        return a
+
+    def _mgr(self, handlers):
+        mgr = MagicMock()
+        mgr.get_telegram_handlers.return_value = handlers
+        return mgr
+
+    def test_handlers_wired_with_their_groups(self):
+        """Each queued handler is add_handler()'d with its requested group."""
+        app = _RecordingApp()
+        adapter = self._adapter(app)
+        h0, h1 = _FakeHandler("a"), _FakeHandler("b")
+
+        with patch("hermes_cli.plugins.get_plugin_manager",
+                   return_value=self._mgr([(h0, 0, "plug_a"), (h1, 1, "plug_b")])):
+            adapter._wire_plugin_handlers()
+
+        assert app.added == [(h0, 0), (h1, 1)]
+
+    def test_no_handlers_is_a_noop(self):
+        """Empty queue (the common case) wires nothing."""
+        app = _RecordingApp()
+        adapter = self._adapter(app)
+
+        with patch("hermes_cli.plugins.get_plugin_manager",
+                   return_value=self._mgr([])):
+            adapter._wire_plugin_handlers()
+
+        assert app.added == []
+
+    def test_plugin_manager_load_failure_is_isolated(self):
+        """If get_plugin_manager() raises, wiring is skipped — connect still safe."""
+        app = _RecordingApp()
+        adapter = self._adapter(app)
+
+        with patch("hermes_cli.plugins.get_plugin_manager",
+                   side_effect=RuntimeError("plugin layer down")):
+            adapter._wire_plugin_handlers()  # must not raise
+
+        assert app.added == []
+
+    def test_one_rejected_handler_does_not_block_others(self):
+        """A handler PTB rejects must not stop later handlers from wiring."""
+        app = _RecordingApp(raise_on=("bad",))
+        adapter = self._adapter(app)
+        good, bad, other = _FakeHandler("good"), _FakeHandler("bad"), _FakeHandler("other")
+
+        with patch("hermes_cli.plugins.get_plugin_manager",
+                   return_value=self._mgr([(bad, 0, "buggy"), (good, 1, "g"), (other, 2, "o")])):
+            adapter._wire_plugin_handlers()
+
+        assert app.added == [(good, 1), (other, 2)]

--- a/tests/gateway/test_telegram_plugin_handlers.py
+++ b/tests/gateway/test_telegram_plugin_handlers.py
@@ -1,16 +1,12 @@
-"""Tests for plugin-registered python-telegram-bot handlers.
+"""Tests for plugin-registered python-telegram-bot handler factories.
 
-Covers the new plugin API that mirrors ``register_slack_action_handler``:
-* ``PluginContext.register_telegram_handler`` validation + queuing
-* ``PluginManager.get_telegram_handlers`` accessor
-* the ``(handler, group, plugin_name)`` tuple shape the Telegram adapter
-  consumes at connect time
-
-(The adapter-side ``connect()`` wiring — ``for h, g, _ in
-get_telegram_handlers(): app.add_handler(h, group=g)`` — is an 8-line mirror
-of the Slack adapter's action-handler wiring; its defensive load/reject
-behaviour matches the pattern covered by
-``test_slack_plugin_action_handlers.py``.)
+Covers the plugin API consolidated onto #59159's factory shape:
+* ``PluginContext.register_telegram_handler(factory)`` validation + queuing
+* ``PluginManager.get_telegram_handler_factories`` accessor
+* ``TelegramAdapter._wire_plugin_handlers`` invoking each factory with
+  ``(application, adapter)`` at connect time, before the core handlers
+* defensive isolation: a factory that raises does NOT prevent the adapter
+  from wiring other factories or continuing to connect.
 """
 
 from __future__ import annotations
@@ -37,30 +33,6 @@ from hermes_cli.plugins import (  # noqa: E402
 )
 
 
-# ---------------------------------------------------------------------------
-# A minimal BaseHandler stand-in. The real telegram.ext.BaseHandler (PTB v22,
-# pinned in pyproject.toml) exposes check_update() + handle_update() and has
-# NO `handle` attribute. We mirror that contract exactly so the test exercises
-# what a real MessageHandler/TypeHandler instance looks like — this is what
-# caught (and now guards against) the earlier `handle`-attr validation bug.
-# ---------------------------------------------------------------------------
-
-class _FakeHandler:
-    def __init__(self, name: str = "fake"):
-        self.name = name
-
-    async def check_update(self, update):  # pragma: no cover - never dispatched
-        return False
-
-    async def handle_update(self, *a, **kw):  # pragma: no cover
-        ...
-
-
-class _NotAHandler:
-    """Something a plugin might mistakenly register."""
-    pass
-
-
 def _make_ctx(name: str = "test_plugin") -> tuple[PluginManager, PluginContext]:
     """Build a fresh PluginManager + PluginContext bound to it."""
     mgr = PluginManager()
@@ -70,69 +42,51 @@ def _make_ctx(name: str = "test_plugin") -> tuple[PluginManager, PluginContext]:
 
 
 # ---------------------------------------------------------------------------
-# PluginContext.register_telegram_handler — input validation + queuing
+# PluginContext.register_telegram_handler — validation + queuing
 # ---------------------------------------------------------------------------
 
 class TestRegisterTelegramHandlerAPI:
-    """Behaviour of ctx.register_telegram_handler()."""
+    """Behaviour of ctx.register_telegram_handler(factory)."""
 
-    def test_basehandler_is_queued_with_default_group(self):
+    def test_factory_is_queued_with_plugin_name(self):
         mgr, ctx = _make_ctx()
-        h = _FakeHandler("reaction")
 
-        ctx.register_telegram_handler(h)
+        def factory(application, adapter):  # pragma: no cover - never called here
+            ...
 
-        handlers = mgr.get_telegram_handlers()
-        assert len(handlers) == 1
-        handler, group, plugin_name = handlers[0]
-        assert handler is h
-        assert group == 0
+        ctx.register_telegram_handler(factory)
+
+        factories = mgr.get_telegram_handler_factories()
+        assert len(factories) == 1
+        fn, plugin_name = factories[0]
+        assert fn is factory
         assert plugin_name == "test_plugin"
 
-    def test_explicit_group_is_recorded(self):
-        """Plugins use group=1 to run alongside built-ins without displacing them."""
-        mgr, ctx = _make_ctx()
-        h = _FakeHandler()
-        ctx.register_telegram_handler(h, group=1)
-        assert mgr.get_telegram_handlers()[0][1] == 1
-
-    def test_accepts_real_ptb_v22_contract(self):
-        """Regression: PTB v22 BaseHandler has check_update/handle_update, no `handle`.
-
-        A real MessageHandler/TypeHandler instance carries no ``handle``
-        attribute, so the validator must key on ``handle_update`` — not
-        ``handle``. An earlier version required ``handle`` and silently
-        rejected every real PTB handler; this pins the correct contract.
-        """
-        mgr, ctx = _make_ctx()
-        h = _FakeHandler("reaction")
-        assert not hasattr(h, "handle"), "fake must mirror real PTB (no handle attr)"
-
-        # Must not raise — a real PTB handler would have failed the old check.
-        ctx.register_telegram_handler(h)
-        assert mgr.get_telegram_handlers()[0][0] is h
-
-    def test_non_handler_raises(self):
-        """A non-BaseHandler object must be rejected, not silently stored."""
+    def test_non_callable_factory_raises(self):
+        """A non-callable factory must be rejected, not silently stored."""
         _mgr, ctx = _make_ctx()
-        with pytest.raises(ValueError, match="BaseHandler"):
-            ctx.register_telegram_handler(_NotAHandler())  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="non-callable"):
+            ctx.register_telegram_handler("not a factory")  # type: ignore[arg-type]
 
-    def test_none_handler_raises(self):
+    def test_none_factory_raises(self):
         _mgr, ctx = _make_ctx()
-        with pytest.raises(ValueError, match="BaseHandler"):
+        with pytest.raises(ValueError, match="non-callable"):
             ctx.register_telegram_handler(None)  # type: ignore[arg-type]
 
-    def test_get_telegram_handlers_returns_copy(self):
+    def test_get_telegram_handler_factories_returns_copy(self):
         """The accessor returns a copy so callers can't mutate plugin state."""
         mgr, ctx = _make_ctx()
-        ctx.register_telegram_handler(_FakeHandler())
 
-        handlers = mgr.get_telegram_handlers()
-        handlers.clear()
-        assert len(mgr.get_telegram_handlers()) == 1
+        def factory(application, adapter):  # pragma: no cover
+            ...
 
-    def test_multiple_plugins_each_recorded(self):
+        ctx.register_telegram_handler(factory)
+        factories = mgr.get_telegram_handler_factories()
+        factories.clear()
+        assert len(mgr.get_telegram_handler_factories()) == 1
+
+    def test_multiple_plugins_each_recorded_in_order(self):
+        """Registration order is preserved (PTB handler precedence is order-sensitive)."""
         mgr = PluginManager()
         ctx_a = PluginContext(
             manifest=PluginManifest(name="plug_a", version="0", description=""),
@@ -142,42 +96,28 @@ class TestRegisterTelegramHandlerAPI:
             manifest=PluginManifest(name="plug_b", version="0", description=""),
             manager=mgr,
         )
-        ctx_a.register_telegram_handler(_FakeHandler("a"), group=1)
-        ctx_b.register_telegram_handler(_FakeHandler("b"), group=1)
 
-        handlers = mgr.get_telegram_handlers()
-        assert {h[2] for h in handlers} == {"plug_a", "plug_b"}
-        # Registration order preserved (PTB group ordering is significant).
-        assert [h[0].name for h in handlers] == ["a", "b"]
+        def fa(application, adapter):  # pragma: no cover
+            ...
 
+        def fb(application, adapter):  # pragma: no cover
+            ...
 
-# ---------------------------------------------------------------------------
-# Contract the Telegram adapter relies on at connect time
-# ---------------------------------------------------------------------------
+        ctx_a.register_telegram_handler(fa)
+        ctx_b.register_telegram_handler(fb)
 
-class TestTelegramHandlerContract:
-    """The shape get_telegram_handlers() yields is exactly what connect() unpacks."""
-
-    def test_tuple_is_handler_group_pluginname(self):
-        mgr, ctx = _make_ctx()
-        h = _FakeHandler()
-        ctx.register_telegram_handler(h, group=2)
-
-        entry = mgr.get_telegram_handlers()[0]
-        assert len(entry) == 3
-        handler, group, plugin_name = entry  # unpacks like the adapter loop
-        assert handler is h
-        assert group == 2
-        assert isinstance(plugin_name, str)
+        factories = mgr.get_telegram_handler_factories()
+        assert [(fn, name) for fn, name in factories] == [(fa, "plug_a"), (fb, "plug_b")]
 
 
 # ---------------------------------------------------------------------------
 # TelegramAdapter connect-path wiring
 # ---------------------------------------------------------------------------
 # Exercises TelegramAdapter._wire_plugin_handlers() — the connect-time code
-# path that consumes get_telegram_handlers() and calls Application.add_handler.
-# python-telegram-bot is an optional dep, so mock the telegram package the same
-# way tests/gateway/test_telegram_network_reconnect.py does.
+# path that consumes get_telegram_handler_factories() and invokes each factory
+# with (application, adapter). python-telegram-bot is an optional dep, so mock
+# the telegram package the same way tests/gateway/test_telegram_network_reconnect
+# .py does.
 
 def _ensure_telegram_mock() -> None:
     if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
@@ -198,21 +138,17 @@ _ensure_telegram_mock()
 from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
 
 
-class _RecordingApp:
-    """Stand-in PTB Application that records add_handler(handler, group=...)."""
+def _recording_factory(log, key):
+    """Build a factory that records the (application, adapter) it receives."""
 
-    def __init__(self, raise_on: tuple = ()):
-        self.added: list = []  # list of (handler, group)
-        self._raise_on = set(raise_on)
+    def factory(application, adapter):
+        log.append((key, application, adapter))
 
-    def add_handler(self, handler, group=None):
-        if getattr(handler, "name", None) in self._raise_on:
-            raise RuntimeError("PTB rejected handler")
-        self.added.append((handler, group))
+    return factory
 
 
 class TestTelegramAdapterPluginHandlerWiring:
-    """_wire_plugin_handlers() (the connect path) registers handlers on the app."""
+    """_wire_plugin_handlers() (the connect path) invokes factories with (app, adapter)."""
 
     def _adapter(self, app) -> TelegramAdapter:
         # object.__new__ skips the heavy __init__. _wire_plugin_handlers only
@@ -224,53 +160,66 @@ class TestTelegramAdapterPluginHandlerWiring:
         a._app = app
         return a
 
-    def _mgr(self, handlers):
+    def _mgr(self, factories):
         mgr = MagicMock()
-        mgr.get_telegram_handlers.return_value = handlers
+        mgr.get_telegram_handler_factories.return_value = factories
         return mgr
 
-    def test_handlers_wired_with_their_groups(self):
-        """Each queued handler is add_handler()'d with its requested group."""
-        app = _RecordingApp()
+    def test_factories_invoked_with_app_and_adapter(self):
+        """Each factory is called exactly once with (application=app, adapter=self)."""
+        app = MagicMock(name="app")
         adapter = self._adapter(app)
-        h0, h1 = _FakeHandler("a"), _FakeHandler("b")
+        log: list = []
+        fa, fb = _recording_factory(log, "a"), _recording_factory(log, "b")
 
-        with patch("hermes_cli.plugins.get_plugin_manager",
-                   return_value=self._mgr([(h0, 0, "plug_a"), (h1, 1, "plug_b")])):
+        with patch(
+            "hermes_cli.plugins.get_plugin_manager",
+            return_value=self._mgr([(fa, "plug_a"), (fb, "plug_b")]),
+        ):
             adapter._wire_plugin_handlers()
 
-        assert app.added == [(h0, 0), (h1, 1)]
+        assert log == [("a", app, adapter), ("b", app, adapter)]
 
-    def test_no_handlers_is_a_noop(self):
-        """Empty queue (the common case) wires nothing."""
-        app = _RecordingApp()
+    def test_no_factories_is_a_noop(self):
+        """Empty factory list (the common case) wires nothing onto the app."""
+        app = MagicMock(name="app")
         adapter = self._adapter(app)
 
-        with patch("hermes_cli.plugins.get_plugin_manager",
-                   return_value=self._mgr([])):
+        with patch(
+            "hermes_cli.plugins.get_plugin_manager",
+            return_value=self._mgr([]),
+        ):
             adapter._wire_plugin_handlers()
 
-        assert app.added == []
+        app.add_handler.assert_not_called()
 
     def test_plugin_manager_load_failure_is_isolated(self):
-        """If get_plugin_manager() raises, wiring is skipped — connect still safe."""
-        app = _RecordingApp()
+        """If get_plugin_manager() raises, wiring is skipped — connect stays safe."""
+        app = MagicMock(name="app")
         adapter = self._adapter(app)
 
-        with patch("hermes_cli.plugins.get_plugin_manager",
-                   side_effect=RuntimeError("plugin layer down")):
+        with patch(
+            "hermes_cli.plugins.get_plugin_manager",
+            side_effect=RuntimeError("plugin layer down"),
+        ):
             adapter._wire_plugin_handlers()  # must not raise
 
-        assert app.added == []
-
-    def test_one_rejected_handler_does_not_block_others(self):
-        """A handler PTB rejects must not stop later handlers from wiring."""
-        app = _RecordingApp(raise_on=("bad",))
+    def test_one_factory_raising_does_not_block_others(self):
+        """A factory that raises must not stop later factories from running."""
+        app = MagicMock(name="app")
         adapter = self._adapter(app)
-        good, bad, other = _FakeHandler("good"), _FakeHandler("bad"), _FakeHandler("other")
+        log: list = []
 
-        with patch("hermes_cli.plugins.get_plugin_manager",
-                   return_value=self._mgr([(bad, 0, "buggy"), (good, 1, "g"), (other, 2, "o")])):
-            adapter._wire_plugin_handlers()
+        def boom(application, adapter):
+            raise RuntimeError("plugin bug")
 
-        assert app.added == [(good, 1), (other, 2)]
+        good = _recording_factory(log, "good")
+        other = _recording_factory(log, "other")
+
+        with patch(
+            "hermes_cli.plugins.get_plugin_manager",
+            return_value=self._mgr([(boom, "buggy"), (good, "g"), (other, "o")]),
+        ):
+            adapter._wire_plugin_handlers()  # must not raise
+
+        assert [key for (key, _app, _adapter) in log] == ["good", "other"]

--- a/tests/gateway/test_telegram_plugin_handlers.py
+++ b/tests/gateway/test_telegram_plugin_handlers.py
@@ -62,14 +62,23 @@ class TestRegisterTelegramHandlerAPI:
         assert fn is factory
         assert plugin_name == "test_plugin"
 
+    def test_registration_handle_releases_factory(self):
+        """The returned PluginRegistration removes the factory on release,
+        so a reloaded plugin's old factory is not re-wired forever."""
+        mgr, ctx = _make_ctx()
+
+        def factory(application, adapter):  # pragma: no cover
+            ...
+
+        handle = ctx.register_telegram_handler(factory)
+        handle.dispose()
+        assert mgr.get_telegram_handler_factories() == []
+
     def test_non_callable_factory_raises(self):
         """A non-callable factory must be rejected, not silently stored."""
         _mgr, ctx = _make_ctx()
         with pytest.raises(ValueError, match="non-callable"):
             ctx.register_telegram_handler("not a factory")  # type: ignore[arg-type]
-
-    def test_none_factory_raises(self):
-        _mgr, ctx = _make_ctx()
         with pytest.raises(ValueError, match="non-callable"):
             ctx.register_telegram_handler(None)  # type: ignore[arg-type]
 
@@ -107,7 +116,7 @@ class TestRegisterTelegramHandlerAPI:
         ctx_b.register_telegram_handler(fb)
 
         factories = mgr.get_telegram_handler_factories()
-        assert [(fn, name) for fn, name in factories] == [(fa, "plug_a"), (fb, "plug_b")]
+        assert factories == [(fa, "plug_a"), (fb, "plug_b")]
 
 
 # ---------------------------------------------------------------------------
@@ -115,25 +124,9 @@ class TestRegisterTelegramHandlerAPI:
 # ---------------------------------------------------------------------------
 # Exercises TelegramAdapter._wire_plugin_handlers() — the connect-time code
 # path that consumes get_telegram_handler_factories() and invokes each factory
-# with (application, adapter). python-telegram-bot is an optional dep, so mock
-# the telegram package the same way tests/gateway/test_telegram_network_reconnect
-# .py does.
-
-def _ensure_telegram_mock() -> None:
-    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
-        return
-    telegram_mod = MagicMock()
-    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
-    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
-    telegram_mod.constants.ChatType.GROUP = "group"
-    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
-    telegram_mod.constants.ChatType.CHANNEL = "channel"
-    telegram_mod.constants.ChatType.PRIVATE = "private"
-    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
-        sys.modules.setdefault(name, telegram_mod)
-
-
-_ensure_telegram_mock()
+# with (application, adapter). The telegram package is mocked by
+# tests/gateway/conftest.py at collection time (python-telegram-bot is an
+# optional dep).
 
 from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
 
@@ -150,14 +143,13 @@ def _recording_factory(log, key):
 class TestTelegramAdapterPluginHandlerWiring:
     """_wire_plugin_handlers() (the connect path) invokes factories with (app, adapter)."""
 
-    def _adapter(self, app) -> TelegramAdapter:
+    def _adapter(self) -> TelegramAdapter:
         # object.__new__ skips the heavy __init__. _wire_plugin_handlers only
-        # needs self._app and self.name; `name` is a read-only property over
-        # self.platform (Platform.TELEGRAM.value.title() -> "Telegram"), so set
-        # a stand-in platform rather than the property itself.
+        # needs self.name; `name` is a read-only property over self.platform
+        # (Platform.TELEGRAM.value.title() -> "Telegram"), so set a stand-in
+        # platform rather than the property itself.
         a = object.__new__(TelegramAdapter)
         a.platform = SimpleNamespace(value="telegram")
-        a._app = app
         return a
 
     def _mgr(self, factories):
@@ -168,7 +160,7 @@ class TestTelegramAdapterPluginHandlerWiring:
     def test_factories_invoked_with_app_and_adapter(self):
         """Each factory is called exactly once with (application=app, adapter=self)."""
         app = MagicMock(name="app")
-        adapter = self._adapter(app)
+        adapter = self._adapter()
         log: list = []
         fa, fb = _recording_factory(log, "a"), _recording_factory(log, "b")
 
@@ -176,38 +168,38 @@ class TestTelegramAdapterPluginHandlerWiring:
             "hermes_cli.plugins.get_plugin_manager",
             return_value=self._mgr([(fa, "plug_a"), (fb, "plug_b")]),
         ):
-            adapter._wire_plugin_handlers()
+            adapter._wire_plugin_handlers(app)
 
         assert log == [("a", app, adapter), ("b", app, adapter)]
 
     def test_no_factories_is_a_noop(self):
         """Empty factory list (the common case) wires nothing onto the app."""
         app = MagicMock(name="app")
-        adapter = self._adapter(app)
+        adapter = self._adapter()
 
         with patch(
             "hermes_cli.plugins.get_plugin_manager",
             return_value=self._mgr([]),
         ):
-            adapter._wire_plugin_handlers()
+            adapter._wire_plugin_handlers(app)
 
         app.add_handler.assert_not_called()
 
     def test_plugin_manager_load_failure_is_isolated(self):
         """If get_plugin_manager() raises, wiring is skipped — connect stays safe."""
         app = MagicMock(name="app")
-        adapter = self._adapter(app)
+        adapter = self._adapter()
 
         with patch(
             "hermes_cli.plugins.get_plugin_manager",
             side_effect=RuntimeError("plugin layer down"),
         ):
-            adapter._wire_plugin_handlers()  # must not raise
+            adapter._wire_plugin_handlers(app)  # must not raise
 
     def test_one_factory_raising_does_not_block_others(self):
         """A factory that raises must not stop later factories from running."""
         app = MagicMock(name="app")
-        adapter = self._adapter(app)
+        adapter = self._adapter()
         log: list = []
 
         def boom(application, adapter):
@@ -220,6 +212,6 @@ class TestTelegramAdapterPluginHandlerWiring:
             "hermes_cli.plugins.get_plugin_manager",
             return_value=self._mgr([(boom, "buggy"), (good, "g"), (other, "o")]),
         ):
-            adapter._wire_plugin_handlers()  # must not raise
+            adapter._wire_plugin_handlers(app)  # must not raise
 
         assert [key for (key, _app, _adapter) in log] == ["good", "other"]

--- a/tests/gateway/test_telegram_plugin_handlers.py
+++ b/tests/gateway/test_telegram_plugin_handlers.py
@@ -42,7 +42,7 @@ def _make_ctx(name: str = "test_plugin") -> tuple[PluginManager, PluginContext]:
 
 
 # ---------------------------------------------------------------------------
-# PluginContext.register_telegram_handler — validation + queuing
+# PluginContext.register_telegram_handler: validation + queuing
 # ---------------------------------------------------------------------------
 
 class TestRegisterTelegramHandlerAPI:
@@ -81,6 +81,18 @@ class TestRegisterTelegramHandlerAPI:
             ctx.register_telegram_handler("not a factory")  # type: ignore[arg-type]
         with pytest.raises(ValueError, match="non-callable"):
             ctx.register_telegram_handler(None)  # type: ignore[arg-type]
+
+    def test_async_factory_rejected_at_registration(self):
+        """async def factories can never be awaited from the synchronous
+        wiring path; they must fail at registration, not silently no-op."""
+        _mgr, ctx = _make_ctx()
+
+        async def factory(application, adapter):  # pragma: no cover
+            ...
+
+        with pytest.raises(ValueError, match="async"):
+            ctx.register_telegram_handler(factory)
+        assert _mgr.get_telegram_handler_factories() == []
 
     def test_get_telegram_handler_factories_returns_copy(self):
         """The accessor returns a copy so callers can't mutate plugin state."""
@@ -122,7 +134,7 @@ class TestRegisterTelegramHandlerAPI:
 # ---------------------------------------------------------------------------
 # TelegramAdapter connect-path wiring
 # ---------------------------------------------------------------------------
-# Exercises TelegramAdapter._wire_plugin_handlers() — the connect-time code
+# Exercises TelegramAdapter._wire_plugin_handlers(): the connect-time code
 # path that consumes get_telegram_handler_factories() and invokes each factory
 # with (application, adapter). The telegram package is mocked by
 # tests/gateway/conftest.py at collection time (python-telegram-bot is an
@@ -186,7 +198,7 @@ class TestTelegramAdapterPluginHandlerWiring:
         app.add_handler.assert_not_called()
 
     def test_plugin_manager_load_failure_is_isolated(self):
-        """If get_plugin_manager() raises, wiring is skipped — connect stays safe."""
+        """If get_plugin_manager() raises, wiring is skipped; connect stays safe."""
         app = MagicMock(name="app")
         adapter = self._adapter()
 
@@ -215,3 +227,115 @@ class TestTelegramAdapterPluginHandlerWiring:
             adapter._wire_plugin_handlers(app)  # must not raise
 
         assert [key for (key, _app, _adapter) in log] == ["good", "other"]
+
+    @staticmethod
+    def _inspectable_app():
+        """A minimal app whose handlers map can be inspected (real PTB shape:
+        dict[group] -> list of handler objects)."""
+
+        class _App:
+            def __init__(self):
+                self.handlers = {}
+
+            def add_handler(self, handler, group=0):
+                self.handlers.setdefault(group, []).append(handler)
+
+        return _App()
+
+    def test_factories_wire_before_core_handlers_inside_register_handlers(self):
+        """_register_handlers must invoke plugin factories BEFORE the core
+        add_handler calls: PTB group-0 first-match means a factory wired after
+        the core set would be shadowed by it."""
+        order: list = []
+
+        app = self._inspectable_app()
+        core_add = app.add_handler
+
+        def recording_add(handler, group=0):
+            order.append("core")
+            core_add(handler, group)
+
+        app.add_handler = recording_add
+
+        def factory(application, adapter):
+            order.append("factory")
+            application.add_handler(object(), group=1)  # scoped plugin handler
+
+        adapter = self._adapter()
+        with patch(
+            "hermes_cli.plugins.get_plugin_manager",
+            return_value=self._mgr([(factory, "plug_a")]),
+        ):
+            adapter._register_handlers(app)
+
+        assert order[0] == "factory"
+        assert order.count("core") >= 5
+
+    def test_unscoped_group0_addition_is_flagged(self, caplog):
+        """A factory adding a group-0 handler gets a warning: it can shadow
+        the core handlers under PTB's first-match-per-group rule."""
+        import logging
+
+        def careless(application, adapter):
+            application.add_handler(object())  # group 0, unscoped
+
+        app = self._inspectable_app()
+        adapter = self._adapter()
+        with patch(
+            "hermes_cli.plugins.get_plugin_manager",
+            return_value=self._mgr([(careless, "plug_a")]),
+        ):
+            with caplog.at_level(
+                logging.WARNING, logger="plugins.platforms.telegram.adapter"
+            ):
+                adapter._wire_plugin_handlers(app)
+
+        assert "group-0" in caplog.text
+        assert "plug_a" in caplog.text
+
+    def test_scoped_group_addition_is_not_flagged(self, caplog):
+        """A factory registering in a non-zero group stays silent."""
+        import logging
+
+        def careful(application, adapter):
+            application.add_handler(object(), group=1)
+
+        app = self._inspectable_app()
+        adapter = self._adapter()
+        with patch(
+            "hermes_cli.plugins.get_plugin_manager",
+            return_value=self._mgr([(careful, "plug_a")]),
+        ):
+            with caplog.at_level(
+                logging.WARNING, logger="plugins.platforms.telegram.adapter"
+            ):
+                adapter._wire_plugin_handlers(app)
+
+        assert "group-0" not in caplog.text
+
+    def test_coroutine_returning_factory_is_discarded_with_error(self, caplog):
+        """Belt for sync-callable factories that return a coroutine anyway:
+        the coroutine is closed and the failure is loud, never a silent
+        never-awaited warning at GC time."""
+        import logging
+
+        async def _unawaited():
+            pass
+
+        def sneaky(application, adapter):
+            return _unawaited()
+
+        app = self._inspectable_app()
+        adapter = self._adapter()
+        with patch(
+            "hermes_cli.plugins.get_plugin_manager",
+            return_value=self._mgr([(sneaky, "plug_a")]),
+        ):
+            with caplog.at_level(
+                logging.ERROR, logger="plugins.platforms.telegram.adapter"
+            ):
+                adapter._wire_plugin_handlers(app)
+
+        assert "coroutine" in caplog.text
+        # No success line for the discarded factory.
+        assert "Wired Telegram handlers" not in caplog.text

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -1256,6 +1256,40 @@ def register(ctx):
 
 This is the public way for plugins to participate in Slack interactivity. Older plugins may patch `SlackAdapter.connect`; prefer this API instead.
 
+### React to Telegram updates
+
+Plugins that need Telegram update types the built-in handlers do not cover (reactions, edited messages, chat-member changes, custom commands) register a wiring **factory** with the Telegram adapter. The adapter invokes it with the live `python-telegram-bot` `Application` every time it builds one, before the core handlers are added:
+
+```python
+def register(ctx):
+    def _wire(application, adapter):
+        from telegram.ext import CallbackQueryHandler
+
+        async def _on_button(update, context):
+            # update.callback_query.data starts with "myplugin:"
+            ...
+
+        application.add_handler(
+            CallbackQueryHandler(_on_button, pattern=r"^myplugin:")
+        )
+
+    ctx.register_telegram_handler(_wire)
+```
+
+**Signature:** `ctx.register_telegram_handler(factory) -> PluginRegistration`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `factory` | sync callable | Receives `(application, adapter)`; wires its own handlers onto the application. Returns a registration handle whose `dispose()` dequeues the factory |
+
+**Runtime behavior:**
+
+- The factory must be a plain synchronous function. It runs from synchronous wiring code, so `async def` factories are rejected at registration time; the callbacks you register may of course be async (the normal PTB pattern).
+- Factories run before the core handlers, so PTB's first-match-per-group rule gives your scoped handlers precedence for their own updates. Always scope callback handlers with `pattern=` (or register in a non-zero group): an unscoped handler in group 0 would swallow the core button flows (approvals, model picker), and the adapter logs a warning when it detects one.
+- The adapter rebuilds its `Application` on transient init failures and re-invokes factories on each rebuild, so keep a factory idempotent: limit its side effects to wiring the application it is given.
+- `adapter` is read-only from the factory's perspective; reach the bot handle via `application.bot`, not `adapter.bot`.
+- Each factory is isolated: if yours raises, the error is logged and the remaining factories (and the connect) proceed.
+
 :::tip
 This guide covers **general plugins** (tools, hooks, slash commands, CLI commands). The sections below sketch the authoring pattern for each specialized plugin type; each links to its full guide for field reference and examples.
 :::


### PR DESCRIPTION
## What

Adds `PluginContext.register_telegram_handler(handler, group=0)` and the matching `PluginManager.get_telegram_handlers()`, wired into the PTB `Application` at `TelegramAdapter.connect()` time. This is the Telegram equivalent of the existing `register_slack_action_handler` / `get_slack_action_handlers()` pair — it fills an asymmetric gap (Slack exposed one, Telegram did not).

## Why

Plugins currently have **no official way to react to Telegram updates the built-in handlers don't cover** — message reactions (`message_reaction`), edited messages, chat-member changes, custom commands. The only options today are monkey-patching the adapter or a `sys.meta_path` import hook, both of which couple to internals that change between releases.

`register_slack_action_handler` already solves this for Slack (`SlackAdapter` wires registered handlers into its `slack_bolt.AsyncApp` at connect). This PR gives Telegram the symmetric treatment so plugins register a `telegram.ext.BaseHandler` once and the adapter adds it to the app at connect — no monkey-patching, no coupling to the adapter's internal import/lifecycle.

## How

- `PluginContext.register_telegram_handler(handler, group=0)` — duck-types a `BaseHandler` via `check_update`/`handle` (so `python-telegram-bot` stays an optional dependency — no import in `plugins.py`), then queues `(handler, group, plugin_name)`.
- `PluginManager._telegram_handlers` + `get_telegram_handlers()` (returns a copy), cleared on forced re-discovery — parallel to `_slack_action_handlers`.
- `TelegramAdapter.connect()` adds each registered handler via `self._app.add_handler(handler, group=g)`. A single bad handler (or a plugin-layer failure) is logged and skipped; gateway connect is never blocked — same defensive shape as the Slack wiring.

## Usage

```python
from telegram import Update
from telegram.ext import TypeHandler

async def _on_reaction(update, context):
    if update.message_reaction:
        ...  # e.g. render a table image fallback for Telegram Web

def register(ctx):
    ctx.register_telegram_handler(TypeHandler(Update, _on_reaction), group=1)
```

Use `group=1` (non-zero) to run alongside the built-in group-0 handlers without displacing them — documented in the docstring.

## Tests

New `tests/gateway/test_telegram_plugin_handlers.py` (7 tests, no PTB dependency — duck-typed handler stand-in) covering validation, queuing, group, accessor-copy semantics, multi-plugin ordering, and the `(handler, group, plugin_name)` tuple contract the adapter loop unpacks.

## Notes

- The per-platform mirror (rather than a generic `register_platform_handler`) is deliberate and matches the existing house style: PTB `add_handler(handler, group)` and slack_bolt `App.action(id)(fn)` have incompatible signatures/semantics, so a generic API would need `**kwargs` + per-platform parsing with no caller saved. Only Slack and Telegram consume plugin handlers today.
- Verified: `connect()` rebuilds `self._app` on each call, so handlers are registered exactly once per connect (no duplication on reconnect) — same property the built-in handler block already relies on.

## Checklist

- [x] Mirrors existing `register_slack_action_handler` (PluginContext + PluginManager + adapter wiring)
- [x] Duck-typed validation keeps `python-telegram-bot` optional
- [x] connect-time wiring is defensive (bad handler / plugin-layer failure skipped, never blocks connect)
- [x] Tests added; `/code-review high` and `/simplify` run before opening