### PR TITLE
fix(tui): register shell hooks from config.yaml in desktop server (_make_agent)

### DIFF
--- a/tests/tui_gateway/test_make_agent_shell_hooks.py
+++ b/tests/tui_gateway/test_make_agent_shell_hooks.py
@@ -1,0 +1,104 @@
+"""Regression test: _make_agent must register shell hooks from config.yaml.
+
+Without register_from_config(), shell hooks defined in config.yaml
+(pre_tool_call, subagent_stop, on_session_end) are silently ignored
+even when hooks_auto_accept is enabled — the Desktop/TUI paths only
+called discover_plugins() which handles Python plugin hooks, not
+config-driven shell hooks.
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+def test_make_agent_calls_register_from_config_without_accept_hooks():
+    """_make_agent must call register_from_config(cfg) — without
+    an explicit accept_hooks argument — so the internal consent
+    resolution in shell_hooks.py:849-854 normalises string values
+    like "false" correctly."""
+    fake_cfg = {
+        "model": {"default": "test-model"},
+        "agent": {"system_prompt": "test"},
+    }
+
+    with (
+        patch("tui_gateway.server._load_cfg", return_value=fake_cfg),
+        patch("tui_gateway.server._get_db", return_value=MagicMock()),
+        patch("tui_gateway.server._load_tool_progress_mode", return_value="compact"),
+        patch("tui_gateway.server._load_reasoning_config", return_value=None),
+        patch("tui_gateway.server._load_service_tier", return_value=None),
+        patch("tui_gateway.server._load_enabled_toolsets", return_value=None),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "provider": "test",
+                "base_url": "https://test.example.com",
+                "api_key": "sk-test",
+                "api_mode": "chat_completions",
+                "command": None,
+                "args": None,
+                "credential_pool": None,
+            },
+        ),
+        patch("run_agent.AIAgent") as mock_agent,
+        patch(
+            "agent.shell_hooks.register_from_config"
+        ) as mock_reg,
+    ):
+        from tui_gateway.server import _make_agent
+
+        _make_agent("sid-reg-test", "key-reg-test")
+
+        # Must call register_from_config exactly once
+        mock_reg.assert_called_once()
+
+        # First positional arg: cfg dict
+        assert mock_reg.call_args[0][0] is fake_cfg
+
+        # Must NOT pass accept_hooks explicitly — let the function
+        # resolve consent internally (line 849-854 normalises strings)
+        assert "accept_hooks" not in mock_reg.call_args.kwargs
+
+
+def test_make_agent_survives_register_from_config_error():
+    """register_from_config is wrapped in try/except — a broken
+    config or import error must not crash the agent creation."""
+    fake_cfg = {
+        "model": {"default": "test-model"},
+        "agent": {"system_prompt": "test"},
+    }
+
+    with (
+        patch("tui_gateway.server._load_cfg", return_value=fake_cfg),
+        patch("tui_gateway.server._get_db", return_value=MagicMock()),
+        patch("tui_gateway.server._load_tool_progress_mode", return_value="compact"),
+        patch("tui_gateway.server._load_reasoning_config", return_value=None),
+        patch("tui_gateway.server._load_service_tier", return_value=None),
+        patch("tui_gateway.server._load_enabled_toolsets", return_value=None),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "provider": "test",
+                "base_url": "https://test.example.com",
+                "api_key": "sk-test",
+                "api_mode": "chat_completions",
+                "command": None,
+                "args": None,
+                "credential_pool": None,
+            },
+        ),
+        patch("run_agent.AIAgent") as mock_agent,
+        patch(
+            "agent.shell_hooks.register_from_config",
+            side_effect=RuntimeError("simulated hook registration failure"),
+        ) as mock_reg,
+    ):
+        from tui_gateway.server import _make_agent
+
+        # Must NOT raise — the try/except swallows the error
+        _make_agent("sid-err-test", "key-err-test")
+
+        # register_from_config was called but raised
+        mock_reg.assert_called_once()
+
+        # Despite the hook error, AIAgent was still created
+        mock_agent.assert_called_once()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4504,6 +4504,19 @@ def _make_agent(
         pass
 
     cfg = _load_cfg()
+
+    # Register shell hooks from config.yaml at the single Desktop chokepoint
+    # (_make_agent).  Entry-point and WebSocket agent creation both converge
+    # here, so a single registration covers all Desktop paths.
+    # Let register_from_config resolve consent internally — don't pass a raw
+    # YAML string that would bypass the normalisation in shell_hooks.py:849-854.
+    try:
+        from agent.shell_hooks import register_from_config as _reg_hooks
+
+        _reg_hooks(cfg)
+    except Exception:
+        logger.debug("register_from_config failed in _make_agent", exc_info=True)
+
     agent_cfg = cfg.get("agent") or {}
     system_prompt = _prompt_text(agent_cfg.get("system_prompt", ""))
     startup_skills = _parse_tui_skills_env()


### PR DESCRIPTION
## Problem

Desktop paths (`tui_gateway/server.py`) were missing `register_from_config()` calls, causing shell hooks defined in `config.yaml` (`pre_tool_call`, `subagent_stop`, `on_session_end`) to be silently ignored even when `hooks_auto_accept` was enabled.

## Root Cause

- `cli.py` and `gateway/run.py` both call `register_from_config()`, but the Desktop/TUI path (`tui_gateway/server.py` `_make_agent`) only called `discover_plugins()` (which handles Python plugin hooks, not config-driven shell hooks)
- `register_from_config()` reads config.yaml -> registers shell hook callbacks into the plugin manager
- Without it, shell hooks never fire in Desktop mode

## Changes (updated from review)

1. **Register once at `_make_agent`**: Both stdio entry and WebSocket agent creation converge here — a single registration covers all Desktop paths
2. **Don't pass raw `accept_hooks`**: Let `register_from_config` resolve consent internally — raw YAML string values like `"false"` would bypass the normalisation in `shell_hooks.py:849-854`
3. **Drop redundant `entry.py` registration**: Entry-point agent creation also goes through `_make_agent`, making the entry.py call unnecessary
4. **Add hermetic tests**: `test_make_agent_shell_hooks.py` — verifies `register_from_config(cfg)` is called without explicit `accept_hooks`, and that registration failures don't crash agent creation
5. **Add `exc_info=True` logging**: Registration failures now log at DEBUG with full traceback for diagnosability

## Related

- #61315 — Addresses the discover_plugins gap (complementary)
- #60544 — Original pre_tool_call approve escalation fix