### PR TITLE
fix(slack): clamp approval message so chat_update survives HTML-escaped >3000-char sections

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3262,10 +3262,14 @@ class SlackAdapter(BasePlatformAdapter):
             # buttons).  execute_code approvals embed the entire script in
             # ``command``, so budget the preview against the fixed parts
             # instead of a flat truncation that overflows once the header +
-            # reason are added.
+            # reason are added.  Target 2900 rather than 3000: Slack
+            # HTML-escapes ``< > &`` on storage, and dangerous commands
+            # (redirects/pipes/``&&``) grow once escaped — the headroom keeps
+            # the *stored* (escaped) section under the cap so the later
+            # chat_update on approval doesn't fail with ``invalid_blocks``.
             header = ":warning: *Command Approval Required*\n"
             reason = f"Reason: {description[:500]}"
-            budget = 3000 - len(header) - len(reason) - len("``````\n") - len("...")
+            budget = 2900 - len(header) - len(reason) - len("``````\n") - len("...")
             cmd_preview = command[:budget] + "..." if len(command) > budget else command
 
             blocks = [
@@ -3635,6 +3639,17 @@ class SlackAdapter(BasePlatformAdapter):
             if block.get("type") == "section":
                 original_text = block.get("text", {}).get("text", "")
                 break
+
+        # Slack HTML-escapes ``< > &`` when it stores the message, so the text
+        # echoed back in the button payload can exceed the 3000-char section
+        # cap that chat_update enforces even though the send path budgeted the
+        # RAW command to <=3000 — dangerous commands (redirects/pipes/``&&``)
+        # balloon once escaped.  Clamp before re-posting so the decision update
+        # never fails with ``invalid_blocks`` (the buttons are stripped anyway,
+        # so truncating the echoed command is harmless).
+        _SECTION_CAP = 2900
+        if len(original_text) > _SECTION_CAP:
+            original_text = original_text[:_SECTION_CAP].rstrip() + "\n... [truncated]"
 
         updated_blocks = [
             {


### PR DESCRIPTION
## Problem

Interactive command-approval buttons (`Allow Once` / `Allow Session` / `Always Allow` / `Deny`) appear dead: clicking leaves the message visually unchanged. The approval **does** resolve — the agent unblocks and continues — but the message never redraws to strip the buttons and stamp the decision, so from the user's seat "nothing happens" and they re-click.

## Root cause

`send_exec_approval` budgets the command preview against Slack's **3000-char section limit measured on the raw string**. But Slack **HTML-escapes** `<` `>` `&` when it stores the message (`>` -> `&gt;`, +3 chars each). Dangerous commands — the ones full of redirects / pipes / `&&` that trigger approval in the first place — grow once escaped.

`chat.postMessage` accepts the escaped text, but the `chat.update` fired on button click (`_handle_approval_action`) enforces the 3000 cap strictly and fails:

```
invalid_blocks: must be less than 3001 characters [json-pointer:/blocks/0/text/text]
```

so the redraw silently fails (only a `logger.warning`), leaving the buttons on screen.

**Observed live:** a prompt budgeted to *exactly* 3000 raw chars was stored by Slack at **3061** (escaping added 61 chars: `&gt;`x7, `&lt;`x8, `&amp;`x4). Every approval update failed while the approval itself resolved normally.

## Fix

- **`_handle_approval_action`** — clamp the echoed section text to 2900 chars before `chat_update`. The buttons are being stripped anyway, so truncating the echoed command is harmless, and it guarantees the decision update never fails regardless of escaping.
- **`send_exec_approval`** — target 2900 instead of 3000 so the *stored* (escaped) section stays under the cap, avoiding the rarer case where a metacharacter-heavy command escapes past 3000 on the initial post and loses its buttons entirely.

Cosmetic / update-path only; no change to approval semantics.