### PR TITLE
fix(gateway): curate Matrix channel discovery

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -25,6 +25,7 @@ DIRECTORY_PATH = get_hermes_home() / "channel_directory.json"
 # letting you pre-name a chat before it has produced any traffic).
 # Format: {"<platform>": {"<chat_id>": "<friendly name>", ...}, ...}
 CHANNEL_ALIASES_PATH = get_hermes_home() / "channel_aliases.json"
+MATRIX_LANE_LABELS_PATH = get_hermes_home() / "matrix_lane_labels.json"
 
 
 def _load_channel_aliases() -> Dict[str, Dict[str, str]]:
@@ -69,6 +70,58 @@ def _apply_channel_aliases(platforms: Dict[str, Any]) -> None:
                     "type": "group" if str(chat_id).endswith("@g.us") else "dm",
                     "thread_id": None,
                 })
+
+
+def _build_matrix_lanes() -> Optional[List[Dict[str, Any]]]:
+    """Build curated Matrix room/thread targets from matrix_lane_labels.json.
+
+    Matrix sessions are intentionally thread-heavy. Falling back to every
+    historical Matrix session pollutes target discovery with stale
+    ``dm / topic $...`` ghosts, so a curated lane file acts as the source
+    of truth when present.
+    """
+    if not MATRIX_LANE_LABELS_PATH.exists():
+        return None
+
+    try:
+        with open(MATRIX_LANE_LABELS_PATH, encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception as e:
+        logger.debug("Channel directory: failed to read Matrix lane labels: %s", e)
+        return []
+
+    rooms = data.get("rooms") if isinstance(data, dict) else None
+    if not isinstance(rooms, dict):
+        return []
+
+    entries: List[Dict[str, Any]] = []
+    for room_id, meta in rooms.items():
+        if not room_id:
+            continue
+        meta = meta if isinstance(meta, dict) else {}
+        raw_name = meta.get("name")
+        room_name = raw_name.strip() if isinstance(raw_name, str) and raw_name.strip() else str(room_id)
+        entries.append({
+            "id": str(room_id),
+            "name": room_name,
+            "type": "group",
+            "thread_id": None,
+        })
+
+        raw_threads = meta.get("threads")
+        threads = raw_threads if isinstance(raw_threads, dict) else {}
+        for thread_id, label in threads.items():
+            if not thread_id:
+                continue
+            label = label if isinstance(label, str) and label.strip() else f"topic {thread_id}"
+            entries.append({
+                "id": f"{room_id}:{thread_id}",
+                "name": f"{room_name} / {label.strip()}",
+                "type": "group",
+                "thread_id": str(thread_id),
+            })
+
+    return entries
 
 
 def _normalize_channel_query(value: str) -> str:
@@ -143,6 +196,11 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
             or plat_name not in adapter_platform_names
         ):
             continue
+        if plat_name == "matrix":
+            matrix_lanes = _build_matrix_lanes()
+            if matrix_lanes is not None:
+                platforms[plat_name] = matrix_lanes
+                continue
         platforms[plat_name] = await asyncio.to_thread(_build_from_sessions, plat_name)
 
     # Include plugin-registered platforms (dynamic enum members aren't in
@@ -157,6 +215,11 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
                 and entry.name not in platforms
                 and entry.name in adapter_platform_names
             ):
+                if entry.name == "matrix":
+                    matrix_lanes = _build_matrix_lanes()
+                    if matrix_lanes is not None:
+                        platforms[entry.name] = matrix_lanes
+                        continue
                 platforms[entry.name] = await asyncio.to_thread(_build_from_sessions, entry.name)
     except Exception:
         pass

--- a/tests/gateway/test_channel_directory_connected_only.py
+++ b/tests/gateway/test_channel_directory_connected_only.py
@@ -44,3 +44,107 @@ def test_connected_platform_still_uses_session_discovery(tmp_path):
 
     assert "telegram" in directory["platforms"]
     mock_sessions.assert_any_call("telegram")
+
+
+def test_connected_homeassistant_still_uses_session_discovery(tmp_path):
+    cache_file = tmp_path / "channel_directory.json"
+
+    with patch(
+        "gateway.channel_directory._build_from_sessions",
+        return_value={"channels": []},
+    ) as mock_sessions, patch("gateway.channel_directory.DIRECTORY_PATH", cache_file):
+        directory = asyncio.run(build_channel_directory({Platform.HOMEASSISTANT: object()}))
+
+    assert "homeassistant" in directory["platforms"]
+    mock_sessions.assert_any_call("homeassistant")
+
+
+def test_matrix_uses_curated_lane_labels_and_suppresses_thread_ghosts(tmp_path):
+    cache_file = tmp_path / "channel_directory.json"
+    labels_file = tmp_path / "matrix_lane_labels.json"
+    labels_file.write_text(
+        """
+        {
+          "rooms": {
+            "!room:example.org": {
+              "name": "Ops Room",
+              "threads": {"$thread": "Restart Notices"}
+            }
+          }
+        }
+        """.strip()
+    )
+
+    ghosts = [
+        {
+            "id": "!room:example.org:$old",
+            "name": "dm / topic $old",
+            "type": "group",
+            "thread_id": "$old",
+        }
+    ]
+
+    with patch("gateway.channel_directory.MATRIX_LANE_LABELS_PATH", labels_file, create=True), \
+         patch("gateway.channel_directory._build_from_sessions", return_value=ghosts), \
+         patch("gateway.channel_directory.DIRECTORY_PATH", cache_file):
+        directory = asyncio.run(build_channel_directory({Platform.MATRIX: object()}))
+
+    entries = directory["platforms"]["matrix"]
+    assert entries == [
+        {
+            "id": "!room:example.org",
+            "name": "Ops Room",
+            "type": "group",
+            "thread_id": None,
+        },
+        {
+            "id": "!room:example.org:$thread",
+            "name": "Ops Room / Restart Notices",
+            "type": "group",
+            "thread_id": "$thread",
+        },
+    ]
+
+
+def test_empty_matrix_lane_labels_suppress_session_fallback(tmp_path):
+    cache_file = tmp_path / "channel_directory.json"
+    labels_file = tmp_path / "matrix_lane_labels.json"
+    labels_file.write_text('{"rooms": {}}')
+    ghosts = [
+        {
+            "id": "!room:example.org:$old",
+            "name": "dm / topic $old",
+            "type": "group",
+            "thread_id": "$old",
+        }
+    ]
+
+    with patch("gateway.channel_directory.MATRIX_LANE_LABELS_PATH", labels_file, create=True), \
+         patch("gateway.channel_directory._build_from_sessions", return_value=ghosts) as mock_sessions, \
+         patch("gateway.channel_directory.DIRECTORY_PATH", cache_file):
+        directory = asyncio.run(build_channel_directory({Platform.MATRIX: object()}))
+
+    assert directory["platforms"]["matrix"] == []
+    mock_sessions.assert_not_called()
+
+
+def test_matrix_lane_labels_work_with_string_adapter_keys(tmp_path):
+    cache_file = tmp_path / "channel_directory.json"
+    labels_file = tmp_path / "matrix_lane_labels.json"
+    labels_file.write_text(
+        '{"rooms": {"!room:example.org": {"name": "Ops Room", "threads": {}}}}'
+    )
+
+    with patch("gateway.channel_directory.MATRIX_LANE_LABELS_PATH", labels_file, create=True), \
+         patch("gateway.channel_directory._build_from_sessions", return_value=[]), \
+         patch("gateway.channel_directory.DIRECTORY_PATH", cache_file):
+        directory = asyncio.run(build_channel_directory({"matrix": object()}))
+
+    assert directory["platforms"]["matrix"] == [
+        {
+            "id": "!room:example.org",
+            "name": "Ops Room",
+            "type": "group",
+            "thread_id": None,
+        }
+    ]


### PR DESCRIPTION
## Summary
- Add a curated Matrix lane-label source for channel directory generation when `matrix_lane_labels.json` is present.
- Avoid falling back to stale Matrix session/thread targets while preserving session discovery for other connected platforms.
- Add regression coverage for curated Matrix lanes and string adapter keys.

## Test Plan
- `./venv/bin/python -m pytest tests/gateway/test_channel_directory_connected_only.py tests/gateway/test_channel_directory.py tests/tools/test_send_message_tool.py tests/hermes_cli/test_send_cmd.py -q -o 'addopts='`
- `./venv/bin/python -m py_compile gateway/channel_directory.py`
- `npm run build --workspace web`
