### PR TITLE
fix(codex): unify app-server turn finalization

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -464,10 +464,14 @@ def run_codex_app_server_turn(
     )
     _record_codex_app_server_compaction(agent, turn)
     if turn_returned:
-        usage_result = _record_codex_app_server_usage(agent, turn)
+        # Folds this turn's usage into agent.session_* BEFORE finalize_turn
+        # runs, so the finalizer's result already reports the correct
+        # cumulative session totals. Do NOT merge the returned per-turn
+        # snapshot into the result: from the second turn on it would clobber
+        # the cumulative token/cost fields with single-turn values.
+        _record_codex_app_server_usage(agent, turn)
         api_calls = 1
     else:
-        usage_result = {}
         api_calls = 0
 
     # Codex owns the model/tool loop, but Hermes must own turn finalization.
@@ -516,7 +520,6 @@ def run_codex_app_server_turn(
             "codex_turn_id": turn.turn_id,
         }
     )
-    result.update(usage_result)
     return result
 
 

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -20,7 +20,7 @@ import logging
 import os
 import time
 from types import SimpleNamespace
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -304,7 +304,9 @@ def run_codex_app_server_turn(
     user_message: str,
     original_user_message: Any,
     messages: List[Dict[str, Any]],
+    conversation_history: Optional[List[Dict[str, Any]]] = None,
     effective_task_id: str,
+    hermes_turn_id: Optional[str] = None,
     should_review_memory: bool = False,
 ) -> Dict[str, Any]:
     """Codex app-server runtime path. Hands the entire turn to a `codex
@@ -316,6 +318,7 @@ def run_codex_app_server_turn(
     """
     from agent.transports.codex_app_server_session import (
         CodexAppServerSession,
+        TurnResult,
         _ServerRequestRouting,
     )
 
@@ -386,28 +389,32 @@ def run_codex_app_server_turn(
     # standard run_conversation() flow (line ~11823) before the early
     # return reaches us. Do NOT append again — that would duplicate.
 
-    try:
-        turn = agent._codex_session.run_turn(user_input=user_message)
-    except Exception as exc:
-        logger.exception("codex app-server turn failed")
-        # Crash → unconditionally drop the session so the next turn
-        # respawns from scratch instead of reusing a dead client.
+    turn_returned = False
+    if getattr(agent, "_interrupt_requested", False) is True:
+        # Match the normal loop's pre-call interrupt check. In particular,
+        # don't let CodexAppServerSession.run_turn() clear or outrun an
+        # interrupt that arrived while the per-turn prologue was running.
+        turn = TurnResult(interrupted=True)
+    else:
         try:
-            agent._codex_session.close()
-        except Exception:
-            pass
-        agent._codex_session = None
-        return {
-            "final_response": (
-                f"Codex app-server turn failed: {exc}. "
-                f"Fall back to default runtime with `/codex-runtime auto`."
-            ),
-            "messages": messages,
-            "api_calls": 0,
-            "completed": False,
-            "partial": True,
-            "error": str(exc),
-        }
+            turn = agent._codex_session.run_turn(user_input=user_message)
+            turn_returned = True
+        except Exception as exc:
+            logger.exception("codex app-server turn failed")
+            # Crash → unconditionally drop the session so the next turn
+            # respawns from scratch instead of reusing a dead client.
+            try:
+                agent._codex_session.close()
+            except Exception:
+                pass
+            agent._codex_session = None
+            turn = TurnResult(
+                final_text=(
+                    f"Codex app-server turn failed: {exc}. "
+                    f"Fall back to default runtime with `/codex-runtime auto`."
+                ),
+                error=str(exc),
+            )
 
     # If the turn signalled the underlying client is wedged (deadline
     # blown, post-tool watchdog tripped, OAuth refresh died, subprocess
@@ -431,27 +438,19 @@ def run_codex_app_server_turn(
     if turn.projected_messages:
         messages.extend(turn.projected_messages)
 
-        # Persist the newly-projected assistant/tool messages ourselves.
-        # This path is an early return that bypasses conversation_loop, whose
-        # normal per-step _persist_session() calls would otherwise flush them.
-        # The inbound user turn was already flushed at turn start
-        # (turn_context.py _persist_session), and _flush_messages_to_session_db
-        # is idempotent via the intrinsic _DB_PERSISTED_MARKER — so this writes
-        # ONLY the new codex projected rows and does NOT re-write the user turn.
-        # Keeping the agent as the sole persister lets us return
-        # agent_persisted=True below, so the gateway skips its own DB write and
-        # we avoid the #860/#42039 duplicate user-message write (append_message
-        # is a raw INSERT with no dedup, so a gateway re-write would duplicate
-        # the already-flushed user turn). See gateway/run.py agent_persisted.
-        if getattr(agent, "_session_db", None) is not None:
-            try:
-                agent._flush_messages_to_session_db(messages)
-            except Exception:
-                logger.debug(
-                    "codex app-server projected-message flush failed",
-                    exc_info=True,
-                )
+        # Codex protocol item enums are non-exhaustive, and older projectors
+        # could emit duplicate user or adjacent assistant rows. Canonicalize
+        # the complete sequence before the shared finalizer persists it.
+        from agent.agent_runtime_helpers import repair_message_sequence_with_cursor
 
+        repaired = repair_message_sequence_with_cursor(agent, messages)
+        if repaired:
+            logger.info(
+                "Repaired %s Codex projection alternation violation(s) "
+                "before persistence (session=%s)",
+                repaired,
+                getattr(agent, "session_id", None) or "-",
+            )
 
     # Counter ticks for the agent-improvement loop.
     # _turns_since_memory and _user_turn_count are ALREADY incremented
@@ -464,73 +463,61 @@ def run_codex_app_server_turn(
         getattr(agent, "_iters_since_skill", 0) + turn.tool_iterations
     )
     _record_codex_app_server_compaction(agent, turn)
-    usage_result = _record_codex_app_server_usage(agent, turn)
-    api_calls = 1
+    if turn_returned:
+        usage_result = _record_codex_app_server_usage(agent, turn)
+        api_calls = 1
+    else:
+        usage_result = {}
+        api_calls = 0
 
-    # Now check the skill nudge AFTER iters were incremented — same
-    # pattern the chat_completions path uses (line ~15432).
-    should_review_skills = False
-    if (
-        agent._skill_nudge_interval > 0
-        and agent._iters_since_skill >= agent._skill_nudge_interval
-        and "skill_manage" in agent.valid_tool_names
-    ):
-        should_review_skills = True
-        agent._iters_since_skill = 0
+    # Codex owns the model/tool loop, but Hermes must own turn finalization.
+    # Running the same finalizer as every other runtime keeps persistence,
+    # output/plugin hooks, trajectory/resource cleanup, interrupt reset,
+    # reasoning extraction, memory sync, and the public result contract from
+    # drifting as the two runtimes evolve.
+    if turn.interrupted:
+        turn_exit_reason = "interrupted_by_user"
+    elif turn.error:
+        turn_exit_reason = "codex_app_server_error"
+    else:
+        turn_exit_reason = "text_response(runtime=codex_app_server)"
 
-    # External memory provider sync (mirrors line ~15439). Skipped on
-    # interrupt/error to avoid feeding partial transcripts to memory.
-    if not turn.interrupted and turn.error is None:
-        try:
-            agent._sync_external_memory_for_turn(
-                original_user_message=original_user_message,
-                final_response=turn.final_text,
-                interrupted=False,
-                messages=messages,
-            )
-        except Exception:
-            logger.debug("external memory sync raised", exc_info=True)
+    from agent.turn_finalizer import finalize_turn
 
-    # Background review fork — same cadence + signature as the default
-    # path (line ~15449). Only fires when a trigger actually tripped AND
-    # we have a real final response.
-    if (
-        turn.final_text
-        and not turn.interrupted
-        and (should_review_memory or should_review_skills)
-    ):
-        try:
-            agent._spawn_background_review(
-                messages_snapshot=list(messages),
-                review_memory=should_review_memory,
-                review_skills=should_review_skills,
-            )
-        except Exception:
-            logger.debug("background review spawn raised", exc_info=True)
-
-    return {
-        "final_response": turn.final_text,
-        "messages": messages,
-        "api_calls": api_calls,
-        "completed": not turn.interrupted and turn.error is None,
-        "partial": turn.interrupted or turn.error is not None,
-        "error": turn.error,
-        # The codex app-server runtime IS an early-return path that bypasses
-        # conversation_loop, but we flush the projected assistant/tool messages
-        # ourselves above (see the _flush_messages_to_session_db call after
-        # messages.extend). The inbound user turn was already flushed at turn
-        # start (turn_context._persist_session) and the flush dedups via
-        # _DB_PERSISTED_MARKER, so state.db ends up with each real message
-        # exactly once and session_search / conversation-distill see the full
-        # gateway conversation. Report agent_persisted=True so the gateway
-        # skips its own append_to_transcript DB write — writing again there
-        # would re-INSERT the already-flushed user turn (append_message has no
-        # dedup), reintroducing the #860 / #42039 duplicate-write bug.
-        "agent_persisted": True,
-        "codex_thread_id": turn.thread_id,
-        "codex_turn_id": turn.turn_id,
-        **usage_result,
-    }
+    failed = bool(turn.error) and not turn.interrupted
+    result = finalize_turn(
+        agent,
+        final_response=turn.final_text,
+        api_call_count=api_calls,
+        interrupted=turn.interrupted,
+        failed=failed,
+        messages=messages,
+        conversation_history=conversation_history,
+        effective_task_id=effective_task_id,
+        turn_id=hermes_turn_id or turn.turn_id or "",
+        user_message=original_user_message,
+        original_user_message=original_user_message,
+        _should_review_memory=should_review_memory,
+        _turn_exit_reason=turn_exit_reason,
+    )
+    result.update(
+        {
+            "completed": bool(turn.final_text)
+            and not turn.interrupted
+            and turn.error is None,
+            "failed": failed,
+            "partial": turn.interrupted or turn.error is not None,
+            "interrupted": turn.interrupted,
+            "error": turn.error,
+            # The shared finalizer persisted the complete transcript. Tell the
+            # gateway not to append the user turn a second time.
+            "agent_persisted": True,
+            "codex_thread_id": turn.thread_id,
+            "codex_turn_id": turn.turn_id,
+        }
+    )
+    result.update(usage_result)
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -79,6 +79,35 @@ logger = logging.getLogger(__name__)
 INTERRUPT_WAITING_FOR_MODEL_PREFIX = "Operation interrupted: waiting for model response ("
 
 
+def _with_ephemeral_user_context(
+    user_message: Any,
+    *,
+    external_memory_context: str = "",
+    plugin_context: str = "",
+) -> Any:
+    """Return the API/runtime view of the current user turn.
+
+    Memory prefetch and ``pre_llm_call`` plugin context are deliberately
+    ephemeral: they must reach whichever runtime owns the turn without
+    mutating the durable ``messages`` transcript.  Keeping this construction
+    in one helper prevents the Codex app-server path from silently dropping
+    context that the normal provider loop receives.
+    """
+    if not isinstance(user_message, str):
+        return user_message
+
+    injections: list[str] = []
+    if isinstance(external_memory_context, str) and external_memory_context:
+        fenced = build_memory_context_block(external_memory_context)
+        if fenced:
+            injections.append(fenced)
+    if isinstance(plugin_context, str) and plugin_context:
+        injections.append(plugin_context)
+    if not injections:
+        return user_message
+    return user_message + "\n\n" + "\n\n".join(injections)
+
+
 def _image_error_max_dimension(error: Exception) -> Optional[int]:
     """Extract a provider-reported image dimension ceiling, if present."""
     parts = []
@@ -628,10 +657,16 @@ def run_conversation(
     # and references/codex-app-server-runtime.md for the rationale.
     if agent.api_mode == "codex_app_server":
         return agent._run_codex_app_server_turn(
-            user_message=user_message,
+            user_message=_with_ephemeral_user_context(
+                user_message,
+                external_memory_context=_ext_prefetch_cache,
+                plugin_context=_plugin_user_context,
+            ),
             original_user_message=original_user_message,
             messages=messages,
+            conversation_history=conversation_history,
             effective_task_id=effective_task_id,
+            hermes_turn_id=turn_id,
             should_review_memory=_should_review_memory,
         )
 
@@ -794,17 +829,11 @@ def run_conversation(
             # API-call-time only — the original message in `messages` is
             # never mutated, so nothing leaks into session persistence.
             if idx == current_turn_user_idx and msg.get("role") == "user":
-                _injections = []
-                if _ext_prefetch_cache:
-                    _fenced = build_memory_context_block(_ext_prefetch_cache)
-                    if _fenced:
-                        _injections.append(_fenced)
-                if _plugin_user_context:
-                    _injections.append(_plugin_user_context)
-                if _injections:
-                    _base = api_msg.get("content", "")
-                    if isinstance(_base, str):
-                        api_msg["content"] = _base + "\n\n" + "\n\n".join(_injections)
+                api_msg["content"] = _with_ephemeral_user_context(
+                    api_msg.get("content", ""),
+                    external_memory_context=_ext_prefetch_cache,
+                    plugin_context=_plugin_user_context,
+                )
 
             # For ALL assistant messages, pass reasoning back to the API
             # This ensures multi-turn reasoning context is preserved

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -79,6 +79,12 @@ class TurnResult:
 # normal completion path fires. Mirrors openclaw beta.8 fix.
 _TURN_ABORTED_MARKERS = ("<turn_aborted>", "<turn_aborted/>")
 
+# How long a user-interrupted turn may take to emit its terminal
+# turn/completed after turn/interrupt before we give up draining and retire
+# the session. Codex normally aborts within well under a second; a longer
+# silence means the queue state is unknown and reuse is unsafe.
+_INTERRUPT_DRAIN_GRACE_SECONDS = 3.0
+
 
 def _coerce_turn_input_text(user_input: Any) -> str:
     """Collapse Hermes/OpenAI rich content into app-server text input.
@@ -214,6 +220,10 @@ class CodexAppServerSession:
         self._client: Optional[CodexAppServerClient] = None
         self._thread_id: Optional[str] = None
         self._interrupt_event = threading.Event()
+        # Turn ids the user interrupted whose terminal turn/completed may
+        # still be in flight. Notifications scoped to these ids are dropped
+        # instead of being taken as the current turn's events.
+        self._stale_turn_ids: set[str] = set()
         # Pending file-change items, keyed by item id. Populated on
         # item/started for fileChange items; consumed by the approval
         # bridge when codex sends item/fileChange/requestApproval. The
@@ -436,6 +446,12 @@ class CodexAppServerSession:
             if self._interrupt_event.is_set():
                 self._issue_interrupt(result.turn_id)
                 result.interrupted = True
+                # Unlike the watchdog/deadline interrupts below (which
+                # retire the session), this path keeps the session alive
+                # for the next turn — so the interrupted turn's remaining
+                # notifications must not stay queued. Drain them, or retire
+                # if the turn's terminal event never arrives.
+                self._drain_interrupted_turn(result, projector)
                 break
 
             # Detect a dead subprocess between iterations. If codex exited
@@ -485,6 +501,17 @@ class CodexAppServerSession:
                     pending = self._client.take_notification(timeout=0)
                     if pending is None:
                         break
+                    pending_turn_id = (
+                        pending.get("params") or {}
+                    ).get("turnId")
+                    if (
+                        pending_turn_id
+                        and pending_turn_id in self._stale_turn_ids
+                    ):
+                        # Tail of an earlier user-interrupted turn — must
+                        # not project into this turn (mirrors the main
+                        # wait-loop filter below).
+                        continue
                     _apply_token_usage_notification(result, pending)
                     _apply_compaction_notification(result, pending)
                     self._track_pending_file_change(pending)
@@ -503,6 +530,7 @@ class CodexAppServerSession:
                                 result.error
                                 or "codex reported turn_aborted"
                             )
+                            self._mark_turn_stale_on_marker(result)
                 self._handle_server_request(sreq)
                 # Activity counts as live signal — reset the post-tool
                 # quiet timer so an approval round-trip doesn't trip it.
@@ -516,6 +544,15 @@ class CodexAppServerSession:
                 continue
 
             method = note.get("method", "")
+            note_scope_turn_id = (note.get("params") or {}).get("turnId")
+            if (
+                note_scope_turn_id
+                and note_scope_turn_id in self._stale_turn_ids
+            ):
+                # Tail item/usage of an earlier user-interrupted turn.
+                # Displaying or projecting it would leak stale work into
+                # the current turn's transcript and misattribute usage.
+                continue
             if self._on_event is not None:
                 try:
                     self._on_event(note)
@@ -560,12 +597,25 @@ class CodexAppServerSession:
                     result.error = (
                         result.error or "codex reported turn_aborted"
                     )
+                    self._mark_turn_stale_on_marker(result)
 
             if method == "turn/completed":
+                note_turn = (note.get("params") or {}).get("turn") or {}
+                note_turn_id = note_turn.get("id")
+                if note_turn_id and note_turn_id in self._stale_turn_ids:
+                    # Terminal event of an earlier user-interrupted turn
+                    # that slipped past the drain. It must never terminate
+                    # the current turn.
+                    self._stale_turn_ids.discard(note_turn_id)
+                    logger.debug(
+                        "ignoring stale turn/completed for interrupted "
+                        "turn %s (current turn %s)",
+                        note_turn_id,
+                        result.turn_id,
+                    )
+                    continue
                 turn_complete = True
-                turn_status = (
-                    (note.get("params") or {}).get("turn") or {}
-                ).get("status")
+                turn_status = note_turn.get("status")
                 if turn_status and turn_status not in {"completed", "interrupted"}:
                     err_obj = (
                         (note.get("params") or {}).get("turn") or {}
@@ -676,6 +726,10 @@ class CodexAppServerSession:
             if self._interrupt_event.is_set():
                 self._issue_interrupt(result.turn_id)
                 result.interrupted = True
+                # Same contamination hazard as run_turn: an interrupted
+                # compaction leaves its tail queued while the session stays
+                # reusable. Drain it (or retire) before returning.
+                self._drain_interrupted_turn(result, projector)
                 break
 
             if not self._client.is_alive():
@@ -726,14 +780,29 @@ class CodexAppServerSession:
                     result.error = (
                         result.error or "codex reported turn_aborted"
                     )
+                    self._mark_turn_stale_on_marker(result)
 
             if method == "turn/started":
                 turn_obj = (note.get("params") or {}).get("turn") or {}
                 result.turn_id = turn_obj.get("id") or result.turn_id
             elif method == "turn/completed":
-                turn_complete = True
                 turn_obj = (note.get("params") or {}).get("turn") or {}
-                result.turn_id = turn_obj.get("id") or result.turn_id
+                completed_turn_id = turn_obj.get("id")
+                if (
+                    completed_turn_id
+                    and completed_turn_id in self._stale_turn_ids
+                ):
+                    # Terminal event of an earlier user-interrupted turn —
+                    # not this compaction's own completion.
+                    self._stale_turn_ids.discard(completed_turn_id)
+                    logger.debug(
+                        "ignoring stale turn/completed for interrupted "
+                        "turn %s during compaction",
+                        completed_turn_id,
+                    )
+                    continue
+                turn_complete = True
+                result.turn_id = completed_turn_id or result.turn_id
                 turn_status = turn_obj.get("status")
                 if turn_status and turn_status not in {"completed", "interrupted"}:
                     err_obj = turn_obj.get("error")
@@ -779,6 +848,165 @@ class CodexAppServerSession:
             logger.debug("turn/interrupt non-fatal: %s", exc)
         except TimeoutError:
             logger.warning("turn/interrupt timed out")
+
+    def _drain_interrupted_turn(
+        self,
+        result: TurnResult,
+        projector: CodexEventProjector,
+        grace_seconds: Optional[float] = None,
+    ) -> None:
+        """Consume the interrupted turn's remaining notifications.
+
+        After turn/interrupt, codex still finishes the turn asynchronously
+        (aborted items, a final token-usage update, then turn/completed with
+        status=interrupted). The tail belongs to THIS turn, so its usage and
+        items are folded into ``result`` rather than dropped. If the turn's
+        terminal event doesn't arrive within the grace window, the queue
+        state is unknown — retire the session so the next turn respawns
+        codex instead of inheriting a contaminated queue.
+        """
+        if self._client is None:
+            return
+        if grace_seconds is None:
+            # Resolved at call time so tests can patch the module constant.
+            grace_seconds = _INTERRUPT_DRAIN_GRACE_SECONDS
+        if result.turn_id:
+            # Remember the interrupted turn until its terminal event is
+            # consumed, so a tail that outlives the grace window can still
+            # be recognized (and dropped) by a later turn's wait loop.
+            self._stale_turn_ids.add(result.turn_id)
+        deadline = time.monotonic() + grace_seconds
+        while time.monotonic() < deadline:
+            # A canceled turn's exec/patch approval must never greet the
+            # next turn as if it were current.
+            self._decline_stale_server_requests()
+            note = self._client.take_notification(timeout=0.1)
+            if note is None:
+                if not self._client.is_alive():
+                    # Subprocess died mid-drain — the terminal event will
+                    # never arrive. Retire so the next turn respawns codex
+                    # instead of failing turn/start on a dead client and
+                    # losing a user-visible turn.
+                    result.should_retire = True
+                    return
+                continue
+            if self._fold_tail_note(result, projector, note):
+                self._finish_drain_reusable(result)
+                return
+        logger.warning(
+            "interrupted codex turn %s did not finish within %.1fs; "
+            "retiring the session to avoid reusing a contaminated queue",
+            result.turn_id,
+            grace_seconds,
+        )
+        result.should_retire = True
+
+    def _mark_turn_stale_on_marker(self, result: TurnResult) -> None:
+        """A marker-terminated turn may still emit its ``turn/completed``
+        later — keep tracking its id so a later wait loop filters (and
+        discards) that event instead of taking it as its own terminal."""
+        if result.turn_id:
+            self._stale_turn_ids.add(result.turn_id)
+
+    def _finish_drain_reusable(self, result: TurnResult) -> None:
+        """Final checks before declaring the drained session reusable.
+
+        The stale-turn id is NOT discarded here: only consuming the turn's
+        matching ``turn/completed`` (in ``_tail_note_is_terminal`` or a
+        later turn's wait loop) fully accounts for the turn. A drain that
+        ended on an abort marker may still have that completion in flight.
+        """
+        # One last sweep: an approval that raced in alongside the terminal
+        # event must not greet the next turn.
+        self._decline_stale_server_requests()
+        if not self._client.is_alive():
+            # Codex emitted its terminal event and then exited — the next
+            # turn/start would fail on a dead client. Retire instead.
+            result.should_retire = True
+
+    def _decline_stale_server_requests(self) -> None:
+        """Decline server-initiated requests queued by an aborted turn.
+
+        A canceled turn's approval request handled as current would show a
+        stale prompt at best or auto-accept a stale command/patch at worst.
+        """
+        while True:
+            sreq = self._client.take_server_request(timeout=0)
+            if sreq is None:
+                return
+            rid = sreq.get("id")
+            method = sreq.get("method", "")
+            logger.debug("declining stale codex server request: %s", method)
+            if method.endswith("/requestApproval"):
+                self._client.respond(rid, {"decision": "decline"})
+            elif method == "mcpServer/elicitation/request":
+                self._client.respond(
+                    rid, {"action": "decline", "content": None, "_meta": None}
+                )
+            else:
+                self._client.respond_error(
+                    rid, code=-32601, message=f"Unsupported method: {method}"
+                )
+
+    def _fold_tail_note(
+        self,
+        result: TurnResult,
+        projector: CodexEventProjector,
+        note: dict,
+    ) -> bool:
+        """Fold one drained notification into the interrupted turn's result.
+
+        The tail belongs to the interrupted turn, so its usage and items are
+        recorded rather than dropped. Returns True when the note is terminal
+        for the interrupted turn, meaning draining is done.
+        """
+        _apply_token_usage_notification(result, note)
+        _apply_compaction_notification(result, note)
+        projection = projector.project(note)
+        if projection.messages:
+            result.projected_messages.extend(projection.messages)
+        if projection.is_tool_iteration:
+            result.tool_iterations += 1
+        if projection.final_text is not None:
+            result.final_text = projection.final_text
+            if _has_turn_aborted_marker(projection.final_text):
+                # Some codex builds tear a turn down with a <turn_aborted>
+                # marker and never send turn/completed (main-loop parity).
+                # Without this, the drain would burn the whole grace window
+                # and retire a healthy, context-bearing thread on every
+                # interrupt against those builds.
+                result.error = result.error or "codex reported turn_aborted"
+                return True
+        return self._tail_note_is_terminal(result, note)
+
+    def _tail_note_is_terminal(self, result: TurnResult, note: dict) -> bool:
+        """True when the drained note is the interrupted turn's own
+        ``turn/completed``; folds a failed terminal's error into the result.
+
+        ``result.interrupted`` deliberately stays True even when the turn
+        raced to status="completed": the user requested the interrupt, and
+        flipping it off while the agent-level interrupt flag is still set
+        would make the next turn's pre-check fire a spurious empty
+        interrupted turn. The completed text/usage are preserved either way.
+        """
+        if note.get("method") != "turn/completed":
+            return False
+        turn_obj = (note.get("params") or {}).get("turn") or {}
+        completed_id = turn_obj.get("id")
+        if completed_id and result.turn_id and completed_id != result.turn_id:
+            return False
+        status = turn_obj.get("status")
+        if status and status not in {"completed", "interrupted"}:
+            err_obj = turn_obj.get("error")
+            if err_obj:
+                result.error = result.error or _format_responses_error(
+                    err_obj, str(status)
+                )
+        if result.turn_id:
+            # The matching terminal event has been consumed — nothing more
+            # can leak from this turn, so stop tracking it as stale.
+            self._stale_turn_ids.discard(result.turn_id)
+        return True
 
     def _handle_server_request(self, req: dict) -> None:
         """Translate a codex server request (approval) into Hermes' approval

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -49,18 +49,6 @@ logger = logging.getLogger(__name__)
 _STDERR_TAIL_LINES = 12
 
 
-# Permission profile mapping mirrors the docstring in PR proposal:
-# Hermes' tools.terminal.security_mode → Codex's permissions profile id.
-# Defaults if config is missing → workspace-write (matches Codex's own default).
-_HERMES_TO_CODEX_PERMISSION_PROFILE = {
-    "auto": "workspace-write",
-    "approval-required": "read-only-with-approval",
-    "unrestricted": "full-access",
-    # Backstop alias used by some skills/tests.
-    "yolo": "full-access",
-}
-
-
 @dataclass
 class TurnResult:
     """Result of one user→assistant→tool turn through the codex app-server."""
@@ -213,12 +201,11 @@ class CodexAppServerSession:
         self._cwd = cwd or os.getcwd()
         self._codex_bin = codex_bin
         self._codex_home = codex_home
-        self._permission_profile = (
-            permission_profile or _HERMES_TO_CODEX_PERMISSION_PROFILE.get(
-                os.environ.get("HERMES_TERMINAL_SECURITY_MODE", "auto"),
-                "workspace-write",
-            )
-        )
+        # Retained as a constructor compatibility hint for older callers.
+        # Current Codex policy is read from sandbox_mode / approval_policy in
+        # config.toml; Hermes no longer invents the removed permissions-profile
+        # protocol on thread/start.
+        self._permission_profile = permission_profile
         self._approval_callback = approval_callback
         self._on_event = on_event  # Display hook (kawaii spinner ticks etc.)
         self._routing = request_routing or _ServerRequestRouting()
@@ -253,20 +240,10 @@ class CodexAppServerSession:
             client_version=_get_hermes_version(),
         )
         # Permission selection is intentionally NOT sent on thread/start.
-        # Two reasons (live-tested against codex 0.130.0):
-        #   1. `thread/start.permissions` is gated behind the experimentalApi
-        #      capability on this codex version — we'd have to opt in during
-        #      initialize and accept the unstable surface.
-        #   2. Even with experimentalApi declared and the correct shape
-        #      (`{"type": "profile", "id": "..."}`, not `{"profileId": ...}`),
-        #      codex requires a matching `[permissions]` table in
-        #      ~/.codex/config.toml or it fails the request with
-        #      'default_permissions requires a [permissions] table'.
-        # Letting codex pick its default (`:read-only` unless the user has
-        # configured otherwise in their codex config.toml) is the standard
-        # codex CLI workflow and avoids fighting codex's own validation.
-        # Users who want a write-capable profile configure it in their
-        # ~/.codex/config.toml the same way they would for any codex usage.
+        # Current Codex releases use config.toml sandbox_mode and
+        # approval_policy; the older permissions-profile request was
+        # experimental and version-specific. The Hermes migration writes a
+        # current sandbox_mode default only when the user has not supplied one.
         params: dict[str, Any] = {"cwd": self._cwd}
         result = self._client.request("thread/start", params, timeout=15)
         # Cross-fill thread.id/sessionId — different codex versions have
@@ -292,7 +269,7 @@ class CodexAppServerSession:
         logger.info(
             "codex app-server thread started: id=%s profile=%s cwd=%s",
             self._thread_id[:8],
-            self._permission_profile,
+            self._permission_profile or "config.toml",
             self._cwd,
         )
         return self._thread_id
@@ -321,6 +298,10 @@ class CodexAppServerSession:
         """Idempotent: signal the active turn loop to issue turn/interrupt
         and unwind. Called by AIAgent's _interrupt_requested path."""
         self._interrupt_event.set()
+
+    def clear_interrupt(self) -> None:
+        """Clear the interrupt only after Hermes has finalized the turn."""
+        self._interrupt_event.clear()
 
     # ---------- diagnostics ----------
 
@@ -400,7 +381,6 @@ class CodexAppServerSession:
         assert self._client is not None and self._thread_id is not None
         result.thread_id = self._thread_id
 
-        self._interrupt_event.clear()
         projector = CodexEventProjector()
 
         user_input_text = _coerce_turn_input_text(user_input)

--- a/agent/transports/codex_event_projector.py
+++ b/agent/transports/codex_event_projector.py
@@ -6,14 +6,14 @@ OpenAI-shaped `{role, content, tool_calls, tool_call_id}` entries that
 `agent/curator.py` already knows how to read.
 
 Codex emits items with a discriminator field `type`:
-  - userMessage         → {role: "user", content}
+  - userMessage         → ignored (Hermes already persisted the inbound turn)
   - agentMessage        → {role: "assistant", content}
   - reasoning           → stashed in the assistant's "reasoning" field
   - commandExecution    → assistant tool_call(name="exec") + tool result
   - fileChange          → assistant tool_call(name="apply_patch") + tool result
   - mcpToolCall         → assistant tool_call(name=f"mcp.{server}.{tool}") + tool result
   - dynamicToolCall     → assistant tool_call(name=tool) + tool result
-  - plan/hookPrompt/collabAgentToolCall → recorded as opaque assistant notes
+  - plan/hookPrompt/collabAgentToolCall/unknown → ignored for conversation replay
 
 Each item maps to AT MOST one assistant entry + one tool entry, preserving
 Hermes' message-alternation invariants (system → user → assistant → user/tool
@@ -107,12 +107,17 @@ class CodexEventProjector:
         if item_type == "dynamicToolCall":
             return self._project_dynamic_tool_call(item, item_id)
         if item_type == "userMessage":
-            return self._project_user_message(item)
+            # Hermes appends and persists the inbound user turn before Codex is
+            # invoked. Projecting Codex's echo would create ``user → user`` and
+            # duplicate the prompt in durable memory/session search.
+            return ProjectionResult()
 
         # Unknown / rare items (plan, hookPrompt, collabAgentToolCall, etc.)
-        # — record as opaque assistant note so memory review can still see
-        # *something* happened, but don't fabricate tool_call structure.
-        return self._project_opaque(item, item_type)
+        # are protocol telemetry, not assistant conversation turns. The Codex
+        # item enum is intentionally non-exhaustive, so fabricating an
+        # assistant row here would make a newly-added item type capable of
+        # breaking role alternation or leaking internal state into memory.
+        return ProjectionResult()
 
     # ---------- per-type projections ----------
 
@@ -123,21 +128,6 @@ class CodexEventProjector:
             msg["reasoning"] = "\n".join(self._pending_reasoning)
             self._pending_reasoning = []
         return ProjectionResult(messages=[msg], final_text=text)
-
-    def _project_user_message(self, item: dict) -> ProjectionResult:
-        # codex's userMessage content is a list of UserInput variants. For
-        # projection purposes we flatten any text fragments and ignore
-        # non-text parts (images, etc.) — Hermes' messages store text only.
-        text_parts: list[str] = []
-        for fragment in item.get("content") or []:
-            if isinstance(fragment, dict):
-                if fragment.get("type") == "text":
-                    text_parts.append(fragment.get("text") or "")
-                elif "text" in fragment:
-                    text_parts.append(str(fragment["text"]))
-        return ProjectionResult(
-            messages=[{"role": "user", "content": "\n".join(text_parts)}]
-        )
 
     def _project_command(self, item: dict, item_id: str) -> ProjectionResult:
         call_id = _deterministic_call_id("exec", item_id)
@@ -295,20 +285,4 @@ class CodexEventProjector:
         }
         return ProjectionResult(
             messages=[assistant_msg, tool_msg], is_tool_iteration=True
-        )
-
-    def _project_opaque(self, item: dict, item_type: str) -> ProjectionResult:
-        # Record the existence of the item without inventing tool_calls.
-        # Memory review will see this and may or may not save anything.
-        try:
-            payload = json.dumps(item, ensure_ascii=False)[:1500]
-        except (TypeError, ValueError):
-            payload = repr(item)[:1500]
-        return ProjectionResult(
-            messages=[
-                {
-                    "role": "assistant",
-                    "content": f"[codex {item_type}] {payload}",
-                }
-            ]
         )

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -121,11 +121,18 @@ def finalize_turn(
                     exc_info=True,
                 )
 
-    # Determine if conversation completed successfully
+    # Determine if conversation completed successfully. An interrupted turn
+    # is never "completed": the classic loop guarantees final_response is
+    # still None when the interrupt breaks it, but the codex app-server
+    # runtime passes turn.final_text, which is "" (not None) for interrupted
+    # turns — without the explicit interrupted term, trajectory persistence
+    # and the on_session_end hook below would classify cancelled work as
+    # successful.
     normal_text_response = str(_turn_exit_reason).startswith("text_response(")
     completed = (
         final_response is not None
         and not failed
+        and not interrupted
         and (
             api_call_count < agent.max_iterations
             or normal_text_response

--- a/hermes_cli/codex_runtime_plugin_migration.py
+++ b/hermes_cli/codex_runtime_plugin_migration.py
@@ -15,8 +15,8 @@ module:
      OpenClaw calls "migrate native codex plugins" — the YouTube-video-
      worthy bit Pash highlighted: Canva, GitHub, Calendar, Gmail
      pre-configured.)
-  3. Writes a [permissions] default profile so users on this runtime
-     don't get an approval prompt on every write attempt.
+  3. Writes Codex's current top-level ``sandbox_mode`` setting so users on
+     this runtime don't get an approval prompt on every workspace write.
 
 What translates (MCP servers):
   Hermes mcp_servers.<n>.command/args/env  → codex stdio transport
@@ -95,7 +95,7 @@ class MigrationReport:
             lines.append(f"Codex plugin discovery skipped: {self.plugin_query_error}")
         if self.wrote_permissions_default:
             lines.append(
-                f"Wrote default_permissions = "
+                f"Wrote sandbox_mode = "
                 f"{self.wrote_permissions_default!r}"
             )
         for err in self.errors:
@@ -243,12 +243,43 @@ def _quote_key(key: str) -> str:
     escaped = key.replace("\\", "\\\\").replace('"', '\\"')
     return f'"{escaped}"'
 
+
+_PERMISSION_PROFILE_TO_SANDBOX_MODE = {
+    "workspace": "workspace-write",
+    "workspace-write": "workspace-write",
+    "read-only": "read-only",
+    "read-only-with-approval": "read-only",
+    "full-access": "danger-full-access",
+    "danger-no-sandbox": "danger-full-access",
+    "danger-full-access": "danger-full-access",
+    "unrestricted": "danger-full-access",
+    "yolo": "danger-full-access",
+}
+
+
+def _sandbox_mode_for_permission_profile(profile: str) -> str:
+    """Translate legacy Hermes/Codex profile names to current Codex config.
+
+    ``default_permissions`` profiles were accepted by early app-server builds
+    but are no longer part of Codex's config schema. Unknown legacy/custom
+    names fail closed to ``read-only`` instead of silently granting writes.
+    """
+    normalized = str(profile or "").strip().lstrip(":").lower()
+    mode = _PERMISSION_PROFILE_TO_SANDBOX_MODE.get(normalized)
+    if mode is None:
+        logger.warning(
+            "Unknown Codex permission profile %r; using sandbox_mode=read-only",
+            profile,
+        )
+        return "read-only"
+    return mode
+
 def render_codex_toml_section(
     servers: dict[str, dict],
     plugins: Optional[list[dict]] = None,
     default_permission_profile: Optional[str] = None,
 ) -> str:
-    """Render the managed [mcp_servers.<n>] / [plugins.<id>] / [permissions]
+    """Render the managed [mcp_servers.<n>] / [plugins.<id>] / sandbox block
     block for ~/.codex/config.toml.
 
     Args:
@@ -256,10 +287,9 @@ def render_codex_toml_section(
         plugins: optional list of {name, marketplace, enabled} for native
             Codex plugins to enable. (E.g. the Linear / Atlassian / Asana
             curated plugins, or per-account ChatGPT apps.)
-        default_permission_profile: when set, write `[permissions] default`
-            so the user doesn't get an approval prompt on every write
-            attempt. Common values: "workspace-write", "read-only",
-            "full-access".
+        default_permission_profile: legacy profile name mapped to Codex's
+            current top-level ``sandbox_mode``. Common values:
+            "workspace-write", "read-only", "full-access".
     """
     out = [MIGRATION_MARKER]
     if not servers and not plugins and not default_permission_profile:
@@ -268,18 +298,11 @@ def render_codex_toml_section(
         return "\n".join(out) + "\n"
 
     if default_permission_profile:
-        # Codex's config schema: `default_permissions` is a top-level
-        # string referencing a profile name. Built-in profile names start
-        # with ":" (":workspace-write", ":read-only", ":full-access"). The
-        # [permissions] table is for *user-defined* named profiles with
-        # structured fields — not what we want.
-        normalized = (
+        sandbox_mode = _sandbox_mode_for_permission_profile(
             default_permission_profile
-            if default_permission_profile.startswith(":")
-            else f":{default_permission_profile}"
         )
         out.append("")
-        out.append(f"default_permissions = {_format_toml_value(normalized)}")
+        out.append(f"sandbox_mode = {_format_toml_value(sandbox_mode)}")
 
     if servers:
         for name in sorted(servers.keys()):
@@ -333,6 +356,27 @@ def _insert_managed_block_at_top_level(user_text: str, managed_block: str) -> st
     if prefix:
         return f"{prefix}\n\n{managed_block}\n{suffix}"
     return f"{managed_block}\n{suffix}"
+
+
+def _has_top_level_toml_key(toml_text: str, key: str) -> bool:
+    """Return whether ``key`` is explicitly set before the first TOML table.
+
+    Root keys cannot resume after a table header in TOML. This lightweight
+    scan is therefore sufficient and avoids rejecting otherwise-valid Codex
+    config extensions that an older Python ``tomllib`` may not understand.
+    """
+    prefix = f"{key}"
+    for line in toml_text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if _looks_like_table_header(stripped):
+            return False
+        if stripped.startswith(prefix):
+            remainder = stripped[len(prefix):].lstrip()
+            if remainder.startswith("="):
+                return True
+    return False
 
 
 def _strip_unmanaged_plugin_tables(toml_text: str) -> str:
@@ -411,7 +455,7 @@ def _strip_existing_managed_block(toml_text: str) -> str:
     Backward compatibility: if the start marker is found but no end marker
     follows, we fall back to the heuristic that swallows lines until we
     hit a section that's not [mcp_servers.*]/[plugins.*]/[permissions]/
-    a `default_permissions =` key. This matches what older versions of
+    a `default_permissions =` / `sandbox_mode =` key. This matches what older versions of
     this code wrote so re-runs don't break configs from prior Hermes
     versions."""
     lines = toml_text.splitlines(keepends=True)
@@ -626,15 +670,12 @@ def migrate(
             the live codex CLI to migrate any installed curated plugins
             into [plugins."<name>@<marketplace>"] entries. Set False to
             skip the subprocess spawn (for tests or restricted environments).
-        default_permission_profile: when set (default ":workspace"), write
-            top-level `default_permissions = "<name>"` so users on this
-            runtime don't get an approval prompt on every write attempt.
-            Built-in codex profile names are ":workspace", ":read-only",
-            ":danger-no-sandbox" (note the leading ":"). Also accepts a
-            user-defined profile name (no leading ":") that the user has
-            configured in their own [permissions.<name>] table. Set None
-            to leave permissions unset and let codex use its compiled-in
-            default (which is read-only).
+        default_permission_profile: legacy profile name mapped to the current
+            top-level ``sandbox_mode`` key. The default ``:workspace`` maps
+            to ``workspace-write``; ``:read-only`` maps to ``read-only`` and
+            full-access aliases map to ``danger-full-access``. Unknown names
+            fail closed to ``read-only``. Set None to leave Codex's existing
+            policy untouched.
         expose_hermes_tools: when True (default), register Hermes' own
             tool surface (web_search, browser_*, delegate_task, vision,
             memory, skills, etc.) as an MCP server in ~/.codex/config.toml
@@ -645,6 +686,16 @@ def migrate(
     codex_home = codex_home or Path.home() / ".codex"
     target = codex_home / "config.toml"
     report.target_path = target
+
+    existing: Optional[str] = None
+    without_managed = ""
+    if target.exists():
+        try:
+            existing = target.read_text(encoding="utf-8")
+        except Exception as exc:
+            report.errors.append(f"could not read {target}: {exc}")
+            return report
+        without_managed = _strip_existing_managed_block(existing)
 
     hermes_servers = (hermes_config or {}).get("mcp_servers") or {}
     if not isinstance(hermes_servers, dict):
@@ -682,10 +733,18 @@ def migrate(
         for p in plugins:
             report.migrated_plugins.append(f"{p['name']}@{p['marketplace']}")
 
-    # Track whether we wrote a default permission profile so the report
-    # surfaces it to the user.
-    if default_permission_profile:
-        report.wrote_permissions_default = default_permission_profile
+    # Respect an explicit user-owned sandbox policy. Hermes only supplies a
+    # workspace-write default when no top-level sandbox_mode exists outside
+    # its managed block; emitting the key twice would make config.toml invalid.
+    effective_permission_profile = default_permission_profile
+    if _has_top_level_toml_key(without_managed, "sandbox_mode"):
+        effective_permission_profile = None
+
+    # Track whether we wrote a sandbox default so the report surfaces it.
+    if effective_permission_profile:
+        report.wrote_permissions_default = _sandbox_mode_for_permission_profile(
+            effective_permission_profile
+        )
 
     # Inject Hermes' own tool surface as an MCP server so the spawned
     # codex subprocess can call back into Hermes for the tools codex
@@ -701,18 +760,12 @@ def migrate(
     # Build the new managed block
     managed_block = render_codex_toml_section(
         translated, plugins=plugins,
-        default_permission_profile=default_permission_profile,
+        default_permission_profile=effective_permission_profile,
     )
 
     # Read existing codex config if any, strip the prior managed block,
     # append the new one.
-    if target.exists():
-        try:
-            existing = target.read_text(encoding="utf-8")
-        except Exception as exc:
-            report.errors.append(f"could not read {target}: {exc}")
-            return report
-        without_managed = _strip_existing_managed_block(existing)
+    if existing is not None:
         # Bug B: when plugin/list ran authoritatively, codex's own
         # [plugins."<name>@<marketplace>"] tables outside our managed block
         # would survive _strip_existing_managed_block and then collide with

--- a/hermes_cli/codex_runtime_plugin_migration.py
+++ b/hermes_cli/codex_runtime_plugin_migration.py
@@ -340,12 +340,10 @@ def _insert_managed_block_at_top_level(user_text: str, managed_block: str) -> st
         return managed_block
 
     lines = user_text.splitlines(keepends=True)
-    first_table_idx: Optional[int] = None
-    for idx, line in enumerate(lines):
-        stripped = line.lstrip()
-        if stripped.startswith("["):
-            first_table_idx = idx
-            break
+    # Fence-aware: a "[header]"-shaped line inside a multiline string is
+    # string content — inserting there would inject the managed block into
+    # the middle of the user's value.
+    first_table_idx = _first_table_header_index(lines)
 
     if first_table_idx is None:
         prefix = user_text.rstrip("\n")
@@ -358,6 +356,186 @@ def _insert_managed_block_at_top_level(user_text: str, managed_block: str) -> st
     return f"{managed_block}\n{suffix}"
 
 
+def _match_top_level_toml_key(stripped_line: str, key: str) -> Optional[str]:
+    """Return the raw right-hand side if ``stripped_line`` assigns ``key``.
+
+    TOML allows the same root key to be written bare (``sandbox_mode``) or
+    quoted (``"sandbox_mode"`` / ``'sandbox_mode'``); all three spellings are
+    the same key, so missing the quoted forms here would make migration emit
+    a duplicate bare key and break the whole config with a TOML parse error.
+    """
+    for candidate in (key, f'"{key}"', f"'{key}'"):
+        if stripped_line.startswith(candidate):
+            remainder = stripped_line[len(candidate):].lstrip()
+            if remainder.startswith("="):
+                return remainder[1:].strip()
+    return None
+
+
+def _skip_singleline_string(line: str, i: int, quote: str) -> int:
+    """Return the index just past the single-line string opening at
+    ``line[i] == quote``. Basic strings honor backslash escapes; literal
+    strings don't. Unterminated (invalid TOML) consumes the rest."""
+    i += 1
+    n = len(line)
+    while i < n:
+        ch = line[i]
+        if quote == '"' and ch == "\\":
+            i += 2
+            continue
+        if ch == quote:
+            return i + 1
+        i += 1
+    return n
+
+
+def _find_unescaped_fence(line: str, fence: str, start: int = 0) -> int:
+    """Index where the CLOSING delimiter of ``fence`` starts, or -1.
+
+    TOML allows 1-2 adjacent quotes as string content right before the
+    closing delimiter (``closes\"\"\"\"`` is one content quote + the
+    delimiter), so within a run of quotes the delimiter is the LAST three.
+    Basic-string fences honor backslash-escape parity (``\\\"\"\"`` is an
+    escaped quote + two content quotes; ``\\\\\"\"\"`` is an escaped
+    backslash + a real fence). Literal fences (``'''``) have no escapes.
+    """
+    quote = fence[0]
+    idx = line.find(fence, start)
+    while idx != -1:
+        if fence == '"""':
+            backslashes = 0
+            j = idx - 1
+            while j >= 0 and line[j] == "\\":
+                backslashes += 1
+                j -= 1
+            if backslashes % 2 == 1:
+                idx = line.find(fence, idx + 1)
+                continue
+        run_end = idx
+        n = len(line)
+        while run_end < n and line[run_end] == quote:
+            run_end += 1
+        return run_end - 3
+    return -1
+
+
+def _line_leaves_multiline_open(line: str) -> Optional[str]:
+    """Return the fence (``\"\"\"`` or ``'''``) when the line opens a
+    multiline string that doesn't close on the same line, else ``None``.
+
+    Comments and single-line strings are skipped first — a triple-quote
+    sequence inside ``# a comment`` or ``"a 'value'"`` is plain text, and
+    counting it would leave the fence state wrongly open for the rest of
+    the document.
+    """
+    i = 0
+    n = len(line)
+    while i < n:
+        ch = line[i]
+        if ch == "#":
+            return None
+        if ch not in ('"', "'"):
+            i += 1
+            continue
+        fence = ch * 3
+        if line.startswith(fence, i):
+            end = _find_unescaped_fence(line, fence, i + 3)
+            if end == -1:
+                return fence
+            i = end + 3
+            continue
+        i = _skip_singleline_string(line, i, ch)
+    return None
+
+
+def _scan_line_fence_state(line: str, fence: Optional[str]) -> Optional[str]:
+    """Consume one physical line and return the multiline-string fence left
+    open after it (``None`` when the line ends outside any multiline string).
+
+    Closing a fence does NOT end the scan: in arrays one line may validly
+    close one multiline string and open another (``closes\"\"\", \"\"\"next``),
+    so the remainder after a close is re-scanned for further openers.
+    """
+    if fence is not None:
+        close = _find_unescaped_fence(line, fence)
+        if close == -1:
+            return fence
+        line = line[close + 3:]
+    return _line_leaves_multiline_open(line)
+
+
+def _first_table_header_index(lines: list[str]) -> Optional[int]:
+    """Index of the first REAL table-header line.
+
+    Lines inside multiline TOML strings (``\"\"\"`` / ``'''``) are string
+    content, not headers — treating them as headers would cut a multiline
+    value in half here and, in the insertion helper, inject the managed
+    block into the middle of a user's string value.
+    """
+    fence: Optional[str] = None
+    for idx, line in enumerate(lines):
+        if fence is None and _looks_like_table_header(line.strip()):
+            return idx
+        fence = _scan_line_fence_state(line, fence)
+    return None
+
+
+def _parse_toml_root_keys(toml_text: str) -> Optional[dict]:
+    """Best-effort dict of the document's root-level entries.
+
+    Tier 1 parses the whole document — spec-accurate for escaped quoted
+    keys (``"sandbox\\u005fmode"`` is the same root key as ``sandbox_mode``)
+    and immune to header-shaped lines inside multiline strings. Tier 2
+    (document uses extensions tomllib rejects) parses only the prefix
+    before the first real table header. Returns ``None`` when neither
+    parses, so callers fall back to the literal line scan.
+    """
+    try:
+        import tomllib
+    except Exception:  # pragma: no cover - py3.11+ always has tomllib
+        return None
+    try:
+        return tomllib.loads(toml_text)
+    except Exception:
+        pass
+    lines = toml_text.splitlines()
+    header_idx = _first_table_header_index(lines)
+    prefix = "\n".join(lines if header_idx is None else lines[:header_idx])
+    try:
+        return tomllib.loads(prefix)
+    except Exception:
+        return None
+
+
+def _read_top_level_toml_key(toml_text: str, key: str) -> Optional[str]:
+    """Return the scalar value of ``key`` if set before the first TOML table.
+
+    Returns ``None`` when the key is absent. Prefers a spec-accurate tomllib
+    parse of the root prefix (handles escaped quoted keys); falls back to a
+    lightweight literal scan when the prefix doesn't parse as valid TOML.
+    """
+    parsed = _parse_toml_root_keys(toml_text)
+    if parsed is not None:
+        if key not in parsed:
+            return None
+        value = parsed[key]
+        return value if isinstance(value, str) else str(value)
+    for line in toml_text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if _looks_like_table_header(stripped):
+            return None
+        raw = _match_top_level_toml_key(stripped, key)
+        if raw is None:
+            continue
+        if raw[:1] in {'"', "'"}:
+            closing = raw.find(raw[0], 1)
+            return raw[1:closing] if closing != -1 else raw[1:]
+        return raw.split("#", 1)[0].strip()
+    return None
+
+
 def _has_top_level_toml_key(toml_text: str, key: str) -> bool:
     """Return whether ``key`` is explicitly set before the first TOML table.
 
@@ -365,18 +543,7 @@ def _has_top_level_toml_key(toml_text: str, key: str) -> bool:
     scan is therefore sufficient and avoids rejecting otherwise-valid Codex
     config extensions that an older Python ``tomllib`` may not understand.
     """
-    prefix = f"{key}"
-    for line in toml_text.splitlines():
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#"):
-            continue
-        if _looks_like_table_header(stripped):
-            return False
-        if stripped.startswith(prefix):
-            remainder = stripped[len(prefix):].lstrip()
-            if remainder.startswith("="):
-                return True
-    return False
+    return _read_top_level_toml_key(toml_text, key) is not None
 
 
 def _strip_unmanaged_plugin_tables(toml_text: str) -> str:
@@ -406,23 +573,113 @@ def _strip_unmanaged_plugin_tables(toml_text: str) -> str:
     lines = toml_text.splitlines(keepends=True)
     out: list[str] = []
     in_plugin_table = False
+    fence: Optional[str] = None
     for line in lines:
         stripped = line.lstrip()
         # Only treat a line as a table header when it has the shape
-        # ``[...]`` (optionally followed by a comment). Multi-line array
-        # continuations like ``["nested"],`` also start with ``[`` after
-        # lstrip but are not headers — without this guard they would
-        # falsely flip ``in_plugin_table`` to False mid-table and leak
-        # array fragments into the output.
-        if _looks_like_table_header(stripped):
+        # ``[...]`` (optionally followed by a comment) AND we are not inside
+        # a multiline string. Multi-line array continuations like
+        # ``["nested"],`` also start with ``[`` after lstrip but are not
+        # headers — without these guards they would falsely flip
+        # ``in_plugin_table`` mid-table, and a ``[plugins.…]``-shaped line
+        # inside a user's multiline string value would start a swallow
+        # region that eats real user content.
+        if fence is None and _looks_like_table_header(stripped):
             in_plugin_table = stripped.startswith("[plugins.")
-            if in_plugin_table:
-                continue
+        fence = _scan_line_fence_state(line, fence)
         if in_plugin_table:
-            # Swallow keys/comments/blanks until the next table header.
+            # Swallow the header and keys/comments/blanks (including
+            # multiline values) until the next real table header.
             continue
         out.append(line)
     return "".join(out)
+
+
+def _lost_or_changed_entry(
+    original: dict,
+    migrated: dict,
+    path: str = "",
+    ignore_roots: frozenset = frozenset(),
+) -> Optional[str]:
+    """First ``original`` entry that ``migrated`` lost or changed.
+
+    Subset semantics: the migrated document may ADD root keys and merge new
+    subtables (e.g. ``[mcp_servers.<n>]``), but every entry in ``original``
+    must survive with an equal value. Root keys in ``ignore_roots`` are
+    exempt (used for ``plugins`` tables that migration intentionally
+    replaces from the authoritative ``plugin/list``).
+    """
+    for key, value in original.items():
+        if not path and key in ignore_roots:
+            continue
+        if key not in migrated:
+            return f"{path}{key} (lost)"
+        migrated_value = migrated[key]
+        if isinstance(value, dict) and isinstance(migrated_value, dict):
+            nested = _lost_or_changed_entry(
+                value, migrated_value, f"{path}{key}."
+            )
+            if nested is not None:
+                return nested
+        elif migrated_value != value:
+            return f"{path}{key} (changed)"
+    return None
+
+
+def _validate_migrated_config(
+    user_text: str,
+    migrated_text: str,
+    managed_text: Optional[str] = None,
+    ignore_user_roots: frozenset = frozenset(),
+) -> Optional[str]:
+    """Return an error string when writing ``migrated_text`` would corrupt
+    the user's configuration; ``None`` when it is safe.
+
+    Two independent checks against the tomllib parse of the migrated text:
+
+    1. Every root entry of ``user_text`` (the user's config BEFORE any
+       lossy textual processing) survives unchanged, except roots in
+       ``ignore_user_roots``.
+    2. Every entry of ``managed_text`` (the rendered managed block, which
+       is valid TOML by construction) exists at its intended root path —
+       this catches placement errors where the block was inserted under an
+       existing table (``features.sandbox_mode``) even though no user entry
+       changed.
+
+    When the user's text itself doesn't parse, check 1 is skipped — codex
+    couldn't have loaded that config either way.
+    """
+    try:
+        import tomllib
+    except Exception:  # pragma: no cover - py3.11+ always has tomllib
+        return None
+    try:
+        migrated = tomllib.loads(migrated_text)
+    except Exception as exc:
+        return f"migrated config would not parse ({exc})"
+    try:
+        original = tomllib.loads(user_text)
+    except Exception:
+        original = None
+    if original is not None:
+        problem = _lost_or_changed_entry(
+            original, migrated, ignore_roots=ignore_user_roots
+        )
+        if problem is not None:
+            return f"migration would corrupt user entry {problem}"
+    if managed_text:
+        try:
+            managed = tomllib.loads(managed_text)
+        except Exception:
+            managed = None
+        if managed:
+            problem = _lost_or_changed_entry(managed, migrated)
+            if problem is not None:
+                return (
+                    f"managed entry {problem} did not land at the "
+                    "document root"
+                )
+    return None
 
 
 def _looks_like_table_header(stripped_line: str) -> bool:
@@ -739,6 +996,20 @@ def migrate(
     effective_permission_profile = default_permission_profile
     if _has_top_level_toml_key(without_managed, "sandbox_mode"):
         effective_permission_profile = None
+    else:
+        legacy_profile = _read_top_level_toml_key(
+            without_managed, "default_permissions"
+        )
+        if legacy_profile is not None:
+            # Early app-server builds accepted a top-level
+            # ``default_permissions`` profile, and the previous runtime docs
+            # told users to keep it outside the managed block. Current Codex
+            # ignores that key entirely, so honoring only ``sandbox_mode``
+            # here would silently upgrade an explicitly read-only user to
+            # the workspace-write default. Translate the user's profile
+            # instead; unknown names fail closed to read-only in
+            # _sandbox_mode_for_permission_profile.
+            effective_permission_profile = legacy_profile
 
     # Track whether we wrote a sandbox default so the report surfaces it.
     if effective_permission_profile:
@@ -772,9 +1043,33 @@ def migrate(
         # the entries we re-emit inside the managed block — producing
         # duplicate-table-header parse errors on codex's next startup. Drop
         # those pre-existing tables since plugin/list is the source of truth.
+        # Keep the pre-strip text as the validation baseline: the plugin
+        # stripper is itself line-based, so validating against its OUTPUT
+        # would blind the backstop to anything the stripper ate by mistake.
+        pre_plugin_strip = without_managed
         if plugin_query_succeeded:
             without_managed = _strip_unmanaged_plugin_tables(without_managed)
         new_text = _insert_managed_block_at_top_level(without_managed, managed_block)
+        # Fail-closed backstop: block placement relies on a line scanner
+        # that approximates TOML; if any corner of it misjudged where the
+        # first real table starts, refuse to write rather than silently
+        # corrupt the user's values or bury the managed settings.
+        validation_error = _validate_migrated_config(
+            pre_plugin_strip,
+            new_text,
+            managed_text=managed_block,
+            ignore_user_roots=(
+                frozenset({"plugins"})
+                if plugin_query_succeeded
+                else frozenset()
+            ),
+        )
+        if validation_error is not None:
+            report.errors.append(
+                f"refusing to write {target}: {validation_error} "
+                "(config.toml left untouched)"
+            )
+            return report
     else:
         new_text = managed_block
 

--- a/hermes_cli/codex_runtime_switch.py
+++ b/hermes_cli/codex_runtime_switch.py
@@ -239,7 +239,7 @@ def apply(
             if mig_report.wrote_permissions_default:
                 msg_lines.append(
                     f"Default sandbox: {mig_report.wrote_permissions_default} "
-                    f"(no approval prompt on every write)"
+                    f"(Codex sandbox_mode; workspace writes stay in-sandbox)"
                 )
             if "hermes-tools" in mig_report.migrated:
                 msg_lines.append(

--- a/run_agent.py
+++ b/run_agent.py
@@ -2711,6 +2711,15 @@ class AIAgent:
                 child.interrupt(message)
             except Exception as e:
                 logger.debug("Failed to propagate interrupt to child agent: %s", e)
+        # Codex app-server owns a separate blocking event loop and cannot see
+        # Hermes' thread-local tool interrupt bit. Signal its protocol bridge
+        # explicitly so the active Codex turn receives turn/interrupt.
+        _codex_session = getattr(self, "_codex_session", None)
+        if _codex_session is not None:
+            try:
+                _codex_session.request_interrupt()
+            except Exception as e:
+                logger.debug("Failed to propagate interrupt to Codex session: %s", e)
         if not self.quiet_mode:
             print("\n⚡ Interrupt requested" + (f": '{message[:40]}...'" if message and len(message) > 40 else f": '{message}'" if message else ""))
 
@@ -2721,6 +2730,12 @@ class AIAgent:
         self._interrupt_thread_signal_pending = False
         if self._execution_thread_id is not None:
             _set_interrupt(False, self._execution_thread_id)
+        _codex_session = getattr(self, "_codex_session", None)
+        if _codex_session is not None:
+            try:
+                _codex_session.clear_interrupt()
+            except Exception:
+                logger.debug("Failed to clear Codex session interrupt", exc_info=True)
         # Also clear any concurrent-tool worker thread bits.  Tracked
         # workers normally clear their own bit on exit, but an explicit
         # clear here guarantees no stale interrupt can survive a turn
@@ -5817,12 +5832,23 @@ class AIAgent:
         user_message: str,
         original_user_message: Any,
         messages: List[Dict[str, Any]],
+        conversation_history: Optional[List[Dict[str, Any]]] = None,
         effective_task_id: str,
+        hermes_turn_id: Optional[str] = None,
         should_review_memory: bool = False,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.codex_runtime.run_codex_app_server_turn``."""
         from agent.codex_runtime import run_codex_app_server_turn
-        return run_codex_app_server_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, should_review_memory=should_review_memory)
+        return run_codex_app_server_turn(
+            self,
+            user_message=user_message,
+            original_user_message=original_user_message,
+            messages=messages,
+            conversation_history=conversation_history,
+            effective_task_id=effective_task_id,
+            hermes_turn_id=hermes_turn_id,
+            should_review_memory=should_review_memory,
+        )
 
 def main(
     query: str = None,

--- a/tests/agent/test_codex_app_server_persist.py
+++ b/tests/agent/test_codex_app_server_persist.py
@@ -139,6 +139,82 @@ def test_codex_turn_persists_each_message_exactly_once():
         shutil.rmtree(tmp)
 
 
+def test_codex_interrupted_turn_finalizes_as_not_completed():
+    """An interrupted codex turn carries final_text == "" (not None); the
+    shared finalizer must not classify it as completed. The finalizer's own
+    ``completed`` drives trajectory persistence and the on_session_end hook,
+    so the result-dict override in codex_runtime alone is not enough."""
+    agent = _make_agent(session_db=None)
+    turn = _make_turn()
+    turn.interrupted = True
+    turn.final_text = ""
+    turn.projected_messages = []
+    agent._codex_session.run_turn.return_value = turn
+
+    saved = {}
+    agent._save_trajectory = (
+        lambda msgs, summary, completed: saved.__setitem__("completed", completed)
+    )
+    result = run_codex_app_server_turn(
+        agent,
+        user_message="hello",
+        original_user_message="hello",
+        messages=[{"role": "user", "content": "hello"}],
+        effective_task_id="task-1",
+    )
+    assert result["completed"] is False
+    assert result["interrupted"] is True
+    assert saved["completed"] is False
+
+
+def test_codex_multi_turn_usage_stays_cumulative():
+    """The turn result must report cumulative session totals. Merging the
+    per-turn usage snapshot back into the result clobbered the cumulative
+    token/cost fields with single-turn values from the second turn on."""
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    agent = _make_agent(session_db=None)
+
+    def make_usage_turn(n):
+        t = _make_turn()
+        t.token_usage_last = {
+            "inputTokens": 100 * n,
+            "cachedInputTokens": 0,
+            "outputTokens": 10 * n,
+            "reasoningOutputTokens": 0,
+            "totalTokens": 110 * n,
+        }
+        return t
+
+    fake_cost = SimpleNamespace(amount_usd=0.0, status="included", source="test")
+    with patch(
+        "agent.usage_pricing.estimate_usage_cost", return_value=fake_cost
+    ):
+        agent._codex_session.run_turn.return_value = make_usage_turn(1)
+        r1 = run_codex_app_server_turn(
+            agent,
+            user_message="one",
+            original_user_message="one",
+            messages=[{"role": "user", "content": "one"}],
+            effective_task_id="task-1",
+        )
+        agent._codex_session.run_turn.return_value = make_usage_turn(2)
+        r2 = run_codex_app_server_turn(
+            agent,
+            user_message="two",
+            original_user_message="two",
+            messages=[{"role": "user", "content": "two"}],
+            effective_task_id="task-1",
+        )
+
+    assert r1["total_tokens"] == 110
+    # Turn 2 reports 110 + 220 cumulative, not the last turn's 220.
+    assert r2["total_tokens"] == 330
+    assert r2["input_tokens"] == 300
+    assert r2["output_tokens"] == 30
+
+
 class TestGatewayPersistedResolution:
     """The gateway default must preserve standard-runtime skip-db behaviour."""
 

--- a/tests/agent/test_codex_app_server_persist.py
+++ b/tests/agent/test_codex_app_server_persist.py
@@ -47,7 +47,15 @@ def _make_turn():
 
 
 def _make_agent(session_db=None, session_id="sess-codex"):
-    agent = MagicMock()
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        session_db=session_db,
+        session_id=session_id,
+    )
     # Pre-seed the session so run_codex_app_server_turn skips the spawn block.
     agent._codex_session = MagicMock()
     agent._codex_session.run_turn.return_value = _make_turn()
@@ -55,9 +63,7 @@ def _make_agent(session_db=None, session_id="sess-codex"):
     agent._iters_since_skill = 0
     agent._skill_nudge_interval = 0
     agent.valid_tool_names = set()
-    agent._session_db = session_db
     agent._session_db_created = True
-    agent.session_id = session_id
     return agent
 
 

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -386,7 +386,6 @@ class TestRunTurn:
 
     def test_interrupt_during_turn_issues_turn_interrupt(self):
         client = FakeClient()
-        # Don't queue turn/completed — the loop has to interrupt out
         client.queue_notification(
             "item/completed",
             item={"type": "commandExecution", "id": "x", "command": "sleep 60",
@@ -394,6 +393,13 @@ class TestRunTurn:
                   "aggregatedOutput": None, "exitCode": None,
                   "commandActions": []},
             threadId="t", turnId="tu1",
+        )
+        # The interrupted turn's terminal event — codex emits it after
+        # turn/interrupt; the drain must consume it before session reuse.
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={"id": "turn-fake-001", "status": "interrupted", "error": None},
         )
         s = make_session(client)
         s.ensure_started()
@@ -407,6 +413,10 @@ class TestRunTurn:
             method == "turn/interrupt" and params.get("turnId") == "turn-fake-001"
             for (method, params) in client.requests
         )
+        # Tail fully drained — session stays reusable, nothing left queued.
+        assert r.should_retire is False
+        assert client._notifications == []
+        assert s._stale_turn_ids == set()
 
     def test_deadline_exceeded_records_error(self):
         client = FakeClient()
@@ -479,6 +489,330 @@ class TestRunTurn:
         r = make_session(client).run_turn("x", turn_timeout=1.0)
 
         assert r.compacted is True
+
+
+class TestInterruptedTurnDrain:
+    """A user interrupt must not leave the interrupted turn's notification
+    tail queued for the next turn (stale turn/completed would terminate the
+    replacement turn instantly; stale items would leak into its transcript)."""
+
+    def test_interrupt_folds_tail_into_interrupted_result(self):
+        client = FakeClient()
+        client.queue_notification(
+            "item/completed",
+            item={"type": "agentMessage", "id": "m1", "text": "partial answer"},
+            threadId="t", turnId="turn-fake-001",
+        )
+        client.queue_notification(
+            "thread/tokenUsage/updated",
+            threadId="t", turnId="turn-fake-001",
+            tokenUsage={
+                "last": {"totalTokens": 42, "inputTokens": 30,
+                         "cachedInputTokens": 0, "outputTokens": 12,
+                         "reasoningOutputTokens": 0},
+                "total": {"totalTokens": 42, "inputTokens": 30,
+                          "cachedInputTokens": 0, "outputTokens": 12,
+                          "reasoningOutputTokens": 0},
+            },
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={"id": "turn-fake-001", "status": "interrupted", "error": None},
+        )
+        s = make_session(client)
+        s.ensure_started()
+        s.request_interrupt()
+        r = s.run_turn("x", turn_timeout=2.0)
+        assert r.interrupted is True
+        assert r.should_retire is False
+        # The tail belongs to the interrupted turn — folded in, not dropped.
+        assert r.final_text == "partial answer"
+        assert r.token_usage_last["totalTokens"] == 42
+        assert client._notifications == []
+
+        # The next turn on the same session completes normally.
+        s.clear_interrupt()
+        client.queue_notification(
+            "item/completed",
+            item={"type": "agentMessage", "id": "m2", "text": "second answer"},
+            threadId="t", turnId="turn-fake-001",
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={"id": "turn-fake-001", "status": "completed", "error": None},
+        )
+        r2 = s.run_turn("y", turn_timeout=2.0)
+        assert r2.interrupted is False
+        assert r2.final_text == "second answer"
+
+    def test_interrupt_drain_timeout_retires_session(self):
+        client = FakeClient()
+        # No terminal event ever arrives for the interrupted turn.
+        s = make_session(client)
+        s.ensure_started()
+        s.request_interrupt()
+        with patch.object(session_mod, "_INTERRUPT_DRAIN_GRACE_SECONDS", 0.05):
+            r = s.run_turn("x", turn_timeout=2.0)
+        assert r.interrupted is True
+        # Queue state unknown — the session must not be reused.
+        assert r.should_retire is True
+        # The interrupted turn stays marked stale in case the session
+        # object is reused anyway.
+        assert "turn-fake-001" in s._stale_turn_ids
+
+    def test_client_death_during_drain_retires_session(self):
+        client = FakeClient()
+        s = make_session(client)
+        s.ensure_started()
+        s.request_interrupt()
+        # Codex dies right after turn/interrupt, before emitting the
+        # terminal event — the drain must retire, not return a session
+        # whose next turn/start would fail on a dead client.
+        client._closed = True
+        r = s.run_turn("x", turn_timeout=2.0)
+        assert r.interrupted is True
+        assert r.should_retire is True
+
+    def test_client_death_after_terminal_event_retires_session(self):
+        client = FakeClient()
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={"id": "turn-fake-001", "status": "interrupted", "error": None},
+        )
+        s = make_session(client)
+        s.ensure_started()
+        s.request_interrupt()
+        # Codex queues its terminal event and then exits: the tail is
+        # clean, but the session must still not be declared reusable.
+        client._closed = True
+        r = s.run_turn("x", turn_timeout=2.0)
+        assert r.interrupted is True
+        assert r.should_retire is True
+
+    def test_interrupt_drain_declines_stale_approvals(self):
+        client = FakeClient()
+        client.queue_server_request(
+            "item/commandExecution/requestApproval",
+            request_id="stale-approval-1",
+            command="rm -rf /scratch", cwd="/",
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={"id": "turn-fake-001", "status": "interrupted", "error": None},
+        )
+        s = make_session(client)
+        s.ensure_started()
+        s.request_interrupt()
+        r = s.run_turn("x", turn_timeout=2.0)
+        assert r.interrupted is True
+        assert r.should_retire is False
+        # The canceled turn's approval was declined, not left queued for
+        # (or auto-accepted by) the next turn.
+        assert ("stale-approval-1", {"decision": "decline"}) in client.responses
+        assert client._server_requests == []
+
+        s.clear_interrupt()
+        client.queue_notification(
+            "item/completed",
+            item={"type": "agentMessage", "id": "m2", "text": "clean turn"},
+            threadId="t", turnId="turn-fake-001",
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={"id": "turn-fake-001", "status": "completed", "error": None},
+        )
+        r2 = s.run_turn("y", turn_timeout=2.0)
+        assert r2.interrupted is False
+        assert r2.final_text == "clean turn"
+
+    def test_drain_recognizes_turn_aborted_marker_as_terminal(self):
+        client = FakeClient()
+        # Marker-only codex builds terminate without turn/completed.
+        client.queue_notification(
+            "item/completed",
+            item={"type": "agentMessage", "id": "m", "text": "<turn_aborted>"},
+            threadId="t", turnId="turn-fake-001",
+        )
+        s = make_session(client)
+        s.ensure_started()
+        s.request_interrupt()
+        r = s.run_turn("x", turn_timeout=2.0)
+        assert r.interrupted is True
+        # The marker is terminal: no grace-window burn, no retirement of a
+        # healthy context-bearing thread.
+        assert r.should_retire is False
+        assert "turn_aborted" in (r.error or "")
+
+    @staticmethod
+    def _distinct_turn_id_handler(ids):
+        id_iter = iter(ids)
+
+        def handler(method, params):
+            if method == "thread/start":
+                return {"thread": {"id": "t"},
+                        "activePermissionProfile": {"id": "workspace-write"}}
+            if method == "turn/start":
+                return {"turn": {"id": next(id_iter)}}
+            return {}
+
+        return handler
+
+    def test_late_completion_after_abort_marker_is_filtered(self):
+        """A marker-ended turn's real turn/completed can arrive during the
+        NEXT turn. Its id must stay tracked as stale until that completion
+        is consumed — discarding it at drain end let the late completion
+        terminate the next turn empty."""
+        client = FakeClient()
+        client._request_handler = self._distinct_turn_id_handler(
+            ["turn-A", "turn-B"]
+        )
+        client.queue_notification(
+            "item/completed",
+            item={"type": "agentMessage", "id": "m", "text": "<turn_aborted>"},
+            threadId="t", turnId="turn-A",
+        )
+        s = make_session(client)
+        s.ensure_started()
+        s.request_interrupt()
+        r1 = s.run_turn("x", turn_timeout=2.0)
+        assert r1.interrupted is True
+        assert r1.should_retire is False
+        # Kept stale: the matching completion has not been seen yet.
+        assert "turn-A" in s._stale_turn_ids
+
+        s.clear_interrupt()
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={"id": "turn-A", "status": "interrupted", "error": None},
+        )
+        client.queue_notification(
+            "item/completed",
+            item={"type": "agentMessage", "id": "m2", "text": "real answer"},
+            threadId="t", turnId="turn-B",
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={"id": "turn-B", "status": "completed", "error": None},
+        )
+        r2 = s.run_turn("y", turn_timeout=2.0)
+        assert r2.interrupted is False
+        assert r2.final_text == "real answer"
+        assert "turn-A" not in s._stale_turn_ids
+
+    def test_marker_ended_turn_without_interrupt_filters_late_completion(self):
+        """Same race via the MAIN wait loop's marker branch (no user
+        interrupt involved)."""
+        client = FakeClient()
+        client._request_handler = self._distinct_turn_id_handler(
+            ["turn-A", "turn-B"]
+        )
+        client.queue_notification(
+            "item/completed",
+            item={"type": "agentMessage", "id": "m", "text": "<turn_aborted>"},
+            threadId="t", turnId="turn-A",
+        )
+        s = make_session(client)
+        s.ensure_started()
+        r1 = s.run_turn("x", turn_timeout=2.0)
+        assert r1.interrupted is True
+        assert "turn-A" in s._stale_turn_ids
+
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={"id": "turn-A", "status": "interrupted", "error": None},
+        )
+        client.queue_notification(
+            "item/completed",
+            item={"type": "agentMessage", "id": "m2", "text": "real answer"},
+            threadId="t", turnId="turn-B",
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={"id": "turn-B", "status": "completed", "error": None},
+        )
+        r2 = s.run_turn("y", turn_timeout=2.0)
+        assert r2.interrupted is False
+        assert r2.final_text == "real answer"
+
+    def test_compaction_marker_keeps_late_completion_filtered(self):
+        """The compaction wait loop has the same marker branch — its turn id
+        must also stay tracked for late-completion filtering."""
+        client = FakeClient()
+        client.queue_notification(
+            "turn/started", threadId="t", turn={"id": "turn-C"}
+        )
+        client.queue_notification(
+            "item/completed",
+            item={"type": "agentMessage", "id": "m", "text": "<turn_aborted>"},
+            threadId="t", turnId="turn-C",
+        )
+        s = make_session(client)
+        s.ensure_started()
+        rc = s.compact_thread(turn_timeout=2.0)
+        assert rc.interrupted is True
+        assert "turn-C" in s._stale_turn_ids
+
+    def test_drain_folds_failed_terminal_error(self):
+        client = FakeClient()
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={"id": "turn-fake-001", "status": "failed",
+                  "error": {"message": "boom from codex"}},
+        )
+        s = make_session(client)
+        s.ensure_started()
+        s.request_interrupt()
+        r = s.run_turn("x", turn_timeout=2.0)
+        assert r.interrupted is True
+        assert r.error and "boom from codex" in r.error
+
+    def test_stale_notifications_are_dropped_by_next_turn(self):
+        client = FakeClient()
+        s = make_session(client)
+        s.ensure_started()
+        # Simulate a tail that outlived the drain window: the id is known
+        # stale, and its notifications arrive during the NEXT turn.
+        s._stale_turn_ids.add("turn-old")
+        client.queue_notification(
+            "item/completed",
+            item={"type": "agentMessage", "id": "old", "text": "stale text"},
+            threadId="t", turnId="turn-old",
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={"id": "turn-old", "status": "interrupted", "error": None},
+        )
+        client.queue_notification(
+            "item/completed",
+            item={"type": "agentMessage", "id": "new", "text": "fresh text"},
+            threadId="t", turnId="turn-fake-001",
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={"id": "turn-fake-001", "status": "completed", "error": None},
+        )
+        r = s.run_turn("x", turn_timeout=2.0)
+        # The stale turn's completion did not terminate this turn, and its
+        # item never reached the transcript.
+        assert r.interrupted is False
+        assert r.final_text == "fresh text"
+        assert all(
+            m.get("content") != "stale text" for m in r.projected_messages
+        )
+        # Consumed stale id is forgotten.
+        assert "turn-old" not in s._stale_turn_ids
 
 
 class TestCompactThread:

--- a/tests/agent/transports/test_codex_event_projector.py
+++ b/tests/agent/transports/test_codex_event_projector.py
@@ -225,8 +225,8 @@ class TestMcpToolCallProjection:
         assert "error" in msgs[1]["content"]
 
 
-class TestUserAndOpaqueProjection:
-    def test_user_message_text_fragments_only(self) -> None:
+class TestNonConversationItems:
+    def test_user_message_is_not_projected_twice(self) -> None:
         item = {
             "type": "userMessage", "id": "u1",
             "content": [
@@ -238,19 +238,27 @@ class TestUserAndOpaqueProjection:
         msgs = CodexEventProjector().project(
             {"method": "item/completed", "params": {"item": item}}
         ).messages
-        assert msgs[0]["role"] == "user"
-        assert "hello" in msgs[0]["content"]
-        assert "world" in msgs[0]["content"]
+        assert msgs == []
 
-    def test_opaque_item_recorded_without_fabricated_tool_calls(self) -> None:
+    def test_opaque_item_is_not_fabricated_as_assistant_turn(self) -> None:
         item = {"type": "plan", "id": "p1", "text": "do the thing"}
         msgs = CodexEventProjector().project(
             {"method": "item/completed", "params": {"item": item}}
         ).messages
-        assert len(msgs) == 1
-        assert msgs[0]["role"] == "assistant"
-        assert "plan" in msgs[0]["content"].lower()
-        assert "tool_calls" not in msgs[0]
+        assert msgs == []
+
+    def test_unknown_item_cannot_break_role_alternation(self) -> None:
+        projector = CodexEventProjector()
+        projected = []
+        for item in (
+            {"type": "userMessage", "id": "u1", "content": []},
+            {"type": "futureProtocolItem", "id": "x1", "payload": "opaque"},
+            {"type": "agentMessage", "id": "a1", "text": "done"},
+        ):
+            projected.extend(projector.project(
+                {"method": "item/completed", "params": {"item": item}}
+            ).messages)
+        assert projected == [{"role": "assistant", "content": "done"}]
 
 
 class TestHelpers:

--- a/tests/hermes_cli/test_codex_runtime_plugin_migration.py
+++ b/tests/hermes_cli/test_codex_runtime_plugin_migration.py
@@ -319,17 +319,53 @@ class TestMigrate:
         assert "no MCP servers" in text or "no MCP servers, plugins, or permissions" in text
 
     def test_no_servers_still_writes_permissions_default(self, tmp_path):
-        """Even with zero MCP servers, enabling the runtime should write the
-        default permissions profile so users don't get prompted on every
-        write attempt. This is the fix for quirk #2."""
+        """The generated default uses Codex's current sandbox_mode schema."""
         report = migrate({}, codex_home=tmp_path, discover_plugins=False, expose_hermes_tools=False)
         assert report.written
         text = (tmp_path / "config.toml").read_text()
-        # Codex's schema: top-level `default_permissions` keying a built-in
-        # profile name (prefixed with ":"). NOT a [permissions] section
-        # (which is for *user-defined* profiles with structured fields).
-        assert 'default_permissions = ":workspace"' in text
-        assert report.wrote_permissions_default == ":workspace"
+        assert 'sandbox_mode = "workspace-write"' in text
+        assert "default_permissions" not in text
+        assert report.wrote_permissions_default == "workspace-write"
+
+    def test_existing_user_sandbox_mode_is_preserved_without_duplicate(self, tmp_path):
+        import tomllib
+
+        target = tmp_path / "config.toml"
+        target.write_text(
+            'sandbox_mode = "read-only"\n\n'
+            '[features]\nterminal_resize_reflow = true\n'
+        )
+
+        report = migrate(
+            {}, codex_home=tmp_path, discover_plugins=False,
+            expose_hermes_tools=False,
+        )
+        text = target.read_text()
+        parsed = tomllib.loads(text)
+        assert parsed["sandbox_mode"] == "read-only"
+        assert text.count("sandbox_mode =") == 1
+        assert report.wrote_permissions_default is None
+
+    @pytest.mark.parametrize(
+        ("profile", "expected"),
+        [
+            (":workspace", "workspace-write"),
+            (":read-only", "read-only"),
+            (":danger-no-sandbox", "danger-full-access"),
+            ("unknown-custom-profile", "read-only"),
+        ],
+    )
+    def test_legacy_permission_names_map_to_current_sandbox_mode(
+        self, tmp_path, profile, expected
+    ):
+        report = migrate(
+            {}, codex_home=tmp_path, discover_plugins=False,
+            expose_hermes_tools=False,
+            default_permission_profile=profile,
+        )
+        text = (tmp_path / "config.toml").read_text()
+        assert f'sandbox_mode = "{expected}"' in text
+        assert report.wrote_permissions_default == expected
 
     def test_explicit_none_permissions_skips_block(self, tmp_path):
         report = migrate({"mcp_servers": {"x": {"command": "y"}}},
@@ -575,8 +611,8 @@ class TestMigrate:
 
     def test_managed_root_keys_stay_top_level_when_config_ends_in_table(self, tmp_path):
         """TOML has no explicit 'leave current table' syntax. If Hermes appends
-        root keys like default_permissions after a user table such as [features],
-        Codex parses them as features.default_permissions and rejects the config.
+        root keys like sandbox_mode after a user table such as [features],
+        Codex parses them as features.sandbox_mode and rejects the config.
         The managed block must therefore be inserted before the first table."""
         import tomllib
 
@@ -590,8 +626,8 @@ class TestMigrate:
         migrate({}, codex_home=tmp_path, discover_plugins=False, expose_hermes_tools=False)
         new_text = target.read_text()
         parsed = tomllib.loads(new_text)
-        assert parsed["default_permissions"] == ":workspace"
-        assert "default_permissions" not in parsed["features"]
+        assert parsed["sandbox_mode"] == "workspace-write"
+        assert "sandbox_mode" not in parsed["features"]
         assert new_text.index(MIGRATION_MARKER) < new_text.index("[features]")
 
     def test_preserves_user_mcp_server_outside_managed_block(self, tmp_path):

--- a/tests/hermes_cli/test_codex_runtime_plugin_migration.py
+++ b/tests/hermes_cli/test_codex_runtime_plugin_migration.py
@@ -367,6 +367,361 @@ class TestMigrate:
         assert f'sandbox_mode = "{expected}"' in text
         assert report.wrote_permissions_default == expected
 
+    @pytest.mark.parametrize("quoted_key", ['"sandbox_mode"', "'sandbox_mode'"])
+    def test_quoted_user_sandbox_mode_is_recognized(self, tmp_path, quoted_key):
+        """TOML allows quoted root keys; missing them would emit a duplicate
+        bare sandbox_mode and break the whole config with a parse error."""
+        import tomllib
+
+        target = tmp_path / "config.toml"
+        target.write_text(f'{quoted_key} = "read-only"\n')
+        report = migrate(
+            {}, codex_home=tmp_path, discover_plugins=False,
+            expose_hermes_tools=False,
+        )
+        text = target.read_text()
+        parsed = tomllib.loads(text)  # a duplicate root key would raise here
+        assert parsed["sandbox_mode"] == "read-only"
+        assert report.wrote_permissions_default is None
+
+    def test_header_like_line_inside_multiline_string_sandbox_recognized(
+        self, tmp_path
+    ):
+        """A '[header]'-shaped line inside a multiline root string is string
+        content. Cutting the scan there would miss a later root sandbox_mode
+        and emit a duplicate."""
+        import tomllib
+
+        target = tmp_path / "config.toml"
+        target.write_text(
+            'developer_instructions = """\n'
+            "[features]\n"
+            "looks like a header but is string content\n"
+            '"""\n'
+            'sandbox_mode = "read-only"\n'
+            "\n"
+            "[features]\n"
+            "real = true\n"
+        )
+        report = migrate(
+            {}, codex_home=tmp_path, discover_plugins=False,
+            expose_hermes_tools=False,
+        )
+        parsed = tomllib.loads(target.read_text())
+        assert parsed["sandbox_mode"] == "read-only"
+        assert "[features]" in parsed["developer_instructions"]
+        assert parsed["features"]["real"] is True
+        assert report.wrote_permissions_default is None
+
+    def test_managed_block_not_injected_into_multiline_string(self, tmp_path):
+        import tomllib
+
+        target = tmp_path / "config.toml"
+        target.write_text(
+            'developer_instructions = """\n'
+            "[fake-header]\n"
+            '"""\n'
+            "\n"
+            "[features]\n"
+            "real = true\n"
+        )
+        migrate(
+            {}, codex_home=tmp_path, discover_plugins=False,
+            expose_hermes_tools=False,
+        )
+        text = target.read_text()
+        parsed = tomllib.loads(text)
+        # The user's string value is intact — the managed block (with the
+        # workspace-write default) landed at the document root, not inside
+        # the multiline string.
+        assert parsed["developer_instructions"] == "[fake-header]\n"
+        assert MIGRATION_MARKER not in parsed["developer_instructions"]
+        assert parsed["sandbox_mode"] == "workspace-write"
+        assert parsed["features"]["real"] is True
+
+    def test_triple_quotes_in_comment_do_not_hide_headers(self, tmp_path):
+        """A triple-quote sequence inside a comment is plain text; counting
+        it as a fence made header detection fail and appended the managed
+        sandbox default AFTER [features] (features.sandbox_mode)."""
+        import tomllib
+
+        target = tmp_path / "config.toml"
+        target.write_text(
+            '# documentation token: """\n'
+            "\n"
+            "[features]\n"
+            "real = true\n"
+        )
+        migrate(
+            {}, codex_home=tmp_path, discover_plugins=False,
+            expose_hermes_tools=False,
+        )
+        parsed = tomllib.loads(target.read_text())
+        assert parsed["sandbox_mode"] == "workspace-write"
+        assert "sandbox_mode" not in parsed["features"]
+
+    def test_triple_quotes_inside_single_line_string_do_not_hide_headers(
+        self, tmp_path
+    ):
+        import tomllib
+
+        target = tmp_path / "config.toml"
+        target.write_text(
+            "note = \"contains ''' inside\"\n"
+            "\n"
+            "[features]\n"
+            "real = true\n"
+        )
+        migrate(
+            {}, codex_home=tmp_path, discover_plugins=False,
+            expose_hermes_tools=False,
+        )
+        parsed = tomllib.loads(target.read_text())
+        assert parsed["sandbox_mode"] == "workspace-write"
+        assert "sandbox_mode" not in parsed["features"]
+
+    def test_escaped_fence_on_opening_line_keeps_multiline_open(self, tmp_path):
+        r"""``x = \"\"\"text \"\"\"`` — the backslash escapes the first quote,
+        so the string stays open; treating it as closed made the next
+        header-shaped line a 'real' header and injected the managed block
+        into the user's string value."""
+        import tomllib
+
+        target = tmp_path / "config.toml"
+        target.write_text(
+            'developer_instructions = """text \\"""\n'
+            "[fake-header]\n"
+            '"""\n'
+            "\n"
+            "[features]\n"
+            "real = true\n"
+        )
+        migrate(
+            {}, codex_home=tmp_path, discover_plugins=False,
+            expose_hermes_tools=False,
+        )
+        parsed = tomllib.loads(target.read_text())
+        # \" is an escaped quote and the following "" are literal content —
+        # the value keeps all three characters.
+        assert parsed["developer_instructions"] == 'text """\n[fake-header]\n'
+        assert MIGRATION_MARKER not in parsed["developer_instructions"]
+        assert parsed["sandbox_mode"] == "workspace-write"
+        assert parsed["features"]["real"] is True
+
+    def test_even_backslash_run_before_closing_fence_closes(self, tmp_path):
+        r"""``\\\"\"\"`` is an escaped backslash followed by a REAL fence —
+        parity-blind escape checks would keep the fence open forever."""
+        import tomllib
+
+        target = tmp_path / "config.toml"
+        target.write_text(
+            'developer_instructions = """\n'
+            'ends with backslash \\\\"""\n'
+            "\n"
+            "[features]\n"
+            "real = true\n"
+        )
+        migrate(
+            {}, codex_home=tmp_path, discover_plugins=False,
+            expose_hermes_tools=False,
+        )
+        parsed = tomllib.loads(target.read_text())
+        assert parsed["developer_instructions"] == "ends with backslash \\"
+        assert parsed["sandbox_mode"] == "workspace-write"
+        assert parsed["features"]["real"] is True
+
+    def test_close_and_reopen_multiline_on_same_line(self, tmp_path):
+        """Arrays may close one multiline string and open another on the
+        SAME line — missing the second opener made a header-shaped line
+        inside the second string look like the first real table."""
+        import tomllib
+
+        target = tmp_path / "config.toml"
+        target.write_text(
+            "values = [\n"
+            '  """first\n'
+            'closes""", """second\n'
+            "[fake-header]\n"
+            '"""\n'
+            "]\n"
+            "\n"
+            "[features]\n"
+            "real = true\n"
+        )
+        migrate(
+            {}, codex_home=tmp_path, discover_plugins=False,
+            expose_hermes_tools=False,
+        )
+        parsed = tomllib.loads(target.read_text())
+        assert parsed["values"] == ["first\ncloses", "second\n[fake-header]\n"]
+        assert parsed["sandbox_mode"] == "workspace-write"
+        assert parsed["features"]["real"] is True
+
+    def test_plugin_strip_leaves_multiline_string_content_alone(self):
+        """A '[plugins.…]'-shaped line inside a multiline string is string
+        content — the stripper eating it (and everything until the next
+        header) was silent user-data loss that predated the backstop."""
+        import hermes_cli.codex_runtime_plugin_migration as mig
+
+        text = (
+            'developer_instructions = """\n'
+            '[plugins."fake@market"]\n'
+            "example line the user wrote\n"
+            '"""\n'
+            '[plugins."real@market"]\n'
+            "enabled = true\n"
+        )
+        out = mig._strip_unmanaged_plugin_tables(text)
+        assert '[plugins."fake@market"]' in out
+        assert "example line the user wrote" in out
+        assert '[plugins."real@market"]' not in out
+        assert "enabled = true" not in out
+
+    def test_four_quote_close_and_reopen_on_same_line(self, tmp_path):
+        """``closes\"\"\"\"`` is one content quote + the closing delimiter —
+        picking the FIRST triple left a stray quote that swallowed the next
+        opener."""
+        import tomllib
+
+        target = tmp_path / "config.toml"
+        target.write_text(
+            "values = [\n"
+            '  """first\n'
+            'closes"""", """second\n'
+            "[fake-header]\n"
+            '"""\n'
+            "]\n"
+            "\n"
+            "[features]\n"
+            "real = true\n"
+        )
+        migrate(
+            {}, codex_home=tmp_path, discover_plugins=False,
+            expose_hermes_tools=False,
+        )
+        parsed = tomllib.loads(target.read_text())
+        assert parsed["values"] == [
+            'first\ncloses"', "second\n[fake-header]\n"
+        ]
+        assert parsed["sandbox_mode"] == "workspace-write"
+        assert parsed["features"]["real"] is True
+
+    def test_validation_backstop_catches_misplaced_managed_entries(
+        self, tmp_path, monkeypatch
+    ):
+        """Even when no user entry changes, a managed block inserted under
+        an existing table (features.sandbox_mode) must be refused — the
+        managed entries are required to land at the document root."""
+        import hermes_cli.codex_runtime_plugin_migration as mig
+
+        target = tmp_path / "config.toml"
+        original = "[features]\nreal = true\n"
+        target.write_text(original)
+        # Force append-at-end placement: the managed block lands after
+        # [features], nesting sandbox_mode under it.
+        monkeypatch.setattr(
+            mig, "_first_table_header_index", lambda lines: None
+        )
+        report = migrate(
+            {}, codex_home=tmp_path, discover_plugins=False,
+            expose_hermes_tools=False,
+        )
+        assert report.written is False
+        assert any("did not land at the document root" in e
+                   for e in report.errors)
+        assert target.read_text() == original
+
+    def test_validation_backstop_refuses_corrupting_write(
+        self, tmp_path, monkeypatch
+    ):
+        """If the placement scanner ever misjudges again, the tomllib
+        validation must refuse the write instead of silently corrupting the
+        user's config."""
+        import hermes_cli.codex_runtime_plugin_migration as mig
+
+        target = tmp_path / "config.toml"
+        original = (
+            'developer_instructions = """\n'
+            "[fake-header]\n"
+            '"""\n'
+            "\n"
+            "[features]\n"
+            "real = true\n"
+        )
+        target.write_text(original)
+        # Force the scanner to pick the header-shaped line INSIDE the string.
+        monkeypatch.setattr(
+            mig, "_first_table_header_index", lambda lines: 1
+        )
+        report = migrate(
+            {}, codex_home=tmp_path, discover_plugins=False,
+            expose_hermes_tools=False,
+        )
+        assert report.written is False
+        assert any("refusing to write" in e for e in report.errors)
+        assert target.read_text() == original
+
+    def test_escaped_quoted_sandbox_mode_key_is_recognized(self, tmp_path):
+        """TOML basic quoted keys may contain escapes: "sandbox\\u005fmode"
+        decodes to sandbox_mode. Missing it would emit a duplicate managed
+        key and make the whole config unparseable."""
+        import tomllib
+
+        target = tmp_path / "config.toml"
+        target.write_text('"sandbox\\u005fmode" = "read-only"\n')
+        report = migrate(
+            {}, codex_home=tmp_path, discover_plugins=False,
+            expose_hermes_tools=False,
+        )
+        parsed = tomllib.loads(target.read_text())  # duplicate would raise
+        assert parsed["sandbox_mode"] == "read-only"
+        assert report.wrote_permissions_default is None
+
+    def test_legacy_user_default_permissions_read_only_is_honored(self, tmp_path):
+        """A user-owned legacy ``default_permissions = ":read-only"`` (the
+        format the previous runtime docs prescribed) must not be silently
+        upgraded to the workspace-write default — current Codex ignores the
+        legacy key entirely."""
+        import tomllib
+
+        target = tmp_path / "config.toml"
+        target.write_text('default_permissions = ":read-only"\n')
+        report = migrate(
+            {}, codex_home=tmp_path, discover_plugins=False,
+            expose_hermes_tools=False,
+        )
+        parsed = tomllib.loads(target.read_text())
+        assert parsed["sandbox_mode"] == "read-only"
+        assert report.wrote_permissions_default == "read-only"
+
+    def test_legacy_user_default_permissions_unknown_fails_closed(self, tmp_path):
+        import tomllib
+
+        target = tmp_path / "config.toml"
+        target.write_text('default_permissions = ":my-custom-profile"\n')
+        migrate(
+            {}, codex_home=tmp_path, discover_plugins=False,
+            expose_hermes_tools=False,
+        )
+        parsed = tomllib.loads(target.read_text())
+        assert parsed["sandbox_mode"] == "read-only"
+
+    def test_user_sandbox_mode_wins_over_legacy_default_permissions(self, tmp_path):
+        import tomllib
+
+        target = tmp_path / "config.toml"
+        target.write_text(
+            'sandbox_mode = "danger-full-access"\n'
+            'default_permissions = ":read-only"\n'
+        )
+        report = migrate(
+            {}, codex_home=tmp_path, discover_plugins=False,
+            expose_hermes_tools=False,
+        )
+        parsed = tomllib.loads(target.read_text())
+        assert parsed["sandbox_mode"] == "danger-full-access"
+        assert report.wrote_permissions_default is None
+
     def test_explicit_none_permissions_skips_block(self, tmp_path):
         report = migrate({"mcp_servers": {"x": {"command": "y"}}},
                          codex_home=tmp_path,

--- a/tests/hermes_cli/test_codex_runtime_switch.py
+++ b/tests/hermes_cli/test_codex_runtime_switch.py
@@ -122,7 +122,7 @@ class TestApply:
             mig.return_value.migrated = ["filesystem", "hermes-tools"]
             mig.return_value.migrated_plugins = []
             mig.return_value.plugin_query_error = None
-            mig.return_value.wrote_permissions_default = ":workspace"
+            mig.return_value.wrote_permissions_default = "workspace-write"
             mig.return_value.errors = []
             mig.return_value.target_path = "/fake/.codex/config.toml"
             r = crs.apply(cfg, "codex_app_server",
@@ -135,7 +135,7 @@ class TestApply:
         # Migration output still surfaces
         assert "Migrated 1 MCP server" in r.message
         assert "filesystem" in r.message
-        assert "Default sandbox: :workspace" in r.message
+        assert "Default sandbox: workspace-write" in r.message
         # No config write needed when value is unchanged — the persist
         # callback should NOT have fired (avoids spurious config.yaml mtimes
         # on every re-apply).
@@ -220,7 +220,7 @@ class TestApply:
             mig.return_value.migrated = ["filesystem", "hermes-tools"]
             mig.return_value.migrated_plugins = []
             mig.return_value.plugin_query_error = None
-            mig.return_value.wrote_permissions_default = ":workspace"
+            mig.return_value.wrote_permissions_default = "workspace-write"
             mig.return_value.errors = []
             mig.return_value.target_path = "/fake/.codex/config.toml"
             r = crs.apply(cfg, "codex_app_server")
@@ -230,7 +230,7 @@ class TestApply:
         assert "Migrated 1 MCP server" in r.message
         assert "filesystem" in r.message
         # Permissions default surfaces
-        assert "Default sandbox: :workspace" in r.message
+        assert "Default sandbox: workspace-write" in r.message
         # Hermes tool callback announcement
         assert "via MCP" in r.message
 

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -84,6 +84,19 @@ class TestRunConversationCodexPath:
         assert result["api_calls"] == 1
         assert result["codex_thread_id"] == "thread-stub-1"
         assert result["codex_turn_id"] == "turn-stub-1"
+        assert result["interrupted"] is False
+        assert result["failed"] is False
+        assert result["turn_exit_reason"] == "text_response(runtime=codex_app_server)"
+        assert result["session_id"] == agent.session_id
+        assert result["model"] == agent.model
+        assert "last_reasoning" in result
+        assert "response_transformed" in result
+        assert "response_previewed" in result
+        for usage_key in (
+            "input_tokens", "output_tokens", "prompt_tokens",
+            "completion_tokens", "total_tokens", "estimated_cost_usd",
+        ):
+            assert usage_key in result
 
     def test_codex_app_server_token_usage_updates_session_accounting(self, monkeypatch):
         def fake_run_turn(self, user_input: str, **kwargs):
@@ -199,6 +212,59 @@ class TestRunConversationCodexPath:
 
         agent._memory_manager.sync_all.assert_called_once()
         assert agent._memory_manager.sync_all.call_args.kwargs["messages"] == result["messages"]
+
+    def test_ephemeral_memory_and_plugin_context_reach_codex_only(
+        self, monkeypatch
+    ):
+        captured = {}
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            captured["user_input"] = user_input
+            return TurnResult(
+                final_text="done",
+                projected_messages=[{"role": "assistant", "content": "done"}],
+                turn_id="turn-context-1",
+                thread_id="thread-context-1",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        agent = _make_codex_agent()
+        agent._memory_manager = MagicMock()
+        agent._memory_manager.build_system_prompt.return_value = ""
+        agent._memory_manager.prefetch_all.return_value = "remembered fact"
+
+        def invoke_hook(name, **kwargs):
+            if name == "pre_llm_call":
+                return [{"context": "plugin-only context"}]
+            return []
+
+        with patch("hermes_cli.plugins.invoke_hook", side_effect=invoke_hook), \
+             patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("durable prompt")
+
+        assert "remembered fact" in captured["user_input"]
+        assert "plugin-only context" in captured["user_input"]
+        durable_user = [m for m in result["messages"] if m.get("role") == "user"]
+        assert durable_user[-1]["content"] == "durable prompt"
+
+    def test_codex_path_runs_common_output_and_lifecycle_hooks(self, fake_session):
+        hook_names = []
+
+        def invoke_hook(name, **kwargs):
+            hook_names.append(name)
+            if name == "transform_llm_output":
+                return ["transformed by plugin"]
+            return []
+
+        agent = _make_codex_agent()
+        with patch("hermes_cli.plugins.invoke_hook", side_effect=invoke_hook), \
+             patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("hello")
+
+        assert result["final_response"] == "transformed by plugin"
+        assert result["response_transformed"] is True
+        assert "post_llm_call" in hook_names
+        assert "on_session_end" in hook_names
 
     def test_nudge_counters_tick(self, fake_session):
         """The skill nudge counter must accumulate tool_iterations across
@@ -583,6 +649,7 @@ class TestErrorHandling:
             result = agent.run_conversation("hi")
         assert result["completed"] is False
         assert result["partial"] is True
+        assert result["api_calls"] == 0
         assert "subprocess died" in result["error"]
         assert "codex-runtime auto" in result["final_response"]
 
@@ -607,6 +674,41 @@ class TestErrorHandling:
         assert result["completed"] is False
         assert result["partial"] is True
         assert result["error"] == "user interrupted"
+        assert result["interrupted"] is True
+        assert result["failed"] is False
+        assert result["turn_exit_reason"] == "interrupted_by_user"
+        assert agent._interrupt_requested is False
+
+    def test_interrupt_before_codex_turn_skips_runtime_call(self, monkeypatch):
+        called = {"run_turn": 0}
+
+        def should_not_run(self, user_input, **kwargs):
+            called["run_turn"] += 1
+            raise AssertionError("pre-turn interrupt must skip Codex")
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", should_not_run)
+        agent = _make_codex_agent()
+        agent.interrupt("new message")
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("old message")
+
+        assert called["run_turn"] == 0
+        assert result["api_calls"] == 0
+        assert result["interrupted"] is True
+        assert result["interrupt_message"] == "new message"
+        assert agent._interrupt_requested is False
+
+    def test_agent_interrupt_bridges_to_existing_codex_session(self):
+        agent = _make_codex_agent()
+        session = MagicMock()
+        agent._codex_session = session
+
+        agent.interrupt("stop")
+        session.request_interrupt.assert_called_once_with()
+
+        agent.clear_interrupt()
+        session.clear_interrupt.assert_called_once_with()
 
 
 class TestSessionRetirementOnRunAgent:
@@ -759,4 +861,3 @@ class TestCodexToolProgressBridge:
 
         assert "on_event" in captured_init and captured_init["on_event"] is not None
         assert ("tool.started", "exec_command", "pytest") in events
-

--- a/website/docs/user-guide/features/codex-app-server-runtime.md
+++ b/website/docs/user-guide/features/codex-app-server-runtime.md
@@ -83,7 +83,7 @@ These four Hermes tools require the running AIAgent context (mid-loop state) to 
 
 **Works on this runtime.** Goals persist in `state_meta` keyed by session id, the continuation prompt feeds back as a normal user message through `run_conversation()`, and codex executes the next turn natively. The goal judge runs via the auxiliary client (configured via `auxiliary.goal_judge` in config.yaml), independent of which runtime is active. The judge's "blocked, needs user input" verdict is a clean escape if codex stalls on approvals.
 
-**One thing to be aware of:** each continuation prompt is a fresh codex turn, which means codex re-evaluates command approval policy from scratch. If you're doing a long-running goal with lots of writes, expect more approval prompts than you'd see on a single in-session task. Set `default_permissions = ":workspace"` (which Hermes does automatically when you enable the runtime) so simple workspace writes don't require prompting.
+**One thing to be aware of:** each continuation prompt is a fresh codex turn, which means codex re-evaluates command approval policy from scratch. If you're doing a long-running goal with lots of writes, expect more approval prompts than you'd see on a single in-session task. Hermes writes `sandbox_mode = "workspace-write"` when no user-owned `sandbox_mode` is already configured, so ordinary workspace writes stay inside Codex's sandbox.
 
 ### Kanban (multi-agent worktree dispatch)
 
@@ -166,7 +166,7 @@ That command:
 - Migrates user MCP servers from `~/.hermes/config.yaml` to `~/.codex/config.toml`.
 - **Discovers and migrates installed native Codex plugins** (Linear, GitHub, Gmail, Calendar, Canva, etc.) by querying Codex's `plugin/list` RPC.
 - **Registers Hermes' own tools as an MCP server** so the codex subprocess can call back for tools codex doesn't ship with.
-- **Writes `default_permissions = ":workspace"`** so the sandbox allows writes within the workspace without prompting for every operation.
+- **Writes `sandbox_mode = "workspace-write"`** when you have not configured a sandbox mode yourself, using the current Codex config schema.
 - Tells you what was migrated. Takes effect on the **next** session — the current cached agent keeps the prior runtime so prompt caches stay valid.
 
 Synonyms: `/codex-runtime on`, `/codex-runtime off`, `/codex-runtime auto`.
@@ -229,20 +229,21 @@ Codex requests approval before executing commands or applying patches. These get
 
 For `apply_patch` (file edit) approvals, Hermes shows a summary of what changed (`1 add, 1 update: /tmp/new.py, /tmp/old.py`) when codex provides the data via the corresponding `fileChange` item.
 
-## Permission profiles
+## Sandbox and approval policy
 
-Codex has three built-in permission profiles:
-- `:read-only` — no writes; every shell command requires approval
-- `:workspace` — writes within the current workspace allowed without prompts (Hermes' default when you enable the runtime)
-- `:danger-no-sandbox` — no sandbox at all (don't use this unless you understand it)
+Codex separates filesystem/network sandboxing from approval policy. Common sandbox modes are:
+- `read-only` — workspace writes are blocked by the sandbox
+- `workspace-write` — writes within the current workspace are allowed (Hermes' default when you enable the runtime)
+- `danger-full-access` — no sandbox boundary (do not use this unless you understand it)
 
-You can override the default in `~/.codex/config.toml` outside Hermes' managed block:
+You can set your own policy in `~/.codex/config.toml` outside Hermes' managed block:
 
 ```toml
-default_permissions = ":read-only"
+sandbox_mode = "read-only"
+approval_policy = "on-request"
 ```
 
-(Hermes will preserve your override on re-migration as long as it lives outside the `# managed by hermes-agent` markers.)
+Hermes detects a user-owned top-level `sandbox_mode`, preserves it, and omits its default on re-migration.
 
 ## Auxiliary tasks and ChatGPT subscription token cost
 
@@ -276,7 +277,7 @@ Hermes wraps everything it manages between two marker comments:
 
 ```toml
 # managed by hermes-agent — `hermes codex-runtime migrate` regenerates this section
-default_permissions = ":workspace"
+sandbox_mode = "workspace-write"
 [mcp_servers.filesystem]
 ...
 [plugins."github@openai-curated"]
@@ -287,9 +288,8 @@ default_permissions = ":workspace"
 Anything **outside** that block is yours. Re-running migration (via `/codex-runtime codex_app_server` or whenever you toggle the runtime on) replaces the managed block in place but preserves user content above and below it verbatim. This means you can:
 
 - Add your own MCP servers Hermes doesn't know about
-- Override `default_permissions` to `:read-only` if you prefer to be prompted
+- Set `sandbox_mode` and `approval_policy` explicitly for a stricter policy
 - Configure codex-only options (model, providers, otel, etc.)
-- Add user-defined permission profiles in `[permissions.<name>]` tables
 
 Anything you add **inside** the managed block will get clobbered on the next migration. If you need a tweak that requires editing the managed block, file an issue and we'll add the knob.
 


### PR DESCRIPTION
## What changed

- Route `codex_app_server` turns through Hermes' shared turn finalizer.
- Normalize the public result contract, lifecycle hooks, persistence, cleanup, reasoning, and interrupt state across runtimes.
- Deliver ephemeral memory/plugin context to Codex without mutating durable conversation history.
- Bridge Hermes interrupts to Codex `turn/interrupt`, including pre-turn interrupts.
- Keep Codex event projection role-safe by ignoring duplicate user echoes and non-conversation protocol items.
- Migrate the removed `default_permissions` setting to current `sandbox_mode`, preserving an explicit user-owned policy.

## Why

The Codex app-server path returned before Hermes' common finalizer. That duplicated lifecycle logic and caused observable contract drift: missing interrupt/result fields, skipped hooks and cleanup, dropped ephemeral context, and role-invalid projected histories. The permission migration also wrote a legacy Codex key that current releases accept but ignore.

## User impact

Codex-backed CLI, gateway, and TUI turns now report interruption and completion consistently, retain Hermes memory/plugin behavior, persist a canonical transcript, and generate a sandbox configuration understood by current Codex releases.

## Validation

- `307 passed` across Codex app-server integration, projection, persistence, finalizer, interrupt, prompt-cache, migration, and runtime-switch tests.
- Generated config loaded successfully with local Codex `0.144.1` (`config.load: ok`).
- `git diff --check` and Python compile checks passed.
- Read-only Claude Code review completed; its one actionable `api_calls` crash-accounting finding was fixed and covered by regression assertion.
