### PR TITLE
fix: let kanban PR feedback respawn

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6792,9 +6792,11 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
         human review rather than immediately re-spawning.
 
     ``"active_pr"``
-        A GitHub PR URL appears in a recent task comment (within
-        ``_RESPAWN_GUARD_PR_WINDOW`` seconds).  A prior worker already
-        opened a PR; re-spawning risks a duplicate PR on the same task.
+        A GitHub PR URL appears in the latest relevant task activity (within
+        ``_RESPAWN_GUARD_PR_WINDOW`` seconds). A prior worker already opened a
+        PR; re-spawning risks a duplicate PR on the same task. Later operator
+        feedback or an explicit unblock supersedes the handoff and allows the
+        review/fix rerun.
 
     Stale / dead claim locks are NOT a guard reason — they are handled
     by ``release_stale_claims`` and ``detect_crashed_workers`` which
@@ -6860,14 +6862,64 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
     ).fetchone():
         return "recent_success"
 
-    # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    # 4. GitHub PR URL in recent task activity — prior worker already opened
+    #    a PR, so an immediate respawn would duplicate the review handoff.
+    #    Later human/operator activity (review feedback, or an explicit unblock)
+    #    supersedes that handoff and means the task is intentionally ready for a
+    #    follow-up run.  Use the most recent PR URL comment as the watermark.
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
-    for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
+    latest_pr_comment = None
+    superseding_pr_terms = (
+        "review feedback",
+        "feedback on",
+        "left review",
+        "merged pr",
+        "pr merged",
+        "closed pr",
+        "pr closed",
+        "unblock",
+        "now passes",
+    )
+    for comment in conn.execute(
+        "SELECT id, author, body, created_at FROM task_comments "
+        "WHERE task_id = ? AND created_at >= ? "
+        "ORDER BY created_at DESC, id DESC",
         (task_id, pr_cutoff),
     ).fetchall():
-        if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
-            return "active_pr"
+        body = comment["body"] or ""
+        if not _RESPAWN_GUARD_PR_URL_RE.search(body):
+            continue
+        if any(term in body.lower() for term in superseding_pr_terms):
+            continue
+        latest_pr_comment = comment
+        break
+    if latest_pr_comment is not None:
+        pr_ts = int(latest_pr_comment["created_at"])
+        pr_id = int(latest_pr_comment["id"])
+        pr_author = latest_pr_comment["author"]
+
+        later_operator_comment = conn.execute(
+            "SELECT id FROM task_comments "
+            "WHERE task_id = ? "
+            "  AND (created_at > ? OR (created_at = ? AND id > ?)) "
+            "  AND author != ? "
+            "ORDER BY created_at ASC, id ASC LIMIT 1",
+            (task_id, pr_ts, pr_ts, pr_id, pr_author),
+        ).fetchone()
+        if later_operator_comment is not None:
+            return None
+
+        later_unblock = conn.execute(
+            "SELECT id FROM task_events "
+            "WHERE task_id = ? AND kind IN ('unblocked', 'promoted_manual') "
+            "  AND created_at > ? "
+            "ORDER BY created_at ASC, id ASC LIMIT 1",
+            (task_id, pr_ts),
+        ).fetchone()
+        if later_unblock is not None:
+            return None
+
+        return "active_pr"
 
     return None
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1905,6 +1905,66 @@ def test_respawn_guard_active_pr_in_comment(kanban_home):
     assert reason == "active_pr"
 
 
+def test_respawn_guard_active_pr_cleared_by_later_operator_comment(kanban_home):
+    """Review feedback after a PR handoff means the task should respawn."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="review-feedback", assignee="alice")
+        pr_comment_id = kb.add_comment(
+            conn,
+            t,
+            "worker",
+            "review-required: PR https://github.com/acme/project/pull/149",
+        )
+        assert kb.block_task(conn, t, reason="review-required: PR #149")
+        feedback_comment_id = kb.add_comment(
+            conn,
+            t,
+            "operator",
+            "review feedback on https://github.com/acme/project/pull/149: please handle the stuck respawn path",
+        )
+        assert kb.unblock_task(conn, t)
+        now = int(time.time())
+        conn.execute(
+            "UPDATE task_comments SET created_at = ? WHERE id = ?",
+            (now - 30, pr_comment_id),
+        )
+        conn.execute(
+            "UPDATE task_comments SET created_at = ? WHERE id = ?",
+            (now - 10, feedback_comment_id),
+        )
+
+        reason = kb.check_respawn_guard(conn, t)
+
+    assert reason is None
+
+
+def test_respawn_guard_active_pr_cleared_by_later_unblock_event(kanban_home):
+    """A deliberate unblock after a PR handoff is human action to rerun."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="merged-pr-followup", assignee="alice")
+        pr_comment_id = kb.add_comment(
+            conn,
+            t,
+            "worker",
+            "PR merged: https://github.com/acme/project/pull/147",
+        )
+        assert kb.block_task(conn, t, reason="review-required: PR #147")
+        assert kb.unblock_task(conn, t)
+        now = int(time.time())
+        conn.execute(
+            "UPDATE task_comments SET created_at = ? WHERE id = ?",
+            (now - 30, pr_comment_id),
+        )
+        conn.execute(
+            "UPDATE task_events SET created_at = ? WHERE task_id = ? AND kind = 'unblocked'",
+            (now - 10, t),
+        )
+
+        reason = kb.check_respawn_guard(conn, t)
+
+    assert reason is None
+
+
 def test_respawn_guard_old_pr_comment_not_guarded(kanban_home):
     """A GitHub PR URL in a comment older than the PR window does not block."""
     with kb.connect() as conn:


### PR DESCRIPTION
## Summary
- Narrow the kanban `active_pr` respawn guard to the PR handoff window instead of any recent PR URL comment.
- Allow respawn after later operator feedback, explicit unblock/manual promotion, or PR-status comments such as review feedback/merged/closed.
- Keep the duplicate-worker protection for an immediate PR handoff with no later human action.

## Test Plan
- `uv run --extra dev python -m pytest tests/hermes_cli/test_kanban_db.py -k active_pr -q`
  - `4 passed, 221 deselected`
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py`
  - `225 tests passed, 0 failed`
- Live-board evidence against the reported stuck paths:
  - On a copy of `/home/eric/.hermes/kanban.db` with only the newer post-rerun handoff for `t_b5a2a0f4` removed, `check_respawn_guard(conn, 't_b5a2a0f4')` returns `None`; this matches the original Eric-review-feedback state and proves it is not trapped by the earlier PR URL handoff.
  - `check_respawn_guard(conn, 't_5052163a')` returns `recent_success` on the live board, not `active_pr`, after the merged-PR follow-up completed.
  - The current live `t_b5a2a0f4` returns `active_pr` again because the respawn already happened and the worker posted a new review-required PR handoff; that is the protection this change intentionally preserves.
