### PR TITLE
fix: keep retained subagents below continuations

### DIFF
--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -549,6 +549,26 @@ async def get_session_stats(profile: Optional[str] = None):
         db.close()
 
 
+@manage_router.get("/api/sessions/{session_id}/children")
+async def get_session_children_endpoint(
+    session_id: str,
+    include_stale: bool = False,
+    profile: Optional[str] = None,
+):
+    """Grouped child sessions for the WebUI parent/child drawer."""
+    db = _open_session_db_for_profile(profile)
+    try:
+        sid = db.resolve_session_id(session_id)
+        if not sid:
+            raise HTTPException(status_code=404, detail="Session not found")
+        grouped = db.get_session_children(sid, include_stale=include_stale)
+        if grouped is None:
+            raise HTTPException(status_code=404, detail="Session not found")
+        return grouped
+    finally:
+        db.close()
+
+
 @manage_router.get("/api/sessions/{session_id}")
 async def get_session_detail(session_id: str, profile: Optional[str] = None):
     db = _open_session_db_for_profile(profile, read_only=True)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11139,6 +11139,7 @@ from hermes_cli.web_routers.sessions import (  # noqa: E402,F401 — legacy re-e
     count_empty_sessions_endpoint,
     delete_empty_sessions_endpoint,
     get_session_stats,
+    get_session_children_endpoint,
     get_session_detail,
     get_session_latest_descendant,
     get_session_messages,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11019,84 +11019,14 @@ async def cancel_oauth_session(
 
 
 def _session_latest_descendant(session_id: str, db):
-    """Resolve a session id to the newest child leaf session.
+    """Resolve a session id to the latest continuable child leaf session.
 
     /model may create child sessions. Dashboard refresh should continue the
-    newest child instead of reopening the old parent.
+    latest continuable child instead of reopening the old parent, while leaving
+    branch/delegate/tool children out of the resume path.
     """
-    def row_get(row, key, index):
-        if isinstance(row, dict):
-            return row.get(key)
-        try:
-            return row[key]
-        except Exception:
-            try:
-                return row[index]
-            except Exception:
-                return None
-
-    sid = db.resolve_session_id(session_id)
-    if not sid or not db.get_session(sid):
-        return None, []
-
-    conn = (
-        getattr(db, "conn", None)
-        or getattr(db, "_conn", None)
-        or getattr(db, "connection", None)
-        or getattr(db, "_connection", None)
-    )
-
-    rows = []
-    if conn is not None:
-        raw_rows = conn.execute(
-            """
-            WITH RECURSIVE descendants(id, parent_session_id, started_at) AS (
-                SELECT id, parent_session_id, started_at FROM sessions WHERE id = ?
-                UNION
-                SELECT s.id, s.parent_session_id, s.started_at
-                FROM sessions s
-                JOIN descendants d ON s.parent_session_id = d.id
-            )
-            SELECT id, parent_session_id, started_at FROM descendants
-            """,
-            (sid,),
-        ).fetchall()
-        for row in raw_rows:
-            rows.append({
-                "id": row_get(row, "id", 0),
-                "parent_session_id": row_get(row, "parent_session_id", 1),
-                "started_at": row_get(row, "started_at", 2),
-            })
-    else:
-        rows = db.list_sessions_rich(limit=10000, offset=0, compact_rows=True)
-
-    children = {}
-    for row in rows:
-        rid = row.get("id")
-        parent = row.get("parent_session_id")
-        if rid and parent:
-            children.setdefault(parent, []).append(row)
-
-    def started(row):
-        try:
-            return float(row.get("started_at") or 0)
-        except Exception:
-            return 0.0
-
-    current = sid
-    path = [sid]
-    seen = {sid}
-
-    while children.get(current):
-        candidates = [r for r in children[current] if r.get("id") not in seen]
-        if not candidates:
-            break
-        candidates.sort(key=started, reverse=True)
-        current = candidates[0]["id"]
-        path.append(current)
-        seen.add(current)
-
-    return current, path
+    resolver = getattr(db, "resolve_latest_descendant_session_id")
+    return resolver(session_id)
 
 
 # CRITICAL — every literal-path route below MUST be declared BEFORE the

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5766,6 +5766,83 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             current = child_id
         return current
 
+    def resolve_latest_descendant_session_id(
+        self,
+        session_id: str,
+    ) -> Tuple[Optional[str], List[str]]:
+        """Resolve a WebUI resume id to the latest continuable descendant.
+
+        ``parent_session_id`` is shared by several edge types. Dashboard chat
+        resume should follow compression/model-switch continuations, but it must
+        not be hijacked by branch, delegate/subagent, or tool children that are
+        retained under the same parent for history/debugging.
+        """
+        if not session_id:
+            return None, []
+
+        sid = self.resolve_session_id(session_id)
+        if not sid or not self.get_session(sid):
+            return None, []
+
+        current = sid
+        path = [sid]
+        seen = {sid}
+        branch_child_sql = _BRANCH_CHILD_SQL.format(a="child")
+
+        # Bound the walk defensively. Normal continuation chains are shallow;
+        # this just prevents malformed parent cycles from looping forever.
+        for _ in range(100):
+            seen_placeholders = ",".join("?" for _ in seen)
+            params: List[Any] = [current, *seen]
+            with self._lock:
+                row = self._conn.execute(
+                    f"""
+                    SELECT child.id
+                    FROM sessions parent
+                    JOIN sessions child ON child.parent_session_id = parent.id
+                    WHERE parent.id = ?
+                      AND child.id NOT IN ({seen_placeholders})
+                      AND (
+                        ({_COMPRESSION_CONTINUATION_CHILD_SQL})
+                        OR (
+                          COALESCE(parent.end_reason, '') != 'compression'
+                          AND NOT ({branch_child_sql})
+                          AND json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from') IS NULL
+                          AND LOWER(COALESCE(child.source, '')) NOT IN ('tool', 'subagent')
+                        )
+                      )
+                    ORDER BY
+                      CASE
+                        WHEN parent.end_reason = 'compression' AND child.end_reason = 'compression' THEN 0
+                        WHEN parent.end_reason = 'compression' AND child.ended_at IS NULL THEN 1
+                        WHEN parent.end_reason = 'compression' THEN 2
+                        ELSE 0
+                      END,
+                      CASE
+                        WHEN parent.end_reason = 'compression' THEN COALESCE(
+                          (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = child.id),
+                          child.started_at
+                        )
+                        ELSE child.started_at
+                      END DESC,
+                      child.started_at DESC,
+                      child.id DESC
+                    LIMIT 1
+                    """,
+                    params,
+                ).fetchone()
+
+            if row is None:
+                break
+            child_id = row["id"] if hasattr(row, "keys") else row[0]
+            if not child_id or child_id in seen:
+                break
+            seen.add(child_id)
+            path.append(child_id)
+            current = child_id
+
+        return current, path
+
     # Columns excluded from compact_rows projections: only the payload-heavy
     # blob no list consumer renders. Everything else — including gateway
     # routing fields and desktop sidebar fields like git_branch — stays, and

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5655,7 +5655,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         the real continuation chain.
 
         Instead, only follow children of compression-ended parents, exclude
-        explicit branch/delegate/tool children, and prefer children that are
+        explicit branch/delegate/tool children, keep retained subagent audit
+        rows out of non-subagent conversations, and prefer children that are
         themselves continuing the compression chain (``end_reason='compression'``)
         or still live over stale closed siblings such as ``ws_orphan_reap``.
         Returns the latest continuation tip, or the input id when no
@@ -5677,6 +5678,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                       AND json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from') IS NULL
                       AND json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from') IS NULL
                       AND COALESCE(child.source, '') != 'tool'
+                      AND (COALESCE(child.source, '') != 'subagent'
+                           OR COALESCE(parent.source, '') = 'subagent')
                     ORDER BY
                       CASE
                         WHEN child.end_reason = 'compression' THEN 0
@@ -5931,6 +5934,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                       AND json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from') IS NULL
                       AND json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from') IS NULL
                       AND COALESCE(child.source, '') != 'tool'
+                      AND (COALESCE(child.source, '') != 'subagent'
+                           OR COALESCE(parent.source, '') = 'subagent')
                 ),
                 chain_max AS (
                     SELECT

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -193,6 +193,89 @@ def _workspace_key_clause(key: str) -> Tuple[str, List[str]]:
     )
 
 
+SESSION_CHILD_KIND_PRIORITY: Dict[str, int] = {
+    "focused_continuation": 0,
+    "branch": 1,
+    "interactive_child": 2,
+    "compression_continuation": 2,
+    "delegate_subagent_active": 3,
+    "delegate_subagent_completed": 4,
+    "delegate_subagent_stale": 5,
+    "child": 6,
+}
+
+_STALE_DELEGATE_END_REASONS = {
+    "error", "failed", "failure", "interrupted", "killed", "orphaned", "stale", "timeout",
+}
+
+
+def _model_config_dict(row: Dict[str, Any]) -> Dict[str, Any]:
+    raw = row.get("model_config")
+    if isinstance(raw, dict):
+        return raw
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, json.JSONDecodeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _truthy_config_value(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def classify_session_child(child: Dict[str, Any], parent: Optional[Dict[str, Any]]) -> str:
+    """Classify a child session for parent/child UI ordering."""
+    cfg = _model_config_dict(child)
+    parent_id = parent.get("id") if parent else child.get("parent_session_id")
+    source = (child.get("source") or "").strip().lower()
+    parent_source = ((parent or {}).get("source") or "").strip().lower()
+    explicit_kind = str(cfg.get("_child_kind") or "").strip().lower()
+
+    focused_of = cfg.get("_focused_continuation_of")
+    if explicit_kind == "focused_continuation" or (
+        focused_of is not None and str(focused_of) == str(parent_id)
+    ):
+        return "focused_continuation"
+
+    if cfg.get("_branched_from") is not None:
+        return "branch"
+    if parent and parent.get("end_reason") == "branched":
+        parent_ended = parent.get("ended_at") or 0
+        if parent_ended and (child.get("started_at") or 0) >= parent_ended:
+            return "branch"
+
+    delegate_marker = cfg.get("_delegate_from") is not None or explicit_kind == "delegate_subagent"
+    promoted = _truthy_config_value(cfg.get("_promoted_from_delegate"))
+    continuable = _truthy_config_value(cfg.get("_continuable"))
+    if promoted or (delegate_marker and continuable):
+        return "interactive_child"
+
+    if parent and parent.get("end_reason") == "compression" and not delegate_marker:
+        if source != "tool" and (source != "subagent" or parent_source == "subagent"):
+            parent_ended = parent.get("ended_at") or 0
+            if not parent_ended or (child.get("started_at") or 0) >= parent_ended:
+                return "compression_continuation"
+
+    if delegate_marker or source == "subagent":
+        if child.get("ended_at") is None:
+            return "delegate_subagent_active"
+        end_reason = str(child.get("end_reason") or "").strip().lower()
+        if end_reason in _STALE_DELEGATE_END_REASONS:
+            return "delegate_subagent_stale"
+        return "delegate_subagent_completed"
+
+    return "child"
+
+
 def _collect_delegate_child_ids(conn, parent_ids: List[str]) -> List[str]:
     """Delegate-subagent ids to cascade-delete with *parent_ids*.
 
@@ -6091,6 +6174,95 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             s["unread"] = self.session_unread(s)
 
         return sessions
+
+    def get_session_children(
+        self,
+        session_id: str,
+        *,
+        include_stale: bool = False,
+        limit: int = 200,
+    ) -> Optional[Dict[str, Any]]:
+        """Return child sessions grouped for WebUI parent/child rendering."""
+        parent = self.get_session(session_id)
+        if not parent:
+            return None
+
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT id FROM sessions WHERE parent_session_id = ? "
+                "ORDER BY started_at DESC, id DESC LIMIT ?",
+                (session_id, max(0, min(limit, 1000))),
+            ).fetchall()
+        child_ids = [r["id"] if hasattr(r, "keys") else r[0] for r in rows]
+
+        now = time.time()
+        children: List[Dict[str, Any]] = []
+        for child_id in child_ids:
+            child = self._get_session_rich_row(child_id, compact_rows=True)
+            if not child:
+                continue
+            kind = classify_session_child(child, parent)
+            child["child_kind"] = kind
+            child["child_priority"] = SESSION_CHILD_KIND_PRIORITY.get(
+                kind, SESSION_CHILD_KIND_PRIORITY["child"]
+            )
+            child["is_active"] = (
+                child.get("ended_at") is None
+                and (now - (child.get("last_active") or child.get("started_at") or 0)) < 300
+            )
+            child["archived"] = bool(child.get("archived"))
+            child.pop("model_config", None)
+            child.pop("system_prompt", None)
+            children.append(child)
+
+        def _sort_key(child: Dict[str, Any]) -> Tuple[int, float, str]:
+            recency = float(child.get("last_active") or child.get("started_at") or 0)
+            raw_priority = child.get("child_priority")
+            priority = int(raw_priority) if raw_priority is not None else 999
+            return (priority, -recency, str(child.get("id") or ""))
+
+        children.sort(key=_sort_key)
+        grouped: Dict[str, Any] = {
+            "parent_session_id": session_id,
+            "focused": [],
+            "branches": [],
+            "interactive": [],
+            "compression": [],
+            "subagents": {"active": [], "completed": [], "stale": [], "stale_count": 0},
+            "other": [],
+            "ordered_children": [],
+        }
+
+        for child in children:
+            kind = child.get("child_kind")
+            if kind == "focused_continuation":
+                grouped["focused"].append(child)
+                grouped["ordered_children"].append(child)
+            elif kind == "branch":
+                grouped["branches"].append(child)
+                grouped["ordered_children"].append(child)
+            elif kind == "interactive_child":
+                grouped["interactive"].append(child)
+                grouped["ordered_children"].append(child)
+            elif kind == "compression_continuation":
+                grouped["compression"].append(child)
+                grouped["ordered_children"].append(child)
+            elif kind == "delegate_subagent_active":
+                grouped["subagents"]["active"].append(child)
+                grouped["ordered_children"].append(child)
+            elif kind == "delegate_subagent_completed":
+                grouped["subagents"]["completed"].append(child)
+                grouped["ordered_children"].append(child)
+            elif kind == "delegate_subagent_stale":
+                grouped["subagents"]["stale_count"] += 1
+                if include_stale:
+                    grouped["subagents"]["stale"].append(child)
+                    grouped["ordered_children"].append(child)
+            else:
+                grouped["other"].append(child)
+                grouped["ordered_children"].append(child)
+
+        return grouped
 
     # =========================================================================
     # Message storage

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -44,6 +44,7 @@ from hermes_cli.sqlite_runtime import (
     is_sqlite_wal_reset_vulnerable as _is_sqlite_wal_reset_vulnerable,
 )
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
+from utils import is_truthy_value
 
 from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _BRANCH_CHILD_SQL,
@@ -204,9 +205,35 @@ SESSION_CHILD_KIND_PRIORITY: Dict[str, int] = {
     "child": 6,
 }
 
+_SESSION_CHILD_KIND_BUCKETS: Dict[str, Tuple[str, ...]] = {
+    "focused_continuation": ("focused",),
+    "branch": ("branches",),
+    "interactive_child": ("interactive",),
+    "compression_continuation": ("compression",),
+    "delegate_subagent_active": ("subagents", "active"),
+    "delegate_subagent_completed": ("subagents", "completed"),
+    "delegate_subagent_stale": ("subagents", "stale"),
+    "child": ("other",),
+}
+
 _STALE_DELEGATE_END_REASONS = {
     "error", "failed", "failure", "interrupted", "killed", "orphaned", "stale", "timeout",
 }
+
+
+def _compression_continuation_child_sql(
+    parent_alias: str = "parent",
+    child_alias: str = "child",
+) -> str:
+    """SQL predicate for real compression-continuation edges."""
+    return (
+        f"{parent_alias}.end_reason = 'compression'"
+        f" AND json_extract(COALESCE({child_alias}.model_config, '{{}}'), '$._branched_from') IS NULL"
+        f" AND json_extract(COALESCE({child_alias}.model_config, '{{}}'), '$._delegate_from') IS NULL"
+        f" AND COALESCE({child_alias}.source, '') != 'tool'"
+        f" AND (COALESCE({child_alias}.source, '') != 'subagent'"
+        f"      OR COALESCE({parent_alias}.source, '') = 'subagent')"
+    )
 
 
 def _model_config_dict(row: Dict[str, Any]) -> Dict[str, Any]:
@@ -220,16 +247,6 @@ def _model_config_dict(row: Dict[str, Any]) -> Dict[str, Any]:
     except (TypeError, json.JSONDecodeError):
         return {}
     return parsed if isinstance(parsed, dict) else {}
-
-
-def _truthy_config_value(value: Any) -> bool:
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, (int, float)):
-        return value != 0
-    if isinstance(value, str):
-        return value.strip().lower() in {"1", "true", "yes", "on"}
-    return bool(value)
 
 
 def classify_session_child(child: Dict[str, Any], parent: Optional[Dict[str, Any]]) -> str:
@@ -254,8 +271,8 @@ def classify_session_child(child: Dict[str, Any], parent: Optional[Dict[str, Any
             return "branch"
 
     delegate_marker = cfg.get("_delegate_from") is not None or explicit_kind == "delegate_subagent"
-    promoted = _truthy_config_value(cfg.get("_promoted_from_delegate"))
-    continuable = _truthy_config_value(cfg.get("_continuable"))
+    promoted = is_truthy_value(cfg.get("_promoted_from_delegate"), default=False)
+    continuable = is_truthy_value(cfg.get("_continuable"), default=False)
     if promoted or (delegate_marker and continuable):
         return "interactive_child"
 
@@ -5757,12 +5774,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     FROM sessions parent
                     JOIN sessions child ON child.parent_session_id = parent.id
                     WHERE parent.id = ?
-                      AND parent.end_reason = 'compression'
-                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from') IS NULL
-                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from') IS NULL
-                      AND COALESCE(child.source, '') != 'tool'
-                      AND (COALESCE(child.source, '') != 'subagent'
-                           OR COALESCE(parent.source, '') = 'subagent')
+                      AND {_compression_continuation_child_sql('parent', 'child')}
                     ORDER BY
                       CASE
                         WHEN child.end_reason = 'compression' THEN 0
@@ -6013,12 +6025,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     FROM chain c
                     JOIN sessions parent ON parent.id = c.cur_id
                     JOIN sessions child ON child.parent_session_id = c.cur_id
-                    WHERE parent.end_reason = 'compression'
-                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from') IS NULL
-                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from') IS NULL
-                      AND COALESCE(child.source, '') != 'tool'
-                      AND (COALESCE(child.source, '') != 'subagent'
-                           OR COALESCE(parent.source, '') = 'subagent')
+                    WHERE {_compression_continuation_child_sql('parent', 'child')}
                 ),
                 chain_max AS (
                     SELECT
@@ -6187,80 +6194,86 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if not parent:
             return None
 
+        visible_limit = max(0, min(limit, 1000))
+        _sel = self._compact_session_cols()
+        query = f"""
+            SELECT {_sel},
+                COALESCE(
+                    (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
+                     FROM messages m
+                     WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                     ORDER BY m.timestamp, m.id LIMIT 1),
+                    ''
+                ) AS _preview_raw,
+                COALESCE(
+                    (SELECT MAX(m2.timestamp) FROM messages m2 WHERE m2.session_id = s.id),
+                    s.started_at
+                ) AS last_active
+            FROM sessions s
+            WHERE s.parent_session_id = ?
+        """
         with self._lock:
-            rows = self._conn.execute(
-                "SELECT id FROM sessions WHERE parent_session_id = ? "
-                "ORDER BY started_at DESC, id DESC LIMIT ?",
-                (session_id, max(0, min(limit, 1000))),
-            ).fetchall()
-        child_ids = [r["id"] if hasattr(r, "keys") else r[0] for r in rows]
+            rows = self._conn.execute(query, (session_id,)).fetchall()
 
         now = time.time()
-        children: List[Dict[str, Any]] = []
-        for child_id in child_ids:
-            child = self._get_session_rich_row(child_id, compact_rows=True)
-            if not child:
-                continue
+        children: List[Tuple[int, float, str, Dict[str, Any]]] = []
+        for row in rows:
+            child = dict(row)
+            raw = child.pop("_preview_raw", "").strip()
+            if raw:
+                text = raw[:60]
+                child["preview"] = text + ("..." if len(raw) > 60 else "")
+            else:
+                child["preview"] = ""
+
+            last_active = float(child.get("last_active") or child.get("started_at") or 0)
+            is_recent_open_delegate = (
+                child.get("ended_at") is None and (now - last_active) < 300
+            )
             kind = classify_session_child(child, parent)
+            if kind == "delegate_subagent_active" and not is_recent_open_delegate:
+                kind = "delegate_subagent_stale"
+
             child["child_kind"] = kind
-            child["child_priority"] = SESSION_CHILD_KIND_PRIORITY.get(
-                kind, SESSION_CHILD_KIND_PRIORITY["child"]
-            )
-            child["is_active"] = (
-                child.get("ended_at") is None
-                and (now - (child.get("last_active") or child.get("started_at") or 0)) < 300
-            )
+            child["is_active"] = is_recent_open_delegate
             child["archived"] = bool(child.get("archived"))
             child.pop("model_config", None)
             child.pop("system_prompt", None)
-            children.append(child)
 
-        def _sort_key(child: Dict[str, Any]) -> Tuple[int, float, str]:
-            recency = float(child.get("last_active") or child.get("started_at") or 0)
-            raw_priority = child.get("child_priority")
-            priority = int(raw_priority) if raw_priority is not None else 999
-            return (priority, -recency, str(child.get("id") or ""))
+            priority = SESSION_CHILD_KIND_PRIORITY.get(
+                kind, SESSION_CHILD_KIND_PRIORITY["child"]
+            )
+            children.append((priority, -last_active, str(child.get("id") or ""), child))
 
-        children.sort(key=_sort_key)
+        children.sort(key=lambda item: (item[0], item[1], item[2]))
         grouped: Dict[str, Any] = {
             "parent_session_id": session_id,
             "focused": [],
             "branches": [],
             "interactive": [],
             "compression": [],
-            "subagents": {"active": [], "completed": [], "stale": [], "stale_count": 0},
+            "subagents": {
+                "active": [],
+                "completed": [],
+                "stale": [],
+                "stale_count": sum(
+                    1
+                    for _, _, _, child in children
+                    if child.get("child_kind") == "delegate_subagent_stale"
+                ),
+            },
             "other": [],
-            "ordered_children": [],
         }
 
-        for child in children:
-            kind = child.get("child_kind")
-            if kind == "focused_continuation":
-                grouped["focused"].append(child)
-                grouped["ordered_children"].append(child)
-            elif kind == "branch":
-                grouped["branches"].append(child)
-                grouped["ordered_children"].append(child)
-            elif kind == "interactive_child":
-                grouped["interactive"].append(child)
-                grouped["ordered_children"].append(child)
-            elif kind == "compression_continuation":
-                grouped["compression"].append(child)
-                grouped["ordered_children"].append(child)
-            elif kind == "delegate_subagent_active":
-                grouped["subagents"]["active"].append(child)
-                grouped["ordered_children"].append(child)
-            elif kind == "delegate_subagent_completed":
-                grouped["subagents"]["completed"].append(child)
-                grouped["ordered_children"].append(child)
-            elif kind == "delegate_subagent_stale":
-                grouped["subagents"]["stale_count"] += 1
-                if include_stale:
-                    grouped["subagents"]["stale"].append(child)
-                    grouped["ordered_children"].append(child)
+        for _, _, _, child in children[:visible_limit]:
+            kind = child.get("child_kind") or "child"
+            if kind == "delegate_subagent_stale" and not include_stale:
+                continue
+            bucket = _SESSION_CHILD_KIND_BUCKETS.get(kind, ("other",))
+            if len(bucket) == 1:
+                grouped[bucket[0]].append(child)
             else:
-                grouped["other"].append(child)
-                grouped["ordered_children"].append(child)
+                grouped[bucket[0]][bucket[1]].append(child)
 
         return grouped
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -44,7 +44,6 @@ from hermes_cli.sqlite_runtime import (
     is_sqlite_wal_reset_vulnerable as _is_sqlite_wal_reset_vulnerable,
 )
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
-from utils import is_truthy_value
 
 from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _BRANCH_CHILD_SQL,
@@ -194,26 +193,13 @@ def _workspace_key_clause(key: str) -> Tuple[str, List[str]]:
     )
 
 
-SESSION_CHILD_KIND_PRIORITY: Dict[str, int] = {
-    "focused_continuation": 0,
-    "branch": 1,
-    "interactive_child": 2,
-    "compression_continuation": 2,
-    "delegate_subagent_active": 3,
-    "delegate_subagent_completed": 4,
-    "delegate_subagent_stale": 5,
-    "child": 6,
-}
-
-_SESSION_CHILD_KIND_BUCKETS: Dict[str, Tuple[str, ...]] = {
-    "focused_continuation": ("focused",),
-    "branch": ("branches",),
-    "interactive_child": ("interactive",),
-    "compression_continuation": ("compression",),
-    "delegate_subagent_active": ("subagents", "active"),
-    "delegate_subagent_completed": ("subagents", "completed"),
-    "delegate_subagent_stale": ("subagents", "stale"),
-    "child": ("other",),
+_SESSION_CHILD_KINDS: Dict[str, Tuple[int, Tuple[str, ...]]] = {
+    "focused_continuation": (0, ("focused",)),
+    "branch": (1, ("branches",)),
+    "delegate_subagent_active": (2, ("subagents", "active")),
+    "delegate_subagent_completed": (3, ("subagents", "completed")),
+    "delegate_subagent_stale": (4, ("subagents", "stale")),
+    "child": (5, ("other",)),
 }
 
 _STALE_DELEGATE_END_REASONS = {
@@ -221,19 +207,14 @@ _STALE_DELEGATE_END_REASONS = {
 }
 
 
-def _compression_continuation_child_sql(
-    parent_alias: str = "parent",
-    child_alias: str = "child",
-) -> str:
-    """SQL predicate for real compression-continuation edges."""
-    return (
-        f"{parent_alias}.end_reason = 'compression'"
-        f" AND json_extract(COALESCE({child_alias}.model_config, '{{}}'), '$._branched_from') IS NULL"
-        f" AND json_extract(COALESCE({child_alias}.model_config, '{{}}'), '$._delegate_from') IS NULL"
-        f" AND COALESCE({child_alias}.source, '') != 'tool'"
-        f" AND (COALESCE({child_alias}.source, '') != 'subagent'"
-        f"      OR COALESCE({parent_alias}.source, '') = 'subagent')"
-    )
+_COMPRESSION_CONTINUATION_CHILD_SQL = (
+    "parent.end_reason = 'compression'"
+    " AND json_extract(COALESCE(child.model_config, '{}'), '$._branched_from') IS NULL"
+    " AND json_extract(COALESCE(child.model_config, '{}'), '$._delegate_from') IS NULL"
+    " AND COALESCE(child.source, '') != 'tool'"
+    " AND (COALESCE(child.source, '') != 'subagent'"
+    "      OR COALESCE(parent.source, '') = 'subagent')"
+)
 
 
 def _model_config_dict(row: Dict[str, Any]) -> Dict[str, Any]:
@@ -250,18 +231,10 @@ def _model_config_dict(row: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def classify_session_child(child: Dict[str, Any], parent: Optional[Dict[str, Any]]) -> str:
-    """Classify a child session for parent/child UI ordering."""
+    """Classify compression, branch, and delegate child sessions."""
     cfg = _model_config_dict(child)
-    parent_id = parent.get("id") if parent else child.get("parent_session_id")
     source = (child.get("source") or "").strip().lower()
     parent_source = ((parent or {}).get("source") or "").strip().lower()
-    explicit_kind = str(cfg.get("_child_kind") or "").strip().lower()
-
-    focused_of = cfg.get("_focused_continuation_of")
-    if explicit_kind == "focused_continuation" or (
-        focused_of is not None and str(focused_of) == str(parent_id)
-    ):
-        return "focused_continuation"
 
     if cfg.get("_branched_from") is not None:
         return "branch"
@@ -270,17 +243,12 @@ def classify_session_child(child: Dict[str, Any], parent: Optional[Dict[str, Any
         if parent_ended and (child.get("started_at") or 0) >= parent_ended:
             return "branch"
 
-    delegate_marker = cfg.get("_delegate_from") is not None or explicit_kind == "delegate_subagent"
-    promoted = is_truthy_value(cfg.get("_promoted_from_delegate"), default=False)
-    continuable = is_truthy_value(cfg.get("_continuable"), default=False)
-    if promoted or (delegate_marker and continuable):
-        return "interactive_child"
-
+    delegate_marker = cfg.get("_delegate_from") is not None
     if parent and parent.get("end_reason") == "compression" and not delegate_marker:
         if source != "tool" and (source != "subagent" or parent_source == "subagent"):
             parent_ended = parent.get("ended_at") or 0
             if not parent_ended or (child.get("started_at") or 0) >= parent_ended:
-                return "compression_continuation"
+                return "focused_continuation"
 
     if delegate_marker or source == "subagent":
         if child.get("ended_at") is None:
@@ -5774,7 +5742,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     FROM sessions parent
                     JOIN sessions child ON child.parent_session_id = parent.id
                     WHERE parent.id = ?
-                      AND {_compression_continuation_child_sql('parent', 'child')}
+                      AND {_COMPRESSION_CONTINUATION_CHILD_SQL}
                     ORDER BY
                       CASE
                         WHEN child.end_reason = 'compression' THEN 0
@@ -6025,7 +5993,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     FROM chain c
                     JOIN sessions parent ON parent.id = c.cur_id
                     JOIN sessions child ON child.parent_session_id = c.cur_id
-                    WHERE {_compression_continuation_child_sql('parent', 'child')}
+                    WHERE {_COMPRESSION_CONTINUATION_CHILD_SQL}
                 ),
                 chain_max AS (
                     SELECT
@@ -6216,7 +6184,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             rows = self._conn.execute(query, (session_id,)).fetchall()
 
         now = time.time()
-        children: List[Tuple[int, float, str, Dict[str, Any]]] = []
+        children: List[Tuple[int, float, str, str, Dict[str, Any]]] = []
         for row in rows:
             child = dict(row)
             raw = child.pop("_preview_raw", "").strip()
@@ -6234,42 +6202,36 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             if kind == "delegate_subagent_active" and not is_recent_open_delegate:
                 kind = "delegate_subagent_stale"
 
-            child["child_kind"] = kind
             child["is_active"] = is_recent_open_delegate
-            child["archived"] = bool(child.get("archived"))
             child.pop("model_config", None)
             child.pop("system_prompt", None)
 
-            priority = SESSION_CHILD_KIND_PRIORITY.get(
-                kind, SESSION_CHILD_KIND_PRIORITY["child"]
-            )
-            children.append((priority, -last_active, str(child.get("id") or ""), child))
+            priority = _SESSION_CHILD_KINDS.get(kind, _SESSION_CHILD_KINDS["child"])[0]
+            children.append((priority, -last_active, str(child.get("id") or ""), kind, child))
 
         children.sort(key=lambda item: (item[0], item[1], item[2]))
         grouped: Dict[str, Any] = {
             "parent_session_id": session_id,
             "focused": [],
             "branches": [],
-            "interactive": [],
-            "compression": [],
             "subagents": {
                 "active": [],
                 "completed": [],
                 "stale": [],
                 "stale_count": sum(
-                    1
-                    for _, _, _, child in children
-                    if child.get("child_kind") == "delegate_subagent_stale"
+                    1 for _, _, _, kind, _ in children
+                    if kind == "delegate_subagent_stale"
                 ),
             },
             "other": [],
         }
 
-        for _, _, _, child in children[:visible_limit]:
-            kind = child.get("child_kind") or "child"
-            if kind == "delegate_subagent_stale" and not include_stale:
-                continue
-            bucket = _SESSION_CHILD_KIND_BUCKETS.get(kind, ("other",))
+        visible = [
+            entry for entry in children
+            if include_stale or entry[3] != "delegate_subagent_stale"
+        ]
+        for _, _, _, kind, child in visible[:visible_limit]:
+            bucket = _SESSION_CHILD_KINDS.get(kind, _SESSION_CHILD_KINDS["child"])[1]
             if len(bucket) == 1:
                 grouped[bucket[0]].append(child)
             else:

--- a/tests/hermes_cli/test_web_server_session_children.py
+++ b/tests/hermes_cli/test_web_server_session_children.py
@@ -17,13 +17,11 @@ class _FakeSessionDB:
         self.include_stale = include_stale
         return {
             "parent_session_id": "parent",
-            "focused": [{"id": "focused", "child_kind": "focused_continuation"}],
+            "focused": [{"id": "focused"}],
             "branches": [],
-            "interactive": [],
-            "compression": [],
             "subagents": {
                 "active": [],
-                "completed": [{"id": "audit", "child_kind": "delegate_subagent_completed"}],
+                "completed": [{"id": "audit"}],
                 "stale": [],
                 "stale_count": 1,
             },

--- a/tests/hermes_cli/test_web_server_session_children.py
+++ b/tests/hermes_cli/test_web_server_session_children.py
@@ -1,0 +1,62 @@
+import asyncio
+
+from hermes_cli import web_server
+
+
+class _FakeSessionDB:
+    def __init__(self):
+        self.closed = False
+        self.include_stale = None
+
+    def resolve_session_id(self, session_id):
+        assert session_id == "parent-prefix"
+        return "parent"
+
+    def get_session_children(self, session_id, *, include_stale=False):
+        assert session_id == "parent"
+        self.include_stale = include_stale
+        return {
+            "parent_session_id": "parent",
+            "focused": [{"id": "focused", "child_kind": "focused_continuation"}],
+            "branches": [],
+            "interactive": [],
+            "compression": [],
+            "subagents": {
+                "active": [],
+                "completed": [{"id": "audit", "child_kind": "delegate_subagent_completed"}],
+                "stale": [],
+                "stale_count": 1,
+            },
+            "other": [],
+            "ordered_children": [
+                {"id": "focused", "child_kind": "focused_continuation"},
+                {"id": "audit", "child_kind": "delegate_subagent_completed"},
+            ],
+        }
+
+    def close(self):
+        self.closed = True
+
+
+def test_session_children_endpoint_returns_grouped_children(monkeypatch):
+    fake_db = _FakeSessionDB()
+    monkeypatch.setattr(
+        web_server,
+        "_open_session_db_for_profile",
+        lambda profile=None: fake_db,
+    )
+
+    response = asyncio.run(
+        web_server.get_session_children_endpoint(
+            "parent-prefix",
+            include_stale=True,
+            profile="default",
+        )
+    )
+
+    assert fake_db.include_stale is True
+    assert fake_db.closed is True
+    assert [row["id"] for row in response["focused"]] == ["focused"]
+    assert [row["id"] for row in response["subagents"]["completed"]] == ["audit"]
+    assert response["subagents"]["stale_count"] == 1
+    assert [row["id"] for row in response["ordered_children"]] == ["focused", "audit"]

--- a/tests/hermes_cli/test_web_server_session_children.py
+++ b/tests/hermes_cli/test_web_server_session_children.py
@@ -28,10 +28,6 @@ class _FakeSessionDB:
                 "stale_count": 1,
             },
             "other": [],
-            "ordered_children": [
-                {"id": "focused", "child_kind": "focused_continuation"},
-                {"id": "audit", "child_kind": "delegate_subagent_completed"},
-            ],
         }
 
     def close(self):
@@ -59,4 +55,3 @@ def test_session_children_endpoint_returns_grouped_children(monkeypatch):
     assert [row["id"] for row in response["focused"]] == ["focused"]
     assert [row["id"] for row in response["subagents"]["completed"]] == ["audit"]
     assert response["subagents"]["stale_count"] == 1
-    assert [row["id"] for row in response["ordered_children"]] == ["focused", "audit"]

--- a/tests/hermes_cli/test_web_server_session_children.py
+++ b/tests/hermes_cli/test_web_server_session_children.py
@@ -1,6 +1,8 @@
 import asyncio
+import time
 
 from hermes_cli import web_server
+from hermes_state import SessionDB
 
 
 class _FakeSessionDB:
@@ -53,3 +55,54 @@ def test_session_children_endpoint_returns_grouped_children(monkeypatch):
     assert [row["id"] for row in response["focused"]] == ["focused"]
     assert [row["id"] for row in response["subagents"]["completed"]] == ["audit"]
     assert response["subagents"]["stale_count"] == 1
+
+
+def test_latest_descendant_prefers_compression_continuation_over_newer_delegate(
+    monkeypatch,
+    tmp_path,
+):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    base = int(time.time()) - 10_000
+    try:
+        db.create_session("root", source="cli")
+        db.append_message("root", "user", "pre-compression")
+        db.end_session("root", "compression")
+        db.create_session("focused_cont", source="cli", parent_session_id="root")
+        db.append_message("focused_cont", "assistant", "real continuation")
+        db.create_session(
+            "delegate_subagent",
+            source="subagent",
+            parent_session_id="root",
+            model_config={"_delegate_from": "root"},
+        )
+        db.append_message("delegate_subagent", "assistant", "newer audit child")
+
+        conn = db._conn
+        assert conn is not None
+        conn.execute(
+            "UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = 'root'",
+            (base, base + 100),
+        )
+        conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = 'focused_cont'",
+            (base + 150,),
+        )
+        conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = 'delegate_subagent'",
+            (base + 300,),
+        )
+        conn.commit()
+
+        monkeypatch.setattr(
+            web_server,
+            "_open_session_db_for_profile",
+            lambda profile=None, read_only=False: db,
+        )
+
+        response = asyncio.run(web_server.get_session_latest_descendant("root"))
+
+        assert response["session_id"] == "focused_cont"
+        assert response["path"] == ["root", "focused_cont"]
+        assert response["changed"] is True
+    finally:
+        db.close()

--- a/tests/hermes_state/test_resolve_resume_session_id.py
+++ b/tests/hermes_state/test_resolve_resume_session_id.py
@@ -101,4 +101,45 @@ def test_prefers_most_recent_child_when_fork_exists(db):
 
 
 
+def test_compression_tip_prefers_continuation_over_retained_subagent_sibling(db):
+    # Read-only delegate/subagent rows can be retained for audit/debugging under
+    # the compressed parent, but they are not the user's focused continuation.
+    # A newer subagent sibling must not consume the projected list/resume slot.
+    base = int(time.time()) - 10_000
+    db.create_session("root", source="cli")
+    db.append_message("root", role="user", content="pre-compression turn")
+    db.end_session("root", "compression")
+
+    db.create_session("focused_cont", source="cli", parent_session_id="root")
+    db.append_message("focused_cont", role="assistant", content="real continuation")
+
+    # Shape produced by retained audit/debug child rows: linked to the parent,
+    # source=subagent, no deletion required, and no reliable legacy marker.
+    db.create_session("audit_subagent", source="subagent", parent_session_id="root")
+    db.append_message("audit_subagent", role="assistant", content="read-only audit child")
+
+    # Separate normal conversation: newer than the real continuation, older
+    # than the audit child. If the audit child leaks into the compression-chain
+    # CTE, the focused continuation incorrectly outranks this row.
+    db.create_session("solo", source="cli")
+    db.append_message("solo", role="user", content="separate normal chat")
+
+    conn = db._conn
+    assert conn is not None
+    conn.execute("UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = 'root'", (base, base + 100))
+    conn.execute("UPDATE sessions SET started_at = ? WHERE id = 'focused_cont'", (base + 90,))
+    conn.execute("UPDATE sessions SET started_at = ? WHERE id = 'audit_subagent'", (base + 200,))
+    conn.execute("UPDATE sessions SET started_at = ? WHERE id = 'solo'", (base + 180,))
+    conn.execute("UPDATE messages SET timestamp = ? WHERE session_id = 'root'", (base + 10,))
+    conn.execute("UPDATE messages SET timestamp = ? WHERE session_id = 'focused_cont'", (base + 110,))
+    conn.execute("UPDATE messages SET timestamp = ? WHERE session_id = 'solo'", (base + 220,))
+    conn.execute("UPDATE messages SET timestamp = ? WHERE session_id = 'audit_subagent'", (base + 300,))
+    conn.commit()
+
+    assert db.get_compression_tip("root") == "focused_cont"
+    assert db.resolve_resume_session_id("root") == "focused_cont"
+
+    listed = db.list_sessions_rich(source="cli", limit=10, order_by_last_active=True)
+    assert [row["id"] for row in listed] == ["solo", "focused_cont"]
+    assert listed[1]["_lineage_root_id"] == "root"
 

--- a/tests/hermes_state/test_session_children.py
+++ b/tests/hermes_state/test_session_children.py
@@ -59,12 +59,6 @@ def test_session_children_group_focused_before_read_only_subagents(tmp_path):
         assert [s["id"] for s in grouped["subagents"]["completed"]] == ["done_subagent"]
         assert grouped["subagents"]["stale_count"] == 1
         assert grouped["subagents"]["stale"] == []
-        assert [s["id"] for s in grouped["ordered_children"]] == [
-            "focused",
-            "branch",
-            "active_subagent",
-            "done_subagent",
-        ]
     finally:
         db.close()
 
@@ -85,6 +79,28 @@ def test_session_children_can_include_stale_subagents(tmp_path):
 
         assert grouped["subagents"]["stale_count"] == 1
         assert [s["id"] for s in grouped["subagents"]["stale"]] == ["stale_subagent"]
-        assert [s["id"] for s in grouped["ordered_children"]] == ["stale_subagent"]
+    finally:
+        db.close()
+
+
+def test_quiet_open_delegate_is_stale_not_active(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("parent", source="cli")
+        db.create_session(
+            "quiet_subagent",
+            source="subagent",
+            parent_session_id="parent",
+            model_config={"_delegate_from": "parent"},
+        )
+        db._conn.execute(
+            "UPDATE sessions SET started_at = started_at - 1000 WHERE id = 'quiet_subagent'"
+        )
+        db._conn.commit()
+
+        grouped = db.get_session_children("parent")
+
+        assert grouped["subagents"]["active"] == []
+        assert grouped["subagents"]["stale_count"] == 1
     finally:
         db.close()

--- a/tests/hermes_state/test_session_children.py
+++ b/tests/hermes_state/test_session_children.py
@@ -9,14 +9,11 @@ def test_session_children_group_focused_before_read_only_subagents(tmp_path):
     db = SessionDB(db_path=tmp_path / "state.db")
     try:
         db.create_session("parent", source="cli")
+        db.end_session("parent", "compression")
         db.create_session(
             "focused",
             source="cli",
             parent_session_id="parent",
-            model_config={
-                "_focused_continuation_of": "parent",
-                "_child_kind": "focused_continuation",
-            },
         )
         db.append_message("focused", "assistant", "focused continuation")
         db.create_session(
@@ -54,6 +51,7 @@ def test_session_children_group_focused_before_read_only_subagents(tmp_path):
 
         assert grouped["parent_session_id"] == "parent"
         assert [s["id"] for s in grouped["focused"]] == ["focused"]
+        assert "child_kind" not in grouped["focused"][0]
         assert [s["id"] for s in grouped["branches"]] == ["branch"]
         assert [s["id"] for s in grouped["subagents"]["active"]] == ["active_subagent"]
         assert [s["id"] for s in grouped["subagents"]["completed"]] == ["done_subagent"]

--- a/tests/hermes_state/test_session_children.py
+++ b/tests/hermes_state/test_session_children.py
@@ -1,0 +1,90 @@
+"""Regression tests for parent/child session classification and grouping."""
+
+from __future__ import annotations
+
+from hermes_state import SessionDB
+
+
+def test_session_children_group_focused_before_read_only_subagents(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("parent", source="cli")
+        db.create_session(
+            "focused",
+            source="cli",
+            parent_session_id="parent",
+            model_config={
+                "_focused_continuation_of": "parent",
+                "_child_kind": "focused_continuation",
+            },
+        )
+        db.append_message("focused", "assistant", "focused continuation")
+        db.create_session(
+            "branch",
+            source="cli",
+            parent_session_id="parent",
+            model_config={"_branched_from": "parent"},
+        )
+        db.append_message("branch", "user", "branch work")
+        db.create_session(
+            "active_subagent",
+            source="subagent",
+            parent_session_id="parent",
+            model_config={"_delegate_from": "parent"},
+        )
+        db.append_message("active_subagent", "assistant", "watch me")
+        db.create_session(
+            "done_subagent",
+            source="subagent",
+            parent_session_id="parent",
+            model_config={"_delegate_from": "parent"},
+        )
+        db.append_message("done_subagent", "assistant", "done")
+        db.end_session("done_subagent", "completed")
+        db.create_session(
+            "stale_subagent",
+            source="subagent",
+            parent_session_id="parent",
+            model_config={"_delegate_from": "parent"},
+        )
+        db.append_message("stale_subagent", "assistant", "failed")
+        db.end_session("stale_subagent", "timeout")
+
+        grouped = db.get_session_children("parent")
+
+        assert grouped["parent_session_id"] == "parent"
+        assert [s["id"] for s in grouped["focused"]] == ["focused"]
+        assert [s["id"] for s in grouped["branches"]] == ["branch"]
+        assert [s["id"] for s in grouped["subagents"]["active"]] == ["active_subagent"]
+        assert [s["id"] for s in grouped["subagents"]["completed"]] == ["done_subagent"]
+        assert grouped["subagents"]["stale_count"] == 1
+        assert grouped["subagents"]["stale"] == []
+        assert [s["id"] for s in grouped["ordered_children"]] == [
+            "focused",
+            "branch",
+            "active_subagent",
+            "done_subagent",
+        ]
+    finally:
+        db.close()
+
+
+def test_session_children_can_include_stale_subagents(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("parent", source="cli")
+        db.create_session(
+            "stale_subagent",
+            source="subagent",
+            parent_session_id="parent",
+            model_config={"_delegate_from": "parent"},
+        )
+        db.end_session("stale_subagent", "failed")
+
+        grouped = db.get_session_children("parent", include_stale=True)
+
+        assert grouped["subagents"]["stale_count"] == 1
+        assert [s["id"] for s in grouped["subagents"]["stale"]] == ["stale_subagent"]
+        assert [s["id"] for s in grouped["ordered_children"]] == ["stale_subagent"]
+    finally:
+        db.close()

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -88,6 +88,30 @@ describe("fetchJSON", () => {
   });
 });
 
+describe("api.getSessionChildren", () => {
+  it("requests the grouped children endpoint", async () => {
+    vi.stubGlobal("window", {});
+
+    const fetchMock = jsonFetchMock({
+      parent_session_id: "parent-1",
+      focused: [],
+      branches: [],
+      interactive: [],
+      compression: [],
+      subagents: { active: [], completed: [], stale: [], stale_count: 0 },
+      ordered_children: [],
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.getSessionChildren("parent-1");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/sessions/parent-1/children",
+      expect.objectContaining({ credentials: "include" }),
+    );
+  });
+});
+
 describe("api.getModelOptions", () => {
   it("requests a live model refresh when asked", async () => {
     vi.stubGlobal("window", {});

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -99,7 +99,7 @@ describe("api.getSessionChildren", () => {
       interactive: [],
       compression: [],
       subagents: { active: [], completed: [], stale: [], stale_count: 0 },
-      ordered_children: [],
+      other: [],
     });
     vi.stubGlobal("fetch", fetchMock);
 

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -96,8 +96,6 @@ describe("api.getSessionChildren", () => {
       parent_session_id: "parent-1",
       focused: [],
       branches: [],
-      interactive: [],
-      compression: [],
       subagents: { active: [], completed: [], stale: [], stale_count: 0 },
       other: [],
     });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1903,25 +1903,12 @@ export interface SessionInfo {
   preview: string | null;
   parent_session_id?: string | null;
   _lineage_root_id?: string | null;
-  child_kind?: SessionChildKind;
 }
-
-export type SessionChildKind =
-  | "focused_continuation"
-  | "branch"
-  | "interactive_child"
-  | "compression_continuation"
-  | "delegate_subagent_active"
-  | "delegate_subagent_completed"
-  | "delegate_subagent_stale"
-  | "child";
 
 export interface SessionChildrenResponse {
   parent_session_id: string;
   focused: SessionInfo[];
   branches: SessionInfo[];
-  interactive: SessionInfo[];
-  compression: SessionInfo[];
   subagents: {
     active: SessionInfo[];
     completed: SessionInfo[];

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -391,6 +391,10 @@ export const api = {
     fetchJSON<SessionInfo>(
       appendProfileParam(`/api/sessions/${encodeURIComponent(id)}`, profile),
     ),
+  getSessionChildren: (id: string, profile = getManagementProfile()) =>
+    fetchJSON<SessionChildrenResponse>(
+      appendProfileParam(`/api/sessions/${encodeURIComponent(id)}/children`, profile),
+    ),
   getSessionLatestDescendant: (id: string, profile = getManagementProfile()) =>
     fetchJSON<SessionLatestDescendantResponse>(
       appendProfileParam(
@@ -1898,6 +1902,34 @@ export interface SessionInfo {
   output_tokens: number;
   preview: string | null;
   parent_session_id?: string | null;
+  child_kind?: SessionChildKind;
+  child_priority?: number;
+}
+
+export type SessionChildKind =
+  | "focused_continuation"
+  | "branch"
+  | "interactive_child"
+  | "compression_continuation"
+  | "delegate_subagent_active"
+  | "delegate_subagent_completed"
+  | "delegate_subagent_stale"
+  | "child";
+
+export interface SessionChildrenResponse {
+  parent_session_id: string;
+  focused: SessionInfo[];
+  branches: SessionInfo[];
+  interactive: SessionInfo[];
+  compression: SessionInfo[];
+  subagents: {
+    active: SessionInfo[];
+    completed: SessionInfo[];
+    stale: SessionInfo[];
+    stale_count: number;
+  };
+  other: SessionInfo[];
+  ordered_children: SessionInfo[];
 }
 
 export interface SessionLatestDescendantResponse {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1902,8 +1902,8 @@ export interface SessionInfo {
   output_tokens: number;
   preview: string | null;
   parent_session_id?: string | null;
+  _lineage_root_id?: string | null;
   child_kind?: SessionChildKind;
-  child_priority?: number;
 }
 
 export type SessionChildKind =
@@ -1929,7 +1929,6 @@ export interface SessionChildrenResponse {
     stale_count: number;
   };
   other: SessionInfo[];
-  ordered_children: SessionInfo[];
 }
 
 export interface SessionLatestDescendantResponse {

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -31,6 +31,8 @@ import {
   Pencil,
   Check,
   Archive,
+  Bot,
+  GitBranch,
 } from "lucide-react";
 import { api } from "@/lib/api";
 import { shouldRefreshSessions } from "@/lib/session-refresh";
@@ -39,6 +41,7 @@ import {
   parseImportSessions,
 } from "@/lib/session-import";
 import type {
+  SessionChildrenResponse,
   SessionInfo,
   SessionMessage,
   SessionSearchResult,
@@ -439,7 +442,7 @@ function MessageList({
 
   useEffect(() => {
     if (!highlight || !containerRef.current) return;
-    // Scroll to first hit after render
+    // Scroll to first hit after render.
     const timer = setTimeout(() => {
       const hit = containerRef.current?.querySelector("[data-search-hit]");
       if (hit) {
@@ -461,6 +464,223 @@ function MessageList({
   );
 }
 
+const CHILD_KIND_LABELS: Record<string, string> = {
+  focused_continuation: "Focused continuation",
+  branch: "Branch",
+  interactive_child: "Interactive child",
+  compression_continuation: "Compression continuation",
+  delegate_subagent_active: "Active delegate",
+  delegate_subagent_completed: "Completed delegate",
+  delegate_subagent_stale: "Stale delegate",
+  child: "Child",
+};
+
+function childSessionTitle(session: SessionInfo, untitled: string): string {
+  const title = session.title?.trim();
+  if (title && title !== "Untitled") return title;
+  const preview = session.preview?.trim();
+  if (preview) return preview.slice(0, 80);
+  return untitled;
+}
+
+function ChildSessionRow({
+  session,
+  onResume,
+}: {
+  session: SessionInfo;
+  onResume: (id: string) => void;
+}) {
+  const { t } = useI18n();
+  const sourceInfo = (session.source
+    ? SOURCE_CONFIG[session.source]
+    : null) ?? { icon: Globe, color: "text-muted-foreground" };
+  const SourceIcon = sourceInfo.icon;
+  return (
+    <div className="flex min-w-0 items-start justify-between gap-3 rounded border border-border/70 bg-background/70 px-3 py-2">
+      <div className="flex min-w-0 items-start gap-2">
+        <SourceIcon className={`mt-0.5 h-3.5 w-3.5 shrink-0 ${sourceInfo.color}`} />
+        <div className="min-w-0 space-y-1">
+          <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+            <span className="min-w-0 truncate text-sm font-medium">
+              {childSessionTitle(session, t.sessions.untitledSession)}
+            </span>
+            {session.child_kind && (
+              <Badge tone="outline" className="text-[10px]">
+                {CHILD_KIND_LABELS[session.child_kind] ?? session.child_kind}
+              </Badge>
+            )}
+            {session.is_active && (
+              <Badge tone="success" className="text-[10px]">
+                {t.common.live}
+              </Badge>
+            )}
+          </div>
+          <div className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5 text-xs text-muted-foreground">
+            <span className="shrink-0">{session.source ?? "local"}</span>
+            <span className="text-border">&#183;</span>
+            <span className="shrink-0">
+              {session.message_count} {t.common.msgs}
+            </span>
+            <span className="text-border">&#183;</span>
+            <span className="shrink-0">{timeAgo(session.last_active)}</span>
+          </div>
+        </div>
+      </div>
+      <Button
+        ghost
+        size="sm"
+        className="shrink-0 text-muted-foreground hover:text-success"
+        onClick={(e) => {
+          e.stopPropagation();
+          onResume(session.id);
+        }}
+        prefix={<Play />}
+      >
+        {t.sessions.resumeInChat}
+      </Button>
+    </div>
+  );
+}
+
+function ChildSessionGroup({
+  title,
+  description,
+  rows,
+  icon: Icon,
+  onResume,
+}: {
+  title: string;
+  description?: string;
+  rows: SessionInfo[];
+  icon: typeof Terminal;
+  onResume: (id: string) => void;
+}) {
+  if (rows.length === 0) return null;
+  return (
+    <section className="space-y-2">
+      <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        <Icon className="h-3.5 w-3.5" />
+        <span>{title}</span>
+        <Badge tone="outline" className="text-[10px]">
+          {rows.length}
+        </Badge>
+      </div>
+      {description && <p className="text-xs text-muted-foreground">{description}</p>}
+      <div className="space-y-1.5">
+        {rows.map((child) => (
+          <ChildSessionRow key={child.id} session={child} onResume={onResume} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ChildSessionsBlock({
+  grouped,
+  onResume,
+}: {
+  grouped: SessionChildrenResponse;
+  onResume: (id: string) => void;
+}) {
+  const activeSubagents = grouped.subagents.active;
+  const completedSubagents = grouped.subagents.completed;
+  const staleCount = grouped.subagents.stale_count;
+  const subagentCount = activeSubagents.length + completedSubagents.length + staleCount;
+  const visibleCount =
+    grouped.focused.length +
+    grouped.branches.length +
+    grouped.interactive.length +
+    grouped.compression.length +
+    grouped.other.length +
+    subagentCount;
+
+  if (visibleCount === 0) return null;
+
+  return (
+    <div className="mb-4 space-y-4 rounded border border-border bg-midground/20 p-3">
+      <div className="flex items-center gap-2 text-sm font-medium">
+        <GitBranch className="h-4 w-4 text-primary" />
+        <span>Continuations and child sessions</span>
+      </div>
+
+      <ChildSessionGroup
+        title="Focused continuations"
+        description="User-intended continuations are always shown before read-only delegate subagents."
+        rows={grouped.focused}
+        icon={GitBranch}
+        onResume={onResume}
+      />
+      <ChildSessionGroup
+        title="Branches"
+        rows={grouped.branches}
+        icon={GitBranch}
+        onResume={onResume}
+      />
+      <ChildSessionGroup
+        title="Interactive promoted children"
+        rows={grouped.interactive}
+        icon={MessageSquare}
+        onResume={onResume}
+      />
+      <ChildSessionGroup
+        title="Compression continuations"
+        rows={grouped.compression}
+        icon={Archive}
+        onResume={onResume}
+      />
+
+      {subagentCount > 0 && (
+        <details className="rounded border border-border/70 bg-background/60 p-2" open={activeSubagents.length > 0}>
+          <summary className="flex cursor-pointer list-none items-center justify-between gap-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            <span className="flex items-center gap-2">
+              <Bot className="h-3.5 w-3.5" />
+              Read-only delegate subagents
+            </span>
+            <span className="flex items-center gap-1.5">
+              {activeSubagents.length > 0 && <Badge tone="success" className="text-[10px]">{activeSubagents.length} active</Badge>}
+              {completedSubagents.length > 0 && <Badge tone="outline" className="text-[10px]">{completedSubagents.length} completed</Badge>}
+              {staleCount > 0 && <Badge tone="outline" className="text-[10px]">{staleCount} hidden stale</Badge>}
+            </span>
+          </summary>
+          <div className="mt-3 space-y-3">
+            {activeSubagents.length > 0 && (
+              <div className="space-y-1.5">
+                {activeSubagents.map((child) => (
+                  <ChildSessionRow key={child.id} session={child} onResume={onResume} />
+                ))}
+              </div>
+            )}
+            {completedSubagents.length > 0 && (
+              <details className="rounded border border-border/60 bg-background/60 p-2">
+                <summary className="cursor-pointer text-xs text-muted-foreground">
+                  Completed read-only subagents ({completedSubagents.length})
+                </summary>
+                <div className="mt-2 space-y-1.5">
+                  {completedSubagents.map((child) => (
+                    <ChildSessionRow key={child.id} session={child} onResume={onResume} />
+                  ))}
+                </div>
+              </details>
+            )}
+            {staleCount > 0 && (
+              <p className="text-xs text-muted-foreground">
+                {staleCount} stale or failed delegate row{staleCount === 1 ? " is" : "s are"} hidden by default for debugging only.
+              </p>
+            )}
+          </div>
+        </details>
+      )}
+
+      <ChildSessionGroup
+        title="Other children"
+        rows={grouped.other}
+        icon={MessageSquare}
+        onResume={onResume}
+      />
+    </div>
+  );
+}
+
 function SessionRow({
   session,
   snippet,
@@ -476,6 +696,9 @@ function SessionRow({
 }: SessionRowProps) {
   const [messages, setMessages] = useState<SessionMessage[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [childGroups, setChildGroups] = useState<SessionChildrenResponse | null>(null);
+  const [childrenLoading, setChildrenLoading] = useState(false);
+  const [childrenError, setChildrenError] = useState<string | null>(null);
   const [renaming, setRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState(session.title ?? "");
   const [renameSaving, setRenameSaving] = useState(false);
@@ -497,6 +720,18 @@ function SessionRow({
       cancelled = true;
     };
   }, [isExpanded, session.id, messages]);
+
+  useEffect(() => {
+    if (isExpanded && childGroups === null && !childrenLoading) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setChildrenLoading(true);
+      api
+        .getSessionChildren(session.id)
+        .then(setChildGroups)
+        .catch((err) => setChildrenError(String(err)))
+        .finally(() => setChildrenLoading(false));
+    }
+  }, [isExpanded, session.id, childGroups, childrenLoading]);
 
   const sourceKey = session.source?.split(":")[0];
   const sourceInfo = (session.source
@@ -737,6 +972,20 @@ function SessionRow({
 
       {isExpanded && (
         <div className="min-w-0 border-t border-border bg-background/50 p-4">
+          {childrenLoading && (
+            <div className="mb-4 flex items-center justify-center gap-2 rounded border border-border bg-midground/10 py-3 text-xs text-muted-foreground">
+              <Spinner /> Loading child sessions
+            </div>
+          )}
+          {childrenError && (
+            <p className="mb-4 text-sm text-destructive text-center">{childrenError}</p>
+          )}
+          {childGroups && (
+            <ChildSessionsBlock
+              grouped={childGroups}
+              onResume={(id) => navigate(`/chat?resume=${encodeURIComponent(id)}`)}
+            />
+          )}
           {messages === null && !error && (
             <div className="flex items-center justify-center py-8">
               <Spinner className="text-xl text-primary" />

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -596,6 +596,23 @@ function ChildSessionsBlock({
 
   if (visibleCount === 0) return null;
 
+  const primaryGroups: Array<{
+    title: string;
+    description?: string;
+    rows: SessionInfo[];
+    icon: typeof Terminal;
+  }> = [
+    {
+      title: "Focused continuations",
+      description: "User-intended continuations are always shown before read-only delegate subagents.",
+      rows: grouped.focused,
+      icon: GitBranch,
+    },
+    { title: "Branches", rows: grouped.branches, icon: GitBranch },
+    { title: "Interactive promoted children", rows: grouped.interactive, icon: MessageSquare },
+    { title: "Compression continuations", rows: grouped.compression, icon: Archive },
+  ];
+
   return (
     <div className="mb-4 space-y-4 rounded border border-border bg-midground/20 p-3">
       <div className="flex items-center gap-2 text-sm font-medium">
@@ -603,31 +620,16 @@ function ChildSessionsBlock({
         <span>Continuations and child sessions</span>
       </div>
 
-      <ChildSessionGroup
-        title="Focused continuations"
-        description="User-intended continuations are always shown before read-only delegate subagents."
-        rows={grouped.focused}
-        icon={GitBranch}
-        onResume={onResume}
-      />
-      <ChildSessionGroup
-        title="Branches"
-        rows={grouped.branches}
-        icon={GitBranch}
-        onResume={onResume}
-      />
-      <ChildSessionGroup
-        title="Interactive promoted children"
-        rows={grouped.interactive}
-        icon={MessageSquare}
-        onResume={onResume}
-      />
-      <ChildSessionGroup
-        title="Compression continuations"
-        rows={grouped.compression}
-        icon={Archive}
-        onResume={onResume}
-      />
+      {primaryGroups.map((group) => (
+        <ChildSessionGroup
+          key={group.title}
+          title={group.title}
+          description={group.description}
+          rows={group.rows}
+          icon={group.icon}
+          onResume={onResume}
+        />
+      ))}
 
       {subagentCount > 0 && (
         <details className="rounded border border-border/70 bg-background/60 p-2" open={activeSubagents.length > 0}>
@@ -702,6 +704,8 @@ function SessionRow({
   const [renaming, setRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState(session.title ?? "");
   const [renameSaving, setRenameSaving] = useState(false);
+  const childParentId = session._lineage_root_id ?? session.id;
+  const childrenRequestRef = useRef<string | null>(null);
   const { t } = useI18n();
   const navigate = useNavigate();
 
@@ -722,16 +726,29 @@ function SessionRow({
   }, [isExpanded, session.id, messages]);
 
   useEffect(() => {
-    if (isExpanded && childGroups === null && !childrenLoading) {
+    if (isExpanded && childrenRequestRef.current !== childParentId && !childrenLoading) {
+      let cancelled = false;
+      childrenRequestRef.current = childParentId;
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setChildrenLoading(true);
+      setChildGroups(null);
+      setChildrenError(null);
       api
-        .getSessionChildren(session.id)
-        .then(setChildGroups)
-        .catch((err) => setChildrenError(String(err)))
-        .finally(() => setChildrenLoading(false));
+        .getSessionChildren(childParentId)
+        .then((groups) => {
+          if (!cancelled) setChildGroups(groups);
+        })
+        .catch((err) => {
+          if (!cancelled) setChildrenError(String(err));
+        })
+        .finally(() => {
+          if (!cancelled) setChildrenLoading(false);
+        });
+      return () => {
+        cancelled = true;
+      };
     }
-  }, [isExpanded, session.id, childGroups, childrenLoading]);
+  }, [isExpanded, childParentId, childrenLoading]);
 
   const sourceKey = session.source?.split(":")[0];
   const sourceInfo = (session.source

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -464,17 +464,6 @@ function MessageList({
   );
 }
 
-const CHILD_KIND_LABELS: Record<string, string> = {
-  focused_continuation: "Focused continuation",
-  branch: "Branch",
-  interactive_child: "Interactive child",
-  compression_continuation: "Compression continuation",
-  delegate_subagent_active: "Active delegate",
-  delegate_subagent_completed: "Completed delegate",
-  delegate_subagent_stale: "Stale delegate",
-  child: "Child",
-};
-
 function childSessionTitle(session: SessionInfo, untitled: string): string {
   const title = session.title?.trim();
   if (title && title !== "Untitled") return title;
@@ -504,11 +493,6 @@ function ChildSessionRow({
             <span className="min-w-0 truncate text-sm font-medium">
               {childSessionTitle(session, t.sessions.untitledSession)}
             </span>
-            {session.child_kind && (
-              <Badge tone="outline" className="text-[10px]">
-                {CHILD_KIND_LABELS[session.child_kind] ?? session.child_kind}
-              </Badge>
-            )}
             {session.is_active && (
               <Badge tone="success" className="text-[10px]">
                 {t.common.live}
@@ -586,16 +570,6 @@ function ChildSessionsBlock({
   const completedSubagents = grouped.subagents.completed;
   const staleCount = grouped.subagents.stale_count;
   const subagentCount = activeSubagents.length + completedSubagents.length + staleCount;
-  const visibleCount =
-    grouped.focused.length +
-    grouped.branches.length +
-    grouped.interactive.length +
-    grouped.compression.length +
-    grouped.other.length +
-    subagentCount;
-
-  if (visibleCount === 0) return null;
-
   const primaryGroups: Array<{
     title: string;
     description?: string;
@@ -609,9 +583,13 @@ function ChildSessionsBlock({
       icon: GitBranch,
     },
     { title: "Branches", rows: grouped.branches, icon: GitBranch },
-    { title: "Interactive promoted children", rows: grouped.interactive, icon: MessageSquare },
-    { title: "Compression continuations", rows: grouped.compression, icon: Archive },
   ];
+
+  const visibleCount = primaryGroups.reduce(
+    (count, group) => count + group.rows.length,
+    grouped.other.length + subagentCount,
+  );
+  if (visibleCount === 0) return null;
 
   return (
     <div className="mb-4 space-y-4 rounded border border-border bg-midground/20 p-3">
@@ -726,29 +704,24 @@ function SessionRow({
   }, [isExpanded, session.id, messages]);
 
   useEffect(() => {
-    if (isExpanded && childrenRequestRef.current !== childParentId && !childrenLoading) {
-      let cancelled = false;
+    if (isExpanded && childrenRequestRef.current !== childParentId) {
       childrenRequestRef.current = childParentId;
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setChildrenLoading(true);
       setChildGroups(null);
       setChildrenError(null);
       api
         .getSessionChildren(childParentId)
         .then((groups) => {
-          if (!cancelled) setChildGroups(groups);
+          if (childrenRequestRef.current === childParentId) setChildGroups(groups);
         })
         .catch((err) => {
-          if (!cancelled) setChildrenError(String(err));
+          if (childrenRequestRef.current === childParentId) setChildrenError(String(err));
         })
         .finally(() => {
-          if (!cancelled) setChildrenLoading(false);
+          if (childrenRequestRef.current === childParentId) setChildrenLoading(false);
         });
-      return () => {
-        cancelled = true;
-      };
     }
-  }, [isExpanded, childParentId, childrenLoading]);
+  }, [isExpanded, childParentId]);
 
   const sourceKey = session.source?.split(":")[0];
   const sourceInfo = (session.source


### PR DESCRIPTION
## Problem

Hermes may retain read-only delegate subagent sessions under a parent chat for audit/debugging. In the WebUI, those retained subagents could be treated like real continuation children, so a read-only subagent could outrank, hide, or consume the visible slot that should belong to the user's focused continuation.

## Fix

- Prevent retained read-only subagents from being followed as normal compression/resume continuations.
- Classify child sessions from existing compression, branch, and delegate metadata rather than adding speculative marker fields.
- Add `GET /api/sessions/{session_id}/children` with only the grouped data the WebUI needs.
- Show focused continuations and branches first while keeping retained delegate subagents secondary and stale rows hidden by default.
- Fetch child rows in one bulk query.

## Tests

- `scripts/run_tests.sh tests/hermes_state/test_session_children.py tests/hermes_cli/test_web_server_session_children.py tests/hermes_state/test_resolve_resume_session_id.py tests/test_hermes_state.py tests/hermes_cli/test_session_listing.py -v --tb=short` — 372 passed
- `npm test --workspace web -- --run src/lib/api.test.ts` — 6 passed
- `npm run typecheck --workspace web`
- `npm run build --workspace web`
