### PR TITLE
fix(agent): strip tool_choice on max-iteration summary for Responses API

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1672,8 +1672,15 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             summary_extra_body["tags"] = _portal_tags()
 
         if agent.api_mode == "codex_responses":
+            # Text-only final summary: strip tools AND tool_choice.
+            # CodexTransport sets tool_choice="auto" whenever tools are present
+            # (see transports/codex.py). Popping tools alone leaves tool_choice
+            # set → xAI/OpenAI Responses 400: "tool_choice was set … but no
+            # tools were specified." (xai-oauth uses api_mode=codex_responses.)
             codex_kwargs = agent._build_api_kwargs(api_messages)
             codex_kwargs.pop("tools", None)
+            codex_kwargs.pop("tool_choice", None)
+            codex_kwargs.pop("parallel_tool_calls", None)
             summary_response = agent._run_codex_stream(codex_kwargs)
             _ct_sum = agent._get_transport()
             _cnr_sum = _ct_sum.normalize_response(summary_response)
@@ -1757,6 +1764,8 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             if agent.api_mode == "codex_responses":
                 codex_kwargs = agent._build_api_kwargs(api_messages)
                 codex_kwargs.pop("tools", None)
+                codex_kwargs.pop("tool_choice", None)
+                codex_kwargs.pop("parallel_tool_calls", None)
                 retry_response = agent._run_codex_stream(codex_kwargs)
                 _ct_retry = agent._get_transport()
                 _cnr_retry = _ct_retry.normalize_response(retry_response)


### PR DESCRIPTION
## Summary
- When `handle_max_iterations` builds a text-only final summary under `api_mode=codex_responses`, it popped `tools` but left `tool_choice="auto"` (set by `CodexTransport` whenever tools are present).
- xAI/OpenAI Responses then returns HTTP 400: *tool_choice was set but no tools were specified*.
- `xai-oauth` uses `api_mode=codex_responses`, so Grok sessions hit this repeatedly on max-iteration wrap-up.
- Fix: also pop `tool_choice` and `parallel_tool_calls` on first attempt and retry.

## Context
Observed on a workstation running Hermes desktop with `xai-oauth` / `grok-4.5`. Error log:

```
Failed to get summary response: Error code: 400 - {'code': 'invalid-argument',
'error': 'Invalid request content: A tool_choice was set on the request but no tools were specified.'}
```

This is **not** the context-compression path (`auxiliary.compression` / DeepSeek). It is the **max-iteration final summary** path in `chat_completion_helpers.handle_max_iterations`.

## Test plan
- [ ] Code review: both first-try and retry codex_responses branches pop tools + tool_choice + parallel_tool_calls
- [ ] On xai-oauth/grok: force or hit max iterations with tools loaded → wrap-up summary should succeed without 400
- [ ] openai-codex Responses path: same (same transport sets tool_choice with tools)
- [ ] chat_completions path unchanged (builds summary_kwargs without tools/tool_choice)