### PR TITLE
fix(cron): malformed job records no longer freeze the scheduler (class fix)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1772,201 +1772,214 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
     _run_claim_ttl = _oneshot_run_claim_ttl_seconds()
 
     for job in jobs:
-        if not job.get("enabled", True):
-            continue
-
-        # Cross-process running-claim guard (#59229): if another scheduler
-        # process already claimed this one-shot and its run is still in flight
-        # (claim younger than the TTL), skip it — do NOT re-dispatch. The
-        # claim is stamped just before we return the job as due (below) and
-        # cleared by mark_job_run() on completion. A claim older than the TTL
-        # is treated as stale (the claiming tick died mid-run) and allowed
-        # through so the job is recovered rather than wedged forever.
-        existing_claim = job.get("run_claim")
-        if existing_claim and job.get("schedule", {}).get("kind") == "once":
-            try:
-                claimed_at = _ensure_aware(
-                    datetime.fromisoformat(existing_claim["at"])
-                )
-                # 0 <= age: a future-dated claim (clock/TZ skew across a
-                # restart) must be treated as stale, not eternally fresh,
-                # or the one-shot is skipped forever (#60703).
-                _age = (now - claimed_at).total_seconds()
-                if 0 <= _age < _run_claim_ttl:
-                    continue  # a fresh claim is held by an in-flight run
-            except (KeyError, ValueError, TypeError):
-                pass  # malformed claim → fall through and (re)claim
-
-        next_run = job.get("next_run_at")
-        if not next_run:
-            schedule = job.get("schedule", {})
-            kind = schedule.get("kind")
-
-            # One-shot jobs use a small grace window via the dedicated helper.
-            recovered_next = _recoverable_oneshot_run_at(
-                schedule,
-                now,
-                last_run_at=job.get("last_run_at"),
-            )
-            recovery_kind = "one-shot" if recovered_next else None
-
-            # Recurring jobs reach here only when something — typically a
-            # direct jobs.json edit that bypassed add_job() — left
-            # next_run_at unset.  Without this branch, such jobs are
-            # silently skipped forever; recompute next_run_at from the
-            # schedule so they pick up at their next scheduled tick.
-            if not recovered_next and kind in {"cron", "interval"}:
-                recovered_next = compute_next_run(schedule, now.isoformat())
-                if recovered_next:
-                    recovery_kind = kind
-
-            if not recovered_next:
+        # Per-job containment (structural guard): one malformed or
+        # unexpected job record must never abort the whole scan. The id /
+        # schedule / timestamp normalizations above repair the known shapes;
+        # this guard catches every FUTURE variant, degrading to "skip this
+        # job this tick" so healthy siblings still run and their recovered
+        # state still reaches save_jobs() below.
+        try:
+            if not job.get("enabled", True):
                 continue
 
-            job["next_run_at"] = recovered_next
-            next_run = recovered_next
-            logger.info(
-                "Job '%s' had no next_run_at; recovering %s run at %s",
-                job.get("name", job.get("id", "?")),
-                recovery_kind,
-                recovered_next,
-            )
-            for rj in raw_jobs:
-                if rj["id"] == job["id"]:
-                    rj["next_run_at"] = recovered_next
-                    needs_save = True
-                    break
+            # Cross-process running-claim guard (#59229): if another scheduler
+            # process already claimed this one-shot and its run is still in flight
+            # (claim younger than the TTL), skip it — do NOT re-dispatch. The
+            # claim is stamped just before we return the job as due (below) and
+            # cleared by mark_job_run() on completion. A claim older than the TTL
+            # is treated as stale (the claiming tick died mid-run) and allowed
+            # through so the job is recovered rather than wedged forever.
+            existing_claim = job.get("run_claim")
+            if existing_claim and job.get("schedule", {}).get("kind") == "once":
+                try:
+                    claimed_at = _ensure_aware(
+                        datetime.fromisoformat(existing_claim["at"])
+                    )
+                    # 0 <= age: a future-dated claim (clock/TZ skew across a
+                    # restart) must be treated as stale, not eternally fresh,
+                    # or the one-shot is skipped forever (#60703).
+                    _age = (now - claimed_at).total_seconds()
+                    if 0 <= _age < _run_claim_ttl:
+                        continue  # a fresh claim is held by an in-flight run
+                except (KeyError, ValueError, TypeError):
+                    pass  # malformed claim → fall through and (re)claim
 
-        raw_next_run_dt = datetime.fromisoformat(next_run)
-        schedule = job.get("schedule", {})
-        kind = schedule.get("kind")
+            next_run = job.get("next_run_at")
+            if not next_run:
+                schedule = job.get("schedule", {})
+                kind = schedule.get("kind")
 
-        next_run_dt = _ensure_aware(raw_next_run_dt)
-        # Migration repair: a cron job persists next_run_at as an absolute
-        # instant, but the cron expr describes local wall-clock intent. If the
-        # configured/system timezone changed after persistence, the stored
-        # instant's offset no longer matches now's, and its converted time can
-        # look due hours early (21:00+10 -> 13:00+02). When the stored *wall
-        # clock* is still in the future, recompute from the schedule so we fire
-        # at the intended local time instead of early-then-again.
-        #
-        # TRADE-OFF: this cannot distinguish a config/host TZ migration from a
-        # legitimate DST offset change. A DST boundary that satisfies all four
-        # conditions will recompute (and thus SKIP the pending occurrence, no
-        # catch-up) rather than fire it. Accepted: in the pure-migration case
-        # the recompute lands on the same wall-clock time later the same period,
-        # and DST-boundary collisions with a still-future stored wall clock are
-        # rare relative to the double-fire bug this prevents (#28934).
-        if (
-            kind == "cron"
-            and next_run_dt <= now
-            and _timezone_offset_mismatch(raw_next_run_dt, now)
-            and _stored_wall_clock_is_future(raw_next_run_dt, now)
-        ):
-            new_next = compute_next_run(schedule, now.isoformat())
-            if new_next:
+                # One-shot jobs use a small grace window via the dedicated helper.
+                recovered_next = _recoverable_oneshot_run_at(
+                    schedule,
+                    now,
+                    last_run_at=job.get("last_run_at"),
+                )
+                recovery_kind = "one-shot" if recovered_next else None
+
+                # Recurring jobs reach here only when something — typically a
+                # direct jobs.json edit that bypassed add_job() — left
+                # next_run_at unset.  Without this branch, such jobs are
+                # silently skipped forever; recompute next_run_at from the
+                # schedule so they pick up at their next scheduled tick.
+                if not recovered_next and kind in {"cron", "interval"}:
+                    recovered_next = compute_next_run(schedule, now.isoformat())
+                    if recovered_next:
+                        recovery_kind = kind
+
+                if not recovered_next:
+                    continue
+
+                job["next_run_at"] = recovered_next
+                next_run = recovered_next
                 logger.info(
-                    "Job '%s' next_run_at offset changed (%s -> %s). "
-                    "Recomputing cron run to preserve local wall-clock intent: %s",
+                    "Job '%s' had no next_run_at; recovering %s run at %s",
                     job.get("name", job.get("id", "?")),
-                    raw_next_run_dt.utcoffset(),
-                    now.utcoffset(),
-                    new_next,
+                    recovery_kind,
+                    recovered_next,
                 )
                 for rj in raw_jobs:
                     if rj["id"] == job["id"]:
-                        rj["next_run_at"] = new_next
+                        rj["next_run_at"] = recovered_next
                         needs_save = True
                         break
-                continue
 
-        if next_run_dt <= now:
+            raw_next_run_dt = datetime.fromisoformat(next_run)
+            schedule = job.get("schedule", {})
+            kind = schedule.get("kind")
 
-            # For recurring jobs, check if the scheduled time is stale
-            # (gateway was down and missed the window). Fast-forward to
-            # the next future occurrence instead of firing a stale run.
-            grace = _compute_grace_seconds(schedule)
-            if kind in {"cron", "interval"} and (now - next_run_dt).total_seconds() > grace:
-                # Job is past its catch-up grace window — skip accumulated
-                # missed runs but still execute once now to avoid deferring
-                # indefinitely (e.g. a long-running job just finished).
+            next_run_dt = _ensure_aware(raw_next_run_dt)
+            # Migration repair: a cron job persists next_run_at as an absolute
+            # instant, but the cron expr describes local wall-clock intent. If the
+            # configured/system timezone changed after persistence, the stored
+            # instant's offset no longer matches now's, and its converted time can
+            # look due hours early (21:00+10 -> 13:00+02). When the stored *wall
+            # clock* is still in the future, recompute from the schedule so we fire
+            # at the intended local time instead of early-then-again.
+            #
+            # TRADE-OFF: this cannot distinguish a config/host TZ migration from a
+            # legitimate DST offset change. A DST boundary that satisfies all four
+            # conditions will recompute (and thus SKIP the pending occurrence, no
+            # catch-up) rather than fire it. Accepted: in the pure-migration case
+            # the recompute lands on the same wall-clock time later the same period,
+            # and DST-boundary collisions with a still-future stored wall clock are
+            # rare relative to the double-fire bug this prevents (#28934).
+            if (
+                kind == "cron"
+                and next_run_dt <= now
+                and _timezone_offset_mismatch(raw_next_run_dt, now)
+                and _stored_wall_clock_is_future(raw_next_run_dt, now)
+            ):
                 new_next = compute_next_run(schedule, now.isoformat())
                 if new_next:
                     logger.info(
-                        "Job '%s' missed its scheduled time (%s, grace=%ds). "
-                        "Running now; next run provisionally set to: %s "
-                        "(re-anchored on completion)",
+                        "Job '%s' next_run_at offset changed (%s -> %s). "
+                        "Recomputing cron run to preserve local wall-clock intent: %s",
                         job.get("name", job.get("id", "?")),
-                        next_run,
-                        grace,
+                        raw_next_run_dt.utcoffset(),
+                        now.utcoffset(),
                         new_next,
                     )
-                    # Persist the fast-forward to storage now (skip accumulated
-                    # slots). In the built-in ticker path this is shortly
-                    # overwritten by advance_next_run + mark_job_run, but it is
-                    # NOT redundant: it (a) protects the crash window between
-                    # here and mark_job_run, and (b) covers the external
-                    # fire_due provider path, which does not call
-                    # advance_next_run. mark_job_run re-anchors next_run_at off
-                    # the actual completion time, so this value is provisional.
                     for rj in raw_jobs:
                         if rj["id"] == job["id"]:
                             rj["next_run_at"] = new_next
                             needs_save = True
                             break
-                    # Fall through to due.append(job) — execute once now
+                    continue
 
-            # One-shot dispatch-limit guard (issue #38758): a finite one-shot
-            # claimed via claim_dispatch() but whose tick died before
-            # mark_job_run could remove it will have completed >= times while
-            # still looking due (last_run_at was never written, so the
-            # recovery helper re-armed it). Remove it instead of re-firing.
-            if kind == "once":
-                repeat = job.get("repeat")
-                if repeat:
-                    times = repeat.get("times")
-                    completed = repeat.get("completed", 0)
-                    if times is not None and times > 0 and completed >= times:
+            if next_run_dt <= now:
+
+                # For recurring jobs, check if the scheduled time is stale
+                # (gateway was down and missed the window). Fast-forward to
+                # the next future occurrence instead of firing a stale run.
+                grace = _compute_grace_seconds(schedule)
+                if kind in {"cron", "interval"} and (now - next_run_dt).total_seconds() > grace:
+                    # Job is past its catch-up grace window — skip accumulated
+                    # missed runs but still execute once now to avoid deferring
+                    # indefinitely (e.g. a long-running job just finished).
+                    new_next = compute_next_run(schedule, now.isoformat())
+                    if new_next:
                         logger.info(
-                            "Job '%s': one-shot dispatch limit reached (%d/%d) "
-                            "— removing stale due entry",
+                            "Job '%s' missed its scheduled time (%s, grace=%ds). "
+                            "Running now; next run provisionally set to: %s "
+                            "(re-anchored on completion)",
                             job.get("name", job.get("id", "?")),
-                            completed,
-                            times,
+                            next_run,
+                            grace,
+                            new_next,
                         )
+                        # Persist the fast-forward to storage now (skip accumulated
+                        # slots). In the built-in ticker path this is shortly
+                        # overwritten by advance_next_run + mark_job_run, but it is
+                        # NOT redundant: it (a) protects the crash window between
+                        # here and mark_job_run, and (b) covers the external
+                        # fire_due provider path, which does not call
+                        # advance_next_run. mark_job_run re-anchors next_run_at off
+                        # the actual completion time, so this value is provisional.
                         for rj in raw_jobs:
                             if rj["id"] == job["id"]:
-                                raw_jobs.remove(rj)
+                                rj["next_run_at"] = new_next
                                 needs_save = True
                                 break
-                        continue
+                        # Fall through to due.append(job) — execute once now
 
-            # Durably claim a one-shot for the DURATION of its run before
-            # returning it as due, so a second scheduler process (gateway +
-            # desktop both run in-process 60s tickers on one HERMES_HOME)
-            # cannot re-dispatch it while the first run is still in flight
-            # (#59229). A plain one-shot's due-state is not resolved until
-            # mark_job_run() completes it minutes later, so advancing
-            # next_run_at by a fixed window is not enough — a job that outlives
-            # one tick (e.g. a 2.5-min research prompt) would simply re-fire on
-            # the next tick after the window. Instead we stamp a run_claim under
-            # the same lock get_due_jobs already holds; the other process reads
-            # a fresh claim on its next tick and skips (handled at the top of
-            # this loop). mark_job_run() clears the claim on completion. The TTL
-            # is only a safety valve: a claiming tick that DIES mid-run leaves a
-            # stale claim that expires after the resolved run-claim TTL
-            # (_oneshot_run_claim_ttl_seconds, derived from HERMES_CRON_TIMEOUT),
-            # so the job is re-dispatched rather than wedged forever.
-            if kind == "once":
-                claim = {"at": now.isoformat(), "by": _machine_id()}
-                job["run_claim"] = claim
-                for rj in raw_jobs:
-                    if rj["id"] == job["id"]:
-                        rj["run_claim"] = claim
-                        needs_save = True
-                        break
+                # One-shot dispatch-limit guard (issue #38758): a finite one-shot
+                # claimed via claim_dispatch() but whose tick died before
+                # mark_job_run could remove it will have completed >= times while
+                # still looking due (last_run_at was never written, so the
+                # recovery helper re-armed it). Remove it instead of re-firing.
+                if kind == "once":
+                    repeat = job.get("repeat")
+                    if repeat:
+                        times = repeat.get("times")
+                        completed = repeat.get("completed", 0)
+                        if times is not None and times > 0 and completed >= times:
+                            logger.info(
+                                "Job '%s': one-shot dispatch limit reached (%d/%d) "
+                                "— removing stale due entry",
+                                job.get("name", job.get("id", "?")),
+                                completed,
+                                times,
+                            )
+                            for rj in raw_jobs:
+                                if rj["id"] == job["id"]:
+                                    raw_jobs.remove(rj)
+                                    needs_save = True
+                                    break
+                            continue
 
-            due.append(job)
+                # Durably claim a one-shot for the DURATION of its run before
+                # returning it as due, so a second scheduler process (gateway +
+                # desktop both run in-process 60s tickers on one HERMES_HOME)
+                # cannot re-dispatch it while the first run is still in flight
+                # (#59229). A plain one-shot's due-state is not resolved until
+                # mark_job_run() completes it minutes later, so advancing
+                # next_run_at by a fixed window is not enough — a job that outlives
+                # one tick (e.g. a 2.5-min research prompt) would simply re-fire on
+                # the next tick after the window. Instead we stamp a run_claim under
+                # the same lock get_due_jobs already holds; the other process reads
+                # a fresh claim on its next tick and skips (handled at the top of
+                # this loop). mark_job_run() clears the claim on completion. The TTL
+                # is only a safety valve: a claiming tick that DIES mid-run leaves a
+                # stale claim that expires after the resolved run-claim TTL
+                # (_oneshot_run_claim_ttl_seconds, derived from HERMES_CRON_TIMEOUT),
+                # so the job is re-dispatched rather than wedged forever.
+                if kind == "once":
+                    claim = {"at": now.isoformat(), "by": _machine_id()}
+                    job["run_claim"] = claim
+                    for rj in raw_jobs:
+                        if rj["id"] == job["id"]:
+                            rj["run_claim"] = claim
+                            needs_save = True
+                            break
+
+                due.append(job)
+        except Exception:
+            logger.exception(
+                "Skipping malformed cron job %r during due scan",
+                job.get("name") or job.get("id") or "?",
+            )
+            continue
 
     if needs_save:
         save_jobs(raw_jobs)

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -568,7 +568,10 @@ def _recoverable_oneshot_run_at(
     if not run_at:
         return None
 
-    run_at_dt = _ensure_aware(datetime.fromisoformat(run_at))
+    try:
+        run_at_dt = _ensure_aware(datetime.fromisoformat(run_at))
+    except Exception:
+        return None
     if run_at_dt >= now - timedelta(seconds=ONESHOT_GRACE_SECONDS):
         return run_at
     return None
@@ -630,9 +633,11 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
         if minutes is None:
             return None
         if last_run_at:
-            # Next run is last_run + interval
-            last = _ensure_aware(datetime.fromisoformat(last_run_at))
-            next_run = last + timedelta(minutes=minutes)
+            try:
+                last = _ensure_aware(datetime.fromisoformat(last_run_at))
+                next_run = last + timedelta(minutes=minutes)
+            except Exception:
+                next_run = now + timedelta(minutes=minutes)
         else:
             # First run is now + interval
             next_run = now + timedelta(minutes=minutes)
@@ -657,7 +662,10 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
         # rather than to an arbitrary restart time.
         base_time = now
         if last_run_at:
-            base_time = _ensure_aware(datetime.fromisoformat(last_run_at))
+            try:
+                base_time = _ensure_aware(datetime.fromisoformat(last_run_at))
+            except Exception:
+                base_time = now
         cron = croniter(expr, base_time)
         next_run = cron.get_next(datetime)
         return next_run.isoformat()
@@ -1702,6 +1710,63 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
         if not isinstance(rj.get("schedule"), dict):
             rj["schedule"] = {}
             needs_save = True
+
+    # Normalize malformed "next_run_at" records (direct jobs.json edit,
+    # corruption, migration, or buggy writer). If present but not a valid
+    # ISO string, datetime.fromisoformat(next_run) later raises and aborts
+    # the entire scan *before* save_jobs(). Healthy siblings then lose any
+    # fast-forwarded next_run_at (same class of bug as bad "id" or "schedule").
+    # Strip the bad value so the existing "no next_run_at" recovery path
+    # recomputes a sane value and persists it for this job.
+    for j in jobs:
+        nr = j.get("next_run_at")
+        if nr is not None:
+            if not isinstance(nr, str):
+                j.pop("next_run_at", None)
+                needs_save = True
+            else:
+                try:
+                    datetime.fromisoformat(nr)
+                except Exception:
+                    j.pop("next_run_at", None)
+                    needs_save = True
+    for rj in raw_jobs:
+        nr = rj.get("next_run_at")
+        if nr is not None:
+            if not isinstance(nr, str):
+                rj.pop("next_run_at", None)
+                needs_save = True
+            else:
+                try:
+                    datetime.fromisoformat(nr)
+                except Exception:
+                    rj.pop("next_run_at", None)
+                    needs_save = True
+
+    # Same treatment for last_run_at (used as base in recovery / compute_next_run).
+    for j in jobs:
+        lr = j.get("last_run_at")
+        if lr is not None and not isinstance(lr, str):
+            j.pop("last_run_at", None)
+            needs_save = True
+        elif isinstance(lr, str):
+            try:
+                datetime.fromisoformat(lr)
+            except Exception:
+                j.pop("last_run_at", None)
+                needs_save = True
+    for rj in raw_jobs:
+        lr = rj.get("last_run_at")
+        if lr is not None and not isinstance(lr, str):
+            rj.pop("last_run_at", None)
+            needs_save = True
+        elif isinstance(lr, str):
+            try:
+                datetime.fromisoformat(lr)
+            except Exception:
+                rj.pop("last_run_at", None)
+                needs_save = True
+
     # Resolve the one-shot running-claim stale-recovery TTL once per scan
     # (derived from HERMES_CRON_TIMEOUT). See _oneshot_run_claim_ttl_seconds.
     _run_claim_ttl = _oneshot_run_claim_ttl_seconds()

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -559,7 +559,7 @@ def _recoverable_oneshot_run_at(
     their requested minute still run on the next tick. Once a one-shot has
     already run, it is never eligible again.
     """
-    if schedule.get("kind") != "once":
+    if not isinstance(schedule, dict) or schedule.get("kind") != "once":
         return None
     if last_run_at:
         return None
@@ -592,16 +592,18 @@ def _compute_grace_seconds(schedule: dict) -> int:
         return max(MIN_GRACE, min(grace, MAX_GRACE))
 
     if kind == "cron" and HAS_CRONITER:
-        try:
-            now = _hermes_now()
-            cron = croniter(schedule["expr"], now)
-            first = cron.get_next(datetime)
-            second = cron.get_next(datetime)
-            period_seconds = int((second - first).total_seconds())
-            grace = period_seconds // 2
-            return max(MIN_GRACE, min(grace, MAX_GRACE))
-        except Exception:
-            pass
+        expr = schedule.get("expr")
+        if expr:
+            try:
+                now = _hermes_now()
+                cron = croniter(expr, now)
+                first = cron.get_next(datetime)
+                second = cron.get_next(datetime)
+                period_seconds = int((second - first).total_seconds())
+                grace = period_seconds // 2
+                return max(MIN_GRACE, min(grace, MAX_GRACE))
+            except Exception:
+                pass
 
     return MIN_GRACE
 
@@ -614,11 +616,19 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
     """
     now = _hermes_now()
 
-    if schedule["kind"] == "once":
+    if not isinstance(schedule, dict):
+        return None
+    kind = schedule.get("kind")
+    if kind is None:
+        return None
+
+    if kind == "once":
         return _recoverable_oneshot_run_at(schedule, now, last_run_at=last_run_at)
 
-    elif schedule["kind"] == "interval":
-        minutes = schedule["minutes"]
+    elif kind == "interval":
+        minutes = schedule.get("minutes")
+        if minutes is None:
+            return None
         if last_run_at:
             # Next run is last_run + interval
             last = _ensure_aware(datetime.fromisoformat(last_run_at))
@@ -628,14 +638,17 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
             next_run = now + timedelta(minutes=minutes)
         return next_run.isoformat()
 
-    elif schedule["kind"] == "cron":
+    elif kind == "cron":
+        expr = schedule.get("expr")
+        if not expr:
+            return None
         if not HAS_CRONITER:
             logger.warning(
                 "Cannot compute next run for cron schedule %r: 'croniter' is "
                 "not installed. croniter is a core dependency as of v0.9.x; "
                 "reinstall hermes-agent or run 'pip install croniter' in your "
                 "runtime env.",
-                schedule.get("expr"),
+                expr,
             )
             return None
         # Use last_run_at as the croniter base when available, consistent
@@ -645,7 +658,7 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
         base_time = now
         if last_run_at:
             base_time = _ensure_aware(datetime.fromisoformat(last_run_at))
-        cron = croniter(schedule["expr"], base_time)
+        cron = croniter(expr, base_time)
         next_run = cron.get_next(datetime)
         return next_run.isoformat()
 
@@ -1672,6 +1685,23 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
 
     jobs = [_apply_skill_fields(j) for j in copy.deepcopy(raw_jobs)]
     due = []
+
+    # Normalize malformed "schedule" records (direct jobs.json edit, old writers,
+    # corruption, etc.). "schedule" must be a dict; a null/string/etc. value
+    # makes `schedule.get("kind")` or direct `schedule["kind"]` / ["expr"] /
+    # ["minutes"] later raise and abort the entire scan *before* save_jobs().
+    # Healthy jobs then lose their fast-forwarded next_run_at (exactly the
+    # failure mode of the id-less job bug fixed above). Repair early at the
+    # source so the rest of the tick can proceed and persist progress for
+    # siblings.
+    for j in jobs:
+        if not isinstance(j.get("schedule"), dict):
+            j["schedule"] = {}
+            needs_save = True
+    for rj in raw_jobs:
+        if not isinstance(rj.get("schedule"), dict):
+            rj["schedule"] = {}
+            needs_save = True
     # Resolve the one-shot running-claim stale-recovery TTL once per scan
     # (derived from HERMES_CRON_TIMEOUT). See _oneshot_run_claim_ttl_seconds.
     _run_claim_ttl = _oneshot_run_claim_ttl_seconds()

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1452,7 +1452,7 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                             "Job '%s' (%s) could not compute next_run_at; "
                             "leaving enabled and marking state=error so the "
                             "job is not silently disabled.",
-                            job.get("name", job["id"]),
+                            job.get("name", job.get("id", "?")),
                             kind,
                         )
                     else:
@@ -1506,7 +1506,7 @@ def claim_dispatch(job_id: str) -> bool:
                 save_jobs(jobs)
                 logger.info(
                     "Job '%s': dispatch limit reached (%d/%d) — removing",
-                    job.get("name", job["id"]),
+                    job.get("name", job.get("id", "?")),
                     completed,
                     times,
                 )
@@ -1516,7 +1516,7 @@ def claim_dispatch(job_id: str) -> bool:
             save_jobs(jobs)
             logger.debug(
                 "Job '%s': claimed dispatch %d/%d",
-                job.get("name", job["id"]),
+                job.get("name", job.get("id", "?")),
                 repeat["completed"],
                 times,
             )
@@ -1653,9 +1653,25 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
     """Inner implementation of get_due_jobs(); must be called with _jobs_lock held."""
     now = _hermes_now()
     raw_jobs = load_jobs()
+    needs_save = False
+
+    # Repair id-less records BEFORE anything keys off ``job["id"]``. A direct
+    # jobs.json edit that bypassed add_job() can leave a record without an "id"
+    # (older writers used "job_id"). Every downstream site — the logging
+    # helpers and the ``for rj in raw_jobs: if rj["id"] == job["id"]``
+    # persistence loops — indexes job["id"] eagerly, so a single malformed
+    # record raised KeyError mid-tick, aborting the whole scan before
+    # save_jobs() ran. That froze the entire profile's scheduler in a
+    # per-minute fast-forward loop (healthy jobs recomputed in memory, then
+    # discarded when the exception unwound). Recover the id from the drifted
+    # "job_id" key when present, else synthesize one, and persist.
+    for rj in raw_jobs:
+        if not rj.get("id"):
+            rj["id"] = rj.pop("job_id", None) or uuid.uuid4().hex[:12]
+            needs_save = True
+
     jobs = [_apply_skill_fields(j) for j in copy.deepcopy(raw_jobs)]
     due = []
-    needs_save = False
     # Resolve the one-shot running-claim stale-recovery TTL once per scan
     # (derived from HERMES_CRON_TIMEOUT). See _oneshot_run_claim_ttl_seconds.
     _run_claim_ttl = _oneshot_run_claim_ttl_seconds()
@@ -1716,7 +1732,7 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
             next_run = recovered_next
             logger.info(
                 "Job '%s' had no next_run_at; recovering %s run at %s",
-                job.get("name", job["id"]),
+                job.get("name", job.get("id", "?")),
                 recovery_kind,
                 recovered_next,
             )
@@ -1757,7 +1773,7 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                 logger.info(
                     "Job '%s' next_run_at offset changed (%s -> %s). "
                     "Recomputing cron run to preserve local wall-clock intent: %s",
-                    job.get("name", job["id"]),
+                    job.get("name", job.get("id", "?")),
                     raw_next_run_dt.utcoffset(),
                     now.utcoffset(),
                     new_next,
@@ -1785,7 +1801,7 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                         "Job '%s' missed its scheduled time (%s, grace=%ds). "
                         "Running now; next run provisionally set to: %s "
                         "(re-anchored on completion)",
-                        job.get("name", job["id"]),
+                        job.get("name", job.get("id", "?")),
                         next_run,
                         grace,
                         new_next,
@@ -1819,7 +1835,7 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                         logger.info(
                             "Job '%s': one-shot dispatch limit reached (%d/%d) "
                             "— removing stale due entry",
-                            job.get("name", job["id"]),
+                            job.get("name", job.get("id", "?")),
                             completed,
                             times,
                         )

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -256,6 +256,7 @@ AUTHOR_MAP = {
     "dkobi16@gmail.com": "Diyoncrz18",
     "arnaud@nolimitdevelopment.com": "ali-nld",
     "sswdarius@gmail.com": "necoweb3",
+    "bassisho@Mac-mini-bassis.local": "hydracoco7",  # PR #61382 salvage (id-less cron job freeze)
     "t.chen@aftership.com": "cypctlinux",  # PR #52403 salvage (Slack bot/workflow auth before no-user-id guard)
     "30854794+YLChen-007@users.noreply.github.com": "YLChen-007",  # PR #26965 (approval remote command substitution)
     "1078345+egilewski@users.noreply.github.com": "egilewski",  # co-author, PR #40663

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1503,6 +1503,60 @@ class TestBadNextRunAtRecovery:
         assert any(j["id"] == "good-sibling" for j in due2)
 
 
+class TestPerJobScanContainment:
+    """Structural guard: ANY per-job exception in the due scan must degrade to
+    skipping that one job for the tick — never abort the scan and starve
+    healthy siblings (the freeze class behind bad id / schedule / next_run_at).
+    """
+
+    def test_unforeseen_per_job_exception_does_not_starve_siblings(self, tmp_cron_dir):
+        """Simulate a FUTURE malformed-field variant none of the shape
+        normalizers repair, by making grace computation raise for one job
+        only. The per-job guard must skip it and still return the sibling."""
+        from datetime import timezone, timedelta as td
+        from unittest.mock import patch as mock_patch
+
+        now = datetime.now(timezone.utc)
+        past = (now - td(seconds=30)).isoformat()
+
+        poison = {
+            "id": "poison",
+            # minutes=7 tags this schedule so the patched helper can target it
+            "schedule": {"kind": "interval", "minutes": 7},
+            "next_run_at": past,
+            "enabled": True,
+            "created_at": past,
+        }
+        good = {
+            "id": "good-sibling",
+            "schedule": {"kind": "interval", "minutes": 5},
+            "next_run_at": past,
+            "enabled": True,
+            "created_at": past,
+        }
+        save_jobs([poison, good])
+
+        import cron.jobs as jobs_mod
+        real_grace = jobs_mod._compute_grace_seconds
+
+        def selective_grace(schedule):
+            if schedule.get("minutes") == 7:
+                raise RuntimeError("simulated unforeseen malformed field")
+            return real_grace(schedule)
+
+        with mock_patch.object(jobs_mod, "_compute_grace_seconds", selective_grace):
+            due = get_due_jobs()  # must not raise
+
+        ids = [j["id"] for j in due]
+        assert "good-sibling" in ids, f"healthy sibling starved: {ids}"
+        assert "poison" not in ids
+
+        # Scheduler stays alive on subsequent ticks too.
+        with mock_patch.object(jobs_mod, "_compute_grace_seconds", selective_grace):
+            due2 = get_due_jobs()
+        assert any(j["id"] == "good-sibling" for j in due2)
+
+
 class TestSaveJobOutput:
     def test_creates_output_file(self, tmp_cron_dir):
         output_file = save_job_output("test123", "# Results\nEverything ok.")

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1446,6 +1446,63 @@ class TestMarkJobRunConcurrency:
             )
 
 
+class TestBadNextRunAtRecovery:
+    """Regression: malformed next_run_at must not crash the due scan or starve siblings.
+
+    Mirrors the id-less and non-dict-schedule patterns: a single bad persisted
+    record in jobs.json must not abort _get_due_jobs_locked before save.
+    """
+
+    def test_bad_next_run_at_does_not_crash_or_block_sibling_jobs(self, tmp_cron_dir):
+        """One job with unparseable next_run_at + one healthy due sibling.
+
+        get_due_jobs must succeed and return the healthy job; the bad record
+        must be repaired (next_run_at cleared so recovery can set a sane value).
+        """
+        from datetime import timezone, timedelta as td
+        now = datetime.now(timezone.utc)
+        past = (now - td(seconds=30)).isoformat()
+        future = (now + td(days=1)).isoformat()
+
+        # Bad record: next_run_at is not a valid ISO string (e.g. from hand-edit or corruption)
+        # Healthy sibling is past due with good schedule.
+        bad_job = {
+            "id": "bad-next",
+            "schedule": {"kind": "interval", "minutes": 60},
+            "next_run_at": "not-a-valid-iso-timestamp!!!",
+            "enabled": True,
+            "created_at": past,
+        }
+        good_job = {
+            "id": "good-sibling",
+            "schedule": {"kind": "interval", "minutes": 5},
+            "next_run_at": past,
+            "enabled": True,
+            "created_at": past,
+        }
+        save_jobs([bad_job, good_job])
+
+        # Must not raise
+        due = get_due_jobs()
+
+        # The healthy job must still be returned
+        ids = [j["id"] for j in due]
+        assert "good-sibling" in ids, f"healthy sibling missing from due jobs: {ids}"
+        assert "bad-next" not in ids  # bad one may be repaired and/or not yet due after repair
+
+        # Bad job should have been auto-repaired (next_run_at stripped or fixed)
+        repaired = get_job("bad-next")
+        assert repaired is not None
+        nr = repaired.get("next_run_at")
+        if nr is not None:
+            # If still present it must now be parseable
+            datetime.fromisoformat(nr)
+
+        # Calling again must remain stable (no crash on re-scan)
+        due2 = get_due_jobs()
+        assert any(j["id"] == "good-sibling" for j in due2)
+
+
 class TestSaveJobOutput:
     def test_creates_output_file(self, tmp_cron_dir):
         output_file = save_job_output("test123", "# Results\nEverything ok.")

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1636,3 +1636,40 @@ class TestClaimDispatch:
         due = get_due_jobs()
         assert due == []
         assert load_jobs() == []  # cleaned up
+
+    def test_bad_schedule_does_not_crash_or_block_sibling_jobs(self, tmp_cron_dir):
+        """Regression for a job with non-dict 'schedule' (null / string / etc.
+
+        from direct jobs.json edit or old writer).
+
+        Such a record must not raise in _get_due_jobs_locked and must not
+        prevent healthy sibling jobs from being returned or having their
+        next_run_at advanced+persisted. Mirrors the id-less job P1 pattern.
+        """
+        past = (datetime.now(timezone.utc) - timedelta(seconds=10)).isoformat()
+        future = (datetime.now(timezone.utc) + timedelta(days=1)).isoformat()
+
+        bad = {
+            "id": "bad-sched",
+            "name": "bad",
+            "enabled": True,
+            "schedule": None,  # poison: not a dict
+            "next_run_at": future,  # not due
+        }
+        good = {
+            "id": "good",
+            "name": "good",
+            "enabled": True,
+            "schedule": {"kind": "interval", "minutes": 5},
+            "next_run_at": past,
+        }
+        save_jobs([bad, good])
+
+        due = get_due_jobs()
+        due_ids = [j["id"] for j in due]
+        assert "good" in due_ids
+        assert "bad-sched" not in due_ids  # bad one ignored, no crash
+
+        # At minimum, the good job's record is still intact (no corruption from the bad neighbor)
+        loaded = {j["id"]: j for j in load_jobs()}
+        assert "good" in loaded

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -835,6 +835,40 @@ class TestGetDueJobs:
         next_dt = _ensure_aware(datetime.fromisoformat(updated["next_run_at"]))
         assert next_dt > _hermes_now()
 
+    def test_idless_job_does_not_crash_or_block_sibling_jobs(self, tmp_cron_dir):
+        """A job missing its 'id' key must not crash the tick or freeze siblings.
+
+        Regression: jobs authored by a direct jobs.json edit (bypassing
+        create_job) sometimes used the key 'job_id' instead of 'id'. The logging
+        helpers evaluated ``job.get("name", job["id"])`` -- Python evaluates the
+        default argument ``job["id"]`` eagerly, so an id-less job raised
+        ``KeyError: 'id'`` mid-tick. That exception aborted
+        ``_get_due_jobs_locked()`` BEFORE ``save_jobs()`` ran, so every healthy
+        job's fast-forwarded next_run_at was computed in memory then discarded --
+        the whole profile's scheduler froze in a per-minute loop.
+        """
+        healthy = create_job(prompt="Healthy", schedule="every 1h")
+
+        jobs = load_jobs()
+        # Push the healthy job beyond its grace window so the fast-forward path
+        # (one of the id-less-crash sites) runs.
+        jobs[0]["next_run_at"] = (datetime.now() - timedelta(minutes=35)).isoformat()
+        # A malformed record: no 'id' key, mirroring the real corruption.
+        jobs.append({
+            "name": "idless-job",
+            "schedule": {"kind": "cron", "expr": "0 4 * * *"},
+            "enabled": True,
+            "no_agent": True,
+            "next_run_at": None,
+        })
+        save_jobs(jobs)
+
+        # Must not raise KeyError.
+        due = get_due_jobs()
+
+        # The healthy sibling is still discovered despite the malformed neighbor.
+        assert any(d.get("id") == healthy["id"] for d in due)
+
 
     def test_long_execution_does_not_perpetually_defer(self, tmp_cron_dir, monkeypatch):
         """#33315: a recurring job whose runtime exceeds interval+grace must still


### PR DESCRIPTION
## Summary
A single malformed record in `cron/jobs.json` can no longer freeze the whole scheduler. The due scan trusted persisted job shape; one bad record (missing `id`, non-dict `schedule`, unparseable `next_run_at`/`last_run_at`) raised mid-loop before `save_jobs()`, discarding every sibling's recovered state — the scheduler re-crashed identically every tick, forever.

Consolidates three contributor fixes (cherry-picked, authorship preserved) and adds the structural guard none of them had:

- #61382 by @hydracoco7 — id-less job repair (recover from drifted `job_id`, else synthesize)
- #61525 by @necoweb3 — non-dict `schedule` normalization
- #61581 by @necoweb3 — malformed `next_run_at`/`last_run_at` stripping + `compute_next_run` hardening (cron portion only; its unrelated process_registry change was left for separate review)
- ours — per-job try/except around the scan body so any FUTURE malformed-field variant degrades to skipping one job for one tick instead of freezing the profile

## Changes
- `cron/jobs.py`: three shape normalizations at the top of `_get_due_jobs_locked` + per-job containment guard
- `tests/cron/test_jobs.py`: three contributor regression tests + containment test; restored `test_repeated_concurrent_runs_accumulate_completed_count` to its original class (accidentally re-parented by the #61581 diff)
- `scripts/release.py`: AUTHOR_MAP for hydracoco7

## Validation
| | Before | After |
|---|---|---|
| One malformed job | whole tick aborts, scheduler frozen | job skipped/repaired, siblings run |
| E2E (all 5 malformed shapes + healthy sibling in one store) | freeze | single tick contains all five, repairs persisted, tick 2 stable |
| Tests | — | 670 cron tests green |

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa19f46/6xv77r7tmVbalkoF6_fJE_IDJYRPnW.png)
