### PR TITLE
feat(gateway): add Telegram Kanban inbox bindings

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8976,6 +8976,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # Record rate limit so subsequent messages are silently ignored
                     self.pairing_store._record_rate_limit(platform_name, source.user_id)
             return None
+
+        # Zero-prefix Telegram Kanban inbox. This intentionally sits AFTER the
+        # normal user/chat authorization gate above, but BEFORE update prompts,
+        # session creation, and the running-agent guard below. Bound topics can
+        # capture task dumps without waiting for an active conversation, while
+        # unauthorized senders and slash commands still use the normal paths.
+        _kanban_inbox_reply = await self._maybe_handle_kanban_inbox_message(event)
+        if _kanban_inbox_reply is not None:
+            return _kanban_inbox_reply
         
         # Intercept messages that are responses to a pending /update prompt.
         # The update process (detached) wrote .update_prompt.json; the watcher

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -271,19 +271,11 @@ class GatewaySlashCommandsMixin:
                     idempotency_key=idempotency_key,
                     board=board,
                 )
-                user_id = str(getattr(source, "user_id", "") or "") or None
-                _kb.add_notify_sub(
-                    conn,
-                    task_id=task_id,
-                    platform=platform_str,
-                    chat_id=chat_id,
-                    thread_id=thread_id,
-                    user_id=user_id,
-                    notifier_profile=(
-                        getattr(self, "_kanban_notifier_profile", None)
-                        or getattr(self, "_active_profile_name", lambda: "default")()
-                    ),
-                )
+                # Inbox topics are capture surfaces, not report channels. Do not
+                # auto-subscribe terminal task notifications back to the same
+                # Telegram topic: worker closeouts/blockers would pollute the
+                # mobile inbox and the topic's conversation context. Operators
+                # can add explicit subscriptions to a separate reports topic.
                 return task_id
             finally:
                 conn.close()

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -19,6 +19,7 @@ import asyncio
 import dataclasses
 import hashlib
 import inspect
+import json
 import logging
 import os
 import re
@@ -39,6 +40,7 @@ from gateway.session import (
     is_shared_multi_user_session,
 )
 from hermes_cli.config import atomic_config_write, cfg_get, clear_model_endpoint_credentials
+from hermes_constants import get_hermes_home
 from utils import (
     atomic_json_write,
     base_url_host_matches,
@@ -85,6 +87,329 @@ def _model_switch_skew_guard() -> Optional[str]:
 
 class GatewaySlashCommandsMixin:
     """In-session slash-command handlers for GatewayRunner."""
+
+    # ------------------------------------------------------------------
+    # Zero-prefix Telegram → native Kanban inbox
+    # ------------------------------------------------------------------
+
+    def _kanban_inbox_bindings_path(self) -> Path:
+        """Profile-aware JSON store for topic/thread → Kanban inbox bindings.
+
+        Bindings are deliberately scoped to the gateway profile's HERMES_HOME:
+        a Telegram topic bound in one profile must not become a zero-prefix
+        task intake surface for another profile that happens to share the bot.
+        """
+        return get_hermes_home() / "kanban_inbox_bindings.json"
+
+    def _load_kanban_inbox_bindings(self) -> dict[str, Any]:
+        path = self._kanban_inbox_bindings_path()
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return {"version": 1, "bindings": []}
+        except Exception:
+            logger.warning("Failed to read kanban inbox bindings from %s", path, exc_info=True)
+            return {"version": 1, "bindings": []}
+        if not isinstance(data, dict):
+            return {"version": 1, "bindings": []}
+        bindings = data.get("bindings")
+        if not isinstance(bindings, list):
+            data["bindings"] = []
+        data.setdefault("version", 1)
+        return data
+
+    def _save_kanban_inbox_bindings(self, data: dict[str, Any]) -> None:
+        path = self._kanban_inbox_bindings_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        tmp.replace(path)
+
+    def _kanban_inbox_source_key(self, source) -> tuple[str, str, Optional[str]]:
+        platform = getattr(source, "platform", None)
+        platform_value = getattr(platform, "value", platform)
+        platform_str = str(platform_value or "").lower()
+        chat_id = str(getattr(source, "chat_id", "") or "")
+        thread_raw = getattr(source, "thread_id", None)
+        thread_id = str(thread_raw) if thread_raw not in (None, "") else None
+        return platform_str, chat_id, thread_id
+
+    def _find_kanban_inbox_binding(self, source) -> Optional[dict[str, Any]]:
+        platform_str, chat_id, thread_id = self._kanban_inbox_source_key(source)
+        if not platform_str or not chat_id:
+            return None
+        data = self._load_kanban_inbox_bindings()
+        for raw in data.get("bindings", []):
+            if not isinstance(raw, dict) or raw.get("enabled") is False:
+                continue
+            if str(raw.get("platform", "")).lower() != platform_str:
+                continue
+            if str(raw.get("chat_id", "")) != chat_id:
+                continue
+            raw_thread = raw.get("thread_id")
+            binding_thread = str(raw_thread) if raw_thread not in (None, "") else None
+            # Thread bindings are exact. Whole-chat bindings are possible but
+            # intentionally opt-in via thread_id=null; do not let a typo in one
+            # topic hijack every other topic.
+            if binding_thread != thread_id:
+                continue
+            return dict(raw)
+        return None
+
+    def _infer_kanban_inbox_kind_and_title(self, event: MessageEvent) -> tuple[str, str]:
+        text = (event.text or "").strip()
+        first_line = next((ln.strip() for ln in text.splitlines() if ln.strip()), "")
+        kind = "triage"
+        title_source = first_line
+        m = re.match(r"^(bug|issue|regression|task|todo|idea|someday|urgent)\s*[:\-–—]?\s*(.+)$", first_line, re.IGNORECASE)
+        if m:
+            raw_kind = m.group(1).lower()
+            title_source = m.group(2).strip()
+            kind = "task" if raw_kind in {"todo"} else raw_kind
+        elif re.search(r"\b(crash|crashes|freezes|broken|bug|error|fails|failure|regression)\b", text, re.IGNORECASE):
+            kind = "bug"
+        elif re.search(r"\b(add|create|implement|test|fix|make|update)\b", text, re.IGNORECASE):
+            kind = "task"
+        elif re.search(r"\b(idea|maybe|could|nice to have)\b", text, re.IGNORECASE):
+            kind = "idea"
+        if not title_source:
+            media_count = len(getattr(event, "media_urls", None) or [])
+            title_source = "Telegram media item" if media_count else "Telegram inbox item"
+        title = re.sub(r"\s+", " ", title_source).strip()
+        if len(title) > 110:
+            title = title[:107].rstrip() + "..."
+        return kind, title or "Telegram inbox item"
+
+    def _kanban_inbox_body(self, event: MessageEvent, binding: dict[str, Any], kind: str) -> str:
+        source = event.source
+        platform_str, chat_id, thread_id = self._kanban_inbox_source_key(source)
+        lines = [
+            "Captured from Telegram Kanban inbox.",
+            f"Kind: {kind}",
+            f"Board: {binding.get('board')}",
+            f"Chat: {chat_id}",
+        ]
+        if thread_id:
+            lines.append(f"Thread/topic: {thread_id}")
+        if getattr(event, "message_id", None):
+            lines.append(f"Message id: {event.message_id}")
+        if getattr(source, "user_name", None):
+            lines.append(f"Sender: {source.user_name}")
+        text = (event.text or "").strip()
+        if text:
+            lines.extend(["", "Message:", text])
+        if getattr(event, "reply_to_text", None):
+            lines.extend(["", "Replied-to context:", str(event.reply_to_text).strip()])
+        media_urls = list(getattr(event, "media_urls", None) or [])
+        media_types = list(getattr(event, "media_types", None) or [])
+        if media_urls:
+            lines.append("")
+            lines.append("Attachments:")
+            for i, url in enumerate(media_urls, 1):
+                typ = media_types[i - 1] if i - 1 < len(media_types) else "media"
+                lines.append(f"- {typ}: {url}")
+        return "\n".join(lines).strip()
+
+    async def _maybe_handle_kanban_inbox_message(self, event: MessageEvent) -> Optional[str]:
+        """Turn plain messages in bound Telegram topics into native Kanban cards.
+
+        This is the zero-prefix mobile path: in a mapped topic/thread, ordinary
+        text/voice/photo messages are control-plane intake, not conversational
+        prompts. Creating the card happens before the running-agent guard, so a
+        gym bug dump never waits behind a long active Hermes turn.
+        """
+        if getattr(event, "internal", False) or event.is_command():
+            return None
+        source = event.source
+        platform_str, chat_id, thread_id = self._kanban_inbox_source_key(source)
+        if platform_str != "telegram" or not chat_id:
+            return None
+        binding = self._find_kanban_inbox_binding(source)
+        if not binding:
+            return None
+        text = (event.text or "").strip()
+        media_urls = list(getattr(event, "media_urls", None) or [])
+        if not text and not media_urls:
+            return None
+        board = str(binding.get("board") or "general").strip().lower()
+        assignee = str(binding.get("assignee") or ("default" if board == "general" else board)).strip() or None
+        project = str(binding.get("project") or "").strip() or None
+        workspace = str(binding.get("workspace") or ("scratch" if board == "general" else "worktree")).strip() or "scratch"
+        if workspace not in {"scratch", "worktree", "dir"}:
+            workspace = "scratch"
+        kind, title = self._infer_kanban_inbox_kind_and_title(event)
+        body = self._kanban_inbox_body(event, binding, kind)
+        message_id = str(getattr(event, "message_id", "") or "")
+        if not message_id:
+            # Telegram normally supplies a message id, which is the stable
+            # redelivery key. Test/downgraded adapters may not; in that case
+            # fall back to a content fingerprint so distinct messages in the
+            # same topic do not collapse into one idempotent task.
+            message_id = "sha256:" + hashlib.sha256(
+                json.dumps(
+                    {"text": text, "media_urls": media_urls},
+                    sort_keys=True,
+                    ensure_ascii=False,
+                ).encode("utf-8")
+            ).hexdigest()[:24]
+        idem_parts = [platform_str, chat_id, thread_id or "", message_id]
+        idempotency_key = "telegram-inbox:" + ":".join(idem_parts)
+
+        def _create() -> str:
+            from hermes_cli import kanban_db as _kb
+            conn = _kb.connect(board=board)
+            try:
+                task_id = _kb.create_task(
+                    conn,
+                    title=title,
+                    body=body,
+                    assignee=assignee,
+                    created_by="telegram-inbox",
+                    workspace_kind=workspace,
+                    project_id=project,
+                    triage=True,
+                    idempotency_key=idempotency_key,
+                    board=board,
+                )
+                user_id = str(getattr(source, "user_id", "") or "") or None
+                _kb.add_notify_sub(
+                    conn,
+                    task_id=task_id,
+                    platform=platform_str,
+                    chat_id=chat_id,
+                    thread_id=thread_id,
+                    user_id=user_id,
+                    notifier_profile=(
+                        getattr(self, "_kanban_notifier_profile", None)
+                        or getattr(self, "_active_profile_name", lambda: "default")()
+                    ),
+                )
+                return task_id
+            finally:
+                conn.close()
+
+        try:
+            task_id = await asyncio.to_thread(_create)
+        except Exception as exc:
+            logger.warning("Kanban inbox create failed", exc_info=True)
+            return f"⚠️ Kanban inbox failed to queue this message: {exc}"
+        return f"Queued `{task_id}` → `{board}` · `{kind}` · triage\n{title}"
+
+    async def _handle_kanban_inbox_command(self, event: MessageEvent, raw_args: str) -> str:
+        """Handle `/kanban inbox ...` management commands."""
+        tokens = shlex.split(raw_args) if raw_args else []
+        if not tokens or tokens[0] in {"help", "-h", "--help"}:
+            return (
+                "Kanban inbox maps this Telegram topic to zero-prefix card capture.\n\n"
+                "Usage:\n"
+                "`/kanban inbox bind general`\n"
+                "`/kanban inbox bind forgewod --assignee forgewod --project forgewod --workspace worktree`\n"
+                "`/kanban inbox status`\n"
+                "`/kanban inbox unbind`"
+            )
+        action = tokens[0]
+        source = event.source
+        platform_str, chat_id, thread_id = self._kanban_inbox_source_key(source)
+        if platform_str != "telegram" or not chat_id:
+            return "Kanban inbox binding is currently implemented for Telegram chats/topics."
+        if action in {"status", "list"}:
+            current = self._find_kanban_inbox_binding(source)
+            data = self._load_kanban_inbox_bindings()
+            lines = ["**Kanban inbox bindings**"]
+            lines.append(f"Current topic: `{chat_id}` / `{thread_id or 'whole-chat'}`")
+            if current:
+                lines.append(
+                    f"Current binding: `{current.get('board')}` → assignee `{current.get('assignee')}` "
+                    f"project `{current.get('project') or '-'}` workspace `{current.get('workspace') or '-'}`"
+                )
+            else:
+                lines.append("Current binding: none")
+            all_bindings = [b for b in data.get("bindings", []) if isinstance(b, dict)]
+            if all_bindings:
+                lines.append("")
+                lines.append("All bindings:")
+                for b in all_bindings:
+                    enabled = "on" if b.get("enabled") is not False else "off"
+                    lines.append(
+                        f"- `{enabled}` {b.get('platform')}:{b.get('chat_id')}:{b.get('thread_id') or '*'} "
+                        f"→ `{b.get('board')}` / `{b.get('assignee')}`"
+                    )
+            return "\n".join(lines)
+        if action == "unbind":
+            data = self._load_kanban_inbox_bindings()
+            before = len(data.get("bindings", []))
+            data["bindings"] = [
+                b for b in data.get("bindings", [])
+                if not (
+                    isinstance(b, dict)
+                    and str(b.get("platform", "")).lower() == platform_str
+                    and str(b.get("chat_id", "")) == chat_id
+                    and ((str(b.get("thread_id")) if b.get("thread_id") not in (None, "") else None) == thread_id)
+                )
+            ]
+            self._save_kanban_inbox_bindings(data)
+            removed = before - len(data.get("bindings", []))
+            return f"Removed {removed} Kanban inbox binding(s) for this topic."
+        if action != "bind":
+            return "Usage: `/kanban inbox bind <board>` or `/kanban inbox status`."
+        if len(tokens) < 2:
+            return "Usage: `/kanban inbox bind <board>`"
+        board = tokens[1].strip().lower()
+        try:
+            from hermes_cli import kanban_db as _kb
+            if not _kb.board_exists(board):
+                return f"Kanban board `{board}` does not exist. Create it first with `hermes kanban boards create {board}`."
+        except Exception:
+            logger.debug("kanban inbox board existence check skipped", exc_info=True)
+        opts: dict[str, str] = {}
+        i = 2
+        while i < len(tokens):
+            tok = tokens[i]
+            if tok.startswith("--"):
+                key = tok[2:].replace("-", "_")
+                if i + 1 < len(tokens) and not tokens[i + 1].startswith("--"):
+                    opts[key] = tokens[i + 1]
+                    i += 2
+                else:
+                    opts[key] = "true"
+                    i += 1
+            else:
+                i += 1
+        assignee = opts.get("assignee") or ("default" if board in {"general", "default"} else board)
+        project = opts.get("project") or (None if board in {"general", "default"} else board)
+        workspace = opts.get("workspace") or ("scratch" if board in {"general", "default"} else "worktree")
+        name = opts.get("name") or f"{board} inbox"
+        data = self._load_kanban_inbox_bindings()
+        bindings = [b for b in data.get("bindings", []) if isinstance(b, dict)]
+        new_binding = {
+            "platform": platform_str,
+            "chat_id": chat_id,
+            "thread_id": thread_id,
+            "board": board,
+            "assignee": assignee,
+            "project": project,
+            "workspace": workspace,
+            "name": name,
+            "enabled": True,
+            "created_at": int(time.time()),
+        }
+        replaced = False
+        for idx, b in enumerate(bindings):
+            b_thread = str(b.get("thread_id")) if b.get("thread_id") not in (None, "") else None
+            if str(b.get("platform", "")).lower() == platform_str and str(b.get("chat_id", "")) == chat_id and b_thread == thread_id:
+                bindings[idx] = new_binding
+                replaced = True
+                break
+        if not replaced:
+            bindings.append(new_binding)
+        data["bindings"] = bindings
+        self._save_kanban_inbox_bindings(data)
+        verb = "Updated" if replaced else "Bound"
+        return (
+            f"{verb} this Telegram topic as Kanban inbox → `{board}`.\n"
+            f"Plain messages here now queue triage cards immediately.\n"
+            f"Assignee: `{assignee}` · project: `{project or '-'}` · workspace: `{workspace}`"
+        )
 
     def _typed_command_prefix_for(self, platform) -> str:
         """Return the prefix users can always type to reach Hermes commands.
@@ -418,6 +743,9 @@ class GatewaySlashCommandsMixin:
         if text.startswith("kanban"):
             text = text[len("kanban"):].lstrip()
 
+        if text == "inbox" or text.startswith("inbox "):
+            return await self._handle_kanban_inbox_command(event, text[len("inbox"):].strip())
+
         tokens = shlex.split(text) if text else []
         requested_board = None
         action = None
@@ -471,7 +799,10 @@ class GatewaySlashCommandsMixin:
                                     platform=platform_str, chat_id=chat_id,
                                     thread_id=thread_id or None,
                                     user_id=user_id,
-                                    notifier_profile=getattr(self, "_kanban_notifier_profile", None) or self._active_profile_name(),
+                                    notifier_profile=(
+                                        getattr(self, "_kanban_notifier_profile", None)
+                                        or getattr(self, "_active_profile_name", lambda: "default")()
+                                    ),
                                 )
                             finally:
                                 conn.close()

--- a/tests/gateway/test_kanban_inbox.py
+++ b/tests/gateway/test_kanban_inbox.py
@@ -62,6 +62,34 @@ async def test_kanban_inbox_bind_and_plain_message_creates_triage_card(tmp_path,
 
 
 @pytest.mark.asyncio
+async def test_kanban_inbox_does_not_subscribe_replies_to_capture_topic(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    kb.write_board_metadata("general", name="General")
+    gateway = DummyGateway()
+    source = _source()
+    await gateway._handle_kanban_inbox_command(
+        MessageEvent(text="/kanban inbox bind general", message_type=MessageType.TEXT, source=source),
+        "bind general",
+    )
+
+    reply = await gateway._maybe_handle_kanban_inbox_message(
+        MessageEvent(
+            text="task: keep this as capture only",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="m-no-sub",
+        )
+    )
+
+    assert reply is not None
+    with kb.connect_closing(board="general") as conn:
+        tasks = kb.list_tasks(conn)
+        subs = kb.list_notify_subs(conn, task_id=tasks[0].id)
+    assert len(tasks) == 1
+    assert subs == []
+
+
+@pytest.mark.asyncio
 async def test_kanban_inbox_is_idempotent_per_platform_message(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     kb.write_board_metadata("general", name="General")

--- a/tests/gateway/test_kanban_inbox.py
+++ b/tests/gateway/test_kanban_inbox.py
@@ -1,0 +1,211 @@
+from datetime import datetime
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionEntry, SessionSource, build_session_key
+from gateway.slash_commands import GatewaySlashCommandsMixin
+from hermes_cli import kanban_db as kb
+
+
+class DummyGateway(GatewaySlashCommandsMixin):
+    _kanban_notifier_profile = "default"
+
+    def _active_profile_name(self):
+        return "default"
+
+
+def _source(thread_id="thread-general"):
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="chat-test",
+        chat_type="group",
+        user_id="user-1",
+        user_name="Alex",
+        thread_id=thread_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_kanban_inbox_bind_and_plain_message_creates_triage_card(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    kb.write_board_metadata("general", name="General")
+    gateway = DummyGateway()
+    source = _source()
+
+    bind_reply = await gateway._handle_kanban_inbox_command(
+        MessageEvent(text="/kanban inbox bind general", message_type=MessageType.TEXT, source=source),
+        "bind general",
+    )
+    assert "Plain messages here now queue" in bind_reply
+
+    reply = await gateway._maybe_handle_kanban_inbox_message(
+        MessageEvent(
+            text="timer freezes after editing a WOD",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="m1",
+        )
+    )
+    assert reply is not None
+    assert "→ `general`" in reply
+    assert "· `bug` · triage" in reply
+
+    with kb.connect_closing(board="general") as conn:
+        tasks = kb.list_tasks(conn)
+    assert len(tasks) == 1
+    assert tasks[0].status == "triage"
+    assert tasks[0].assignee == "default"
+
+
+@pytest.mark.asyncio
+async def test_kanban_inbox_is_idempotent_per_platform_message(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    kb.write_board_metadata("general", name="General")
+    gateway = DummyGateway()
+    source = _source()
+    await gateway._handle_kanban_inbox_command(
+        MessageEvent(text="/kanban inbox bind general", message_type=MessageType.TEXT, source=source),
+        "bind general",
+    )
+    event = MessageEvent(text="Bug: duplicate smoke", message_type=MessageType.TEXT, source=source, message_id="same")
+
+    first = await gateway._maybe_handle_kanban_inbox_message(event)
+    second = await gateway._maybe_handle_kanban_inbox_message(event)
+
+    assert first == second
+    with kb.connect_closing(board="general") as conn:
+        tasks = kb.list_tasks(conn)
+    assert len(tasks) == 1
+
+
+@pytest.mark.asyncio
+async def test_kanban_inbox_missing_message_id_uses_content_fingerprint(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    kb.write_board_metadata("general", name="General")
+    gateway = DummyGateway()
+    source = _source()
+    await gateway._handle_kanban_inbox_command(
+        MessageEvent(text="/kanban inbox bind general", message_type=MessageType.TEXT, source=source),
+        "bind general",
+    )
+
+    first = await gateway._maybe_handle_kanban_inbox_message(
+        MessageEvent(text="Bug: one", message_type=MessageType.TEXT, source=source)
+    )
+    second = await gateway._maybe_handle_kanban_inbox_message(
+        MessageEvent(text="Bug: two", message_type=MessageType.TEXT, source=source)
+    )
+
+    assert first != second
+    with kb.connect_closing(board="general") as conn:
+        tasks = kb.list_tasks(conn)
+    assert len(tasks) == 2
+
+
+@pytest.mark.asyncio
+async def test_kanban_inbox_skips_slash_commands_and_unbound_topics(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    kb.write_board_metadata("general", name="General")
+    gateway = DummyGateway()
+    source = _source()
+    await gateway._handle_kanban_inbox_command(
+        MessageEvent(text="/kanban inbox bind general", message_type=MessageType.TEXT, source=source),
+        "bind general",
+    )
+
+    assert await gateway._maybe_handle_kanban_inbox_message(
+        MessageEvent(text="/status", message_type=MessageType.TEXT, source=source, message_id="cmd")
+    ) is None
+    assert await gateway._maybe_handle_kanban_inbox_message(
+        MessageEvent(text="plain in another thread", message_type=MessageType.TEXT, source=_source("other"), message_id="m2")
+    ) is None
+
+
+def _make_runner_for_inbox_handle_message(monkeypatch, *, authorized=True):
+    from gateway.run import GatewayRunner
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *args, **kwargs: [])
+
+    runner = cast(Any, object.__new__(GatewayRunner))
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    runner.session_store = MagicMock()
+    runner._scale_to_zero_note_real_inbound = MagicMock()
+    runner._is_user_authorized = MagicMock(return_value=authorized)
+    runner._get_unauthorized_dm_behavior = MagicMock(return_value="ignore")
+    runner._adapter_for_source = MagicMock(return_value=None)
+    runner._kanban_notifier_profile = "default"
+    runner._active_profile_name = MagicMock(return_value="default")
+    runner._startup_restore_in_progress = False
+    runner._update_prompt_pending = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._voice_mode = {}
+    adapter = MagicMock()
+    adapter._pending_messages = {}
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_kanban_inbox_handle_message_runs_after_auth_but_before_session_and_busy_guard(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    kb.write_board_metadata("general", name="General")
+    runner = _make_runner_for_inbox_handle_message(monkeypatch, authorized=True)
+    source = _source()
+    await runner._handle_kanban_inbox_command(
+        MessageEvent(text="/kanban inbox bind general", message_type=MessageType.TEXT, source=source),
+        "bind general",
+    )
+    sk = build_session_key(source)
+    session_entry = SessionEntry(
+        session_key=sk,
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+    runner.session_store.get_or_create_session.return_value = session_entry
+    running_agent = MagicMock()
+    runner._running_agents[sk] = running_agent
+
+    reply = await runner._handle_message(
+        MessageEvent(text="bug: captured before busy path", message_type=MessageType.TEXT, source=source, message_id="m3")
+    )
+
+    assert reply is not None
+    assert "Queued `" in reply
+    runner._is_user_authorized.assert_called_once_with(source)
+    runner.session_store.get_or_create_session.assert_not_called()
+    running_agent.interrupt.assert_not_called()
+    with kb.connect_closing(board="general") as conn:
+        tasks = kb.list_tasks(conn)
+    assert [task.title for task in tasks] == ["captured before busy path"]
+
+
+@pytest.mark.asyncio
+async def test_kanban_inbox_handle_message_does_not_capture_unauthorized_sender(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    kb.write_board_metadata("general", name="General")
+    runner = _make_runner_for_inbox_handle_message(monkeypatch, authorized=False)
+    source = _source()
+    await runner._handle_kanban_inbox_command(
+        MessageEvent(text="/kanban inbox bind general", message_type=MessageType.TEXT, source=source),
+        "bind general",
+    )
+
+    reply = await runner._handle_message(
+        MessageEvent(text="bug: unauthorized", message_type=MessageType.TEXT, source=source, message_id="m4")
+    )
+
+    assert reply is None
+    with kb.connect_closing(board="general") as conn:
+        assert kb.list_tasks(conn) == []

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -19,6 +19,15 @@ The board has two front doors, both backed by the same `~/.hermes/kanban.db`:
 
 Both surfaces route through the same `kanban_db` layer, so reads see a consistent view and writes can't drift. The rest of this page shows CLI examples because they're easy to copy-paste, but every CLI verb has a tool-call equivalent the model uses.
 
+Telegram gateway users can also bind a dedicated topic as a **zero-prefix Kanban inbox**: after `/kanban inbox bind <board>` in that topic, ordinary non-slash messages are captured as triage cards immediately, without waiting for the current chat agent turn to finish. The binding is exact to the Telegram chat/topic and profile-scoped under that gateway's `HERMES_HOME`, so one profile or topic does not silently hijack another. Slash commands and unauthorized senders still take the normal gateway path.
+
+```text
+/kanban inbox bind general
+/kanban inbox bind forgewod --assignee forgewod --project forgewod --workspace worktree
+/kanban inbox status
+/kanban inbox unbind
+```
+
 This is the shape that covers the workloads `delegate_task` can't:
 
 - **Research triage** — parallel researchers + analyst + writer, human-in-the-loop.


### PR DESCRIPTION
## Summary
- bind a Telegram topic to a Kanban board for zero-prefix card capture
- capture authenticated messages before session creation and busy-agent routing
- make delivery idempotent and keep capture topics separate from report notifications

## Verification
- `scripts/run_tests.sh tests/gateway/test_kanban_inbox.py -q` (7 passed)

## Design
Capture topics intentionally do not auto-subscribe to task notifications. Operators can route semantic closeout/blocker reports to a separate reports topic, keeping the mobile inbox clean.