### PR TITLE
fix(agent): log kwargs keys + middleware trace on unexpected-kwarg TypeError at dispatch

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -845,6 +845,37 @@ def _notify_context_engine_turn_complete(
             exc_info=True,
         )
 
+def _format_unexpected_kwarg_diagnostics(api_kwargs, middleware_trace) -> str:
+    """One-line diagnostic for ``TypeError: ... unexpected keyword argument``.
+
+    A kwarg the provider SDK rejects at dispatch means something upstream
+    injected a key the active api_mode's transport never emits. The two
+    invisible injectors are ``llm_request`` middleware (plugins may replace
+    the entire request dict, and their exceptions/traces are otherwise
+    never logged) and stale kwargs crossing an api_mode switch. #60821 —
+    a plugin writing the Anthropic-shape ``system`` key onto
+    chat_completions kwargs — took a multi-day forensic hunt precisely
+    because neither the kwargs keys nor the middleware trace appeared in
+    any log. Rendering both makes the injector a one-log diagnosis.
+    """
+    if isinstance(api_kwargs, dict):
+        keys = ", ".join(sorted(str(k) for k in api_kwargs))
+    else:
+        keys = "<unavailable>"
+    if middleware_trace:
+        rendered = []
+        for entry in middleware_trace:
+            if isinstance(entry, dict):
+                rendered.append(
+                    entry.get("name") or entry.get("source") or str(entry)
+                )
+            else:
+                rendered.append(str(entry))
+        trace = "; ".join(rendered)
+    else:
+        trace = "none applied"
+    return f"api_kwargs keys: [{keys}]; llm_request middleware trace: {trace}"
+
 
 def run_conversation(
     agent,
@@ -3687,6 +3718,20 @@ def run_conversation(
                     agent._client_log_context(),
                     _error_summary,
                 )
+
+                if error_type == "TypeError" and "unexpected keyword argument" in error_msg:
+                    # Identify the kwarg injector (middleware / mode mismatch)
+                    # in the log instead of leaving a multi-day hunt (#60821).
+                    try:
+                        _diag_kwargs, _diag_trace = api_kwargs, _llm_middleware_trace
+                    except NameError:
+                        _diag_kwargs, _diag_trace = None, None
+                    logger.warning(
+                        "%sUnexpected-kwarg TypeError at dispatch (api_mode=%s) — %s",
+                        agent.log_prefix,
+                        getattr(agent, "api_mode", "unknown"),
+                        _format_unexpected_kwarg_diagnostics(_diag_kwargs, _diag_trace),
+                    )
 
                 _provider = getattr(agent, "provider", "unknown")
                 _base = getattr(agent, "base_url", "unknown")

--- a/tests/agent/test_dispatch_kwarg_diagnostics.py
+++ b/tests/agent/test_dispatch_kwarg_diagnostics.py
@@ -1,0 +1,48 @@
+"""Tests for the unexpected-kwarg TypeError dispatch diagnostic (#60821).
+
+When the provider SDK rejects a kwarg at dispatch, the failure handler
+renders the api_kwargs keys plus the llm_request middleware trace so the
+injector (a plugin replacing the request dict, or stale kwargs crossing an
+api_mode switch) is identifiable from one log line.
+"""
+
+from agent.conversation_loop import _format_unexpected_kwarg_diagnostics
+
+
+class TestFormatUnexpectedKwargDiagnostics:
+    def test_renders_sorted_kwargs_keys(self):
+        rendered = _format_unexpected_kwarg_diagnostics(
+            {"system": "x", "messages": [], "model": "m"}, []
+        )
+        assert "api_kwargs keys: [messages, model, system]" in rendered
+
+    def test_renders_middleware_trace_entries(self):
+        trace = [
+            {"name": "skill-enforce", "source": "plugin"},
+            {"source": "plugin"},
+            "raw-entry",
+        ]
+        rendered = _format_unexpected_kwarg_diagnostics({"model": "m"}, trace)
+        assert "skill-enforce" in rendered
+        assert "plugin" in rendered
+        assert "raw-entry" in rendered
+
+    def test_no_trace_reads_as_none_applied(self):
+        rendered = _format_unexpected_kwarg_diagnostics({"model": "m"}, [])
+        assert "none applied" in rendered
+
+    def test_unavailable_kwargs_do_not_crash(self):
+        rendered = _format_unexpected_kwarg_diagnostics(None, None)
+        assert "<unavailable>" in rendered
+        assert "none applied" in rendered
+
+    def test_the_60821_shape_is_identifiable(self):
+        """The exact #60821 payload: Anthropic-shape 'system' on
+        chat_completions kwargs, injected by a plugin middleware."""
+        rendered = _format_unexpected_kwarg_diagnostics(
+            {"model": "tencent/Hy3", "messages": [], "system": "reminder",
+             "stream": True, "tools": []},
+            [{"name": "skill-enforce"}],
+        )
+        assert "system" in rendered
+        assert "skill-enforce" in rendered


### PR DESCRIPTION
## What does this PR do?

Makes unexpected-kwarg `TypeError`s at API dispatch diagnosable from one log line, closing the observability gap that made #60821 a multi-day hunt.

When the provider SDK rejects a kwarg (`Completions.create() got an unexpected keyword argument 'system'`), something upstream injected a key the active api_mode's transport never emits. The two invisible injectors are:

- **`llm_request` middleware** — plugins may replace the *entire* request dict (`hermes_cli/middleware.py`), and the applied-middleware trace lived and died in a local variable, never logged; and
- **stale kwargs crossing an `api_mode` switch** (Anthropic-shaped kwargs reaching OpenAI dispatch).

In #60821 a user-installed plugin wrote the Anthropic-shape `system` key onto chat_completions kwargs; identifying it required eliminating configs, provider profiles, fast-mode overrides, and two debug dumps by hand, because no log showed either the kwargs keys or which middleware had touched the request.

**Change:** when the retry handler classifies a `TypeError` containing `unexpected keyword argument`, it emits one extra WARNING with the active `api_mode`, the sorted `api_kwargs` keys, and the `llm_request` middleware trace (or `none applied`). The rendering lives in a pure helper (`_format_unexpected_kwarg_diagnostics`), and the wiring is guarded so a diagnostics failure can never mask the original error path. No behavior change beyond the added log line.

Example output for the #60821 case:

```
Unexpected-kwarg TypeError at dispatch (api_mode=chat_completions) — api_kwargs keys: [messages, model, stream, system, tools]; llm_request middleware trace: skill-enforce
```

## Related Issue

Follow-up to #60821 (closed as a plugin bug; this makes the next occurrence a one-log diagnosis — offered on the thread before it closed)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_loop.py` — new module-level `_format_unexpected_kwarg_diagnostics()` helper + guarded WARNING in the API-failure handler
- `tests/agent/test_dispatch_kwarg_diagnostics.py` — 5 tests: sorted key rendering, middleware-trace entry shapes (named / source-only / raw), no-trace wording, None-safety, and the exact #60821 payload shape

## How to Test

1. `pytest tests/agent/test_dispatch_kwarg_diagnostics.py -q` → 5 passed
2. `pytest tests/agent/test_empty_tool_name_loop_dampening.py tests/agent/test_crossloop_client_cache.py -q` → 10 passed (neighboring loop tests unaffected)
3. Manual repro: register an `llm_request` middleware that sets `request["system"]` on a chat_completions provider — the failure log now names the middleware and shows the stray key.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (offered on #60821 first; no competing PR)
- [x] My PR contains **only** changes related to this fix
- [x] I've run the test suites listed above and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (CachyOS, Python 3.12)

### Documentation & Housekeeping

- [x] Relevant documentation — behavior documented in the helper docstring; N/A otherwise
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] Cross-platform impact — pure logging; platform-independent
