### PR TITLE
fix(approval): include display_target in auto-approve audit log

### DIFF
--- a/tests/tools/test_command_guards.py
+++ b/tests/tools/test_command_guards.py
@@ -417,3 +417,48 @@ class TestGatewayApprovalAllowPermanent:
         renderer hides "Always allow"."""
         payload = self._capture_gateway_payload("curl https://bit.ly/abc", "gw-no-perm")
         assert payload["allow_permanent"] is False
+
+
+
+class TestAutoApproveAuditLog:
+    """Regression tests for non-interactive auto-approve audit log (#61671)."""
+
+    def _call_gate(self, display_target: str) -> list:
+        """Call _run_approval_gate in non-interactive auto-approve context."""
+        import logging
+        from unittest.mock import patch
+        from tools.approval import _run_approval_gate
+        warnings = []
+        with patch("tools.approval.logger") as mock_log:
+            mock_log.warning.side_effect = lambda fmt, *a, **kw: warnings.append(fmt % a)
+            _run_approval_gate(
+                pattern_key="test_pattern",
+                description="test dangerous command",
+                display_target=display_target,
+                approval_callback=None,
+                cron_deny_message="",
+                autoapprove_log_prefix="[auto-approve]",
+                fail_closed_when_no_human=False,
+                no_human_block_message="",
+            )
+        return warnings
+
+    def test_display_target_included_in_audit_log(self):
+        """Auto-approve warning must include the display_target."""
+        cmd = "rm -rf /tmp/test"
+        warnings = self._call_gate(cmd)
+        assert any(cmd in w for w in warnings), (
+            f"display_target must appear in audit log, got: {warnings}"
+        )
+
+    def test_display_target_truncated_at_200_chars(self):
+        """display_target longer than 200 chars must be truncated in the log."""
+        long_cmd = "rm -rf /tmp/" + "a" * 300
+        warnings = self._call_gate(long_cmd)
+        assert warnings, "Expected at least one warning log entry"
+        assert all("a" * 201 not in w for w in warnings), (
+            "display_target must be truncated to 200 chars in audit log"
+        )
+        assert any("a" * 10 in w for w in warnings), (
+            "display_target should still partially appear in audit log"
+        )

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2099,9 +2099,9 @@ def _run_approval_gate(
                 "description": description,
             }
         logger.warning(
-            "%s (pattern: %s): %s — set HERMES_INTERACTIVE or "
+            "%s (pattern: %s): %s — target: %s — set HERMES_INTERACTIVE or "
             "HERMES_GATEWAY_SESSION to require approval.",
-            autoapprove_log_prefix, pattern_key, description,
+            autoapprove_log_prefix, pattern_key, description, display_target[:200],
         )
         return {"approved": True, "message": None}
 


### PR DESCRIPTION
## What does this PR do?

Fixes a missing audit log entry for auto-approved dangerous commands in non-interactive contexts.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

`_run_approval_gate` logs a warning when a dangerous command is auto-approved in a non-interactive/non-gateway context. The log line only included `autoapprove_log_prefix`, `pattern_key`, and `description` — the actual command or tool target (`display_target`) was omitted.

This means the specific command being auto-approved is never captured in the audit trail, which is precisely the scenario where logging matters most (unattended auto-approval of a flagged dangerous command).

Fix: add `display_target` to the `logger.warning` call so the full command/tool label appears in the audit log.

## How to Test

In a non-interactive context (no HERMES_INTERACTIVE, no HERMES_GATEWAY_SESSION), trigger a command that matches a dangerous pattern. Before: the log shows only the pattern key and description. After: the log also shows the actual command/tool target.

## Checklist
- [x] Single focused change
- [x] No unrelated modifications
- [x] No new dependencies