### PR TITLE
fix(cli): route dashboard re-exec through a mockable seam so tests cannot spawn real servers

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12937,6 +12937,27 @@ def _is_electron_packaged_web_dist(path: str) -> bool:
     return "app.asar" in path.replace("\\", "/")
 
 
+def _reexec_dashboard(reexec_argv, env):
+    """Hand control to the machine-level dashboard process; never returns.
+
+    Kept as a module-level seam so unit tests can intercept the entire
+    hand-off with one monkeypatch: the Windows path below goes through
+    subprocess.Popen, so tests that only patch os.execvpe would launch a
+    real dashboard server and then hang forever on proc.wait() (#61729).
+
+    On Windows, os.execvpe() does not truly replace the process — it
+    spawns via CreateProcess then the parent exits.  Under Python 3.14+
+    this can crash with STATUS_ACCESS_VIOLATION (0xC0000005) when
+    re-executing the dashboard for a non-default profile.  Use
+    subprocess.Popen + sys.exit() on Windows to avoid the crash.
+    """
+    if sys.platform == "win32":
+        proc = subprocess.Popen(reexec_argv, env=env)
+        sys.exit(proc.wait())
+    else:
+        os.execvpe(sys.executable, reexec_argv, env)
+
+
 def cmd_dashboard(args):
     """Start the web UI server, or (with --stop/--status) manage running ones."""
     _token_file = getattr(args, "ssh_session_token_file", None)
@@ -13074,16 +13095,7 @@ def cmd_dashboard(args):
             # Best-effort: if root resolution fails, fall back to the prior
             # behaviour (drop HERMES_HOME) rather than block the reroute.
             env.pop("HERMES_HOME", None)
-        # On Windows, os.execvpe() does not truly replace the process — it
-        # spawns via CreateProcess then the parent exits.  Under Python 3.14+
-        # this can crash with STATUS_ACCESS_VIOLATION (0xC0000005) when
-        # re-executing the dashboard for a non-default profile.  Use
-        # subprocess.Popen + sys.exit() on Windows to avoid the crash.
-        if sys.platform == "win32":
-            proc = subprocess.Popen(reexec_argv, env=env)
-            sys.exit(proc.wait())
-        else:
-            os.execvpe(sys.executable, reexec_argv, env)
+        _reexec_dashboard(reexec_argv, env)
 
     if _token_file:
         _ssh_session_token = _read_ssh_session_token_file(_token_file)

--- a/tests/hermes_cli/test_dashboard_unified_launch.py
+++ b/tests/hermes_cli/test_dashboard_unified_launch.py
@@ -7,6 +7,8 @@ launching profile preselected. `--isolated` opts out.
 """
 import sys
 import types
+from pathlib import PurePath
+
 import pytest
 
 
@@ -33,7 +35,7 @@ class TestUnifiedDashboardRouting:
         )
         monkeypatch.setattr(main_mod, "_dashboard_listening", lambda host, port: True)
         execs = []
-        monkeypatch.setattr(main_mod.os, "execvpe", lambda *a, **k: execs.append(a))
+        monkeypatch.setattr(main_mod, "_reexec_dashboard", lambda *a, **k: execs.append(a))
 
         with pytest.raises(SystemExit) as exc:
             main_mod.cmd_dashboard(_args())
@@ -64,18 +66,21 @@ class TestUnifiedDashboardRouting:
         monkeypatch.setattr(main_mod, "_dashboard_listening", lambda host, port: False)
         execs = []
 
-        def fake_exec(exe, argv, env):
-            execs.append((exe, argv, env))
-            raise SystemExit(0)  # execvpe never returns
+        def fake_reexec(argv, env):
+            execs.append((argv, env))
+            raise SystemExit(0)  # the real hand-off never returns
 
-        monkeypatch.setattr(main_mod.os, "execvpe", fake_exec)
+        # Patch the platform-neutral seam, NOT os.execvpe: on Windows the real
+        # hand-off goes through subprocess.Popen, so an execvpe-only patch
+        # would spawn a real dashboard server and hang the test (#61729).
+        monkeypatch.setattr(main_mod, "_reexec_dashboard", fake_reexec)
 
         with pytest.raises(SystemExit):
             main_mod.cmd_dashboard(_args())
 
         assert len(execs) == 1
-        exe, argv, env = execs[0]
-        assert exe == sys.executable
+        argv, env = execs[0]
+        assert argv[0] == sys.executable
         # Pinned to the default profile + launching profile preselected.
         assert "-p" in argv and argv[argv.index("-p") + 1] == "default"
         assert "--open-profile" in argv
@@ -105,21 +110,22 @@ class TestUnifiedDashboardRouting:
         monkeypatch.setattr(main_mod, "_dashboard_listening", lambda host, port: False)
         execs = []
 
-        def fake_exec(exe, argv, env):
-            execs.append((exe, argv, env))
+        def fake_reexec(argv, env):
+            execs.append((argv, env))
             raise SystemExit(0)
 
-        monkeypatch.setattr(main_mod.os, "execvpe", fake_exec)
+        monkeypatch.setattr(main_mod, "_reexec_dashboard", fake_reexec)
 
         with pytest.raises(SystemExit):
             main_mod.cmd_dashboard(_args())
 
         assert len(execs) == 1
-        _exe, _argv, env = execs[0]
+        _argv, env = execs[0]
         # get_default_hermes_root() strips the trailing profiles/<name>, so the
         # child binds /opt/data — where the real default/oracle/saga profiles
-        # and the .install_method stamp actually live.
-        assert env.get("HERMES_HOME") == "/opt/data"
+        # and the .install_method stamp actually live.  Compare as paths, not
+        # strings: on Windows the resolved root stringifies with backslashes.
+        assert PurePath(env.get("HERMES_HOME")) == PurePath("/opt/data")
 
     def test_desktop_profile_backend_skips_machine_dashboard_reroute(self, main_mod, monkeypatch):
         """A desktop-spawned named-profile backend (HERMES_DESKTOP=1) must NOT
@@ -136,7 +142,7 @@ class TestUnifiedDashboardRouting:
             lambda host, port: listening_calls.append(1) or False,
         )
         execs = []
-        monkeypatch.setattr(main_mod.os, "execvpe", lambda *a, **k: execs.append(a))
+        monkeypatch.setattr(main_mod, "_reexec_dashboard", lambda *a, **k: execs.append(a))
         monkeypatch.setitem(sys.modules, "fastapi", None)
 
         with pytest.raises((SystemExit, AttributeError, ImportError, TypeError)):
@@ -184,7 +190,7 @@ class TestUnifiedDashboardRouting:
             "hermes_cli.profiles.get_active_profile_name", lambda: "worker_x"
         )
         execs = []
-        monkeypatch.setattr(main_mod.os, "execvpe", lambda *a, **k: execs.append(a))
+        monkeypatch.setattr(main_mod, "_reexec_dashboard", lambda *a, **k: execs.append(a))
         monkeypatch.setitem(sys.modules, "fastapi", None)
 
         with pytest.raises((SystemExit, AttributeError, ImportError, TypeError)):


### PR DESCRIPTION
## What does this PR do?

Stops `tests/hermes_cli/test_dashboard_unified_launch.py` from launching a **real machine-dashboard server** (and then hanging forever) when the suite runs on Windows.

`cmd_dashboard`'s unified-launch reroute has a Windows-only branch — `subprocess.Popen` + `sys.exit(proc.wait())`, because `os.execvpe` does not truly replace a Windows process and can crash under Python 3.14+. The tests monkeypatched **only `os.execvpe`**, so on Windows the real `Popen` ran on every test execution: an actual dashboard server was spawned on port 9119 (identifiable by the test's mocked profile name in `--open-profile worker_x`), and pytest then blocked forever on `proc.wait()`. Killing pytest orphaned the servers, which also hold inherited stdio handles and wedge any harness draining pytest's output.

This PR extracts the entire hand-off into a module-level `_reexec_dashboard(reexec_argv, env)` seam and has the tests patch that (one platform-neutral patch) instead of `os.execvpe`. Behavior of the production code path is unchanged on both platforms — the same two branches simply live in a named function.

It also fixes the one further Windows failure in the same file that the hang was hiding: the Docker machine-root test compared `HERMES_HOME` to the string `"/opt/data"`, which can never match on Windows where the resolved root stringifies with backslashes — it now compares `PurePath`s.

## Related Issue

Fixes #61729

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`: extract the win32 `Popen`/posix `execvpe` hand-off from `cmd_dashboard` into module-level `_reexec_dashboard(reexec_argv, env)` (docstring documents why the seam exists). No behavior change.
- `tests/hermes_cli/test_dashboard_unified_launch.py`: all five mock sites patch `main_mod._reexec_dashboard` instead of `main_mod.os.execvpe`; the two re-exec assertions unpack `(argv, env)` and assert `argv[0] == sys.executable`.
- Same file: `test_reexec_pins_docker_machine_root` compares `PurePath(env["HERMES_HOME"]) == PurePath("/opt/data")` so the assertion is separator-agnostic.

## How to Test

On Windows (before this PR: hangs indefinitely and leaves `hermes_cli.main ... dashboard --port 9119 --open-profile worker_x` processes running after pytest is killed):

```
uv run --extra all --extra dev pytest -q tests/hermes_cli/test_dashboard_unified_launch.py
```

After this PR: `9 passed` in under a second, and `tasklist | findstr dashboard` shows nothing spawned. On Linux/macOS the file passed before and still passes — the seam is exercised by the same tests through the posix branch.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

Full suite run locally on Windows 11 via `scripts/run_tests_parallel.py`: 1,952 files / ~38.7k tests, **38,217 passed**, and `tests/hermes_cli/test_dashboard_unified_launch.py` passes inside the full run (9 tests, 5.7s) where it previously hung before collection. The 512 failures across 93 files are the same Windows-environment set independently verified pre-existing on `main` (per-file standalone A/B against the base; details in #61606's validation note); none touch `cmd_dashboard`, and the `cmd_dashboard`-adjacent suites were additionally A/B'd with this change stashed — identical results.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the seam's docstring documents the Windows constraint and the test contract
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config changes)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before (Windows): orphaned processes captured ~2 hours after pytest was killed —

```
pytest.exe  -q -x tests/hermes_cli/test_dashboard_unified_launch.py      (age 135.8 min)
python.exe  -m hermes_cli.main -p default dashboard --port 9119
            --host 127.0.0.1 --open-profile worker_x --no-open           (age 135.8 min)
```

After (Windows):

```
$ uv run --extra all --extra dev pytest -q tests/hermes_cli/test_dashboard_unified_launch.py
.........
9 passed in 0.49s
```

Validation performed:

- `python -m py_compile hermes_cli/main.py tests/hermes_cli/test_dashboard_unified_launch.py`
- `uv run --extra all --extra dev ruff check hermes_cli/main.py tests/hermes_cli/test_dashboard_unified_launch.py` — clean
- All suites referencing `cmd_dashboard` (`test_dashboard_lifecycle_flags`, `test_dashboard_register`, `test_dashboard_web_dist_validation`, `test_serve_command`, `test_subcommands_batch`, `test_web_ui_build`): 111 passed; the 5 failures are Windows-pre-existing and reproduce identically with this change stashed (verified).
