### PR TITLE
Reuse gateway config during relay self-provision

### DIFF
--- a/gateway/relay/__init__.py
+++ b/gateway/relay/__init__.py
@@ -29,6 +29,11 @@ _RELAY_GATEWAY_CONFIG_SNAPSHOT: ContextVar[object] = ContextVar(
 )
 
 
+class _LazyGatewayConfigSnapshot:
+    def __init__(self) -> None:
+        self.value: object = _CONFIG_SNAPSHOT_UNSET
+
+
 def _read_gateway_config() -> dict:
     """Read gateway config once; absence or parse errors are treated as empty."""
     try:
@@ -42,6 +47,10 @@ def _read_gateway_config() -> dict:
 
 def _gateway_config() -> dict:
     snapshot = _RELAY_GATEWAY_CONFIG_SNAPSHOT.get()
+    if isinstance(snapshot, _LazyGatewayConfigSnapshot):
+        if snapshot.value is _CONFIG_SNAPSHOT_UNSET:
+            snapshot.value = _read_gateway_config()
+        return snapshot.value if isinstance(snapshot.value, dict) else {}
     if snapshot is not _CONFIG_SNAPSHOT_UNSET:
         return snapshot if isinstance(snapshot, dict) else {}
     return _read_gateway_config()
@@ -563,7 +572,7 @@ def self_provision_relay() -> bool:
 
     logger = logging.getLogger("gateway.relay")
 
-    snapshot_token = _RELAY_GATEWAY_CONFIG_SNAPSHOT.set(_read_gateway_config())
+    snapshot_token = _RELAY_GATEWAY_CONFIG_SNAPSHOT.set(_LazyGatewayConfigSnapshot())
     try:
         dial_url = relay_url()
         if not dial_url:

--- a/gateway/relay/__init__.py
+++ b/gateway/relay/__init__.py
@@ -18,8 +18,33 @@ that don't set it are unaffected — exactly the same shape as ``gateway.proxy_u
 
 from __future__ import annotations
 
+from contextvars import ContextVar
 import os
 from typing import Optional
+
+_CONFIG_SNAPSHOT_UNSET = object()
+_RELAY_GATEWAY_CONFIG_SNAPSHOT: ContextVar[object] = ContextVar(
+    "relay_gateway_config_snapshot",
+    default=_CONFIG_SNAPSHOT_UNSET,
+)
+
+
+def _read_gateway_config() -> dict:
+    """Read gateway config once; absence or parse errors are treated as empty."""
+    try:
+        from gateway.run import _load_gateway_config  # late import to avoid cycle
+
+        cfg = _load_gateway_config()
+        return cfg if isinstance(cfg, dict) else {}
+    except Exception:  # noqa: BLE001 - config absence/parse must never crash relay boot
+        return {}
+
+
+def _gateway_config() -> dict:
+    snapshot = _RELAY_GATEWAY_CONFIG_SNAPSHOT.get()
+    if snapshot is not _CONFIG_SNAPSHOT_UNSET:
+        return snapshot if isinstance(snapshot, dict) else {}
+    return _read_gateway_config()
 
 
 def relay_url() -> Optional[str]:
@@ -33,9 +58,7 @@ def relay_url() -> Optional[str]:
     if url:
         return url.rstrip("/")
     try:
-        from gateway.run import _load_gateway_config  # late import to avoid cycle
-
-        cfg = _load_gateway_config()
+        cfg = _gateway_config()
         url = (cfg.get("gateway") or {}).get("relay_url")
         url = (url or "").strip()
         if url:
@@ -136,9 +159,7 @@ def relay_connection_auth() -> tuple[Optional[str], Optional[str]]:
     secret = os.environ.get("GATEWAY_RELAY_SECRET", "").strip()
     if not (gateway_id and secret):
         try:
-            from gateway.run import _load_gateway_config  # late import to avoid cycle
-
-            cfg = (_load_gateway_config().get("gateway") or {})
+            cfg = (_gateway_config().get("gateway") or {})
             gateway_id = gateway_id or str(cfg.get("relay_id", "") or "").strip()
             secret = secret or str(cfg.get("relay_secret", "") or "").strip()
         except Exception:  # noqa: BLE001 - config absence/parse must never crash registration
@@ -163,9 +184,7 @@ def relay_endpoint() -> Optional[str]:
     url = os.environ.get("GATEWAY_RELAY_ENDPOINT", "").strip()
     if not url:
         try:
-            from gateway.run import _load_gateway_config  # late import to avoid cycle
-
-            cfg = (_load_gateway_config().get("gateway") or {})
+            cfg = (_gateway_config().get("gateway") or {})
             url = str(cfg.get("relay_endpoint", "") or "").strip()
         except Exception:  # noqa: BLE001 - config absence/parse must never crash boot
             url = ""
@@ -186,9 +205,7 @@ def relay_route_keys() -> list[str]:
     raw = os.environ.get("GATEWAY_RELAY_ROUTE_KEYS", "").strip()
     if not raw:
         try:
-            from gateway.run import _load_gateway_config  # late import to avoid cycle
-
-            cfg = (_load_gateway_config().get("gateway") or {})
+            cfg = (_gateway_config().get("gateway") or {})
             val = cfg.get("relay_route_keys", "")
             if isinstance(val, (list, tuple)):
                 return [str(k).strip() for k in val if str(k).strip()]
@@ -216,9 +233,7 @@ def relay_instance_id() -> Optional[str]:
     value = os.environ.get("GATEWAY_RELAY_INSTANCE_ID", "").strip()
     if not value:
         try:
-            from gateway.run import _load_gateway_config  # late import to avoid cycle
-
-            cfg = (_load_gateway_config().get("gateway") or {})
+            cfg = (_gateway_config().get("gateway") or {})
             value = str(cfg.get("relay_instance_id", "") or "").strip()
         except Exception:  # noqa: BLE001 - config absence/parse must never crash boot
             value = ""
@@ -247,9 +262,7 @@ def relay_wake_url() -> Optional[str]:
     value = os.environ.get("GATEWAY_RELAY_WAKE_URL", "").strip()
     if not value:
         try:
-            from gateway.run import _load_gateway_config  # late import to avoid cycle
-
-            cfg = (_load_gateway_config().get("gateway") or {})
+            cfg = (_gateway_config().get("gateway") or {})
             value = str(cfg.get("relay_wake_url", "") or "").strip()
         except Exception:  # noqa: BLE001 - config absence/parse must never crash boot
             value = ""
@@ -461,9 +474,7 @@ def _resolve_relay_identity_token() -> str:
     scope = os.environ.get("GATEWAY_RELAY_IDP_SCOPE", "").strip()
     if not token_url:
         try:
-            from gateway.run import _load_gateway_config  # late import to avoid cycle
-
-            idp = ((_load_gateway_config().get("gateway") or {}).get("idp") or {})
+            idp = ((_gateway_config().get("gateway") or {}).get("idp") or {})
             token_url = str(idp.get("token_url", "") or "").strip()
             client_id = client_id or str(idp.get("client_id", "") or "").strip()
             client_secret = client_secret or str(idp.get("client_secret", "") or "").strip()
@@ -552,38 +563,42 @@ def self_provision_relay() -> bool:
 
     logger = logging.getLogger("gateway.relay")
 
-    dial_url = relay_url()
-    if not dial_url:
-        return False
-
-    # Respect an already-present (pinned/stamped) secret — don't stomp it. This
-    # is also what makes a self-hosted, enrolled gateway skip self-provision.
-    existing_id, existing_secret = relay_connection_auth()
-    if existing_id and existing_secret:
-        logger.info("relay self-provision skipped: GATEWAY_RELAY_SECRET already set")
-        return False
-
+    snapshot_token = _RELAY_GATEWAY_CONFIG_SNAPSHOT.set(_read_gateway_config())
     try:
-        access_token = _resolve_relay_identity_token()
-    except Exception as exc:  # noqa: BLE001 - boot must survive a token failure
-        # No resolvable identity (e.g. a self-hosted box that hasn't enrolled and
-        # configured no IdP) -> nothing to provision with; skip quietly and boot.
-        logger.warning("relay self-provision skipped: could not resolve identity token (%s)", exc)
-        return False
+        dial_url = relay_url()
+        if not dial_url:
+            return False
 
-    identities = relay_platform_identities()
-    # gatewayId default mirrors the enroll CLI's hostname-based slug.
-    import socket
+        # Respect an already-present (pinned/stamped) secret — don't stomp it. This
+        # is also what makes a self-hosted, enrolled gateway skip self-provision.
+        existing_id, existing_secret = relay_connection_auth()
+        if existing_id and existing_secret:
+            logger.info("relay self-provision skipped: GATEWAY_RELAY_SECRET already set")
+            return False
 
-    try:
-        host = socket.gethostname().strip()
-    except Exception:  # noqa: BLE001
-        host = ""
-    gateway_id = os.environ.get("GATEWAY_RELAY_ID", "").strip() or f"gw-{host or 'hermes'}"
-    endpoint = relay_endpoint()
-    route_keys = relay_route_keys()
-    instance_id = relay_instance_id()
-    wake_url = relay_wake_url()
+        try:
+            access_token = _resolve_relay_identity_token()
+        except Exception as exc:  # noqa: BLE001 - boot must survive a token failure
+            # No resolvable identity (e.g. a self-hosted box that hasn't enrolled and
+            # configured no IdP) -> nothing to provision with; skip quietly and boot.
+            logger.warning("relay self-provision skipped: could not resolve identity token (%s)", exc)
+            return False
+
+        identities = relay_platform_identities()
+        # gatewayId default mirrors the enroll CLI's hostname-based slug.
+        import socket
+
+        try:
+            host = socket.gethostname().strip()
+        except Exception:  # noqa: BLE001
+            host = ""
+        gateway_id = os.environ.get("GATEWAY_RELAY_ID", "").strip() or f"gw-{host or 'hermes'}"
+        endpoint = relay_endpoint()
+        route_keys = relay_route_keys()
+        instance_id = relay_instance_id()
+        wake_url = relay_wake_url()
+    finally:
+        _RELAY_GATEWAY_CONFIG_SNAPSHOT.reset(snapshot_token)
 
     # Phase 1.5 (D-Q1.5c): provision EACH fronted platform under the SAME
     # gatewayId + the SAME (platform-less) per-gateway secret. The connector's

--- a/tests/gateway/relay/test_self_provision.py
+++ b/tests/gateway/relay/test_self_provision.py
@@ -210,6 +210,27 @@ def test_self_provision_reuses_one_gateway_config_snapshot(monkeypatch):
     assert captured["wake_url"] == "https://gw.example.com/wake"
 
 
+def test_self_provision_secret_env_skip_does_not_read_config(monkeypatch):
+    calls = {"n": 0}
+
+    def _fake_config():
+        calls["n"] += 1
+        return {
+            "gateway": {
+                "relay_url": "wss://from-config.example/relay",
+                "relay_secret": "should-not-be-read",
+            }
+        }
+
+    monkeypatch.setenv("GATEWAY_RELAY_URL", "wss://connector.example/relay")
+    monkeypatch.setenv("GATEWAY_RELAY_ID", "gw-env")
+    monkeypatch.setenv("GATEWAY_RELAY_SECRET", "pinned-env-secret")
+    monkeypatch.setattr("gateway.run._load_gateway_config", _fake_config, raising=False)
+
+    assert relay.self_provision_relay() is False
+    assert calls["n"] == 0
+
+
 # ─────────────────── instance-id forwarding (Phase 6 Unit α) ───────────────────
 
 def test_forwards_instance_id_to_provision(monkeypatch):

--- a/tests/gateway/relay/test_self_provision.py
+++ b/tests/gateway/relay/test_self_provision.py
@@ -181,6 +181,35 @@ def test_outbound_only_when_no_endpoint(monkeypatch):
     assert relay.relay_connection_auth()[1] == "a" * 64
 
 
+def test_self_provision_reuses_one_gateway_config_snapshot(monkeypatch):
+    calls = {"n": 0}
+
+    def _fake_config():
+        calls["n"] += 1
+        return {
+            "gateway": {
+                "relay_url": "wss://connector.example/relay",
+                "relay_endpoint": "https://gw.example.com/inbound",
+                "relay_route_keys": ["guild-1", "guild-2"],
+                "relay_instance_id": "inst-abc",
+                "relay_wake_url": "https://gw.example.com/wake",
+            }
+        }
+
+    monkeypatch.setattr("gateway.run._load_gateway_config", _fake_config, raising=False)
+    monkeypatch.setattr("hermes_cli.auth.resolve_nous_access_token", lambda: "nas-token")
+    captured: dict = {}
+    monkeypatch.setattr(relay, "_post_provision", _stub_post(captured))
+
+    assert relay.self_provision_relay() is True
+    assert calls["n"] == 1
+    assert captured["provision_url"] == "https://connector.example/relay/provision"
+    assert captured["gateway_endpoint"] == "https://gw.example.com/inbound"
+    assert captured["route_keys"] == ["guild-1", "guild-2"]
+    assert captured["instance_id"] == "inst-abc"
+    assert captured["wake_url"] == "https://gw.example.com/wake"
+
+
 # ─────────────────── instance-id forwarding (Phase 6 Unit α) ───────────────────
 
 def test_forwards_instance_id_to_provision(monkeypatch):


### PR DESCRIPTION
Problem
- relay self-provision reads several gateway settings during boot: relay URL, pinned auth, IdP token config, endpoint, route keys, instance id, and wake URL. Without a per-call snapshot, each accessor can call _load_gateway_config separately.

Solution
- Add a context-local relay gateway config snapshot used by the existing no-arg accessors.
- self_provision_relay reads config once, then resolves all provision-time settings through that snapshot.
- Public accessor signatures stay unchanged.

Validation
- python -m pytest tests/gateway/relay/test_self_provision.py tests/gateway/relay/test_relay_multiplatform.py -q

Impact
- The new regression test verifies config loads drop to 1 call for a config-only self-provision path that previously touched config from multiple accessors. Test run: 33 passed, 2 skipped; skips/warnings are the existing async marker environment in test_relay_multiplatform.py.