### PR TITLE
fix(feishu): render Markdown tables natively instead of falling back to plain text (#61643)

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -151,8 +151,12 @@ logger = logging.getLogger(__name__)
 # Regex patterns
 # ---------------------------------------------------------------------------
 
+# Markdown-style content we want to render via post-type 'md' elements.
+# Tables are included so a message containing ONLY a markdown table still
+# routes to post (without this, the `_MARKDOWN_HINT_RE` check below would
+# fall through to plain text and show raw pipes).
 _MARKDOWN_HINT_RE = re.compile(
-    r"(^#{1,6}\s)|(^\s*[-*]\s)|(^\s*\d+\.\s)|(^\s*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^*\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s)",
+    r"(^#{1,6}\s)|(^\s*[-*]\s)|(^\s*\d+\.\s)|(^\s*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^*\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s)|(^\|.*\|)",
     re.MULTILINE,
 )
 # Detect markdown tables: a line starting with | followed by a separator line.
@@ -4522,12 +4526,10 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
+        # Feishu post-type 'md' elements DO render GFM markdown tables natively
+        # (verified 2026-07-10: pipes + separator lines render as proper
+        # tables on both PC and mobile). Keep the original markdown untouched
+        # and route to 'post' so tables, bold, lists, code, etc. all render.
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}


### PR DESCRIPTION
Fixes #61643.

## Summary

The Feishu outbound payload builder was force-routing any message containing a Markdown table to the `text` message type, based on an outdated assumption that post-type `md` elements do not render tables.

Verified on Feishu IM (PC + mobile, 2026-07-10) that GFM tables now render natively inside `md` elements — pipe syntax and separator lines render as proper tables with column alignment (left/right/center via `:---` / `---:` / `:---:`).

## Changes

1. **`_MARKDOWN_HINT_RE`** — added `(^\|.*\|)` so messages containing only a Markdown table still route to `post`. The existing regex had no clause matching `|`, which meant table-only messages fell through to plain text.
2. **`_build_outbound_payload`** — removed the force-`text` branch for content matching `_MARKDOWN_TABLE_RE`. Tables now flow through the standard Markdown rendering path.

Net diff: +9 / −7 lines.

## Testing

Stress-tested locally with `hermes send --to feishu`:

- 2-column simple table → renders correctly
- 4-column table with mixed bold + list + table → renders correctly
- 8-column × 12-row English table → renders with horizontal scroll on mobile (expected)
- 5-column Chinese table → Unicode preserved, no garbled headers
- Long cell content → wraps within cell, doesn't break layout
- Code block containing `|` → not misidentified as table

## Impact

Currently 100% affected: every Feishu message containing a Markdown table displays raw pipe syntax. After this fix, tables render natively.

## Environment

- Hermes: latest main
- Feishu client: PC + iOS, 2026-07-10
- Repro: `hermes send --to feishu --file <md_with_table.md>`