### PR TITLE
feat(kanban): add `amend` command to edit task title/body in place

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -554,6 +554,24 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="JSON dict of structured facts to store on the latest completed run.",
     )
 
+    p_amend = sub.add_parser(
+        "amend",
+        help="Edit a task's title and/or body in place (recovery for a "
+             "wrong/stale spec, e.g. a mis-pointed source URL). Works on any "
+             "live task; use --body-file for large or multi-line bodies.",
+    )
+    p_amend.add_argument("task_id")
+    p_amend.add_argument("--title", default=None, help="New task title")
+    p_amend.add_argument(
+        "--body", default=None,
+        help="New task body (markdown). For multi-line bodies use --body-file.",
+    )
+    p_amend.add_argument(
+        "--body-file", default=None,
+        help="Read the new body from a file ('-' for stdin). "
+             "Mutually exclusive with --body.",
+    )
+
     p_block = sub.add_parser("block", help="Mark one or more tasks blocked")
     p_block.add_argument("task_id")
     p_block.add_argument("reason", nargs="*", help="Reason (also appended as a comment)")
@@ -953,6 +971,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "comment":  _cmd_comment,
             "complete": _cmd_complete,
             "edit":     _cmd_edit,
+            "amend":    _cmd_amend,
             "block":    _cmd_block,
             "schedule": _cmd_schedule,
             "unblock":  _cmd_unblock,
@@ -1933,6 +1952,45 @@ def _cmd_edit(args: argparse.Namespace) -> int:
             )
             return 1
     print(f"Edited {args.task_id}")
+    return 0
+
+
+def _cmd_amend(args: argparse.Namespace) -> int:
+    body = getattr(args, "body", None)
+    body_file = getattr(args, "body_file", None)
+    if body is not None and body_file is not None:
+        print("kanban: use only one of --body / --body-file", file=sys.stderr)
+        return 2
+    if body_file is not None:
+        try:
+            if body_file == "-":
+                body = sys.stdin.read()
+            else:
+                with open(body_file, "r", encoding="utf-8") as fh:
+                    body = fh.read()
+        except OSError as exc:
+            print(f"kanban: --body-file: {exc}", file=sys.stderr)
+            return 2
+    title = getattr(args, "title", None)
+    if title is None and body is None:
+        print(
+            "kanban: nothing to edit — pass --title and/or --body/--body-file",
+            file=sys.stderr,
+        )
+        return 2
+    with kb.connect_closing() as conn:
+        try:
+            ok = kb.edit_task_fields(conn, args.task_id, title=title, body=body)
+        except ValueError as exc:
+            print(f"kanban: {exc}", file=sys.stderr)
+            return 2
+    if not ok:
+        print(f"cannot amend {args.task_id} (unknown id)", file=sys.stderr)
+        return 1
+    changed = ", ".join(
+        name for name, val in (("title", title), ("body", body)) if val is not None
+    )
+    print(f"Amended {args.task_id} ({changed})")
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4538,6 +4538,62 @@ def edit_completed_task_result(
     return True
 
 
+def edit_task_fields(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    title: Optional[str] = None,
+    body: Optional[str] = None,
+) -> bool:
+    """Amend a task's authored ``title`` and/or ``body`` in place.
+
+    This is the recovery path for a task created with a wrong or stale
+    spec — e.g. an ingest task pointing at the wrong source URL. Unlike
+    :func:`edit_completed_task_result` (which backfills the *result* of a
+    *done* task), this edits the spec of a task in any live state and
+    logs an ``edited`` event so the change is auditable rather than a
+    silent out-of-band DB write.
+
+    At least one of ``title`` / ``body`` must be provided. ``title`` is
+    stripped and may not be blank; ``body`` is stored verbatim (pass an
+    empty string to clear it). Returns ``False`` for an unknown id;
+    raises ``ValueError`` for an archived task or a blank title.
+    """
+    fields: list[str] = []
+    params: list[Any] = []
+    if title is not None:
+        stripped = title.strip()
+        if not stripped:
+            raise ValueError("title cannot be blank")
+        fields.append("title")
+        params.append(stripped)
+    if body is not None:
+        fields.append("body")
+        params.append(body)
+    if not fields:
+        raise ValueError("nothing to edit: provide title and/or body")
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (task_id,),
+        ).fetchone()
+        if not row:
+            return False
+        if row["status"] == "archived":
+            raise ValueError(f"cannot edit archived task {task_id}")
+        set_clause = ", ".join(f"{name} = ?" for name in fields)
+        conn.execute(
+            f"UPDATE tasks SET {set_clause} WHERE id = ?",
+            (*params, task_id),
+        )
+        payload: dict[str, Any] = {"fields": fields}
+        if title is not None:
+            payload["title"] = title.strip()[:200]
+        if body is not None:
+            payload["body_len"] = len(body)
+        _append_event(conn, task_id, "edited", payload)
+    return True
+
+
 def block_task(
     conn: sqlite3.Connection,
     task_id: str,

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -4790,3 +4790,70 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# edit_task_fields — amend title/body of a live task
+# ---------------------------------------------------------------------------
+
+def _events(conn, task_id):
+    return conn.execute(
+        "SELECT kind, payload FROM task_events WHERE task_id = ? ORDER BY id",
+        (task_id,),
+    ).fetchall()
+
+
+def test_edit_task_fields_updates_title_and_body(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="wrong source", body="old body")
+        ok = kb.edit_task_fields(conn, tid, title="right source", body="new body")
+        assert ok is True
+        task = kb.get_task(conn, tid)
+        assert task.title == "right source"
+        assert task.body == "new body"
+        # An auditable `edited` event is logged (not a silent DB write).
+        kinds = [r["kind"] for r in _events(conn, tid)]
+        assert kinds.count("edited") == 1
+
+
+def test_edit_task_fields_body_only_leaves_title(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="keep me", body="old")
+        assert kb.edit_task_fields(conn, tid, body="repointed") is True
+        task = kb.get_task(conn, tid)
+        assert task.title == "keep me"
+        assert task.body == "repointed"
+
+
+def test_edit_task_fields_can_clear_body(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="t", body="something")
+        assert kb.edit_task_fields(conn, tid, body="") is True
+        assert kb.get_task(conn, tid).body == ""
+
+
+def test_edit_task_fields_unknown_id_returns_false(kanban_home):
+    with kb.connect() as conn:
+        assert kb.edit_task_fields(conn, "t_ghost", title="x") is False
+
+
+def test_edit_task_fields_blank_title_raises(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="t")
+        with pytest.raises(ValueError):
+            kb.edit_task_fields(conn, tid, title="   ")
+
+
+def test_edit_task_fields_nothing_to_edit_raises(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="t")
+        with pytest.raises(ValueError):
+            kb.edit_task_fields(conn, tid)
+
+
+def test_edit_task_fields_archived_raises(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="t")
+        kb.archive_task(conn, tid)
+        with pytest.raises(ValueError):
+            kb.edit_task_fields(conn, tid, title="x")


### PR DESCRIPTION
## Problem

The kanban CLI can edit a *completed* task's **result** (`hermes kanban edit`), but there is no way to fix a live task's authored **title** or **body** after creation. When a task is created with a wrong or stale spec — e.g. an ingest task whose source URL points at the wrong article — the only recovery is a raw `sqlite3 UPDATE` against the board DB. That bypasses the event log entirely, leaving no audit trail, and is easy to get wrong (board-scoped DB path, escaping a multi-line markdown body, FTS/trigger assumptions).

This came up in practice while repointing a mis-sourced ingest task: the fix required hand-editing `boards/<slug>/kanban.db`, which records no `edited` event.

## Change

Add `hermes kanban amend <task_id> [--title T] [--body B | --body-file PATH]`:

- Edits **title** and/or **body** on any live (non-archived) task.
- `--body-file` (with `-` for stdin) handles large / multi-line markdown bodies that are painful to pass as a shell argument — the exact case that previously forced raw SQL.
- Logs an `edited` event, so the change shows up in `show`/history like every other mutation. Matches the existing `edit` / `block` / `comment` conventions.
- `--body` and `--body-file` are mutually exclusive; at least one of `--title` / `--body` is required.

Store layer: `edit_task_fields()` in `kanban_db.py` — validates a non-blank title, refuses archived tasks (raises `ValueError`), returns `False` on unknown id, and writes the `edited` event inside the same `write_txn`.

## Tests

7 new unit tests in `tests/hermes_cli/test_kanban_db.py` covering: title+body update (and that an `edited` event is logged), body-only edit leaving title intact, clearing the body, unknown-id → `False`, blank-title → raises, no-fields → raises, archived → raises. All green; also smoke-tested the CLI end-to-end (inline body, `--body-file`, stdin, and the error paths).

## Notes

- Exit-code note: like the existing `block` / `complete` / `comment` subcommands, the top-level `hermes kanban` wrapper currently returns 0 even on handler error. `_cmd_amend` returns the correct non-zero codes internally; propagating them is a pre-existing, separate concern left out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
