### PR TITLE
feat(kanban): one instructed retry for protocol violations before the breaker

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6413,7 +6413,11 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 protocol_violation = True
                 error_text = (
                     "worker exited cleanly (rc=0) without calling "
-                    "kanban_complete or kanban_block — protocol violation"
+                    "kanban_complete or kanban_block — protocol violation. "
+                    "RETRY INSTRUCTION: if the prior run already did the "
+                    "work, verify it and report the result via "
+                    "kanban_complete; a run that ends without a terminal "
+                    "kanban call counts as failed no matter what it did."
                 )
                 event_kind = "protocol_violation"
                 event_payload = {
@@ -6518,11 +6522,18 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 not protocol_violation
                 and _fp_counts.get(fp, 0) >= 3
             )
+            # Protocol violations get exactly ONE instructed retry (limit 2)
+            # instead of an instant breaker trip: small local models commonly
+            # finish the work but exit without the terminal kanban call, and
+            # the retry worker sees the instructive error text below in its
+            # prior-attempts context — which usually fixes the second run.
+            # The no-infinite-loop guarantee is preserved (breaker on the
+            # 2nd consecutive violation). Systemic crashes keep limit 1.
             tripped = _record_task_failure(
                 conn, tid,
                 error=error_text,
                 outcome="crashed",
-                failure_limit=1 if (protocol_violation or is_systemic) else None,
+                failure_limit=2 if protocol_violation else (1 if is_systemic else None),
                 release_claim=False,
                 end_run=False,
                 event_payload_extra={"pid": pid, "claimer": claimer},

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -788,6 +788,62 @@ def test_detect_crashed_workers_isolated_failure_normal_retry(
             )
 
 
+def _run_as_protocol_violation(conn, monkeypatch, tid, pid):
+    import hermes_cli.kanban_db as _kb
+
+    host = _kb._claimer_id().split(":", 1)[0]
+    conn.execute(
+        "UPDATE tasks SET status='running', worker_pid=?, claim_lock=? " "WHERE id=?",
+        (pid, f"{host}:wpv", tid),
+    )
+    conn.commit()
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setattr(_kb, "_classify_worker_exit", lambda _pid: ("clean_exit", 0))
+    return kb.detect_crashed_workers(conn)
+
+
+def test_protocol_violation_first_offense_gets_instructed_retry(
+    kanban_home,
+    monkeypatch,
+):
+    """A clean-exit-without-complete worker gets exactly one retry, with an
+    instructive error the retry worker sees in its prior-attempts context —
+    small local models commonly do the work but skip the terminal call."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="pv-once", assignee="a")
+        _run_as_protocol_violation(conn, monkeypatch, tid, 91000)
+
+        task = kb.get_task(conn, tid)
+        assert (
+            task.status == "ready"
+        ), f"first protocol violation should allow a retry, got {task.status}"
+        row = conn.execute(
+            "SELECT consecutive_failures, last_failure_error FROM tasks " "WHERE id=?",
+            (tid,),
+        ).fetchone()
+        assert row["consecutive_failures"] == 1
+        assert "RETRY INSTRUCTION" in (row["last_failure_error"] or "")
+
+
+def test_protocol_violation_second_offense_trips_breaker(
+    kanban_home,
+    monkeypatch,
+):
+    """The no-infinite-loop guarantee: a second consecutive protocol
+    violation blocks the task."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="pv-twice", assignee="a")
+        _run_as_protocol_violation(conn, monkeypatch, tid, 92000)
+        assert kb.get_task(conn, tid).status == "ready"
+
+        _run_as_protocol_violation(conn, monkeypatch, tid, 92001)
+
+        task = kb.get_task(conn, tid)
+        assert (
+            task.status == "blocked"
+        ), f"second protocol violation should trip breaker, got {task.status}"
+
+
 def test_detect_crashed_workers_skips_freshly_claimed_tasks(
     kanban_home, monkeypatch,
 ):


### PR DESCRIPTION
## Problem

A worker that exits cleanly (rc=0) without calling `kanban_complete`/`kanban_block` trips the circuit breaker **immediately** (`failure_limit=1` in `detect_crashed_workers`). The design concern is sound — a worker whose CLI keeps returning 0 without a terminal transition would loop forever — but the instant breaker punishes the most common real-world case with small local models: **the worker did the task correctly and only skipped the paperwork.**

Observed in the field (2026-07-09, Qwen3-4B workers on a local board): two decomposed children each produced complete, correct results in their session logs, exited without reporting, and permanently bricked their cards while the finished work sat in the transcripts. Operator backfill was the only recovery.

## Fix

Protocol violations now get `failure_limit=2` — **exactly one retry** — with a `RETRY INSTRUCTION` appended to `last_failure_error`:

> if the prior run already did the work, verify it and report the result via kanban_complete; a run that ends without a terminal kanban call counts as failed no matter what it did.

Because `build_worker_context` surfaces prior-attempt errors to the next worker, this text lands directly in the retry worker's prompt context — turning the failure record into corrective instruction, which is usually all a small model needs on round two.

- The no-infinite-loop guarantee is preserved: the breaker still trips on the **2nd consecutive** violation
- Systemic crash fast-block (same-fingerprint ≥3, `failure_limit=1`) is unchanged
- Real crashes (nonzero exit, signaled, unknown) are unchanged

## Tests

2 new tests (`test_protocol_violation_first_offense_gets_instructed_retry`, `test_protocol_violation_second_offense_trips_breaker`) following the existing `detect_crashed_workers` fixture patterns. Full `test_kanban_db.py` suite: 229 passed.

Companion to #61591 (timeout-retry stagger) — both are resilience fixes for boards driven by small local models.