### PR TITLE
feat(sessions): copy conversations between profiles

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13456,7 +13456,7 @@ def main():
     # =========================================================================
     sessions_parser = subparsers.add_parser(
         "sessions",
-        help="Manage session history (list, rename, export, prune, delete)",
+        help="Manage session history (list, rename, copy, export, prune, delete)",
         description="View and manage the SQLite session store",
     )
     sessions_subparsers = sessions_parser.add_subparsers(dest="sessions_action")
@@ -13645,6 +13645,30 @@ def main():
         help="md/qmd only: overwrite an existing export file",
     )
 
+    sessions_copy = sessions_subparsers.add_parser(
+        "copy",
+        help="Copy one session/conversation to another Hermes profile",
+        description=(
+            "Copy a session row and transcript into another profile's state.db. "
+            "Profile memory, config, skills, credentials, cron, and gateway "
+            "routing are not copied."
+        ),
+    )
+    sessions_copy.add_argument("session_id", help="Session ID or unique prefix to copy")
+    sessions_copy.add_argument(
+        "--to-profile",
+        required=True,
+        help="Target profile name (for example: coder, ponytail, default)",
+    )
+    sessions_copy.add_argument(
+        "--from-profile",
+        help="Source profile name (default: currently active profile)",
+    )
+    sessions_copy.add_argument(
+        "--new-session-id",
+        help="Use this session ID in the target profile instead of auto-suffixing collisions",
+    )
+
     sessions_delete = sessions_subparsers.add_parser(
         "delete", help="Delete a specific session"
     )
@@ -13779,6 +13803,85 @@ def main():
                 if report.get("backup_path"):
                     print(f"  A backup is preserved at: {report['backup_path']}")
                 print("  Keep state.db and the backup; do not delete them.")
+            return
+
+        if action == "copy":
+            try:
+                from hermes_cli.profiles import (
+                    get_profile_dir,
+                    normalize_profile_name,
+                    profile_exists,
+                )
+                from hermes_state import SessionDB
+            except Exception as e:
+                print(f"Error: Could not load profile/session helpers: {e}")
+                return
+
+            def _current_profile_label(home):
+                try:
+                    if home.resolve() == get_profile_dir("default").resolve():
+                        return "default"
+                    if home.parent.name == "profiles":
+                        return home.name
+                except Exception:
+                    pass
+                return "current"
+
+            try:
+                target_profile = normalize_profile_name(args.to_profile)
+                source_profile = (
+                    normalize_profile_name(args.from_profile)
+                    if args.from_profile
+                    else None
+                )
+            except ValueError as e:
+                print(f"Error: {e}")
+                return
+
+            if source_profile and not profile_exists(source_profile):
+                print(f"Error: Source profile '{source_profile}' does not exist.")
+                return
+            if not profile_exists(target_profile):
+                print(f"Error: Target profile '{target_profile}' does not exist.")
+                return
+
+            source_home = get_profile_dir(source_profile) if source_profile else get_hermes_home()
+            source_label = source_profile or _current_profile_label(source_home)
+            target_home = get_profile_dir(target_profile)
+
+            source_db = target_db = None
+            try:
+                source_db = SessionDB(db_path=source_home / "state.db")
+                resolved_session_id = source_db.resolve_session_id(args.session_id)
+                if not resolved_session_id:
+                    print(
+                        f"Session '{args.session_id}' not found in profile '{source_label}'."
+                    )
+                    return
+                target_db = SessionDB(db_path=target_home / "state.db")
+                copied_id = source_db.copy_session_to(
+                    resolved_session_id,
+                    target_db,
+                    new_session_id=getattr(args, "new_session_id", None),
+                )
+            except ValueError as e:
+                print(f"Error: {e}")
+                return
+            except Exception as e:
+                print(f"Error: Could not copy session: {e}")
+                return
+            finally:
+                if source_db is not None:
+                    source_db.close()
+                if target_db is not None:
+                    target_db.close()
+
+            suffix = f" as '{copied_id}'" if copied_id != resolved_session_id else ""
+            print(
+                f"Copied session '{resolved_session_id}' from profile '{source_label}' "
+                f"to profile '{target_profile}'{suffix}."
+            )
+            print("Profile memory, config, skills, credentials, cron, and gateway routing were not copied.")
             return
 
         try:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2592,6 +2592,103 @@ class SessionDB:
             row = cursor.fetchone()
         return dict(row) if row else None
 
+    def copy_session_to(
+        self,
+        session_id: str,
+        target_db: "SessionDB",
+        *,
+        new_session_id: Optional[str] = None,
+        include_inactive: bool = True,
+    ) -> str:
+        """Copy one session row and its transcript into another SessionDB.
+
+        This is intentionally a session-store operation only: it copies rows
+        from ``sessions`` and ``messages`` and does not touch profile memory,
+        config, skills, credentials, gateway routing, cron, or filesystem
+        session artifacts.  When the target already has ``session_id`` and no
+        explicit ``new_session_id`` was requested, a stable ``-copy`` suffix is
+        generated so repeated imports are non-destructive.
+        """
+
+        if not session_id:
+            raise ValueError("session_id is required")
+
+        with self._lock:
+            conn = self._conn
+            if conn is None:
+                raise RuntimeError("SessionDB is closed")
+            session_row = conn.execute(
+                "SELECT * FROM sessions WHERE id = ?", (session_id,)
+            ).fetchone()
+            if not session_row:
+                raise ValueError(f"Session '{session_id}' not found")
+            source_session = dict(session_row)
+
+            message_where = "session_id = ?"
+            if not include_inactive:
+                message_where += " AND active = 1"
+            message_rows = conn.execute(
+                f"SELECT * FROM messages WHERE {message_where} ORDER BY timestamp, id",
+                (session_id,),
+            ).fetchall()
+            source_messages = [dict(row) for row in message_rows]
+
+        def _target_columns(conn: sqlite3.Connection, table: str) -> List[str]:
+            return [row["name"] for row in conn.execute(f"PRAGMA table_info({table})")]
+
+        def _copy(conn: sqlite3.Connection) -> str:
+            requested_id = new_session_id.strip() if new_session_id else None
+            target_id = requested_id or session_id
+
+            def _exists(candidate: str) -> bool:
+                row = conn.execute(
+                    "SELECT 1 FROM sessions WHERE id = ? LIMIT 1", (candidate,)
+                ).fetchone()
+                return row is not None
+
+            if _exists(target_id):
+                if requested_id:
+                    raise ValueError(f"Target session '{target_id}' already exists")
+                base = f"{session_id}-copy"
+                target_id = base
+                suffix = 2
+                while _exists(target_id):
+                    target_id = f"{base}-{suffix}"
+                    suffix += 1
+
+            session_columns = [
+                col for col in _target_columns(conn, "sessions") if col in source_session
+            ]
+            session_values = dict(source_session)
+            session_values["id"] = target_id
+            placeholders = ", ".join("?" for _ in session_columns)
+            conn.execute(
+                f"INSERT INTO sessions ({', '.join(session_columns)}) VALUES ({placeholders})",
+                [session_values.get(col) for col in session_columns],
+            )
+
+            message_columns = [
+                col
+                for col in _target_columns(conn, "messages")
+                if col != "id" and (not source_messages or col in source_messages[0])
+            ]
+            if source_messages:
+                message_placeholders = ", ".join("?" for _ in message_columns)
+                conn.executemany(
+                    f"INSERT INTO messages ({', '.join(message_columns)}) "
+                    f"VALUES ({message_placeholders})",
+                    [
+                        [
+                            target_id if col == "session_id" else msg.get(col)
+                            for col in message_columns
+                        ]
+                        for msg in source_messages
+                    ],
+                )
+            return target_id
+
+        return target_db._execute_write(_copy)
+
     def resolve_session_id(self, session_id_or_prefix: str) -> Optional[str]:
         """Resolve an exact or uniquely prefixed session ID to the full ID.
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2628,7 +2628,7 @@ class SessionDB:
             if not include_inactive:
                 message_where += " AND active = 1"
             message_rows = conn.execute(
-                f"SELECT * FROM messages WHERE {message_where} ORDER BY timestamp, id",
+                f"SELECT * FROM messages WHERE {message_where} ORDER BY id",
                 (session_id,),
             ).fetchall()
             source_messages = [dict(row) for row in message_rows]
@@ -2661,6 +2661,13 @@ class SessionDB:
             ]
             session_values = dict(source_session)
             session_values["id"] = target_id
+            # This command copies exactly one session/conversation.  Preserve
+            # the transcript, but intentionally orphan lineage metadata: a
+            # copied child cannot reference a missing source-profile parent,
+            # and an unrelated target-profile row with the same id must not
+            # become a false ancestor.
+            if "parent_session_id" in session_values:
+                session_values["parent_session_id"] = None
             placeholders = ", ".join("?" for _ in session_columns)
             conn.execute(
                 f"INSERT INTO sessions ({', '.join(session_columns)}) VALUES ({placeholders})",

--- a/tests/hermes_cli/test_sessions_copy_profile.py
+++ b/tests/hermes_cli/test_sessions_copy_profile.py
@@ -1,0 +1,103 @@
+import sys
+from pathlib import Path
+
+from hermes_state import SessionDB
+
+
+def _run_hermes(monkeypatch, capsys, home: Path, *args: str) -> str:
+    from hermes_cli import main as main_mod
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(sys, "argv", ["hermes", *args])
+    monkeypatch.setattr(main_mod, "_recover_from_interrupted_install", lambda: None)
+    monkeypatch.setattr(main_mod, "_prepare_agent_startup", lambda _args: None)
+    main_mod.main()
+    return capsys.readouterr().out
+
+
+def test_sessions_copy_to_profile_copies_transcript_without_memories(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "hermes"
+    target_home = home / "profiles" / "coder"
+    target_home.mkdir(parents=True)
+    (home / "memories").mkdir(parents=True)
+    (home / "memories" / "MEMORY.md").write_text("source-only memory\n", encoding="utf-8")
+
+    source_db = SessionDB(db_path=home / "state.db")
+    source_db.create_session(
+        "sess-alpha",
+        source="cli",
+        model="test-model",
+        model_config={"temperature": 0.2},
+        system_prompt="source prompt",
+        cwd="/tmp/project",
+    )
+    source_db.append_message("sess-alpha", role="user", content="hello", timestamp=10)
+    source_db.append_message("sess-alpha", role="assistant", content="hi", timestamp=11)
+    source_db.close()
+
+    output = _run_hermes(
+        monkeypatch,
+        capsys,
+        home,
+        "sessions",
+        "copy",
+        "sess-alpha",
+        "--from-profile",
+        "default",
+        "--to-profile",
+        "coder",
+    )
+
+    assert "Copied session 'sess-alpha' from profile 'default' to profile 'coder'" in output
+
+    target_db = SessionDB(db_path=target_home / "state.db")
+    copied = target_db.get_session("sess-alpha")
+    assert copied is not None
+    assert copied["source"] == "cli"
+    assert copied["model"] == "test-model"
+    assert copied["system_prompt"] == "source prompt"
+    assert copied["cwd"] == "/tmp/project"
+    messages = target_db.get_messages("sess-alpha")
+    assert [(m["role"], m["content"]) for m in messages] == [
+        ("user", "hello"),
+        ("assistant", "hi"),
+    ]
+    target_db.close()
+
+    assert not (target_home / "memories" / "MEMORY.md").exists()
+
+
+def test_sessions_copy_to_profile_generates_new_id_on_collision(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "hermes"
+    target_home = home / "profiles" / "coder"
+    target_home.mkdir(parents=True)
+
+    source_db = SessionDB(db_path=home / "state.db")
+    source_db.create_session("sess-alpha", source="cli")
+    source_db.append_message("sess-alpha", role="user", content="source", timestamp=10)
+    source_db.close()
+
+    target_db = SessionDB(db_path=target_home / "state.db")
+    target_db.create_session("sess-alpha", source="cli")
+    target_db.append_message("sess-alpha", role="user", content="existing", timestamp=20)
+    target_db.close()
+
+    output = _run_hermes(
+        monkeypatch,
+        capsys,
+        home,
+        "sessions",
+        "copy",
+        "sess-alpha",
+        "--to-profile",
+        "coder",
+    )
+
+    assert "as 'sess-alpha-copy'" in output
+
+    target_db = SessionDB(db_path=target_home / "state.db")
+    assert target_db.get_session("sess-alpha") is not None
+    assert target_db.get_session("sess-alpha-copy") is not None
+    copied_messages = target_db.get_messages("sess-alpha-copy")
+    assert [(m["role"], m["content"]) for m in copied_messages] == [("user", "source")]
+    target_db.close()

--- a/tests/hermes_cli/test_sessions_copy_profile.py
+++ b/tests/hermes_cli/test_sessions_copy_profile.py
@@ -101,3 +101,122 @@ def test_sessions_copy_to_profile_generates_new_id_on_collision(tmp_path, monkey
     copied_messages = target_db.get_messages("sess-alpha-copy")
     assert [(m["role"], m["content"]) for m in copied_messages] == [("user", "source")]
     target_db.close()
+
+
+def test_sessions_copy_to_profile_clears_missing_parent_lineage(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "hermes"
+    target_home = home / "profiles" / "coder"
+    target_home.mkdir(parents=True)
+
+    source_db = SessionDB(db_path=home / "state.db")
+    source_db.create_session("parent-source", source="cli")
+    source_db.create_session("child-source", source="cli", parent_session_id="parent-source")
+    source_db.append_message("child-source", role="user", content="child transcript", timestamp=10)
+    source_db.close()
+
+    _run_hermes(
+        monkeypatch,
+        capsys,
+        home,
+        "sessions",
+        "copy",
+        "child-source",
+        "--to-profile",
+        "coder",
+    )
+
+    target_db = SessionDB(db_path=target_home / "state.db")
+    copied = target_db.get_session("child-source")
+    assert copied is not None
+    assert copied["parent_session_id"] is None
+    assert [(m["role"], m["content"]) for m in target_db.get_messages("child-source")] == [
+        ("user", "child transcript"),
+    ]
+    target_db.close()
+
+
+def test_sessions_copy_to_profile_does_not_link_to_colliding_target_parent(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "hermes"
+    target_home = home / "profiles" / "coder"
+    target_home.mkdir(parents=True)
+
+    source_db = SessionDB(db_path=home / "state.db")
+    source_db.create_session("shared-parent-id", source="cli")
+    source_db.create_session("child-source", source="cli", parent_session_id="shared-parent-id")
+    source_db.close()
+
+    target_db = SessionDB(db_path=target_home / "state.db")
+    target_db.create_session("shared-parent-id", source="cli")
+    target_db.close()
+
+    _run_hermes(
+        monkeypatch,
+        capsys,
+        home,
+        "sessions",
+        "copy",
+        "child-source",
+        "--to-profile",
+        "coder",
+    )
+
+    target_db = SessionDB(db_path=target_home / "state.db")
+    copied = target_db.get_session("child-source")
+    assert copied is not None
+    assert copied["parent_session_id"] is None
+    target_db.close()
+
+
+def test_sessions_copy_to_profile_preserves_insertion_order_not_timestamp_order(
+    tmp_path, monkeypatch, capsys
+):
+    home = tmp_path / "hermes"
+    target_home = home / "profiles" / "coder"
+    target_home.mkdir(parents=True)
+
+    source_db = SessionDB(db_path=home / "state.db")
+    source_db.create_session("sess-alpha", source="cli")
+    source_db.append_message("sess-alpha", role="user", content="call the tool", timestamp=30)
+    source_db.append_message(
+        "sess-alpha",
+        role="assistant",
+        tool_calls=[
+            {
+                "id": "call-1",
+                "type": "function",
+                "function": {"name": "terminal", "arguments": "{}"},
+            }
+        ],
+        timestamp=20,
+    )
+    source_db.append_message(
+        "sess-alpha",
+        role="tool",
+        content='{"ok": true}',
+        tool_name="terminal",
+        tool_call_id="call-1",
+        timestamp=10,
+    )
+    source_db.append_message("sess-alpha", role="assistant", content="done", timestamp=40)
+    source_db.close()
+
+    _run_hermes(
+        monkeypatch,
+        capsys,
+        home,
+        "sessions",
+        "copy",
+        "sess-alpha",
+        "--to-profile",
+        "coder",
+    )
+
+    target_db = SessionDB(db_path=target_home / "state.db")
+    messages = target_db.get_messages("sess-alpha")
+    assert [(m["role"], m["content"], m.get("tool_call_id")) for m in messages] == [
+        ("user", "call the tool", None),
+        ("assistant", None, None),
+        ("tool", '{"ok": true}', "call-1"),
+        ("assistant", "done", None),
+    ]
+    target_db.close()


### PR DESCRIPTION
## Summary

Adds a first-class CLI path for copying one conversation/session into another Hermes profile:

```bash
hermes sessions copy <session_id> --to-profile <profile>
```

Optional flags:

- `--from-profile <profile>` to copy from a named source profile instead of the current profile
- `--new-session-id <id>` to force a specific target session id

The copy is intentionally transcript-only: it copies the source `sessions` row and `messages` rows into the target profile's `state.db`. It does **not** copy memories, config, skills, credentials, cron, gateway routing, or other profile runtime state.

Collision behavior is non-destructive: if the target already has the same session id and no explicit `--new-session-id` is provided, the imported session is written as `<session_id>-copy`, then `<session_id>-copy-2`, etc.

## Rationale

Profiles are isolation boundaries, but users still need a safe way to re-home a single conversation when it clearly belongs under another profile. Existing profile clone/export flows intentionally avoid copying `state.db` history wholesale, so a focused session-copy command keeps that boundary explicit without coupling profiles together.

I searched existing issues/PRs for variations of:

- `copy session profile`
- `copy conversation profile`
- `move session profile`
- `move conversation profile`
- `cross-profile session`
- `sessions copy`
- `session transfer profile`

I found profile/session isolation work, but not an existing first-class feature for copying one conversation between profiles.

## Tests

```bash
scripts/run_tests.sh tests/hermes_cli/test_sessions_copy_profile.py tests/hermes_cli/test_profiles.py tests/test_hermes_state.py -q
```

Result: `496 tests passed, 0 failed`.

Also checked:

```bash
git diff --check -- hermes_cli/main.py hermes_state.py tests/hermes_cli/test_sessions_copy_profile.py
```
