### PR TITLE
fix(tui): preserve reasoning and tool chronology

### DIFF
--- a/ui-tui/src/lib/liveProgress.test.ts
+++ b/ui-tui/src/lib/liveProgress.test.ts
@@ -36,6 +36,12 @@ describe('tool shelf helpers', () => {
 })
 
 describe('appendToolShelfMessage', () => {
+  it('appends an initial tool shelf when the history is empty', () => {
+    const shelf: Msg = { kind: 'trail', role: 'system', text: '', tools: ['one ✓'] }
+
+    expect(appendToolShelfMessage([], shelf)).toEqual([shelf])
+  })
+
   it('merges adjacent tool shelves into one contextual shelf', () => {
     const merged = appendToolShelfMessage([{ kind: 'trail', role: 'system', text: '', tools: ['one ✓'] }], {
       kind: 'trail',
@@ -56,7 +62,7 @@ describe('appendToolShelfMessage', () => {
     expect(merged).toEqual([{ kind: 'trail', role: 'system', text: '', thinking: 'plan', tools: ['one ✓', 'two ✓'] }])
   })
 
-  it('merges through intervening thinking-only rows back into the nearest holder', () => {
+  it('attaches a tool shelf to the immediately preceding thinking row', () => {
     const prev: Msg[] = [
       { kind: 'trail', role: 'system', text: '', thinking: 'plan', tools: ['one ✓'] },
       { kind: 'trail', role: 'system', text: '', thinking: 'more plan' }
@@ -75,12 +81,18 @@ describe('appendToolShelfMessage', () => {
       role: 'system',
       text: '',
       thinking: 'plan',
-      tools: ['one ✓', 'two ✓']
+      tools: ['one ✓']
     })
-    expect(merged[1]).toEqual({ kind: 'trail', role: 'system', text: '', thinking: 'more plan' })
+    expect(merged[1]).toEqual({
+      kind: 'trail',
+      role: 'system',
+      text: '',
+      thinking: 'more plan',
+      tools: ['two ✓']
+    })
   })
 
-  it('collapses a chronological thinking/tool/thinking/tool stream into one shelf', () => {
+  it('preserves a chronological thinking/tool/thinking/tool stream', () => {
     const events: Msg[] = [
       { kind: 'trail', role: 'system', text: '', thinking: 'plan' },
       { kind: 'trail', role: 'system', text: '', tools: ['one ✓'] },
@@ -97,9 +109,15 @@ describe('appendToolShelfMessage', () => {
       role: 'system',
       text: '',
       thinking: 'plan',
-      tools: ['one ✓', 'two ✓', 'three ✓']
+      tools: ['one ✓']
     })
-    expect(reduced[1]).toEqual({ kind: 'trail', role: 'system', text: '', thinking: 'more plan' })
+    expect(reduced[1]).toEqual({
+      kind: 'trail',
+      role: 'system',
+      text: '',
+      thinking: 'more plan',
+      tools: ['two ✓', 'three ✓']
+    })
   })
 
   it('starts a new shelf across assistant text boundaries', () => {

--- a/ui-tui/src/lib/liveProgress.ts
+++ b/ui-tui/src/lib/liveProgress.ts
@@ -38,42 +38,20 @@ const isBarrierMessage = (msg: Msg | undefined) => {
   return false
 }
 
-const isToolCarryingTrail = (msg: Msg | undefined) => Boolean(msg?.kind === 'trail' && !msg.text && msg.tools?.length)
-
 export const appendToolShelfMessage = (prev: readonly Msg[], msg: Msg): Msg[] => {
   if (!isToolShelfMessage(msg)) {
     return [...prev, msg]
   }
 
-  let fallbackHolder: number | null = null
+  const tail = prev.at(-1)
 
-  for (let index = prev.length - 1; index >= 0; index--) {
-    const candidate = prev[index]
-
-    if (isToolCarryingTrail(candidate)) {
-      const next = [...prev]
-
-      next[index] = mergeToolShelfInto(candidate!, msg)
-
-      return next
-    }
-
-    if (fallbackHolder === null && canHoldToolShelf(candidate)) {
-      fallbackHolder = index
-    }
-
-    if (isBarrierMessage(candidate)) {
-      break
-    }
+  // A tool result belongs only to the chronological segment immediately
+  // before it. Scanning farther back folds thinking/tool/thinking/tool into
+  // grouped-by-type shelves and loses which reasoning led to which call.
+  // Keep the explicit empty-input fallback: an initial tool shelf must append.
+  if (!tail || isBarrierMessage(tail) || !canHoldToolShelf(tail)) {
+    return [...prev, msg]
   }
 
-  if (fallbackHolder !== null) {
-    const next = [...prev]
-
-    next[fallbackHolder] = mergeToolShelfInto(prev[fallbackHolder]!, msg)
-
-    return next
-  }
-
-  return [...prev, msg]
+  return [...prev.slice(0, -1), mergeToolShelfInto(tail, msg)]
 }


### PR DESCRIPTION
## What does this PR do?

The TUI now keeps each reasoning phase paired with the tool calls that immediately follow it instead of scanning backward and regrouping later tools under an older thinking block. The committed reasoning segment remains mounted while its tool executes, then the next reasoning phase starts a new chronological segment.

## Related Issue

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Shared root cause

- `ui-tui/src/lib/liveProgress.ts` compacted tool shelves by scanning backward across newer thinking-only rows. A `thinking → tool → thinking → tool` event stream therefore attached the second tool to the first reasoning shelf and erased the causal ordering already present in `segmentMessages`.
- Tool shelves now merge only into the immediate tail segment. Adjacent tool calls still compact, while a newer reasoning block remains a chronological boundary. Empty history explicitly falls back to appending the initial shelf.

## How this fixes each issue

- #18241: later tools no longer jump backward across intervening reasoning. Each reasoning/tool phase is retained in event order for both live and settled rendering.
- #55036: tool start closes only the live reasoning state; its committed segment stays mounted as the visible anchor throughout execution and receives that tool's completed row. It collapses naturally only when final response rendering takes over.

## Changes Made

- Replace backward tool-shelf scans with tail-only chronological compaction.
- Preserve the empty-input reducer fallback for initial tool-only turns.
- Add reducer tests for empty input, adjacent compaction, and interleaved reasoning/tool phases.
- Add gateway-event coverage proving a completed reasoning block remains present during tool execution and that multiple phases retain their matching calls.

## How to Test

1. `npm exec --workspace ui-tui -- vitest run src/lib/liveProgress.test.ts src/__tests__/createGatewayEventHandler.test.ts` (87 passed)
2. `npm exec --workspace ui-tui -- eslint src/lib/liveProgress.ts src/lib/liveProgress.test.ts src/__tests__/createGatewayEventHandler.test.ts`
3. `npm run typecheck --workspace ui-tui`
4. Full TUI suite after building `@hermes/ink`: 1,111 passed and 1 skipped; four unrelated baseline failures remain in `statusRule.test.ts` (two removed-cost assertions), `virtualHeights.test.ts` (existing height expectation), and `cursorDriftRegression.test.ts` (5-second timeout).
5. The required full Python suite stopped on the unrelated `tests/acp/test_approval_isolation.py::TestAcpExecAskGate::test_interactive_env_var_routes_to_callback` assertion after collection and six passes.

## What platforms tested on

- macOS on darwin-arm64 (local)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [x] I've run the mechanically covering tests and added regression coverage
- [x] I've tested on macOS on darwin-arm64

### Documentation & Housekeeping

- [x] Documentation update is N/A
- [x] `cli-config.yaml.example` update is N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A
- [x] Cross-platform impact considered; this is platform-neutral TypeScript reducer logic
- [x] Tool schema update is N/A

---
_This coordinated PR bundles a fix that spans several issues. Happy to split it back into focused per-issue PRs if you'd prefer to review them separately._

Refs #18241
Refs #55036

<!-- autocontrib:worker-id=pr-spanning-82c84a65 kind=pr-open -->