### PR TITLE
feat(kanban): stagger timed-out task retries with jittered cooldown

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -275,6 +275,25 @@ def _resolve_rate_limit_cooldown_seconds() -> int:
     return DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS
 
 
+def _resolve_timeout_retry_cooldown_seconds() -> int:
+    """Return the timed-out-run respawn cooldown in seconds.
+
+    Reads ``HERMES_KANBAN_TIMEOUT_RETRY_COOLDOWN_SECONDS`` from the
+    environment; falls back to ``DEFAULT_TIMEOUT_RETRY_COOLDOWN_SECONDS`` when
+    absent, empty, non-integer, or negative. A value of 0 disables the
+    cooldown (re-spawn on the next tick), preserving pre-cooldown behavior.
+    """
+    raw = os.environ.get("HERMES_KANBAN_TIMEOUT_RETRY_COOLDOWN_SECONDS", "").strip()
+    if raw:
+        try:
+            parsed = int(raw)
+        except ValueError:
+            parsed = -1
+        if parsed >= 0:
+            return parsed
+    return DEFAULT_TIMEOUT_RETRY_COOLDOWN_SECONDS
+
+
 # Worker-context caps so build_worker_context() stays bounded on
 # pathological boards (retry-heavy tasks, comment storms, giant
 # summaries). Values chosen to fit a typical 100k-char LLM prompt with
@@ -5676,6 +5695,14 @@ _RESPAWN_GUARD_SUCCESS_WINDOW = 3600  # 1 hour
 # for operators who want a tighter/looser probe cadence.
 DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS = 300  # 5 minutes
 
+# Timed-out runs must not respawn in the same tick they expired: when several
+# workers time out together (shared backend congestion), a synchronized mass
+# retry recreates the exact load that killed them (observed 2026-07-09 on a
+# local-LLM board: 6 workers timed out and were all re-spawned in one tick,
+# repeating the collapse). The cooldown plus per-task jitter spreads retries
+# across ticks.
+DEFAULT_TIMEOUT_RETRY_COOLDOWN_SECONDS = 180  # 3 minutes base, + 0-100% jitter
+
 # Within this window a GitHub PR URL in a comment blocks re-spawn.
 _RESPAWN_GUARD_PR_WINDOW = 86400  # 24 hours
 
@@ -6776,6 +6803,12 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
         never increments ``consecutive_failures``, so the breaker can't free
         it). Once the cooldown elapses the task falls through and respawns.
 
+    ``"timeout_cooldown"``
+        The task's most recent run ended ``timed_out`` within the base
+        cooldown (``_resolve_timeout_retry_cooldown_seconds()``) plus a
+        deterministic per-task jitter. Prevents synchronized mass retry of
+        workers that timed out together under shared-backend congestion.
+
     ``"blocker_auth"``
         The task's last failure error matches a quota / authentication
         pattern. Retrying immediately is unlikely to help (rate limits
@@ -6845,6 +6878,22 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
         # (cheaply, spaced by the cooldown) until quota returns or a real
         # crash/completion supersedes it.
         return None
+
+    # 1b. Timeout cooldown: the most recent run TIMED OUT. enforce_max_runtime
+    #     flips expired tasks straight back to 'ready' in the same tick, so
+    #     without this guard every worker that timed out under shared load is
+    #     re-spawned together and recreates the congestion that killed it.
+    #     Defer by a base cooldown plus deterministic per-task jitter (hash of
+    #     the task id) so retries spread across ticks instead of stampeding.
+    if latest_run is not None and latest_run["outcome"] == "timed_out":
+        to_cooldown = _resolve_timeout_retry_cooldown_seconds()
+        if to_cooldown > 0:
+            ended_at = latest_run["ended_at"]
+            jitter = int(
+                hashlib.sha256(task_id.encode("utf-8")).hexdigest()[:8], 16
+            ) % (to_cooldown + 1)
+            if ended_at is not None and (now - int(ended_at)) < to_cooldown + jitter:
+                return "timeout_cooldown"
 
     # 2. Quota / auth blocker: retrying immediately will not help.
     err = row["last_failure_error"]

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1063,6 +1063,91 @@ def test_resolve_rate_limit_cooldown_handles_bad_env(monkeypatch):
         )
 
 
+def _mark_latest_run_timed_out(conn, tid, ended_at):
+    run_id = kb.get_task(conn, tid).current_run_id
+    conn.execute(
+        "UPDATE task_runs SET outcome='timed_out', status='timed_out', "
+        "ended_at=? WHERE id=?",
+        (ended_at, run_id),
+    )
+    conn.execute(
+        "UPDATE tasks SET status='ready', current_run_id=NULL, "
+        "claim_lock=NULL WHERE id=?",
+        (tid,),
+    )
+    conn.commit()
+
+
+def test_respawn_guard_defers_timed_out_within_cooldown(
+    kanban_home,
+    monkeypatch,
+):
+    """A run that timed out moments ago must not respawn on the next tick —
+    synchronized mass retry of timed-out workers recreates the congestion
+    that caused the timeouts."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setenv("HERMES_KANBAN_TIMEOUT_RETRY_COOLDOWN_SECONDS", "180")
+    now = 6_000_000
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="to-cooldown", assignee="a")
+        kb.claim_task(conn, tid)
+        _mark_latest_run_timed_out(conn, tid, now)
+
+        monkeypatch.setattr(_kb.time, "time", lambda: now + 1)
+        assert kb.check_respawn_guard(conn, tid) == "timeout_cooldown"
+
+
+def test_respawn_guard_timed_out_allows_after_cooldown_and_jitter(
+    kanban_home,
+    monkeypatch,
+):
+    """Beyond base cooldown + max jitter (2x base) the respawn is allowed."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setenv("HERMES_KANBAN_TIMEOUT_RETRY_COOLDOWN_SECONDS", "180")
+    now = 6_000_000
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="to-elapsed", assignee="a")
+        kb.claim_task(conn, tid)
+        _mark_latest_run_timed_out(conn, tid, now)
+
+        monkeypatch.setattr(_kb.time, "time", lambda: now + 361)
+        assert kb.check_respawn_guard(conn, tid) is None
+
+
+def test_respawn_guard_timeout_cooldown_zero_allows_immediately(
+    kanban_home,
+    monkeypatch,
+):
+    """Cooldown of 0 preserves pre-cooldown behavior (respawn next tick)."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setenv("HERMES_KANBAN_TIMEOUT_RETRY_COOLDOWN_SECONDS", "0")
+    now = 6_000_000
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="to-zero", assignee="a")
+        kb.claim_task(conn, tid)
+        _mark_latest_run_timed_out(conn, tid, now)
+
+        monkeypatch.setattr(_kb.time, "time", lambda: now + 1)
+        assert kb.check_respawn_guard(conn, tid) is None
+
+
+def test_resolve_timeout_retry_cooldown_handles_bad_env(monkeypatch):
+    import hermes_cli.kanban_db as _kb
+
+    for bad_val in ("notanumber", "-5", ""):
+        monkeypatch.setenv("HERMES_KANBAN_TIMEOUT_RETRY_COOLDOWN_SECONDS", bad_val)
+        assert (
+            _kb._resolve_timeout_retry_cooldown_seconds()
+            == _kb.DEFAULT_TIMEOUT_RETRY_COOLDOWN_SECONDS
+        )
+
+
 def test_max_runtime_uses_current_run_start_after_retry(kanban_home, monkeypatch):
     """A retry should get a fresh max-runtime window.
 


### PR DESCRIPTION
## Problem

`enforce_max_runtime` flips expired tasks straight back to `ready`, and it runs at the top of the same dispatcher tick that then scans ready tasks — so workers that time out **together** (shared backend congestion, e.g. a saturated local-LLM server) are all re-spawned **together**, recreating the exact load that killed them. With `failure_limit` counting each timeout, the board burns through retry budgets in lockstep and tasks fail permanently without ever getting a fair retry.

Observed in the field (2026-07-09, local 27B board): 6 concurrent workers slowed each other past their 40m cap, timed out in the same tick, were all re-spawned in one tick, and repeated the collapse — a congestion death spiral that required manual load-shedding via `reclaim`.

## Fix

Add a `timeout_cooldown` branch to `check_respawn_guard` (mirroring the existing `rate_limited` cooldown pattern): a task whose latest run ended `timed_out` defers respawn for a base cooldown plus a **deterministic per-task jitter** (sha256 of task id, 0–100% of base), so retries spread across dispatcher ticks instead of stampeding.

- Default base: 180s; env-tunable via `HERMES_KANBAN_TIMEOUT_RETRY_COOLDOWN_SECONDS`; `0` restores pre-patch behavior
- No schema change, no failure-count side effects, reuses the existing per-tick deferral mechanism
- Deterministic jitter (no RNG state) keeps dispatch behavior reproducible

## Tests

5 new tests in `tests/hermes_cli/test_kanban_db.py` following the existing rate-limit cooldown test patterns: defers within cooldown, allows after cooldown+max-jitter, `0` disables, bad env values fall back to default. Full guard/timeout selection: 25/25 green.

Pairs well with the (already-implemented but undocumented) `kanban.max_spawn` / `kanban.max_in_progress` config keys — those cap live load; this patch prevents the synchronized retry stampede when timeouts do happen.