### PR TITLE
feat(codex): allow configuring app-server binary

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -27,6 +27,21 @@ from agent.stream_single_writer import claim_stream_writer, stream_writer_is_cur
 logger = logging.getLogger(__name__)
 
 
+def _configured_codex_binary() -> str:
+    """Resolve the app-server executable from the active profile config."""
+    try:
+        from hermes_cli.codex_runtime_switch import get_configured_codex_binary
+        from hermes_cli.config import load_config
+
+        return get_configured_codex_binary(load_config())
+    except Exception:
+        logger.debug(
+            "codex app-server binary config unavailable; using PATH default",
+            exc_info=True,
+        )
+        return "codex"
+
+
 def _coerce_usage_int(value: Any) -> int:
     if isinstance(value, bool):
         return 0
@@ -682,6 +697,7 @@ def run_codex_app_server_turn(
         # Supersedes the narrower item/started-only bridge from #38835.
         agent._codex_session = CodexAppServerSession(
             cwd=cwd,
+            codex_bin=_configured_codex_binary(),
             approval_callback=approval_callback,
             request_routing=_ServerRequestRouting(
                 auto_approve_exec=auto_approve_requests,

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -86,6 +86,21 @@ def _log_codex_request_failure(
     )
 
 
+def _configured_codex_binary() -> str:
+    """Resolve the app-server executable from the active profile config."""
+    try:
+        from hermes_cli.codex_runtime_switch import get_configured_codex_binary
+        from hermes_cli.config import load_config
+
+        return get_configured_codex_binary(load_config())
+    except Exception:
+        logger.debug(
+            "codex app-server binary config unavailable; using PATH default",
+            exc_info=True,
+        )
+        return "codex"
+
+
 def _coerce_usage_int(value: Any) -> int:
     if isinstance(value, bool):
         return 0
@@ -741,6 +756,7 @@ def run_codex_app_server_turn(
         # Supersedes the narrower item/started-only bridge from #38835.
         agent._codex_session = CodexAppServerSession(
             cwd=cwd,
+            codex_bin=_configured_codex_binary(),
             approval_callback=approval_callback,
             request_routing=_ServerRequestRouting(
                 auto_approve_exec=auto_approve_requests,

--- a/hermes_cli/codex_runtime_plugin_migration.py
+++ b/hermes_cli/codex_runtime_plugin_migration.py
@@ -450,6 +450,7 @@ def _strip_existing_managed_block(toml_text: str) -> str:
 def _query_codex_plugins(
     codex_home: Optional[Path] = None,
     timeout: float = 8.0,
+    codex_bin: str = "codex",
 ) -> tuple[list[dict], Optional[str]]:
     """Query codex's `plugin/list` for installed curated plugins.
 
@@ -469,7 +470,8 @@ def _query_codex_plugins(
 
     try:
         with CodexAppServerClient(
-            codex_home=str(codex_home) if codex_home else None
+            codex_bin=codex_bin,
+            codex_home=str(codex_home) if codex_home else None,
         ) as client:
             client.initialize(client_name="hermes-migration")
             resp = client.request("plugin/list", {}, timeout=timeout)
@@ -671,7 +673,12 @@ def migrate(
     plugins: list[dict] = []
     plugin_query_succeeded = False
     if discover_plugins and not dry_run:
-        plugins, plugin_err = _query_codex_plugins(codex_home=codex_home)
+        from hermes_cli.codex_runtime_switch import get_configured_codex_binary
+
+        plugins, plugin_err = _query_codex_plugins(
+            codex_home=codex_home,
+            codex_bin=get_configured_codex_binary(hermes_config),
+        )
         if plugin_err:
             report.plugin_query_error = plugin_err
         else:

--- a/hermes_cli/codex_runtime_switch.py
+++ b/hermes_cli/codex_runtime_switch.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 VALID_RUNTIMES = ("auto", "codex_app_server")
+DEFAULT_CODEX_BINARY = "codex"
 
 
 @dataclass
@@ -73,6 +74,24 @@ def get_current_runtime(config: dict) -> str:
     return "auto"
 
 
+def get_configured_codex_binary(config: dict) -> str:
+    """Return ``model.codex_bin`` or the backward-compatible default.
+
+    The value is intentionally kept as an argv element instead of being
+    shell-parsed. This supports absolute paths with spaces while preserving
+    the subprocess boundary used by the app-server transport.
+    """
+    if not isinstance(config, dict):
+        return DEFAULT_CODEX_BINARY
+    model_cfg = config.get("model") or {}
+    if not isinstance(model_cfg, dict):
+        return DEFAULT_CODEX_BINARY
+    value = model_cfg.get("codex_bin")
+    if not isinstance(value, str):
+        return DEFAULT_CODEX_BINARY
+    return value.strip() or DEFAULT_CODEX_BINARY
+
+
 def set_runtime(config: dict, new_value: str) -> str:
     """Mutate the config dict in place to persist the new runtime value.
     Returns the previous value for callers that want to report a delta."""
@@ -87,13 +106,15 @@ def set_runtime(config: dict, new_value: str) -> str:
     return old
 
 
-def check_codex_binary_ok() -> tuple[bool, Optional[str]]:
+def check_codex_binary_ok(
+    codex_bin: str = DEFAULT_CODEX_BINARY,
+) -> tuple[bool, Optional[str]]:
     """Best-effort verification that codex CLI is installed at acceptable
     version. Returns (ok, version_or_message)."""
     try:
         from agent.transports.codex_app_server import check_codex_binary
 
-        return check_codex_binary()
+        return check_codex_binary(codex_bin=codex_bin)
     except Exception as exc:  # pragma: no cover
         return False, f"codex check failed: {exc}"
 
@@ -115,6 +136,7 @@ def apply(
     Returns: CodexRuntimeStatus describing the outcome.
     """
     current = get_current_runtime(config)
+    codex_bin = get_configured_codex_binary(config)
 
     # Cache the codex binary check for this apply() call. Subprocess spawn
     # is cheap (~50ms for `codex --version`), but we'd otherwise call it up
@@ -125,7 +147,7 @@ def apply(
     def _check_binary_cached() -> tuple[bool, Optional[str]]:
         nonlocal _binary_check
         if _binary_check is None:
-            _binary_check = check_codex_binary_ok()
+            _binary_check = check_codex_binary_ok(codex_bin)
         return _binary_check
 
     # Read-only call: just report state

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -168,6 +168,43 @@ class TestSpawnEnvIsolation:
             "subprocesses (gh, git, aws, npm) need the user's real HOME."
         )
 
+    def test_configured_binary_path_with_spaces_is_one_argv_element(
+        self, monkeypatch
+    ):
+        import subprocess
+        from agent.transports import codex_app_server as cas
+
+        captured = {}
+
+        class FakePopen:
+            def __init__(self, cmd, *args, **kwargs):
+                captured["cmd"] = list(cmd)
+                self.stdin = None
+                self.stdout = None
+                self.stderr = None
+                self.pid = 1
+                self.returncode = None
+
+            def poll(self):
+                return None
+
+            def terminate(self):
+                pass
+
+            def wait(self, timeout=None):
+                return 0
+
+            def kill(self):
+                pass
+
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        configured = "/Applications/Codex Preview.app/Contents/Resources/codex"
+
+        client = cas.CodexAppServerClient(codex_bin=configured)
+        client._closed = True
+
+        assert captured["cmd"][:2] == [configured, "app-server"]
+
     def test_spawn_env_sets_CODEX_HOME_when_provided(self, monkeypatch):
         """CODEX_HOME isolation must still work — that's the whole point
         of the codex_home arg."""

--- a/tests/hermes_cli/test_codex_runtime_plugin_migration.py
+++ b/tests/hermes_cli/test_codex_runtime_plugin_migration.py
@@ -169,7 +169,7 @@ class TestMigrate:
         blocks. This is what OpenClaw calls 'migrate native codex plugins.'"""
         from hermes_cli import codex_runtime_plugin_migration as crpm
 
-        def fake_query(codex_home=None, timeout=8.0):
+        def fake_query(codex_home=None, timeout=8.0, codex_bin="codex"):
             return [
                 {"name": "google-calendar", "marketplace": "openai-curated",
                  "enabled": True},
@@ -186,13 +186,35 @@ class TestMigrate:
         assert "google-calendar@openai-curated" in report.migrated_plugins
         assert "github@openai-curated" in report.migrated_plugins
 
+    def test_plugin_discovery_uses_configured_codex_binary(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli import codex_runtime_plugin_migration as crpm
+
+        captured = {}
+
+        def fake_query(codex_home=None, timeout=8.0, codex_bin="codex"):
+            captured["codex_bin"] = codex_bin
+            return [], None
+
+        monkeypatch.setattr(crpm, "_query_codex_plugins", fake_query)
+        configured = "/Applications/Codex.app/Contents/Resources/codex"
+
+        migrate(
+            {"model": {"codex_bin": configured}},
+            codex_home=tmp_path,
+            discover_plugins=True,
+            expose_hermes_tools=False,
+        )
+
+        assert captured["codex_bin"] == configured
 
     def test_plugin_discovery_failure_non_fatal(self, tmp_path, monkeypatch):
         """If codex isn't installed or RPC fails, MCP migration still
         completes. The error surfaces in the report but doesn't abort."""
         from hermes_cli import codex_runtime_plugin_migration as crpm
 
-        def fake_query_fails(codex_home=None, timeout=8.0):
+        def fake_query_fails(codex_home=None, timeout=8.0, codex_bin="codex"):
             return [], "codex CLI not available"
         monkeypatch.setattr(crpm, "_query_codex_plugins", fake_query_fails)
 
@@ -355,7 +377,7 @@ class TestStripUnmanagedPluginTables:
         )
 
         # Simulate codex's plugin/list reporting the same plugin tasks@openai-curated.
-        def fake_query(codex_home=None, timeout=8.0):
+        def fake_query(codex_home=None, timeout=8.0, codex_bin="codex"):
             return (
                 [{"name": "tasks", "marketplace": "openai-curated", "enabled": True}],
                 None,

--- a/tests/hermes_cli/test_codex_runtime_switch.py
+++ b/tests/hermes_cli/test_codex_runtime_switch.py
@@ -45,6 +45,24 @@ class TestGetCurrentRuntime:
         ) == "auto"
 
 
+class TestGetConfiguredCodexBinary:
+    def test_defaults_for_missing_or_invalid_values(self):
+        assert crs.get_configured_codex_binary({}) == "codex"
+        assert crs.get_configured_codex_binary({"model": {}}) == "codex"
+        assert crs.get_configured_codex_binary(
+            {"model": {"codex_bin": ""}}
+        ) == "codex"
+        assert crs.get_configured_codex_binary(
+            {"model": {"codex_bin": 42}}
+        ) == "codex"
+
+    def test_returns_trimmed_configured_path(self):
+        configured = "/Applications/Codex.app/Contents/Resources/codex"
+        assert crs.get_configured_codex_binary(
+            {"model": {"codex_bin": f"  {configured}  "}}
+        ) == configured
+
+
 class TestSetRuntime:
     def test_creates_model_section_if_missing(self):
         cfg = {}
@@ -59,7 +77,21 @@ class TestSetRuntime:
 
 
 class TestApply:
+    def test_binary_check_uses_configured_path(self):
+        configured = "/Applications/Codex.app/Contents/Resources/codex"
+        cfg = {
+            "model": {
+                "openai_runtime": "codex_app_server",
+                "codex_bin": configured,
+            }
+        }
+        with patch.object(
+            crs, "check_codex_binary_ok", return_value=(True, "0.130.0")
+        ) as binary_check:
+            result = crs.apply(cfg, None)
 
+        assert result.success
+        binary_check.assert_called_once_with(configured)
 
     def test_reapply_codex_app_server_runs_migration(self):
         """Re-applying codex_app_server when already enabled must still
@@ -168,5 +200,4 @@ class TestApply:
         assert r.new_value == "codex_app_server"
         assert "MCP migration skipped" in r.message
         assert "disk full" in r.message
-
 

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -378,6 +378,37 @@ class TestRunConversationCodexPath:
 
         assert captured["cwd"] == str(tmp_path)
 
+    def test_configured_codex_binary_seeds_app_server_session(self, monkeypatch):
+        configured = "/Applications/Codex.app/Contents/Resources/codex"
+        captured: dict = {}
+
+        def fake_init(self, **kwargs):
+            captured.update(kwargs)
+            self._thread_id = "thread-stub-1"
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            return TurnResult(
+                final_text="ok",
+                projected_messages=[{"role": "assistant", "content": "ok"}],
+                turn_id="turn-stub-1",
+                thread_id="thread-stub-1",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "__init__", fake_init)
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"model": {"codex_bin": configured}},
+        ):
+            agent = _make_codex_agent()
+            with patch.object(
+                agent, "_spawn_background_review", return_value=None
+            ):
+                agent.run_conversation("hi")
+
+        assert captured["codex_bin"] == configured
+
     def _capture_routing_agent(self, monkeypatch):
         """Build a codex agent with a CodexAppServerSession stub that captures
         the request_routing passed at construction time, so we can assert how

--- a/website/docs/user-guide/features/codex-app-server-runtime.md
+++ b/website/docs/user-guide/features/codex-app-server-runtime.md
@@ -197,6 +197,19 @@ model:
   openai_runtime: codex_app_server   # default is "auto" (= Hermes runtime)
 ```
 
+If the Hermes process cannot resolve `codex` from `PATH` (common for gateway
+services and desktop-launched workers), configure the executable explicitly:
+
+```yaml
+model:
+  openai_runtime: codex_app_server
+  codex_bin: /Applications/Codex.app/Contents/Resources/codex
+```
+
+The configured path is used consistently for the enablement check, native
+plugin discovery, and the long-lived app-server subprocess. Paths containing
+spaces are passed as a single subprocess argument; do not add shell quoting.
+
 ## Self-improvement loop (memory + skill nudges)
 
 Hermes' background self-improvement fires on counter thresholds:


### PR DESCRIPTION
## Summary
- add `model.codex_bin` with a backward-compatible `codex` default
- use the configured executable for runtime enablement checks, native plugin discovery, and the long-lived app-server session
- document service/minimal-`PATH` configuration and preserve paths with spaces as one argv element

## Root cause
The transport and session APIs already accepted a `codex_bin`, but the runtime toggle, plugin migration, and live turn path never supplied one from Hermes config. Gateway, desktop, and Kanban processes with a minimal `PATH` therefore could not use a Codex binary installed elsewhere, even when the path was known.

## Coverage
The sibling subprocess paths were audited together so a configured binary cannot pass `/codex-runtime` validation and then silently fall back to bare `codex` during plugin discovery or the actual turn.

## Validation
- `uv run --extra dev pytest tests/hermes_cli/test_codex_runtime_switch.py tests/hermes_cli/test_codex_runtime_plugin_migration.py tests/agent/transports/test_codex_app_server_runtime.py tests/run_agent/test_codex_app_server_integration.py -q` — 162 passed
- `uv run --extra dev pytest tests/agent/transports/test_codex_app_server_session.py tests/agent/test_codex_app_server_persist.py tests/run_agent/test_codex_app_server_compaction.py tests/run_agent/test_codex_app_server_integration.py tests/hermes_cli/test_codex_runtime_switch.py tests/hermes_cli/test_codex_runtime_plugin_migration.py -q` — 205 passed
- `uv run ruff check agent/codex_runtime.py hermes_cli/codex_runtime_switch.py hermes_cli/codex_runtime_plugin_migration.py tests/agent/transports/test_codex_app_server_runtime.py tests/hermes_cli/test_codex_runtime_switch.py tests/hermes_cli/test_codex_runtime_plugin_migration.py tests/run_agent/test_codex_app_server_integration.py`
- `git diff --check origin/main..HEAD`
- `gitleaks git --log-opts='origin/main..HEAD' --redact .` — no leaks found

Fixes #61360