### PR TITLE
fix(cli): normalize /approve and /deny tokens in yes/no prompts

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6490,6 +6490,16 @@ def _restore_stashed_changes(
             response = input_fn("Restore local changes now? [Y/n]", "y")
         else:
             response = input().strip().lower()
+        # Normalize: treat /approve as yes, /deny as no for yes/no prompts
+        # This handles mixed inputs like "Y /approve" or "/approve yes"
+        response_lower = response.lower()
+        if "/approve" in response_lower:
+            response = "y"
+        elif "/deny" in response_lower:
+            response = "n"
+        else:
+            # Extract first word for natural language responses
+            response = response_lower.split()[0] if response_lower else ""
         if response not in {"", "y", "yes"}:
             print("Skipped restoring local changes.")
             print("Your changes are still preserved in git stash.")

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -174,6 +174,93 @@ def test_restore_stashed_changes_applies_without_prompt_when_disabled(monkeypatc
     assert "Restore local changes now?" not in capsys.readouterr().out
 
 
+def test_restore_stashed_changes_treats_slash_approve_as_yes(monkeypatch, tmp_path, capsys):
+    """Test that /approve token is treated as affirmative for yes/no prompts."""
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[1:3] == ["stash", "apply"]:
+            return SimpleNamespace(stdout="applied\n", stderr="", returncode=0)
+        if cmd[1:3] == ["diff", "--name-only"]:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if cmd[1:3] == ["stash", "list"]:
+            return SimpleNamespace(stdout="stash@{0} abc123\n", stderr="", returncode=0)
+        if cmd[1:3] == ["stash", "drop"]:
+            return SimpleNamespace(stdout="dropped\n", stderr="", returncode=0)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+    monkeypatch.setattr("builtins.input", lambda: "Y /approve")
+
+    restored = hermes_main._restore_stashed_changes(["git"], tmp_path, "abc123", prompt_user=True)
+
+    assert restored is True
+    assert calls[0][0] == ["git", "stash", "apply", "abc123"]
+
+
+def test_restore_stashed_changes_treats_slash_approve_only_as_yes(monkeypatch, tmp_path, capsys):
+    """Test that /approve by itself is treated as affirmative."""
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[1:3] == ["stash", "apply"]:
+            return SimpleNamespace(stdout="applied\n", stderr="", returncode=0)
+        if cmd[1:3] == ["diff", "--name-only"]:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if cmd[1:3] == ["stash", "list"]:
+            return SimpleNamespace(stdout="stash@{0} abc123\n", stderr="", returncode=0)
+        if cmd[1:3] == ["stash", "drop"]:
+            return SimpleNamespace(stdout="dropped\n", stderr="", returncode=0)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+    monkeypatch.setattr("builtins.input", lambda: "/approve")
+
+    restored = hermes_main._restore_stashed_changes(["git"], tmp_path, "abc123", prompt_user=True)
+
+    assert restored is True
+    assert calls[0][0] == ["git", "stash", "apply", "abc123"]
+
+
+def test_restore_stashed_changes_treats_slash_deny_as_no(monkeypatch, tmp_path, capsys):
+    """Test that /deny token is treated as negative for yes/no prompts."""
+    monkeypatch.setattr(hermes_main.subprocess, "run", lambda *a, **k: (_ for _ in ()).throw(AssertionError("unexpected command")))
+    monkeypatch.setattr("builtins.input", lambda: "/deny")
+
+    restored = hermes_main._restore_stashed_changes(["git"], tmp_path, "abc123", prompt_user=True)
+
+    assert restored is False
+    out = capsys.readouterr().out
+    assert "Restore local changes now? [Y/n]" in out
+    assert "Your changes are still preserved in git stash." in out
+
+
+def test_restore_stashed_changes_treats_approve_yes_mixed(monkeypatch, tmp_path, capsys):
+    """Test that /approve yes is treated as affirmative."""
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[1:3] == ["stash", "apply"]:
+            return SimpleNamespace(stdout="applied\n", stderr="", returncode=0)
+        if cmd[1:3] == ["diff", "--name-only"]:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if cmd[1:3] == ["stash", "list"]:
+            return SimpleNamespace(stdout="stash@{0} abc123\n", stderr="", returncode=0)
+        if cmd[1:3] == ["stash", "drop"]:
+            return SimpleNamespace(stdout="dropped\n", stderr="", returncode=0)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+    monkeypatch.setattr("builtins.input", lambda: "/approve yes")
+
+    restored = hermes_main._restore_stashed_changes(["git"], tmp_path, "abc123", prompt_user=True)
+
+    assert restored is True
+    assert calls[0][0] == ["git", "stash", "apply", "abc123"]
+
 
 def test_print_stash_cleanup_guidance_with_selector(capsys):
     hermes_main._print_stash_cleanup_guidance("abc123", "stash@{2}")


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in the `/update` command's yes/no prompt normalization. When a user responds with mixed input like `Y /approve` or `/approve yes`, the prompt logic previously treated it as a negative response because the full string didn't match the expected `{"", "y", "yes"}` set. This caused Hermes to skip restoring stashed local changes despite the user's clear affirmative intent.

The fix normalizes responses by:
1. Checking for `/approve` token first and treating it as affirmative
2. Checking for `/deny` token and treating it as negative
3. Falling back to first-word extraction for natural language responses

This approach handles all the patterns mentioned in the issue: `y`, `Y`, `yes`, `/approve`, `Y /approve`, `/approve yes`, and their `/deny` counterparts.


## Related Issue

Fixes #61627


## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)


## Changes Made

- `hermes_cli/main.py`: Added response normalization in `_restore_stashed_changes()` to handle `/approve` and `/deny` tokens (10 lines)
- `tests/hermes_cli/test_update_autostash.py`: Added 4 new tests covering mixed input patterns (87 lines)


## How to Test

Run the new tests that verify the fix:

```bash
python -m pytest tests/hermes_cli/test_update_autostash.py::test_restore_stashed_changes_treats_slash_approve_as_yes -xvs
python -m pytest tests/hermes_cli/test_update_autostash.py::test_restore_stashed_changes_treats_slash_approve_only_as_yes -xvs
python -m pytest tests/hermes_cli/test_update_autostash.py::test_restore_stashed_changes_treats_slash_deny_as_no -xvs
python -m pytest tests/hermes_cli/test_update_autostash.py::test_restore_stashed_changes_treats_approve_yes_mixed -xvs
```

All tests pass. The fix handles:
- `Y /approve` → treated as yes (restores stash)
- `/approve` alone → treated as yes (restores stash)
- `/approve yes` → treated as yes (restores stash)
- `/deny` → treated as no (skips restore)


## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_update_autostash.py -q` and all tests pass (37 tests)
- [x] I've added tests for my changes (4 new tests covering /approve, /deny, and mixed inputs)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (no docs needed for this fix)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config changes)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (no architecture changes)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (fix works on all platforms)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no tool changes)