### PR TITLE
fix(cli): handle chat -q interrupts cleanly

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -16256,8 +16256,14 @@ def main(
                 # Surface security advisories before the agent runs — short
                 # banner, doesn't depend on the welcome banner being shown.
                 cli._show_security_advisories()
-                cli.chat(query, images=single_query_images or None)
-                cli._print_exit_summary(clear_screen=False)
+                try:
+                    cli.chat(query, images=single_query_images or None)
+                except KeyboardInterrupt:
+                    _emit_interrupted_session_end(cli, reason="keyboard_interrupt")
+                    cli._print_exit_summary(clear_screen=False)
+                    sys.exit(130)
+                else:
+                    cli._print_exit_summary(clear_screen=False)
         finally:
             _finalize_single_query(cli)
         return

--- a/tests/cli/test_chat_q_exit_clear.py
+++ b/tests/cli/test_chat_q_exit_clear.py
@@ -116,6 +116,61 @@ def test_single_query_main_skips_clear_on_exit_summary(monkeypatch):
     )
 
 
+def test_single_query_main_handles_keyboard_interrupt_without_traceback(monkeypatch):
+    """The human-facing -q path exits 130 instead of leaking KeyboardInterrupt."""
+    calls = []
+
+    class FakeCLI:
+        def __init__(self, **_kwargs):
+            self.console = SimpleNamespace(print=lambda *_a, **_kw: calls.append("query-label"))
+            self.session_id = "sq-interrupt"
+            self.agent = SimpleNamespace(
+                session_id="sq-interrupt",
+                platform="cli",
+            )
+
+        def _claim_active_session(self, surface, *, stderr=False):
+            calls.append(("claim", surface, stderr))
+            return True
+
+        def _show_security_advisories(self):
+            calls.append("advisories")
+
+        def chat(self, query, images=None):
+            calls.append(("chat", query, images))
+            raise KeyboardInterrupt
+
+        def _print_exit_summary(self, clear_screen=True):
+            calls.append(("summary", clear_screen))
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_a, **_kw: None)
+    monkeypatch.setattr(
+        cli_mod,
+        "_emit_interrupted_session_end",
+        lambda fake_cli, *, reason: calls.append(("interrupted", fake_cli.session_id, reason)),
+    )
+    monkeypatch.setattr(
+        cli_mod,
+        "_finalize_single_query",
+        lambda fake_cli: calls.append(("finalize", fake_cli.session_id)),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli_mod.main(query="hello", quiet=False, toolsets="terminal")
+
+    assert exc.value.code == 130
+    assert calls == [
+        ("claim", "cli", False),
+        "query-label",
+        "advisories",
+        ("chat", "hello", None),
+        ("interrupted", "sq-interrupt", "keyboard_interrupt"),
+        ("summary", False),
+        ("finalize", "sq-interrupt"),
+    ]
+
+
 # ── Verify interactive mode still clears ────────────────────────────────────
 
 def test_print_exit_summary_still_clears_in_interactive_path(monkeypatch):


### PR DESCRIPTION
## Problem

Human-facing single-query mode (`hermes chat -q ...`) could leak a raw Python `KeyboardInterrupt` traceback when SIGINT/SIGTERM landed while `cli.chat()` was blocked in the main thread. Fixes #61508.

## Root cause

The quiet `-Q` path already catches `KeyboardInterrupt` around the one-shot agent run, emits interrupted session metadata, and exits 130. The non-quiet `-q` path called `cli.chat()` directly, so a `KeyboardInterrupt` raised by the single-query signal handler bubbled to the console before `_finalize_single_query()` ran.

## Fix

Wrap the non-quiet `cli.chat()` call with the same explicit interrupt contract:

- emit the interrupted session end hook
- print the normal one-shot exit summary without clearing the response
- exit with code 130
- leave `_finalize_single_query()` in the existing `finally` so resources and the active-session lease are still released

## Tests

- `scripts/run_tests.sh tests/cli/test_chat_q_exit_clear.py -q`

## Verification

The added regression test drives the production `main(query=..., quiet=False)` branch with a `HermesCLI` stub whose `chat()` raises `KeyboardInterrupt`; it now exits with code 130 and does not let the exception escape.
