### PR TITLE
Memoize context length cache loads

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import re
+import threading
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -201,6 +202,8 @@ MINIMUM_CONTEXT_LENGTH = 64_000
 # restart freshness is handled by the reconcile logic re-probing after expiry.
 _LOCAL_CTX_PROBE_TTL_SECONDS = 30.0
 _LOCAL_CTX_PROBE_CACHE: Dict[tuple, tuple] = {}
+_CONTEXT_CACHE_LOCK = threading.Lock()
+_CONTEXT_CACHE_SNAPSHOT: Optional[Tuple[Path, Optional[Tuple[int, int]], Dict[str, int]]] = None
 
 # Thin fallback defaults — only broad model family patterns.
 # These fire only when provider is unknown AND models.dev/OpenRouter/Anthropic
@@ -1069,17 +1072,53 @@ def _get_context_cache_path() -> Path:
     return get_hermes_home() / "context_length_cache.yaml"
 
 
+def _context_cache_signature(path: Path) -> Optional[Tuple[int, int]]:
+    """Return a cheap file signature for the context cache, or None if missing."""
+    try:
+        stat = path.stat()
+        return stat.st_mtime_ns, stat.st_size
+    except FileNotFoundError:
+        return None
+    except Exception as e:
+        logger.debug("Failed to stat context length cache: %s", e)
+        return None
+
+
+def _store_context_cache_snapshot(
+    path: Path,
+    signature: Optional[Tuple[int, int]],
+    cache: Dict[str, int],
+) -> None:
+    global _CONTEXT_CACHE_SNAPSHOT
+    with _CONTEXT_CACHE_LOCK:
+        _CONTEXT_CACHE_SNAPSHOT = (path, signature, dict(cache))
+
+
 def _load_context_cache() -> Dict[str, int]:
     """Load the model+provider -> context_length cache from disk."""
     path = _get_context_cache_path()
-    if not path.exists():
+    signature = _context_cache_signature(path)
+    with _CONTEXT_CACHE_LOCK:
+        if (
+            _CONTEXT_CACHE_SNAPSHOT is not None
+            and _CONTEXT_CACHE_SNAPSHOT[0] == path
+            and _CONTEXT_CACHE_SNAPSHOT[1] == signature
+        ):
+            return dict(_CONTEXT_CACHE_SNAPSHOT[2])
+    if signature is None:
+        _store_context_cache_snapshot(path, signature, {})
         return {}
     try:
         with open(path, encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
-        return data.get("context_lengths") or {}
+        cache = data.get("context_lengths", {}) if isinstance(data, dict) else {}
+        if not isinstance(cache, dict):
+            cache = {}
+        _store_context_cache_snapshot(path, signature, cache)
+        return dict(cache)
     except Exception as e:
         logger.debug("Failed to load context length cache: %s", e)
+        _store_context_cache_snapshot(path, signature, {})
         return {}
 
 
@@ -1109,6 +1148,7 @@ def save_context_length(model: str, base_url: str, length: int) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
         with open(path, "w", encoding="utf-8") as f:
             yaml.dump({"context_lengths": cache}, f, default_flow_style=False)
+        _store_context_cache_snapshot(path, _context_cache_signature(path), cache)
         logger.info("Cached context length %s -> %s tokens", key, f"{length:,}")
     except Exception as e:
         logger.debug("Failed to save context length cache: %s", e)
@@ -1158,6 +1198,7 @@ def _invalidate_cached_context_length(model: str, base_url: str) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
         with open(path, "w", encoding="utf-8") as f:
             yaml.dump({"context_lengths": cache}, f, default_flow_style=False)
+        _store_context_cache_snapshot(path, _context_cache_signature(path), cache)
     except Exception as e:
         logger.debug("Failed to invalidate context length cache entry %s: %s", key, e)
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1567,6 +1567,63 @@ class TestContextLengthCache:
             save_context_length(model, url, 200000)
             assert get_cached_context_length(model, url) == 200000
 
+    def test_repeated_load_reuses_unchanged_file_snapshot(self, tmp_path, monkeypatch):
+        import agent.model_metadata as mm
+
+        cache_file = tmp_path / "cache.yaml"
+        cache_file.write_text(
+            yaml.dump({"context_lengths": {"model@http://x": 64000}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(mm, "_get_context_cache_path", lambda: cache_file)
+
+        load_count = 0
+        original_safe_load = yaml.safe_load
+
+        def counting_safe_load(stream):
+            nonlocal load_count
+            load_count += 1
+            return original_safe_load(stream)
+
+        monkeypatch.setattr(mm.yaml, "safe_load", counting_safe_load)
+
+        assert mm.get_cached_context_length("model", "http://x") == 64000
+        assert mm.get_cached_context_length("model", "http://x") == 64000
+        assert load_count == 1
+
+    def test_cache_snapshot_invalidates_when_file_signature_changes(self, tmp_path, monkeypatch):
+        import agent.model_metadata as mm
+
+        cache_file = tmp_path / "cache.yaml"
+        cache_file.write_text(
+            yaml.dump({"context_lengths": {"model@http://x": 64000}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(mm, "_get_context_cache_path", lambda: cache_file)
+
+        assert mm.get_cached_context_length("model", "http://x") == 64000
+
+        cache_file.write_text(
+            yaml.dump({"context_lengths": {"model@http://x": 128000, "pad@x": 1}}),
+            encoding="utf-8",
+        )
+
+        assert mm.get_cached_context_length("model", "http://x") == 128000
+
+    def test_save_updates_snapshot_without_reloading_yaml(self, tmp_path, monkeypatch):
+        import agent.model_metadata as mm
+
+        cache_file = tmp_path / "cache.yaml"
+        monkeypatch.setattr(mm, "_get_context_cache_path", lambda: cache_file)
+
+        mm.save_context_length("model", "http://x", 64000)
+
+        def fail_safe_load(_stream):
+            raise AssertionError("unchanged cache file should use the in-process snapshot")
+
+        monkeypatch.setattr(mm.yaml, "safe_load", fail_safe_load)
+        assert mm.get_cached_context_length("model", "http://x") == 64000
+
 
 class TestGrok43StaleCacheGuard:
     """Pre-catalog builds resolved grok-4.3 via the generic 'grok-4' catch-all


### PR DESCRIPTION
Problem
- Persistent context-length lookups re-read and re-parse context_length_cache.yaml on every get_cached_context_length call, even when the file has not changed. Startup/model-resolution hot paths can call this repeatedly.

Solution
- Cache the parsed YAML in-process by cache path plus st_mtime_ns/st_size signature.
- Return defensive dict copies, refresh automatically when the file signature changes, and update the snapshot after save/invalidate writes.

Validation
- python -m pytest tests/agent/test_model_metadata.py::TestContextLengthCache tests/agent/test_probe_cache_followups.py::TestContextCacheKeyNormalization -q
- python -m pytest tests/agent/test_model_metadata.py::TestGrok43StaleCacheGuard -q

Impact
- Repeated unchanged cache lookups parse YAML once per file signature instead of once per lookup. The new regression test verifies two identical lookups perform one yaml.safe_load call, while file changes still invalidate the snapshot.