### PR TITLE
fix(desktop): restore Memory Provider picker in Memory & Context settings

### DIFF
--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -18,9 +18,9 @@ import { setHermesConfigCache, useHermesConfigRecord } from '../hooks/use-config
 import { useOnProfileSwitch } from '../hooks/use-on-profile-switch'
 import { PanelEmpty } from '../overlays/panel'
 
-import { CONTROL_TEXT, EMPTY_SELECT_VALUE, FIELD_DESCRIPTIONS, FIELD_LABELS, SECTIONS } from './constants'
+import { CONTROL_TEXT, EMPTY_SELECT_VALUE, FIELD_DESCRIPTIONS, FIELD_LABELS } from './constants'
 import { fieldCopyForSchemaKey } from './field-copy'
-import { enumOptionsFor, getNested, prettyName, setNested } from './helpers'
+import { enumOptionsFor, getNested, prettyName, sectionFieldEntries, setNested } from './helpers'
 import { MemoryConnect } from './memory/connect'
 import { ModelSettings, ModelSettingsSkeleton } from './model-settings'
 import { EmptyState, ListRow, LoadingState, SettingsContent } from './primitives'
@@ -328,14 +328,12 @@ export function ConfigSettings({
   }
 
   const sectionFields = useMemo(() => {
-    if (!schema) {
+    if (!schema || !config) {
       return new Map<string, [string, ConfigFieldSchema][]>()
     }
 
-    return new Map(
-      SECTIONS.map(s => [s.id, s.keys.flatMap(k => (schema[k] ? [[k, schema[k]] as [string, ConfigFieldSchema]] : []))])
-    )
-  }, [schema])
+    return sectionFieldEntries(schema, config)
+  }, [schema, config])
 
   const fields = sectionFields.get(activeSectionId) ?? []
 

--- a/apps/desktop/src/app/settings/helpers.test.ts
+++ b/apps/desktop/src/app/settings/helpers.test.ts
@@ -3,7 +3,15 @@ import { describe, expect, it } from 'vitest'
 import type { HermesConfigRecord } from '@/types/hermes'
 
 import { defineFieldCopy, fieldCopyForSchemaKey, schemaKeyToFieldCopyKey } from './field-copy'
-import { enumOptionsFor, getNested, providerGroup, setNested, stripToolsetLabel, toolsetDisplayLabel } from './helpers'
+import {
+  enumOptionsFor,
+  getNested,
+  providerGroup,
+  sectionFieldEntries,
+  setNested,
+  stripToolsetLabel,
+  toolsetDisplayLabel
+} from './helpers'
 
 describe('settings helpers', () => {
   it('lists Hindsight as a built-in desktop memory provider option', () => {
@@ -173,6 +181,41 @@ describe('settings helpers', () => {
       const opts = enumOptionsFor('tts.provider', 'my-custom-command-tts', config)
       expect(opts).toContain('my-custom-command-tts')
       expect(opts).toContain('xai')
+    })
+  })
+
+  describe('sectionFieldEntries', () => {
+    it('renders memory.provider from config even when the backend schema omits it', () => {
+      const schema = { 'memory.memory_enabled': { type: 'boolean' as const } }
+      const config: HermesConfigRecord = { memory: { memory_enabled: true, provider: '' } }
+
+      const memoryKeys = (sectionFieldEntries(schema, config).get('memory') ?? []).map(([key]) => key)
+
+      expect(memoryKeys).toContain('memory.provider')
+    })
+
+    it('infers the field type from the config value when the schema omits the key', () => {
+      const config: HermesConfigRecord = { memory: { provider: '', memory_enabled: true, memory_char_limit: 2200 } }
+
+      const fields = new Map(sectionFieldEntries({}, config).get('memory') ?? [])
+
+      expect(fields.get('memory.provider')?.type).toBe('string')
+      expect(fields.get('memory.memory_enabled')?.type).toBe('boolean')
+      expect(fields.get('memory.memory_char_limit')?.type).toBe('number')
+    })
+
+    it('prefers the backend schema entry over inference when both exist', () => {
+      const schema = { 'memory.provider': { type: 'select' as const, options: ['honcho'] } }
+      const config: HermesConfigRecord = { memory: { provider: 'honcho' } }
+
+      const field = new Map(sectionFieldEntries(schema, config).get('memory') ?? []).get('memory.provider')
+
+      expect(field?.type).toBe('select')
+      expect(field?.options).toEqual(['honcho'])
+    })
+
+    it('hides declared keys absent from both schema and config', () => {
+      expect(sectionFieldEntries({}, {}).get('memory') ?? []).toHaveLength(0)
     })
   })
 })

--- a/apps/desktop/src/app/settings/helpers.ts
+++ b/apps/desktop/src/app/settings/helpers.ts
@@ -1,7 +1,7 @@
 import { asText } from '@/lib/text'
-import type { HermesConfigRecord, ToolsetInfo } from '@/types/hermes'
+import type { ConfigFieldSchema, HermesConfigRecord, ToolsetInfo } from '@/types/hermes'
 
-import { BUILTIN_PERSONALITIES, ENUM_OPTIONS, PROVIDER_GROUPS } from './constants'
+import { BUILTIN_PERSONALITIES, ENUM_OPTIONS, PROVIDER_GROUPS, SECTIONS } from './constants'
 
 // Canonical implementations live in @/lib/text; re-exported here so the many
 // settings/capabilities call sites keep their import path.
@@ -95,6 +95,40 @@ export function getNested(obj: HermesConfigRecord, path: string): unknown {
   }
 
   return cur
+}
+
+export function inferFieldSchema(value: unknown): ConfigFieldSchema {
+  if (typeof value === 'boolean') {
+    return { type: 'boolean' }
+  }
+
+  if (typeof value === 'number') {
+    return { type: 'number' }
+  }
+
+  if (Array.isArray(value)) {
+    return { type: 'list' }
+  }
+
+  return { type: 'string' }
+}
+
+// Backend schema omits some declared keys (e.g. memory.provider); config presence is the availability signal.
+export function sectionFieldEntries(
+  schema: Record<string, ConfigFieldSchema>,
+  config: HermesConfigRecord
+): Map<string, [string, ConfigFieldSchema][]> {
+  return new Map(
+    SECTIONS.map(s => [
+      s.id,
+      s.keys.flatMap(k => {
+        const value = getNested(config, k)
+        const field = schema[k] ?? (value === undefined ? undefined : inferFieldSchema(value))
+
+        return field ? [[k, field] as [string, ConfigFieldSchema]] : []
+      })
+    ])
+  )
 }
 
 export function setNested(obj: HermesConfigRecord, path: string, value: unknown): HermesConfigRecord {

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -413,15 +413,16 @@ export function saveHermesConfig(config: HermesConfigRecord): Promise<{ ok: bool
   })
 }
 
+// surface=declared serves the curated desktop schema; the dashboard consumes the raw plugin schema.
 export function getMemoryProviderConfig(provider: string): Promise<MemoryProviderConfig> {
   return window.hermesDesktop.api<MemoryProviderConfig>({
-    path: `/api/memory/providers/${encodeURIComponent(provider)}/config`
+    path: `/api/memory/providers/${encodeURIComponent(provider)}/config?surface=declared`
   })
 }
 
 export function saveMemoryProviderConfig(provider: string, values: Record<string, string>): Promise<{ ok: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean }>({
-    path: `/api/memory/providers/${encodeURIComponent(provider)}/config`,
+    path: `/api/memory/providers/${encodeURIComponent(provider)}/config?surface=declared`,
     method: 'PUT',
     body: { values }
   })

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -84,6 +84,11 @@ from gateway.status import (
     parse_active_agents,
     read_runtime_status,
 )
+from hermes_cli.memory_providers import (
+    MemoryProvider as DeclaredMemoryProvider,
+    ProviderField as DeclaredProviderField,
+    get_memory_provider as get_declared_memory_provider,
+)
 from utils import env_var_enabled
 
 try:
@@ -5028,9 +5033,129 @@ def _require_valid_memory_provider_name(name: str) -> None:
         raise HTTPException(status_code=404, detail=f"Unknown memory provider: {name}")
 
 
+# ---------------------------------------------------------------------------
+# Declared surface — curated desktop schema from hermes_cli.memory_providers.
+# The desktop panel requests ?surface=declared; the dashboard keeps the raw
+# plugin schema. Providers without a declaration render no desktop panel.
+# ---------------------------------------------------------------------------
+
+def _declared_provider_file_path(provider: DeclaredMemoryProvider) -> Path:
+    return get_hermes_home() / provider.name / "config.json"
+
+
+def _read_declared_provider_file(provider: DeclaredMemoryProvider) -> Dict[str, Any]:
+    return _read_json_file(_declared_provider_file_path(provider))
+
+
+def _declared_read_field_value(field: DeclaredProviderField, data: Dict[str, Any]) -> str:
+    for source_key in (field.key, *field.aliases):
+        value = data.get(source_key)
+        if value:
+            return str(value)
+
+    env_on_disk = load_env()
+    for env_key in field.env_fallbacks:
+        value = env_on_disk.get(env_key)
+        if value:
+            return str(value)
+
+    return field.default
+
+
+def _declared_field_is_set(field: DeclaredProviderField, data: Dict[str, Any]) -> bool:
+    env_on_disk = load_env()
+    for env_key in (field.env_key, *field.env_fallbacks):
+        if env_key and env_on_disk.get(env_key):
+            return True
+    return any(data.get(source_key) for source_key in (field.key, *field.aliases))
+
+
+def _declared_provider_payload(provider: DeclaredMemoryProvider) -> Dict[str, Any]:
+    data = _read_declared_provider_file(provider)
+    fields: List[Dict[str, Any]] = []
+
+    for field in provider.fields:
+        entry: Dict[str, Any] = {
+            "key": field.key,
+            "label": field.label,
+            "kind": field.kind,
+            "description": field.description,
+            "placeholder": field.placeholder,
+            "options": [
+                {"value": opt.value, "label": opt.label, "description": opt.description}
+                for opt in field.options
+            ],
+        }
+
+        if field.is_secret:
+            # Secrets are write-only over the API; only expose whether one is set.
+            entry["value"] = ""
+            entry["is_set"] = _declared_field_is_set(field, data)
+        else:
+            value = _declared_read_field_value(field, data)
+            if field.kind == "select" and value not in field.allowed_values():
+                value = field.default
+            entry["value"] = value
+            entry["is_set"] = bool(value)
+
+        fields.append(entry)
+
+    return {"name": provider.name, "label": provider.label, "fields": fields}
+
+
+def _coerce_declared_field_value(field: DeclaredProviderField, raw: str) -> str:
+    value = (raw or "").strip()
+    if field.kind == "select":
+        if not value:
+            value = field.default
+        if value not in field.allowed_values():
+            raise ValueError(f"Invalid value for '{field.key}'")
+        return value
+    return value or field.default
+
+
+def _update_declared_provider_config(provider: DeclaredMemoryProvider, values: Dict[str, Any]) -> None:
+    existing = _read_declared_provider_file(provider)
+    json_values: Dict[str, Any] = {}
+    secrets: Dict[str, str] = {}
+
+    for field in provider.fields:
+        if field.is_secret:
+            submitted = str(values.get(field.key) or "").strip()
+            if submitted and field.env_key:
+                secrets[field.env_key] = submitted
+            continue
+
+        raw = (
+            values[field.key]
+            if field.key in values
+            else str(existing.get(field.key, field.default))
+        )
+        json_values[field.key] = _coerce_declared_field_value(field, str(raw))
+
+    path = _declared_provider_file_path(provider)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing.update(json_values)
+    from utils import atomic_json_write
+
+    atomic_json_write(path, existing, mode=0o600)
+
+    for env_key, secret in secrets.items():
+        save_env_value(env_key, secret)
+
+
 @app.get("/api/memory/providers/{name}/config")
-async def get_memory_provider_config(name: str):
+async def get_memory_provider_config(name: str, surface: Optional[str] = None):
     _require_valid_memory_provider_name(name)
+
+    if surface == "declared":
+        declared = get_declared_memory_provider(name)
+        if declared is None:
+            # Undeclared providers (e.g. builtin, honcho) have no desktop
+            # config surface; the generic panel renders nothing.
+            return {"name": name, "label": name, "fields": []}
+        return _declared_provider_payload(declared)
+
     provider = _load_memory_provider(name)
     if provider is None:
         # Undeclared providers (e.g. builtin) have no config surface. Return an
@@ -5061,8 +5186,22 @@ async def setup_memory_provider(name: str, body: MemoryProviderSetupRequest):
 
 
 @app.put("/api/memory/providers/{name}/config")
-async def update_memory_provider_config(name: str, body: MemoryProviderConfigUpdate):
+async def update_memory_provider_config(name: str, body: MemoryProviderConfigUpdate, surface: Optional[str] = None):
     _require_valid_memory_provider_name(name)
+
+    if surface == "declared":
+        declared = get_declared_memory_provider(name)
+        if declared is None:
+            raise HTTPException(status_code=404, detail=f"Unknown memory provider: {name}")
+        try:
+            _update_declared_provider_config(declared, body.values or {})
+            return {"ok": True}
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except Exception:
+            _log.exception("PUT /api/memory/providers/%s/config (declared) failed", name)
+            raise HTTPException(status_code=500, detail="Internal server error")
+
     provider = _load_memory_provider(name)
     if provider is None:
         raise HTTPException(status_code=404, detail=f"Unknown memory provider: {name}")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -491,6 +491,55 @@ class TestWebServerEndpoints:
         assert fields["api_key"]["url"] == "https://app.honcho.dev"
         assert fields["baseUrl"]["kind"] == "text"
 
+    def test_declared_surface_serves_curated_hindsight_schema(self):
+        resp = self.client.get("/api/memory/providers/hindsight/config?surface=declared")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        fields = self._provider_field_map(data)
+        assert set(fields) == {"mode", "api_key", "api_url", "bank_id", "recall_budget"}
+        assert fields["mode"]["kind"] == "select"
+        assert fields["api_key"]["kind"] == "secret"
+
+    def test_declared_surface_hides_undeclared_providers(self):
+        resp = self.client.get("/api/memory/providers/honcho/config?surface=declared")
+
+        assert resp.status_code == 200
+        assert resp.json()["fields"] == []
+
+    def test_declared_surface_put_writes_config_and_secret(self):
+        from hermes_constants import get_hermes_home
+        from hermes_cli.config import load_env
+
+        resp = self.client.put(
+            "/api/memory/providers/hindsight/config?surface=declared",
+            json={
+                "values": {
+                    "mode": "local_external",
+                    "api_url": "http://localhost:8888",
+                    "api_key": "hs-declared-key",
+                }
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+        assert load_env()["HINDSIGHT_API_KEY"] == "hs-declared-key"
+
+        config_path = get_hermes_home() / "hindsight" / "config.json"
+        provider_config = json.loads(config_path.read_text(encoding="utf-8"))
+        assert provider_config["mode"] == "local_external"
+        assert provider_config["api_url"] == "http://localhost:8888"
+        assert "api_key" not in provider_config
+
+    def test_declared_surface_put_rejects_undeclared_provider(self):
+        resp = self.client.put(
+            "/api/memory/providers/honcho/config?surface=declared",
+            json={"values": {"api_key": "x"}},
+        )
+
+        assert resp.status_code == 404
+
     def test_all_listed_memory_provider_configs_fetch(self):
         resp = self.client.get("/api/memory")
 


### PR DESCRIPTION
## Problem

The desktop Settings → Memory & Context tab lost its Memory Provider picker, and the provider config panel behind it regressed: hindsight went from 5 curated fields to 35 raw internals while honcho grew a config panel it never had.

## Cause

The dashboard provider-switching rework (#60569) changed two things the desktop depended on:

1. `memory.provider` is now skipped in `/api/config/schema` (the dashboard got a dedicated Plugins page instead) — but the desktop form only renders schema-listed keys, so the picker vanished.
2. The shared provider config route switched from the curated `hermes_cli/memory_providers.py` declarations to raw plugin `get_config_schema()`, so the desktop began dumping every internal field.

## Fix

- **Picker**: render a declared settings row when the schema has it *or* the config carries a value (`sectionFieldEntries` in `helpers.ts`). Keys an older backend doesn't know stay hidden. The schema skip and dashboard are untouched.
- **Curated schema**: `?surface=declared` on the config route serves the curated declarations (empty for undeclared providers → OAuth connect only, no panel); the desktop opts in, the dashboard keeps the raw schema unchanged.

Per review, the desktop-side `when` visibility filter was dropped from this PR: declared fields carry no `when` metadata, so it was unreachable on the surface the desktop now consumes. Modeling the mode-dependent field/default contract (cloud vs local_external `api_url`) on the declared surface is deferred until that contract exists.

## Testing

- 8 new tests (4 vitest, 4 pytest) covering the picker gate and both surfaces — all green alongside the existing suites; `tsc` and eslint clean
- Verified in the built app: picker back (builtin/hindsight/honcho), hindsight shows its 5 curated fields, honcho shows OAuth connect only
- `model-settings.test.tsx` failures are pre-existing on main (broken `@/hermes` mock), unrelated

## CI note

Earlier runs failed on disjoint test sets in files this PR doesn't touch (11 tests in `test_tui_gateway_server.py`, then 1 in `test_gateway_service.py`) with identical content between runs — nondeterministic, not reproducible locally via `scripts/run_tests.sh`.