### PR TITLE
fix(compression): carry user_id into the continuation session on context-compression rollover

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -792,6 +792,7 @@ def compress_context(
                             model=agent.model,
                             model_config=agent._session_init_model_config,
                             parent_session_id=old_session_id,
+                            user_id=getattr(agent, "_user_id", None),
                         )
                     except Exception as _cs_err:
                         # The child row could not be created (e.g. FK constraint,

--- a/tests/run_agent/test_compression_user_id.py
+++ b/tests/run_agent/test_compression_user_id.py
@@ -1,0 +1,89 @@
+"""Test: the context-compression rollover carries the owner's user_id into
+the continuation session row (parity with the normal gateway session-create).
+
+Regression guard for the bug where conversation_compression rotated onto a fresh
+session_id but wrote the new state.db row via create_session(...) WITHOUT user_id,
+orphaning gateway (Telegram/Discord) sessions to user_id=NULL on every compaction.
+
+Mirrors the real driving pattern in tests/run_agent/test_compression_boundary_hook.py.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+class TestCompressionCarriesUserId:
+    def _make_agent(self, session_db, user_id):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+            from run_agent import AIAgent
+
+            agent = AIAgent(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                session_db=session_db,
+                session_id="original-session",
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        # Force the ROTATION path (mint a new session_id) so the rollover
+        # create_session runs — mirrors test_compression_boundary_hook.py (#38763).
+        agent.compression_in_place = False
+        agent._user_id = user_id
+        return agent
+
+    def _stub_compressor(self, agent):
+        compressor = MagicMock()
+        compressor.compress.return_value = [
+            {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+            {"role": "user", "content": "tail question"},
+        ]
+        compressor.compression_count = 1
+        compressor.last_prompt_tokens = 0
+        compressor.last_completion_tokens = 0
+        compressor._last_summary_error = None
+        # Clear the abort flag so the post-compress abort branch does not
+        # short-circuit before the session-id rotation we assert on.
+        compressor._last_compress_aborted = False
+        agent.context_compressor = compressor
+
+    def test_rollover_persists_gateway_user_id(self):
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(db, "U-12345")
+            self._stub_compressor(agent)
+
+            old_sid = agent.session_id
+            messages = [{"role": "user", "content": f"m{i}"} for i in range(10)]
+            agent._compress_context(messages, "sys", approx_tokens=10_000)
+
+            assert agent.session_id != old_sid, "compression should rotate session_id"
+            row = db.get_session(agent.session_id)
+            assert row is not None, "continuation session row was not persisted"
+            assert row["user_id"] == "U-12345", (
+                f"continuation row must carry owner user_id, got {row['user_id']!r}"
+            )
+
+    def test_rollover_userless_stays_none(self):
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(db, None)  # CLI / user-less
+            self._stub_compressor(agent)
+
+            old_sid = agent.session_id
+            messages = [{"role": "user", "content": f"m{i}"} for i in range(10)]
+            agent._compress_context(messages, "sys", approx_tokens=10_000)
+
+            assert agent.session_id != old_sid
+            row = db.get_session(agent.session_id)
+            assert row is not None
+            assert row["user_id"] is None, (
+                f"user-less session must stay NULL (no behavior change), got {row['user_id']!r}"
+            )


### PR DESCRIPTION
## Problem

When a session hits the context limit, `agent/conversation_compression.py` rotates the agent onto a fresh `session_id` and writes a new `state.db` session row via `agent._session_db.create_session(...)`. That rollover passes `source`, `model`, `model_config`, and `parent_session_id` **but not `user_id`**, so every compression-continuation session is written with `user_id = NULL` — even though the original session (and the live agent) has a known gateway user.

The gateway ensure-session path DOES pass `user_id` (`create_session(..., user_id=source.user_id)` — e.g. `gateway/session.py`, `gateway/run.py`), so the rollover silently diverges from it. This bites **gateway (Telegram/Discord) sessions specifically** — CLI has no user identity, so its `create_session` omissions are harmless.

## Impact

`create_session(self, session_id, source, **kwargs)` (`hermes_state.py`) forwards `**kwargs` → `_insert_session_row` (default `user_id: str = None`) → the nullable `sessions.user_id TEXT` column. So the omitted kwarg stores `NULL`. The consumer of that column, `list_unlinked_telegram_sessions_for_user`, therefore cannot see compression-continuation sessions (`NULL != user_id`), so they become owner-less for attribution, auditing, and per-user resume scoping.

## Fix

One line, matching the existing defensive idiom (`getattr(agent, "_user_id", None)`, as used in `agent/turn_context.py`), safe even if `_user_id` was never set (CLI → `None`, identical to today). `agent._user_id` is set in `agent/agent_init.py` ("Platform user identifier (gateway sessions)").

```diff
                             model_config=agent._session_init_model_config,
                             parent_session_id=old_session_id,
+                            user_id=getattr(agent, "_user_id", None),
                         )
```

For CLI / user-less sessions `_user_id` is `None`, storing `NULL` exactly as before — **no behavior change for non-gateway sessions.**

## Test

`tests/run_agent/test_compression_user_id.py` mirrors the driving pattern of `test_compression_boundary_hook.py` (real `AIAgent` + real `SessionDB` + a stubbed `MagicMock` compressor with `_last_compress_aborted=False` + `compression_in_place=False` to force the rollover, driven via `agent._compress_context(...)`), then asserts the persisted row via `db.get_session(new_sid)["user_id"]`:

- gateway session (`_user_id="U-12345"`) → continuation row carries `U-12345`
- user-less session (`_user_id=None`) → continuation row stays `NULL` (no behavior change)

## Notes

- **Behavior-change disclosure:** after this fix, compression-continuation Telegram sessions (previously invisible because `user_id=NULL`) will start appearing in per-user unlinked-session listings via `list_unlinked_telegram_sessions_for_user` (resume-selectable for their owner). This is the intended/correct effect.
- Blast radius is minimal: an additive kwarg into an existing `**kwargs` sink, a nullable column, `INSERT OR IGNORE` idempotent.
- Other non-gateway `create_session` sites (CLI `/new`, `/branch`) also omit `user_id`, but they have no operator identity, so they are intentionally out of scope.
