### PR TITLE
fix(mcp): follow nextCursor pagination in MCP tools/resources/prompts discovery (port opencode#35439/#35500)

### DIFF
--- a/tests/tools/test_mcp_list_pagination.py
+++ b/tests/tools/test_mcp_list_pagination.py
@@ -1,0 +1,103 @@
+"""Tests for MCP list_* pagination (nextCursor draining).
+
+The MCP spec allows servers to paginate ``tools/list``, ``resources/list``,
+and ``prompts/list`` via an opaque ``nextCursor`` token. The Python SDK
+fetches one page per call, so hermes must follow the cursor to see items
+past page 1. Port of the invariant behind anomalyco/opencode#35439/#35500.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from tools.mcp_tool import _MCP_LIST_MAX_PAGES, _paginate_full_list
+
+
+def _tool(name):
+    t = MagicMock()
+    t.name = name
+    return t
+
+
+class TestPaginateFullList:
+    def test_single_page_no_cursor(self):
+        """A result without nextCursor returns just that page."""
+        list_method = AsyncMock(
+            return_value=SimpleNamespace(tools=[_tool("a"), _tool("b")])
+        )
+        items = asyncio.run(_paginate_full_list(list_method, "tools", "srv"))
+        assert [t.name for t in items] == ["a", "b"]
+        list_method.assert_called_once_with()
+
+    def test_follows_next_cursor_across_pages(self):
+        """Pages are concatenated in order; cursor passed back verbatim."""
+        pages = {
+            None: SimpleNamespace(tools=[_tool("p1a"), _tool("p1b")], nextCursor="c2"),
+            "c2": SimpleNamespace(tools=[_tool("p2a")], nextCursor="c3"),
+            "c3": SimpleNamespace(tools=[_tool("p3a")], nextCursor=None),
+        }
+
+        async def fake_list(cursor=None):
+            return pages[cursor]
+
+        items = asyncio.run(_paginate_full_list(fake_list, "tools", "srv"))
+        assert [t.name for t in items] == ["p1a", "p1b", "p2a", "p3a"]
+
+    def test_empty_page_with_cursor_continues(self):
+        """An empty middle page doesn't abort the walk."""
+        pages = {
+            None: SimpleNamespace(resources=[_tool("r1")], nextCursor="c2"),
+            "c2": SimpleNamespace(resources=[], nextCursor="c3"),
+            "c3": SimpleNamespace(resources=[_tool("r2")]),
+        }
+
+        async def fake_list(cursor=None):
+            return pages[cursor]
+
+        items = asyncio.run(_paginate_full_list(fake_list, "resources", "srv"))
+        assert [t.name for t in items] == ["r1", "r2"]
+
+    def test_missing_items_attr_tolerated(self):
+        """A malformed result without the items attribute yields nothing."""
+        list_method = AsyncMock(return_value=SimpleNamespace())
+        items = asyncio.run(_paginate_full_list(list_method, "prompts", "srv"))
+        assert items == []
+
+    def test_runaway_cursor_capped(self):
+        """A server that returns a cursor forever is bounded by the page cap."""
+        calls = {"n": 0}
+
+        async def evil_list(cursor=None):
+            calls["n"] += 1
+            return SimpleNamespace(
+                tools=[_tool(f"t{calls['n']}")], nextCursor=f"c{calls['n']}"
+            )
+
+        items = asyncio.run(_paginate_full_list(evil_list, "tools", "srv"))
+        assert calls["n"] == _MCP_LIST_MAX_PAGES
+        assert len(items) == _MCP_LIST_MAX_PAGES
+
+
+class TestDiscoveryUsesPagination:
+    def test_discover_tools_drains_all_pages(self):
+        """MCPServerTask._discover_tools registers tools from every page."""
+        from tools.mcp_tool import MCPServerTask
+
+        server = MCPServerTask("pag_srv")
+        server._config = {"command": "test"}
+        pages = {
+            None: SimpleNamespace(tools=[_tool("first")], nextCursor="page-2"),
+            "page-2": SimpleNamespace(tools=[_tool("second")]),
+        }
+
+        async def fake_list(cursor=None):
+            return pages[cursor]
+
+        server.session = MagicMock()
+        server.session.list_tools = fake_list
+        # capability gate: _advertises_tools() returns True when no
+        # capability info was captured (legacy fallback), so no override
+        # is needed here.
+
+        asyncio.run(server._discover_tools())
+        assert [t.name for t in server._tools] == ["first", "second"]

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -574,6 +574,51 @@ def _prepend_path(env: dict, directory: str) -> dict:
     return updated
 
 
+# Safety cap on nextCursor pagination loops so a misbehaving server that
+# returns a cursor forever cannot spin discovery indefinitely. 50 pages at
+# the common 50-100 items/page covers thousands of tools/resources/prompts.
+_MCP_LIST_MAX_PAGES = 50
+
+
+async def _paginate_full_list(list_method, items_attr: str, server_name: str):
+    """Drain a paginated MCP ``list_*`` call by following ``nextCursor``.
+
+    The MCP spec allows servers to paginate ``tools/list``,
+    ``resources/list``, and ``prompts/list`` responses via an opaque
+    ``nextCursor`` token. The Python SDK's ``ClientSession.list_*`` methods
+    fetch exactly one page per call, so a client that never passes the
+    cursor back silently sees only the first page — on a paginated server
+    every tool/resource/prompt past page 1 would be invisible to the agent.
+
+    Args:
+        list_method: Bound ``session.list_tools`` / ``list_resources`` /
+            ``list_prompts`` coroutine function.
+        items_attr: Result attribute holding the page's items
+            (``"tools"``, ``"resources"``, or ``"prompts"``).
+        server_name: For log messages.
+
+    Returns:
+        Combined list of items across all pages. Callers must hold the
+        server's ``_rpc_lock`` for the duration so pages come from a
+        consistent snapshot.
+    """
+    items: list = []
+    cursor = None
+    for _ in range(_MCP_LIST_MAX_PAGES):
+        result = await (list_method(cursor=cursor) if cursor else list_method())
+        items.extend(getattr(result, items_attr, None) or [])
+        cursor = getattr(result, "nextCursor", None)
+        if not cursor:
+            break
+    else:
+        logger.warning(
+            "MCP server '%s': %s pagination exceeded %d pages; "
+            "truncating at %d items",
+            server_name, items_attr, _MCP_LIST_MAX_PAGES, len(items),
+        )
+    return items
+
+
 def _resolve_stdio_command(command: str, env: dict) -> tuple[str, dict]:
     """Resolve a stdio MCP command against the exact subprocess environment.
 
@@ -1774,10 +1819,11 @@ class MCPServerTask:
             # Capture old tool names for change diff
             old_tool_names = set(self._registered_tool_names)
 
-            # 1. Fetch current tool list from server
+            # 1. Fetch current tool list from server (follow nextCursor)
             async with self._rpc_lock:
-                tools_result = await self.session.list_tools()
-            new_mcp_tools = tools_result.tools if hasattr(tools_result, "tools") else []
+                new_mcp_tools = await _paginate_full_list(
+                    self.session.list_tools, "tools", self.name
+                )
 
             # 2. Re-register with fresh tool list. Avoid nuke-and-repave for
             # all names: live agent turns may already have tool-call IDs
@@ -2579,12 +2625,9 @@ class MCPServerTask:
             self._register_discovered_tools_if_needed()
             return
         async with self._rpc_lock:
-            tools_result = await self.session.list_tools()
-        self._tools = (
-            tools_result.tools
-            if hasattr(tools_result, "tools")
-            else []
-        )
+            self._tools = await _paginate_full_list(
+                self.session.list_tools, "tools", self.name
+            )
         self._register_discovered_tools_if_needed()
 
     def _register_discovered_tools_if_needed(self) -> None:
@@ -4055,9 +4098,11 @@ def _make_list_resources_handler(server_name: str, tool_timeout: float):
         async def _call():
             _mark_server_call_started(server)
             async with server._rpc_lock:
-                result = await server.session.list_resources()
+                all_resources = await _paginate_full_list(
+                    server.session.list_resources, "resources", server_name
+                )
             resources = []
-            for r in (result.resources if hasattr(result, "resources") else []):
+            for r in all_resources:
                 entry = {}
                 if hasattr(r, "uri"):
                     entry["uri"] = str(r.uri)
@@ -4173,9 +4218,11 @@ def _make_list_prompts_handler(server_name: str, tool_timeout: float):
         async def _call():
             _mark_server_call_started(server)
             async with server._rpc_lock:
-                result = await server.session.list_prompts()
+                all_prompts = await _paginate_full_list(
+                    server.session.list_prompts, "prompts", server_name
+                )
             prompts = []
-            for p in (result.prompts if hasattr(result, "prompts") else []):
+            for p in all_prompts:
                 entry = {}
                 if hasattr(p, "name"):
                     entry["name"] = p.name


### PR DESCRIPTION
## Summary
MCP servers that paginate `tools/list` / `resources/list` / `prompts/list` now expose their full catalog to the agent — previously everything past page 1 was silently invisible.

Port of the invariant behind [anomalyco/opencode#35439](https://github.com/anomalyco/opencode/pull/35439) / [#35500](https://github.com/anomalyco/opencode/pull/35500) (preserve MCP metadata across paginated `tools/list`), adapted to hermes's Python MCP layer.

Root cause: the MCP spec allows servers to paginate all `list_*` responses via an opaque `nextCursor` token. The Python SDK's `ClientSession.list_*` methods fetch exactly one page per call, and hermes never passed the cursor back — so a paginated server's tools/resources/prompts beyond the first page were never discovered, registered, or callable.

## Changes
- `tools/mcp_tool.py`: new `_paginate_full_list()` helper — drains `nextCursor` with a 50-page runaway cap (a misbehaving server returning a cursor forever can't spin discovery); applied at all three discovery sites:
  - `MCPServerTask._discover_tools()` (initial + reconnect discovery)
  - the `tools/list_changed` dynamic refresh handler
  - the `list_resources` / `list_prompts` utility tool handlers
- The keepalive probe intentionally keeps its single-page `list_tools()` call — it only proves liveness, and draining an 800-tool catalog for a heartbeat would be wasteful.
- `tests/tools/test_mcp_list_pagination.py`: 6 tests — multi-page ordering, empty middle pages, missing items attr, runaway-cursor cap, and `_discover_tools()` draining through the real capability gate.

## Adaptation notes
OpenCode fixed this by patching the vendored TypeScript SDK's metadata cache (their SDK 1.29.0 pin). Hermes doesn't need SDK surgery — the Python SDK already accepts a `cursor` kwarg and appends output-schema cache entries per page (it deliberately doesn't clear the cache "as we may be using a cursor") — the missing piece was purely client-side cursor following, so the fix lives in our discovery layer.

## Validation
| | Before | After |
|---|---|---|
| Real stdio MCP server, 3 pages (2/1/1 tools) | 2 tools discovered | all 4 discovered |
| `tests/tools/test_mcp_*` (267 tests) | — | all pass |
| New pagination tests | — | 6/6 pass |

E2E used a real `mcp.server.Server` over stdio with a cursor-aware `ListToolsRequest` handler, exercised through `MCPServerTask._discover_tools()` with a real `ClientSession`.

## Infographic

![mcp-nextcursor-pagination](https://v3b.fal.media/files/b/0aa19f4b/nKUSELbkC73TcS2LySVGV_gcNb06oP.png)
