### PR TITLE
perf(tui): skip rebuild when production bundle is fresh

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1783,7 +1783,8 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             node = _node_bin("node")
             return [node, "--expose-gc", str(bundled)], bundled.parent
 
-    # 2. Normal flow: npm install if needed, always esbuild, then node dist/entry.js.
+    # 2. Normal flow: npm install if needed, esbuild when the bundle is
+    #    missing/stale, then node dist/entry.js.
     #    --dev flow: npm install if needed, then tsx src/entry.tsx.
     #    Existing desktop behaviour runs npm from the workspace root.  Termux
     #    scopes the install to ui-tui so launch does not pull desktop/web
@@ -1873,12 +1874,12 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             return [str(tsx), "src/entry.tsx"], tui_dir
         return [npm, "start"], tui_dir
 
-    # Desktop/dev launches retain the historical "always rebuild" behaviour.
-    # Termux cold starts use the freshness check because esbuild startup is
-    # expensive on old mobile CPUs.
-    should_build = True
+    # Production launches only rebuild when dependencies changed or the bundle
+    # is missing/stale.  The freshness check also honors HERMES_TUI_FORCE_BUILD.
     if termux_startup:
         should_build = did_install or termux_need_rebuild
+    else:
+        should_build = did_install or _tui_need_rebuild(tui_dir)
 
     if should_build:
         npm = _node_bin("npm")

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -158,13 +158,19 @@ def test_rebuild_when_tui_source_newer_than_bundle(tmp_path: Path, main_mod) -> 
     assert main_mod._tui_need_rebuild(tmp_path) is True
 
 
-def test_make_tui_argv_skips_build_only_on_termux_when_fresh(
+def test_make_tui_argv_skips_build_on_termux_when_fresh(
     tmp_path: Path, main_mod, monkeypatch
 ) -> None:
     _touch_tui_entry(tmp_path)
     monkeypatch.setenv("TERMUX_VERSION", "1")
     monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: False)
-    monkeypatch.setattr(main_mod, "_tui_need_rebuild", lambda _root: False)
+    rebuild_calls = []
+
+    def need_rebuild(root: Path) -> bool:
+        rebuild_calls.append(root)
+        return False
+
+    monkeypatch.setattr(main_mod, "_tui_need_rebuild", need_rebuild)
     monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
 
     def fail_run(*_args, **_kwargs):
@@ -176,6 +182,7 @@ def test_make_tui_argv_skips_build_only_on_termux_when_fresh(
 
     assert argv == ["/bin/node", "--expose-gc", str(tmp_path / "dist" / "entry.js")]
     assert cwd == tmp_path
+    assert rebuild_calls == [tmp_path]
 
 
 def test_make_tui_argv_skips_install_on_termux_when_bundle_fresh(
@@ -275,7 +282,7 @@ def test_make_tui_argv_keeps_desktop_workspace_install_behaviour(
     _assert_utf8_replace_capture(calls[1][1])
 
 
-def test_make_tui_argv_keeps_desktop_always_build_behaviour(
+def test_make_tui_argv_skips_desktop_build_when_bundle_is_fresh(
     tmp_path: Path, main_mod, monkeypatch
 ) -> None:
     _touch_tui_entry(tmp_path)
@@ -283,6 +290,27 @@ def test_make_tui_argv_keeps_desktop_always_build_behaviour(
     monkeypatch.setenv("PREFIX", "/usr")
     monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: False)
     monkeypatch.setattr(main_mod, "_tui_need_rebuild", lambda _root: False)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+
+    def fail_run(*_args, **_kwargs):
+        raise AssertionError("fresh desktop TUI launch must not rebuild")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fail_run)
+
+    argv, cwd = main_mod._make_tui_argv(tmp_path, tui_dev=False)
+
+    assert argv == ["/bin/node", "--expose-gc", str(tmp_path / "dist" / "entry.js")]
+    assert cwd == tmp_path
+
+
+def test_make_tui_argv_force_builds_fresh_desktop_bundle(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    _touch_tui_entry(tmp_path)
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setenv("HERMES_TUI_FORCE_BUILD", "1")
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: False)
     monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
     calls = []
 
@@ -294,7 +322,30 @@ def test_make_tui_argv_keeps_desktop_always_build_behaviour(
 
     main_mod._make_tui_argv(tmp_path, tui_dev=False)
 
-    assert calls
+    assert len(calls) == 1
+    assert calls[0][0][0] == ["/bin/npm", "run", "build"]
+    _assert_utf8_replace_capture(calls[0][1])
+
+
+def test_make_tui_argv_builds_desktop_bundle_when_stale(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    _touch_tui_entry(tmp_path)
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: False)
+    monkeypatch.setattr(main_mod, "_tui_need_rebuild", lambda _root: True)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    main_mod._make_tui_argv(tmp_path, tui_dev=False)
+
     assert calls[0][0][0] == ["/bin/npm", "run", "build"]
     _assert_utf8_replace_capture(calls[0][1])
 


### PR DESCRIPTION
## What does this PR do?

Stops normal production TUI launches from synchronously rebuilding the frontend
when the existing bundle is already fresh.

`_make_tui_argv()` already has `_tui_need_rebuild()` and uses its cached result
for Termux, but the desktop/normal production path still hardcodes
`should_build = True`. As a result, Windows, macOS, and Linux desktop launches
run `npm run build` even when `dist/entry.js` is newer than every build input.

This change uses the same freshness check for non-Termux production launches.
It continues to rebuild after dependency installation, when the bundle is
missing/stale, or when `HERMES_TUI_FORCE_BUILD=1` is set. `--dev` behavior is
unchanged.

On the affected Windows host, launcher-to-Node startup improved from 13.213s to
1.323s. A second real TUI launch left `dist/entry.js` mtime unchanged, proving
the fresh bundle was not rebuilt.

## Related Issue

Related to #45657, but fixes a separate remaining cause. That issue and PRs
#45732 / #52904 focus on npm workspace install scope and false-positive
staleness. This PR removes the explicit desktop `should_build = True` policy
that ignores a correct `False` result from `_tui_need_rebuild()`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`
  - Rebuild normal production TUI bundles only after dependency installation or
    when `_tui_need_rebuild()` reports a missing/stale bundle.
  - Preserve the existing cached Termux startup decision.
  - Preserve `HERMES_TUI_FORCE_BUILD` through `_tui_need_rebuild()`.
- `tests/hermes_cli/test_tui_npm_install.py`
  - Replace the desktop “always build” expectation with a regression test that
    fails if a fresh bundle invokes npm.
  - Add coverage proving a stale desktop bundle still builds.

## How to Test

1. Run the focused suite:

   ```bash
   pytest tests/hermes_cli/test_tui_npm_install.py -q -o addopts=''
   ```

2. Verify a fresh desktop bundle produces no `subprocess.run()` build call,
   while stale, dependency-install, and force-build paths still build.
3. Build the TUI once, launch `hermes --tui` twice, and confirm the second launch
   does not change `ui-tui/dist/entry.js` mtime.

Local results:

```text
31 passed in 0.67s
py_compile=PASS
git_diff_check=PASS
ruff=PASS
fresh/stale/install/force harness=PASS
Windows launcher-to-Node: 13.213s -> 1.323s
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run the complete `pytest tests/ -q` suite locally (focused suite: 31/31 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10, Python 3.11.9, Node.js 24.13.1

### Documentation & Housekeeping

- [x] Relevant documentation update is N/A; behavior and rationale are documented in code/tests and this PR
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact; the change applies to normal production launches on Windows/macOS/Linux while retaining the Termux-specific cached path
- [x] Tool descriptions/schemas update is N/A; no tools changed

## Screenshots / Logs

No UI rendering changes. Startup timing and bundle-mtime verification are included
above.
