### PR TITLE
fix(dashboard): eliminate avoidable status-poll subprocess forks

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -179,9 +179,17 @@ def get_process_start_time(pid: int) -> Optional[int]:
 def _read_process_cmdline(pid: int) -> Optional[str]:
     """Return the process command line as a space-separated string.
 
-    On Linux, reads /proc/<pid>/cmdline directly.  On macOS and other
-    platforms without /proc, falls back to ``ps -p <pid> -o command=``.
-    On Windows (no /proc, no ps), uses psutil.
+    Preference order (zero avoidable forks on the hot dashboard path):
+
+    1. Linux ``/proc/<pid>/cmdline`` (no subprocess)
+    2. ``psutil.Process(pid).cmdline()`` when available (in-process; works on
+       macOS/Windows and is a hard Hermes dependency on those platforms)
+    3. ``ps -p <pid> -o command=`` only as a last-resort fallback when psutil
+       is unavailable or fails
+
+    High-frequency ``/api/status`` polling previously forked ``ps`` once per
+    live gateway profile on every request. Preferring psutil eliminates those
+    forks while preserving the historical ``ps`` path for stripped installs.
     """
     cmdline_path = Path(f"/proc/{pid}/cmdline")
     try:
@@ -191,6 +199,18 @@ def _read_process_cmdline(pid: int) -> Optional[str]:
     else:
         if raw:
             return raw.replace(b"\x00", b" ").decode("utf-8", errors="ignore").strip()
+
+    # Prefer in-process psutil before forking ``ps``. Dashboard status topology
+    # probes every profile's PID; forking once per profile per poll is the
+    # dominant idle-CPU cost on multi-profile hosts (macOS especially).
+    try:
+        import psutil  # type: ignore
+        proc = psutil.Process(pid)
+        cmdline_parts = proc.cmdline()
+        if cmdline_parts:
+            return " ".join(cmdline_parts)
+    except Exception:
+        pass
 
     if not _IS_WINDOWS:
         try:
@@ -204,16 +224,6 @@ def _read_process_cmdline(pid: int) -> Optional[str]:
                 return result.stdout.strip()
         except (OSError, subprocess.TimeoutExpired):
             pass
-
-    # Windows fallback: psutil (already used by _pid_exists)
-    try:
-        import psutil  # type: ignore
-        proc = psutil.Process(pid)
-        cmdline_parts = proc.cmdline()
-        if cmdline_parts:
-            return " ".join(cmdline_parts)
-    except Exception:
-        pass
 
     return None
 

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -710,9 +710,14 @@ def _check_gateway_running(profile_dir: Path) -> bool:
     agree.  Parameterized by ``profile_dir`` so it never mutates ``HERMES_HOME``.
     """
     try:
-        from gateway.status import get_running_pid
+        # Read-side only (dashboard /api/status topology, profiles sidebar).
+        # Use the short-lived PID cache so multi-profile status polls do not
+        # re-open/lock every profile's gateway.lock + re-probe cmdline on every
+        # HTTP hit. Control paths (start/stop/replace) still call
+        # get_running_pid() directly for an authoritative lock probe.
+        from gateway.status import get_running_pid_cached
         if (
-            get_running_pid(profile_dir / "gateway.pid", cleanup_stale=False)
+            get_running_pid_cached(profile_dir / "gateway.pid", cleanup_stale=False)
             is not None
         ):
             return True

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2379,6 +2379,37 @@ def _profile_platform_ports(profile_home: Path, runtime: Optional[dict]) -> Dict
     return ports
 
 
+# Short-lived topology cache for high-frequency /api/status polls (sidebar +
+# multi-tab dashboards). Invalidates when any profile's gateway.pid /
+# gateway.lock / gateway_state.json mtime/size changes, or after a short TTL
+# so start/stop still surfaces within ~1s.
+_TOPOLOGY_CACHE_TTL_SECONDS = 1.0
+_topology_cache_lock = threading.Lock()
+_topology_cache: dict[str, Any] | None = None
+_topology_cache_at: float = 0.0
+_topology_cache_signature: tuple[Any, ...] | None = None
+
+
+def _topology_file_signature(path: Path) -> tuple[bool, Optional[int], Optional[int]]:
+    try:
+        st = path.stat()
+    except OSError:
+        return (False, None, None)
+    return (True, int(st.st_mtime_ns), int(st.st_size))
+
+
+def _profile_gateway_topology_signature(
+    homes: List[Tuple[str, Path]],
+) -> tuple[Any, ...]:
+    parts: List[Any] = []
+    for name, home in homes:
+        parts.append(name)
+        parts.append(_topology_file_signature(home / "gateway.pid"))
+        parts.append(_topology_file_signature(home / "gateway.lock"))
+        parts.append(_topology_file_signature(home / "gateway_state.json"))
+    return tuple(parts)
+
+
 def _collect_profile_gateway_topology() -> Dict[str, Any]:
     """Enumerate profiles and the gateways serving them for ``/api/status``.
 
@@ -2394,7 +2425,13 @@ def _collect_profile_gateway_topology() -> Dict[str, Any]:
       multiple profiles (gateway.multiplex_profiles), ``"single"`` for one
       live gateway, ``"multiple"`` for independent per-profile gateways,
       ``"none"`` when nothing is running.
+
+    Results are cached briefly (see ``_TOPOLOGY_CACHE_TTL_SECONDS``) and
+    invalidated when profile gateway identity files change, so multi-tab
+    status polling does not re-walk every profile on every HTTP request.
     """
+    global _topology_cache, _topology_cache_at, _topology_cache_signature
+
     try:
         from hermes_cli.profiles import _check_gateway_running, profiles_to_serve
         from gateway.status import read_runtime_status
@@ -2402,6 +2439,16 @@ def _collect_profile_gateway_topology() -> Dict[str, Any]:
     except Exception:
         _log.debug("profile/gateway topology enumeration failed", exc_info=True)
         return {"profiles": [], "gateway_mode": "unknown", "gateways": []}
+
+    signature = _profile_gateway_topology_signature(homes)
+    now = time.monotonic()
+    with _topology_cache_lock:
+        if (
+            _topology_cache is not None
+            and _topology_cache_signature == signature
+            and now - _topology_cache_at <= _TOPOLOGY_CACHE_TTL_SECONDS
+        ):
+            return _topology_cache
 
     profile_names = [name for name, _home in homes]
     gateways: List[Dict[str, Any]] = []
@@ -2436,7 +2483,12 @@ def _collect_profile_gateway_topology() -> Dict[str, Any]:
     else:
         mode = "none"
 
-    return {"profiles": profile_names, "gateway_mode": mode, "gateways": gateways}
+    result = {"profiles": profile_names, "gateway_mode": mode, "gateways": gateways}
+    with _topology_cache_lock:
+        _topology_cache = result
+        _topology_cache_at = time.monotonic()
+        _topology_cache_signature = signature
+    return result
 
 
 @app.get("/api/status")

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -1448,11 +1448,24 @@ class TestPlannedStopMarker:
 
 
 class TestReadProcessCmdlinePsFallback:
-    """Tests for _read_process_cmdline falling back to ps on non-Linux."""
+    """Tests for _read_process_cmdline process-table probes."""
+
+    def _block_proc_and_psutil(self, monkeypatch):
+        monkeypatch.setattr(
+            status.Path,
+            "read_bytes",
+            lambda self: (_ for _ in ()).throw(FileNotFoundError),
+        )
+        monkeypatch.setattr(status, "_IS_WINDOWS", False)
+        # Force the psutil path to fail so the historical ``ps`` fallback runs.
+        monkeypatch.setitem(
+            sys.modules,
+            "psutil",
+            SimpleNamespace(Process=lambda pid: (_ for _ in ()).throw(RuntimeError("no psutil"))),
+        )
 
     def test_ps_fallback_when_proc_unavailable(self, monkeypatch):
-        monkeypatch.setattr(status.Path, "read_bytes", lambda self: (_ for _ in ()).throw(FileNotFoundError))
-        monkeypatch.setattr(status, "_IS_WINDOWS", False)
+        self._block_proc_and_psutil(monkeypatch)
         monkeypatch.setattr(
             status.subprocess, "run",
             lambda args, **kwargs: SimpleNamespace(returncode=0, stdout="/usr/libexec/bluetoothuserd\n"),
@@ -1461,8 +1474,7 @@ class TestReadProcessCmdlinePsFallback:
         assert result == "/usr/libexec/bluetoothuserd"
 
     def test_ps_fallback_returns_none_on_failure(self, monkeypatch):
-        monkeypatch.setattr(status.Path, "read_bytes", lambda self: (_ for _ in ()).throw(FileNotFoundError))
-        monkeypatch.setattr(status, "_IS_WINDOWS", False)
+        self._block_proc_and_psutil(monkeypatch)
         monkeypatch.setattr(
             status.subprocess, "run",
             lambda args, **kwargs: SimpleNamespace(returncode=1, stdout=""),
@@ -1485,12 +1497,47 @@ class TestReadProcessCmdlinePsFallback:
     def test_ps_fallback_used_when_proc_returns_empty(self, monkeypatch):
         monkeypatch.setattr(status.Path, "read_bytes", lambda self: b"")
         monkeypatch.setattr(status, "_IS_WINDOWS", False)
+        monkeypatch.setitem(
+            sys.modules,
+            "psutil",
+            SimpleNamespace(Process=lambda pid: (_ for _ in ()).throw(RuntimeError("no psutil"))),
+        )
         monkeypatch.setattr(
             status.subprocess, "run",
             lambda args, **kwargs: SimpleNamespace(returncode=0, stdout="python hermes_cli/main.py gateway run\n"),
         )
         result = status._read_process_cmdline(12345)
         assert "hermes_cli/main.py" in result
+
+    def test_psutil_preferred_over_ps_on_non_linux(self, monkeypatch):
+        """Dashboard status polls must not fork ``ps`` when psutil works."""
+        monkeypatch.setattr(
+            status.Path,
+            "read_bytes",
+            lambda self: (_ for _ in ()).throw(FileNotFoundError),
+        )
+        monkeypatch.setattr(status, "_IS_WINDOWS", False)
+        ps_calls = []
+        monkeypatch.setattr(
+            status.subprocess,
+            "run",
+            lambda args, **kwargs: ps_calls.append(list(args))
+            or SimpleNamespace(returncode=0, stdout="ps should not run\n"),
+        )
+
+        class _Proc:
+            def __init__(self, pid):
+                self.pid = pid
+
+            def cmdline(self):
+                return ["python3", "-m", "hermes_cli.main", "gateway", "run"]
+
+        monkeypatch.setitem(sys.modules, "psutil", SimpleNamespace(Process=_Proc))
+
+        result = status._read_process_cmdline(4242)
+
+        assert result == "python3 -m hermes_cli.main gateway run"
+        assert ps_calls == []
 
     def test_windows_skips_ps_fallback_and_uses_psutil(self, monkeypatch):
         monkeypatch.setattr(status.Path, "read_bytes", lambda self: (_ for _ in ()).throw(FileNotFoundError))

--- a/tests/hermes_cli/test_check_gateway_running_cached.py
+++ b/tests/hermes_cli/test_check_gateway_running_cached.py
@@ -1,0 +1,29 @@
+"""_check_gateway_running must use the short-lived PID cache on the read path."""
+
+from pathlib import Path
+
+
+def test_check_gateway_running_uses_cached_pid_probe(tmp_path, monkeypatch):
+    import hermes_cli.profiles as profiles_mod
+    import gateway.status as status_mod
+
+    pid_path = tmp_path / "gateway.pid"
+    pid_path.write_text("1\n", encoding="utf-8")
+    calls = {"cached": 0, "uncached": 0}
+
+    def cached(path=None, *args, **kwargs):
+        calls["cached"] += 1
+        assert path == pid_path
+        assert kwargs.get("cleanup_stale") is False
+        return 1234
+
+    def uncached(path=None, *args, **kwargs):
+        calls["uncached"] += 1
+        return None
+
+    monkeypatch.setattr(status_mod, "get_running_pid_cached", cached)
+    monkeypatch.setattr(status_mod, "get_running_pid", uncached)
+
+    assert profiles_mod._check_gateway_running(tmp_path) is True
+    assert calls["cached"] == 1
+    assert calls["uncached"] == 0

--- a/tests/hermes_cli/test_web_server_gateway_topology.py
+++ b/tests/hermes_cli/test_web_server_gateway_topology.py
@@ -93,6 +93,13 @@ def _patch_topology(monkeypatch, homes, running, runtimes):
     """
     import hermes_cli.profiles as profiles_mod
     import gateway.status as status_mod
+    import hermes_cli.web_server as web_server_mod
+
+    # Topology results are short-lived cached; wipe between unit cases so
+    # sequential tests with different collaborator patches stay independent.
+    web_server_mod._topology_cache = None
+    web_server_mod._topology_cache_at = 0.0
+    web_server_mod._topology_cache_signature = None
 
     monkeypatch.setattr(profiles_mod, "profiles_to_serve", lambda multiplex: homes)
     monkeypatch.setattr(
@@ -167,6 +174,37 @@ class TestCollectProfileGatewayTopology:
         monkeypatch.setattr(profiles_mod, "profiles_to_serve", _boom)
         topo = _collect_profile_gateway_topology()
         assert topo == {"profiles": [], "gateway_mode": "unknown", "gateways": []}
+
+
+    def test_topology_cache_reuses_result_within_ttl(self, tmp_path, monkeypatch):
+        """Second call within TTL must not re-probe gateway liveness."""
+        import hermes_cli.profiles as profiles_mod
+        import hermes_cli.web_server as web_server_mod
+
+        homes = [("default", tmp_path / "d")]
+        (tmp_path / "d").mkdir()
+        checks = {"n": 0}
+
+        def _check(home):
+            checks["n"] += 1
+            return True
+
+        web_server_mod._topology_cache = None
+        web_server_mod._topology_cache_at = 0.0
+        web_server_mod._topology_cache_signature = None
+        monkeypatch.setattr(profiles_mod, "profiles_to_serve", lambda multiplex: homes)
+        monkeypatch.setattr(profiles_mod, "_check_gateway_running", _check)
+        monkeypatch.setattr(
+            __import__("gateway.status", fromlist=["read_runtime_status"]),
+            "read_runtime_status",
+            lambda path=None: {"platforms": {}},
+        )
+
+        first = _collect_profile_gateway_topology()
+        second = _collect_profile_gateway_topology()
+        assert first == second
+        assert first["gateway_mode"] == "single"
+        assert checks["n"] == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Multi-profile dashboard `/api/status` topology was forking `ps` once per live gateway profile on every poll, even after the short-lived PID cache landed.

This PR:
1. Prefers in-process `psutil` for process cmdline (macOS/Windows), with `ps` only as last resort
2. Routes `_check_gateway_running` through `get_running_pid_cached` for read-side status/topology
3. Adds a 1s topology assembly cache invalidated by gateway.pid/lock/state file signatures

## Measurements (6 live gateways on macOS)
| Path | Median | Forks/call |
|---|---:|---:|
| Before topology | ~96 ms | 6 |
| After warm topology | ~0.2 ms | 0 |
| After cold topology | ~92 ms | 0 |

## Tests
- `tests/gateway/test_status.py` (95)
- `tests/hermes_cli/test_web_server_gateway_topology.py` (17)
- `tests/hermes_cli/test_check_gateway_running_cached.py` (1)
- `tests/hermes_cli/test_dashboard_auth_status_endpoint.py` (5)
- `tests/hermes_cli/test_web_server.py` (366)

No live main checkout changes; branch is based on current origin/main.