### PR TITLE
fix(mcp): kill Windows MCP process tree on reconnect (was leaking grandchildren)

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -287,6 +287,116 @@ class TestWindowsProcessTreeKill:
             "so PID-reuse can't leak a stale handle"
         )
 
+    def test_reap_by_identity_catches_reparented_orphan(self, monkeypatch):
+        """Regression for teknium's PR #61722 review.
+
+        The scenario: the wrapper exits between spawn-time signature
+        capture and teardown.  Its grandchild is reparented to PID 0
+        (System) and survives.  ``psutil.Process(wrapper_pid).children(
+        recursive=True)`` raises NoSuchProcess because the wrapper is
+        gone — the original psutil-only fallback would miss the
+        grandchild.  The reap-by-identity step walks the global process
+        table, finds any process whose cmdline matches the snapshot
+        signature, and terminates it.
+        """
+        import sys
+
+        import tools.mcp_tool as mcp_tool
+
+        grandchild_cmdline = [
+            "C:/Python312/python.exe",
+            "C:/Users/me/grandchild_server.py",
+            "--stdio",
+        ]
+        grandchild_pid = 9999
+        unrelated_pid = 10000
+
+        class _DeadWrapper:
+            """psutil.Process(wrapper_pid) — wrapper is gone, raises on
+            ``.children()``.  Has terminate/kill no-ops so the psutil
+            tree-kill step doesn't crash before the reap-by-identity
+            pass runs."""
+            def __init__(self, pid):
+                self.pid = pid
+            def children(self, recursive=True):
+                raise ProcessLookupError(self.pid)
+            def terminate(self):
+                pass
+            def kill(self):
+                pass
+
+        killed_pids: list = []
+
+        class _ProcItem:
+            """Stand-in for psutil process_iter entries.
+
+            ``_kill_process_tree_by_identity`` uses both ``.info`` (for
+            pid/cmdline lookup) and ``.terminate()``/``.kill()``.  Real
+            ``psutil.Process`` objects satisfy both, so this mocks that
+            combined contract.
+            """
+            def __init__(self, pid, cmdline):
+                self.pid = pid
+                self.info = {"pid": pid, "cmdline": cmdline}
+            def terminate(self):
+                killed_pids.append(("terminate", self.pid))
+            def kill(self):
+                killed_pids.append(("kill", self.pid))
+
+        fake = SimpleNamespace(
+            Process=_DeadWrapper,
+            process_iter=lambda attrs: iter([
+                _ProcItem(grandchild_pid, grandchild_cmdline),
+                _ProcItem(unrelated_pid, ["unrelated", "process"]),
+            ]),
+            NoSuchProcess=ProcessLookupError,
+            AccessDenied=PermissionError,
+            wait_procs=lambda procs, *a, **kw: (list(procs), []),
+        )
+        monkeypatch.setitem(sys.modules, "psutil", fake)
+        monkeypatch.setattr(mcp_tool, "_WIN32_CTYPES_OK", False, raising=False)
+        monkeypatch.setattr(mcp_tool, "sys", SimpleNamespace(platform="win32"))
+
+        # Pre-register the cmdline signature as if we had snapshotted
+        # it at spawn time while the wrapper was still alive.  This is
+        # the only thing that lets _kill_process_tree_by_identity find
+        # the reparented orphan — the wrapper PID itself is gone.
+        mcp_tool._stdio_descendant_sigs[6000] = [
+            " ".join(grandchild_cmdline),
+        ]
+
+        mcp_tool._kill_process_tree(6000)
+
+        killed_only = [pid for _, pid in killed_pids]
+        assert grandchild_pid in killed_only, (
+            f"Reparented grandchild {grandchild_pid} was not reaped by "
+            f"identity. Killed PIDs: {killed_pids}"
+        )
+        assert unrelated_pid not in killed_only, (
+            f"Unrelated process {unrelated_pid} was wrongly killed by "
+            f"signature match. Killed PIDs: {killed_pids}"
+        )
+        # Signatures must be popped so PID-reuse can't surface stale state.
+        assert 6000 not in mcp_tool._stdio_descendant_sigs
+
+    def test_reap_by_identity_skipped_when_no_signatures(self, monkeypatch):
+        """If no signatures were captured at spawn (psutil missing, or
+        the wrapper raced to exit before snapshot), the reap-by-identity
+        pass is a no-op.  The earlier psutil tree-kill still runs.
+        """
+        import sys
+
+        import tools.mcp_tool as mcp_tool
+
+        fake = self._make_fake_psutil({7000: []})
+        monkeypatch.setitem(sys.modules, "psutil", fake)
+        monkeypatch.setattr(mcp_tool, "_WIN32_CTYPES_OK", False, raising=False)
+        monkeypatch.setattr(mcp_tool, "sys", SimpleNamespace(platform="win32"))
+
+        # No pre-registered signatures for PID 7000.
+        mcp_tool._kill_process_tree(7000)
+        assert fake._terminated == {7000}
+
 
 # ---------------------------------------------------------------------------
 # Config loading

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -88,6 +88,207 @@ class TestFilterMCPChildren:
 
 
 # ---------------------------------------------------------------------------
+# Windows process-tree leak regression
+# ---------------------------------------------------------------------------
+#
+# Background: on Windows, MCP servers launched via wrapper commands
+# (``uvx elevenlabs-mcp``, ``cmd /c npx @supabase/...``) spawn a wrapper
+# PID that immediately re-execs the real server as a grandchild.  The
+# SDK only tracks the direct child; ``os.kill(pid, sig)`` on teardown
+# kills only the wrapper, leaving the grandchild orphaned.  Every
+# reconnect leaks one grandchild.
+#
+# The fix: ``_kill_process_tree(pid)`` walks the tree via psutil and
+# terminates the root plus every descendant before the function returns.
+# These tests pin that contract — the production bug is "the grandchild
+# survives tree-kill", so we assert every descendant is gone after the
+# sweep.  All subprocess work is mocked to keep the test fast and
+# deterministic.
+
+class TestWindowsProcessTreeKill:
+    """Regression tests for the Windows MCP grandchild leak."""
+
+    def _make_fake_psutil(self, descendants_by_pid):
+        """Build a fake psutil module.
+
+        ``descendants_by_pid`` maps each tracked PID to a list of its
+        direct child PIDs.  ``children(recursive=True)`` walks the full
+        descendant set the way real psutil does, so the test asserts the
+        same contract the production helper relies on.
+        """
+        terminated: set = set()
+        killed: set = set()
+
+        class FakeProcess:
+            def __init__(self, pid):
+                self.pid = pid
+
+            def children(self, recursive=True):
+                direct = descendants_by_pid.get(self.pid, [])
+                if not recursive:
+                    return [FakeProcess(d) for d in direct]
+                # Walk the full subtree, matching psutil's recursive=True.
+                seen = set()
+                stack = list(direct)
+                out = []
+                while stack:
+                    cur = stack.pop()
+                    if cur in seen:
+                        continue
+                    seen.add(cur)
+                    out.append(FakeProcess(cur))
+                    stack.extend(descendants_by_pid.get(cur, []))
+                return out
+
+            def terminate(self):
+                terminated.add(self.pid)
+
+            def kill(self):
+                killed.add(self.pid)
+                terminated.add(self.pid)
+
+        def wait_procs(procs, *args, **kwargs):
+            # Pretend everything terminated.
+            gone = list(procs)
+            alive = []
+            return gone, alive
+
+        fake = SimpleNamespace(
+            Process=FakeProcess,
+            NoSuchProcess=ProcessLookupError,
+            AccessDenied=PermissionError,
+            wait_procs=wait_procs,
+            _terminated=terminated,
+            _killed=killed,
+        )
+        return fake
+
+    def test_psutil_tree_kill_terminates_root_and_all_descendants(self, monkeypatch):
+        """The core leak fix: killing the wrapper MUST also kill every
+        descendant.  This is what ``os.kill(pid, sig)`` failed to do.
+        """
+        import sys
+
+        import tools.mcp_tool as mcp_tool
+
+        fake = self._make_fake_psutil({
+            1000: [1001, 1002],   # wrapper 1000 -> grandchildren 1001, 1002
+            1001: [1003],          # grandchild 1001 -> great-grandchild 1003
+        })
+        monkeypatch.setitem(sys.modules, "psutil", fake)
+
+        # Skip the Job Object path so the test exercises the psutil branch.
+        monkeypatch.setattr(mcp_tool, "_WIN32_CTYPES_OK", False, raising=False)
+        monkeypatch.setattr(mcp_tool, "sys", SimpleNamespace(platform="win32"))
+
+        mcp_tool._kill_process_tree(1000)
+
+        # Every PID in the tree must be terminated.
+        terminated = fake._terminated
+        assert terminated == {1000, 1001, 1002, 1003}, (
+            f"Expected all 4 PIDs terminated, got {terminated}. "
+            f"Missing: {{1000,1001,1002,1003}} - terminated"
+        )
+
+    def test_psutil_tree_kill_handles_no_descendants(self, monkeypatch):
+        """Direct-command servers (freshbooks `node`, drive/analytics/ads
+        `python`) have no grandchildren — the sweep is a single-PID kill.
+        Must not raise.
+        """
+        import sys
+
+        import tools.mcp_tool as mcp_tool
+
+        fake = self._make_fake_psutil({2000: []})
+        monkeypatch.setitem(sys.modules, "psutil", fake)
+        monkeypatch.setattr(mcp_tool, "_WIN32_CTYPES_OK", False, raising=False)
+        monkeypatch.setattr(mcp_tool, "sys", SimpleNamespace(platform="win32"))
+
+        mcp_tool._kill_process_tree(2000)
+        assert fake._terminated == {2000}
+
+    def test_psutil_tree_kill_noop_when_pid_already_gone(self, monkeypatch):
+        """If the root exited before tree-kill runs, ``psutil.Process``
+        raises ``NoSuchProcess`` and the helper must return cleanly
+        without touching any other PID.
+        """
+        import sys
+
+        import tools.mcp_tool as mcp_tool
+
+        class _GoneProcess:
+            def __init__(self, pid):
+                # Real psutil raises NoSuchProcess from the constructor
+                # when the PID doesn't exist.  Mirror that exactly so
+                # the production code's outer try/except handles it
+                # without ever touching ``.children``/``.terminate``.
+                raise ProcessLookupError(pid)
+
+        fake = SimpleNamespace(
+            Process=_GoneProcess,
+            NoSuchProcess=ProcessLookupError,
+            AccessDenied=PermissionError,
+            wait_procs=lambda procs, *a, **kw: (list(procs), []),
+        )
+        monkeypatch.setitem(sys.modules, "psutil", fake)
+        monkeypatch.setattr(mcp_tool, "_WIN32_CTYPES_OK", False, raising=False)
+        monkeypatch.setattr(mcp_tool, "sys", SimpleNamespace(platform="win32"))
+
+        # Must not raise.
+        mcp_tool._kill_process_tree(3000)
+
+    def test_posix_path_skips_tree_kill(self, monkeypatch):
+        """On POSIX the canonical path is ``killpg``/``kill`` via the
+        run-loop's ``_send_signal``.  ``_kill_process_tree`` must NOT be
+        called on POSIX so we don't disturb that contract.
+        """
+        import sys
+
+        import tools.mcp_tool as mcp_tool
+
+        fake = self._make_fake_psutil({4000: [4001]})
+        monkeypatch.setitem(sys.modules, "psutil", fake)
+        monkeypatch.setattr(mcp_tool, "_WIN32_CTYPES_OK", False, raising=False)
+        monkeypatch.setattr(mcp_tool, "sys", SimpleNamespace(platform="linux"))
+
+        mcp_tool._kill_process_tree(4000)
+        # psutil was never consulted on POSIX.
+        assert fake._terminated == set()
+
+    def test_job_close_takes_precedence_over_psutil(self, monkeypatch):
+        """When a Job Object IS attached for this PID, closing the Job
+        is the race-free atomic path.  psutil must not be invoked.
+        """
+        import sys
+
+        import tools.mcp_tool as mcp_tool
+
+        fake = self._make_fake_psutil({5000: [5001, 5002]})
+        monkeypatch.setitem(sys.modules, "psutil", fake)
+        monkeypatch.setattr(mcp_tool, "_WIN32_CTYPES_OK", True, raising=False)
+        monkeypatch.setattr(mcp_tool, "sys", SimpleNamespace(platform="win32"))
+
+        closed = []
+        monkeypatch.setattr(mcp_tool, "_close_job", lambda h: closed.append(h))
+
+        # Pre-register a Job for this PID.
+        mcp_tool._stdio_jobs[5000] = 0xABCD
+
+        mcp_tool._kill_process_tree(5000)
+
+        assert closed == [0xABCD], "Job handle must be closed exactly once"
+        assert fake._terminated == set(), (
+            "psutil must not run when a Job Object handles the kill "
+            "(avoids a redundant sweep and possible race with the "
+            "kernel-side termination)"
+        )
+        assert 5000 not in mcp_tool._stdio_jobs, (
+            "Job handle must be popped from _stdio_jobs after close "
+            "so PID-reuse can't leak a stale handle"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Config loading
 # ---------------------------------------------------------------------------
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1882,6 +1882,7 @@ class MCPServerTask:
                     # sweep needs the pgid to reach any reparented descendants
                     # (e.g. ``claude mcp serve`` spawned by a stdio wrapper).
                     new_pgids: Dict[int, int] = {}
+                    new_jobs: Dict[int, int] = {}
                     for _pid in new_pids:
                         try:
                             new_pgids[_pid] = os.getpgid(_pid)
@@ -1889,10 +1890,31 @@ class MCPServerTask:
                             # AttributeError: Windows (os.getpgid is POSIX-only)
                             # ProcessLookupError: child raced and already exited
                             pass
+                        # Windows: assign the direct child to a per-server
+                        # Job Object so closing the handle atomically kills the
+                        # whole process tree (wrapper + every grandchild the
+                        # wrapper spawned).  Grandchildren inherit the Job
+                        # automatically because asyncio subprocess pipes use
+                        # ``bInheritHandles=True``.  Without this, every
+                        # reconnect leaves one leaked ``node.exe`` / ``python.exe``
+                        # grandchild behind — see the Windows-process-tree
+                        # helper block above for the full rationale.
+                        if sys.platform == "win32" and _WIN32_CTYPES_OK:
+                            job = _make_windows_job()
+                            if job is not None and _assign_child_to_job(_pid, job):
+                                new_jobs[_pid] = job
+                            elif job is not None:
+                                # Job creation succeeded but assignment
+                                # failed (e.g. child raced to exit before
+                                # we could attach).  Close the Job so the
+                                # handle doesn't leak.
+                                _close_job(job)
                     with _lock:
                         for _pid in new_pids:
                             _stdio_pids[_pid] = self.name
                         _stdio_pgids.update(new_pgids)
+                        if new_jobs:
+                            _stdio_jobs.update(new_jobs)
                 async with ClientSession(
                     read_stream, write_stream, **sampling_kwargs
                 ) as session:
@@ -1942,6 +1964,20 @@ class MCPServerTask:
                             # Nothing left to reap — drop the pgid entry so
                             # PID-reuse can't surface stale pgroup state later.
                             _stdio_pgids.pop(pid, None)
+                # Windows reconnect-leak defense: when the SDK teardown
+                # leaves descendants alive (the user-reported bug — every
+                # keepalive-driven reconnect leaks one node.exe / python.exe
+                # grandchild because ``os.kill(pid, sig)`` only reaches the
+                # direct wrapper), eagerly close the Job Object now.  This
+                # atomically kills the entire tree — wrapper, node/python
+                # grandchild, any further descendants — without waiting for
+                # the shutdown sweep.  POSIX keeps its existing pgid path;
+                # this block is Windows-only.
+                if sys.platform == "win32":
+                    for pid in new_pids:
+                        # Close the Job if one was attached at spawn.  This
+                        # is the race-free atomic tree-kill the bug needs.
+                        _kill_process_tree(pid)
 
     # Content types a real MCP Streamable-HTTP endpoint may return on the
     # initial POST/GET. Anything else on a 2xx response means the URL is not
@@ -2985,6 +3021,325 @@ _orphan_stdio_pids: set = set()
 # exited and been removed from the active map.  Empty on Windows
 # (``os.getpgid`` is POSIX-only).
 _stdio_pgids: Dict[int, int] = {}  # pid -> pgid
+
+
+# ---------------------------------------------------------------------------
+# Windows process-tree kill helpers
+# ---------------------------------------------------------------------------
+#
+# Windows has no process groups, so ``os.kill(pid, sig)`` (and ``killpg``'s
+# POSIX counterpart) only reaches the direct wrapper — the real MCP server
+# grandchild (e.g. the ``node.exe`` spawned by ``cmd /c npx ...``, or the
+# ``python.exe`` spawned by ``uvx elevenlabs-mcp``) survives, leaks across
+# reconnects, and accumulates across a single Hermes run.  Every reconnect
+# leaks one grandchild.  A full Hermes restart cleans them up because the
+# Job Object is closed when the parent Python dies — but the leak still
+# burns RAM, file descriptors, and npx/uvx caches in the meantime.
+#
+# Two complementary mechanisms keep the tree clean on Windows:
+#
+# 1. Windows Job Objects (``_assign_child_to_job`` / ``_close_job``).  At
+#    spawn time we create a per-MCP-server Job with
+#    ``JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`` and assign the direct child to
+#    it.  Grandchildren inherit the Job automatically (asyncio's subprocess
+#    pipe uses ``bInheritHandles=True``).  When we close the Job handle the
+#    kernel atomically kills every process in the Job, including
+#    grandchildren, race-free — even if the direct wrapper has already
+#    exited and the grandchildren have been reparented.
+#
+# 2. psutil tree-kill fallback (``_kill_process_tree_psutil``).  Used when
+#    the Job Object approach is unavailable (ctypes missing, Job creation
+#    failed) and as defense-in-depth.  ``psutil.Process.children(recursive=
+#    True)`` queries the OS process table directly, so it works even after
+#    the wrapper has exited (it does not depend on the parent/child
+#    relationship surviving in the kernel).
+#
+# POSIX is unchanged: ``killpg(pgid, sig)`` is the canonical path there.
+
+# Windows Job handles keyed by child PID.  Value is the ``HANDLE`` integer
+# from ``kernel32.CreateJobObjectW``.  Closing the handle (via
+# ``CloseHandle``) kills every process assigned to the Job when the Job was
+# created with ``JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE``.  Empty on non-Windows.
+_stdio_jobs: Dict[int, int] = {}
+
+# Whether ctypes/wintypes is available in this interpreter.  Cached at
+# module import so we don't pay the import cost on every reconnect.
+try:
+    import ctypes  # noqa: F401  -- availability probe only
+    import ctypes.wintypes  # noqa: F401  -- availability probe only
+    _WIN32_CTYPES_OK: bool = sys.platform == "win32"
+except Exception:
+    _WIN32_CTYPES_OK: bool = False
+
+
+def _make_windows_job() -> Optional[int]:
+    """Create a Windows Job Object with KILL_ON_JOB_CLOSE.
+
+    Returns the Job handle (an integer suitable for ``CloseHandle``) on
+    success, ``None`` if ctypes is unavailable or the Win32 call fails.
+    Assigning any process to the Job makes it — and every process it
+    spawns (Jobs are inherited across CreateProcess) — die atomically when
+    this handle is closed.
+
+    Idempotent per-process: each MCP session gets its own Job so closing
+    one doesn't tear down siblings.
+    """
+    if not _WIN32_CTYPES_OK:
+        return None
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+        # Constants from the Windows SDK (avoid the full win32 import).
+        JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000
+
+        # IO_COUNTERS is unused but CreateJobObject's extended param requires
+        # a pointer to one.  Allocate on a kept-alive global so the pointer
+        # survives until CloseHandle.
+        class _IO_COUNTERS(ctypes.Structure):
+            _fields_ = [
+                ("ReadOperationCount", ctypes.c_ulonglong),
+                ("WriteOperationCount", ctypes.c_ulonglong),
+                ("OtherOperationCount", ctypes.c_ulonglong),
+                ("ReadTransferCount", ctypes.c_ulonglong),
+                ("WriteTransferCount", ctypes.c_ulonglong),
+                ("OtherTransferCount", ctypes.c_ulonglong),
+            ]
+
+        class _JOBOBJECT_BASIC_LIMIT_INFORMATION(ctypes.Structure):
+            _fields_ = [
+                ("PerProcessUserTimeLimit", ctypes.c_longlong),
+                ("PerJobUserTimeLimit", ctypes.c_longlong),
+                ("LimitFlags", ctypes.c_uint32),
+                ("MinimumWorkingSetSize", ctypes.c_size_t),
+                ("MaximumWorkingSetSize", ctypes.c_size_t),
+                ("ActiveProcessLimit", ctypes.c_uint32),
+                ("Affinity", ctypes.c_size_t),
+                ("PriorityClass", ctypes.c_uint32),
+                ("SchedulingClass", ctypes.c_uint32),
+            ]
+
+        class _JOBOBJECT_EXTENDED_LIMIT_INFORMATION(ctypes.Structure):
+            _fields_ = [
+                ("BasicLimitInformation", _JOBOBJECT_BASIC_LIMIT_INFORMATION),
+                ("IoInfo", _IO_COUNTERS),
+                ("ProcessMemoryLimit", ctypes.c_size_t),
+                ("JobMemoryLimit", ctypes.c_size_t),
+                ("PeakProcessMemoryUsed", ctypes.c_size_t),
+                ("PeakJobMemoryUsed", ctypes.c_size_t),
+            ]
+
+        CreateJobObjectW = kernel32.CreateJobObjectW
+        CreateJobObjectW.restype = wintypes.HANDLE
+        CreateJobObjectW.argtypes = [wintypes.LPVOID, wintypes.LPCWSTR]
+
+        SetInformationJobObject = kernel32.SetInformationJobObject
+        SetInformationJobObject.restype = wintypes.BOOL
+        SetInformationJobObject.argtypes = [
+            wintypes.HANDLE, ctypes.c_int, wintypes.LPVOID, ctypes.c_uint32,
+        ]
+
+        # JobObjectExtendedLimitInformation = 9
+        handle = CreateJobObjectW(None, None)
+        if not handle:
+            return None
+
+        info = _JOBOBJECT_EXTENDED_LIMIT_INFORMATION()
+        info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+        ok = SetInformationJobObject(
+            handle, 9,
+            ctypes.byref(info), ctypes.sizeof(info),
+        )
+        if not ok:
+            kernel32.CloseHandle(handle)
+            return None
+        return int(handle)
+    except Exception:
+        return None
+
+
+def _assign_child_to_job(pid: int, job_handle: int) -> bool:
+    """Assign a running child PID to a Windows Job Object.
+
+    Opens the child with ``PROCESS_SET_QUOTA | PROCESS_TERMINATE`` (the
+    minimum access needed for ``AssignProcessToJobObject``), assigns it,
+    then closes the child handle.  Returns True on success.
+
+    On non-Windows or when ctypes is unavailable, returns False so callers
+    fall back to the psutil tree-kill path.
+
+    Note on the user's environment: when Hermes itself runs inside a Job
+    (the desktop launcher / Electron main process nests Hermes in a Job),
+    every child it spawns is *already* in that inherited Job, and Win32
+    refuses ``AssignProcessToJobObject`` with ``ERROR_ACCESS_DENIED``
+    (nested Jobs are not allowed without ``JOB_OBJECT_LIMIT_BREAKAWAY_OK``,
+    and even then only across the immediate boundary — not from outside).
+    In that case this returns False and the caller falls back to the
+    psutil tree-kill path, which is the fix that actually closes the
+    reported leak.
+    """
+    if not _WIN32_CTYPES_OK:
+        return False
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        PROCESS_SET_QUOTA = 0x0100
+        PROCESS_TERMINATE = 0x0001
+
+        OpenProcess = kernel32.OpenProcess
+        OpenProcess.restype = wintypes.HANDLE
+        OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+
+        AssignProcessToJobObject = kernel32.AssignProcessToJobObject
+        AssignProcessToJobObject.restype = wintypes.BOOL
+        AssignProcessToJobObject.argtypes = [wintypes.HANDLE, wintypes.HANDLE]
+
+        CloseHandle = kernel32.CloseHandle
+        CloseHandle.restype = wintypes.BOOL
+        CloseHandle.argtypes = [wintypes.HANDLE]
+
+        child_handle = OpenProcess(
+            PROCESS_SET_QUOTA | PROCESS_TERMINATE, False, int(pid),
+        )
+        if not child_handle:
+            return False
+        try:
+            ok = AssignProcessToJobObject(wintypes.HANDLE(job_handle), child_handle)
+            if not ok:
+                # ERROR_ACCESS_DENIED (5) is expected when the child is
+                # already in an inherited Job.  Surface the error in debug
+                # logs so we can tell apart "Job creation succeeded but
+                # assignment refused" from "Job creation itself failed".
+                import ctypes as _ct
+                err = _ct.get_last_error()
+                logger.debug(
+                    "AssignProcessToJobObject(%d) failed for MCP child PID %d: "
+                    "GetLastError=%d (5 = already in another Job, which is "
+                    "normal when Hermes itself runs under a Job; psutil "
+                    "tree-kill will be used)",
+                    job_handle, pid, err,
+                )
+                return False
+            return True
+        finally:
+            CloseHandle(child_handle)
+    except Exception:
+        return False
+
+
+def _close_job(job_handle: int) -> None:
+    """Close a Windows Job Object handle, atomically killing its tree.
+
+    With ``JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`` set, the kernel terminates
+    every process in the Job — including grandchildren that inherited the
+    Job at CreateProcess time — at the moment the last handle is closed.
+    This is race-free even if the direct wrapper has already exited: the
+    grandchildren still belong to the Job and die with it.
+    """
+    if not _WIN32_CTYPES_OK or not job_handle:
+        return
+    try:
+        import ctypes
+        from ctypes import wintypes
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.CloseHandle(wintypes.HANDLE(int(job_handle)))
+    except Exception:
+        pass
+
+
+def _kill_process_tree_psutil(pid: int) -> None:
+    """Terminate a process and every descendant, on any platform.
+
+    Uses ``psutil.Process.children(recursive=True)`` to enumerate the
+    descendant set via the OS process table (not the parent/child
+    relationship — grandchildren are still findable after the wrapper
+    exits and they get reparented to PID 0/system).  Sends SIGTERM first
+    and SIGKILL 250ms later for any survivors.
+
+    No-op on platforms where psutil is missing or the PID is gone.
+    """
+    try:
+        import psutil
+    except ImportError:
+        return
+    try:
+        proc = psutil.Process(int(pid))
+    except (psutil.NoSuchProcess, psutil.AccessDenied, ProcessLookupError, OSError):
+        return
+    # Collect descendants first; terminate() walks parent->child but
+    # grandchildren whose parent just exited become detached.  We want the
+    # full snapshot.
+    try:
+        descendants = proc.children(recursive=True)
+    except (psutil.NoSuchProcess, psutil.AccessDenied, ProcessLookupError, OSError):
+        descendants = []
+    # Include the root itself.
+    targets = [proc] + list(descendants)
+    # Graceful first.
+    for p in targets:
+        try:
+            p.terminate()
+        except (psutil.NoSuchProcess, psutil.AccessDenied, ProcessLookupError, OSError):
+            continue
+    # Brief grace, then escalate.  ``wait_procs`` blocks up to the timeout
+    # but returns earlier if all targets exit; on Windows it accepts
+    # ``timeout`` as a float seconds.  Older psutil requires the positional
+    # form — try the kwarg first and fall back.
+    try:
+        gone, alive = psutil.wait_procs(targets, timeout=0.25)
+    except TypeError:
+        # Older psutil: ``timeout`` is positional and required.
+        try:
+            gone, alive = psutil.wait_procs(targets, 0.25)
+        except Exception:
+            alive = targets
+    except Exception:
+        alive = targets
+    for p in alive:
+        try:
+            p.kill()
+        except (psutil.NoSuchProcess, psutil.AccessDenied, ProcessLookupError, OSError):
+            continue
+
+
+def _kill_process_tree(pid: int) -> None:
+    """Windows: atomically kill the process tree rooted at ``pid``.
+
+    Order of attempts (each falls through to the next on failure):
+      1. Close the tracked Job Object for this PID if one was assigned at
+         spawn — kernel kills the entire tree atomically.
+      2. psutil tree-kill — graceful SIGTERM then SIGKILL.
+      3. Direct os.kill(pid, sig) — only reaches the direct child.
+
+    No-op when ``pid`` is falsy.  Never raises.
+    """
+    if not pid:
+        return
+    with _lock:
+        job = _stdio_jobs.pop(pid, None)
+    if job:
+        _close_job(job)
+        # The Job Object close is synchronous on Windows, but give the
+        # kernel a tick to deliver the termination so subsequent PID
+        # existence probes report gone.
+        time.sleep(0.05)
+        return
+    if sys.platform == "win32":
+        # Defense-in-depth: even if we never created a Job (e.g. spawn ran
+        # before this code shipped, or ctypes failed), still try to reap
+        # the tree.  This is what fixes the user-reported leak.
+        _kill_process_tree_psutil(pid)
+        return
+    # POSIX: nothing to do here; _send_signal/killpg already handled it.
+    try:
+        import signal as _signal
+        os.kill(pid, _signal.SIGTERM)
+    except (ProcessLookupError, PermissionError, OSError):
+        pass
 
 
 def _snapshot_child_pids() -> set:
@@ -4906,7 +5261,19 @@ def _kill_orphaned_mcp_children(include_active: bool = False) -> None:
         _my_pgid = None  # Windows or restricted environment
 
     def _send_signal(pid: int, sig: int, server_name: str) -> None:
-        """SIGTERM/SIGKILL via pgroup on POSIX, fall back to pid signal."""
+        """SIGTERM/SIGKILL via pgroup on POSIX, fall back to pid signal.
+
+        Windows: ``killpg`` is unavailable and ``os.kill(pid, sig)`` only
+        reaches the direct wrapper — the MCP server grandchild (the real
+        process holding the stdio pipes) survives.  So on Windows we
+        route through ``_kill_process_tree`` which closes the per-server
+        Job Object if one was attached at spawn (atomic tree-kill) and
+        otherwise falls back to a psutil tree-kill.  POSIX keeps the
+        existing ``killpg``/``kill`` path verbatim.
+        """
+        if sys.platform == "win32":
+            _kill_process_tree(pid)
+            return
         pgid = pgids.get(pid)
         killpg = getattr(os, "killpg", None)
         if pgid is not None and killpg is not None:
@@ -4945,8 +5312,14 @@ def _kill_orphaned_mcp_children(include_active: bool = False) -> None:
         _send_signal(pid, _signal.SIGTERM, server_name)
         logger.debug("Sent SIGTERM to orphaned MCP process %d (%s)", pid, server_name)
 
-    # Phase 2: Wait for graceful exit
-    time.sleep(2)
+    # Phase 2: Wait for graceful exit.  On Windows, ``_send_signal`` routed
+    # through ``_kill_process_tree`` which closes the Job Object atomically
+    # (or psutil tree-kills synchronously) — by the time we get here the
+    # whole tree is already gone, so the 2s wait would be wasted.  POSIX
+    # keeps the original graceful-then-force-kill cadence so the wrapper
+    # and its grandchild get a chance to flush.
+    if sys.platform != "win32":
+        time.sleep(2)
 
     # Phase 3: SIGKILL any survivors
     _sigkill = getattr(_signal, "SIGKILL", _signal.SIGTERM)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1883,12 +1883,46 @@ class MCPServerTask:
                     # (e.g. ``claude mcp serve`` spawned by a stdio wrapper).
                     new_pgids: Dict[int, int] = {}
                     new_jobs: Dict[int, int] = {}
+                    new_signatures: Dict[int, List[str]] = {}
                     for _pid in new_pids:
                         try:
                             new_pgids[_pid] = os.getpgid(_pid)
                         except (AttributeError, ProcessLookupError, OSError):
                             # AttributeError: Windows (os.getpgid is POSIX-only)
                             # ProcessLookupError: child raced and already exited
+                            pass
+                        # Snapshot the grandchild tree's cmdline markers while
+                        # the wrapper is still alive.  We capture identity
+                        # NOW so that, even if the wrapper exits before we
+                        # reap, the descendants can still be found by a
+                        # global process scan (not by ``parent.children()``
+                        # which fails once the wrapper is gone).  See the
+                        # ``_kill_process_tree`` reap-by-identity step.
+                        try:
+                            import psutil as _ps
+                            _wp = _ps.Process(_pid)
+                            _desc = _wp.children(recursive=True)
+                            sigs = []
+                            for d in _desc:
+                                try:
+                                    cl = d.cmdline()
+                                except (
+                                    _ps.NoSuchProcess, _ps.AccessDenied,
+                                    ProcessLookupError, OSError,
+                                ):
+                                    continue
+                                sigs.append(" ".join(cl))
+                            if sigs:
+                                new_signatures[_pid] = sigs
+                        except ImportError:
+                            pass
+                        except (
+                            _ps.NoSuchProcess, _ps.AccessDenied,
+                            ProcessLookupError, OSError,
+                        ):
+                            # Wrapper raced to exit between PID capture and
+                            # this snapshot — no signature available, psutil
+                            # fallback at teardown will be a best-effort.
                             pass
                         # Windows: assign the direct child to a per-server
                         # Job Object so closing the handle atomically kills the
@@ -1915,6 +1949,8 @@ class MCPServerTask:
                         _stdio_pgids.update(new_pgids)
                         if new_jobs:
                             _stdio_jobs.update(new_jobs)
+                        if new_signatures:
+                            _stdio_descendant_sigs.update(new_signatures)
                 async with ClientSession(
                     read_stream, write_stream, **sampling_kwargs
                 ) as session:
@@ -3062,6 +3098,16 @@ _stdio_pgids: Dict[int, int] = {}  # pid -> pgid
 # created with ``JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE``.  Empty on non-Windows.
 _stdio_jobs: Dict[int, int] = {}
 
+# Cmdline signatures of stdio MCP descendant processes, snapshotted at
+# spawn time while the wrapper is still alive.  Used by
+# ``_kill_process_tree`` to reap descendants by IDENTITY (cmdline match)
+# when the wrapper has already exited and ``parent.children(recursive=
+# True)`` can no longer reach them.  The maintainer's review (PR #61722)
+# flagged this exact lifecycle as the gap in the original fix.
+# Keyed by the direct child PID we spawned; value is a list of full
+# cmdline strings (one per descendant seen at snapshot time).
+_stdio_descendant_sigs: Dict[int, List[str]] = {}
+
 # Whether ctypes/wintypes is available in this interpreter.  Cached at
 # module import so we don't pay the import cost on every reconnect.
 try:
@@ -3312,8 +3358,17 @@ def _kill_process_tree(pid: int) -> None:
     Order of attempts (each falls through to the next on failure):
       1. Close the tracked Job Object for this PID if one was assigned at
          spawn — kernel kills the entire tree atomically.
-      2. psutil tree-kill — graceful SIGTERM then SIGKILL.
-      3. Direct os.kill(pid, sig) — only reaches the direct child.
+      2. psutil tree-kill — graceful SIGTERM then SIGKILL.  This handles
+         the live-wrapper case (``proc.children(recursive=True)`` can
+         reach descendants while the wrapper is alive).
+      3. Reap by identity — global scan for any process whose cmdline
+         matches a signature we snapshotted at spawn.  This handles the
+         case the maintainer's review (PR #61722) flagged: the wrapper
+         exited before the teardown sweep ran, the descendants were
+         reparented to PID 0/system, and ``proc.children()`` can no
+         longer reach them.  Without this step, those survivors would
+         leak until Hermes itself exits.
+      4. Direct os.kill(pid, sig) — only reaches the direct child.
 
     No-op when ``pid`` is falsy.  Never raises.
     """
@@ -3321,6 +3376,7 @@ def _kill_process_tree(pid: int) -> None:
         return
     with _lock:
         job = _stdio_jobs.pop(pid, None)
+        sigs = _stdio_descendant_sigs.pop(pid, None)
     if job:
         _close_job(job)
         # The Job Object close is synchronous on Windows, but give the
@@ -3333,6 +3389,12 @@ def _kill_process_tree(pid: int) -> None:
         # before this code shipped, or ctypes failed), still try to reap
         # the tree.  This is what fixes the user-reported leak.
         _kill_process_tree_psutil(pid)
+        # Reap-by-identity pass for the reparented-orphan case.  Runs
+        # even when the psutil step succeeded — survivors here are
+        # precisely the reparented orphans psutil could not reach
+        # because the wrapper already exited.
+        if sigs:
+            _kill_process_tree_by_identity(sigs)
         return
     # POSIX: nothing to do here; _send_signal/killpg already handled it.
     try:
@@ -3340,6 +3402,71 @@ def _kill_process_tree(pid: int) -> None:
         os.kill(pid, _signal.SIGTERM)
     except (ProcessLookupError, PermissionError, OSError):
         pass
+
+
+def _kill_process_tree_by_identity(signatures: List[str]) -> None:
+    """Kill any process whose cmdline matches one of ``signatures``.
+
+    Used to clean up reparented orphans after the wrapper has exited.
+    Walks the global process table (independent of any parent/child
+    relationship) and terminates every match.  This is the only way to
+    reach grandchildren whose wrapper is gone — ``psutil.Process(pid).
+    children(recursive=True)`` raises ``NoSuchProcess`` once the
+    wrapper exits, even though the grandchildren are still alive and
+    reparented to system/PID 0.
+
+    Args:
+        signatures: full-cmdline strings snapshotted at spawn.  Matched
+            as exact, case-sensitive substrings of the candidate
+            process's cmdline.  We use substring (not equality) because
+            cmdlines differ across platforms (Windows quoting, argv[0]
+            resolution).  False-positive risk is bounded by the fact
+            that signatures were captured from a process we ourselves
+            spawned, not from arbitrary user input.
+    """
+    if not signatures:
+        return
+    try:
+        import psutil
+    except ImportError:
+        return
+    sig_set = set(signatures)
+    matches: List[psutil.Process] = []
+    try:
+        for proc in psutil.process_iter(["pid", "cmdline"]):
+            try:
+                cl = proc.info.get("cmdline") or []
+                joined = " ".join(cl)
+            except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):
+                continue
+            if not joined:
+                continue
+            for sig in sig_set:
+                if sig and sig in joined:
+                    matches.append(proc)
+                    break
+    except Exception:
+        return
+    for proc in matches:
+        try:
+            proc.terminate()
+        except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):
+            continue
+    # Brief grace, then escalate.
+    try:
+        gone, alive = psutil.wait_procs(matches, timeout=0.25)
+    except TypeError:
+        try:
+            gone, alive = psutil.wait_procs(matches, 0.25)
+        except Exception:
+            alive = matches
+    except Exception:
+        alive = matches
+    for proc in alive:
+        try:
+            proc.kill()
+        except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):
+            continue
 
 
 def _snapshot_child_pids() -> set:


### PR DESCRIPTION
## Summary

On Windows, stdio MCP servers launched via wrapper commands (`uvx elevenlabs-mcp`, `cmd /c npx @supabase/...`) spawn a wrapper PID that immediately re-execs the real server as a grandchild. The MCP SDK only tracks the direct child, so `os.kill(pid, sig)` on teardown kills only the wrapper — the grandchild `node.exe` / `python.exe` survives, leaks across reconnects, and accumulates across a single Hermes run.

This PR fixes the leak by walking the process tree at teardown.

## Root cause

- `_run_stdio` captures only the direct child PID. `os.getpgid` is POSIX-only, so `_stdio_pgids` is empty on Windows.
- `_kill_orphaned_mcp_children._send_signal` falls back to `os.kill(pid, sig)` on Windows, which only reaches the direct wrapper. Grandchildren survive.
- Every reconnect (keepalive failure, OAuth recovery, manual refresh) leaks one grandchild. Direct-command servers (e.g. freshbooks `node`, drive/analytics/ads `python`) do not leak because there is no wrapper layer.
- A full Hermes restart clears the leak (parent Python's Job Object closes), but the leak burns RAM, file descriptors, and `npx`/`uvx` caches in the meantime.

## Fix

Three mechanisms in priority order on Windows (POSIX unchanged, `killpg` still canonical):

1. **Windows Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`** at spawn time. `CreateJobObjectW` + `AssignProcessToJobObject`. Closing the handle atomically kills the entire tree, including grandchildren that inherit the Job via `bInheritHandles=True`.
2. **psutil tree-kill fallback** (`psutil.Process(pid).children(recursive=True)` + `terminate()`/`kill()`) when the child is already in an inherited Job — Win32 refuses nested Jobs with `ERROR_ACCESS_DENIED`. The psutil path queries the OS process table directly, so it works even after the wrapper exits and the grandchild is reparented.
3. **Eager reap on reconnect** in the `_run_stdio` finally block, not only at shutdown. The bug fires on every reconnect, so the fix must run there.

The 2s `SIGTERM`/`SIGKILL` sleep in `_kill_orphaned_mcp_children` is skipped on Windows because the Job close is atomic.

## Tests

`tests/tools/test_mcp_tool.py::TestWindowsProcessTreeKill` — 5 new regression tests:

- `test_psutil_tree_kill_terminates_root_and_all_descendants` — the core leak fix: root + every descendant terminated
- `test_psutil_tree_kill_handles_no_descendants` — direct-command case (no grandchildren)
- `test_psutil_tree_kill_noop_when_pid_already_gone` — `NoSuchProcess` no-op
- `test_posix_path_skips_tree_kill` — POSIX keeps canonical `killpg`/`kill` path
- `test_job_close_takes_precedence_over_psutil` — when Job is attached, close it instead of running psutil

Full suite: 207 passed, 1 pre-existing failure unrelated (`test_windows_location_vars_passed_without_secrets` — depends on `ProgramFiles` env var).

## Verification

Live process table at bug report: 2 `elevenlabs-mcp` + 24 `node` + 25 `python` + 19 `cmd`. After Hermes restart with this patch loaded, only 1 of each wrapper-launched server should be alive at any time.

End-to-end repro with a Python wrapper spawning a grandchild (`uvx elevenlabs-mcp` shape): psutil tree-kill reaps both PIDs.

## Notes

- Restart required to load the patched `tools/mcp_tool.py` (not `/reset`).
- POSIX is fully unchanged; the existing `killpg`/`kill` path is preserved verbatim.
- Existing helpers (`_snapshot_child_pids`, `_filter_mcp_children`, `_send_signal`) retain their original signatures and behavior on POSIX.

