### PR TITLE
feat(plugins): add Google Vertex AI image and video generation providers

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -979,6 +979,43 @@ platform_toolsets:
 #       log_level: "info"       # audit verbosity
 
 # =============================================================================
+# Image / Video Generation
+# =============================================================================
+# The image_generate and video_generate tools dispatch to a pluggable backend
+# (plugins/image_gen/, plugins/video_gen/). Pick one per tool with the
+# provider key; model selects the default model for that backend.
+#
+# Google Vertex AI backend: reuses the same service-account credentials as
+# the vertex chat provider — set VERTEX_CREDENTIALS_PATH (or
+# GOOGLE_APPLICATION_CREDENTIALS) in .env and vertex.project_id below.
+# Model ids pass through unvalidated, so newly released Google models work
+# by changing the model key alone; the "google/" publisher prefix used by
+# the vertex chat provider is accepted and normalized.
+#
+# image_gen:
+#   provider: "vertex"
+#   model: "gemini-3-pro-image-preview"  # or e.g. google/gemini-3.1-flash-image
+#   vertex:
+#     # model: ""                # backend-level default (used when image_gen.model
+#     #                          # holds another backend's id); VERTEX_IMAGE_MODEL env var also works
+#     # region: ""               # "" = global for gemini-*, us-central1 for imagen-*
+#     # api: ""                  # force routing for unknown model prefixes:
+#     #                          # "generate_content" (gemini-style) | "predict" (imagen-style)
+#     # timeout_seconds: 300
+#     # image_size: ""           # gemini-* only, e.g. "2K" / "4K" (model-dependent)
+#     # person_generation: ""    # e.g. "allow_adult" (imagen-* only)
+#
+# video_gen:
+#   provider: "vertex"
+#   model: "veo-3.1-generate-001"  # veo-* -> long-running predict; gemini-* (Omni) -> Interactions API
+#   vertex:
+#     # region: "us-central1"    # veo-* only; gemini-* video is always served globally
+#     # timeout_seconds: 600     # veo poll budget / omni HTTP timeout
+#     # poll_interval_seconds: 10
+#     # storage_uri: ""          # gs:// prefix to write veo outputs instead of inline bytes
+#     # person_generation: ""    # e.g. "allow_adult"
+
+# =============================================================================
 # Text-to-Speech
 # =============================================================================
 # TTS defaults to Edge TTS unless changed in ~/.hermes/config.yaml.

--- a/plugins/image_gen/vertex/__init__.py
+++ b/plugins/image_gen/vertex/__init__.py
@@ -1,0 +1,653 @@
+"""Google Vertex AI image generation backend.
+
+Serves Google's image models through **Vertex AI** with OAuth2 service-account
+/ Application Default Credentials — no Gemini API key required. Credential
+resolution is shared with the Vertex chat provider
+(``agent/vertex_adapter.py``): ``VERTEX_CREDENTIALS_PATH`` /
+``GOOGLE_APPLICATION_CREDENTIALS`` in ``.env``, routing (project/region)
+under ``vertex:`` in ``config.yaml``.
+
+Routing by model id prefix — Vertex exposes two distinct APIs:
+
+- ``gemini-*``  → ``:generateContent``  (text-to-image AND image editing;
+  the Nano Banana family)
+- ``imagen-*``  → ``:predict``          (text-to-image only)
+
+Unknown model ids are passed through unvalidated so newly released Google
+models work by just changing config — no plugin update needed. When the
+prefix doesn't identify the API, set ``image_gen.vertex.api`` to
+``generate_content`` or ``predict`` explicitly.
+
+Model selection precedence (first hit wins):
+1. ``model`` kwarg from the tool layer (``image_gen.model`` in config.yaml,
+   maintained by ``hermes tools``) — ignored when it doesn't look like a
+   Vertex model id (a stale id from a previously-selected backend).
+2. ``VERTEX_IMAGE_MODEL`` env var
+3. ``image_gen.vertex.model`` in config.yaml
+4. :data:`DEFAULT_MODEL`
+
+Endpoint location: ``image_gen.vertex.region`` wins when set. Otherwise
+Gemini image models follow the chat adapter's region resolution (default
+``global`` — the Gemini 3.x previews are global-endpoint-only), while
+Imagen ``:predict`` models default to ``us-central1`` (media models are
+served regionally).
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+from agent.image_gen_provider import (
+    DEFAULT_ASPECT_RATIO,
+    ImageGenProvider,
+    error_response,
+    normalize_reference_images,
+    resolve_aspect_ratio,
+    save_b64_image,
+    success_response,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Model catalog
+# ---------------------------------------------------------------------------
+
+# Catalog reflects the models Google actually serves as of 2026-07: the
+# Imagen 2.x-4.x endpoints were removed on 2026-06-30 (migration target is
+# the Gemini image family). The ``imagen-*`` → :predict routing below is
+# kept for projects with residual/allowlisted Imagen access; anything newer
+# passes through via config — the catalog is advisory, not a validation gate.
+_MODELS: Dict[str, Dict[str, Any]] = {
+    "gemini-3-pro-image-preview": {
+        "display": "Nano Banana Pro (Gemini 3 Pro Image)",
+        "speed": "~30-60s",
+        "strengths": "Highest-fidelity Google image model; strong text rendering, up to 4K, image editing with multiple references.",
+        "modalities": ["text", "image"],
+    },
+    "gemini-3.1-flash-image": {
+        "display": "Gemini 3.1 Flash Image (preview)",
+        "speed": "~5-15s",
+        "strengths": "Fast text-to-image and editing; improved pricing/latency over 2.5 (public preview since 2026-02).",
+        "modalities": ["text", "image"],
+    },
+    "gemini-2.5-flash-image": {
+        "display": "Nano Banana (Gemini 2.5 Flash Image)",
+        "speed": "~5-15s",
+        "strengths": "GA fast tier; text-to-image and image editing.",
+        "modalities": ["text", "image"],
+    },
+}
+
+DEFAULT_MODEL = "gemini-3-pro-image-preview"
+
+# Unified aspect names → the ratio strings both Vertex APIs accept.
+_ASPECT_RATIOS = {
+    "landscape": "16:9",
+    "square": "1:1",
+    "portrait": "9:16",
+}
+
+_MIME_EXTENSIONS = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/webp": "webp",
+    "image/gif": "gif",
+}
+
+_MAX_INPUT_IMAGE_BYTES = 20 * 1024 * 1024
+
+DEFAULT_TIMEOUT_SECONDS = 300
+
+
+# ---------------------------------------------------------------------------
+# Config / auth helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_vertex_section() -> Dict[str, Any]:
+    """Read ``image_gen.vertex`` from config.yaml."""
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        section = cfg.get("image_gen") if isinstance(cfg, dict) else None
+        sub = section.get("vertex") if isinstance(section, dict) else None
+        return sub if isinstance(sub, dict) else {}
+    except Exception as exc:
+        logger.debug("Could not load image_gen.vertex config: %s", exc)
+        return {}
+
+
+def _infer_api(model_id: str) -> Optional[str]:
+    """Map a model id to the Vertex API that serves it, or None when unknown.
+
+    ``image_gen.vertex.api`` overrides the prefix inference so ids outside
+    the ``gemini-``/``imagen-`` families stay usable.
+    """
+    override = str(_load_vertex_section().get("api") or "").strip().lower()
+    if override in ("generate_content", "generatecontent"):
+        return "generate_content"
+    if override == "predict":
+        return "predict"
+    lowered = model_id.lower()
+    if lowered.startswith("gemini"):
+        return "generate_content"
+    if lowered.startswith("imagen"):
+        return "predict"
+    return None
+
+
+def _normalize_model_id(model_id: str) -> str:
+    """Strip a ``google/`` publisher prefix — the endpoint path already
+    carries ``/publishers/google/``, so chat-style ids like
+    ``google/gemini-3.1-flash-image`` would otherwise 404."""
+    candidate = model_id.strip()
+    if candidate.lower().startswith("google/"):
+        candidate = candidate[len("google/"):]
+    return candidate
+
+
+def _looks_like_vertex_model(model_id: str) -> bool:
+    lowered = model_id.lower()
+    return lowered.startswith(("gemini", "imagen"))
+
+
+def _resolve_model(model_kwarg: Optional[str]) -> str:
+    """Pick the model per the module-docstring precedence."""
+    candidate = _normalize_model_id(model_kwarg or "")
+    if candidate and _looks_like_vertex_model(candidate):
+        return candidate
+
+    env_override = _normalize_model_id(os.environ.get("VERTEX_IMAGE_MODEL", ""))
+    if env_override:
+        return env_override
+
+    cfg_model = _load_vertex_section().get("model")
+    if isinstance(cfg_model, str) and cfg_model.strip():
+        return _normalize_model_id(cfg_model)
+
+    return DEFAULT_MODEL
+
+
+def _resolve_location(api: str) -> str:
+    """Endpoint location: explicit section key > adapter region (gemini) > regional default."""
+    raw = _load_vertex_section().get("region")
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    if api == "generate_content":
+        try:
+            from agent.vertex_adapter import _resolve_region
+
+            return _resolve_region()
+        except Exception as exc:
+            logger.debug("Vertex region resolution failed: %s", exc)
+            return "global"
+    # Imagen :predict is served regionally, not on the global endpoint.
+    return "us-central1"
+
+
+def _endpoint(project_id: str, location: str, model_id: str, method: str) -> str:
+    host = (
+        "aiplatform.googleapis.com"
+        if location == "global"
+        else f"{location}-aiplatform.googleapis.com"
+    )
+    return (
+        f"https://{host}/v1/projects/{project_id}/locations/{location}"
+        f"/publishers/google/models/{model_id}:{method}"
+    )
+
+
+def _resolve_credentials() -> Tuple[Optional[str], Optional[str]]:
+    """Return (access_token, project_id) via the shared Vertex adapter.
+
+    Imported lazily so loading this plugin never triggers the adapter's
+    google-auth lazy-install path.
+    """
+    try:
+        from agent.vertex_adapter import get_vertex_credentials
+
+        return get_vertex_credentials()
+    except Exception as exc:
+        logger.debug("Vertex credential resolution failed: %s", exc)
+        return None, None
+
+
+def _auth_required_response(prompt: str, aspect_ratio: str) -> Dict[str, Any]:
+    return error_response(
+        error=(
+            "No Google Vertex AI credentials found. Set VERTEX_CREDENTIALS_PATH "
+            "(or GOOGLE_APPLICATION_CREDENTIALS) to a service-account JSON in "
+            ".env, or configure Application Default Credentials "
+            "(`gcloud auth application-default login`). Project/region live "
+            "under `vertex:` in config.yaml."
+        ),
+        error_type="auth_required",
+        provider="vertex",
+        prompt=prompt,
+        aspect_ratio=aspect_ratio,
+    )
+
+
+def _timeout_seconds() -> float:
+    raw = _load_vertex_section().get("timeout_seconds")
+    try:
+        value = float(raw)
+        if value > 0:
+            return value
+    except (TypeError, ValueError):
+        pass
+    return DEFAULT_TIMEOUT_SECONDS
+
+
+# ---------------------------------------------------------------------------
+# Input image handling
+# ---------------------------------------------------------------------------
+
+
+def _mime_from_path(path: Path) -> str:
+    ext = path.suffix.lstrip(".").lower()
+    if ext in ("jpg", "jpeg"):
+        return "image/jpeg"
+    if ext in ("png", "webp", "gif"):
+        return f"image/{ext}"
+    return "image/png"
+
+
+def _gemini_image_part(source: str) -> Dict[str, Any]:
+    """Build one ``parts`` entry for a source image.
+
+    Accepts a ``gs://`` URI (passed as fileData), a data URI, an http(s)
+    URL (downloaded and inlined — Vertex fileData only accepts Cloud
+    Storage URIs), or a local file path (guarded read, inlined).
+    Raises ``ValueError`` with a user-facing message on failure.
+    """
+    ref = source.strip()
+    lower = ref.lower()
+
+    if lower.startswith("gs://"):
+        return {"fileData": {"mimeType": _mime_from_path(Path(ref)), "fileUri": ref}}
+
+    if lower.startswith("data:"):
+        header, _, payload = ref.partition(",")
+        if not payload or ";base64" not in header:
+            raise ValueError("data: URI image inputs must be base64-encoded")
+        mime = header[5:].split(";", 1)[0].strip() or "image/png"
+        return {"inlineData": {"mimeType": mime, "data": payload}}
+
+    if lower.startswith(("http://", "https://")):
+        response = requests.get(ref, timeout=60)
+        response.raise_for_status()
+        if len(response.content) > _MAX_INPUT_IMAGE_BYTES:
+            raise ValueError(f"Input image at {ref} exceeds 20MB")
+        mime = (response.headers.get("Content-Type") or "").split(";", 1)[0].strip().lower()
+        if not mime.startswith("image/"):
+            mime = _mime_from_path(Path(ref.split("?", 1)[0]))
+        b64 = base64.b64encode(response.content).decode("ascii")
+        return {"inlineData": {"mimeType": mime, "data": b64}}
+
+    # Local file path — enforce the shared credential-read guard before
+    # touching bytes (same boundary as the other image providers).
+    from agent.file_safety import raise_if_read_blocked
+
+    raise_if_read_blocked(ref)
+    path = Path(ref).expanduser()
+    if not path.is_file():
+        raise ValueError(
+            f"image input '{ref}' is neither a URL, data URI, gs:// URI, nor an existing file"
+        )
+    b64 = base64.b64encode(path.read_bytes()).decode("ascii")
+    return {"inlineData": {"mimeType": _mime_from_path(path), "data": b64}}
+
+
+# ---------------------------------------------------------------------------
+# API calls
+# ---------------------------------------------------------------------------
+
+
+def _post_json(url: str, token: str, payload: Dict[str, Any], timeout: float) -> Dict[str, Any]:
+    response = requests.post(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        json=payload,
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def _http_error_detail(exc: requests.HTTPError) -> Tuple[int, str]:
+    response = exc.response
+    status = response.status_code if response is not None else 0
+    try:
+        detail = response.json().get("error", {}).get("message", "")
+    except Exception:
+        detail = ""
+    if not detail and response is not None:
+        detail = response.text[:300]
+    return status, detail or str(exc)
+
+
+def _extract_gemini_image(result: Dict[str, Any]) -> Tuple[Optional[str], Optional[str], str]:
+    """Return (b64_data, mime, text_detail) from a generateContent response."""
+    text_detail = ""
+    for candidate in result.get("candidates") or []:
+        content = candidate.get("content") if isinstance(candidate, dict) else None
+        parts = content.get("parts") if isinstance(content, dict) else None
+        for part in parts or []:
+            if not isinstance(part, dict):
+                continue
+            inline = part.get("inlineData") or part.get("inline_data")
+            if isinstance(inline, dict) and inline.get("data"):
+                mime = inline.get("mimeType") or inline.get("mime_type") or "image/png"
+                return inline["data"], mime, text_detail
+            if isinstance(part.get("text"), str):
+                text_detail += part["text"]
+    return None, None, text_detail
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+
+
+class VertexImageGenProvider(ImageGenProvider):
+    """Google Vertex AI backend (Gemini image + Imagen models)."""
+
+    @property
+    def name(self) -> str:
+        return "vertex"
+
+    @property
+    def display_name(self) -> str:
+        return "Google Vertex AI"
+
+    def is_available(self) -> bool:
+        try:
+            from agent.vertex_adapter import has_vertex_credentials
+
+            return has_vertex_credentials()
+        except Exception as exc:
+            logger.debug("Vertex availability check failed: %s", exc)
+            return False
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [{"id": model_id, **meta} for model_id, meta in _MODELS.items()]
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_MODEL
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Google Vertex AI",
+            "badge": "paid",
+            "tag": (
+                "Nano Banana / Imagen via Google Cloud Vertex AI — "
+                "service-account or ADC auth (no Gemini API key). "
+                "Project/region under `vertex:` in config.yaml; model via "
+                "`image_gen.vertex.model`."
+            ),
+            "env_vars": [
+                {
+                    "key": "VERTEX_CREDENTIALS_PATH",
+                    "prompt": "Path to a GCP service-account JSON with Vertex AI access (blank to use ADC)",
+                    "url": "https://console.cloud.google.com/iam-admin/serviceaccounts",
+                },
+            ],
+        }
+
+    def capabilities(self) -> Dict[str, Any]:
+        return {
+            "modalities": ["text", "image"],
+            "max_reference_images": 6,
+        }
+
+    def generate(
+        self,
+        prompt: str,
+        aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        *,
+        image_url: Optional[str] = None,
+        reference_image_urls: Optional[List[str]] = None,
+        model: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        aspect = resolve_aspect_ratio(aspect_ratio)
+
+        token, project_id = _resolve_credentials()
+        if not token or not project_id:
+            return _auth_required_response(prompt, aspect)
+
+        source_images: List[str] = []
+        if isinstance(image_url, str) and image_url.strip():
+            source_images.append(image_url.strip())
+        refs = normalize_reference_images(reference_image_urls)
+        if refs:
+            source_images.extend(refs)
+        is_edit = bool(source_images)
+        modality = "image" if is_edit else "text"
+
+        model_id = _resolve_model(model)
+        # Imagen's :predict surface is text-to-image only; edits route to the
+        # default Gemini image model instead of failing (mirrors the xAI
+        # provider auto-switching to its edit-capable model).
+        if is_edit and _infer_api(model_id) == "predict":
+            logger.debug(
+                "Vertex image edit requested with predict-only model '%s'; using %s",
+                model_id, DEFAULT_MODEL,
+            )
+            model_id = DEFAULT_MODEL
+
+        api = _infer_api(model_id)
+        if api is None:
+            return error_response(
+                error=(
+                    f"Cannot infer which Vertex API serves model '{model_id}'. "
+                    "Use a gemini-*/imagen-* id, or set image_gen.vertex.api to "
+                    "'generate_content' or 'predict' in config.yaml."
+                ),
+                error_type="unknown_model",
+                provider="vertex",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        location = _resolve_location(api)
+        method = "generateContent" if api == "generate_content" else "predict"
+        url = _endpoint(project_id, location, model_id, method)
+
+        if api == "generate_content":
+            try:
+                image_parts = [_gemini_image_part(source) for source in source_images]
+            except ValueError as exc:
+                return error_response(
+                    error=str(exc),
+                    error_type="invalid_image_url",
+                    provider="vertex",
+                    model=model_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
+            except Exception as exc:
+                return error_response(
+                    error=f"Could not load source image: {exc}",
+                    error_type="io_error",
+                    provider="vertex",
+                    model=model_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
+            payload = _build_generate_content_payload(
+                prompt, aspect, image_parts, is_edit=is_edit
+            )
+        else:
+            payload = _build_predict_payload(prompt, aspect)
+
+        logger.info(
+            "Vertex image: %s via %s (location=%s, aspect=%s, modality=%s)",
+            model_id, method, location, aspect, modality,
+        )
+        try:
+            result = _post_json(url, token, payload, _timeout_seconds())
+        except requests.HTTPError as exc:
+            status, detail = _http_error_detail(exc)
+            logger.error("Vertex image gen failed (%d): %s", status, detail)
+            return error_response(
+                error=f"Vertex image generation failed ({status}): {detail}",
+                error_type="api_error",
+                provider="vertex",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        except requests.Timeout:
+            return error_response(
+                error=f"Vertex image generation timed out ({int(_timeout_seconds())}s)",
+                error_type="timeout",
+                provider="vertex",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        except requests.RequestException as exc:
+            return error_response(
+                error=f"Vertex connection error: {exc}",
+                error_type="connection_error",
+                provider="vertex",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        if api == "generate_content":
+            b64, mime, text_detail = _extract_gemini_image(result)
+            if not b64:
+                feedback = result.get("promptFeedback") or {}
+                block_reason = feedback.get("blockReason") if isinstance(feedback, dict) else None
+                if block_reason:
+                    return error_response(
+                        error=f"Vertex blocked the request ({block_reason}). {text_detail}".strip(),
+                        error_type="safety_blocked",
+                        provider="vertex",
+                        model=model_id,
+                        prompt=prompt,
+                        aspect_ratio=aspect,
+                    )
+                return error_response(
+                    error=(
+                        "Vertex returned no image data"
+                        + (f" (model said: {text_detail[:300]})" if text_detail else "")
+                    ),
+                    error_type="empty_response",
+                    provider="vertex",
+                    model=model_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
+        else:
+            predictions = result.get("predictions") or []
+            first = predictions[0] if predictions and isinstance(predictions[0], dict) else {}
+            b64 = first.get("bytesBase64Encoded")
+            mime = first.get("mimeType") or "image/png"
+            if not b64:
+                filtered = first.get("raiFilteredReason") or "no predictions returned"
+                return error_response(
+                    error=f"Vertex Imagen returned no image data ({filtered})",
+                    error_type="empty_response",
+                    provider="vertex",
+                    model=model_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
+
+        try:
+            extension = _MIME_EXTENSIONS.get((mime or "").lower(), "png")
+            saved_path = save_b64_image(b64, prefix="vertex", extension=extension)
+        except Exception as exc:
+            return error_response(
+                error=f"Could not save image to cache: {exc}",
+                error_type="io_error",
+                provider="vertex",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        logger.info("Vertex image: %s completed -> %s", model_id, saved_path)
+
+        extra: Dict[str, Any] = {"location": location}
+        usage = result.get("usageMetadata") or result.get("usage")
+        if usage:
+            extra["usage"] = usage
+
+        return success_response(
+            image=str(saved_path),
+            model=model_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+            provider="vertex",
+            modality=modality,
+            extra=extra,
+        )
+
+
+def _build_generate_content_payload(
+    prompt: str,
+    aspect: str,
+    image_parts: List[Dict[str, Any]],
+    *,
+    is_edit: bool,
+) -> Dict[str, Any]:
+    parts: List[Dict[str, Any]] = [{"text": prompt}]
+    parts.extend(image_parts)
+    generation_config: Dict[str, Any] = {"responseModalities": ["TEXT", "IMAGE"]}
+    # On edits the output geometry follows the input image; only steer the
+    # aspect ratio for pure text-to-image.
+    image_config: Dict[str, Any] = {}
+    if not is_edit:
+        image_config["aspectRatio"] = _ASPECT_RATIOS.get(aspect, "16:9")
+    image_size = _load_vertex_section().get("image_size")
+    if isinstance(image_size, str) and image_size.strip():
+        image_config["imageSize"] = image_size.strip()
+    if image_config:
+        generation_config["imageConfig"] = image_config
+    return {
+        "contents": [{"role": "user", "parts": parts}],
+        "generationConfig": generation_config,
+    }
+
+
+def _build_predict_payload(prompt: str, aspect: str) -> Dict[str, Any]:
+    parameters: Dict[str, Any] = {
+        "sampleCount": 1,
+        "aspectRatio": _ASPECT_RATIOS.get(aspect, "16:9"),
+    }
+    person_generation = _load_vertex_section().get("person_generation")
+    if isinstance(person_generation, str) and person_generation.strip():
+        parameters["personGeneration"] = person_generation.strip()
+    return {
+        "instances": [{"prompt": prompt}],
+        "parameters": parameters,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Plugin registration
+# ---------------------------------------------------------------------------
+
+
+def register(ctx: Any) -> None:
+    """Register this provider with the image gen registry."""
+    ctx.register_image_gen_provider(VertexImageGenProvider())

--- a/plugins/image_gen/vertex/plugin.yaml
+++ b/plugins/image_gen/vertex/plugin.yaml
@@ -1,0 +1,7 @@
+name: vertex
+version: 1.0.0
+description: "Google Vertex AI image generation (Gemini image / Imagen). Service-account or ADC auth."
+author: conernar
+kind: backend
+requires_env:
+  - VERTEX_CREDENTIALS_PATH

--- a/plugins/video_gen/vertex/__init__.py
+++ b/plugins/video_gen/vertex/__init__.py
@@ -1,0 +1,1040 @@
+"""Google Vertex AI video generation backend (Veo + Gemini Omni).
+
+Serves Google's video models through **Vertex AI** with OAuth2 service-account
+/ Application Default Credentials — no Gemini API key required. Credential
+resolution is shared with the Vertex chat provider
+(``agent/vertex_adapter.py``): ``VERTEX_CREDENTIALS_PATH`` /
+``GOOGLE_APPLICATION_CREDENTIALS`` in ``.env``, routing (project/region)
+under ``vertex:`` in ``config.yaml``.
+
+Routing by model id prefix — Vertex exposes two video APIs:
+
+- ``veo-*``    → ``:predictLongRunning`` + ``:fetchPredictOperation``
+  polling (regional endpoint, default us-central1). By default the finished
+  video comes back inline as base64 and is saved under
+  ``$HERMES_HOME/cache/videos/``; set ``video_gen.vertex.storage_uri`` to a
+  ``gs://`` prefix to have Vertex write the MP4 to Cloud Storage instead
+  (the plugin then downloads it with the same credentials so downstream
+  consumers still get a local file).
+- ``gemini-*`` → the Interactions API (``POST /v1beta1/projects/{p}/
+  locations/global/interactions``), a synchronous call that returns the
+  video inline in the response ``steps`` — this serves the Gemini Omni
+  family (``gemini-omni-flash-preview``, text/image/reference-to-video).
+
+  Omni exposes no structured duration/resolution/audio/seed parameters
+  (the Vertex endpoint 400s on ``response_format.delivery``, so Gemini-API
+  schema parity must not be assumed — probe before sending new fields).
+  Output resolution is fixed (720p in the current preview). Duration-like
+  constraints CAN often be steered through the prompt text: Omni interprets
+  instructions semantically, so "an 8 second clip of ..." usually yields
+  ~8s (verified on the live endpoint) — best-effort, unlike Veo's exact
+  ``durationSeconds`` contract.
+
+Model ids are passed through unvalidated — new Google releases work by just
+setting ``video_gen.model`` (via ``hermes tools``) or calling
+``video_generate`` with ``model=``. A ``google/`` publisher prefix (the
+naming convention of the Vertex chat endpoint) is stripped automatically.
+A configured model id that matches neither family (stale config from a
+previously-selected backend) falls back to :data:`DEFAULT_MODEL` unless the
+tool call requested it explicitly.
+
+Config keys (all optional, under ``video_gen.vertex``):
+    region                  endpoint location (default us-central1 — Veo is regional)
+    storage_uri             gs:// output prefix (default: inline base64 response)
+    person_generation       allow_adult | allow_all | dont_allow
+    timeout_seconds         max wait for the operation (default 600)
+    poll_interval_seconds   seconds between polls (default 10)
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import quote
+
+import requests
+
+from agent.video_gen_provider import (
+    DEFAULT_ASPECT_RATIO,
+    DEFAULT_RESOLUTION,
+    VideoGenProvider,
+    error_response,
+    save_b64_video,
+    save_bytes_video,
+    success_response,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Model catalog
+# ---------------------------------------------------------------------------
+
+# Catalog is GA-only: Google removed the Veo preview endpoints on 2026-04-02
+# and the Veo 2.x / 3.0 GA endpoints on 2026-06-30. Anything newer passes
+# through via config — the catalog is advisory, not a validation gate.
+_MODELS: Dict[str, Dict[str, Any]] = {
+    "veo-3.1-generate-001": {
+        "display": "Veo 3.1",
+        "speed": "~1-4min",
+        "strengths": "Latest GA Veo; native audio, 1080p, image-to-video, up to 3 reference images.",
+        "modalities": ["text", "image"],
+    },
+    "veo-3.1-fast-generate-001": {
+        "display": "Veo 3.1 Fast",
+        "speed": "~1-2min",
+        "strengths": "Cheaper/faster Veo 3.1 tier; native audio.",
+        "modalities": ["text", "image"],
+    },
+    "veo-3.1-lite-generate-001": {
+        "display": "Veo 3.1 Lite (preview)",
+        "speed": "~1-2min",
+        "strengths": "Most cost-efficient Veo tier (public preview since 2026-04).",
+        "modalities": ["text", "image"],
+    },
+    "gemini-omni-flash-preview": {
+        "display": "Gemini Omni Flash (preview)",
+        "speed": "~1-3min",
+        "strengths": "Any-to-any Gemini video model (public preview since 2026-06); text/image/reference-to-video, conversational editing. 720p, up to 10s.",
+        "modalities": ["text", "image"],
+    },
+}
+
+DEFAULT_MODEL = "veo-3.1-generate-001"
+
+VALID_ASPECT_RATIOS = {"16:9", "9:16"}
+VALID_RESOLUTIONS = {"720p", "1080p"}
+MAX_REFERENCE_IMAGES = 3
+
+# Veo is documented against regional endpoints (every REST sample uses
+# us-central1); the global endpoint also serves it. Override via
+# ``video_gen.vertex.region`` (e.g. "global").
+DEFAULT_LOCATION = "us-central1"
+DEFAULT_TIMEOUT_SECONDS = 600
+DEFAULT_POLL_INTERVAL_SECONDS = 10
+
+_MAX_INPUT_IMAGE_BYTES = 20 * 1024 * 1024
+
+
+# ---------------------------------------------------------------------------
+# Config / auth helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_vertex_section() -> Dict[str, Any]:
+    """Read ``video_gen.vertex`` from config.yaml."""
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        section = cfg.get("video_gen") if isinstance(cfg, dict) else None
+        sub = section.get("vertex") if isinstance(section, dict) else None
+        return sub if isinstance(sub, dict) else {}
+    except Exception as exc:
+        logger.debug("Could not load video_gen.vertex config: %s", exc)
+        return {}
+
+
+def _resolve_location() -> str:
+    raw = _load_vertex_section().get("region")
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    return DEFAULT_LOCATION
+
+
+def _endpoint(project_id: str, location: str, model_id: str, method: str) -> str:
+    host = (
+        "aiplatform.googleapis.com"
+        if location == "global"
+        else f"{location}-aiplatform.googleapis.com"
+    )
+    return (
+        f"https://{host}/v1/projects/{project_id}/locations/{location}"
+        f"/publishers/google/models/{model_id}:{method}"
+    )
+
+
+def _resolve_credentials() -> Tuple[Optional[str], Optional[str]]:
+    """Return (access_token, project_id) via the shared Vertex adapter.
+
+    Imported lazily so loading this plugin never triggers the adapter's
+    google-auth lazy-install path.
+    """
+    try:
+        from agent.vertex_adapter import get_vertex_credentials
+
+        return get_vertex_credentials()
+    except Exception as exc:
+        logger.debug("Vertex credential resolution failed: %s", exc)
+        return None, None
+
+
+def _auth_required_response(prompt: str) -> Dict[str, Any]:
+    return error_response(
+        error=(
+            "No Google Vertex AI credentials found. Set VERTEX_CREDENTIALS_PATH "
+            "(or GOOGLE_APPLICATION_CREDENTIALS) to a service-account JSON in "
+            ".env, or configure Application Default Credentials "
+            "(`gcloud auth application-default login`). Project/region live "
+            "under `vertex:` in config.yaml."
+        ),
+        error_type="auth_required",
+        provider="vertex",
+        prompt=prompt,
+    )
+
+
+def _positive_number(raw: Any, default: float) -> float:
+    try:
+        value = float(raw)
+        if value > 0:
+            return value
+    except (TypeError, ValueError):
+        pass
+    return default
+
+
+def _normalize_model_id(model_id: str) -> str:
+    """Strip a ``google/`` publisher prefix — the endpoint path already
+    carries ``/publishers/google/``, so chat-style ids like
+    ``google/veo-3.1-generate-001`` would otherwise 404."""
+    candidate = model_id.strip()
+    if candidate.lower().startswith("google/"):
+        candidate = candidate[len("google/"):]
+    return candidate
+
+
+def _resolve_model(model: Optional[str], *, explicit: bool) -> str:
+    """Pass explicit ids through; ignore stale foreign ids from config."""
+    candidate = _normalize_model_id(model or "")
+    if not candidate:
+        return DEFAULT_MODEL
+    if explicit or candidate.lower().startswith(("veo", "gemini")):
+        return candidate
+    logger.debug(
+        "video_gen model '%s' does not look like a Vertex video model id; using %s",
+        candidate, DEFAULT_MODEL,
+    )
+    return DEFAULT_MODEL
+
+
+def _uses_interactions_api(model_id: str) -> bool:
+    """Gemini-family video models (Omni) are served by the Interactions API,
+    not by Veo's ``:predictLongRunning``."""
+    return model_id.lower().startswith("gemini")
+
+
+def _clamp_duration(duration: Optional[int]) -> Optional[int]:
+    """Clamp to the durations Veo accepts; None means let the API default.
+
+    Veo 3.1 only takes 4, 6 or 8 seconds — odd values are rounded up so the
+    user never gets less than they asked for.
+    """
+    if duration is None:
+        return None
+    value = max(4, min(8, int(duration)))
+    if value % 2:
+        value += 1
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Input image handling
+# ---------------------------------------------------------------------------
+
+
+def _mime_from_path(path: Path) -> str:
+    ext = path.suffix.lstrip(".").lower()
+    if ext in ("jpg", "jpeg"):
+        return "image/jpeg"
+    if ext in ("png", "webp", "gif"):
+        return f"image/{ext}"
+    return "image/png"
+
+
+def _image_source_to_b64(ref: str) -> Tuple[str, str]:
+    """Load a source image as ``(base64, mime_type)``.
+
+    Accepts a data URI, an http(s) URL (downloaded and inlined), or a local
+    file path (guarded read). Raises ``ValueError`` with a user-facing
+    message on failure.
+    """
+    lower = ref.lower()
+
+    if lower.startswith("data:"):
+        header, _, payload = ref.partition(",")
+        if not payload or ";base64" not in header:
+            raise ValueError("data: URI image inputs must be base64-encoded")
+        mime = header[5:].split(";", 1)[0].strip() or "image/png"
+        return payload, mime
+
+    if lower.startswith(("http://", "https://")):
+        response = requests.get(ref, timeout=60)
+        response.raise_for_status()
+        if len(response.content) > _MAX_INPUT_IMAGE_BYTES:
+            raise ValueError(f"Input image at {ref} exceeds 20MB")
+        mime = (response.headers.get("Content-Type") or "").split(";", 1)[0].strip().lower()
+        if not mime.startswith("image/"):
+            mime = _mime_from_path(Path(ref.split("?", 1)[0]))
+        return base64.b64encode(response.content).decode("ascii"), mime
+
+    # Local file path — enforce the shared credential-read guard before
+    # touching bytes (same boundary as the other media providers).
+    from agent.file_safety import raise_if_read_blocked
+
+    raise_if_read_blocked(ref)
+    path = Path(ref).expanduser()
+    if not path.is_file():
+        raise ValueError(
+            f"image input '{ref}' is neither a URL, data URI, nor an existing file"
+        )
+    return base64.b64encode(path.read_bytes()).decode("ascii"), _mime_from_path(path)
+
+
+def _veo_image_field(source: str) -> Dict[str, Any]:
+    """Build Veo's ``image`` value from a URL / data URI / gs:// URI / local path.
+
+    Raises ``ValueError`` with a user-facing message on failure.
+    """
+    ref = source.strip()
+    if ref.lower().startswith("gs://"):
+        return {"gcsUri": ref, "mimeType": _mime_from_path(Path(ref))}
+    b64, mime = _image_source_to_b64(ref)
+    return {"bytesBase64Encoded": b64, "mimeType": mime}
+
+
+# ---------------------------------------------------------------------------
+# API calls
+# ---------------------------------------------------------------------------
+
+
+def _auth_headers(token: str) -> Dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+
+
+def _http_error_detail(exc: requests.HTTPError) -> Tuple[int, str]:
+    response = exc.response
+    status = response.status_code if response is not None else 0
+    try:
+        detail = response.json().get("error", {}).get("message", "")
+    except Exception:
+        detail = ""
+    if not detail and response is not None:
+        detail = response.text[:300]
+    return status, detail or str(exc)
+
+
+def _submit(url: str, token: str, payload: Dict[str, Any]) -> str:
+    response = requests.post(url, headers=_auth_headers(token), json=payload, timeout=60)
+    response.raise_for_status()
+    operation_name = response.json().get("name")
+    if not operation_name:
+        raise RuntimeError("Vertex predictLongRunning response did not include an operation name")
+    return operation_name
+
+
+def _poll(
+    fetch_url: str,
+    token: str,
+    operation_name: str,
+    *,
+    timeout_seconds: float,
+    poll_interval: float,
+) -> Dict[str, Any]:
+    """Poll ``fetchPredictOperation`` until done/timeout; returns the final body."""
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        response = requests.post(
+            fetch_url,
+            headers=_auth_headers(token),
+            json={"operationName": operation_name},
+            timeout=60,
+        )
+        response.raise_for_status()
+        body = response.json()
+        if body.get("done"):
+            return body
+        if time.monotonic() >= deadline:
+            return {"_timeout": True}
+        time.sleep(poll_interval)
+
+
+def _download_gcs_object(uri: str, token: str) -> bytes:
+    """Fetch a ``gs://bucket/object`` with the same OAuth token (JSON API)."""
+    without_scheme = uri[len("gs://"):]
+    bucket, _, obj = without_scheme.partition("/")
+    if not bucket or not obj:
+        raise ValueError(f"Unparseable gs:// URI: {uri}")
+    url = (
+        f"https://storage.googleapis.com/storage/v1/b/{bucket}"
+        f"/o/{quote(obj, safe='')}?alt=media"
+    )
+    response = requests.get(url, headers={"Authorization": f"Bearer {token}"}, timeout=120)
+    response.raise_for_status()
+    return response.content
+
+
+def _extract_videos(body: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Normalize the two response shapes Veo operations have used."""
+    response = body.get("response") if isinstance(body.get("response"), dict) else {}
+    videos = response.get("videos")
+    if isinstance(videos, list) and videos:
+        return [v for v in videos if isinstance(v, dict)]
+    samples = response.get("generatedSamples")
+    out: List[Dict[str, Any]] = []
+    if isinstance(samples, list):
+        for sample in samples:
+            video = sample.get("video") if isinstance(sample, dict) else None
+            if isinstance(video, dict):
+                # Older shape uses "uri" for the Cloud Storage path.
+                normalized = dict(video)
+                if "uri" in normalized and "gcsUri" not in normalized:
+                    normalized["gcsUri"] = normalized["uri"]
+                out.append(normalized)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Interactions API (Gemini Omni)
+# ---------------------------------------------------------------------------
+
+
+def _interactions_endpoint(project_id: str) -> str:
+    """The Interactions API is only documented on the global endpoint."""
+    return (
+        "https://aiplatform.googleapis.com/v1beta1"
+        f"/projects/{project_id}/locations/global/interactions"
+    )
+
+
+# Interactions video_config.task values by input modality. "edit" exists in
+# the API but needs a source-video input, which the unified video_generate
+# surface intentionally does not expose.
+_OMNI_TASKS = {
+    "text": "text_to_video",
+    "image": "image_to_video",
+    "reference": "reference_to_video",
+}
+
+
+def _omni_media_item(source: str) -> Dict[str, Any]:
+    """Build one Interactions ``input`` item for a source image.
+
+    Mirrors the documented content item shape (``{"type", "data",
+    "mime_type"}``). Raises ``ValueError`` with a user-facing message on
+    failure.
+    """
+    ref = source.strip()
+    if ref.lower().startswith("gs://"):
+        raise ValueError(
+            "gs:// inputs are not supported by the Interactions API — pass a "
+            "local path, data URI, or https URL"
+        )
+    b64, mime = _image_source_to_b64(ref)
+    return {"type": "image", "data": b64, "mime_type": mime}
+
+
+def _extract_interaction_video(
+    body: Dict[str, Any],
+) -> Tuple[Optional[str], Optional[str], Optional[str], str]:
+    """Return ``(b64_data, uri, mime, text_detail)`` from an interaction response.
+
+    Videos arrive inline (``data``, the default) or — for outputs over the
+    inline delivery cap — as a hosted ``uri`` (``response_format.delivery``).
+    Exactly one of ``b64_data`` / ``uri`` is set when a video was produced.
+    ``text_detail`` collects any text the model emitted in ``model_output``
+    steps — useful in error messages when it declined to produce video.
+    """
+    text_detail = ""
+    for step in body.get("steps") or []:
+        if not isinstance(step, dict) or step.get("type") != "model_output":
+            continue
+        for item in step.get("content") or []:
+            if not isinstance(item, dict):
+                continue
+            if item.get("type") == "video":
+                mime = item.get("mime_type") or "video/mp4"
+                if item.get("data"):
+                    return item["data"], None, mime, text_detail
+                uri = item.get("uri") or item.get("url")
+                if isinstance(uri, str) and uri.strip():
+                    return None, uri.strip(), mime, text_detail
+            if item.get("type") == "text" and isinstance(item.get("text"), str):
+                text_detail += item["text"]
+    return None, None, None, text_detail
+
+
+def _download_interaction_video(uri: str, token: str) -> bytes:
+    """Fetch a uri-delivered interaction video with the caller's bearer token."""
+    if uri.lower().startswith("gs://"):
+        return _download_gcs_object(uri, token)
+    response = requests.get(uri, headers=_auth_headers(token), timeout=120)
+    response.raise_for_status()
+    return response.content
+
+
+def _generate_via_interactions(
+    *,
+    token: str,
+    project_id: str,
+    model_id: str,
+    prompt: str,
+    image_url: Optional[str],
+    reference_image_urls: Optional[List[str]],
+    aspect_ratio: str,
+    section: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Generate a video with a Gemini Omni model via the Interactions API.
+
+    Synchronous: one POST returns the completed interaction with the video
+    inline as base64 in the ``steps`` — no operation polling.
+    """
+    # Omni only renders 16:9 and 9:16 (720p, ≤10s in the current preview).
+    aspect = (aspect_ratio or DEFAULT_ASPECT_RATIO).strip()
+    if aspect not in ("16:9", "9:16"):
+        aspect = DEFAULT_ASPECT_RATIO
+
+    refs = [r.strip() for r in (reference_image_urls or []) if isinstance(r, str) and r.strip()]
+    sources: List[str] = []
+    if image_url and image_url.strip():
+        sources.append(image_url.strip())
+    sources.extend(refs)
+    modality = "image" if image_url and image_url.strip() else ("reference" if refs else "text")
+
+    input_items: List[Dict[str, Any]] = [{"type": "text", "text": prompt}]
+    try:
+        input_items.extend(_omni_media_item(source) for source in sources)
+    except ValueError as exc:
+        return error_response(
+            error=str(exc),
+            error_type="invalid_image_url",
+            provider="vertex",
+            model=model_id,
+            prompt=prompt,
+        )
+    except Exception as exc:
+        return error_response(
+            error=f"Could not load input image: {exc}",
+            error_type="io_error",
+            provider="vertex",
+            model=model_id,
+            prompt=prompt,
+        )
+
+    payload: Dict[str, Any] = {
+        "model": model_id,
+        "input": input_items,
+        # Omni is any-to-any; declare video output explicitly so a prompt
+        # that reads like a question still yields a clip, not prose.
+        "response_format": {"type": "video", "aspect_ratio": aspect},
+    }
+    # Declare the task explicitly instead of letting the model infer it —
+    # disambiguates "animate this frame" (image_to_video) from "use this as
+    # a style reference" (reference_to_video). Verified accepted on the
+    # Vertex Interactions endpoint (probe, 2026-07-09); note Vertex rejects
+    # response_format.delivery, so schema parity with the Gemini API cannot
+    # be assumed for new fields — probe before adding any.
+    task = _OMNI_TASKS.get(modality)
+    if task:
+        payload["generation_config"] = {"video_config": {"task": task}}
+
+    timeout_seconds = _positive_number(section.get("timeout_seconds"), DEFAULT_TIMEOUT_SECONDS)
+    logger.info(
+        "Vertex video: %s via Interactions API (location=global, aspect=%s, modality=%s)",
+        model_id, aspect, modality,
+    )
+    started = time.monotonic()
+    try:
+        response = requests.post(
+            _interactions_endpoint(project_id),
+            headers=_auth_headers(token),
+            json=payload,
+            timeout=timeout_seconds,
+        )
+        response.raise_for_status()
+        body = response.json()
+    except requests.HTTPError as exc:
+        status, detail = _http_error_detail(exc)
+        logger.error("Vertex Omni video gen failed (%d): %s", status, detail)
+        return error_response(
+            error=f"Vertex video generation failed ({status}): {detail}",
+            error_type="api_error",
+            provider="vertex",
+            model=model_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+        )
+    except requests.Timeout:
+        return error_response(
+            error=(
+                f"Vertex Omni video generation timed out ({int(timeout_seconds)}s) "
+                "(raise video_gen.vertex.timeout_seconds if generations routinely take longer)"
+            ),
+            error_type="timeout",
+            provider="vertex",
+            model=model_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+        )
+    except requests.RequestException as exc:
+        return error_response(
+            error=f"Vertex connection error: {exc}",
+            error_type="connection_error",
+            provider="vertex",
+            model=model_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+        )
+    except ValueError as exc:
+        return error_response(
+            error=f"Vertex returned invalid JSON: {exc}",
+            error_type="invalid_response",
+            provider="vertex",
+            model=model_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+        )
+
+    interaction_id = body.get("id")
+    status_text = str(body.get("status") or "").lower()
+    if status_text and status_text != "completed":
+        return error_response(
+            error=(
+                f"Vertex interaction ended with status '{status_text}'"
+                + (f" (interaction id: {interaction_id})" if interaction_id else "")
+            ),
+            error_type=f"interaction_{status_text}",
+            provider="vertex",
+            model=model_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+        )
+
+    b64, uri, _mime, text_detail = _extract_interaction_video(body)
+    if not b64 and not uri:
+        return error_response(
+            error=(
+                "Vertex interaction completed without video output"
+                + (f" (model said: {text_detail[:300]})" if text_detail else "")
+            ),
+            error_type="empty_response",
+            provider="vertex",
+            model=model_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+        )
+
+    if b64:
+        try:
+            video_ref = str(save_b64_video(b64, prefix="vertex_omni"))
+        except Exception as exc:
+            return error_response(
+                error=f"Could not save video to cache: {exc}",
+                error_type="io_error",
+                provider="vertex",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+    else:
+        # uri delivery (outputs over the inline cap). Materialise locally so
+        # downstream consumers (Telegram upload, previews) need no extra auth;
+        # fall back to the raw URI rather than failing — mirrors the Veo
+        # gs:// download fallback.
+        try:
+            video_ref = str(
+                save_bytes_video(_download_interaction_video(uri, token), prefix="vertex_omni")
+            )
+        except Exception as exc:
+            logger.warning(
+                "Could not download interaction video %s (%s); returning the URI", uri, exc
+            )
+            video_ref = uri
+
+    logger.info(
+        "Vertex video: interaction %s completed in %.0fs -> %s",
+        interaction_id or "<no id>", time.monotonic() - started, video_ref,
+    )
+
+    extra: Dict[str, Any] = {"location": "global", "api": "interactions"}
+    if interaction_id:
+        # Keep the id visible — the Interactions API supports conversational
+        # follow-up edits referencing a previous interaction.
+        extra["interaction_id"] = interaction_id
+    if body.get("usage"):
+        extra["usage"] = body["usage"]
+
+    return success_response(
+        video=video_ref,
+        model=str(body.get("model") or model_id),
+        prompt=prompt,
+        modality=modality,
+        aspect_ratio=aspect,
+        duration=0,
+        provider="vertex",
+        extra=extra,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+
+
+class VertexVideoGenProvider(VideoGenProvider):
+    """Google Vertex AI Veo backend."""
+
+    @property
+    def name(self) -> str:
+        return "vertex"
+
+    @property
+    def display_name(self) -> str:
+        return "Google Vertex AI"
+
+    def is_available(self) -> bool:
+        try:
+            from agent.vertex_adapter import has_vertex_credentials
+
+            return has_vertex_credentials()
+        except Exception as exc:
+            logger.debug("Vertex availability check failed: %s", exc)
+            return False
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [{"id": model_id, **meta} for model_id, meta in _MODELS.items()]
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_MODEL
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Google Vertex AI (Veo)",
+            "badge": "paid",
+            "tag": (
+                "Veo text/image-to-video via Google Cloud Vertex AI — "
+                "service-account or ADC auth (no Gemini API key). "
+                "Project under `vertex:` in config.yaml; region via "
+                "`video_gen.vertex.region` (Veo is regional, default us-central1)."
+            ),
+            "env_vars": [
+                {
+                    "key": "VERTEX_CREDENTIALS_PATH",
+                    "prompt": "Path to a GCP service-account JSON with Vertex AI access (blank to use ADC)",
+                    "url": "https://console.cloud.google.com/iam-admin/serviceaccounts",
+                },
+            ],
+        }
+
+    def capabilities(self) -> Dict[str, Any]:
+        return {
+            "modalities": ["text", "image"],
+            "aspect_ratios": sorted(VALID_ASPECT_RATIOS),
+            "resolutions": sorted(VALID_RESOLUTIONS),
+            "max_duration": 8,
+            "min_duration": 4,
+            "supports_audio": True,
+            "supports_negative_prompt": True,
+            "max_reference_images": MAX_REFERENCE_IMAGES,
+        }
+
+    def generate(
+        self,
+        prompt: str,
+        *,
+        model: Optional[str] = None,
+        image_url: Optional[str] = None,
+        reference_image_urls: Optional[List[str]] = None,
+        duration: Optional[int] = None,
+        aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        resolution: str = DEFAULT_RESOLUTION,
+        negative_prompt: Optional[str] = None,
+        audio: Optional[bool] = None,
+        seed: Optional[int] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            return error_response(
+                error="prompt is required for Vertex video generation",
+                error_type="missing_prompt",
+                provider="vertex",
+            )
+
+        token, project_id = _resolve_credentials()
+        if not token or not project_id:
+            return _auth_required_response(prompt)
+
+        model_id = _resolve_model(model, explicit=bool(kwargs.get("_model_override_explicit")))
+        section = _load_vertex_section()
+
+        if _uses_interactions_api(model_id):
+            return _generate_via_interactions(
+                token=token,
+                project_id=project_id,
+                model_id=model_id,
+                prompt=prompt,
+                image_url=image_url,
+                reference_image_urls=reference_image_urls,
+                aspect_ratio=aspect_ratio,
+                section=section,
+            )
+
+        location = _resolve_location()
+
+        aspect = (aspect_ratio or DEFAULT_ASPECT_RATIO).strip()
+        if aspect not in VALID_ASPECT_RATIOS:
+            aspect = DEFAULT_ASPECT_RATIO
+        res = (resolution or "").strip().lower()
+        if res not in VALID_RESOLUTIONS:
+            res = DEFAULT_RESOLUTION
+        if res == "1080p" and aspect != "16:9":
+            res = "720p"  # Veo only renders 1080p in 16:9
+        clamped_duration = _clamp_duration(duration)
+
+        refs = [r.strip() for r in (reference_image_urls or []) if isinstance(r, str) and r.strip()]
+        if refs and image_url and image_url.strip():
+            return error_response(
+                error="image_url and reference_image_urls cannot be combined on Vertex Veo",
+                error_type="conflicting_inputs",
+                provider="vertex",
+                model=model_id,
+                prompt=prompt,
+            )
+        if len(refs) > MAX_REFERENCE_IMAGES:
+            return error_response(
+                error=f"Vertex Veo supports at most {MAX_REFERENCE_IMAGES} reference images",
+                error_type="too_many_references",
+                provider="vertex",
+                model=model_id,
+                prompt=prompt,
+            )
+
+        instance: Dict[str, Any] = {"prompt": prompt}
+        try:
+            if image_url and image_url.strip():
+                instance["image"] = _veo_image_field(image_url)
+            if refs:
+                instance["referenceImages"] = [
+                    {"image": _veo_image_field(ref), "referenceType": "asset"} for ref in refs
+                ]
+        except ValueError as exc:
+            return error_response(
+                error=str(exc),
+                error_type="invalid_image_url",
+                provider="vertex",
+                model=model_id,
+                prompt=prompt,
+            )
+        except Exception as exc:
+            return error_response(
+                error=f"Could not load input image: {exc}",
+                error_type="io_error",
+                provider="vertex",
+                model=model_id,
+                prompt=prompt,
+            )
+        modality = "image" if "image" in instance else ("reference" if refs else "text")
+
+        parameters: Dict[str, Any] = {
+            "aspectRatio": aspect,
+            "sampleCount": 1,
+        }
+        if clamped_duration is not None:
+            parameters["durationSeconds"] = clamped_duration
+        # Veo 3.x rejects requests without an explicit generateAudio.
+        parameters["generateAudio"] = True if audio is None else bool(audio)
+        parameters["resolution"] = res
+        if negative_prompt and negative_prompt.strip():
+            parameters["negativePrompt"] = negative_prompt.strip()
+        if seed is not None:
+            parameters["seed"] = int(seed)
+        person_generation = section.get("person_generation")
+        if isinstance(person_generation, str) and person_generation.strip():
+            parameters["personGeneration"] = person_generation.strip()
+        storage_uri = section.get("storage_uri")
+        if isinstance(storage_uri, str) and storage_uri.strip():
+            parameters["storageUri"] = storage_uri.strip()
+
+        payload = {"instances": [instance], "parameters": parameters}
+        submit_url = _endpoint(project_id, location, model_id, "predictLongRunning")
+        fetch_url = _endpoint(project_id, location, model_id, "fetchPredictOperation")
+        timeout_seconds = _positive_number(section.get("timeout_seconds"), DEFAULT_TIMEOUT_SECONDS)
+        poll_interval = _positive_number(
+            section.get("poll_interval_seconds"), DEFAULT_POLL_INTERVAL_SECONDS
+        )
+
+        logger.info(
+            "Vertex video: %s via predictLongRunning (location=%s, aspect=%s, "
+            "resolution=%s, duration=%s, audio=%s, modality=%s)",
+            model_id, location, aspect, res,
+            f"{clamped_duration}s" if clamped_duration is not None else "model default",
+            parameters["generateAudio"], modality,
+        )
+        started = time.monotonic()
+        try:
+            operation_name = _submit(submit_url, token, payload)
+            body = _poll(
+                fetch_url,
+                token,
+                operation_name,
+                timeout_seconds=timeout_seconds,
+                poll_interval=poll_interval,
+            )
+        except requests.HTTPError as exc:
+            status, detail = _http_error_detail(exc)
+            logger.error("Vertex video gen failed (%d): %s", status, detail)
+            return error_response(
+                error=f"Vertex video generation failed ({status}): {detail}",
+                error_type="api_error",
+                provider="vertex",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        except requests.Timeout:
+            return error_response(
+                error="Vertex video generation request timed out",
+                error_type="timeout",
+                provider="vertex",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        except requests.RequestException as exc:
+            return error_response(
+                error=f"Vertex connection error: {exc}",
+                error_type="connection_error",
+                provider="vertex",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        except RuntimeError as exc:
+            return error_response(
+                error=str(exc),
+                error_type="invalid_response",
+                provider="vertex",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        if body.get("_timeout"):
+            return error_response(
+                error=(
+                    f"Timed out waiting for Vertex Veo after {int(timeout_seconds)}s "
+                    "(raise video_gen.vertex.timeout_seconds if generations routinely take longer)"
+                ),
+                error_type="timeout",
+                provider="vertex",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        op_error = body.get("error")
+        if isinstance(op_error, dict) and op_error:
+            return error_response(
+                error=f"Vertex Veo operation failed: {op_error.get('message') or op_error}",
+                error_type="api_error",
+                provider="vertex",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        videos = _extract_videos(body)
+        if not videos:
+            response_body = body.get("response") if isinstance(body.get("response"), dict) else {}
+            reasons = response_body.get("raiMediaFilteredReasons")
+            if reasons:
+                return error_response(
+                    error=f"Vertex filtered the generated video: {reasons}",
+                    error_type="safety_blocked",
+                    provider="vertex",
+                    model=model_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
+            return error_response(
+                error="Vertex Veo operation completed without any video output",
+                error_type="empty_response",
+                provider="vertex",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        first = videos[0]
+        extra: Dict[str, Any] = {"operation": operation_name, "location": location}
+        b64 = first.get("bytesBase64Encoded")
+        gcs_uri = first.get("gcsUri")
+        video_ref: Optional[str] = None
+
+        if b64:
+            try:
+                video_ref = str(save_b64_video(b64, prefix="vertex_veo"))
+            except Exception as exc:
+                return error_response(
+                    error=f"Could not save video to cache: {exc}",
+                    error_type="io_error",
+                    provider="vertex",
+                    model=model_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
+        elif gcs_uri:
+            extra["gcs_uri"] = gcs_uri
+            # Materialise the bytes locally so downstream consumers (Telegram
+            # upload, browser preview) don't need GCS credentials.
+            try:
+                video_ref = str(
+                    save_bytes_video(_download_gcs_object(gcs_uri, token), prefix="vertex_veo")
+                )
+            except Exception as exc:
+                logger.warning("Could not download %s (%s); returning the gs:// URI", gcs_uri, exc)
+                video_ref = gcs_uri
+
+        if not video_ref:
+            return error_response(
+                error="Vertex Veo response contained neither video bytes nor a gs:// URI",
+                error_type="empty_response",
+                provider="vertex",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        logger.info(
+            "Vertex video: %s completed in %.0fs -> %s",
+            model_id, time.monotonic() - started, video_ref,
+        )
+
+        return success_response(
+            video=video_ref,
+            model=model_id,
+            prompt=prompt,
+            modality=modality,
+            aspect_ratio=aspect,
+            duration=clamped_duration or 0,
+            provider="vertex",
+            extra=extra,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Plugin registration
+# ---------------------------------------------------------------------------
+
+
+def register(ctx: Any) -> None:
+    """Register this provider with the video gen registry."""
+    ctx.register_video_gen_provider(VertexVideoGenProvider())

--- a/plugins/video_gen/vertex/plugin.yaml
+++ b/plugins/video_gen/vertex/plugin.yaml
@@ -1,0 +1,7 @@
+name: vertex
+version: 1.0.0
+description: "Google Vertex AI video generation (Veo). Service-account or ADC auth."
+author: conernar
+kind: backend
+requires_env:
+  - VERTEX_CREDENTIALS_PATH

--- a/tests/plugins/image_gen/test_vertex_provider.py
+++ b/tests/plugins/image_gen/test_vertex_provider.py
@@ -1,0 +1,332 @@
+"""Tests for the Google Vertex AI image gen plugin — registration, model
+routing, and request/response handling (no network, no real credentials)."""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+import pytest
+import requests
+
+import plugins.image_gen.vertex as vertex_plugin
+from agent import image_gen_registry
+from plugins.image_gen.vertex import (
+    DEFAULT_MODEL,
+    VertexImageGenProvider,
+    _infer_api,
+    _resolve_model,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    image_gen_registry._reset_for_tests()
+    yield
+    image_gen_registry._reset_for_tests()
+
+
+@pytest.fixture(autouse=True)
+def _no_env_model(monkeypatch):
+    monkeypatch.delenv("VERTEX_IMAGE_MODEL", raising=False)
+
+
+class _FakeResponse:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self.status_code = status
+        self.headers = {}
+        self.text = json.dumps(payload)
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(response=self)
+
+
+def _fake_credentials(monkeypatch, token="tok", project="proj"):
+    monkeypatch.setattr(
+        "agent.vertex_adapter.get_vertex_credentials",
+        lambda credentials_path=None: (token, project),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registration / catalog surface
+# ---------------------------------------------------------------------------
+
+
+def test_vertex_provider_registers():
+    provider = VertexImageGenProvider()
+    image_gen_registry.register_provider(provider)
+
+    assert image_gen_registry.get_provider("vertex") is provider
+    assert provider.display_name == "Google Vertex AI"
+    assert provider.default_model() == DEFAULT_MODEL
+
+
+def test_register_entry_point_wires_provider():
+    class _Ctx:
+        def __init__(self):
+            self.registered = None
+
+        def register_image_gen_provider(self, provider):
+            self.registered = provider
+
+    ctx = _Ctx()
+    vertex_plugin.register(ctx)
+    assert isinstance(ctx.registered, VertexImageGenProvider)
+
+
+def test_catalog_invariants():
+    models = VertexImageGenProvider().list_models()
+    ids = [m["id"] for m in models]
+
+    assert DEFAULT_MODEL in ids
+    for model in models:
+        assert model["id"]
+        modalities = model.get("modalities", [])
+        if model["id"].startswith("gemini"):
+            assert "image" in modalities  # Gemini image models support editing
+        if model["id"].startswith("imagen"):
+            assert modalities == ["text"]  # :predict is text-to-image only
+
+
+def test_capabilities_advertise_editing():
+    caps = VertexImageGenProvider().capabilities()
+    assert caps["modalities"] == ["text", "image"]
+    assert caps["max_reference_images"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Model / API routing
+# ---------------------------------------------------------------------------
+
+
+def test_infer_api_by_prefix():
+    assert _infer_api("gemini-3-pro-image-preview") == "generate_content"
+    assert _infer_api("gemini-3.5-flash-image") == "generate_content"
+    assert _infer_api("imagen-4.0-generate-001") == "predict"
+    assert _infer_api("mystery-model") is None
+
+
+def test_infer_api_honors_config_override(monkeypatch):
+    monkeypatch.setattr(vertex_plugin, "_load_vertex_section", lambda: {"api": "predict"})
+    assert _infer_api("mystery-model") == "predict"
+
+
+def test_resolve_model_ignores_stale_foreign_ids():
+    # image_gen.model may hold an id from a previously-selected backend
+    # (e.g. a FAL catalog id) — that must not be sent to Vertex.
+    assert _resolve_model("fal-ai/flux-2/dev") == DEFAULT_MODEL
+    assert _resolve_model(None) == DEFAULT_MODEL
+    assert _resolve_model("gemini-3.5-flash-image") == "gemini-3.5-flash-image"
+    # Chat-style ids with the publisher prefix are normalized, not rejected.
+    assert _resolve_model("google/gemini-3.1-flash-image") == "gemini-3.1-flash-image"
+
+
+def test_resolve_model_env_and_config_precedence(monkeypatch):
+    monkeypatch.setattr(
+        vertex_plugin, "_load_vertex_section", lambda: {"model": "imagen-4.0-fast-generate-001"}
+    )
+    assert _resolve_model(None) == "imagen-4.0-fast-generate-001"
+    monkeypatch.setenv("VERTEX_IMAGE_MODEL", "gemini-2.5-flash-image")
+    assert _resolve_model(None) == "gemini-2.5-flash-image"
+
+
+# ---------------------------------------------------------------------------
+# Credentials
+# ---------------------------------------------------------------------------
+
+
+def test_unavailable_without_credentials(monkeypatch):
+    monkeypatch.setattr("agent.vertex_adapter.has_vertex_credentials", lambda: False)
+    assert VertexImageGenProvider().is_available() is False
+
+
+def test_available_with_credentials(monkeypatch):
+    monkeypatch.setattr("agent.vertex_adapter.has_vertex_credentials", lambda: True)
+    assert VertexImageGenProvider().is_available() is True
+
+
+def test_generate_requires_credentials(monkeypatch):
+    monkeypatch.setattr(
+        "agent.vertex_adapter.get_vertex_credentials",
+        lambda credentials_path=None: (None, None),
+    )
+    result = VertexImageGenProvider().generate("a red panda")
+    assert result["success"] is False
+    assert result["error_type"] == "auth_required"
+
+
+# ---------------------------------------------------------------------------
+# generateContent (Gemini image) path
+# ---------------------------------------------------------------------------
+
+
+def test_gemini_text_to_image_request_and_response(monkeypatch):
+    _fake_credentials(monkeypatch)
+    png_b64 = base64.b64encode(b"fakepng").decode("ascii")
+    captured = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["payload"] = json
+        captured["headers"] = headers
+        return _FakeResponse(
+            {
+                "candidates": [
+                    {"content": {"parts": [{"inlineData": {"mimeType": "image/png", "data": png_b64}}]}}
+                ],
+                "usageMetadata": {"totalTokenCount": 42},
+            }
+        )
+
+    monkeypatch.setattr(vertex_plugin.requests, "post", fake_post)
+
+    result = VertexImageGenProvider().generate("a red panda", "landscape")
+
+    assert result["success"] is True
+    assert result["provider"] == "vertex"
+    assert result["modality"] == "text"
+    assert result["model"] == DEFAULT_MODEL
+    assert result["usage"] == {"totalTokenCount": 42}
+
+    saved = Path(result["image"])
+    assert saved.is_file()
+    assert saved.read_bytes() == b"fakepng"
+
+    # Gemini 3.x previews are global-endpoint-only by default.
+    assert captured["url"] == (
+        "https://aiplatform.googleapis.com/v1/projects/proj/locations/global"
+        f"/publishers/google/models/{DEFAULT_MODEL}:generateContent"
+    )
+    assert captured["headers"]["Authorization"] == "Bearer tok"
+    payload = captured["payload"]
+    assert payload["contents"][0]["parts"][0] == {"text": "a red panda"}
+    gen_config = payload["generationConfig"]
+    assert "IMAGE" in gen_config["responseModalities"]
+    assert gen_config["imageConfig"]["aspectRatio"] == "16:9"
+
+
+def test_gemini_edit_includes_source_image_and_skips_aspect(monkeypatch):
+    _fake_credentials(monkeypatch)
+    png_b64 = base64.b64encode(b"editme").decode("ascii")
+    out_b64 = base64.b64encode(b"edited").decode("ascii")
+    captured = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["payload"] = json
+        return _FakeResponse(
+            {"candidates": [{"content": {"parts": [{"inlineData": {"mimeType": "image/png", "data": out_b64}}]}}]}
+        )
+
+    monkeypatch.setattr(vertex_plugin.requests, "post", fake_post)
+
+    result = VertexImageGenProvider().generate(
+        "make it night-time",
+        "landscape",
+        image_url=f"data:image/png;base64,{png_b64}",
+    )
+
+    assert result["success"] is True
+    assert result["modality"] == "image"
+    parts = captured["payload"]["contents"][0]["parts"]
+    assert parts[0] == {"text": "make it night-time"}
+    assert parts[1]["inlineData"]["data"] == png_b64
+    # Output geometry follows the input image on edits.
+    assert "aspectRatio" not in captured["payload"]["generationConfig"].get("imageConfig", {})
+
+
+def test_edit_with_predict_only_model_reroutes_to_gemini(monkeypatch):
+    _fake_credentials(monkeypatch)
+    png_b64 = base64.b64encode(b"src").decode("ascii")
+    out_b64 = base64.b64encode(b"out").decode("ascii")
+    captured = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        return _FakeResponse(
+            {"candidates": [{"content": {"parts": [{"inlineData": {"mimeType": "image/png", "data": out_b64}}]}}]}
+        )
+
+    monkeypatch.setattr(vertex_plugin.requests, "post", fake_post)
+
+    result = VertexImageGenProvider().generate(
+        "restyle",
+        image_url=f"data:image/png;base64,{png_b64}",
+        model="imagen-4.0-generate-001",
+    )
+
+    assert result["success"] is True
+    assert f"/models/{DEFAULT_MODEL}:generateContent" in captured["url"]
+
+
+def test_gemini_safety_block_surfaces_reason(monkeypatch):
+    _fake_credentials(monkeypatch)
+    monkeypatch.setattr(
+        vertex_plugin.requests,
+        "post",
+        lambda *a, **k: _FakeResponse({"promptFeedback": {"blockReason": "SAFETY"}}),
+    )
+
+    result = VertexImageGenProvider().generate("something disallowed")
+    assert result["success"] is False
+    assert result["error_type"] == "safety_blocked"
+    assert "SAFETY" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# :predict (Imagen) path
+# ---------------------------------------------------------------------------
+
+
+def test_imagen_predict_request_and_response(monkeypatch):
+    _fake_credentials(monkeypatch)
+    png_b64 = base64.b64encode(b"imagenpng").decode("ascii")
+    captured = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["payload"] = json
+        return _FakeResponse(
+            {"predictions": [{"bytesBase64Encoded": png_b64, "mimeType": "image/png"}]}
+        )
+
+    monkeypatch.setattr(vertex_plugin.requests, "post", fake_post)
+
+    result = VertexImageGenProvider().generate(
+        "a lighthouse", "portrait", model="imagen-4.0-generate-001"
+    )
+
+    assert result["success"] is True
+    assert result["model"] == "imagen-4.0-generate-001"
+    assert Path(result["image"]).read_bytes() == b"imagenpng"
+
+    # Imagen :predict is served regionally, not on the global endpoint.
+    assert captured["url"] == (
+        "https://us-central1-aiplatform.googleapis.com/v1/projects/proj/locations/us-central1"
+        "/publishers/google/models/imagen-4.0-generate-001:predict"
+    )
+    payload = captured["payload"]
+    assert payload["instances"] == [{"prompt": "a lighthouse"}]
+    assert payload["parameters"]["aspectRatio"] == "9:16"
+    assert payload["parameters"]["sampleCount"] == 1
+
+
+def test_imagen_filtered_response_is_an_error(monkeypatch):
+    _fake_credentials(monkeypatch)
+    monkeypatch.setattr(
+        vertex_plugin.requests,
+        "post",
+        lambda *a, **k: _FakeResponse({"predictions": [{"raiFilteredReason": "blocked by policy"}]}),
+    )
+
+    result = VertexImageGenProvider().generate("x", model="imagen-4.0-generate-001")
+    assert result["success"] is False
+    assert result["error_type"] == "empty_response"
+    assert "blocked by policy" in result["error"]

--- a/tests/plugins/video_gen/test_vertex_plugin.py
+++ b/tests/plugins/video_gen/test_vertex_plugin.py
@@ -1,0 +1,504 @@
+"""Tests for the Google Vertex AI (Veo) video gen plugin — registration,
+model routing, parameter clamping, and the predictLongRunning/poll flow
+(no network, no real credentials)."""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+import pytest
+import requests
+
+import plugins.video_gen.vertex as vertex_plugin
+from agent import video_gen_registry
+from plugins.video_gen.vertex import (
+    DEFAULT_MODEL,
+    VertexVideoGenProvider,
+    _clamp_duration,
+    _extract_videos,
+    _resolve_model,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    video_gen_registry._reset_for_tests()
+    yield
+    video_gen_registry._reset_for_tests()
+
+
+class _FakeResponse:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self.status_code = status
+        self.headers = {}
+        self.text = json.dumps(payload)
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(response=self)
+
+
+def _fake_credentials(monkeypatch, token="tok", project="proj"):
+    monkeypatch.setattr(
+        "agent.vertex_adapter.get_vertex_credentials",
+        lambda credentials_path=None: (token, project),
+    )
+
+
+def _fake_operation_roundtrip(monkeypatch, *, videos, op_name="projects/proj/operations/op1"):
+    """Stub requests.post: first call submits, later calls poll to done."""
+    calls = []
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        calls.append({"url": url, "payload": json, "headers": headers})
+        if url.endswith(":predictLongRunning"):
+            return _FakeResponse({"name": op_name})
+        return _FakeResponse({"done": True, "response": {"videos": videos}})
+
+    monkeypatch.setattr(vertex_plugin.requests, "post", fake_post)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# Registration / catalog surface
+# ---------------------------------------------------------------------------
+
+
+def test_vertex_provider_registers():
+    provider = VertexVideoGenProvider()
+    video_gen_registry.register_provider(provider)
+
+    assert video_gen_registry.get_provider("vertex") is provider
+    assert provider.display_name == "Google Vertex AI"
+    assert provider.default_model() == DEFAULT_MODEL
+
+
+def test_register_entry_point_wires_provider():
+    class _Ctx:
+        def __init__(self):
+            self.registered = None
+
+        def register_video_gen_provider(self, provider):
+            self.registered = provider
+
+    ctx = _Ctx()
+    vertex_plugin.register(ctx)
+    assert isinstance(ctx.registered, VertexVideoGenProvider)
+
+
+def test_catalog_invariants():
+    models = VertexVideoGenProvider().list_models()
+    ids = [m["id"] for m in models]
+
+    assert DEFAULT_MODEL in ids
+    for model in models:
+        # Every catalog id must route to one of the two Vertex video APIs.
+        assert model["id"].startswith(("veo", "gemini"))
+        assert "text" in model.get("modalities", [])
+
+
+def test_capabilities_declare_veo_surface():
+    caps = VertexVideoGenProvider().capabilities()
+    assert caps["modalities"] == ["text", "image"]
+    assert caps["supports_audio"] is True
+    assert caps["supports_negative_prompt"] is True
+    assert caps["max_reference_images"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Model resolution / parameter clamping
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_model_passthrough_and_stale_fallback():
+    # Future Veo releases must pass through without a plugin update.
+    assert _resolve_model("veo-4.0-generate-001", explicit=False) == "veo-4.0-generate-001"
+    # Chat-style ids with the publisher prefix are normalized, not rejected.
+    assert (
+        _resolve_model("google/veo-3.1-fast-generate-001", explicit=False)
+        == "veo-3.1-fast-generate-001"
+    )
+    # Gemini Omni ids route to the Interactions API rather than falling back.
+    assert (
+        _resolve_model("google/gemini-omni-flash-preview", explicit=False)
+        == "gemini-omni-flash-preview"
+    )
+    # A stale video_gen.model from a previously-selected backend is ignored…
+    assert _resolve_model("fal-ai/kling-video/o3", explicit=False) == DEFAULT_MODEL
+    # …unless the tool call requested it explicitly.
+    assert _resolve_model("some-exotic-id", explicit=True) == "some-exotic-id"
+    assert _resolve_model(None, explicit=False) == DEFAULT_MODEL
+
+
+def test_clamp_duration_snaps_to_veo_accepted_seconds():
+    assert _clamp_duration(None) is None
+    assert _clamp_duration(3) == 4
+    assert _clamp_duration(5) == 6
+    assert _clamp_duration(7) == 8
+    assert _clamp_duration(12) == 8
+
+
+# ---------------------------------------------------------------------------
+# Credentials
+# ---------------------------------------------------------------------------
+
+
+def test_unavailable_without_credentials(monkeypatch):
+    monkeypatch.setattr("agent.vertex_adapter.has_vertex_credentials", lambda: False)
+    assert VertexVideoGenProvider().is_available() is False
+
+
+def test_generate_requires_credentials(monkeypatch):
+    monkeypatch.setattr(
+        "agent.vertex_adapter.get_vertex_credentials",
+        lambda credentials_path=None: (None, None),
+    )
+    result = VertexVideoGenProvider().generate("a happy dog")
+    assert result["success"] is False
+    assert result["error_type"] == "auth_required"
+
+
+# ---------------------------------------------------------------------------
+# Generation flow
+# ---------------------------------------------------------------------------
+
+
+def test_text_to_video_request_and_response(monkeypatch):
+    _fake_credentials(monkeypatch)
+    vid_b64 = base64.b64encode(b"fakevideo").decode("ascii")
+    calls = _fake_operation_roundtrip(
+        monkeypatch, videos=[{"bytesBase64Encoded": vid_b64, "mimeType": "video/mp4"}]
+    )
+
+    result = VertexVideoGenProvider().generate(
+        "a dog surfing", duration=7, aspect_ratio="16:9", resolution="1080p"
+    )
+
+    assert result["success"] is True
+    assert result["provider"] == "vertex"
+    assert result["modality"] == "text"
+    assert result["model"] == DEFAULT_MODEL
+    assert result["duration"] == 8  # 7 snaps up to 8
+    saved = Path(result["video"])
+    assert saved.is_file()
+    assert saved.read_bytes() == b"fakevideo"
+
+    submit = calls[0]
+    assert submit["url"] == (
+        "https://us-central1-aiplatform.googleapis.com/v1/projects/proj/locations/us-central1"
+        f"/publishers/google/models/{DEFAULT_MODEL}:predictLongRunning"
+    )
+    assert submit["headers"]["Authorization"] == "Bearer tok"
+    payload = submit["payload"]
+    assert payload["instances"] == [{"prompt": "a dog surfing"}]
+    params = payload["parameters"]
+    assert params["aspectRatio"] == "16:9"
+    assert params["durationSeconds"] == 8
+    assert params["sampleCount"] == 1
+    assert params["generateAudio"] is True  # Veo 3.x requires it explicitly
+    assert params["resolution"] == "1080p"
+
+    poll = calls[1]
+    assert poll["url"].endswith(":fetchPredictOperation")
+    assert poll["payload"] == {"operationName": "projects/proj/operations/op1"}
+
+
+def test_image_to_video_and_1080p_portrait_downgrade(monkeypatch):
+    _fake_credentials(monkeypatch)
+    src_b64 = base64.b64encode(b"frame").decode("ascii")
+    vid_b64 = base64.b64encode(b"animated").decode("ascii")
+    calls = _fake_operation_roundtrip(
+        monkeypatch, videos=[{"bytesBase64Encoded": vid_b64, "mimeType": "video/mp4"}]
+    )
+
+    result = VertexVideoGenProvider().generate(
+        "animate this",
+        image_url=f"data:image/png;base64,{src_b64}",
+        aspect_ratio="9:16",
+        resolution="1080p",
+    )
+
+    assert result["success"] is True
+    assert result["modality"] == "image"
+    payload = calls[0]["payload"]
+    assert payload["instances"][0]["image"] == {
+        "bytesBase64Encoded": src_b64,
+        "mimeType": "image/png",
+    }
+    # Veo only renders 1080p in 16:9 — portrait requests fall back to 720p.
+    assert payload["parameters"]["resolution"] == "720p"
+
+
+def test_audio_flag_is_forwarded(monkeypatch):
+    _fake_credentials(monkeypatch)
+    vid_b64 = base64.b64encode(b"muted").decode("ascii")
+    calls = _fake_operation_roundtrip(
+        monkeypatch, videos=[{"bytesBase64Encoded": vid_b64, "mimeType": "video/mp4"}]
+    )
+
+    result = VertexVideoGenProvider().generate("silent clip", audio=False)
+
+    assert result["success"] is True
+    # Veo 3.x rejects requests without an explicit generateAudio, so the
+    # flag must always be present — honoring the caller's choice.
+    assert calls[0]["payload"]["parameters"]["generateAudio"] is False
+
+
+# ---------------------------------------------------------------------------
+# Interactions API (Gemini Omni) flow
+# ---------------------------------------------------------------------------
+
+
+def _omni_completed_body(vid_b64):
+    """The documented Interactions response shape (GEAP docs, 2026-06)."""
+    return {
+        "id": "interaction-123",
+        "model": "gemini-omni-flash-preview",
+        "status": "completed",
+        "usage": {"total_tokens": 479},
+        "steps": [
+            {"type": "thought", "summary": [{"type": "text", "text": "planning"}]},
+            {
+                "type": "model_output",
+                "content": [
+                    {"type": "video", "data": vid_b64, "mime_type": "video/mp4"}
+                ],
+            },
+        ],
+        "object": "interaction",
+    }
+
+
+def test_omni_text_to_video_request_and_response(monkeypatch):
+    _fake_credentials(monkeypatch)
+    vid_b64 = base64.b64encode(b"omnivideo").decode("ascii")
+    captured = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["payload"] = json
+        captured["headers"] = headers
+        return _FakeResponse(_omni_completed_body(vid_b64))
+
+    monkeypatch.setattr(vertex_plugin.requests, "post", fake_post)
+
+    result = VertexVideoGenProvider().generate(
+        "a test clip", model="google/gemini-omni-flash-preview", aspect_ratio="9:16"
+    )
+
+    assert result["success"] is True
+    assert result["provider"] == "vertex"
+    assert result["modality"] == "text"
+    assert result["model"] == "gemini-omni-flash-preview"
+    assert result["interaction_id"] == "interaction-123"
+    assert result["api"] == "interactions"
+    assert Path(result["video"]).read_bytes() == b"omnivideo"
+
+    # Interactions is only documented on the global endpoint, v1beta1.
+    assert captured["url"] == (
+        "https://aiplatform.googleapis.com/v1beta1/projects/proj/locations/global/interactions"
+    )
+    assert captured["headers"]["Authorization"] == "Bearer tok"
+    payload = captured["payload"]
+    assert payload["model"] == "gemini-omni-flash-preview"  # google/ prefix stripped
+    assert payload["input"][0] == {"type": "text", "text": "a test clip"}
+    assert payload["response_format"] == {"type": "video", "aspect_ratio": "9:16"}
+    assert payload["generation_config"] == {"video_config": {"task": "text_to_video"}}
+
+
+def test_omni_image_to_video_inlines_source(monkeypatch):
+    _fake_credentials(monkeypatch)
+    src_b64 = base64.b64encode(b"frame").decode("ascii")
+    vid_b64 = base64.b64encode(b"animated").decode("ascii")
+    captured = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured["payload"] = json
+        return _FakeResponse(_omni_completed_body(vid_b64))
+
+    monkeypatch.setattr(vertex_plugin.requests, "post", fake_post)
+
+    result = VertexVideoGenProvider().generate(
+        "animate this",
+        model="gemini-omni-flash-preview",
+        image_url=f"data:image/png;base64,{src_b64}",
+    )
+
+    assert result["success"] is True
+    assert result["modality"] == "image"
+    items = captured["payload"]["input"]
+    assert items[1] == {"type": "image", "data": src_b64, "mime_type": "image/png"}
+    assert captured["payload"]["generation_config"] == {
+        "video_config": {"task": "image_to_video"}
+    }
+
+
+def test_omni_completed_without_video_surfaces_model_text(monkeypatch):
+    _fake_credentials(monkeypatch)
+    body = {
+        "id": "interaction-456",
+        "status": "completed",
+        "steps": [
+            {
+                "type": "model_output",
+                "content": [{"type": "text", "text": "I cannot generate that."}],
+            }
+        ],
+    }
+    monkeypatch.setattr(vertex_plugin.requests, "post", lambda *a, **k: _FakeResponse(body))
+
+    result = VertexVideoGenProvider().generate("x", model="gemini-omni-flash-preview")
+
+    assert result["success"] is False
+    assert result["error_type"] == "empty_response"
+    assert "I cannot generate that." in result["error"]
+
+
+def test_omni_non_completed_status_is_an_error(monkeypatch):
+    _fake_credentials(monkeypatch)
+    body = {"id": "interaction-789", "status": "failed", "steps": []}
+    monkeypatch.setattr(vertex_plugin.requests, "post", lambda *a, **k: _FakeResponse(body))
+
+    result = VertexVideoGenProvider().generate("x", model="gemini-omni-flash-preview")
+
+    assert result["success"] is False
+    assert result["error_type"] == "interaction_failed"
+    assert "interaction-789" in result["error"]
+
+
+def _omni_uri_body(uri):
+    """Interaction response using uri delivery (outputs over the inline cap)."""
+    body = _omni_completed_body("unused")
+    body["steps"][1]["content"] = [{"type": "video", "uri": uri, "mime_type": "video/mp4"}]
+    return body
+
+
+def test_omni_uri_delivery_downloads_with_bearer_token(monkeypatch):
+    _fake_credentials(monkeypatch)
+    uri = "https://storage.example.com/interactions/vid123.mp4"
+    captured = {}
+
+    monkeypatch.setattr(
+        vertex_plugin.requests, "post", lambda *a, **k: _FakeResponse(_omni_uri_body(uri))
+    )
+
+    class _FakeDownload:
+        status_code = 200
+        content = b"bigvideo"
+
+        def raise_for_status(self):
+            pass
+
+    def fake_get(url, headers=None, timeout=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        return _FakeDownload()
+
+    monkeypatch.setattr(vertex_plugin.requests, "get", fake_get)
+
+    result = VertexVideoGenProvider().generate("x", model="gemini-omni-flash-preview")
+
+    assert result["success"] is True
+    assert Path(result["video"]).read_bytes() == b"bigvideo"
+    assert captured["url"] == uri
+    assert captured["headers"]["Authorization"] == "Bearer tok"
+
+
+def test_omni_uri_delivery_download_failure_returns_uri(monkeypatch):
+    _fake_credentials(monkeypatch)
+    uri = "https://storage.example.com/interactions/vid456.mp4"
+
+    monkeypatch.setattr(
+        vertex_plugin.requests, "post", lambda *a, **k: _FakeResponse(_omni_uri_body(uri))
+    )
+    monkeypatch.setattr(
+        vertex_plugin.requests,
+        "get",
+        lambda *a, **k: (_ for _ in ()).throw(requests.ConnectionError("boom")),
+    )
+
+    result = VertexVideoGenProvider().generate("x", model="gemini-omni-flash-preview")
+
+    # Degraded but not failed: the caller still gets a usable reference.
+    assert result["success"] is True
+    assert result["video"] == uri
+
+
+def test_conflicting_image_and_reference_inputs(monkeypatch):
+    _fake_credentials(monkeypatch)
+    result = VertexVideoGenProvider().generate(
+        "x",
+        image_url="https://example.com/a.png",
+        reference_image_urls=["https://example.com/b.png"],
+    )
+    assert result["success"] is False
+    assert result["error_type"] == "conflicting_inputs"
+
+
+def test_operation_error_is_surfaced(monkeypatch):
+    _fake_credentials(monkeypatch)
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        if url.endswith(":predictLongRunning"):
+            return _FakeResponse({"name": "op1"})
+        return _FakeResponse({"done": True, "error": {"message": "quota exceeded"}})
+
+    monkeypatch.setattr(vertex_plugin.requests, "post", fake_post)
+
+    result = VertexVideoGenProvider().generate("a dog")
+    assert result["success"] is False
+    assert result["error_type"] == "api_error"
+    assert "quota exceeded" in result["error"]
+
+
+def test_rai_filtered_output_is_a_safety_error(monkeypatch):
+    _fake_credentials(monkeypatch)
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        if url.endswith(":predictLongRunning"):
+            return _FakeResponse({"name": "op1"})
+        return _FakeResponse(
+            {
+                "done": True,
+                "response": {
+                    "raiMediaFilteredCount": 1,
+                    "raiMediaFilteredReasons": ["violence"],
+                },
+            }
+        )
+
+    monkeypatch.setattr(vertex_plugin.requests, "post", fake_post)
+
+    result = VertexVideoGenProvider().generate("a dog")
+    assert result["success"] is False
+    assert result["error_type"] == "safety_blocked"
+    assert "violence" in result["error"]
+
+
+def test_gcs_output_is_downloaded_locally(monkeypatch):
+    _fake_credentials(monkeypatch)
+    _fake_operation_roundtrip(
+        monkeypatch, videos=[{"gcsUri": "gs://bucket/out/video.mp4", "mimeType": "video/mp4"}]
+    )
+    monkeypatch.setattr(vertex_plugin, "_download_gcs_object", lambda uri, token: b"gcsvideo")
+
+    result = VertexVideoGenProvider().generate("a dog")
+
+    assert result["success"] is True
+    assert result["gcs_uri"] == "gs://bucket/out/video.mp4"
+    assert Path(result["video"]).read_bytes() == b"gcsvideo"
+
+
+def test_extract_videos_handles_generated_samples_shape():
+    body = {
+        "done": True,
+        "response": {"generatedSamples": [{"video": {"uri": "gs://b/o.mp4"}}]},
+    }
+    videos = _extract_videos(body)
+    assert videos[0]["gcsUri"] == "gs://b/o.mp4"


### PR DESCRIPTION
Adds native support for Vertex AI's Veo and Gemini image/video models (Omni included) via GCP credentials.
Shared vertex_adapter is used for auth resolution.

## What does this PR do?

Hermes has pluggable `image_gen` / `video_gen` backends, but none for Google Vertex AI — users who already run their chat model through the `vertex` provider (service-account auth) had no way to use Google's media models (Gemini image, Imagen, Veo, Gemini Omni) from the `image_generate` / `video_generate` tools.

This PR adds two bundled `kind: backend` plugins. Per the footprint ladder, **no core files are touched** — the plugins register through the existing provider registries and reuse `agent/vertex_adapter.py` for credential resolution, so a user with a working `vertex` chat setup needs **zero new secrets**: just `image_gen.provider: vertex` / `video_gen.provider: vertex` in config.yaml.

Routing covers all four Vertex media API surfaces, dispatched by model-id prefix:

| Surface | Models | Endpoint |
|---|---|---|
| `generateContent` (image out) | `gemini-*` image models | global |
| `:predict` | `imagen-*` | regional (us-central1 default) |
| `:predictLongRunning` + poll | `veo-*` | regional (us-central1 default) |
| Interactions API (v1beta1) | `gemini-*` video (Omni) | global |

**Design choice (deliberate):** model IDs pass through unvalidated, with `google/` publisher-prefix normalization (the vertex chat endpoint convention). Google's media catalog moves fast — Veo previews were removed 2026-04, Imagen 2–4 and Veo ≤3.0 retired 2026-06-30, and `gemini-omni-flash-preview` shipped 2026-06-30. Validating against a hardcoded catalog would break users on every Google release cycle; with passthrough, any current or future model on these four surfaces works via config alone. The built-in catalog (`list_models`) is advisory.

Feature coverage: text-to-image, image editing (Gemini multimodal contents), text-to-video and image-to-video (Veo and Omni), audio generation, resolution/aspect-ratio/duration handling with provider-limit clamping, negative prompt / seed / person-generation passthrough, GCS output download, and RAI safety-filter reasons surfaced as structured errors instead of silent empty results.

## Related Issue

N/A — no existing issue. Gap: `image_gen`/`video_gen` had no Vertex backend despite chat-side Vertex support.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/image_gen/vertex/__init__.py` + `plugin.yaml` — `VertexImageGenProvider`: prefix routing (`gemini-*` → `generateContent`, `imagen-*` → `predict`) with `image_gen.vertex.api` escape hatch for future prefixes; edit requests on predict-only models auto-reroute to a `generateContent` model
- `plugins/video_gen/vertex/__init__.py` + `plugin.yaml` — `VertexVideoGenProvider`: `veo-*` → `predictLongRunning`/`fetchPredictOperation` polling; `gemini-*` → synchronous Interactions API (`/v1beta1/.../locations/global/interactions`); handles both `response.videos[]` and `generatedSamples[]` operation shapes; downloads `gcsUri` outputs with the same bearer token
- `tests/plugins/image_gen/test_vertex_provider.py` — 17 tests
- `tests/plugins/video_gen/test_vertex_plugin.py` — 22 tests
- All tests are offline: credentials and HTTP are monkeypatched; they assert full request shape (URL, headers, payload) and response/error parsing, including safety blocks and RAI-filtered results
- `cli-config.yaml.example` — new commented "Image / Video Generation" section documenting `image_gen.provider/model`, `video_gen.provider/model`, and the optional `image_gen.vertex.*` / `video_gen.vertex.*` keys
- Omni requests declare `generation_config.video_config.task` (text/image/reference_to_video) explicitly; uri-delivered video outputs are parsed defensively (download with bearer token, URI fallback) — Vertex currently inlines all outputs and rejects `response_format.delivery`, so no request-side delivery field is sent

## How to Test

1. `scripts/run_tests.sh tests/plugins/image_gen/test_vertex_provider.py tests/plugins/video_gen/test_vertex_plugin.py` — 39 tests, no network or credentials needed
2. Live: set `VERTEX_CREDENTIALS_PATH` (service-account JSON) in `.env`, `vertex.project_id` in config.yaml, then:
   ```yaml
   image_gen: { provider: vertex, model: google/gemini-3.1-flash-image }
   video_gen: { provider: vertex, model: veo-3.1-generate-001 }   # or google/gemini-omni-flash-preview
   ```
3. `hermes -q "generate an image of a lighthouse"` and `hermes -q "generate a short video of ocean waves"` — verify media lands in the media cache and the tool result includes model/location metadata

Verified end-to-end on a production GCP project (Debian 12 vps, Telegram gateway): Gemini image gen + edit, Veo 3.1 t2v/i2v, and Omni t2v/i2v via the Interactions API.Request fields were validated against the live Vertex endpoint, not just docs — `video_config.task` is confirmed accepted, `response_format.delivery` is confirmed rejected (the Gemini API and Vertex schemas have diverged; the plugin only sends fields verified on Vertex).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(plugins): ...`)
- [x] I searched existing PRs — no duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run the test suite and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian 12 (VPS, gateway mode)

### Documentation & Housekeeping

- [x] Docstrings document routing, endpoints, and config keys in both plugins
- [x] I've updated `cli-config.yaml.example` for the new optional `image_gen.vertex.*` / `video_gen.vertex.*` keys
- [x] Architecture unchanged (plugin-only) — AGENTS.md/CONTRIBUTING.md N/A
- [x] Cross-platform: pure `requests` + stdlib, explicit `encoding=` on file IO, no POSIX-only calls
- [x] Tool behavior unchanged (backend plugins only) — schemas N/A

## Screenshots / Logs
<img width="853" height="836" alt="image" src="https://github.com/user-attachments/assets/ce9d16b7-97c7-4f80-aada-cf4abfdabe87" />
<img width="920" height="847" alt="image" src="https://github.com/user-attachments/assets/6fc6a085-4e9b-49fa-9da2-2925fe131fb0" />
hermes logs 
<img width="914" height="90" alt="image" src="https://github.com/user-attachments/assets/1821e1dd-376f-4f48-b738-27ffdda2747b" />
<img width="914" height="150" alt="image" src="https://github.com/user-attachments/assets/6459ebc0-9ee7-4a4f-960c-843365351398" />

