### PR TITLE
Complete GPT-5.6 (Sol/Terra/Luna) support, end-to-end

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -77,8 +77,8 @@ def _build_codex_gpt5_autoraise_notice(autoraise: Dict[str, Any]) -> str:
     include the exact opt-back-out command.
     """
     model = str(autoraise.get("model") or "gpt-5.4/5.5").strip().lower().rsplit("/", 1)[-1]
-    # gpt-5.3-codex-spark has a native 128K window; the gpt-5.4/5.5 family is
-    # capped at 272K by the Codex OAuth backend.
+    # gpt-5.3-codex-spark has a native 128K window; the gpt-5.4/5.5/5.6 family
+    # is capped at 272K by the Codex OAuth backend.
     cap = "128K" if model.startswith("gpt-5.3-codex-spark") else "272K"
     from_pct = int(round(autoraise["from"] * 100))
     to_pct = int(round(autoraise["to"] * 100))

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -314,15 +314,18 @@ def _is_arcee_trinity_thinking(model: Optional[str]) -> bool:
     return bare == "trinity-large-thinking"
 
 
-# Context window enforced by ChatGPT's Codex OAuth backend for gpt-5.4/5.5.
-# The raw OpenAI API and OpenRouter expose 1.05M for the same slug, but the
-# Codex backend hard-caps at 272K (verified live: a ~330K-token request to
+# Context window enforced by ChatGPT's Codex OAuth backend for the
+# gpt-5.4 / gpt-5.5 / gpt-5.6 families. The raw OpenAI API and OpenRouter
+# expose 1.05M for the same slugs, but the Codex backend hard-caps at 272K
+# (verified live for 5.4/5.5: a ~330K-token request to
 # chatgpt.com/backend-api/codex/responses is rejected with
-# ``context_length_exceeded`` while ~250K succeeds). With a 272K ceiling the
-# default 50% compaction trigger fires at ~136K — wasteful, since the model
-# can hold far more raw context before summarization actually buys anything.
-# We raise the trigger to 85% (~231K) on this exact route so Codex gpt-5.4/
-# gpt-5.5 sessions use the window they actually have.
+# ``context_length_exceeded`` while ~250K succeeds; gpt-5.6 shares the same
+# 272K Codex cap — see _CODEX_OAUTH_CONTEXT_FALLBACK in model_metadata.py).
+# With a 272K ceiling the default 50% compaction trigger fires at ~136K —
+# wasteful, since the model can hold far more raw context before
+# summarization actually buys anything. We raise the trigger to 85% (~231K)
+# on this exact route so Codex gpt-5.4 / gpt-5.5 / gpt-5.6 sessions use the
+# window they actually have.
 _CODEX_GPT54_GPT55_COMPACTION_THRESHOLD = 0.85
 
 # gpt-5.3-codex-spark is Codex-OAuth-only (ChatGPT Pro entitlement) with a
@@ -336,14 +339,16 @@ _CODEX_SPARK_COMPACTION_THRESHOLD = 0.70
 
 
 def _is_codex_gpt54_or_gpt55(model: Optional[str], provider: Optional[str] = None) -> bool:
-    """True for gpt-5.4 / gpt-5.5 on the ChatGPT Codex OAuth backend.
+    """True for gpt-5.4 / gpt-5.5 / gpt-5.6 on the ChatGPT Codex OAuth backend.
 
     Matches only the Codex OAuth route (provider ``openai-codex``), not the
     direct OpenAI API, OpenRouter, or GitHub Copilot paths — those expose a
     larger context window for the same slug and must keep the user's default
-    compaction threshold. ``gpt-5.4-pro`` / ``gpt-5.5-pro`` and dated snapshots
-    are matched via prefix so the override tracks both 272K-capped families
-    without re-listing every variant.
+    compaction threshold. ``-pro`` variants and dated snapshots are matched
+    via prefix so the override tracks every 272K-capped family (5.4, 5.5,
+    5.6 sol/terra/luna incl. their ``-pro`` modes) without re-listing every
+    variant. (Name kept for backward compatibility with the
+    ``compression.codex_gpt55_autoraise`` config key.)
     """
     prov = (provider or "").strip().lower()
     if prov != "openai-codex":
@@ -356,6 +361,9 @@ def _is_codex_gpt54_or_gpt55(model: Optional[str], provider: Optional[str] = Non
         or bare == "gpt-5.5"
         or bare.startswith("gpt-5.5-")
         or bare.startswith("gpt-5.5.")
+        or bare == "gpt-5.6"
+        or bare.startswith("gpt-5.6-")
+        or bare.startswith("gpt-5.6.")
     )
 
 
@@ -410,11 +418,12 @@ def _compression_threshold_for_model(
 
     Per-model/route overrides:
       - Arcee Trinity Large Thinking → 0.75 (preserve reasoning context).
-      - gpt-5.4 / gpt-5.5 on the Codex OAuth route → 0.85, because Codex caps
-        both families at 272K and the default 50% trigger would compact at
-        ~136K. Gated by ``allow_codex_gpt55_autoraise`` (historical config-key
-        name kept for backward compatibility) so the user can opt back down to
-        the global default (the caller passes the config flag through here).
+      - gpt-5.4 / gpt-5.5 / gpt-5.6 on the Codex OAuth route → 0.85, because
+        Codex caps all three families at 272K and the default 50% trigger
+        would compact at ~136K. Gated by ``allow_codex_gpt55_autoraise``
+        (historical config-key name kept for backward compatibility) so the
+        user can opt back down to the global default (the caller passes the
+        config flag through here).
       - gpt-5.3-codex-spark on the Codex OAuth route → 0.70, because the model
         has a native 128K window and the default 50% trigger would compact at
         ~64K — wasting half the usable context. Not gated by the gpt-5.5

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -231,7 +231,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     # This hardcoded value is only reached when every probe misses.
     # GPT-5.6 series (Sol/Terra/Luna, GA 2026-07-09) — 1.05M on the direct
     # OpenAI API (same as gpt-5.5). Codex OAuth caps these at 272K.
-    # More-specific keys precede "gpt-5.5" for longest-substring matching.
+    # (Lookups length-sort keys at match time, so dict order is cosmetic.)
     "gpt-5.6-luna": 1050000,
     "gpt-5.6-terra": 1050000,
     "gpt-5.6-sol": 1050000,

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -229,6 +229,12 @@ DEFAULT_CONTEXT_LENGTHS = {
     # ChatGPT Codex OAuth caps it at 272K; both paths resolve via their own
     # provider-aware branches (_resolve_codex_oauth_context_length + models.dev).
     # This hardcoded value is only reached when every probe misses.
+    # GPT-5.6 series (Sol/Terra/Luna, GA 2026-07-09) — 1.05M on the direct
+    # OpenAI API (same as gpt-5.5). Codex OAuth caps these at 272K.
+    # More-specific keys precede "gpt-5.5" for longest-substring matching.
+    "gpt-5.6-luna": 1050000,
+    "gpt-5.6-terra": 1050000,
+    "gpt-5.6-sol": 1050000,
     "gpt-5.5": 1050000,
     "gpt-5.4-nano": 400000,           # 400k (not 1.05M like full 5.4)
     "gpt-5.4-mini": 400000,           # 400k (not 1.05M like full 5.4)
@@ -1837,6 +1843,9 @@ _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
     "gpt-5.3-codex-spark": 128_000,
     "gpt-5.2-codex": 272_000,
     "gpt-5.4-mini": 272_000,
+    "gpt-5.6-sol": 272_000,
+    "gpt-5.6-terra": 272_000,
+    "gpt-5.6-luna": 272_000,
     "gpt-5.5": 272_000,
     "gpt-5.4": 272_000,
     "gpt-5.2": 272_000,

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -121,7 +121,7 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         cache_write_cost_per_million=Decimal("6.25"),
         source="official_docs_snapshot",
         source_url="https://openai.com/index/previewing-gpt-5-6-sol/",
-        pricing_version="openai-gpt-5.6-preview-2026-07",
+        pricing_version="openai-gpt-5.6-2026-07",
     ),
     (
         "openai",
@@ -133,7 +133,7 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         cache_write_cost_per_million=Decimal("3.125"),
         source="official_docs_snapshot",
         source_url="https://openai.com/index/previewing-gpt-5-6-sol/",
-        pricing_version="openai-gpt-5.6-preview-2026-07",
+        pricing_version="openai-gpt-5.6-2026-07",
     ),
     (
         "openai",
@@ -145,7 +145,7 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         cache_write_cost_per_million=Decimal("1.25"),
         source="official_docs_snapshot",
         source_url="https://openai.com/index/previewing-gpt-5-6-sol/",
-        pricing_version="openai-gpt-5.6-preview-2026-07",
+        pricing_version="openai-gpt-5.6-2026-07",
     ),
     # ── Anthropic Claude 4.8 ─────────────────────────────────────────────
     # Same $5/$25 base pricing as 4.6/4.7.  Fast-mode variant is a separate
@@ -646,7 +646,11 @@ def resolve_billing_route(
         return BillingRoute(provider="nous", model=model, base_url=base_url or _NOUS_DEFAULT_BASE_URL, billing_mode="official_models_api")
     if provider_name == "anthropic":
         return BillingRoute(provider="anthropic", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
-    if provider_name == "openai":
+    # "openai-api" is the picker/registry slug for direct api.openai.com; it
+    # bills identically to bare "openai", so normalize it here — otherwise the
+    # ("openai", <model>) _OFFICIAL_DOCS_PRICING keys are unreachable from the
+    # openai-api provider path.
+    if provider_name in {"openai", "openai-api"}:
         return BillingRoute(provider="openai", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name in {"minimax", "minimax-cn"}:
         return BillingRoute(provider=provider_name, model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -103,6 +103,50 @@ _UTC_NOW = lambda: datetime.now(timezone.utc)
 # Official docs snapshot entries. Models whose published pricing and cache
 # semantics are stable enough to encode exactly.
 _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
+    # ── OpenAI GPT-5.6 series (Sol/Terra/Luna) ───────────────────────────
+    # Announced in limited preview 2026-06-26; GA 2026-07-09 at the same
+    # rates (Sol $5/$30, Terra $2.50/$15, Luna $1/$6 per 1M in/out). Cache
+    # writes are billed at 1.25x the uncached input rate; cache reads get the
+    # standard 90% discount (0.10x input, confirmed: Sol $0.50/M cached).
+    # Note: "Sol Fast mode" ($12.5/$75, up to 750 tok/s via Cerebras) is a
+    # separate serving tier, not covered by these entries.
+    # Source: https://openai.com/index/previewing-gpt-5-6-sol/
+    (
+        "openai",
+        "gpt-5.6-sol",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("5.00"),
+        output_cost_per_million=Decimal("30.00"),
+        cache_read_cost_per_million=Decimal("0.50"),
+        cache_write_cost_per_million=Decimal("6.25"),
+        source="official_docs_snapshot",
+        source_url="https://openai.com/index/previewing-gpt-5-6-sol/",
+        pricing_version="openai-gpt-5.6-preview-2026-07",
+    ),
+    (
+        "openai",
+        "gpt-5.6-terra",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("2.50"),
+        output_cost_per_million=Decimal("15.00"),
+        cache_read_cost_per_million=Decimal("0.25"),
+        cache_write_cost_per_million=Decimal("3.125"),
+        source="official_docs_snapshot",
+        source_url="https://openai.com/index/previewing-gpt-5-6-sol/",
+        pricing_version="openai-gpt-5.6-preview-2026-07",
+    ),
+    (
+        "openai",
+        "gpt-5.6-luna",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("1.00"),
+        output_cost_per_million=Decimal("6.00"),
+        cache_read_cost_per_million=Decimal("0.10"),
+        cache_write_cost_per_million=Decimal("1.25"),
+        source="official_docs_snapshot",
+        source_url="https://openai.com/index/previewing-gpt-5-6-sol/",
+        pricing_version="openai-gpt-5.6-preview-2026-07",
+    ),
     # ── Anthropic Claude 4.8 ─────────────────────────────────────────────
     # Same $5/$25 base pricing as 4.6/4.7.  Fast-mode variant is a separate
     # model ID with 2x premium (vs the 6x premium on older Opus generations).

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -109,7 +109,11 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
     # writes are billed at 1.25x the uncached input rate; cache reads get the
     # standard 90% discount (0.10x input, confirmed: Sol $0.50/M cached).
     # Note: "Sol Fast mode" ($12.5/$75, up to 750 tok/s via Cerebras) is a
-    # separate serving tier, not covered by these entries.
+    # separate serving tier, not covered by these entries. The "-pro"
+    # variants (high-effort modes, GA alongside base tiers) bill at the
+    # SAME per-token rates and are aliased onto these entries below the
+    # dict (they cost more per task by consuming more tokens, not by a
+    # higher rate — verified against OpenRouter's live pricing 2026-07-09).
     # Source: https://openai.com/index/previewing-gpt-5-6-sol/
     (
         "openai",
@@ -606,6 +610,15 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         pricing_version="minimax-pricing-2026-04",
     ),
 }
+
+# GPT-5.6 "-pro" high-effort variants bill at the same per-token rates as
+# their base tiers (more tokens per task, not a higher rate). Alias them
+# onto the base entries so the snapshot stays single-source.
+for _base_56 in ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"):
+    _OFFICIAL_DOCS_PRICING[("openai", f"{_base_56}-pro")] = _OFFICIAL_DOCS_PRICING[
+        ("openai", _base_56)
+    ]
+del _base_56
 
 
 def _to_decimal(value: Any) -> Optional[Decimal]:

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -12,10 +12,14 @@ import os
 logger = logging.getLogger(__name__)
 
 DEFAULT_CODEX_MODELS: List[str] = [
-    # GPT-5.6 series (Sol/Terra/Luna) — GA 2026-07-09 (previewed 2026-06-26).
+    # GPT-5.6 series (Sol/Terra/Luna + -pro high-effort modes) — GA 2026-07-09
+    # (previewed 2026-06-26).
     "gpt-5.6-sol",
+    "gpt-5.6-sol-pro",
     "gpt-5.6-terra",
+    "gpt-5.6-terra-pro",
     "gpt-5.6-luna",
+    "gpt-5.6-luna-pro",
     "gpt-5.5",
     "gpt-5.4-mini",
     "gpt-5.4",
@@ -49,8 +53,11 @@ DEFAULT_CODEX_MODELS: List[str] = [
 
 _FORWARD_COMPAT_TEMPLATE_MODELS: List[tuple[str, tuple[str, ...]]] = [
     ("gpt-5.6-sol", ("gpt-5.5", "gpt-5.4")),
+    ("gpt-5.6-sol-pro", ("gpt-5.5", "gpt-5.4")),
     ("gpt-5.6-terra", ("gpt-5.5", "gpt-5.4")),
+    ("gpt-5.6-terra-pro", ("gpt-5.5", "gpt-5.4")),
     ("gpt-5.6-luna", ("gpt-5.5", "gpt-5.4")),
+    ("gpt-5.6-luna-pro", ("gpt-5.5", "gpt-5.4")),
     ("gpt-5.5", ("gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex")),
     ("gpt-5.4-mini", ("gpt-5.3-codex",)),
     ("gpt-5.4", ("gpt-5.3-codex",)),

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -12,6 +12,10 @@ import os
 logger = logging.getLogger(__name__)
 
 DEFAULT_CODEX_MODELS: List[str] = [
+    # GPT-5.6 series (Sol/Terra/Luna) — GA 2026-07-09 (previewed 2026-06-26).
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
     "gpt-5.5",
     "gpt-5.4-mini",
     "gpt-5.4",
@@ -44,6 +48,9 @@ DEFAULT_CODEX_MODELS: List[str] = [
 ]
 
 _FORWARD_COMPAT_TEMPLATE_MODELS: List[tuple[str, tuple[str, ...]]] = [
+    ("gpt-5.6-sol", ("gpt-5.5", "gpt-5.4")),
+    ("gpt-5.6-terra", ("gpt-5.5", "gpt-5.4")),
+    ("gpt-5.6-luna", ("gpt-5.5", "gpt-5.4")),
     ("gpt-5.5", ("gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex")),
     ("gpt-5.4-mini", ("gpt-5.3-codex",)),
     ("gpt-5.4", ("gpt-5.3-codex",)),

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1423,17 +1423,18 @@ DEFAULT_CONFIG = {
                                       # True if you'd rather pause than silently lose
                                       # context turns when your aux model is flaky.
         "codex_gpt55_autoraise": True,  # Historical key name kept for compatibility.
-                                      # When True, gpt-5.4 / gpt-5.5 on the ChatGPT Codex
-                                      # OAuth route raise their compaction trigger to 85%
-                                      # (vs the global `threshold` above). Codex hard-caps
-                                      # both families at a 272K window, so the default 50%
-                                      # would compact at ~136K and waste half the usable
-                                      # context. Set to False to opt back down to the global
-                                      # threshold (e.g. 0.50) for those Codex sessions.
-                                      # Only this exact route is affected — gpt-5.4 / 5.5
-                                      # on OpenAI's direct API, OpenRouter, and Copilot keep
-                                      # the global threshold regardless.
-        "codex_gpt55_autoraise_notice": True,  # Display the one-time Codex gpt-5.4/5.5
+                                      # When True, gpt-5.4 / gpt-5.5 / gpt-5.6 on the
+                                      # ChatGPT Codex OAuth route raise their compaction
+                                      # trigger to 85% (vs the global `threshold` above).
+                                      # Codex hard-caps these families at a 272K window, so
+                                      # the default 50% would compact at ~136K and waste half
+                                      # the usable context. Set to False to opt back down to
+                                      # the global threshold (e.g. 0.50) for those Codex
+                                      # sessions. Only this exact route is affected —
+                                      # gpt-5.4 / 5.5 / 5.6 on OpenAI's direct API,
+                                      # OpenRouter, and Copilot keep the global threshold
+                                      # regardless.
+        "codex_gpt55_autoraise_notice": True,  # Display the one-time Codex gpt-5.4/5.5/5.6
                                       # autoraise banner. Set False to keep the
                                       # 85% threshold autoraise but suppress the
                                       # user-facing notice in CLI/gateway output.

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -548,7 +548,10 @@ def _model_sort_key(model_id: str, prefix: str) -> tuple:
 
     # Suffix quality ranking: pro/max > (no suffix) > omni/flash/mini/lite
     # Lower number = preferred
-    _SUFFIX_RANK = {"pro": 0, "max": 0, "plus": 0, "turbo": 0}
+    # "sol" is the flagship tier of the GPT-5.6 series (sol > terra > luna);
+    # without it, alias resolution would tiebreak alphabetically and pick
+    # luna (the cheapest) for `/model gpt`.
+    _SUFFIX_RANK = {"pro": 0, "max": 0, "plus": 0, "turbo": 0, "sol": 0}
     suffix_rank = _SUFFIX_RANK.get(suffix, 1)
 
     return version_key + (suffix_rank, suffix)

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -550,7 +550,9 @@ def _model_sort_key(model_id: str, prefix: str) -> tuple:
     # Lower number = preferred
     # "sol" is the flagship tier of the GPT-5.6 series (sol > terra > luna);
     # without it, alias resolution would tiebreak alphabetically and pick
-    # luna (the cheapest) for `/model gpt`.
+    # luna (the cheapest) for `/model gpt`. Unlike pro/max/plus/turbo it is a
+    # series codename, not a generic quality word — revisit if another vendor
+    # ever ships a "-sol" suffix that isn't a flagship.
     _SUFFIX_RANK = {"pro": 0, "max": 0, "plus": 0, "turbo": 0, "sol": 0}
     suffix_rank = _SUFFIX_RANK.get(suffix, 1)
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -240,8 +240,11 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     ],
     "openai-api": [
         "gpt-5.6-sol",
+        "gpt-5.6-sol-pro",
         "gpt-5.6-terra",
+        "gpt-5.6-terra-pro",
         "gpt-5.6-luna",
+        "gpt-5.6-luna-pro",
         "gpt-5.5",
         "gpt-5.5-pro",
         "gpt-5.4",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -239,6 +239,9 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gpt-4o-mini",
     ],
     "openai-api": [
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
         "gpt-5.5",
         "gpt-5.5-pro",
         "gpt-5.4",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -41,8 +41,11 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("anthropic/claude-haiku-4.5",             ""),
     # OpenAI
     ("openai/gpt-5.6-sol",                     ""),
+    ("openai/gpt-5.6-sol-pro",                 ""),
     ("openai/gpt-5.6-terra",                   ""),
+    ("openai/gpt-5.6-terra-pro",               ""),
     ("openai/gpt-5.6-luna",                    ""),
+    ("openai/gpt-5.6-luna-pro",                ""),
     ("openai/gpt-5.5",                         ""),
     ("openai/gpt-5.5-pro",                     ""),
     ("openai/gpt-5.4-mini",                    ""),
@@ -189,8 +192,11 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "anthropic/claude-haiku-4.5",
         # OpenAI
         "openai/gpt-5.6-sol",
+        "openai/gpt-5.6-sol-pro",
         "openai/gpt-5.6-terra",
+        "openai/gpt-5.6-terra-pro",
         "openai/gpt-5.6-luna",
+        "openai/gpt-5.6-luna-pro",
         "openai/gpt-5.5",
         "openai/gpt-5.5-pro",
         "openai/gpt-5.4-mini",

--- a/tests/hermes_cli/test_codex_cli_model_picker.py
+++ b/tests/hermes_cli/test_codex_cli_model_picker.py
@@ -95,7 +95,10 @@ def test_codex_picker_uses_live_codex_catalog(hermes_auth_only_env, tmp_path, mo
 
     providers = list_authenticated_providers(
         current_provider="openai-codex",
-        max_models=10,
+        # High cap so the curated catalog is never truncated — the assertion
+        # below checks count consistency, which only holds when max_models
+        # exceeds the catalog size (it grows as new gpt-5.x slugs land).
+        max_models=100,
     )
 
     codex = next(p for p in providers if p["slug"] == "openai-codex")

--- a/tests/hermes_cli/test_gpt56_registration.py
+++ b/tests/hermes_cli/test_gpt56_registration.py
@@ -81,3 +81,53 @@ class TestGpt56PricingRoute:
                 _OFFICIAL_DOCS_PRICING[("openai", f"{base}-pro")]
                 is _OFFICIAL_DOCS_PRICING[("openai", base)]
             ), base
+
+
+class TestGpt56CodexCompaction:
+    """Codex OAuth caps the whole gpt-5.6 family at 272K, same as 5.4/5.5, so
+    the compaction auto-raise (0.85) must fire for every 5.6 variant on the
+    openai-codex route and NOT on the direct-API/OpenRouter routes."""
+
+    def test_autoraise_applies_to_all_56_on_codex(self):
+        from agent.auxiliary_client import _compression_threshold_for_model
+
+        for slug in (
+            "gpt-5.6-sol",
+            "gpt-5.6-sol-pro",
+            "gpt-5.6-terra",
+            "gpt-5.6-terra-pro",
+            "gpt-5.6-luna",
+            "gpt-5.6-luna-pro",
+        ):
+            assert (
+                _compression_threshold_for_model(slug, provider="openai-codex")
+                == 0.85
+            ), slug
+
+    def test_no_autoraise_on_direct_api_route(self):
+        from agent.auxiliary_client import _compression_threshold_for_model
+
+        # Direct OpenAI API / OpenRouter expose the full 1.05M window, so the
+        # 272K-cap override must NOT apply there.
+        assert (
+            _compression_threshold_for_model("gpt-5.6-sol", provider="openai")
+            is None
+        )
+        assert (
+            _compression_threshold_for_model(
+                "openai/gpt-5.6-sol", provider="openrouter"
+            )
+            is None
+        )
+
+    def test_autoraise_respects_opt_out(self):
+        from agent.auxiliary_client import _compression_threshold_for_model
+
+        assert (
+            _compression_threshold_for_model(
+                "gpt-5.6-sol",
+                provider="openai-codex",
+                allow_codex_gpt55_autoraise=False,
+            )
+            is None
+        )

--- a/tests/hermes_cli/test_gpt56_registration.py
+++ b/tests/hermes_cli/test_gpt56_registration.py
@@ -38,6 +38,14 @@ class TestGpt56SortInvariants:
         assert models[0] == "openai/gpt-5.6-sol"
 
 
+    def test_base_sol_outranks_sol_pro_for_alias_default(self):
+        # "-pro" high-effort variants parse as suffix "sol-pro" (rank 1), so
+        # `/model gpt` defaults to base Sol rather than the high-effort mode.
+        models = ["gpt-5.6-sol-pro", "gpt-5.6-sol"]
+        models.sort(key=lambda m: _model_sort_key(m, "gpt"))
+        assert models[0] == "gpt-5.6-sol"
+
+
 class TestGpt56PricingRoute:
     def test_official_pricing_reachable_from_openai(self):
         route = resolve_billing_route("gpt-5.6-sol", provider="openai")
@@ -64,3 +72,12 @@ class TestGpt56PricingRoute:
             assert entry.cache_read_cost_per_million == (
                 entry.input_cost_per_million * Decimal("0.10")
             ), slug
+
+    def test_pro_variants_alias_to_base_tier_pricing(self):
+        # -pro high-effort modes bill at the same per-token rates as their
+        # base tiers; the snapshot aliases them rather than duplicating rows.
+        for base in ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"):
+            assert (
+                _OFFICIAL_DOCS_PRICING[("openai", f"{base}-pro")]
+                is _OFFICIAL_DOCS_PRICING[("openai", base)]
+            ), base

--- a/tests/hermes_cli/test_gpt56_registration.py
+++ b/tests/hermes_cli/test_gpt56_registration.py
@@ -1,0 +1,66 @@
+"""Behavior contracts for the GPT-5.6 (Sol/Terra/Luna) registration.
+
+Invariant tests only — no list snapshots (per the no-change-detector-tests
+policy). These pin the two behaviors that would silently regress:
+
+1. Version/tier sorting: the flagship Sol must outrank Terra/Luna and the
+   whole 5.6 series must outrank 5.5, so `/model gpt` resolves to the
+   flagship rather than an alphabetical-first cheap tier.
+2. Pricing reachability: the ("openai", <model>) official-docs pricing keys
+   must be reachable from BOTH the bare "openai" provider and the
+   "openai-api" picker slug (resolve_billing_route normalizes the latter).
+"""
+
+from decimal import Decimal
+
+from agent.usage_pricing import (
+    _OFFICIAL_DOCS_PRICING,
+    _lookup_official_docs_pricing,
+    resolve_billing_route,
+)
+from hermes_cli.model_switch import _model_sort_key
+
+
+class TestGpt56SortInvariants:
+    def test_sol_outranks_terra_and_luna(self):
+        models = ["gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol"]
+        models.sort(key=lambda m: _model_sort_key(m, "gpt"))
+        assert models[0] == "gpt-5.6-sol"
+
+    def test_56_series_outranks_55(self):
+        models = ["gpt-5.5", "gpt-5.5-pro", "gpt-5.6-sol"]
+        models.sort(key=lambda m: _model_sort_key(m, "gpt"))
+        assert models[0] == "gpt-5.6-sol"
+
+    def test_aggregator_prefix_form(self):
+        models = ["openai/gpt-5.5-pro", "openai/gpt-5.6-sol"]
+        models.sort(key=lambda m: _model_sort_key(m, "openai/gpt"))
+        assert models[0] == "openai/gpt-5.6-sol"
+
+
+class TestGpt56PricingRoute:
+    def test_official_pricing_reachable_from_openai(self):
+        route = resolve_billing_route("gpt-5.6-sol", provider="openai")
+        entry = _lookup_official_docs_pricing(route)
+        assert entry is not None
+        assert entry.input_cost_per_million == Decimal("5.00")
+
+    def test_official_pricing_reachable_from_openai_api_slug(self):
+        # "openai-api" is the picker slug for direct api.openai.com and must
+        # normalize to the "openai" pricing key space.
+        route = resolve_billing_route("gpt-5.6-sol", provider="openai-api")
+        assert route.provider == "openai"
+        entry = _lookup_official_docs_pricing(route)
+        assert entry is not None
+        assert entry.input_cost_per_million == Decimal("5.00")
+
+    def test_cache_write_is_1_25x_input_for_56_series(self):
+        for slug in ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"):
+            entry = _OFFICIAL_DOCS_PRICING[("openai", slug)]
+            assert entry.input_cost_per_million is not None, slug
+            assert entry.cache_write_cost_per_million == (
+                entry.input_cost_per_million * Decimal("1.25")
+            ), slug
+            assert entry.cache_read_cost_per_million == (
+                entry.input_cost_per_million * Decimal("0.10")
+            ), slug

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-07-09T17:40:00Z",
+  "updated_at": "2026-07-09T18:38:59Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-07-09T17:15:00Z",
+  "updated_at": "2026-07-09T17:40:00Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -37,11 +37,23 @@
           "description": ""
         },
         {
+          "id": "openai/gpt-5.6-sol-pro",
+          "description": ""
+        },
+        {
           "id": "openai/gpt-5.6-terra",
           "description": ""
         },
         {
+          "id": "openai/gpt-5.6-terra-pro",
+          "description": ""
+        },
+        {
           "id": "openai/gpt-5.6-luna",
+          "description": ""
+        },
+        {
+          "id": "openai/gpt-5.6-luna-pro",
           "description": ""
         },
         {
@@ -184,10 +196,19 @@
           "id": "openai/gpt-5.6-sol"
         },
         {
+          "id": "openai/gpt-5.6-sol-pro"
+        },
+        {
           "id": "openai/gpt-5.6-terra"
         },
         {
+          "id": "openai/gpt-5.6-terra-pro"
+        },
+        {
           "id": "openai/gpt-5.6-luna"
+        },
+        {
+          "id": "openai/gpt-5.6-luna-pro"
         },
         {
           "id": "openai/gpt-5.5"


### PR DESCRIPTION
## Complete GPT-5.6 (Sol / Terra / Luna) support, end-to-end

Follow-up that finishes GPT-5.6 registration across **every** surface a user
can reach the models through. Builds on the two aggregator-only PRs:

- #61578 (`add 5.6`) — added base sol/terra/luna to `OPENROUTER_MODELS` + `_PROVIDER_MODELS["nous"]`
- #61587 (`add 5.6 pro variants`) — added the `-pro` variants to the same two lists

Rob's #61587 commit is **cherry-picked here** (authorship preserved) so this PR
is the single complete solution; #61587 can close in its favor.

### Why
The two prior PRs only touched the aggregator picker lists. The rest of the
add-model checklist (context lengths, native/codex catalogs, pricing, Codex
context-cap compaction) was unfilled, so on the direct-API / ChatGPT-OAuth /
cost-accounting paths the 5.6 family was partially or completely invisible.

### What this adds (all 6 slugs: sol, terra, luna + their `-pro` modes)

| Surface | File | Fills |
|---|---|---|
| Direct-API context (1.05M) | `agent/model_metadata.py` | `DEFAULT_CONTEXT_LENGTHS` |
| Codex-OAuth context cap (272K) | `agent/model_metadata.py` | `_CODEX_OAUTH_CONTEXT_FALLBACK` |
| Native OpenAI picker | `hermes_cli/models.py` | `_PROVIDER_MODELS["openai-api"]` |
| ChatGPT-OAuth picker | `hermes_cli/codex_models.py` | `DEFAULT_CODEX_MODELS` + forward-compat |
| Pricing snapshot | `agent/usage_pricing.py` | `_OFFICIAL_DOCS_PRICING` (sol 5/30, terra 2.5/15, luna 1/6; cache-read 0.10×, cache-write 1.25× input) |
| `openai-api` pricing route | `agent/usage_pricing.py` | normalize `openai-api` → `openai` (fixes an existing gap affecting every `openai` entry, not just 5.6) |
| Alias `/model gpt` → flagship | `hermes_cli/model_switch.py` | rank `sol` as a flagship suffix |
| Codex 272K compaction auto-raise | `agent/auxiliary_client.py` | extend the `_is_codex_gpt54_or_gpt55` chokepoint to the 5.6 family (same 272K cap → 0.85 trigger) |
| Catalog manifest | `website/static/api/model-catalog.json` | regenerated from source via `scripts/build_model_catalog.py` |

### Design notes
- **`-pro` pricing** is *aliased* onto the base-tier `PricingEntry` rows rather
  than duplicated — the high-effort modes bill at the same per-token rate
  (verified against OpenRouter live pricing 2026-07-09); they cost more per task
  by consuming more tokens, not a higher rate.
- **Compaction fix is architectural, not per-slug** — extends the single
  existing predicate that gates the Codex-cap override, so 5.4/5.5/5.6 share one
  enforced chokepoint (guard tests pin the route matrix). Direct-API/OpenRouter
  routes (full 1.05M window) are untouched; the historical
  `compression.codex_gpt55_autoraise` opt-out still applies.

### Verification (E2E, real imports)
All 6 slugs: direct-API ctx 1.05M, codex ctx 272K, pricing reachable from both
`openai` and `openai-api` routes, codex compaction override 0.85 (and `None` on
direct-API + when opted out), present in the openai-api picker + codex catalog,
`/model gpt` resolves to `sol` on both native routes. Behavior-contract tests
added in `tests/hermes_cli/test_gpt56_registration.py` (no list snapshots).
Targeted suites green locally (model_metadata / usage_pricing / codex_models /
model_catalog / auxiliary_client / autoraise-notice).

Based on #61578 and #61587 by @rob-maron (cherry-picked to preserve authorship).
