### PR TITLE
fix(image-routing): detect Windows image paths

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -63,10 +63,13 @@ _IMAGE_EXTS = (
 _IMAGE_EXT_PATTERN = "|".join(e.lstrip(".") for e in _IMAGE_EXTS)
 
 # Absolute / home-relative local image path. Matches the same shape gateway's
-# extract_local_files() uses: anchors to ``~/`` or ``/``, ignores matches inside
-# URLs (the ``(?<![/:\w.])`` lookbehind), and case-insensitive on the extension.
+# extract_local_files() uses: anchors to ``~/``, ``/``, or Windows drive-letter
+# absolutes, ignores matches inside URLs (the ``(?<![/:\w.])`` lookbehind), and
+# is case-insensitive on the extension.
 _LOCAL_IMAGE_PATH_RE = re.compile(
-    r"(?<![/:\w.])(?:~/|/)(?:[\w.\-]+/)*[\w.\-]+\.(?:" + _IMAGE_EXT_PATTERN + r")\b",
+    r"(?<![/:\w.])(?:~/|/|[A-Za-z]:[/\\])(?:[\w.\-]+[/\\])*[\w.\-]+\.(?:"
+    + _IMAGE_EXT_PATTERN
+    + r")\b",
     re.IGNORECASE,
 )
 
@@ -84,9 +87,10 @@ def extract_image_refs(text: str) -> Tuple[List[str], List[str]]:
 
     Returns ``(local_paths, urls)``:
 
-      * ``local_paths`` — absolute (``/``) or home-relative (``~/``) paths
-        whose suffix is an image extension AND whose expanded form exists
-        on disk as a file. Order-preserving, deduplicated.
+      * ``local_paths`` — absolute (``/`` or Windows drive-letter) or
+        home-relative (``~/``) paths whose suffix is an image extension AND
+        whose expanded form exists on disk as a file. Order-preserving,
+        deduplicated.
       * ``urls`` — ``http(s)://…`` URLs whose path ends in an image
         extension (a ``?query`` is allowed after the extension).
         Order-preserving, deduplicated.
@@ -119,16 +123,17 @@ def extract_image_refs(text: str) -> Tuple[List[str], List[str]]:
         if _in_code(match.start()):
             continue
         raw = match.group(0)
-        expanded = os.path.expanduser(raw)
+        expanded = os.path.normpath(os.path.expanduser(raw))
         try:
             if not os.path.isfile(expanded):
                 continue
         except OSError:
             # ENAMETOOLONG / EINVAL on pathological inputs — skip rather than crash.
             continue
-        if expanded in seen_paths:
+        dedupe_key = os.path.normcase(expanded)
+        if dedupe_key in seen_paths:
             continue
-        seen_paths.add(expanded)
+        seen_paths.add(dedupe_key)
         local_paths.append(expanded)
 
     urls: list[str] = []

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -539,11 +539,49 @@ class TestExtractImageRefs:
     def test_finds_home_relative_path(self, tmp_path: Path, monkeypatch):
         # Simulate ~/foo.png by pointing HOME at tmp_path and creating the file
         monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
         img = tmp_path / "foo.png"
         img.write_bytes(_png_bytes())
         paths, urls = extract_image_refs("see ~/foo.png please")
         assert paths == [str(img)]
         assert urls == []
+
+    def test_finds_windows_drive_letter_paths(self):
+        first = "C:\\Users\\Hiro\\shot.png"
+        second = "D:/captures/current.JPG"
+
+        with patch("agent.image_routing.os.path.isfile", return_value=True):
+            paths, urls = extract_image_refs(f"Compare {first} against {second}.")
+
+        assert paths == [first, second]
+        assert urls == []
+
+    def test_windows_drive_letter_paths_are_case_insensitive(self):
+        path = "c:/captures/current.PNG"
+
+        with patch("agent.image_routing.os.path.isfile", return_value=True):
+            paths, urls = extract_image_refs(f"Check {path}")
+
+        assert paths == [path]
+        assert urls == []
+
+    def test_ignores_relative_windows_drive_paths(self):
+        with patch("agent.image_routing.os.path.isfile", return_value=True):
+            paths, urls = extract_image_refs(
+                "Do not attach C:relative.png or C:folder\\nested.png"
+            )
+
+        assert paths == []
+        assert urls == []
+
+    def test_does_not_match_windows_path_inside_url(self):
+        body = "Only the URL: https://example.com/files/C:/captures/current.png"
+
+        with patch("agent.image_routing.os.path.isfile", return_value=True):
+            paths, urls = extract_image_refs(body)
+
+        assert paths == []
+        assert urls == ["https://example.com/files/C:/captures/current.png"]
 
     def test_skips_nonexistent_paths(self, tmp_path: Path):
         # Path-shaped but no file on disk → skipped.


### PR DESCRIPTION
## Problem

`extract_image_refs()` only recognized POSIX-style `/` and `~/` image paths. On native Windows, kanban task-body image enrichment silently skipped drive-letter paths such as `C:\Users\Hiro\shot.png`. Fixes #61568.

## Root cause

`agent/image_routing.py` claimed to match the gateway `extract_local_files()` shape, but its local-image regex was never updated after #34632 added Windows drive-letter support to the gateway path. It also deduped before path normalization.

## Fix

- Extend the local-image regex to accept absolute Windows drive-letter paths with `/` or `\` separators.
- Normalize expanded local paths before file checks and dedupe with `normcase()` so native Windows separator/case normalization is respected.
- Set `USERPROFILE` in the tilde expansion test so the same test matches Python's Windows `expanduser()` behavior.
- Add platform-independent regression tests for Windows drive-letter paths, lowercase drives, relative-drive non-matches, and URL lookbehind behavior.

## Tests

- `scripts/run_tests.sh tests/agent/test_image_routing.py -q`
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_worker_image_extraction.py -q`

## Repro

On current `main`, `_LOCAL_IMAGE_PATH_RE` returns no match for `C:\Users\Hiro\shot.png`, `C:/Users/Hiro/shot.png`, or `c:/shot.PNG`. After the fix, all three match and still pass the existing file-existence gate.
