### PR TITLE
fix(tui): recover missing esbuild platform binary

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -272,6 +272,7 @@ if _try_termux_ultrafast_version():
 import argparse
 import hashlib
 import json
+import platform
 import shlex
 import shutil
 import stat
@@ -1507,6 +1508,11 @@ def _tui_need_npm_install(root: Path) -> bool:
         return True
     if not lock.is_file():
         return False
+    required_esbuild_pkg = _required_esbuild_platform_package(ws_root)
+    if required_esbuild_pkg and not _esbuild_platform_binary_is_available(
+        ws_root, required_esbuild_pkg
+    ):
+        return True
     marker = ws_root / "node_modules" / ".package-lock.json"
     if not marker.is_file():
         return True
@@ -1543,6 +1549,73 @@ def _tui_need_npm_install(root: Path) -> bool:
     return False
 
 
+def _required_esbuild_platform_package(ws_root: Path) -> str | None:
+    """Return the esbuild helper package required by the current platform."""
+    esbuild_pkg = ws_root / "node_modules" / "esbuild" / "package.json"
+    if not esbuild_pkg.is_file():
+        return None
+
+    try:
+        package_data = json.loads(esbuild_pkg.read_text(encoding="utf-8"))
+        optional = package_data.get("optionalDependencies") or {}
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+
+    token = _ESBUILD_PLATFORM_TOKENS.get(sys.platform)
+    machine = platform.machine().lower()
+    if not token:
+        return None
+
+    for arch in _ESBUILD_ARCH_ALIASES.get(machine, (machine,)):
+        candidate = f"@esbuild/{token}-{arch}"
+        if candidate in optional:
+            return candidate
+    return None
+
+
+def _esbuild_platform_binary_is_available(ws_root: Path, package: str) -> bool:
+    """Accept esbuild's optional package or its postinstall fallback."""
+    if (ws_root / "node_modules" / package).is_dir():
+        return True
+
+    binary = "esbuild.exe" if sys.platform == "win32" else "esbuild"
+    fallback = (
+        ws_root
+        / "node_modules"
+        / "esbuild"
+        / "lib"
+        / f"downloaded-{package.replace('/', '-')}-{binary}"
+    )
+    return fallback.is_file()
+
+
+def _invalidate_stale_esbuild_install(ws_root: Path) -> None:
+    """Force npm to re-run esbuild's installer when its binary is missing."""
+    esbuild_dir = ws_root / "node_modules" / "esbuild"
+    esbuild_pkg = esbuild_dir / "package.json"
+    hidden_lock = ws_root / "node_modules" / ".package-lock.json"
+
+    required_esbuild_pkg = _required_esbuild_platform_package(ws_root)
+    if esbuild_pkg.is_file() and (
+        not required_esbuild_pkg
+        or _esbuild_platform_binary_is_available(ws_root, required_esbuild_pkg)
+    ):
+        return
+
+    try:
+        if esbuild_dir.exists():
+            shutil.rmtree(esbuild_dir)
+    except OSError:
+        pass
+
+    try:
+        hidden_lock.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError:
+        pass
+
+
 _TUI_BUILD_INPUT_DIRS = (
     "src",
     "packages/hermes-ink/src",
@@ -1563,6 +1636,35 @@ _TUI_BUILD_INPUT_FILES = (
 _TUI_BUILD_INPUT_SUFFIXES = frozenset(
     {".cjs", ".js", ".jsx", ".json", ".mjs", ".ts", ".tsx"}
 )
+
+_ESBUILD_PLATFORM_TOKENS = {
+    "aix": "aix",
+    "android": "android",
+    "darwin": "darwin",
+    "freebsd": "freebsd",
+    "linux": "linux",
+    "netbsd": "netbsd",
+    "openbsd": "openbsd",
+    "sunos": "sunos",
+    "win32": "win32",
+}
+
+_ESBUILD_ARCH_ALIASES = {
+    "aarch64": ("arm64",),
+    "amd64": ("x64",),
+    "arm64": ("arm64",),
+    "armv6l": ("arm",),
+    "armv7l": ("arm",),
+    "i386": ("ia32",),
+    "i686": ("ia32",),
+    "loongarch64": ("loong64",),
+    "mips64el": ("mips64el",),
+    "ppc64": ("ppc64",),
+    "ppc64le": ("ppc64",),
+    "riscv64": ("riscv64",),
+    "s390x": ("s390x",),
+    "x86_64": ("x64",),
+}
 
 
 def _iter_tui_build_inputs(root: Path):
@@ -1817,11 +1919,13 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
                 tui_dir,
                 include_child_workspaces=True,
             )
+        _invalidate_stale_esbuild_install(npm_cwd)
         result = subprocess.run(
             [
                 npm,
                 "install",
                 *npm_workspace_args,
+                "--include=optional",
                 "--silent",
                 "--no-fund",
                 "--no-audit",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1655,6 +1655,7 @@ _ESBUILD_ARCH_ALIASES = {
     "arm64": ("arm64",),
     "armv6l": ("arm",),
     "armv7l": ("arm",),
+    "x86": ("ia32",),
     "i386": ("ia32",),
     "i686": ("ia32",),
     "loongarch64": ("loong64",),

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -20,6 +20,34 @@ def _touch_ink(root: Path) -> None:
     ink.write_text("{}")
 
 
+def _configure_darwin_x64(main_mod, monkeypatch) -> None:
+    monkeypatch.setitem(
+        main_mod._ESBUILD_PLATFORM_TOKENS, main_mod.sys.platform, "darwin"
+    )
+    monkeypatch.setattr(main_mod.platform, "machine", lambda: "x86_64")
+
+
+def _touch_esbuild(root: Path) -> None:
+    esbuild = root / "node_modules" / "esbuild" / "package.json"
+    esbuild.parent.mkdir(parents=True, exist_ok=True)
+    esbuild.write_text(
+        '{"optionalDependencies":{"@esbuild/darwin-x64":"0.28.1"}}'
+    )
+
+
+def _touch_esbuild_fallback(root: Path, main_mod) -> None:
+    binary = "esbuild.exe" if main_mod.sys.platform == "win32" else "esbuild"
+    fallback = (
+        root
+        / "node_modules"
+        / "esbuild"
+        / "lib"
+        / f"downloaded-@esbuild-darwin-x64-{binary}"
+    )
+    fallback.parent.mkdir(parents=True, exist_ok=True)
+    fallback.write_text("binary")
+
+
 def _touch_tui_entry(root: Path) -> None:
     entry = root / "dist" / "entry.js"
     entry.parent.mkdir(parents=True, exist_ok=True)
@@ -116,6 +144,60 @@ def test_need_install_when_marker_missing(tmp_path: Path, main_mod) -> None:
     _touch_ink(tmp_path)
     (tmp_path / "package-lock.json").write_text("{}")
     assert main_mod._tui_need_npm_install(tmp_path) is True
+
+
+def test_need_install_when_esbuild_platform_binary_missing(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    _touch_ink(tmp_path)
+    _touch_esbuild(tmp_path)
+    (tmp_path / "package-lock.json").write_text("{}")
+    (tmp_path / "node_modules" / ".package-lock.json").write_text("{}")
+    _configure_darwin_x64(main_mod, monkeypatch)
+
+    assert main_mod._tui_need_npm_install(tmp_path) is True
+
+
+def test_no_install_when_esbuild_downloaded_fallback_exists(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    _touch_ink(tmp_path)
+    _touch_esbuild(tmp_path)
+    _touch_esbuild_fallback(tmp_path, main_mod)
+    (tmp_path / "package-lock.json").write_text("{}")
+    (tmp_path / "node_modules" / ".package-lock.json").write_text("{}")
+    _configure_darwin_x64(main_mod, monkeypatch)
+
+    assert main_mod._tui_need_npm_install(tmp_path) is False
+
+
+def test_invalidate_stale_esbuild_install_removes_cached_state(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    _touch_esbuild(tmp_path)
+    marker = tmp_path / "node_modules" / ".package-lock.json"
+    marker.write_text("{}")
+    _configure_darwin_x64(main_mod, monkeypatch)
+
+    main_mod._invalidate_stale_esbuild_install(tmp_path)
+
+    assert not (tmp_path / "node_modules" / "esbuild").exists()
+    assert not marker.exists()
+
+
+def test_invalidate_stale_esbuild_install_keeps_downloaded_fallback(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    _touch_esbuild(tmp_path)
+    _touch_esbuild_fallback(tmp_path, main_mod)
+    marker = tmp_path / "node_modules" / ".package-lock.json"
+    marker.write_text("{}")
+    _configure_darwin_x64(main_mod, monkeypatch)
+
+    main_mod._invalidate_stale_esbuild_install(tmp_path)
+
+    assert (tmp_path / "node_modules" / "esbuild").is_dir()
+    assert marker.is_file()
 
 
 def test_no_install_without_lockfile_when_ink_present(tmp_path: Path, main_mod) -> None:
@@ -233,6 +315,7 @@ def test_make_tui_argv_scopes_npm_install_on_termux_workspace(
         "ui-tui/packages/hermes-ink",
         "--include-workspace-root=false",
     ]
+    assert "--include=optional" in install_cmd
     assert calls[0][1]["cwd"] == str(tmp_path)
     _assert_utf8_replace_capture(calls[0][1])
     _assert_utf8_replace_capture(calls[1][1])
@@ -265,6 +348,7 @@ def test_make_tui_argv_keeps_desktop_workspace_install_behaviour(
         "install",
         "--workspace",
         "ui-tui",
+        "--include=optional",
         "--silent",
         "--no-fund",
         "--no-audit",

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -27,12 +27,11 @@ def _configure_darwin_x64(main_mod, monkeypatch) -> None:
     monkeypatch.setattr(main_mod.platform, "machine", lambda: "x86_64")
 
 
-def _touch_esbuild(root: Path) -> None:
+def _touch_esbuild(root: Path, package_name: str = "@esbuild/darwin-x64") -> None:
     esbuild = root / "node_modules" / "esbuild" / "package.json"
     esbuild.parent.mkdir(parents=True, exist_ok=True)
-    esbuild.write_text(
-        '{"optionalDependencies":{"@esbuild/darwin-x64":"0.28.1"}}'
-    )
+    payload = f'{{"optionalDependencies":{{"{package_name}":"0.28.1"}}}}'
+    esbuild.write_text(payload)
 
 
 def _touch_esbuild_fallback(root: Path, main_mod) -> None:
@@ -169,6 +168,21 @@ def test_no_install_when_esbuild_downloaded_fallback_exists(
     _configure_darwin_x64(main_mod, monkeypatch)
 
     assert main_mod._tui_need_npm_install(tmp_path) is False
+
+
+def test_need_install_when_esbuild_windows_x86_alias_missing_binary(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    _touch_ink(tmp_path)
+    _touch_esbuild(tmp_path, "@esbuild/win32-ia32")
+    (tmp_path / "package-lock.json").write_text("{}")
+    (tmp_path / "node_modules" / ".package-lock.json").write_text("{}")
+
+    monkeypatch.setitem(main_mod._ESBUILD_PLATFORM_TOKENS, "win32", "win32")
+    monkeypatch.setattr(main_mod.platform, "machine", lambda: "x86")
+    monkeypatch.setattr(main_mod.sys, "platform", "win32")
+
+    assert main_mod._tui_need_npm_install(tmp_path) is True
 
 
 def test_invalidate_stale_esbuild_install_removes_cached_state(


### PR DESCRIPTION
## What does this PR do?

Self-heals `hermes --tui` when the JavaScript `esbuild` package is installed but its required native `@esbuild/<platform>-<arch>` package is missing.

The TUI freshness check intentionally ignores absent optional packages because most are legitimately platform-specific. That is unsafe for esbuild: its platform package is marked optional in npm metadata but is required to build `ui-tui/dist/entry.js`. A stale hidden npm lock can therefore report the dependency tree as current while esbuild fails with `The package "@esbuild/darwin-x64" could not be found`.

The fix derives the required helper package from esbuild's own `optionalDependencies`, accepts either the normal package or esbuild's supported postinstall-downloaded fallback, and invalidates only stale esbuild state before the existing scoped npm install. The install now explicitly includes optional dependencies.

This is complementary to #54814, which addresses unrelated-workspace false positives in the TUI freshness comparison. This PR handles recovery once the esbuild platform binary is already missing.

## Related Issue

Related to #54814, #53089, and #37934.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Detect the required esbuild platform package using the installed esbuild package metadata and normalized OS/CPU aliases.
- Treat esbuild's `lib/downloaded-@esbuild-...` fallback as a valid native binary.
- Remove stale esbuild package state and npm's hidden lock before reinstalling when neither binary form exists.
- Pass `--include=optional` to the scoped TUI npm install.
- Add regression tests for missing binaries, downloaded fallbacks, cache invalidation, and npm arguments.

## How to Test

1. Install dependencies, then remove the current esbuild platform package and fallback binary while leaving `node_modules/esbuild` and `node_modules/.package-lock.json` present.
2. Run `hermes --tui` and verify it repairs esbuild, builds the TUI bundle, and reaches the prompt.
3. Run the focused and related test commands below.

```bash
scripts/run_tests.sh tests/hermes_cli/test_tui_npm_install.py
scripts/run_tests.sh \
  tests/hermes_cli/test_tui_npm_install.py \
  tests/hermes_cli/test_web_ui_build.py \
  tests/hermes_cli/test_cmd_update.py
uvx ruff check hermes_cli/main.py tests/hermes_cli/test_tui_npm_install.py
```

Results:

```text
33 focused tests passed
81 related tests passed
Ruff checks passed
```

The full 1,952-file test wrapper was also started after installing its missing `pytest-asyncio` plugin. It was clean through 473 tests but was stopped because the per-file isolated run was too long for this focused change; upstream CI remains the complete-suite gate for this draft.

Runtime smoke test: macOS x86_64, Node.js 24.6.0, npm 11.5.2. The original `@esbuild/darwin-x64` failure was reproduced, the fallback binary was repaired, and `hermes --tui` reached `ready`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing issues and open/closed PRs
- [x] My PR contains only changes related to this fix
- [ ] I've run the complete `pytest tests/ -q` suite and all tests pass (focused and related suites pass; full CI pending)
- [x] I've added tests for my changes
- [x] I've tested on macOS x86_64

### Documentation & Housekeeping

- [x] Documentation update is not required
- [x] `cli-config.yaml.example` update is not required
- [x] `CONTRIBUTING.md` / `AGENTS.md` updates are not required
- [x] Cross-platform impact was considered; platform and architecture aliases cover supported esbuild targets, including Windows `.exe` fallback naming
- [x] Tool descriptions/schemas are not affected

## Screenshots / Logs

Before:

```text
Error: The package "@esbuild/darwin-x64" could not be found, and is needed by esbuild.
TUI build failed.
```

After:

```text
built ui-tui/dist/entry.js
ready | gpt-5.5
```
