### PR TITLE
fix(reasoning): project max to provider capabilities

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -21,7 +21,7 @@ import subprocess
 from pathlib import Path
 from urllib.parse import urlparse
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, project_reasoning_effort
 from typing import Any, Dict, List, Optional, Tuple
 from utils import base_url_host_matches, normalize_proxy_env_vars
 
@@ -2641,7 +2641,6 @@ def build_anthropic_kwargs(
     if reasoning_config and isinstance(reasoning_config, dict) and not _is_kimi_coding:
         if reasoning_config.get("enabled") is not False and "haiku" not in model.lower():
             effort = str(reasoning_config.get("effort", "medium")).lower()
-            budget = THINKING_BUDGET.get(effort, 8000)
             if _supports_adaptive_thinking(model):
                 kwargs["thinking"] = {
                     "type": "adaptive",
@@ -2656,6 +2655,8 @@ def build_anthropic_kwargs(
                     "effort": adaptive_effort,
                 }
             else:
+                budget_effort = project_reasoning_effort(effort, THINKING_BUDGET)
+                budget = THINKING_BUDGET.get(budget_effort or "medium", 8000)
                 kwargs["thinking"] = {"type": "enabled", "budget_tokens": budget}
                 # Anthropic requires temperature=1 when thinking is enabled on older models
                 kwargs["temperature"] = 1

--- a/agent/lmstudio_reasoning.py
+++ b/agent/lmstudio_reasoning.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 from typing import List, Optional
 
+from hermes_constants import project_reasoning_effort
+
 # LM Studio accepts these top-level reasoning_effort values via its
 # OpenAI-compatible chat.completions endpoint.
 _LM_VALID_EFFORTS = {"none", "minimal", "low", "medium", "high", "xhigh"}
@@ -27,10 +29,10 @@ def resolve_lmstudio_effort(
 ) -> Optional[str]:
     """Return the ``reasoning_effort`` string to send to LM Studio, or ``None``.
 
-    ``None`` means "omit the field": the user picked a level the model can't
-    honor, so let LM Studio fall back to the model's declared default rather
-    than silently substituting a different effort. When ``allowed_options`` is
-    falsy (probe failed), skip clamping and send the resolved effort anyway.
+    When options are advertised, ``max`` projects to the strongest lower
+    supported tier. Other unsupported efforts retain the existing omission
+    behavior. When ``allowed_options`` is falsy (probe failed), preserve the
+    legacy fallback instead of sending an unverified ``max`` value.
     """
     effort = "medium"
     if reasoning_config and isinstance(reasoning_config, dict):
@@ -39,10 +41,18 @@ def resolve_lmstudio_effort(
         else:
             raw = (reasoning_config.get("effort") or "").strip().lower()
             raw = _LM_EFFORT_ALIASES.get(raw, raw)
-            if raw in _LM_VALID_EFFORTS:
+            if raw == "max" or raw in _LM_VALID_EFFORTS:
                 effort = raw
     if allowed_options:
-        allowed = {_LM_EFFORT_ALIASES.get(opt, opt) for opt in allowed_options}
-        if effort not in allowed:
-            return None
-    return effort
+        allowed = set()
+        for option in allowed_options:
+            normalized_option = str(option).strip().lower()
+            allowed.add(_LM_EFFORT_ALIASES.get(normalized_option, normalized_option))
+        if effort == "none":
+            return effort if effort in allowed else None
+        if effort in allowed:
+            return effort
+        if effort == "max":
+            return project_reasoning_effort(effort, allowed)
+        return None
+    return "medium" if effort == "max" else effort

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -16,6 +16,7 @@ from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
+from hermes_constants import project_reasoning_effort
 
 
 def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> dict | None:
@@ -52,24 +53,28 @@ def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> 
     if normalized_model.startswith("gemini-2.5-"):
         return thinking_config
 
-    if effort not in {"minimal", "low", "medium", "high", "xhigh"}:
-        effort = "medium"
-
     # Gemini 3 Flash documents low/medium/high thinking levels; Gemini 3 Pro
-    # is stricter (low/high). Clamp Hermes' wider effort set to what each
+    # is stricter (low/high). Project Hermes' wider effort set to what each
     # family accepts so we never forward an undocumented level verbatim.
     if normalized_model.startswith(("gemini-3", "gemini-3.1")):
         if "flash" in normalized_model:
-            if effort in {"minimal", "low"}:
-                thinking_config["thinkingLevel"] = "low"
-            elif effort in {"high", "xhigh"}:
-                thinking_config["thinkingLevel"] = "high"
-            else:
-                thinking_config["thinkingLevel"] = "medium"
+            supported_efforts = ("low", "medium", "high")
         elif "pro" in normalized_model:
-            thinking_config["thinkingLevel"] = (
-                "high" if effort in {"high", "xhigh"} else "low"
+            supported_efforts = ("low", "high")
+        else:
+            supported_efforts = ()
+
+        if supported_efforts:
+            projected_effort = (
+                "low"
+                if effort == "minimal"
+                else project_reasoning_effort(effort, supported_efforts)
             )
+            if projected_effort is None:
+                projected_effort = project_reasoning_effort(
+                    "medium", supported_efforts
+                )
+            thinking_config["thinkingLevel"] = projected_effort
 
     return thinking_config
 
@@ -371,6 +376,7 @@ class ChatCompletionsTransport(ProviderTransport):
             api_kwargs["max_tokens"] = anthropic_max_out
 
         # Kimi: top-level reasoning_effort (unless thinking disabled)
+        _kimi_projected_max = False
         if is_kimi:
             _kimi_thinking_off = bool(
                 reasoning_config
@@ -381,7 +387,14 @@ class ChatCompletionsTransport(ProviderTransport):
                 _kimi_effort = "medium"
                 if reasoning_config and isinstance(reasoning_config, dict):
                     _e = (reasoning_config.get("effort") or "").strip().lower()
-                    if _e in {"low", "medium", "high"}:
+                    if _e == "max":
+                        _projected_effort = project_reasoning_effort(
+                            _e, ("low", "medium", "high")
+                        )
+                        if _projected_effort is not None:
+                            _kimi_effort = _projected_effort
+                            _kimi_projected_max = True
+                    elif _e in {"low", "medium", "high"}:
                         _kimi_effort = _e
                 api_kwargs["reasoning_effort"] = _kimi_effort
 
@@ -441,7 +454,7 @@ class ChatCompletionsTransport(ProviderTransport):
                     ]
 
         # Kimi extra_body.thinking
-        if is_kimi:
+        if is_kimi and not _kimi_projected_max:
             _kimi_thinking_enabled = True
             if reasoning_config and isinstance(reasoning_config, dict):
                 if reasoning_config.get("enabled") is False:

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -9,6 +9,7 @@ import shutil
 import stat
 import sys
 import sysconfig
+from collections.abc import Iterable
 from contextvars import ContextVar, Token
 from pathlib import Path
 
@@ -792,6 +793,33 @@ def apply_subprocess_home_env(env: dict[str, str]) -> None:
 
 
 VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh", "max")
+_REASONING_EFFORT_RANK = {
+    effort: rank for rank, effort in enumerate(VALID_REASONING_EFFORTS)
+}
+
+
+def project_reasoning_effort(
+    requested_effort: object,
+    supported_efforts: Iterable[str] | None,
+) -> str | None:
+    """Project a requested effort to the strongest supported lower tier."""
+    requested = str(requested_effort or "").strip().lower()
+    requested_rank = _REASONING_EFFORT_RANK.get(requested)
+    if requested_rank is None or supported_efforts is None:
+        return None
+
+    best_effort = None
+    best_rank = -1
+    for supported_effort in supported_efforts:
+        normalized = str(supported_effort or "").strip().lower()
+        supported_rank = _REASONING_EFFORT_RANK.get(normalized)
+        if (
+            supported_rank is not None
+            and best_rank < supported_rank <= requested_rank
+        ):
+            best_effort = normalized
+            best_rank = supported_rank
+    return best_effort
 
 
 def parse_reasoning_effort(effort) -> dict | None:

--- a/plugins/model-providers/copilot/__init__.py
+++ b/plugins/model-providers/copilot/__init__.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from providers import register_provider
 from providers.base import ProviderProfile
+from hermes_constants import project_reasoning_effort
 
 
 class CopilotProfile(ProviderProfile):
@@ -34,11 +35,16 @@ class CopilotProfile(ProviderProfile):
 
                 supported_efforts = github_model_reasoning_efforts(model)
                 if supported_efforts and reasoning_config:
-                    effort = reasoning_config.get("effort", "medium")
-                    # Normalize non-standard effort levels to the nearest supported
-                    if effort == "xhigh":
+                    requested_effort = reasoning_config.get("effort", "medium")
+                    if requested_effort == "max":
+                        effort = project_reasoning_effort(
+                            requested_effort, supported_efforts
+                        )
+                    elif requested_effort == "xhigh":
                         effort = "high"
-                    if effort in supported_efforts:
+                    else:
+                        effort = requested_effort
+                    if effort is not None and effort in supported_efforts:
                         extra_body["reasoning"] = {"effort": effort}
                 elif supported_efforts:
                     extra_body["reasoning"] = {"effort": "medium"}

--- a/plugins/model-providers/kimi-coding/__init__.py
+++ b/plugins/model-providers/kimi-coding/__init__.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from providers import register_provider
 from providers.base import OMIT_TEMPERATURE, ProviderProfile
+from hermes_constants import project_reasoning_effort
 
 
 class KimiProfile(ProviderProfile):
@@ -46,7 +47,13 @@ class KimiProfile(ProviderProfile):
         # Enabled: prefer an explicit effort; only fall back to extra_body
         # thinking when no recognized effort is requested.
         effort = (reasoning_config.get("effort") or "").strip().lower()
-        if effort in {"low", "medium", "high"}:
+        if effort == "max":
+            projected_effort = project_reasoning_effort(
+                effort, ("low", "medium", "high")
+            )
+            if projected_effort is not None:
+                top_level["reasoning_effort"] = projected_effort
+        elif effort in {"low", "medium", "high"}:
             top_level["reasoning_effort"] = effort
         else:
             extra_body["thinking"] = {"type": "enabled"}

--- a/plugins/model-providers/kimi-coding/__init__.py
+++ b/plugins/model-providers/kimi-coding/__init__.py
@@ -18,7 +18,11 @@ class KimiProfile(ProviderProfile):
     """Kimi/Moonshot — temperature omitted, thinking xor reasoning_effort."""
 
     def build_api_kwargs_extras(
-        self, *, reasoning_config: dict | None = None, **context
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        model: str | None = None,
+        **context,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         """Kimi reasoning controls.
 
@@ -47,7 +51,9 @@ class KimiProfile(ProviderProfile):
         # Enabled: prefer an explicit effort; only fall back to extra_body
         # thinking when no recognized effort is requested.
         effort = (reasoning_config.get("effort") or "").strip().lower()
-        if effort == "max":
+        # Project Hermes' global ceiling only while shaping a concrete request.
+        # Context-free profile probes retain the conservative unsupported fallback.
+        if effort == "max" and model:
             projected_effort = project_reasoning_effort(
                 effort, ("low", "medium", "high")
             )

--- a/run_agent.py
+++ b/run_agent.py
@@ -62,7 +62,7 @@ from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, project_reasoning_effort
 
 
 def _launch_cwd_for_session(source: str) -> Optional[str]:
@@ -5438,6 +5438,13 @@ class AIAgent:
             ).strip().lower()
         else:
             requested_effort = "medium"
+
+        if requested_effort == "max":
+            projected_effort = project_reasoning_effort(
+                requested_effort, supported_efforts
+            )
+            if projected_effort is not None:
+                return {"effort": projected_effort}
 
         if requested_effort == "xhigh" and "high" in supported_efforts:
             requested_effort = "high"

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1402,6 +1402,19 @@ class TestBuildAnthropicKwargs:
         assert kwargs["max_tokens"] >= 16000 + 4096
         assert "output_config" not in kwargs
 
+    def test_manual_thinking_max_uses_strongest_budget(self):
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-20250514",
+            messages=[{"role": "user", "content": "think hardest"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "max"},
+        )
+
+        assert kwargs["thinking"] == {"type": "enabled", "budget_tokens": 32000}
+        assert kwargs["max_tokens"] >= 32000 + 4096
+        assert "output_config" not in kwargs
+
     def test_reasoning_config_maps_to_adaptive_thinking_for_4_6_models(self):
         kwargs = build_anthropic_kwargs(
             model="claude-opus-4-6",

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -5,12 +5,33 @@ from types import SimpleNamespace
 
 from agent.transports import get_transport
 from agent.transports.types import NormalizedResponse
+from hermes_constants import VALID_REASONING_EFFORTS, project_reasoning_effort
 
 
 @pytest.fixture
 def transport():
     import agent.transports.chat_completions  # noqa: F401
     return get_transport("chat_completions")
+
+
+class TestReasoningEffortProjection:
+    def test_preserves_each_exact_supported_effort(self):
+        for effort in VALID_REASONING_EFFORTS:
+            assert project_reasoning_effort(effort, VALID_REASONING_EFFORTS) == effort
+
+    @pytest.mark.parametrize(
+        "requested, supported, expected",
+        [
+            ("max", ["low", "medium", "high", "xhigh"], "xhigh"),
+            ("max", ["low", "medium", "high"], "high"),
+            ("xhigh", ["low", "medium", "high"], "high"),
+            ("medium", ["high"], None),
+        ],
+    )
+    def test_selects_nearest_supported_effort_not_above_request(
+        self, requested, supported, expected
+    ):
+        assert project_reasoning_effort(requested, supported) == expected
 
 
 class TestChatCompletionsBasic:
@@ -362,6 +383,34 @@ class TestChatCompletionsBuildKwargs:
         # Nous rejects enabled=false; reasoning omitted entirely
         assert "reasoning" not in kw.get("extra_body", {})
 
+    @pytest.mark.parametrize(
+        "supported_efforts, expected",
+        [
+            (["low", "medium", "high"], "high"),
+            (["low", "medium", "high", "xhigh"], "xhigh"),
+        ],
+    )
+    def test_copilot_profile_max_projects_to_strongest_lower(
+        self, transport, monkeypatch, supported_efforts, expected
+    ):
+        from hermes_cli import models
+        from providers import get_provider_profile
+
+        monkeypatch.setattr(
+            models,
+            "github_model_reasoning_efforts",
+            lambda _model: supported_efforts,
+        )
+        kw = transport.build_kwargs(
+            model="gpt-test",
+            messages=[{"role": "user", "content": "Hi"}],
+            supports_reasoning=True,
+            reasoning_config={"enabled": True, "effort": "max"},
+            provider_profile=get_provider_profile("copilot"),
+        )
+
+        assert kw["extra_body"]["reasoning"] == {"effort": expected}
+
     def test_ollama_num_ctx(self, transport):
         from providers import get_provider_profile
         profile = get_provider_profile("custom")
@@ -409,6 +458,32 @@ class TestChatCompletionsBuildKwargs:
             "includeThoughts": True,
             "thinkingLevel": "high",
         }
+
+    @pytest.mark.parametrize(
+        "model",
+        ["gemini-3.1-pro-preview", "gemini-3-flash-preview"],
+    )
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "https://generativelanguage.googleapis.com/v1beta",
+            "https://generativelanguage.googleapis.com/v1beta/openai",
+        ],
+    )
+    def test_gemini_max_projects_to_high(self, transport, model, base_url):
+        kw = transport.build_kwargs(
+            model=model,
+            messages=[{"role": "user", "content": "Hi"}],
+            provider_name="gemini",
+            base_url=base_url,
+            reasoning_config={"enabled": True, "effort": "max"},
+        )
+
+        if base_url.endswith("/openai"):
+            thinking_config = kw["extra_body"]["extra_body"]["google"]["thinking_config"]
+            assert thinking_config["thinking_level"] == "high"
+        else:
+            assert kw["extra_body"]["thinking_config"]["thinkingLevel"] == "high"
 
     def test_gemini_openai_compat_flash_reasoning_maps_to_nested_google_thinking_config(self, transport):
         msgs = [{"role": "user", "content": "Hi"}]
@@ -643,6 +718,30 @@ class TestChatCompletionsKimi:
         # Kimi requires reasoning_effort as a top-level parameter
         assert kw["reasoning_effort"] == "high"
 
+    def test_kimi_profile_max_projects_to_high(self, transport):
+        from providers import get_provider_profile
+
+        kw = transport.build_kwargs(
+            model="kimi-k2",
+            messages=[{"role": "user", "content": "Hi"}],
+            provider_profile=get_provider_profile("kimi-coding"),
+            reasoning_config={"enabled": True, "effort": "max"},
+        )
+
+        assert kw["reasoning_effort"] == "high"
+        assert "thinking" not in kw.get("extra_body", {})
+
+    def test_kimi_legacy_max_projects_to_high(self, transport):
+        kw = transport.build_kwargs(
+            model="kimi-k2",
+            messages=[{"role": "user", "content": "Hi"}],
+            is_kimi=True,
+            reasoning_config={"enabled": True, "effort": "max"},
+        )
+
+        assert kw["reasoning_effort"] == "high"
+        assert "thinking" not in kw.get("extra_body", {})
+
     def test_kimi_reasoning_effort_omitted_when_thinking_disabled(self, transport):
         kw = transport.build_kwargs(
             model="kimi-k2", messages=[{"role": "user", "content": "Hi"}],
@@ -725,13 +824,57 @@ class TestChatCompletionsKimi:
         assert "type" not in kw["tools"][0]["function"]["parameters"]["properties"]["q"]
 
 
+class TestChatCompletionsTokenHub:
+    def test_max_never_reaches_tokenhub_wire(self, transport):
+        kw = transport.build_kwargs(
+            model="hy3-preview",
+            messages=[{"role": "user", "content": "Hi"}],
+            is_tokenhub=True,
+            reasoning_config={"enabled": True, "effort": "max"},
+        )
+
+        assert kw["reasoning_effort"] == "high"
+        assert kw["reasoning_effort"] != "max"
+
+
 class TestChatCompletionsLmStudioReasoning:
-    """LM Studio publishes per-model reasoning ``allowed_options``. When the
-    user requests an effort the model can't honor (e.g. ``high`` on a
-    toggle-style ``["off","on"]`` model), the transport omits
-    ``reasoning_effort`` so LM Studio falls back to the model's default —
-    silently downgrading "high" to "low" would mislead the user.
-    """
+    """LM Studio clamps against each model's advertised allowed options."""
+
+    @pytest.mark.parametrize(
+        "allowed_options, expected",
+        [
+            (["off", "low", "medium", "high", "max"], "max"),
+            (["off", "low", "medium", "high"], "high"),
+        ],
+    )
+    def test_max_uses_strongest_advertised_effort(
+        self, transport, allowed_options, expected
+    ):
+        kw = transport.build_kwargs(
+            model="gpt-oss",
+            messages=[{"role": "user", "content": "Hi"}],
+            is_lmstudio=True,
+            supports_reasoning=True,
+            reasoning_config={"enabled": True, "effort": "max"},
+            lmstudio_reasoning_options=allowed_options,
+        )
+
+        assert kw["reasoning_effort"] == expected
+
+    @pytest.mark.parametrize("allowed_options", [None, []])
+    def test_max_without_catalog_keeps_legacy_default(
+        self, transport, allowed_options
+    ):
+        kw = transport.build_kwargs(
+            model="gpt-oss",
+            messages=[{"role": "user", "content": "Hi"}],
+            is_lmstudio=True,
+            supports_reasoning=True,
+            reasoning_config={"enabled": True, "effort": "max"},
+            lmstudio_reasoning_options=allowed_options,
+        )
+
+        assert kw["reasoning_effort"] == "medium"
 
     def test_omits_effort_when_high_not_allowed_toggle(self, transport):
         kw = transport.build_kwargs(

--- a/tests/plugins/model_providers/test_kimi_profile.py
+++ b/tests/plugins/model_providers/test_kimi_profile.py
@@ -60,7 +60,7 @@ class TestKimiReasoningWireShape:
         assert extra_body == {"thinking": {"type": "enabled"}}
         assert top_level == {}
 
-    @pytest.mark.parametrize("effort", ["", "garbage", "xhigh"])
+    @pytest.mark.parametrize("effort", ["", "garbage", "xhigh", "max"])
     def test_unrecognized_effort_falls_back_to_thinking(self, kimi_profile, effort):
         """Unknown/strong efforts aren't in Moonshot's low|medium|high set, so
         we drop to the thinking toggle rather than sending an invalid effort."""

--- a/tests/plugins/model_providers/test_kimi_profile.py
+++ b/tests/plugins/model_providers/test_kimi_profile.py
@@ -60,7 +60,7 @@ class TestKimiReasoningWireShape:
         assert extra_body == {"thinking": {"type": "enabled"}}
         assert top_level == {}
 
-    @pytest.mark.parametrize("effort", ["", "garbage", "xhigh", "max"])
+    @pytest.mark.parametrize("effort", ["", "garbage", "xhigh"])
     def test_unrecognized_effort_falls_back_to_thinking(self, kimi_profile, effort):
         """Unknown/strong efforts aren't in Moonshot's low|medium|high set, so
         we drop to the thinking toggle rather than sending an invalid effort."""

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -441,6 +441,31 @@ def test_build_api_kwargs_copilot_responses_omits_openai_only_fields(monkeypatch
     assert "include" not in kwargs
 
 
+@pytest.mark.parametrize(
+    "supported_efforts, expected",
+    [
+        (["low", "medium", "high"], "high"),
+        (["low", "medium", "high", "xhigh"], "xhigh"),
+    ],
+)
+def test_build_api_kwargs_copilot_responses_projects_max_to_strongest_lower(
+    monkeypatch, supported_efforts, expected
+):
+    from hermes_cli import models
+
+    monkeypatch.setattr(
+        models,
+        "github_model_reasoning_efforts",
+        lambda _model: supported_efforts,
+    )
+    agent = _build_copilot_agent(monkeypatch)
+    agent.reasoning_config = {"enabled": True, "effort": "max"}
+
+    kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+
+    assert kwargs["reasoning"] == {"effort": expected}
+
+
 def test_build_api_kwargs_copilot_responses_omits_reasoning_for_non_reasoning_model(monkeypatch):
     agent = _build_copilot_agent(monkeypatch, model="gpt-4.1")
     kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])


### PR DESCRIPTION
## What does this PR do?

Fixes the provider-only projection defects exposed after `max` became a valid Hermes reasoning effort. This is a fresh, narrow rederivation from current `upstream/main` at `a7f65e3bcd937cd095ba599ab5927af2093a0d95`; no commits were cherry-picked from #61648.

The shared helper preserves exact supported efforts and otherwise selects the strongest supported lower tier. At callers with deliberate behavior for older unsupported values, only the newly accepted `max` path uses projection.

## Related Work and Scope

- Narrow successor to only the provider-projection portion of #61648.
- #61638 owns `/reasoning max` command-surface acceptance, help, locales, and docs; none of that surface is duplicated here.
- Related to #61634. This PR does not add `ultra` or the Responses Multi-agent beta.
- TokenHub remains explicit-only (`low|medium|high`); its production path is unchanged and a negative-control test proves literal `max` never reaches its wire payload.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests only
- [ ] Refactor

## Changes Made

- Add one import-safe ordered projection helper beside `VALID_REASONING_EFFORTS`.
- Project Gemini 3 Pro/Flash `max` to `high` for native and OpenAI-compatible payloads.
- Project Anthropic legacy/manual `max` to the existing 32,000-token strongest budget.
- Make LM Studio preserve advertised `max`, select advertised `high` when that is the ceiling, and retain the legacy `medium` fallback when catalog evidence is unavailable.
- Project `max` through both Copilot chat-profile and Responses paths without dropping below advertised `xhigh`.
- Project Kimi profile and legacy `max` to `high` while preserving the effort/thinking XOR wire contract.

### Before / after reproduction

| Path | Current-main before | This branch after |
| --- | --- | --- |
| Gemini 3 Pro | `thinkingLevel: low` | `thinkingLevel: high` |
| Gemini 3 Flash | `thinkingLevel: medium` | `thinkingLevel: high` |
| Anthropic manual | `budget_tokens: 8000`, `max_tokens: 12096` | `budget_tokens: 32000`, `max_tokens: 36096` |
| LM Studio, `max` advertised | `medium` | `max` |
| LM Studio, `high` ceiling | `medium` | `high` |
| Copilot chat profile | reasoning omitted | `reasoning.effort: high` |
| Copilot Responses | `reasoning.effort: medium` | `reasoning.effort: high` |
| Kimi profile | thinking toggle, effort omitted | `reasoning_effort: high`, thinking omitted |
| Kimi legacy | `reasoning_effort: medium` plus thinking | `reasoning_effort: high`, thinking omitted |
| TokenHub | `reasoning_effort: high` | unchanged |

The added regression selection produced `8 failed, 1 passed` on the fresh base; the one pass was the TokenHub negative control.

## Base and Changed Files

Base: `a7f65e3bcd937cd095ba599ab5927af2093a0d95`

```text
agent/anthropic_adapter.py
agent/lmstudio_reasoning.py
agent/transports/chat_completions.py
hermes_constants.py
plugins/model-providers/copilot/__init__.py
plugins/model-providers/kimi-coding/__init__.py
run_agent.py
tests/agent/test_anthropic_adapter.py
tests/agent/transports/test_chat_completions.py
tests/run_agent/test_run_agent_codex_responses.py
```

## How to Test

Owner suites:

```bash
timeout 600 env HERMES_HOME=/tmp/hermes-provider-projection-owner-final \
  $HOME/.hermes/hermes-agent/venv/bin/python -m pytest \
  tests/test_hermes_constants.py \
  tests/agent/test_anthropic_adapter.py \
  tests/agent/transports/test_chat_completions.py \
  tests/run_agent/test_run_agent_codex_responses.py -q
# 448 passed in 20.04s
```

Kimi transport/profile consolidation:

```bash
timeout 600 env HERMES_HOME=/tmp/hermes-provider-projection-kimi-postfix \
  scripts/run_tests.sh \
  tests/agent/transports/test_chat_completions.py \
  tests/plugins/model_providers/test_kimi_profile.py -q
# 121 passed in 2.2s
```

Nearest provider/runtime neighbors:

```bash
timeout 600 env HERMES_HOME=/tmp/hermes-provider-projection-neighbors-final2 \
  $HOME/.hermes/hermes-agent/venv/bin/python -m pytest \
  tests/providers/test_provider_profiles.py \
  tests/providers/test_profile_wiring.py \
  tests/providers/test_transport_parity.py \
  tests/run_agent/test_provider_parity.py \
  tests/run_agent/test_run_agent.py -q
# 606 passed in 90.27s
```

Static proof:

```bash
SOURCE_FILES=(
  hermes_constants.py
  agent/anthropic_adapter.py
  agent/lmstudio_reasoning.py
  agent/transports/chat_completions.py
  plugins/model-providers/copilot/__init__.py
  plugins/model-providers/kimi-coding/__init__.py
  run_agent.py
)
TEST_FILES=(
  tests/agent/test_anthropic_adapter.py
  tests/agent/transports/test_chat_completions.py
  tests/run_agent/test_run_agent_codex_responses.py
)

$HOME/.hermes/hermes-agent/venv/bin/python -m ruff check \
  "${SOURCE_FILES[@]}" "${TEST_FILES[@]}"
# All checks passed

$HOME/.hermes/hermes-agent/venv/bin/python -m py_compile "${SOURCE_FILES[@]}"
git diff --check upstream/main...HEAD
# passed
```

Bounded `ty check` over the seven changed source files reports the same 287 pre-existing diagnostics on base and head, with no count increase. Independent read-only diff review found no blockers after its LM Studio and Kimi findings were corrected.

Platform: Pop!_OS 24.04 LTS, Linux 6.18.7, x86_64.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing PRs and documented the ownership split above
- [x] This PR contains only provider projection and focused regression changes
- [ ] Full `pytest tests/ -q` matrix (not run locally; bounded owner and neighboring suites are above, with GitHub CI handling the full matrix)
- [x] Regression tests cover every changed provider path
- [x] Tested on Pop!_OS 24.04 LTS, Linux 6.18.7, x86_64

### Documentation and Housekeeping

- [x] User documentation: N/A; no user-facing command or configuration surface changed
- [x] `cli-config.yaml.example`: N/A; no config key changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no workflow or architecture contract changed
- [x] Cross-platform impact considered; the change is pure request shaping
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

N/A. The behavior is provider request shaping and is covered by payload assertions and the before/after reproductions above.
