### PR TITLE
fix(browser): add timeout to proc.wait() after kill in browser tool

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1114,7 +1114,10 @@ def _run_chrome_fallback_command(
             proc.wait(timeout=timeout)
         except subprocess.TimeoutExpired:
             proc.kill()
-            proc.wait()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                pass
             return {"success": False, "error": f"Chrome fallback '{cmd}' timed out"}
         try:
             with open(stdout_path, "r", encoding="utf-8") as f:
@@ -2457,7 +2460,10 @@ def _run_browser_command(
             proc.wait(timeout=timeout)
         except subprocess.TimeoutExpired:
             proc.kill()
-            proc.wait()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                pass
             stdout, stderr = _read_command_output_files(stdout_path, stderr_path)
             _unlink_command_output_files(stdout_path, stderr_path)
             if stderr and stderr.strip():


### PR DESCRIPTION
## Summary

Added `timeout=10` to `proc.wait()` calls that follow `proc.kill()` in `_run_browser_command` and `_run_chrome_fallback_command`.

## Problem

Both `_run_browser_command` and `_run_chrome_fallback_command` call `proc.kill()` after a `TimeoutExpired`, then call `proc.wait()` **without a timeout**. If the killed process becomes unresponsive (zombie state, I/O hang), this would permanently block the entire agent turn — the exact bug class these functions are trying to prevent.

## Fix

```python
# Before:
proc.kill()
proc.wait()  # ← no timeout, could hang forever

# After:
proc.kill()
try:
    proc.wait(timeout=10)
except subprocess.TimeoutExpired:
    pass  # Process is dead or unresponsive, continue anyway
```

This defensive timeout applies to both locations:
- `tools/browser_tool.py:1117` (`_run_chrome_fallback_command`)
- `tools/browser_tool.py:2463` (`_run_browser_command`)

## Testing
- Syntax check passed (py_compile)
- Diff: +8/-2 lines, minimal and focused