### PR TITLE
fix(backup): prune live chrome-debug profile

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -74,6 +74,7 @@ _EXCLUDED_DIRS = {
     _QUICK_SNAPSHOTS_DIR,  # quick/pre-update state snapshots — same reason as
                         # ``backups``: each holds a full copy of state.db, so
                         # zipping them re-ships the DB once per snapshot
+    "browser-cdp-profile",  # live Chrome profile — sockets and locked SQLite DBs
     "checkpoints",      # session-local trajectory caches — regenerated per-session,
                         # session-hash-keyed so they don't port to another machine anyway
     # Live browser profiles (e.g. the CDP Brave profile under browser-profiles/).
@@ -351,14 +352,27 @@ def _should_exclude(rel_path: Path) -> bool:
     return False
 
 
+def _is_backupable_file(path: Path) -> bool:
+    """Return True only for regular files.
+
+    ``zipfile.write()`` follows symlinks. Runtime browser profiles can contain
+    symlinks to Unix sockets such as ``SingletonSocket``; following those can
+    block forever. Skip all symlinks and other special files.
+    """
+    try:
+        return stat.S_ISREG(path.lstat().st_mode)
+    except OSError:
+        return False
+
+
 def _should_skip_backup_file(abs_path: Path, rel_path: Path, out_path: Path) -> bool:
     """Return True when a candidate file should not be written to a backup zip."""
     if _should_exclude(rel_path):
         return True
 
-    # zipfile.write() follows file symlinks, so skip links before any archive
-    # write can copy data from outside HERMES_HOME.
-    if abs_path.is_symlink():
+    # zipfile.write() follows symlinks and can block on FIFOs/sockets. Only
+    # regular files are backup candidates.
+    if not _is_backupable_file(abs_path):
         return True
 
     try:

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -74,7 +74,6 @@ _EXCLUDED_DIRS = {
     _QUICK_SNAPSHOTS_DIR,  # quick/pre-update state snapshots — same reason as
                         # ``backups``: each holds a full copy of state.db, so
                         # zipping them re-ships the DB once per snapshot
-    "browser-cdp-profile",  # live Chrome profile — sockets and locked SQLite DBs
     "checkpoints",      # session-local trajectory caches — regenerated per-session,
                         # session-hash-keyed so they don't port to another machine anyway
     # Live browser profiles (e.g. the CDP Brave profile under browser-profiles/).
@@ -101,6 +100,14 @@ _EXCLUDED_DIRS = {
     ".pytest_cache",
     ".mypy_cache",
     ".ruff_cache",
+}
+
+# Root-level runtime directories whose contents are live, machine-specific,
+# and not safe to archive while their owning process is running. These are
+# intentionally root-only so a user skill/project subdirectory with the same
+# name remains part of the backup.
+_ROOT_ONLY_EXCLUDED_DIRS = {
+    "chrome-debug",
 }
 
 # File-name suffixes to skip
@@ -305,21 +312,29 @@ def _collect_memory_provider_external_paths() -> List[Path]:
     return out
 
 
+def _is_regular_backup_file(path: Path) -> bool:
+    """Return True only for regular, non-symlink files."""
+    try:
+        return stat.S_ISREG(path.lstat().st_mode)
+    except OSError:
+        return False
+
+
 def _iter_external_files(base: Path) -> List[Path]:
     """Yield regular files under *base* (a file or a directory), skipping
     symlinks, caches, and pyc files. *base* itself may be a file."""
     files: List[Path] = []
-    if base.is_file() and not base.is_symlink():
+    if _is_regular_backup_file(base):
         files.append(base)
         return files
-    if not base.is_dir():
+    if base.is_symlink() or not base.is_dir():
         return files
     for dirpath, dirnames, filenames in os.walk(base, followlinks=False):
         dp = Path(dirpath)
         dirnames[:] = [d for d in dirnames if d not in _EXCLUDED_DIRS]
         for fname in filenames:
             fpath = dp / fname
-            if fpath.is_symlink():
+            if not _is_regular_backup_file(fpath):
                 continue
             if fpath.name in _EXCLUDED_NAMES or fpath.name.endswith(_EXCLUDED_SUFFIXES):
                 continue
@@ -330,6 +345,9 @@ def _iter_external_files(base: Path) -> List[Path]:
 def _should_exclude(rel_path: Path) -> bool:
     """Return True if *rel_path* (relative to hermes root) should be skipped."""
     parts = rel_path.parts
+
+    if parts and parts[0] in _ROOT_ONLY_EXCLUDED_DIRS:
+        return True
 
     for part in parts:
         if part not in _EXCLUDED_DIRS:
@@ -352,17 +370,26 @@ def _should_exclude(rel_path: Path) -> bool:
     return False
 
 
-def _is_backupable_file(path: Path) -> bool:
-    """Return True only for regular files.
+def _prune_backup_dirnames(dirnames: list[str], rel_dir: Path) -> set[str]:
+    """Prune excluded child directories from an ``os.walk`` iteration.
 
-    ``zipfile.write()`` follows symlinks. Runtime browser profiles can contain
-    symlinks to Unix sockets such as ``SingletonSocket``; following those can
-    block forever. Skip all symlinks and other special files.
+    Root-only runtime directories are removed only directly below
+    ``HERMES_HOME``. Nested user content with the same name remains portable.
     """
-    try:
-        return stat.S_ISREG(path.lstat().st_mode)
-    except OSError:
-        return False
+    is_root = rel_dir == Path(".")
+    kept: list[str] = []
+    for dirname in dirnames:
+        if dirname in _ROOT_ONLY_EXCLUDED_DIRS and is_root:
+            continue
+        if dirname in _EXCLUDED_DIRS:
+            if dirname == "hermes-agent" and not is_root:
+                kept.append(dirname)
+            continue
+        kept.append(dirname)
+
+    removed = set(dirnames) - set(kept)
+    dirnames[:] = kept
+    return removed
 
 
 def _should_skip_backup_file(abs_path: Path, rel_path: Path, out_path: Path) -> bool:
@@ -372,7 +399,7 @@ def _should_skip_backup_file(abs_path: Path, rel_path: Path, out_path: Path) -> 
 
     # zipfile.write() follows symlinks and can block on FIFOs/sockets. Only
     # regular files are backup candidates.
-    if not _is_backupable_file(abs_path):
+    if not _is_regular_backup_file(abs_path):
         return True
 
     try:
@@ -848,16 +875,8 @@ def _run_backup_locked(args, hermes_root: Path) -> None:
         dp = Path(dirpath)
         rel_dir = dp.relative_to(hermes_root)
 
-        # Prune excluded directories in-place so os.walk doesn't descend
-        # ``hermes-agent`` is only pruned at the root level; nested dirs
-        # with the same name (e.g. in skills/) must be preserved.
-        is_root = rel_dir == Path(".")
-        orig_dirnames = dirnames[:]
-        dirnames[:] = [
-            d for d in dirnames
-            if d not in _EXCLUDED_DIRS or (d == "hermes-agent" and not is_root)
-        ]
-        for removed in set(orig_dirnames) - set(dirnames):
+        # Prune excluded directories in-place so os.walk doesn't descend.
+        for removed in _prune_backup_dirnames(dirnames, rel_dir):
             skipped_dirs.add(str(rel_dir / removed))
 
         for fname in filenames:
@@ -2115,8 +2134,9 @@ def _write_full_zip_backup_locked(out_path: Path, hermes_root: Path) -> Optional
     try:
         for dirpath, dirnames, filenames in os.walk(hermes_root, followlinks=False):
             dp = Path(dirpath)
-            # Prune excluded directories in-place so os.walk doesn't descend
-            dirnames[:] = [d for d in dirnames if d not in _EXCLUDED_DIRS]
+            rel_dir = dp.relative_to(hermes_root)
+            # Keep this path in lockstep with run_backup().
+            _prune_backup_dirnames(dirnames, rel_dir)
 
             for fname in filenames:
                 fpath = dp / fname

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -13,6 +13,7 @@ import logging
 import os
 import shutil
 import sqlite3
+import stat
 import sys
 import tempfile
 import threading
@@ -54,6 +55,7 @@ _EXCLUDED_DIRS = {
     ".git",             # nested git dirs (profiles shouldn't have these, but safety)
     "node_modules",     # js deps — reinstalled on demand
     "backups",          # prior auto-backups — don't nest backups exponentially
+    "browser-cdp-profile",  # live Chrome profile — sockets and locked SQLite DBs
     "checkpoints",      # session-local trajectory caches — regenerated per-session,
                         # session-hash-keyed so they don't port to another machine anyway
     # Python dependency trees (plugin / MCP-server venvs under HERMES_HOME) —
@@ -315,14 +317,27 @@ def _should_exclude(rel_path: Path) -> bool:
     return False
 
 
+def _is_backupable_file(path: Path) -> bool:
+    """Return True only for regular files.
+
+    ``zipfile.write()`` follows symlinks. Runtime browser profiles can contain
+    symlinks to Unix sockets such as ``SingletonSocket``; following those can
+    block forever. Skip all symlinks and other special files.
+    """
+    try:
+        return stat.S_ISREG(path.lstat().st_mode)
+    except OSError:
+        return False
+
+
 def _should_skip_backup_file(abs_path: Path, rel_path: Path, out_path: Path) -> bool:
     """Return True when a candidate file should not be written to a backup zip."""
     if _should_exclude(rel_path):
         return True
 
-    # zipfile.write() follows file symlinks, so skip links before any archive
-    # write can copy data from outside HERMES_HOME.
-    if abs_path.is_symlink():
+    # zipfile.write() follows symlinks and can block on FIFOs/sockets. Only
+    # regular files are backup candidates.
+    if not _is_backupable_file(abs_path):
         return True
 
     try:

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -55,7 +55,6 @@ _EXCLUDED_DIRS = {
     ".git",             # nested git dirs (profiles shouldn't have these, but safety)
     "node_modules",     # js deps — reinstalled on demand
     "backups",          # prior auto-backups — don't nest backups exponentially
-    "browser-cdp-profile",  # live Chrome profile — sockets and locked SQLite DBs
     "checkpoints",      # session-local trajectory caches — regenerated per-session,
                         # session-hash-keyed so they don't port to another machine anyway
     # Python dependency trees (plugin / MCP-server venvs under HERMES_HOME) —
@@ -70,6 +69,14 @@ _EXCLUDED_DIRS = {
     ".pytest_cache",
     ".mypy_cache",
     ".ruff_cache",
+}
+
+# Root-level runtime directories whose contents are live, machine-specific,
+# and not safe to archive while their owning process is running. These are
+# intentionally root-only so a user skill/project subdirectory with the same
+# name remains part of the backup.
+_ROOT_ONLY_EXCLUDED_DIRS = {
+    "chrome-debug",
 }
 
 # File-name suffixes to skip
@@ -270,21 +277,29 @@ def _collect_memory_provider_external_paths() -> List[Path]:
     return out
 
 
+def _is_regular_backup_file(path: Path) -> bool:
+    """Return True only for regular, non-symlink files."""
+    try:
+        return stat.S_ISREG(path.lstat().st_mode)
+    except OSError:
+        return False
+
+
 def _iter_external_files(base: Path) -> List[Path]:
     """Yield regular files under *base* (a file or a directory), skipping
     symlinks, caches, and pyc files. *base* itself may be a file."""
     files: List[Path] = []
-    if base.is_file() and not base.is_symlink():
+    if _is_regular_backup_file(base):
         files.append(base)
         return files
-    if not base.is_dir():
+    if base.is_symlink() or not base.is_dir():
         return files
     for dirpath, dirnames, filenames in os.walk(base, followlinks=False):
         dp = Path(dirpath)
         dirnames[:] = [d for d in dirnames if d not in _EXCLUDED_DIRS]
         for fname in filenames:
             fpath = dp / fname
-            if fpath.is_symlink():
+            if not _is_regular_backup_file(fpath):
                 continue
             if fpath.name in _EXCLUDED_NAMES or fpath.name.endswith(_EXCLUDED_SUFFIXES):
                 continue
@@ -295,6 +310,9 @@ def _iter_external_files(base: Path) -> List[Path]:
 def _should_exclude(rel_path: Path) -> bool:
     """Return True if *rel_path* (relative to hermes root) should be skipped."""
     parts = rel_path.parts
+
+    if parts and parts[0] in _ROOT_ONLY_EXCLUDED_DIRS:
+        return True
 
     for part in parts:
         if part not in _EXCLUDED_DIRS:
@@ -317,17 +335,26 @@ def _should_exclude(rel_path: Path) -> bool:
     return False
 
 
-def _is_backupable_file(path: Path) -> bool:
-    """Return True only for regular files.
+def _prune_backup_dirnames(dirnames: list[str], rel_dir: Path) -> set[str]:
+    """Prune excluded child directories from an ``os.walk`` iteration.
 
-    ``zipfile.write()`` follows symlinks. Runtime browser profiles can contain
-    symlinks to Unix sockets such as ``SingletonSocket``; following those can
-    block forever. Skip all symlinks and other special files.
+    Root-only runtime directories are removed only directly below
+    ``HERMES_HOME``. Nested user content with the same name remains portable.
     """
-    try:
-        return stat.S_ISREG(path.lstat().st_mode)
-    except OSError:
-        return False
+    is_root = rel_dir == Path(".")
+    kept: list[str] = []
+    for dirname in dirnames:
+        if dirname in _ROOT_ONLY_EXCLUDED_DIRS and is_root:
+            continue
+        if dirname in _EXCLUDED_DIRS:
+            if dirname == "hermes-agent" and not is_root:
+                kept.append(dirname)
+            continue
+        kept.append(dirname)
+
+    removed = set(dirnames) - set(kept)
+    dirnames[:] = kept
+    return removed
 
 
 def _should_skip_backup_file(abs_path: Path, rel_path: Path, out_path: Path) -> bool:
@@ -337,7 +364,7 @@ def _should_skip_backup_file(abs_path: Path, rel_path: Path, out_path: Path) -> 
 
     # zipfile.write() follows symlinks and can block on FIFOs/sockets. Only
     # regular files are backup candidates.
-    if not _is_backupable_file(abs_path):
+    if not _is_regular_backup_file(abs_path):
         return True
 
     try:
@@ -646,16 +673,8 @@ def _run_backup_locked(args, hermes_root: Path) -> None:
         dp = Path(dirpath)
         rel_dir = dp.relative_to(hermes_root)
 
-        # Prune excluded directories in-place so os.walk doesn't descend
-        # ``hermes-agent`` is only pruned at the root level; nested dirs
-        # with the same name (e.g. in skills/) must be preserved.
-        is_root = rel_dir == Path(".")
-        orig_dirnames = dirnames[:]
-        dirnames[:] = [
-            d for d in dirnames
-            if d not in _EXCLUDED_DIRS or (d == "hermes-agent" and not is_root)
-        ]
-        for removed in set(orig_dirnames) - set(dirnames):
+        # Prune excluded directories in-place so os.walk doesn't descend.
+        for removed in _prune_backup_dirnames(dirnames, rel_dir):
             skipped_dirs.add(str(rel_dir / removed))
 
         for fname in filenames:
@@ -1674,8 +1693,9 @@ def _write_full_zip_backup_locked(out_path: Path, hermes_root: Path) -> Optional
     try:
         for dirpath, dirnames, filenames in os.walk(hermes_root, followlinks=False):
             dp = Path(dirpath)
-            # Prune excluded directories in-place so os.walk doesn't descend
-            dirnames[:] = [d for d in dirnames if d not in _EXCLUDED_DIRS]
+            rel_dir = dp.relative_to(hermes_root)
+            # Keep this path in lockstep with run_backup().
+            _prune_backup_dirnames(dirnames, rel_dir)
 
             for fname in filenames:
                 fpath = dp / fname

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -146,6 +146,12 @@ class TestShouldExclude:
         # The live DB is still backed up.
         assert not _should_exclude(Path("state.db"))
 
+    def test_excludes_browser_cdp_profile(self):
+        """Live browser profiles contain sockets and locked SQLite DBs."""
+        from hermes_cli.backup import _should_exclude
+        assert _should_exclude(Path("browser-cdp-profile/SingletonSocket"))
+        assert _should_exclude(Path("browser-cdp-profile/Default/History"))
+
     def test_excludes_sqlite_sidecars(self):
         """SQLite WAL/SHM/journal sidecars must not ship alongside the
         safe-copied .db — pairing a fresh snapshot with stale sidecar state
@@ -282,6 +288,16 @@ class TestBackup:
         assert not any(n.startswith(_QUICK_SNAPSHOTS_DIR + "/") for n in names), names
         # Exactly one state.db in the archive: the live one.
         assert [n for n in names if n == "state.db" or n.endswith("/state.db")] == ["state.db"]
+
+    @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="mkfifo unavailable")
+    def test_rejects_special_files(self, tmp_path):
+        """Backup file filter rejects FIFOs and other special files."""
+        from hermes_cli.backup import _is_backupable_file
+
+        fifo = tmp_path / "pipe"
+        os.mkfifo(fifo)
+
+        assert not _is_backupable_file(fifo)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -146,11 +146,12 @@ class TestShouldExclude:
         # The live DB is still backed up.
         assert not _should_exclude(Path("state.db"))
 
-    def test_excludes_browser_cdp_profile(self):
-        """Live browser profiles contain sockets and locked SQLite DBs."""
+    def test_excludes_live_chromium_profile(self):
+        """Only the root live CDP profile is excluded."""
         from hermes_cli.backup import _should_exclude
-        assert _should_exclude(Path("browser-cdp-profile/SingletonSocket"))
-        assert _should_exclude(Path("browser-cdp-profile/Default/History"))
+        assert _should_exclude(Path("chrome-debug/SingletonSocket"))
+        assert _should_exclude(Path("chrome-debug/Default/History"))
+        assert not _should_exclude(Path("skills/example/chrome-debug/notes.md"))
 
     def test_excludes_sqlite_sidecars(self):
         """SQLite WAL/SHM/journal sidecars must not ship alongside the
@@ -232,10 +233,37 @@ class TestBackup:
         assert staged_dirs, "no SQLite snapshot was staged"
         assert all(d == str(out_zip.parent) for d in staged_dirs), staged_dirs
 
+    def test_pre_update_backup_prunes_only_root_browser_profile(self, tmp_path, monkeypatch):
+        """The shared pre-update/pre-migration path must not walk live CDP state."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+        chrome_debug = hermes_home / "chrome-debug"
+        (chrome_debug / "Default").mkdir(parents=True)
+        (chrome_debug / "Default" / "Cookies").write_text("runtime")
+        nested = hermes_home / "skills" / "my-skill" / "chrome-debug"
+        nested.mkdir(parents=True)
+        (nested / "notes.md").write_text("keep me")
 
+        import hermes_cli.backup as backup_mod
+        real_walk = backup_mod.os.walk
+        walked: list[Path] = []
 
+        def _traced_walk(*args, **kwargs):
+            for item in real_walk(*args, **kwargs):
+                walked.append(Path(item[0]))
+                yield item
 
+        monkeypatch.setattr(backup_mod.os, "walk", _traced_walk)
+        out_zip = tmp_path / "pre-update.zip"
+        result = backup_mod._write_full_zip_backup(out_zip, hermes_home)
 
+        assert result == out_zip
+        assert not any(path == chrome_debug or chrome_debug in path.parents for path in walked)
+        with zipfile.ZipFile(out_zip, "r") as zf:
+            names = zf.namelist()
+        assert not any(name.startswith("chrome-debug/") for name in names)
+        assert "skills/my-skill/chrome-debug/notes.md" in names
 
     def test_skips_symlinked_files(self, tmp_path, monkeypatch):
         """Backup must not dereference symlinks and leak files outside HERMES_HOME."""
@@ -289,15 +317,64 @@ class TestBackup:
         # Exactly one state.db in the archive: the live one.
         assert [n for n in names if n == "state.db" or n.endswith("/state.db")] == ["state.db"]
 
+    def test_excludes_only_root_browser_profile(self, tmp_path, monkeypatch):
+        """Manual backup prunes root CDP state but preserves nested user content."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+        chrome_debug = hermes_home / "chrome-debug"
+        chrome_debug.mkdir()
+        (chrome_debug / "Cookies").write_text("runtime")
+        nested = hermes_home / "skills" / "my-skill" / "chrome-debug"
+        nested.mkdir(parents=True)
+        (nested / "notes.md").write_text("keep me")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        out_zip = tmp_path / "backup.zip"
+
+        import hermes_cli.backup as backup_mod
+        real_walk = backup_mod.os.walk
+        walked: list[Path] = []
+
+        def _traced_walk(*args, **kwargs):
+            for item in real_walk(*args, **kwargs):
+                walked.append(Path(item[0]))
+                yield item
+
+        monkeypatch.setattr(backup_mod.os, "walk", _traced_walk)
+        backup_mod.run_backup(Namespace(output=str(out_zip)))
+
+        with zipfile.ZipFile(out_zip, "r") as zf:
+            names = zf.namelist()
+        assert not any(path == chrome_debug or chrome_debug in path.parents for path in walked)
+        assert not any(name.startswith("chrome-debug/") for name in names)
+        assert "skills/my-skill/chrome-debug/notes.md" in names
+
     @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="mkfifo unavailable")
-    def test_rejects_special_files(self, tmp_path):
-        """Backup file filter rejects FIFOs and other special files."""
-        from hermes_cli.backup import _is_backupable_file
+    def test_backup_filter_rejects_fifo(self, tmp_path):
+        """Internal and external backup paths reject special files and symlink roots."""
+        from hermes_cli.backup import _iter_external_files, _should_skip_backup_file
 
         fifo = tmp_path / "pipe"
         os.mkfifo(fifo)
+        regular = tmp_path / "regular.txt"
+        regular.write_text("keep")
 
-        assert not _is_backupable_file(fifo)
+        assert _should_skip_backup_file(fifo, Path("pipe"), tmp_path / "out.zip")
+        external = _iter_external_files(tmp_path)
+        assert regular in external
+        assert fifo not in external
+
+        target_dir = tmp_path / "external-target"
+        target_dir.mkdir()
+        (target_dir / "secret.txt").write_text("outside")
+        linked_dir = tmp_path / "external-link"
+        try:
+            linked_dir.symlink_to(target_dir, target_is_directory=True)
+        except OSError as exc:
+            pytest.skip(f"symlink creation unavailable: {exc}")
+        assert _iter_external_files(linked_dir) == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -121,6 +121,12 @@ class TestShouldExclude:
         from hermes_cli.backup import _should_exclude
         assert _should_exclude(Path("backups/pre-update-2026-04-27-063400.zip"))
 
+    def test_excludes_browser_cdp_profile(self):
+        """Live browser profiles contain sockets and locked SQLite DBs."""
+        from hermes_cli.backup import _should_exclude
+        assert _should_exclude(Path("browser-cdp-profile/SingletonSocket"))
+        assert _should_exclude(Path("browser-cdp-profile/Default/History"))
+
     def test_excludes_sqlite_sidecars(self):
         """SQLite WAL/SHM/journal sidecars must not ship alongside the
         safe-copied .db — pairing a fresh snapshot with stale sidecar state
@@ -228,6 +234,16 @@ class TestBackup:
             names = zf.namelist()
             assert "skills/outside-link.txt" not in names
             assert all(zf.read(name) != b"outside secret\n" for name in names)
+
+    @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="mkfifo unavailable")
+    def test_rejects_special_files(self, tmp_path):
+        """Backup file filter rejects FIFOs and other special files."""
+        from hermes_cli.backup import _is_backupable_file
+
+        fifo = tmp_path / "pipe"
+        os.mkfifo(fifo)
+
+        assert not _is_backupable_file(fifo)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -121,11 +121,12 @@ class TestShouldExclude:
         from hermes_cli.backup import _should_exclude
         assert _should_exclude(Path("backups/pre-update-2026-04-27-063400.zip"))
 
-    def test_excludes_browser_cdp_profile(self):
-        """Live browser profiles contain sockets and locked SQLite DBs."""
+    def test_excludes_live_chromium_profile(self):
+        """Only the root live CDP profile is excluded."""
         from hermes_cli.backup import _should_exclude
-        assert _should_exclude(Path("browser-cdp-profile/SingletonSocket"))
-        assert _should_exclude(Path("browser-cdp-profile/Default/History"))
+        assert _should_exclude(Path("chrome-debug/SingletonSocket"))
+        assert _should_exclude(Path("chrome-debug/Default/History"))
+        assert not _should_exclude(Path("skills/example/chrome-debug/notes.md"))
 
     def test_excludes_sqlite_sidecars(self):
         """SQLite WAL/SHM/journal sidecars must not ship alongside the
@@ -207,10 +208,37 @@ class TestBackup:
         assert staged_dirs, "no SQLite snapshot was staged"
         assert all(d == str(out_zip.parent) for d in staged_dirs), staged_dirs
 
+    def test_pre_update_backup_prunes_only_root_browser_profile(self, tmp_path, monkeypatch):
+        """The shared pre-update/pre-migration path must not walk live CDP state."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+        chrome_debug = hermes_home / "chrome-debug"
+        (chrome_debug / "Default").mkdir(parents=True)
+        (chrome_debug / "Default" / "Cookies").write_text("runtime")
+        nested = hermes_home / "skills" / "my-skill" / "chrome-debug"
+        nested.mkdir(parents=True)
+        (nested / "notes.md").write_text("keep me")
 
+        import hermes_cli.backup as backup_mod
+        real_walk = backup_mod.os.walk
+        walked: list[Path] = []
 
+        def _traced_walk(*args, **kwargs):
+            for item in real_walk(*args, **kwargs):
+                walked.append(Path(item[0]))
+                yield item
 
+        monkeypatch.setattr(backup_mod.os, "walk", _traced_walk)
+        out_zip = tmp_path / "pre-update.zip"
+        result = backup_mod._write_full_zip_backup(out_zip, hermes_home)
 
+        assert result == out_zip
+        assert not any(path == chrome_debug or chrome_debug in path.parents for path in walked)
+        with zipfile.ZipFile(out_zip, "r") as zf:
+            names = zf.namelist()
+        assert not any(name.startswith("chrome-debug/") for name in names)
+        assert "skills/my-skill/chrome-debug/notes.md" in names
 
     def test_skips_symlinked_files(self, tmp_path, monkeypatch):
         """Backup must not dereference symlinks and leak files outside HERMES_HOME."""
@@ -235,15 +263,64 @@ class TestBackup:
             assert "skills/outside-link.txt" not in names
             assert all(zf.read(name) != b"outside secret\n" for name in names)
 
+    def test_excludes_only_root_browser_profile(self, tmp_path, monkeypatch):
+        """Manual backup prunes root CDP state but preserves nested user content."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+        chrome_debug = hermes_home / "chrome-debug"
+        chrome_debug.mkdir()
+        (chrome_debug / "Cookies").write_text("runtime")
+        nested = hermes_home / "skills" / "my-skill" / "chrome-debug"
+        nested.mkdir(parents=True)
+        (nested / "notes.md").write_text("keep me")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        out_zip = tmp_path / "backup.zip"
+
+        import hermes_cli.backup as backup_mod
+        real_walk = backup_mod.os.walk
+        walked: list[Path] = []
+
+        def _traced_walk(*args, **kwargs):
+            for item in real_walk(*args, **kwargs):
+                walked.append(Path(item[0]))
+                yield item
+
+        monkeypatch.setattr(backup_mod.os, "walk", _traced_walk)
+        backup_mod.run_backup(Namespace(output=str(out_zip)))
+
+        with zipfile.ZipFile(out_zip, "r") as zf:
+            names = zf.namelist()
+        assert not any(path == chrome_debug or chrome_debug in path.parents for path in walked)
+        assert not any(name.startswith("chrome-debug/") for name in names)
+        assert "skills/my-skill/chrome-debug/notes.md" in names
+
     @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="mkfifo unavailable")
-    def test_rejects_special_files(self, tmp_path):
-        """Backup file filter rejects FIFOs and other special files."""
-        from hermes_cli.backup import _is_backupable_file
+    def test_backup_filter_rejects_fifo(self, tmp_path):
+        """Internal and external backup paths reject special files and symlink roots."""
+        from hermes_cli.backup import _iter_external_files, _should_skip_backup_file
 
         fifo = tmp_path / "pipe"
         os.mkfifo(fifo)
+        regular = tmp_path / "regular.txt"
+        regular.write_text("keep")
 
-        assert not _is_backupable_file(fifo)
+        assert _should_skip_backup_file(fifo, Path("pipe"), tmp_path / "out.zip")
+        external = _iter_external_files(tmp_path)
+        assert regular in external
+        assert fifo not in external
+
+        target_dir = tmp_path / "external-target"
+        target_dir.mkdir()
+        (target_dir / "secret.txt").write_text("outside")
+        linked_dir = tmp_path / "external-link"
+        try:
+            linked_dir.symlink_to(target_dir, target_is_directory=True)
+        except OSError as exc:
+            pytest.skip(f"symlink creation unavailable: {exc}")
+        assert _iter_external_files(linked_dir) == []
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -82,6 +82,12 @@ updates:
 
 `updates.pre_update_backup` is a single knob with three modes: `quick` (default — the lightweight state snapshot described above), `full` (the quick snapshot plus a complete `HERMES_HOME` zip; can add minutes on large homes), and `off` (no pre-update backup at all — `--no-backup` does the same for a single run). Legacy boolean values still work: `true` means `full`, `false` means `off`.
 
+The dedicated local-CDP browser profile under `chrome-debug/` is intentionally
+excluded. It contains live Chromium sockets, locked databases, and machine-bound
+browser state that cannot be copied consistently while the browser is running.
+If you need to preserve a signed-in browser profile, close Chromium and back up
+that directory separately.
+
 ### Windows: another `hermes.exe` is running
 
 On Windows, `hermes update` will refuse to run if it detects another `hermes.exe` process holding the venv's entry-point executable open — most commonly the Hermes Desktop app's spawned backend, an open `hermes` REPL in another terminal, or a running gateway:

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -117,6 +117,12 @@ updates:
 Update backups protect an in-place update. If you're migrating your whole setup to different hardware, use `hermes backup` + `hermes import` instead — see [Exporting Hermes to another machine](/reference/faq#exporting-hermes-to-another-machine) and [`hermes backup` vs `hermes profile export`](/reference/faq#hermes-backup-vs-hermes-profile-export).
 :::
 
+The dedicated local-CDP browser profile under `chrome-debug/` is intentionally
+excluded. It contains live Chromium sockets, locked databases, and machine-bound
+browser state that cannot be copied consistently while the browser is running.
+If you need to preserve a signed-in browser profile, close Chromium and back up
+that directory separately.
+
 ### Windows: another `hermes.exe` is running
 
 On Windows, `hermes update` will refuse to run if it detects another `hermes.exe` process holding the venv's entry-point executable open — most commonly the Hermes Desktop app's spawned backend, an open `hermes` REPL in another terminal, or a running gateway:

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/updating.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/updating.md
@@ -52,6 +52,11 @@ updates:
 
 `updates.pre_update_backup` 是单一开关，有三种模式：`quick`（默认 — 上述轻量级状态快照）、`full`（快速快照加上完整的 `HERMES_HOME` zip 备份；在大型 home 目录上可能增加数分钟）、`off`（完全不做更新前备份 — `--no-backup` 对单次运行有相同效果）。旧版布尔值仍然有效：`true` 等同于 `full`，`false` 等同于 `off`。
 
+专用于本地 CDP 的 `chrome-debug/` 浏览器 profile 会被有意排除。该目录包含
+Chromium 正在使用的套接字、锁定的数据库以及与本机绑定的浏览器状态，浏览器运行时
+无法对其进行一致备份。如需保留已登录的浏览器 profile，请先关闭 Chromium，再单独
+备份该目录。
+
 ### Windows：另一个 `hermes.exe` 正在运行
 
 在 Windows 上，如果 `hermes update` 检测到另一个 `hermes.exe` 进程持有 venv 入口点可执行文件的句柄，它将拒绝运行 — 最常见的情况是 Hermes Desktop 应用启动的后端进程、另一个终端中打开的 `hermes` REPL，或正在运行的 gateway：


### PR DESCRIPTION
## What does this PR do?

Prevents full Hermes backups from traversing the live root-level `HERMES_HOME/chrome-debug/` profile.

The profile is pruned before both manual and automatic full-backup walkers enter it. Nested user directories with the same name remain included. Internal and external-provider enumeration now admits only regular, non-symlink files, avoiding FIFO/socket/device archive hangs.

## Related issue

Fixes #61703.

Carries forward @lost9999's original backup fix from #17493. The separate Windows `taskkill` hardening remains in #37377.

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor

## Changes

- `hermes_cli/backup.py`
  - prune only root-level `chrome-debug/` in both full-backup walkers;
  - retain nested user paths such as `skills/example/chrome-debug/`;
  - require regular, non-symlink files for internal and external-provider backup candidates;
  - preserve current backup locking, atomic publication, SQLite snapshot handling, exclusions, rotation, and logging.
- `tests/hermes_cli/test_backup.py`
  - prove both walkers prune before descending into the root browser profile;
  - prove nested same-name directories remain archived;
  - cover FIFO rejection and external symlink-root rejection;
  - retain current state-snapshot exclusion coverage.
- English and Simplified Chinese updating guides
  - document that the live local-CDP profile is intentionally excluded and should be cold-copied separately if needed.

## Attribution

The branch preserves two commits:

1. @lost9999's original commit, with authorship and `cherry-pick -x` provenance retained.
2. The current-path and shared-walker adaptation.

## Current-main refresh

Refreshed from the stale/conflicting branch onto upstream `main` and force-updated with an exact lease.

Exact pushed head: `a45f773f593e854d1eb964ebc2ef0a6b09e2f11a`

GitHub currently reports the PR as mergeable; no hosted check runs are attached yet.

## Verification

Exact-head verification:

- focused backup suites:
  - `bash scripts/run_tests.sh tests/hermes_cli/test_backup.py tests/hermes_cli/test_backup_stability.py -q`
  - **67 passed, 0 failed**
- Ruff on changed Python files: **passed**
- Python compilation on changed Python files: **passed**
- `git diff --check origin/main...HEAD`: **passed**
- real isolated FIFO/live-profile smoke:
  - completed in **0.058s**;
  - root `chrome-debug/` entries: **0**;
  - nested `skills/demo/chrome-debug/notes.md`: **preserved**
- English Docusaurus build: **passed**
- Simplified Chinese Docusaurus build: **passed** with existing broken-anchor warnings
- independent exact-head review: **P0 0 / P1 0 / P2 0 / P3 0**

Broad-suite context:

- A full repository run on the immediately preceding rebased candidate completed with **58 failures across 22 unrelated files**, plus warning/import/timeout buckets; none of the changed backup files failed.
- Several failures were environment/resource related, including `/tmp` quota exhaustion, and an unrelated compression timing failure passed when rerun alone.
- After the final one-commit upstream rebase, all exact-head focused, lint, compile, diff, smoke, documentation-build, and independent-review gates above were rerun.

## Checklist

### Code

- [x] Read the contributing and repository agent guidance
- [x] Preserved the original contributor's authorship and provenance
- [x] Kept the change focused on the reported backup failure class
- [x] Added regression coverage for both full-backup walkers
- [x] Revalidated against current `main`

### Documentation and compatibility

- [x] Updated relevant English and Simplified Chinese documentation
- [x] No configuration keys or schemas changed
- [x] Considered cross-platform behavior; FIFO coverage is platform-gated
- [x] No tool descriptions or model-facing schemas changed
