### PR TITLE
fix(desktop): prevent slow voice transcription timeout

### DIFF
--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -10,7 +10,8 @@ import {
   getSessionMessages,
   getStatus,
   listAllProfileSessions,
-  listSessions
+  listSessions,
+  transcribeAudio
 } from './hermes'
 import { refreshActiveProfile } from './store/profile'
 
@@ -109,6 +110,20 @@ describe('Hermes REST session helpers', () => {
       await call()
       expect(api).toHaveBeenCalledWith(expect.objectContaining({ path, timeoutMs: 60_000 }))
     }
+  })
+
+  it('gives desktop voice transcription enough time for CPU/local Whisper', async () => {
+    api.mockResolvedValue({ ok: true, transcript: 'hello', provider: 'local' })
+
+    await transcribeAudio('data:audio/webm;base64,ZmFrZQ==', 'audio/webm')
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/api/audio/transcribe',
+        method: 'POST',
+        timeoutMs: 600_000
+      })
+    )
   })
 
   it('keeps the liveness poll on the short default so a dead backend fails fast', async () => {

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -70,6 +70,11 @@ import type {
 // keep the short default so a genuinely-dead backend is still detected fast.
 export const STARTUP_REQUEST_TIMEOUT_MS = 60_000
 const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 30_000
+// Local faster-whisper can legitimately take longer than the generic request
+// timeout for longer clips, especially on CPU or after a cold model load.
+// Keep the default timeout snappy for normal UI calls, but give transcription
+// enough time to finish instead of surfacing a false backend-connect failure.
+export const AUDIO_TRANSCRIPTION_REQUEST_TIMEOUT_MS = 600_000
 const SESSION_LIST_REQUEST_TIMEOUT_MS = 60_000
 // prompt.submit is effectively fire-and-forget: turn completion is signaled by
 // stream / message.complete events, NOT by the RPC return. A long turn (MoA
@@ -979,6 +984,7 @@ export function transcribeAudio(dataUrl: string, mimeType?: string): Promise<Aud
   return window.hermesDesktop.api<AudioTranscriptionResponse>({
     path: '/api/audio/transcribe',
     method: 'POST',
+    timeoutMs: AUDIO_TRANSCRIPTION_REQUEST_TIMEOUT_MS,
     body: {
       data_url: dataUrl,
       mime_type: mimeType


### PR DESCRIPTION
## Problem
Desktop voice dictation used the generic 15-second REST request timeout. Local faster-whisper can exceed that during CPU inference or a cold model load, causing a false backend connection timeout.

## Fix
Give `/api/audio/transcribe` a dedicated 10-minute timeout and add a focused regression test. Normal API calls and liveness checks retain their existing timeouts.

## Validation
- Desktop typecheck passes
- Focused Desktop UI test passes
- Reproduced in a real macOS ARM64 packaged build; dictation works after rebuild