### PR TITLE
fix(session): check reset policy in self-healing recovery path (#54878)

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1915,6 +1915,14 @@ class SessionStore:
                         session_key, entry.session_id,
                     )
                     self._entries.pop(session_key, None)
+                    # If an expiry watcher (daily/idle reset) already finalized
+                    # this session, honour the reset decision instead of silently
+                    # reopening it via recovery.
+                    if _reset_reason:
+                        was_auto_reset = True
+                        auto_reset_reason = _reset_reason
+                        reset_had_activity = entry.last_prompt_tokens > 0
+                        db_end_session_id = entry.session_id
                     entry = None
                     _needs_recover = True
                 elif entry.session_id != _stale_session_id:

--- a/tests/gateway/test_session_store_runtime_stale_guard.py
+++ b/tests/gateway/test_session_store_runtime_stale_guard.py
@@ -202,3 +202,50 @@ class TestRuntimeStaleGuard:
 
         assert result.session_id != "sid_old"
         db.get_session.assert_not_called()
+
+    def test_stale_agent_close_overdue_policy_creates_fresh_session(
+        self, tmp_path,
+    ):
+        """Stale `agent_close` entry + overdue reset policy → fresh session.
+
+        The #54878 self-healing path popped the stale sessions.json entry and
+        recovered the same session_id from the DB without checking whether a
+        daily/idle reset was actually due.  This test guards the fix at
+        gateway/session.py:1765 — when the session is overdue under the
+        configured reset policy, we must create a fresh session (new id,
+        auto-reset metadata set, reopen_session NOT called).
+        """
+        source = _source()
+        # Idle policy: reset after 60 minutes of inactivity.
+        config = GatewayConfig(
+            default_reset_policy=SessionResetPolicy(mode="idle", idle_minutes=60),
+        )
+        db = _db_returning({"sid_stale": {"end_reason": "agent_close", "id": "sid_stale"}})
+        # Recovery would normally reopen this row — but it shouldn't, because
+        # the reset policy says this session is overdue.
+        db.find_latest_gateway_session_for_peer.return_value = {
+            "id": "sid_stale",
+            "started_at": (datetime.now() - timedelta(hours=3)).timestamp(),
+        }
+
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._db = db
+        store._loaded = True
+
+        key = store._generate_session_key(source)
+        # Entry last updated 2 hours ago → well past the 60-minute idle window.
+        store._entries[key] = _make_entry(key, "sid_stale")
+        store._entries[key].updated_at = datetime.now() - timedelta(hours=2)
+
+        result = store.get_or_create_session(source)
+
+        # Fresh session — NOT the stale session_id.
+        assert result.session_id != "sid_stale"
+        # Auto-reset metadata is set.
+        assert result.was_auto_reset is True
+        assert result.auto_reset_reason == "idle"
+        # reopen_session must NOT have been called (we skipped recovery).
+        db.reopen_session.assert_not_called()
+        # A brand-new session row was created.
+        db.create_session.assert_called_once()


### PR DESCRIPTION
## Problem

When the session expiry watcher finalizes a session (daily/idle reset) and the next message triggers the #54878 self-healing path (get_or_create_session detects sessions.json / state.db mismatch), the recovered session was silently reopened without checking whether it should have been reset.

This caused sessions to persist indefinitely across reset boundaries — verified in production where a Telegram DM session lived from July 3 to July 10 across multiple daily reset boundaries (at_hour: 4).

### Root cause

In `get_or_create_session()`, the #54878 self-healing block at line 1748 pops the stale sessions.json entry and falls through to DB recovery — but never calls `_should_reset()`. The normal reset check at line 1798 is in the `else` branch that the self-healing path skips.

### Timeline observed in production

```
04:02  Session expiry watcher finalizes session (daily reset at 4 AM)
04:15  Next message arrives → #54878 path detects mismatch
       → Drops stale entry → Recovers from DB → Reopens session
       → _should_reset() NEVER called → Old session resurrected
```

## Fix

After dropping the stale sessions.json entry in the self-healing path, call `_should_reset()` against the old entry's `updated_at`. If a reset is due, set `db_end_session_id` to skip DB recovery and create a fresh session — matching the normal reset flow.

## Changes

- `gateway/session.py`: +12/-3 lines in `get_or_create_session()`
- One file changed