### PR TITLE
fix(gateway): check rate-limit before auth-error to prevent 429 → authentication failed misclassification (#60846)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -354,19 +354,24 @@ def _redact_approval_command(cmd: "str | None") -> str:
 
 
 def _gateway_provider_error_reply(text: str) -> str:
-    """Map raw provider/API errors to a short user-safe Telegram reply."""
-    if _GATEWAY_AUTH_ERROR_RE.search(text):
-        return (
-            "⚠️ Provider authentication failed. Check the configured credentials; "
-            "raw provider details are in the gateway logs."
-        )
+    """Map raw provider/API errors to a short user-safe Telegram reply.
+
+    Order matters: rate-limit detection runs before auth-error detection so a
+    429 rate-limit / quota-exhausted response is not misclassified as an
+    authentication failure (#60846).
+    """
+    if _GATEWAY_RATE_LIMIT_RE.search(text):
+        return "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
     if _GATEWAY_PROVIDER_POLICY_RE.search(text):
         return (
             "⚠️ The model provider rejected the request. I kept the raw provider "
             "error out of chat; check gateway logs for details or try rephrasing."
         )
-    if _GATEWAY_RATE_LIMIT_RE.search(text):
-        return "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
+    if _GATEWAY_AUTH_ERROR_RE.search(text):
+        return (
+            "⚠️ Provider authentication failed. Check the configured credentials; "
+            "raw provider details are in the gateway logs."
+        )
     return (
         "⚠️ The model provider failed after retries. I kept raw provider details "
         "out of chat; check gateway logs for diagnostics."


### PR DESCRIPTION
## Summary
Provider HTTP 429 (rate-limit/quota exhausted) was being caught by the auth-error classification and surfaced as "Provider authentication failed" — sending users on a wild goose chase re-authenticating valid credentials.

## Root Cause
`_gateway_provider_error_reply()` in `gateway/run.py` checked auth-error patterns before rate-limit patterns. A 429 response body often contains substring patterns that match the auth regex, so it was classified as auth failure before the rate-limit branch could catch it.

## Change
Reordered the if-chain in `_gateway_provider_error_reply()` to check rate-limit first, then policy, then auth-error, then generic fallback. Added docstring noting the ordering is intentional.

## Verification
137 rate-related gateway tests pass, 1 skipped.