### PR TITLE
fix(run_agent): refresh Copilot token and base_url together during credential rotation

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4505,6 +4505,16 @@ class AIAgent:
         runtime_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
         runtime_base = getattr(entry, "runtime_base_url", None) or getattr(entry, "base_url", None) or self.base_url
 
+        # For Copilot, refresh both token and base_url from a live exchange to avoid
+        # reusing a stale public endpoint with a valid Enterprise credential (#61746).
+        if self.provider == "copilot":
+            try:
+                from hermes_cli.copilot_auth import get_copilot_api_token
+                runtime_key, runtime_base = get_copilot_api_token(entry.access_token or "")
+            except Exception:
+                # Fall back to the existing entry values if exchange fails.
+                pass
+
         if self.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client, _is_oauth_token
 

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -235,3 +235,109 @@ class TestPoolRotationCycle:
         )
         assert recovered is False
         assert has_retried is False
+
+
+# ---------------------------------------------------------------------------
+# 6. Copilot credential rotation refreshes both token and base_url
+# ---------------------------------------------------------------------------
+
+
+class TestCopilotCredentialRefresh:
+    """Copilot-specific: _swap_credential fetches fresh token+base_url together."""
+
+    def _make_copilot_entry(self, base_url: str) -> MagicMock:
+        """Create a mock pool entry for Copilot."""
+        entry = MagicMock()
+        entry.access_token = "gho_test_token"
+        entry.runtime_api_key = None
+        entry.runtime_base_url = None
+        entry.base_url = base_url
+        return entry
+
+    @patch("hermes_cli.copilot_auth.get_copilot_api_token")
+    def test_copilot_swap_refreshes_token_and_base_url(self, mock_exchange):
+        """When provider is copilot, _swap_credential calls live token exchange."""
+        from run_agent import AIAgent
+
+        # Mock live exchange returning Enterprise endpoint
+        mock_exchange.return_value = ("exchanged_jwt", "https://api.enterprise.githubcopilot.com")
+
+        with patch.object(AIAgent, "__init__", lambda self, **kw: None):
+            agent = AIAgent()
+        agent.provider = "copilot"
+        agent.api_mode = "openai"
+        agent._client_kwargs = {}
+        agent.base_url = "https://api.githubcopilot.com"  # initial public endpoint
+        agent._replace_primary_openai_client = MagicMock()
+
+        # Pool entry with stale public endpoint
+        stale_entry = self._make_copilot_entry("https://api.githubcopilot.com")
+
+        # Swap credential - should trigger live exchange
+        agent._swap_credential(stale_entry)
+
+        # Verify live exchange was called with the entry's raw token
+        mock_exchange.assert_called_once_with("gho_test_token")
+
+        # Verify the client was updated with fresh Enterprise endpoint
+        assert agent.api_key == "exchanged_jwt"
+        assert agent.base_url == "https://api.enterprise.githubcopilot.com"
+        assert agent._client_kwargs["api_key"] == "exchanged_jwt"
+        assert agent._client_kwargs["base_url"] == "https://api.enterprise.githubcopilot.com"
+
+    @patch("hermes_cli.copilot_auth.get_copilot_api_token")
+    def test_copilot_swap_falls_back_on_exchange_failure(self, mock_exchange):
+        """If Copilot exchange fails, _swap_credential falls back to entry values."""
+        from run_agent import AIAgent
+
+        # Simulate exchange failure
+        mock_exchange.side_effect = ValueError("network error")
+
+        with patch.object(AIAgent, "__init__", lambda self, **kw: None):
+            agent = AIAgent()
+        agent.provider = "copilot"
+        agent.api_mode = "openai"
+        agent._client_kwargs = {}
+        agent.base_url = "https://api.githubcopilot.com"
+        agent._replace_primary_openai_client = MagicMock()
+
+        # Pool entry
+        entry = self._make_copilot_entry("https://api.githubcopilot.com")
+
+        # Swap credential - should attempt exchange, fall back on failure
+        agent._swap_credential(entry)
+
+        # Verify exchange was attempted
+        mock_exchange.assert_called_once_with("gho_test_token")
+
+        # Verify fallback to entry values occurred
+        assert agent.api_key == "gho_test_token"  # from entry.access_token
+        assert agent.base_url == "https://api.githubcopilot.com"
+
+    def test_non_copilot_swap_does_not_call_exchange(self):
+        """For non-Copilot providers, _swap_credential uses entry values directly."""
+        from run_agent import AIAgent
+
+        with patch.object(AIAgent, "__init__", lambda self, **kw: None):
+            agent = AIAgent()
+        agent.provider = "openai"  # Not Copilot
+        agent.api_mode = "openai"
+        agent._client_kwargs = {}
+        agent.base_url = "https://api.openai.com"
+        agent._replace_primary_openai_client = MagicMock()
+
+        # Entry
+        entry = MagicMock()
+        entry.access_token = "sk_test"
+        entry.runtime_api_key = None
+        entry.runtime_base_url = None
+        entry.base_url = "https://api.openai.com"
+
+        # Swap - should NOT call Copilot exchange
+        with patch("hermes_cli.copilot_auth.get_copilot_api_token") as mock_exchange:
+            agent._swap_credential(entry)
+            mock_exchange.assert_not_called()
+
+        # Verify entry values were used
+        assert agent.api_key == "sk_test"
+        assert agent.base_url == "https://api.openai.com"


### PR DESCRIPTION
## What does this PR do?

Fixes a Copilot credential rotation bug where a valid Enterprise credential could be marked exhausted after a single 403 error, even though it succeeds on a fresh turn.

Root cause: when rotating to a Copilot pool entry, `_swap_credential()` trusted the entry's persisted `base_url` (which might still carry the old public default `https://api.githubcopilot.com`). The subsequent request sent the Enterprise API token to the public endpoint, received HTTP 403, and the credential was marked exhausted. A new agent turn succeeds because normal initialization performs a live token exchange and receives the account-specific Enterprise endpoint.

This change makes Copilot credential rotation perform a live token exchange at rotation time, ensuring the API token and `base_url` are updated together from a single exchange result before rebuilding the client.

## Related Issue

Fixes #61746

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py::_swap_credential()`: For `provider == "copilot"`, call `get_copilot_api_token()` to refresh both the API token and base_url from a live exchange before updating the client.
- `tests/agent/test_credential_pool_routing.py::TestCopilotCredentialRefresh`: Add 3 regression tests for the Copilot credential rotation behavior.

## How to Test

1. Run the Copilot-specific tests: `pytest tests/agent/test_credential_pool_routing.py::TestCopilotCredentialRefresh -v`. Expected result: All 3 tests pass.
2. Run the full credential pool routing test suite: `pytest tests/agent/test_credential_pool_routing.py -v`. Expected result: All 13 tests pass.
3. Manual verification with a Copilot Enterprise credential: Configure two Copilot Enterprise credential pool entries where the first entry has a stale public `base_url` (e.g., `https://api.githubcopilot.com`) while the second entry is fresh. Trigger credential rotation (e.g., by sending a malformed request that causes a 403). Observed result: The rotated credential now fetches both the API token and base_url from a live token exchange, so the request goes to the Enterprise endpoint (`https://api.enterprise.githubcopilot.com`) and succeeds with HTTP 200 instead of failing with HTTP 403 on the stale public endpoint.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_credential_pool_routing.py` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A