### PR TITLE
fix(tests): restore module identities after vision-routing reload tests

### DIFF
--- a/tests/agent/test_vision_routing_31179.py
+++ b/tests/agent/test_vision_routing_31179.py
@@ -60,13 +60,36 @@ def _write_config(home: str, text: str) -> None:
         fp.write(text)
 
 
+_RELOADED_MODULE_PREFIXES = ("agent.auxiliary_client", "agent.image_routing",
+                             "tools.vision_tools", "tools.browser_tool",
+                             "hermes_cli.config")
+
+
 def _fresh_modules():
     """Drop cached hermes modules so each test reloads against current env."""
     for mod in list(sys.modules.keys()):
-        if mod.startswith(("agent.auxiliary_client", "agent.image_routing",
-                           "tools.vision_tools", "tools.browser_tool",
-                           "hermes_cli.config")):
+        if mod.startswith(_RELOADED_MODULE_PREFIXES):
             del sys.modules[mod]
+
+
+@pytest.fixture(autouse=True)
+def _restore_module_identities():
+    """Put the original module objects back after each test.
+
+    ``_fresh_modules`` swaps new module objects into ``sys.modules``. Other
+    test files bind names from these modules at collection time but patch
+    them via string targets (``patch("agent.image_routing...")``), which
+    resolve through ``sys.modules`` — leaving the identities swapped makes
+    those patches land on a different module object than the one under
+    test, failing order-dependently.
+    """
+    saved = {name: mod for name, mod in sys.modules.items()
+             if name.startswith(_RELOADED_MODULE_PREFIXES)}
+    yield
+    for name in list(sys.modules.keys()):
+        if name.startswith(_RELOADED_MODULE_PREFIXES):
+            del sys.modules[name]
+    sys.modules.update(saved)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes order-dependent flaky failures in the vision-routing test files. `tests/agent/test_vision_routing_31179.py` has a `_fresh_modules()` helper (called by every test in the file) that deletes `agent.auxiliary_client`, `agent.image_routing`, `tools.vision_tools`, `tools.browser_tool` and `hermes_cli.config` from `sys.modules` so each scenario reloads against a hermetic env — but it never restores the original module objects. Later test files bind names from these modules at collection time (`from agent.image_routing import decide_image_input_mode`) yet patch them via string targets (`patch("agent.image_routing._lookup_supports_vision", ...)`), which resolve through `sys.modules`. After this file runs, those patches land on the re-imported module while the collection-time function is exercised — the patch is invisible, the real code path runs (live models.dev lookups, real provider resolution), and tests fail with a membership that varies with registry/network state.

The fix keeps `_fresh_modules()` exactly as-is (the reload-against-env behavior is what the file tests) and adds an autouse fixture that snapshots the affected `sys.modules` entries before each test and restores them afterwards, so module identities seen by every other test file are unchanged.

## Related Issue

Fixes #61597 (flagged in the footnote of #61568)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tests/agent/test_vision_routing_31179.py`: hoist the reloaded-module prefixes to `_RELOADED_MODULE_PREFIXES`; add autouse `_restore_module_identities` fixture (snapshot before test, delete reloads + restore originals after).

## How to Test

1. Deterministic repro on clean `main` (each file passes standalone, fails combined):
   `python -m pytest tests/agent/test_vision_routing_31179.py tests/agent/test_image_routing.py -q` → 5 failures in `TestDecideImageInputMode` / `TestLookupSupportsVisionOverride` before, 0 after (drive-path failures tracked in #61568 aside).
2. `python -m pytest tests/agent/test_vision_routing_31179.py tests/tools/test_vision_native_fast_path.py -q` → `test_text_mode_wins_over_supports_vision_override` fails before, passes after.
3. Full 8-file combination from #61568's footnote, 3 consecutive runs → no order-dependent failures remain (only the pre-existing #61568 drive-path set, fixed by #61571).
4. `python -m pytest tests/agent/test_vision_routing_31179.py -q` → still 12/12 standalone.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (native Windows; remaining failures are the pre-existing #61568 set, unrelated)
- [x] I've added tests for my changes (the fix is itself test-infrastructure; the reproducing orderings above act as the regression check)
- [x] I've tested on my platform: Windows 11 Pro, Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (fixture docstring explains the mechanism)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — mechanism is pure `sys.modules` identity, platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before (clean main, polluter file first):

```
FAILED tests/agent/test_image_routing.py::TestDecideImageInputMode::test_auto_with_vision_capable_model
FAILED tests/agent/test_image_routing.py::TestDecideImageInputMode::test_auto_prefers_native_for_vision_capable_main_model_even_with_aux_configured
FAILED tests/agent/test_image_routing.py::TestDecideImageInputMode::test_none_config_is_auto
FAILED tests/agent/test_image_routing.py::TestDecideImageInputMode::test_invalid_mode_coerces_to_auto
FAILED tests/agent/test_image_routing.py::TestLookupSupportsVisionOverride::test_ollama_probe_false_for_text_only_model
```

After: same command, 0 order-dependent failures across 3 consecutive runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
