### PR TITLE
feat(delegation): add opt-in execution router

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5709,6 +5709,7 @@ class AIAgent:
             tasks=_strip_model_hidden_task_fields(function_args.get("tasks")),
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
+            router_mode=function_args.get("router_mode"),
             background=(not _is_subagent),
             parent_agent=self,
         )

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -113,6 +113,22 @@ def test_completion_event_lands_on_shared_queue_with_session_key():
     assert evt["delegation_id"] == res["delegation_id"]
 
 
+def test_completion_event_preserves_explicit_empty_toolsets():
+    def runner():
+        return {"status": "completed", "summary": "done"}
+
+    res = ad.dispatch_async_delegation(
+        goal="compute X", context=None, toolsets=[],
+        role="leaf", model="test-model", session_key="",
+        runner=runner, max_async_children=3,
+    )
+    assert res["status"] == "dispatched"
+
+    evt = _drain_one()
+    assert evt is not None
+    assert evt["toolsets"] == []
+
+
 def test_rich_reinjection_block_is_self_contained():
     def runner():
         return {"status": "completed", "summary": "The answer is 42.",
@@ -351,6 +367,59 @@ def test_delegate_task_background_uses_live_tui_agent_session_id(monkeypatch):
     assert evt["type"] == "async_delegation"
     assert evt["session_key"] == "post-compress-tip"
     assert evt["origin_ui_session_id"] == "origin-tab"
+
+
+def test_background_batch_completion_event_preserves_route_summary(monkeypatch):
+    import json
+    from unittest.mock import MagicMock
+    import tools.delegate_tool as dt
+
+    parent = MagicMock()
+    parent._delegate_depth = 0
+    parent.session_id = "sess"
+    parent._interrupt_requested = False
+    parent._active_children = []
+    parent._active_children_lock = None
+
+    fake_child = MagicMock()
+    fake_child._delegate_role = "leaf"
+    fake_child._subagent_id = "s1"
+
+    def child_result(task_index, goal, child=None, parent_agent=None, **kw):
+        return {
+            "task_index": task_index,
+            "status": "completed",
+            "summary": f"done: {goal}",
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+            "model": "m",
+        }
+
+    creds = {
+        "model": "m", "provider": None, "base_url": None, "api_key": None,
+        "api_mode": None, "command": None, "args": None,
+    }
+    monkeypatch.setattr(dt, "_build_child_agent", lambda **kw: fake_child)
+    monkeypatch.setattr(dt, "_run_single_child", child_result)
+    monkeypatch.setattr(dt, "_resolve_delegation_credentials", lambda *a, **k: creds)
+
+    out = dt.delegate_task(
+        tasks=[
+            {"goal": "Summarize prompt only"},
+            {"goal": "Research docs", "route_override": "strong-worker"},
+        ],
+        router_mode="auto",
+        background=True,
+        parent_agent=parent,
+    )
+    parsed = json.loads(out)
+    assert parsed["status"] == "dispatched"
+    assert parsed["route_summary"]["requires_verifier"] is True
+
+    evt = _drain_one()
+    assert evt is not None
+    assert evt["route_summary"] == parsed["route_summary"]
+    assert evt["route_summary"]["routes"][0]["toolsets"] == []
 
 
 def test_delegate_task_background_batch_runs_as_one_unit(monkeypatch):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -15,6 +15,7 @@ import threading
 import time
 import types
 import unittest
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from tools.delegate_tool import (
@@ -31,6 +32,10 @@ from tools.delegate_tool import (
     _build_child_progress_callback,
     _build_child_system_prompt,
     _extract_output_tail,
+    _build_route_summary,
+    _detect_parallel_edit_conflicts,
+    _infer_execution_route,
+    _prepare_routed_task,
     _strip_blocked_tools,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
@@ -154,6 +159,258 @@ class TestChildSystemPrompt(unittest.TestCase):
     def test_empty_context_ignored(self):
         prompt = _build_child_system_prompt("Do something", "  ")
         self.assertNotIn("CONTEXT", prompt)
+
+
+class TestExecutionRouter(unittest.TestCase):
+    def test_infers_code_edit_route(self):
+        route = _infer_execution_route(
+            "Add pytest coverage and patch src/router.py for failing repo tests",
+            "",
+        )
+        self.assertEqual(route["depth"], "cheap-worker")
+        self.assertEqual(route["toolsets"], ["terminal", "file"])
+
+    def test_infers_strong_debug_route(self):
+        route = _infer_execution_route(
+            "Find root cause of a security-sensitive architecture bug",
+            "",
+        )
+        self.assertEqual(route["depth"], "strong-worker")
+        self.assertEqual(route["toolsets"], ["terminal", "file"])
+
+    def test_strong_web_research_keeps_web_toolset(self):
+        route = _infer_execution_route(
+            "Review security-sensitive current docs and cite sources",
+            "https://example.com/docs",
+        )
+        self.assertEqual(route["depth"], "strong-worker")
+        self.assertEqual(route["toolsets"], ["web"])
+
+    def test_infers_web_research_route(self):
+        route = _infer_execution_route(
+            "Research current docs and cite sources for the API change",
+            "https://example.com/docs",
+        )
+        self.assertEqual(route["depth"], "cheap-worker")
+        self.assertEqual(route["toolsets"], ["web"])
+
+    def test_code_edit_beats_browser_signal(self):
+        route = _infer_execution_route(
+            "Fix UI bug in src/App.tsx after browser screenshot review",
+            "",
+        )
+        self.assertEqual(route["toolsets"], ["terminal", "file"])
+
+    def test_prepare_routed_task_preserves_top_level_toolsets(self):
+        task = {"goal": "Patch src/router.py"}
+        routed = _prepare_routed_task(task, fallback_toolsets=["browser"], router_mode="auto")
+        self.assertEqual(routed["toolsets"], ["browser"])
+
+    def test_prepare_routed_task_preserves_explicit_empty_toolsets(self):
+        task = {"goal": "Patch src/router.py", "toolsets": []}
+        routed = _prepare_routed_task(task, fallback_toolsets=["browser"], router_mode="auto")
+        self.assertEqual(routed["toolsets"], [])
+        self.assertNotIn("[EXECUTION ROUTER]", routed.get("context", ""))
+
+    def test_prepare_routed_task_preserves_top_level_empty_toolsets(self):
+        task = {"goal": "Patch src/router.py"}
+        routed = _prepare_routed_task(task, fallback_toolsets=[], router_mode="auto")
+        self.assertEqual(routed["toolsets"], [])
+
+    def test_prepare_routed_task_preserves_explicit_toolsets(self):
+        task = {"goal": "Research a logged-in website", "toolsets": ["browser"]}
+        routed = _prepare_routed_task(task, fallback_toolsets=["terminal"], router_mode="auto")
+        self.assertEqual(routed["toolsets"], ["browser"])
+        self.assertNotIn("[EXECUTION ROUTER]", routed.get("context", ""))
+
+    def test_prepare_routed_task_adds_route_hint_when_auto(self):
+        task = {"goal": "Count JSON rows in local logs", "context": "Use ./events.jsonl"}
+        routed = _prepare_routed_task(task, fallback_toolsets=None, router_mode="auto")
+        self.assertEqual(routed["toolsets"], ["terminal", "file"])
+        self.assertIn("[EXECUTION ROUTER]", routed["context"])
+        self.assertIn("deterministic", routed["context"])
+
+    def test_prepare_routed_task_records_empty_default_toolsets(self):
+        task = {"goal": "Summarize this short prompt"}
+        routed = _prepare_routed_task(task, fallback_toolsets=None, router_mode="auto")
+        self.assertEqual(routed["_execution_route"]["depth"], "cheap-worker")
+        self.assertEqual(routed["toolsets"], [])
+        self.assertIn("Toolsets: []", routed["context"])
+
+    def test_schema_exposes_router_mode(self):
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        self.assertIn("router_mode", props)
+        self.assertEqual(props["router_mode"]["enum"], ["none", "auto"])
+        task_props = props["tasks"]["items"]["properties"]
+        self.assertIn("route_override", task_props)
+        self.assertEqual(
+            task_props["route_override"]["enum"],
+            ["deterministic", "cheap-worker", "strong-worker"],
+        )
+
+    def test_route_override_forces_depth_and_default_toolsets(self):
+        task = {
+            "goal": "Review current docs and cite sources",
+            "route_override": "strong-worker",
+        }
+        routed = _prepare_routed_task(task, fallback_toolsets=None, router_mode="auto")
+        self.assertEqual(routed["_execution_route"]["depth"], "strong-worker")
+        self.assertEqual(routed["toolsets"], ["terminal", "file"])
+        self.assertIn("Override: strong-worker", routed["context"])
+
+    def test_route_override_can_force_empty_toolsets(self):
+        task = {
+            "goal": "Review the provided prompt only",
+            "route_override": "cheap-worker",
+        }
+        routed = _prepare_routed_task(task, fallback_toolsets=None, router_mode="auto")
+        self.assertEqual(routed["_execution_route"]["depth"], "cheap-worker")
+        self.assertEqual(routed["toolsets"], [])
+        self.assertIn("Toolsets: []", routed["context"])
+
+    def test_route_override_preserves_explicit_toolsets(self):
+        task = {
+            "goal": "Review logged-in UI",
+            "toolsets": ["browser"],
+            "route_override": "strong-worker",
+        }
+        routed = _prepare_routed_task(task, fallback_toolsets=None, router_mode="auto")
+        self.assertEqual(routed["toolsets"], ["browser"])
+        self.assertEqual(routed["_execution_route"]["depth"], "strong-worker")
+
+    def test_parallel_edit_conflict_detects_same_explicit_path(self):
+        tasks = [
+            _prepare_routed_task(
+                {"goal": "Patch tools/router.py to add option"},
+                fallback_toolsets=None,
+                router_mode="auto",
+            ),
+            _prepare_routed_task(
+                {"goal": "Edit ./tools/router.py tests for option"},
+                fallback_toolsets=None,
+                router_mode="auto",
+            ),
+        ]
+        conflict = _detect_parallel_edit_conflicts(tasks)
+        self.assertIsNotNone(conflict)
+        self.assertIn("tools/router.py", conflict)
+
+    def test_parallel_edit_conflict_detects_basename_paths(self):
+        tasks = [
+            _prepare_routed_task(
+                {"goal": "Patch router.py to add option"},
+                fallback_toolsets=None,
+                router_mode="auto",
+            ),
+            _prepare_routed_task(
+                {"goal": "Edit router.py tests for option"},
+                fallback_toolsets=None,
+                router_mode="auto",
+            ),
+        ]
+        conflict = _detect_parallel_edit_conflicts(tasks)
+        self.assertIsNotNone(conflict)
+        self.assertIn("router.py", conflict)
+
+    def test_parallel_edit_conflict_detects_extensionless_special_files(self):
+        tasks = [
+            _prepare_routed_task(
+                {"goal": "Patch Dockerfile base image"},
+                fallback_toolsets=None,
+                router_mode="auto",
+            ),
+            _prepare_routed_task(
+                {"goal": "Edit ./Dockerfile build args"},
+                fallback_toolsets=None,
+                router_mode="auto",
+            ),
+        ]
+        conflict = _detect_parallel_edit_conflicts(tasks)
+        self.assertIsNotNone(conflict)
+        self.assertIn("Dockerfile", conflict)
+
+    def test_parallel_edit_conflict_detects_full_path_vs_basename(self):
+        tasks = [
+            _prepare_routed_task(
+                {"goal": "Patch src/router.py"},
+                fallback_toolsets=None,
+                router_mode="auto",
+            ),
+            _prepare_routed_task(
+                {"goal": "Edit router.py"},
+                fallback_toolsets=None,
+                router_mode="auto",
+            ),
+        ]
+        conflict = _detect_parallel_edit_conflicts(tasks)
+        self.assertIsNotNone(conflict)
+        self.assertIn("router.py", conflict)
+
+    def test_parallel_edit_conflict_allows_distinct_full_paths_with_same_basename(self):
+        tasks = [
+            _prepare_routed_task(
+                {"goal": "Patch src/config.py"},
+                fallback_toolsets=None,
+                router_mode="auto",
+            ),
+            _prepare_routed_task(
+                {"goal": "Edit tests/config.py"},
+                fallback_toolsets=None,
+                router_mode="auto",
+            ),
+        ]
+        self.assertIsNone(_detect_parallel_edit_conflicts(tasks))
+
+    def test_parallel_edit_conflict_detects_mjs_paths(self):
+        tasks = [
+            _prepare_routed_task(
+                {"goal": "Patch src/config.mjs"},
+                fallback_toolsets=None,
+                router_mode="auto",
+            ),
+            _prepare_routed_task(
+                {"goal": "Edit ./src/config.mjs"},
+                fallback_toolsets=None,
+                router_mode="auto",
+            ),
+        ]
+        conflict = _detect_parallel_edit_conflicts(tasks)
+        self.assertIsNotNone(conflict)
+        self.assertIn("src/config.mjs", conflict)
+
+    def test_parallel_edit_conflict_ignores_read_only_same_path(self):
+        tasks = [
+            _prepare_routed_task(
+                {"goal": "Inspect tools/router.py for API shape"},
+                fallback_toolsets=None,
+                router_mode="auto",
+            ),
+            _prepare_routed_task(
+                {"goal": "Read ./tools/router.py and summarize behavior"},
+                fallback_toolsets=None,
+                router_mode="auto",
+            ),
+        ]
+        self.assertIsNone(_detect_parallel_edit_conflicts(tasks))
+
+    def test_build_route_summary_reports_task_routes(self):
+        tasks = [
+            _prepare_routed_task(
+                {"goal": "Count rows in data/events.jsonl"},
+                fallback_toolsets=None,
+                router_mode="auto",
+            ),
+            _prepare_routed_task(
+                {"goal": "Research docs", "route_override": "strong-worker"},
+                fallback_toolsets=None,
+                router_mode="auto",
+            ),
+        ]
+        summary = _build_route_summary(tasks, router_mode="auto")
+        self.assertEqual(summary["mode"], "auto")
+        self.assertEqual(summary["routes"][0]["depth"], "deterministic")
+        self.assertEqual(summary["routes"][1]["depth"], "strong-worker")
+        self.assertTrue(summary["requires_verifier"])
 
 
 class TestStripBlockedTools(unittest.TestCase):
@@ -316,6 +573,112 @@ class TestDelegateTask(unittest.TestCase):
         self.assertIn("error", result)
         self.assertIn("could not be parsed as JSON", result["error"])
         mock_run.assert_not_called()
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_router_mode_rejects_non_string_value(self, mock_run):
+        parent = _make_mock_parent()
+        bad_router_mode: Any = True
+        result = json.loads(
+            delegate_task(goal="Summarize", router_mode=bad_router_mode, parent_agent=parent)
+        )
+
+        self.assertIn("error", result)
+        self.assertIn("router_mode must be 'none' or 'auto'", result["error"])
+        mock_run.assert_not_called()
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_router_mode_rejects_parallel_same_path_edit_conflict(self, mock_run):
+        parent = _make_mock_parent()
+        result = json.loads(
+            delegate_task(
+                tasks=[
+                    {"goal": "Patch tools/router.py to add option"},
+                    {"goal": "Edit ./tools/router.py tests for option"},
+                ],
+                router_mode="auto",
+                parent_agent=parent,
+            )
+        )
+
+        self.assertIn("error", result)
+        self.assertIn("router_mode='auto' refused parallel delegation", result["error"])
+        self.assertIn("tools/router.py", result["error"])
+        mock_run.assert_not_called()
+
+    @patch("tools.async_delegation.dispatch_async_delegation_batch")
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_router_mode_background_dispatch_includes_route_summary(self, mock_build, mock_dispatch):
+        child = MagicMock()
+        child._delegate_saved_tool_names = []
+        mock_build.return_value = child
+        mock_dispatch.return_value = {"status": "dispatched", "delegation_id": "dg-1"}
+        parent = _make_mock_parent()
+        result = json.loads(
+            delegate_task(
+                tasks=[
+                    {"goal": "Count rows in events.jsonl"},
+                    {"goal": "Research docs", "route_override": "strong-worker"},
+                ],
+                router_mode="auto",
+                background=True,
+                parent_agent=parent,
+            )
+        )
+
+        self.assertEqual(result["status"], "dispatched")
+        self.assertIn("route_summary", result)
+        self.assertTrue(result["route_summary"]["requires_verifier"])
+        self.assertEqual(result["route_summary"]["routes"][1]["depth"], "strong-worker")
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_router_mode_success_includes_route_summary_and_preserves_explicit_task_toolsets(self, mock_run):
+        mock_run.side_effect = [
+            {"task_index": 0, "status": "completed", "summary": "A", "api_calls": 1, "duration_seconds": 1.0},
+            {"task_index": 1, "status": "completed", "summary": "B", "api_calls": 1, "duration_seconds": 1.0},
+        ]
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["browser", "terminal", "file"]
+        result = json.loads(
+            delegate_task(
+                tasks=[
+                    {"goal": "Patch src/router.py", "toolsets": ["browser"]},
+                    {"goal": "Research docs", "route_override": "strong-worker"},
+                ],
+                router_mode="auto",
+                parent_agent=parent,
+            )
+        )
+
+        self.assertIn("route_summary", result)
+        self.assertTrue(result["route_summary"]["requires_verifier"])
+        self.assertEqual(result["route_summary"]["routes"][0]["toolsets"], ["browser"])
+        self.assertEqual(result["route_summary"]["routes"][1]["depth"], "strong-worker")
+        first_child_call = mock_run.call_args_list[0]
+        self.assertEqual(first_child_call.kwargs["child"].enabled_toolsets, ["browser"])
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_router_mode_empty_toolset_route_does_not_inherit_parent_tools(self, mock_run):
+        mock_run.return_value = {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "A",
+            "api_calls": 1,
+            "duration_seconds": 1.0,
+        }
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["browser", "terminal", "file"]
+        result = json.loads(
+            delegate_task(
+                goal="Summarize this prompt only",
+                router_mode="auto",
+                parent_agent=parent,
+            )
+        )
+
+        self.assertEqual(result["route_summary"]["routes"][0]["toolsets"], [])
+        child_call = mock_run.call_args
+        child = child_call.args[2] if len(child_call.args) > 2 else child_call.kwargs["child"]
+        self.assertEqual(child.enabled_toolsets, [])
 
     @patch("tools.delegate_tool._run_single_child")
     def test_batch_capped_at_3(self, mock_run):
@@ -1859,6 +2222,28 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
             ["web", "browser", "mcp-MiniMax"],
         )
 
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_build_child_agent_empty_toolsets_do_not_preserve_parent_mcp_toolsets(self, mock_cfg):
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["browser", "mcp-MiniMax"]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="Test explicitly no tools",
+                context=None,
+                toolsets=[],
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        self.assertEqual(MockAgent.call_args[1]["enabled_toolsets"], [])
+
     @patch(
         "tools.delegate_tool._load_config",
         return_value={"inherit_mcp_toolsets": False},
@@ -2265,6 +2650,22 @@ class TestDispatchDelegateTask(unittest.TestCase):
         self.assertEqual(captured["goal"], "test")
         self.assertNotIn("acp_command", captured["tasks"][0])
         self.assertNotIn("acp_args", captured["tasks"][0])
+
+    def test_router_mode_forwarded_from_live_dispatch_path(self):
+        from run_agent import AIAgent
+
+        parent = _make_mock_parent(depth=0)
+        with patch("tools.delegate_tool.delegate_task", return_value='{"status":"ok"}') as mock_delegate:
+            result = AIAgent._dispatch_delegate_task(
+                parent,
+                {
+                    "tasks": [{"goal": "Patch tools/router.py"}],
+                    "router_mode": "auto",
+                },
+            )
+
+        self.assertEqual(json.loads(result)["status"], "ok")
+        self.assertEqual(mock_delegate.call_args.kwargs["router_mode"], "auto")
 
 class TestDelegateEventEnum(unittest.TestCase):
     """Tests for DelegateEvent enum and back-compat aliases."""

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -175,7 +175,7 @@ def dispatch_async_delegation(
         "delegation_id": delegation_id,
         "goal": goal,
         "context": context,
-        "toolsets": list(toolsets) if toolsets else None,
+        "toolsets": list(toolsets) if toolsets is not None else None,
         "role": role,
         "model": model,
         "session_key": session_key,
@@ -365,7 +365,7 @@ def dispatch_async_delegation_batch(
         "goal": combined_goal,
         "goals": list(goals),
         "context": context,
-        "toolsets": list(toolsets) if toolsets else None,
+        "toolsets": list(toolsets) if toolsets is not None else None,
         "role": role,
         "model": model,
         "session_key": session_key,
@@ -481,6 +481,7 @@ def _finalize_batch(
         # The full per-task results list — the formatter renders a
         # consolidated multi-task block from this.
         "results": combined.get("results") or [],
+        "route_summary": combined.get("route_summary"),
         "error": combined.get("error"),
         "total_duration_seconds": combined.get("total_duration_seconds"),
         "dispatched_at": dispatched_at,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -19,6 +19,7 @@ never the child's intermediate tool calls or reasoning.
 import enum
 import json
 import logging
+import re
 
 logger = logging.getLogger(__name__)
 import os
@@ -129,6 +130,260 @@ _MIN_SPAWN_DEPTH = 1
 # No upper ceiling on spawn depth — like max_concurrent_children, depth has a
 # floor of 1 and no ceiling. Deeper trees multiply API cost, so the default
 # stays flat (MAX_DEPTH = 1); raising the config knob is an explicit opt-in.
+
+
+_EXECUTION_ROUTE_KEYWORDS = {
+    "browser": (
+        "browser", "click", "login", "logged-in", "screenshot", "captcha",
+        "ui", "web app", "page visually", "dom", "form",
+    ),
+    "web": (
+        "http://", "https://", "web", "research", "source", "cite",
+        "docs", "documentation", "news", "current", "search", "article",
+    ),
+    "code": (
+        "code", "repo", "test", "pytest", "patch", "edit", "fix",
+        "implement", "refactor", ".py", ".ts", ".tsx", ".js", "git",
+    ),
+    "file": (
+        "read", "inspect", "file", "directory", "search", "grep",
+        "scan", "find", "path", "diff",
+    ),
+    "deterministic": (
+        "count", "parse", "json", "jsonl", "csv", "sqlite", "sql",
+        "log", "extract", "convert", "transform", "summarize rows",
+    ),
+    "strong": (
+        "root cause", "architecture", "security", "threat", "review",
+        "hard", "ambiguous", "race", "deadlock", "design", "tradeoff",
+    ),
+}
+_ROUTE_OVERRIDE_TOOLSETS = {
+    "deterministic": ["terminal", "file"],
+    "cheap-worker": [],
+    "strong-worker": ["terminal", "file"],
+}
+
+_EDIT_INTENT_KEYWORDS = (
+    "add", "change", "edit", "fix", "implement", "modify", "patch",
+    "refactor", "remove", "rewrite", "update", "write",
+)
+
+_READ_ONLY_INTENT_KEYWORDS = (
+    "audit", "inspect", "read", "review", "scan", "summarize", "summarise",
+)
+
+_PATH_RE = re.compile(
+    r"(?<![\w@:-])(?:"
+    r"(?:\./|/)?[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*"
+    r"\.(?:py|pyi|js|jsx|ts|tsx|mjs|cjs|mts|cts|json|jsonl|ya?ml|toml|md|txt|sql|sh|bash|css|html|go|rs|java|c|cc|cpp|h|hpp|env|ini|conf|lock)"
+    r"|(?:\./|/)?[A-Za-z0-9_.-]*(?:Dockerfile|Makefile|Procfile|Brewfile|Gemfile)"
+    r")"
+)
+
+
+def _contains_any(text: str, needles: tuple[str, ...]) -> bool:
+    return any(needle in text for needle in needles)
+
+
+def _infer_execution_route(goal: str, context: Optional[str] = None) -> Dict[str, Any]:
+    """Infer a safe execution depth/toolset for a delegated subtask.
+
+    This is deliberately deterministic and conservative.  It does not choose a
+    different model/provider; it only narrows toolsets and adds a context hint so
+    the child knows why it was routed.  Explicit user/model-provided toolsets
+    still win in _prepare_routed_task().
+    """
+    text = f"{goal or ''}\n{context or ''}".lower()
+
+    browser = _contains_any(text, _EXECUTION_ROUTE_KEYWORDS["browser"])
+    web = _contains_any(text, _EXECUTION_ROUTE_KEYWORDS["web"])
+    code = _contains_any(text, _EXECUTION_ROUTE_KEYWORDS["code"])
+    fileish = _contains_any(text, _EXECUTION_ROUTE_KEYWORDS["file"])
+    deterministic = _contains_any(text, _EXECUTION_ROUTE_KEYWORDS["deterministic"])
+    strong = _contains_any(text, _EXECUTION_ROUTE_KEYWORDS["strong"])
+
+    if code or deterministic:
+        toolsets = ["terminal", "file"]
+    elif browser:
+        toolsets = ["browser"]
+    elif web:
+        toolsets = ["web"]
+    elif fileish or strong:
+        toolsets = ["terminal", "file"] if strong else ["file"]
+    else:
+        toolsets = []
+
+    if strong:
+        depth = "strong-worker"
+    elif deterministic:
+        depth = "deterministic"
+    else:
+        depth = "cheap-worker"
+
+    reasons: list[str] = []
+    for label, matched in (
+        ("browser", browser),
+        ("web", web),
+        ("code", code),
+        ("file", fileish),
+        ("deterministic", deterministic),
+        ("strong", strong),
+    ):
+        if matched:
+            reasons.append(label)
+
+    return {
+        "depth": depth,
+        "toolsets": toolsets,
+        "rationale": ", ".join(reasons) if reasons else "default cheap-worker route",
+    }
+
+
+def _route_from_override(override: str, inferred: Dict[str, Any]) -> Dict[str, Any]:
+    """Return route metadata for an explicit per-task route_override."""
+    route = dict(inferred)
+    route["depth"] = override
+    route["override"] = True
+    route["rationale"] = f"override: {override}; inferred: {inferred.get('rationale', 'unknown')}"
+    if override in _ROUTE_OVERRIDE_TOOLSETS:
+        override_toolsets = _ROUTE_OVERRIDE_TOOLSETS[override]
+        route["toolsets"] = list(override_toolsets)
+    return route
+
+
+def _prepare_routed_task(
+    task: Dict[str, Any],
+    *,
+    fallback_toolsets: Optional[List[str]],
+    router_mode: Optional[str],
+) -> Dict[str, Any]:
+    """Apply execution-router metadata to one task when router_mode='auto'."""
+    if router_mode != "auto":
+        return dict(task)
+
+    routed = dict(task)
+    inferred = _infer_execution_route(
+        str(routed.get("goal") or ""),
+        str(routed.get("context") or ""),
+    )
+    override = str(routed.get("route_override") or "").strip().lower()
+    route = _route_from_override(override, inferred) if override else inferred
+    route.setdefault("override", False)
+    routed["_execution_route"] = route
+
+    explicit_toolsets = routed.get("toolsets")
+    explicit_toolsets_present = "toolsets" in routed and routed.get("toolsets") is not None
+    if explicit_toolsets_present and not override:
+        return routed
+    if explicit_toolsets_present:
+        pass
+    elif fallback_toolsets is not None:
+        routed["toolsets"] = list(fallback_toolsets)
+    else:
+        if "toolsets" in route:
+            inferred_toolsets = route.get("toolsets") or []
+            routed["toolsets"] = list(inferred_toolsets)
+
+    toolsets_label = routed["toolsets"] if "toolsets" in routed else "inherit"
+
+    hint = (
+        "[EXECUTION ROUTER]\n"
+        f"Depth: {route['depth']}\n"
+        f"Toolsets: {toolsets_label}\n"
+        f"Rationale: {route['rationale']}\n"
+        f"Override: {override or 'none'}\n"
+        "Requires verifier: true\n"
+        "Stay within this routed scope. If the task needs stronger reasoning, "
+        "say so in the summary instead of expanding scope silently."
+    )
+    existing_context = str(routed.get("context") or "").strip()
+    routed["context"] = f"{existing_context}\n\n{hint}" if existing_context else hint
+    return routed
+
+
+def _normalise_task_path(path: str) -> str:
+    return path.strip().strip("`'\".,;:)").removeprefix("./").lstrip("/")
+
+
+def _extract_explicit_paths(task: Dict[str, Any]) -> List[str]:
+    text = f"{task.get('goal') or ''}\n{task.get('context') or ''}"
+    paths = []
+    seen = set()
+    for match in _PATH_RE.finditer(text):
+        path = _normalise_task_path(match.group(0))
+        if path and path not in seen:
+            seen.add(path)
+            paths.append(path)
+    return paths
+
+
+def _task_has_edit_intent(task: Dict[str, Any]) -> bool:
+    text = f"{task.get('goal') or ''}\n{task.get('context') or ''}".lower()
+    route = task.get("_execution_route") or {}
+    has_edit_keyword = _contains_any(text, _EDIT_INTENT_KEYWORDS)
+    read_only = _contains_any(text, _READ_ONLY_INTENT_KEYWORDS) and not has_edit_keyword
+    route_is_code = "code" in str(route.get("rationale") or "").lower()
+    return bool((has_edit_keyword or route_is_code) and not read_only)
+
+
+def _detect_parallel_edit_conflicts(tasks: List[Dict[str, Any]]) -> Optional[str]:
+    """Return an error string when parallel tasks appear to edit the same path."""
+    exact_path_to_tasks: Dict[str, List[int]] = {}
+    basename_mentions: Dict[str, List[tuple[int, str]]] = {}
+    full_path_mentions: Dict[str, List[tuple[int, str]]] = {}
+    for index, task in enumerate(tasks):
+        if not _task_has_edit_intent(task):
+            continue
+        for path in _extract_explicit_paths(task):
+            exact_path_to_tasks.setdefault(path, []).append(index)
+            basename = path.rsplit("/", 1)[-1]
+            if "/" in path:
+                full_path_mentions.setdefault(basename, []).append((index, path))
+            else:
+                basename_mentions.setdefault(basename, []).append((index, path))
+
+    conflicts: Dict[str, List[int]] = {
+        path: idxs for path, idxs in exact_path_to_tasks.items() if len(set(idxs)) > 1
+    }
+    for basename, basename_entries in basename_mentions.items():
+        related = basename_entries + full_path_mentions.get(basename, [])
+        related_tasks = [idx for idx, _ in related]
+        if len(set(related_tasks)) > 1:
+            conflicts.setdefault(basename, []).extend(related_tasks)
+
+    if not conflicts:
+        return None
+    details = "; ".join(
+        f"{path} in tasks {', '.join(str(i) for i in sorted(set(idxs)))}"
+        for path, idxs in sorted(conflicts.items())
+    )
+    return (
+        "router_mode='auto' refused parallel delegation because multiple edit-like "
+        f"tasks mention the same explicit path: {details}. Split these tasks, "
+        "serialize them, or give one task the shared edit scope."
+    )
+
+
+def _build_route_summary(tasks: List[Dict[str, Any]], router_mode: str) -> Optional[Dict[str, Any]]:
+    if router_mode != "auto":
+        return None
+    routes = []
+    for index, task in enumerate(tasks):
+        route = task.get("_execution_route") or {}
+        routes.append({
+            "task_index": index,
+            "depth": route.get("depth", "unknown"),
+            "toolsets": task.get("toolsets") or [],
+            "rationale": route.get("rationale", ""),
+            "override": bool(route.get("override", False)),
+            "requires_verifier": True,
+        })
+    return {
+        "mode": "auto",
+        "routes": routes,
+        "requires_verifier": bool(routes),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -1116,13 +1371,13 @@ def _build_child_agent(
     else:
         parent_toolsets = set(DEFAULT_TOOLSETS)
 
-    if toolsets:
+    if toolsets is not None:
         # Intersect with parent — subagent must not gain tools the parent lacks.
         # Expand composite toolsets (e.g. hermes-cli) so that individual
         # toolset names (e.g. web, terminal) are recognised during intersection.
         expanded_parent = _expand_parent_toolsets(parent_toolsets)
         child_toolsets = [t for t in toolsets if t in expanded_parent]
-        if _get_inherit_mcp_toolsets():
+        if child_toolsets and _get_inherit_mcp_toolsets():
             child_toolsets = _preserve_parent_mcp_toolsets(
                 child_toolsets, parent_toolsets
             )
@@ -2345,6 +2600,7 @@ def delegate_task(
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
     role: Optional[str] = None,
+    router_mode: Optional[str] = None,
     background: Optional[bool] = None,
     parent_agent=None,
 ) -> str:
@@ -2453,7 +2709,17 @@ def delegate_task(
     if not task_list:
         return tool_error("No tasks provided.")
 
-    # Validate each task has a goal
+    if router_mode is None:
+        router_mode = "none"
+    elif not isinstance(router_mode, str):
+        return tool_error("router_mode must be 'none' or 'auto'.")
+    else:
+        router_mode = router_mode.strip().lower()
+    if router_mode not in {"none", "auto"}:
+        return tool_error("router_mode must be 'none' or 'auto'.")
+
+    # Validate each task has a goal and valid optional router override
+    valid_route_overrides = set(_ROUTE_OVERRIDE_TOOLSETS.keys())
     for i, task in enumerate(task_list):
         if not isinstance(task, dict):
             return tool_error(
@@ -2461,6 +2727,29 @@ def delegate_task(
             )
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
+        route_override = str(task.get("route_override") or "").strip().lower()
+        if route_override and route_override not in valid_route_overrides:
+            return tool_error(
+                "route_override must be one of: "
+                + ", ".join(sorted(valid_route_overrides))
+                + "."
+            )
+
+    route_summary = None
+    if router_mode == "auto":
+        task_list = [
+            _prepare_routed_task(
+                task,
+                fallback_toolsets=None,
+                router_mode=router_mode,
+            )
+            for task in task_list
+        ]
+        if len(task_list) > 1:
+            conflict_error = _detect_parallel_edit_conflicts(task_list)
+            if conflict_error:
+                return tool_error(conflict_error)
+        route_summary = _build_route_summary(task_list, router_mode)
 
     overall_start = time.monotonic()
     results = []
@@ -2489,9 +2778,7 @@ def delegate_task(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
-                # Subagents always inherit the parent's toolsets; the model
-                # cannot choose or narrow them (no model-facing toolsets arg).
-                toolsets=None,
+                toolsets=(t["toolsets"] if "toolsets" in t else None),
                 model=creds["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
@@ -2751,10 +3038,13 @@ def delegate_task(
 
         total_duration = round(time.monotonic() - overall_start, 2)
 
-        return {
+        payload = {
             "results": results,
             "total_duration_seconds": total_duration,
         }
+        if route_summary:
+            payload["route_summary"] = route_summary
+        return payload
 
     # ----- Background dispatch: run the WHOLE batch as one async unit -----
     # When background is true, the entire fan-out runs on the daemon executor
@@ -2885,6 +3175,8 @@ def delegate_task(
                 "goals": _goals,
                 "note": note,
             }
+            if route_summary:
+                payload["route_summary"] = route_summary
             return json.dumps(payload, ensure_ascii=False)
 
         # Pool at capacity / schedule failure — children are still attached
@@ -3262,7 +3554,10 @@ def _build_top_level_description() -> str:
         "delegation.orchestrator_enabled=false.\n"
         "- Subagent model is NOT selectable per call: children inherit the parent model (plus its fallback chain) unless you pin all subagents to a model via delegation.provider / delegation.model in config.yaml.\n"
         "- Each subagent gets its own terminal session (separate working directory and state).\n"
-        "- Results are always returned as an array, one entry per task."
+        "- Results are always returned as an array, one entry per task.\n"
+        "- For mixed-complexity batches with no explicit per-task toolsets, "
+        "set router_mode='auto' so Hermes narrows each child to deterministic, "
+        "cheap-worker, or strong-worker scope and adds a route hint to context."
     )
 
 
@@ -3389,6 +3684,14 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "route_override": {
+                            "type": "string",
+                            "enum": ["deterministic", "cheap-worker", "strong-worker"],
+                            "description": (
+                                "Per-task execution depth override used only when router_mode='auto'. "
+                                "Forces the router depth while preserving explicit task toolsets."
+                            ),
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -3401,6 +3704,18 @@ DELEGATE_TASK_SCHEMA = {
                 "type": "string",
                 "enum": ["leaf", "orchestrator"],
                 "description": "(rebuilt at get_definitions() time)",
+            },
+            "router_mode": {
+                "type": "string",
+                "enum": ["none", "auto"],
+                "description": (
+                    "Optional execution router. Use 'auto' when a batch has "
+                    "mixed-complexity subtasks and no explicit per-task "
+                    "toolsets: Hermes will infer narrow toolsets and add a "
+                    "depth hint (deterministic, cheap-worker, strong-worker) "
+                    "to each child's context. Explicit toolsets are preserved. "
+                    "Default 'none'."
+                ),
             },
             "background": {
                 "type": "boolean",
@@ -3472,6 +3787,7 @@ registry.register(
         tasks=_strip_model_hidden_task_fields(args.get("tasks")),
         max_iterations=args.get("max_iterations"),
         role=args.get("role"),
+        router_mode=args.get("router_mode"),
         background=_model_background_value(args, kw.get("parent_agent")),
         parent_agent=kw.get("parent_agent"),
     ),


### PR DESCRIPTION
## Summary
- Add opt-in `delegate_task(router_mode="auto")` execution router.
- Infer deterministic/cheap/strong route metadata and narrow child toolsets when routed.
- Add same-file parallel edit conflict guard and route summaries, including async completion preservation.
- Preserve explicit empty toolsets through child construction, including parent MCP toolset inheritance edge cases.

## Verification
- `python -m pytest tests/tools/test_delegate.py tests/tools/test_async_delegation.py -q -o 'addopts='` → 207 passed
- `python -m compileall -q run_agent.py tools/delegate_tool.py tools/async_delegation.py tests/tools/test_delegate.py tests/tools/test_async_delegation.py`
- `git diff --check -- run_agent.py tools/delegate_tool.py tools/async_delegation.py tests/tools/test_delegate.py tests/tools/test_async_delegation.py`

## Review
- Fresh Codex review approved after blockers were fixed.
