### PR TITLE
fix(gateway): in-place compaction no longer wipes the archived transcript

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11240,7 +11240,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                         )
 
                                     # Only rewrite the transcript when rotation produced
-                                    # a NEW session id OR in-place compaction succeeded.
+                                    # a NEW session id.  In-place compaction does NOT
+                                    # need a rewrite: archive_and_compact() has already
+                                    # soft-archived the previous active rows and inserted
+                                    # the compacted messages as the new active set inside
+                                    # _compress_context().  Calling rewrite_transcript()
+                                    # after in-place compaction would invoke
+                                    # replace_messages(active_only=False) which DELETEs
+                                    # ALL rows — including the archived turns that
+                                    # archive_and_compact() deliberately preserved
+                                    # (silent data loss, #61145).
+                                    #
                                     # The danger this guards against (mirrors the
                                     # /compress fix #44794/#39704): if _compress_context
                                     # returns a summary but neither rotates nor completes
@@ -11249,11 +11259,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     # rewrite_transcript() would DELETE the original
                                     # messages and replace them with only the compressed
                                     # summary (permanent data loss, #21301).
-                                    if _hyg_rotated or _hyg_in_place:
+                                    if _hyg_rotated:
                                         self.session_store.rewrite_transcript(
                                             session_entry.session_id, _compressed
                                         )
                                         # Reset stored token count — transcript rewritten
+                                        session_entry.last_prompt_tokens = 0
+                                        history = _compressed
+                                        _new_count = len(_compressed)
+                                        _new_tokens = estimate_messages_tokens_rough(
+                                            _compressed
+                                        )
+                                    elif _hyg_in_place:
+                                        # archive_and_compact() already persisted the
+                                        # compacted transcript inside _compress_context.
+                                        # Reset counts to match the new active set.
                                         session_entry.last_prompt_tokens = 0
                                         history = _compressed
                                         _new_count = len(_compressed)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3262,18 +3262,23 @@ class GatewaySlashCommandsMixin:
                 # at it; in place the original transcript is untouched) and lets
                 # the outer handler surface a "compress failed" banner instead.
                 #
-                # The rewrite runs when EITHER rotation produced a new id OR
-                # in-place compaction succeeded. It is skipped in the THIRD
-                # case: _compress_context could NOT rotate AND was not in-place
-                # (e.g. legacy mode but _session_db unavailable / the DB split
-                # raised) — there session_id is unchanged for a FAILURE reason,
-                # and rewrite_transcript() would DELETE the original messages and
-                # replace them with only the compressed summary (permanent data
-                # loss #44794, #39704). In in-place mode the unchanged id is
-                # SUCCESS, so the rewrite is exactly right (and is the durable
-                # write when the throwaway /compress agent has no _session_db of
-                # its own).
-                if rotated or _in_place:
+                # Only rewrite the transcript when rotation produced a NEW
+                # session id.  In-place compaction does NOT need a rewrite:
+                # archive_and_compact() has already soft-archived the previous
+                # active rows and inserted the compacted messages as the new
+                # active set inside _compress_context().  Calling
+                # rewrite_transcript() after in-place compaction would invoke
+                # replace_messages(active_only=False) which DELETEs ALL rows —
+                # including the archived turns that archive_and_compact()
+                # deliberately preserved (silent data loss, #61145).
+                #
+                # The third case: _compress_context could NOT rotate AND was
+                # not in-place (e.g. legacy mode but _session_db unavailable /
+                # the DB split raised) — there session_id is unchanged for a
+                # FAILURE reason, and rewrite_transcript() would DELETE the
+                # original messages and replace them with only the compressed
+                # summary (permanent data loss #44794, #39704).
+                if rotated:
                     if not self.session_store.rewrite_transcript(
                         new_session_id, compressed
                     ):
@@ -3281,13 +3286,16 @@ class GatewaySlashCommandsMixin:
                             f"failed to persist compressed transcript for "
                             f"session {new_session_id}"
                         )
-                    if rotated:
-                        session_entry.session_id = new_session_id
-                        self.session_store._save()
-                        await asyncio.to_thread(
-                            self._sync_telegram_topic_binding,
-                            source, session_entry, reason="compress-command",
-                        )
+                    session_entry.session_id = new_session_id
+                    self.session_store._save()
+                    await asyncio.to_thread(
+                        self._sync_telegram_topic_binding,
+                        source, session_entry, reason="compress-command",
+                    )
+                elif _in_place:
+                    # archive_and_compact() already persisted the compacted
+                    # transcript inside _compress_context — nothing to do.
+                    pass
                 else:
                     logger.warning(
                         "Manual /compress: session rotation did not occur "

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -257,6 +257,7 @@ AUTHOR_MAP = {
     "arnaud@nolimitdevelopment.com": "ali-nld",
     "sswdarius@gmail.com": "necoweb3",
     "bassisho@Mac-mini-bassis.local": "hydracoco7",  # PR #61382 salvage (id-less cron job freeze)
+    "AlexFucuson9@users.noreply.github.com": "AlexFucuson9",  # PR #61209 salvage (hygiene compression data loss)
     "t.chen@aftership.com": "cypctlinux",  # PR #52403 salvage (Slack bot/workflow auth before no-user-id guard)
     "30854794+YLChen-007@users.noreply.github.com": "YLChen-007",  # PR #26965 (approval remote command substitution)
     "1078345+egilewski@users.noreply.github.com": "egilewski",  # co-author, PR #40663

--- a/tests/gateway/test_compress_command.py
+++ b/tests/gateway/test_compress_command.py
@@ -369,11 +369,14 @@ async def test_compress_command_does_not_repoint_session_when_transcript_write_f
 
 
 @pytest.mark.asyncio
-async def test_compress_command_in_place_write_failure_reports_error():
-    """In-place compaction (compression.in_place / #38763) does not rotate the
-    session_id, so a failed rewrite_transcript would leave the DB untouched
-    while the handler reported success. The write failure must surface as a
-    failure banner, not a false "Compressed" success."""
+async def test_compress_command_in_place_skips_destructive_rewrite():
+    """In-place compaction (compression.in_place / #38763) persists via
+    archive_and_compact() inside _compress_context — the previous active rows
+    are soft-archived and the compacted set inserted. Calling
+    rewrite_transcript() afterwards would invoke
+    replace_messages(active_only=False), DELETEing the just-archived rows
+    (silent data loss, #61145). The handler must skip the rewrite and still
+    report success."""
     history = _make_history()
     compressed = [
         history[0],
@@ -383,7 +386,7 @@ async def test_compress_command_in_place_write_failure_reports_error():
     runner = _make_runner(history)
     runner._session_db = object()
     session_entry = runner.session_store.get_or_create_session.return_value
-    runner.session_store.rewrite_transcript = MagicMock(return_value=False)
+    runner.session_store.rewrite_transcript = MagicMock()
 
     agent_instance = MagicMock()
     agent_instance.shutdown_memory_provider = MagicMock()
@@ -397,7 +400,11 @@ async def test_compress_command_in_place_write_failure_reports_error():
     agent_instance._compress_context.return_value = (compressed, "")
 
     def _estimate(messages, **_kwargs):
-        return 100
+        if messages == history:
+            return 100
+        if messages == compressed:
+            return 60
+        raise AssertionError(f"unexpected transcript: {messages!r}")
 
     with (
         patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "***"}),
@@ -407,10 +414,11 @@ async def test_compress_command_in_place_write_failure_reports_error():
     ):
         result = await runner._handle_compress_command(_make_event())
 
-    assert "failed" in result.lower()
-    assert "Compressed:" not in result
+    assert "Compressed:" in result
+    # The destructive rewrite must NOT run — archive_and_compact() already
+    # persisted, and rewrite_transcript would wipe the archived rows.
+    runner.session_store.rewrite_transcript.assert_not_called()
     assert session_entry.session_id == "sess-1"
-    runner.session_store._save.assert_not_called()
     agent_instance.shutdown_memory_provider.assert_called_once()
     agent_instance.close.assert_called_once()
 

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -950,9 +950,10 @@ async def test_session_hygiene_forces_in_place_compaction_with_bound_session_db(
     agent = FakeInPlaceCompressAgent.last_instance
     assert agent is not None
     agent.context_compressor.bind_session_state.assert_called_once_with(fake_db, "sess-1")
-    runner.session_store.rewrite_transcript.assert_called_once_with(
-        "sess-1", [{"role": "assistant", "content": "compressed in place"}]
-    )
+    # In-place compaction already persisted via archive_and_compact() —
+    # rewrite_transcript would replace_messages(active_only=False) and DELETE
+    # the just-archived rows (#61145). The hygiene handler must skip it.
+    runner.session_store.rewrite_transcript.assert_not_called()
     runner._run_agent.assert_awaited_once()
 
 


### PR DESCRIPTION
## Summary
Gateway in-place compaction no longer destroys the transcript it just archived — the redundant destructive `rewrite_transcript()` after `archive_and_compact()` is skipped. Closes #61145.

Root cause: in-place compaction (default since #52658) soft-archives the previous active rows and inserts the compacted set inside `_compress_context()`. The hygiene handler and the `/compress` handler then both called `rewrite_transcript()` → `replace_messages(active_only=False)`, which the docstring itself calls "DESTRUCTIVE by default: every row for the session is DELETEd" — wiping the just-archived turns. Silent, permanent data loss on every routine compaction.

Salvages PR #61209 by @AlexFucuson9 (cherry-picked, authorship preserved).

## Changes
- `gateway/run.py`: hygiene path rewrites only when rotation produced a new session id; in-place success re-baselines counters without touching the DB (contributor commit)
- `gateway/slash_commands.py`: same guard for the interactive `/compress` handler (contributor commit)
- `tests/gateway/test_compress_command.py`, `tests/gateway/test_session_hygiene.py`: flipped the two tests that pinned the old destructive behavior into regression tests asserting `rewrite_transcript` is NOT called on the in-place path (our follow-up commit)

## Validation
| | Before | After |
|---|---|---|
| In-place compaction | archived rows DELETEd by rewrite | archived rows preserved |
| Targeted tests | 2 pinned buggy behavior | 36/36 green across 5 compression test files |
| E2E (real SessionDB) | 6 archived rows wiped by `replace_messages` default | premise + fix confirmed |

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa19ed9/kTluYK19NInagmuVEplpV_MAUccUNS.png)
