### PR TITLE
fix(desktop): avoid recursive cpSync in stage-native-deps (Windows build crash)

### DIFF
--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -52,6 +52,32 @@ function copyGlobByExt(srcDir, destDir, extensions) {
 }
 
 /**
+ * Recursively copies a directory by walking it and copying each file with a
+ * non-recursive cpSync.
+ *
+ * We deliberately avoid `cpSync(src, dest, { recursive: true })`: on Windows
+ * its native cpSyncCopyDir binding (Node 22.x) is unreliable — it throws
+ * "EIO: Access is denied." on the `\\?\`-prefixed destination for plain
+ * directory copies, and can hard-crash the whole process (exit 0xC0000409 /
+ * STATUS_STACK_BUFFER_OVERRUN) while copying node-pty's conpty payload. That
+ * crash is silent and killed the packaged desktop build at the stage step.
+ * Per-file copies use a different codepath that works reliably; this mirrors
+ * the manual walk copyGlobByExt already relies on.
+ */
+export function copyDirRecursive(srcDir, destDir) {
+  mkdirSync(destDir, { recursive: true })
+  for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
+    const src = join(srcDir, entry.name)
+    const dest = join(destDir, entry.name)
+    if (entry.isDirectory()) {
+      copyDirRecursive(src, dest)
+    } else {
+      cpSync(src, dest)
+    }
+  }
+}
+
+/**
  * Copies the locally-compiled build/Release output (used when no prebuild
  * was available and node-pty was built from source for the host machine).
  *
@@ -68,7 +94,7 @@ function copyBuildRelease(srcDir, destDir) {
   mkdirSync(destDir, { recursive: true })
   for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
     if (entry.isDirectory()) {
-      cpSync(join(srcDir, entry.name), join(destDir, entry.name), { recursive: true })
+      copyDirRecursive(join(srcDir, entry.name), join(destDir, entry.name))
       continue
     }
     if (entry.name === 'spawn-helper' || /\.(node|dll|exe)$/.test(entry.name)) {
@@ -106,7 +132,7 @@ export function stageNodePty({ platform = process.platform, arch = process.arch 
     mkdirSync(destPrebuild, { recursive: true })
     for (const entry of readdirSync(prebuildDir, { withFileTypes: true })) {
       if (entry.name === 'conpty' && entry.isDirectory()) {
-        cpSync(join(prebuildDir, 'conpty'), join(destPrebuild, 'conpty'), { recursive: true })
+        copyDirRecursive(join(prebuildDir, 'conpty'), join(destPrebuild, 'conpty'))
         continue
       }
       if (entry.isFile() && /\.(node|dll|exe)$/.test(entry.name)) {

--- a/apps/desktop/scripts/stage-native-deps.test.mjs
+++ b/apps/desktop/scripts/stage-native-deps.test.mjs
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+
+import { copyDirRecursive } from '../scripts/stage-native-deps.mjs'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+
+test('copyDirRecursive reproduces a nested tree with exact bytes', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-stage-'))
+  try {
+    const src = path.join(tempRoot, 'src')
+    const dest = path.join(tempRoot, 'dest')
+    // Mirror node-pty's payload shape: top-level files plus a nested conpty/
+    // dir holding a binary blob (the .dll/.exe that trip Windows cpSync).
+    fs.mkdirSync(path.join(src, 'conpty'), { recursive: true })
+    fs.writeFileSync(path.join(src, 'pty.node'), Buffer.from([0, 1, 2, 253, 254, 255]))
+    fs.writeFileSync(path.join(src, 'index.js'), 'module.exports = {}\n', 'utf8')
+    fs.writeFileSync(path.join(src, 'conpty', 'conpty.dll'), Buffer.from([77, 90, 0, 255]))
+    fs.writeFileSync(path.join(src, 'conpty', 'OpenConsole.exe'), Buffer.from([77, 90, 144, 0]))
+
+    copyDirRecursive(src, dest)
+
+    for (const rel of ['pty.node', 'index.js', 'conpty/conpty.dll', 'conpty/OpenConsole.exe']) {
+      assert.ok(fs.existsSync(path.join(dest, rel)), `missing ${rel}`)
+      assert.deepEqual(
+        fs.readFileSync(path.join(dest, rel)),
+        fs.readFileSync(path.join(src, rel)),
+        `bytes differ for ${rel}`
+      )
+    }
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('copyDirRecursive creates the destination even for an empty source', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-stage-'))
+  try {
+    const src = path.join(tempRoot, 'empty-src')
+    const dest = path.join(tempRoot, 'empty-dest')
+    fs.mkdirSync(src, { recursive: true })
+
+    copyDirRecursive(src, dest)
+
+    assert.equal(fs.existsSync(dest), true)
+    assert.deepEqual(fs.readdirSync(dest), [])
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('stage-native-deps uses no recursive cpSync (Windows 0xC0000409 regression)', () => {
+  // Node 22.x's native recursive cpSync crashes/hard-faults on Windows while
+  // copying the conpty payload; directory copies must go through the manual
+  // walk instead. Guard against anyone reintroducing `cpSync(.., recursive)`.
+  const source = fs.readFileSync(path.join(here, 'stage-native-deps.mjs'), 'utf8')
+  // Drop comments so the guard inspects real calls, not the doc comment that
+  // names the very API we're avoiding.
+  const code = source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^\s*\/\/.*$/gm, '')
+  const recursiveCpSync = /cpSync\([^\n]*recursive/.test(code)
+  assert.equal(recursiveCpSync, false, 'stage-native-deps.mjs must not call cpSync with { recursive: true }')
+})


### PR DESCRIPTION
## What does this PR do?

Fixes a hard crash that makes the desktop app impossible to build/package on Windows.

`npm run pack` (invoked by `hermes desktop`) dies silently at the `stage-native-deps` step with exit code `3221226505` (`0xC0000409` / `STATUS_STACK_BUFFER_OVERRUN`):

```
bundled ...\dist\electron-preload.js
npm error Lifecycle script `build` failed with error:
npm error code 3221226505
```

Root cause: **Node 22.x's native recursive `cpSync` (`cpSyncCopyDir`) is unreliable on Windows.** `cpSync(src, dest, { recursive: true })` throws `EIO: "Access is denied."` on the `\\?\`-prefixed destination — reproducible even for a plain directory of `.js` files — and *hard-crashes the whole process* (0xC0000409) when copying node-pty's `conpty` payload (`OpenConsole.exe` + `conpty.dll`). Per-file, non-recursive `cpSync` works every time.

Because the fault is native (not a JS exception), there's no stack trace and it can't be caught/retried — the process just vanishes. The desktop launcher then **misreports** this as a blocked Electron download and retries via a mirror, but the build never actually reaches the `electron-builder` step, so the retry can't help.

The fix routes the two recursive-`cpSync` directory copies in `stage-native-deps.mjs` through a small manual walk (`copyDirRecursive`) that copies files individually — the exact pattern the neighbouring `copyGlobByExt` already uses reliably. No behavior change on macOS/Linux (they were fine; this just uses a codepath that also works on Windows).

## Related Issue

No linked issue — happy to open one if you'd prefer to track it. Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/scripts/stage-native-deps.mjs`
  - Added `copyDirRecursive(srcDir, destDir)` — walks a directory with `readdirSync` and copies each file with a **non-recursive** `cpSync` (recursing into subdirs itself), with a comment explaining why recursive `cpSync` is avoided.
  - Replaced the two `cpSync(dir, { recursive: true })` calls (`copyBuildRelease` for `build/Release/*` subdirs, and the `prebuilds/<target>/conpty` copy) with `copyDirRecursive`.
- `apps/desktop/scripts/stage-native-deps.test.mjs` (new)
  - Verifies `copyDirRecursive` reproduces a nested tree (incl. a `conpty/` subdir with binary blobs) with byte-exact copies.
  - Verifies it creates the destination even for an empty source.
  - Regression guard asserting `stage-native-deps.mjs` never calls `cpSync` with `{ recursive: true }` (the crashing API).

## How to Test

Reproduction (Windows 11, Node 22.x, from `apps/desktop`):

1. On `main`: `npm run build` → crashes at `stage-native-deps` with `npm error code 3221226505`, no stack trace.
2. With this PR: `npm run build` → exits `0`; `npm run pack` → exits `0` and produces `release/win-unpacked/Hermes.exe` with the node-pty conpty binaries staged under `resources/app.asar.unpacked/dist/node_modules/node-pty/`.

Unit tests:

```
cd apps/desktop && node --test scripts/stage-native-deps.test.mjs
# tests 3  pass 3  fail 0
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, this is a desktop build-script (Node) change; ran `node --test scripts/stage-native-deps.test.mjs` (3/3 pass) instead
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (WSL2), Node 22.23.x — full `npm run pack` now succeeds

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — code comment added explaining the Windows cpSync pitfall; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — macOS/Linux behavior unchanged (they already worked); fix only swaps to a codepath that additionally works on Windows
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before (on `main`):

```
  dist\electron-preload.js  15.5kb
bundled ...\dist\electron-preload.js
npm error Lifecycle script `build` failed with error:
npm error code 3221226505
```

After (this PR):

```
[stage-native-deps] staged node-pty (win32-x64) -> ...\apps\desktop\dist\node_modules\node-pty
> hermes@0.17.0 postbuild
✓ assert-dist-built: dist/index.html + assets present
  • packaging       platform=win32 arch=x64 electron=40.10.2 appOutDir=release\win-unpacked
===PACK_ERRORLEVEL=0===
```
