### PR TITLE
fix(tests): stop cmd_update tests leaking real detached Windows gateways

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -421,6 +421,7 @@ markers = [
     "linux_only: exercises Linux-specific behaviour; skipped on other hosts",
     "macos_only: exercises macOS-specific behaviour; skipped on other hosts",
     "windows_only: exercises native-Windows behaviour; skipped on other hosts",
+    "real_windows_gateway_respawn: opt out of the autouse stub that no-ops the update flow's Windows gateway pause/resume",
 ]
 # integration tests take way too long to run in the normal CI environments
 addopts = "-m 'not integration'"

--- a/tests/hermes_cli/conftest.py
+++ b/tests/hermes_cli/conftest.py
@@ -54,3 +54,41 @@ def _suppress_concurrent_hermes_gate(request, monkeypatch):
         lambda *_a, **_k: [],
         raising=False,
     )
+
+
+@pytest.fixture(autouse=True)
+def _suppress_windows_gateway_respawn(request, monkeypatch):
+    """Default the update flow's Windows gateway pause/resume to no-ops.
+
+    ``cmd_update`` pauses running Windows gateways and afterwards respawns
+    them DETACHED (``pythonw -m hermes_cli.main gateway run``) via
+    ``_resume_windows_gateways_after_update`` (or the cold-start path when
+    none were found but the service is installed). The pause scan inspects
+    the REAL machine, so on a Windows dev box every ``cmd_update`` test that
+    reached the resume step launched a real, windowless gateway that detaches
+    into its own process group and outlives pytest — dozens of orphaned
+    servers accumulate per full-suite run, invisibly eating RAM.
+
+    Tests that exercise the pause/resume helpers themselves opt out with
+    ``@pytest.mark.real_windows_gateway_respawn`` (they mock the inner
+    ``launch_detached_*`` primitives instead).
+    """
+    if request.node.get_closest_marker("real_windows_gateway_respawn"):
+        return
+    try:
+        from hermes_cli import main as _cli_main
+    except Exception:
+        return
+    # raising=False for the same transient-import race documented above.
+    monkeypatch.setattr(
+        _cli_main,
+        "_pause_windows_gateways_for_update",
+        lambda *_a, **_k: None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        _cli_main,
+        "_resume_windows_gateways_after_update",
+        lambda *_a, **_k: None,
+        raising=False,
+    )

--- a/tests/hermes_cli/test_update_concurrent_quarantine.py
+++ b/tests/hermes_cli/test_update_concurrent_quarantine.py
@@ -24,7 +24,10 @@ from hermes_cli import main as cli_main
 # helper (and need the autouse stub in tests/hermes_cli/conftest.py disabled),
 # or supply their own explicit return value via patch.object. Mark the whole
 # module so the conftest fixture skips its default stub.
-pytestmark = pytest.mark.real_concurrent_gate
+# real_windows_gateway_respawn: this module unit-tests the pause/resume
+# helpers themselves (mocking the inner launch_detached_* primitives), so it
+# opts out of the conftest autouse stub that no-ops them for everyone else.
+pytestmark = [pytest.mark.real_concurrent_gate, pytest.mark.real_windows_gateway_respawn]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Stops the `cmd_update` tests from leaking **real, detached Windows gateway processes** on every run.

On Windows, any `cmd_update` test that reaches the update flow's gateway pause/resume step launches a real windowless gateway: `_pause_windows_gateways_for_update()` scans the **actual machine**, and `_resume_windows_gateways_after_update()` (or the cold-start path when nothing was found but the service looks installed) respawns gateways **detached** via `pythonw -m hermes_cli.main gateway run`. Because they detach into their own process group, they escape pytest's exit, `taskkill /T` on the test tree, and `scripts/run_tests_parallel.py`'s grandchild reaper — so every full-suite run silently accumulates orphaned gateway servers that keep running (and eating RAM) until killed by hand.

Measured on Windows 11 by snapshotting every new `pythonw` process's parent command line the moment it appeared during a suite run:

| File | real gateways spawned per run |
|---|---|
| `tests/hermes_cli/test_cmd_update.py` | 11 |
| `tests/hermes_cli/test_update_autostash.py` | 11 |
| `tests/hermes_cli/test_update_yes_flag.py` | 1 |

I found **57 orphaned `pythonw -m hermes_cli.main gateway run` processes** on my machine after a day of suite runs (~35–40 MB each).

The fix mirrors the existing `_suppress_concurrent_hermes_gate` pattern in `tests/hermes_cli/conftest.py`: an autouse fixture no-ops `_pause_windows_gateways_for_update` / `_resume_windows_gateways_after_update` for every test, with a `real_windows_gateway_respawn` marker (registered in `pyproject.toml`) to opt out for tests that exercise the helpers themselves.

## Related Issue

Same family as #61729 (tests spawning real processes past their mocks); found while chasing the orphaned processes from that investigation.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `tests/hermes_cli/conftest.py`: new autouse `_suppress_windows_gateway_respawn` fixture no-ops the pause/resume pair (docstring documents the leak mechanism); `raising=False` for the same transient-import race as the existing fixture.
- `tests/hermes_cli/test_update_concurrent_quarantine.py`: opts out via the new marker — it unit-tests the pause/resume helpers directly against mocked `launch_detached_*` primitives (verified it spawns nothing).
- `pyproject.toml`: register the `real_windows_gateway_respawn` marker.

No production code is touched. `tests/hermes_cli/test_update_venv_health.py` needs no change — it already patches the pair explicitly, which layers fine over the autouse stub.

## How to Test

On Windows, watch the process table while running the previously-leaking files:

```
uv run --extra all --extra dev pytest -q tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_update_autostash.py tests/hermes_cli/test_update_yes_flag.py
tasklist | findstr pythonw
```

Before this PR: ~23 new `pythonw -m hermes_cli.main gateway run` processes remain after pytest exits. After: zero.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

Validation: the three spawning files plus the two suites that exercise the pause/resume helpers directly (`test_update_concurrent_quarantine`, `test_update_venv_health`) produce **identical results with and without this change** (8 failed / 70 passed both ways on Windows — those failures are pre-existing Windows-environment issues, reproduced with this change stashed; see #61606's validation note for the full-suite pre-existing set) — while real gateway spawns go from 23 per run to **zero**.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the fixture docstring documents the leak and the opt-out contract
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the stubbed functions are Windows-only no-ops on POSIX already
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Watcher output during a full-suite run (parent snapshotted before it exited):

```
!! NEW pythonw PID 6980: "C:\Program Files\Python313\pythonw.exe" -m hermes_cli.main gateway run
   parent 39492: ...\.venv\Scripts\python.exe -m pytest ...\tests\hermes_cli\test_cmd_update.py
!! NEW pythonw PID 14264: "C:\Program Files\Python313\pythonw.exe" -m hermes_cli.main gateway run
   parent 39492: ...\.venv\Scripts\python.exe -m pytest ...\tests\hermes_cli\test_cmd_update.py
(... 21 more across test_cmd_update.py / test_update_autostash.py / test_update_yes_flag.py)
```

After this PR, the same watcher reports zero new processes across all five update-test files.
