### PR TITLE
fix(desktop): preserve macOS TCC identity across rebuilds

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5442,8 +5442,32 @@ def _stop_desktop_processes_locking_build(desktop_dir: Path) -> list[int]:
     return stopped
 
 
+def _desktop_macos_local_signing_identity() -> str | None:
+    """Return the opt-in identity used to keep local macOS TCC grants stable."""
+    if sys.platform != "darwin":
+        return None
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config()
+        desktop = config.get("desktop", {})
+        if not isinstance(desktop, dict):
+            return None
+        identity = desktop.get("macos_signing_identity")
+        if not isinstance(identity, str):
+            return None
+        identity = identity.strip()
+        return identity or None
+    except Exception as exc:
+        print(
+            "  (warning: could not load desktop.macos_signing_identity: "
+            f"{exc}; falling back to ad-hoc signing)"
+        )
+        return None
+
+
 def _desktop_macos_relaunchable_fixup(desktop_dir: Path) -> None:
-    """Make a locally-built (unsigned) macOS desktop app survive in-place self-update.
+    """Make a locally-built macOS desktop app survive in-place self-update.
 
     An ad-hoc-signed .app has no stable Designated Requirement (no Team ID), so
     when the self-updater rebuilds the bundle in place with a fresh build (a new,
@@ -5452,11 +5476,15 @@ def _desktop_macos_relaunchable_fixup(desktop_dir: Path) -> None:
     bundle also inherits the com.apple.quarantine flag from the downloaded
     installer process chain. Both make the relaunch fail.
 
-    Clearing the quarantine xattrs and re-applying a clean deep ad-hoc signature
-    (omitting the hardened-runtime flag, which is meaningless without a real
-    Developer ID) lets the rebuilt app relaunch. No-op when a real signing
-    identity is configured (CSC_LINK / APPLE_SIGNING_IDENTITY) so a properly
-    signed/notarized build is never clobbered. Best-effort: never raises.
+    Clearing quarantine and re-applying a clean deep signature lets the rebuilt
+    app relaunch. By default that signature remains ad-hoc. Users who grant the
+    app TCC permissions such as Full Disk Access may set
+    ``desktop.macos_signing_identity`` to a persistent identity in their login
+    keychain; codesign then emits a certificate-based Designated Requirement
+    that survives future rebuilds instead of changing with every cdhash.
+
+    Publisher signing (CSC_LINK / APPLE_SIGNING_IDENTITY) still wins and is
+    never clobbered. Best-effort: never raises.
     """
     if sys.platform != "darwin":
         return
@@ -5472,9 +5500,25 @@ def _desktop_macos_relaunchable_fixup(desktop_dir: Path) -> None:
     codesign = shutil.which("codesign")
     if not codesign:
         return
+    identity = _desktop_macos_local_signing_identity() or "-"
     try:
         subprocess.run(["xattr", "-cr", str(app)], check=False)
-        subprocess.run([codesign, "--force", "--deep", "--sign", "-", str(app)], check=False)
+        command = [codesign, "--force", "--deep", "--sign", identity]
+        if identity != "-":
+            # Preserve electron-builder's entitlements and hardened-runtime
+            # flags while allowing codesign to derive a new stable requirement
+            # from the selected certificate.
+            command.extend([
+                "--timestamp=none",
+                "--preserve-metadata=entitlements,flags,runtime",
+            ])
+        command.append(str(app))
+        result = subprocess.run(command, check=False)
+        if result.returncode != 0 and identity != "-":
+            print(
+                "  (warning: configured macOS signing identity failed: "
+                f"{identity!r}; Full Disk Access may need to be granted again)"
+            )
     except Exception as exc:
         print(f"  (warning: macOS relaunch fixup skipped: {exc})")
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2913,16 +2913,26 @@ install_desktop() {
         fi
     fi
 
-    # macOS: make the locally-built (ad-hoc) app relaunchable after an in-place
-    # self-update. An ad-hoc bundle has no stable Designated Requirement, so a
-    # later in-place rebuild (new cdhash) plus the inherited quarantine flag
-    # trips Gatekeeper's tamper check ("Hermes is damaged and can't be opened").
-    # Strip quarantine + re-apply a clean deep ad-hoc signature (no
-    # hardened-runtime flag, which an ad-hoc build can't satisfy). Skipped when a
-    # real signing identity is configured so a signed build isn't clobbered.
+    # macOS: use the same config-aware signing fixup as `hermes desktop` so
+    # install/repair and self-update cannot disagree about the app's identity.
+    # Fall back to the historical ad-hoc repair only if the venv is unavailable.
     if [ "$OS" = "macos" ] && [ -z "${CSC_LINK:-}" ] && [ -z "${APPLE_SIGNING_IDENTITY:-}" ] && command -v codesign >/dev/null 2>&1; then
-        xattr -cr "$app" 2>/dev/null || true
-        codesign --force --deep --sign - "$app" >/dev/null 2>&1 || true
+        local config_python="$INSTALL_DIR/venv/bin/python"
+        if [ -x "$config_python" ]; then
+            if ! HERMES_HOME="$HERMES_HOME" "$config_python" -c '
+import sys
+from pathlib import Path
+from hermes_cli.main import _desktop_macos_relaunchable_fixup
+_desktop_macos_relaunchable_fixup(Path(sys.argv[1]))
+' "$desktop_dir"; then
+                log_warn "Config-aware macOS signing fixup failed; applying the historical ad-hoc fallback."
+                xattr -cr "$app" 2>/dev/null || true
+                codesign --force --deep --sign - "$app" >/dev/null 2>&1 || true
+            fi
+        else
+            xattr -cr "$app" 2>/dev/null || true
+            codesign --force --deep --sign - "$app" >/dev/null 2>&1 || true
+        fi
     fi
 
     # `npm install` + `npm run pack` rewrite lockfiles; restore them so the

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import argparse
+import os
+import plistlib
 import subprocess
 import sys
 from pathlib import Path
@@ -1006,6 +1008,202 @@ def test_force_adhoc_signing_respects_explicit_caller_flag(monkeypatch):
     env = {"CSC_IDENTITY_AUTO_DISCOVERY": "true"}
     assert cli_main._force_adhoc_macos_signing(env, source_mode=False) is False
     assert env["CSC_IDENTITY_AUTO_DISCOVERY"] == "true"
+
+
+def test_desktop_macos_local_signing_identity_reads_config(monkeypatch):
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+    config = {"desktop": {"macos_signing_identity": "  Hermes Local  "}}
+    with patch("hermes_cli.config.load_config", return_value=config):
+        assert cli_main._desktop_macos_local_signing_identity() == "Hermes Local"
+
+
+@pytest.mark.parametrize(
+    "platform,config",
+    [
+        ("linux", {"desktop": {"macos_signing_identity": "Hermes Local"}}),
+        ("darwin", {}),
+        ("darwin", {"desktop": {"macos_signing_identity": "  "}}),
+        ("darwin", {"desktop": {"macos_signing_identity": True}}),
+    ],
+)
+def test_desktop_macos_local_signing_identity_ignores_unusable_values(
+    monkeypatch, platform, config
+):
+    monkeypatch.setattr(cli_main.sys, "platform", platform)
+    with patch("hermes_cli.config.load_config", return_value=config):
+        assert cli_main._desktop_macos_local_signing_identity() is None
+
+
+def test_desktop_macos_fixup_uses_configured_stable_identity(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+    monkeypatch.delenv("CSC_LINK", raising=False)
+    monkeypatch.delenv("APPLE_SIGNING_IDENTITY", raising=False)
+    app = tmp_path / "Hermes.app"
+    executable = app / "Contents" / "MacOS" / "Hermes"
+    executable.parent.mkdir(parents=True)
+    executable.touch()
+    completed = subprocess.CompletedProcess([], 0)
+
+    with patch("hermes_cli.main._desktop_packaged_executable", return_value=executable), \
+         patch("hermes_cli.main._desktop_macos_local_signing_identity", return_value="Hermes Local"), \
+         patch("hermes_cli.main.shutil.which", return_value="/usr/bin/codesign"), \
+         patch("hermes_cli.main.subprocess.run", return_value=completed) as mock_run:
+        cli_main._desktop_macos_relaunchable_fixup(tmp_path)
+
+    assert mock_run.call_args_list[1].args[0] == [
+        "/usr/bin/codesign",
+        "--force",
+        "--deep",
+        "--sign",
+        "Hermes Local",
+        "--timestamp=none",
+        "--preserve-metadata=entitlements,flags,runtime",
+        str(app),
+    ]
+
+
+def test_desktop_macos_fixup_defaults_to_adhoc_signature(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+    monkeypatch.delenv("CSC_LINK", raising=False)
+    monkeypatch.delenv("APPLE_SIGNING_IDENTITY", raising=False)
+    app = tmp_path / "Hermes.app"
+    executable = app / "Contents" / "MacOS" / "Hermes"
+    executable.parent.mkdir(parents=True)
+    executable.touch()
+    completed = subprocess.CompletedProcess([], 0)
+
+    with patch("hermes_cli.main._desktop_packaged_executable", return_value=executable), \
+         patch("hermes_cli.main._desktop_macos_local_signing_identity", return_value=None), \
+         patch("hermes_cli.main.shutil.which", return_value="/usr/bin/codesign"), \
+         patch("hermes_cli.main.subprocess.run", return_value=completed) as mock_run:
+        cli_main._desktop_macos_relaunchable_fixup(tmp_path)
+
+    assert mock_run.call_args_list[1].args[0] == [
+        "/usr/bin/codesign", "--force", "--deep", "--sign", "-", str(app)
+    ]
+
+
+def test_desktop_macos_signing_config_error_is_visible(monkeypatch, capsys):
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+    with patch("hermes_cli.config.load_config", side_effect=OSError("unreadable")):
+        assert cli_main._desktop_macos_local_signing_identity() is None
+    output = capsys.readouterr().out
+    assert "could not load desktop.macos_signing_identity" in output
+    assert "unreadable" in output
+
+
+@pytest.mark.parametrize("key", ["CSC_LINK", "APPLE_SIGNING_IDENTITY"])
+def test_desktop_macos_fixup_never_clobbers_publisher_signing(
+    monkeypatch, tmp_path, key
+):
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+    monkeypatch.setenv(key, "publisher-signing-configured")
+    with patch("hermes_cli.main._desktop_packaged_executable") as mock_executable, \
+         patch("hermes_cli.main.subprocess.run") as mock_run:
+        cli_main._desktop_macos_relaunchable_fixup(tmp_path)
+    mock_executable.assert_not_called()
+    mock_run.assert_not_called()
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="requires macOS codesign")
+def test_desktop_macos_stable_signing_real_config_and_codesign(monkeypatch, tmp_path):
+    identity = os.environ.get("HERMES_TEST_CODESIGN_IDENTITY")
+    if not identity:
+        pytest.skip("set HERMES_TEST_CODESIGN_IDENTITY to run the real signing test")
+    assert identity is not None
+
+    hermes_home = tmp_path / "hermes-home"
+    desktop_dir = tmp_path / "desktop"
+    app = desktop_dir / "release" / "mac-arm64" / "Hermes.app"
+    executable = app / "Contents" / "MacOS" / "Hermes"
+    executable.parent.mkdir(parents=True)
+    source = tmp_path / "main.c"
+    clang = Path("/usr/bin/clang")
+    if not clang.exists():
+        pytest.skip("requires clang to build a disposable Mach-O executable")
+    with (app / "Contents" / "Info.plist").open("wb") as handle:
+        plistlib.dump(
+            {
+                "CFBundleIdentifier": "com.nousresearch.hermes.integration-test",
+                "CFBundleExecutable": "Hermes",
+            },
+            handle,
+        )
+    entitlements = tmp_path / "entitlements.plist"
+    with entitlements.open("wb") as handle:
+        plistlib.dump({"com.apple.security.cs.allow-jit": True}, handle)
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("CSC_LINK", raising=False)
+    monkeypatch.delenv("APPLE_SIGNING_IDENTITY", raising=False)
+    repo_root = Path(__file__).resolve().parents[2]
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "hermes_cli.main",
+            "config",
+            "set",
+            "desktop.macos_signing_identity",
+            identity,
+        ],
+        cwd=repo_root,
+        env={**os.environ, "HERMES_HOME": str(hermes_home)},
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    requirements = []
+    for return_code in (0, 1):
+        source.write_text(f"int main(void) {{ return {return_code}; }}\n")
+        subprocess.run(
+            [str(clang), str(source), "-o", str(executable)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(
+            [
+                "/usr/bin/codesign",
+                "--force",
+                "--sign",
+                "-",
+                "--options",
+                "runtime",
+                "--entitlements",
+                str(entitlements),
+                str(app),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        cli_main._desktop_macos_relaunchable_fixup(desktop_dir)
+        subprocess.run(
+            ["/usr/bin/codesign", "--verify", "--deep", "--strict", str(app)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        requirement_result = subprocess.run(
+            ["/usr/bin/codesign", "-dr", "-", str(app)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        requirement = requirement_result.stdout + requirement_result.stderr
+        entitlements_result = subprocess.run(
+            ["/usr/bin/codesign", "-d", "--entitlements", ":-", str(app)],
+            check=True,
+            capture_output=True,
+        )
+        entitlements_output = entitlements_result.stdout + entitlements_result.stderr
+        assert b"com.apple.security.cs.allow-jit" in entitlements_output
+        requirements.append(requirement)
+
+    assert requirements[0] == requirements[1]
+    assert "certificate root" in requirements[0]
 
 
 # --- desktop.* launch options (config.yaml) -------------------------------

--- a/tests/test_install_sh_macos_signing_fallback.py
+++ b/tests/test_install_sh_macos_signing_fallback.py
@@ -1,0 +1,80 @@
+"""Regression coverage for the macOS desktop signing fallback in install.sh."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _extract_macos_signing_block() -> str:
+    text = INSTALL_SH.read_text()
+    match = re.search(
+        r'    # macOS: use the same config-aware signing fixup.*?^    fi\n',
+        text,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert match is not None, "macOS signing block not found"
+    return match.group(0)
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content)
+    path.chmod(0o755)
+
+
+def test_executable_python_failure_runs_historical_signing_fallback(tmp_path: Path) -> None:
+    install_dir = tmp_path / "hermes-agent"
+    python = install_dir / "venv" / "bin" / "python"
+    python.parent.mkdir(parents=True)
+    _write_executable(python, "#!/bin/sh\nexit 42\n")
+
+    desktop_dir = install_dir / "apps" / "desktop"
+    app = desktop_dir / "release" / "mac-arm64" / "Hermes.app"
+    app.mkdir(parents=True)
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    calls = tmp_path / "calls.log"
+    for command in ("xattr", "codesign"):
+        _write_executable(
+            fake_bin / command,
+            f'#!/bin/sh\nprintf "%s\\n" "{command} $*" >> "$CALLS"\n',
+        )
+
+    script = f"""
+set -e
+log_warn() {{ printf 'WARN: %s\\n' "$*"; }}
+run_signing_block() {{
+{_extract_macos_signing_block()}
+}}
+run_signing_block
+"""
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:/usr/bin:/bin",
+        "CALLS": str(calls),
+        "OS": "macos",
+        "INSTALL_DIR": str(install_dir),
+        "HERMES_HOME": str(tmp_path / "home"),
+        "desktop_dir": str(desktop_dir),
+        "app": str(app),
+    }
+    result = subprocess.run(
+        ["bash", "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "config-aware macos signing fixup failed" in result.stdout.lower()
+    assert calls.read_text().splitlines() == [
+        f"xattr -cr {app}",
+        f"codesign --force --deep --sign - {app}",
+    ]

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -261,6 +261,41 @@ rm -f "$HOME/Library/Caches/electron"/electron-*.zip   # macOS
 rm -f "$HOME/.cache/electron"/electron-*.zip            # Linux
 ```
 
+### Keep macOS privacy permissions across local rebuilds
+
+Hermes normally ad-hoc signs a locally rebuilt desktop app. That is enough to
+launch it, but the signature's Designated Requirement changes whenever the app
+changes. macOS may therefore ask you to grant Full Disk Access, Accessibility,
+or other TCC permissions again after an update.
+
+To keep those grants stable, create a persistent **Code Signing** identity in
+your login keychain (Keychain Access → Certificate Assistant → Create a
+Certificate), then opt Hermes into that identity:
+
+```bash
+# Copy the 40-character fingerprint from this command:
+security find-identity -v -p codesigning
+hermes config set desktop.macos_signing_identity FC28EA62B943BB9653345007C2219287DCB912AC
+hermes desktop --force-build
+```
+
+Use the certificate fingerprint rather than its display name so another
+certificate with the same name cannot be selected accidentally. Hermes
+preserves electron-builder's entitlements and runtime flags while re-signing
+each local rebuild with that certificate. You should then grant the rebuilt
+Hermes app the desired privacy permissions one final time.
+
+Keep the certificate and its private key in the keychain: deleting or replacing
+them changes the app's identity and invalidates existing grants. Anyone who can
+use that private key can also sign a `com.nousresearch.hermes` build that macOS
+may recognize as the same Full Disk Access identity. Use a dedicated local
+certificate, do not export or share its private key, and keep this feature
+opt-in.
+
+Official release builds configured with `CSC_LINK` or
+`APPLE_SIGNING_IDENTITY` retain publisher signing and ignore this local
+setting.
+
 ## Building from source
 
 If you want to hack on the app itself, install workspace deps from the repo root once, then run the dev server from `apps/desktop`:


### PR DESCRIPTION
## Problem

Hermes Desktop rebuilds its local macOS Electron bundle during updates. Ad-hoc signing gives each rebuild a new cdhash-based Designated Requirement, so macOS can treat it as a different app and invalidate Full Disk Access and other TCC grants.

## Fix

- add opt-in `desktop.macos_signing_identity` config
- re-sign local desktop rebuilds with that persistent keychain identity
- preserve electron-builder entitlements and runtime flags
- keep publisher signing (`CSC_LINK` / `APPLE_SIGNING_IDENTITY`) untouched
- retain ad-hoc signing as the default fallback
- route both CLI rebuilds and install/repair through the same signing implementation
- warn instead of silently masking config-load failures
- document one-time macOS setup

## Verification

- `HERMES_TEST_CODESIGN_IDENTITY="Hermes Local Code Signing" uv run pytest tests/hermes_cli/test_gui_command.py -o "addopts=" -q` — 72 passed
- `uv run pytest tests/test_install*.py -o "addopts=" -q` — 62 passed
- `uv run ruff check hermes_cli/main.py tests/hermes_cli/test_gui_command.py`
- `bash -n scripts/install.sh`
- real macOS integration test writes the setting through `hermes config set` into a temporary `HERMES_HOME`, compiles two different Mach-O app builds, signs both through the production fixup, verifies stable certificate-based Designated Requirements, checks strict signature validity, and confirms entitlements survive