### PR TITLE
fix(matrix): honor MSC2530 filename field for inbound media captions

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2790,6 +2790,11 @@ class MatrixAdapter(BasePlatformAdapter):
     ) -> None:
         """Process a media message event (image, audio, video, file)."""
         body = source_content.get("body", "") or ""
+        # MSC2530: a top-level "filename" field is the authoritative transport
+        # filename; body then carries the user caption whenever it differs.
+        # Legacy clients never send "filename" and put the filename in body.
+        declared_filename = str(source_content.get("filename") or "").strip()
+        transport_filename = declared_filename or body
         url = source_content.get("url", "")
         if url and not str(url).startswith("mxc://"):
             logger.warning(
@@ -2927,7 +2932,7 @@ class MatrixAdapter(BasePlatformAdapter):
                         elif msg_type in {MessageType.AUDIO, MessageType.VOICE}:
                             ext = (
                                 Path(
-                                    body
+                                    transport_filename
                                     or (
                                         "voice.ogg" if is_voice_message else "audio.ogg"
                                     )
@@ -2936,7 +2941,7 @@ class MatrixAdapter(BasePlatformAdapter):
                             )
                             cached_path = cache_audio_from_bytes(file_bytes, ext=ext)
                         else:
-                            filename = body or (
+                            filename = transport_filename or (
                                 "video.mp4"
                                 if msg_type == MessageType.VIDEO
                                 else "document"
@@ -2959,12 +2964,10 @@ class MatrixAdapter(BasePlatformAdapter):
             return
         body, is_dm, chat_type, thread_id, display_name, source = ctx
 
-        # MSC2530: a top-level "filename" field marks the
-        # transport name; the body is a user-typed caption only when it differs. This is
-        # authoritative — even a caption that *looks* like a filename (e.g. "screenshot.png")
-        # is kept when the sender declared a different real filename. The old suffix
-        # heuristic remains only for legacy clients that never send "filename".
-        declared_filename = str(source_content.get("filename") or "").strip()
+        # MSC2530: the declared filename (resolved above) is authoritative — even a
+        # caption that *looks* like a filename (e.g. "screenshot.png") is kept when
+        # the sender declared a different real filename. The old suffix heuristic
+        # remains only for legacy clients that never send "filename".
         if declared_filename:
             if body.strip() == declared_filename:
                 body = ""

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2959,7 +2959,16 @@ class MatrixAdapter(BasePlatformAdapter):
             return
         body, is_dm, chat_type, thread_id, display_name, source = ctx
 
-        if msgtype == "m.image" and _looks_like_matrix_image_filename(body):
+        # MSC2530: a top-level "filename" field marks the
+        # transport name; the body is a user-typed caption only when it differs. This is
+        # authoritative — even a caption that *looks* like a filename (e.g. "screenshot.png")
+        # is kept when the sender declared a different real filename. The old suffix
+        # heuristic remains only for legacy clients that never send "filename".
+        declared_filename = str(source_content.get("filename") or "").strip()
+        if declared_filename:
+            if body.strip() == declared_filename:
+                body = ""
+        elif msgtype == "m.image" and _looks_like_matrix_image_filename(body):
             body = ""
 
         allow_http_fallback = bool(http_url) and not is_encrypted_media

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -3583,6 +3583,11 @@ class MatrixAdapter(BasePlatformAdapter):
     ) -> None:
         """Process a media message event (image, audio, video, file)."""
         body = source_content.get("body", "") or ""
+        # MSC2530: a top-level "filename" field is the authoritative transport
+        # filename; body then carries the user caption whenever it differs.
+        # Legacy clients never send "filename" and put the filename in body.
+        declared_filename = str(source_content.get("filename") or "").strip()
+        transport_filename = declared_filename or body
         url = source_content.get("url", "")
         if url and not str(url).startswith("mxc://"):
             logger.warning(
@@ -3720,7 +3725,7 @@ class MatrixAdapter(BasePlatformAdapter):
                         elif msg_type in {MessageType.AUDIO, MessageType.VOICE}:
                             ext = (
                                 Path(
-                                    body
+                                    transport_filename
                                     or (
                                         "voice.ogg" if is_voice_message else "audio.ogg"
                                     )
@@ -3729,7 +3734,7 @@ class MatrixAdapter(BasePlatformAdapter):
                             )
                             cached_path = cache_audio_from_bytes(file_bytes, ext=ext)
                         else:
-                            filename = body or (
+                            filename = transport_filename or (
                                 "video.mp4"
                                 if msg_type == MessageType.VIDEO
                                 else "document"
@@ -3770,7 +3775,14 @@ class MatrixAdapter(BasePlatformAdapter):
                     room_id, reply_to_author_id
                 )
 
-        if msgtype == "m.image" and _looks_like_matrix_image_filename(body):
+        # MSC2530: the declared filename (resolved above) is authoritative. Even a
+        # caption that *looks* like a filename (e.g. "screenshot.png") is kept when
+        # the sender declared a different real filename. The suffix heuristics
+        # remain only for legacy clients that never send "filename".
+        if declared_filename:
+            if body.strip() == declared_filename:
+                body = ""
+        elif msgtype == "m.image" and _looks_like_matrix_image_filename(body):
             body = ""
         elif msgtype in ("m.audio", "m.file", "m.video") and _looks_like_matrix_media_filename(body):
             body = ""

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -3353,6 +3353,135 @@ class TestMatrixImageOnlyMediaNormalization:
         assert captured_event.text == "Please describe this chart"
 
     @pytest.mark.asyncio
+    async def test_msc2530_body_matching_declared_filename_is_cleared(self):
+        captured_event = None
+
+        async def capture(msg_event):
+            nonlocal captured_event
+            captured_event = msg_event
+
+        self.adapter.handle_message = capture
+
+        await self.adapter._handle_media_message(
+            room_id="!room:example.org",
+            sender="@alice:example.org",
+            event_id="$image3",
+            event_ts=0.0,
+            source_content={
+                "msgtype": "m.image",
+                "body": "IMG_1234.png",
+                "filename": "IMG_1234.png",
+                "url": "mxc://example/30.png",
+                "info": {"mimetype": "image/png"},
+            },
+            relates_to={},
+            msgtype="m.image",
+        )
+
+        assert captured_event is not None
+        assert captured_event.text == ""
+
+    @pytest.mark.asyncio
+    async def test_msc2530_filename_looking_caption_is_preserved(self):
+        captured_event = None
+
+        async def capture(msg_event):
+            nonlocal captured_event
+            captured_event = msg_event
+
+        self.adapter.handle_message = capture
+
+        await self.adapter._handle_media_message(
+            room_id="!room:example.org",
+            sender="@alice:example.org",
+            event_id="$image4",
+            event_ts=0.0,
+            source_content={
+                "msgtype": "m.image",
+                "body": "screenshot.png",
+                "filename": "IMG_1234.png",
+                "url": "mxc://example/30.png",
+                "info": {"mimetype": "image/png"},
+            },
+            relates_to={},
+            msgtype="m.image",
+        )
+
+        assert captured_event is not None
+        assert captured_event.text == "screenshot.png"
+
+    @pytest.mark.asyncio
+    async def test_msc2530_declared_filename_used_for_document_cache(self):
+        captured_event = None
+
+        async def capture(msg_event):
+            nonlocal captured_event
+            captured_event = msg_event
+
+        self.adapter.handle_message = capture
+        self.adapter._client.download_media = AsyncMock(return_value=b"pdf-bytes")
+
+        with patch(
+            "gateway.platforms.base.cache_document_from_bytes",
+            return_value="/cache/report.pdf",
+        ) as mock_cache:
+            await self.adapter._handle_media_message(
+                room_id="!room:example.org",
+                sender="@alice:example.org",
+                event_id="$file1",
+                event_ts=0.0,
+                source_content={
+                    "msgtype": "m.file",
+                    "body": "check this out!",
+                    "filename": "report.pdf",
+                    "url": "mxc://example/report.pdf",
+                    "info": {"mimetype": "application/pdf"},
+                },
+                relates_to={},
+                msgtype="m.file",
+            )
+
+        mock_cache.assert_called_once_with(b"pdf-bytes", "report.pdf")
+        assert captured_event is not None
+        assert captured_event.text == "check this out!"
+        assert captured_event.media_urls == ["/cache/report.pdf"]
+
+    @pytest.mark.asyncio
+    async def test_msc2530_declared_filename_used_for_audio_cache_extension(self):
+        captured_event = None
+
+        async def capture(msg_event):
+            nonlocal captured_event
+            captured_event = msg_event
+
+        self.adapter.handle_message = capture
+        self.adapter._client.download_media = AsyncMock(return_value=b"mp3-bytes")
+
+        with patch(
+            "gateway.platforms.base.cache_audio_from_bytes",
+            return_value="/cache/audio.mp3",
+        ) as mock_cache:
+            await self.adapter._handle_media_message(
+                room_id="!room:example.org",
+                sender="@alice:example.org",
+                event_id="$audio1",
+                event_ts=0.0,
+                source_content={
+                    "msgtype": "m.audio",
+                    "body": "great tune, give it a listen",
+                    "filename": "song.mp3",
+                    "url": "mxc://example/song.mp3",
+                    "info": {"mimetype": "audio/mpeg"},
+                },
+                relates_to={},
+                msgtype="m.audio",
+            )
+
+        mock_cache.assert_called_once_with(b"mp3-bytes", ext=".mp3")
+        assert captured_event is not None
+        assert captured_event.text == "great tune, give it a listen"
+
+    @pytest.mark.asyncio
     async def test_inbound_oversized_media_is_rejected(self):
         captured_event = None
 

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1981,6 +1981,162 @@ class TestMatrixImageOnlyMediaNormalization:
         ]
         assert captured_event.message_type == MessageType.PHOTO
 
+    @pytest.mark.asyncio
+    async def test_msc2530_body_matching_declared_filename_is_cleared(self):
+        captured_event = None
+
+        async def capture(msg_event):
+            nonlocal captured_event
+            captured_event = msg_event
+
+        self.adapter.handle_message = capture
+
+        await self.adapter._handle_media_message(
+            room_id="!room:example.org",
+            sender="@alice:example.org",
+            event_id="$image3",
+            event_ts=0.0,
+            source_content={
+                "msgtype": "m.image",
+                "body": "IMG_1234.png",
+                "filename": "IMG_1234.png",
+                "url": "mxc://example/30.png",
+                "info": {"mimetype": "image/png"},
+            },
+            relates_to={},
+            msgtype="m.image",
+        )
+
+        assert captured_event is not None
+        assert captured_event.text == ""
+
+    @pytest.mark.asyncio
+    async def test_msc2530_filename_looking_caption_is_preserved(self):
+        captured_event = None
+
+        async def capture(msg_event):
+            nonlocal captured_event
+            captured_event = msg_event
+
+        self.adapter.handle_message = capture
+
+        await self.adapter._handle_media_message(
+            room_id="!room:example.org",
+            sender="@alice:example.org",
+            event_id="$image4",
+            event_ts=0.0,
+            source_content={
+                "msgtype": "m.image",
+                "body": "screenshot.png",
+                "filename": "IMG_1234.png",
+                "url": "mxc://example/30.png",
+                "info": {"mimetype": "image/png"},
+            },
+            relates_to={},
+            msgtype="m.image",
+        )
+
+        assert captured_event is not None
+        assert captured_event.text == "screenshot.png"
+
+    @pytest.mark.asyncio
+    async def test_msc2530_declared_filename_used_for_document_cache(self):
+        captured_event = None
+
+        async def capture(msg_event):
+            nonlocal captured_event
+            captured_event = msg_event
+
+        self.adapter.handle_message = capture
+        self.adapter._client.download_media = AsyncMock(return_value=b"pdf-bytes")
+
+        with patch(
+            "gateway.platforms.base.cache_document_from_bytes",
+            return_value="/cache/report.pdf",
+        ) as mock_cache:
+            await self.adapter._handle_media_message(
+                room_id="!room:example.org",
+                sender="@alice:example.org",
+                event_id="$file1",
+                event_ts=0.0,
+                source_content={
+                    "msgtype": "m.file",
+                    "body": "check this out!",
+                    "filename": "report.pdf",
+                    "url": "mxc://example/report.pdf",
+                    "info": {"mimetype": "application/pdf"},
+                },
+                relates_to={},
+                msgtype="m.file",
+            )
+
+        mock_cache.assert_called_once_with(b"pdf-bytes", "report.pdf")
+        assert captured_event is not None
+        assert captured_event.text == "check this out!"
+        assert captured_event.media_urls == ["/cache/report.pdf"]
+
+    @pytest.mark.asyncio
+    async def test_msc2530_declared_filename_used_for_audio_cache_extension(self):
+        captured_event = None
+
+        async def capture(msg_event):
+            nonlocal captured_event
+            captured_event = msg_event
+
+        self.adapter.handle_message = capture
+        self.adapter._client.download_media = AsyncMock(return_value=b"mp3-bytes")
+
+        with patch(
+            "gateway.platforms.base.cache_audio_from_bytes",
+            return_value="/cache/audio.mp3",
+        ) as mock_cache:
+            await self.adapter._handle_media_message(
+                room_id="!room:example.org",
+                sender="@alice:example.org",
+                event_id="$audio1",
+                event_ts=0.0,
+                source_content={
+                    "msgtype": "m.audio",
+                    "body": "great tune, give it a listen",
+                    "filename": "song.mp3",
+                    "url": "mxc://example/song.mp3",
+                    "info": {"mimetype": "audio/mpeg"},
+                },
+                relates_to={},
+                msgtype="m.audio",
+            )
+
+        mock_cache.assert_called_once_with(b"mp3-bytes", ext=".mp3")
+        assert captured_event is not None
+        assert captured_event.text == "great tune, give it a listen"
+
+    @pytest.mark.asyncio
+    async def test_legacy_audio_filename_body_without_declared_filename_is_cleared(self):
+        captured_event = None
+
+        async def capture(msg_event):
+            nonlocal captured_event
+            captured_event = msg_event
+
+        self.adapter.handle_message = capture
+
+        await self.adapter._handle_media_message(
+            room_id="!room:example.org",
+            sender="@alice:example.org",
+            event_id="$audio2",
+            event_ts=0.0,
+            source_content={
+                "msgtype": "m.audio",
+                "body": "song.mp3",
+                "url": "mxc://example/song.mp3",
+                "info": {"mimetype": "audio/mpeg"},
+            },
+            relates_to={},
+            msgtype="m.audio",
+        )
+
+        assert captured_event is not None
+        assert captured_event.text == ""
 
     @pytest.mark.asyncio
     async def test_inbound_oversized_media_is_rejected(self):


### PR DESCRIPTION
## What

Makes the MSC2530 `filename` field authoritative for inbound Matrix media:

- If the event declares a top-level `filename`, `body` is treated as a user caption whenever it differs from that filename (per MSC2530), and cleared only when they're equal.
- The existing looks-like-a-filename suffix heuristic is kept **only** for legacy clients that never send `filename`.

## Why

The current inbound path applies the suffix heuristic unconditionally, which:
1. **Drops real captions** that happen to look like filenames (a user captioning a photo "screenshot.png" loses the caption), and
2. treats the transport filename as a caption for spec-compliant clients that send both fields.

Element, Element X, and most maintained clients send MSC2530 fields today.

## Testing

Running in production since 2026-07-08 (image+caption round-trips from Element and a custom Trixnity client); captions survive, transport filenames are suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
