### PR TITLE
fix(agent): exclude ollama.com from local-Ollama stop heuristic; add newline separator in continuation join (#60928)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1933,7 +1933,7 @@ def run_conversation(
                                 _retry.restart_with_length_continuation = True
                                 break
 
-                            partial_response = agent._strip_think_blocks("".join(truncated_response_parts)).strip()
+                            partial_response = agent._strip_think_blocks("\n".join(truncated_response_parts)).strip()
                             agent._cleanup_task_resources(effective_task_id)
                             agent._persist_session(messages, conversation_history)
                             return {
@@ -5101,7 +5101,7 @@ def run_conversation(
                 codex_ack_continuations = 0
 
                 if truncated_response_parts:
-                    final_response = "".join(truncated_response_parts) + final_response
+                    final_response = "\n".join(truncated_response_parts) + final_response
                     truncated_response_parts = []
                     length_continue_retries = 0
                 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1487,7 +1487,10 @@ class AIAgent:
         provider_lower = (self.provider or "").lower()
         if "glm" not in model_lower and provider_lower != "zai":
             return False
-        if "ollama" in self._base_url_lower or ":11434" in self._base_url_lower:
+        base = self._base_url_lower
+        if ":11434" in base or "localhost" in base or "127.0.0.1" in base:
+            return True
+        if "ollama" in base and "ollama.com" not in base and "ollama.ai" not in base:
             return True
         return provider_lower == "ollama"
 


### PR DESCRIPTION
## Summary
Two bugs causing Ollama Cloud users to get raw MEDIA:/...ogg text instead of voice bubbles.

## Bug 1 — ollama.com misdetected as local Ollama
`_is_ollama_glm_backend()` matched the substring "ollama" anywhere in the base URL, including ollama.com. Local Ollama uses :11434/localhost/127.0.0.1. Fixed to only match those local patterns.

## Bug 2 — separatorless continuation join
`"".join(truncated_response_parts)` concatenated continuation text directly onto the prior response. When the prior response ends with `MEDIA:/...ogg`, the tag gets fused to the next word (e.g. `.oggIt's`), defeating MEDIA_TAG_CLEANUP_RE. Fixed to `"\n".join(...)`.

## Verification
1933 run_agent tests pass, 3 skipped.