### PR TITLE
fix(auxiliary): fall through explicit compression to built-in chain

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3909,6 +3909,7 @@ def _try_configured_fallback_chain(
         return None, None, ""
 
     skip = failed_provider.lower().strip()
+    skip_label = _normalize_chain_label(skip)
     tried = []
     min_ctx = _task_minimum_context_length(task)
 
@@ -3916,11 +3917,15 @@ def _try_configured_fallback_chain(
         if not isinstance(entry, dict):
             continue
         fb_provider = str(entry.get("provider", "")).strip()
-        if not fb_provider or fb_provider.lower() == skip:
+        fb_label_norm = _normalize_chain_label(fb_provider)
+        label = f"fallback_chain[{i}]({fb_provider})"
+        if not fb_provider or fb_provider.lower() == skip or fb_label_norm == skip_label:
+            continue
+        if fb_label_norm and _is_provider_unhealthy(fb_label_norm):
+            _log_skip_unhealthy(fb_label_norm, task)
+            tried.append(f"{label} (unhealthy)")
             continue
         fb_model = str(entry.get("model", "")).strip() or None
-
-        label = f"fallback_chain[{i}]({fb_provider})"
 
         try:
             fb_client, resolved_model = _resolve_fallback_entry(entry)
@@ -6910,6 +6915,8 @@ def call_llm(
             #   2. For auto: top-level main fallback_providers/fallback_model
             #   3. For auto: built-in auxiliary discovery chain
             #   4. For explicit aux providers: main agent model safety net
+            #   5. For explicit compression: built-in auxiliary discovery chain
+            #      as the final fail-closed escape hatch for giant sessions
             fb_client, fb_model, fb_label = (None, None, "")
             if is_auto:
                 fb_client, fb_model, fb_label = _try_configured_fallback_chain(
@@ -6925,6 +6932,9 @@ def call_llm(
                     task, resolved_provider or "auto", reason=reason)
                 if fb_client is None:
                     fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
+                        resolved_provider, task, reason=reason)
+                if fb_client is None and task == "compression":
+                    fb_client, fb_model, fb_label = _try_payment_fallback(
                         resolved_provider, task, reason=reason)
 
             if fb_client is not None:
@@ -6955,7 +6965,8 @@ def call_llm(
             # (#26882) The error itself is re-raised below.
             logger.warning(
                 "Auxiliary %s: %s on %s and all fallbacks exhausted "
-                "(fallback_chain + main agent model). Raising original error.",
+                "(fallback_chain + main agent model + built-in provider chain where eligible). "
+                "Raising original error.",
                 task or "call", reason, resolved_provider,
             )
         # Connection/timeout errors leave the cached client poisoned (closed
@@ -7415,6 +7426,8 @@ async def async_call_llm(
             #   2. For auto: top-level main fallback_providers/fallback_model
             #   3. For auto: built-in auxiliary discovery chain
             #   4. For explicit aux providers: main agent model safety net
+            #   5. For explicit compression: built-in auxiliary discovery chain
+            #      as the final fail-closed escape hatch for giant sessions
             fb_client, fb_model, fb_label = (None, None, "")
             if is_auto:
                 fb_client, fb_model, fb_label = _try_configured_fallback_chain(
@@ -7430,6 +7443,9 @@ async def async_call_llm(
                     task, resolved_provider or "auto", reason=reason)
                 if fb_client is None:
                     fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
+                        resolved_provider, task, reason=reason)
+                if fb_client is None and task == "compression":
+                    fb_client, fb_model, fb_label = _try_payment_fallback(
                         resolved_provider, task, reason=reason)
 
             if fb_client is not None:
@@ -7464,7 +7480,8 @@ async def async_call_llm(
             # All fallback layers exhausted — warn before re-raising. (#26882)
             logger.warning(
                 "Auxiliary %s (async): %s on %s and all fallbacks exhausted "
-                "(fallback_chain + main agent model). Raising original error.",
+                "(fallback_chain + main agent model + built-in provider chain where eligible). "
+                "Raising original error.",
                 task or "call", reason, resolved_provider,
             )
         # Mirror the sync path: drop poisoned clients on connection/timeout

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2500,6 +2500,81 @@ class TestAuxiliaryFallbackLayering:
 
         assert main_client.chat.completions.create.called
 
+    def test_explicit_compression_uses_builtin_chain_when_chain_and_main_exhausted(self, monkeypatch):
+        """Giant-session compression must not die on a fragile explicit aux route.
+
+        If auxiliary.compression pins Codex (or any explicit provider) and that
+        route is quota-limited/timed out, an empty fallback_chain plus identical
+        main model used to re-raise immediately. Compression now gets one final
+        built-in provider-chain escape hatch so the oversized session can still
+        compact.
+        """
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = self._make_payment_err()
+
+        builtin_client = MagicMock()
+        builtin_client.chat.completions.create.return_value = MagicMock(choices=[
+            MagicMock(message=MagicMock(content="from builtin provider chain"))
+        ])
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "gpt-5.5")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("openai-codex", "gpt-5.5", None, None, None)), \
+             patch("agent.auxiliary_client._try_configured_fallback_chain",
+                   return_value=(None, None, "")) as mock_chain, \
+             patch("agent.auxiliary_client._try_main_agent_model_fallback",
+                   return_value=(None, None, "")) as mock_main, \
+             patch("agent.auxiliary_client._try_payment_fallback",
+                   return_value=(builtin_client, "nous-safe-model", "nous")) as mock_builtin:
+            result = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+            )
+
+        assert result.choices[0].message.content == "from builtin provider chain"
+        mock_chain.assert_called_once_with(
+            "compression", "openai-codex", reason="payment error")
+        mock_main.assert_called_once_with(
+            "openai-codex", "compression", reason="payment error")
+        mock_builtin.assert_called_once_with(
+            "openai-codex", "compression", reason="payment error")
+        assert builtin_client.chat.completions.create.called
+
+    @pytest.mark.asyncio
+    async def test_async_explicit_compression_uses_builtin_chain_when_chain_and_main_exhausted(self, monkeypatch):
+        """Async compression fallback has parity with the sync path."""
+        primary_client = MagicMock()
+        primary_client.chat.completions.create = AsyncMock(side_effect=self._make_payment_err())
+
+        sync_builtin = MagicMock()
+        async_builtin = MagicMock()
+        async_builtin.chat.completions.create = AsyncMock(return_value=MagicMock(choices=[
+            MagicMock(message=MagicMock(content="from async builtin chain"))
+        ]))
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "gpt-5.5")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("openai-codex", "gpt-5.5", None, None, None)), \
+             patch("agent.auxiliary_client._try_configured_fallback_chain",
+                   return_value=(None, None, "")), \
+             patch("agent.auxiliary_client._try_main_agent_model_fallback",
+                   return_value=(None, None, "")), \
+             patch("agent.auxiliary_client._try_payment_fallback",
+                   return_value=(sync_builtin, "nous-safe-model", "nous")) as mock_builtin, \
+             patch("agent.auxiliary_client._to_async_client",
+                   return_value=(async_builtin, "nous-safe-model")):
+            result = await async_call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+            )
+
+        assert result.choices[0].message.content == "from async builtin chain"
+        mock_builtin.assert_called_once_with(
+            "openai-codex", "compression", reason="payment error")
+        assert async_builtin.chat.completions.create.await_count == 1
+
     def test_explicit_provider_rate_limit_triggers_fallback(self, monkeypatch):
         """429 rate-limit on an explicit provider must trigger fallback (not be ignored).
 
@@ -5202,6 +5277,48 @@ class TestCompressionFallbackContextFilter:
             "screening by context window.")
         assert model == "huge-1m"
         assert "big-provider" in label
+
+    def test_configured_chain_skips_unhealthy_candidate(self, monkeypatch):
+        """A configured fallback_chain must not re-enter a provider already
+        quarantined for quota/payment failure."""
+        from agent.auxiliary_client import (
+            _mark_provider_unhealthy,
+            _reset_aux_unhealthy_cache,
+            _try_configured_fallback_chain,
+        )
+
+        unhealthy_client = MagicMock(name="unhealthy")
+        healthy_client = MagicMock(name="healthy")
+        entries = [
+            self._make_chain_entry("openrouter", "fragile-model"),
+            self._make_chain_entry("nous", "stable-model"),
+        ]
+
+        def fake_resolve(entry):
+            if entry is entries[0]:
+                return unhealthy_client, "fragile-model"
+            return healthy_client, "stable-model"
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {"fallback_chain": entries} if task == "compression" else {},
+        )
+
+        _reset_aux_unhealthy_cache()
+        try:
+            _mark_provider_unhealthy("openrouter", ttl=60)
+            with patch("agent.auxiliary_client._resolve_fallback_entry",
+                       side_effect=fake_resolve), \
+                 patch("agent.auxiliary_client.get_model_context_length",
+                       return_value=256_000):
+                client, model, label = _try_configured_fallback_chain(
+                    task="compression", failed_provider="openai-codex")
+        finally:
+            _reset_aux_unhealthy_cache()
+
+        assert client is healthy_client
+        assert model == "stable-model"
+        assert "nous" in label
 
     def test_configured_chain_continues_after_skipping_too_small(self, monkeypatch):
         """When all small candidates are skipped and only the last is large enough,


### PR DESCRIPTION
## Summary
- When `auxiliary.compression` pins an explicit provider (e.g. Codex) and that route hits payment/quota/timeout, empty `fallback_chain` plus a matching main model previously re-raised immediately — giant sessions could not compact.
- Explicit compression now gets one final built-in provider-chain escape hatch after configured chain + main-agent fallbacks fail (sync + async parity).
- Configured `fallback_chain` walks also skip already-quarantined / alias-equivalent providers so we do not re-pay doomed RTTs.

## Test plan
- [x] `scripts/run_tests.sh tests/agent/test_auxiliary_client.py -k 'explicit_compression_uses_builtin or configured_chain_skips_unhealthy or configured_chain_continues_after_skipping or TestAuxiliaryFallbackLayering'`
- [x] `scripts/run_tests.sh tests/agent/test_context_compressor.py tests/run_agent/test_compressor_fallback_update.py tests/run_agent/test_compression_feasibility.py`
- [x] Synthetic no-transcript smoke: explicit compression chain→main→builtin fallthrough
- [x] Synthetic quarantine smoke: unhealthy openrouter skipped, nous selected

## Scope notes
- Narrow delta: only `agent/auxiliary_client.py` + focused tests.
- Does not change auto-provider routing, main agent fallback, or provider-health quarantine semantics beyond skipping unhealthy entries already marked by existing quarantine.