### PR TITLE
fix(session-export): escape HTML tool-call names

### DIFF
--- a/hermes_cli/session_export_html.py
+++ b/hermes_cli/session_export_html.py
@@ -8,7 +8,9 @@ Enhanced with UI-UX-PRO-MAX design intelligence.
 
 import json
 import datetime
+import secrets
 from typing import Any, Dict, List
+from urllib.parse import quote
 
 # --- Icons (Lucide-style SVGs) ---
 ICON_USER = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-user"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>'
@@ -26,6 +28,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'nonce-{script_nonce}'; style-src 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src data:; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; object-src 'none'">
     <title>{page_title}</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -566,13 +569,13 @@ HTML_TEMPLATE = """<!DOCTYPE html>
         </div>
     </div>
 
-    <script>
+    <script nonce="{script_nonce}">
         // Session Switching
         function showSession(id) {{
             // Update Sidebar
-            document.querySelectorAll('.session-item').forEach(el => el.classList.remove('active'));
-            const activeItem = document.querySelector(`.session-item[data-id="${{id}}"]`);
-            if (activeItem) activeItem.classList.add('active');
+            document.querySelectorAll('.session-item').forEach(el => {{
+                el.classList.toggle('active', el.dataset.id === id);
+            }});
 
             // Update View
             document.querySelectorAll('.session-view').forEach(el => {{
@@ -582,8 +585,15 @@ HTML_TEMPLATE = """<!DOCTYPE html>
             if (activeView) activeView.classList.add('active');
 
             // Store in URL hash
-            window.location.hash = id;
+            window.location.hash = encodeURIComponent(id);
         }}
+
+        document.querySelectorAll('.session-item').forEach(item => {{
+            item.addEventListener('click', (e) => {{
+                e.preventDefault();
+                showSession(item.dataset.id || '');
+            }});
+        }});
 
         // Search Filter
         const searchInput = document.getElementById('session-search');
@@ -611,7 +621,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
 
         // Initialization
         window.addEventListener('load', () => {{
-            const hash = window.location.hash.slice(1);
+            const hash = decodeURIComponent(window.location.hash.slice(1));
             if (hash) {{
                 showSession(hash);
             }} else {{
@@ -706,7 +716,7 @@ def _generate_messages_html(messages: List[Dict[str, Any]]) -> str:
                 <div class="tool-call">
                     <div class="tool-call-header">
                         {ICON_CHEVRON_RIGHT.replace('class="', 'class="chevron ')}
-                        {ICON_WRENCH} Tool Call: {fn_name}
+                        {ICON_WRENCH} Tool Call: {_escape_html(fn_name)}
                     </div>
                     <div class="tool-call-content">
                         <pre><code>{_escape_html(args)}</code></pre>
@@ -753,16 +763,17 @@ def generate_multi_session_html_export(sessions: List[Dict[str, Any]]) -> str:
     if is_multi:
         sidebar_items = []
         for s in sessions:
-            sid = s.get("id", "N/A")
+            sid = str(s.get("id", "N/A"))
+            escaped_sid = _escape_html(sid)
             title = s.get("title") or s.get("preview") or "Untitled Session"
             if len(title) > 50: title = title[:47] + "..."
             date = _format_timestamp(s.get("started_at", 0)).split(" ")[0]
             
             item = f'''
-            <a class="session-item" data-id="{sid}" onclick="showSession('{sid}')">
+            <a class="session-item" data-id="{escaped_sid}" href="#{quote(sid, safe='')}">
                 <div class="session-item-title">{_escape_html(title)}</div>
                 <div class="session-item-meta">
-                    <span>{sid[:8]}</span>
+                    <span>{_escape_html(sid[:8])}</span>
                     <span>{date}</span>
                 </div>
             </a>
@@ -789,7 +800,8 @@ def generate_multi_session_html_export(sessions: List[Dict[str, Any]]) -> str:
     # Main Content
     sessions_html_list = []
     for s in sessions:
-        sid = s.get("id", "N/A")
+        sid = str(s.get("id", "N/A"))
+        escaped_sid = _escape_html(sid)
         title = s.get("title") or "Hermes Session"
         model = s.get("model", "Unknown")
         started_at = _format_timestamp(s.get("started_at", 0))
@@ -800,7 +812,7 @@ def generate_multi_session_html_export(sessions: List[Dict[str, Any]]) -> str:
         view_class = "session-view"
         if not is_multi: view_class += " active"
         
-        session_view_id = f"view-{sid}"
+        session_view_id = f"view-{escaped_sid}"
         
         system_prompt = s.get("system_prompt")
         system_html = ""
@@ -822,7 +834,7 @@ def generate_multi_session_html_export(sessions: List[Dict[str, Any]]) -> str:
             <header class="fade-in">
                 <h1>{_escape_html(title)}</h1>
                 <div class="meta">
-                    <div class="meta-item"><strong>ID:</strong> {sid}</div>
+                    <div class="meta-item"><strong>ID:</strong> {escaped_sid}</div>
                     <div class="meta-item"><strong>Model:</strong> {_escape_html(model)}</div>
                     <div class="meta-item"><strong>Started:</strong> {started_at}</div>
                 </div>
@@ -835,13 +847,15 @@ def generate_multi_session_html_export(sessions: List[Dict[str, Any]]) -> str:
         '''
         sessions_html_list.append(session_html)
 
+    script_nonce = secrets.token_urlsafe(16)
     return HTML_TEMPLATE.format(
         page_title="Hermes Session Export" if is_multi else _escape_html(sessions[0].get("title", "Hermes Session")),
         sidebar_html=sidebar_html,
         sessions_html="\n".join(sessions_html_list),
         main_margin="var(--sidebar-width)" if is_multi else "0",
         layout_class="layout-multi" if is_multi else "layout-single",
-        generated_at=generated_at
+        generated_at=generated_at,
+        script_nonce=script_nonce,
     )
 
 def generate_html_export(session_data: Dict[str, Any]) -> str:

--- a/tests/hermes_cli/test_session_export.py
+++ b/tests/hermes_cli/test_session_export.py
@@ -2,6 +2,10 @@ import json
 import sys
 
 from hermes_cli.session_export import export_record_count, render_sessions_export
+from hermes_cli.session_export_html import (
+    _generate_messages_html,
+    generate_multi_session_html_export,
+)
 
 
 def _sample_session():
@@ -111,6 +115,42 @@ def test_full_markdown_renderer_collapses_tool_output_and_filters_system():
     assert "<details><summary>read_file</summary>" in rendered
     assert "```text\ndef redirect_after_login(): pass\n```" in rendered
     assert "hidden system context" not in rendered
+
+
+def test_html_export_escapes_tool_call_names():
+    payload = '<img src=x onerror="alert(document.domain)">'
+
+    rendered = _generate_messages_html(
+        [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": payload, "arguments": "<b>x</b>"},
+                    }
+                ],
+            }
+        ]
+    )
+
+    assert payload not in rendered
+    assert '&lt;img src=x onerror=&quot;alert(document.domain)&quot;&gt;' in rendered
+    assert "&lt;b&gt;x&lt;/b&gt;" in rendered
+
+
+def test_html_export_uses_csp_without_inline_event_handlers():
+    first = _sample_session()
+    second = {**_sample_session(), "id": "sess-456", "title": "Second session"}
+
+    rendered = generate_multi_session_html_export([first, second])
+
+    assert "Content-Security-Policy" in rendered
+    assert "script-src 'nonce-" in rendered
+    assert "<script nonce=" in rendered
+    assert "onclick=" not in rendered
 
 
 def test_export_record_count_switches_unit_for_prompt_only_exports():


### PR DESCRIPTION
## Problem

HTML session export interpolated assistant tool-call names directly into body HTML. A stored transcript with an attacker-controlled tool-call name could execute script when the exported file was opened. Fixes #61343.

## Root cause

`_generate_messages_html()` escaped sibling fields such as tool arguments and message content, but left `function.name` raw in the tool-call header. The export template also allowed inline script/event execution with no CSP.

## Fix

- Escape tool-call names before rendering them in the export.
- Add a CSP meta tag with a per-export script nonce.
- Replace inline sidebar `onclick` handlers with nonce-authorized event listeners so injected inline handlers stay blocked.
- Escape session IDs in sidebar and metadata attributes touched by the sidebar interaction path.

## Tests

- `scripts/run_tests.sh tests/hermes_cli/test_session_export.py -q`

## Repro

Before the fix, the issue repro printed `name unescaped: True`; after the fix it prints `name unescaped: False` while keeping tool arguments escaped.
