### PR TITLE
feat(gateway): support curated model picker policy

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1414,6 +1414,7 @@ class GatewaySlashCommandsMixin:
             resolve_persist_behavior,
             list_authenticated_providers,
             list_picker_providers,
+            apply_model_picker_policy,
         )
         from hermes_cli.providers import get_label
 
@@ -1444,6 +1445,7 @@ class GatewaySlashCommandsMixin:
         current_api_key = ""
         user_provs = None
         custom_provs = None
+        cfg = {}
         config_path = _hermes_home / "config.yaml"
         try:
             cfg = _load_gateway_config()
@@ -1500,6 +1502,12 @@ class GatewaySlashCommandsMixin:
                         custom_providers=custom_provs,
                         max_models=50,
                         include_moa=True,
+                    )
+                    providers = apply_model_picker_policy(
+                        providers,
+                        cfg.get("model_picker") if isinstance(cfg, dict) else None,
+                        current_provider=current_provider,
+                        current_model=current_model,
                     )
                 except Exception:
                     providers = []

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1449,6 +1449,98 @@ def prewarm_picker_cache_async() -> Optional["_threading.Thread"]:
     return t
 
 
+def apply_model_picker_policy(
+    providers: List[dict],
+    policy: Any,
+    *,
+    current_provider: str = "",
+    current_model: str = "",
+) -> List[dict]:
+    """Apply an optional ordered allowlist to an interactive model picker.
+
+    ``policy`` is read from the top-level ``model_picker`` config section::
+
+        model_picker:
+          include_current: true
+          providers:
+            openai-codex: [gpt-5.6-sol]
+            anthropic: [claude-opus-4-8, claude-sonnet-5]
+
+    Provider and model order follows the config. Unknown or unavailable entries
+    are skipped, so one policy can be shared across profiles with different
+    credentials. By default, the active model is retained in its provider row.
+
+    A missing or malformed policy is a no-op for backward compatibility. JSON
+    strings are accepted because ``hermes config set`` stores object values as
+    scalar text.
+    """
+    if isinstance(policy, str):
+        try:
+            import json
+
+            policy = json.loads(policy)
+        except (TypeError, ValueError):
+            return providers
+    if not isinstance(policy, dict):
+        return providers
+
+    configured = policy.get("providers")
+    if not isinstance(configured, dict):
+        return providers
+
+    by_slug = {
+        str(row.get("slug", "")).strip().lower(): row
+        for row in providers
+        if isinstance(row, dict) and str(row.get("slug", "")).strip()
+    }
+    current_slug = str(current_provider or "").strip().lower()
+    current_id = str(current_model or "").strip()
+    include_current = policy.get("include_current", True) is not False
+    filtered: List[dict] = []
+
+    for raw_slug, raw_models in configured.items():
+        slug = str(raw_slug or "").strip().lower()
+        row = by_slug.get(slug)
+        if row is None:
+            continue
+
+        if isinstance(raw_models, str):
+            requested = [raw_models]
+        elif isinstance(raw_models, (list, tuple)):
+            requested = [model for model in raw_models if isinstance(model, str)]
+        else:
+            continue
+
+        available = {
+            str(model).strip().lower(): str(model)
+            for model in (row.get("models") or [])
+            if str(model).strip()
+        }
+        selected: List[str] = []
+        seen: set[str] = set()
+        for requested_model in requested:
+            key = requested_model.strip().lower()
+            actual = available.get(key)
+            if actual and key not in seen:
+                selected.append(actual)
+                seen.add(key)
+
+        if include_current and slug == current_slug and current_id:
+            current_key = current_id.lower()
+            actual_current = available.get(current_key)
+            if actual_current and current_key not in seen:
+                selected.insert(0, actual_current)
+
+        if not selected:
+            continue
+        curated_row = dict(row)
+        curated_row["models"] = selected
+        curated_row["total_models"] = len(selected)
+        filtered.append(curated_row)
+
+    return filtered
+
+
 def list_authenticated_providers(
     current_provider: str = "",
     current_base_url: str = "",

--- a/tests/gateway/test_model_command_async_offload.py
+++ b/tests/gateway/test_model_command_async_offload.py
@@ -124,7 +124,11 @@ class _FakePickerAdapter:
     """Adapter whose *type* exposes ``send_model_picker`` (the gate the handler
     checks via ``getattr(type(adapter), 'send_model_picker', None)``)."""
 
+    def __init__(self):
+        self.sent_kwargs = None
+
     async def send_model_picker(self, **kwargs):
+        self.sent_kwargs = kwargs
         return _FakePickerResult()
 
     def _thread_metadata(self, *a, **k):  # pragma: no cover - not exercised
@@ -192,3 +196,52 @@ async def test_picker_path_requests_moa_presets(_isolated_config, monkeypatch):
 
     assert result is None
     assert captured["include_moa"] is True
+
+
+@pytest.mark.asyncio
+async def test_picker_path_applies_configured_model_policy(_isolated_config, monkeypatch):
+    config_path = _isolated_config / "config.yaml"
+    config_path.write_text(
+        "model:\n"
+        "  default: gpt-old\n"
+        "  provider: openai-codex\n"
+        "providers: {}\n"
+        "model_picker:\n"
+        "  providers:\n"
+        "    openai-codex: [gpt-new]\n"
+        "    anthropic: [claude-new]\n",
+        encoding="utf-8",
+    )
+    listed = [
+        {
+            "slug": "anthropic",
+            "name": "Anthropic",
+            "models": ["claude-old", "claude-new"],
+            "total_models": 2,
+        },
+        {
+            "slug": "openai-codex",
+            "name": "OpenAI Codex",
+            "models": ["gpt-old", "gpt-new"],
+            "total_models": 2,
+        },
+    ]
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_picker_providers",
+        lambda **kwargs: listed,
+    )
+
+    adapter = _FakePickerAdapter()
+    runner = _make_runner()
+    runner.adapters = {Platform.TELEGRAM: adapter}  # type: ignore[assignment]
+    monkeypatch.setattr(runner, "_thread_metadata_for_source", lambda *a, **k: None, raising=False)
+    monkeypatch.setattr(runner, "_reply_anchor_for_event", lambda *a, **k: None, raising=False)
+
+    result = await runner._handle_model_command(_make_event())
+
+    assert result is None
+    assert adapter.sent_kwargs is not None
+    providers = adapter.sent_kwargs["providers"]
+    assert [row["slug"] for row in providers] == ["openai-codex", "anthropic"]
+    assert providers[0]["models"] == ["gpt-old", "gpt-new"]
+    assert providers[1]["models"] == ["claude-new"]

--- a/tests/hermes_cli/test_model_picker_policy.py
+++ b/tests/hermes_cli/test_model_picker_policy.py
@@ -1,0 +1,79 @@
+from hermes_cli.model_switch import apply_model_picker_policy
+
+
+def _rows():
+    return [
+        {
+            "slug": "anthropic",
+            "name": "Anthropic",
+            "models": ["claude-opus-old", "claude-opus-new", "claude-sonnet-new"],
+            "total_models": 3,
+        },
+        {
+            "slug": "openai-codex",
+            "name": "OpenAI Codex",
+            "models": ["gpt-old", "gpt-new"],
+            "total_models": 2,
+        },
+    ]
+
+
+def test_picker_policy_filters_and_orders_providers_and_models():
+    result = apply_model_picker_policy(
+        _rows(),
+        {
+            "providers": {
+                "openai-codex": ["gpt-new", "missing"],
+                "anthropic": ["claude-sonnet-new", "claude-opus-new"],
+                "not-authenticated": ["anything"],
+            }
+        },
+    )
+
+    assert [row["slug"] for row in result] == ["openai-codex", "anthropic"]
+    assert result[0]["models"] == ["gpt-new"]
+    assert result[0]["total_models"] == 1
+    assert result[1]["models"] == ["claude-sonnet-new", "claude-opus-new"]
+
+
+def test_picker_policy_keeps_current_model_by_default():
+    result = apply_model_picker_policy(
+        _rows(),
+        {"providers": {"anthropic": ["claude-opus-new"]}},
+        current_provider="Anthropic",
+        current_model="claude-opus-old",
+    )
+
+    assert result[0]["models"] == ["claude-opus-old", "claude-opus-new"]
+    assert result[0]["total_models"] == 2
+
+
+def test_picker_policy_can_exclude_current_model():
+    result = apply_model_picker_policy(
+        _rows(),
+        {
+            "include_current": False,
+            "providers": {"anthropic": ["claude-opus-new"]},
+        },
+        current_provider="anthropic",
+        current_model="claude-opus-old",
+    )
+
+    assert result[0]["models"] == ["claude-opus-new"]
+
+
+def test_picker_policy_malformed_values_are_noop():
+    rows = _rows()
+
+    for policy in (None, [], "not-json", {"providers": []}):
+        assert apply_model_picker_policy(rows, policy) is rows
+
+
+def test_picker_policy_accepts_json_string_config():
+    result = apply_model_picker_policy(
+        _rows(),
+        '{"providers":{"openai-codex":["gpt-new"]}}',
+    )
+
+    assert [row["slug"] for row in result] == ["openai-codex"]
+    assert result[0]["models"] == ["gpt-new"]


### PR DESCRIPTION
## Summary

- add an optional top-level `model_picker` policy for ordered provider/model allowlisting in gateway pickers
- keep the active model visible by default, while allowing `include_current: false`
- treat missing/malformed policies as no-ops and accept JSON-string object values from `hermes config set`
- apply the policy only after authenticated picker rows are resolved, so unavailable providers/models are skipped

Example:

```yaml
model_picker:
  include_current: true
  providers:
    openai-codex: [gpt-5.6-sol]
    anthropic: [claude-opus-4-8, claude-sonnet-5]
```

## Verification

- `scripts/run_tests.sh` across 10 model-picker files: 68 passed
- gateway model-command regression group: 28 passed
- `git diff --check`
- redaction scan passed

The default behavior is unchanged when `model_picker` is absent or malformed.