### PR TITLE
fix(agent): handle YAML null value in context_length_cache (#47135)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1077,7 +1077,7 @@ def _load_context_cache() -> Dict[str, int]:
     try:
         with open(path, encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
-        return data.get("context_lengths", {})
+        return data.get("context_lengths") or {}
     except Exception as e:
         logger.debug("Failed to load context length cache: %s", e)
         return {}

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1492,6 +1492,17 @@ class TestContextLengthCache:
         with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
             assert get_cached_context_length("test/model", "http://x") is None
 
+    def test_null_context_lengths_key_returns_empty(self, tmp_path):
+        """``context_lengths:`` with no value parses as None — must behave
+        like an empty cache instead of crashing every caller (#47135)."""
+        cache_file = tmp_path / "cache.yaml"
+        cache_file.write_text("context_lengths:\n")
+        with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
+            assert get_cached_context_length("test/model", "http://x") is None
+            # save must also survive the null key and repair the file
+            save_context_length("test/model", "http://x", 32768)
+            assert get_cached_context_length("test/model", "http://x") == 32768
+
     def test_multiple_models_cached(self, tmp_path):
         cache_file = tmp_path / "cache.yaml"
         with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):


### PR DESCRIPTION
## Summary

A `context_length_cache.yaml` containing `context_lengths:` with no value (YAML null) no longer crashes every context-length lookup with `AttributeError: 'NoneType' object has no attribute 'get'` — it now behaves like an empty cache.

Salvages the one relevant commit from @ygd58's #47147 (which bundled 5 unrelated fixes on a stale branch) with authorship preserved. #47185 (@kyssta-exe) was an identical later fix. Closes #47135.

## Changes

- `agent/model_metadata.py` `_load_context_cache()` (cherry-picked): `data.get("context_lengths", {})` → `data.get("context_lengths") or {}` — `dict.get` only defaults on an absent key, not a present-but-null one
- `tests/agent/test_model_metadata.py`: regression test — null key returns empty cache, and `save_context_length()` repairs the file

## Validation

| | Before | After |
|---|---|---|
| `get_cached_context_length()` with null key | AttributeError | returns None (cache miss) |
| `save_context_length()` on the null file | AttributeError | writes, subsequent reads work |
| tests/agent/test_model_metadata.py | — | green |

Reproduced live on current main before the fix (real file, real imports, temp HERMES_HOME).

## Infographic

![context-cache-null](https://v3b.fal.media/files/b/0aa1a21f/oyOuUdn53cnfRQp2Ri21O_yzzKDPBZ.png)
