### PR TITLE
fix(cli): set HERMES_YOLO_MODE before plugin discovery freezes the approval bypass (#60328)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2358,7 +2358,11 @@ def cmd_chat(args):
     except Exception:
         pass
 
-    # --yolo: bypass all dangerous command approvals
+    # --yolo: bypass all dangerous command approvals.
+    # Also set in main() before _prepare_agent_startup() — that is the
+    # authoritative site because it runs before tool imports freeze
+    # _YOLO_MODE_FROZEN.  This redundant set is a safety net for callers
+    # that invoke cmd_chat directly (e.g. subcommand dispatch).
     if getattr(args, "yolo", False):
         os.environ["HERMES_YOLO_MODE"] = "1"
 
@@ -14626,6 +14630,15 @@ def main():
     if args.version:
         cmd_version(args)
         return
+
+    # --yolo: set HERMES_YOLO_MODE *before* plugin discovery.  The call to
+    # _prepare_agent_startup() below triggers discover_plugins() → tool
+    # imports, and tools.approval freezes _YOLO_MODE_FROZEN at module
+    # import time (PR #7994, security hardening against prompt-injection).
+    # If the env var is set only later (e.g. inside cmd_chat), the frozen
+    # value is already False and --yolo silently does nothing.
+    if getattr(args, "yolo", False):
+        os.environ["HERMES_YOLO_MODE"] = "1"
 
     # Discover Python plugins and register shell hooks once, before any
     # command that can fire lifecycle hooks.  Both are idempotent; gated

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12414,6 +12414,15 @@ def _should_background_mcp_startup(args) -> bool:
 
 def _prepare_agent_startup(args) -> None:
     """Discover plugins/MCP/hooks for commands that can run an agent turn."""
+    # --yolo: chokepoint guarantee that HERMES_YOLO_MODE is set before ANY
+    # plugin/tool discovery below imports tools.approval, which freezes
+    # _YOLO_MODE_FROZEN at import time (PR #7994 security design).  main()'s
+    # dispatch path also sets this earlier, but _prepare_agent_startup() is
+    # reachable from other launchers too (e.g. the Termux fast-CLI path),
+    # so the guarantee lives here where the import is actually triggered
+    # (#60328).
+    if getattr(args, "yolo", False):
+        os.environ["HERMES_YOLO_MODE"] = "1"
     _apply_safe_mode(args)
 
     _sub_attr, _sub_set = _AGENT_SUBCOMMANDS.get(args.command, (None, None))

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -299,6 +299,7 @@ AUTHOR_MAP = {
     "290859878+synapsesx@users.noreply.github.com": "synapsesx",
     "157689911+itsflownium@users.noreply.github.com": "itsflownium",
     "dirtyren@users.noreply.github.com": "dirtyren",
+    "chenkun_lws@126.com": "bytesnail",  # PR #60360 salvage (--yolo startup ordering; #60328)
     "iamgexin@qq.com": "nullptr0807",  # PR #60956 salvage (gateway hygiene in-place compaction; #60947)
     "embwl0x@users.noreply.github.com": "embwl0x",  # PR #60810 salvage (channel directory offload)
     "caztronics@yahoo.com": "doncazper",

--- a/tests/hermes_cli/test_yolo_startup_order.py
+++ b/tests/hermes_cli/test_yolo_startup_order.py
@@ -1,0 +1,77 @@
+"""Regression tests for #60328: --yolo must set HERMES_YOLO_MODE in
+main() before _prepare_agent_startup() triggers tool imports.
+
+The freeze mechanism in tools.approval (_YOLO_MODE_FROZEN) is correct
+by design (PR #7994). The bug was that main() set the env var inside
+cmd_chat(), which runs *after* _prepare_agent_startup() has already
+imported tools.approval and frozen the constant to False.
+
+These tests verify the ordering in main() itself: the env var must
+already be set at the moment _prepare_agent_startup() is called.
+If someone moves the assignment back into cmd_chat(), these tests
+fail — catching the exact #60328 regression.
+"""
+
+import os
+import sys
+
+
+def _run_main_and_capture_yolo_at_startup(monkeypatch, argv):
+    """Run main() with *argv*, capturing HERMES_YOLO_MODE at the
+    moment _prepare_agent_startup is called.
+
+    Returns the captured env var value (or None if unset).
+    """
+    yolo_at_startup = {}
+
+    def spy_prepare_startup(args):
+        yolo_at_startup["value"] = os.environ.get("HERMES_YOLO_MODE")
+
+    monkeypatch.setattr(
+        "hermes_cli.main._prepare_agent_startup", spy_prepare_startup
+    )
+    # Stub cmd_chat so main() returns cleanly without entering chat.
+    monkeypatch.setattr("hermes_cli.main.cmd_chat", lambda args: None)
+    monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+    monkeypatch.setattr(sys, "argv", argv)
+
+    from hermes_cli.main import main as cli_main
+
+    cli_main()
+
+    return yolo_at_startup.get("value")
+
+
+def test_top_level_yolo_flag_sets_env_before_startup(monkeypatch):
+    """hermes --yolo must set HERMES_YOLO_MODE before
+    _prepare_agent_startup imports tools.approval."""
+    result = _run_main_and_capture_yolo_at_startup(
+        monkeypatch, ["hermes", "--yolo"]
+    )
+    assert result == "1", (
+        "HERMES_YOLO_MODE was not '1' when _prepare_agent_startup was "
+        "called from main() with --yolo. This is the #60328 regression: "
+        "the env var is set too late (inside cmd_chat, after tool imports)."
+    )
+
+
+def test_chat_subcommand_yolo_flag_sets_env_before_startup(monkeypatch):
+    """hermes chat --yolo must also set HERMES_YOLO_MODE before
+    _prepare_agent_startup."""
+    result = _run_main_and_capture_yolo_at_startup(
+        monkeypatch, ["hermes", "chat", "--yolo"]
+    )
+    assert result == "1", (
+        "HERMES_YOLO_MODE was not '1' when _prepare_agent_startup was "
+        "called from main() with 'chat --yolo'."
+    )
+
+
+def test_no_yolo_flag_leaves_env_unset_at_startup(monkeypatch):
+    """Without --yolo, HERMES_YOLO_MODE must not be set at startup."""
+    result = _run_main_and_capture_yolo_at_startup(
+        monkeypatch, ["hermes"]
+    )
+    assert result is None, (
+        "HERMES_YOLO_MODE was unexpectedly set at startup without --yolo."
+    )


### PR DESCRIPTION
## Summary
`hermes --yolo` works again: `HERMES_YOLO_MODE` is now set before plugin discovery imports `tools/approval.py`, which freezes `_YOLO_MODE_FROZEN` at import time. Salvages PR #60360 by @bytesnail (also the reporter of #60328; competing fixes #60349 by @ms-alan and #60963 by @AIalliAI closed with credit).

Root cause: the freeze-at-import is intentional security design (PR #7994 — prompt-injected skills can't flip the bypass mid-session). But the CLI set the env var inside `cmd_chat()`, which runs AFTER `_prepare_agent_startup()` → `discover_plugins()` → `tools.registry` → `tools.terminal_tool` → `tools.approval` had already frozen the flag to False. Result: `--yolo` silently ignored since v0.11.0.

## Changes
- `hermes_cli/main.py` (contributor commit): set `HERMES_YOLO_MODE` in `main()` before `_prepare_agent_startup()`; keep the `cmd_chat()` set as a safety net for direct callers.
- `hermes_cli/main.py` (follow-up): also set it inside `_prepare_agent_startup()` itself — the chokepoint where the import is actually triggered — so every launcher path (including the Termux fast-CLI dispatch, which calls `_prepare_agent_startup()` without going through `main()`'s dispatch) gets the same ordering guarantee.
- `tests/hermes_cli/test_yolo_startup_order.py` (contributor): regression tests pinning that the env var is set at the moment `_prepare_agent_startup` is called.
- `scripts/release.py`: AUTHOR_MAP entry for @bytesnail.

## Validation
| | Result |
|---|---|
| Live process E2E (`--yolo` args → `_prepare_agent_startup` → import) | `_YOLO_MODE_FROZEN=True` |
| Negative control (no `--yolo`) | `_YOLO_MODE_FROZEN=False` (fail-closed preserved) |
| tests/hermes_cli -k yolo | 6/6 pass |

The #7994 freeze design is untouched — this only fixes WHEN the env var is set, not how the freeze works.

Contributor authorship preserved via cherry-pick; merge with rebase. Closes #60328.

## Infographic

![yolo-startup-ordering](https://v3b.fal.media/files/b/0aa19eb5/PPG2ryWRK5Z5gyFCGKoUS_kgBPD7K4.png)
