### PR TITLE
fix(agent): add return_exceptions to asyncio.gather in context ref expansion

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -167,9 +167,14 @@ async def preprocess_context_references_async(
                 allowed_root=allowed_root_path,
             )
             for ref in refs
-        )
+        ),
+        return_exceptions=True,
     )
-    for warning, block in expanded:
+    for result in expanded:
+        if isinstance(result, BaseException):
+            warnings.append(f"@ context reference expansion failed: {result}")
+            continue
+        warning, block = result
         if warning:
             warnings.append(warning)
         if block:


### PR DESCRIPTION
## Summary

Add `return_exceptions=True` to `asyncio.gather()` in `preprocess_context_references_async` and guard the result loop against `BaseException`.

## Problem

`agent/context_references.py` called `asyncio.gather()` without `return_exceptions=True`. If one reference expansion (e.g., a URL fetch or file read) fails, the exception propagates immediately and crashes the entire gather, aborting the agent turn — even when other references would have resolved fine.

## Fix

1. Added `return_exceptions=True` to the gather call.
2. Updated the result iteration to check `isinstance(result, BaseException)` and append a warning instead of crashing.

## Testing
- Syntax check passed (py_compile)
- Behavior verified