### PR TITLE
Bound Codex Responses tool payloads for shared gateways

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1487,9 +1487,12 @@ def init_agent(
     agent._platform_hint_overrides = _platform_hints_cfg
 
     # App-level API retry count (wraps each model API call).  Default 3,
-    # overridable via agent.api_max_retries in config.yaml.  See #11616.
+    # overridable via HERMES_API_MAX_RETRIES or agent.api_max_retries in
+    # config.yaml.  See #11616.
     try:
-        _raw_api_retries = _agent_section.get("api_max_retries", 3)
+        _raw_api_retries = os.getenv("HERMES_API_MAX_RETRIES", "").strip()
+        if not _raw_api_retries:
+            _raw_api_retries = _agent_section.get("api_max_retries", 3)
         _api_retries = int(_raw_api_retries)
         _api_retries = max(_api_retries, 1)  # 1 = no retry (single attempt)
     except (TypeError, ValueError):

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -7,10 +7,14 @@ streaming, or the _run_codex_stream() call path.
 
 import hashlib
 import json
+import logging
+import os
 from typing import Any, Dict, List, Optional
 
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall
+
+logger = logging.getLogger(__name__)
 
 
 def _content_cache_key(instructions: str, tools: Optional[List[Dict[str, Any]]]) -> Optional[str]:
@@ -44,6 +48,84 @@ def _content_cache_key(instructions: str, tools: Optional[List[Dict[str, Any]]])
     content = f"{instructions or ''}\x00{tools_part}"
     digest = hashlib.sha256(content.encode("utf-8", errors="replace")).hexdigest()[:24]
     return f"pck_{digest}"
+
+
+def _env_positive_int(name: str) -> Optional[int]:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("Ignoring invalid %s=%r; expected a positive integer", name, raw)
+        return None
+    return value if value > 0 else None
+
+
+def _codex_tool_priority_names() -> List[str]:
+    raw = os.getenv("HERMES_CODEX_TOOL_PRIORITY", "").strip()
+    if not raw:
+        return []
+    names: List[str] = []
+    seen = set()
+    for item in raw.split(","):
+        name = item.strip()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        names.append(name)
+    return names
+
+
+def _budget_codex_response_tools(tools: Optional[List[Dict[str, Any]]]) -> Optional[List[Dict[str, Any]]]:
+    """Optionally reduce Codex Responses tool payload size for OAuth-backed frontends."""
+    if not tools:
+        return tools
+
+    limit = _env_positive_int("HERMES_CODEX_TOOL_LIMIT")
+    char_budget = _env_positive_int("HERMES_CODEX_TOOL_CHAR_BUDGET")
+    if limit is None and char_budget is None:
+        return tools
+
+    remaining_by_name = {
+        tool.get("name"): tool
+        for tool in tools
+        if isinstance(tool.get("name"), str)
+    }
+    ordered: List[Dict[str, Any]] = []
+    for name in _codex_tool_priority_names():
+        tool = remaining_by_name.pop(name, None)
+        if tool is not None:
+            ordered.append(tool)
+    priority_names = {tool.get("name") for tool in ordered}
+    ordered.extend(tool for tool in tools if tool.get("name") not in priority_names)
+
+    selected: List[Dict[str, Any]] = []
+    for tool in ordered:
+        if limit is not None and len(selected) >= limit:
+            break
+        candidate = selected + [tool]
+        if char_budget is not None:
+            encoded_len = len(
+                json.dumps(candidate, separators=(",", ":"), ensure_ascii=False)
+            )
+            if encoded_len > char_budget:
+                if not selected:
+                    selected.append(tool)
+                continue
+        selected.append(tool)
+
+    if not selected:
+        selected = ordered[:1]
+    if len(selected) < len(tools):
+        logger.info(
+            "Codex tool payload reduced from %d to %d tools (limit=%s, char_budget=%s)",
+            len(tools),
+            len(selected),
+            limit if limit is not None else "none",
+            char_budget if char_budget is not None else "none",
+        )
+    return selected
 
 
 class ResponsesApiTransport(ProviderTransport):
@@ -166,6 +248,8 @@ class ResponsesApiTransport(ProviderTransport):
         reasoning_effort = _effort_clamp.get(reasoning_effort, reasoning_effort)
 
         response_tools = _responses_tools(tools)
+        if is_codex_backend:
+            response_tools = _budget_codex_response_tools(response_tools)
 
         # xAI server-side web search.
         #

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -367,6 +367,160 @@ def test_build_api_kwargs_codex(monkeypatch):
     assert "extra_body" not in kwargs
 
 
+def test_build_api_kwargs_codex_honors_tool_limit_with_priority(monkeypatch):
+    monkeypatch.setenv("HERMES_CODEX_TOOL_LIMIT", "3")
+    monkeypatch.setenv("HERMES_CODEX_TOOL_PRIORITY", "terminal,read_file,send_message")
+    agent = _build_agent(monkeypatch)
+    agent.tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "browser_click",
+                "description": "Click.",
+                "parameters": {"type": "object"},
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "description": "Read.",
+                "parameters": {"type": "object"},
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "terminal",
+                "description": "Run.",
+                "parameters": {"type": "object"},
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "send_message",
+                "description": "Send.",
+                "parameters": {"type": "object"},
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "write_file",
+                "description": "Write.",
+                "parameters": {"type": "object"},
+            },
+        },
+    ]
+
+    kwargs = agent._build_api_kwargs(
+        [
+            {"role": "system", "content": "You are Hermes."},
+            {"role": "user", "content": "Ping"},
+        ]
+    )
+
+    assert [tool["name"] for tool in kwargs["tools"]] == [
+        "terminal",
+        "read_file",
+        "send_message",
+    ]
+
+
+def test_build_api_kwargs_codex_tool_limit_is_opt_in(monkeypatch):
+    monkeypatch.delenv("HERMES_CODEX_TOOL_LIMIT", raising=False)
+    monkeypatch.delenv("HERMES_CODEX_TOOL_CHAR_BUDGET", raising=False)
+    agent = _build_agent(monkeypatch)
+    agent.tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "browser_click",
+                "description": "Click.",
+                "parameters": {"type": "object"},
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "description": "Read.",
+                "parameters": {"type": "object"},
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "terminal",
+                "description": "Run.",
+                "parameters": {"type": "object"},
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "send_message",
+                "description": "Send.",
+                "parameters": {"type": "object"},
+            },
+        },
+    ]
+
+    kwargs = agent._build_api_kwargs([{"role": "user", "content": "Ping"}])
+
+    assert [tool["name"] for tool in kwargs["tools"]] == [
+        "browser_click",
+        "read_file",
+        "terminal",
+        "send_message",
+    ]
+
+
+def test_build_api_kwargs_codex_honors_tool_char_budget(monkeypatch):
+    monkeypatch.setenv("HERMES_CODEX_TOOL_CHAR_BUDGET", "360")
+    agent = _build_agent(monkeypatch)
+    agent.tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "small_one",
+                "description": "a",
+                "parameters": {"type": "object"},
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "small_two",
+                "description": "b",
+                "parameters": {"type": "object"},
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "large_three",
+                "description": "x" * 500,
+                "parameters": {"type": "object"},
+            },
+        },
+    ]
+
+    kwargs = agent._build_api_kwargs([{"role": "user", "content": "Ping"}])
+
+    assert [tool["name"] for tool in kwargs["tools"]] == ["small_one", "small_two"]
+
+
+def test_api_max_retries_can_be_lowered_by_env(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    assert agent._api_max_retries == 3
+
+    monkeypatch.setenv("HERMES_API_MAX_RETRIES", "1")
+    tuned = _build_agent(monkeypatch)
+    assert tuned._api_max_retries == 1
+
+
 def test_build_api_kwargs_codex_clamps_minimal_effort(monkeypatch):
     """'minimal' reasoning effort is clamped to 'low' on the Responses API.
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -727,9 +727,13 @@ Advanced per-platform knobs for throttling the outbound message batcher. Most us
 | `CODEX_HOME` | When [Codex app-server runtime](../user-guide/features/codex-app-server-runtime) is enabled, override the directory Codex CLI reads its config + auth from (default: `~/.codex`). Hermes' migration writes the managed block to `<CODEX_HOME>/config.toml`. |
 | `HERMES_KANBAN_TASK` | Set by the kanban dispatcher when spawning a worker (task UUID). Workers and the spawned `hermes-tools` MCP subprocess inherit it so kanban tools gate correctly. Don't set manually. |
 | `HERMES_API_TIMEOUT` | LLM API call timeout in seconds (default: `1800`) |
+| `HERMES_API_MAX_RETRIES` | Optional positive integer maximum API attempts before surfacing failure (default: `3`) |
 | `HERMES_API_CALL_STALE_TIMEOUT` | Non-streaming stale-call timeout in seconds (default: `90`). Auto-disabled for local providers when left unset, and may scale upward for very large contexts. Also configurable via `providers.<id>.stale_timeout_seconds` or `providers.<id>.models.<model>.stale_timeout_seconds` in `config.yaml`. |
 | `HERMES_STREAM_READ_TIMEOUT` | Streaming socket read timeout in seconds (default: `120`). Auto-increased to `HERMES_API_TIMEOUT` for local providers. Increase if local LLMs time out during long code generation. |
 | `HERMES_STREAM_STALE_TIMEOUT` | Stale stream detection timeout in seconds (default: `180`). Auto-disabled for local providers. Triggers connection kill if no chunks arrive within this window. |
+| `HERMES_CODEX_TOOL_LIMIT` | Optional positive integer cap on tools sent to the OpenAI Codex Responses backend. Unset/`0` keeps the full tool list. |
+| `HERMES_CODEX_TOOL_PRIORITY` | Optional comma-separated tool names to keep first when `HERMES_CODEX_TOOL_LIMIT` is set, for example `terminal,read_file,search_files,send_message`. |
+| `HERMES_CODEX_TOOL_CHAR_BUDGET` | Optional positive integer character budget for the serialized Codex Responses tool payload. Unset/`0` keeps the full payload. |
 | `HERMES_STREAM_RETRIES` | Number of mid-stream reconnect attempts on transient network errors (default: `3`). |
 | `HERMES_STREAM_STALE_GIVEUP` | Cross-turn circuit breaker: after this many consecutive stale kills (streaming or non-streaming) with no completed response, abort each call immediately with an actionable error instead of re-waiting out the stale timeout (default: `5`, `0` disables). Resets on any completed response, `/model` switch, fallback activation, or turn-start primary restore. |
 | `HERMES_AGENT_TIMEOUT` | Gateway inactivity timeout for a running agent in seconds (default: `1800`, 30 minutes). Resets on every tool call and streamed token. Set to `0` to disable. |


### PR DESCRIPTION
## Summary
- add opt-in env knobs to cap OpenAI Codex Responses tool payloads by count, priority, and serialized size
- let operators lower app-level API attempts with HERMES_API_MAX_RETRIES
- document the new runtime knobs and cover them in Codex Responses tests

## Why
Shared Slack-style deployments can route Codex OAuth through constrained gateway/session pools. Sending the full Hermes tool catalog can make these turns slow or fail before the user gets a useful response. These knobs preserve default Hermes behavior while allowing deployments like ZeroClaw to keep the shared Codex bridge usable until a dedicated backend is enabled.

## Tests
- pytest -q -o addopts='' tests/run_agent/test_run_agent_codex_responses.py -k 'tool_limit or tool_char_budget or api_max_retries or build_api_kwargs_codex'
- pytest -q -o addopts='' tests/run_agent/test_run_agent_codex_responses.py