### PR TITLE
fix(compression): preserve active work and visible transcript

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2442,6 +2442,36 @@ This compaction should PRIORITISE preserving all information related to the focu
             idx = check
         return idx
 
+    def _protect_active_user_boundary(
+        self, messages: List[Dict[str, Any]], compress_start: int
+    ) -> int:
+        """Keep an in-flight turn's user request outside the summary window.
+
+        A user can land exactly at ``compress_start`` when the protected head
+        ends immediately before a long assistant/tool run.  The tail anchor
+        cannot pull the cut back to that same boundary because that would leave
+        no compressible window, so the old causal-coupling fallback summarized
+        the request with the first tool group.  The resumed model then had no
+        real user instruction to continue.
+
+        When the transcript still ends in tool work, extend the protected head
+        through that user and align past the first complete tool group.  Later
+        tool groups remain compressible, while the active request stays verbatim.
+        Completed turns (a terminal assistant reply) keep the existing boundary.
+        """
+        last_user_idx = self._find_last_user_message_idx(messages, 0)
+        if last_user_idx != compress_start or not messages:
+            return compress_start
+
+        tail = messages[-1]
+        turn_is_in_flight = tail.get("role") == "tool" or (
+            tail.get("role") == "assistant" and bool(tail.get("tool_calls"))
+        )
+        if not turn_is_in_flight:
+            return compress_start
+
+        return self._find_turn_pair_end(messages, last_user_idx)
+
     # ------------------------------------------------------------------
     # Tail protection by token budget
     # ------------------------------------------------------------------
@@ -2783,6 +2813,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         the protected head/tail.
         """
         compress_start = self._align_boundary_forward(messages, self._protect_head_size(messages))
+        compress_start = self._protect_active_user_boundary(messages, compress_start)
         compress_end = self._find_tail_cut_by_tokens(messages, compress_start)
         return compress_start < compress_end
 
@@ -2860,6 +2891,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         # Phase 2: Determine boundaries
         compress_start = self._protect_head_size(messages)
         compress_start = self._align_boundary_forward(messages, compress_start)
+        compress_start = self._protect_active_user_boundary(messages, compress_start)
 
         # Use token-budget tail protection instead of fixed message count
         compress_end = self._find_tail_cut_by_tokens(messages, compress_start)
@@ -3164,5 +3196,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         # are positional; this single terminal sweep makes it structural so a
         # future copy site cannot re-leak the marker into the child-session flush.
         _strip_persistence_markers(compressed)
+        for message in compressed:
+            message["_context_snapshot"] = True
 
         return compressed

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -704,6 +704,11 @@ def compress_context(
         if todo_snapshot:
             compressed.append({"role": "user", "content": todo_snapshot})
         _ensure_compressed_has_user_turn(messages, compressed)
+        # Everything assembled for the post-compaction model context is a
+        # replay snapshot. Mark after TODO/user continuity additions so none of
+        # that synthetic state is mistaken for a durable chat turn.
+        for message in compressed:
+            message["_context_snapshot"] = True
 
         agent._invalidate_system_prompt()
         new_system_prompt = agent._build_system_prompt(system_message)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1819,9 +1819,9 @@ class APIServerAdapter(BasePlatformAdapter):
             return err
         db = self._ensure_session_db()
         resolved_id = db.resolve_resume_session_id(session_id)
-        messages = db.get_messages_as_conversation(resolved_id, include_ancestors=True)
-        # Strip tool-call fields the WebUI doesn't need and get_messages_as_conversation
-        # includes for model replay. Keep role, content, finish_reason, reasoning_content.
+        messages = db.get_messages_for_display(resolved_id, include_ancestors=True)
+        # Strip tool-call fields the WebUI doesn't need and the display loader
+        # preserves from durable rows. Keep role, content, finish_reason, reasoning_content.
         display_messages = []
         for m in messages:
             msg = {"role": m["role"], "content": m.get("content", "")}

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1819,11 +1819,27 @@ class APIServerAdapter(BasePlatformAdapter):
             return err
         db = self._ensure_session_db()
         resolved_id = db.resolve_resume_session_id(session_id)
-        messages = db.get_messages(resolved_id)
+        messages = db.get_messages_as_conversation(resolved_id, include_ancestors=True)
+        # Strip tool-call fields the WebUI doesn't need and get_messages_as_conversation
+        # includes for model replay. Keep role, content, finish_reason, reasoning_content.
+        display_messages = []
+        for m in messages:
+            msg = {"role": m["role"], "content": m.get("content", "")}
+            if m.get("finish_reason"):
+                msg["finish_reason"] = m["finish_reason"]
+            if m.get("reasoning_content"):
+                msg["reasoning_content"] = m["reasoning_content"]
+            if m.get("tool_calls"):
+                msg["tool_calls"] = m["tool_calls"]
+            if m.get("tool_call_id"):
+                msg["tool_call_id"] = m["tool_call_id"]
+            if m.get("tool_name"):
+                msg["tool_name"] = m["tool_name"]
+            display_messages.append(msg)
         return web.json_response({
             "object": "list",
             "session_id": resolved_id,
-            "data": [self._message_response(m) for m in messages],
+            "data": [self._message_response(m) for m in display_messages],
         })
 
     async def _handle_fork_session(self, request: "web.Request") -> "web.Response":
@@ -1885,8 +1901,10 @@ class APIServerAdapter(BasePlatformAdapter):
         _, err = self._get_existing_session_or_404(session_id)
         if err:
             return err
+        db = self._ensure_session_db()
+        session_id = db.resolve_resume_session_id(session_id)
         body, err = await self._read_json_body(request)
-        if err:
+        if err is not None:
             return err
         user_message, err = _session_chat_user_message(body)
         if err is not None:
@@ -1929,6 +1947,8 @@ class APIServerAdapter(BasePlatformAdapter):
         _, err = self._get_existing_session_or_404(session_id)
         if err:
             return err
+        db = self._ensure_session_db()
+        session_id = db.resolve_resume_session_id(session_id)
         body, err = await self._read_json_body(request)
         if err:
             return err

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -2281,6 +2281,9 @@ class SessionStore:
                     ),
                     observed=bool(message.get("observed")),
                     timestamp=message.get("timestamp"),
+                    context_snapshot=bool(
+                        message.get("_context_snapshot") or message.get("context_snapshot")
+                    ),
                 )
             except Exception as e:
                 logger.debug("Session DB operation failed: %s", e)
@@ -2320,7 +2323,11 @@ class SessionStore:
         if not self._db:
             return True
         try:
-            self._db.replace_messages(session_id, messages)
+            self._db.replace_messages(
+                session_id,
+                messages,
+                active_only=self._db.has_archived_messages(session_id),
+            )
             return True
         except Exception as e:
             logger.debug("Failed to rewrite transcript in DB: %s", e)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -235,26 +235,25 @@ def _is_background_review_harness_message(msg: Dict[str, Any]) -> bool:
 def _strip_background_review_harness(
     messages: List[Dict[str, Any]],
 ) -> List[Dict[str, Any]]:
-    """Drop background-review harness messages and the curator-mode assistant
-    reply that immediately followed each one.
+    """Drop a polluted background-review turn through its terminal reply.
 
-    Walk the list once; when a harness user/system message is found, skip it and
-    also skip the next message if it is the assistant turn that answered it.
-    Everything else passes through untouched and in order.
+    Older curator forks could persist a complete assistant/tool chain under the
+    real session id. Once a harness is found, discard every assistant/tool row
+    until the next genuine user/system turn starts.
     """
     if not messages:
         return messages
     out: List[Dict[str, Any]] = []
-    skip_next_assistant = False
+    in_review_turn = False
     for msg in messages:
         if _is_background_review_harness_message(msg):
-            skip_next_assistant = True
+            in_review_turn = True
             continue
-        if skip_next_assistant:
-            skip_next_assistant = False
-            if isinstance(msg, dict) and msg.get("role") == "assistant":
-                # The curator-mode reply to the harness prompt — drop it.
+        if in_review_turn:
+            role = msg.get("role") if isinstance(msg, dict) else None
+            if role not in {"user", "system"}:
                 continue
+            in_review_turn = False
         out.append(msg)
     return out
 
@@ -764,7 +763,8 @@ CREATE TABLE IF NOT EXISTS messages (
     platform_message_id TEXT,
     observed INTEGER DEFAULT 0,
     active INTEGER NOT NULL DEFAULT 1,
-    compacted INTEGER NOT NULL DEFAULT 0
+    compacted INTEGER NOT NULL DEFAULT 0,
+    context_snapshot INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS state_meta (
@@ -3456,6 +3456,7 @@ class SessionDB:
         platform_message_id: str = None,
         observed: bool = False,
         timestamp: Any = None,
+        context_snapshot: bool = False,
     ) -> int:
         """
         Append a message to a session. Returns the message row ID.
@@ -3507,8 +3508,9 @@ class SessionDB:
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed, active)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, observed, active,
+                   context_snapshot)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -3527,6 +3529,7 @@ class SessionDB:
                     platform_message_id,
                     1 if observed else 0,
                     1,
+                    1 if context_snapshot else 0,
                 ),
             )
             msg_id = cursor.lastrowid
@@ -3599,8 +3602,9 @@ class SessionDB:
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed, active)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, observed, active,
+                   context_snapshot)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -3619,6 +3623,7 @@ class SessionDB:
                     platform_msg_id,
                     1 if msg.get("observed") else 0,
                     1,
+                    1 if (msg.get("_context_snapshot") or msg.get("context_snapshot")) else 0,
                 ),
             )
             inserted += 1
@@ -3730,8 +3735,12 @@ class SessionDB:
                 "WHERE session_id = ? AND active = 1",
                 (session_id,),
             )
+            snapshot_messages = [
+                {**message, "_context_snapshot": True}
+                for message in compacted_messages
+            ]
             inserted, tool_calls_total = self._insert_message_rows(
-                conn, session_id, compacted_messages
+                conn, session_id, snapshot_messages
             )
             # message_count / tool_call_count reflect the LIVE (active) set —
             # the archived rows are still on disk but not part of the live count.
@@ -4105,7 +4114,8 @@ class SessionDB:
             rows = self._conn.execute(
                 "SELECT role, content, tool_call_id, tool_calls, tool_name, "
                 "finish_reason, reasoning, reasoning_content, reasoning_details, "
-                "codex_reasoning_items, codex_message_items, platform_message_id, observed, timestamp "
+                "codex_reasoning_items, codex_message_items, platform_message_id, observed, "
+                "timestamp, context_snapshot "
                 f"FROM messages WHERE session_id IN ({placeholders})"
                 # Order by AUTOINCREMENT id (true insertion order), NOT timestamp:
                 # append_message stamps rows with time.time(), which is not
@@ -4146,6 +4156,8 @@ class SessionDB:
                 msg["message_id"] = row["platform_message_id"]
             if row["observed"]:
                 msg["observed"] = True
+            if row["context_snapshot"]:
+                msg["_context_snapshot"] = True
             # Restore reasoning fields on assistant messages so providers
             # that replay reasoning (OpenRouter, OpenAI, Nous) receive
             # coherent multi-turn reasoning context.
@@ -4189,6 +4201,113 @@ class SessionDB:
         # resumes clean even if stray rows exist.
         messages = _strip_background_review_harness(messages)
         return messages
+
+    def get_messages_for_display(
+        self, session_id: str, include_ancestors: bool = False
+    ) -> List[Dict[str, Any]]:
+        """Return the durable user-visible transcript, not the model context.
+
+        New compaction snapshots carry ``context_snapshot=1`` and are excluded
+        structurally.  A conservative boundary-overlap fallback handles legacy
+        rotation/in-place rows created before that marker existed without
+        globally deduplicating legitimate repeated messages.
+        """
+        from agent.context_compressor import ContextCompressor
+
+        session_ids = (
+            self._session_lineage_root_to_tip(session_id)
+            if include_ancestors
+            else [session_id]
+        )
+        display: List[Dict[str, Any]] = []
+
+        def _signature(msg: Dict[str, Any]) -> str:
+            content = msg.get("content")
+            if isinstance(content, str):
+                content = sanitize_context(content).strip()
+            return json.dumps(
+                {
+                    "role": msg.get("role"),
+                    "content": content,
+                    "tool_call_id": msg.get("tool_call_id"),
+                    "tool_calls": msg.get("tool_calls"),
+                    "tool_name": msg.get("tool_name"),
+                },
+                sort_keys=True,
+                ensure_ascii=False,
+                default=str,
+            )
+
+        def _append_sanitized(rows: List[Dict[str, Any]]) -> None:
+            for raw in rows:
+                row = dict(raw)
+                content = row.get("content")
+                if isinstance(content, str):
+                    row["content"] = sanitize_context(content).strip()
+                display.append(row)
+
+        def _prefix_overlap(left: List[Dict[str, Any]], right: List[Dict[str, Any]]) -> int:
+            size = min(len(left), len(right))
+            matched = 0
+            while matched < size and _signature(left[matched]) == _signature(right[matched]):
+                matched += 1
+            return matched
+
+        def _tail_overlap(rows: List[Dict[str, Any]]) -> int:
+            max_overlap = min(len(rows), len(display))
+            for size in range(max_overlap, 0, -1):
+                if (
+                    [_signature(row) for row in rows[:size]]
+                    == [_signature(row) for row in display[-size:]]
+                ):
+                    return size
+            return 0
+
+        for lineage_id in session_ids:
+            rows = [
+                row for row in self.get_messages(lineage_id, include_inactive=True)
+                if (row.get("active", 1) or row.get("compacted", 0))
+                and not row.get("context_snapshot")
+            ]
+
+            # Legacy snapshots predate context_snapshot. Split on each handoff
+            # summary, then remove only the copied head/tail overlaps at segment
+            # boundaries. Marked snapshots were already removed above, so mixed
+            # pre-marker/post-marker sessions still retain their real turns.
+            segments: List[List[Dict[str, Any]]] = [[]]
+            for row in rows:
+                if ContextCompressor._is_context_summary_content(row.get("content")):
+                    segments.append([])
+                else:
+                    segments[-1].append(row)
+
+            if len(segments) == 1:
+                _append_sanitized(segments[0])
+                continue
+
+            for index, segment in enumerate(segments):
+                candidate = list(segment)
+                if index == 0:
+                    candidate = candidate[_prefix_overlap(candidate, display):]
+                else:
+                    candidate = candidate[_tail_overlap(candidate):]
+
+                # A snapshot's protected head sits immediately before the next
+                # summary. Remove the longest proper suffix matching the visible
+                # transcript prefix, including the same-session first generation.
+                if index < len(segments) - 1 and candidate:
+                    reference = display + candidate
+                    max_suffix = min(len(candidate) - 1, len(reference))
+                    for size in range(max_suffix, 0, -1):
+                        if (
+                            [_signature(row) for row in candidate[-size:]]
+                            == [_signature(row) for row in reference[:size]]
+                        ):
+                            candidate = candidate[:-size]
+                            break
+                _append_sanitized(candidate)
+
+        return _strip_background_review_harness(display)
 
     def _session_lineage_root_to_tip(self, session_id: str) -> List[str]:
         if not session_id:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1901,6 +1901,7 @@ class AIAgent:
                     codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
                     codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
                     timestamp=_row_timestamp,
+                    context_snapshot=bool(msg.get("_context_snapshot")),
                 )
                 msg[_DB_PERSISTED_MARKER] = True
             # The intrinsic markers are now the sole source of truth. Reset the

--- a/tests/agent/test_compressor_assistant_tail_anchor.py
+++ b/tests/agent/test_compressor_assistant_tail_anchor.py
@@ -479,6 +479,86 @@ class TestCompactionRollupReproduction:
             f"{len(reply_rows)}"
         )
 
+    def test_active_user_at_head_boundary_survives_mid_turn_compaction(
+        self, compressor
+    ):
+        """Compaction during a long tool run must keep the request that started it.
+
+        With ``protect_first_n=2`` the active user lands exactly at the first
+        compressible index.  The old causal-coupling guard moved the cut beyond
+        that user and the first tool group, so the resumed model saw only a
+        handoff summary and often stopped, returned a fragment, or waited for a
+        repeated prompt.
+        """
+        from agent.context_compressor import (
+            SUMMARY_PREFIX,
+            COMPRESSED_SUMMARY_METADATA_KEY,
+        )
+
+        c = compressor
+        c.tail_token_budget = 10
+        active_request = "Finish the implementation, verify it, and report the result."
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "older question"},
+            {"role": "assistant", "content": "older answer"},
+            {"role": "user", "content": active_request},
+        ]
+        for i in range(2):
+            call_id = f"call-{i}"
+            messages.extend([
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [{
+                        "id": call_id,
+                        "function": {"name": "terminal", "arguments": "{}"},
+                    }],
+                },
+                {
+                    "role": "tool",
+                    "content": f"tool output {i} " + ("x" * 200),
+                    "tool_call_id": call_id,
+                },
+            ])
+
+        with patch.object(
+            c,
+            "_generate_summary",
+            return_value=f"{SUMMARY_PREFIX}\nwork completed so far",
+        ):
+            result = c.compress(messages, current_tokens=90_000)
+
+        assert any(
+            m.get(COMPRESSED_SUMMARY_METADATA_KEY) for m in result
+        ), "test fixture did not trigger compaction"
+        active_rows = [
+            m for m in result
+            if m.get("role") == "user" and m.get("content") == active_request
+        ]
+        assert len(active_rows) == 1, (
+            "Mid-turn compaction lost the active user request, so the agent no "
+            "longer knows what work to continue after the summary handoff."
+        )
+
+        tool_call_ids = {
+            tc["id"]
+            for message in result
+            for tc in (message.get("tool_calls") or [])
+        }
+        tool_result_ids = {
+            message.get("tool_call_id")
+            for message in result
+            if message.get("role") == "tool"
+        }
+        assert tool_call_ids == tool_result_ids
+        assert all(
+            left.get("role") != right.get("role")
+            for left, right in zip(result, result[1:])
+            if left.get("role") in {"user", "assistant"}
+            and right.get("role") in {"user", "assistant"}
+        ), "Compaction introduced adjacent same-role chat messages"
+
 
 # ---------------------------------------------------------------------------
 # Source guardrail

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -189,6 +189,134 @@ async def test_session_messages_follow_compression_tip(adapter, session_db):
 
 
 @pytest.mark.asyncio
+async def test_session_messages_hide_compaction_handoff_and_deduplicate_snapshot(
+    adapter, session_db
+):
+    """The user-facing transcript stays continuous across rotating compaction."""
+    from agent.context_compressor import SUMMARY_PREFIX
+
+    root_id = session_db.create_session("display-root", "api_server")
+    session_db.append_message(root_id, "user", "Build the feature")
+    session_db.append_message(root_id, "assistant", "Working on it")
+    session_db.end_session(root_id, "compression")
+
+    tip_id = session_db.create_session(
+        "display-tip", "api_server", parent_session_id=root_id
+    )
+    session_db.append_message(tip_id, "user", f"{SUMMARY_PREFIX}\ninternal handoff")
+    # A preserved tail row copied into the compacted child must not appear twice.
+    session_db.append_message(tip_id, "assistant", "Working on it")
+    session_db.append_message(tip_id, "assistant", "Finished and verified")
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.get(f"/api/sessions/{root_id}/messages")
+        assert response.status == 200
+        payload = await response.json()
+
+    assert [m["content"] for m in payload["data"]] == [
+        "Build the feature",
+        "Working on it",
+        "Finished and verified",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_session_messages_include_archived_turns_after_in_place_compaction(
+    adapter, session_db
+):
+    """Model-context compaction must not erase the visible chat transcript."""
+    from agent.context_compressor import SUMMARY_PREFIX
+
+    session_id = session_db.create_session("display-in-place", "api_server")
+    session_db.append_message(session_id, "user", "Original request")
+    session_db.append_message(session_id, "assistant", "Original visible answer")
+    session_db.archive_and_compact(
+        session_id,
+        [
+            {"role": "user", "content": f"{SUMMARY_PREFIX}\ninternal handoff"},
+            {"role": "assistant", "content": "Original visible answer"},
+        ],
+    )
+    session_db.append_message(session_id, "assistant", "Continuation after compaction")
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.get(f"/api/sessions/{session_id}/messages")
+        assert response.status == 200
+        payload = await response.json()
+
+    assert [m["content"] for m in payload["data"]] == [
+        "Original request",
+        "Original visible answer",
+        "Continuation after compaction",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_session_messages_preserve_legitimate_repeated_turns(adapter, session_db):
+    """Snapshot removal must not become global content deduplication."""
+    from agent.context_compressor import SUMMARY_PREFIX
+
+    session_id = session_db.create_session("display-repeats", "api_server")
+    for role, content in [
+        ("user", "repeat"),
+        ("assistant", "ack"),
+        ("user", "repeat"),
+        ("assistant", "ack"),
+    ]:
+        session_db.append_message(session_id, role, content)
+    session_db.archive_and_compact(
+        session_id,
+        [{"role": "user", "content": f"{SUMMARY_PREFIX}\ninternal handoff"}],
+    )
+    session_db.append_message(session_id, "user", "repeat")
+    session_db.append_message(session_id, "assistant", "ack")
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.get(f"/api/sessions/{session_id}/messages")
+        assert response.status == 200
+        payload = await response.json()
+
+    assert [(m["role"], m["content"]) for m in payload["data"]] == [
+        ("user", "repeat"),
+        ("assistant", "ack"),
+        ("user", "repeat"),
+        ("assistant", "ack"),
+        ("user", "repeat"),
+        ("assistant", "ack"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_session_messages_sanitize_internal_context_fences(adapter, session_db):
+    session_id = session_db.create_session("display-sanitized", "api_server")
+    session_db.append_message(
+        session_id,
+        "assistant",
+        "<memory-context>PRIVATE INTERNAL MEMORY</memory-context>Visible answer",
+    )
+    session_db.append_message(
+        session_id,
+        "tool",
+        "<memory-context>PRIVATE TOOL MEMORY</memory-context>Visible tool output",
+    )
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.get(f"/api/sessions/{session_id}/messages")
+        assert response.status == 200
+        payload = await response.json()
+
+    rendered = "\n".join(str(message.get("content") or "") for message in payload["data"])
+    assert "PRIVATE INTERNAL MEMORY" not in rendered
+    assert "PRIVATE TOOL MEMORY" not in rendered
+    assert "Visible answer" in rendered
+    assert "Visible tool output" in rendered
+
+
+@pytest.mark.asyncio
 async def test_session_fork_uses_current_sessiondb_branch_primitives(adapter, session_db):
     source_id = session_db.create_session("source-session", "api_server", model="test-model")
     session_db.set_session_title(source_id, "Original")

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -175,7 +175,6 @@ async def test_session_messages_follow_compression_tip(adapter, session_db):
     session_db.append_message(source_id, "user", "before compression")
     session_db.end_session(source_id, "compression")
     session_db.create_session("tip-session", "api_server", parent_session_id=source_id)
-    session_db.replace_messages(source_id, [])
     session_db.append_message("tip-session", "user", "after compression")
 
     app = _create_session_app(adapter)
@@ -186,7 +185,7 @@ async def test_session_messages_follow_compression_tip(adapter, session_db):
 
     assert messages["object"] == "list"
     assert messages["session_id"] == "tip-session"
-    assert [m["content"] for m in messages["data"]] == ["after compression"]
+    assert [m["content"] for m in messages["data"]] == ["before compression", "after compression"]
 
 
 @pytest.mark.asyncio
@@ -407,6 +406,60 @@ async def test_session_chat_stream_run_completed_carries_turn_transcript(adapter
     # The tool call is preserved alongside the intermediate text.
     assert any(m.get("tool_calls") for m in messages)
 
+
+
+@pytest.mark.asyncio
+async def test_session_chat_stream_resolves_stale_compression_root(adapter, session_db):
+    """If the client sends to a compression-ended root, the API must resolve
+    to the current tip before running, preventing sibling continuations."""
+    root_id = session_db.create_session("root-session", "api_server")
+    session_db.append_message(root_id, "user", "hello root")
+    session_db.end_session(root_id, "compression")
+    tip_id = session_db.create_session("tip-session", "api_server", parent_session_id=root_id)
+    session_db.append_message(tip_id, "user", "hello tip")
+
+    captured_kwargs = {}
+
+    async def fake_run(**kwargs):
+        captured_kwargs.update(kwargs)
+        kwargs["stream_delta_callback"]("response")
+        return {"final_response": "response", "session_id": tip_id}, {"total_tokens": 1}
+
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", side_effect=fake_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{root_id}/chat/stream",
+                json={"message": "next message"},
+            )
+            assert resp.status == 200
+
+    assert captured_kwargs["session_id"] == tip_id, (
+        "Chat stream must resolve a stale compression root to the current tip"
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_chat_resolves_stale_compression_root(adapter, session_db):
+    """Non-streaming chat must also resolve a stale root to the tip."""
+    root_id = session_db.create_session("root-chat", "api_server")
+    session_db.append_message(root_id, "user", "hello root")
+    session_db.end_session(root_id, "compression")
+    tip_id = session_db.create_session("tip-chat", "api_server", parent_session_id=root_id)
+    session_db.append_message(tip_id, "user", "hello tip")
+
+    mock_run = AsyncMock(return_value=({"final_response": "ok", "session_id": tip_id}, {"total_tokens": 1}))
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", mock_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{root_id}/chat",
+                json={"message": "next"},
+            )
+            assert resp.status == 200
+
+    _, kwargs = mock_run.call_args
+    assert kwargs["session_id"] == tip_id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Summary

- resolve stale compression roots to the active child before chat or message requests
- return the durable root-to-tip transcript instead of the compacted model snapshot
- mark compacted context rows structurally so internal handoffs and copied tails never render as chat
- preserve archived pre-compaction turns across in-place rewrites
- keep the active user request verbatim when compaction occurs during a tool-running turn
- sanitize internal context fences from every display role
- preserve legitimate repeated user and assistant turns

Regression covered

A long tool-running turn could compact while the active user request sat exactly at the head boundary. The request was summarized away, so the model could stop, require a repeated prompt, or return only a short fragment. The boundary now advances past the active request and first complete tool group while leaving later work compressible.

Verification

- 45 focused compression, API, and archived-history tests passed
- 498 tests passed in the broader selected suite
- 3 additional failures are pre-existing Windows SQLite tempfile cleanup failures and reproduce unchanged on origin/main
- Python compilation and git diff checks passed
- the display loader reconstructed Mason's real compacted session copy with the original request and final response visible and no internal compaction summary
