### PR TITLE
fix(kanban): propagate GitHub CLI auth config to workers

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7643,6 +7643,60 @@ def _worker_terminal_timeout_env(
     return str(desired)
 
 
+def _worker_github_cli_config_dir(env: dict[str, str]) -> Optional[str]:
+    """Return a GitHub CLI config dir workers should inherit, if one exists.
+
+    Profile-scoped workers often run with ``HOME={HERMES_HOME}/home``. That is
+    correct for Hermes state isolation, but it hides the host GitHub CLI login
+    stored under the real user's config directory. ``GH_CONFIG_DIR`` is the gh
+    CLI's supported path override and carries no token material itself, so pin
+    it when we can identify an existing host config dir.
+    """
+    explicit = str(env.get("GH_CONFIG_DIR") or "").strip()
+    if explicit:
+        return explicit
+
+    candidates: list[Path] = []
+
+    xdg_config_home = str(env.get("XDG_CONFIG_HOME") or "").strip()
+    if xdg_config_home:
+        candidates.append(Path(os.path.expanduser(xdg_config_home)) / "gh")
+
+    real_home = str(env.get("HERMES_REAL_HOME") or "").strip()
+    if real_home:
+        candidates.append(Path(os.path.expanduser(real_home)) / ".config" / "gh")
+
+    try:
+        import pwd
+
+        getuid = getattr(os, "getuid", None)
+        if getuid is not None:
+            pw_home = pwd.getpwuid(getuid()).pw_dir.strip()
+            if pw_home:
+                candidates.append(Path(pw_home) / ".config" / "gh")
+    except Exception:
+        pass
+
+    appdata = str(env.get("APPDATA") or "").strip()
+    if appdata:
+        candidates.append(Path(os.path.expanduser(appdata)) / "GitHub CLI")
+
+    seen: set[str] = set()
+    for candidate in candidates:
+        try:
+            resolved = str(candidate)
+            key = os.path.normcase(os.path.abspath(os.path.expanduser(resolved)))
+        except Exception:
+            resolved = str(candidate)
+            key = os.path.normcase(resolved)
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        if os.path.isdir(resolved):
+            return resolved
+    return None
+
+
 def _resolve_worker_cli_toolsets(hermes_home: Optional[str]) -> Optional[list[str]]:
     """Return the assigned profile's effective CLI toolsets for a worker.
 
@@ -7785,6 +7839,14 @@ def _default_spawn(
     # what the tool reads — set it explicitly here so comments are
     # attributed correctly regardless of how the child loads config.
     env["HERMES_PROFILE"] = profile_arg
+
+    # Keep host GitHub CLI auth visible to workers without copying token env
+    # vars. This matters when profile HOME isolation would otherwise make `gh`
+    # look under {HERMES_HOME}/home/.config/gh instead of the logged-in user's
+    # config dir.
+    github_cli_config_dir = _worker_github_cli_config_dir(env)
+    if github_cli_config_dir:
+        env["GH_CONFIG_DIR"] = github_cli_config_dir
 
     # A worker must NEVER boot the interactive TUI: an inherited HERMES_TUI=1
     # or a `display.interface: tui` in the profile's config would send the

--- a/tests/hermes_cli/test_kanban_worker_github_auth_env.py
+++ b/tests/hermes_cli/test_kanban_worker_github_auth_env.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import subprocess
+
+
+def _make_task(kb, *, assignee: str = "w"):
+    return kb.Task(
+        id="t_gh_auth_env",
+        title="github auth env",
+        body=None,
+        assignee=assignee,
+        status="running",
+        priority=0,
+        created_by="test",
+        created_at=1,
+        started_at=None,
+        completed_at=None,
+        workspace_kind="dir",
+        workspace_path=None,
+        claim_lock="lock",
+        claim_expires=None,
+        tenant=None,
+        current_run_id=9,
+    )
+
+
+def _capture_spawn_env(kb, monkeypatch, workspace: str) -> dict[str, str]:
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+
+    captured: dict[str, dict[str, str]] = {}
+
+    class FakeProc:
+        pid = 4242
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["env"] = dict(kwargs.get("env") or {})
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    kb._default_spawn(_make_task(kb), workspace)
+    return captured["env"]
+
+
+def test_default_spawn_sets_gh_config_dir_from_real_home(monkeypatch, tmp_path):
+    """Workers should see host GitHub CLI auth even when profile HOME is isolated.
+
+    In profile/worker sessions HOME can point at ``{HERMES_HOME}/home``. GitHub
+    CLI then misses the host's ``~/.config/gh`` unless the dispatcher pins
+    GH_CONFIG_DIR into the worker env.
+    """
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "w"
+    profile_home = profile / "home"
+    profile_home.mkdir(parents=True)
+    profile.joinpath("config.yaml").write_text("toolsets:\n  - kanban\n", encoding="utf-8")
+    root.joinpath("config.yaml").write_text("toolsets:\n  - kanban\n", encoding="utf-8")
+
+    real_home = tmp_path / "host-home"
+    gh_config_dir = real_home / ".config" / "gh"
+    gh_config_dir.mkdir(parents=True)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setenv("HERMES_REAL_HOME", str(real_home))
+    monkeypatch.setenv("HOME", str(profile_home))
+    monkeypatch.delenv("GH_CONFIG_DIR", raising=False)
+
+    from hermes_cli import kanban_db as kb
+
+    env = _capture_spawn_env(kb, monkeypatch, str(workspace))
+
+    assert env["HERMES_HOME"] == str(profile)
+    assert env["GH_CONFIG_DIR"] == str(gh_config_dir)
+
+
+def test_default_spawn_preserves_explicit_gh_config_dir(monkeypatch, tmp_path):
+    """An operator-supplied GH_CONFIG_DIR is the source of truth."""
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "w"
+    (profile / "home").mkdir(parents=True)
+    profile.joinpath("config.yaml").write_text("toolsets:\n  - kanban\n", encoding="utf-8")
+    root.joinpath("config.yaml").write_text("toolsets:\n  - kanban\n", encoding="utf-8")
+
+    explicit = tmp_path / "custom-gh-config"
+    explicit.mkdir()
+    real_home = tmp_path / "host-home"
+    (real_home / ".config" / "gh").mkdir(parents=True)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setenv("HERMES_REAL_HOME", str(real_home))
+    monkeypatch.setenv("HOME", str(profile / "home"))
+    monkeypatch.setenv("GH_CONFIG_DIR", str(explicit))
+
+    from hermes_cli import kanban_db as kb
+
+    env = _capture_spawn_env(kb, monkeypatch, str(workspace))
+
+    assert env["GH_CONFIG_DIR"] == str(explicit)


### PR DESCRIPTION
## Summary
- Pin `GH_CONFIG_DIR` into dispatcher-spawned Kanban worker envs when a host GitHub CLI config dir exists.
- Preserve an explicit operator-provided `GH_CONFIG_DIR` unchanged.
- Add focused regression coverage for profile-home-isolated workers and explicit env preservation.

## Proof
- RED: `HOME=/home/fardochebot scripts/run_tests.sh tests/hermes_cli/test_kanban_worker_github_auth_env.py -q` failed before the fix with `KeyError: 'GH_CONFIG_DIR'`.
- GREEN: `HOME=/home/fardochebot scripts/run_tests.sh tests/hermes_cli/test_kanban_worker_github_auth_env.py -q` — 2 passed.
- REGRESSION: `HOME=/home/fardochebot scripts/run_tests.sh tests/hermes_cli/test_kanban_worker_github_auth_env.py tests/hermes_cli/test_kanban_worker_spawn_toolsets.py tests/hermes_cli/test_kanban_worker_terminal_cwd.py tests/hermes_cli/test_kanban_goal_mode.py -q` — 19 passed.
- Compile: `python3 -m py_compile hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_worker_github_auth_env.py` — passed.
- Auth probe:
  - `HOME=/home/fardochebot gh auth status --hostname github.com` — logged in as `fardoche6`.
  - `PYTHONPATH=/home/fardochebot/Source/hermes-agent-t_dc16a67b-gh-auth-env HOME=/home/fardochebot/.hermes/profiles/programmer/home HERMES_REAL_HOME=/home/fardochebot python3 - <<'PY' ...` — captured worker env had `PROBE_GH_CONFIG_DIR=/home/fardochebot/.config/gh`, and `gh auth status --hostname github.com` returned logged in; `PROBE_RESULT=pass`.

## Notes
- This uses the existing `_default_spawn` worker env construction path. No parallel launcher or new worker subsystem.
- Only the `GH_CONFIG_DIR` path is propagated; token env vars are not copied or introduced by this change.
