### PR TITLE
docs(memory-tool): warn against confusing content/old_text with new_string/old_string

### DIFF
--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -1073,6 +1073,10 @@ MEMORY_SCHEMA = {
         "reports current/limit chars and confirms completion; one batch call finishes the "
         "update, so don't repeat it. Use the bare action/content/old_text fields only for a "
         "single lone change.\n\n"
+        "FIELD NAMES (differ from the 'patch' tool — do NOT confuse them): this tool uses "
+        "'content' for the replacement text and 'old_text' for the find-substring. The 'patch' "
+        "tool uses 'new_string' and 'old_string'. If you pass 'new_string' here, it will be "
+        "silently ignored and the call will fail because 'content' is missing.\n\n"
         "WHEN: save proactively when the user states a preference, correction, or personal "
         "detail, or you learn a stable fact about their environment, conventions, or workflow. "
         "Priority: user preferences & corrections > environment facts > procedures. The best "
@@ -1100,11 +1104,11 @@ MEMORY_SCHEMA = {
             },
             "content": {
                 "type": "string",
-                "description": "The entry content. Required for 'add' and 'replace' (single-op shape)."
+                "description": "The entry text. For 'add' this is the new entry; for 'replace' this is the REPLACEMENT text (NOT 'new_string' — that field name belongs to the 'patch' tool). Required for 'add' and 'replace' (single-op shape)."
             },
             "old_text": {
                 "type": "string",
-                "description": "REQUIRED for 'replace' and 'remove' (single-op shape): a short unique substring identifying the existing entry to modify. Omit only for 'add'."
+                "description": "REQUIRED for 'replace' and 'remove' (single-op shape): a short unique substring identifying the existing entry to modify. (NOT 'old_string' — that field name belongs to the 'patch' tool.) Omit only for 'add'."
             },
             "operations": {
                 "type": "array",
@@ -1117,8 +1121,8 @@ MEMORY_SCHEMA = {
                     "type": "object",
                     "properties": {
                         "action": {"type": "string", "enum": ["add", "replace", "remove"]},
-                        "content": {"type": "string", "description": "Entry content for add/replace."},
-                        "old_text": {"type": "string", "description": "Substring identifying the entry for replace/remove."},
+                        "content": {"type": "string", "description": "Entry content for add/replace. For 'replace', this is the REPLACEMENT text — not 'new_string' (that's the 'patch' tool's field name)."},
+                        "old_text": {"type": "string", "description": "Substring identifying the entry for replace/remove — not 'old_string' (that's the 'patch' tool's field name)."},
                     },
                     "required": ["action"],
                 },


### PR DESCRIPTION
## Problem

The `memory` tool and the `patch` tool both do find-and-replace semantics but use different parameter names for the same semantic:

| Semantic          | `patch` tool  | `memory` tool |
|-------------------|---------------|---------------|
| Find-string       | `old_string`  | `old_text`    |
| Replacement text  | `new_string`  | `content`     |

Agents that use one tool then reach for the other pass the wrong field name and the call fails. The existing error message (`content is required for 'replace' action`) is technically correct but doesn't tell the caller which field name to use instead of the one they picked from the patch tool.

## Repro (from live use)

An agent trying to batch-replace via `memory` used `new_string` (patch tool convention). The call returned a clear "content is required" error, but the caller had to guess-and-check to find that this tool wants `content`.

## Fix

Doc-only patch to `tools/memory_tool.py`. Three touch-points:

1. Top-level `MEMORY_SCHEMA["description"]`: new paragraph explicitly naming the field convention and calling out the mismatch with the `patch` tool.
2. Field descriptions for `content` and `old_text` (top-level params): each names the semantic explicitly and points to the patch tool's alternate name so the confusion is caught wherever the schema is inspected.
3. Same treatment for `content` / `old_text` inside the batch `operations` items schema.

No runtime behavior change. All 88 existing tests in `tests/tools/test_memory_tool.py` + `test_memory_tool_schema.py` pass unchanged.

## Why not just rename to align with patch tool?

Two reasons:
1. `content` in the memory tool carries semantic weight for `add` operations (there's no "old text" for adds), so `new_string` doesn't map cleanly onto it as a rename.
2. Renaming param names on a heavily-used core tool is a breaking change to every caller. A doc-only fix prevents the confusion at prompt-injection time without breaking anyone.

A future coordinated rename discussion is welcome as its own issue/PR — this PR keeps the scope narrow to the immediate friction.

## Testing

```
$ pytest tests/tools/test_memory_tool.py tests/tools/test_memory_tool_schema.py
============================== 88 passed in 0.92s ==============================
```
