### PR TITLE
fix(secrets): defer plugin sources until first consumer

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -38,6 +38,12 @@ _SECRET_SOURCES: dict[str, str] = {}
 # config re-parse, and the ASCII sanitization sweep still ran every time.
 _APPLIED_HOMES: set[str] = set()
 
+# Homes currently inside ``_apply_external_secret_sources``.  Plugin discovery
+# (needed for plugin-registered secret sources) can re-enter env loading via
+# import side effects; this set makes nested calls no-ops so we do not recurse
+# and so the outer call remains the one that runs apply_all.
+_APPLYING_HOMES: set[str] = set()
+
 
 def get_secret_source(env_var: str) -> str | None:
     """Return the label of the secret source that supplied ``env_var``, if any.
@@ -63,6 +69,7 @@ def reset_secret_source_cache() -> None:
     that want to refresh after a config change.
     """
     _APPLIED_HOMES.clear()
+    _APPLYING_HOMES.clear()
 
 
 def format_secret_source_suffix(env_var: str) -> str:
@@ -221,6 +228,7 @@ def load_hermes_dotenv(
     *,
     hermes_home: str | os.PathLike | None = None,
     project_env: str | os.PathLike | None = None,
+    resolve_external_secrets: bool = True,
 ) -> list[Path]:
     """Load Hermes environment files with user config taking precedence.
 
@@ -229,6 +237,10 @@ def load_hermes_dotenv(
     - project `.env` acts as a dev fallback and only fills missing values when
       the user env exists.
     - if no user env exists, the project `.env` also overrides stale shell vars.
+    - external secret managers are resolved by default. Cold administrative CLI
+      bootstrap may pass ``resolve_external_secrets=False`` and call
+      :func:`ensure_external_secret_sources_loaded` before a real consumer reads
+      provider credentials.
     """
     loaded: list[Path] = []
 
@@ -264,10 +276,31 @@ def load_hermes_dotenv(
         _load_dotenv_with_fallback(project_env_path, override=not loaded)
         loaded.append(project_env_path)
 
-    _apply_external_secret_sources(home_path)
+    if resolve_external_secrets:
+        _apply_external_secret_sources(home_path)
     _apply_managed_env()
 
     return loaded
+
+
+def ensure_external_secret_sources_loaded(
+    *, hermes_home: str | os.PathLike | None = None
+) -> None:
+    """Resolve configured external secrets once, immediately before use.
+
+    The top-level CLI loads local ``.env`` files before parsing commands, but
+    deliberately defers remote vault calls so administrative commands do not
+    inherit network latency. Agent/provider entrypoints call this helper before
+    their first credential read. The existing once-per-home and re-entrancy
+    guards keep repeated consumer calls cheap.
+    """
+    home_path = Path(
+        hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes")
+    )
+    _apply_external_secret_sources(home_path)
+    # Managed values are authoritative and must remain last even when external
+    # resolution was deferred from the initial dotenv bootstrap.
+    _apply_managed_env()
 
 
 def _apply_managed_env() -> None:
@@ -302,6 +335,53 @@ def _apply_managed_env() -> None:
     _load_dotenv_with_fallback(managed_env, override=True)
 
 
+def _config_requests_plugin_secret_sources(secrets_cfg: dict) -> bool:
+    """True when config may need plugin-registered secret backends.
+
+    Bundled sources (Bitwarden, 1Password) register lazily without plugins.
+    Plugin backends only exist after ``discover_plugins()`` runs, so we detect
+    when config names a non-bundled source or enables a non-bundled section.
+    """
+    if not isinstance(secrets_cfg, dict) or not secrets_cfg:
+        return False
+    # Keep this list local and tiny — it is only an optimization gate for
+    # whether to pay for plugin discovery before apply.  New *bundled*
+    # sources should be added here; third-party backends stay as plugins.
+    bundled = frozenset({"bitwarden", "onepassword"})
+    sources = secrets_cfg.get("sources")
+    if isinstance(sources, list):
+        for entry in sources:
+            if isinstance(entry, str) and entry and entry not in bundled:
+                return True
+    for key, section in secrets_cfg.items():
+        if key == "sources" or key in bundled:
+            continue
+        if isinstance(section, dict) and section.get("enabled"):
+            return True
+    return False
+
+
+def _ensure_plugin_secret_sources_registered(secrets_cfg: dict) -> None:
+    """Discover plugins when config references non-bundled secret sources.
+
+    ``load_hermes_dotenv()`` often runs at import time — before command
+    handlers call ``discover_plugins()``.  Without this step, plugin
+    backends named in ``secrets.sources`` appear as "unknown source" and
+    never run on the first process env load.  Fail-open: discovery errors
+    never block startup.
+    """
+    if not _config_requests_plugin_secret_sources(secrets_cfg):
+        return
+    try:
+        from hermes_cli.plugins import discover_plugins
+    except Exception:  # noqa: BLE001 — plugins optional during early bootstrap
+        return
+    try:
+        discover_plugins()
+    except Exception:  # noqa: BLE001 — never block secret/env startup
+        return
+
+
 def _apply_external_secret_sources(home_path: Path) -> None:
     """Pull secrets from every enabled external source into env.
 
@@ -309,6 +389,11 @@ def _apply_external_secret_sources(home_path: Path) -> None:
     to locate bootstrap tokens) but BEFORE the rest of Hermes reads
     ``os.environ`` for credentials.  Any failure here is logged and
     swallowed — external secret sources must never block startup.
+
+    When config references a non-bundled secret source, this path also
+    runs plugin discovery first so plugin-registered backends participate
+    in the same first-process env load (eliminating the historical
+    "unknown source" warning and skipped apply for plugin vaults).
 
     The heavy lifting (source ordering, mapped-beats-bulk precedence,
     first-claim-wins conflict handling, override semantics, provenance)
@@ -326,53 +411,64 @@ def _apply_external_secret_sources(home_path: Path) -> None:
     (tests, long-running processes after a config change).
     """
     home_key = str(Path(home_path).resolve())
-    if home_key in _APPLIED_HOMES:
+    if home_key in _APPLIED_HOMES or home_key in _APPLYING_HOMES:
         return
-    _APPLIED_HOMES.add(home_key)
-
+    _APPLYING_HOMES.add(home_key)
     try:
-        cfg = _load_secrets_config(home_path)
-    except Exception:  # noqa: BLE001 — config errors must not block startup
-        return
-    if not cfg:
-        return
+        try:
+            cfg = _load_secrets_config(home_path)
+        except Exception:  # noqa: BLE001 — config errors must not block startup
+            return
+        if not cfg:
+            return
 
-    try:
-        from agent.secret_sources.registry import apply_all
-    except ImportError:
-        return
+        # Register plugin backends before apply so a plugin source is
+        # available on this first load, not only after a later
+        # discover_plugins() + reset_secret_source_cache() cycle.
+        _ensure_plugin_secret_sources_registered(cfg)
 
-    try:
-        report = apply_all(cfg, home_path)
-    except Exception:  # noqa: BLE001 — belt-and-braces; apply_all shouldn't raise
-        return
+        try:
+            from agent.secret_sources.registry import apply_all
+        except ImportError:
+            return
 
-    if report.applied_any:
-        # Re-run the ASCII sanitization pass: vault values are
-        # user-supplied and might have the same copy-paste corruption as
-        # a manually edited .env (see #6843).
-        _sanitize_loaded_credentials()
-        # Remember where each var came from so setup / `hermes model`
-        # flows can label detected credentials with "(from Bitwarden)" /
-        # "(from 1Password)" — otherwise users see "credentials ✓" with
-        # no hint the value came from a vault rather than .env.
-        for name, applied in report.provenance.items():
-            _SECRET_SOURCES[name] = applied.source
+        try:
+            report = apply_all(cfg, home_path)
+        except Exception:  # noqa: BLE001 — belt-and-braces; apply_all shouldn't raise
+            return
 
-    for src in report.sources:
-        if src.applied:
-            print(
-                f"  {src.label}: applied {len(src.applied)} "
-                f"secret{'s' if len(src.applied) != 1 else ''} "
-                f"({', '.join(sorted(src.applied))})",
-                file=sys.stderr,
-            )
-        if src.result.error:
-            print(f"  {src.label}: {src.result.error}", file=sys.stderr)
-        for warn in src.result.warnings:
-            print(f"  {src.label}: {warn}", file=sys.stderr)
-    for conflict in report.conflicts:
-        print(f"  Secret sources: {conflict}", file=sys.stderr)
+        if report.applied_any:
+            # Re-run the ASCII sanitization pass: vault values are
+            # user-supplied and might have the same copy-paste corruption as
+            # a manually edited .env (see #6843).
+            _sanitize_loaded_credentials()
+            # Remember where each var came from so setup / `hermes model`
+            # flows can label detected credentials with "(from Bitwarden)" /
+            # "(from 1Password)" — otherwise users see "credentials ✓" with
+            # no hint the value came from a vault rather than .env.
+            for name, applied in report.provenance.items():
+                _SECRET_SOURCES[name] = applied.source
+
+        for src in report.sources:
+            if src.applied:
+                print(
+                    f"  {src.label}: applied {len(src.applied)} "
+                    f"secret{'s' if len(src.applied) != 1 else ''} "
+                    f"({', '.join(sorted(src.applied))})",
+                    file=sys.stderr,
+                )
+            if src.result.error:
+                print(f"  {src.label}: {src.result.error}", file=sys.stderr)
+            for warn in src.result.warnings:
+                print(f"  {src.label}: {warn}", file=sys.stderr)
+        for conflict in report.conflicts:
+            print(f"  Secret sources: {conflict}", file=sys.stderr)
+    finally:
+        # Once-per-home semantics (including empty/error paths after entry),
+        # and clear the re-entrancy window so nested import-time loads cannot
+        # skip a still-running outer apply.
+        _APPLIED_HOMES.add(home_key)
+        _APPLYING_HOMES.discard(home_key)
 
 
 def _load_secrets_config(home_path: Path) -> dict:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -530,9 +530,19 @@ _apply_profile_override()
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
 from hermes_cli.config import get_hermes_home
-from hermes_cli.env_loader import load_hermes_dotenv
+from hermes_cli.env_loader import (
+    ensure_external_secret_sources_loaded,
+    load_hermes_dotenv,
+)
 
-load_hermes_dotenv(project_env=PROJECT_ROOT / ".env")
+# Load local bootstrap values immediately, but do not contact remote secret
+# managers before we even know which command is running. Agent/provider
+# entrypoints resolve those sources immediately before their first credential
+# read; administrative commands remain network-free.
+load_hermes_dotenv(
+    project_env=PROJECT_ROOT / ".env",
+    resolve_external_secrets=False,
+)
 
 # Bridge security.redact_secrets from config.yaml → HERMES_REDACT_SECRETS env
 # var BEFORE hermes_logging imports agent.redact (which snapshots the flag at
@@ -2252,6 +2262,10 @@ def cmd_chat(args):
 
     _apply_safe_mode(args)
 
+    # Chat is the first real provider consumer on this path. Resolve deferred
+    # vault-backed credentials before the first-run/provider checks below.
+    ensure_external_secret_sources_loaded()
+
     # Resolve --continue into --resume with the latest session or by name
     continue_val = getattr(args, "continue_last", None)
     if continue_val and not getattr(args, "resume", None):
@@ -2711,6 +2725,8 @@ def cmd_whatsapp_cloud(args):
 
 def cmd_setup(args):
     """Interactive setup wizard."""
+    # Setup reports available credentials, including vault-backed ones.
+    ensure_external_secret_sources_loaded()
     from hermes_cli.setup import run_setup_wizard
 
     run_setup_wizard(args)
@@ -2739,6 +2755,9 @@ def cmd_postinstall(args):
 
 def cmd_model(args):
     """Select default model — starts with provider selection, then model picker."""
+    # The picker labels and validates detected credentials, so it is a real
+    # secret consumer rather than an administrative status command.
+    ensure_external_secret_sources_loaded()
     _require_tty("model")
     if getattr(args, "refresh", False):
         try:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -802,22 +802,22 @@ class PluginContext:
 
         ``source`` must be an instance of
         :class:`agent.secret_sources.base.SecretSource`.  Registered
-        sources run during ``load_hermes_dotenv()`` startup — after
-        ``~/.hermes/.env`` loads, before Hermes reads credentials — when
-        their ``secrets.<source.name>`` config section is enabled.  The
+        sources run after ``~/.hermes/.env`` loads and before Hermes reads
+        credentials when their ``secrets.<source.name>`` config section is
+        enabled. Administrative CLI commands may defer the remote fetch until
+        an agent/provider consumer starts. The
         orchestrator (``agent.secret_sources.registry.apply_all``) owns
         ordering, mapped-vs-bulk precedence, conflict warnings, and
         provenance; the source only fetches.
 
-        NOTE ON TIMING: plugin discovery happens later in startup than
-        the first ``load_hermes_dotenv()`` call, so a plugin-registered
-        source is not consulted by the initial env load of the process
-        that discovers it.  It IS consulted by every subsequently
-        spawned Hermes process (gateway children, cron sessions,
-        subagents), and immediately after a
-        ``reset_secret_source_cache()`` re-pull.  Plugin sources are
-        therefore best for supplying credentials to the running fleet;
-        the bundled sources cover first-process bootstrap.
+        NOTE ON TIMING: local dotenv bootstrap runs early (often at import
+        time), while top-level administrative CLI startup defers remote secret
+        resolution. Before the first actual consumer, Hermes calls
+        ``ensure_external_secret_sources_loaded``; when config names a
+        non-bundled source, that path discovers plugins before applying it.
+        Bundled sources still cover installs that never enable plugins.
+        Discovery is fail-open and re-entrancy-safe if import side effects
+        re-enter env loading.
 
         Contract requirements (rejected with a warning otherwise):
         inherit from ``SecretSource``, ``api_version`` matching

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -36,6 +36,7 @@ from hermes_cli.config import (
     load_config,
     normalize_extra_headers,
 )
+from hermes_cli.env_loader import ensure_external_secret_sources_loaded
 from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches, base_url_hostname, env_int
 
@@ -1534,6 +1535,12 @@ def resolve_runtime_provider(
             "source": "moa-virtual-provider",
             "requested_provider": requested_provider,
         }
+
+    # This is the shared first-use boundary for CLI, gateway, cron, ACP, and
+    # helper consumers. Top-level administrative CLI bootstrap deliberately
+    # leaves remote vaults unresolved; provider resolution must populate mapped
+    # credentials before any provider-specific env lookup below.
+    ensure_external_secret_sources_loaded()
 
     # Azure Anthropic short-circuit: when explicitly targeting an Azure endpoint
     # with provider="anthropic", bypass _resolve_named_custom_runtime (which would

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -21,6 +21,30 @@ def _fake_invoke_jwt(ttl_seconds=3600):
     return f"{header}.{payload}.sig"
 
 
+def test_resolve_runtime_provider_loads_external_secrets_before_credentials(monkeypatch):
+    order = []
+
+    monkeypatch.setattr(
+        rp,
+        "ensure_external_secret_sources_loaded",
+        lambda: order.append("external-secrets"),
+    )
+    monkeypatch.setattr(
+        rp,
+        "_getenv",
+        lambda name, default="": order.append(f"env:{name}") or default,
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="anthropic",
+        explicit_api_key="test-key",
+        explicit_base_url="https://example.azure.com/anthropic",
+    )
+
+    assert resolved["provider"] == "anthropic"
+    assert order[0] == "external-secrets"
+
+
 def test_resolve_runtime_provider_uses_credential_pool(monkeypatch):
     class _Entry:
         access_token = "pool-token"

--- a/tests/hermes_cli/test_safe_mode.py
+++ b/tests/hermes_cli/test_safe_mode.py
@@ -29,9 +29,11 @@ def test_cmd_chat_safe_mode_sets_env_before_startup(monkeypatch):
     chat_parser.set_defaults(func=main_mod.cmd_chat)
     args = parser.parse_args(["chat", "--safe-mode"])
     captured: dict[str, object] = {}
+    startup_order: list[str] = []
     fake_cli = types.ModuleType("cli")
 
     def fake_has_provider() -> bool:
+        startup_order.append("provider-check")
         assert os.environ["HERMES_SAFE_MODE"] == "1"
         assert os.environ["HERMES_IGNORE_USER_CONFIG"] == "1"
         assert os.environ["HERMES_IGNORE_RULES"] == "1"
@@ -41,6 +43,11 @@ def test_cmd_chat_safe_mode_sets_env_before_startup(monkeypatch):
         captured.update(kwargs)
 
     monkeypatch.setattr(main_mod, "_has_any_provider_configured", fake_has_provider)
+    monkeypatch.setattr(
+        main_mod,
+        "ensure_external_secret_sources_loaded",
+        lambda: startup_order.append("external-secrets"),
+    )
     monkeypatch.setattr(main_mod, "_pin_kanban_board_env", lambda: None)
     monkeypatch.setattr(main_mod, "_sync_bundled_skills_for_startup", lambda: None)
     monkeypatch.setattr(main_mod, "_termux_should_prefetch_update_check", lambda: False)
@@ -51,6 +58,7 @@ def test_cmd_chat_safe_mode_sets_env_before_startup(monkeypatch):
 
     assert captured["ignore_user_config"] is True
     assert captured["ignore_rules"] is True
+    assert startup_order == ["external-secrets", "provider-check"]
 
 
 def test_prepare_agent_startup_applies_safe_mode_before_plugin_discovery(monkeypatch):

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -7,6 +7,7 @@ don't see an unexplained "credentials ✓" line when their .env is empty.
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -274,3 +275,163 @@ def test_apply_external_secret_sources_bad_ttl_does_not_crash(tmp_path, monkeypa
 
     # Coerced to the 300s default rather than raising ValueError.
     assert captured["cache_ttl_seconds"] == 300
+
+
+def test_config_requests_plugin_secret_sources_detects_non_bundled_name():
+    assert env_loader._config_requests_plugin_secret_sources(
+        {"sources": ["protonpass"], "protonpass": {"enabled": True}}
+    )
+    assert env_loader._config_requests_plugin_secret_sources(
+        {"myvault": {"enabled": True}}
+    )
+    assert not env_loader._config_requests_plugin_secret_sources(
+        {"sources": ["bitwarden"], "bitwarden": {"enabled": True}}
+    )
+    assert not env_loader._config_requests_plugin_secret_sources({})
+    assert not env_loader._config_requests_plugin_secret_sources(
+        {"bitwarden": {"enabled": False}, "onepassword": {"enabled": False}}
+    )
+
+
+def test_apply_discovers_plugins_for_non_bundled_source(tmp_path, monkeypatch):
+    """Plugin backends named in secrets.sources must be discovered before apply.
+
+    Without this, first-process env load warns "unknown source" and skips the
+    plugin backend entirely because discover_plugins() usually runs later.
+    """
+    from agent.secret_sources.base import FetchResult, SecretSource
+    from agent.secret_sources import registry as reg
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("PLUGIN_TEST_API_KEY", raising=False)
+    (tmp_path / "config.yaml").write_text(
+        "secrets:\n"
+        "  sources:\n"
+        "  - plugintest\n"
+        "  plugintest:\n"
+        "    enabled: true\n",
+        encoding="utf-8",
+    )
+
+    class _PluginTestSource(SecretSource):
+        name = "plugintest"
+        label = "Plugin Test"
+        shape = "mapped"
+
+        def fetch(self, cfg, home_path):
+            del cfg, home_path
+            result = FetchResult()
+            result.secrets = {"PLUGIN_TEST_API_KEY": "from-plugin"}
+            return result
+
+    discovered = {"count": 0}
+
+    def _fake_discover():
+        discovered["count"] += 1
+        reg.register_source(_PluginTestSource(), replace=True)
+
+    reg._reset_registry_for_tests()
+    monkeypatch.setattr(
+        "hermes_cli.plugins.discover_plugins",
+        _fake_discover,
+        raising=False,
+    )
+    # Ensure import path used by env_loader resolves to our fake.
+    import hermes_cli.plugins as plugins_mod
+
+    monkeypatch.setattr(plugins_mod, "discover_plugins", _fake_discover)
+
+    env_loader.reset_secret_source_cache()
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    assert discovered["count"] == 1
+    assert env_loader.get_secret_source("PLUGIN_TEST_API_KEY") == "plugintest"
+    import os
+
+    assert os.environ.get("PLUGIN_TEST_API_KEY") == "from-plugin"
+
+
+def test_dotenv_bootstrap_can_defer_plugin_fetch_until_consumer(
+    tmp_path, monkeypatch, capsys
+):
+    """Administrative startup must not pay remote plugin fetch latency.
+
+    A later consumer must still discover the source and resolve its mapped
+    credential before reading it.
+    """
+    from agent.secret_sources.base import FetchResult, SecretSource
+    from agent.secret_sources import registry as reg
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("DEFERRED_TEST_API_KEY", raising=False)
+    (tmp_path / "config.yaml").write_text(
+        "secrets:\n"
+        "  sources:\n"
+        "  - deferredtest\n"
+        "  deferredtest:\n"
+        "    enabled: true\n",
+        encoding="utf-8",
+    )
+
+    class _DeferredSource(SecretSource):
+        name = "deferredtest"
+        label = "Deferred Test"
+        shape = "mapped"
+
+        def fetch(self, cfg, home_path):
+            del cfg, home_path
+            result = FetchResult()
+            result.secrets = {"DEFERRED_TEST_API_KEY": "resolved-at-consumer"}
+            return result
+
+    discovered = {"count": 0}
+
+    def _fake_discover():
+        discovered["count"] += 1
+        reg.register_source(_DeferredSource(), replace=True)
+
+    import hermes_cli.plugins as plugins_mod
+
+    reg._reset_registry_for_tests()
+    monkeypatch.setattr(plugins_mod, "discover_plugins", _fake_discover)
+
+    env_loader.load_hermes_dotenv(
+        hermes_home=tmp_path,
+        resolve_external_secrets=False,
+    )
+
+    assert discovered["count"] == 0
+    assert "DEFERRED_TEST_API_KEY" not in os.environ
+    assert str(tmp_path.resolve()) not in env_loader._APPLIED_HOMES
+
+    env_loader.ensure_external_secret_sources_loaded(hermes_home=tmp_path)
+
+    assert discovered["count"] == 1
+    assert os.environ["DEFERRED_TEST_API_KEY"] == "resolved-at-consumer"
+    assert env_loader.get_secret_source("DEFERRED_TEST_API_KEY") == "deferredtest"
+    captured = capsys.readouterr()
+    assert "resolved-at-consumer" not in captured.out
+    assert "resolved-at-consumer" not in captured.err
+
+
+def test_apply_skips_plugin_discovery_for_bundled_only(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "secrets:\n"
+        "  sources:\n"
+        "  - bitwarden\n"
+        "  bitwarden:\n"
+        "    enabled: false\n",
+        encoding="utf-8",
+    )
+    calls = {"count": 0}
+
+    def _fake_discover():
+        calls["count"] += 1
+
+    import hermes_cli.plugins as plugins_mod
+
+    monkeypatch.setattr(plugins_mod, "discover_plugins", _fake_discover)
+    env_loader.reset_secret_source_cache()
+    env_loader._apply_external_secret_sources(tmp_path)
+    assert calls["count"] == 0

--- a/website/docs/developer-guide/secret-source-plugin.md
+++ b/website/docs/developer-guide/secret-source-plugin.md
@@ -126,7 +126,7 @@ def register(ctx):
 Registration is rejected (with a log warning, never a crash) for: non-`SecretSource` instances, invalid/duplicate names, a `scheme` another source owns, wrong `api_version`, or a `shape` outside `mapped`/`bulk`.
 
 :::note Timing
-Plugin discovery runs later in startup than the first `load_hermes_dotenv()` call, so a plugin source is not consulted by the very first env load of the process that discovers it. It IS consulted by every subsequently spawned Hermes process (gateway children, cron sessions, subagents). Bundled sources cover first-process bootstrap.
+Hermes loads local dotenv files early, but administrative CLI commands defer remote secret resolution so commands such as `hermes config`, `hermes cron`, and `hermes kanban` do not inherit vault network latency. Before the first agent/provider consumer reads credentials, Hermes discovers plugins and applies configured sources. When your `secrets` config names a non-bundled source (or enables a non-bundled `secrets.<name>` section), your backend is therefore registered before that first consumer read. Bundled sources (Bitwarden, 1Password) do not require plugins.
 :::
 
 ## Users configure it like any other source


### PR DESCRIPTION
## What does this PR do?

Plugin-registered secret backends (for example a standalone Proton Pass `SecretSource`) were not available during the first process env load. The initial fix discovered plugins before `apply_all`, but that also moved every remote vault fetch onto every `hermes` command and added roughly 9–18 seconds to administrative commands.

This revision separates local bootstrap from remote resolution:

- `load_hermes_dotenv()` keeps its existing eager default for direct/runtime callers, but accepts `resolve_external_secrets=False` for cold administrative bootstrap.
- The top-level CLI loads local dotenv and managed values without contacting vaults.
- Chat, setup, model selection, and the shared `resolve_runtime_provider()` boundary call `ensure_external_secret_sources_loaded()` before the first credential read.
- Plugin discovery still occurs before `apply_all`, with the existing fail-open and re-entrancy guards.
- No secret values are persisted or logged.

This keeps third-party vault backends on the standalone-plugin path and preserves profile-scoped `HERMES_HOME` behavior.

## Measured behavior

Live Proton Pass source, same profile and machine:

| Command | Prior PR | This revision (cold / repeat) |
|---|---:|---:|
| `hermes kanban --help` | 12.164s | 0.132s / 0.101s |
| `hermes cron list` | 9.500s | 0.140s / 0.139s |
| `hermes config path` | 9.438s | 0.103s / 0.100s |
| `hermes status` | 17.610s | 1.177s / 0.940s |

All four fixed commands completed without the old unknown-source warning and without a Proton fetch/status line.

Consumer probe:

- local bootstrap: 0.047s, mapped source absent as expected
- first `resolve_runtime_provider(requested="deepseek")`: 10.051s
- credential present: yes
- provenance after resolution: `protonpass`

The network cost is therefore paid at first real provider use, not by unrelated commands.

## Verification

- 598 focused loader, secret registry, plugin, CLI, runtime-provider, setup, and profile-isolation tests passed through `scripts/run_tests.sh`
- Added regression coverage for deferred bootstrap → plugin discovery → consumer resolution
- Added ordering coverage proving chat resolves external secrets before provider readiness checks
- Added runtime-provider boundary coverage
- Added log assertion proving a fetched sentinel value never appears on stdout/stderr
- Diff redaction scan: no private-key, AWS, GitHub-token, or long secret-assignment matches
- `git diff --check` clean

## Adoption / rollback

The change is one focused commit on current `origin/main`. Rollback is a normal revert of this commit; no config migration, plaintext cache, gateway restart, or live-install patch is required.
