### PR TITLE
fix: deliver cron output without scheduler wrapper by default

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1438,13 +1438,16 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     from gateway.config import load_gateway_config, Platform
 
     # Optionally wrap the content with a header/footer so the user knows this
-    # is a cron delivery.  Wrapping is on by default; set cron.wrap_response: false
-    # in config.yaml for clean output.
-    wrap_response = True
+    # is a cron delivery.  Wrapping is OFF by default because user-facing cron
+    # jobs should deliver the agent/script's polished card verbatim; the old
+    # header/footer ("Cronjob Response", job_id, stop/manage instructions) made
+    # WhatsApp deliveries look like debug output.  Set cron.wrap_response: true
+    # only for debugging/admin surfaces that explicitly want scheduler metadata.
+    wrap_response = False
     user_cfg = None
     try:
         user_cfg = load_config()
-        wrap_response = user_cfg.get("cron", {}).get("wrap_response", True)
+        wrap_response = user_cfg.get("cron", {}).get("wrap_response", False)
     except Exception:
         pass
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -566,8 +566,8 @@ class TestDeliverResultWrapping:
         )
         return media_file.resolve()
 
-    def test_delivery_wraps_content_with_header_and_footer(self):
-        """Delivered content should include task name header and agent-invisible note."""
+    def test_delivery_defaults_to_clean_content_without_header_or_footer(self):
+        """Delivered content should be the clean card by default, with no scheduler chrome."""
         from gateway.config import Platform
 
         pconfig = MagicMock()
@@ -576,7 +576,8 @@ class TestDeliverResultWrapping:
         mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
 
         with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
-             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("cron.scheduler.load_config", return_value={}):
             job = {
                 "id": "test-job",
                 "name": "daily-report",
@@ -587,14 +588,13 @@ class TestDeliverResultWrapping:
 
         send_mock.assert_called_once()
         sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
-        assert "Cronjob Response: daily-report" in sent_content
-        assert "(job_id: test-job)" in sent_content
-        assert "-------------" in sent_content
-        assert "Here is today's summary." in sent_content
-        assert "To stop or manage this job" in sent_content
+        assert sent_content == "Here is today's summary."
+        assert "Cronjob Response:" not in sent_content
+        assert "(job_id:" not in sent_content
+        assert "To stop or manage this job" not in sent_content
 
-    def test_delivery_uses_job_id_when_no_name(self):
-        """When a job has no name, the wrapper should fall back to job id."""
+    def test_delivery_wraps_content_when_config_enabled(self):
+        """cron.wrap_response=true keeps the legacy scheduler wrapper for debug/admin use."""
         from gateway.config import Platform
 
         pconfig = MagicMock()
@@ -603,7 +603,8 @@ class TestDeliverResultWrapping:
         mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
 
         with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
-             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": True}}):
             job = {
                 "id": "abc-123",
                 "deliver": "origin",
@@ -613,6 +614,9 @@ class TestDeliverResultWrapping:
 
         sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
         assert "Cronjob Response: abc-123" in sent_content
+        assert "(job_id: abc-123)" in sent_content
+        assert "Output." in sent_content
+        assert "To stop or manage this job" in sent_content
 
     def test_delivery_skips_wrapping_when_config_disabled(self):
         """When cron.wrap_response is false, deliver raw content without header/footer."""


### PR DESCRIPTION
## Summary
- default cron delivery to the agent/script body without the scheduler chrome
- keep legacy wrapper available behind cron.wrap_response=true
- update scheduler delivery tests for clean default vs explicit wrapper opt-in

## Test Plan
- ./venv/bin/python -m pytest tests/cron/test_scheduler.py -k 'delivery_defaults_to_clean_content_without_header_or_footer or delivery_wraps_content_when_config_enabled or delivery_skips_wrapping_when_config_disabled or delivery_mirrors_clean_content_not_wrapped' -q -o addopts=
