### PR TITLE
fix(desktop): avoid false profile switch resets

### DIFF
--- a/apps/desktop/src/app/hooks/use-on-profile-switch.test.tsx
+++ b/apps/desktop/src/app/hooks/use-on-profile-switch.test.tsx
@@ -1,0 +1,44 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { StrictMode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $activeGatewayProfile } from '@/store/profile'
+
+import { useOnProfileSwitch } from './use-on-profile-switch'
+
+describe('useOnProfileSwitch', () => {
+  beforeEach(() => {
+    $activeGatewayProfile.set('default')
+  })
+
+  afterEach(() => {
+    cleanup()
+    $activeGatewayProfile.set('default')
+  })
+
+  it('does not fire for StrictMode effect replay when the profile did not change', () => {
+    const onSwitch = vi.fn()
+
+    const { rerender } = renderHook(() => useOnProfileSwitch(onSwitch), {
+      wrapper: StrictMode
+    })
+
+    rerender()
+
+    expect(onSwitch).not.toHaveBeenCalled()
+  })
+
+  it('fires once when the active gateway profile changes', () => {
+    const onSwitch = vi.fn()
+
+    renderHook(() => useOnProfileSwitch(onSwitch), {
+      wrapper: StrictMode
+    })
+
+    act(() => {
+      $activeGatewayProfile.set('coder')
+    })
+
+    expect(onSwitch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/app/hooks/use-on-profile-switch.ts
+++ b/apps/desktop/src/app/hooks/use-on-profile-switch.ts
@@ -1,22 +1,21 @@
 import { useStore } from '@nanostores/react'
 import { useEffect, useRef } from 'react'
 
-import { $activeGatewayProfile } from '@/store/profile'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 
 /** Run `onSwitch` when the active gateway profile changes — never on first
  *  mount. For dropping per-profile view state (probes, cached usage, drafts)
  *  when the backend the app talks to swaps underneath a still-mounted view. */
 export function useOnProfileSwitch(onSwitch: () => void): void {
-  const profile = useStore($activeGatewayProfile)
-  const first = useRef(true)
+  const profile = normalizeProfileKey(useStore($activeGatewayProfile))
+  const previous = useRef(profile)
 
   useEffect(() => {
-    if (first.current) {
-      first.current = false
-
+    if (previous.current === profile) {
       return
     }
 
+    previous.current = profile
     onSwitch()
     // Fire on profile change only; onSwitch identity is intentionally ignored.
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Summary
- make desktop profile-switch callbacks fire only when the profile value actually changes
- prevent React StrictMode effect replay from clearing settings state on mount
- add a regression test for StrictMode replay and real profile changes

## Tests
- npm --workspace apps/desktop run test:ui -- src/app/hooks/use-on-profile-switch.test.tsx
- npm --workspace apps/desktop exec eslint -- --quiet src/app/hooks/use-on-profile-switch.ts src/app/hooks/use-on-profile-switch.test.tsx
- npm --workspace apps/desktop run typecheck
- npm --workspace apps/desktop run build