### PR TITLE
fix: minimax-oauth auth_type unhandled — all 12 auxiliary tasks silently no-op (vision, compression, title gen, web_extract, skills_hub, approval, mcp, memory_query_rewrite, tts_audio_tags, triage_specifier, kanban_decomposer, profile_describer)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2431,6 +2431,77 @@ def _build_xai_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional[str
     return CodexAuxiliaryClient(real_client, model), model
 
 
+def _build_minimax_oauth_aux_client(
+    model: str,
+) -> Tuple[Optional[Any], Optional[str]]:
+    """Build an AnthropicAuxiliaryClient for a MiniMax OAuth-authenticated session.
+
+    MiniMax's OAuth inference endpoint (api.minimax.io/anthropic) speaks the
+    Anthropic Messages protocol, so we wrap a native Anthropic client in
+    ``AnthropicAuxiliaryClient`` to translate ``chat.completions.create()``
+    calls into ``/v1/messages`` requests.
+
+    Without this, ``resolve_provider_client`` has no branch for the
+    ``oauth_minimax`` auth type — it falls through every ``if pconfig.auth_type
+    == ...`` check and returns ``(None, None)``, silently breaking every
+    auxiliary task (vision, title generation, compression, etc.) configured
+    with ``auxiliary.<task>.provider: minimax-oauth``.
+
+    The caller should pass an explicit model.  Returns ``(None, None)`` when
+    the user has not authenticated with MiniMax OAuth.
+    """
+    if not model:
+        logger.warning(
+            "Auxiliary client: minimax-oauth requested without a model; "
+            "pass model explicitly (auxiliary.<task>.model in config.yaml)."
+        )
+        return None, None
+    try:
+        from hermes_cli.auth import resolve_minimax_oauth_runtime_credentials
+    except ImportError:
+        logger.warning(
+            "Auxiliary client: minimax-oauth requested but "
+            "resolve_minimax_oauth_runtime_credentials is unavailable"
+        )
+        return None, None
+    try:
+        creds = resolve_minimax_oauth_runtime_credentials(as_token_provider=True)
+    except Exception as exc:
+        logger.warning(
+            "Auxiliary client: minimax-oauth credentials unavailable (%s)", exc
+        )
+        return None, None
+    token_provider = creds["api_key"]
+    base_url = creds["base_url"]
+    logger.debug("Auxiliary client: MiniMax OAuth (%s via Anthropic Messages)", model)
+    try:
+        from agent.anthropic_adapter import build_anthropic_client
+
+        real_client = build_anthropic_client(token_provider, base_url)
+    except ImportError:
+        logger.warning(
+            "Auxiliary client: minimax-oauth needs the anthropic SDK "
+            "(pip install 'anthropic>=0.39.0')"
+        )
+        return None, None
+    except Exception as exc:
+        logger.warning(
+            "Auxiliary client: failed to build Anthropic client for "
+            "minimax-oauth (%s) — falling back to OpenAI-wire.",
+            exc,
+        )
+        # Last-resort: plain OpenAI client (the /anthropic endpoint may
+        # also accept OpenAI wire on some configurations).
+        real_client = _create_openai_client(api_key=token_provider, base_url=base_url)
+        return real_client, model
+    return (
+        AnthropicAuxiliaryClient(
+            real_client, model, token_provider, base_url, is_oauth=True
+        ),
+        model,
+    )
+
+
 def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
     """Build a CodexAuxiliaryClient for an explicitly-requested model.
 
@@ -4601,6 +4672,25 @@ def resolve_provider_client(
             logger.warning(
                 "resolve_provider_client: xai-oauth requested but no xAI "
                 "OAuth token found (run: hermes model -> xAI Grok OAuth — SuperGrok / Premium+)"
+            )
+            return None, None
+        final_model = _normalize_resolved_model(model or default, provider)
+        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                else (client, final_model))
+
+    # ── MiniMax OAuth (browser login → Anthropic Messages API) ──────
+    # Same class of bug as xai-oauth above: without this branch, a
+    # minimax-oauth provider configured for auxiliary tasks falls through
+    # every auth_type check (oauth_minimax is not api_key, external_process,
+    # vertex, or aws_sdk) and returns (None, None).  The vision auto-fallback
+    # then picks the main provider (zai) but carries the MiniMax model name,
+    # producing "Unknown Model" errors on the wrong endpoint.
+    if provider == "minimax-oauth":
+        client, default = _build_minimax_oauth_aux_client(model)
+        if client is None:
+            logger.warning(
+                "resolve_provider_client: minimax-oauth requested but no "
+                "MiniMax OAuth token found (run: hermes model -> MiniMax OAuth)"
             )
             return None, None
         final_model = _normalize_resolved_model(model or default, provider)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2485,18 +2485,27 @@ def _build_minimax_oauth_aux_client(
         )
         return None, None
     except Exception as exc:
+        # Do NOT fall back to an OpenAI-wire client here — the MiniMax
+        # ``/anthropic`` endpoint speaks Anthropic Messages, not OpenAI
+        # chat.completions.  Returning ``(None, None)`` lets the caller's
+        # auto-fallback chain pick the next configured provider cleanly,
+        # rather than emitting misformatted requests to the wrong wire
+        # format.  (See PR #61585 review feedback.)
         logger.warning(
             "Auxiliary client: failed to build Anthropic client for "
-            "minimax-oauth (%s) — falling back to OpenAI-wire.",
+            "minimax-oauth (%s) — returning None so auto-fallback engages.",
             exc,
         )
-        # Last-resort: plain OpenAI client (the /anthropic endpoint may
-        # also accept OpenAI wire on some configurations).
-        real_client = _create_openai_client(api_key=token_provider, base_url=base_url)
-        return real_client, model
+        return None, None
+    # is_oauth=False: the ``is_oauth`` flag is Claude-Code-OAuth-specific
+    # (it injects Claude Code system-prompt identity and tool-name
+    # transforms via ``_AnthropicCompletionsAdapter``).  MiniMax OAuth is a
+    # third-party Anthropic-compatible endpoint, not Claude Code, so those
+    # transforms must not apply.  See ``agent/agent_init.py`` which keeps
+    # third-party Anthropic-compatible providers out of the is_oauth path.
     return (
         AnthropicAuxiliaryClient(
-            real_client, model, token_provider, base_url, is_oauth=True
+            real_client, model, token_provider, base_url, is_oauth=False
         ),
         model,
     )

--- a/tests/agent/test_auxiliary_client_minimax_oauth.py
+++ b/tests/agent/test_auxiliary_client_minimax_oauth.py
@@ -1,0 +1,195 @@
+"""Tests for MiniMax OAuth auxiliary client routing.
+
+Mirrors the xAI OAuth auxiliary routing contract tests
+(``test_auth_xai_oauth_provider.py``).  Without the ``minimax-oauth`` branch
+in ``resolve_provider_client``, a minimax-oauth main provider falls through
+every ``auth_type`` check (it is not ``api_key``, ``oauth_external``,
+``oauth_external_process``, ``vertex``, or ``aws_sdk``) and returns
+``(None, None)`` — silently breaking every auxiliary task (vision, title
+generation, compression, etc.) configured with
+``auxiliary.<task>.provider: minimax-oauth``.
+
+These tests pin three routing contracts:
+
+1. **Authenticated (sync + async)** → returns a non-None
+   ``AnthropicAuxiliaryClient`` (sync) / ``AsyncAnthropicAuxiliaryClient``
+   (async) with ``is_oauth=False`` (MiniMax is a third-party
+   Anthropic-compatible endpoint, NOT Claude Code OAuth — the ``is_oauth``
+   flag injects Claude Code identity transforms that must not apply).
+2. **Unauthenticated** → returns ``(None, None)`` so auto-fallback engages.
+3. **Construction failure** → returns ``(None, None)`` rather than falling
+   back to an OpenAI-wire client (the ``/anthropic`` endpoint speaks
+   Anthropic Messages, not OpenAI chat.completions).
+"""
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from agent.auxiliary_client import (
+    AnthropicAuxiliaryClient,
+    AsyncAnthropicAuxiliaryClient,
+    resolve_provider_client,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+MINIMAX_OAUTH_INFERENCE_URL = "https://api.minimax.io/anthropic"
+MINIMAX_OAUTH_PORTAL_URL = "https://api.minimax.io"
+
+
+def _setup_minimax_oauth_auth(
+    hermes_home: Path,
+    *,
+    access_token: str = "mm_access",
+    refresh_token: str = "mm_refresh",
+    inference_base_url: str = MINIMAX_OAUTH_INFERENCE_URL,
+) -> Path:
+    """Write MiniMax OAuth state into the Hermes auth store at ``hermes_home``."""
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    # Set expiry well in the future so _refresh_minimax_oauth_state is a no-op.
+    expires_dt = datetime.now(timezone.utc) + timedelta(hours=2)
+    state = {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "inference_base_url": inference_base_url,
+        "portal_base_url": MINIMAX_OAUTH_PORTAL_URL,
+        "client_id": "test-client-id",
+        "region": "global",
+        "obtained_at": datetime.now(timezone.utc).isoformat(),
+        "expires_at": expires_dt.isoformat(),
+        "expires_in": 7200,
+        "auth_mode": "oauth_pkce",
+    }
+    auth_store = {
+        "version": 1,
+        "active_provider": "minimax-oauth",
+        "providers": {"minimax-oauth": state},
+    }
+    auth_file = hermes_home / "auth.json"
+    auth_file.write_text(json.dumps(auth_store, indent=2))
+    return auth_file
+
+
+def _empty_auth_store(hermes_home: Path) -> Path:
+    """Write an auth store with no providers configured."""
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    auth_file = hermes_home / "auth.json"
+    auth_file.write_text(json.dumps({"version": 1, "providers": {}}))
+    return auth_file
+
+
+# ---------------------------------------------------------------------------
+# Routing contract tests
+# ---------------------------------------------------------------------------
+
+
+def test_auxiliary_client_routes_minimax_oauth_through_anthropic(
+    tmp_path, monkeypatch
+):
+    """``resolve_provider_client("minimax-oauth", model)`` must return a
+    non-None ``AnthropicAuxiliaryClient``.
+
+    Without the minimax-oauth branch, the provider falls through every
+    ``auth_type`` check and returns ``(None, None)``, silently re-routing
+    every auxiliary task to whatever fallback chain the user has configured.
+    """
+    hermes_home = tmp_path / "hermes"
+    _setup_minimax_oauth_auth(hermes_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    client, model = resolve_provider_client(
+        "minimax-oauth", model="MiniMax-M2.7"
+    )
+    assert client is not None, (
+        "minimax-oauth must route to an AnthropicAuxiliaryClient; falling "
+        "through silently swaps providers for every auxiliary task."
+    )
+    assert isinstance(client, AnthropicAuxiliaryClient)
+    assert model == "MiniMax-M2.7"
+    # MiniMax OAuth is a third-party Anthropic-compatible endpoint, NOT
+    # Claude Code OAuth.  The is_oauth flag is Claude-Code-specific (it
+    # injects Claude Code system-prompt identity + tool-name transforms via
+    # _AnthropicCompletionsAdapter).  Pin is_oauth=False so those transforms
+    # do not apply.  (PR #61585 review feedback.)
+    assert client.chat.completions._is_oauth is False, (
+        "is_oauth must be False for MiniMax OAuth — it is a third-party "
+        "Anthropic-compatible endpoint, not Claude Code OAuth."
+    )
+
+
+def test_auxiliary_client_minimax_oauth_async_routes_through_anthropic(
+    tmp_path, monkeypatch
+):
+    """Async mode must return an ``AsyncAnthropicAuxiliaryClient`` wrapping
+    the same ``is_oauth=False`` adapter."""
+    hermes_home = tmp_path / "hermes"
+    _setup_minimax_oauth_auth(hermes_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    client, model = resolve_provider_client(
+        "minimax-oauth", model="MiniMax-M2.7", async_mode=True
+    )
+    assert client is not None
+    assert isinstance(client, AsyncAnthropicAuxiliaryClient)
+    assert model == "MiniMax-M2.7"
+    # The async adapter delegates to the sync adapter, so the is_oauth flag
+    # lives on the underlying _AnthropicCompletionsAdapter.
+    assert client.chat.completions._sync._is_oauth is False
+
+
+def test_auxiliary_client_minimax_oauth_returns_none_when_unauthenticated(
+    tmp_path, monkeypatch
+):
+    """No MiniMax OAuth tokens in the auth store → must return ``(None, None)``
+    so ``_resolve_auto`` falls through to the next provider in the chain."""
+    hermes_home = tmp_path / "hermes"
+    _empty_auth_store(hermes_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    client, model = resolve_provider_client(
+        "minimax-oauth", model="MiniMax-M2.7"
+    )
+    assert client is None
+    assert model is None
+
+
+def test_auxiliary_client_minimax_oauth_no_openai_fallback_on_failure(
+    tmp_path, monkeypatch
+):
+    """When Anthropic client construction fails, the builder must return
+    ``(None, None)`` — NOT fall back to an OpenAI-wire client.
+
+    The MiniMax ``/anthropic`` endpoint speaks Anthropic Messages, not OpenAI
+    chat.completions.  A previous version of this code fell back to
+    ``_create_openai_client`` on construction failure, which would emit
+    misformatted OpenAI-wire requests to the wrong API format.  Returning
+    ``(None, None)`` lets the caller's auto-fallback chain pick the next
+    configured provider cleanly.  (PR #61585 review feedback.)
+    """
+    hermes_home = tmp_path / "hermes"
+    _setup_minimax_oauth_auth(hermes_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    # Force build_anthropic_client to raise a non-ImportError so the
+    # construction-failure branch is exercised (not the ImportError branch).
+    import agent.anthropic_adapter as _aa
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("simulated SDK construction failure")
+
+    monkeypatch.setattr(_aa, "build_anthropic_client", _boom)
+
+    client, model = resolve_provider_client(
+        "minimax-oauth", model="MiniMax-M2.7"
+    )
+    assert client is None, (
+        "Construction failure must return (None, None), not an OpenAI-wire "
+        "client — the /anthropic endpoint does not accept OpenAI wire format."
+    )
+    assert model is None


### PR DESCRIPTION
## Bug

`minimax-oauth` has `auth_type="oauth_minimax"` in `PROVIDER_REGISTRY`, but `resolve_provider_client()` has no branch that handles this auth type. It falls through every `if pconfig.auth_type == ...` check and returns `(None, None)`.

This **silently breaks all 12 default auxiliary tasks** when `auxiliary.<task>.provider` resolves to `minimax-oauth` (either explicitly or via `auto` fallback when it is the main provider):

| Task | Failure mode |
|---|---|
| `vision` | `browser_vision` / `vision_analyze` fail with `code: 1211, "Unknown Model"` |
| `compression` | Context compression silently no-ops — long sessions hit overflow and die |
| `title_generation` | `Title generation failed: Provider 'minimax-oauth' is set in config.yaml but no API key was found` |
| `web_extract` | Silent no-op |
| `skills_hub` | Silent no-op |
| `approval` | Silent no-op |
| `mcp` | Silent no-op |
| `memory_query_rewrite` | Silent no-op |
| `tts_audio_tags` | Silent no-op |
| `triage_specifier` | Silent no-op |
| `kanban_decomposer` | Silent no-op |
| `profile_describer` | Silent no-op |

The blast radius is broader than vision/compression/title-gen — triage should not route this through `sweeper:blast-contained`.

### The misleading error chain

The vision auto-fallback masks the real problem. When `resolve_provider_client("minimax-oauth")` returns `None`, the fallback picks the user's main provider (e.g. `zai`) **but carries the MiniMax model name** (e.g. `MiniMax-M3`) from the config. The main provider's API receives a model it doesn't recognize:

```
WARNING: Vision provider minimax-oauth unavailable, falling back to auto vision backends
WARNING: browser_vision failed: Error code: 400 - {'error': {'code': '1211', 'message': 'Unknown Model, please check the model code.'}}
```

### MiniMax M3 is natively multimodal

MiniMax-M3 was trained with multimodality from day one (image, video, text). The model and endpoint handle vision perfectly — confirmed by direct API calls to `api.minimax.io/anthropic/v1/messages` with Anthropic-format image blocks. The bug is purely in Hermes's client resolution, not the model.

## Fix

Follows the exact pattern already used for `xai-oauth` (which was fixed for the same class of bug — OAuth auth type with no handler in `resolve_provider_client`).

### 1. `_build_minimax_oauth_aux_client(model)`

Resolves OAuth credentials via `resolve_minimax_oauth_runtime_credentials(as_token_provider=True)` (the same function the main agent runtime uses), builds a native Anthropic client pointed at `api.minimax.io/anthropic`, and wraps it in `AnthropicAuxiliaryClient` with `is_oauth=False`.

**`is_oauth=False`** (corrected per @teknium1's review): the `is_oauth` flag is Claude-Code-OAuth-specific — it injects Claude Code system-prompt identity and tool-name transforms. MiniMax OAuth is a third-party Anthropic-compatible endpoint, not Claude Code, so those transforms must not apply. `agent_init.py` already keeps third-party Anthropic-compatible providers out of the `is_oauth` path.

### 2. `minimax-oauth` branch in `resolve_provider_client()`

Placed right after the existing `xai-oauth` branch, before the `custom` endpoint branch. Same shape as xai-oauth: build client → null check → normalize model → return (with async + vision support).

### 3. No OpenAI-wire fallback (per @teknium1's review)

On Anthropic client construction failure, the builder returns `(None, None)` so the caller's auto-fallback chain picks the next configured provider cleanly. The previous version fell back to `_create_openai_client` against the `/anthropic` endpoint, which speaks Anthropic Messages — not OpenAI `chat.completions`.

## Verification

**Before patch:** `browser_vision` on any page → `code: 1211, "Unknown Model"`

**After patch:** `browser_vision` on localhost landing page → MiniMax-M3 successfully reads and describes the page:

> Here's a detailed breakdown of what I can see: The page uses a dark theme... **LETHAL BRIDGE** in a monospace, retro/terminal-style font... A dark red/maroon colored US map sits behind the central card... THREAT LEVEL / MODERATE... scrolling marquee with text reading "43% OF US BRIDGES ARE >50 YEARS OLD"

Client build verified:
```python
>>> _build_minimax_oauth_aux_client('MiniMax-M3')
AnthropicAuxiliaryClient, model=MiniMax-M3
  base_url: https://api.minimax.io/anthropic
```

## Tests

New file: `tests/agent/test_auxiliary_client_minimax_oauth.py` (4 tests, all passing). Mirrors the xAI OAuth auxiliary test pattern (`test_auth_xai_oauth_provider.py`):

- `test_auxiliary_client_routes_minimax_oauth_through_anthropic` — sync: returns `AnthropicAuxiliaryClient` with `is_oauth=False`
- `test_auxiliary_client_minimax_oauth_async_routes_through_anthropic` — async: returns `AsyncAnthropicAuxiliaryClient` with `is_oauth=False`
- `test_auxiliary_client_minimax_oauth_returns_none_when_unauthenticated` — no tokens → `(None, None)`
- `test_auxiliary_client_minimax_oauth_no_openai_fallback_on_failure` — construction failure → `(None, None)`, no OpenAI fallback

```
4 passed in 2.04s
```

## Test environment

- Hermes v0.18.2 on Windows
- MiniMax OAuth (Coding Plan, global region)
- `auxiliary.vision: { provider: minimax-oauth, model: MiniMax-M3 }`
- 3 profiles affected by this bug — all fixed by this single patch

## Duplicate cluster

This is the canonical PR among the duplicates: #22213, #36779, #42128, #49232, #23639. Per @alt-glitch's triage, this PR has the cleanest test base (4 routing tests with mocked creds vs. #22213's single test that exposed an `UnboundLocalError` on `OpenAI(...)`).