### PR TITLE
feat(gateway): make Slack document size cap configurable

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -9,6 +9,7 @@ import asyncio
 import inspect
 import ipaddress
 import logging
+import math
 import os
 import random
 import re
@@ -616,6 +617,43 @@ def get_inbound_media_max_bytes() -> int:
         return int(gw["max_inbound_media_bytes"])
     except (TypeError, ValueError):
         return DEFAULT_INBOUND_MEDIA_MAX_BYTES
+
+
+# Documents use a separate cap because their typical size profile differs
+# from image/audio/video payloads. Slack is the first consumer; other adapters
+# retain their protocol-specific limits.
+DEFAULT_INBOUND_DOCUMENT_MAX_BYTES = 20 * 1024 * 1024
+
+
+def get_inbound_document_max_bytes() -> int:
+    """Return ``gateway.max_inbound_document_bytes`` from config.yaml.
+
+    The historical 20 MiB Slack limit remains the default. Zero or a negative
+    value disables the cap; invalid values fall back to the default.
+    """
+    try:
+        from hermes_cli.config import load_config as _load_config
+
+        cfg = _load_config()
+    except Exception:
+        return DEFAULT_INBOUND_DOCUMENT_MAX_BYTES
+    gateway_cfg = cfg.get("gateway", {}) if isinstance(cfg, dict) else {}
+    if not isinstance(gateway_cfg, dict):
+        return DEFAULT_INBOUND_DOCUMENT_MAX_BYTES
+    raw = gateway_cfg.get("max_inbound_document_bytes")
+    if raw is None or raw == "":
+        return DEFAULT_INBOUND_DOCUMENT_MAX_BYTES
+    try:
+        if isinstance(raw, bool):
+            raise ValueError("boolean is not a byte count")
+        if isinstance(raw, float) and (
+            not math.isfinite(raw) or not raw.is_integer()
+        ):
+            raise ValueError("byte count must be a finite integer")
+        parsed = int(raw)
+    except (TypeError, ValueError, OverflowError):
+        return DEFAULT_INBOUND_DOCUMENT_MAX_BYTES
+    return max(0, parsed)
 
 
 def validate_inbound_media_size(

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2911,6 +2911,10 @@ DEFAULT_CONFIG = {
         # adapter. ``0`` disables the cap. Default 128 MiB.
         "max_inbound_media_bytes": 134217728,
 
+        # Maximum bytes buffered for one inbound document attachment. The
+        # default preserves Slack's historical 20 MiB cap; set 0 to disable.
+        "max_inbound_document_bytes": 20971520,
+
         # When false (default), any file path the agent emits is delivered
         # as a native attachment as long as it isn't under the credential /
         # system-path denylist (/etc, /proc, ~/.ssh, ~/.aws, ~/.hermes/.env,

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -52,6 +52,7 @@ from gateway.platforms.base import (
     safe_url_for_log,
     cache_document_from_bytes,
     cache_video_from_bytes,
+    get_inbound_document_max_bytes,
 )
 
 try:  # sibling module; support both package and flat plugin-dir import
@@ -61,6 +62,37 @@ except ImportError:  # pragma: no cover - plugin loaded outside package context
 
 
 logger = logging.getLogger(__name__)
+
+
+class _SlackDownloadTooLarge(ValueError):
+    """Raised when a streamed Slack document crosses its configured cap."""
+
+    def __init__(self, actual_bytes: int, max_bytes: int):
+        self.actual_bytes = actual_bytes
+        self.max_bytes = max_bytes
+        super().__init__(
+            f"Slack document is too large ({actual_bytes} bytes > {max_bytes} bytes)"
+        )
+
+
+def _escape_slack_notice_label(value: Any) -> str:
+    """Render an untrusted filename as inert Slack inline code."""
+    label = re.sub(r"[\x00-\x1f\x7f]+", " ", str(value or "this attachment")).strip()
+    label = (label or "this attachment")[:200].replace("`", "ˋ")
+    escaped = (
+        label.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+    )
+    return f"`{escaped}`"
+
+
+def _document_limit_notice(filename: Any, actual_bytes: int, max_bytes: int) -> str:
+    return (
+        f"Attachment {_escape_slack_notice_label(filename)} skipped: "
+        f"{actual_bytes} bytes exceeds the inbound Slack document limit "
+        f"({max_bytes} bytes). Ask the sender to shrink or split the file."
+    )
 
 # ContextVar carrying the user_id of the slash-command invoker.
 # Set in _handle_slash_command, read in send() to match the correct
@@ -3083,19 +3115,38 @@ class SlackAdapter(BasePlatformAdapter):
                     # tools.
                     in_allowlist = ext in SUPPORTED_DOCUMENT_TYPES
 
-                    # Check file size (Slack limit: 20 MB for bots)
-                    file_size = f.get("size", 0)
-                    MAX_DOC_BYTES = 20 * 1024 * 1024
-                    if not file_size or file_size > MAX_DOC_BYTES:
-                        logger.warning(
-                            "[Slack] Document too large or unknown size: %s", file_size
+                    # Slack metadata is only a preflight optimization. The
+                    # downloader enforces the same cap against streamed body
+                    # bytes, so missing or inaccurate size metadata is safe.
+                    max_doc_bytes = get_inbound_document_max_bytes()
+                    raw_file_size = f.get("size")
+                    try:
+                        file_size = int(raw_file_size)
+                    except (TypeError, ValueError, OverflowError):
+                        file_size = 0
+                    if max_doc_bytes and file_size > max_doc_bytes:
+                        notice = _document_limit_notice(
+                            original_filename or "document",
+                            file_size,
+                            max_doc_bytes,
                         )
+                        attachment_notices.append(notice)
+                        logger.warning("[Slack] %s", notice)
                         continue
 
                     # Download and cache
                     raw_bytes = await self._download_slack_file_bytes(
-                        url, team_id=team_id
+                        url,
+                        team_id=team_id,
+                        max_bytes=max_doc_bytes,
                     )
+                    # Test doubles and future alternate downloaders must obey
+                    # the same acceptance boundary as the production stream.
+                    if max_doc_bytes and len(raw_bytes) > max_doc_bytes:
+                        raise _SlackDownloadTooLarge(
+                            len(raw_bytes),
+                            max_doc_bytes,
+                        )
                     cached_path = cache_document_from_bytes(
                         raw_bytes, original_filename or f"document{ext or '.bin'}"
                     )
@@ -3128,6 +3179,14 @@ class SlackAdapter(BasePlatformAdapter):
                         except UnicodeDecodeError:
                             pass  # Binary content, skip injection
 
+                except _SlackDownloadTooLarge as e:
+                    notice = _document_limit_notice(
+                        original_filename or "document",
+                        e.actual_bytes,
+                        e.max_bytes,
+                    )
+                    attachment_notices.append(notice)
+                    logger.warning("[Slack] %s", notice)
                 except Exception as e:  # pragma: no cover - defensive logging
                     detail = self._describe_slack_download_failure(e, file_obj=f)
                     if detail:
@@ -3141,7 +3200,7 @@ class SlackAdapter(BasePlatformAdapter):
                             exc_info=True,
                         )
 
-        if attachment_notices:
+        if attachment_notices and msg_type != MessageType.COMMAND:
             notice_block = "[Slack attachment notice]\n" + "\n".join(
                 f"- {n}" for n in attachment_notices
             )
@@ -4102,8 +4161,18 @@ class SlackAdapter(BasePlatformAdapter):
                         continue
                     raise
 
-    async def _download_slack_file_bytes(self, url: str, team_id: str = "") -> bytes:
-        """Download a Slack file and return raw bytes, with retry."""
+    async def _download_slack_file_bytes(
+        self,
+        url: str,
+        team_id: str = "",
+        *,
+        max_bytes: Optional[int] = None,
+    ) -> bytes:
+        """Download a Slack file, optionally enforcing a streamed byte cap.
+
+        ``max_bytes=None`` preserves the existing buffered video path. Passing
+        an integer opts into streaming; zero streams without a size limit.
+        """
         import httpx
 
         bot_token = (
@@ -4112,24 +4181,105 @@ class SlackAdapter(BasePlatformAdapter):
             else self.config.token
         )
 
-        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+        headers = {"Authorization": f"Bearer {bot_token}"}
+        if max_bytes is not None:
+            headers["Accept-Encoding"] = "identity"
+
+        async with httpx.AsyncClient(
+            timeout=30.0,
+            # Auto-follow can buffer redirect bodies. Capped document reads
+            # follow manually so every accepted body is streamed explicitly.
+            follow_redirects=max_bytes is None,
+        ) as client:
             for attempt in range(3):
                 try:
-                    response = await client.get(
-                        url,
-                        headers={"Authorization": f"Bearer {bot_token}"},
-                    )
-                    response.raise_for_status()
-                    ct = response.headers.get("content-type", "")
-                    if "text/html" in ct:
-                        raise ValueError(
-                            "Slack returned HTML instead of file bytes "
-                            f"(content-type: {ct}); "
-                            "check bot token scopes and file permissions"
+                    if max_bytes is None:
+                        response = await client.get(url, headers=headers)
+                        response.raise_for_status()
+                        ct = response.headers.get("content-type", "")
+                        if "text/html" in ct:
+                            raise ValueError(
+                                "Slack returned HTML instead of file bytes "
+                                f"(content-type: {ct}); "
+                                "check bot token scopes and file permissions"
+                            )
+                        return response.content
+
+                    limit = max(0, max_bytes)
+                    request = client.build_request("GET", url, headers=headers)
+                    redirect_count = 0
+                    while True:
+                        response = await client.send(
+                            request,
+                            stream=True,
+                            follow_redirects=False,
                         )
-                    return response.content
+                        try:
+                            if response.has_redirect_location:
+                                if redirect_count >= client.max_redirects:
+                                    raise httpx.TooManyRedirects(
+                                        "Exceeded maximum allowed redirects",
+                                        request=request,
+                                    )
+                                next_request = response.next_request
+                                if next_request is None:
+                                    response.raise_for_status()
+                                    raise ValueError(
+                                        "Slack returned an unusable redirect response"
+                                    )
+                                request = next_request
+                                redirect_count += 1
+                                continue
+
+                            response.raise_for_status()
+                            ct = response.headers.get("content-type", "")
+                            if "text/html" in ct:
+                                raise ValueError(
+                                    "Slack returned HTML instead of file bytes "
+                                    f"(content-type: {ct}); "
+                                    "check bot token scopes and file permissions"
+                                )
+
+                            content_encoding = (
+                                response.headers.get("content-encoding", "")
+                                .strip()
+                                .lower()
+                            )
+                            if content_encoding not in {"", "identity"}:
+                                raise ValueError(
+                                    "Slack returned unexpected Content-Encoding "
+                                    f"{content_encoding!r} despite "
+                                    "Accept-Encoding: identity"
+                                )
+
+                            content_length = response.headers.get("content-length")
+                            if limit and content_length:
+                                try:
+                                    declared_size = int(content_length)
+                                except (TypeError, ValueError, OverflowError):
+                                    logger.debug(
+                                        "Ignoring invalid Slack Content-Length: %r",
+                                        content_length,
+                                    )
+                                else:
+                                    if declared_size > limit:
+                                        raise _SlackDownloadTooLarge(
+                                            declared_size,
+                                            limit,
+                                        )
+
+                            chunks: List[bytes] = []
+                            total = 0
+                            async for chunk in response.aiter_bytes():
+                                total += len(chunk)
+                                if limit and total > limit:
+                                    raise _SlackDownloadTooLarge(total, limit)
+                                chunks.append(chunk)
+                            return b"".join(chunks)
+                        finally:
+                            await response.aclose()
                 except (
-                    httpx.TimeoutException,
+                    httpx.TransportError,
                     httpx.HTTPStatusError,
                     ValueError,
                 ) as exc:

--- a/tests/gateway/test_media_download_retry.py
+++ b/tests/gateway/test_media_download_retry.py
@@ -34,7 +34,11 @@ def _make_timeout_error() -> httpx.TimeoutException:
     return httpx.TimeoutException("timed out")
 
 
-def _make_stream_response(content: bytes = b"\xff\xd8\xff fake media"):
+def _make_stream_response(
+    content: bytes = b"\xff\xd8\xff fake media",
+    *,
+    headers=None,
+):
     """Build a mock httpx response suitable for ``client.stream()`` usage.
 
     Exposes ``raise_for_status``, an empty ``headers`` mapping (no
@@ -43,7 +47,10 @@ def _make_stream_response(content: bytes = b"\xff\xd8\xff fake media"):
     """
     resp = MagicMock()
     resp.raise_for_status = MagicMock()
-    resp.headers = {}
+    resp.headers = headers or {}
+    resp.has_redirect_location = False
+    resp.next_request = None
+    resp.aclose = AsyncMock()
 
     async def _aiter():
         yield content
@@ -53,16 +60,23 @@ def _make_stream_response(content: bytes = b"\xff\xd8\xff fake media"):
 
 
 def _make_stream_client(*, responses=None, side_effect=None):
-    """Build a mock httpx client whose ``.stream()`` is an async CM.
+    """Build a mock httpx client supporting streamed ``send``/``stream``.
 
-    ``responses`` is a list of response objects (or exceptions) returned on
-    successive ``.stream()`` calls; ``side_effect`` is a single exception
-    raised on every call. The returned client also supports being used as an
-    ``async with`` context manager (``httpx.AsyncClient(...)``).
+    ``responses`` supplies successive response objects (or exceptions), and
+    ``side_effect`` is raised on every request. The client also implements the
+    async context-manager protocol used by ``httpx.AsyncClient``.
     """
     mock_client = AsyncMock()
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.max_redirects = 20
+    mock_client.build_request = MagicMock(
+        side_effect=lambda method, url, **kwargs: httpx.Request(
+            method,
+            url,
+            headers=kwargs.get("headers"),
+        )
+    )
 
     call_state = {"i": 0}
 
@@ -80,6 +94,18 @@ def _make_stream_client(*, responses=None, side_effect=None):
         return cm
 
     mock_client.stream = MagicMock(side_effect=_stream)
+
+    async def _send(_request, **_kwargs):
+        idx = call_state["i"]
+        call_state["i"] += 1
+        if side_effect is not None:
+            raise side_effect
+        item = responses[idx]
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    mock_client.send = AsyncMock(side_effect=_send)
     mock_client._call_state = call_state
     return mock_client
 
@@ -753,6 +779,176 @@ class TestSlackDownloadSlackFileBytes:
 
         result = asyncio.run(run())
         assert result == b"raw bytes here"
+
+    def test_limited_stream_returns_body_under_cap(self):
+        adapter = _make_slack_adapter()
+        response = _make_stream_response(b"1234")
+        mock_client = _make_stream_client(responses=[response])
+
+        async def run():
+            with patch("httpx.AsyncClient", return_value=mock_client):
+                return await adapter._download_slack_file_bytes(
+                    "https://files.slack.com/file.bin",
+                    max_bytes=5,
+                )
+
+        assert asyncio.run(run()) == b"1234"
+        assert mock_client.send.await_count == 1
+        assert (
+            mock_client.build_request.call_args.kwargs["headers"]["Accept-Encoding"]
+            == "identity"
+        )
+
+    def test_limited_stream_rejects_content_encoding_before_read(self):
+        adapter = _make_slack_adapter()
+        response = _make_stream_response(
+            b"compressed",
+            headers={"content-encoding": "gzip", "content-length": "10"},
+        )
+        response.aiter_bytes = MagicMock(side_effect=AssertionError("body was read"))
+        mock_client = _make_stream_client(responses=[response])
+
+        async def run():
+            with patch("httpx.AsyncClient", return_value=mock_client):
+                await adapter._download_slack_file_bytes(
+                    "https://files.slack.com/file.bin",
+                    max_bytes=5,
+                )
+
+        with pytest.raises(ValueError, match="unexpected Content-Encoding"):
+            asyncio.run(run())
+        assert mock_client.send.await_count == 1
+
+    def test_limited_stream_rejects_actual_body_over_cap(self):
+        adapter = _make_slack_adapter()
+        response = _make_stream_response(b"123456")
+        mock_client = _make_stream_client(responses=[response])
+
+        async def run():
+            with patch("httpx.AsyncClient", return_value=mock_client):
+                await adapter._download_slack_file_bytes(
+                    "https://files.slack.com/file.bin",
+                    max_bytes=5,
+                )
+
+        with pytest.raises(ValueError, match="too large"):
+            asyncio.run(run())
+        assert mock_client.send.await_count == 1
+
+    def test_limited_stream_rejects_oversized_content_length_before_read(self):
+        adapter = _make_slack_adapter()
+        response = _make_stream_response(
+            b"123456",
+            headers={"content-length": "6"},
+        )
+        response.aiter_bytes = MagicMock(side_effect=AssertionError("body was read"))
+        mock_client = _make_stream_client(responses=[response])
+
+        async def run():
+            with patch("httpx.AsyncClient", return_value=mock_client):
+                await adapter._download_slack_file_bytes(
+                    "https://files.slack.com/file.bin",
+                    max_bytes=5,
+                )
+
+        with pytest.raises(ValueError, match="too large"):
+            asyncio.run(run())
+        assert mock_client.send.await_count == 1
+
+    def test_zero_stream_cap_allows_body(self):
+        adapter = _make_slack_adapter()
+        response = _make_stream_response(b"123456")
+        mock_client = _make_stream_client(responses=[response])
+
+        async def run():
+            with patch("httpx.AsyncClient", return_value=mock_client):
+                return await adapter._download_slack_file_bytes(
+                    "https://files.slack.com/file.bin",
+                    max_bytes=0,
+                )
+
+        assert asyncio.run(run()) == b"123456"
+
+    def test_limited_stream_retries_mid_body_read_error(self):
+        adapter = _make_slack_adapter()
+        broken = _make_stream_response()
+
+        async def _broken_body():
+            yield b"partial"
+            raise httpx.ReadError("connection reset")
+
+        broken.aiter_bytes = lambda: _broken_body()
+        recovered = _make_stream_response(b"complete")
+        mock_client = _make_stream_client(responses=[broken, recovered])
+
+        async def run():
+            with (
+                patch("httpx.AsyncClient", return_value=mock_client),
+                patch("asyncio.sleep", new_callable=AsyncMock),
+            ):
+                return await adapter._download_slack_file_bytes(
+                    "https://files.slack.com/file.bin",
+                    max_bytes=32,
+                )
+
+        assert asyncio.run(run()) == b"complete"
+        assert mock_client.send.await_count == 2
+
+    def test_limited_stream_does_not_read_redirect_body_or_leak_auth(self):
+        adapter = _make_slack_adapter()
+        seen_headers = []
+
+        class TrackingStream(httpx.AsyncByteStream):
+            def __init__(self):
+                self.reads = 0
+                self.closed = 0
+
+            async def __aiter__(self):
+                self.reads += 1
+                yield b"x" * (1024 * 1024)
+
+            async def aclose(self):
+                self.closed += 1
+
+        redirect_body = TrackingStream()
+
+        def handler(request):
+            seen_headers.append((request.url.host, dict(request.headers)))
+            if request.url.host == "files.slack.com":
+                return httpx.Response(
+                    302,
+                    headers={
+                        "location": "https://cdn.example/file.bin",
+                        "content-encoding": "gzip",
+                    },
+                    stream=redirect_body,
+                )
+            return httpx.Response(200, content=b"ok")
+
+        transport = httpx.MockTransport(handler)
+        real_client = httpx.AsyncClient
+
+        async def run():
+            with patch(
+                "httpx.AsyncClient",
+                side_effect=lambda **kwargs: real_client(
+                    transport=transport,
+                    **kwargs,
+                ),
+            ):
+                return await adapter._download_slack_file_bytes(
+                    "https://files.slack.com/file.bin",
+                    max_bytes=10,
+                )
+
+        assert asyncio.run(run()) == b"ok"
+        assert redirect_body.reads == 0
+        assert redirect_body.closed == 1
+        assert seen_headers[0][1]["authorization"] == (
+            f"Bearer {adapter.config.token}"
+        )
+        assert "authorization" not in seen_headers[1][1]
+        assert seen_headers[1][1]["accept-encoding"] == "identity"
 
     def test_rejects_html_response(self):
         """Slack HTML sign-in pages should not be accepted as file bytes."""

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -72,6 +72,73 @@ class TestInboundMediaSizeCap:
             validate_inbound_media_size(300, media_type="image", max_bytes=200)
 
 
+class TestInboundDocumentSizeCap:
+    def test_default_is_20_mib(self, monkeypatch):
+        import gateway.platforms.base as base
+        import hermes_cli.config as config
+
+        monkeypatch.setattr(config, "load_config", lambda: {})
+
+        assert base.DEFAULT_INBOUND_DOCUMENT_MAX_BYTES == 20 * 1024 * 1024
+        assert (
+            base.get_inbound_document_max_bytes()
+            == base.DEFAULT_INBOUND_DOCUMENT_MAX_BYTES
+        )
+
+    @pytest.mark.parametrize("raw", [0, -1, "0", "-1"])
+    def test_non_positive_values_disable_cap(self, monkeypatch, raw):
+        import gateway.platforms.base as base
+        import hermes_cli.config as config
+
+        monkeypatch.setattr(
+            config,
+            "load_config",
+            lambda: {"gateway": {"max_inbound_document_bytes": raw}},
+        )
+
+        assert base.get_inbound_document_max_bytes() == 0
+
+    def test_positive_override_is_returned(self, monkeypatch):
+        import gateway.platforms.base as base
+        import hermes_cli.config as config
+
+        monkeypatch.setattr(
+            config,
+            "load_config",
+            lambda: {"gateway": {"max_inbound_document_bytes": "33554432"}},
+        )
+
+        assert base.get_inbound_document_max_bytes() == 32 * 1024 * 1024
+
+    @pytest.mark.parametrize(
+        "raw",
+        [True, "nonsense", 1.5, float("inf"), float("nan")],
+    )
+    def test_invalid_values_fall_back_to_default(self, monkeypatch, raw):
+        import gateway.platforms.base as base
+        import hermes_cli.config as config
+
+        monkeypatch.setattr(
+            config,
+            "load_config",
+            lambda: {"gateway": {"max_inbound_document_bytes": raw}},
+        )
+
+        assert (
+            base.get_inbound_document_max_bytes()
+            == base.DEFAULT_INBOUND_DOCUMENT_MAX_BYTES
+        )
+
+    def test_default_config_exposes_setting(self):
+        import gateway.platforms.base as base
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        assert (
+            DEFAULT_CONFIG["gateway"]["max_inbound_document_bytes"]
+            == base.DEFAULT_INBOUND_DOCUMENT_MAX_BYTES
+        )
+
+
 class TestSecretCaptureGuidance:
     def test_gateway_secret_capture_message_points_to_local_setup(self):
         message = GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1386,8 +1386,13 @@ class TestIncomingDocumentHandling:
         assert msg_event.media_types == ["application/zip"]
 
     @pytest.mark.asyncio
-    async def test_oversized_document_skipped(self, adapter):
-        """A document over 20MB should be skipped."""
+    async def test_oversized_document_skipped(self, adapter, monkeypatch):
+        """The default 20 MiB cap skips metadata-known oversized documents."""
+        monkeypatch.setattr(
+            _slack_mod,
+            "get_inbound_document_max_bytes",
+            lambda: 20 * 1024 * 1024,
+        )
         event = self._make_event(
             files=[
                 {
@@ -1402,6 +1407,191 @@ class TestIncomingDocumentHandling:
 
         msg_event = adapter.handle_message.call_args[0][0]
         assert len(msg_event.media_urls) == 0
+        assert "[Slack attachment notice]" in msg_event.text
+        assert "huge.pdf" in msg_event.text
+        assert "exceeds" in msg_event.text
+
+    @pytest.mark.asyncio
+    async def test_document_accepted_when_cap_raised(self, adapter, monkeypatch):
+        monkeypatch.setattr(
+            _slack_mod,
+            "get_inbound_document_max_bytes",
+            lambda: 128 * 1024 * 1024,
+        )
+        with patch.object(
+            adapter, "_download_slack_file_bytes", new_callable=AsyncMock
+        ) as dl:
+            dl.return_value = b"%PDF-1.7 big"
+            event = self._make_event(
+                files=[
+                    {
+                        "mimetype": "application/pdf",
+                        "name": "huge.pdf",
+                        "url_private_download": "https://files.slack.com/huge.pdf",
+                        "size": 25 * 1024 * 1024,
+                    }
+                ]
+            )
+            await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.message_type == MessageType.DOCUMENT
+        assert len(msg_event.media_urls) == 1
+        dl.assert_awaited_once_with(
+            "https://files.slack.com/huge.pdf",
+            team_id="",
+            max_bytes=128 * 1024 * 1024,
+        )
+
+    @pytest.mark.asyncio
+    async def test_unknown_size_document_is_capped_while_streaming(
+        self,
+        adapter,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(
+            _slack_mod,
+            "get_inbound_document_max_bytes",
+            lambda: 20 * 1024 * 1024,
+        )
+        with patch.object(
+            adapter, "_download_slack_file_bytes", new_callable=AsyncMock
+        ) as dl:
+            dl.return_value = b"small"
+            event = self._make_event(
+                files=[
+                    {
+                        "mimetype": "application/pdf",
+                        "name": "unknown.pdf",
+                        "url_private_download": "https://files.slack.com/unknown.pdf",
+                    }
+                ]
+            )
+            await adapter._handle_slack_message(event)
+
+        assert adapter.handle_message.call_args[0][0].media_urls
+        dl.assert_awaited_once_with(
+            "https://files.slack.com/unknown.pdf",
+            team_id="",
+            max_bytes=20 * 1024 * 1024,
+        )
+
+    @pytest.mark.asyncio
+    async def test_zero_cap_allows_unknown_size_document(self, adapter, monkeypatch):
+        monkeypatch.setattr(
+            _slack_mod,
+            "get_inbound_document_max_bytes",
+            lambda: 0,
+        )
+        with patch.object(
+            adapter, "_download_slack_file_bytes", new_callable=AsyncMock
+        ) as dl:
+            dl.return_value = b"unlimited"
+            event = self._make_event(
+                files=[
+                    {
+                        "mimetype": "application/pdf",
+                        "name": "unknown.pdf",
+                        "url_private_download": "https://files.slack.com/unknown.pdf",
+                    }
+                ]
+            )
+            await adapter._handle_slack_message(event)
+
+        assert adapter.handle_message.call_args[0][0].media_urls
+        dl.assert_awaited_once_with(
+            "https://files.slack.com/unknown.pdf",
+            team_id="",
+            max_bytes=0,
+        )
+
+    @pytest.mark.asyncio
+    async def test_actual_body_over_cap_surfaces_notice(self, adapter, monkeypatch):
+        monkeypatch.setattr(
+            _slack_mod,
+            "get_inbound_document_max_bytes",
+            lambda: 20,
+        )
+        with patch.object(
+            adapter, "_download_slack_file_bytes", new_callable=AsyncMock
+        ) as dl:
+            dl.return_value = b"x" * 21
+            event = self._make_event(
+                text="please read this",
+                files=[
+                    {
+                        "mimetype": "application/pdf",
+                        "name": "lying-size.pdf",
+                        "url_private_download": "https://files.slack.com/lying.pdf",
+                        "size": 1,
+                    }
+                ],
+            )
+            await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert not msg_event.media_urls
+        assert "please read this" in msg_event.text
+        assert "lying-size.pdf" in msg_event.text
+        assert "21 bytes" in msg_event.text
+
+    @pytest.mark.asyncio
+    async def test_oversized_attachment_does_not_mutate_command(
+        self,
+        adapter,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(
+            _slack_mod,
+            "get_inbound_document_max_bytes",
+            lambda: 20 * 1024 * 1024,
+        )
+        event = self._make_event(
+            text="!stop",
+            files=[
+                {
+                    "mimetype": "application/pdf",
+                    "name": "huge.pdf",
+                    "url_private_download": "https://files.slack.com/huge.pdf",
+                    "size": 25 * 1024 * 1024,
+                }
+            ],
+        )
+
+        await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "/stop"
+        assert msg_event.message_type == MessageType.COMMAND
+        assert msg_event.get_command() == "stop"
+
+    @pytest.mark.asyncio
+    async def test_limit_notice_neutralizes_slack_broadcast_filename(
+        self,
+        adapter,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(
+            _slack_mod,
+            "get_inbound_document_max_bytes",
+            lambda: 20 * 1024 * 1024,
+        )
+        event = self._make_event(
+            files=[
+                {
+                    "mimetype": "application/pdf",
+                    "name": "<!channel>.pdf",
+                    "url_private_download": "https://files.slack.com/huge.pdf",
+                    "size": 25 * 1024 * 1024,
+                }
+            ]
+        )
+
+        await adapter._handle_slack_message(event)
+
+        text = adapter.handle_message.call_args[0][0].text
+        assert "<!channel>" not in text
+        assert "&lt;!channel&gt;.pdf" in text
 
     @pytest.mark.asyncio
     async def test_document_download_error_handled(self, adapter):

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -369,6 +369,17 @@ platforms:
 | `platforms.slack.extra.rich_blocks` | `false` | When `true`, agent messages are rendered as [Block Kit](https://docs.slack.dev/block-kit/) blocks (headers, dividers, true nested lists, and native tables). A plain-text fallback is always sent. Tables over Slack's limits fall back to aligned monospace. No app reinstall required — it's a send-side change only. |
 | `platforms.slack.extra.cron_continuable_surface` | `"thread"` | Delivery surface for [continuable cron jobs](../features/cron.md#flat-in-channel-continuation-slack). `"thread"` opens a dedicated thread per delivery (default); `"in_channel"` delivers flat into the channel timeline. Pair `in_channel` with `reply_in_thread: false` (and `require_mention: false`) so a plain channel reply continues the job. |
 
+### Inbound document size limit
+
+Slack documents are capped at 20 MiB by default. Hermes checks both Slack's
+declared size and the actual streamed response body, so missing or inaccurate
+metadata cannot bypass the limit. Configure the cap under `gateway`:
+
+```yaml
+gateway:
+  max_inbound_document_bytes: 20971520  # 20 MiB; 0 disables the cap
+```
+
 ### Session Isolation
 
 ```yaml

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/slack.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/slack.md
@@ -323,6 +323,17 @@ platforms:
 | `platforms.slack.extra.rich_blocks` | `false` | 为 `true` 时，Agent 消息会渲染为 [Block Kit](https://docs.slack.dev/block-kit/) 区块（标题、分隔线、真正的嵌套列表以及原生表格）。始终附带纯文本回退。超出 Slack 限制的表格会回退为对齐的等宽文本。无需重新安装应用——这仅是发送端的改动。 |
 | `platforms.slack.extra.cron_continuable_surface` | `"thread"` | [可继续 cron 任务](../features/cron.md)的投递方式。`"thread"` 为每次投递新建专用话题（默认）；`"in_channel"` 直接平铺投递到频道时间线。使用 `in_channel` 时需搭配 `reply_in_thread: false`（及 `require_mention: false`），纯文本回复即可继续任务。 |
 
+### 入站文档大小限制
+
+Slack 文档默认限制为 20 MiB。Hermes 会同时检查 Slack 声明的大小和
+实际流式响应正文，因此缺失或不准确的元数据无法绕过限制。请在
+`gateway` 下配置：
+
+```yaml
+gateway:
+  max_inbound_document_bytes: 20971520  # 20 MiB；设为 0 可禁用限制
+```
+
 ### 会话隔离
 
 ```yaml


### PR DESCRIPTION
## Problem

Slack capped inbound document attachments at a hardcoded 20 MiB and silently dropped oversized files. The limit was not configurable, and checking Slack metadata alone could not bound memory when the declared size was missing or differed from the response body.

## Change

- Add `gateway.max_inbound_document_bytes` in `config.yaml`.
  - Default: 20 MiB, preserving existing behavior.
  - `0` or a negative value disables the cap.
  - Invalid values fall back to 20 MiB.
- Reject metadata-known oversized documents before download.
- Enforce the same limit against `Content-Length` and the running streamed response size, so missing or inaccurate metadata cannot bypass it.
- Stream capped document downloads without buffering redirect bodies, preserve HTTPX cross-origin authorization stripping, and request identity encoding.
- Accept unknown-size documents when their actual streamed body stays within the cap.
- Surface sanitized attachment notices for ordinary messages while leaving command text and command type unchanged.
- Keep Slack video downloads and other platforms unchanged.
- Document the setting in the English and Simplified Chinese Slack guides.

## Validation

- 702 focused and adjacent tests passed; 2 skipped.
- Ruff, compileall, and `git diff --check` passed.
- Independent Slack and regression reviews both returned LGTM.
