### PR TITLE
fix(cli): keep tool activity visible when token streaming is disabled

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -387,12 +387,13 @@ class CLIAgentSetupMixin:
                 tool_start_callback=self._on_tool_start if self._inline_diffs_enabled else None,
                 tool_complete_callback=self._on_tool_complete if self._inline_diffs_enabled else None,
                 stream_delta_callback=self._stream_delta if self.streaming_enabled else None,
-                # Tool-call argument generation can pause visible output before
-                # any tool.started event fires. Keep the compact CLI activity
-                # indicator wired even when token streaming is disabled so
-                # non-streaming runs do not look stalled while tools are being
-                # prepared.
-                tool_gen_callback=self._on_tool_gen_start,
+                # Keep tool preparation visible when CLI token display is
+                # disabled, while preserving display.tool_progress=off.
+                tool_gen_callback=(
+                    self._on_tool_gen_start
+                    if getattr(self, "tool_progress_mode", "all") != "off"
+                    else None
+                ),
                 notice_callback=self._on_notice,
                 notice_clear_callback=self._on_notice_clear,
                 reaction_callback=self._on_reaction,

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -387,7 +387,12 @@ class CLIAgentSetupMixin:
                 tool_start_callback=self._on_tool_start if self._inline_diffs_enabled else None,
                 tool_complete_callback=self._on_tool_complete if self._inline_diffs_enabled else None,
                 stream_delta_callback=self._stream_delta if self.streaming_enabled else None,
-                tool_gen_callback=self._on_tool_gen_start if self.streaming_enabled else None,
+                # Tool-call argument generation can pause visible output before
+                # any tool.started event fires. Keep the compact CLI activity
+                # indicator wired even when token streaming is disabled so
+                # non-streaming runs do not look stalled while tools are being
+                # prepared.
+                tool_gen_callback=self._on_tool_gen_start,
                 notice_callback=self._on_notice,
                 notice_clear_callback=self._on_notice_clear,
                 reaction_callback=self._on_reaction,

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -172,6 +172,53 @@ def test_runtime_resolution_failure_is_not_sticky(monkeypatch):
     assert shell.agent is not None
 
 
+@pytest.mark.parametrize(
+    ("tool_progress_mode", "streaming_enabled", "expects_callback"),
+    [
+        ("all", False, True),
+        ("off", False, False),
+        ("off", True, False),
+    ],
+)
+def test_tool_generation_callback_respects_progress_mode(
+    monkeypatch,
+    tool_progress_mode,
+    streaming_enabled,
+    expects_callback,
+):
+    cli = _import_cli()
+    captured = {}
+
+    def _runtime_resolve(**kwargs):
+        return {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "test-key",
+            "source": "env/config",
+        }
+
+    class _DummyAgent:
+        def __init__(self, *args, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        _runtime_resolve,
+    )
+    monkeypatch.setattr(cli, "AIAgent", _DummyAgent)
+
+    shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)
+    shell.tool_progress_mode = tool_progress_mode
+    shell.streaming_enabled = streaming_enabled
+
+    assert shell._init_agent() is True
+    if expects_callback:
+        assert captured["tool_gen_callback"] == shell._on_tool_gen_start
+    else:
+        assert captured["tool_gen_callback"] is None
+
+
 def test_runtime_resolution_rebuilds_agent_on_routing_change(monkeypatch):
     cli = _import_cli()
 


### PR DESCRIPTION
Closes #61456

## Summary
- Keep the CLI tool-generation activity callback wired when CLI token streaming is disabled
- Preserve the compact `preparing <tool>` indicator before `tool.started`
- Preserve `display.tool_progress: off` regardless of streaming configuration

This change covers disabled CLI token display. It does not change provider transport fallback behavior.

## Verification
- `scripts/run_tests.sh tests/cli/test_cli_provider_resolution.py tests/cli/test_tool_progress_scrollback.py` (45 passed)
- `git diff --check`