### PR TITLE
feat(tool_search): opt-in deferral for infrequent built-in toolsets

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1446,3 +1446,25 @@ updates:
 #     binary_path: ""                               # "" = resolve op via PATH; else absolute path
 #     cache_ttl_seconds: 300                        # 0 disables BOTH cache layers
 #     override_existing: true                       # resolved values win over existing env
+
+# =============================================================================
+# Tool search (progressive tool disclosure)
+# =============================================================================
+# Replaces deferrable tool schemas in the model-facing tools array with three
+# small bridge tools (tool_search / tool_describe / tool_call), cutting the
+# schema entry tax every session pays on its first prefill. Deferred tools
+# stay fully usable — the model finds them by search and calls them through
+# the bridge, with guardrails/approvals/hooks firing identically.
+#
+# tools:
+#   tool_search:
+#     enabled: auto            # auto | on | off
+#     threshold_pct: 10.0
+#     search_default_limit: 5
+#     max_search_limit: 20
+#     # Built-in toolsets are never deferred unless listed here. Keep the hot
+#     # path (terminal/file/web/skills/clarify) direct; opt in only infrequent
+#     # surfaces. Trade-off: turns that use a deferred tool pay one extra
+#     # bridge round-trip to discover it.
+#     # defer_toolsets: [browser, browser-cdp, cronjob, delegation, image_gen, tts, vision, homeassistant, computer_use, session_search]
+

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2778,10 +2778,11 @@ DEFAULT_CONFIG = {
     # in the model-facing tools array with three bridge tools —
     # tool_search / tool_describe / tool_call — and surfaced on demand.
     #
-    # Core Hermes tools (terminal, read_file, write_file, patch,
-    # search_files, todo, memory, browser_*, etc.) are NEVER deferred.
-    # See tools/tool_search.py for full design notes and the
-    # openclaw-tool-search-report PDF in this PR for the rationale.
+    # Core Hermes tools never defer by default. Opt specific built-in
+    # toolsets into deferral via ``defer_toolsets`` when those schemas are
+    # themselves the entry tax (browser, cronjob, delegation, image_gen, …).
+    # Keep terminal/file/web/skills/clarify direct for the hot path.
+    # See tools/tool_search.py and website docs for design notes.
     "tools": {
         "tool_search": {
             # "auto" (default) — activate only when deferrable tool schemas
@@ -2800,6 +2801,11 @@ DEFAULT_CONFIG = {
             "search_default_limit": 5,
             # Hard upper bound the model can request via ``limit``. Range 1..50.
             "max_search_limit": 20,
+            # Built-in toolset names to push behind the bridge. Empty by
+            # default (no behavior change). Example for infrequent core:
+            # [browser, browser-cdp, cronjob, delegation, image_gen, tts,
+            #  vision, homeassistant, computer_use, session_search]
+            "defer_toolsets": [],
         },
     },
 

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -90,15 +90,20 @@ class TestConfigParsing:
 
 class TestClassification:
     def test_core_tools_never_defer(self):
-        """The critical invariant from the OpenClaw report."""
+        """The critical invariant from the OpenClaw report.
+
+        Without an explicit ``defer_toolsets`` opt-in, core tools never defer.
+        Pass ``frozenset()`` so this assertion is independent of the developer's
+        local ``~/.hermes/config.yaml``.
+        """
         from tools.tool_search import is_deferrable_tool_name
         # Sample of core tools from _HERMES_CORE_TOOLS.
         for core_name in ["terminal", "read_file", "write_file", "patch",
                           "search_files", "todo", "memory", "browser_navigate",
                           "web_search", "session_search", "clarify",
                           "execute_code", "delegate_task", "send_message"]:
-            assert not is_deferrable_tool_name(core_name), (
-                f"Core tool '{core_name}' must NEVER be deferrable"
+            assert not is_deferrable_tool_name(core_name, frozenset()), (
+                f"Core tool '{core_name}' must NEVER be deferrable by default"
             )
 
     def test_bridge_tools_never_defer(self):
@@ -126,6 +131,166 @@ class TestClassification:
         names = {(td.get("function") or {}).get("name") for td in visible}
         assert "xx_unknown_tool" in names
         assert deferrable == []
+
+
+# ---------------------------------------------------------------------------
+# defer_toolsets opt-in (built-in toolsets behind the bridge)
+# ---------------------------------------------------------------------------
+
+
+def _register_session_search():
+    """Import a real built-in tool module so the registry holds its entry."""
+    import tools.session_search_tool  # noqa: F401 — registers at import
+    from tools.registry import registry
+    entry = registry.get_entry("session_search")
+    assert entry is not None, "session_search must be registered for these tests"
+    return entry.toolset
+
+
+class TestDeferToolsetsOptIn:
+    """``defer_toolsets`` lets named BUILT-IN toolsets ride the bridge.
+
+    Core protection stays the default: everything here requires the explicit
+    per-toolset opt-in, and the bridge/dispatch paths must agree with the
+    assembly about what was deferred (an opted-in tool that assembly strips
+    but dispatch rejects would be unreachable).
+    """
+
+    def test_config_parses_defer_toolsets(self):
+        from tools.tool_search import ToolSearchConfig
+        cfg = ToolSearchConfig.from_raw({
+            "enabled": "on",
+            "defer_toolsets": ["session_search", "  delegation  ", "", None, 7],
+        })
+        assert cfg.defer_toolsets == frozenset({"session_search", "delegation", "7"})
+
+    def test_config_defer_toolsets_defaults_empty(self):
+        from tools.tool_search import ToolSearchConfig
+        assert ToolSearchConfig.from_raw(None).defer_toolsets == frozenset()
+        assert ToolSearchConfig.from_raw(True).defer_toolsets == frozenset()
+        assert ToolSearchConfig.from_raw({"defer_toolsets": "not-a-list"}).defer_toolsets == frozenset()
+
+    def test_core_tool_defers_only_with_opt_in(self):
+        from tools.tool_search import is_deferrable_tool_name
+        toolset = _register_session_search()
+        assert not is_deferrable_tool_name("session_search", frozenset())
+        assert is_deferrable_tool_name("session_search", frozenset({toolset}))
+
+    def test_bridge_tools_never_defer_even_with_opt_in(self):
+        from tools.tool_search import is_deferrable_tool_name, BRIDGE_TOOL_NAMES
+        for name in BRIDGE_TOOL_NAMES:
+            assert not is_deferrable_tool_name(name, frozenset({"tool_search", "core"}))
+
+    def test_unknown_toolset_opt_in_is_harmless(self):
+        from tools.tool_search import is_deferrable_tool_name
+        _register_session_search()
+        assert not is_deferrable_tool_name(
+            "session_search", frozenset({"xx_no_such_toolset"})
+        )
+
+    def test_assemble_strips_opted_in_core_toolset(self):
+        from tools.tool_search import (
+            assemble_tool_defs, ToolSearchConfig, BRIDGE_TOOL_NAMES,
+        )
+        toolset = _register_session_search()
+        defs = [_td("terminal", "Run a command"),
+                _td("session_search", "Search past sessions")]
+        cfg = ToolSearchConfig.from_raw(
+            {"enabled": "on", "defer_toolsets": [toolset]}
+        )
+        result = assemble_tool_defs(defs, context_length=131072, config=cfg)
+        assert result.activated
+        names = {(td.get("function") or {}).get("name") for td in result.tool_defs}
+        assert "session_search" not in names       # deferred
+        assert "terminal" in names                 # untouched core stays
+        assert BRIDGE_TOOL_NAMES <= names          # bridge present
+
+    def test_hot_path_toolsets_stay_direct_when_infrequent_deferred(self):
+        """Acceptance: terminal stays direct while opted-in infrequent core defers.
+
+        Real registry entries are required so ``defer_toolsets`` can match the
+        toolset name. Hot tools are not opted in and therefore remain direct.
+        """
+        from tools.tool_search import assemble_tool_defs, ToolSearchConfig, BRIDGE_TOOL_NAMES
+        import tools.terminal_tool  # noqa: F401
+        import tools.cronjob_tools  # noqa: F401
+        import tools.delegate_tool  # noqa: F401
+        import tools.browser_tool  # noqa: F401
+        from tools.registry import registry
+
+        # Sanity: registry toolsets match the opt-in keys we will use.
+        assert registry.get_entry("terminal").toolset == "terminal"
+        assert registry.get_entry("cronjob").toolset == "cronjob"
+        assert registry.get_entry("delegate_task").toolset == "delegation"
+        assert registry.get_entry("browser_navigate").toolset == "browser"
+
+        hot = ["terminal", "process"]
+        infrequent = ["browser_navigate", "cronjob", "delegate_task"]
+        defs = [_td(n, n) for n in hot + infrequent]
+        cfg = ToolSearchConfig.from_raw({
+            "enabled": "on",
+            "defer_toolsets": ["browser", "cronjob", "delegation"],
+        })
+        result = assemble_tool_defs(defs, context_length=131072, config=cfg)
+        assert result.activated
+        names = {(td.get("function") or {}).get("name") for td in result.tool_defs}
+        for n in hot:
+            assert n in names, f"hot path tool {n} must stay direct"
+        for n in infrequent:
+            assert n not in names, f"infrequent tool {n} should be deferred"
+        assert BRIDGE_TOOL_NAMES <= names
+
+    def test_dispatch_paths_accept_opted_in_tool(self, monkeypatch):
+        """describe/tool_call must agree with assembly about the opt-in."""
+        import tools.tool_search as ts
+        toolset = _register_session_search()
+        cfg = ts.ToolSearchConfig.from_raw(
+            {"enabled": "on", "defer_toolsets": [toolset]}
+        )
+        monkeypatch.setattr(ts, "load_config", lambda: cfg)
+
+        td = _td("session_search", "Search past sessions")
+        described = json.loads(ts.dispatch_tool_describe(
+            {"name": "session_search"}, current_tool_defs=[td]))
+        assert described.get("name") == "session_search"
+        assert "error" not in described
+
+        name, args, err = ts.resolve_underlying_call(
+            {"name": "session_search", "arguments": {"query": "x"}})
+        assert err is None
+        assert name == "session_search"
+        assert args == {"query": "x"}
+
+    def test_dispatch_paths_reject_without_opt_in(self, monkeypatch):
+        import tools.tool_search as ts
+        _register_session_search()
+        cfg = ts.ToolSearchConfig.from_raw({"enabled": "on"})
+        monkeypatch.setattr(ts, "load_config", lambda: cfg)
+
+        described = json.loads(ts.dispatch_tool_describe(
+            {"name": "session_search"},
+            current_tool_defs=[_td("session_search", "Search past sessions")]))
+        assert "error" in described
+
+        _, _, err = ts.resolve_underlying_call({"name": "session_search", "arguments": {}})
+        assert err is not None
+
+    def test_session_byte_stable_across_identical_assemblies(self):
+        """Prompt-cache safety: identical input → identical tool_defs bytes."""
+        import json
+        from tools.tool_search import assemble_tool_defs, ToolSearchConfig
+        toolset = _register_session_search()
+        defs = [_td("terminal", "Run a command"),
+                _td("session_search", "Search past sessions"),
+                _td("cronjob", "Schedule jobs")]
+        cfg = ToolSearchConfig.from_raw({
+            "enabled": "on",
+            "defer_toolsets": [toolset, "cronjob"],
+        })
+        a = assemble_tool_defs(defs, context_length=131072, config=cfg)
+        b = assemble_tool_defs(defs, context_length=131072, config=cfg)
+        assert a.activated and b.activated
+        assert json.dumps(a.tool_defs, sort_keys=True, separators=(",", ":")) ==                json.dumps(b.tool_defs, sort_keys=True, separators=(",", ":"))
 
 
 # ---------------------------------------------------------------------------

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -2,13 +2,19 @@
 
 When enabled, MCP and non-core plugin tools are replaced in the model-visible
 tools array by three bridge tools — ``tool_search``, ``tool_describe``,
-``tool_call`` — and surfaced on demand. Core Hermes tools never defer.
+``tool_call`` — and surfaced on demand. Core Hermes tools never defer unless
+their toolset is explicitly opted in via ``tools.tool_search.defer_toolsets``.
 
 Design constraints this module is built around (see ``openclaw-tool-search-report``
 for the full rationale):
 
-* Core tools defined in ``toolsets._HERMES_CORE_TOOLS`` are *never* deferred.
-  Always-load means always-load. No exceptions.
+* Core tools defined in ``toolsets._HERMES_CORE_TOOLS`` are *never* deferred
+  by default. The single exception is an explicit per-toolset opt-in:
+  ``defer_toolsets: [browser, cronjob, ...]`` pushes every tool of the named
+  built-in toolsets behind the bridge. This exists because on schema-heavy
+  installs the built-in toolsets themselves are the entry tax (10k+ tokens
+  of every session's first prefill), and only the user knows which of them
+  their sessions actually lean on. Opt-in, never inferred.
 * The threshold gate runs every assembly: when deferrable tools would consume
   less than ``threshold_pct`` of the model's context window (default 10%),
   tool search is a no-op and the tools array passes through unchanged.
@@ -68,6 +74,11 @@ class ToolSearchConfig:
     threshold_pct: float  # 0..100 — only used when enabled == "auto"
     search_default_limit: int
     max_search_limit: int
+    # Built-in toolsets explicitly opted in for deferral. Tools of these
+    # toolsets defer even when listed in ``_HERMES_CORE_TOOLS`` — the user
+    # is trading first-prefill size for an extra bridge round-trip on the
+    # turns that actually use them. Empty by default (no behavior change).
+    defer_toolsets: frozenset = frozenset()
 
     @classmethod
     def from_raw(cls, raw: Any) -> "ToolSearchConfig":
@@ -81,13 +92,16 @@ class ToolSearchConfig:
         """
         if raw is True:
             return cls(enabled="auto", threshold_pct=10.0,
-                       search_default_limit=5, max_search_limit=20)
+                       search_default_limit=5, max_search_limit=20,
+                       defer_toolsets=frozenset())
         if raw is False:
             return cls(enabled="off", threshold_pct=10.0,
-                       search_default_limit=5, max_search_limit=20)
+                       search_default_limit=5, max_search_limit=20,
+                       defer_toolsets=frozenset())
         if not isinstance(raw, dict):
             return cls(enabled="auto", threshold_pct=10.0,
-                       search_default_limit=5, max_search_limit=20)
+                       search_default_limit=5, max_search_limit=20,
+                       defer_toolsets=frozenset())
 
         enabled_raw = str(raw.get("enabled", "auto")).strip().lower()
         if enabled_raw in ("true", "1", "yes"):
@@ -106,11 +120,20 @@ class ToolSearchConfig:
         search_default_limit = max(1, min(max_search_limit,
                                           _safe_int(raw.get("search_default_limit"), 5)))
 
+        defer_raw = raw.get("defer_toolsets")
+        defer_toolsets: frozenset = frozenset()
+        if isinstance(defer_raw, (list, tuple, set)):
+            defer_toolsets = frozenset(
+                str(item).strip() for item in defer_raw
+                if isinstance(item, (str, int)) and str(item).strip()
+            )
+
         return cls(
             enabled=enabled,
             threshold_pct=threshold_pct,
             search_default_limit=search_default_limit,
             max_search_limit=max_search_limit,
+            defer_toolsets=defer_toolsets,
         )
 
 
@@ -160,39 +183,57 @@ def _core_tool_names() -> frozenset[str]:
         return frozenset()
 
 
-def is_deferrable_tool_name(name: str) -> bool:
+def is_deferrable_tool_name(name: str,
+                            defer_toolsets: Optional[frozenset] = None) -> bool:
     """Return True if a tool with this name is *eligible* for deferral.
 
     A tool is deferrable iff it is registered with an MCP toolset prefix
-    OR it is not in ``_HERMES_CORE_TOOLS``. Core tools are never deferred
-    even when their toolset is technically plugin-provided (this protects
-    against accidental shadowing).
+    OR it is not in ``_HERMES_CORE_TOOLS`` OR its toolset is explicitly
+    opted in via ``defer_toolsets``. Outside the opt-in, core tools are
+    never deferred even when their toolset is technically plugin-provided
+    (this protects against accidental shadowing).
+
+    ``defer_toolsets=None`` resolves the opt-in set from user config —
+    the dispatch paths (``tool_describe`` / ``tool_call`` / session
+    scoping) must accept whatever the assembly deferred, so both sides
+    read the same source. Pass the set explicitly in per-tool loops to
+    avoid a config read per tool. Pass ``frozenset()`` for the strict
+    default invariant (no built-in opt-ins).
     """
     if name in BRIDGE_TOOL_NAMES:
         return False
-    if name in _core_tool_names():
-        return False
-    # Check registry toolset for MCP prefix.
+    if defer_toolsets is None:
+        defer_toolsets = load_config().defer_toolsets
+    entry = None
     try:
         from tools.registry import registry
         entry = registry.get_entry(name)
-        if entry is None:
-            return False
-        if entry.toolset.startswith("mcp-"):
-            return True
-        # Non-MCP, non-core → plugin tool, eligible.
-        return True
     except Exception:
+        entry = None
+    if defer_toolsets and entry is not None and entry.toolset in defer_toolsets:
+        # Explicit per-toolset opt-in overrides core protection.
+        return True
+    if name in _core_tool_names():
         return False
+    if entry is None:
+        return False
+    if entry.toolset.startswith("mcp-"):
+        return True
+    # Non-MCP, non-core → plugin tool, eligible.
+    return True
 
 
-def classify_tools(tool_defs: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+def classify_tools(tool_defs: List[Dict[str, Any]],
+                   defer_toolsets: Optional[frozenset] = None,
+                   ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
     """Split a tool-defs list into (visible, deferrable).
 
     ``visible`` retains every tool that must stay in the model-facing array:
-    every core tool, plus any tool we can't classify. ``deferrable`` is the
-    candidate set for catalog entry.
+    every core tool (minus ``defer_toolsets`` opt-ins), plus any tool we
+    can't classify. ``deferrable`` is the candidate set for catalog entry.
     """
+    if defer_toolsets is None:
+        defer_toolsets = load_config().defer_toolsets
     visible: List[Dict[str, Any]] = []
     deferrable: List[Dict[str, Any]] = []
     for td in tool_defs:
@@ -202,7 +243,7 @@ def classify_tools(tool_defs: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]
             # Should never happen — bridge tools are added after classification —
             # but be defensive.
             continue
-        if is_deferrable_tool_name(name):
+        if is_deferrable_tool_name(name, defer_toolsets):
             deferrable.append(td)
         else:
             visible.append(td)
@@ -270,7 +311,7 @@ class CatalogEntry:
     name: str
     description: str
     schema: Dict[str, Any]  # The full {"type":"function", "function": {...}} entry.
-    source: str  # "mcp" | "plugin" | "other"
+    source: str  # "mcp" | "plugin" | "builtin" | "other"
     source_name: str  # Toolset name, e.g. "mcp-github" or "kanban"
 
     # Pre-tokenized fields for BM25.
@@ -313,6 +354,8 @@ def _classify_source(name: str) -> Tuple[str, str]:
             return ("other", "")
         if entry.toolset.startswith("mcp-"):
             return ("mcp", entry.toolset)
+        if name in _core_tool_names():
+            return ("builtin", entry.toolset)
         return ("plugin", entry.toolset)
     except Exception:
         return ("other", "")
@@ -535,9 +578,10 @@ def assemble_tool_defs(
     """Return the tool-defs list the model should actually see.
 
     When tool search is inactive (off, no deferrable tools, or below
-    threshold), this is a passthrough. When active, MCP and plugin tools
-    are stripped from the visible list and replaced with the three bridge
-    tools. Core tools are *never* deferred regardless of config.
+    threshold), this is a passthrough. When active, MCP and plugin tools —
+    plus any built-in toolsets opted in via ``defer_toolsets`` — are
+    stripped from the visible list and replaced with the three bridge
+    tools. Outside that explicit opt-in, core tools are never deferred.
 
     Idempotent: calling with bridge tools already in the input is a no-op
     (they classify as non-core/non-deferrable but their names are reserved,
@@ -551,7 +595,7 @@ def assemble_tool_defs(
     incoming = [td for td in tool_defs
                 if (td.get("function") or {}).get("name") not in BRIDGE_TOOL_NAMES]
 
-    visible, deferrable = classify_tools(incoming)
+    visible, deferrable = classify_tools(incoming, config.defer_toolsets)
     if not deferrable:
         return AssemblyResult(tool_defs=incoming, activated=False)
 
@@ -619,7 +663,7 @@ def dispatch_tool_search(args: Dict[str, Any],
     else:
         limit = max(1, min(config.max_search_limit, _safe_int(raw_limit, config.search_default_limit)))
 
-    _, deferrable = classify_tools(current_tool_defs)
+    _, deferrable = classify_tools(current_tool_defs, config.defer_toolsets)
     catalog = build_catalog(deferrable)
     hits = search_catalog(catalog, query, limit=limit)
     return json.dumps({
@@ -670,9 +714,10 @@ def scoped_deferrable_names(tool_defs: List[Dict[str, Any]]) -> frozenset[str]:
     an out-of-scope tool via the bridge.
     """
     names: set[str] = set()
+    defer_toolsets = load_config().defer_toolsets  # resolve once, not per tool
     for td in tool_defs:
         name = (td.get("function") or {}).get("name", "")
-        if name and is_deferrable_tool_name(name):
+        if name and is_deferrable_tool_name(name, defer_toolsets):
             names.add(name)
     return frozenset(names)
 

--- a/website/docs/user-guide/features/tool-search.md
+++ b/website/docs/user-guide/features/tool-search.md
@@ -15,13 +15,12 @@ problem. When activated, MCP and plugin tools are replaced in the
 model-visible tools array by three bridge tools, and the model loads each
 specific tool's schema on demand.
 
-:::info Built-in Hermes tools never defer
-The tools that make up Hermes' core capability set (`terminal`,
-`read_file`, `write_file`, `patch`, `search_files`, `todo`, `memory`,
-`browser_*`, `web_search`, `web_extract`, `clarify`, `execute_code`,
-`delegate_task`, `session_search`, and the rest of
-`_HERMES_CORE_TOOLS`) are *always* loaded directly. Only MCP tools and
-non-core plugin tools are eligible for deferral.
+:::info Built-in Hermes tools never defer by default
+The tools that make up Hermes' core capability set
+(`_HERMES_CORE_TOOLS`) are *always* loaded directly unless you
+explicitly opt their toolset into deferral via
+`tools.tool_search.defer_toolsets`. Only MCP tools, non-core plugin
+tools, and those opted-in built-in toolsets ride the bridge.
 :::
 
 ## How it works
@@ -78,6 +77,19 @@ tools:
     threshold_pct: 10   # percentage of context — only used in auto mode
     search_default_limit: 5
     max_search_limit: 20
+    # Optional: push infrequent built-in toolsets behind the bridge.
+    # Empty by default. Keep terminal/file/web/skills/clarify direct.
+    # defer_toolsets:
+    #   - browser
+    #   - browser-cdp
+    #   - cronjob
+    #   - delegation
+    #   - image_gen
+    #   - tts
+    #   - vision
+    #   - homeassistant
+    #   - computer_use
+    #   - session_search
 ```
 
 | Key | Default | Meaning |
@@ -86,6 +98,38 @@ tools:
 | `threshold_pct` | `10` | Percentage of context length at which `auto` mode kicks in. Range 0–100. |
 | `search_default_limit` | `5` | Hits returned when the model calls `tool_search` without a `limit`. |
 | `max_search_limit` | `20` | Hard upper bound the model can request via `limit`. Range 1–50. |
+| `defer_toolsets` | `[]` | Built-in toolset names to treat as deferrable (in addition to MCP/plugin tools). Empty = core tools never defer. |
+
+## Deferring infrequent built-in tools (opt-in)
+
+On MCP-light installs the built-in schemas themselves dominate the tools-array
+tax (~15–20k tokens). Opt specific infrequent toolsets into the same bridge:
+
+```yaml
+tools:
+  tool_search:
+    enabled: auto
+    defer_toolsets:
+      - browser
+      - browser-cdp
+      - cronjob
+      - delegation
+      - image_gen
+      - tts
+      - vision
+      - homeassistant
+      - computer_use
+      - session_search
+```
+
+Recommended hot path that should stay direct: `terminal`, `file`, `web`,
+`skills`, `clarify`, `todo`, `memory`, `code_execution`. Do **not** put those
+toolset names in `defer_toolsets` unless you accept an extra search/describe
+round-trip on every use.
+
+Kanban workers usually need `kanban` tools hot when that is their only
+surface — leave `kanban` out of `defer_toolsets` for worker profiles, or keep
+it direct globally and rely on check_fn gating.
 
 You can also flip the legacy boolean shape:
 


### PR DESCRIPTION
## What does this PR do?

Tool Search already defers MCP/plugin tools behind `tool_search` / `tool_describe` / `tool_call`, but built-in toolsets always load. On MCP-light installs the **built-in schemas are the entry tax** (~15-20k tokens per turn).

This adds `tools.tool_search.defer_toolsets`: an explicit, **default-empty** list of built-in toolset names whose tools ride the existing bridge. Zero behavior change unless configured.

## Why not invent a new mechanism?

Six open PRs already approach this (#60182, #43521, #45147, #53193, #42551, #41800). This is a focused rebased variant of the `defer_toolsets` design (#60182), with:

- docs + `DEFAULT_CONFIG` + `cli-config.yaml.example`
- hot-path acceptance test (terminal stays direct when browser/cron/delegation defer)
- session byte-stability test (prompt-cache safety)
- catalog source kind `builtin` for opted-in core tools

## Measured impact (MCP-light personal install)

| Config | Tool schema tokens | Saved |
| --- | ---: | ---: |
| baseline / auto (no defer) | 19928 | 0 |
| `enabled: on` + recommended `defer_toolsets` | 10770 | **46%** (~9.2k tokens) |
| Telegram/CLI/cron platform sets, same config | 17716 -> 10770 | **39%** |

Recommended opt-in (keeps terminal/file/web/skills/clarify/todo/memory/code_execution direct; leaves `kanban` direct for workers):

```yaml
tools:
  tool_search:
    enabled: on   # auto@10% of 200k still needs ~20k deferrable; core opt-in alone is ~9.5k
    defer_toolsets:
      - browser
      - browser-cdp
      - cronjob
      - delegation
      - image_gen
      - tts
      - vision
      - homeassistant
      - computer_use
      - session_search
```

Capability catalog BM25 still finds cron, browser, delegation, image, TTS, Cursor, and X-search tools. Assemblies are byte-stable within a session.

## Related

- Builds on the same idea as #60182 (defer_toolsets)
- Addresses builtin half of #6839
- Does **not** hard-defer write_file/patch (unlike some defer_core proposals)

## Type of Change

- [x] New feature (non-breaking; default empty)

## How to Test

1. `scripts/run_tests.sh tests/tools/test_tool_search.py tests/test_get_tool_definitions_cache_isolation.py tests/test_model_tools.py -q` (87 passed locally)
2. With empty `defer_toolsets`, classification is identical to main
3. With the recommended list + `enabled: on`, infrequent core schemas leave the tools array; hot path tools remain direct; bridge can describe/call deferred tools

## Checklist

- [x] Conventional Commits
- [x] Focused files only
- [x] Tests added
- [x] Docs + DEFAULT_CONFIG + cli-config example updated
- [x] Cross-platform: pure Python/config, no OS paths
