### PR TITLE
fix(config): empty YAML section keys no longer replace default dicts (#58277)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -543,6 +543,8 @@ def load_cli_config() -> Dict[str, Any]:
                 if key == "model":
                     continue  # Already handled above
                 if key in file_config:
+                    if isinstance(defaults[key], dict) and file_config[key] is None:
+                        continue
                     if isinstance(defaults[key], dict) and isinstance(file_config[key], dict):
                         defaults[key].update(file_config[key])
                     else:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6243,6 +6243,12 @@ def _deep_merge(base: dict, override: dict) -> dict:
     Keys in *override* take precedence. If both values are dicts the merge
     recurses, so a user who overrides only ``tts.elevenlabs.voice_id`` will
     keep the default ``tts.elevenlabs.model_id`` intact.
+
+    An empty section key in config.yaml (``terminal:`` with no value) parses
+    as YAML ``None``; treating that as an override would replace the entire
+    default dict with ``None`` and crash every downstream consumer that
+    expects a mapping (#58277). A ``None`` override of a dict default is
+    ignored — same as the key being absent.
     """
     result = base.copy()
     for key, value in override.items():
@@ -6252,6 +6258,8 @@ def _deep_merge(base: dict, override: dict) -> dict:
             and isinstance(value, dict)
         ):
             result[key] = _deep_merge(result[key], value)
+        elif key in result and isinstance(result[key], dict) and value is None:
+            continue
         else:
             result[key] = value
     return result

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -360,6 +360,34 @@ class TestLoadConfigParseFailure:
             assert capsys.readouterr().err == ""
 
 
+class TestEmptyConfigSections:
+    """Empty section keys (``terminal:`` with no value) parse as YAML None
+    and must not replace the default dict for that section (#58277)."""
+
+    def test_null_section_keeps_defaults_in_load_config(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            (tmp_path / "config.yaml").write_text(
+                "model:\n  default: test/custom\n"
+                "terminal:\n"
+                "display:\n"
+            )
+            config = load_config()
+            assert config["model"]["default"] == "test/custom"
+            assert isinstance(config["terminal"], dict)
+            assert config["terminal"] == DEFAULT_CONFIG["terminal"]
+            assert isinstance(config["display"], dict)
+
+    def test_null_override_of_non_dict_default_still_applies(self, tmp_path):
+        """None only shields dict defaults — explicit null for a scalar
+        key remains an override (unchanged behavior)."""
+        from hermes_cli.config import _deep_merge
+
+        merged = _deep_merge({"scalar": 5, "section": {"a": 1}},
+                             {"scalar": None, "section": None})
+        assert merged["scalar"] is None
+        assert merged["section"] == {"a": 1}
+
+
 class TestSaveAndLoadRoundtrip:
     @staticmethod
     def _deny_config_reads(config_path):

--- a/tests/hermes_cli/test_config_env_expansion.py
+++ b/tests/hermes_cli/test_config_env_expansion.py
@@ -150,6 +150,18 @@ class TestLoadConfigCacheEnvStaleness:
 class TestLoadCliConfigExpansion:
     """Verify that load_cli_config() also expands ${VAR} references."""
 
+    def test_cli_config_ignores_empty_terminal_section(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("terminal:\n")
+
+        monkeypatch.setattr("cli._hermes_home", tmp_path)
+
+        from cli import load_cli_config
+        config = load_cli_config()
+
+        assert isinstance(config["terminal"], dict)
+        assert config["terminal"]["env_type"] == "local"
+
     def test_cli_config_expands_auxiliary_api_key(self, tmp_path, monkeypatch):
         config_yaml = (
             "auxiliary:\n"


### PR DESCRIPTION
## Summary

An empty section key in config.yaml (`terminal:` with no value) parses as YAML `None` and no longer clobbers that section's defaults — previously it crashed `load_cli_config()` with `TypeError` at startup (#58277) and silently replaced entire default sections with `None` in `load_config()`.

Salvages #58306 by @yungchentang (earliest of two competing fixes; general merge-loop guard rather than a single-site patch), widened to the sibling `_deep_merge` in `hermes_cli/config.py`.

## Changes

- `cli.py` (cherry-picked from #58306, authorship preserved): merge loop skips a `None` file value when the default for that key is a dict
- `hermes_cli/config.py` `_deep_merge()`: same guard — a `None` override of a dict default is ignored (same as key absent); scalar-null overrides unchanged
- Tests: contributor's regression test + 2 new tests for the `load_config()` path (null sections keep full defaults; scalar nulls still apply)

## Validation

| | Before | After |
|---|---|---|
| `load_cli_config()` with `terminal:` null | TypeError crash at startup | loads, terminal = defaults |
| `load_config()` with `terminal:`/`display:` null | sections become `None` | sections keep full defaults |
| explicit `terminal.backend: docker` | merges | merges (unchanged) |
| targeted tests | — | test_config.py + test_config_env_expansion.py all pass |

E2E (real imports, temp HERMES_HOME): reproduced both failure modes on main, both clean after fix.

Closes #58277. Supersedes #58361 (later duplicate, point-fix at one consumption site).

## Infographic

![empty-config-sections](https://v3b.fal.media/files/b/0aa19fe6/nJyA4sEedGabg-8lm86La_EbDNqWUk.png)
