### PR TITLE
fix(honcho): search target peer self-scope in addition to assistant-target scope

### DIFF
--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -964,7 +964,12 @@ class HonchoSessionManager:
         *,
         target: str | None = None,
     ) -> dict[str, Any]:
-        """Fetch representation + peer card directly from a peer object."""
+        """Fetch representation + peer card directly from a peer object.
+
+        When an observer requests context for a different target, merge the
+        observer-owned scope with the target peer's self-scope. Conclusions
+        may be stored in either scope depending on the observation settings.
+        """
         peer = self._get_or_create_peer(peer_id)
         representation = ""
         card: list[str] = []
@@ -998,6 +1003,25 @@ class HonchoSessionManager:
                 card = self._fetch_peer_card(peer_id, target=target)
             except Exception as e:
                 logger.debug("Direct peer card fetch failed for '%s': %s", peer_id, e)
+
+        # Conclusions about a target may also live in its self-scope
+        # (target observing target). Keep the observer-owned result primary,
+        # and treat a failed self-scope lookup as non-fatal.
+        if target is not None and target != peer_id:
+            try:
+                self_ctx = self._fetch_peer_context(
+                    target,
+                    search_query=search_query,
+                    target=target,
+                )
+                self_representation = self_ctx["representation"]
+                if self_representation:
+                    representation = "\n\n".join(
+                        part for part in (representation, self_representation) if part
+                    )
+                card.extend(item for item in self_ctx["card"] if item not in card)
+            except Exception as e:
+                logger.debug("Target peer self-scope fetch failed for '%s': %s", target, e)
 
         return {"representation": representation, "card": card}
 

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -348,18 +348,24 @@ class TestPeerLookupHelpers:
                 else ["Name: Robert"]
             ),
         )
-        mgr._get_or_create_peer = MagicMock(side_effect=[user_peer, ai_peer])
+        mgr._get_or_create_peer = MagicMock(
+            side_effect=lambda peer_id: (
+                ai_peer if peer_id == session.assistant_peer_id else user_peer
+            )
+        )
 
         result = mgr.get_prefetch_context(session.key)
 
         assert result == {
-            "representation": "User representation",
+            "representation": "Mixed representation\n\nUser representation",
             "card": "Name: Robert",
             "ai_representation": "AI representation",
             "ai_card": "Role: Assistant",
         }
         user_peer.context.assert_called_once_with(target=session.user_peer_id)
-        ai_peer.context.assert_called_once_with(target=session.assistant_peer_id)
+        assert ai_peer.context.call_count == 2
+        ai_peer.context.assert_any_call(target=session.user_peer_id)
+        ai_peer.context.assert_any_call(target=session.assistant_peer_id)
 
     def test_get_prefetch_context_uses_assistant_observer_for_user_when_ai_observe_others(self):
         """With ai_observe_others enabled, get_prefetch_context must query
@@ -383,21 +389,115 @@ class TestPeerLookupHelpers:
             return SimpleNamespace(representation="Unknown", peer_card=[])
 
         assistant_peer.context.side_effect = _assistant_context
+        user_peer = MagicMock()
+        user_peer.context.return_value = SimpleNamespace(
+            representation="User self",
+            peer_card=["Prefers: concise answers"],
+        )
         mgr._get_or_create_peer = MagicMock(
-            side_effect=[assistant_peer, assistant_peer],
+            side_effect=lambda peer_id: (
+                assistant_peer if peer_id == session.assistant_peer_id else user_peer
+            ),
         )
 
         result = mgr.get_prefetch_context(session.key)
 
         assert result == {
-            "representation": "User via assistant",
-            "card": "Name: Robert",
+            "representation": "User via assistant\n\nUser self",
+            "card": "Name: Robert\nPrefers: concise answers",
             "ai_representation": "AI self",
             "ai_card": "Role: Assistant",
         }
         assert assistant_peer.context.call_count == 2
         assistant_peer.context.assert_any_call(target=session.user_peer_id)
         assistant_peer.context.assert_any_call(target=session.assistant_peer_id)
+
+    def test_fetch_peer_context_merges_directional_and_target_self_scopes(self):
+        mgr, session = self._make_cached_manager()
+        assistant_peer = MagicMock()
+        assistant_peer.context.return_value = SimpleNamespace(
+            representation="Assistant-observed context",
+            peer_card=["Location: Melbourne"],
+        )
+        user_peer = MagicMock()
+        user_peer.context.return_value = SimpleNamespace(
+            representation="User self-scope context",
+            peer_card=["Prefers: concise answers"],
+        )
+        mgr._get_or_create_peer = MagicMock(
+            side_effect=lambda peer_id: (
+                assistant_peer if peer_id == session.assistant_peer_id else user_peer
+            )
+        )
+
+        result = mgr._fetch_peer_context(
+            session.assistant_peer_id,
+            search_query="preferences",
+            target=session.user_peer_id,
+        )
+
+        assert result == {
+            "representation": "Assistant-observed context\n\nUser self-scope context",
+            "card": ["Location: Melbourne", "Prefers: concise answers"],
+        }
+        assistant_peer.context.assert_called_once_with(
+            target=session.user_peer_id,
+            search_query="preferences",
+        )
+        user_peer.context.assert_called_once_with(
+            target=session.user_peer_id,
+            search_query="preferences",
+        )
+
+    def test_fetch_peer_context_preserves_primary_result_when_self_scope_fails(self):
+        mgr, session = self._make_cached_manager()
+        assistant_peer = MagicMock()
+        assistant_peer.context.return_value = SimpleNamespace(
+            representation="Primary representation",
+            peer_card=["Primary card"],
+        )
+
+        def _peer(peer_id):
+            if peer_id == session.assistant_peer_id:
+                return assistant_peer
+            raise RuntimeError("self-scope unavailable")
+
+        mgr._get_or_create_peer = MagicMock(side_effect=_peer)
+
+        result = mgr._fetch_peer_context(
+            session.assistant_peer_id,
+            target=session.user_peer_id,
+        )
+
+        assert result == {
+            "representation": "Primary representation",
+            "card": ["Primary card"],
+        }
+
+    def test_fetch_peer_context_assistant_self_uses_one_scope_call(self):
+        mgr, session = self._make_cached_manager()
+        assistant_peer = MagicMock()
+        assistant_peer.context.return_value = SimpleNamespace(
+            representation="Assistant self context",
+            peer_card=["Role: Assistant"],
+        )
+        mgr._get_or_create_peer = MagicMock(return_value=assistant_peer)
+
+        result = mgr._fetch_peer_context(
+            session.assistant_peer_id,
+            search_query="identity",
+            target=session.assistant_peer_id,
+        )
+
+        assert result == {
+            "representation": "Assistant self context",
+            "card": ["Role: Assistant"],
+        }
+        mgr._get_or_create_peer.assert_called_once_with(session.assistant_peer_id)
+        assistant_peer.context.assert_called_once_with(
+            target=session.assistant_peer_id,
+            search_query="identity",
+        )
 
     def test_get_ai_representation_uses_peer_api(self):
         mgr, session = self._make_cached_manager()


### PR DESCRIPTION
## Problem

Honcho conclusions can be written from multiple observer/observed perspectives. Depending on configuration or direct SDK usage, facts may live in either of these Honcho scopes:

- assistant observing target (for example, `hermes -> jarvis`)
- target observing itself (for example, `jarvis -> jarvis`)

The peer-context fallback path only queried the assistant/observer-owned scope. As a result, context stored in the target peer's self-scope could be silently missed, producing empty or incomplete prefetch/reasoning context even though the data existed in Honcho.

## Why it matters

This is a general robustness fix rather than a deployment-specific workaround. Any Hermes user who writes, migrates, or imports conclusions from the target peer's own perspective can hit this. It also keeps recall working while Honcho/Hermes deployments converge on a single default write scope.

## Fix

`HonchoSessionManager._fetch_peer_context()` now keeps the existing observer-owned lookup as the primary result, then, when the requested target differs from the observer peer, fetches the target peer's self-scope (`target -> target`) and merges representation/card output without duplicating existing card entries. Self-scope lookup failures are debug-logged and non-fatal so the primary lookup remains usable.

The `target != peer_id` guard also addresses the prior reviewer concern for `peer="ai"`: assistant self-context is fetched once instead of issuing a duplicate assistant-to-assistant request.

## Test strategy

Covered in `tests/honcho_plugin/test_session.py`:

- `test_fetch_peer_context_merges_directional_and_target_self_scopes` verifies observer-owned and target self-scope context are both returned.
- `test_fetch_peer_context_preserves_primary_result_when_self_scope_fails` verifies the primary result survives a self-scope failure.
- `test_fetch_peer_context_assistant_self_uses_one_scope_call` verifies assistant self-search does not duplicate the query/output.
- Existing prefetch-context tests were updated so the real caller path exercises the merged-scope behavior.

Latest local verification: `python3 -m pytest tests/honcho_plugin/test_session.py -v` passes (`144 passed`), the targeted `search_context or fetch_peer_context` subset passes (`8 passed`), and ruff passes for the touched files.

## Rebaseline history

This PR was rebased onto current `main` after upstream Honcho changes, including #62290. #62290 rewrote `search_context()` to use workspace message search with `peer_perspective`, but it did not close this bug class in `_fetch_peer_context()`, which is still used by `get_prefetch_context()` and `get_reason_context()`. The patch therefore remains relevant on current main and now applies without conflicts.

A temporary successor draft (#67861) was opened during the rebaseline and is closed; this PR is the active branch for review.

Related: #61661 surfaced the Honcho conclusion/write path that can create data needing to be recalled from the target peer's perspective; this PR fixes the corresponding peer-context recall gap.
