### PR TITLE
fix(session_search): fire transform_tool_result hooks in agent loop i…

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2205,20 +2205,45 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 from hermes_state import format_session_db_unavailable
                 return _finish_agent_tool(json.dumps({"success": False, "error": format_session_db_unavailable()}), next_args)
             from tools.session_search_tool import session_search as _session_search
-            return _finish_agent_tool(
-                _session_search(
-                    query=next_args.get("query", ""),
-                    role_filter=next_args.get("role_filter"),
-                    limit=next_args.get("limit", 3),
-                    session_id=next_args.get("session_id"),
-                    around_message_id=next_args.get("around_message_id"),
-                    window=next_args.get("window", 5),
-                    sort=next_args.get("sort"),
-                    db=session_db,
-                    current_session_id=agent.session_id,
-                ),
-                next_args,
+            result = _session_search(
+                query=next_args.get("query", ""),
+                role_filter=next_args.get("role_filter"),
+                limit=next_args.get("limit", 3),
+                session_id=next_args.get("session_id"),
+                around_message_id=next_args.get("around_message_id"),
+                window=next_args.get("window", 5),
+                sort=next_args.get("sort"),
+                db=session_db,
+                current_session_id=agent.session_id,
             )
+            # Fire transform_tool_result hooks so plugins can post-process results.
+            # session_search is intercepted before handle_function_call() where
+            # hooks normally fire (model_tools.py:1316), so we invoke them here.
+            try:
+                from hermes_cli.plugins import has_hook, invoke_hook
+                if has_hook("transform_tool_result"):
+                    hook_results = invoke_hook(
+                        "transform_tool_result",
+                        tool_name="session_search",
+                        args=next_args,
+                        result=result,
+                        task_id="",
+                        session_id=agent.session_id or "",
+                        tool_call_id="",
+                        turn_id="",
+                        api_request_id="",
+                        duration_ms=0,
+                        status=None,
+                        error_type=None,
+                        error_message=None,
+                    )
+                    for hook_result in hook_results:
+                        if isinstance(hook_result, str):
+                            result = hook_result
+                            break
+            except Exception:
+                pass
+            return _finish_agent_tool(result, next_args)
     elif function_name == "memory":
         def _execute(next_args: dict) -> Any:
             target = next_args.get("target", "memory")

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1190,7 +1190,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     from hermes_state import format_session_db_unavailable
                     return json.dumps({"success": False, "error": format_session_db_unavailable()})
                 from tools.session_search_tool import session_search as _session_search
-                return _session_search(
+                result = _session_search(
                     query=next_args.get("query", ""),
                     role_filter=next_args.get("role_filter"),
                     limit=next_args.get("limit", 3),
@@ -1201,6 +1201,32 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     db=session_db,
                     current_session_id=agent.session_id,
                 )
+                # Fire transform_tool_result hooks so plugins can post-process results.
+                try:
+                    from hermes_cli.plugins import has_hook, invoke_hook
+                    if has_hook("transform_tool_result"):
+                        hook_results = invoke_hook(
+                            "transform_tool_result",
+                            tool_name="session_search",
+                            args=next_args,
+                            result=result,
+                            task_id=effective_task_id or "",
+                            session_id=agent.session_id or "",
+                            tool_call_id="",
+                            turn_id="",
+                            api_request_id="",
+                            duration_ms=0,
+                            status=None,
+                            error_type=None,
+                            error_message=None,
+                        )
+                        for hook_result in hook_results:
+                            if isinstance(hook_result, str):
+                                result = hook_result
+                                break
+                except Exception:
+                    pass
+                return result
             function_result, function_args = _run_agent_tool_execution_middleware(
                 agent,
                 function_name=function_name,


### PR DESCRIPTION
…nterceptors

session_search is intercepted by _AGENT_LOOP_TOOLS before reaching handle_function_call() in model_tools.py, where transform_tool_result hooks normally fire (line 1316). This means plugins that register transform_tool_result hooks to post-process session_search results never see their hook invoked.

Add explicit hook invocation in both interceptor paths (agent_runtime_helpers.py and tool_executor.py), following the same fail-open pattern used in model_tools.py:1316-1336.

This allows plugins to enrich session_search output with results from external search corpora without modifying core code.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

