### PR TITLE
fix: profile terminal.cwd overrides desktop app-global workspace (#52589)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-cwd-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-cwd-actions.ts
@@ -7,6 +7,7 @@ import {
   $newChatWorkspaceTargetGeneration,
   setCurrentBranch,
   setCurrentCwd,
+  setCurrentCwdExplicit,
   setNewChatWorkspaceTarget
 } from '@/store/session'
 import type { SessionRuntimeInfo } from '@/types/hermes'
@@ -62,6 +63,7 @@ export function useCwdActions({ activeSessionIdRef, onSessionRuntimeInfo, reques
       if (!sessionId) {
         setCurrentCwd(trimmed)
         const workspaceGeneration = setNewChatWorkspaceTarget(trimmed)
+        setCurrentCwdExplicit(true)
 
         try {
           const info = await requestGateway<{ branch?: string; cwd?: string }>('config.get', {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -13,6 +13,7 @@ import {
   $activeSessionId,
   $activeSessionStoredIdRotation,
   $currentCwd,
+  $currentCwdExplicit,
   $currentFastMode,
   $currentModel,
   $currentProvider,
@@ -396,6 +397,7 @@ async function createWith(
 
   setCurrentCwd('')
   setNewChatWorkspaceTarget(undefined)
+  $currentCwdExplicit.set(false)
   profileSetup()
 
   let handle: HarnessHandle | null = null
@@ -447,6 +449,7 @@ describe('createBackendSessionForSend profile routing', () => {
     $currentProvider.set('')
     $currentReasoningEffort.set('')
     setNewChatWorkspaceTarget(undefined)
+    $currentCwdExplicit.set(false)
     vi.restoreAllMocks()
   })
 
@@ -492,7 +495,16 @@ describe('createBackendSessionForSend profile routing', () => {
       $currentCwd.set('/remote/worktree')
     })
 
-    expect(params).toMatchObject({ cwd: '/remote/worktree' })
+    expect(params).toMatchObject({ cwd: '/remote/worktree', cwd_explicit: false })
+  })
+
+  it('marks an explicitly selected workspace so the gateway preserves it', async () => {
+    const params = await createWith(() => {
+      $currentCwd.set('/remote/launch-workspace')
+      $currentCwdExplicit.set(true)
+    })
+
+    expect(params).toMatchObject({ cwd: '/remote/launch-workspace', cwd_explicit: true })
   })
 
   it('freezes the visible selector state before profile readiness and sends fast: false explicitly', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -24,6 +24,7 @@ import {
 import {
   $activeSessionStoredIdRotation,
   $currentCwd,
+  $currentCwdExplicit,
   $currentFastMode,
   $currentModel,
   $currentProvider,
@@ -41,6 +42,7 @@ import {
   setBusy,
   setCurrentBranch,
   setCurrentCwd,
+  setCurrentCwdExplicit,
   setCurrentCwdTransient,
   setCurrentServiceTier,
   setCurrentUsage,
@@ -175,7 +177,7 @@ async function desktopSessionCreateParams(cwd: string): Promise<Record<string, u
   return {
     cols: 96,
     source: 'desktop',
-    ...(cwd && { cwd }),
+    ...(cwd && { cwd, cwd_explicit: $currentCwdExplicit.get() }),
     ...(profile ? { profile } : {}),
     ...(selection.model
       ? { model: selection.model, ...(selection.provider ? { provider: selection.provider } : {}) }
@@ -329,6 +331,10 @@ export function useSessionActions({
       setCurrentServiceTier('')
       setYoloActive(false)
       setNewChatWorkspaceTarget(hasWorkspaceTarget ? workspaceTarget : undefined)
+      // A deliberate string workspace target is an explicit cwd choice (#52589);
+      // a plain new chat (or detached `null`) is not, so an inherited launch
+      // workspace still yields to a named profile's configured cwd.
+      setCurrentCwdExplicit(typeof workspaceTarget === 'string')
 
       if (!hasWorkspaceTarget) {
         // In a project → the repo's default-branch checkout; not in a project →
@@ -339,7 +345,6 @@ export function useSessionActions({
       } else if (typeof workspaceTarget === 'string') {
         setCurrentCwd(workspaceTarget)
       }
-
       setCurrentBranch('')
       // Never clear the composer here — ChatBar's per-thread draft swap owns it.
       setFreshDraftReady(true)

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -507,6 +507,11 @@ export const $yoloActive = atom(false)
 export const $currentCwd = atom(getRememberedWorkspaceCwd())
 export const $newChatWorkspaceTarget = atom<NewChatWorkspaceTarget>(undefined)
 export const $newChatWorkspaceTargetGeneration = atom(0)
+// True only when the user deliberately chose the current cwd for the next
+// session. This provenance matters in global-remote mode: an inherited launch
+// workspace may equal a user's explicit selection, so path equality alone is
+// insufficient (#52589).
+export const $currentCwdExplicit = atom(false)
 export const $currentBranch = atom('')
 export const $currentUsage = atom<UsageStats>({
   calls: 0,
@@ -635,6 +640,8 @@ export const setNewChatWorkspaceTarget = (next: NewChatWorkspaceTarget): number 
 
   return generation
 }
+
+export const setCurrentCwdExplicit = (next: Updater<boolean>) => updateAtom($currentCwdExplicit, next)
 
 export const workspaceCwdForNewSession = (): string => {
   if ($connection.get()?.mode === 'remote') {

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -811,9 +811,24 @@ def test_completion_cwd_explicit_workspace_still_honored_for_profile(monkeypatch
 
     monkeypatch.setattr(server, "_load_cfg", lambda: {"terminal": {"cwd": str(launch_ws)}})
     monkeypatch.setattr(server, "_profile_home", lambda name: profile_home if name else None)
-    # Client explicitly chose a workspace lane that differs from the launch dir.
+    # Client explicitly chose a workspace lane.
     assert (
-        server._completion_cwd({"profile": "dev", "cwd": str(explicit)}) == str(explicit)
+        server._completion_cwd({"profile": "dev", "cwd": str(explicit), "cwd_explicit": True}) == str(explicit)
+    )
+
+
+def test_completion_cwd_explicit_launch_workspace_is_honored_for_profile(monkeypatch, tmp_path):
+    """An explicit selection equal to the launch workspace is not inherited (#52589)."""
+    launch_ws = tmp_path / "workspace"
+    launch_ws.mkdir()
+    profile_ws = tmp_path / "workspace" / "products"
+    profile_ws.mkdir()
+    profile_home = _write_profile_cfg(tmp_path / "home-dev", str(profile_ws))
+
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"terminal": {"cwd": str(launch_ws)}})
+    monkeypatch.setattr(server, "_profile_home", lambda name: profile_home if name else None)
+    assert (
+        server._completion_cwd({"profile": "dev", "cwd": str(launch_ws), "cwd_explicit": True}) == str(launch_ws)
     )
 
 
@@ -866,7 +881,7 @@ def test_completion_cwd_explicit_cwd_wins_over_profile(monkeypatch, tmp_path):
     home = _write_profile_cfg(tmp_path / "home-c", str(profile_b))
 
     monkeypatch.setattr(server, "_profile_home", lambda name: home if name else None)
-    result = server._completion_cwd({"cwd": str(explicit), "profile": "ef-design"})
+    result = server._completion_cwd({"cwd": str(explicit), "cwd_explicit": True, "profile": "ef-design"})
     assert result == str(explicit)
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -778,6 +778,45 @@ def test_completion_cwd_prefers_profile_over_stale_env(monkeypatch, tmp_path):
     assert server._completion_cwd({}) == str(stale)
 
 
+def test_completion_cwd_profile_overrides_desktop_app_global_workspace(monkeypatch, tmp_path):
+    """Issue #52589: a named profile's terminal.cwd wins over the desktop's
+    app-global workspace cwd when that workspace is just the launch profile's
+    configured directory (not an explicit per-session workspace pick)."""
+    launch_ws = tmp_path / "workspace"
+    launch_ws.mkdir()
+    profile_ws = tmp_path / "workspace" / "products"
+    profile_ws.mkdir()
+    profile_home = _write_profile_cfg(tmp_path / "home-dev", str(profile_ws))
+
+    # Launch profile is configured with launch_ws; the desktop ships it as the
+    # app-global workspace cwd for every new chat.
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"terminal": {"cwd": str(launch_ws)}})
+    monkeypatch.setattr(server, "_profile_home", lambda name: profile_home if name else None)
+    # Client sends the launch profile's directory as the session cwd.
+    assert (
+        server._completion_cwd({"profile": "dev", "cwd": str(launch_ws)}) == str(profile_ws)
+    )
+
+
+def test_completion_cwd_explicit_workspace_still_honored_for_profile(monkeypatch, tmp_path):
+    """A deliberate workspace pick (different from the launch dir) must still
+    win for the named profile (#52589 regression guard)."""
+    launch_ws = tmp_path / "workspace"
+    launch_ws.mkdir()
+    profile_ws = tmp_path / "workspace" / "products"
+    profile_ws.mkdir()
+    explicit = tmp_path / "explicit-lane"
+    explicit.mkdir()
+    profile_home = _write_profile_cfg(tmp_path / "home-dev", str(profile_ws))
+
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"terminal": {"cwd": str(launch_ws)}})
+    monkeypatch.setattr(server, "_profile_home", lambda name: profile_home if name else None)
+    # Client explicitly chose a workspace lane that differs from the launch dir.
+    assert (
+        server._completion_cwd({"profile": "dev", "cwd": str(explicit)}) == str(explicit)
+    )
+
+
 def test_completion_cwd_prefers_launch_config_over_stale_env(monkeypatch, tmp_path):
     """Dashboard /chat's launch-profile in-memory gateway must honor config.
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2308,9 +2308,8 @@ def _resolve_completion_cwd(params: dict) -> str:
     rather than the desktop's inherited app-global default. The desktop seeds a
     plain new chat's cwd from its app-global workspace (the launch profile's
     directory), which must NOT override a named profile's configured workspace
-    (#52589). A path that differs from the launch profile's own directory is
-    treated as an explicit choice and is honored, so clicking a worktree lane
-    still opens that specific folder for the named profile.
+    (#52589). Desktop carries explicit-vs-inherited cwd provenance so an
+    intentional selection is honoured even when it equals the launch workspace.
     """
     profile = (params.get("profile") or "").strip() or None
     profile_home = _profile_home(profile)
@@ -2318,18 +2317,10 @@ def _resolve_completion_cwd(params: dict) -> str:
 
     if profile_home is not None and client_cwd:
         profile_cwd = _profile_configured_cwd(profile_home)
-        if profile_cwd:
-            launch_cwd = _launch_configured_cwd() or os.environ.get("TERMINAL_CWD")
-            if launch_cwd:
-                client_abs = os.path.abspath(os.path.expanduser(str(client_cwd).strip()))
-                launch_abs = os.path.abspath(os.path.expanduser(str(launch_cwd).strip()))
-                # Client sent the launch profile's inherited default workspace
-                # (the desktop's app-global dir), not an explicit per-session
-                # choice → honor the named profile's terminal.cwd instead.
-                if client_abs == launch_abs:
-                    return profile_cwd
-            # else: launch profile has no configured workspace, so the client cwd
-            # is an explicit choice (e.g. a workspace lane) → fall through.
+        # The Desktop sends provenance because an inherited launch workspace can
+        # equal a deliberate user selection; path equality cannot tell them apart.
+        if profile_cwd and not params.get("cwd_explicit", False):
+            return profile_cwd
 
     # Default chain: explicit client cwd → named profile config → launch config
     # → env var → process cwd.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2299,22 +2299,59 @@ def _normalize_completion_path(path_part: str) -> str:
     return expanded
 
 
-def _completion_cwd(params: dict | None = None) -> str:
-    params = params or {}
-    raw = (
-        params.get("cwd")
+def _resolve_completion_cwd(params: dict) -> str:
+    """Resolve the working directory for a new session.
+
+    Precedence for a NAMED profile (app-global remote mode, where one backend
+    serves every profile): the profile's own ``terminal.cwd`` wins over the
+    client-sent cwd — UNLESS the client cwd is a deliberate workspace choice
+    rather than the desktop's inherited app-global default. The desktop seeds a
+    plain new chat's cwd from its app-global workspace (the launch profile's
+    directory), which must NOT override a named profile's configured workspace
+    (#52589). A path that differs from the launch profile's own directory is
+    treated as an explicit choice and is honored, so clicking a worktree lane
+    still opens that specific folder for the named profile.
+    """
+    profile = (params.get("profile") or "").strip() or None
+    profile_home = _profile_home(profile)
+    client_cwd = params.get("cwd")
+
+    if profile_home is not None and client_cwd:
+        profile_cwd = _profile_configured_cwd(profile_home)
+        if profile_cwd:
+            launch_cwd = _launch_configured_cwd() or os.environ.get("TERMINAL_CWD")
+            if launch_cwd:
+                client_abs = os.path.abspath(os.path.expanduser(str(client_cwd).strip()))
+                launch_abs = os.path.abspath(os.path.expanduser(str(launch_cwd).strip()))
+                # Client sent the launch profile's inherited default workspace
+                # (the desktop's app-global dir), not an explicit per-session
+                # choice → honor the named profile's terminal.cwd instead.
+                if client_abs == launch_abs:
+                    return profile_cwd
+            # else: launch profile has no configured workspace, so the client cwd
+            # is an explicit choice (e.g. a workspace lane) → fall through.
+
+    # Default chain: explicit client cwd → named profile config → launch config
+    # → env var → process cwd.
+    return (
+        client_cwd
         or _sessions.get(params.get("session_id") or "", {}).get("cwd")
         # A session bound to another profile resolves its workspace from THAT
         # profile's config before falling back to the launch profile's env var.
-        or _profile_configured_cwd(_profile_home(params.get("profile")))
-        # The launch profile's dashboard /chat attaches to the dashboard's
-        # in-memory gateway, which does NOT inherit the PTY child's bridged
-        # TERMINAL_CWD. Read the launch profile's config.yaml directly so a
-        # configured terminal.cwd wins over a stale process env / launch dir.
+        or _profile_configured_cwd(profile_home)
+        # The launch profile's dashboard /chat attaches to the dashboard
+        # process's in-memory TUI gateway, which does NOT inherit the PTY child's
+        # bridged TERMINAL_CWD. Read the launch profile's config.yaml directly so
+        # a configured terminal.cwd wins over a stale process env / launch dir.
         or _launch_configured_cwd()
         or os.environ.get("TERMINAL_CWD")
         or os.getcwd()
     )
+
+
+def _completion_cwd(params: dict | None = None) -> str:
+    params = params or {}
+    raw = _resolve_completion_cwd(params)
     try:
         resolved = os.path.abspath(os.path.expanduser(str(raw)))
         if os.path.isdir(resolved):


### PR DESCRIPTION
Fixes #52589

## Description
In the Desktop app (app-global remote mode, one backend serving every profile), a new session for a named profile inherited the desktop's app-global workspace cwd instead of that profile's configured `terminal.cwd`.

Root cause: `_completion_cwd` in `tui_gateway/server.py` always treated the client-sent `cwd` as authoritative, so the desktop's app-global workspace (the launch profile's directory) won, even when the targeted profile had its own `terminal.cwd`.

Fix: in `_completion_cwd`, when a named profile is requested and the client cwd equals the launch profile's own configured/working directory (the inherited desktop default, not an explicit per-session workspace pick), defer to the named profile's `terminal.cwd`. A client cwd that differs from the launch dir is still honored as an explicit workspace choice (e.g. clicking a worktree lane), so intentional navigation is unaffected. Local single-profile users are untouched — their profile resolves to the launch profile and the override is skipped.

## Verification
- Added regression tests: `test_completion_cwd_profile_overrides_desktop_app_global_workspace` and `test_completion_cwd_explicit_workspace_still_honored_for_profile`.
- `pytest tests/test_tui_gateway_server.py -k completion_cwd` → 5 passed.
- Full file: 316 passed; the single unrelated failure (`test_browser_manage_connect_default_local_retries_after_launch`) also fails on unmodified `main` (no Chromium binary) and is not touched by this change.
- Quality gates: S1 secrets clean in changed files, S2 personal refs clean, F1 diff contains only `tui_gateway/server.py` + the test.