### PR TITLE
fix(theme): ignore inherited COLORFGBG in Zed

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2202,7 +2202,7 @@ def _detect_light_mode() -> bool:
             return result
         # 4. COLORFGBG (xterm/Konsole/urxvt)
         cfgbg = (os.environ.get("COLORFGBG") or "").strip()
-        if cfgbg:
+        if cfgbg and not _is_zed_terminal():
             last = cfgbg.split(";")[-1] if ";" in cfgbg else cfgbg
             if last.isdigit():
                 bg = int(last)
@@ -2229,6 +2229,12 @@ def _detect_light_mode() -> bool:
         result = False
     _LIGHT_MODE_CACHE = result
     return result
+
+
+def _is_zed_terminal() -> bool:
+    term_program = (os.environ.get("TERM_PROGRAM") or "").strip().lower()
+    zed_term = (os.environ.get("ZED_TERM") or "").strip().lower()
+    return term_program == "zed" or zed_term in {"1", "true", "yes", "on"}
 
 
 # Light-mode equivalents of skin colors that are unreadable on cream

--- a/tests/cli/test_cli_light_mode.py
+++ b/tests/cli/test_cli_light_mode.py
@@ -67,6 +67,41 @@ class TestLightModeDetection:
         monkeypatch.setenv("COLORFGBG", "0;15")  # bg slot 15 = light
         assert cli_mod._detect_light_mode() is True
 
+    def test_zed_terminal_ignores_inherited_colorfgbg(self, cli_mod, monkeypatch):
+        monkeypatch.delenv("HERMES_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_TUI_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_TUI_THEME", raising=False)
+        monkeypatch.delenv("HERMES_TUI_BACKGROUND", raising=False)
+        monkeypatch.setenv("TERM_PROGRAM", "zed")
+        monkeypatch.setenv("COLORFGBG", "0;15")
+        assert cli_mod._detect_light_mode() is False
+
+    def test_zed_term_flag_ignores_inherited_colorfgbg(self, cli_mod, monkeypatch):
+        monkeypatch.delenv("HERMES_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_TUI_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_TUI_THEME", raising=False)
+        monkeypatch.delenv("HERMES_TUI_BACKGROUND", raising=False)
+        monkeypatch.setenv("ZED_TERM", "true")
+        monkeypatch.setenv("COLORFGBG", "0;15")
+        assert cli_mod._detect_light_mode() is False
+
+    def test_zed_terminal_still_honors_explicit_theme_override(self, cli_mod, monkeypatch):
+        monkeypatch.delenv("HERMES_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_TUI_LIGHT", raising=False)
+        monkeypatch.setenv("TERM_PROGRAM", "zed")
+        monkeypatch.setenv("COLORFGBG", "0;15")
+        monkeypatch.setenv("HERMES_TUI_THEME", "light")
+        assert cli_mod._detect_light_mode() is True
+
+    def test_zed_terminal_still_honors_explicit_background_override(self, cli_mod, monkeypatch):
+        monkeypatch.delenv("HERMES_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_TUI_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_TUI_THEME", raising=False)
+        monkeypatch.setenv("TERM_PROGRAM", "zed")
+        monkeypatch.setenv("COLORFGBG", "0;15")
+        monkeypatch.setenv("HERMES_TUI_BACKGROUND", "#ffffff")
+        assert cli_mod._detect_light_mode() is True
+
     def test_cache_is_sticky(self, cli_mod, monkeypatch):
         monkeypatch.setenv("HERMES_LIGHT", "1")
         assert cli_mod._detect_light_mode() is True

--- a/ui-tui/src/__tests__/theme.test.ts
+++ b/ui-tui/src/__tests__/theme.test.ts
@@ -17,7 +17,8 @@ const RELEVANT_ENV = [
   'HERMES_TUI_BACKGROUND',
   'COLORFGBG',
   'COLORTERM',
-  'TERM_PROGRAM'
+  'TERM_PROGRAM',
+  'ZED_TERM'
 ] as const
 
 async function importThemeWithEnv(env: Partial<Record<(typeof RELEVANT_ENV)[number], string>> = {}) {
@@ -113,6 +114,20 @@ describe('detectLightMode', () => {
     expect(detectLightMode({ COLORFGBG: '0;7' })).toBe(true)
     expect(detectLightMode({ COLORFGBG: '15;0' })).toBe(false)
     expect(detectLightMode({ COLORFGBG: '7;default;0' })).toBe(false)
+  })
+
+  it('ignores inherited COLORFGBG inside Zed terminals', async () => {
+    const { detectLightMode } = await importThemeWithCleanEnv()
+
+    expect(detectLightMode({ TERM_PROGRAM: 'zed', COLORFGBG: '0;15' })).toBe(false)
+    expect(detectLightMode({ ZED_TERM: 'true', COLORFGBG: '0;15' })).toBe(false)
+  })
+
+  it('still lets explicit overrides win inside Zed terminals', async () => {
+    const { detectLightMode } = await importThemeWithCleanEnv()
+
+    expect(detectLightMode({ TERM_PROGRAM: 'zed', COLORFGBG: '0;15', HERMES_TUI_THEME: 'light' })).toBe(true)
+    expect(detectLightMode({ TERM_PROGRAM: 'zed', COLORFGBG: '0;15', HERMES_TUI_BACKGROUND: '#ffffff' })).toBe(true)
   })
 
   it('falls through on malformed COLORFGBG with empty/non-numeric trailing field', async () => {

--- a/ui-tui/src/theme.ts
+++ b/ui-tui/src/theme.ts
@@ -355,6 +355,13 @@ const FALSE_RE = /^(?:0|false|no|off)$/
 // so dark Apple Terminal profiles that advertise a dark background stay dark.
 const LIGHT_DEFAULT_TERM_PROGRAMS = new Set<string>(['Apple_Terminal'])
 
+function isZedTerminal(env: NodeJS.ProcessEnv): boolean {
+  const termProgram = (env.TERM_PROGRAM ?? '').trim().toLowerCase()
+  const zedTerm = (env.ZED_TERM ?? '').trim().toLowerCase()
+
+  return termProgram === 'zed' || ['1', 'true', 'yes', 'on'].includes(zedTerm)
+}
+
 // Best-effort RGB → luminance check.  Currently only accepts a 3- or
 // 6-digit hex value (with or without a leading `#`); the env var name
 // `HERMES_TUI_BACKGROUND` is intentionally generic so a future OSC11
@@ -443,7 +450,7 @@ export function detectLightMode(
 
   const colorfgbg = (env.COLORFGBG ?? '').trim()
 
-  if (colorfgbg) {
+  if (colorfgbg && !isZedTerminal(env)) {
     // Validate as a decimal integer before coercing — `Number('')` is 0,
     // so a malformed `COLORFGBG='15;'` would otherwise look like an
     // authoritative dark slot and incorrectly block the TERM_PROGRAM


### PR DESCRIPTION
## Summary
- ignore inherited `COLORFGBG` when Hermes is running inside Zed terminals
- keep explicit light-mode overrides authoritative in both the CLI and Ink TUI paths
- add focused regression tests for the Python and TypeScript detectors

Closes #61536.

## Testing
- `./.venv/bin/python -m pytest tests/cli/test_cli_light_mode.py -q -o 'addopts='`
- `npx vitest run ui-tui/src/__tests__/theme.test.ts`
