### PR TITLE
fix(codex): drop unsupported pro defaults

### DIFF
--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -12,14 +12,13 @@ import os
 logger = logging.getLogger(__name__)
 
 DEFAULT_CODEX_MODELS: List[str] = [
-    # GPT-5.6 series (Sol/Terra/Luna + -pro high-effort modes) — GA 2026-07-09
-    # (previewed 2026-06-26).
+    # GPT-5.6 series (Sol/Terra/Luna) — GA 2026-07-09
+    # (previewed 2026-06-26). The public API exposes "-pro" variants, but the
+    # chatgpt.com Codex OAuth backend rejects them for ChatGPT accounts with
+    # HTTP 400, so the curated offline fallback must not surface them.
     "gpt-5.6-sol",
-    "gpt-5.6-sol-pro",
     "gpt-5.6-terra",
-    "gpt-5.6-terra-pro",
     "gpt-5.6-luna",
-    "gpt-5.6-luna-pro",
     "gpt-5.5",
     "gpt-5.4-mini",
     "gpt-5.4",
@@ -53,11 +52,8 @@ DEFAULT_CODEX_MODELS: List[str] = [
 
 _FORWARD_COMPAT_TEMPLATE_MODELS: List[tuple[str, tuple[str, ...]]] = [
     ("gpt-5.6-sol", ("gpt-5.5", "gpt-5.4")),
-    ("gpt-5.6-sol-pro", ("gpt-5.5", "gpt-5.4")),
     ("gpt-5.6-terra", ("gpt-5.5", "gpt-5.4")),
-    ("gpt-5.6-terra-pro", ("gpt-5.5", "gpt-5.4")),
     ("gpt-5.6-luna", ("gpt-5.5", "gpt-5.4")),
-    ("gpt-5.6-luna-pro", ("gpt-5.5", "gpt-5.4")),
     ("gpt-5.5", ("gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex")),
     ("gpt-5.4-mini", ("gpt-5.3-codex",)),
     ("gpt-5.4", ("gpt-5.3-codex",)),

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -4,6 +4,17 @@ from unittest.mock import patch
 from hermes_cli.codex_models import DEFAULT_CODEX_MODELS, get_codex_model_ids
 
 
+CHATGPT_REJECTED_CODEX_PRO_SLUGS = {
+    "gpt-5.6-sol-pro",
+    "gpt-5.6-terra-pro",
+    "gpt-5.6-luna-pro",
+}
+
+
+def test_curated_codex_defaults_exclude_chatgpt_rejected_pro_slugs():
+    assert CHATGPT_REJECTED_CODEX_PRO_SLUGS.isdisjoint(DEFAULT_CODEX_MODELS)
+
+
 def test_get_codex_model_ids_prioritizes_default_and_cache(tmp_path, monkeypatch):
     codex_home = tmp_path / "codex-home"
     codex_home.mkdir(parents=True, exist_ok=True)
@@ -75,6 +86,20 @@ def test_get_codex_model_ids_adds_forward_compat_models_from_templates(monkeypat
         "gpt-5.4",
         "gpt-5.3-codex-spark",
     ]
+
+
+def test_forward_compat_models_exclude_chatgpt_rejected_pro_slugs(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.codex_models._fetch_models_from_api",
+        lambda access_token: ["gpt-5.5"],
+    )
+
+    models = get_codex_model_ids(access_token="codex-access-token")
+
+    assert "gpt-5.6-sol" in models
+    assert "gpt-5.6-terra" in models
+    assert "gpt-5.6-luna" in models
+    assert CHATGPT_REJECTED_CODEX_PRO_SLUGS.isdisjoint(models)
 
 
 def test_fetch_from_api_keeps_supported_in_api_false_models(monkeypatch):


### PR DESCRIPTION
Summary
- Remove the ChatGPT-account-rejected `gpt-5.6-sol-pro`, `gpt-5.6-terra-pro`, and `gpt-5.6-luna-pro` slugs from the curated Codex OAuth fallback list.
- Stop forward-compat model synthesis from surfacing those `-pro` slugs while keeping the non-pro GPT-5.6 Sol/Terra/Luna entries available.

Root Cause
- PR #61616 added public-API-style `-pro` GPT-5.6 slugs to the Codex OAuth curated fallback/template list.
- The chatgpt.com Codex backend rejects those slugs for ChatGPT accounts with HTTP 400, so offline fallback or live discovery failures could expose dead model choices.

Live Evidence
- Reporter tested the `chatgpt.com/backend-api/codex/responses` OAuth Codex route on a ChatGPT Pro account on 2026-07-10.
- Accepted on that route: `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex-spark`, `gpt-5.6-sol`, and `gpt-5.6-terra`.
- Rejected on that route with HTTP 400: `gpt-5.6-sol-pro`, `gpt-5.6-terra-pro`, and `gpt-5.6-luna-pro`.
- The rejection message says those models are not supported when using Codex with a ChatGPT account, which makes them unsafe curated fallback entries even if they exist in a public API catalog.

Tests
- `scripts/run_tests.sh tests/hermes_cli/test_codex_models.py -q`
- `python3 -m py_compile hermes_cli/codex_models.py tests/hermes_cli/test_codex_models.py`
- `git diff --check`

Fixes #61660
