### PR TITLE
fix(nous): forward provider routing through Portal

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1701,11 +1701,31 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             _provider_sort = _validated_openrouter_provider_sort(agent.provider_sort)
             if _provider_sort:
                 provider_preferences["sort"] = _provider_sort
-            if provider_preferences and (
-                (agent.provider or "").strip().lower() == "openrouter"
-                or agent._is_openrouter_url()
-            ):
-                summary_extra_body["provider"] = provider_preferences
+            if agent.provider_require_parameters:
+                provider_preferences["require_parameters"] = True
+            if agent.provider_data_collection:
+                provider_preferences["data_collection"] = agent.provider_data_collection
+            if provider_preferences:
+                profile_provider_preferences = None
+                try:
+                    from providers import get_provider_profile
+
+                    provider_profile = get_provider_profile(agent.provider)
+                    if provider_profile is not None:
+                        profile_extra_body = provider_profile.build_extra_body(
+                            provider_preferences=provider_preferences,
+                        )
+                        profile_provider_preferences = profile_extra_body.get("provider")
+                except Exception:
+                    pass
+
+                if profile_provider_preferences:
+                    summary_extra_body["provider"] = profile_provider_preferences
+                elif (
+                    (agent.provider or "").strip().lower() == "openrouter"
+                    or agent._is_openrouter_url()
+                ):
+                    summary_extra_body["provider"] = provider_preferences
 
             # Pareto Code router plugin — model-gated. Same shape as
             # the main-loop emission so summary calls on

--- a/plugins/model-providers/nous/__init__.py
+++ b/plugins/model-providers/nous/__init__.py
@@ -13,7 +13,11 @@ class NousProfile(ProviderProfile):
     def build_extra_body(
         self, *, session_id: str | None = None, **context
     ) -> dict[str, Any]:
-        return {"tags": nous_portal_tags()}
+        body: dict[str, Any] = {"tags": nous_portal_tags()}
+        provider_preferences = context.get("provider_preferences")
+        if provider_preferences:
+            body["provider"] = provider_preferences
+        return body
 
     def build_api_kwargs_extras(
         self,

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -414,6 +414,18 @@ class TestNousProfile:
         body = p.build_extra_body()
         assert body["tags"] == nous_portal_tags()
 
+    def test_extra_body_with_provider_preferences(self):
+        from agent.portal_tags import nous_portal_tags
+
+        p = get_provider_profile("nous")
+        preferences = {"only": ["deepseek"], "ignore": ["deepinfra"]}
+        body = p.build_extra_body(provider_preferences=preferences)
+
+        assert body == {
+            "tags": nous_portal_tags(),
+            "provider": preferences,
+        }
+
     def test_auth_type(self):
         p = get_provider_profile("nous")
         assert p.auth_type == "oauth_device_code"

--- a/tests/providers/test_transport_parity.py
+++ b/tests/providers/test_transport_parity.py
@@ -208,6 +208,21 @@ class TestNousParity:
         )
         assert kw["extra_body"]["tags"] == nous_portal_tags()
 
+    def test_provider_preferences(self, transport):
+        preferences = {
+            "only": ["deepseek"],
+            "ignore": ["deepinfra"],
+            "sort": "throughput",
+        }
+        kw = transport.build_kwargs(
+            model="deepseek/deepseek-v4-flash",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("nous"),
+            provider_preferences=preferences,
+        )
+        assert kw["extra_body"]["provider"] == preferences
+
     def test_reasoning_omitted_when_disabled(self, transport):
         """Nous special case: reasoning omitted entirely when disabled."""
         kw = transport.build_kwargs(

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3789,6 +3789,30 @@ class TestHandleMaxIterations:
         kwargs = agent.client.chat.completions.create.call_args.kwargs
         assert kwargs["extra_body"]["provider"]["only"] == ["Anthropic"]
 
+    def test_summary_keeps_provider_preferences_for_nous(self, agent):
+        agent.base_url = "https://inference-api.nousresearch.com/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.provider = "nous"
+        agent.providers_allowed = ["deepseek"]
+        agent.providers_ignored = ["deepinfra"]
+        agent.provider_sort = "throughput"
+        agent.provider_require_parameters = True
+        agent.provider_data_collection = "deny"
+        agent.client.chat.completions.create.return_value = _mock_response(content="Summary")
+        agent._cached_system_prompt = "You are helpful."
+
+        result = agent._handle_max_iterations([{"role": "user", "content": "do stuff"}], 60)
+
+        assert result == "Summary"
+        kwargs = agent.client.chat.completions.create.call_args.kwargs
+        assert kwargs["extra_body"]["provider"] == {
+            "only": ["deepseek"],
+            "ignore": ["deepinfra"],
+            "sort": "throughput",
+            "require_parameters": True,
+            "data_collection": "deny",
+        }
+
     def test_summary_drops_invalid_provider_sort(self, agent):
         agent.base_url = "https://openrouter.ai/api/v1"
         agent._base_url_lower = agent.base_url.lower()

--- a/website/docs/user-guide/features/provider-routing.md
+++ b/website/docs/user-guide/features/provider-routing.md
@@ -1,18 +1,18 @@
 ---
 title: Provider Routing
-description: Configure OpenRouter provider preferences to optimize for cost, speed, or quality.
+description: Configure OpenRouter or Nous Portal provider preferences to optimize for cost, speed, or quality.
 sidebar_label: Provider Routing
 sidebar_position: 7
 ---
 
 # Provider Routing
 
-When using [OpenRouter](https://openrouter.ai) as your LLM provider, Hermes Agent supports **provider routing** — fine-grained control over which underlying AI providers handle your requests and how they're prioritized.
+When using [OpenRouter](https://openrouter.ai) or [Nous Portal](/integrations/nous-portal) as your LLM provider, Hermes Agent supports **provider routing** — fine-grained control over which underlying AI providers handle your requests and how they're prioritized.
 
 OpenRouter routes requests to many providers (e.g., Anthropic, Google, AWS Bedrock, Together AI). Provider routing lets you optimize for cost, speed, quality, or enforce specific provider requirements.
 
 :::tip
-Traffic routed through [Nous Portal](/integrations/nous-portal) still respects per-model routing and priority configs — and Portal subscribers get 10% off token-billed providers.
+Traffic routed through Nous Portal respects the same provider preferences — and Portal subscribers get 10% off token-billed providers.
 :::
 
 ## Configuration
@@ -30,7 +30,7 @@ provider_routing:
 ```
 
 :::info
-Provider routing only applies when using OpenRouter. It has no effect with direct provider connections (e.g., connecting directly to the Anthropic API).
+Provider routing only applies when using OpenRouter or Nous Portal. It has no effect with direct provider connections (e.g., connecting directly to the Anthropic API).
 :::
 
 ## Options
@@ -52,13 +52,13 @@ provider_routing:
 
 ### `only`
 
-Whitelist of provider names. When set, **only** these providers will be used. All others are excluded.
+Whitelist of provider slugs. When set, **only** these providers will be used. All others are excluded. Use the lowercase slug shown by OpenRouter for each provider.
 
 ```yaml
 provider_routing:
   only:
-    - "Anthropic"
-    - "Google"
+    - "anthropic"
+    - "google"
 ```
 
 ### `ignore`
@@ -68,8 +68,8 @@ Blacklist of provider names. These providers will **never** be used, even if the
 ```yaml
 provider_routing:
   ignore:
-    - "Together"
-    - "DeepInfra"
+    - "together"
+    - "deepinfra"
 ```
 
 ### `order`
@@ -79,9 +79,9 @@ Explicit priority order. Providers listed first are preferred. Unlisted provider
 ```yaml
 provider_routing:
   order:
-    - "Anthropic"
-    - "Google"
-    - "AWS Bedrock"
+    - "anthropic"
+    - "google"
+    - "amazon-bedrock"
 ```
 
 ### `require_parameters`
@@ -138,7 +138,7 @@ Ensure all requests go through a specific provider for consistency:
 ```yaml
 provider_routing:
   only:
-    - "Anthropic"
+    - "anthropic"
 ```
 
 ### Avoid Specific Providers
@@ -148,8 +148,8 @@ Exclude providers you don't want to use (e.g., for data privacy):
 ```yaml
 provider_routing:
   ignore:
-    - "Together"
-    - "Lepton"
+    - "together"
+    - "lepton"
   data_collection: "deny"
 ```
 
@@ -160,14 +160,14 @@ Try your preferred providers first, fall back to others if unavailable:
 ```yaml
 provider_routing:
   order:
-    - "Anthropic"
-    - "Google"
+    - "anthropic"
+    - "google"
   require_parameters: true
 ```
 
 ## How It Works
 
-Provider routing preferences are passed to the OpenRouter API via the `extra_body.provider` field on every API call. This applies to both:
+Provider routing preferences are passed to OpenRouter or Nous Portal via the `extra_body.provider` field on every API call. (`extra_body` is the OpenAI Python SDK argument; it becomes the top-level `provider` object in the JSON request.) This applies to both:
 
 - **CLI mode** — configured in `~/.hermes/config.yaml`, loaded at startup
 - **Gateway mode** — same config file, loaded when the gateway starts
@@ -189,7 +189,7 @@ You can combine multiple options. For example, sort by price but exclude certain
 ```yaml
 provider_routing:
   sort: "price"
-  ignore: ["Together"]
+  ignore: ["together"]
   require_parameters: true
   data_collection: "deny"
 ```
@@ -197,8 +197,8 @@ provider_routing:
 
 ## Default Behavior
 
-When no `provider_routing` section is configured (the default), OpenRouter uses its own default routing logic, which generally balances cost and availability automatically.
+When no `provider_routing` section is configured (the default), the aggregator uses its own default routing logic, which generally balances cost and availability automatically.
 
 :::tip Provider Routing vs. Fallback Models
-Provider routing controls which **sub-providers within OpenRouter** handle your requests. For automatic failover to an entirely different provider when your primary model fails, see [Fallback Providers](/user-guide/features/fallback-providers).
+Provider routing controls which **sub-providers behind OpenRouter or Nous Portal** handle your requests. For automatic failover to an entirely different provider when your primary model fails, see [Fallback Providers](/user-guide/features/fallback-providers).
 :::


### PR DESCRIPTION
## What does this PR do?

`provider_routing` is loaded into `AIAgent` for Nous Portal sessions, but the Nous provider profile currently drops those preferences while building the request body. As a result, Portal requests keep the Hermes product tags but never receive the top-level `provider` routing object documented for `only`, `ignore`, `order`, `sort`, `require_parameters`, and `data_collection`.

This change forwards routing preferences through `NousProfile.build_extra_body()`, preserving the existing Portal tags. It also fixes the max-iteration summary path, which bypasses the normal transport and previously hardcoded routing passthrough to OpenRouter. That path now accepts routing only from provider profiles that explicitly emit a `provider` object, while retaining the legacy OpenRouter URL fallback.

The provider-routing documentation now consistently describes OpenRouter and Nous Portal support and uses lowercase provider slugs in its examples.

## Related Issue

Discord support thread: https://discord.com/channels/1053877538025386074/1524954997274579076

Related but not duplicate: #53033 changes only auxiliary-call detection and does not make the Nous profile emit provider preferences on normal requests.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Forward `provider_preferences` alongside Portal tags in `plugins/model-providers/nous/__init__.py`.
- Preserve profile-declared routing preferences in max-iteration summary requests in `agent/chat_completion_helpers.py`.
- Cover the Nous profile, chat-completions transport, and summary request path with focused regression tests.
- Reconcile the Portal/OpenRouter documentation and replace display names with lowercase provider slugs.

## How to Test

1. Configure `provider: nous` with `provider_routing.only: [deepseek]`.
2. Build a normal chat-completions request and verify `extra_body.provider.only == ["deepseek"]` while `extra_body.tags` remains present.
3. Trigger a max-iteration summary and verify the same routing object is included in that request.
4. Confirm a non-aggregator profile still omits `extra_body.provider`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no architecture or workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — provider request construction is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool behavior changed

## Screenshots / Logs

Focused verification on Windows 11:

- Parsed all changed Python files successfully.
- Direct assertions passed for Nous profile output, chat-completions transport output, and the max-iteration summary request.
- `uvx ruff check` passed for all changed Python files.
- `git diff --check` passed.

The full pytest suite was not run locally; GitHub CI will provide suite coverage.