### PR TITLE
fix(errors): classify Z.AI GLM token-limit message as context overflow (port opencode#35671)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -267,6 +267,8 @@ _CONTEXT_OVERFLOW_PATTERNS = [
     # Chinese error messages (some providers return these)
     "超过最大长度",
     "上下文长度",
+    # Z.AI / Zhipu GLM pattern (English form; error code 1210)
+    "tokens in request more than max tokens allowed",
     # AWS Bedrock Converse API error patterns
     "input is too long",
     "max input token",

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1226,6 +1226,20 @@ class TestClassifyApiError:
         result = classify_api_error(e)
         assert result.reason == FailoverReason.context_overflow
 
+    # ── Z.AI / Zhipu GLM error messages ──
+
+    def test_zai_glm_token_limit_overflow(self):
+        """Z.AI GLM's 'tokens in request more than max tokens allowed'
+        (error code 1210) → context_overflow, so the agent compresses
+        instead of blindly retrying. Port of anomalyco/opencode#35671."""
+        e = MockAPIError(
+            '{"error": {"code": "1210", "message": '
+            '"tokens in request more than max tokens allowed"}}',
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="zai")
+        assert result.reason == FailoverReason.context_overflow
+
     # ── vLLM / local inference server error messages ──
 
     def test_vllm_max_model_len_overflow(self):


### PR DESCRIPTION
## Summary
Z.AI / Zhipu GLM context-overflow errors now classify as `context_overflow` and route to compression — previously they classified as `unknown`/retryable, so the agent retried the same oversized request instead of compressing.

Port of [anomalyco/opencode#35671](https://github.com/anomalyco/opencode/pull/35671) (classify zai token limit overflow). Root cause: Z.AI's overflow message `tokens in request more than max tokens allowed` (error code 1210) matched no entry in `_CONTEXT_OVERFLOW_PATTERNS`.

## Changes
- `agent/error_classifier.py`: add the Z.AI/GLM pattern to `_CONTEXT_OVERFLOW_PATTERNS`
- `tests/agent/test_error_classifier.py`: regression test with the real error shape (code 1210, provider=zai)

## Validation
| | Before | After |
|---|---|---|
| `classify_api_error()` on the exact Z.AI 400 body | `FailoverReason.unknown` | `FailoverReason.context_overflow` |
| `tests/agent/test_error_classifier.py` | 192 pass | 193 pass |

Bug was reproduced live on current main before the fix (the exact error string returned `unknown`).

## Infographic

![zai-glm-overflow](https://v3b.fal.media/files/b/0aa19f6b/35vJKHkUxv8JUOr_34DiB_J6Mwk4gu.png)
