### PR TITLE
fix(export): escape remaining role sinks + nonce-based CSP in HTML session export

### DIFF
--- a/hermes_cli/session_export_html.py
+++ b/hermes_cli/session_export_html.py
@@ -8,7 +8,9 @@ Enhanced with UI-UX-PRO-MAX design intelligence.
 
 import json
 import datetime
+import secrets
 from typing import Any, Dict, List
+from urllib.parse import quote
 
 # --- Icons (Lucide-style SVGs) ---
 ICON_USER = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-user"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>'
@@ -26,6 +28,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'nonce-{script_nonce}'; style-src 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src data:; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; object-src 'none'">
     <title>{page_title}</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -566,13 +569,13 @@ HTML_TEMPLATE = """<!DOCTYPE html>
         </div>
     </div>
 
-    <script>
+    <script nonce="{script_nonce}">
         // Session Switching
         function showSession(id) {{
             // Update Sidebar
-            document.querySelectorAll('.session-item').forEach(el => el.classList.remove('active'));
-            const activeItem = document.querySelector(`.session-item[data-id="${{id}}"]`);
-            if (activeItem) activeItem.classList.add('active');
+            document.querySelectorAll('.session-item').forEach(el => {{
+                el.classList.toggle('active', el.dataset.id === id);
+            }});
 
             // Update View
             document.querySelectorAll('.session-view').forEach(el => {{
@@ -582,8 +585,15 @@ HTML_TEMPLATE = """<!DOCTYPE html>
             if (activeView) activeView.classList.add('active');
 
             // Store in URL hash
-            window.location.hash = id;
+            window.location.hash = encodeURIComponent(id);
         }}
+
+        document.querySelectorAll('.session-item').forEach(item => {{
+            item.addEventListener('click', (e) => {{
+                e.preventDefault();
+                showSession(item.dataset.id || '');
+            }});
+        }});
 
         // Search Filter
         const searchInput = document.getElementById('session-search');
@@ -611,7 +621,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
 
         // Initialization
         window.addEventListener('load', () => {{
-            const hash = window.location.hash.slice(1);
+            const hash = decodeURIComponent(window.location.hash.slice(1));
             if (hash) {{
                 showSession(hash);
             }} else {{
@@ -761,16 +771,17 @@ def generate_multi_session_html_export(sessions: List[Dict[str, Any]]) -> str:
     if is_multi:
         sidebar_items = []
         for s in sessions:
-            sid = s.get("id", "N/A")
+            sid = str(s.get("id", "N/A"))
+            escaped_sid = _escape_html(sid)
             title = s.get("title") or s.get("preview") or "Untitled Session"
             if len(title) > 50: title = title[:47] + "..."
             date = _format_timestamp(s.get("started_at", 0)).split(" ")[0]
             
             item = f'''
-            <a class="session-item" data-id="{sid}" onclick="showSession('{sid}')">
+            <a class="session-item" data-id="{escaped_sid}" href="#{quote(sid, safe='')}">
                 <div class="session-item-title">{_escape_html(title)}</div>
                 <div class="session-item-meta">
-                    <span>{sid[:8]}</span>
+                    <span>{_escape_html(sid[:8])}</span>
                     <span>{date}</span>
                 </div>
             </a>
@@ -797,7 +808,8 @@ def generate_multi_session_html_export(sessions: List[Dict[str, Any]]) -> str:
     # Main Content
     sessions_html_list = []
     for s in sessions:
-        sid = s.get("id", "N/A")
+        sid = str(s.get("id", "N/A"))
+        escaped_sid = _escape_html(sid)
         title = s.get("title") or "Hermes Session"
         model = s.get("model", "Unknown")
         started_at = _format_timestamp(s.get("started_at", 0))
@@ -808,7 +820,7 @@ def generate_multi_session_html_export(sessions: List[Dict[str, Any]]) -> str:
         view_class = "session-view"
         if not is_multi: view_class += " active"
         
-        session_view_id = f"view-{sid}"
+        session_view_id = f"view-{escaped_sid}"
         
         system_prompt = s.get("system_prompt")
         system_html = ""
@@ -830,7 +842,7 @@ def generate_multi_session_html_export(sessions: List[Dict[str, Any]]) -> str:
             <header class="fade-in">
                 <h1>{_escape_html(title)}</h1>
                 <div class="meta">
-                    <div class="meta-item"><strong>ID:</strong> {sid}</div>
+                    <div class="meta-item"><strong>ID:</strong> {escaped_sid}</div>
                     <div class="meta-item"><strong>Model:</strong> {_escape_html(model)}</div>
                     <div class="meta-item"><strong>Started:</strong> {started_at}</div>
                 </div>
@@ -843,13 +855,15 @@ def generate_multi_session_html_export(sessions: List[Dict[str, Any]]) -> str:
         '''
         sessions_html_list.append(session_html)
 
+    script_nonce = secrets.token_urlsafe(16)
     return HTML_TEMPLATE.format(
         page_title="Hermes Session Export" if is_multi else _escape_html(sessions[0].get("title", "Hermes Session")),
         sidebar_html=sidebar_html,
         sessions_html="\n".join(sessions_html_list),
         main_margin="var(--sidebar-width)" if is_multi else "0",
         layout_class="layout-multi" if is_multi else "layout-single",
-        generated_at=generated_at
+        generated_at=generated_at,
+        script_nonce=script_nonce,
     )
 
 def generate_html_export(session_data: Dict[str, Any]) -> str:

--- a/hermes_cli/session_export_html.py
+++ b/hermes_cli/session_export_html.py
@@ -682,8 +682,16 @@ def _generate_messages_html(messages: List[Dict[str, Any]]) -> str:
                     content_parts.append(str(part))
             content = "\n".join(content_parts)
 
-        # Build message HTML
-        msg_class = f"message message-{role} active"
+        # Build message HTML. The role feeds two sinks and for tool/MCP messages
+        # is externally influenced, so treat each sink on its own terms:
+        #  - display text: HTML-escape (prevents markup/JS injection).
+        #  - class attribute: reduce to a single safe CSS token (alnum/-/_),
+        #    so a crafted role can neither break out of the attribute nor split
+        #    into several unintended classes. Real roles (user/assistant/system/
+        #    tool) are unchanged, so the `.message-<role>` rules still match.
+        safe_role = _escape_html(role)
+        role_class = "".join(c if c.isalnum() or c in "-_" else "-" for c in str(role).lower())
+        msg_class = f"message message-{role_class} active"
         # Delay animation for initial items
         delay_style = f' style="animation-delay: {min(i * 0.05, 1.0)}s"' if i < 10 else ""
         
@@ -691,7 +699,7 @@ def _generate_messages_html(messages: List[Dict[str, Any]]) -> str:
         
         html = f'<div class="{msg_class}"{delay_style}>'
         html += f'  <div class="message-header">'
-        html += f'    <div class="role-badge">{chevron_html} {role_icon} {role}</div>'
+        html += f'    <div class="role-badge">{chevron_html} {role_icon} {safe_role}</div>'
         html += f'    <div class="timestamp">{timestamp}</div>'
         html += '  </div>'
         html += '  <div class="message-body">'

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -260,6 +260,7 @@ AUTHOR_MAP = {
     "bassisho@Mac-mini-bassis.local": "hydracoco7",  # PR #61382 salvage (id-less cron job freeze)
     "AlexFucuson9@users.noreply.github.com": "AlexFucuson9",  # PR #61209 salvage (hygiene compression data loss)
     "email@adambig.gs": "adambiggs",  # PR #43819 salvage (holographic shared SQLite connection)
+    "koho.jung@outlook.com": "kohoj",  # PR #61667 salvage (nonce-CSP HTML session export)
     "t.chen@aftership.com": "cypctlinux",  # PR #52403 salvage (Slack bot/workflow auth before no-user-id guard)
     "30854794+YLChen-007@users.noreply.github.com": "YLChen-007",  # PR #26965 (approval remote command substitution)
     "1078345+egilewski@users.noreply.github.com": "egilewski",  # co-author, PR #40663

--- a/tests/hermes_cli/test_session_export.py
+++ b/tests/hermes_cli/test_session_export.py
@@ -2,6 +2,10 @@ import json
 import sys
 
 from hermes_cli.session_export import export_record_count, render_sessions_export
+from hermes_cli.session_export_html import (
+    _generate_messages_html,
+    generate_multi_session_html_export,
+)
 
 
 def _sample_session():
@@ -111,6 +115,42 @@ def test_full_markdown_renderer_collapses_tool_output_and_filters_system():
     assert "<details><summary>read_file</summary>" in rendered
     assert "```text\ndef redirect_after_login(): pass\n```" in rendered
     assert "hidden system context" not in rendered
+
+
+def test_html_export_escapes_tool_call_names():
+    payload = '<img src=x onerror="alert(document.domain)">'
+
+    rendered = _generate_messages_html(
+        [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": payload, "arguments": "<b>x</b>"},
+                    }
+                ],
+            }
+        ]
+    )
+
+    assert payload not in rendered
+    assert '&lt;img src=x onerror=&quot;alert(document.domain)&quot;&gt;' in rendered
+    assert "&lt;b&gt;x&lt;/b&gt;" in rendered
+
+
+def test_html_export_uses_csp_without_inline_event_handlers():
+    first = _sample_session()
+    second = {**_sample_session(), "id": "sess-456", "title": "Second session"}
+
+    rendered = generate_multi_session_html_export([first, second])
+
+    assert "Content-Security-Policy" in rendered
+    assert "script-src 'nonce-" in rendered
+    assert "<script nonce=" in rendered
+    assert "onclick=" not in rendered
 
 
 def test_export_record_count_switches_unit_for_prompt_only_exports():

--- a/tests/hermes_cli/test_session_export_html_escape.py
+++ b/tests/hermes_cli/test_session_export_html_escape.py
@@ -1,0 +1,56 @@
+import re
+
+from hermes_cli.session_export_html import _generate_messages_html
+
+
+def test_tool_call_name_is_escaped_in_html_export():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "timestamp": 1700000000,
+            "tool_calls": [
+                {
+                    "function": {
+                        "name": "<script>alert(1)</script>",
+                        "arguments": "{}",
+                    }
+                }
+            ],
+        }
+    ]
+
+    html = _generate_messages_html(messages)
+
+    # Raw, executable markup must never reach the standalone artifact.
+    assert "<script>alert(1)</script>" not in html
+    # The escaped form must be present instead.
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+
+
+def test_role_is_escaped_in_html_export():
+    messages = [
+        {
+            "role": "<img src=x onerror=alert(document.domain)>",
+            "content": "hello",
+            "timestamp": 1700000000,
+        }
+    ]
+
+    html = _generate_messages_html(messages)
+
+    assert "<img src=x onerror=alert(document.domain)>" not in html
+    assert "&lt;img src=x onerror=alert(document.domain)&gt;" in html
+    # The class attribute must remain a single, well-formed token: a crafted
+    # role must not break out of it nor split into several unintended classes.
+    class_value = re.search(r'class="(message message-[^"]*active)"', html)
+    assert class_value is not None
+    assert " message-" in class_value.group(1)  # exactly one message-<role> class
+    assert class_value.group(1).count("message-") == 1
+
+
+def test_known_role_keeps_its_css_class():
+    html = _generate_messages_html(
+        [{"role": "assistant", "content": "hi", "timestamp": 1700000000}]
+    )
+    assert 'class="message message-assistant active"' in html


### PR DESCRIPTION
## Summary
Completes the HTML session-export hardening that #61345 started: the two remaining externally-influenced sinks (role badge, message CSS class) are now escaped/sanitized, and the export ships a nonce-based Content-Security-Policy so any markup that slips a future sink is inert.

Consolidates two contributor PRs (cherry-picked, authorship preserved):
- #61348 by @briandevans (submitted BEFORE the merged #61345 — earliest fn_name fix; the surviving remainder here is role escaping + CSS-token sanitization, plus his test file)
- #61667 by @kohoj — per-export random nonce CSP (`default-src 'none'`, `script-src 'nonce-…'`, `base-uri/object-src/frame-ancestors 'none'`) with the multi-session switcher refactored onto the nonce (dataset toggle), avoiding the blanket-CSP breakage that #61345 had to revert

## Changes
- `hermes_cli/session_export_html.py`: role escaped in badge, role reduced to a single safe CSS token for the class attribute; nonce CSP meta + nonce'd inline script
- `tests/hermes_cli/test_session_export_html_escape.py` (new) + additions to `test_session_export.py`
- `scripts/release.py`: AUTHOR_MAP for kohoj

## Validation
| | Before | After |
|---|---|---|
| Hostile role (`<img onerror=…>`) | executes on export open | escaped, inert |
| Injected markup via any future sink | executes | blocked by CSP (nonce-only script) |
| Export tests | — | 23/23 green across all 4 export test files |
| E2E | — | hostile role + tool name inert; nonce consistent single+multi; switcher works |

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa1a19f/e9V_1RspyS4AuXlYonWi__kBoNuhiq.png)
