### PR TITLE
fix(gateway): malformed scalar config sections no longer crash gateway startup (#40834)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -130,6 +130,11 @@ def _coerce_optional_positive_int(value: Any, key: str) -> Optional[int]:
     return parsed
 
 
+def _coerce_dict(value: Any) -> Dict[str, Any]:
+    """Return *value* when it is a mapping, otherwise an empty dict."""
+    return value if isinstance(value, dict) else {}
+
+
 def _normalize_unauthorized_dm_behavior(value: Any, default: str = "pair") -> str:
     """Normalize unauthorized DM behavior to a supported value."""
     if isinstance(value, str):
@@ -383,6 +388,7 @@ class SessionResetPolicy:
     
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "SessionResetPolicy":
+        data = _coerce_dict(data)
         # Handle both missing keys and explicit null values (YAML null → None)
         mode = data.get("mode")
         at_hour = data.get("at_hour")
@@ -492,24 +498,26 @@ class PlatformConfig:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "PlatformConfig":
+        data = _coerce_dict(data)
         home_channel = None
-        if "home_channel" in data:
+        if isinstance(data.get("home_channel"), dict):
             home_channel = HomeChannel.from_dict(data["home_channel"])
 
         # gateway_restart_notification may be bridged into extra via the
         # shared-key loop in load_gateway_config(); check both top-level
         # and extra so YAML ``discord: gateway_restart_notification: false``
         # works without needing a separate platforms: block.
+        extra = _coerce_dict(data.get("extra", {}))
         _grn = data.get("gateway_restart_notification")
         if _grn is None:
-            _grn = data.get("extra", {}).get("gateway_restart_notification")
+            _grn = extra.get("gateway_restart_notification")
 
         # typing_indicator mirrors gateway_restart_notification: it may arrive
         # top-level or bridged into extra by the shared-key loop in
         # load_gateway_config(), so check both.
         _typing = data.get("typing_indicator")
         if _typing is None:
-            _typing = data.get("extra", {}).get("typing_indicator")
+            _typing = extra.get("typing_indicator")
 
         channel_overrides: Dict[str, ChannelOverride] = {}
         raw_overrides = data.get("channel_overrides") or {}
@@ -527,7 +535,7 @@ class PlatformConfig:
             gateway_restart_notification=_coerce_bool(_grn, True),
             typing_indicator=_coerce_bool(_typing, True),
             channel_overrides=channel_overrides,
-            extra=data.get("extra", {}),
+            extra=extra,
         )
 
 
@@ -586,7 +594,7 @@ class StreamingConfig:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "StreamingConfig":
-        if not data:
+        if not isinstance(data, dict) or not data:
             return cls()
         return cls(
             enabled=_coerce_bool(data.get("enabled"), False),
@@ -823,8 +831,12 @@ class GatewayConfig:
     
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "GatewayConfig":
+        data = _coerce_dict(data)
         platforms = {}
-        for platform_name, platform_data in data.get("platforms", {}).items():
+        platforms_data = _coerce_dict(data.get("platforms", {}))
+        for platform_name, platform_data in platforms_data.items():
+            if not isinstance(platform_data, dict):
+                continue
             try:
                 platform = Platform(platform_name)
                 platforms[platform] = PlatformConfig.from_dict(platform_data)
@@ -832,11 +844,11 @@ class GatewayConfig:
                 pass  # Skip unknown platforms
         
         reset_by_type = {}
-        for type_name, policy_data in data.get("reset_by_type", {}).items():
+        for type_name, policy_data in _coerce_dict(data.get("reset_by_type", {})).items():
             reset_by_type[type_name] = SessionResetPolicy.from_dict(policy_data)
         
         reset_by_platform = {}
-        for platform_name, policy_data in data.get("reset_by_platform", {}).items():
+        for platform_name, policy_data in _coerce_dict(data.get("reset_by_platform", {})).items():
             try:
                 platform = Platform(platform_name)
                 reset_by_platform[platform] = SessionResetPolicy.from_dict(policy_data)

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1039,6 +1039,8 @@ def load_gateway_config() -> GatewayConfig:
             if "stt_echo_transcripts" in yaml_cfg:
                 gw_data["stt_echo_transcripts"] = yaml_cfg["stt_echo_transcripts"]
 
+            gateway_cfg = yaml_cfg.get("gateway")
+
             if "group_sessions_per_user" in yaml_cfg:
                 gw_data["group_sessions_per_user"] = yaml_cfg["group_sessions_per_user"]
 
@@ -1066,7 +1068,11 @@ def load_gateway_config() -> GatewayConfig:
             if not isinstance(streaming_cfg, dict):
                 # Fall back to nested gateway.streaming written by
                 # ``hermes config set gateway.streaming.*``
-                streaming_cfg = yaml_cfg.get("gateway", {}).get("streaming")
+                streaming_cfg = (
+                    gateway_cfg.get("streaming")
+                    if isinstance(gateway_cfg, dict)
+                    else None
+                )
             if isinstance(streaming_cfg, dict):
                 gw_data["streaming"] = streaming_cfg
 
@@ -1099,7 +1105,6 @@ def load_gateway_config() -> GatewayConfig:
             # ``gateway.platforms`` are loaded the same way as top-level
             # ``platforms``. Merge nested first so top-level config keeps
             # precedence, matching the existing gateway.streaming fallback.
-            gateway_cfg = yaml_cfg.get("gateway")
             gateway_platforms = gateway_cfg.get("platforms") if isinstance(gateway_cfg, dict) else None
             platforms_data = gw_data.setdefault("platforms", {})
             if not isinstance(platforms_data, dict):

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -608,6 +608,18 @@ class TestLoadGatewayConfig:
 
         assert config.max_concurrent_sessions == 2
 
+    def test_scalar_gateway_section_does_not_crash_streaming_fallback(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("gateway: disabled\n", encoding="utf-8")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.streaming.transport == "auto"
+
     def test_bridges_discord_thread_require_mention_from_config_yaml(self, tmp_path, monkeypatch):
         """discord.thread_require_mention in config.yaml should reach the runtime env var."""
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -142,6 +142,21 @@ class TestChannelOverride:
         assert d["system_prompt"] == "Hi"
 
 
+class TestPlatformConfigMalformedSections:
+    def test_from_dict_ignores_malformed_nested_sections(self):
+        restored = PlatformConfig.from_dict(
+            {
+                "enabled": True,
+                "home_channel": "telegram:123",
+                "extra": "oops",
+            }
+        )
+
+        assert restored.enabled is True
+        assert restored.home_channel is None
+        assert restored.extra == {}
+
+
 class TestGetConnectedPlatforms:
     def test_returns_enabled_with_token(self):
         config = GatewayConfig(
@@ -238,6 +253,12 @@ class TestSessionResetPolicy:
         restored = SessionResetPolicy.from_dict({"notify": "false"})
         assert restored.notify is False
 
+    def test_from_dict_malformed_section_falls_back_to_defaults(self):
+        restored = SessionResetPolicy.from_dict("oops")
+        assert restored.mode == SessionResetPolicy().mode
+        assert restored.at_hour == 4
+        assert restored.idle_minutes == 1440
+
 
 class TestStreamingConfig:
     def test_defaults_to_auto_transport(self):
@@ -262,6 +283,11 @@ class TestStreamingConfig:
         assert restored.edit_interval == 0.8
         assert restored.buffer_threshold == 24
         assert restored.fresh_final_after_seconds == 0.0
+
+    def test_from_dict_malformed_section_falls_back_to_defaults(self):
+        restored = StreamingConfig.from_dict("enabled")
+        assert restored.enabled is False
+        assert restored.transport == "auto"
 
 
 class TestGatewayConfigRoundtrip:
@@ -364,6 +390,27 @@ class TestGatewayConfigRoundtrip:
     def test_from_dict_coerces_quoted_false_always_log_local(self):
         restored = GatewayConfig.from_dict({"always_log_local": "false"})
         assert restored.always_log_local is False
+
+    def test_from_dict_ignores_malformed_nested_sections(self):
+        restored = GatewayConfig.from_dict(
+            {
+                "platforms": {
+                    "telegram": "enabled",
+                    "discord": {"enabled": True, "token": "tok"},
+                },
+                "default_reset_policy": "daily",
+                "reset_by_type": ["oops"],
+                "reset_by_platform": "oops",
+                "streaming": "enabled",
+            }
+        )
+
+        assert Platform.TELEGRAM not in restored.platforms
+        assert restored.platforms[Platform.DISCORD].enabled is True
+        assert restored.default_reset_policy.mode == SessionResetPolicy().mode
+        assert restored.reset_by_type == {}
+        assert restored.reset_by_platform == {}
+        assert restored.streaming.transport == "auto"
 
     def test_get_notice_delivery_defaults_to_public(self):
         config = GatewayConfig(


### PR DESCRIPTION
## Summary

A single malformed scalar in gateway config (`gateway: disabled`, `platforms: {telegram: "enabled"}`, `streaming: "enabled"`, `reset_by_type: [oops]`) no longer crashes config loading with `AttributeError` — malformed sections are ignored and valid sibling config keeps loading.

Salvages both draft PRs from @sharziki (#40835 + #40837, cherry-picked with authorship preserved) onto current main. Closes #40834.

## Changes

- `gateway/config.py` (#40835): new `_coerce_dict()` helper; applied in `GatewayConfig` / `PlatformConfig` / `StreamingConfig` / `SessionResetPolicy` `from_dict()`; malformed per-platform entries skipped while valid siblings load
- `gateway/config.py` (#40837): `load_gateway_config()` streaming fallback reads the `gateway:` block once and checks it is a mapping before `.get("streaming")`
- Conflict resolution follow-up: rebased the contributor's changes over the `typing_indicator` / `channel_overrides` / `max_concurrent_sessions` code that landed on main since June; `typing_indicator` extra-fallback now uses the coerced `extra` dict; two stale test assertions updated (`SessionResetPolicy` default mode changed from "both" to "none" on main in July — asserts now compare against `SessionResetPolicy().mode` instead of freezing the value)

## Validation

| | Before | After |
|---|---|---|
| 16-case malformed-scalar probe (real imports) | 12 crashed with AttributeError/TypeError | 0 crashes (1 remaining case is an unreachable direct call, guarded at its only call site) |
| `platforms: {telegram: "enabled", discord: {...}}` | crash | telegram skipped, discord loads |
| `gateway: disabled` in config.yaml | crash in streaming fallback | defaults, gateway boots |
| tests/gateway/test_config.py | — | full file green |

E2E (temp HERMES_HOME, real YAML, real `load_gateway_config()`): gateway config loads with corrupt sections; valid discord platform config preserved.

## Infographic

![gateway-config-hardening](https://v3b.fal.media/files/b/0aa1a03c/-Z2stjrKY3QB4boB9QZLo_Pyneimre.png)
