### PR TITLE
fix(web,mcp): add headers support to MCP server create API and dashboard UI

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10588,6 +10588,8 @@ class MCPServerCreate(BaseModel):
     args: List[str] = []
     # env: KEY=VALUE map for stdio servers (API keys, etc.)
     env: Dict[str, str] = {}
+    # headers: HTTP headers for HTTPS MCP servers (e.g. Authorization: Bearer <token>)
+    headers: Dict[str, str] = {}
     # auth: "oauth" | "header" | None
     auth: Optional[str] = None
     profile: Optional[str] = None
@@ -10619,6 +10621,7 @@ def _mcp_server_summary(name: str, cfg: Dict[str, Any]) -> Dict[str, Any]:
         "command": cfg.get("command"),
         "args": list(cfg.get("args") or []),
         "env": _redact_mcp_env(cfg.get("env") or {}),
+        "headers": _redact_mcp_env(cfg.get("headers") or {}),
         "auth": cfg.get("auth"),
         "enabled": cfg.get("enabled", True) is not False,
         # Tool selection: list of enabled tool names, or None = all.
@@ -10667,6 +10670,8 @@ async def add_mcp_server(body: MCPServerCreate, profile: Optional[str] = None):
         server_config["env"] = dict(body.env)
     if body.auth:
         server_config["auth"] = body.auth
+    if body.headers:
+        server_config["headers"] = dict(body.headers)
 
     try:
         with _profile_scope(body.profile or profile):

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1388,6 +1388,7 @@ export interface McpServer {
   command: string | null;
   args: string[];
   env: Record<string, string>;
+  headers?: Record<string, string>;
   auth: string | null;
   enabled: boolean;
   tools: string[] | null;
@@ -1429,6 +1430,7 @@ export interface McpServerCreate {
   command?: string;
   args?: string[];
   env?: Record<string, string>;
+  headers?: Record<string, string>;
   auth?: string;
 }
 

--- a/web/src/pages/McpPage.tsx
+++ b/web/src/pages/McpPage.tsx
@@ -79,6 +79,7 @@ export default function McpPage() {
   const [command, setCommand] = useState("");
   const [args, setArgs] = useState("");
   const [env, setEnv] = useState("");
+  const [headersStr, setHeadersStr] = useState("");
   const [creating, setCreating] = useState(false);
   const closeCreateModal = useCallback(() => setCreateModalOpen(false), []);
   const createModalRef = useModalBehavior({
@@ -156,6 +157,8 @@ export default function McpPage() {
       }
       const envMap = parseEnv(env);
       if (Object.keys(envMap).length) body.env = envMap;
+      const headerMap = parseEnv(headersStr);
+      if (Object.keys(headerMap).length) body.headers = headerMap;
 
       await api.addMcpServer(body);
       showToast("Add ✓", "success");
@@ -164,6 +167,7 @@ export default function McpPage() {
       setCommand("");
       setArgs("");
       setEnv("");
+      setHeadersStr("");
       setTransport("http");
       setCreateModalOpen(false);
       loadServers();
@@ -435,6 +439,19 @@ export default function McpPage() {
                 />
               </div>
 
+              {transport === "http" && (
+                <div className="grid gap-2">
+                  <Label htmlFor="mcp-headers">Headers (KEY=VALUE per line)</Label>
+                  <textarea
+                    id="mcp-headers"
+                    className="flex min-h-[80px] w-full border border-border bg-background/40 px-3 py-2 text-sm font-courier shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground/30 focus-visible:border-foreground/25"
+                    placeholder={"Authorization=Bearer my-token\nX-Custom=value"}
+                    value={headersStr}
+                    onChange={(e) => setHeadersStr(e.target.value)}
+                  />
+                </div>
+              )}
+
               <div className="flex justify-end">
                 <Button
                   className="uppercase"
@@ -561,6 +578,7 @@ export default function McpPage() {
 
         {servers.map((server) => {
           const envCount = Object.keys(server.env ?? {}).length;
+          const headerCount = Object.keys(server.headers ?? {}).length;
           const result = testResults[server.name];
 
           return (
@@ -600,6 +618,11 @@ export default function McpPage() {
                     {envCount > 0 && (
                       <span>
                         {envCount} env var{envCount === 1 ? "" : "s"}
+                      </span>
+                    )}
+                    {headerCount > 0 && (
+                      <span>
+                        {headerCount} header{headerCount === 1 ? "" : "s"}
                       </span>
                     )}
                   </div>


### PR DESCRIPTION
## Summary

The MCP dashboard create form and API lacked a way to specify HTTP headers (e.g. `Authorization: Bearer <token>`) for Streamable HTTP MCP servers. Users had to embed tokens in the URL (exposing secrets in the UI) or edit config.yaml manually.

## Changes

- Add `headers` field to `MCPServerCreate` Pydantic model (backend)
- Pass headers through to `server_config` in `add_mcp_server` handler
- Include redacted headers in `_mcp_server_summary` response
- Add `headers` to `McpServerCreate` and `McpServer` TypeScript interfaces
- Add 'Headers (KEY=VALUE per line)' textarea in dashboard MCP create form (shown only for HTTP transport)
- Show headers count badge in MCP server list

Fixes #61562