### PR TITLE
fix(gateway): label Windows planned stops instead of reporting signal=UNKNOWN

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20909,6 +20909,17 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 spawn_async_diagnostic,
             )
             _shutdown_ctx = snapshot_shutdown_context(received_signal)
+            # Windows planned stops arrive via the marker watcher with
+            # signal=None, which snapshots as UNKNOWN and makes a normal
+            # `hermes gateway stop` log like an external kill (#61596).
+            # The marker consumption above already proved operator intent.
+            from gateway.shutdown_forensics import label_marker_driven_shutdown
+            label_marker_driven_shutdown(
+                _shutdown_ctx,
+                planned_takeover=planned_takeover,
+                planned_stop=planned_stop,
+                received_signal=received_signal,
+            )
         except Exception as _e:
             _shutdown_ctx = None
             logger.debug("snapshot_shutdown_context failed: %s", _e)

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -45,6 +45,36 @@ def _signal_name(sig: Any) -> str:
     return _SIGNAL_NAME_BY_NUM.get(sig_int, f"signal#{sig_int}")
 
 
+def label_marker_driven_shutdown(
+    ctx: Dict[str, Any],
+    *,
+    planned_takeover: bool,
+    planned_stop: bool,
+    received_signal: Any,
+) -> None:
+    """Relabel ``ctx["signal"]`` for marker-driven shutdowns with no OS signal.
+
+    On Windows, ``asyncio.add_signal_handler`` raises NotImplementedError, so
+    ``hermes gateway stop`` / ``/restart`` reach the shutdown handler via the
+    planned-stop marker watcher, which invokes it with ``signal=None``
+    (#33778). ``snapshot_shutdown_context(None)`` renders that as UNKNOWN —
+    making every normal Windows stop log like an external kill
+    ("Received UNKNOWN as a planned gateway stop",
+    "Shutdown context: signal=UNKNOWN"), #61596.
+
+    The marker consumption has already proven operator intent by the time
+    the snapshot exists, so label the context accordingly. A real OS signal
+    (POSIX SIGTERM/SIGINT) keeps its true name — this only replaces the
+    UNKNOWN placeholder. Mutates *ctx* in place; never raises.
+    """
+    if received_signal is not None or not isinstance(ctx, dict):
+        return
+    if planned_takeover:
+        ctx["signal"] = "PLANNED_TAKEOVER"
+    elif planned_stop:
+        ctx["signal"] = "PLANNED_STOP"
+
+
 def _read_proc_field(pid: int, key: str) -> Optional[str]:
     """Read a single field from /proc/<pid>/status.  Linux only; None elsewhere."""
     try:

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -248,3 +248,67 @@ class TestCheckSystemdTimingAlignment:
         # for whatever unit pytest IS in.  Both are valid; we just ensure
         # the function doesn't raise.
         assert result is None or isinstance(result, dict)
+
+
+class TestLabelMarkerDrivenShutdown:
+    """#61596: Windows planned stops (marker watcher → signal=None) must not
+    be reported as signal=UNKNOWN — the marker already proved intent."""
+
+    def _ctx(self):
+        from gateway.shutdown_forensics import snapshot_shutdown_context
+        return snapshot_shutdown_context(None)
+
+    def test_planned_stop_with_no_signal_is_labeled(self):
+        from gateway.shutdown_forensics import label_marker_driven_shutdown
+
+        ctx = self._ctx()
+        assert ctx["signal"] == "UNKNOWN"
+        label_marker_driven_shutdown(
+            ctx, planned_takeover=False, planned_stop=True, received_signal=None
+        )
+        assert ctx["signal"] == "PLANNED_STOP"
+
+    def test_planned_takeover_wins_over_planned_stop(self):
+        from gateway.shutdown_forensics import label_marker_driven_shutdown
+
+        ctx = self._ctx()
+        label_marker_driven_shutdown(
+            ctx, planned_takeover=True, planned_stop=True, received_signal=None
+        )
+        assert ctx["signal"] == "PLANNED_TAKEOVER"
+
+    def test_real_signal_keeps_its_true_name(self):
+        """POSIX behavior unchanged: a real SIGTERM that happens to carry a
+        planned-stop marker keeps the actual signal name."""
+        import signal as _signal
+
+        from gateway.shutdown_forensics import (
+            label_marker_driven_shutdown,
+            snapshot_shutdown_context,
+        )
+
+        ctx = snapshot_shutdown_context(_signal.SIGTERM)
+        before = ctx["signal"]
+        label_marker_driven_shutdown(
+            ctx, planned_takeover=False, planned_stop=True,
+            received_signal=_signal.SIGTERM,
+        )
+        assert ctx["signal"] == before
+        assert "TERM" in ctx["signal"]
+
+    def test_unplanned_none_signal_stays_unknown(self):
+        """A genuinely unexplained handler invocation keeps UNKNOWN."""
+        from gateway.shutdown_forensics import label_marker_driven_shutdown
+
+        ctx = self._ctx()
+        label_marker_driven_shutdown(
+            ctx, planned_takeover=False, planned_stop=False, received_signal=None
+        )
+        assert ctx["signal"] == "UNKNOWN"
+
+    def test_never_raises_on_non_dict_ctx(self):
+        from gateway.shutdown_forensics import label_marker_driven_shutdown
+
+        label_marker_driven_shutdown(
+            None, planned_takeover=False, planned_stop=True, received_signal=None
+        )


### PR DESCRIPTION
## What does this PR do?

Fixes #61596: on Windows, every normal `hermes gateway stop` / `/restart` logs as if the gateway was externally killed:

```
INFO  gateway.run: Received UNKNOWN as a planned gateway stop
WARNING gateway.run: Shutdown context: signal=UNKNOWN ...
```

**Why:** `asyncio.add_signal_handler` raises `NotImplementedError` on Windows, so planned stops reach the shutdown handler via the planned-stop marker watcher, which invokes it with `signal=None` (#33778). `snapshot_shutdown_context(None)` renders that as `UNKNOWN` — in the exact log lines that exist to diagnose "the gateway keeps dying" tickets, planned stops become indistinguishable from crashes.

**Fix:** new `label_marker_driven_shutdown()` in `gateway/shutdown_forensics.py` — when the handler ran with **no OS signal** and a takeover/planned-stop **marker was consumed** (operator intent already proven at that point), relabel `ctx["signal"]` to `PLANNED_TAKEOVER` / `PLANNED_STOP`. Three properties pinned by tests:

- a real POSIX signal keeps its true name (the label only ever replaces the `UNKNOWN` placeholder, so existing POSIX log output is unchanged);
- a genuinely unexplained invocation stays `UNKNOWN` (the "external killer" forensics remain trustworthy);
- takeover wins over planned-stop when both markers were consumed.

The label flows to all three consumers: the `Received … as a planned gateway stop` line, the `Shutdown context:` line, and the async shutdown diagnostic.

## Related Issue

Fixes #61596

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/shutdown_forensics.py` — new pure `label_marker_driven_shutdown()` helper (mutates ctx in place, never raises)
- `gateway/run.py` — shutdown handler calls it right after `snapshot_shutdown_context()`, inside the existing defensive try
- `tests/gateway/test_shutdown_forensics.py` — 5 new tests: planned-stop labeling, takeover precedence, real-signal name preserved, unplanned-None stays UNKNOWN, never-raises on non-dict ctx

## How to Test

1. `pytest tests/gateway/test_shutdown_forensics.py tests/gateway/test_planned_stop_watcher.py tests/gateway/test_signal_format.py -q` → 100 passed (5 new)
2. Manual on Windows: `hermes gateway stop` now logs `Received PLANNED_STOP as a planned gateway stop — exiting cleanly` and `Shutdown context: signal=PLANNED_STOP …`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (issue had zero cross-references at claim time)
- [x] My PR contains **only** changes related to this fix
- [x] I've run the test suites listed above and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (CachyOS, Python 3.12) — the labeled path is the Windows marker-watcher flow, exercised via the unit tests; POSIX behavior is pinned unchanged

### Documentation & Housekeeping

- [x] Relevant documentation — behavior + invariants documented in the helper docstring; N/A otherwise
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] Cross-platform impact — Windows gets correct labels; POSIX output pinned unchanged by test
