### PR TITLE
fix(codex): honor configured context length as a cap

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -162,10 +162,22 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
     compressor = getattr(agent, "context_compressor", None)
     if compressor is not None:
         try:
-            compressor.update_from_response(usage_dict)
             context_window = getattr(turn, "model_context_window", None)
-            if isinstance(context_window, int) and context_window > 0:
-                compressor.context_length = context_window
+            if type(context_window) is int and context_window > 0:
+                configured_cap = getattr(agent, "_config_context_length", None)
+                effective_context = context_window
+                if type(configured_cap) is int and configured_cap > 0:
+                    effective_context = min(context_window, configured_cap)
+                if compressor.context_length != effective_context:
+                    compressor.update_model(
+                        model=agent.model,
+                        context_length=effective_context,
+                        base_url=agent.base_url,
+                        api_key=getattr(agent, "api_key", ""),
+                        provider=agent.provider,
+                        api_mode=agent.api_mode,
+                    )
+            compressor.update_from_response(usage_dict)
         except Exception:
             logger.debug("codex app-server usage update failed", exc_info=True)
 

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -135,6 +135,55 @@ class TestRunConversationCodexPath:
         assert agent.context_compressor.last_total_tokens == 130
         assert agent.context_compressor.context_length == 200000
 
+    @pytest.mark.parametrize(
+        ("provider_window", "configured_cap", "expected_context"),
+        [
+            (372_000, 200_000, 200_000),
+            (200_000, 372_000, 200_000),
+            (372_000, None, 372_000),
+            (372_000, "invalid", 372_000),
+            (372_000, 0, 372_000),
+            (372_000, -1, 372_000),
+            (372_000, True, 372_000),
+        ],
+    )
+    def test_codex_app_server_context_length_config_is_a_cap(
+        self, monkeypatch, provider_window, configured_cap, expected_context,
+    ):
+        def fake_run_turn(self, user_input: str, **kwargs):
+            return TurnResult(
+                final_text="done",
+                projected_messages=[{"role": "assistant", "content": "done"}],
+                turn_id="turn-context-cap-1",
+                thread_id="thread-context-cap-1",
+                token_usage_last={"inputTokens": 80, "outputTokens": 20},
+                model_context_window=provider_window,
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession,
+            "ensure_started",
+            lambda self: "thread-context-cap-1",
+        )
+        agent = _make_codex_agent()
+        agent._config_context_length = configured_cap
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hello")
+
+        compressor = agent.context_compressor
+        assert compressor.context_length == expected_context
+        assert compressor.threshold_tokens == compressor._compute_threshold_tokens(
+            expected_context,
+            compressor.threshold_percent,
+            compressor.max_tokens,
+        )
+        assert compressor.last_prompt_tokens == 80
+        status = compressor.get_status()
+        assert status["context_length"] == expected_context
+        assert status["usage_percent"] == pytest.approx(80 / expected_context * 100)
+
     def test_native_codex_compaction_updates_bookkeeping(self, monkeypatch):
         def fake_run_turn(self, user_input: str, **kwargs):
             return TurnResult(


### PR DESCRIPTION
## What does this PR do?

Codex app-server telemetry can report a provider context window larger than an explicitly configured Hermes `model.context_length`. The runtime currently replaces the compressor's configured context with the provider-reported value after a turn. That silently enlarges compression thresholds and status accounting beyond the user's configured limit.

This patch treats a positive integer `model.context_length` as a cap for Codex app-server runtime bookkeeping:

```text
effective context = min(provider-reported window, configured context)
```

It never enlarges the provider window, ignores invalid cap values at this boundary, recalculates the compressor threshold before recording usage, and preserves the provider's original telemetry.

This is distinct from open PR #44947 (runtime model switching/config saves) and #60154 (probing real local-provider windows): this path is the Codex app-server turn telemetry update in `agent/codex_runtime.py`.

## Related Issue

N/A — reproduced directly on current `main` in the Codex app-server integration path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/codex_runtime.py`: cap the provider-reported Codex context window by a valid configured context length and update the compressor through `update_model()` before usage bookkeeping.
- `tests/run_agent/test_codex_app_server_integration.py`: add behavior-contract coverage for smaller/larger provider windows plus absent, string, boolean, zero, and negative configured caps.

## How to Test

1. Run the Codex app-server integration and persistence tests:
   `scripts/run_tests.sh tests/run_agent/test_codex_app_server_integration.py tests/agent/test_codex_app_server_persist.py -q`
2. Run GPT-5.6 registration invariants:
   `scripts/run_tests.sh tests/hermes_cli/test_gpt56_registration.py -q`
3. Run Ruff and compilation checks on the two changed files.
4. Run the full canonical test suite with `scripts/run_tests.sh -j 4 -q`.

Validated results:

- 41 Codex integration/persistence tests passed.
- 11 GPT-5.6 registration tests passed.
- Ruff, `py_compile`, `git diff --check`, file allowlist, and clean-clone patch apply/reverse/reapply passed.
- Full canonical runner in the existing production-install venv completed scheduling all files but was not green: 49 failures across 15 files and 542 files that could not collect after optional dependencies were unavailable mid-run.
- The changed Codex integration file passed 36/36 inside that full run; combined with persistence it passed 41/41. GPT-5.6 registration passed 11/11.
- 39 failures across 12 unrelated files were reproduced on the untouched upstream base (root/temporary-workspace/plugin-state assumptions); the candidate was not worse.
- The remaining 10 failures across 3 unrelated files were transient missing-dependency imports; all 18 tests in those files passed when rerun on both the untouched upstream base and this candidate after dependency availability recovered.
- Because the existing production venv is not a clean `[all,dev]` environment, the full-suite checkbox below remains intentionally unchecked. Upstream CI is requested as the clean-environment gate.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing open and closed PRs/issues and found no duplicate for this Codex app-server telemetry path
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — full canonical runner is still being classified; any baseline failures will be disclosed rather than hidden
- [x] I've added tests for the bug
- [x] I've tested on Ubuntu 24.04

### Documentation & Housekeeping

- [x] Documentation update — N/A; no user-facing key or API added
- [x] `cli-config.yaml.example` update — N/A; no config key added or changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no architecture or workflow change
- [x] Cross-platform impact considered — pure Python logic with no OS-specific behavior
- [x] Tool descriptions/schemas update — N/A

## Screenshots / Logs

Behavior-contract tests assert that a configured 200,000-token cap remains 200,000 when Codex reports 372,000, while a provider window smaller than the configured value is never enlarged.
