### PR TITLE
Page session_search read-mode transcripts

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4975,15 +4975,18 @@ class SessionDB:
             cursor = self._conn.execute(f"SELECT COUNT(*) FROM sessions s{where_sql}", params)
             return cursor.fetchone()[0]
 
-    def message_count(self, session_id: str = None) -> int:
+    def message_count(self, session_id: str = None, include_inactive: bool = True) -> int:
         """Count messages, optionally for a specific session."""
+        active_clause = "" if include_inactive else " WHERE active = 1"
         with self._lock:
             if session_id:
+                active_clause = "" if include_inactive else " AND active = 1"
                 cursor = self._conn.execute(
-                    "SELECT COUNT(*) FROM messages WHERE session_id = ?", (session_id,)
+                    f"SELECT COUNT(*) FROM messages WHERE session_id = ?{active_clause}",
+                    (session_id,),
                 )
             else:
-                cursor = self._conn.execute("SELECT COUNT(*) FROM messages")
+                cursor = self._conn.execute(f"SELECT COUNT(*) FROM messages{active_clause}")
             return cursor.fetchone()[0]
 
     def has_platform_message_id(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3794,6 +3794,60 @@ class SessionDB:
             result.append(msg)
         return result
 
+    def get_message_head_tail_window(
+        self,
+        session_id: str,
+        head: int = 20,
+        tail: int = 10,
+        include_inactive: bool = False,
+    ) -> Tuple[int, List[Dict[str, Any]]]:
+        """Return active count plus first ``head`` and last ``tail`` messages.
+
+        The count and selected rows are read by one SQLite statement, so callers
+        cannot observe ``message_count`` from one active transcript snapshot and
+        rows from another after rewind/compaction changes the active set.
+        """
+        head = max(0, int(head or 0))
+        tail = max(0, int(tail or 0))
+        active_clause = "" if include_inactive else " AND active = 1"
+        sql = (
+            "WITH ordered AS ("
+            "  SELECT messages.*, "
+            "         ROW_NUMBER() OVER (ORDER BY id) AS __rn, "
+            "         COUNT(*) OVER () AS __total "
+            "  FROM messages "
+            "  WHERE session_id = ?"
+            f"{active_clause}"
+            ") "
+            "SELECT * FROM ordered "
+            "WHERE __total <= ? OR __rn <= ? OR __rn > (__total - ?) "
+            "ORDER BY id"
+        )
+        with self._lock:
+            rows = self._conn.execute(
+                sql,
+                (session_id, head + tail, head, tail),
+            ).fetchall()
+
+        total = int(rows[0]["__total"]) if rows else 0
+        result = []
+        for row in rows:
+            msg = dict(row)
+            msg.pop("__rn", None)
+            msg.pop("__total", None)
+            if "content" in msg:
+                msg["content"] = self._decode_content(msg["content"])
+            if msg.get("tool_calls"):
+                try:
+                    msg["tool_calls"] = json.loads(msg["tool_calls"])
+                except (json.JSONDecodeError, TypeError):
+                    logger.warning(
+                        "Failed to deserialize tool_calls in get_message_head_tail_window, falling back to []"
+                    )
+                    msg["tool_calls"] = []
+            result.append(msg)
+        return total, result
+
     def get_messages_around(
         self,
         session_id: str,

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -495,27 +495,56 @@ class TestReadShape:
         db._conn.commit()
 
         calls = []
-        original_get_messages = db.get_messages
+        original_window = db.get_message_head_tail_window
 
-        def spy_get_messages(session_id, include_inactive=False, limit=None, offset=0):
-            calls.append((session_id, include_inactive, limit, offset))
-            return original_get_messages(
+        def spy_window(session_id, head=20, tail=10, include_inactive=False):
+            calls.append((session_id, head, tail, include_inactive))
+            return original_window(
                 session_id,
+                head=head,
+                tail=tail,
                 include_inactive=include_inactive,
-                limit=limit,
-                offset=offset,
             )
 
-        monkeypatch.setattr(db, "get_messages", spy_get_messages)
+        monkeypatch.setattr(db, "get_message_head_tail_window", spy_window)
 
         result = json.loads(session_search(session_id="s_big", db=db))
 
         assert result["message_count"] == 50
         assert result["truncated"] is True
-        assert calls == [
-            ("s_big", False, 20, 0),
-            ("s_big", False, 10, 40),
-        ]
+        assert [m["content"] for m in result["messages"][:3]] == ["m0", "m1", "m2"]
+        assert [m["content"] for m in result["messages"][-3:]] == ["m47", "m48", "m49"]
+        assert calls == [("s_big", 20, 10, False)]
+
+    def test_read_large_session_uses_one_active_snapshot(self, db, monkeypatch):
+        db.create_session("s_big", source="cli")
+        for i in range(50):
+            db.append_message("s_big", role="user" if i % 2 == 0 else "assistant", content=f"m{i}")
+        db._conn.commit()
+
+        original_count = db.message_count
+
+        def count_then_change_active_set(session_id, include_inactive=True):
+            total = original_count(session_id, include_inactive=include_inactive)
+            db._conn.execute(
+                "UPDATE messages SET active = 0 "
+                "WHERE session_id = ? AND id NOT IN ("
+                "  SELECT id FROM messages WHERE session_id = ? ORDER BY id DESC LIMIT 5"
+                ")",
+                (session_id, session_id),
+            )
+            db._conn.commit()
+            return total
+
+        monkeypatch.setattr(db, "message_count", count_then_change_active_set)
+
+        result = json.loads(session_search(session_id="s_big", db=db))
+
+        assert result["message_count"] == 50
+        assert result["truncated"] is True
+        assert len(result["messages"]) == 30
+        assert [m["content"] for m in result["messages"][:2]] == ["m0", "m1"]
+        assert [m["content"] for m in result["messages"][-2:]] == ["m48", "m49"]
 
 
 # =========================================================================

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -488,6 +488,35 @@ class TestReadShape:
         assert result["truncated"] is True
         assert len(result["messages"]) == 30  # head 20 + tail 10
 
+    def test_read_large_session_pages_head_and_tail(self, db, monkeypatch):
+        db.create_session("s_big", source="cli")
+        for i in range(50):
+            db.append_message("s_big", role="user" if i % 2 == 0 else "assistant", content=f"m{i}")
+        db._conn.commit()
+
+        calls = []
+        original_get_messages = db.get_messages
+
+        def spy_get_messages(session_id, include_inactive=False, limit=None, offset=0):
+            calls.append((session_id, include_inactive, limit, offset))
+            return original_get_messages(
+                session_id,
+                include_inactive=include_inactive,
+                limit=limit,
+                offset=offset,
+            )
+
+        monkeypatch.setattr(db, "get_messages", spy_get_messages)
+
+        result = json.loads(session_search(session_id="s_big", db=db))
+
+        assert result["message_count"] == 50
+        assert result["truncated"] is True
+        assert calls == [
+            ("s_big", False, 20, 0),
+            ("s_big", False, 10, 40),
+        ]
+
 
 # =========================================================================
 # Cross-profile read — `profile` swaps in another profile's DB (read-only)

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -225,15 +225,20 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10) -> str:
         return tool_error(f"session_id not found: {session_id}", success=False)
 
     try:
-        rows = db.get_messages(session_id)
+        total = db.message_count(session_id, include_inactive=False)
+        truncated = total > head + tail
+        if truncated:
+            head_rows = db.get_messages(session_id, limit=head)
+            tail_rows = db.get_messages(session_id, limit=tail, offset=max(total - tail, 0))
+            rows = head_rows + tail_rows
+        else:
+            rows = db.get_messages(session_id, limit=total)
     except Exception as e:
         logging.error("get_messages failed for %s: %s", session_id, e, exc_info=True)
         return tool_error(f"failed to load session: {e}", success=False)
 
-    shaped = [_shape_message(m) for m in rows]
-    total = len(shaped)
+    window = [_shape_message(m) for m in rows]
     truncated = total > head + tail
-    window = shaped[:head] + shaped[-tail:] if truncated else shaped
 
     response = {
         "success": True,

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -225,16 +225,19 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10) -> str:
         return tool_error(f"session_id not found: {session_id}", success=False)
 
     try:
-        total = db.message_count(session_id, include_inactive=False)
-        truncated = total > head + tail
-        if truncated:
-            head_rows = db.get_messages(session_id, limit=head)
-            tail_rows = db.get_messages(session_id, limit=tail, offset=max(total - tail, 0))
-            rows = head_rows + tail_rows
-        else:
-            rows = db.get_messages(session_id, limit=total)
+        total, rows = db.get_message_head_tail_window(
+            session_id,
+            head=head,
+            tail=tail,
+            include_inactive=False,
+        )
     except Exception as e:
-        logging.error("get_messages failed for %s: %s", session_id, e, exc_info=True)
+        logging.error(
+            "get_message_head_tail_window failed for %s: %s",
+            session_id,
+            e,
+            exc_info=True,
+        )
         return tool_error(f"failed to load session: {e}", success=False)
 
     window = [_shape_message(m) for m in rows]


### PR DESCRIPTION
Problem
- session_search read-mode loaded every active message for a session before slicing large transcripts down to the first 20 and last 10 messages. Large @session reads paid avoidable DB, decode, and allocation cost.

Solution
- Count active messages first, then use existing get_messages(limit, offset) pagination to fetch only the head and tail windows when the response will be truncated.
- Preserve the existing full response for small sessions.

Validation
- python -m pytest tests/tools/test_session_search.py::TestReadShape -q
- python -m pytest tests/tools/test_session_search.py -q

Impact
- Large read-mode sessions now decode at most 30 messages instead of the full transcript. For a 50-message regression fixture this changes get_messages from 1 unbounded read to two bounded reads: LIMIT 20 OFFSET 0 and LIMIT 10 OFFSET 40.