### PR TITLE
feat(acp): surface tool generation status

### DIFF
--- a/acp_adapter/events.py
+++ b/acp_adapter/events.py
@@ -19,7 +19,7 @@ from acp.schema import AgentPlanUpdate, PlanEntry
 from .tools import (
     build_tool_complete,
     build_tool_start,
-    get_tool_kind,
+    build_tool_started_update,
     make_tool_call_id,
 )
 
@@ -135,6 +135,7 @@ def make_tool_gen_cb(
     def _tool_gen(name: str, *args: Any, **kwargs: Any) -> None:
         if not name:
             return
+        generation_key = kwargs.get("generation_key")
 
         queue = tool_call_ids.get(name)
         if queue is None:
@@ -144,9 +145,31 @@ def make_tool_gen_cb(
             queue = deque([queue])
             tool_call_ids[name] = queue
 
+        if generation_key is not None:
+            for existing_name, existing_queue in list(tool_call_ids.items()):
+                if isinstance(existing_queue, str):
+                    existing_queue = deque([existing_queue])
+                    tool_call_ids[existing_name] = existing_queue
+                for candidate in list(existing_queue):
+                    meta = tool_call_meta.get(candidate, {})
+                    if not (meta.get("generated") and meta.get("generation_key") == generation_key):
+                        continue
+                    if existing_name == name:
+                        return
+                    existing_queue.remove(candidate)
+                    if not existing_queue:
+                        tool_call_ids.pop(existing_name, None)
+                    queue.append(candidate)
+                    update = build_tool_started_update(candidate, name, {})
+                    _send_update(conn, session_id, loop, update)
+                    return
+
         tc_id = make_tool_call_id()
         queue.append(tc_id)
-        tool_call_meta[tc_id] = {"args": {}, "snapshot": None, "generated": True}
+        meta = {"args": {}, "snapshot": None, "generated": True}
+        if generation_key is not None:
+            meta["generation_key"] = generation_key
+        tool_call_meta[tc_id] = meta
 
         update = build_tool_start(tc_id, name, {})
         _send_update(conn, session_id, loop, update)
@@ -235,12 +258,7 @@ def make_tool_progress_cb(
                 logger.debug("Failed to prepare auto-approved ACP edit diff for %s", name, exc_info=True)
 
         if already_started:
-            update = acp.update_tool_call(
-                tc_id,
-                kind=get_tool_kind(name),
-                status="pending",
-                raw_input=args,
-            )
+            update = build_tool_started_update(tc_id, name, args, edit_diff=edit_diff)
             _send_update(conn, session_id, loop, update)
         else:
             update = build_tool_start(tc_id, name, args, edit_diff=edit_diff)

--- a/acp_adapter/events.py
+++ b/acp_adapter/events.py
@@ -144,11 +144,6 @@ def make_tool_gen_cb(
             queue = deque([queue])
             tool_call_ids[name] = queue
 
-        for existing_id in queue:
-            meta = tool_call_meta.get(existing_id, {})
-            if meta.get("generated"):
-                return
-
         tc_id = make_tool_call_id()
         queue.append(tc_id)
         tool_call_meta[tc_id] = {"args": {}, "snapshot": None, "generated": True}
@@ -205,10 +200,11 @@ def make_tool_progress_cb(
 
         tc_id = None
         if queue:
-            candidate = queue[0]
-            meta = tool_call_meta.get(candidate, {})
-            if meta.get("generated"):
-                tc_id = candidate
+            for candidate in queue:
+                meta = tool_call_meta.get(candidate, {})
+                if meta.get("generated"):
+                    tc_id = candidate
+                    break
 
         already_started = tc_id is not None
         if tc_id is None:

--- a/acp_adapter/events.py
+++ b/acp_adapter/events.py
@@ -19,6 +19,7 @@ from acp.schema import AgentPlanUpdate, PlanEntry
 from .tools import (
     build_tool_complete,
     build_tool_start,
+    get_tool_kind,
     make_tool_call_id,
 )
 
@@ -108,6 +109,57 @@ def _send_update(
 
 
 # ------------------------------------------------------------------
+# Tool generation callback
+# ------------------------------------------------------------------
+
+def make_tool_gen_cb(
+    conn: acp.Client,
+    session_id: str,
+    loop: asyncio.AbstractEventLoop,
+    tool_call_ids: Dict[str, Deque[str]],
+    tool_call_meta: Dict[str, Dict[str, Any]],
+) -> Callable:
+    """Create a ``tool_gen_callback`` for AIAgent.
+
+    AIAgent fires this callback as soon as the model stream has produced a
+    complete tool name, before the tool input JSON has necessarily finished
+    streaming. Emit a lightweight ToolCallStart with empty arguments so ACP
+    clients can show that a tool call is being prepared instead of appearing
+    idle while large tool inputs are still being generated.
+
+    The later ``tool_progress_callback("tool.started", ...)`` reuses this
+    reserved tool-call id and fills in the real argument metadata for the
+    eventual completion update.
+    """
+
+    def _tool_gen(name: str, *args: Any, **kwargs: Any) -> None:
+        if not name:
+            return
+
+        queue = tool_call_ids.get(name)
+        if queue is None:
+            queue = deque()
+            tool_call_ids[name] = queue
+        elif isinstance(queue, str):
+            queue = deque([queue])
+            tool_call_ids[name] = queue
+
+        for existing_id in queue:
+            meta = tool_call_meta.get(existing_id, {})
+            if meta.get("generated"):
+                return
+
+        tc_id = make_tool_call_id()
+        queue.append(tc_id)
+        tool_call_meta[tc_id] = {"args": {}, "snapshot": None, "generated": True}
+
+        update = build_tool_start(tc_id, name, {})
+        _send_update(conn, session_id, loop, update)
+
+    return _tool_gen
+
+
+# ------------------------------------------------------------------
 # Tool progress callback
 # ------------------------------------------------------------------
 
@@ -143,7 +195,6 @@ def make_tool_progress_cb(
         if not isinstance(args, dict):
             args = {}
 
-        tc_id = make_tool_call_id()
         queue = tool_call_ids.get(name)
         if queue is None:
             queue = deque()
@@ -151,7 +202,18 @@ def make_tool_progress_cb(
         elif isinstance(queue, str):
             queue = deque([queue])
             tool_call_ids[name] = queue
-        queue.append(tc_id)
+
+        tc_id = None
+        if queue:
+            candidate = queue[0]
+            meta = tool_call_meta.get(candidate, {})
+            if meta.get("generated"):
+                tc_id = candidate
+
+        already_started = tc_id is not None
+        if tc_id is None:
+            tc_id = make_tool_call_id()
+            queue.append(tc_id)
 
         snapshot = None
         if name in {"write_file", "patch", "skill_manage"}:
@@ -176,8 +238,17 @@ def make_tool_progress_cb(
             except Exception:
                 logger.debug("Failed to prepare auto-approved ACP edit diff for %s", name, exc_info=True)
 
-        update = build_tool_start(tc_id, name, args, edit_diff=edit_diff)
-        _send_update(conn, session_id, loop, update)
+        if already_started:
+            update = acp.update_tool_call(
+                tc_id,
+                kind=get_tool_kind(name),
+                status="pending",
+                raw_input=args,
+            )
+            _send_update(conn, session_id, loop, update)
+        else:
+            update = build_tool_start(tc_id, name, args, edit_diff=edit_diff)
+            _send_update(conn, session_id, loop, update)
 
     return _tool_progress
 

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -68,6 +68,7 @@ from acp_adapter.events import (
     make_message_cb,
     make_step_cb,
     make_thinking_cb,
+    make_tool_gen_cb,
     make_tool_progress_cb,
 )
 from acp_adapter.permissions import make_approval_callback
@@ -1410,6 +1411,7 @@ class HermesACPAgent(acp.Agent):
             )
             reasoning_cb = make_thinking_cb(conn, session_id, loop)
             step_cb = make_step_cb(conn, session_id, loop, tool_call_ids, tool_call_meta)
+            tool_gen_cb = make_tool_gen_cb(conn, session_id, loop, tool_call_ids, tool_call_meta)
             message_cb = make_message_cb(conn, session_id, loop)
 
             def stream_delta_cb(text: str) -> None:
@@ -1434,6 +1436,7 @@ class HermesACPAgent(acp.Agent):
             tool_progress_cb = None
             reasoning_cb = None
             step_cb = None
+            tool_gen_cb = None
             stream_delta_cb = None
             approval_cb = None
 
@@ -1445,6 +1448,7 @@ class HermesACPAgent(acp.Agent):
         agent.thinking_callback = None
         agent.reasoning_callback = reasoning_cb
         agent.step_callback = step_cb
+        agent.tool_gen_callback = tool_gen_cb
         agent.stream_delta_callback = stream_delta_cb
 
         # Approval callback is per-thread (thread-local, GHSA-qg5c-hvr5-hjgr).

--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -1242,6 +1242,26 @@ def build_tool_start(
     )
 
 
+def build_tool_started_update(
+    tool_call_id: str,
+    tool_name: str,
+    arguments: Dict[str, Any],
+    *,
+    edit_diff: Any = None,
+) -> ToolCallProgress:
+    """Create a pending update that refreshes an early generated placeholder."""
+    start = build_tool_start(tool_call_id, tool_name, arguments, edit_diff=edit_diff)
+    return acp.update_tool_call(
+        tool_call_id,
+        title=start.title,
+        kind=start.kind,
+        status="pending",
+        content=start.content,
+        locations=start.locations,
+        raw_input=start.raw_input,
+    )
+
+
 def _is_structured_json_result(result: Optional[str]) -> bool:
     return isinstance(_json_loads_maybe(result), (dict, list))
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2330,7 +2330,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     if name and idx not in tool_gen_notified:
                         tool_gen_notified.add(idx)
                         _fire_first_delta()
-                        agent._fire_tool_gen_started(name)
+                        agent._fire_tool_gen_started(name, generation_key=f"chat:{idx}")
                         # Record the partial tool-call name so the outer
                         # stub-builder can surface a user-visible warning
                         # if streaming dies before this tool's arguments
@@ -2543,7 +2543,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         tool_name = getattr(block, "name", None)
                         if tool_name:
                             _fire_first_delta()
-                            agent._fire_tool_gen_started(tool_name)
+                            block_index = getattr(event, "index", None)
+                            generation_key = (
+                                f"anthropic:{block_index}"
+                                if block_index is not None
+                                else None
+                            )
+                            agent._fire_tool_gen_started(tool_name, generation_key=generation_key)
 
                 elif event_type == "content_block_delta":
                     delta = getattr(event, "delta", None)

--- a/run_agent.py
+++ b/run_agent.py
@@ -4739,10 +4739,10 @@ class AIAgent:
             except Exception:
                 pass
 
-    def _fire_tool_gen_started(self, tool_name: str) -> None:
+    def _fire_tool_gen_started(self, tool_name: str, generation_key: str = None) -> None:
         """Notify display layer that the model is generating tool call arguments.
 
-        Fires once per tool name when the streaming response begins producing
+        Fires once per streamed tool call when the response begins producing
         tool_call / tool_use tokens.  Gives the TUI a chance to show a spinner
         or status line so the user isn't staring at a frozen screen while a
         large tool payload (e.g. a 45 KB write_file) is being generated.
@@ -4750,7 +4750,15 @@ class AIAgent:
         cb = self.tool_gen_callback
         if cb is not None:
             try:
-                cb(tool_name)
+                if generation_key is not None:
+                    cb(tool_name, generation_key=generation_key)
+                else:
+                    cb(tool_name)
+            except TypeError:
+                try:
+                    cb(tool_name)
+                except Exception:
+                    pass
             except Exception:
                 pass
 

--- a/tests/acp/test_events.py
+++ b/tests/acp/test_events.py
@@ -95,29 +95,39 @@ class TestToolGenerationCallback:
 
         gen_cb = make_tool_gen_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
         progress_cb = make_tool_progress_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
+        step_cb = make_step_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
 
         with patch("acp_adapter.events.make_tool_call_id", side_effect=["tc-gen-1", "tc-gen-2"]), \
-             patch("acp_adapter.events._send_update") as mock_send:
+             patch("acp_adapter.events._send_update") as mock_send, \
+             patch("acp_adapter.events.build_tool_complete") as mock_complete:
             gen_cb("read_file")
             gen_cb("read_file")
             progress_cb("tool.started", "read_file", "reading a.py", {"path": "a.py"})
             progress_cb("tool.started", "read_file", "reading b.py", {"path": "b.py"})
+            assert list(tool_call_ids["read_file"]) == ["tc-gen-1", "tc-gen-2"]
+            assert tool_call_meta["tc-gen-1"] == {
+                "args": {"path": "a.py"},
+                "snapshot": None,
+            }
+            assert tool_call_meta["tc-gen-2"] == {
+                "args": {"path": "b.py"},
+                "snapshot": None,
+            }
+            updates = [call.args[3] for call in mock_send.call_args_list]
+            assert [getattr(update, "session_update", None) for update in updates] == [
+                "tool_call",
+                "tool_call",
+                "tool_call_update",
+                "tool_call_update",
+            ]
+            step_cb(1, [{"name": "read_file", "result": "contents of a.py"}])
+            step_cb(2, [{"name": "read_file", "result": "contents of b.py"}])
 
-        assert list(tool_call_ids["read_file"]) == ["tc-gen-1", "tc-gen-2"]
-        assert tool_call_meta["tc-gen-1"] == {
-            "args": {"path": "a.py"},
-            "snapshot": None,
-        }
-        assert tool_call_meta["tc-gen-2"] == {
-            "args": {"path": "b.py"},
-            "snapshot": None,
-        }
-        updates = [call.args[3] for call in mock_send.call_args_list]
-        assert [getattr(update, "session_update", None) for update in updates] == [
-            "tool_call",
-            "tool_call",
-            "tool_call_update",
-            "tool_call_update",
+        assert "read_file" not in tool_call_ids
+        assert [call.args[0] for call in mock_complete.call_args_list] == ["tc-gen-1", "tc-gen-2"]
+        assert [call.kwargs["function_args"] for call in mock_complete.call_args_list] == [
+            {"path": "a.py"},
+            {"path": "b.py"},
         ]
 
 

--- a/tests/acp/test_events.py
+++ b/tests/acp/test_events.py
@@ -62,6 +62,63 @@ class TestToolGenerationCallback:
         update = mock_send.call_args.args[3]
         assert getattr(update, "session_update", None) == "tool_call"
 
+    def test_same_generation_key_reuses_existing_placeholder(self, mock_conn, event_loop_fixture):
+        """A streamed retry for the same tool slot should not leak a new card."""
+        tool_call_ids = {}
+        tool_call_meta = {}
+        loop = event_loop_fixture
+
+        cb = make_tool_gen_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
+
+        with patch("acp_adapter.events.make_tool_call_id", side_effect=["tc-gen-1", "tc-gen-2"]), \
+             patch("acp_adapter.events._send_update") as mock_send:
+            cb("read_file", generation_key="chat:0")
+            cb("read_file", generation_key="chat:0")
+
+        assert list(tool_call_ids["read_file"]) == ["tc-gen-1"]
+        assert tool_call_meta["tc-gen-1"]["generation_key"] == "chat:0"
+        mock_send.assert_called_once()
+
+    def test_distinct_generation_keys_reserve_fifo_tool_calls(self, mock_conn, event_loop_fixture):
+        """Same-name parallel streamed tools should still each get placeholders."""
+        tool_call_ids = {}
+        tool_call_meta = {}
+        loop = event_loop_fixture
+
+        cb = make_tool_gen_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
+
+        with patch("acp_adapter.events.make_tool_call_id", side_effect=["tc-gen-1", "tc-gen-2"]), \
+             patch("acp_adapter.events._send_update") as mock_send:
+            cb("read_file", generation_key="chat:0")
+            cb("read_file", generation_key="chat:1")
+
+        assert list(tool_call_ids["read_file"]) == ["tc-gen-1", "tc-gen-2"]
+        assert tool_call_meta["tc-gen-1"]["generation_key"] == "chat:0"
+        assert tool_call_meta["tc-gen-2"]["generation_key"] == "chat:1"
+        assert mock_send.call_count == 2
+
+    def test_generation_key_retry_with_new_tool_name_moves_placeholder(self, mock_conn, event_loop_fixture):
+        """A retry that changes the tool name should update the existing card."""
+        tool_call_ids = {}
+        tool_call_meta = {}
+        loop = event_loop_fixture
+
+        cb = make_tool_gen_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
+
+        with patch("acp_adapter.events.make_tool_call_id", side_effect=["tc-gen-1", "tc-gen-2"]), \
+             patch("acp_adapter.events._send_update") as mock_send:
+            cb("read_file", generation_key="chat:0")
+            cb("terminal", generation_key="chat:0")
+
+        assert "read_file" not in tool_call_ids
+        assert list(tool_call_ids["terminal"]) == ["tc-gen-1"]
+        assert tool_call_meta["tc-gen-1"]["generation_key"] == "chat:0"
+        assert mock_send.call_count == 2
+        update = mock_send.call_args_list[-1].args[3]
+        assert getattr(update, "session_update", None) == "tool_call_update"
+        assert update.tool_call_id == "tc-gen-1"
+        assert update.title == "terminal: "
+
     def test_tool_started_reuses_generated_tool_call_id(self, mock_conn, event_loop_fixture):
         """The real tool.started event should complete the early placeholder."""
         tool_call_ids = {}

--- a/tests/acp/test_events.py
+++ b/tests/acp/test_events.py
@@ -87,21 +87,38 @@ class TestToolGenerationCallback:
             "tool_call_update",
         ]
 
-    def test_ignores_duplicate_generation_for_same_tool(self, mock_conn, event_loop_fixture):
-        """Repeated generation callbacks for the same tool should be idempotent."""
+    def test_same_name_generation_callbacks_reserve_fifo_tool_calls(self, mock_conn, event_loop_fixture):
+        """Same-name streamed tool calls should each get an early FIFO placeholder."""
         tool_call_ids = {}
         tool_call_meta = {}
         loop = event_loop_fixture
 
-        cb = make_tool_gen_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
+        gen_cb = make_tool_gen_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
+        progress_cb = make_tool_progress_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
 
-        with patch("acp_adapter.events.make_tool_call_id", return_value="tc-gen"), \
+        with patch("acp_adapter.events.make_tool_call_id", side_effect=["tc-gen-1", "tc-gen-2"]), \
              patch("acp_adapter.events._send_update") as mock_send:
-            cb("read_file")
-            cb("read_file")
+            gen_cb("read_file")
+            gen_cb("read_file")
+            progress_cb("tool.started", "read_file", "reading a.py", {"path": "a.py"})
+            progress_cb("tool.started", "read_file", "reading b.py", {"path": "b.py"})
 
-        assert list(tool_call_ids["read_file"]) == ["tc-gen"]
-        assert mock_send.call_count == 1
+        assert list(tool_call_ids["read_file"]) == ["tc-gen-1", "tc-gen-2"]
+        assert tool_call_meta["tc-gen-1"] == {
+            "args": {"path": "a.py"},
+            "snapshot": None,
+        }
+        assert tool_call_meta["tc-gen-2"] == {
+            "args": {"path": "b.py"},
+            "snapshot": None,
+        }
+        updates = [call.args[3] for call in mock_send.call_args_list]
+        assert [getattr(update, "session_update", None) for update in updates] == [
+            "tool_call",
+            "tool_call",
+            "tool_call_update",
+            "tool_call_update",
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/acp/test_events.py
+++ b/tests/acp/test_events.py
@@ -17,6 +17,7 @@ from acp_adapter.events import (
     make_message_cb,
     make_step_cb,
     make_thinking_cb,
+    make_tool_gen_cb,
     make_tool_progress_cb,
 )
 
@@ -35,6 +36,72 @@ def event_loop_fixture():
     loop = asyncio.new_event_loop()
     yield loop
     loop.close()
+
+
+# ---------------------------------------------------------------------------
+# Tool generation callback
+# ---------------------------------------------------------------------------
+
+
+class TestToolGenerationCallback:
+    def test_emits_placeholder_tool_call_start(self, mock_conn, event_loop_fixture):
+        """Tool generation should surface an early placeholder tool call."""
+        tool_call_ids = {}
+        tool_call_meta = {}
+        loop = event_loop_fixture
+
+        cb = make_tool_gen_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
+
+        with patch("acp_adapter.events.make_tool_call_id", return_value="tc-gen"), \
+             patch("acp_adapter.events._send_update") as mock_send:
+            cb("web_search")
+
+        assert list(tool_call_ids["web_search"]) == ["tc-gen"]
+        assert tool_call_meta["tc-gen"] == {"args": {}, "snapshot": None, "generated": True}
+        mock_send.assert_called_once()
+        update = mock_send.call_args.args[3]
+        assert getattr(update, "session_update", None) == "tool_call"
+
+    def test_tool_started_reuses_generated_tool_call_id(self, mock_conn, event_loop_fixture):
+        """The real tool.started event should complete the early placeholder."""
+        tool_call_ids = {}
+        tool_call_meta = {}
+        loop = event_loop_fixture
+
+        gen_cb = make_tool_gen_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
+        progress_cb = make_tool_progress_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
+
+        with patch("acp_adapter.events.make_tool_call_id", return_value="tc-gen"), \
+             patch("acp_adapter.events._send_update") as mock_send:
+            gen_cb("web_search")
+            progress_cb("tool.started", "web_search", "searching", {"query": "hermes"})
+
+        assert list(tool_call_ids["web_search"]) == ["tc-gen"]
+        assert tool_call_meta["tc-gen"] == {
+            "args": {"query": "hermes"},
+            "snapshot": None,
+        }
+        updates = [call.args[3] for call in mock_send.call_args_list]
+        assert [getattr(update, "session_update", None) for update in updates] == [
+            "tool_call",
+            "tool_call_update",
+        ]
+
+    def test_ignores_duplicate_generation_for_same_tool(self, mock_conn, event_loop_fixture):
+        """Repeated generation callbacks for the same tool should be idempotent."""
+        tool_call_ids = {}
+        tool_call_meta = {}
+        loop = event_loop_fixture
+
+        cb = make_tool_gen_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
+
+        with patch("acp_adapter.events.make_tool_call_id", return_value="tc-gen"), \
+             patch("acp_adapter.events._send_update") as mock_send:
+            cb("read_file")
+            cb("read_file")
+
+        assert list(tool_call_ids["read_file"]) == ["tc-gen"]
+        assert mock_send.call_count == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1045,6 +1045,7 @@ class TestPrompt:
         assert resp.stop_reason == "end_turn"
         state.agent.run_conversation.assert_called_once()
         assert state.agent.tool_progress_callback is not None
+        assert state.agent.tool_gen_callback is not None
         assert state.agent.step_callback is not None
         assert state.agent.stream_delta_callback is not None
         assert state.agent.reasoning_callback is not None

--- a/tests/acp/test_tools.py
+++ b/tests/acp/test_tools.py
@@ -6,6 +6,7 @@ from acp_adapter.tools import (
     TOOL_KIND_MAP,
     build_tool_complete,
     build_tool_start,
+    build_tool_started_update,
     build_tool_title,
     extract_locations,
     get_tool_kind,
@@ -291,6 +292,31 @@ class TestBuildToolStart:
         result = build_tool_start("tc-5", "some_tool", args)
         assert isinstance(result, ToolCallStart)
         assert result.kind == "other"
+
+
+class TestBuildToolStartedUpdate:
+    def test_build_tool_started_update_refreshes_terminal_display_fields(self):
+        """Argument-complete updates should refresh the early placeholder display."""
+        result = build_tool_started_update("tc-terminal", "terminal", {"command": "ls -la"})
+
+        assert isinstance(result, ToolCallProgress)
+        assert result.tool_call_id == "tc-terminal"
+        assert result.status == "pending"
+        assert result.kind == "execute"
+        assert result.title == "terminal: ls -la"
+        assert result.content[0].content.text == "$ ls -la"
+        assert result.raw_input is None
+
+    def test_build_tool_started_update_refreshes_read_file_location(self):
+        result = build_tool_started_update("tc-read", "read_file", {"path": "a.py", "offset": 12})
+
+        assert isinstance(result, ToolCallProgress)
+        assert result.status == "pending"
+        assert result.kind == "read"
+        assert result.title == "read: a.py"
+        assert result.content is None
+        assert result.locations == [ToolCallLocation(path="a.py", line=12)]
+        assert result.raw_input is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/run_agent/test_tool_gen_callback.py
+++ b/tests/run_agent/test_tool_gen_callback.py
@@ -1,0 +1,29 @@
+from run_agent import AIAgent
+
+
+def test_fire_tool_gen_started_passes_generation_key_to_aware_callback():
+    agent = object.__new__(AIAgent)
+    calls = []
+
+    def callback(name, *, generation_key=None):
+        calls.append((name, generation_key))
+
+    agent.tool_gen_callback = callback
+
+    agent._fire_tool_gen_started("read_file", generation_key="chat:0")
+
+    assert calls == [("read_file", "chat:0")]
+
+
+def test_fire_tool_gen_started_falls_back_for_legacy_callback():
+    agent = object.__new__(AIAgent)
+    calls = []
+
+    def callback(name):
+        calls.append(name)
+
+    agent.tool_gen_callback = callback
+
+    agent._fire_tool_gen_started("read_file", generation_key="chat:0")
+
+    assert calls == ["read_file"]


### PR DESCRIPTION
## Summary
Expose Hermes' existing `tool_gen_callback` through the ACP adapter so clients can show an early tool-call status while large tool inputs are still being generated.

## Details
- Adds `make_tool_gen_cb` to emit a lightweight `ToolCallStart` as soon as a streamed tool name is available.
- Reuses the generated tool call id when `tool_progress_callback("tool.started", ...)` later receives full arguments.
- Updates the pending tool call with real `raw_input` instead of creating a duplicate tool call.
- Wires `agent.tool_gen_callback` in the ACP server.

## Tests
- `uv run ruff check acp_adapter/events.py acp_adapter/server.py tests/acp/test_events.py tests/acp/test_server.py`
- `uv run pytest tests/acp/test_events.py tests/acp/test_server.py::TestPrompt::test_prompt_runs_agent -q`