### PR TITLE
fix(hindsight): surface the exception chain when the local runtime is unavailable

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -124,6 +124,33 @@ def _export_port_health_grace_timeout(config: dict[str, Any]) -> None:
     os.environ.setdefault(_PORT_HEALTH_GRACE_ENV, repr(seconds))
 
 
+def _format_exception_chain(exc: BaseException, max_links: int = 5) -> str:
+    """Render *exc* plus its ``__cause__``/``__context__`` chain as one line.
+
+    Upstream wrappers hide the real failure behind a generic re-raise:
+    hindsight_api's ``LocalSTEmbeddings.initialize()`` catches the actual
+    error and re-raises "sentence-transformers is required ... pip install
+    sentence-transformers" even when the package IS installed and the real
+    problem is a dependency conflict underneath it (#60783: a forced
+    huggingface-hub downgrade — the chained exception held the actual
+    "huggingface-hub>=1.5.0,<2.0 is required ... found huggingface-hub==1.2.3"
+    while the surfaced message sent users reinstalling the wrong package).
+    ``str(exc)`` drops that chain; walking the links keeps the diagnosis in
+    the reason Hermes reports.
+    """
+    parts: list[str] = []
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen and len(parts) < max_links:
+        seen.add(id(current))
+        message = str(current).strip()
+        parts.append(
+            f"{type(current).__name__}: {message}" if message else type(current).__name__
+        )
+        current = current.__cause__ or current.__context__
+    return " <- caused by: ".join(parts)
+
+
 def _check_local_runtime() -> tuple[bool, str | None]:
     """Return whether local embedded Hindsight imports cleanly.
 
@@ -139,6 +166,13 @@ def _check_local_runtime() -> tuple[bool, str | None]:
     healthy and ``hermes memory status`` would stay green while the daemon
     aborts at startup on every retain/recall. Import it too so the probe (and
     status) reports the real ImportError.
+
+    That ``sentence_transformers`` import is also the one most likely to
+    arrive pre-wrapped: its failure is frequently re-raised as a generic
+    "install sentence-transformers" message with the real dependency
+    conflict demoted to ``__cause__``. So the returned reason includes the
+    exception's cause/context chain, not just the top message — see
+    :func:`_format_exception_chain` (#60783).
     """
     try:
         importlib.import_module("hindsight")
@@ -146,7 +180,8 @@ def _check_local_runtime() -> tuple[bool, str | None]:
         importlib.import_module("sentence_transformers")
         return True, None
     except Exception as exc:
-        return False, str(exc)
+        logger.debug("Hindsight local runtime import failed", exc_info=True)
+        return False, _format_exception_chain(exc)
 
 
 def _ensure_cloud_client_dependency() -> None:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1169,3 +1169,77 @@ class TestClientAutoUpgradeRoutesThroughLazyDeps:
         assert len(calls) == 1  # attempted exactly once, init still completed
         assert any("runtime installs are disabled" in r.getMessage()
                    for r in caplog.records)
+
+
+class TestLocalRuntimeErrorChain:
+    """_check_local_runtime must surface the exception chain, not just the
+    top message — upstream wrappers re-raise generic "package missing"
+    errors that hide the real dependency conflict (#60783)."""
+
+    def test_format_chain_includes_cause(self):
+        from plugins.memory.hindsight import _format_exception_chain
+
+        try:
+            try:
+                raise ImportError(
+                    "huggingface-hub>=1.5.0,<2.0 is required for a normal "
+                    "functioning of this module, but found huggingface-hub==1.2.3."
+                )
+            except ImportError as real:
+                raise ImportError(
+                    "sentence-transformers is required for LocalSTEmbeddings. "
+                    "Install it with: pip install sentence-transformers"
+                ) from real
+        except ImportError as exc:
+            rendered = _format_exception_chain(exc)
+
+        assert "sentence-transformers is required" in rendered
+        assert "huggingface-hub>=1.5.0,<2.0" in rendered
+        assert "caused by" in rendered
+
+    def test_format_chain_follows_implicit_context(self):
+        """A bare re-raise (no `from e`) still chains via __context__."""
+        from plugins.memory.hindsight import _format_exception_chain
+
+        try:
+            try:
+                raise RuntimeError("real root cause")
+            except RuntimeError:
+                raise ImportError("generic wrapper message")
+        except ImportError as exc:
+            rendered = _format_exception_chain(exc)
+
+        assert "generic wrapper message" in rendered
+        assert "real root cause" in rendered
+
+    def test_format_chain_plain_exception_unchanged_shape(self):
+        from plugins.memory.hindsight import _format_exception_chain
+
+        rendered = _format_exception_chain(ValueError("just one error"))
+        assert rendered == "ValueError: just one error"
+
+    def test_format_chain_survives_cycles(self):
+        from plugins.memory.hindsight import _format_exception_chain
+
+        a = ValueError("a")
+        b = ValueError("b")
+        a.__cause__ = b
+        b.__cause__ = a
+        rendered = _format_exception_chain(a)
+        assert rendered.count("ValueError") == 2
+
+    def test_check_local_runtime_reason_contains_root_cause(self, monkeypatch):
+        from plugins.memory import hindsight as hs
+
+        def _fail(name):
+            try:
+                raise ImportError("huggingface-hub>=1.5.0,<2.0 is required")
+            except ImportError as real:
+                raise ImportError("sentence-transformers is required") from real
+
+        monkeypatch.setattr(hs.importlib, "import_module", _fail)
+        available, reason = hs._check_local_runtime()
+
+        assert available is False
+        assert "sentence-transformers is required" in reason
+        assert "huggingface-hub>=1.5.0,<2.0" in reason


### PR DESCRIPTION
## What does this PR do?

Diagnosability fix for the failure mode documented in #60783's second confirming report: when the local Hindsight runtime fails to import, `_check_local_runtime()` returned `str(exc)` — which drops the exception cause/context chain. Upstream, `hindsight_api`'s `LocalSTEmbeddings.initialize()` catches the real error and re-raises a generic *"sentence-transformers is required … pip install sentence-transformers"* even when that package **is** installed — during the #60783 huggingface-hub downgrade the actual conflict (`huggingface-hub>=1.5.0,<2.0 is required … found 1.2.3`) lived only in the chained cause, and the surfaced message sent users reinstalling the wrong package.

Fix: a `_format_exception_chain()` helper walks `__cause__`/`__context__` (cycle-safe, capped at 5 links) and renders the chain into the reason — which flows verbatim into `_get_client()`'s `RuntimeError` and availability messaging — plus a debug-level full traceback. The root cause becomes visible in one Hermes log read instead of requiring a dig through the Hindsight daemon's own profile logs.

Kept deliberately separate from #60797 (which fixes the downgrade itself) so each PR stays single-concern.

## Related Issue

Diagnosability follow-up to #60783 (root cause fixed by #60797)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/hindsight/__init__.py` — new `_format_exception_chain()`; `_check_local_runtime()` returns the rendered chain and logs the traceback at debug level
- `tests/plugins/memory/test_hindsight_provider.py` — 5 new tests: explicit `from e` chain, implicit `__context__` chain, single-exception shape, cycle safety, and the end-to-end `_check_local_runtime` reason containing the root cause

## How to Test

1. `pytest tests/plugins/memory/test_hindsight_provider.py -q` → 121 passed (5 new)
2. Manual: with a broken hindsight import (e.g. the #60783 downgrade state), `hermes` memory init now reports `ImportError: sentence-transformers is required … <- caused by: ImportError: huggingface-hub>=1.5.0,<2.0 is required …` instead of only the misleading first half.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (offered on the #60783 thread first; no objections, no competing PR)
- [x] My PR contains **only** changes related to this fix
- [x] I've run the test suite listed above and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (CachyOS, Python 3.12)

### Documentation & Housekeeping

- [x] Relevant documentation — rationale documented in the helper docstring; N/A otherwise
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] Cross-platform impact — pure Python exception formatting; platform-independent
