### PR TITLE
fix(context): revalidate Codex OAuth context windows

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -534,8 +534,13 @@ def _skip_persistent_context_cache(base_url: str, provider: str) -> bool:
 
     LM Studio excludes caching because loaded context is transient — the user
     can reload the model with a different context_length at any time.
-   """
-    return provider == "lmstudio"
+
+    Codex OAuth excludes caching because its context window is account- and
+    entitlement-specific metadata supplied by the authenticated /models
+    endpoint. A fallback value written after a transient probe failure must
+    not prevent a later live probe from observing an updated allocation.
+    """
+    return (provider or "").strip().lower() in {"lmstudio", "openai-codex"}
 
 
 def _maybe_cache_local_context_length(
@@ -1909,27 +1914,31 @@ def _fetch_codex_oauth_context_lengths(access_token: str) -> Dict[str, int]:
     return result
 
 
-def _resolve_codex_oauth_context_length(
+def _resolve_codex_oauth_context_length_with_source(
     model: str, access_token: str = ""
-) -> Optional[int]:
+) -> Tuple[Optional[int], str]:
     """Resolve a Codex OAuth model's real context window.
 
     Prefers a live probe of chatgpt.com/backend-api/codex/models (when we
     have a bearer token), then falls back to ``_CODEX_OAUTH_CONTEXT_FALLBACK``.
+
+    Returns ``(context_length, source)`` where source is ``"live"`` for a
+    value returned by the authenticated endpoint or ``"fallback"`` for the
+    static conservative table. Callers must not persist the latter.
     """
     model_bare = _strip_provider_prefix(model).strip()
     if not model_bare:
-        return None
+        return None, ""
 
     if access_token:
         live = _fetch_codex_oauth_context_lengths(access_token)
         if model_bare in live:
-            return live[model_bare]
+            return live[model_bare], "live"
         # Case-insensitive match in case casing drifts
         model_lower = model_bare.lower()
         for slug, ctx in live.items():
             if slug.lower() == model_lower:
-                return ctx
+                return ctx, "live"
 
     # Fallback: longest-key-first substring match over hardcoded defaults.
     model_lower = model_bare.lower()
@@ -1937,9 +1946,19 @@ def _resolve_codex_oauth_context_length(
         _CODEX_OAUTH_CONTEXT_FALLBACK.items(), key=lambda x: len(x[0]), reverse=True
     ):
         if slug in model_lower:
-            return ctx
+            return ctx, "fallback"
 
-    return None
+    return None, ""
+
+
+def _resolve_codex_oauth_context_length(
+    model: str, access_token: str = ""
+) -> Optional[int]:
+    """Resolve a Codex OAuth model's context length (compatibility wrapper)."""
+    context_length, _source = _resolve_codex_oauth_context_length_with_source(
+        model, access_token=access_token,
+    )
+    return context_length
 
 
 def _resolve_nous_context_length(
@@ -2028,9 +2047,9 @@ def get_model_context_length(
 
     Resolution order:
     0. Explicit config override (model.context_length or custom_providers per-model)
-    1. Persistent cache (previously discovered via probing).  Nous URLs
-       bypass the cache here so step 5b can always reconcile against
-       the authoritative portal /v1/models response.
+    1. Persistent cache (previously discovered via probing).  Nous URLs,
+       LM Studio, and Codex OAuth bypass the cache here so their provider
+       metadata can be reconciled against the authoritative live source.
     1b. AWS Bedrock static table (must precede custom-endpoint probe)
     2. Active endpoint metadata (/models for explicit custom endpoints)
     3. Local server query (for local endpoints)
@@ -2106,24 +2125,13 @@ def get_model_context_length(
     # LM Studio is excluded — its loaded context length is transient (the
     # user can reload the model with a different context_length at any time
     # via /api/v1/models/load), so a stale cached value would mask reloads.
+    # Codex OAuth is excluded because the authenticated /models catalogue is
+    # account-specific and a fallback must never suppress later revalidation.
     if base_url and not _skip_persistent_context_cache(base_url, provider):
         cached = get_cached_context_length(model, base_url)
         if cached is not None:
-            # Invalidate stale Codex OAuth cache entries: pre-PR #14935 builds
-            # resolved gpt-5.x to the direct-API value (e.g. 1.05M) via
-            # models.dev and persisted it. Codex OAuth caps at 272K for every
-            # slug, so any cached Codex entry at or above 400K is a leftover
-            # from the old resolution path. Drop it and fall through to the
-            # live /models probe in step 5 below.
-            if provider == "openai-codex" and cached >= 400_000:
-                logger.info(
-                    "Dropping stale Codex cache entry %s@%s -> %s (pre-fix value); "
-                    "re-resolving via live /models probe",
-                    model, base_url, f"{cached:,}",
-                )
-                _invalidate_cached_context_length(model, base_url)
             # Invalidate stale 32k cache entries for Kimi-family models.
-            elif cached <= 32768 and _model_name_suggests_kimi(model):
+            if cached <= 32768 and _model_name_suggests_kimi(model):
                 logger.info(
                     "Dropping stale Kimi cache entry %s@%s -> %s (OpenRouter underreport); "
                     "re-resolving via hardcoded defaults",
@@ -2310,9 +2318,14 @@ def get_model_context_length(
         # Codex OAuth enforces lower context limits than the direct OpenAI
         # API for the same slug (e.g. gpt-5.5 is 1.05M on the API but 272K
         # on Codex). Authoritative source is Codex's own /models endpoint.
-        codex_ctx = _resolve_codex_oauth_context_length(model, access_token=api_key or "")
+        codex_ctx, codex_source = _resolve_codex_oauth_context_length_with_source(
+            model, access_token=api_key or "",
+        )
         if codex_ctx:
-            if base_url:
+            # Only a successful authenticated catalogue response is safe to
+            # persist. The static fallback is deliberately runtime-only so a
+            # transient OAuth/network failure cannot poison future probes.
+            if base_url and codex_source == "live":
                 save_context_length(model, base_url, codex_ctx)
             return codex_ctx
     if effective_provider == "gmi" and base_url:

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -4,6 +4,7 @@ Pure utility functions with no AIAgent dependency. Used by ContextCompressor
 and run_agent.py for pre-flight context checks.
 """
 
+import hashlib
 import ipaddress
 import json
 import logging
@@ -1858,27 +1859,34 @@ _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
 }
 
 
-_codex_oauth_context_cache: Dict[str, int] = {}
-_codex_oauth_context_cache_time: float = 0.0
+_codex_oauth_context_cache: Dict[str, Tuple[Dict[str, int], float]] = {}
 _CODEX_OAUTH_CONTEXT_CACHE_TTL = 3600  # 1 hour
 
 
-def _fetch_codex_oauth_context_lengths(access_token: str) -> Dict[str, int]:
-    """Probe the ChatGPT Codex /models endpoint for per-slug context windows.
+def _codex_oauth_token_fingerprint(access_token: str) -> str:
+    """Return a non-secret cache key for a Codex OAuth access token."""
+    return hashlib.sha256(access_token.encode("utf-8")).hexdigest()[:16]
 
-    Codex OAuth imposes its own context limits that differ from the direct
-    OpenAI API (e.g. gpt-5.5 is 1.05M on the API, 272K on Codex). The
-    `context_window` field in each model entry is the authoritative source.
 
-    Returns a ``{slug: context_window}`` dict. Empty on failure.
+def _fetch_codex_oauth_context_lengths_with_source(
+    access_token: str,
+) -> Tuple[Dict[str, int], bool]:
+    """Fetch Codex catalogue data and report whether it came from HTTP.
+
+    The in-process cache is scoped by token fingerprint because Codex model
+    availability and context windows can vary by account entitlement. The raw
+    token is never retained in the cache key. The boolean is false for a
+    same-token in-process hit, which must not be treated as a fresh provider
+    confirmation when deciding whether to update persistent state.
     """
-    global _codex_oauth_context_cache, _codex_oauth_context_cache_time
+    global _codex_oauth_context_cache
     now = time.time()
-    if (
-        _codex_oauth_context_cache
-        and now - _codex_oauth_context_cache_time < _CODEX_OAUTH_CONTEXT_CACHE_TTL
-    ):
-        return _codex_oauth_context_cache
+    cache_key = _codex_oauth_token_fingerprint(access_token)
+    cached = _codex_oauth_context_cache.get(cache_key)
+    if cached is not None:
+        cached_models, cached_at = cached
+        if now - cached_at < _CODEX_OAUTH_CONTEXT_CACHE_TTL:
+            return cached_models, False
 
     try:
         resp = requests.get(
@@ -1892,11 +1900,11 @@ def _fetch_codex_oauth_context_lengths(access_token: str) -> Dict[str, int]:
                 "Codex /models probe returned HTTP %s; falling back to hardcoded defaults",
                 resp.status_code,
             )
-            return {}
+            return {}, False
         data = resp.json()
     except Exception as exc:
         logger.debug("Codex /models probe failed: %s", exc)
-        return {}
+        return {}, False
 
     entries = data.get("models", []) if isinstance(data, dict) else []
     result: Dict[str, int] = {}
@@ -1909,8 +1917,20 @@ def _fetch_codex_oauth_context_lengths(access_token: str) -> Dict[str, int]:
             result[slug.strip()] = ctx
 
     if result:
-        _codex_oauth_context_cache = result
-        _codex_oauth_context_cache_time = now
+        _codex_oauth_context_cache[cache_key] = (result, now)
+    return result, True
+
+
+def _fetch_codex_oauth_context_lengths(access_token: str) -> Dict[str, int]:
+    """Probe the ChatGPT Codex /models endpoint for per-slug context windows.
+
+    Codex OAuth imposes its own context limits that differ from the direct
+    OpenAI API (e.g. gpt-5.5 is 1.05M on the API, 272K on Codex). The
+    `context_window` field in each model entry is the authoritative source.
+
+    Returns a ``{slug: context_window}`` dict. Empty on failure.
+    """
+    result, _fresh = _fetch_codex_oauth_context_lengths_with_source(access_token)
     return result
 
 
@@ -1923,22 +1943,24 @@ def _resolve_codex_oauth_context_length_with_source(
     have a bearer token), then falls back to ``_CODEX_OAUTH_CONTEXT_FALLBACK``.
 
     Returns ``(context_length, source)`` where source is ``"live"`` for a
-    value returned by the authenticated endpoint or ``"fallback"`` for the
-    static conservative table. Callers must not persist the latter.
+    value returned by a fresh authenticated endpoint probe, ``"memory"`` for
+    a same-token in-process catalogue hit, or ``"fallback"`` for the static
+    conservative table. Only ``"live"`` is eligible for persistent writes.
     """
     model_bare = _strip_provider_prefix(model).strip()
     if not model_bare:
         return None, ""
 
     if access_token:
-        live = _fetch_codex_oauth_context_lengths(access_token)
+        live, fresh_probe = _fetch_codex_oauth_context_lengths_with_source(access_token)
+        live_source = "live" if fresh_probe else "memory"
         if model_bare in live:
-            return live[model_bare], "live"
+            return live[model_bare], live_source
         # Case-insensitive match in case casing drifts
         model_lower = model_bare.lower()
         for slug, ctx in live.items():
             if slug.lower() == model_lower:
-                return ctx, "live"
+                return ctx, live_source
 
     # Fallback: longest-key-first substring match over hardcoded defaults.
     model_lower = model_bare.lower()

--- a/cli.py
+++ b/cli.py
@@ -12176,6 +12176,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 from agent.model_metadata import get_model_context_length
                 _ctx_len = get_model_context_length(
                     self.model, base_url=self.base_url or "", api_key=self.api_key or "",
+                    provider=self.provider or "",
                     config_context_length=getattr(self.agent, "_config_context_length", None) if self.agent else None)
                 _ctx_result = preprocess_context_references(
                     message, cwd=os.getcwd(), context_length=_ctx_len)

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -522,8 +522,15 @@ class TestCodexOAuthContextLength:
             "leaked outside openai-codex provider"
         )
 
-    def test_stale_codex_cache_is_bypassed_and_live_probe_wins(self, tmp_path, monkeypatch):
-        """A stale Codex disk entry must not mask the authenticated catalogue."""
+    @pytest.mark.parametrize(
+        "stale_context,live_context",
+        [(272_000, 372_000), (372_000, 272_000)],
+        ids=("expansion", "rollback"),
+    )
+    def test_live_codex_context_replaces_stale_cache_in_both_directions(
+        self, tmp_path, monkeypatch, stale_context, live_context
+    ):
+        """Authenticated metadata must replace stale disk values in either direction."""
         from agent import model_metadata as mm
 
         cache_file = tmp_path / "context_length_cache.yaml"
@@ -534,14 +541,14 @@ class TestCodexOAuthContextLength:
         other_key = "other-model@https://api.openai.com/v1/"
         import yaml as _yaml
         cache_file.write_text(_yaml.dump({"context_lengths": {
-            stale_key: 272_000,
+            stale_key: stale_context,
             other_key: 128_000,
         }}))
 
         fake_response = MagicMock()
         fake_response.status_code = 200
         fake_response.json.return_value = {
-            "models": [{"slug": "gpt-5.6-terra", "context_window": 372_000}]
+            "models": [{"slug": "gpt-5.6-terra", "context_window": live_context}]
         }
         # Exercise real persistence here: this test verifies that a live value
         # replaces the stale on-disk entry. Failure-path tests below mock the
@@ -554,10 +561,10 @@ class TestCodexOAuthContextLength:
                 provider="openai-codex",
             )
 
-        assert ctx == 372_000
+        assert ctx == live_context
         mock_get.assert_called_once()
         remaining = _yaml.safe_load(cache_file.read_text()).get("context_lengths", {})
-        assert remaining.get(stale_key) == 372_000
+        assert remaining.get(stale_key) == live_context
         assert remaining.get(other_key) == 128_000
 
     def test_codex_fallback_is_not_persisted(self, tmp_path, monkeypatch):

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -495,7 +495,9 @@ class TestCodexOAuthContextLength:
         fake_response.json.return_value = {
             "models": [{"slug": "gpt-5.6-terra", "context_window": 372_000}]
         }
-
+        # Exercise real persistence here: this test verifies that a live value
+        # replaces the stale on-disk entry. Failure-path tests below mock the
+        # writer because they assert that fallback values are not persisted.
         with patch("agent.model_metadata.requests.get", return_value=fake_response) as mock_get:
             ctx = mm.get_model_context_length(
                 model="gpt-5.6-terra",

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -355,11 +355,10 @@ class TestDefaultContextLengths:
 # =========================================================================
 
 class TestCodexOAuthContextLength:
-    """ChatGPT Codex OAuth imposes lower context limits than the direct
-    OpenAI API for the same slugs. Verified Apr 2026 via live probe of
-    chatgpt.com/backend-api/codex/models: most models return 272k, while
-    models.dev reports 1.05M for gpt-5.5/gpt-5.4 and 400k for the rest.
-    (Known exception: gpt-5.3-codex-spark is 128k.)
+    """ChatGPT Codex OAuth context windows come from the authenticated
+    /models catalogue and may differ from the static fallback table or the
+    direct OpenAI API allocation. The fallback values below are conservative
+    defaults used only when the live probe is unavailable.
     """
 
     def setup_method(self):
@@ -475,97 +474,95 @@ class TestCodexOAuthContextLength:
             "leaked outside openai-codex provider"
         )
 
-    def test_stale_codex_cache_over_400k_is_invalidated(self, tmp_path, monkeypatch):
-        """Pre-PR #14935 builds cached gpt-5.5 at 1.05M (from models.dev)
-        before the Codex-aware branch existed. Upgrading users keep that
-        stale entry on disk and the cache-first lookup returns it forever.
-        Codex OAuth caps at 272k for every slug, so any cached Codex
-        entry >= 400k must be dropped and re-resolved via the live probe.
-        """
+    def test_stale_codex_cache_is_bypassed_and_live_probe_wins(self, tmp_path, monkeypatch):
+        """A stale Codex disk entry must not mask the authenticated catalogue."""
         from agent import model_metadata as mm
 
-        # Isolate the cache file to tmp_path
         cache_file = tmp_path / "context_length_cache.yaml"
         monkeypatch.setattr(mm, "_get_context_cache_path", lambda: cache_file)
 
-        base_url = "https://chatgpt.com/backend-api/codex/"
-        stale_key = f"gpt-5.5@{base_url}"
+        base_url = "https://chatgpt.com/backend-api/codex"
+        stale_key = f"gpt-5.6-terra@{base_url}"
         other_key = "other-model@https://api.openai.com/v1/"
         import yaml as _yaml
         cache_file.write_text(_yaml.dump({"context_lengths": {
-            stale_key: 1_050_000,   # stale pre-fix value
-            other_key: 128_000,     # unrelated, must survive
+            stale_key: 272_000,
+            other_key: 128_000,
         }}))
 
         fake_response = MagicMock()
         fake_response.status_code = 200
         fake_response.json.return_value = {
-            "models": [{"slug": "gpt-5.5", "context_window": 272_000}]
+            "models": [{"slug": "gpt-5.6-terra", "context_window": 372_000}]
         }
+
+        with patch("agent.model_metadata.requests.get", return_value=fake_response) as mock_get:
+            ctx = mm.get_model_context_length(
+                model="gpt-5.6-terra",
+                base_url=base_url,
+                api_key="fake-token",
+                provider="openai-codex",
+            )
+
+        assert ctx == 372_000
+        mock_get.assert_called_once()
+        remaining = _yaml.safe_load(cache_file.read_text()).get("context_lengths", {})
+        assert remaining.get(stale_key) == 372_000
+        assert remaining.get(other_key) == 128_000
+
+    def test_codex_fallback_is_not_persisted(self, tmp_path, monkeypatch):
+        """A failed live probe must not poison the persistent cache."""
+        from agent import model_metadata as mm
+
+        cache_file = tmp_path / "context_length_cache.yaml"
+        monkeypatch.setattr(mm, "_get_context_cache_path", lambda: cache_file)
+        base_url = "https://chatgpt.com/backend-api/codex"
+
+        fake_response = MagicMock()
+        fake_response.status_code = 401
+        fake_response.json.return_value = {}
 
         with patch("agent.model_metadata.requests.get", return_value=fake_response), \
              patch("agent.model_metadata.save_context_length") as mock_save:
             ctx = mm.get_model_context_length(
-                model="gpt-5.5",
+                model="gpt-5.6-terra",
                 base_url=base_url,
-                api_key="fake-token",
+                api_key="expired-token",
                 provider="openai-codex",
             )
 
-        assert ctx == 272_000, f"Stale entry should have been re-resolved to 272k, got {ctx}"
-        # Live save was called with the fresh value
-        mock_save.assert_called_with("gpt-5.5", base_url, 272_000)
-        # The stale entry was removed from disk; unrelated entries survived
-        remaining = _yaml.safe_load(cache_file.read_text()).get("context_lengths", {})
-        assert stale_key not in remaining, "Stale entry was not invalidated from the cache file"
-        assert remaining.get(other_key) == 128_000, "Unrelated cache entries must not be touched"
-
-    def test_fresh_codex_cache_under_400k_is_respected(self, tmp_path, monkeypatch):
-        """Codex entries at the correct 272k must NOT be invalidated —
-        only stale pre-fix values (>= 400k) get dropped."""
-        from agent import model_metadata as mm
-
-        cache_file = tmp_path / "context_length_cache.yaml"
-        monkeypatch.setattr(mm, "_get_context_cache_path", lambda: cache_file)
-
-        base_url = "https://chatgpt.com/backend-api/codex/"
-        import yaml as _yaml
-        cache_file.write_text(_yaml.dump({"context_lengths": {
-            f"gpt-5.5@{base_url}": 272_000,
-        }}))
-
-        # If the invalidation incorrectly fired, this would be called; assert it isn't.
-        with patch("agent.model_metadata.requests.get") as mock_get:
-            ctx = mm.get_model_context_length(
-                model="gpt-5.5",
-                base_url=base_url,
-                api_key="fake-token",
-                provider="openai-codex",
-            )
         assert ctx == 272_000
-        mock_get.assert_not_called()
+        mock_save.assert_not_called()
+        assert not cache_file.exists()
 
-    def test_stale_invalidation_scoped_to_codex_provider(self, tmp_path, monkeypatch):
-        """A cached 1M entry for a non-Codex provider (e.g. Anthropic opus on
-        OpenRouter, legitimately 1M) must NOT be invalidated by this guard."""
+    def test_codex_cache_is_not_used_when_probe_fails(self, tmp_path, monkeypatch):
+        """Even a previously live-looking Codex row must not suppress probing."""
         from agent import model_metadata as mm
 
         cache_file = tmp_path / "context_length_cache.yaml"
         monkeypatch.setattr(mm, "_get_context_cache_path", lambda: cache_file)
-
-        base_url = "https://openrouter.ai/api/v1"
+        base_url = "https://chatgpt.com/backend-api/codex"
         import yaml as _yaml
         cache_file.write_text(_yaml.dump({"context_lengths": {
-            f"anthropic/claude-opus-4.6@{base_url}": 1_000_000,
+            f"gpt-5.6-terra@{base_url}": 372_000,
         }}))
 
-        ctx = mm.get_model_context_length(
-            model="anthropic/claude-opus-4.6",
-            base_url=base_url,
-            api_key="fake",
-            provider="openrouter",
-        )
-        assert ctx == 1_000_000, "Non-codex 1M cache entries must be respected"
+        fake_response = MagicMock()
+        fake_response.status_code = 401
+        fake_response.json.return_value = {}
+
+        with patch("agent.model_metadata.requests.get", return_value=fake_response) as mock_get:
+            ctx = mm.get_model_context_length(
+                model="gpt-5.6-terra",
+                base_url=base_url,
+                api_key="expired-token",
+                provider="openai-codex",
+            )
+
+        assert ctx == 272_000
+        mock_get.assert_called_once()
+        remaining = _yaml.safe_load(cache_file.read_text()).get("context_lengths", {})
+        assert remaining.get(f"gpt-5.6-terra@{base_url}") == 372_000
 
 
 # =========================================================================

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -364,7 +364,6 @@ class TestCodexOAuthContextLength:
     def setup_method(self):
         import agent.model_metadata as mm
         mm._codex_oauth_context_cache = {}
-        mm._codex_oauth_context_cache_time = 0.0
 
     def test_fallback_table_used_without_token(self):
         """With no access token, the hardcoded Codex fallback table wins
@@ -428,6 +427,55 @@ class TestCodexOAuthContextLength:
             )
         assert ctx_55 == 300_000
         assert ctx_54 == 400_000
+
+    def test_live_catalogue_cache_is_scoped_to_access_token(self):
+        """Different OAuth tokens must not share entitlement-specific metadata."""
+        from agent import model_metadata as mm
+        from agent.model_metadata import get_model_context_length
+
+        first_response = MagicMock()
+        first_response.status_code = 200
+        first_response.json.return_value = {
+            "models": [{"slug": "gpt-5.6-terra", "context_window": 272_000}]
+        }
+        second_response = MagicMock()
+        second_response.status_code = 200
+        second_response.json.return_value = {
+            "models": [{"slug": "gpt-5.6-terra", "context_window": 372_000}]
+        }
+
+        with patch(
+            "agent.model_metadata.requests.get",
+            side_effect=[first_response, second_response],
+        ) as mock_get, patch("agent.model_metadata.save_context_length") as mock_save:
+            first = get_model_context_length(
+                "gpt-5.6-terra",
+                base_url="https://chatgpt.com/backend-api/codex",
+                api_key="token-account-a",
+                provider="openai-codex",
+            )
+            first_again = get_model_context_length(
+                "gpt-5.6-terra",
+                base_url="https://chatgpt.com/backend-api/codex",
+                api_key="token-account-a",
+                provider="openai-codex",
+            )
+            second = get_model_context_length(
+                "gpt-5.6-terra",
+                base_url="https://chatgpt.com/backend-api/codex",
+                api_key="token-account-b",
+                provider="openai-codex",
+            )
+
+        assert (first, first_again, second) == (272_000, 272_000, 372_000)
+        assert mock_get.call_count == 2
+        assert mock_get.call_args_list[0].kwargs["headers"]["Authorization"] == "Bearer token-account-a"
+        assert mock_get.call_args_list[1].kwargs["headers"]["Authorization"] == "Bearer token-account-b"
+        assert mock_save.call_count == 2
+        assert all(
+            "token-account" not in key
+            for key in mm._codex_oauth_context_cache
+        )
 
     def test_probe_failure_falls_back_to_hardcoded(self):
         """If the probe fails (non-200 / network error), we still return

--- a/tests/cli/test_cli_codex_context_reference.py
+++ b/tests/cli/test_cli_codex_context_reference.py
@@ -1,0 +1,48 @@
+"""Regression coverage for provider-aware @-context sizing in the CLI."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def test_at_context_resolution_passes_active_provider():
+    """The CLI @-reference path must preserve the active Codex provider."""
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.model = "gpt-5.6-terra"
+    cli.base_url = "https://chatgpt.com/backend-api/codex"
+    cli.api_key = "token"
+    cli.provider = "openai-codex"
+    cli.agent = SimpleNamespace(_config_context_length=None)
+    cli._active_agent_route_signature = "route"
+    cli._secret_capture_callback = lambda *_args, **_kwargs: None
+    cli._last_turn_interrupted = False
+    cli._ensure_runtime_credentials = lambda: True
+    cli._resolve_turn_agent_config = lambda _message: {
+        "signature": "route",
+        "model": cli.model,
+        "runtime": None,
+        "request_overrides": None,
+    }
+    cli._init_agent = lambda **_kwargs: True
+
+    blocked_result = SimpleNamespace(
+        expanded=False,
+        blocked=True,
+        references=[],
+        injected_tokens=0,
+        warnings=["blocked for test"],
+    )
+    with patch("agent.context_references.preprocess_context_references", return_value=blocked_result), \
+         patch("agent.model_metadata.get_model_context_length", return_value=372_000) as mock_context, \
+         patch("cli._cprint"):
+        result = cli.chat("inspect @file:example.py")
+
+    assert result == "blocked for test"
+    mock_context.assert_called_once_with(
+        "gpt-5.6-terra",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="token",
+        provider="openai-codex",
+        config_context_length=None,
+    )


### PR DESCRIPTION
## Bug Description

`get_model_context_length()` could return a stale value from
`~/.hermes/context_length_cache.yaml` before reaching the authenticated Codex
`/backend-api/codex/models` resolver. A fallback such as `272000` could therefore
be persisted after a transient probe failure and continue to mask a later live
allocation (for example, `372000`) across restarts, `/model`, and model-picker
changes for the same model/base URL.

Fixes #

## Root Cause

The generic persistent context cache was checked before the provider-specific
Codex OAuth resolver. Codex fallback values and live catalogue values were both
persisted without source information, so a cache hit prevented revalidation.

## Fix

- Bypass the generic persistent context cache for `openai-codex`, while retaining
  the existing in-process Codex catalogue cache.
- Track whether a Codex resolution came from the live authenticated catalogue
  or the static fallback table.
- Persist only values confirmed by the live `/models` response; fallback values
  remain runtime-only and cannot poison future probes.
- Leave other providers' persistent-cache behavior unchanged. Existing legacy
  Codex rows are bypassed and replaced on the next successful live resolution.

## How to Verify

1. Seed the persistent cache with:
   `gpt-5.6-terra@https://chatgpt.com/backend-api/codex: 272000`.
2. Resolve the model with a mocked authenticated `/models` response containing
   `context_window: 372000`.
3. Confirm the resolver calls the live endpoint, returns `372000`, and replaces
   the cache entry with `372000`.
4. Resolve with a failed/unauthorized live probe and confirm the runtime falls
   back to `272000` without writing that fallback to disk.

## Test Plan

- [x] Added regression test for this bug
- [x] Existing targeted tests still pass
- [x] Manual verification of the live-value and failed-probe cache behavior

Validation:

- `scripts/run_tests.sh tests/agent/test_model_metadata.py tests/hermes_cli/test_model_switch_context_display.py tests/hermes_cli/test_apply_model_switch_result_context.py tests/hermes_cli/test_context_switch_guard.py tests/hermes_cli/test_gpt56_registration.py -q`
- Result: **145 passed**
- `git diff --check` and Python compilation passed.

## Risk Assessment

Low — the change is scoped to the `openai-codex` provider. Explicit context
configuration remains higher priority, and other providers retain their
existing persistent-cache behavior. When the Codex endpoint is unavailable,
the conservative static fallback is still used for the current resolution but
is no longer persisted as authoritative metadata.
