### PR TITLE
feat(state): add user-scoped execution artifacts

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3851,6 +3851,46 @@ def _strip_session_list_rows(sessions: List[Dict[str, Any]]) -> List[Dict[str, A
     return sessions
 
 
+@app.get("/api/execution-artifacts")
+def get_execution_artifacts(
+    run_id: str,
+    user_id: str,
+    limit: int = 100,
+    offset: int = 0,
+):
+    """Return dashboard artifacts scoped to one run and one user."""
+    from hermes_state import DEFAULT_DB_PATH, SessionDB
+
+    if not DEFAULT_DB_PATH.exists():
+        return {
+            "artifacts": [],
+            "total": 0,
+            "run_id": run_id,
+            "user_id": user_id,
+            "limit": limit,
+            "offset": offset,
+        }
+
+    db = SessionDB(read_only=True)
+    try:
+        artifacts = db.list_execution_artifacts(
+            run_id=run_id,
+            user_id=user_id,
+            limit=limit,
+            offset=offset,
+        )
+        return {
+            "artifacts": artifacts,
+            "total": len(artifacts),
+            "run_id": run_id,
+            "user_id": user_id,
+            "limit": min(max(limit, 1), 500),
+            "offset": max(offset, 0),
+        }
+    finally:
+        db.close()
+
+
 @app.get("/api/sessions")
 def get_sessions(
     limit: int = 20,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -15,6 +15,7 @@ Key design decisions:
 """
 
 import asyncio
+import hashlib
 import json
 import logging
 import random
@@ -23,6 +24,7 @@ import sqlite3
 import sys
 import threading
 import time
+import uuid
 from pathlib import Path
 
 from agent.memory_manager import sanitize_context
@@ -122,7 +124,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 19
+SCHEMA_VERSION = 20
 
 # Cap on user-controlled FTS5 query input before regex/sanitizer processing.
 # Search queries do not need to be arbitrarily large, and bounding them keeps
@@ -787,12 +789,36 @@ CREATE TABLE IF NOT EXISTS compression_locks (
     expires_at REAL NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS execution_artifacts (
+    artifact_id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    execution_id TEXT NOT NULL,
+    parent_execution_id TEXT,
+    user_id TEXT NOT NULL,
+    task_id TEXT,
+    source TEXT NOT NULL,
+    artifact_type TEXT NOT NULL,
+    artifact_uri TEXT,
+    content_hash TEXT NOT NULL,
+    content_preview TEXT,
+    parser_status TEXT NOT NULL DEFAULT 'pending',
+    visibility_status TEXT NOT NULL DEFAULT 'pending',
+    status_reason TEXT,
+    metadata TEXT,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL
+);
+
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_sessions_source_id ON sessions(source, id);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
 CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(expires_at);
+CREATE INDEX IF NOT EXISTS idx_execution_artifacts_user_run
+    ON execution_artifacts(user_id, run_id, created_at);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_execution_artifacts_idempotency
+    ON execution_artifacts(user_id, run_id, execution_id, artifact_type, content_hash);
 """
 
 # Indexes that reference columns added in later schema versions must be
@@ -2373,6 +2399,177 @@ class SessionDB:
                 (model, session_id),
             )
         self._execute_write(_do)
+
+    @staticmethod
+    def _execution_artifact_row_to_dict(row: sqlite3.Row) -> Dict[str, Any]:
+        data = dict(row)
+        raw_metadata = data.get("metadata")
+        if raw_metadata:
+            try:
+                data["metadata"] = json.loads(raw_metadata)
+            except (TypeError, json.JSONDecodeError):
+                data["metadata"] = {}
+        else:
+            data["metadata"] = {}
+        return data
+
+    @staticmethod
+    def _execution_artifact_preview(content: Optional[str], limit: int = 500) -> str:
+        if not content:
+            return ""
+        preview = sanitize_context(str(content))
+        if len(preview) > limit:
+            return preview[: limit - 1] + "…"
+        return preview
+
+    def record_execution_artifact(
+        self,
+        *,
+        run_id: str,
+        execution_id: str,
+        user_id: str,
+        source: str,
+        artifact_type: str,
+        content: Optional[str] = None,
+        parent_execution_id: Optional[str] = None,
+        task_id: Optional[str] = None,
+        artifact_uri: Optional[str] = None,
+        parser_status: str = "pending",
+        visibility_status: str = "pending",
+        status_reason: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Create a durable, user-scoped execution artifact envelope.
+
+        Replays for the same user, run, execution, artifact type, and content
+        return the existing row. The user scope is part of both the unique key
+        and lookup so identical executions from different users cannot collide.
+        """
+        required = {
+            "run_id": run_id,
+            "execution_id": execution_id,
+            "user_id": user_id,
+            "source": source,
+            "artifact_type": artifact_type,
+        }
+        for field, value in required.items():
+            if not value:
+                raise ValueError(f"{field} is required for execution artifacts")
+
+        now = time.time()
+        content_text = "" if content is None else str(content)
+        content_hash = hashlib.sha256(content_text.encode("utf-8")).hexdigest()
+        artifact_id = str(uuid.uuid4())
+        metadata_json = json.dumps(metadata or {}, sort_keys=True)
+        content_preview = self._execution_artifact_preview(content_text)
+
+        def _do(conn):
+            conn.execute(
+                """INSERT OR IGNORE INTO execution_artifacts (
+                   artifact_id, run_id, execution_id, parent_execution_id,
+                   user_id, task_id, source, artifact_type, artifact_uri,
+                   content_hash, content_preview, parser_status,
+                   visibility_status, status_reason, metadata, created_at,
+                   updated_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    artifact_id,
+                    run_id,
+                    execution_id,
+                    parent_execution_id,
+                    user_id,
+                    task_id,
+                    source,
+                    artifact_type,
+                    artifact_uri,
+                    content_hash,
+                    content_preview,
+                    parser_status,
+                    visibility_status,
+                    status_reason,
+                    metadata_json,
+                    now,
+                    now,
+                ),
+            )
+            row = conn.execute(
+                """SELECT * FROM execution_artifacts
+                   WHERE user_id = ? AND run_id = ? AND execution_id = ?
+                     AND artifact_type = ? AND content_hash = ?""",
+                (user_id, run_id, execution_id, artifact_type, content_hash),
+            ).fetchone()
+            if row is None:
+                raise RuntimeError("execution artifact insert did not return a row")
+            return self._execution_artifact_row_to_dict(row)
+
+        return self._execute_write(_do)
+
+    def record_parser_result_artifact(
+        self,
+        *,
+        raw_artifact_id: str,
+        parser_status: str,
+        status_reason: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Persist a parser outcome without overwriting the raw artifact."""
+        raw = self._conn.execute(
+            "SELECT * FROM execution_artifacts WHERE artifact_id = ?",
+            (raw_artifact_id,),
+        ).fetchone()
+        if raw is None:
+            raise ValueError(f"raw artifact not found: {raw_artifact_id}")
+        raw_data = self._execution_artifact_row_to_dict(raw)
+        parser_metadata = {
+            "raw_artifact_id": raw_artifact_id,
+            **(metadata or {}),
+        }
+        content = json.dumps(
+            {
+                "raw_artifact_id": raw_artifact_id,
+                "parser_status": parser_status,
+                "status_reason": status_reason,
+            },
+            sort_keys=True,
+        )
+        return self.record_execution_artifact(
+            run_id=raw_data["run_id"],
+            execution_id=raw_data["execution_id"],
+            parent_execution_id=raw_data.get("parent_execution_id"),
+            user_id=raw_data["user_id"],
+            task_id=raw_data.get("task_id"),
+            source="parser",
+            artifact_type="parser_result",
+            content=content,
+            parser_status=parser_status,
+            visibility_status="pending",
+            status_reason=status_reason,
+            metadata=parser_metadata,
+        )
+
+    def list_execution_artifacts(
+        self,
+        *,
+        run_id: str,
+        user_id: str,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> List[Dict[str, Any]]:
+        """Return execution artifacts scoped to exactly one user and run."""
+        if not run_id:
+            raise ValueError("run_id is required for execution artifacts")
+        if not user_id:
+            raise ValueError("user_id is required for execution artifacts")
+        bounded_limit = min(max(int(limit), 1), 500)
+        bounded_offset = max(int(offset), 0)
+        rows = self._conn.execute(
+            """SELECT * FROM execution_artifacts
+               WHERE user_id = ? AND run_id = ?
+               ORDER BY created_at ASC, artifact_id ASC
+               LIMIT ? OFFSET ?""",
+            (user_id, run_id, bounded_limit, bounded_offset),
+        ).fetchall()
+        return [self._execution_artifact_row_to_dict(row) for row in rows]
 
     def update_session_billing_route(
         self,

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1883,6 +1883,44 @@ class TestWebServerEndpoints:
         # Should contain known env var names
         assert any(k.endswith("_API_KEY") or k.endswith("_TOKEN") for k in data.keys())
 
+    def test_get_execution_artifacts_scopes_by_user_and_run(self):
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.record_execution_artifact(
+                run_id="dashboard-run",
+                execution_id="exec-a",
+                user_id="user-a",
+                source="specialist",
+                artifact_type="stdout",
+                content="visible artifact",
+            )
+            db.record_execution_artifact(
+                run_id="dashboard-run",
+                execution_id="exec-b",
+                user_id="user-b",
+                source="specialist",
+                artifact_type="stdout",
+                content="other user artifact",
+            )
+        finally:
+            db.close()
+
+        resp = self.client.get(
+            "/api/execution-artifacts?run_id=dashboard-run&user_id=user-a"
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["run_id"] == "dashboard-run"
+        assert data["user_id"] == "user-a"
+        assert data["total"] == 1
+        assert data["artifacts"][0]["execution_id"] == "exec-a"
+        assert data["artifacts"][0]["content_preview"] == "visible artifact"
+        assert data["artifacts"][0]["parser_status"] == "pending"
+        assert data["artifacts"][0]["visibility_status"] == "pending"
+
     def test_get_env_vars_marks_channel_managed_keys(self):
         from hermes_cli.web_server import _channel_managed_env_keys
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -648,6 +648,119 @@ class TestSessionLifecycle:
 
 
 # =========================================================================
+# Execution artifact visibility
+# =========================================================================
+
+class TestExecutionArtifacts:
+    def test_execution_artifact_created_for_successful_run(self, db):
+        artifact = db.record_execution_artifact(
+            run_id="run-1",
+            execution_id="exec-1",
+            user_id="user-a",
+            source="specialist",
+            artifact_type="stdout",
+            content="successful output",
+        )
+
+        artifacts = db.list_execution_artifacts(run_id="run-1", user_id="user-a")
+
+        assert len(artifacts) == 1
+        assert artifacts[0]["artifact_id"] == artifact["artifact_id"]
+        assert artifacts[0]["user_id"] == "user-a"
+        assert artifacts[0]["parser_status"] == "pending"
+        assert artifacts[0]["visibility_status"] == "pending"
+        assert artifacts[0]["content_preview"] == "successful output"
+
+    def test_replay_is_idempotent_within_user_scope(self, db):
+        first = db.record_execution_artifact(
+            run_id="run-replay",
+            execution_id="exec-replay",
+            user_id="user-a",
+            source="specialist",
+            artifact_type="stdout",
+            content="same output",
+        )
+        second = db.record_execution_artifact(
+            run_id="run-replay",
+            execution_id="exec-replay",
+            user_id="user-a",
+            source="specialist",
+            artifact_type="stdout",
+            content="same output",
+        )
+
+        assert second["artifact_id"] == first["artifact_id"]
+        assert len(db.list_execution_artifacts(run_id="run-replay", user_id="user-a")) == 1
+
+    def test_identical_artifacts_do_not_collide_across_users(self, db):
+        first = db.record_execution_artifact(
+            run_id="shared-run",
+            execution_id="shared-exec",
+            user_id="user-a",
+            source="specialist",
+            artifact_type="stdout",
+            content="same output",
+        )
+        second = db.record_execution_artifact(
+            run_id="shared-run",
+            execution_id="shared-exec",
+            user_id="user-b",
+            source="specialist",
+            artifact_type="stdout",
+            content="same output",
+        )
+
+        assert first["artifact_id"] != second["artifact_id"]
+        assert [
+            row["artifact_id"]
+            for row in db.list_execution_artifacts(run_id="shared-run", user_id="user-a")
+        ] == [first["artifact_id"]]
+        assert [
+            row["artifact_id"]
+            for row in db.list_execution_artifacts(run_id="shared-run", user_id="user-b")
+        ] == [second["artifact_id"]]
+
+    def test_parser_failure_preserves_raw_artifact(self, db):
+        raw = db.record_execution_artifact(
+            run_id="run-parse-fail",
+            execution_id="exec-parse-fail",
+            user_id="user-a",
+            source="specialist",
+            artifact_type="json",
+            content="{not valid json",
+        )
+
+        parser_result = db.record_parser_result_artifact(
+            raw_artifact_id=raw["artifact_id"],
+            parser_status="failed",
+            status_reason="invalid JSON at byte 1",
+        )
+
+        artifacts = db.list_execution_artifacts(run_id="run-parse-fail", user_id="user-a")
+
+        assert len(artifacts) == 2
+        raw_after = next(a for a in artifacts if a["artifact_id"] == raw["artifact_id"])
+        parser_after = next(a for a in artifacts if a["artifact_id"] == parser_result["artifact_id"])
+        assert raw_after["artifact_type"] == "json"
+        assert raw_after["parser_status"] == "pending"
+        assert raw_after["content_preview"] == "{not valid json"
+        assert parser_after["artifact_type"] == "parser_result"
+        assert parser_after["parser_status"] == "failed"
+        assert parser_after["status_reason"] == "invalid JSON at byte 1"
+        assert parser_after["metadata"]["raw_artifact_id"] == raw["artifact_id"]
+
+    def test_user_scope_is_required(self, db):
+        with pytest.raises(ValueError, match="user_id is required"):
+            db.record_execution_artifact(
+                run_id="run-1",
+                execution_id="exec-1",
+                user_id="",
+                source="specialist",
+                artifact_type="stdout",
+            )
+
+
+# =========================================================================
 # Message storage
 # =========================================================================
 
@@ -2778,6 +2891,7 @@ class TestSchemaInit:
         assert "sessions" in tables
         assert "messages" in tables
         assert "schema_version" in tables
+        assert "execution_artifacts" in tables
 
     def test_schema_version(self, db):
         from hermes_state import SCHEMA_VERSION


### PR DESCRIPTION
## What changed

- adds a schema-versioned `execution_artifacts` table for durable run outputs
- records raw and parser-result artifacts without overwriting source evidence
- exposes a session-token-protected dashboard endpoint scoped by `run_id` and `user_id`
- sanitizes stored previews, bounds pagination, and makes same-user replay idempotent
- adds state, schema, parser-failure, API, and cross-user isolation tests

## Why

Hermes can persist sessions, but downstream run outputs need a separate durable envelope so dashboards and orchestration surfaces can inspect evidence without treating it as conversation history.

## Isolation and safety

`user_id` is mandatory and is included in the unique idempotency key, insert lookup, and list query. This prevents identical run/execution/content tuples from colliding across users. Raw artifact rows remain intact when parser-result artifacts are added.

## Validation

- `pytest tests/test_hermes_state.py -q` — 344 passed
- `pytest tests/hermes_cli/test_web_server.py -q -k execution_artifacts` — 1 passed
- `python -m py_compile hermes_state.py hermes_cli/web_server.py`
- `git diff --check`

The feature was ported onto current upstream `main`; older local changes already superseded upstream were deliberately excluded.
