### PR TITLE
Offload dashboard session search DB work

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4077,8 +4077,7 @@ def get_profiles_sessions(
     }
 
 
-@app.get("/api/sessions/search")
-async def search_sessions(q: str = "", limit: int = 20, profile: Optional[str] = None):
+def _search_sessions_sync(q: str, limit: int, profile: Optional[str]) -> dict:
     """Search sessions by ID plus full-text message content using FTS5.
 
     Direct session-id matches are surfaced first, then FTS message-content
@@ -4089,151 +4088,157 @@ async def search_sessions(q: str = "", limit: int = 20, profile: Optional[str] =
     Branches also use ``parent_session_id``, but they are real alternate
     conversations; don't collapse branch-specific hits back into the parent.
     """
+    db = _open_session_db_for_profile(profile)
+    try:
+        safe_limit = max(1, min(int(limit or 20), 100))
+
+        # Walk parent_session_id to the compression root, memoized so a
+        # chain of compression segments only costs one walk. We deliberately
+        # stop at branch/delegate edges: those sessions may diverge from the
+        # parent and should remain searchable on their own.
+        root_cache: dict = {}
+
+        def compression_root(session_id: str) -> str:
+            if not session_id:
+                return session_id
+            if session_id in root_cache:
+                return root_cache[session_id]
+            chain = []
+            cur = session_id
+            visited = set()
+            root = session_id
+            while cur and cur not in visited:
+                visited.add(cur)
+                chain.append(cur)
+                if cur in root_cache:
+                    root = root_cache[cur]
+                    break
+                try:
+                    s = db.get_session(cur)
+                except Exception:
+                    s = None
+                if not s:
+                    root = cur
+                    break
+                parent = s.get("parent_session_id") if isinstance(s, dict) else None
+                if not parent:
+                    root = cur
+                    break
+                try:
+                    parent_session = db.get_session(parent)
+                except Exception:
+                    parent_session = None
+                if not parent_session:
+                    root = cur
+                    break
+                parent_ended_at = parent_session.get("ended_at")
+                started_at = s.get("started_at")
+                is_compression_edge = (
+                    parent_session.get("end_reason") == "compression"
+                    and parent_ended_at is not None
+                    and started_at is not None
+                    and started_at >= parent_ended_at
+                )
+                if not is_compression_edge:
+                    root = cur
+                    break
+                cur = parent
+            for node in chain:
+                root_cache[node] = root
+            return root
+
+        tip_cache: dict = {}
+
+        def lineage_tip(root_id: str) -> str:
+            if root_id in tip_cache:
+                return tip_cache[root_id]
+            tip = root_id
+            try:
+                resolved = db.get_compression_tip(root_id)
+                if resolved:
+                    tip = resolved
+            except Exception:
+                pass
+            tip_cache[root_id] = tip
+            return tip
+
+        # Both ID matches and content matches share one keyspace, keyed by
+        # compression lineage root, so an id-hit and a content-hit on the
+        # same logical conversation collapse to a single result. The first
+        # hit for a lineage wins; ID matches run first and take priority.
+        seen: dict = {}
+
+        def add_lineage_result(raw_sid: str, payload: dict) -> None:
+            if not raw_sid:
+                return
+            root = compression_root(raw_sid)
+            if root in seen or len(seen) >= safe_limit:
+                return
+            payload = dict(payload)
+            payload["session_id"] = lineage_tip(root)
+            payload["lineage_root"] = root
+            seen[root] = payload
+
+        # Direct ID matches first: users often paste a session id from CLI,
+        # logs, or another Hermes surface. FTS can't find those unless the
+        # id happens to appear in message text. search_sessions_by_id is
+        # SQL-bounded, so this stays cheap even with thousands of sessions.
+        for row in db.search_sessions_by_id(q, limit=safe_limit, include_archived=True):
+            sid = row.get("id")
+            preview = (row.get("preview") or "").strip()
+            snippet = preview or f"Session ID: {sid}"
+            add_lineage_result(
+                sid,
+                {
+                    "snippet": snippet,
+                    "role": None,
+                    "source": row.get("source"),
+                    "model": row.get("model"),
+                    "session_started": row.get("started_at"),
+                },
+            )
+
+        # Auto-add prefix wildcards so partial words match
+        # e.g. "nimb" → "nimb*" matches "nimby"
+        # Preserve quoted phrases and existing wildcards as-is
+        import re
+        terms = []
+        for token in re.findall(r'"[^"]*"|\S+', q.strip()):
+            if token.startswith('"') or token.endswith("*"):
+                terms.append(token)
+            else:
+                terms.append(token + "*")
+        prefix_query = " ".join(terms)
+        # Over-fetch so lineage dedup can still surface `limit` distinct
+        # conversations even when several hits collapse onto one root.
+        fetch_limit = max(safe_limit * 5, 50)
+        matches = db.search_messages(query=prefix_query, limit=fetch_limit)
+
+        for m in matches:
+            if len(seen) >= safe_limit:
+                break
+            add_lineage_result(
+                m["session_id"],
+                {
+                    "snippet": m.get("snippet", ""),
+                    "role": m.get("role"),
+                    "source": m.get("source"),
+                    "model": m.get("model"),
+                    "session_started": m.get("session_started"),
+                },
+            )
+        return {"results": list(seen.values())}
+    finally:
+        db.close()
+
+
+@app.get("/api/sessions/search")
+async def search_sessions(q: str = "", limit: int = 20, profile: Optional[str] = None):
+    """Search sessions by ID plus full-text message content using FTS5."""
     if not q or not q.strip():
         return {"results": []}
     try:
-        db = _open_session_db_for_profile(profile)
-        try:
-            safe_limit = max(1, min(int(limit or 20), 100))
-
-            # Walk parent_session_id to the compression root, memoized so a
-            # chain of compression segments only costs one walk. We deliberately
-            # stop at branch/delegate edges: those sessions may diverge from the
-            # parent and should remain searchable on their own.
-            root_cache: dict = {}
-
-            def compression_root(session_id: str) -> str:
-                if not session_id:
-                    return session_id
-                if session_id in root_cache:
-                    return root_cache[session_id]
-                chain = []
-                cur = session_id
-                visited = set()
-                root = session_id
-                while cur and cur not in visited:
-                    visited.add(cur)
-                    chain.append(cur)
-                    if cur in root_cache:
-                        root = root_cache[cur]
-                        break
-                    try:
-                        s = db.get_session(cur)
-                    except Exception:
-                        s = None
-                    if not s:
-                        root = cur
-                        break
-                    parent = s.get("parent_session_id") if isinstance(s, dict) else None
-                    if not parent:
-                        root = cur
-                        break
-                    try:
-                        parent_session = db.get_session(parent)
-                    except Exception:
-                        parent_session = None
-                    if not parent_session:
-                        root = cur
-                        break
-                    parent_ended_at = parent_session.get("ended_at")
-                    started_at = s.get("started_at")
-                    is_compression_edge = (
-                        parent_session.get("end_reason") == "compression"
-                        and parent_ended_at is not None
-                        and started_at is not None
-                        and started_at >= parent_ended_at
-                    )
-                    if not is_compression_edge:
-                        root = cur
-                        break
-                    cur = parent
-                for node in chain:
-                    root_cache[node] = root
-                return root
-
-            tip_cache: dict = {}
-
-            def lineage_tip(root_id: str) -> str:
-                if root_id in tip_cache:
-                    return tip_cache[root_id]
-                tip = root_id
-                try:
-                    resolved = db.get_compression_tip(root_id)
-                    if resolved:
-                        tip = resolved
-                except Exception:
-                    pass
-                tip_cache[root_id] = tip
-                return tip
-
-            # Both ID matches and content matches share one keyspace, keyed by
-            # compression lineage root, so an id-hit and a content-hit on the
-            # same logical conversation collapse to a single result. The first
-            # hit for a lineage wins; ID matches run first and take priority.
-            seen: dict = {}
-
-            def add_lineage_result(raw_sid: str, payload: dict) -> None:
-                if not raw_sid:
-                    return
-                root = compression_root(raw_sid)
-                if root in seen or len(seen) >= safe_limit:
-                    return
-                payload = dict(payload)
-                payload["session_id"] = lineage_tip(root)
-                payload["lineage_root"] = root
-                seen[root] = payload
-
-            # Direct ID matches first: users often paste a session id from CLI,
-            # logs, or another Hermes surface. FTS can't find those unless the
-            # id happens to appear in message text. search_sessions_by_id is
-            # SQL-bounded, so this stays cheap even with thousands of sessions.
-            for row in db.search_sessions_by_id(q, limit=safe_limit, include_archived=True):
-                sid = row.get("id")
-                preview = (row.get("preview") or "").strip()
-                snippet = preview or f"Session ID: {sid}"
-                add_lineage_result(
-                    sid,
-                    {
-                        "snippet": snippet,
-                        "role": None,
-                        "source": row.get("source"),
-                        "model": row.get("model"),
-                        "session_started": row.get("started_at"),
-                    },
-                )
-
-            # Auto-add prefix wildcards so partial words match
-            # e.g. "nimb" → "nimb*" matches "nimby"
-            # Preserve quoted phrases and existing wildcards as-is
-            import re
-            terms = []
-            for token in re.findall(r'"[^"]*"|\S+', q.strip()):
-                if token.startswith('"') or token.endswith("*"):
-                    terms.append(token)
-                else:
-                    terms.append(token + "*")
-            prefix_query = " ".join(terms)
-            # Over-fetch so lineage dedup can still surface `limit` distinct
-            # conversations even when several hits collapse onto one root.
-            fetch_limit = max(safe_limit * 5, 50)
-            matches = db.search_messages(query=prefix_query, limit=fetch_limit)
-
-            for m in matches:
-                if len(seen) >= safe_limit:
-                    break
-                add_lineage_result(
-                    m["session_id"],
-                    {
-                        "snippet": m.get("snippet", ""),
-                        "role": m.get("role"),
-                        "source": m.get("source"),
-                        "model": m.get("model"),
-                        "session_started": m.get("session_started"),
-                    },
-                )
-            return {"results": list(seen.values())}
-        finally:
-            db.close()
+        return await asyncio.to_thread(_search_sessions_sync, q, limit, profile)
     except HTTPException:
         raise
     except Exception:

--- a/tests/hermes_cli/test_web_server_session_search.py
+++ b/tests/hermes_cli/test_web_server_session_search.py
@@ -88,3 +88,19 @@ def test_desktop_session_search_merges_id_matches_before_content_matches(monkeyp
             },
         ]
     }
+
+
+def test_desktop_session_search_offloads_db_work(monkeypatch):
+    monkeypatch.setattr("hermes_state.SessionDB", _FakeSessionDB)
+    calls = []
+
+    async def fake_to_thread(func, *args, **kwargs):
+        calls.append((func, args, kwargs))
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(web_server.asyncio, "to_thread", fake_to_thread)
+
+    response = asyncio.run(web_server.search_sessions(q="20260603", limit=2))
+
+    assert response["results"][0]["session_id"] == "20260603_090200_exact"
+    assert calls == [(web_server._search_sessions_sync, ("20260603", 2, None), {})]


### PR DESCRIPTION
Problem
- /api/sessions/search is an async FastAPI route but performs SQLite/FTS session search, lineage walking, and DB close work directly on the event loop. Large history searches can add avoidable dashboard latency for concurrent requests.

Solution
- Move the existing synchronous search implementation into _search_sessions_sync.
- Keep the empty-query fast path inline, then run DB/search work with asyncio.to_thread so the DB connection is opened and closed in the worker thread.

Validation
- python -m pytest tests/hermes_cli/test_web_server_session_search.py tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_search_dedupes_compression_lineage_to_tip tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_search_keeps_branch_specific_hits_on_branch -q

Impact
- The route now yields the event loop while SQLite/FTS work runs in a worker thread. A new regression test spies on asyncio.to_thread and verifies the route offloads to _search_sessions_sync.