### PR TITLE
fix(kanban): honor explicit board over env DB pin

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -27,11 +27,10 @@ Board resolution order (highest precedence first, all optional):
 * ``board=`` argument passed directly to :func:`connect` / :func:`init_db`
   (explicit — used by the CLI ``--board`` flag and the dashboard
   ``?board=...`` query param).
+* ``HERMES_KANBAN_DB`` env var (pins the DB file path directly — legacy
+  override still honoured when no board is explicitly selected).
 * ``HERMES_KANBAN_BOARD`` env var (used by the dispatcher to pin workers
   to the board their task lives on — workers cannot see other boards).
-* ``HERMES_KANBAN_DB`` env var (pins the DB file path directly — legacy
-  override still honoured; highest precedence when the file path itself
-  is what the caller wants to force).
 * ``<root>/kanban/current`` — a one-line text file holding the slug of
   the "currently selected" board. Written by ``hermes kanban boards
   switch <slug>``. When absent, the active board is ``default``.
@@ -517,20 +516,25 @@ def kanban_db_path(board: Optional[str] = None) -> Path:
 
     Resolution (highest precedence first):
 
-    1. ``HERMES_KANBAN_DB`` env var — pins the path directly. Honoured for
-       back-compat and for the dispatcher→worker handoff (defense in
-       depth: dispatcher injects this into worker env so workers are
-       immune to any path-resolution disagreement).
-    2. When ``board`` arg is None, the active board from
+    1. Explicit ``board`` argument (or scoped per-call board override).
+    2. ``HERMES_KANBAN_DB`` env var — pins the path directly when no board
+       is explicit. Honoured for back-compat and for the dispatcher→worker
+       handoff (defense in depth: dispatcher injects this into worker env so
+       ordinary worker calls are immune to path-resolution disagreement).
+    3. When ``board`` is not explicit, the active board from
        :func:`get_current_board` is used.
-    3. Board ``default`` → ``<root>/kanban.db`` (back-compat path).
+    4. Board ``default`` → ``<root>/kanban.db`` (back-compat path).
        Other boards → ``<root>/kanban/boards/<slug>/kanban.db``.
     """
-    override = os.environ.get("HERMES_KANBAN_DB", "").strip()
-    if override:
-        return Path(override).expanduser()
     slug = _normalize_board_slug(board)
     if slug is None:
+        scoped = (_CURRENT_BOARD_OVERRIDE.get() or "").strip()
+        if scoped:
+            slug = _normalize_board_slug(scoped)
+    if slug is None:
+        override = os.environ.get("HERMES_KANBAN_DB", "").strip()
+        if override:
+            return Path(override).expanduser()
         slug = get_current_board()
     if slug == DEFAULT_BOARD:
         return kanban_home() / "kanban.db"

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -126,12 +126,26 @@ class TestPathResolution:
             fresh_home / "kanban" / "boards" / "other" / "logs"
         )
 
-    def test_env_var_db_override_still_wins(self, fresh_home, tmp_path, monkeypatch):
-        """``HERMES_KANBAN_DB`` pins the file regardless of board= arg."""
+    def test_explicit_board_overrides_env_var_db(self, fresh_home, tmp_path, monkeypatch):
+        """An explicit ``board=`` overrides the worker's env-pinned DB."""
         forced = tmp_path / "custom.db"
         monkeypatch.setenv("HERMES_KANBAN_DB", str(forced))
         assert kb.kanban_db_path() == forced
-        assert kb.kanban_db_path(board="ignored") == forced
+        assert kb.kanban_db_path(board="target") == (
+            fresh_home / "kanban" / "boards" / "target" / "kanban.db"
+        )
+
+    def test_scoped_board_overrides_env_var_db(self, fresh_home, tmp_path, monkeypatch):
+        """CLI/dashboard per-call board scopes have the same precedence."""
+        forced = tmp_path / "custom.db"
+        monkeypatch.setenv("HERMES_KANBAN_DB", str(forced))
+
+        with kb.scoped_current_board("target"):
+            assert kb.kanban_db_path() == (
+                fresh_home / "kanban" / "boards" / "target" / "kanban.db"
+            )
+
+        assert kb.kanban_db_path() == forced
 
     def test_env_var_workspaces_override(self, fresh_home, tmp_path, monkeypatch):
         forced = tmp_path / "ws"
@@ -315,6 +329,30 @@ class TestBoardCRUD:
 # ---------------------------------------------------------------------------
 
 class TestConnectionIsolation:
+    def test_explicit_board_beats_conflicting_env_db_without_task_leakage(
+        self, fresh_home, tmp_path, monkeypatch,
+    ):
+        """Explicit and omitted connects stay isolated under a worker DB pin."""
+        explicit_db = fresh_home / "kanban" / "boards" / "target" / "kanban.db"
+        env_db = tmp_path / "env-board" / "kanban.db"
+        monkeypatch.setenv("HERMES_KANBAN_DB", str(env_db))
+
+        with kb.connect(board="target") as conn:
+            kb.create_task(conn, title="explicit-only", assignee="dev")
+
+        with kb.connect() as conn:
+            assert kb.list_tasks(conn) == []
+            kb.create_task(conn, title="env-only", assignee="dev")
+
+        with kb.connect(board="target") as conn:
+            assert [task.title for task in kb.list_tasks(conn)] == ["explicit-only"]
+        with kb.connect() as conn:
+            assert [task.title for task in kb.list_tasks(conn)] == ["env-only"]
+
+        assert explicit_db.exists()
+        assert env_db.exists()
+        assert explicit_db.resolve() != env_db.resolve()
+
     def test_tasks_do_not_leak_across_boards(self, fresh_home):
         kb.create_board("alpha")
         kb.create_board("beta")

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -146,6 +146,79 @@ def test_kanban_tools_visible_with_toolset_config(monkeypatch, tmp_path):
 # Handler happy paths
 # ---------------------------------------------------------------------------
 
+def test_explicit_board_routes_all_handlers_away_from_conflicting_env_db(
+    monkeypatch, tmp_path,
+):
+    """Explicit tool calls never leak into the worker's env-pinned board."""
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    env_db = tmp_path / "env-board" / "kanban.db"
+    explicit_db = home / "kanban" / "boards" / "target" / "kanban.db"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(env_db))
+    monkeypatch.setenv("HERMES_PROFILE", "project-manager")
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    kb._INITIALIZED_PATHS.clear()
+
+    implicit = json.loads(kt._handle_create({
+        "title": "env-only", "assignee": "reviewer",
+    }))
+    assert implicit["ok"] is True
+
+    parent = json.loads(kt._handle_create({
+        "title": "explicit-parent", "assignee": "reviewer", "board": "target",
+    }))
+    child = json.loads(kt._handle_create({
+        "title": "explicit-child", "assignee": "reviewer", "board": "target",
+    }))
+    assert parent["ok"] is True
+    assert child["ok"] is True
+
+    shown = json.loads(kt._handle_show({
+        "task_id": parent["task_id"], "board": "target",
+    }))
+    assert shown["task"]["title"] == "explicit-parent"
+    assert "error" in json.loads(kt._handle_show({"task_id": parent["task_id"]}))
+
+    commented = json.loads(kt._handle_comment({
+        "task_id": parent["task_id"], "body": "target-only", "board": "target",
+    }))
+    linked = json.loads(kt._handle_link({
+        "parent_id": parent["task_id"],
+        "child_id": child["task_id"],
+        "board": "target",
+    }))
+    completed = json.loads(kt._handle_complete({
+        "task_id": parent["task_id"],
+        "summary": "completed on target",
+        "board": "target",
+    }))
+    assert commented["ok"] is True
+    assert linked["ok"] is True
+    assert completed.get("ok") is True, completed
+
+    with kb.connect() as conn:
+        assert [task.title for task in kb.list_tasks(conn)] == ["env-only"]
+    with kb.connect(board="target") as conn:
+        tasks = {task.title: task for task in kb.list_tasks(conn)}
+        assert set(tasks) == {"explicit-parent", "explicit-child"}
+        assert tasks["explicit-parent"].status == "done"
+        assert tasks["explicit-child"].status == "ready"
+        assert kb.child_ids(conn, parent["task_id"]) == [child["task_id"]]
+        assert [comment.body for comment in kb.list_comments(conn, parent["task_id"])] == [
+            "target-only"
+        ]
+
+    assert env_db.exists()
+    assert explicit_db.exists()
+    assert env_db.resolve() != explicit_db.resolve()
+
+
 @pytest.fixture
 def worker_env(monkeypatch, tmp_path):
     """Simulate being a worker: HERMES_HOME isolated, HERMES_KANBAN_TASK set


### PR DESCRIPTION
## Summary
- make explicit `board=` and scoped per-call board selection override `HERMES_KANBAN_DB`
- preserve the existing env DB → env board → current/default chain when board is omitted
- cover kernel and kanban create/show/comment/link/complete isolation against two temporary DBs

## Tests
- `pytest tests/hermes_cli/test_kanban_boards.py tests/tools/test_kanban_tools.py` (156 passed)
- same suites with `CI=true GITHUB_ACTIONS=true` (156 passed)
- `ruff check` on changed files
- Semgrep diff scan: 0 findings