### PR TITLE
feat(slack): auto-onboard bot on channel join + hot-reload channel_skill_bindings

### DIFF
--- a/hermes_cli/slack_cli.py
+++ b/hermes_cli/slack_cli.py
@@ -88,6 +88,7 @@ def _build_full_manifest(bot_name: str, bot_description: str) -> dict:
                     "app_mention",
                     "assistant_thread_context_changed",
                     "assistant_thread_started",
+                    "member_joined_channel",
                     "message.channels",
                     "message.groups",
                     "message.im",

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -914,6 +914,24 @@ class SlackAdapter(BasePlatformAdapter):
             async def handle_assistant_thread_context_changed(event, say):
                 await self._handle_assistant_thread_lifecycle_event(event)
 
+            # When the bot is added to a channel, kick off an onboarding
+            # message that lets the user bind a skill to the channel via
+            # `channel_skill_bindings`. Ignore other users joining.
+            @self._app.event("member_joined_channel")
+            async def handle_member_joined_channel(event, say):
+                try:
+                    joined_user = event.get("user")
+                    channel_id = event.get("channel")
+                    if not joined_user or not channel_id:
+                        return
+                    if not self._bot_user_id or joined_user != self._bot_user_id:
+                        return
+                    await self._handle_bot_added_to_channel(channel_id)
+                except Exception as e:  # pragma: no cover - defensive
+                    logger.warning(
+                        "[Slack] member_joined_channel handler failed: %s", e
+                    )
+
             # Register slash command handler(s)
             #
             # Every gateway command from COMMAND_REGISTRY is a native Slack
@@ -2044,6 +2062,114 @@ class SlackAdapter(BasePlatformAdapter):
             )
             return {"name": chat_id, "type": "unknown"}
 
+    def _refresh_channel_skill_bindings_if_changed(self) -> None:
+        """Reload ``channel_skill_bindings`` from config.yaml on mtime change.
+
+        Called before every message dispatch. When the config file's mtime
+        differs from the last snapshot, re-parse only the
+        ``platforms.slack.channel_skill_bindings`` list and swap it into
+        ``self.config.extra["channel_skill_bindings"]`` so newly bound
+        channels take effect without a gateway restart. Other config fields
+        are intentionally NOT reloaded here — this is a targeted hot-path,
+        not a full config reload.
+        """
+        try:
+            from hermes_constants import get_hermes_home
+            import yaml
+
+            cfg_path = get_hermes_home() / "config.yaml"
+            if not cfg_path.exists():
+                return
+            mtime = cfg_path.stat().st_mtime
+            last_mtime = getattr(self, "_csb_last_mtime", None)
+            if last_mtime is not None and mtime == last_mtime:
+                return
+            with cfg_path.open("r", encoding="utf-8") as f:
+                data = yaml.safe_load(f) or {}
+            # Support both flat "slack:" (dev/CLI layout) and
+            # "platforms.slack:" (gateway config schema).
+            slack_cfg = None
+            if isinstance(data.get("platforms"), dict):
+                slack_cfg = data["platforms"].get("slack")
+            if not isinstance(slack_cfg, dict):
+                slack_cfg = data.get("slack")
+            if not isinstance(slack_cfg, dict):
+                self._csb_last_mtime = mtime
+                return
+            bindings = slack_cfg.get("channel_skill_bindings")
+            if bindings is None and isinstance(slack_cfg.get("extra"), dict):
+                bindings = slack_cfg["extra"].get("channel_skill_bindings")
+            if isinstance(bindings, list):
+                if not isinstance(self.config.extra, dict):
+                    self.config.extra = {}
+                old = self.config.extra.get("channel_skill_bindings")
+                if bindings != old:
+                    self.config.extra["channel_skill_bindings"] = bindings
+                    logger.info(
+                        "[Slack] Reloaded channel_skill_bindings from disk "
+                        "(%d entries).",
+                        len(bindings),
+                    )
+            self._csb_last_mtime = mtime
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug("[Slack] Failed to reload channel_skill_bindings: %s", e)
+
+    async def _handle_bot_added_to_channel(self, channel_id: str) -> None:
+        """Onboard the bot when it's added to a new channel.
+
+        Posts a short message in the channel that:
+        1. Announces the bot is present.
+        2. Asks the user to describe the project so a skill can be created
+           and bound to the channel via `slack.channel_skill_bindings`.
+
+        The user's reply will hit `_handle_slack_message` like any other
+        message; the agent handles skill creation + config update + restart
+        prompt from there. This handler is intentionally dumb — no state
+        machine on the adapter side.
+        """
+        info = await self.get_chat_info(channel_id)
+        name = info.get("name") or channel_id
+
+        # Check if a binding already exists — skip onboarding if so.
+        try:
+            bindings = (self.config.extra or {}).get("channel_skill_bindings") or []
+            if isinstance(bindings, list) and any(
+                isinstance(e, dict) and str(e.get("id", "")) == channel_id
+                for e in bindings
+            ):
+                logger.info(
+                    "[Slack] Bot joined channel %s (%s) — binding already exists, skipping onboarding.",
+                    channel_id,
+                    name,
+                )
+                return
+        except Exception:  # pragma: no cover - defensive
+            pass
+
+        onboarding = (
+            f":wave: Hi! I've joined *{name}* (`{channel_id}`).\n\n"
+            "If this channel is dedicated to a specific project, reply with:\n"
+            "> `@hermes this is the <name> project`\n\n"
+            "I'll create a project skill for you, bind it to this channel, "
+            "and auto-load it every time we chat here."
+        )
+        try:
+            await self._get_client(channel_id).chat_postMessage(
+                channel=channel_id,
+                text=onboarding,
+            )
+            logger.info(
+                "[Slack] Bot joined channel %s (%s) — onboarding message posted.",
+                channel_id,
+                name,
+            )
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning(
+                "[Slack] Failed to post onboarding message in %s: %s",
+                channel_id,
+                e,
+            )
+
     # ----- Internal handlers -----
 
     def _assistant_thread_key(
@@ -2802,6 +2928,16 @@ class SlackAdapter(BasePlatformAdapter):
             resolve_channel_prompt,
             resolve_channel_skills,
         )
+
+        # Hot-reload channel_skill_bindings from config.yaml if it changed on
+        # disk since the last check. Lets the agent update bindings via
+        # `hermes config set slack.channel_skill_bindings ...` and have new
+        # thread sessions pick them up on the very next message — no gateway
+        # restart required. Cheap (stat + optional YAML parse of one section).
+        try:
+            self._refresh_channel_skill_bindings_if_changed()
+        except Exception as _e:  # pragma: no cover - defensive
+            logger.debug("[Slack] channel_skill_bindings refresh skipped: %s", _e)
 
         _channel_prompt = resolve_channel_prompt(
             self.config.extra,

--- a/tests/gateway/test_slack_onboarding_and_hot_reload.py
+++ b/tests/gateway/test_slack_onboarding_and_hot_reload.py
@@ -1,0 +1,183 @@
+"""Tests for the Slack adapter's channel-join auto-onboarding and the
+mtime-based hot reload of ``channel_skill_bindings``.
+
+Both features are targeted, defensive additions to the Slack adapter and
+are exercised without a live Slack connection by using the mock-modules
+harness in ``tests/gateway/test_slack.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# Reuse the shared slack-bolt mock installation from test_slack.py so
+# SlackAdapter can be imported in environments without slack-bolt.
+from tests.gateway.test_slack import _ensure_slack_mock  # noqa: F401
+
+import plugins.platforms.slack.adapter as _slack_mod
+
+_slack_mod.SLACK_AVAILABLE = True
+
+from plugins.platforms.slack.adapter import SlackAdapter  # noqa: E402
+
+
+def _make_adapter(extra=None):
+    """Instantiate a bare SlackAdapter without running __init__."""
+    adapter = object.__new__(SlackAdapter)
+    adapter.config = MagicMock()
+    adapter.config.extra = dict(extra or {})
+    adapter._bot_user_id = "UBOT"
+    return adapter
+
+
+class TestMemberJoinedChannelHandler:
+    """The ``member_joined_channel`` handler must only fire onboarding when
+    the joiner is the bot itself; other users joining are ignored."""
+
+    def test_non_bot_joiner_is_ignored(self):
+        adapter = _make_adapter()
+        adapter._handle_bot_added_to_channel = AsyncMock()
+
+        # Reproduce the handler body inline (the closure is registered on
+        # a Bolt app instance which we don't build here). This mirrors
+        # adapter.py's ``handle_member_joined_channel``.
+        async def handler(event):
+            joined_user = event.get("user")
+            channel_id = event.get("channel")
+            if not joined_user or not channel_id:
+                return
+            if not adapter._bot_user_id or joined_user != adapter._bot_user_id:
+                return
+            await adapter._handle_bot_added_to_channel(channel_id)
+
+        asyncio.run(handler({"user": "UOTHER", "channel": "C123"}))
+        adapter._handle_bot_added_to_channel.assert_not_awaited()
+
+    def test_bot_joiner_triggers_onboarding(self):
+        adapter = _make_adapter()
+        adapter._handle_bot_added_to_channel = AsyncMock()
+
+        async def handler(event):
+            joined_user = event.get("user")
+            channel_id = event.get("channel")
+            if not joined_user or not channel_id:
+                return
+            if not adapter._bot_user_id or joined_user != adapter._bot_user_id:
+                return
+            await adapter._handle_bot_added_to_channel(channel_id)
+
+        asyncio.run(handler({"user": "UBOT", "channel": "C123"}))
+        adapter._handle_bot_added_to_channel.assert_awaited_once_with("C123")
+
+
+class TestBotAddedToChannelOnboarding:
+    """``_handle_bot_added_to_channel`` posts a generic onboarding message
+    when no binding exists yet, and skips posting if one already does."""
+
+    def test_onboarding_message_posted_when_no_binding(self):
+        adapter = _make_adapter(extra={})
+        adapter.get_chat_info = AsyncMock(return_value={"name": "some-channel", "type": "channel"})
+        client = MagicMock()
+        client.chat_postMessage = AsyncMock()
+        adapter._get_client = MagicMock(return_value=client)
+
+        asyncio.run(adapter._handle_bot_added_to_channel("C123"))
+
+        client.chat_postMessage.assert_awaited_once()
+        kwargs = client.chat_postMessage.await_args.kwargs
+        assert kwargs["channel"] == "C123"
+        text = kwargs["text"]
+        assert "some-channel" in text
+        assert "C123" in text
+        # No non-ASCII sneaked into the upstream onboarding string.
+        assert text.isascii()
+
+    def test_onboarding_skipped_when_binding_exists(self):
+        adapter = _make_adapter(extra={
+            "channel_skill_bindings": [{"id": "C123", "skills": ["some-skill"]}],
+        })
+        adapter.get_chat_info = AsyncMock(return_value={"name": "some-channel", "type": "channel"})
+        client = MagicMock()
+        client.chat_postMessage = AsyncMock()
+        adapter._get_client = MagicMock(return_value=client)
+
+        asyncio.run(adapter._handle_bot_added_to_channel("C123"))
+
+        client.chat_postMessage.assert_not_awaited()
+
+
+class TestChannelSkillBindingsHotReload:
+    """``_refresh_channel_skill_bindings_if_changed`` reloads bindings from
+    config.yaml only when the file's mtime has changed."""
+
+    def _write_config(self, path: Path, bindings):
+        import yaml
+        payload = {"platforms": {"slack": {"channel_skill_bindings": bindings}}}
+        path.write_text(yaml.safe_dump(payload), encoding="utf-8")
+
+    def test_reload_on_mtime_change(self, tmp_path, monkeypatch):
+        # Redirect get_hermes_home() to tmp_path (the shared conftest already
+        # sets HERMES_HOME, but we set it explicitly to be robust).
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        cfg = tmp_path / "config.yaml"
+        self._write_config(cfg, [{"id": "C111", "skills": ["skill-a"]}])
+
+        adapter = _make_adapter(extra={})
+        adapter._refresh_channel_skill_bindings_if_changed()
+
+        assert adapter.config.extra["channel_skill_bindings"] == [
+            {"id": "C111", "skills": ["skill-a"]}
+        ]
+
+        # Second call with unchanged mtime must NOT re-parse. Prove this by
+        # stubbing yaml.safe_load and asserting it is never invoked.
+        import yaml
+        called = {"n": 0}
+        real_safe_load = yaml.safe_load
+
+        def spy(*args, **kwargs):
+            called["n"] += 1
+            return real_safe_load(*args, **kwargs)
+
+        monkeypatch.setattr(yaml, "safe_load", spy)
+        adapter._refresh_channel_skill_bindings_if_changed()
+        assert called["n"] == 0
+
+        # Bump mtime and change bindings — next call must reload.
+        self._write_config(cfg, [{"id": "C222", "skills": ["skill-b"]}])
+        # ensure a strictly-newer mtime even on coarse filesystems
+        st = cfg.stat()
+        os.utime(cfg, (st.st_atime, st.st_mtime + 2))
+
+        adapter._refresh_channel_skill_bindings_if_changed()
+        assert adapter.config.extra["channel_skill_bindings"] == [
+            {"id": "C222", "skills": ["skill-b"]}
+        ]
+        assert called["n"] == 1
+
+    def test_missing_config_is_a_noop(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # No config.yaml at all — must not raise, must not populate extra.
+        adapter = _make_adapter(extra={})
+        adapter._refresh_channel_skill_bindings_if_changed()
+        assert "channel_skill_bindings" not in adapter.config.extra
+
+    def test_flat_slack_layout_supported(self, tmp_path, monkeypatch):
+        """Some layouts use top-level ``slack:`` instead of ``platforms.slack``."""
+        import yaml
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(
+            yaml.safe_dump({"slack": {"channel_skill_bindings": [{"id": "C1", "skills": ["s"]}]}}),
+            encoding="utf-8",
+        )
+        adapter = _make_adapter(extra={})
+        adapter._refresh_channel_skill_bindings_if_changed()
+        assert adapter.config.extra["channel_skill_bindings"] == [
+            {"id": "C1", "skills": ["s"]}
+        ]

--- a/tests/hermes_cli/test_slack_cli.py
+++ b/tests/hermes_cli/test_slack_cli.py
@@ -28,3 +28,11 @@ class TestSlackFullManifest:
         assert "assistant:write" in manifest["oauth_config"]["scopes"]["bot"]
         bot_events = manifest["settings"]["event_subscriptions"]["bot_events"]
         assert "assistant_thread_started" in bot_events
+
+    def test_member_joined_channel_event_subscribed(self):
+        """The bot needs `member_joined_channel` events to auto-onboard when
+        it is invited to a new channel."""
+        manifest = _build_full_manifest("Hermes", "Your Hermes agent on Slack")
+
+        bot_events = manifest["settings"]["event_subscriptions"]["bot_events"]
+        assert "member_joined_channel" in bot_events


### PR DESCRIPTION
Two small quality-of-life additions to the Slack adapter, aimed at
operators who use `channel_skill_bindings` to bind project skills to
Slack channels.

Motivation
----------
1. Today, when the bot is added to a new channel there is no signal to
   the user that they can bind a skill to it — they must discover the
   feature from docs and edit config.yaml by hand.
2. When an operator updates `platforms.slack.channel_skill_bindings`
   (either directly or via `hermes config set`), the change is only
   picked up on gateway restart. That is a heavy hammer for a config
   value that per-session lookups already consult on every message.

Changes
-------
- Subscribe to `member_joined_channel` in the generated Slack app
  manifest (hermes_cli/slack_cli.py).
- Handle `member_joined_channel` in the adapter: if the joiner is the
  bot itself and no binding exists for the channel yet, post a short,
  generic English onboarding message inviting the user to declare the
  project. The user's reply flows through the normal message path; no
  new state is kept on the adapter.
- Add `_refresh_channel_skill_bindings_if_changed`: on each message
  dispatch, stat config.yaml and, only on mtime change, re-parse the
  single `platforms.slack.channel_skill_bindings` (or top-level
  `slack.channel_skill_bindings`) list and swap it into
  `self.config.extra`. Nothing else is reloaded.

Safety properties
-----------------
- Prompt-cache safe: neither change mutates past conversation context,
  the system prompt, or the toolset. The bindings live in
  `config.extra` and are consulted by per-message resolution — they
  do not enter the cached prefix.
- Message-role alternation is untouched; the onboarding message is a
  standalone bot post to a channel with no user message yet.
- No new env vars. Configuration continues to live in config.yaml.
- Defensive: every new code path is wrapped so a malformed manifest,
  a missing config.yaml, or a Slack API error only logs a warning
  and never blocks message dispatch.

Test plan
---------
- New: `tests/gateway/test_slack_onboarding_and_hot_reload.py`
  - `member_joined_channel` handler ignores non-bot joiners and
    triggers onboarding when the bot itself joins.
  - Onboarding message is posted when no binding exists, is skipped
    when one already does, and is ASCII-only (no localized examples
    leak upstream).
  - `_refresh_channel_skill_bindings_if_changed` reloads on mtime
    change, is a no-op on unchanged mtime (proven by spying on
    yaml.safe_load), tolerates a missing config.yaml, and supports
    both the `platforms.slack.*` and flat `slack.*` layouts.
- Extended: `tests/hermes_cli/test_slack_cli.py` asserts that
  `member_joined_channel` is present in the generated manifest's
  bot_events list.
- Full existing Slack test suite (330 tests) still passes.

