### PR TITLE
fix(scheduler): match conversation_loop exit reasons in graceful-delivery exemption

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3177,10 +3177,18 @@ def run_job(
         # builds the proper failure tuple. (issue #17855)
         turn_exit_reason = str(result.get("turn_exit_reason") or "")
         final_response_text = (result.get("final_response") or "").strip()
+        # Graceful delivery exemption: when the iteration budget is exhausted
+        # but a full response was composed, deliver it instead of raising.
+        # conversation_loop.py may set "budget_exhausted" (explicit exhaustion)
+        # or "unknown" (while-expiry fall-through); turn_finalizer.py may set
+        # "max_iterations_reached(N/N)". Match all three values.
         max_iteration_summary = (
             result.get("failed") is not True
             and result.get("completed") is False
-            and turn_exit_reason.startswith("max_iterations_reached(")
+            and (
+                turn_exit_reason.startswith("max_iterations_reached(")
+                or turn_exit_reason in ("budget_exhausted", "unknown")
+            )
             and bool(final_response_text)
         )
         if result.get("failed") is True or (result.get("completed") is False and not max_iteration_summary):

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -4810,3 +4810,98 @@ class TestMultiTargetDeliveryContinuesOnFailure:
         assert "a@example.com" in result
         assert "b@example.com" in result
         assert mock_pool.submit.call_count == 2
+
+
+    def test_run_job_delivers_budget_exhausted_summary(self, tmp_path):
+        """Budget-exhausted runs with a composed response should be delivered.
+
+        conversation_loop.py sets turn_exit_reason to "budget_exhausted"
+        (explicit exhaustion) or "unknown" (while-expiry fall-through).
+        These values should trigger the graceful delivery exemption,
+        delivering the composed response instead of raising as RuntimeError.
+        (issue #61631)
+        """
+        job = {
+            "id": "budget-job",
+            "name": "budget-test",
+            "prompt": "complete the task",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {
+                "final_response": "budget-exhausted but complete report",
+                "completed": False,
+                "failed": False,
+                "turn_exit_reason": "budget_exhausted",
+            }
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "budget-exhausted but complete report"
+        assert "budget-exhausted but complete report" in output
+        assert "(FAILED)" not in output
+
+    def test_run_job_delivers_unknown_fallthrough_summary(self, tmp_path):
+        """Unknown fall-through exit reasons should also trigger graceful delivery.
+
+        When the while-loop expires without an explicit turn_exit_reason,
+        the "unknown" value should still trigger the exemption for
+        composed responses. (issue #61631)
+        """
+        job = {
+            "id": "unknown-job",
+            "name": "unknown-test",
+            "prompt": "complete the task",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {
+                "final_response": "unknown exit but complete report",
+                "completed": False,
+                "failed": False,
+                "turn_exit_reason": "unknown",
+            }
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "unknown exit but complete report"
+        assert "unknown exit but complete report" in output
+        assert "(FAILED)" not in output


### PR DESCRIPTION
## What does this PR do?

The scheduler's graceful-delivery exemption matches `turn_exit_reason` to decide whether a budget-exhausted run with a composed response should be delivered instead of raised as a RuntimeError. Previously, it only matched `"max_iterations_reached(N/N)"` produced by `turn_finalizer.py`, but `conversation_loop.py` produces `"budget_exhausted"` (explicit exhaustion) or `"unknown"` (while-expiry fall-through). This mismatch caused budget-exhausted runs with complete reports to be raised as errors, losing the composed output.

## Related Issue

Fixes #61631

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py`: Updated graceful-delivery exemption to match all three exit reason values:
  - `"max_iterations_reached(N/N)"` (existing, from `turn_finalizer.py`)
  - `"budget_exhausted"` (new, from `conversation_loop.py` line 660)
  - `"unknown"` (new, from `conversation_loop.py` line 615 fall-through)
- `tests/cron/test_scheduler.py`: Added two regression tests:
  - `test_run_job_delivers_budget_exhausted_summary`: Verifies `"budget_exhausted"` exemption
  - `test_run_job_delivers_unknown_fallthrough_summary`: Verifies `"unknown"` exemption

## How to Test

1. Run the new regression tests:
   ```bash
   pytest tests/cron/test_scheduler.py -k "budget_exhausted or unknown_fallthrough" -q
   ```
2. Run all scheduler tests to verify no regressions:
   ```bash
   pytest tests/cron/test_scheduler.py -q
   ```
3. Observed result: All tests pass (including the existing `test_run_job_delivers_max_iteration_fallback_summary`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A