### PR TITLE
fix(cron): non-dict schedule crashes 6 direct-call sites the due-scan repair doesn't reach

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -817,6 +817,28 @@ def _compute_grace_seconds(schedule: dict) -> int:
     return MIN_GRACE
 
 
+def _job_schedule_dict(job: Dict[str, Any]) -> Dict[str, Any]:
+    """Return ``job["schedule"]`` as a dict, repairing it in place if malformed.
+
+    A jobs.json record can carry a non-dict ``schedule`` (``null``, a stray
+    string, etc.) from a direct edit or an old writer. ``_get_due_jobs_locked``
+    already repairs this during the periodic due-scan tick (#61525), but
+    ``resume_job`` / ``mark_job_run`` / ``claim_dispatch`` / ``advance_next_run``
+    / ``claim_job_for_fire`` can all run on a record the scan hasn't repaired
+    yet (e.g. a paused job, or a call made before the scheduler's first tick) —
+    each calls ``schedule.get(...)`` directly and a non-dict value raises
+    ``AttributeError`` before that caller's own ``save_jobs()`` can persist
+    anything, crashing the request outright instead of treating the schedule
+    as merely absent. Repairing in place here means each caller's normal
+    save path already persists the fix.
+    """
+    schedule = job.get("schedule")
+    if not isinstance(schedule, dict):
+        schedule = {}
+        job["schedule"] = schedule
+    return schedule
+
+
 def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None) -> Optional[str]:
     """
     Compute the next run time for a schedule.
@@ -1908,6 +1930,15 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     bool(updated.get("no_agent")),
                     _upd_script or None,
                 )
+
+            # A stored or caller-supplied non-dict, non-string schedule (null,
+            # a stray int, etc.) makes every `.get()` below raise before this
+            # loop's save_jobs() can persist anything — repair it the same way
+            # `_get_due_jobs_locked` does for the due-scan tick (#61525). A
+            # string is left alone here — it's a valid raw-schedule update
+            # ("every 10m") that the block below still needs to parse.
+            if not isinstance(updated.get("schedule"), (dict, str)):
+                updated["schedule"] = {}
             schedule_changed = "schedule" in updates
             inference_fields_changed = bool(
                 {"provider", "model", "base_url", "no_agent"}.intersection(updates)
@@ -2003,9 +2034,10 @@ def resume_job(job_id: str) -> Optional[Dict[str, Any]]:
     if not job:
         return None
 
-    next_run_at = compute_next_run(job["schedule"])
-    if next_run_at is None and job["schedule"].get("kind") == "once":
-        run_at = job["schedule"].get("run_at", "unknown")
+    schedule = _job_schedule_dict(job)
+    next_run_at = compute_next_run(schedule)
+    if next_run_at is None and schedule.get("kind") == "once":
+        run_at = schedule.get("run_at", "unknown")
         raise ValueError(
             f"Cannot resume: one-shot time {run_at} is in the past "
             f"(grace window: {ONESHOT_GRACE_SECONDS}s) and will never fire."
@@ -2130,6 +2162,7 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
         jobs = load_jobs()
         for i, job in enumerate(jobs):
             if job["id"] == job_id:
+                schedule = _job_schedule_dict(job)
                 now = _hermes_now().isoformat()
                 job["last_run_at"] = now
                 job["last_status"] = status or ("ok" if success else "error")
@@ -2159,7 +2192,7 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                     repeat = job["repeat"]
                     times = repeat.get("times")
                     completed = repeat.get("completed", 0)
-                    kind = job.get("schedule", {}).get("kind")
+                    kind = schedule.get("kind")
                     preclaimed_oneshot = (
                         kind == "once"
                         and times is not None
@@ -2189,7 +2222,7 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                         return
                 
                 # Compute next run
-                job["next_run_at"] = compute_next_run(job["schedule"], now)
+                job["next_run_at"] = compute_next_run(schedule, now)
 
                 # If no next run, decide whether this is terminal completion
                 # (one-shot) or a transient failure (recurring schedule couldn't
@@ -2198,7 +2231,7 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                 # missing runtime dep into "job completed" and the user's
                 # schedule quietly goes off. See issue #16265.
                 if job["next_run_at"] is None:
-                    kind = job.get("schedule", {}).get("kind")
+                    kind = schedule.get("kind")
                     if kind in {"cron", "interval"}:
                         job["state"] = "error"
                         if not job.get("last_error"):
@@ -2292,7 +2325,13 @@ def claim_dispatch(job_id: str) -> bool:
         for i, job in enumerate(jobs):
             if job["id"] != job_id:
                 continue
-            if job.get("schedule", {}).get("kind") != "once":
+            schedule_was_malformed = not isinstance(job.get("schedule"), dict)
+            if _job_schedule_dict(job).get("kind") != "once":
+                if schedule_was_malformed:
+                    # _job_schedule_dict() repaired job["schedule"] in place;
+                    # persist it now since this path returns before the
+                    # dispatch-claim save below would otherwise do it.
+                    save_jobs(jobs)
                 return True  # recurring jobs use advance_next_run(), not dispatch claims
             repeat = job.get("repeat")
             if not repeat:
@@ -2406,17 +2445,31 @@ def advance_next_runs(job_ids) -> int:
         jobs = load_jobs()
         now = _hermes_now().isoformat()
         advanced = 0
+        schedule_repaired = False
         for job in jobs:
             if job["id"] not in ids:
                 continue
-            kind = job.get("schedule", {}).get("kind")
+            # A stored non-dict schedule (null, a stray int, etc.) raises on
+            # the raw .get() below before this function's own save_jobs()
+            # persists anything for the whole batch — repair in place the
+            # same way _get_due_jobs_locked does for the due-scan tick
+            # (#61525), so one malformed record can't crash advancing the
+            # rest of the batch.
+            schedule_was_malformed = not isinstance(job.get("schedule"), dict)
+            schedule = _job_schedule_dict(job)
+            if schedule_was_malformed:
+                # The repair above only lives in memory until save_jobs()
+                # runs — force a persist below even if nothing in the batch
+                # actually advances, or the fix disappears on next load.
+                schedule_repaired = True
+            kind = schedule.get("kind")
             if kind not in {"cron", "interval"}:
                 continue
-            new_next = compute_next_run(job["schedule"], now)
+            new_next = compute_next_run(schedule, now)
             if new_next and new_next != job.get("next_run_at"):
                 job["next_run_at"] = new_next
                 advanced += 1
-        if advanced:
+        if advanced or schedule_repaired:
             save_jobs(jobs)
         return advanced
 
@@ -2502,9 +2555,10 @@ def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300) -> bool:
                 except Exception:
                     pass  # malformed claim → overwrite
             job["fire_claim"] = {"at": now.isoformat(), "by": _machine_id()}
-            kind = job.get("schedule", {}).get("kind")
+            schedule = _job_schedule_dict(job)
+            kind = schedule.get("kind")
             if kind in {"cron", "interval"}:
-                nxt = compute_next_run(job["schedule"], now.isoformat())
+                nxt = compute_next_run(schedule, now.isoformat())
                 if nxt:
                     job["next_run_at"] = nxt
             save_jobs(jobs)

--- a/tests/cron/test_claim_job_for_fire.py
+++ b/tests/cron/test_claim_job_for_fire.py
@@ -58,3 +58,21 @@ def test_mark_job_run_clears_claim(temp_home):
     assert get_job(jid).get("fire_claim") is None
     # …and the re-armed recurring job is claimable again.
     assert claim_job_for_fire(jid) is True
+
+
+def test_claim_does_not_crash_on_non_dict_schedule(temp_home):
+    """A non-dict 'schedule' (direct jobs.json edit, old writer, corruption)
+    must not crash claim_job_for_fire with AttributeError — it's repaired
+    in place like the due-scan's own malformed-schedule guard."""
+    from cron.jobs import claim_job_for_fire, save_jobs, get_job
+
+    save_jobs([{
+        "id": "bad-sched",
+        "name": "bad",
+        "enabled": True,
+        "schedule": None,  # poison: not a dict
+        "state": "scheduled",
+    }])
+
+    assert claim_job_for_fire("bad-sched") is True
+    assert get_job("bad-sched")["schedule"] == {}

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1354,3 +1354,72 @@ class TestCompletedOneshotRetentionSweep:
         assert updated["enabled"] is True
         assert updated["state"] == "scheduled"
         assert updated["next_run_at"] is not None
+
+
+class TestScheduleNoneSiblingCrashes:
+    """A non-dict 'schedule' (direct jobs.json edit, old writer, corruption)
+
+    is repaired by ``_get_due_jobs_locked`` during the periodic due-scan tick,
+    but ``resume_job``/``mark_job_run``/``claim_dispatch``/``advance_next_run``/
+    ``update_job`` can all run on a record the scan hasn't repaired yet (a
+    paused job, or a call made before the scheduler's first tick) — each read
+    ``schedule.get(...)`` directly, and a non-dict value raised
+    ``AttributeError`` before this fix. Sibling of the id-less/malformed
+    next_run_at/non-dict schedule due-scan fixes, but for the direct-call
+    paths rather than the scan.
+    """
+
+    def _write_bad_job(self, job_id="bad-sched", **overrides):
+        job = {
+            "id": job_id,
+            "name": "bad",
+            "prompt": "test",
+            "enabled": True,
+            "schedule": None,  # poison: not a dict
+            "state": "scheduled",
+            "next_run_at": None,
+        }
+        job.update(overrides)
+        save_jobs([job])
+        return job
+
+    def test_resume_job_does_not_crash(self, tmp_cron_dir):
+        self._write_bad_job(enabled=False, state="paused")
+        result = resume_job("bad-sched")
+        assert result is not None
+        assert result["schedule"] == {}
+
+    def test_mark_job_run_does_not_crash(self, tmp_cron_dir):
+        self._write_bad_job(enabled=False, state="paused")
+        mark_job_run("bad-sched", success=True)  # must not raise
+        assert load_jobs()[0]["schedule"] == {}
+
+    def test_claim_dispatch_does_not_crash(self, tmp_cron_dir):
+        self._write_bad_job(enabled=False, state="paused")
+        assert claim_dispatch("bad-sched") is True
+        # The in-place schedule repair must be persisted, not just avoid the
+        # crash in memory — otherwise jobs.json stays malformed on disk and
+        # every future call pays the same repair-without-persist cost.
+        assert load_jobs()[0]["schedule"] == {}
+
+    def test_advance_next_run_does_not_crash(self, tmp_cron_dir):
+        self._write_bad_job(enabled=False, state="paused")
+        assert advance_next_run("bad-sched") is False
+        assert load_jobs()[0]["schedule"] == {}
+
+    def test_update_job_does_not_crash_on_unrelated_field(self, tmp_cron_dir):
+        """Updating a field other than 'schedule' must not crash just
+        because the stored schedule is malformed."""
+        self._write_bad_job(enabled=True, state="scheduled")
+        result = update_job("bad-sched", {"assignee": "someone"})
+        assert result is not None
+        assert result["schedule"] == {}
+        assert result["assignee"] == "someone"
+
+    def test_update_job_still_parses_raw_string_schedule(self, tmp_cron_dir):
+        """The malformed-schedule guard must not swallow a legitimate raw
+        string schedule update (e.g. "every 10m") before it's parsed."""
+        job = create_job(prompt="hi", schedule="every 1h")
+        updated = update_job(job["id"], {"schedule": "every 2h"})
+        assert updated["schedule"]["kind"] == "interval"
+        assert updated["schedule"]["minutes"] == 120


### PR DESCRIPTION
## Summary

The recent malformed-job hardening series (#61382 id-less job, #61525 non-dict schedule, #61581 bad next_run_at, and the final per-job containment guard) fixed `_get_due_jobs_locked()` so a non-dict `"schedule"` (`null`, a stray string, etc. from a direct jobs.json edit or an old writer) no longer aborts the periodic due-scan tick. That fix normalizes the schedule to `{}` and persists the repair via `save_jobs()` — but only inside the scan.

Six other places in `cron/jobs.py` read `job.get("schedule", {}).get(...)` or `job["schedule"].get(...)` directly, and each can run on a record the scan hasn't repaired yet (a paused job, or any of these called before the scheduler's next tick):

- `resume_job()`
- `mark_job_run()` (two call sites)
- `claim_dispatch()`
- `advance_next_run()`
- `claim_job_for_fire()`
- `update_job()`'s inherited-schedule fallback (when `updates` doesn't touch `"schedule"` but the stored value is malformed)

`dict.get(key, default)` only returns `default` when the key is *absent* — a key present with value `None` still returns `None`. So `job.get("schedule", {}).get("kind")` crashes with `AttributeError: 'NoneType' object has no attribute 'get'` when `schedule` is explicitly `None`, instead of treating it as absent.

All 6 were reproduced empirically against the real `cron.jobs` module (no mocks) before this fix:

```
resume_job            -> AttributeError: 'NoneType' object has no attribute 'get'
mark_job_run          -> AttributeError: 'NoneType' object has no attribute 'get'
claim_dispatch        -> AttributeError: 'NoneType' object has no attribute 'get'
advance_next_run      -> AttributeError: 'NoneType' object has no attribute 'get'
claim_job_for_fire    -> AttributeError: 'NoneType' object has no attribute 'get'
update_job            -> AttributeError: 'NoneType' object has no attribute 'get'
```

## Fix

Added a shared `_job_schedule_dict(job)` helper that returns `job["schedule"]` as a dict, repairing it in place (mirroring the due-scan's own normalization) when it isn't one, and used it at the 5 function-level sites. `update_job()` gets an equivalent inline guard that's careful to skip strings, since a raw string (e.g. `"every 10m"`) is a valid update payload that's parsed later in the same function — a blanket `not isinstance(..., dict)` check would have broken that path.

## Testing

- Added a regression test class (`TestScheduleNoneSiblingCrashes`) in `tests/cron/test_jobs.py` covering `resume_job`, `mark_job_run`, `claim_dispatch`, `advance_next_run`, and `update_job` (including a test confirming the raw-string schedule update path still works).
- Added a regression test in `tests/cron/test_claim_job_for_fire.py` for `claim_job_for_fire`.
- Mutation-verified: reverting the fix causes all 6 new tests to fail against pre-fix code (confirmed via `git stash`); restoring the fix makes them pass.
- Full `tests/cron/` suite + `tests/tools/test_cronjob_run_immediate.py` + all other test files importing `cron.jobs`: 989 tests pass.
- `ruff check` clean on all changed files.

## Checklist

- [x] Tests added/updated and passing
- [x] Mutation-verified (fix reverted -> new tests fail; fix restored -> tests pass)
- [x] `ruff check` clean
- [x] Legitimate raw-string schedule update path in `update_job` still works (explicit regression test)