### PR TITLE
fix(agent): refresh fallback chain during model switch

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1216,12 +1216,10 @@ def init_agent(
                     elif isinstance(fallback_model, dict) and fallback_model.get("provider") and fallback_model.get("model"):
                         _fb_entries = [fallback_model]
                     _fb_resolved = False
+                    from hermes_cli.fallback_config import resolve_entry_api_key
+
                     for _fb in _fb_entries:
-                        _fb_explicit_key = (_fb.get("api_key") or "").strip() or None
-                        if not _fb_explicit_key:
-                            _fb_key_env = (_fb.get("key_env") or _fb.get("api_key_env") or "").strip()
-                            if _fb_key_env:
-                                _fb_explicit_key = os.getenv(_fb_key_env, "").strip() or None
+                        _fb_explicit_key = resolve_entry_api_key(_fb)
                         _fb_client, _fb_model = resolve_provider_client(
                             _fb["provider"], model=_fb["model"], raw_codex=True,
                             explicit_base_url=_fb.get("base_url"),

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1363,6 +1363,9 @@ def init_agent(
         agent._fallback_chain = [fallback_model]
     else:
         agent._fallback_chain = []
+    # Keep the last authoritative, unpruned config snapshot separate from the
+    # operational chain, which model switches may prune for the active provider.
+    agent._fallback_config_chain = list(agent._fallback_chain)
     agent._fallback_index = 0
     agent._fallback_activated = getattr(agent, "_fallback_activated", False)
     # Legacy attribute kept for backward compat (tests, external callers)

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2406,20 +2406,40 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     agent._fallback_activated = False
     agent._fallback_index = 0
 
-    # When the user deliberately swaps primary providers (e.g. openrouter
-    # → anthropic), drop any fallback entries that target the OLD primary
-    # or the NEW one.  The chain was seeded from config at agent init for
-    # the original provider — without pruning, a failed turn on the new
-    # primary silently re-activates the provider the user just rejected,
-    # which is exactly what was reported during TUI v2 blitz testing
-    # ("switched to anthropic, tui keeps trying openrouter").
+    # In-place switches happen on long-lived agents (gateway, dashboard/TUI,
+    # desktop).  Their in-memory chain may predate a config edit; if we prune
+    # that stale chain here, the next 429 can walk old fallbacks even though the
+    # profile's current ``fallback_providers`` is different (#61614).  Prefer a
+    # non-empty fresh config chain when available, falling back to the agent's
+    # current chain when config cannot be read or has no fallback entries.
     old_norm = (old_provider or "").strip().lower()
     new_norm = (new_provider or "").strip().lower()
-    fallback_chain = list(getattr(agent, "_fallback_chain", []) or [])
+    fallback_chain_from_config = False
+    try:
+        from hermes_cli.config import load_config_readonly
+        from hermes_cli.fallback_config import get_fallback_chain
+
+        fresh_chain = list(get_fallback_chain(load_config_readonly()) or [])
+        if fresh_chain:
+            fallback_chain = fresh_chain
+            fallback_chain_from_config = True
+        else:
+            fallback_chain = list(getattr(agent, "_fallback_chain", []) or [])
+    except Exception:
+        fallback_chain = list(getattr(agent, "_fallback_chain", []) or [])
+
     if old_norm and new_norm and old_norm != new_norm:
+        # If we only have the agent's launch-time chain, keep the old defensive
+        # behavior and remove both the rejected OLD primary and the selected NEW
+        # primary.  If the chain was just read from config, treat entries as the
+        # user's current explicit fallback policy: only remove the NEW primary
+        # provider so fallback does not immediately route back to the same
+        # backend, but allow the old provider if the current config still names
+        # it as a later fallback.
+        blocked = {new_norm} if fallback_chain_from_config else {old_norm, new_norm}
         fallback_chain = [
             entry for entry in fallback_chain
-            if (entry.get("provider") or "").strip().lower() not in {old_norm, new_norm}
+            if (entry.get("provider") or "").strip().lower() not in blocked
         ]
     agent._fallback_chain = fallback_chain
     agent._fallback_model = fallback_chain[0] if fallback_chain else None

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2415,28 +2415,18 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     old_norm = (old_provider or "").strip().lower()
     new_norm = (new_provider or "").strip().lower()
     old_fallback_chain = list(getattr(agent, "_fallback_chain", []) or [])
+    previous_config_chain = list(
+        getattr(agent, "_fallback_config_chain", old_fallback_chain) or []
+    )
     fallback_chain_from_config = False
     fallback_chain_changed_from_config = False
     try:
-        import yaml as _yaml
+        from hermes_cli.fallback_config import load_fallback_chain_strict
 
-        from hermes_cli.config import get_config_path, load_config_readonly
-        from hermes_cli.fallback_config import get_fallback_chain
-
-        # ``load_config_readonly`` intentionally swallows YAML parse failures and
-        # returns defaults. Validate the raw file first so malformed YAML does not
-        # become indistinguishable from a deliberate empty fallback config.
-        try:
-            with open(get_config_path(), encoding="utf-8") as config_file:
-                raw_config = _yaml.safe_load(config_file)
-            if raw_config is not None and not isinstance(raw_config, dict):
-                raise ValueError("config.yaml root must be a mapping")
-        except FileNotFoundError:
-            pass
-
-        fallback_chain = list(get_fallback_chain(load_config_readonly()) or [])
+        fallback_chain = list(load_fallback_chain_strict() or [])
         fallback_chain_from_config = True
-        fallback_chain_changed_from_config = fallback_chain != old_fallback_chain
+        fallback_chain_changed_from_config = fallback_chain != previous_config_chain
+        agent._fallback_config_chain = list(fallback_chain)
     except Exception:
         fallback_chain = old_fallback_chain
 

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2409,24 +2409,36 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     # In-place switches happen on long-lived agents (gateway, dashboard/TUI,
     # desktop).  Their in-memory chain may predate a config edit; if we prune
     # that stale chain here, the next 429 can walk old fallbacks even though the
-    # profile's current ``fallback_providers`` is different (#61614).  Prefer a
-    # non-empty fresh config chain when available, falling back to the agent's
-    # current chain when config cannot be read or has no fallback entries.
+    # profile's current ``fallback_providers`` is different (#61614).  A
+    # successful config read is authoritative even when the chain is empty;
+    # only a read/parse failure keeps the agent's last-known-good chain.
     old_norm = (old_provider or "").strip().lower()
     new_norm = (new_provider or "").strip().lower()
+    old_fallback_chain = list(getattr(agent, "_fallback_chain", []) or [])
     fallback_chain_from_config = False
+    fallback_chain_changed_from_config = False
     try:
-        from hermes_cli.config import load_config_readonly
+        import yaml as _yaml
+
+        from hermes_cli.config import get_config_path, load_config_readonly
         from hermes_cli.fallback_config import get_fallback_chain
 
-        fresh_chain = list(get_fallback_chain(load_config_readonly()) or [])
-        if fresh_chain:
-            fallback_chain = fresh_chain
-            fallback_chain_from_config = True
-        else:
-            fallback_chain = list(getattr(agent, "_fallback_chain", []) or [])
+        # ``load_config_readonly`` intentionally swallows YAML parse failures and
+        # returns defaults. Validate the raw file first so malformed YAML does not
+        # become indistinguishable from a deliberate empty fallback config.
+        try:
+            with open(get_config_path(), encoding="utf-8") as config_file:
+                raw_config = _yaml.safe_load(config_file)
+            if raw_config is not None and not isinstance(raw_config, dict):
+                raise ValueError("config.yaml root must be a mapping")
+        except FileNotFoundError:
+            pass
+
+        fallback_chain = list(get_fallback_chain(load_config_readonly()) or [])
+        fallback_chain_from_config = True
+        fallback_chain_changed_from_config = fallback_chain != old_fallback_chain
     except Exception:
-        fallback_chain = list(getattr(agent, "_fallback_chain", []) or [])
+        fallback_chain = old_fallback_chain
 
     if old_norm and new_norm and old_norm != new_norm:
         # If we only have the agent's launch-time chain, keep the old defensive
@@ -2443,6 +2455,10 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         ]
     agent._fallback_chain = fallback_chain
     agent._fallback_model = fallback_chain[0] if fallback_chain else None
+    if fallback_chain_changed_from_config:
+        unavailable = getattr(agent, "_unavailable_fallback_keys", None)
+        if unavailable:
+            unavailable.clear()
 
     logger.info(
         "Model switched in-place: %s (%s) -> %s (%s)",

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2123,7 +2123,9 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
         # the OPENROUTER_API_KEY env-var path rather than failing outright.
         logger.debug("Auxiliary client: OpenRouter pool exhausted, trying OPENROUTER_API_KEY")
 
-    or_key = explicit_api_key or os.getenv("OPENROUTER_API_KEY")
+    from agent.secret_scope import get_secret
+
+    or_key = explicit_api_key or get_secret("OPENROUTER_API_KEY")
     if not or_key:
         _mark_provider_unhealthy("openrouter", ttl=60)
         return None, None
@@ -2140,7 +2142,9 @@ def _describe_openrouter_unavailable() -> str:
             return "OpenRouter credential pool has no usable entries (credentials may be exhausted)"
         if not _pool_runtime_api_key(entry):
             return "OpenRouter credential pool entry is missing a runtime API key"
-    if not str(os.getenv("OPENROUTER_API_KEY") or "").strip():
+    from agent.secret_scope import get_secret
+
+    if not str(get_secret("OPENROUTER_API_KEY") or "").strip():
         return "OPENROUTER_API_KEY not set"
     return "no usable OpenRouter credentials found"
 
@@ -4416,14 +4420,10 @@ def _try_configured_fallback_for_unavailable_client(
 
 
 def _fallback_entry_api_key(entry: Dict[str, Any]) -> Optional[str]:
-    """Resolve inline or env-backed API key from a fallback-chain entry."""
-    explicit = str(entry.get("api_key") or "").strip()
-    if explicit:
-        return explicit
-    key_env = str(entry.get("key_env") or entry.get("api_key_env") or "").strip()
-    if key_env:
-        return os.getenv(key_env, "").strip() or None
-    return None
+    """Resolve inline or profile-scoped key from a fallback-chain entry."""
+    from hermes_cli.fallback_config import resolve_entry_api_key
+
+    return resolve_entry_api_key(entry)
 
 
 def _resolve_fallback_entry(entry: Dict[str, Any]) -> Tuple[Optional[Any], Optional[str]]:
@@ -5095,10 +5095,12 @@ def resolve_provider_client(
         custom_base = ""
         custom_key = ""
         if explicit_base_url:
+            from agent.secret_scope import get_secret
+
             custom_base = _to_openai_base_url(explicit_base_url).strip()
             custom_key = (
                 (explicit_api_key or "").strip()
-                or os.getenv("OPENAI_API_KEY", "").strip()
+                or (get_secret("OPENAI_API_KEY") or "").strip()
                 or _read_main_api_key_if_same_host(custom_base)
                 or "no-key-required"  # local servers don't need auth
             )
@@ -5191,10 +5193,9 @@ def resolve_provider_client(
             custom_entry = _get_named_custom_provider(provider)
         if custom_entry:
             custom_base = (custom_entry.get("base_url") or "").strip()
-            custom_key = (custom_entry.get("api_key") or "").strip()
-            custom_key_env = (custom_entry.get("key_env") or custom_entry.get("api_key_env") or "").strip()
-            if not custom_key and custom_key_env:
-                custom_key = os.getenv(custom_key_env, "").strip()
+            from hermes_cli.fallback_config import resolve_entry_api_key
+
+            custom_key = resolve_entry_api_key(custom_entry) or ""
             custom_key = custom_key or "no-key-required"
             if custom_key == "no-key-required":
                 logger.warning(

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1677,18 +1677,16 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # endpoints (e.g. Ollama Cloud) resolve correctly instead of
         # falling through to OpenRouter defaults.
         fb_base_url_hint = (fb.get("base_url") or "").strip() or None
-        fb_api_key_hint = (fb.get("api_key") or "").strip() or None
-        if not fb_api_key_hint:
-            # key_env and api_key_env are both documented aliases (see
-            # _normalize_custom_provider_entry in hermes_cli/config.py).
-            fb_key_env = (fb.get("key_env") or fb.get("api_key_env") or "").strip()
-            if fb_key_env:
-                fb_api_key_hint = os.getenv(fb_key_env, "").strip() or None
-        # For Ollama Cloud endpoints, pull OLLAMA_API_KEY from env
-        # when no explicit key is in the fallback config. Host match
-        # (not substring) — see GHSA-76xc-57q6-vm5m.
+        from hermes_cli.fallback_config import resolve_entry_api_key
+
+        fb_api_key_hint = resolve_entry_api_key(fb)
+        # For Ollama Cloud endpoints, pull OLLAMA_API_KEY from the active
+        # profile scope when no explicit key is in the fallback config. Host
+        # match (not substring) — see GHSA-76xc-57q6-vm5m.
         if fb_base_url_hint and base_url_host_matches(fb_base_url_hint, "ollama.com") and not fb_api_key_hint:
-            fb_api_key_hint = os.getenv("OLLAMA_API_KEY") or None
+            from agent.secret_scope import get_secret
+
+            fb_api_key_hint = get_secret("OLLAMA_API_KEY") or None
         fb_client, _resolved_fb_model = resolve_provider_client(
             fb_provider, model=fb_model, raw_codex=True,
             explicit_base_url=fb_base_url_hint,

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -16,7 +16,10 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import OPENROUTER_BASE_URL
 from hermes_cli.config import load_env
-from agent.secret_scope import get_secret as _get_secret
+from agent.secret_scope import (
+    get_secret as _get_secret,
+    is_secret_scope_authoritative,
+)
 from agent.credential_persistence import (
     is_borrowed_credential_source,
     sanitize_borrowed_credential_payload,
@@ -2511,22 +2514,15 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
     # processes (Codex CLI, test scripts, etc.) should not override deliberate
     # changes to the .env file.
     def _get_env_prefer_dotenv(key: str) -> str:
-        env_file = load_env()
-        raw = env_file.get(key, "").strip()
-        scoped_value = (_get_secret(key, "") or "").strip()
-        # If .env contains an unresolved op:// reference, prefer the
-        # already-resolved value supplied by the active secret scope (or by
-        # os.environ in legacy single-profile mode), set by
-        # load_hermes_dotenv() -> apply_onepassword_secrets()).  The raw
-        # "op://Vault/Item/field" string would otherwise win and every
-        # provider auth attempt would receive a URL instead of a key.  This
-        # happens during a partial migration, or when the user wrote op://
-        # references straight into .env rather than the secrets.onepassword
-        # config block.  For every non-op:// value the original
-        # .env-takes-precedence behaviour is preserved unchanged.
-        if raw.startswith("op://") and scoped_value:
-            return scoped_value
-        return raw or scoped_value
+        if not is_secret_scope_authoritative():
+            raw = load_env().get(key, "").strip()
+            if raw and not raw.startswith("op://"):
+                return raw
+
+        # Unresolved op:// references are never credentials. Scoped reads are
+        # authoritative, including an explicitly empty scope.
+        resolved = (_get_secret(key, "") or "").strip()
+        return "" if resolved.startswith("op://") else resolved
 
     # Honour user suppression — `hermes auth remove <provider> <N>` for an
     # env-seeded credential marks the env:<VAR> source as suppressed so it

--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -86,6 +86,16 @@ def current_secret_scope() -> Optional[Mapping[str, str]]:
     return _SECRET_SCOPE.get()
 
 
+def is_secret_scope_authoritative() -> bool:
+    """Return whether credential reads must be resolved through ``get_secret``.
+
+    A bound scope is authoritative even when it is empty. In multiplex mode,
+    an unbound read must also enter ``get_secret`` so it fails closed instead
+    of consulting a profile file or the process environment first.
+    """
+    return _SECRET_SCOPE.get() is not None or _MULTIPLEX_ACTIVE
+
+
 # ── genuinely-global env vars (NOT per-profile secrets) ──────────────────
 # These are process/deployment-level settings, not profile credentials. They
 # legitimately live in os.environ and must keep reading from it even in
@@ -212,11 +222,12 @@ def load_env_file(env_path: Path) -> Dict[str, str]:
 
 
 def build_profile_secret_scope(hermes_home: Path) -> Dict[str, str]:
-    """Build a profile's secret mapping from its ``<home>/.env``.
+    """Build a profile's effective secret mapping.
 
-    Returns a fresh dict (safe to install via ``set_secret_scope``). Genuinely
-    global vars are intentionally NOT copied in — ``get_secret`` reads those
-    from ``os.environ`` directly, so the scope holds only profile secrets.
+    Profile ``<home>/.env`` values are isolated per scope. Machine-global
+    managed ``.env`` values are then applied with override precedence, matching
+    the startup environment contract without exposing another profile's process
+    environment.
     """
     home = Path(hermes_home)
     secrets = load_env_file(home / ".env")

--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -22,10 +22,13 @@ Design rationale lives in ``docs/design/multiplexing-gateway.md`` (Workstream A)
 """
 from __future__ import annotations
 
+import logging
 import os
 from contextvars import ContextVar, Token
 from pathlib import Path
 from typing import Dict, Mapping, Optional
+
+logger = logging.getLogger(__name__)
 
 
 # ── multiplex-active flag ────────────────────────────────────────────────
@@ -236,6 +239,12 @@ def build_profile_secret_scope(hermes_home: Path) -> Dict[str, str]:
         from hermes_cli.env_loader import get_secret_source_values
         external_secrets = get_secret_source_values(home)
     except Exception:
+        logger.debug(
+            "external secret source values load failed for %s; "
+            "continuing with profile .env only",
+            hermes_home,
+            exc_info=True,
+        )
         external_secrets = {}
 
     for key, value in external_secrets.items():

--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -252,4 +252,21 @@ def build_profile_secret_scope(hermes_home: Path) -> Dict[str, str]:
             continue
         secrets[key] = value
 
+    try:
+        from hermes_cli.managed_scope import load_managed_env
+
+        managed_secrets = load_managed_env()
+    except Exception:
+        logger.debug(
+            "managed env load failed for %s; continuing without managed secrets",
+            hermes_home,
+            exc_info=True,
+        )
+        managed_secrets = {}
+
+    for key, value in managed_secrets.items():
+        if _is_global_env(key):
+            continue
+        secrets[key] = value
+
     return secrets

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -68,7 +68,7 @@ from agent.conversation_compression import (
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from agent.i18n import t
 from hermes_cli.config import cfg_get
-from hermes_cli.fallback_config import get_fallback_chain
+from hermes_cli.fallback_config import get_fallback_chain, load_fallback_chain_strict
 
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in
@@ -3341,6 +3341,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._restart_drain_timeout = self._load_restart_drain_timeout()
         self._provider_routing = self._load_provider_routing()
         self._fallback_model = self._load_fallback_model()
+        self._fallback_models_by_home = {
+            str(_hermes_home): self._fallback_model,
+        }
 
         # Wire process registry into session store for reset protection.
         # A background process older than the configured threshold (default 24h,
@@ -5820,23 +5823,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         cached agent's working fallback for that turn.  Only a successful read
         that genuinely lacks the key clears the chain.
         """
+        profile_home = str(get_hermes_home())
+        fallback_models_by_home = getattr(self, "_fallback_models_by_home", None)
+        if fallback_models_by_home is None:
+            fallback_models_by_home = {}
+            self._fallback_models_by_home = fallback_models_by_home
+
         try:
-            import yaml as _y
-            cfg_path = _hermes_home / "config.yaml"
-            if not cfg_path.exists():
-                self._fallback_model = None
-                return self._fallback_model
-            with open(cfg_path, encoding="utf-8") as _f:
-                cfg = _y.safe_load(_f) or {}
+            refreshed = load_fallback_chain_strict() or None
         except Exception:
             # Transient failure — keep last known-good chain.
             logger.debug(
                 "fallback_providers refresh: config.yaml read failed; "
                 "keeping last known-good chain", exc_info=True,
             )
-            return self._fallback_model
-        self._fallback_model = get_fallback_chain(cfg) or None
-        return self._fallback_model
+            return fallback_models_by_home.get(profile_home)
+
+        fallback_models_by_home[profile_home] = refreshed
+        if profile_home == str(_hermes_home):
+            self._fallback_model = refreshed
+        return refreshed
 
     @staticmethod
     def _apply_fallback_chain_to_agent(agent: Any, chain: list | None) -> None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5858,6 +5858,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ):
             return
         old_chain = list(getattr(agent, "_fallback_chain", []) or [])
+        old_config_chain = list(
+            getattr(agent, "_fallback_config_chain", old_chain) or []
+        )
+        agent._fallback_config_chain = list(new_chain)
         agent._fallback_chain = new_chain
         agent._fallback_model = new_chain[0] if new_chain else None
         if not getattr(agent, "_fallback_activated", False):
@@ -5869,7 +5873,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # cached agent's lifetime.  Only on actual content change, so
         # the per-message no-op refresh keeps the memo's rate-limiting
         # benefit (#60955).
-        if new_chain != old_chain:
+        if new_chain != old_config_chain:
             unavailable = getattr(agent, "_unavailable_fallback_keys", None)
             if unavailable:
                 unavailable.clear()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -28,6 +28,7 @@ import asyncio
 import concurrent.futures
 import dataclasses
 import faulthandler
+import hashlib
 import inspect
 import json
 import logging
@@ -37,6 +38,7 @@ import shlex
 import site
 import sys
 import signal
+import secrets
 import tempfile
 import threading
 import time
@@ -68,7 +70,7 @@ from agent.conversation_compression import (
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from agent.i18n import t
 from hermes_cli.config import cfg_get
-from hermes_cli.fallback_config import get_fallback_chain, load_fallback_chain_strict
+from hermes_cli.fallback_config import load_fallback_chain_strict
 
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in
@@ -2157,6 +2159,8 @@ from gateway.whatsapp_identity import (
 
 logger = logging.getLogger(__name__)
 
+_FALLBACK_CREDENTIAL_FINGERPRINT_KEY = secrets.token_bytes(32)
+
 
 _OWN_POLICY_OPEN_ENV = {
     Platform.WECOM: ("WECOM_DM_POLICY", "WECOM_GROUP_POLICY", "WECOM_ALLOW_ALL_USERS"),
@@ -2358,13 +2362,7 @@ def _try_resolve_fallback_provider() -> dict | None:
     """Attempt to resolve credentials from the fallback_model/fallback_providers config."""
     from hermes_cli.runtime_provider import resolve_runtime_provider
     try:
-        import yaml as _y
-        cfg_path = _hermes_home / "config.yaml"
-        if not cfg_path.exists():
-            return None
-        with open(cfg_path, encoding="utf-8") as _f:
-            cfg = _y.safe_load(_f) or {}
-        fb_list = get_fallback_chain(cfg)
+        fb_list = GatewayRunner._load_fallback_model()
         if not fb_list:
             return None
         for entry in fb_list:
@@ -3340,6 +3338,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._busy_text_mode = self._load_busy_text_mode()
         self._restart_drain_timeout = self._load_restart_drain_timeout()
         self._provider_routing = self._load_provider_routing()
+        self._fallback_refresh_lock = threading.RLock()
         self._fallback_model = self._load_fallback_model()
         self._fallback_models_by_home = {
             str(_hermes_home): self._fallback_model,
@@ -5790,24 +5789,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     @staticmethod
     def _load_fallback_model() -> list | None:
-        """Load fallback provider chain from config.yaml.
-
-        Returns the merged effective chain from ``fallback_providers`` plus any
-        legacy ``fallback_model`` entries. ``fallback_providers`` stays first
-        when both keys are present.
-        """
+        """Load the effective fallback chain for the active profile."""
         try:
-            import yaml as _y
-            cfg_path = _hermes_home / "config.yaml"
-            if cfg_path.exists():
-                with open(cfg_path, encoding="utf-8") as _f:
-                    cfg = _y.safe_load(_f) or {}
-                fb = get_fallback_chain(cfg)
-                if fb:
-                    return fb
+            return load_fallback_chain_strict() or None
         except Exception:
-            pass
-        return None
+            return None
 
     def _refresh_fallback_model(self) -> list | None:
         """Re-read fallback_providers from disk for the next agent create/reuse.
@@ -5823,26 +5809,79 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         cached agent's working fallback for that turn.  Only a successful read
         that genuinely lacks the key clears the chain.
         """
-        profile_home = str(get_hermes_home())
-        fallback_models_by_home = getattr(self, "_fallback_models_by_home", None)
-        if fallback_models_by_home is None:
-            fallback_models_by_home = {}
-            self._fallback_models_by_home = fallback_models_by_home
-
-        try:
-            refreshed = load_fallback_chain_strict() or None
-        except Exception:
-            # Transient failure — keep last known-good chain.
-            logger.debug(
-                "fallback_providers refresh: config.yaml read failed; "
-                "keeping last known-good chain", exc_info=True,
+        lock = getattr(self, "_fallback_refresh_lock", None)
+        if lock is None:
+            lock = threading.RLock()
+            self._fallback_refresh_lock = lock
+        with lock:
+            profile_home = str(get_hermes_home())
+            fallback_models_by_home = getattr(
+                self, "_fallback_models_by_home", None
             )
-            return fallback_models_by_home.get(profile_home)
+            if fallback_models_by_home is None:
+                fallback_models_by_home = {}
+                self._fallback_models_by_home = fallback_models_by_home
 
-        fallback_models_by_home[profile_home] = refreshed
-        if profile_home == str(_hermes_home):
-            self._fallback_model = refreshed
-        return refreshed
+            try:
+                refreshed = load_fallback_chain_strict() or None
+            except Exception:
+                # Transient failure — keep last known-good chain.
+                logger.debug(
+                    "fallback_providers refresh: config.yaml read failed; "
+                    "keeping last-known-good chain",
+                    exc_info=True,
+                )
+                return fallback_models_by_home.get(profile_home)
+
+            fallback_models_by_home[profile_home] = refreshed
+            if profile_home == str(_hermes_home):
+                self._fallback_model = refreshed
+            return refreshed
+
+    @staticmethod
+    def _fallback_credential_fingerprint(chain: list[dict[str, Any]]) -> tuple:
+        """Digest credentials that affect *chain* without retaining secrets."""
+        from agent.secret_scope import get_secret
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        from hermes_cli.fallback_config import resolve_entry_api_key
+
+        fingerprints = []
+        for entry in chain:
+            secret = resolve_entry_api_key(entry) or ""
+            provider = str(entry.get("provider") or "").strip().lower()
+            if not secret:
+                pconfig = PROVIDER_REGISTRY.get(provider)
+                for env_name in getattr(pconfig, "api_key_env_vars", ()):
+                    secret = get_secret(env_name, "") or ""
+                    if secret:
+                        break
+            if not secret and provider == "openrouter":
+                secret = get_secret("OPENROUTER_API_KEY", "") or ""
+            if not secret and provider in {"ollama", "ollama-cloud"}:
+                secret = get_secret("OLLAMA_API_KEY", "") or ""
+            digest = ""
+            if secret:
+                digest = hashlib.blake2b(
+                    secret.encode("utf-8"),
+                    key=_FALLBACK_CREDENTIAL_FINGERPRINT_KEY,
+                    digest_size=16,
+                ).hexdigest()
+            fingerprints.append(
+                (
+                    provider,
+                    str(entry.get("model") or ""),
+                    str(entry.get("key_env") or entry.get("api_key_env") or ""),
+                    digest,
+                )
+            )
+
+        auth_path = get_hermes_home() / "auth.json"
+        try:
+            stat = auth_path.stat()
+            auth_revision = (stat.st_mtime_ns, stat.st_size)
+        except OSError:
+            auth_revision = None
+        return tuple(fingerprints), auth_revision
 
     @staticmethod
     def _apply_fallback_chain_to_agent(agent: Any, chain: list | None) -> None:
@@ -5867,19 +5906,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         old_config_chain = list(
             getattr(agent, "_fallback_config_chain", old_chain) or []
         )
+        credential_fingerprint = GatewayRunner._fallback_credential_fingerprint(
+            new_chain
+        )
+        previous_credential_fingerprint = getattr(
+            agent, "_fallback_credential_fingerprint", None
+        )
+        credentials_changed = (
+            previous_credential_fingerprint is not None
+            and previous_credential_fingerprint != credential_fingerprint
+        )
+        agent._fallback_credential_fingerprint = credential_fingerprint
         agent._fallback_config_chain = list(new_chain)
         agent._fallback_chain = new_chain
         agent._fallback_model = new_chain[0] if new_chain else None
         if not getattr(agent, "_fallback_activated", False):
             agent._fallback_index = 0
-        # A config edit signals the user changed something — drop the
-        # session-scoped unavailability memo so re-configured entries
-        # (e.g. credentials added mid-uptime for a previously-failing
-        # provider) get retried instead of staying suppressed for the
-        # cached agent's lifetime.  Only on actual content change, so
-        # the per-message no-op refresh keeps the memo's rate-limiting
-        # benefit (#60955).
-        if new_chain != old_config_chain:
+        # Config or credential rotation signals that a previously unavailable
+        # entry may now work. Clear only on an actual change so per-message
+        # no-op refreshes keep the memo's rate-limiting benefit (#60955).
+        if new_chain != old_config_chain or credentials_changed:
             unavailable = getattr(agent, "_unavailable_fallback_keys", None)
             if unavailable:
                 unavailable.clear()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -8417,24 +8417,17 @@ def get_env_value_prefer_dotenv(key: str) -> Optional[str]:
     is scope-checked rather than leaking another profile's raw ``os.environ``
     value — matching the credential-pool seeding path's behaviour.
     """
+    from agent.secret_scope import (
+        get_secret as _get_secret,
+        is_secret_scope_authoritative,
+    )
+
+    if is_secret_scope_authoritative():
+        return _get_secret(key)
+
     env_vars = load_env()
     val = env_vars.get(key)
-    if val:
-        return val
-    try:
-        from agent.secret_scope import (
-            UnscopedSecretError,
-            get_secret as _get_secret,
-        )
-    except Exception:
-        return os.environ.get(key)
-
-    try:
-        return _get_secret(key)
-    except UnscopedSecretError:
-        raise
-    except Exception:
-        return os.environ.get(key)
+    return val if val else _get_secret(key)
 
 
 # =============================================================================

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import os
-from typing import Any
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
 
 
 def _normalized_base_url(value: Any) -> str:
@@ -90,3 +93,44 @@ def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
             chain.append(entry)
 
     return chain
+
+
+def _read_yaml_mapping_strict(path: Path) -> dict[str, Any]:
+    """Read one YAML mapping snapshot, raising on I/O or invalid content."""
+    try:
+        with open(path, encoding="utf-8") as config_file:
+            parsed = yaml.safe_load(config_file)
+    except FileNotFoundError:
+        return {}
+    if parsed is None:
+        return {}
+    if not isinstance(parsed, dict):
+        raise ValueError(f"{path} root must be a mapping")
+    return parsed
+
+
+def load_fallback_chain_strict() -> list[dict[str, Any]]:
+    """Read the effective user + managed fallback chain without fail-open gaps.
+
+    The general config loaders intentionally convert parse/read failures to
+    defaults so startup can continue. A live-agent refresh cannot use that
+    fail-open result: defaults are indistinguishable from a user deliberately
+    removing every fallback and would erase the session's last-known-good
+    chain. Read each source exactly once and raise on failures so the caller
+    can retain its cached chain.
+    """
+    from hermes_cli import managed_scope
+    from hermes_cli.config import _deep_merge, _expand_env_vars, get_config_path
+
+    effective = cast(
+        dict[str, Any], _expand_env_vars(_read_yaml_mapping_strict(get_config_path()))
+    )
+
+    managed_dir = managed_scope.get_managed_dir()
+    if managed_dir is not None:
+        managed = _read_yaml_mapping_strict(managed_dir / "config.yaml")
+        if managed:
+            managed_expanded = cast(dict[str, Any], _expand_env_vars(managed))
+            effective = _deep_merge(effective, managed_expanded)
+
+    return get_fallback_chain(effective)

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -2,11 +2,29 @@
 
 from __future__ import annotations
 
-import os
+import re
 from pathlib import Path
 from typing import Any, cast
 
 import yaml
+
+from agent.secret_scope import get_secret
+
+
+def _replace_profile_env_reference(match: re.Match[str]) -> str:
+    resolved = get_secret(match.group(1))
+    return match.group(0) if resolved is None else resolved
+
+
+def _expand_profile_env_vars(value: Any) -> Any:
+    """Expand config templates through the active profile's secret scope."""
+    if isinstance(value, str):
+        return re.sub(r"\${([^}]+)}", _replace_profile_env_reference, value)
+    if isinstance(value, dict):
+        return {key: _expand_profile_env_vars(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_expand_profile_env_vars(item) for item in value]
+    return value
 
 
 def _normalized_base_url(value: Any) -> str:
@@ -30,7 +48,7 @@ def resolve_entry_api_key(entry: dict[str, Any] | None) -> str | None:
         return inline
     key_env = str(entry.get("key_env") or entry.get("api_key_env") or "").strip()
     if key_env:
-        return os.getenv(key_env, "").strip() or None
+        return (get_secret(key_env) or "").strip() or None
     return None
 
 
@@ -120,17 +138,25 @@ def load_fallback_chain_strict() -> list[dict[str, Any]]:
     can retain its cached chain.
     """
     from hermes_cli import managed_scope
-    from hermes_cli.config import _deep_merge, _expand_env_vars, get_config_path
-
-    effective = cast(
-        dict[str, Any], _expand_env_vars(_read_yaml_mapping_strict(get_config_path()))
+    from hermes_cli.config import (
+        _CONFIG_LOCK,
+        _deep_merge,
+        get_config_path,
     )
 
-    managed_dir = managed_scope.get_managed_dir()
-    if managed_dir is not None:
-        managed = _read_yaml_mapping_strict(managed_dir / "config.yaml")
-        if managed:
-            managed_expanded = cast(dict[str, Any], _expand_env_vars(managed))
-            effective = _deep_merge(effective, managed_expanded)
+    with _CONFIG_LOCK:
+        effective = cast(
+            dict[str, Any],
+            _expand_profile_env_vars(_read_yaml_mapping_strict(get_config_path())),
+        )
 
-    return get_fallback_chain(effective)
+        managed_dir = managed_scope.get_managed_dir()
+        if managed_dir is not None:
+            managed = _read_yaml_mapping_strict(managed_dir / "config.yaml")
+            if managed:
+                managed_expanded = cast(
+                    dict[str, Any], _expand_profile_env_vars(managed)
+                )
+                effective = _deep_merge(effective, managed_expanded)
+
+        return get_fallback_chain(effective)

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -141,6 +141,7 @@ def load_fallback_chain_strict() -> list[dict[str, Any]]:
     from hermes_cli.config import (
         _CONFIG_LOCK,
         _deep_merge,
+        _expand_env_vars,
         get_config_path,
     )
 
@@ -155,7 +156,7 @@ def load_fallback_chain_strict() -> list[dict[str, Any]]:
             managed = _read_yaml_mapping_strict(managed_dir / "config.yaml")
             if managed:
                 managed_expanded = cast(
-                    dict[str, Any], _expand_profile_env_vars(managed)
+                    dict[str, Any], _expand_env_vars(managed)
                 )
                 effective = _deep_merge(effective, managed_expanded)
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1599,6 +1599,85 @@ class TestExplicitProviderRouting:
         assert mock_openai.call_args.kwargs["api_key"] == "sk-or-env-fallback"
         assert mock_openai.call_args.kwargs["base_url"] == OPENROUTER_BASE_URL
 
+    def test_try_openrouter_uses_active_profile_secret_scope(self, monkeypatch):
+        from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+        monkeypatch.setenv(
+            "OPENROUTER_API_KEY", "global-default-openrouter-key"
+        )
+        token = set_secret_scope({"OPENROUTER_API_KEY": "profile-openrouter-key"})
+        try:
+            with patch(
+                "agent.auxiliary_client._select_pool_entry",
+                return_value=(False, None),
+            ), patch("agent.auxiliary_client.OpenAI") as mock_openai:
+                mock_openai.return_value = MagicMock(name="openrouter_client")
+                _try_openrouter()
+        finally:
+            reset_secret_scope(token)
+
+        assert mock_openai.call_args.kwargs["api_key"] == "profile-openrouter-key"
+
+    def test_explicit_custom_endpoint_uses_active_profile_secret_scope(
+        self, monkeypatch
+    ):
+        from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+        monkeypatch.setenv("OPENAI_API_KEY", "global-default-openai-key")
+        token = set_secret_scope({"OPENAI_API_KEY": "profile-openai-key"})
+        try:
+            with patch(
+                "agent.auxiliary_client._create_openai_client",
+                return_value=MagicMock(
+                    api_key="profile-openai-key",
+                    base_url="https://custom.example/v1",
+                ),
+            ) as create_client:
+                client, model = resolve_provider_client(
+                    "custom",
+                    model="custom-model",
+                    explicit_base_url="https://custom.example/v1",
+                )
+        finally:
+            reset_secret_scope(token)
+
+        assert client is not None
+        assert model == "custom-model"
+        assert create_client.call_args.kwargs["api_key"] == "profile-openai-key"
+
+    def test_named_custom_key_env_does_not_use_global_under_empty_scope(
+        self, monkeypatch
+    ):
+        from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+        monkeypatch.setenv("LEGACY_CUSTOM_KEY", "global-legacy-custom-key")
+        token = set_secret_scope({})
+        try:
+            with patch(
+                "hermes_cli.runtime_provider._get_named_custom_provider",
+                return_value={
+                    "name": "legacy-custom",
+                    "base_url": "https://legacy.example/v1",
+                    "model": "legacy-model",
+                    "key_env": "LEGACY_CUSTOM_KEY",
+                },
+            ), patch(
+                "agent.auxiliary_client._create_openai_client",
+                return_value=MagicMock(
+                    api_key="no-key-required",
+                    base_url="https://legacy.example/v1",
+                ),
+            ) as create_client:
+                client, model = resolve_provider_client(
+                    "legacy-custom", model="legacy-model"
+                )
+        finally:
+            reset_secret_scope(token)
+
+        assert client is not None
+        assert model == "legacy-model"
+        assert create_client.call_args.kwargs["api_key"] == "no-key-required"
+
     def test_try_openrouter_pool_exhausted_no_env_marks_unhealthy(self, monkeypatch):
         """Pool exhausted AND no env var → final failure marks provider unhealthy."""
         monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
@@ -3120,6 +3199,32 @@ class TestAuxiliaryFallbackLayering:
         assert model == "gpt-5.4-mini"
         mock_openai.assert_called_once()
         assert mock_openai.call_args.kwargs["api_key"] == "codex-oauth-token"
+
+    def test_fallback_entry_key_env_uses_active_profile_secret_scope(self, monkeypatch):
+        from agent.auxiliary_client import _resolve_fallback_entry
+        from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+        monkeypatch.setenv("FB_KEY", "global-default-profile-key")
+        token = set_secret_scope({"FB_KEY": "profile-key"})
+        try:
+            with patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(MagicMock(), "resolved-model"),
+            ) as resolve_provider_client:
+                _resolve_fallback_entry(
+                    {
+                        "provider": "custom:secondary",
+                        "model": "secondary-model",
+                        "base_url": "https://secondary.example/v1",
+                        "key_env": "FB_KEY",
+                    }
+                )
+        finally:
+            reset_secret_scope(token)
+
+        assert resolve_provider_client.call_args.kwargs["explicit_api_key"] == (
+            "profile-key"
+        )
 
 
 class TestTryMainAgentModelFallback:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1648,9 +1648,14 @@ class TestExplicitProviderRouting:
     def test_named_custom_key_env_does_not_use_global_under_empty_scope(
         self, monkeypatch
     ):
-        from agent.secret_scope import reset_secret_scope, set_secret_scope
+        from agent.secret_scope import (
+            reset_secret_scope,
+            set_multiplex_active,
+            set_secret_scope,
+        )
 
         monkeypatch.setenv("LEGACY_CUSTOM_KEY", "global-legacy-custom-key")
+        set_multiplex_active(True)
         token = set_secret_scope({})
         try:
             with patch(
@@ -1673,6 +1678,7 @@ class TestExplicitProviderRouting:
                 )
         finally:
             reset_secret_scope(token)
+            set_multiplex_active(False)
 
         assert client is not None
         assert model == "legacy-model"

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -10,6 +10,59 @@ from datetime import datetime, timezone
 import pytest
 
 
+def test_env_seed_does_not_use_global_secret_under_empty_profile_scope(
+    tmp_path, monkeypatch
+):
+    from agent.credential_pool import load_pool
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    (hermes_home / ".env").write_text(
+        "OPENROUTER_API_KEY=profile-file-key\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("OPENROUTER_API_KEY", "global-default-key")
+
+    token = set_secret_scope({})
+    try:
+        pool = load_pool("openrouter")
+    finally:
+        reset_secret_scope(token)
+
+    assert pool.has_credentials() is False
+    auth_path = hermes_home / "auth.json"
+    if auth_path.exists():
+        auth = json.loads(auth_path.read_text(encoding="utf-8"))
+        assert auth.get("credential_pool", {}).get("openrouter", []) == []
+
+
+def test_env_seed_prefers_authoritative_managed_scope_over_profile_dotenv(
+    tmp_path, monkeypatch
+):
+    from agent.credential_pool import _seed_from_env
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    (hermes_home / ".env").write_text(
+        "OPENROUTER_API_KEY=profile-file-key\n", encoding="utf-8"
+    )
+
+    token = set_secret_scope({"OPENROUTER_API_KEY": "managed-scope-key"})
+    try:
+        entries = []
+        changed, active = _seed_from_env("openrouter", entries)
+    finally:
+        reset_secret_scope(token)
+
+    assert changed is True
+    assert active == {"env:OPENROUTER_API_KEY"}
+    assert len(entries) == 1
+    assert entries[0].runtime_api_key == "managed-scope-key"
+
+
 def _write_auth_store(tmp_path, payload: dict) -> None:
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir(parents=True, exist_ok=True)

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -14,7 +14,11 @@ def test_env_seed_does_not_use_global_secret_under_empty_profile_scope(
     tmp_path, monkeypatch
 ):
     from agent.credential_pool import load_pool
-    from agent.secret_scope import reset_secret_scope, set_secret_scope
+    from agent.secret_scope import (
+        reset_secret_scope,
+        set_multiplex_active,
+        set_secret_scope,
+    )
 
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir()
@@ -24,11 +28,13 @@ def test_env_seed_does_not_use_global_secret_under_empty_profile_scope(
     )
     monkeypatch.setenv("OPENROUTER_API_KEY", "global-default-key")
 
+    set_multiplex_active(True)
     token = set_secret_scope({})
     try:
         pool = load_pool("openrouter")
     finally:
         reset_secret_scope(token)
+        set_multiplex_active(False)
 
     assert pool.has_credentials() is False
     auth_path = hermes_home / "auth.json"

--- a/tests/agent/test_secret_scope.py
+++ b/tests/agent/test_secret_scope.py
@@ -209,3 +209,67 @@ class TestEnvFileParsing:
         )
 
         assert ss.build_profile_secret_scope(profile) == {}
+    def test_managed_env_overrides_profile_secret_scope(self, tmp_path, monkeypatch):
+        from hermes_cli import managed_scope
+
+        (tmp_path / ".env").write_text(
+            "OPENROUTER_API_KEY=profile-key\nPROFILE_ONLY=profile-only\n"
+        )
+        monkeypatch.setattr(
+            managed_scope,
+            "load_managed_env",
+            lambda: {
+                "OPENROUTER_API_KEY": "managed-key",
+                "MANAGED_ONLY": "managed-only",
+            },
+        )
+
+        assert ss.build_profile_secret_scope(tmp_path) == {
+            "OPENROUTER_API_KEY": "managed-key",
+            "PROFILE_ONLY": "profile-only",
+            "MANAGED_ONLY": "managed-only",
+        }
+
+
+def test_config_env_lookup_does_not_swallow_unscoped_secret_error(
+    tmp_path, monkeypatch
+):
+    from hermes_cli.config import get_env_value_prefer_dotenv
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / ".env").write_text(
+        "OLLAMA_API_KEY=profile-file-key\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("OLLAMA_API_KEY", "global-default-key")
+    ss.set_multiplex_active(True)
+    try:
+        with pytest.raises(ss.UnscopedSecretError):
+            get_env_value_prefer_dotenv("OLLAMA_API_KEY")
+    finally:
+        ss.set_multiplex_active(False)
+
+
+def test_provider_resolver_is_fail_closed_in_scope_but_legacy_global_unscoped(
+    tmp_path, monkeypatch
+):
+    from hermes_cli.auth import resolve_api_key_provider_credentials
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    (hermes_home / ".env").write_text(
+        "OLLAMA_API_KEY=profile-file-key\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("OLLAMA_API_KEY", "single-profile-global-key")
+
+    token = ss.set_secret_scope({})
+    try:
+        scoped = resolve_api_key_provider_credentials("ollama-cloud")
+    finally:
+        ss.reset_secret_scope(token)
+    unscoped = resolve_api_key_provider_credentials("ollama-cloud")
+
+    assert scoped.get("api_key") in (None, "")
+    assert unscoped["api_key"] == "profile-file-key"

--- a/tests/agent/test_secret_scope.py
+++ b/tests/agent/test_secret_scope.py
@@ -264,11 +264,13 @@ def test_provider_resolver_is_fail_closed_in_scope_but_legacy_global_unscoped(
     )
     monkeypatch.setenv("OLLAMA_API_KEY", "single-profile-global-key")
 
+    ss.set_multiplex_active(True)
     token = ss.set_secret_scope({})
     try:
         scoped = resolve_api_key_provider_credentials("ollama-cloud")
     finally:
         ss.reset_secret_scope(token)
+        ss.set_multiplex_active(False)
     unscoped = resolve_api_key_provider_credentials("ollama-cloud")
 
     assert scoped.get("api_key") in (None, "")

--- a/tests/gateway/test_auth_fallback.py
+++ b/tests/gateway/test_auth_fallback.py
@@ -21,6 +21,7 @@ class TestResolveRuntimeAgentKwargsAuthFallback:
         )
 
         monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
         call_count = {"n": 0}
 
@@ -62,6 +63,7 @@ class TestResolveRuntimeAgentKwargsAuthFallback:
         config_path.write_text("model:\n  provider: openai-codex\n")
 
         monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
         with patch(
             "hermes_cli.runtime_provider.resolve_runtime_provider",
@@ -84,6 +86,7 @@ class TestResolveRuntimeAgentKwargsAuthFallback:
         )
 
         monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
         calls = []
 
@@ -113,3 +116,46 @@ class TestResolveRuntimeAgentKwargsAuthFallback:
         assert calls == ["openrouter", "nous"]
         assert result["provider"] == "nous"
         assert result["model"] == "Hermes-4"
+
+    def test_fallback_resolution_reads_active_profile_config(self, tmp_path, monkeypatch):
+        from gateway import run as gateway_run
+
+        default_home = tmp_path / "default"
+        secondary_home = tmp_path / "secondary"
+        default_home.mkdir()
+        secondary_home.mkdir()
+        (default_home / "config.yaml").write_text(
+            "fallback_providers:\n"
+            "  - provider: default-only\n"
+            "    model: default-model\n",
+            encoding="utf-8",
+        )
+        (secondary_home / "config.yaml").write_text(
+            "fallback_providers:\n"
+            "  - provider: secondary-only\n"
+            "    model: secondary-model\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(gateway_run, "_hermes_home", default_home)
+        requested = []
+
+        def fake_resolve(**kwargs):
+            requested.append(kwargs["requested"])
+            return {
+                "api_key": "profile-key",
+                "base_url": "https://secondary.example/v1",
+                "provider": kwargs["requested"],
+                "api_mode": "chat_completions",
+                "command": None,
+                "args": [],
+                "credential_pool": None,
+            }
+
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=fake_resolve,
+        ), gateway_run._profile_runtime_scope(secondary_home):
+            result = gateway_run._try_resolve_fallback_provider()
+
+        assert requested == ["secondary-only"]
+        assert result["model"] == "secondary-model"

--- a/tests/gateway/test_fallback_chain_reload.py
+++ b/tests/gateway/test_fallback_chain_reload.py
@@ -11,6 +11,7 @@ full Feishu session path.
 
 from __future__ import annotations
 
+import threading
 import time
 from types import SimpleNamespace
 
@@ -181,6 +182,48 @@ def test_refresh_fallback_model_keeps_last_known_good_per_profile(
     ]
 
 
+def test_refresh_fallback_model_serializes_load_and_lkg_publication(monkeypatch):
+    from gateway.run import GatewayRunner
+
+    runner = SimpleNamespace(
+        _fallback_model=None,
+        _fallback_models_by_home={},
+        _fallback_refresh_lock=threading.RLock(),
+    )
+    entered = threading.Event()
+    release = threading.Event()
+    state_lock = threading.Lock()
+    active = 0
+    max_active = 0
+
+    def fake_load():
+        nonlocal active, max_active
+        with state_lock:
+            active += 1
+            max_active = max(max_active, active)
+            entered.set()
+        release.wait(timeout=1)
+        with state_lock:
+            active -= 1
+        return [{"provider": "test", "model": "model"}]
+
+    monkeypatch.setattr("gateway.run.load_fallback_chain_strict", fake_load)
+    bound = GatewayRunner._refresh_fallback_model.__get__(runner)
+    first = threading.Thread(target=bound)
+    second = threading.Thread(target=bound)
+    first.start()
+    assert entered.wait(timeout=1)
+    second.start()
+    time.sleep(0.05)
+    release.set()
+    first.join(timeout=1)
+    second.join(timeout=1)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert max_active == 1
+
+
 def test_apply_fallback_chain_updates_primary_agent():
     from gateway.run import GatewayRunner
 
@@ -281,6 +324,72 @@ def test_apply_fallback_chain_keeps_unavailable_memo_when_unchanged():
     assert agent._unavailable_fallback_keys == memo
 
 
+def test_apply_fallback_chain_clears_unavailable_memo_on_secret_rotation():
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+    from gateway.run import GatewayRunner
+
+    chain = [
+        {
+            "provider": "custom:secondary",
+            "model": "secondary-model",
+            "key_env": "FB_KEY",
+        }
+    ]
+    agent = SimpleNamespace(
+        _fallback_chain=list(chain),
+        _fallback_model=chain[0],
+        _fallback_index=0,
+        _fallback_activated=False,
+        _rate_limited_until=0,
+        _unavailable_fallback_keys=set(),
+    )
+    token = set_secret_scope({})
+    try:
+        GatewayRunner._apply_fallback_chain_to_agent(agent, list(chain))
+    finally:
+        reset_secret_scope(token)
+
+    agent._unavailable_fallback_keys = {
+        ("custom:secondary", "secondary-model", "")
+    }
+    token = set_secret_scope({"FB_KEY": "rotated-profile-key"})
+    try:
+        GatewayRunner._apply_fallback_chain_to_agent(agent, list(chain))
+    finally:
+        reset_secret_scope(token)
+
+    assert agent._unavailable_fallback_keys == set()
+
+
+def test_apply_fallback_chain_clears_memo_on_openrouter_secret_rotation():
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+    from gateway.run import GatewayRunner
+
+    chain = [{"provider": "openrouter", "model": "fallback-model"}]
+    agent = SimpleNamespace(
+        _fallback_chain=list(chain),
+        _fallback_model=chain[0],
+        _fallback_index=0,
+        _fallback_activated=False,
+        _rate_limited_until=0,
+        _unavailable_fallback_keys=set(),
+    )
+    token = set_secret_scope({})
+    try:
+        GatewayRunner._apply_fallback_chain_to_agent(agent, list(chain))
+    finally:
+        reset_secret_scope(token)
+
+    agent._unavailable_fallback_keys = {("openrouter", "fallback-model", "")}
+    token = set_secret_scope({"OPENROUTER_API_KEY": "rotated-openrouter-key"})
+    try:
+        GatewayRunner._apply_fallback_chain_to_agent(agent, list(chain))
+    finally:
+        reset_secret_scope(token)
+
+    assert agent._unavailable_fallback_keys == set()
+
+
 def test_apply_fallback_chain_compares_authoritative_snapshot_after_pruning():
     """Operational pruning alone must not invalidate unavailable-entry memoization."""
     from gateway.run import GatewayRunner
@@ -308,30 +417,12 @@ def test_apply_fallback_chain_compares_authoritative_snapshot_after_pruning():
     assert agent._unavailable_fallback_keys == memo
 
 
-def test_background_and_main_agent_paths_call_refresh():
-    """Both AIAgent construction sites must pass a refreshed chain, not the
-    startup snapshot, and the cached-agent reuse path must apply the refreshed
-    chain. Source-level invariant for call sites that resist unit testing.
-    """
-    from pathlib import Path
-
-    source = (
-        Path(__file__).resolve().parent.parent.parent / "gateway" / "run.py"
-    ).read_text(encoding="utf-8")
-    assert "fallback_model=self._refresh_fallback_model()" in source
-    assert source.count("fallback_model=self._refresh_fallback_model()") >= 2
-    # The cached-agent reuse path (the load-bearing fix for a long-lived
-    # session in a running gateway) must apply the refreshed chain.
-    assert "self._apply_fallback_chain_to_agent(" in source
-    # The stale startup-snapshot form must not remain at create sites.
-    assert "fallback_model=self._fallback_model," not in source
-
-
 def test_load_fallback_model_static_unchanged_contract(tmp_path, monkeypatch):
     """_load_fallback_model remains a pure static reader used by refresh."""
     from gateway.run import GatewayRunner
 
     monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     (tmp_path / "config.yaml").write_text(
         "fallback_providers:\n"
         "  - provider: deepseek\n"
@@ -345,4 +436,31 @@ def test_load_fallback_model_static_unchanged_contract(tmp_path, monkeypatch):
     assert chain == [
         {"provider": "deepseek", "model": "deepseek-v4-flash"},
         {"provider": "nous", "model": "Hermes-4"},
+    ]
+
+
+def test_load_fallback_model_applies_managed_overlay(tmp_path, monkeypatch):
+    from gateway.run import GatewayRunner
+    from hermes_cli import managed_scope
+
+    (tmp_path / "config.yaml").write_text(
+        "fallback_providers:\n"
+        "  - provider: user-provider\n"
+        "    model: user-model\n",
+        encoding="utf-8",
+    )
+    managed_dir = tmp_path / "managed"
+    managed_dir.mkdir()
+    (managed_dir / "config.yaml").write_text(
+        "fallback_providers:\n"
+        "  - provider: managed-provider\n"
+        "    model: managed-model\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    monkeypatch.setattr(managed_scope, "get_managed_dir", lambda: managed_dir)
+
+    assert GatewayRunner._load_fallback_model() == [
+        {"provider": "managed-provider", "model": "managed-model"}
     ]

--- a/tests/gateway/test_fallback_chain_reload.py
+++ b/tests/gateway/test_fallback_chain_reload.py
@@ -199,6 +199,33 @@ def test_apply_fallback_chain_keeps_unavailable_memo_when_unchanged():
     assert agent._unavailable_fallback_keys == memo
 
 
+def test_apply_fallback_chain_compares_authoritative_snapshot_after_pruning():
+    """Operational pruning alone must not invalidate unavailable-entry memoization."""
+    from gateway.run import GatewayRunner
+
+    authoritative = [
+        {"provider": "custom:zenmux", "model": "zenmux-fallback"},
+        {"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"},
+    ]
+    operational = [authoritative[1]]
+    memo = {("openrouter", "anthropic/claude-sonnet-4.6", "")}
+    agent = SimpleNamespace(
+        _fallback_config_chain=list(authoritative),
+        _fallback_chain=list(operational),
+        _fallback_model=operational[0],
+        _fallback_index=0,
+        _fallback_activated=False,
+        _rate_limited_until=0,
+        _unavailable_fallback_keys=set(memo),
+    )
+
+    GatewayRunner._apply_fallback_chain_to_agent(agent, list(authoritative))
+
+    assert agent._fallback_config_chain == authoritative
+    assert agent._fallback_chain == authoritative
+    assert agent._unavailable_fallback_keys == memo
+
+
 def test_background_and_main_agent_paths_call_refresh():
     """Both AIAgent construction sites must pass a refreshed chain, not the
     startup snapshot, and the cached-agent reuse path must apply the refreshed

--- a/tests/gateway/test_fallback_chain_reload.py
+++ b/tests/gateway/test_fallback_chain_reload.py
@@ -19,6 +19,7 @@ def test_refresh_fallback_model_rereads_config(tmp_path, monkeypatch):
     from gateway.run import GatewayRunner
 
     monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     cfg = tmp_path / "config.yaml"
     cfg.write_text(
         "fallback_providers:\n"
@@ -52,6 +53,7 @@ def test_refresh_fallback_model_clears_when_config_removed(tmp_path, monkeypatch
     from gateway.run import GatewayRunner
 
     monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     cfg = tmp_path / "config.yaml"
     cfg.write_text(
         "fallback_providers:\n"
@@ -80,6 +82,7 @@ def test_refresh_fallback_model_keeps_last_known_good_on_read_failure(
     from gateway.run import GatewayRunner
 
     monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     cfg = tmp_path / "config.yaml"
     cfg.write_text(
         "fallback_providers:\n"
@@ -97,6 +100,85 @@ def test_refresh_fallback_model_keeps_last_known_good_on_read_failure(
     cfg.write_text("fallback_providers:\n  - provider: [unclosed\n")
     assert bound() == good
     assert runner._fallback_model == good
+
+
+def test_refresh_fallback_model_reads_active_profile_config(tmp_path, monkeypatch):
+    from gateway import run as gateway_run
+    from gateway.run import GatewayRunner
+
+    default_home = tmp_path / "default"
+    secondary_home = tmp_path / "secondary"
+    default_home.mkdir()
+    secondary_home.mkdir()
+    (default_home / "config.yaml").write_text(
+        "fallback_providers:\n"
+        "  - provider: default-provider\n"
+        "    model: default-model\n",
+        encoding="utf-8",
+    )
+    (secondary_home / "config.yaml").write_text(
+        "fallback_providers:\n"
+        "  - provider: secondary-provider\n"
+        "    model: secondary-model\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", default_home)
+
+    runner = SimpleNamespace(
+        _fallback_model=None,
+        _fallback_models_by_home={str(default_home): None},
+    )
+    bound = GatewayRunner._refresh_fallback_model.__get__(runner)
+
+    with gateway_run._profile_runtime_scope(secondary_home):
+        assert bound() == [
+            {"provider": "secondary-provider", "model": "secondary-model"}
+        ]
+
+
+def test_refresh_fallback_model_keeps_last_known_good_per_profile(
+    tmp_path, monkeypatch
+):
+    from gateway import run as gateway_run
+    from gateway.run import GatewayRunner
+
+    default_home = tmp_path / "default"
+    secondary_home = tmp_path / "secondary"
+    default_home.mkdir()
+    secondary_home.mkdir()
+    (default_home / "config.yaml").write_text(
+        "fallback_providers:\n"
+        "  - provider: default-provider\n"
+        "    model: default-model\n",
+        encoding="utf-8",
+    )
+    secondary_config = secondary_home / "config.yaml"
+    secondary_config.write_text(
+        "fallback_providers:\n"
+        "  - provider: secondary-provider\n"
+        "    model: secondary-model\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", default_home)
+
+    runner = SimpleNamespace(
+        _fallback_model=[{"provider": "default-provider", "model": "default-model"}],
+        _fallback_models_by_home={
+            str(default_home): [
+                {"provider": "default-provider", "model": "default-model"}
+            ]
+        },
+    )
+    bound = GatewayRunner._refresh_fallback_model.__get__(runner)
+
+    with gateway_run._profile_runtime_scope(secondary_home):
+        secondary_chain = bound()
+        secondary_config.write_text("fallback_providers: [", encoding="utf-8")
+        assert bound() == secondary_chain
+
+    assert runner._fallback_model == [
+        {"provider": "default-provider", "model": "default-model"}
+    ]
 
 
 def test_apply_fallback_chain_updates_primary_agent():

--- a/tests/hermes_cli/test_fallback_config.py
+++ b/tests/hermes_cli/test_fallback_config.py
@@ -147,3 +147,33 @@ def test_profile_env_expansion_preserves_explicit_empty_value():
         assert fallback_config._expand_profile_env_vars("${EMPTY_KEY}") == ""
     finally:
         reset_secret_scope(token)
+
+
+def test_strict_loader_expands_managed_overlay_from_process_environment(
+    tmp_path, monkeypatch
+):
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+    from hermes_cli import config, managed_scope
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("{}\n", encoding="utf-8")
+    managed_dir = tmp_path / "managed"
+    managed_dir.mkdir()
+    (managed_dir / "config.yaml").write_text(
+        "fallback_providers:\n"
+        "  - provider: custom:managed\n"
+        "    model: managed-model\n"
+        "    api_key: ${MANAGED_KEY}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(config, "get_config_path", lambda: config_path)
+    monkeypatch.setattr(managed_scope, "get_managed_dir", lambda: managed_dir)
+    monkeypatch.setenv("MANAGED_KEY", "managed-process-key")
+
+    token = set_secret_scope({"MANAGED_KEY": "profile-key"})
+    try:
+        assert fallback_config.load_fallback_chain_strict()[0]["api_key"] == (
+            "managed-process-key"
+        )
+    finally:
+        reset_secret_scope(token)

--- a/tests/hermes_cli/test_fallback_config.py
+++ b/tests/hermes_cli/test_fallback_config.py
@@ -1,5 +1,9 @@
-"""Tests for hermes_cli/fallback_config.py — fallback entry API-key resolution."""
+"""Tests for hermes_cli/fallback_config.py — fallback config resolution."""
 
+import threading
+import time
+
+from hermes_cli import fallback_config
 from hermes_cli.fallback_config import resolve_entry_api_key
 
 
@@ -38,3 +42,108 @@ class TestResolveEntryApiKey:
         monkeypatch.setenv("FB_KEY", "env-key")
         entry = {"api_key": "   ", "key_env": "FB_KEY"}
         assert resolve_entry_api_key(entry) == "env-key"
+
+    def test_key_env_uses_active_profile_secret_scope(self, monkeypatch):
+        from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+        monkeypatch.setenv("FB_KEY", "default-profile-key")
+        token = set_secret_scope({"FB_KEY": "secondary-profile-key"})
+        try:
+            assert resolve_entry_api_key({"key_env": "FB_KEY"}) == (
+                "secondary-profile-key"
+            )
+        finally:
+            reset_secret_scope(token)
+
+    def test_key_env_does_not_fall_through_outside_active_profile_scope(
+        self, monkeypatch
+    ):
+        from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+        monkeypatch.setenv("FB_KEY", "default-profile-key")
+        token = set_secret_scope({})
+        try:
+            assert resolve_entry_api_key({"key_env": "FB_KEY"}) is None
+        finally:
+            reset_secret_scope(token)
+
+
+def test_strict_loader_serializes_yaml_parsing(tmp_path, monkeypatch):
+    """Concurrent strict refreshes must not enter libyaml simultaneously."""
+    from hermes_cli import config, managed_scope
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("fallback_providers: []\n", encoding="utf-8")
+    monkeypatch.setattr(config, "get_config_path", lambda: config_path)
+    monkeypatch.setattr(managed_scope, "get_managed_dir", lambda: None)
+
+    state = {"active": 0, "max_active": 0}
+    state_lock = threading.Lock()
+
+    def slow_safe_load(_stream):
+        with state_lock:
+            state["active"] += 1
+            state["max_active"] = max(state["max_active"], state["active"])
+        try:
+            time.sleep(0.05)
+            return {"fallback_providers": []}
+        finally:
+            with state_lock:
+                state["active"] -= 1
+
+    monkeypatch.setattr(fallback_config.yaml, "safe_load", slow_safe_load)
+
+    start = threading.Barrier(3)
+    results = []
+
+    def load():
+        start.wait()
+        results.append(fallback_config.load_fallback_chain_strict())
+
+    threads = [threading.Thread(target=load) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    start.wait()
+    for thread in threads:
+        thread.join(timeout=2)
+
+    assert not any(thread.is_alive() for thread in threads)
+    assert results == [[], []]
+    assert state["max_active"] == 1
+
+
+def test_strict_loader_expands_fallback_secrets_from_active_profile(
+    tmp_path, monkeypatch
+):
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+    from hermes_cli import config, managed_scope
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "fallback_providers:\n"
+        "  - provider: custom:secondary\n"
+        "    model: secondary-model\n"
+        "    api_key: ${FB_KEY}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(config, "get_config_path", lambda: config_path)
+    monkeypatch.setattr(managed_scope, "get_managed_dir", lambda: None)
+    monkeypatch.setenv("FB_KEY", "default-profile-key")
+
+    token = set_secret_scope({"FB_KEY": "secondary-profile-key"})
+    try:
+        assert fallback_config.load_fallback_chain_strict()[0]["api_key"] == (
+            "secondary-profile-key"
+        )
+    finally:
+        reset_secret_scope(token)
+
+
+def test_profile_env_expansion_preserves_explicit_empty_value():
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    token = set_secret_scope({"EMPTY_KEY": ""})
+    try:
+        assert fallback_config._expand_profile_env_vars("${EMPTY_KEY}") == ""
+    finally:
+        reset_secret_scope(token)

--- a/tests/hermes_cli/test_fallback_config.py
+++ b/tests/hermes_cli/test_fallback_config.py
@@ -58,14 +58,20 @@ class TestResolveEntryApiKey:
     def test_key_env_does_not_fall_through_outside_active_profile_scope(
         self, monkeypatch
     ):
-        from agent.secret_scope import reset_secret_scope, set_secret_scope
+        from agent.secret_scope import (
+            reset_secret_scope,
+            set_multiplex_active,
+            set_secret_scope,
+        )
 
         monkeypatch.setenv("FB_KEY", "default-profile-key")
+        set_multiplex_active(True)
         token = set_secret_scope({})
         try:
             assert resolve_entry_api_key({"key_env": "FB_KEY"}) is None
         finally:
             reset_secret_scope(token)
+            set_multiplex_active(False)
 
 
 def test_strict_loader_serializes_yaml_parsing(tmp_path, monkeypatch):

--- a/tests/run_agent/test_fallback_credential_isolation.py
+++ b/tests/run_agent/test_fallback_credential_isolation.py
@@ -167,6 +167,120 @@ class TestFallbackCredentialIsolation:
         assert agent._credential_pool.provider == "openai-codex"
         assert agent._transport_cache == {}
 
+    def test_fallback_key_env_uses_active_profile_secret_scope(self, monkeypatch):
+        from agent.chat_completion_helpers import try_activate_fallback
+        from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+        agent = _make_agent(provider="primary", model="primary-model")
+        agent._fallback_chain = [
+            {
+                "provider": "custom:secondary",
+                "model": "secondary-model",
+                "base_url": "https://secondary.example/v1",
+                "key_env": "FB_KEY",
+            }
+        ]
+        agent._credential_pool = None
+        agent._buffer_status = MagicMock()
+        agent._is_azure_openai_url.return_value = False
+        agent._is_direct_openai_url.return_value = False
+        agent._provider_model_requires_responses_api.return_value = False
+        agent._anthropic_prompt_cache_policy.return_value = (False, False)
+        agent._ensure_lmstudio_runtime_loaded = MagicMock()
+        agent._replace_primary_openai_client = MagicMock()
+        agent.context_compressor = None
+        fallback_client = SimpleNamespace(
+            api_key="profile-key",
+            base_url="https://secondary.example/v1",
+            _custom_headers={},
+        )
+        monkeypatch.setenv("FB_KEY", "global-default-profile-key")
+
+        token = set_secret_scope({"FB_KEY": "profile-key"})
+        try:
+            with patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(fallback_client, "secondary-model"),
+            ) as resolve_provider_client:
+                assert try_activate_fallback(agent) is True
+        finally:
+            reset_secret_scope(token)
+
+        assert resolve_provider_client.call_args.kwargs["explicit_api_key"] == (
+            "profile-key"
+        )
+
+    def test_ollama_fallback_uses_active_profile_secret_scope(self, monkeypatch):
+        from agent.chat_completion_helpers import try_activate_fallback
+        from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+        agent = _make_agent(provider="primary", model="primary-model")
+        agent._fallback_chain = [
+            {
+                "provider": "ollama-cloud",
+                "model": "secondary-model",
+                "base_url": "https://ollama.com/v1",
+            }
+        ]
+        agent._credential_pool = None
+        agent._buffer_status = MagicMock()
+        agent._is_azure_openai_url.return_value = False
+        agent._is_direct_openai_url.return_value = False
+        agent._provider_model_requires_responses_api.return_value = False
+        agent._anthropic_prompt_cache_policy.return_value = (False, False)
+        agent._ensure_lmstudio_runtime_loaded = MagicMock()
+        agent._replace_primary_openai_client = MagicMock()
+        agent.context_compressor = None
+        fallback_client = SimpleNamespace(
+            api_key="profile-ollama-key",
+            base_url="https://ollama.com/v1",
+            _custom_headers={},
+        )
+        monkeypatch.setenv("OLLAMA_API_KEY", "global-default-ollama-key")
+
+        token = set_secret_scope({"OLLAMA_API_KEY": "profile-ollama-key"})
+        try:
+            with patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(fallback_client, "secondary-model"),
+            ) as resolve_provider_client:
+                assert try_activate_fallback(agent) is True
+        finally:
+            reset_secret_scope(token)
+
+        assert resolve_provider_client.call_args.kwargs["explicit_api_key"] == (
+            "profile-ollama-key"
+        )
+
+    def test_openrouter_fallback_ignores_real_dotenv_under_empty_scope(
+        self, tmp_path, monkeypatch
+    ):
+        from agent.chat_completion_helpers import try_activate_fallback
+        from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / ".env").write_text(
+            "OPENROUTER_API_KEY=profile-file-key\n", encoding="utf-8"
+        )
+        agent = _make_agent(provider="primary", model="primary-model")
+        agent._fallback_chain = [
+            {"provider": "openrouter", "model": "fallback-model"}
+        ]
+        agent._credential_pool = None
+        agent._unavailable_fallback_keys = set()
+        agent._try_activate_fallback = MagicMock(return_value=False)
+
+        token = set_secret_scope({})
+        try:
+            assert try_activate_fallback(agent) is False
+        finally:
+            reset_secret_scope(token)
+
+        agent._try_activate_fallback.assert_called_once()
+        assert ("openrouter", "fallback-model", "") in (
+            agent._unavailable_fallback_keys
+        )
+
 
 # ── Test: _recover_with_credential_pool rejects mismatched pool ──────
 

--- a/tests/run_agent/test_init_fallback_on_exhausted_pool.py
+++ b/tests/run_agent/test_init_fallback_on_exhausted_pool.py
@@ -49,6 +49,53 @@ def test_init_tries_fallback_when_primary_returns_none():
         assert agent._fallback_activated is True
 
 
+def test_init_fallback_key_env_uses_active_profile_secret_scope(monkeypatch):
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    fb = _mock_client(api_key="profile-fallback-key")
+    fallback_explicit_keys = []
+
+    def fake_resolve(provider, model=None, raw_codex=False,
+                     explicit_base_url=None, explicit_api_key=None):
+        if provider == "tencent-token-plan":
+            fallback_explicit_keys.append(explicit_api_key)
+            return fb, "kimi2.5"
+        return None, None
+
+    monkeypatch.setenv("FB_KEY", "global-default-profile-key")
+    token = set_secret_scope({"FB_KEY": "profile-fallback-key"})
+    try:
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            side_effect=fake_resolve,
+        ), patch(
+            "run_agent.get_tool_definitions", return_value=_make_tool_defs()
+        ), patch(
+            "run_agent.check_toolset_requirements", return_value={}
+        ), patch("run_agent.OpenAI", return_value=MagicMock()):
+            agent = AIAgent(
+                provider="alibaba-coding-plan",
+                model="qwen3.6-plus",
+                api_key=None,
+                base_url=None,
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                fallback_model=[
+                    {
+                        "provider": "tencent-token-plan",
+                        "model": "kimi2.5",
+                        "key_env": "FB_KEY",
+                    }
+                ],
+            )
+    finally:
+        reset_secret_scope(token)
+
+    assert agent._fallback_activated is True
+    assert fallback_explicit_keys == ["profile-fallback-key"]
+
+
 def test_init_raises_when_no_fallback_configured():
     """When primary returns None and no fallback is set, should raise."""
     with patch("agent.auxiliary_client.resolve_provider_client", return_value=(None, None)), \
@@ -67,3 +114,34 @@ def test_init_raises_when_no_fallback_configured():
                 skip_memory=True,
                 fallback_model=None,
             )
+
+
+def test_init_does_not_use_real_dotenv_fallback_under_empty_scope(
+    tmp_path, monkeypatch
+):
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text(
+        "OPENROUTER_API_KEY=profile-file-key\n", encoding="utf-8"
+    )
+    token = set_secret_scope({})
+    try:
+        with patch(
+            "run_agent.get_tool_definitions", return_value=_make_tool_defs()
+        ), patch(
+            "run_agent.check_toolset_requirements", return_value={}
+        ), patch("run_agent.OpenAI", return_value=MagicMock()):
+            with pytest.raises(RuntimeError, match="no API key was found"):
+                AIAgent(
+                    provider="alibaba-coding-plan",
+                    model="primary-model",
+                    quiet_mode=True,
+                    skip_context_files=True,
+                    skip_memory=True,
+                    fallback_model=[
+                        {"provider": "openrouter", "model": "fallback-model"}
+                    ],
+                )
+    finally:
+        reset_secret_scope(token)

--- a/tests/run_agent/test_switch_model_fallback_prune.py
+++ b/tests/run_agent/test_switch_model_fallback_prune.py
@@ -43,7 +43,7 @@ def _switch_to_anthropic(agent):
         patch("agent.anthropic_adapter.resolve_anthropic_token", return_value="sk-ant-xyz"),
         patch("agent.anthropic_adapter._is_oauth_token", return_value=False),
         patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None),
-        patch("hermes_cli.config.load_config_readonly", side_effect=OSError("unavailable")),
+        patch("hermes_cli.fallback_config.load_fallback_chain_strict", side_effect=OSError("unavailable")),
     ):
         agent.switch_model(
             new_model="claude-sonnet-4-5",
@@ -96,7 +96,7 @@ def test_switch_within_same_provider_preserves_chain():
 
     with (
         patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None),
-        patch("hermes_cli.config.load_config_readonly", side_effect=OSError("unavailable")),
+        patch("hermes_cli.fallback_config.load_fallback_chain_strict", side_effect=OSError("unavailable")),
     ):
         agent.switch_model(
             new_model="openai/gpt-5",

--- a/tests/run_agent/test_switch_model_fallback_prune.py
+++ b/tests/run_agent/test_switch_model_fallback_prune.py
@@ -43,6 +43,7 @@ def _switch_to_anthropic(agent):
         patch("agent.anthropic_adapter.resolve_anthropic_token", return_value="sk-ant-xyz"),
         patch("agent.anthropic_adapter._is_oauth_token", return_value=False),
         patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None),
+        patch("hermes_cli.config.load_config_readonly", side_effect=OSError("unavailable")),
     ):
         agent.switch_model(
             new_model="claude-sonnet-4-5",
@@ -93,7 +94,10 @@ def test_switch_within_same_provider_preserves_chain():
     chain = [{"provider": "openrouter", "model": "x-ai/grok-4"}]
     agent = _make_agent(chain)
 
-    with patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None):
+    with (
+        patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None),
+        patch("hermes_cli.config.load_config_readonly", side_effect=OSError("unavailable")),
+    ):
         agent.switch_model(
             new_model="openai/gpt-5",
             new_provider="openrouter",

--- a/tests/run_agent/test_switch_model_refreshes_fallback_chain_61614.py
+++ b/tests/run_agent/test_switch_model_refreshes_fallback_chain_61614.py
@@ -1,0 +1,90 @@
+"""Regression tests for #61614: in-place model switches must not prune
+stale fallback chains.
+
+Gateway and dashboard sessions can keep an ``AIAgent`` alive while the profile's
+``fallback_providers`` config changes.  A later model switch calls
+``agent.switch_model()``, which historically pruned whatever
+``agent._fallback_chain`` happened to hold in memory.  If that chain was stale,
+the next 429 attempted the old fallback entry instead of the current config.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from agent.agent_runtime_helpers import switch_model
+
+
+def _make_agent(current_provider="zai", current_model="glm-5.2"):
+    agent = MagicMock(name="Agent")
+    agent.provider = current_provider
+    agent.model = current_model
+    agent.base_url = f"https://{current_provider}.example/v1"
+    agent.api_key = f"{current_provider}-key"
+    agent.api_mode = "chat_completions"
+    agent.client = MagicMock(name="Client")
+    agent._client_kwargs = {
+        "api_key": agent.api_key,
+        "base_url": agent.base_url,
+    }
+    agent._anthropic_client = None
+    agent._anthropic_api_key = ""
+    agent._anthropic_base_url = None
+    agent._is_anthropic_oauth = False
+    agent._config_context_length = None
+    agent._transport_cache = {}
+    agent._cached_system_prompt = "cached-system-prompt"
+    agent.context_compressor = None
+    agent._use_prompt_caching = False
+    agent._use_native_cache_layout = False
+    agent._primary_runtime = {}
+    agent._fallback_activated = False
+    agent._fallback_index = 2
+    agent._fallback_model = {"provider": "openai-codex", "model": "gpt-5.5"}
+    agent._fallback_chain = [
+        {"provider": "openai-codex", "model": "gpt-5.5"},
+    ]
+    agent._credential_pool = MagicMock(provider=current_provider)
+    agent._anthropic_prompt_cache_policy = MagicMock(return_value=(False, False))
+    agent._ensure_lmstudio_runtime_loaded = MagicMock()
+    agent._create_openai_client = MagicMock(return_value=MagicMock(name="NewClient"))
+    return agent
+
+
+def test_switch_model_refreshes_fallback_chain_from_current_config_before_pruning():
+    """A stale cached chain must be replaced by the current config on switch.
+
+    Repro shape from #61614: the live session still holds
+    ``openai-codex/gpt-5.5`` in memory, while config now says
+    ``openai-codex/gpt-5.6 -> xai-oauth/grok-4.5 -> zai/glm-5.2``.  Switching
+    away from ``zai`` should not preserve the stale gpt-5.5 entry, and because
+    the freshly-read config explicitly names ``zai`` as a fallback, the old
+    primary remains available as a user-configured later fallback.
+    """
+    agent = _make_agent()
+    current_config = {
+        "fallback_providers": [
+            {"provider": "openai-codex", "model": "gpt-5.6", "reasoning_effort": "high"},
+            {"provider": "xai-oauth", "model": "grok-4.5", "reasoning_effort": "high"},
+            {"provider": "zai", "model": "glm-5.2", "reasoning_effort": "xhigh"},
+        ]
+    }
+
+    with (
+        patch("agent.credential_pool.load_pool", return_value=MagicMock(provider="custom:zenmux")),
+        patch("hermes_cli.config.load_config_readonly", return_value=current_config),
+    ):
+        switch_model(
+            agent,
+            new_model="anthropic/claude-fable-5-free",
+            new_provider="custom:zenmux",
+            api_key="zenmux-key",
+            base_url="https://zenmux.ai/api/v1",
+            api_mode="chat_completions",
+        )
+
+    assert [entry["model"] for entry in agent._fallback_chain] == [
+        "gpt-5.6",
+        "grok-4.5",
+        "glm-5.2",
+    ]
+    assert agent._fallback_model == agent._fallback_chain[0]
+    assert agent._fallback_index == 0

--- a/tests/run_agent/test_switch_model_refreshes_fallback_chain_61614.py
+++ b/tests/run_agent/test_switch_model_refreshes_fallback_chain_61614.py
@@ -10,7 +10,10 @@ the next 429 attempted the old fallback entry instead of the current config.
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from agent.agent_runtime_helpers import switch_model
+from agent.chat_completion_helpers import try_activate_fallback
 
 
 def _make_agent(current_provider="zai", current_model="glm-5.2"):
@@ -49,6 +52,26 @@ def _make_agent(current_provider="zai", current_model="glm-5.2"):
     return agent
 
 
+def _switch_to_zenmux(agent, *, config=None, config_error=None):
+    config_patch = (
+        patch("hermes_cli.config.load_config_readonly", side_effect=config_error)
+        if config_error is not None
+        else patch("hermes_cli.config.load_config_readonly", return_value=config)
+    )
+    with (
+        patch("agent.credential_pool.load_pool", return_value=MagicMock(provider="custom:zenmux")),
+        config_patch,
+    ):
+        switch_model(
+            agent,
+            new_model="anthropic/claude-fable-5-free",
+            new_provider="custom:zenmux",
+            api_key="zenmux-key",
+            base_url="https://zenmux.ai/api/v1",
+            api_mode="chat_completions",
+        )
+
+
 def test_switch_model_refreshes_fallback_chain_from_current_config_before_pruning():
     """A stale cached chain must be replaced by the current config on switch.
 
@@ -68,9 +91,47 @@ def test_switch_model_refreshes_fallback_chain_from_current_config_before_prunin
         ]
     }
 
+    _switch_to_zenmux(agent, config=current_config)
+
+    assert [entry["model"] for entry in agent._fallback_chain] == [
+        "gpt-5.6",
+        "grok-4.5",
+        "glm-5.2",
+    ]
+    assert agent._fallback_model == agent._fallback_chain[0]
+    assert agent._fallback_index == 0
+
+
+def test_switch_model_clears_cached_chain_after_successful_empty_config_read():
+    """Removing fallback_providers must clear a live agent's stale chain."""
+    agent = _make_agent()
+    _switch_to_zenmux(agent, config={})
+
+    assert agent._fallback_chain == []
+    assert agent._fallback_model is None
+
+
+def test_switch_model_keeps_cached_chain_when_config_read_fails():
+    """A transient read failure must preserve the last-known-good chain."""
+    agent = _make_agent()
+    cached_chain = list(agent._fallback_chain)
+    _switch_to_zenmux(agent, config_error=OSError("mid-write"))
+
+    assert agent._fallback_chain == cached_chain
+    assert agent._fallback_model == cached_chain[0]
+
+
+@pytest.mark.parametrize("config_text", ["fallback_providers: [", "- not-a-mapping\n"])
+def test_switch_model_keeps_cached_chain_when_config_parse_fails(tmp_path, config_text):
+    """Malformed or structurally invalid YAML must not clear cached fallback state."""
+    agent = _make_agent()
+    cached_chain = list(agent._fallback_chain)
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(config_text, encoding="utf-8")
+
     with (
         patch("agent.credential_pool.load_pool", return_value=MagicMock(provider="custom:zenmux")),
-        patch("hermes_cli.config.load_config_readonly", return_value=current_config),
+        patch("hermes_cli.config.get_config_path", return_value=config_path),
     ):
         switch_model(
             agent,
@@ -81,10 +142,63 @@ def test_switch_model_refreshes_fallback_chain_from_current_config_before_prunin
             api_mode="chat_completions",
         )
 
-    assert [entry["model"] for entry in agent._fallback_chain] == [
-        "gpt-5.6",
-        "grok-4.5",
-        "glm-5.2",
-    ]
-    assert agent._fallback_model == agent._fallback_chain[0]
-    assert agent._fallback_index == 0
+    assert agent._fallback_chain == cached_chain
+    assert agent._fallback_model == cached_chain[0]
+
+
+def test_switch_model_clears_unavailable_memo_when_fresh_chain_changes():
+    """A config edit must make previously unavailable entries retryable."""
+    agent = _make_agent()
+    agent._unavailable_fallback_keys = {("openai-codex", "gpt-5.5", "")}
+    current_config = {
+        "fallback_providers": [
+            {"provider": "openai-codex", "model": "gpt-5.5"},
+            {"provider": "xai-oauth", "model": "grok-4.5"},
+        ]
+    }
+
+    _switch_to_zenmux(agent, config=current_config)
+
+    assert agent._unavailable_fallback_keys == set()
+
+
+def test_switched_agent_walks_current_chain_past_unavailable_first_entry():
+    """Activation must walk the refreshed chain, not the launch-time chain."""
+    agent = _make_agent()
+    current_config = {
+        "fallback_providers": [
+            {"provider": "nous", "model": "anthropic/claude-sonnet-4.6"},
+            {"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"},
+        ]
+    }
+
+    _switch_to_zenmux(agent, config=current_config)
+
+    fallback_client = MagicMock()
+    fallback_client.api_key = "openrouter-key"
+    fallback_client.base_url = "https://openrouter.ai/api/v1"
+    fallback_client._custom_headers = None
+    fallback_client.default_headers = None
+    agent._rate_limited_until = 0
+    agent._is_azure_openai_url = MagicMock(return_value=False)
+    agent._is_direct_openai_url = MagicMock(return_value=False)
+    agent._provider_model_requires_responses_api = MagicMock(return_value=False)
+    agent._try_activate_fallback = lambda reason=None: try_activate_fallback(agent, reason)
+
+    with (
+        patch("hermes_cli.auth.get_provider_auth_state", return_value={}),
+        patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(fallback_client, "anthropic/claude-sonnet-4.6"),
+        ),
+        patch(
+            "hermes_cli.model_normalize.normalize_model_for_provider",
+            side_effect=lambda model, provider: model,
+        ),
+    ):
+        activated = agent._try_activate_fallback(None)
+
+    assert activated is True
+    assert agent.provider == "openrouter"
+    assert agent.model == "anthropic/claude-sonnet-4.6"
+    assert agent._fallback_index == 2

--- a/tests/run_agent/test_switch_model_refreshes_fallback_chain_61614.py
+++ b/tests/run_agent/test_switch_model_refreshes_fallback_chain_61614.py
@@ -14,6 +14,7 @@ import pytest
 
 from agent.agent_runtime_helpers import switch_model
 from agent.chat_completion_helpers import try_activate_fallback
+from hermes_cli.fallback_config import get_fallback_chain
 
 
 def _make_agent(current_provider="zai", current_model="glm-5.2"):
@@ -45,6 +46,7 @@ def _make_agent(current_provider="zai", current_model="glm-5.2"):
     agent._fallback_chain = [
         {"provider": "openai-codex", "model": "gpt-5.5"},
     ]
+    agent._fallback_config_chain = list(agent._fallback_chain)
     agent._credential_pool = MagicMock(provider=current_provider)
     agent._anthropic_prompt_cache_policy = MagicMock(return_value=(False, False))
     agent._ensure_lmstudio_runtime_loaded = MagicMock()
@@ -53,14 +55,17 @@ def _make_agent(current_provider="zai", current_model="glm-5.2"):
 
 
 def _switch_to_zenmux(agent, *, config=None, config_error=None):
-    config_patch = (
-        patch("hermes_cli.config.load_config_readonly", side_effect=config_error)
+    chain_patch = (
+        patch("hermes_cli.fallback_config.load_fallback_chain_strict", side_effect=config_error)
         if config_error is not None
-        else patch("hermes_cli.config.load_config_readonly", return_value=config)
+        else patch(
+            "hermes_cli.fallback_config.load_fallback_chain_strict",
+            return_value=get_fallback_chain(config),
+        )
     )
     with (
         patch("agent.credential_pool.load_pool", return_value=MagicMock(provider="custom:zenmux")),
-        config_patch,
+        chain_patch,
     ):
         switch_model(
             agent,
@@ -102,10 +107,27 @@ def test_switch_model_refreshes_fallback_chain_from_current_config_before_prunin
     assert agent._fallback_index == 0
 
 
-def test_switch_model_clears_cached_chain_after_successful_empty_config_read():
+def test_switch_model_clears_cached_chain_after_successful_empty_config_read(
+    tmp_path, monkeypatch
+):
     """Removing fallback_providers must clear a live agent's stale chain."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("{}\n", encoding="utf-8")
+    monkeypatch.delenv("HERMES_MANAGED_DIR", raising=False)
     agent = _make_agent()
-    _switch_to_zenmux(agent, config={})
+
+    with (
+        patch("agent.credential_pool.load_pool", return_value=MagicMock(provider="custom:zenmux")),
+        patch("hermes_cli.config.get_config_path", return_value=config_path),
+    ):
+        switch_model(
+            agent,
+            new_model="anthropic/claude-fable-5-free",
+            new_provider="custom:zenmux",
+            api_key="zenmux-key",
+            base_url="https://zenmux.ai/api/v1",
+            api_mode="chat_completions",
+        )
 
     assert agent._fallback_chain == []
     assert agent._fallback_model is None
@@ -146,6 +168,83 @@ def test_switch_model_keeps_cached_chain_when_config_parse_fails(tmp_path, confi
     assert agent._fallback_model == cached_chain[0]
 
 
+def test_switch_model_keeps_cached_chain_when_managed_config_parse_fails(
+    tmp_path, monkeypatch
+):
+    """A broken managed overlay must not masquerade as an empty config."""
+    user_config_path = tmp_path / "user-config.yaml"
+    user_config_path.write_text("{}\n", encoding="utf-8")
+    managed_dir = tmp_path / "managed"
+    managed_dir.mkdir()
+    (managed_dir / "config.yaml").write_text(
+        "fallback_providers: [", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_dir))
+
+    from hermes_cli import managed_scope
+
+    managed_scope.invalidate_managed_cache()
+    agent = _make_agent()
+    cached_chain = list(agent._fallback_chain)
+    unavailable = {("openai-codex", "gpt-5.5", "")}
+    agent._unavailable_fallback_keys = set(unavailable)
+
+    with (
+        patch("agent.credential_pool.load_pool", return_value=MagicMock(provider="custom:zenmux")),
+        patch("hermes_cli.config.get_config_path", return_value=user_config_path),
+    ):
+        switch_model(
+            agent,
+            new_model="anthropic/claude-fable-5-free",
+            new_provider="custom:zenmux",
+            api_key="zenmux-key",
+            base_url="https://zenmux.ai/api/v1",
+            api_mode="chat_completions",
+        )
+
+    assert agent._fallback_chain == cached_chain
+    assert agent._fallback_model == cached_chain[0]
+    assert agent._unavailable_fallback_keys == unavailable
+
+
+def test_switch_model_uses_valid_managed_fallback_overlay(tmp_path, monkeypatch):
+    """The strict snapshot must preserve managed-scope override semantics."""
+    user_config_path = tmp_path / "user-config.yaml"
+    user_config_path.write_text(
+        "fallback_providers:\n"
+        "  - provider: openrouter\n"
+        "    model: stale-user-model\n",
+        encoding="utf-8",
+    )
+    managed_dir = tmp_path / "managed"
+    managed_dir.mkdir()
+    (managed_dir / "config.yaml").write_text(
+        "fallback_providers:\n"
+        "  - provider: xai-oauth\n"
+        "    model: grok-4.5\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_dir))
+
+    agent = _make_agent()
+    with (
+        patch("agent.credential_pool.load_pool", return_value=MagicMock(provider="custom:zenmux")),
+        patch("hermes_cli.config.get_config_path", return_value=user_config_path),
+    ):
+        switch_model(
+            agent,
+            new_model="anthropic/claude-fable-5-free",
+            new_provider="custom:zenmux",
+            api_key="zenmux-key",
+            base_url="https://zenmux.ai/api/v1",
+            api_mode="chat_completions",
+        )
+
+    assert agent._fallback_chain == [
+        {"provider": "xai-oauth", "model": "grok-4.5"}
+    ]
+
+
 def test_switch_model_clears_unavailable_memo_when_fresh_chain_changes():
     """A config edit must make previously unavailable entries retryable."""
     agent = _make_agent()
@@ -160,6 +259,57 @@ def test_switch_model_clears_unavailable_memo_when_fresh_chain_changes():
     _switch_to_zenmux(agent, config=current_config)
 
     assert agent._unavailable_fallback_keys == set()
+
+
+def test_switch_model_keeps_unavailable_memo_when_fresh_chain_is_unchanged():
+    """A no-op refresh must retain session-scoped suppression state."""
+    agent = _make_agent()
+    unavailable = {("openai-codex", "gpt-5.5", "")}
+    agent._unavailable_fallback_keys = set(unavailable)
+    current_config = {
+        "fallback_providers": [
+            {"provider": "openai-codex", "model": "gpt-5.5"},
+        ]
+    }
+
+    _switch_to_zenmux(agent, config=current_config)
+
+    assert agent._unavailable_fallback_keys == unavailable
+
+
+def test_repeated_switch_with_same_config_keeps_unavailable_memo_after_pruning():
+    """Operational pruning must not look like an authoritative config edit."""
+    agent = _make_agent()
+    current_config = {
+        "fallback_providers": [
+            {"provider": "custom:zenmux", "model": "zenmux-fallback"},
+            {"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"},
+        ]
+    }
+    authoritative_chain = get_fallback_chain(current_config)
+
+    _switch_to_zenmux(agent, config=current_config)
+    assert agent._fallback_chain == [authoritative_chain[1]]
+
+    unavailable = {("openrouter", "anthropic/claude-sonnet-4.6", "")}
+    agent._unavailable_fallback_keys = set(unavailable)
+    with (
+        patch("agent.credential_pool.load_pool", return_value=MagicMock(provider="custom:other")),
+        patch(
+            "hermes_cli.fallback_config.load_fallback_chain_strict",
+            return_value=authoritative_chain,
+        ),
+    ):
+        switch_model(
+            agent,
+            new_model="other-model",
+            new_provider="custom:other",
+            api_key="other-key",
+            base_url="https://other.example/v1",
+            api_mode="chat_completions",
+        )
+
+    assert agent._unavailable_fallback_keys == unavailable
 
 
 def test_switched_agent_walks_current_chain_past_unavailable_first_entry():


### PR DESCRIPTION
## Summary

Fixes #61614.

Long-lived gateway/dashboard sessions can hold an `AIAgent` while the profile's `fallback_providers` config changes. `switch_model()` previously pruned whatever `agent._fallback_chain` already held in memory. If that chain was stale, the next 429 walked old fallbacks (for example `openai-codex/gpt-5.5`) instead of the current config chain (`gpt-5.6 -> xai-oauth -> zai`).

This change makes in-place model switches prefer a fresh non-empty fallback chain from current config before pruning. When the fresh config chain is used, the switch removes only the newly-selected primary provider from fallback; it preserves the old provider if the current config explicitly still names it as a later fallback. If config has no fallback entries or cannot be read, the old in-memory-chain behavior is preserved.

## Tests

- `scripts/run_tests.sh tests/run_agent/test_switch_model_refreshes_fallback_chain_61614.py -v --tb=short`
- `scripts/run_tests.sh tests/run_agent/test_switch_model_refreshes_fallback_chain_61614.py tests/run_agent/test_switch_model_pool_reload_52727.py tests/run_agent/test_switch_model_rollback.py tests/run_agent/test_switch_model_context.py tests/test_tui_gateway_server.py tests/gateway/test_fallback_chain_reload.py tests/run_agent/test_switch_model_fallback_prune.py tests/run_agent/test_provider_fallback.py tests/run_agent/test_32646_fallback_429_after_timeout.py tests/run_agent/test_24996_fallback_exhaustion_cooldown.py tests/gateway/test_fallback_eviction.py tests/gateway/test_auth_fallback.py -v --tb=short`
