### PR TITLE
fix(copilot): keep rotated credentials on account endpoint

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -141,6 +141,14 @@ _GATEWAY_AUTH_ERROR_RE = re.compile(
     re.IGNORECASE,
 )
 
+_GATEWAY_ENDPOINT_ACCESS_ERROR_RE = re.compile(
+    r"^\s*HTTP\s*403\s*:\s*Access to this endpoint is forbidden\.\s*"
+    r"Please review our \[Terms of Service\]"
+    r"\(https://docs\.github\.com/en/site-policy/github-terms/"
+    r"github-terms-of-service\)\.\s*$",
+    re.IGNORECASE,
+)
+
 _GATEWAY_RATE_LIMIT_RE = re.compile(
     r"(rate\s+limit|rate-limited|\b429\b|quota|usage\s+limit)",
     re.IGNORECASE,
@@ -355,6 +363,12 @@ def _redact_approval_command(cmd: "str | None") -> str:
 
 def _gateway_provider_error_reply(text: str) -> str:
     """Map raw provider/API errors to a short user-safe Telegram reply."""
+    if _GATEWAY_ENDPOINT_ACCESS_ERROR_RE.search(text):
+        return (
+            "⚠️ Provider authentication or endpoint access failed. Check the "
+            "configured credentials and endpoint; raw provider details are in "
+            "the gateway logs."
+        )
     if _GATEWAY_AUTH_ERROR_RE.search(text):
         return (
             "⚠️ Provider authentication failed. Check the configured credentials; "

--- a/run_agent.py
+++ b/run_agent.py
@@ -4505,6 +4505,27 @@ class AIAgent:
         runtime_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
         runtime_base = getattr(entry, "runtime_base_url", None) or getattr(entry, "base_url", None) or self.base_url
 
+        # Pool entries may contain either a raw GitHub token or an already
+        # exchanged Copilot API token. Exchange only the former, while deriving
+        # the account endpoint directly from the latter, so credential rotation
+        # installs the token and its Enterprise endpoint as one runtime pair.
+        # Keep the selected pool credential unchanged if resolution fails.
+        if self.provider == "copilot":
+            try:
+                from hermes_cli.copilot_auth import (
+                    _derive_base_url_from_proxy_ep,
+                    get_copilot_api_token,
+                )
+
+                if ";" in runtime_key:
+                    account_base_url = _derive_base_url_from_proxy_ep(runtime_key)
+                else:
+                    runtime_key, account_base_url = get_copilot_api_token(runtime_key)
+                if account_base_url:
+                    runtime_base = account_base_url
+            except Exception:
+                logger.debug("Copilot credential exchange failed during rotation", exc_info=True)
+
         if self.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client, _is_oauth_token
 

--- a/tests/agent/test_restore_primary_pool_reselect.py
+++ b/tests/agent/test_restore_primary_pool_reselect.py
@@ -220,3 +220,97 @@ class TestRestorePrimaryPoolReselect:
         assert result is True
         assert "custom-endpoint.example.com" in agent.base_url
         assert "custom-endpoint.example.com" in agent._client_kwargs["base_url"]
+
+
+def _make_copilot_swap_agent():
+    from run_agent import AIAgent
+
+    agent = AIAgent.__new__(AIAgent)
+    agent.provider = "copilot"
+    agent.api_mode = "codex_responses"
+    agent.base_url = "https://api.githubcopilot.com"
+    agent.api_key = "test-old-api-token"
+    agent._client_kwargs = {
+        "api_key": "test-old-api-token",
+        "base_url": "https://api.githubcopilot.com",
+    }
+    agent._apply_client_headers_for_base_url = MagicMock()
+    agent._replace_primary_openai_client = MagicMock(return_value=True)
+    return agent
+
+
+def _make_copilot_entry(access_token: str):
+    return PooledCredential.from_dict(
+        "copilot",
+        {
+            "id": "enterprise",
+            "label": "enterprise",
+            "auth_type": "api_key",
+            "source": "manual",
+            "priority": 0,
+            "access_token": access_token,
+            # Regression setup: this public endpoint was persisted before the
+            # token exchange learned the account-specific Enterprise host.
+            "base_url": "https://api.githubcopilot.com",
+        },
+    )
+
+
+def test_swap_raw_copilot_credential_exchanges_token_and_account_endpoint():
+    """Raw GitHub credentials must install the exchanged token/endpoint pair."""
+    agent = _make_copilot_swap_agent()
+    entry = _make_copilot_entry("ghu_raw_enterprise_token")
+
+    with patch(
+        "hermes_cli.copilot_auth.get_copilot_api_token",
+        return_value=(
+            "tid=example;exp=9999999999;proxy-ep=proxy.enterprise.githubcopilot.com",
+            "https://api.enterprise.githubcopilot.com",
+        ),
+    ) as exchange:
+        agent._swap_credential(entry)
+
+    exchange.assert_called_once_with("ghu_raw_enterprise_token")
+    assert agent.api_key.startswith("tid=example;")
+    assert agent.base_url == "https://api.enterprise.githubcopilot.com"
+    assert agent._client_kwargs["api_key"] == agent.api_key
+    assert agent._client_kwargs["base_url"] == agent.base_url
+    agent._replace_primary_openai_client.assert_called_once_with(
+        reason="credential_rotation",
+    )
+
+
+def test_swap_exchanged_copilot_credential_repairs_stale_account_endpoint():
+    """A cached API token must repair a stale pool URL without re-exchange."""
+    agent = _make_copilot_swap_agent()
+    api_token = (
+        "tid=example;exp=9999999999;"
+        "proxy-ep=proxy.enterprise.githubcopilot.com;sku=copilot_enterprise"
+    )
+    entry = _make_copilot_entry(api_token)
+
+    with patch("hermes_cli.copilot_auth.get_copilot_api_token") as exchange:
+        agent._swap_credential(entry)
+
+    exchange.assert_not_called()
+    assert agent.api_key == api_token
+    assert agent.base_url == "https://api.enterprise.githubcopilot.com"
+    assert agent._client_kwargs["base_url"] == agent.base_url
+
+
+def test_swap_raw_copilot_credential_falls_back_if_exchange_raises():
+    """A transient exchange failure must not break credential rotation."""
+    agent = _make_copilot_swap_agent()
+    entry = _make_copilot_entry("ghu_raw_enterprise_token")
+
+    with patch(
+        "hermes_cli.copilot_auth.get_copilot_api_token",
+        side_effect=RuntimeError("network unavailable"),
+    ):
+        agent._swap_credential(entry)
+
+    assert agent.api_key == "ghu_raw_enterprise_token"
+    assert agent.base_url == "https://api.githubcopilot.com"
+    agent._replace_primary_openai_client.assert_called_once_with(
+        reason="credential_rotation",
+    )

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -198,6 +198,51 @@ def test_telegram_final_response_redacts_auth_secrets():
     assert "sk-live" not in sanitized
 
 
+def test_telegram_final_response_classifies_endpoint_forbidden_as_access_error():
+    """GitHub's exact endpoint 403 is not generic retry exhaustion (#61746)."""
+    raw = (
+        "HTTP 403: Access to this endpoint is forbidden. Please review our "
+        "[Terms of Service](https://docs.github.com/en/site-policy/github-terms/"
+        "github-terms-of-service)."
+    )
+
+    sanitized = _sanitize_gateway_final_response(Platform.TELEGRAM, raw)
+
+    assert "authentication or endpoint access failed" in sanitized.lower()
+    assert "after retries" not in sanitized.lower()
+    assert "terms of service" not in sanitized.lower()
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "Non-retryable error: HTTP 403: Access to this endpoint is forbidden. "
+        "Please review our [Terms of Service](https://docs.github.com/en/site-policy/"
+        "github-terms/github-terms-of-service).",
+        "HTTP 403: Access to this endpoint is forbidden. Please review our "
+        "[Terms of Service](https://example.com/terms).",
+        "HTTP 403: Access to this endpoint is forbidden. Please review our "
+        "[Terms of Service](https://docs.github.com/en/site-policy/github-terms/"
+        "github-terms-of-service). trailing text",
+    ],
+)
+def test_telegram_final_response_does_not_overmatch_endpoint_forbidden_near_misses(raw):
+    """Only the complete known GitHub envelope gets the access diagnosis."""
+    sanitized = _sanitize_gateway_final_response(Platform.TELEGRAM, raw)
+
+    assert "authentication or endpoint access failed" not in sanitized.lower()
+
+
+def test_telegram_final_response_keeps_other_403s_generic():
+    """Only GitHub's endpoint-forbidden envelope is categorized as access."""
+    raw = "HTTP 403: Organization policy denied this request."
+
+    sanitized = _sanitize_gateway_final_response(Platform.TELEGRAM, raw)
+
+    assert "provider failed after retries" in sanitized.lower()
+    assert "authentication or endpoint access failed" not in sanitized.lower()
+
+
 def test_telegram_final_response_keeps_normal_answers():
     """Normal assistant content should not be rewritten."""
     answer = "Here is the clean summary you asked for."


### PR DESCRIPTION
## What does this PR do?

Fixes Copilot credential rotation for Enterprise/proxied accounts by keeping the runtime API token and account-specific endpoint together.

When a pool entry contains a raw GitHub token, `_swap_credential()` exchanges it and applies the returned short-lived Copilot token plus `base_url` as one runtime pair. When the pool already contains an exchanged semicolon metadata token, Hermes avoids an invalid re-exchange and derives the Enterprise endpoint from `proxy-ep` instead. Exchange failures remain fail-soft and preserve the selected pool values.

The PR also categorizes GitHub's exact endpoint-forbidden HTTP 403 envelope as an authentication/endpoint-access failure on chat gateways rather than the misleading generic “failed after retries” message.

This builds on the core fix in #61754, while covering the already-exchanged token path and the gateway diagnostic reported in the issue.

## Related Issue

Fixes #61746

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `run_agent.py`
  - exchange raw Copilot pool credentials during rotation
  - derive account-specific endpoints from already-exchanged Copilot tokens without re-exchanging them
  - preserve existing token/endpoint values when resolution fails
- `gateway/run.py`
  - recognize GitHub's endpoint-forbidden 403 envelope, including its Markdown Terms-of-Service link
  - return an authentication/endpoint-access diagnostic without broadening every HTTP 403 into an auth error
- `tests/agent/test_restore_primary_pool_reselect.py`
  - cover raw-token exchange, exchanged-token endpoint repair, and fail-soft behavior
- `tests/gateway/test_telegram_noise_filter.py`
  - cover the real wrapped GitHub 403 and a negative unrelated-403 case

## How to Test

1. Run focused Copilot, credential-pool, Responses transport, and gateway tests:

   ```bash
   python -m pytest \
     tests/run_agent/test_run_agent_codex_responses.py \
     tests/agent/test_restore_primary_pool_reselect.py \
     tests/agent/test_credential_pool_routing.py \
     tests/gateway/test_telegram_noise_filter.py \
     tests/hermes_cli/test_copilot_token_exchange.py \
     -o 'addopts=' -q
   ```

   Expected: `335 passed`.

2. Run lint and whitespace checks:

   ```bash
   python -m ruff check \
     run_agent.py gateway/run.py \
     tests/agent/test_restore_primary_pool_reselect.py \
     tests/gateway/test_telegram_noise_filter.py
   git diff origin/main...HEAD --check
   ```

3. With a Copilot Enterprise credential whose token advertises `proxy-ep=proxy.enterprise.githubcopilot.com`, rotate from a stale pool entry whose stored URL is `https://api.githubcopilot.com`. The rebuilt client should use `https://api.enterprise.githubcopilot.com`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing issues and PRs
- [x] My PR contains only changes related to this fix
- [ ] I've run the entire `pytest tests/ -q` suite — the hermetic full-suite runner reached 16.1% with no failures before the local 10-minute command timeout; focused affected tests pass
- [x] I've added regression tests
- [x] I've tested on Linux 6.17 / Python 3.11.15

### Documentation & Housekeeping

- [x] Documentation update — N/A; no user-facing configuration changed
- [x] `cli-config.yaml.example` update — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A
- [x] Cross-platform impact considered; implementation is platform-neutral Python
- [x] Tool descriptions/schemas update — N/A

## Test Results

```text
335 passed in 28.27s
240 passed in 5.41s
All checks passed!  # ruff
git diff --check: clean
```
