### PR TITLE
feat(gateway): declare per-adapter media-send capabilities

### DIFF
--- a/docs/relay-connector-contract.md
+++ b/docs/relay-connector-contract.md
@@ -51,6 +51,7 @@ JSON object. Source of truth: `gateway/relay/descriptor.py`.
 | `emoji` | string | no | Display emoji (default 🔌). |
 | `platform_hint` | string | no | System-prompt platform hint. |
 | `pii_safe` | bool | no | Redact PII in session descriptions. |
+| `media_capabilities` | array of string | no | Media kinds (subset of `voice`, `video`, `document`, `image_file`, `animation`) the adapter natively sends, vs. falling back to a text-notice. |
 
 Most fields are a projection of the gateway's existing `PlatformEntry`; the
 runtime-only fields (`len_unit`, `supports_*`, `markdown_dialect`) come from the

--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -97,6 +97,14 @@ class PlatformEntry:
     # If True, session descriptions redact PII (phone numbers, etc.)
     pii_safe: bool = False
 
+    # ── Media ──
+    # Declares which of {"voice", "video", "document", "image_file",
+    # "animation"} this adapter natively overrides (i.e. implements its own
+    # send_voice/send_video/send_document/send_image_file/send_animation),
+    # as opposed to falling back to BasePlatformAdapter's generic text-notice
+    # fallback for that media kind.
+    media_capabilities: frozenset[str] = frozenset()
+
     # ── Display ──
     # Emoji for CLI/gateway display (e.g. "💬")
     emoji: str = "🔌"

--- a/gateway/relay/descriptor.py
+++ b/gateway/relay/descriptor.py
@@ -24,8 +24,8 @@ the per-instance capability methods on ``BasePlatformAdapter``):
   Telegram yes; Signal/SMS no -> consumer degrades to one-message-per-segment).
 - ``supports_threads``   -> ``create_handoff_thread`` capability flag.
 - ``markdown_dialect``   -> presentation hint (e.g. "markdown_v2", "discord").
-- ``emoji`` / ``platform_hint`` / ``pii_safe`` -> ``PlatformEntry`` fields of the
-  same name.
+- ``emoji`` / ``platform_hint`` / ``pii_safe`` / ``media_capabilities`` ->
+  ``PlatformEntry`` fields of the same name.
 """
 
 from __future__ import annotations
@@ -58,6 +58,7 @@ class CapabilityDescriptor:
     emoji: str = "\U0001f50c"  # 🔌 default (matches PlatformEntry default)
     platform_hint: str = ""
     pii_safe: bool = False
+    media_capabilities: tuple[str, ...] = ()
 
     def to_json(self) -> str:
         """Serialize to a compact, stable JSON string for the handshake frame."""
@@ -74,6 +75,8 @@ class CapabilityDescriptor:
         raw = json.loads(data)
         known = {f for f in cls.__dataclass_fields__}  # type: ignore[attr-defined]
         filtered = {k: v for k, v in raw.items() if k in known}
+        if "media_capabilities" in filtered:
+            filtered["media_capabilities"] = tuple(filtered["media_capabilities"])
         return cls(**filtered)
 
     @classmethod
@@ -115,4 +118,7 @@ class CapabilityDescriptor:
             emoji=getattr(entry, "emoji", "\U0001f50c"),
             platform_hint=getattr(entry, "platform_hint", ""),
             pii_safe=getattr(entry, "pii_safe", False),
+            media_capabilities=tuple(
+                sorted(getattr(entry, "media_capabilities", frozenset()))
+            ),
         )

--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -1702,6 +1702,7 @@ def register(ctx) -> None:
         allow_all_env="DINGTALK_ALLOW_ALL_USERS",
         cron_deliver_env_var="DINGTALK_HOME_CHANNEL",
         standalone_sender_fn=_standalone_send,
+        media_capabilities=frozenset({"image_file", "document"}),
         emoji="🐳",
         allow_update_command=True,
     )

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -8402,6 +8402,9 @@ def register(ctx) -> None:
         standalone_sender_fn=_standalone_send,
         # Discord hard limit per message
         max_message_length=2000,
+        media_capabilities=frozenset(
+            {"image_file", "document", "voice", "video", "animation"}
+        ),
         # Display
         emoji="🎮",
         allow_update_command=True,

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -1267,6 +1267,7 @@ def register(ctx) -> None:
         cron_deliver_env_var="EMAIL_HOME_ADDRESS",
         standalone_sender_fn=_standalone_send,
         max_message_length=50_000,
+        media_capabilities=frozenset({"document"}),
         pii_safe=True,
         emoji="📧",
         allow_update_command=True,

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -5657,6 +5657,9 @@ def register(ctx) -> None:
         cron_deliver_env_var="FEISHU_HOME_CHANNEL",
         standalone_sender_fn=_standalone_send,
         max_message_length=8000,
+        media_capabilities=frozenset(
+            {"image_file", "document", "voice", "video", "animation"}
+        ),
         emoji="🪽",
         allow_update_command=True,
     )

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -3322,6 +3322,9 @@ def register(ctx) -> None:
         # Chat caps text messages at 4096 chars; we leave margin to fit
         # the "Hermes is thinking..." marker patches and edit overhead.
         max_message_length=4000,
+        media_capabilities=frozenset(
+            {"image_file", "document", "voice", "video", "animation"}
+        ),
         emoji="💬",
         allow_update_command=True,
         platform_hint=(

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -1636,6 +1636,7 @@ def register(ctx) -> None:
         allow_all_env="LINE_ALLOW_ALL_USERS",
         # LINE per-bubble cap is 5000; smart-chunker uses 4500.
         max_message_length=LINE_SAFE_BUBBLE_CHARS,
+        media_capabilities=frozenset({"image_file", "voice", "video"}),
         emoji="💚",
         pii_safe=False,
         allow_update_command=True,

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -4608,6 +4608,7 @@ def register(ctx) -> None:
         cron_deliver_env_var="MATRIX_HOME_ROOM",
         standalone_sender_fn=_standalone_send,
         max_message_length=4000,
+        media_capabilities=frozenset({"image_file", "document", "voice", "video"}),
         emoji="🔐",
         allow_update_command=True,
     )

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -1275,6 +1275,7 @@ def register(ctx) -> None:
         # but 4000 is the readable threshold the adapter has used since
         # day one).
         max_message_length=MAX_POST_LENGTH,
+        media_capabilities=frozenset({"image_file", "document", "voice", "video"}),
         # Display
         emoji="💬",
         allow_update_command=True,

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -1770,6 +1770,9 @@ def register(ctx) -> None:
         allowed_users_env="PHOTON_ALLOWED_USERS",
         allow_all_env="PHOTON_ALLOW_ALL_USERS",
         max_message_length=_MAX_MESSAGE_LENGTH,
+        media_capabilities=frozenset(
+            {"image_file", "document", "voice", "video", "animation"}
+        ),
         emoji="📱",
         # iMessage carries E.164 phone numbers — treat session descriptions
         # as PII-sensitive so they get redacted before reaching the LLM

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -1295,6 +1295,7 @@ def register(ctx) -> None:
         allowed_users_env="SIMPLEX_ALLOWED_USERS",
         allow_all_env="SIMPLEX_ALLOW_ALL_USERS",
         max_message_length=MAX_MESSAGE_LENGTH,
+        media_capabilities=frozenset({"image_file", "document", "voice", "video"}),
         emoji="🔒",
         # SimpleX uses opaque contact IDs only — no phone numbers or email
         # addresses to redact.

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -4568,6 +4568,7 @@ def register(ctx) -> None:
         # Slack API allows 40,000 chars; leave margin (matches the legacy
         # SlackAdapter.MAX_MESSAGE_LENGTH).
         max_message_length=39000,
+        media_capabilities=frozenset({"image_file", "document", "voice", "video"}),
         # Display
         emoji="💼",
         allow_update_command=True,

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -1438,6 +1438,7 @@ def register(ctx) -> None:
         allow_all_env="TEAMS_ALLOW_ALL_USERS",
         # Teams supports up to ~28 KB per message
         max_message_length=28000,
+        media_capabilities=frozenset({"image_file", "document", "voice", "video"}),
         # Display
         emoji="💼",
         allow_update_command=True,

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8771,6 +8771,9 @@ def register(ctx) -> None:
         cron_deliver_env_var="TELEGRAM_HOME_CHANNEL",
         standalone_sender_fn=_standalone_send,
         max_message_length=4096,
+        media_capabilities=frozenset(
+            {"image_file", "document", "voice", "video", "animation"}
+        ),
         emoji="✈️",
         allow_update_command=True,
     )

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -1867,6 +1867,7 @@ def register(ctx) -> None:
         cron_deliver_env_var="WECOM_HOME_CHANNEL",
         standalone_sender_fn=_standalone_send,
         max_message_length=4000,
+        media_capabilities=frozenset({"image_file", "document", "voice", "video"}),
         emoji="💼",
         allow_update_command=True,
     )

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1789,6 +1789,7 @@ def register(ctx) -> None:
         cron_deliver_env_var="WHATSAPP_HOME_CHANNEL",
         standalone_sender_fn=_standalone_send,
         max_message_length=4096,
+        media_capabilities=frozenset({"image_file", "document", "voice", "video"}),
         emoji="💬",
         allow_update_command=True,
     )


### PR DESCRIPTION
## What does this PR do?
Adds a `media_capabilities` field to `PlatformEntry` and the relay `CapabilityDescriptor`, so each platform adapter declares which media kinds (`voice`/`video`/`document`/`image_file`/`animation`) it natively sends via a real `send_*` override, as opposed to falling back to `BasePlatformAdapter`'s generic text-notice fallback.

This is groundwork for the plugin-interface expansion discussed in the #Developer channel: once `tools/send_message_tool.py`'s cross-channel send routes through this declared capability set instead of its current hardcoded per-platform allowlist, adapters (core or plugin) will be able to add/fix media support entirely inside their own `register(ctx)` call — no core `send_message_tool.py` edit required.

## Related Issue
Groundwork toward #17261 (Slack cross-channel media falls through to text-only). This PR is additive metadata only and does not change `send_message_tool.py`'s routing yet — that follow-up is intentionally separated out pending direction on the capability-routing approach.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes Made
- `gateway/platform_registry.py`: new `media_capabilities: frozenset[str] = frozenset()` field on `PlatformEntry`.
- `gateway/relay/descriptor.py`: new `media_capabilities: tuple[str, ...] = ()` field on `CapabilityDescriptor`, projected in `from_platform_entry()`, with a JSON round-trip fix in `from_json()` (list→tuple cast).
- `docs/relay-connector-contract.md`: documented the new descriptor field (required by `test_contract_doc_conformance.py`).
- All 15 platform adapters: added `media_capabilities=frozenset({...})` to their `register(ctx)` call, matching their actual `send_voice`/`send_video`/`send_document`/`send_image_file`/`send_animation` overrides (verified per-adapter against source, not assumed).

## How to Test
`scripts/run_tests.sh tests/gateway tests/plugins` — full suite passes except two pre-existing flakes unrelated to this change (confirmed identical failures on unmodified main): an mtime-memoization test and an asyncio-timeout race in `test_startup_restart_race.py`.

## Checklist
- [x] Single focused commit
- [x] Tests pass (see above)
