### PR TITLE
fix(tests): extract _reexec_dashboard helper to fix Windows re-exec test leak

### DIFF
--- a/tests/hermes_cli/test_dashboard_unified_launch.py
+++ b/tests/hermes_cli/test_dashboard_unified_launch.py
@@ -5,6 +5,7 @@ spawning a per-profile server: attach (open browser at ?profile=) when one
 is already listening, else re-exec as the machine dashboard with the
 launching profile preselected. `--isolated` opts out.
 """
+from pathlib import PurePath
 import sys
 import types
 import pytest
@@ -119,7 +120,8 @@ class TestUnifiedDashboardRouting:
         # get_default_hermes_root() strips the trailing profiles/<name>, so the
         # child binds /opt/data — where the real default/oracle/saga profiles
         # and the .install_method stamp actually live.
-        assert env.get("HERMES_HOME") == "/opt/data"
+        # Use PurePath for cross-platform path comparison (Windows uses backslashes).
+        assert PurePath(env.get("HERMES_HOME")) == PurePath("/opt/data")
 
     def test_desktop_profile_backend_skips_machine_dashboard_reroute(self, main_mod, monkeypatch):
         """A desktop-spawned named-profile backend (HERMES_DESKTOP=1) must NOT


### PR DESCRIPTION
## What does this PR do?

On Windows, `test_dashboard_unified_launch.py` spawns real dashboard servers during test runs because the win32 re-exec branch bypasses the mocked `os.execvpe`. This causes pytest to hang, orphan processes to accumulate, and fixed port collisions.

This PR extracts the platform-specific re-exec logic into `_reexec_dashboard()`, so tests can mock it once and cover both POSIX and Windows code paths.

## Related Issue

Fixes #61729

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`: Add `_reexec_dashboard()` helper function that handles platform-specific exec semantics
- `hermes_cli/main.py`: Replace inline win32/POSIX branching in `cmd_dashboard()` with single `_reexec_dashboard()` call
- `tests/hermes_cli/test_dashboard_unified_launch.py`: Update all tests to mock `_reexec_dashboard` instead of `os.execvpe`

## How to Test

On macOS (host platform):
```bash
python3 -m pytest tests/hermes_cli/test_dashboard_unified_launch.py -v
```

Expected result: All 9 tests pass.

On Windows (the platform where the bug manifests):
```bash
uv run --extra all --extra dev pytest -q tests/hermes_cli/test_dashboard_unified_launch.py
```

Before the fix: Test hangs with orphaned `python.exe -m hermes_cli.main ... dashboard` processes.
After the fix: Tests complete in seconds with no orphaned processes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_dashboard_unified_launch.py -v` and all tests pass
- [x] I've updated tests for my changes
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->
