### PR TITLE
fix: scope kanban blocker notifier dedupe to events

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3104,7 +3104,7 @@ def _append_event(
     payload: Optional[dict] = None,
     *,
     run_id: Optional[int] = None,
-) -> None:
+) -> int:
     """Record an event row.  Called from within an already-open txn.
 
     ``run_id`` is optional: pass the current run id so UIs can group
@@ -3114,11 +3114,12 @@ def _append_event(
     """
     now = int(time.time())
     pl = json.dumps(payload, ensure_ascii=False) if payload else None
-    conn.execute(
+    cur = conn.execute(
         "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
         "VALUES (?, ?, ?, ?, ?)",
         (task_id, run_id, kind, pl, now),
     )
+    return int(cur.lastrowid or 0)
 
 
 def _end_run(
@@ -4624,77 +4625,28 @@ def block_task(
                 run_id = _synthesize_ended_run(
                     conn, task_id, outcome="blocked", summary=reason,
                 )
-            _append_event(
+            event_id = _append_event(
                 conn, task_id, "dependency_wait",
                 {"reason": reason, "kind": kind}, run_id=run_id,
             )
             routed_to = "todo"
-            _blocked_task = get_task(conn, task_id)
-            _fire_kanban_lifecycle_hook(
-                "kanban_task_blocked",
-                task_id,
-                board=get_current_board(),
-                assignee=_blocked_task.assignee if _blocked_task else None,
-                run_id=run_id,
-                reason=reason,
-            )
-            return True
-
-        # Truly-blocked kinds. Increment the unblock-loop counter when this is a
-        # re-block for the SAME reason after a prior unblock. block_task only
-        # fires from running/ready (i.e. AFTER an unblock returned the task to
-        # the work pool), so a stored block_kind that matches the incoming kind
-        # means: blocked → unblocked → about-to-re-block for the same cause.
-        # An un-typed (None) block compares as "same" to a prior un-typed block.
-        same_cause = prev_kind == kind
-        recurrences = prev_recurrences + 1 if same_cause else 1
-
-        if recurrences >= BLOCK_RECURRENCE_LIMIT:
-            # Loop detected — stop letting the unblocker spin this task. Route
-            # to triage for a human-in-the-loop decision instead of blocked.
-            cur = conn.execute(
-                """
-                UPDATE tasks
-                   SET status        = 'triage',
-                       claim_lock    = NULL,
-                       claim_expires = NULL,
-                       worker_pid    = NULL,
-                       block_kind    = ?,
-                       block_recurrences = ?
-                 WHERE id = ?
-                   AND status IN ('running', 'ready')
-                """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
-                (kind, recurrences, task_id) if expected_run_id is None
-                else (kind, recurrences, task_id, int(expected_run_id)),
-            )
-            if cur.rowcount != 1:
-                return False
-            run_id = _end_run(
-                conn, task_id,
-                outcome="blocked", status="blocked",
-                summary=reason,
-            )
-            if run_id is None and reason:
-                run_id = _synthesize_ended_run(
-                    conn, task_id, outcome="blocked", summary=reason,
-                )
-            _append_event(
-                conn, task_id, "block_loop_detected",
-                {
-                    "reason": reason,
-                    "kind": kind,
-                    "recurrences": recurrences,
-                    "limit": BLOCK_RECURRENCE_LIMIT,
-                },
-                run_id=run_id,
-            )
-            routed_to = "triage"
         else:
-            if expected_run_id is None:
+            # Truly-blocked kinds. Increment the unblock-loop counter when this is a
+            # re-block for the SAME reason after a prior unblock. block_task only
+            # fires from running/ready (i.e. AFTER an unblock returned the task to
+            # the work pool), so a stored block_kind that matches the incoming kind
+            # means: blocked → unblocked → about-to-re-block for the same cause.
+            # An un-typed (None) block compares as "same" to a prior un-typed block.
+            same_cause = prev_kind == kind
+            recurrences = prev_recurrences + 1 if same_cause else 1
+
+            if recurrences >= BLOCK_RECURRENCE_LIMIT:
+                # Loop detected — stop letting the unblocker spin this task. Route
+                # to triage for a human-in-the-loop decision instead of blocked.
                 cur = conn.execute(
                     """
                     UPDATE tasks
-                       SET status        = 'blocked',
+                       SET status        = 'triage',
                            claim_lock    = NULL,
                            claim_expires = NULL,
                            worker_pid    = NULL,
@@ -4702,52 +4654,93 @@ def block_task(
                            block_recurrences = ?
                      WHERE id = ?
                        AND status IN ('running', 'ready')
-                    """,
-                    (kind, recurrences, task_id),
+                    """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
+                    (kind, recurrences, task_id) if expected_run_id is None
+                    else (kind, recurrences, task_id, int(expected_run_id)),
                 )
-            else:
-                cur = conn.execute(
-                    """
-                    UPDATE tasks
-                       SET status        = 'blocked',
-                           claim_lock    = NULL,
-                           claim_expires = NULL,
-                           worker_pid    = NULL,
-                           block_kind    = ?,
-                           block_recurrences = ?
-                     WHERE id = ?
-                       AND status IN ('running', 'ready')
-                       AND current_run_id = ?
-                    """,
-                    (kind, recurrences, task_id, int(expected_run_id)),
-                )
-            if cur.rowcount != 1:
-                return False
-            run_id = _end_run(
-                conn, task_id,
-                outcome="blocked", status="blocked",
-                summary=reason,
-            )
-            # Synthesize a run when blocking a never-claimed task so the
-            # reason is preserved in attempt history.
-            if run_id is None and reason:
-                run_id = _synthesize_ended_run(
+                if cur.rowcount != 1:
+                    return False
+                run_id = _end_run(
                     conn, task_id,
-                    outcome="blocked",
+                    outcome="blocked", status="blocked",
                     summary=reason,
                 )
-            _append_event(
-                conn, task_id, "blocked",
-                {"reason": reason, "kind": kind, "recurrences": recurrences},
-                run_id=run_id,
-            )
+                if run_id is None and reason:
+                    run_id = _synthesize_ended_run(
+                        conn, task_id, outcome="blocked", summary=reason,
+                    )
+                event_id = _append_event(
+                    conn, task_id, "block_loop_detected",
+                    {
+                        "reason": reason,
+                        "kind": kind,
+                        "recurrences": recurrences,
+                        "limit": BLOCK_RECURRENCE_LIMIT,
+                    },
+                    run_id=run_id,
+                )
+                routed_to = "triage"
+            else:
+                if expected_run_id is None:
+                    cur = conn.execute(
+                        """
+                        UPDATE tasks
+                           SET status        = 'blocked',
+                               claim_lock    = NULL,
+                               claim_expires = NULL,
+                               worker_pid    = NULL,
+                               block_kind    = ?,
+                               block_recurrences = ?
+                         WHERE id = ?
+                           AND status IN ('running', 'ready')
+                        """,
+                        (kind, recurrences, task_id),
+                    )
+                else:
+                    cur = conn.execute(
+                        """
+                        UPDATE tasks
+                           SET status        = 'blocked',
+                               claim_lock    = NULL,
+                               claim_expires = NULL,
+                               worker_pid    = NULL,
+                               block_kind    = ?,
+                               block_recurrences = ?
+                         WHERE id = ?
+                           AND status IN ('running', 'ready')
+                           AND current_run_id = ?
+                        """,
+                        (kind, recurrences, task_id, int(expected_run_id)),
+                    )
+                if cur.rowcount != 1:
+                    return False
+                run_id = _end_run(
+                    conn, task_id,
+                    outcome="blocked", status="blocked",
+                    summary=reason,
+                )
+                # Synthesize a run when blocking a never-claimed task so the
+                # reason is preserved in attempt history.
+                if run_id is None and reason:
+                    run_id = _synthesize_ended_run(
+                        conn, task_id,
+                        outcome="blocked",
+                        summary=reason,
+                    )
+                event_id = _append_event(
+                    conn, task_id, "blocked",
+                    {"reason": reason, "kind": kind, "recurrences": recurrences},
+                    run_id=run_id,
+                )
         _blocked_task = get_task(conn, task_id)
     _fire_kanban_lifecycle_hook(
         "kanban_task_blocked",
         task_id,
         board=get_current_board(),
+        event_id=event_id,
         assignee=_blocked_task.assignee if _blocked_task else None,
         run_id=run_id,
+        kind=kind,
         reason=reason,
     )
     return True

--- a/plugins/kanban-block-notifier/__init__.py
+++ b/plugins/kanban-block-notifier/__init__.py
@@ -60,7 +60,7 @@ def _as_list(value: Any, default: list[str]) -> list[str]:
     return list(default)
 
 
-def _state_db_path(config: dict[str, Any]) -> Path:
+def _state_db_path(config: dict[str, Any]) -> Path | None:
     raw = str(config.get("state_db") or "").strip()
     if raw:
         return Path(raw).expanduser()
@@ -69,7 +69,10 @@ def _state_db_path(config: dict[str, Any]) -> Path:
 
         return kb.kanban_home() / "kanban" / "kanban-block-notifier.sqlite3"
     except Exception:
-        return Path.home() / ".hermes" / "kanban" / "kanban-block-notifier.sqlite3"
+        # Persistent state must follow Hermes' profile/custom-home resolution.
+        # If that resolver is unavailable, fail closed rather than writing to a
+        # parallel ~/.hermes tree and weakening event-scoped deduplication.
+        return None
 
 
 def _ensure_state(conn: sqlite3.Connection) -> None:
@@ -239,6 +242,11 @@ def _on_kanban_task_blocked(**kwargs: Any) -> None:
         config=config,
     )
     state_db = _state_db_path(config)
+    if state_db is None:
+        logger.warning(
+            "kanban-block-notifier: persistent state root unavailable; notification skipped"
+        )
+        return
     key = _dedupe_key(
         board,
         task_id,

--- a/plugins/kanban-block-notifier/__init__.py
+++ b/plugins/kanban-block-notifier/__init__.py
@@ -1,0 +1,245 @@
+"""Event-driven notifier for human-facing Kanban blockers.
+
+The plugin listens to the existing ``kanban_task_blocked`` lifecycle hook and
+sends a one-shot message through ``hermes send`` when a task blocks for a human
+decision/capability issue. It deliberately does not poll the board.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import re
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Iterable
+
+logger = logging.getLogger(__name__)
+
+HUMAN_BLOCK_KINDS = {"needs_input", "capability"}
+DEFAULT_TARGETS = ["telegram"]
+LEGACY_HUMAN_KEYWORDS = (
+    "secret", "credential", "token", "password", "api key", "access",
+    "permission", "dns", "cloudflare", "https", "domain", "choose",
+    "decision", "user input", "human", "manual",
+)
+
+_LONG_SECRETISH_RE = re.compile(r"(?<![A-Za-z0-9_])[A-Za-z0-9_\-]{28,}(?![A-Za-z0-9_])")
+_ASSIGNMENT_SECRET_RE = re.compile(
+    r"(?i)\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASS|KEY|CREDENTIAL)[A-Z0-9_]*)\s*=\s*([^\s,;]+)"
+)
+_URL_TOKEN_RE = re.compile(r"(?i)([?&](?:token|key|secret|password|access_token)=)[^&#\s]+")
+
+
+def register(ctx) -> None:
+    ctx.register_hook("kanban_task_blocked", _on_kanban_task_blocked)
+
+
+def _plugin_config() -> dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        entry = (((cfg.get("plugins") or {}).get("entries") or {}).get("kanban-block-notifier") or {})
+        return entry if isinstance(entry, dict) else {}
+    except Exception:
+        return {}
+
+
+def _as_list(value: Any, default: list[str]) -> list[str]:
+    if value is None:
+        return list(default)
+    if isinstance(value, str):
+        return [part.strip() for part in value.split(",") if part.strip()]
+    if isinstance(value, Iterable):
+        return [str(part).strip() for part in value if str(part).strip()]
+    return list(default)
+
+
+def _state_db_path(config: dict[str, Any]) -> Path:
+    raw = str(config.get("state_db") or "").strip()
+    if raw:
+        return Path(raw).expanduser()
+    try:
+        from hermes_cli import kanban_db as kb
+
+        return kb.kanban_home() / "kanban" / "kanban-block-notifier.sqlite3"
+    except Exception:
+        return Path.home() / ".hermes" / "kanban" / "kanban-block-notifier.sqlite3"
+
+
+def _ensure_state(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS sent_block_notifications (
+            dedupe_key TEXT NOT NULL,
+            target TEXT NOT NULL,
+            sent_at INTEGER NOT NULL,
+            PRIMARY KEY (dedupe_key, target)
+        )
+        """
+    )
+    conn.commit()
+
+
+def _mark_sent_once(db_path: Path, dedupe_key: str, target: str) -> bool:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(str(db_path), timeout=30) as conn:
+        _ensure_state(conn)
+        try:
+            conn.execute(
+                "INSERT INTO sent_block_notifications (dedupe_key, target, sent_at) VALUES (?, ?, ?)",
+                (dedupe_key, target, int(time.time())),
+            )
+            conn.commit()
+            return True
+        except sqlite3.IntegrityError:
+            return False
+
+
+def _unmark_sent(db_path: Path, dedupe_key: str, target: str) -> None:
+    try:
+        with sqlite3.connect(str(db_path), timeout=30) as conn:
+            conn.execute(
+                "DELETE FROM sent_block_notifications WHERE dedupe_key = ? AND target = ?",
+                (dedupe_key, target),
+            )
+            conn.commit()
+    except Exception:
+        pass
+
+
+def _sanitize(text: str, limit: int = 240) -> str:
+    text = str(text or "").replace("\r", " ").strip()
+    text = _ASSIGNMENT_SECRET_RE.sub(lambda m: f"{m.group(1)}=[redacted]", text)
+    text = _URL_TOKEN_RE.sub(lambda m: f"{m.group(1)}[redacted]", text)
+    text = _LONG_SECRETISH_RE.sub("[redacted]", text)
+    text = re.sub(r"\s+", " ", text)
+    if len(text) > limit:
+        text = text[: limit - 1].rstrip() + "…"
+    return text
+
+
+def _fetch_task(board: str | None, task_id: str):
+    try:
+        from hermes_cli import kanban_db as kb
+
+        conn = kb.connect(board=board)
+        try:
+            return kb.get_task(conn, task_id)
+        finally:
+            conn.close()
+    except Exception:
+        return None
+
+
+def _is_human_block(kind: str | None, reason: str, config: dict[str, Any]) -> bool:
+    reason_l = (reason or "").casefold()
+    if str(config.get("suppress_review_required", True)).lower() not in {"0", "false", "no", "off"}:
+        if reason_l.startswith("review-required") or "review-required" in reason_l:
+            return False
+    notify_kinds = set(_as_list(config.get("notify_kinds"), sorted(HUMAN_BLOCK_KINDS)))
+    if kind in notify_kinds:
+        return True
+    # Legacy/untyped blocks: notify only when the text strongly suggests a human-only input.
+    return (not kind) and any(word in reason_l for word in LEGACY_HUMAN_KEYWORDS)
+
+
+def _build_message(*, board: str | None, task_id: str, title: str, assignee: str | None, kind: str | None, reason: str, config: dict[str, Any]) -> str:
+    safe_reason = _sanitize(reason, limit=int(config.get("reason_limit", 220) or 220))
+    safe_title = _sanitize(title or task_id, limit=120)
+    board_part = f"[{_sanitize(board or 'default', 64)}] "
+    assignee_part = f" @{_sanitize(assignee, 48)}" if assignee else ""
+    kind_part = _sanitize(kind or "blocked", 32)
+    lines = [
+        f"⏸ {board_part}Kanban {task_id}{assignee_part}: нужен ввод человека",
+        f"Задача: {safe_title}",
+        f"Тип блокера: {kind_part}",
+    ]
+    if safe_reason:
+        lines.append(f"Причина: {safe_reason}")
+    if _looks_secret_related(reason):
+        secure_drop_url = str(config.get("secure_drop_url") or "").strip()
+        if secure_drop_url:
+            lines.append(f"Секреты не присылайте в чат; secure-drop: {secure_drop_url}")
+        else:
+            lines.append("Секреты не присылайте в чат; secure-drop не настроен.")
+    return "\n".join(lines)
+
+
+def _looks_secret_related(reason: str) -> bool:
+    r = (reason or "").casefold()
+    return any(word in r for word in ("secret", "token", "credential", "password", "api key", "ключ", "секрет", "парол"))
+
+
+def _send(target: str, message: str, config: dict[str, Any]) -> None:
+    hermes_exe = str(config.get("hermes_command") or os.environ.get("HERMES_CLI", "hermes"))
+    timeout = int(config.get("send_timeout_seconds", 30) or 30)
+    subprocess.run(
+        [hermes_exe, "send", "--to", target, "--quiet"],
+        input=message,
+        text=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=timeout,
+        check=True,
+    )
+
+
+def _dedupe_key(board: str | None, task_id: str, kind: str | None, reason: str) -> str:
+    reason_hash = hashlib.sha256(_sanitize(reason, 500).encode("utf-8")).hexdigest()[:20]
+    return f"{board or 'default'}:{task_id}:{kind or 'legacy'}:{reason_hash}"
+
+
+def _on_kanban_task_blocked(**kwargs: Any) -> None:
+    task_id = str(kwargs.get("task_id") or "").strip()
+    if not task_id:
+        return
+    config = _plugin_config()
+    if str(config.get("enabled", True)).lower() in {"0", "false", "no", "off"}:
+        return
+
+    board = kwargs.get("board") or None
+    reason = str(kwargs.get("reason") or "")
+    task = _fetch_task(board, task_id)
+    kind = getattr(task, "block_kind", None) or kwargs.get("kind") or None
+    title = getattr(task, "title", "") or task_id
+    assignee = getattr(task, "assignee", None) or kwargs.get("assignee") or None
+
+    if not _is_human_block(kind, reason, config):
+        return
+
+    targets = _as_list(config.get("targets"), DEFAULT_TARGETS)
+    if not targets:
+        return
+    message = _build_message(
+        board=board,
+        task_id=task_id,
+        title=title,
+        assignee=assignee,
+        kind=kind,
+        reason=reason,
+        config=config,
+    )
+    state_db = _state_db_path(config)
+    key = _dedupe_key(board, task_id, kind, reason)
+
+    for target in targets:
+        if not _mark_sent_once(state_db, key, target):
+            continue
+        try:
+            _send(target, message, config)
+        except Exception as exc:
+            _unmark_sent(state_db, key, target)
+            # Never log the raw reason/message; it may mention credentials.
+            logger.warning(
+                "kanban-block-notifier: failed to send %s notification for task %s to %s: %s",
+                kind or "blocked",
+                task_id,
+                target,
+                exc.__class__.__name__,
+            )

--- a/plugins/kanban-block-notifier/__init__.py
+++ b/plugins/kanban-block-notifier/__init__.py
@@ -178,7 +178,7 @@ def _looks_secret_related(reason: str) -> bool:
 
 def _send(target: str, message: str, config: dict[str, Any]) -> None:
     hermes_exe = str(config.get("hermes_command") or os.environ.get("HERMES_CLI", "hermes"))
-    timeout = int(config.get("send_timeout_seconds", 30) or 30)
+    timeout = int(config.get("send_timeout_seconds", 10) or 10)
     subprocess.run(
         [hermes_exe, "send", "--to", target, "--quiet"],
         input=message,
@@ -190,9 +190,22 @@ def _send(target: str, message: str, config: dict[str, Any]) -> None:
     )
 
 
-def _dedupe_key(board: str | None, task_id: str, kind: str | None, reason: str) -> str:
+def _dedupe_key(
+    board: str | None,
+    task_id: str,
+    kind: str | None,
+    reason: str,
+    *,
+    event_id: Any = None,
+    run_id: Any = None,
+) -> str:
+    board_key = board or "default"
+    if event_id is not None:
+        return f"{board_key}:{task_id}:event:{event_id}"
+    if run_id is not None:
+        return f"{board_key}:{task_id}:run:{run_id}"
     reason_hash = hashlib.sha256(_sanitize(reason, 500).encode("utf-8")).hexdigest()[:20]
-    return f"{board or 'default'}:{task_id}:{kind or 'legacy'}:{reason_hash}"
+    return f"{board_key}:{task_id}:{kind or 'legacy'}:{reason_hash}"
 
 
 def _on_kanban_task_blocked(**kwargs: Any) -> None:
@@ -226,7 +239,14 @@ def _on_kanban_task_blocked(**kwargs: Any) -> None:
         config=config,
     )
     state_db = _state_db_path(config)
-    key = _dedupe_key(board, task_id, kind, reason)
+    key = _dedupe_key(
+        board,
+        task_id,
+        kind,
+        reason,
+        event_id=kwargs.get("event_id"),
+        run_id=kwargs.get("run_id"),
+    )
 
     for target in targets:
         if not _mark_sent_once(state_db, key, target):

--- a/plugins/kanban-block-notifier/plugin.yaml
+++ b/plugins/kanban-block-notifier/plugin.yaml
@@ -1,0 +1,11 @@
+name: kanban-block-notifier
+version: 0.1.0
+description: "Event-driven Telegram/home notifications for human-facing Kanban blockers via lifecycle hooks."
+author: NousResearch
+kind: standalone
+provides_hooks:
+  - kanban_task_blocked
+platforms:
+  - linux
+  - macos
+  - windows

--- a/tests/plugins/test_kanban_block_notifier.py
+++ b/tests/plugins/test_kanban_block_notifier.py
@@ -37,6 +37,24 @@ def test_redacts_secretish_reason_text():
     assert "secure-drop: https://drop.example/one" in msg
 
 
+def test_redacts_long_tokens_and_russian_secret_keywords():
+    mod = _load_plugin_module()
+
+    msg = mod._build_message(
+        board="proj",
+        task_id="t_1234abcd",
+        title="Need secret",
+        assignee="developer",
+        kind="needs_input",
+        reason="Нужен секрет ключ ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890 для доступа",
+        config={},
+    )
+
+    assert "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890" not in msg
+    assert "[redacted]" in msg
+    assert "secure-drop не настроен" in msg
+
+
 def test_skips_review_required_and_dependency_blocks():
     mod = _load_plugin_module()
 
@@ -73,6 +91,39 @@ def test_dedupes_same_blocker_per_target(tmp_path, monkeypatch):
     assert "Need DNS decision" in sent[0][1]
 
 
+def test_dedupe_is_scoped_to_block_event_and_board(tmp_path, monkeypatch):
+    mod = _load_plugin_module()
+    sent: list[tuple[str, str]] = []
+    state_db = tmp_path / "state.sqlite3"
+
+    monkeypatch.setattr(mod, "_plugin_config", lambda: {"state_db": str(state_db), "targets": ["telegram:test"]})
+    monkeypatch.setattr(
+        mod,
+        "_fetch_task",
+        lambda board, task_id: SimpleNamespace(
+            id=task_id,
+            title="Blocked task",
+            assignee="developer",
+            block_kind="needs_input",
+        ),
+    )
+    monkeypatch.setattr(mod, "_send", lambda target, message, config: sent.append((target, message)))
+
+    kwargs = {"board": "project-board", "task_id": "t_deadbeef", "reason": "Need DNS decision"}
+    mod._on_kanban_task_blocked(**kwargs, event_id=101)
+    mod._on_kanban_task_blocked(**kwargs, event_id=101)
+    mod._on_kanban_task_blocked(**kwargs, event_id=102)
+
+    assert len(sent) == 2
+    assert all("[project-board]" in message for _, message in sent)
+    with mod.sqlite3.connect(str(state_db)) as conn:
+        keys = [row[0] for row in conn.execute("SELECT dedupe_key FROM sent_block_notifications ORDER BY dedupe_key")]
+    assert keys == [
+        "project-board:t_deadbeef:event:101",
+        "project-board:t_deadbeef:event:102",
+    ]
+
+
 def test_real_kanban_block_event_sends_once(tmp_path, monkeypatch):
     mod = _load_plugin_module()
     sent: list[tuple[str, str]] = []
@@ -95,14 +146,51 @@ def test_real_kanban_block_event_sends_once(tmp_path, monkeypatch):
     try:
         tid = kb.create_task(conn, title="Configure HTTPS", assignee="developer", initial_status="running")
         assert kb.block_task(conn, tid, reason="Need DNS decision", kind="needs_input")
+        event_id = kb.list_events(conn, tid)[-1].id
         # Same blocker fired again through the lifecycle callback should be deduped.
-        mod._on_kanban_task_blocked(board="default", task_id=tid, reason="Need DNS decision")
+        mod._on_kanban_task_blocked(board="default", task_id=tid, reason="Need DNS decision", event_id=event_id)
     finally:
         conn.close()
 
     assert len(sent) == 1
     assert "Configure HTTPS" in sent[0][1]
     assert "Need DNS decision" in sent[0][1]
+
+
+def test_unblock_then_reblock_same_reason_sends_again(tmp_path, monkeypatch):
+    mod = _load_plugin_module()
+    sent: list[tuple[str, str]] = []
+    home = tmp_path / "kanban-home"
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "project-board")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setattr(mod, "_plugin_config", lambda: {"state_db": str(tmp_path / "state.sqlite3"), "targets": ["telegram:test"]})
+    monkeypatch.setattr(mod, "_send", lambda target, message, config: sent.append((target, message)))
+
+    from hermes_cli import kanban_db as kb
+    import hermes_cli.plugins as plugins
+
+    monkeypatch.setattr(
+        plugins,
+        "invoke_hook",
+        lambda event, **kwargs: mod._on_kanban_task_blocked(**kwargs) if event == "kanban_task_blocked" else None,
+    )
+    kb.init_db(board="project-board")
+    conn = kb.connect(board="project-board")
+    try:
+        tid = kb.create_task(conn, title="Configure HTTPS", assignee="developer", initial_status="running")
+        assert kb.block_task(conn, tid, reason="Need DNS decision", kind="needs_input")
+        first_event_id = kb.list_events(conn, tid)[-1].id
+        # Replaying the same lifecycle event should not duplicate the notification.
+        mod._on_kanban_task_blocked(board="project-board", task_id=tid, reason="Need DNS decision", event_id=first_event_id)
+        ok, refusal = kb.promote_task(conn, tid, actor="test", force=True)
+        assert ok, refusal
+        assert kb.block_task(conn, tid, reason="Need DNS decision", kind="needs_input")
+    finally:
+        conn.close()
+
+    assert len(sent) == 2
+    assert all("[project-board]" in message for _, message in sent)
 
 
 def test_retries_after_send_failure(tmp_path, monkeypatch):

--- a/tests/plugins/test_kanban_block_notifier.py
+++ b/tests/plugins/test_kanban_block_notifier.py
@@ -127,6 +127,7 @@ def test_dedupe_is_scoped_to_block_event_and_board(tmp_path, monkeypatch):
 def test_real_kanban_block_event_sends_once(tmp_path, monkeypatch):
     mod = _load_plugin_module()
     sent: list[tuple[str, str]] = []
+    hook_calls: list[dict] = []
     home = tmp_path / "kanban-home"
     monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
@@ -136,15 +137,29 @@ def test_real_kanban_block_event_sends_once(tmp_path, monkeypatch):
     from hermes_cli import kanban_db as kb
     import hermes_cli.plugins as plugins
 
-    monkeypatch.setattr(
-        plugins,
-        "invoke_hook",
-        lambda event, **kwargs: mod._on_kanban_task_blocked(**kwargs) if event == "kanban_task_blocked" else None,
-    )
     kb.init_db()
     conn = kb.connect()
     try:
         tid = kb.create_task(conn, title="Configure HTTPS", assignee="developer", initial_status="running")
+
+        def capture_hook(event, **kwargs):
+            if event != "kanban_task_blocked":
+                return
+            # A separate connection can only observe the event after commit,
+            # proving lifecycle dispatch is outside the write transaction.
+            observer = kb.connect()
+            try:
+                row = observer.execute(
+                    "SELECT id, kind FROM task_events WHERE id = ?", (kwargs["event_id"],)
+                ).fetchone()
+            finally:
+                observer.close()
+            assert row is not None
+            assert row["kind"] == "blocked"
+            hook_calls.append(kwargs)
+            mod._on_kanban_task_blocked(**kwargs)
+
+        monkeypatch.setattr(plugins, "invoke_hook", capture_hook)
         assert kb.block_task(conn, tid, reason="Need DNS decision", kind="needs_input")
         event_id = kb.list_events(conn, tid)[-1].id
         # Same blocker fired again through the lifecycle callback should be deduped.
@@ -153,8 +168,59 @@ def test_real_kanban_block_event_sends_once(tmp_path, monkeypatch):
         conn.close()
 
     assert len(sent) == 1
+    assert len(hook_calls) == 1
+    assert hook_calls[0]["event_id"] == event_id
+    assert hook_calls[0]["kind"] == "needs_input"
     assert "Configure HTTPS" in sent[0][1]
     assert "Need DNS decision" in sent[0][1]
+
+
+def test_dependency_block_hook_has_committed_event_id_and_kind(tmp_path, monkeypatch):
+    home = tmp_path / "kanban-home"
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    from hermes_cli import kanban_db as kb
+    import hermes_cli.plugins as plugins
+
+    calls: list[dict] = []
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="Wait for parent", assignee="developer", initial_status="running")
+
+        def capture_hook(event, **kwargs):
+            if event != "kanban_task_blocked":
+                return
+            observer = kb.connect()
+            try:
+                row = observer.execute(
+                    "SELECT id, kind FROM task_events WHERE id = ?", (kwargs["event_id"],)
+                ).fetchone()
+            finally:
+                observer.close()
+            assert row is not None
+            assert row["kind"] == "dependency_wait"
+            calls.append(kwargs)
+
+        monkeypatch.setattr(plugins, "invoke_hook", capture_hook)
+        assert kb.block_task(conn, tid, reason="waiting for parent", kind="dependency")
+        event = kb.list_events(conn, tid)[-1]
+    finally:
+        conn.close()
+
+    assert len(calls) == 1
+    assert calls[0]["event_id"] == event.id
+    assert calls[0]["kind"] == "dependency"
+
+
+def test_state_db_path_fails_closed_without_kanban_resolver(monkeypatch):
+    mod = _load_plugin_module()
+    import hermes_cli
+
+    monkeypatch.setattr(hermes_cli, "kanban_db", None, raising=False)
+
+    assert mod._state_db_path({}) is None
 
 
 def test_unblock_then_reblock_same_reason_sends_again(tmp_path, monkeypatch):

--- a/tests/plugins/test_kanban_block_notifier.py
+++ b/tests/plugins/test_kanban_block_notifier.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _load_plugin_module():
+    root = Path(__file__).resolve().parents[2]
+    path = root / "plugins" / "kanban-block-notifier" / "__init__.py"
+    spec = importlib.util.spec_from_file_location("kanban_block_notifier_under_test", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_redacts_secretish_reason_text():
+    mod = _load_plugin_module()
+
+    msg = mod._build_message(
+        board="proj",
+        task_id="t_1234abcd",
+        title="Need Cloudflare",
+        assignee="developer",
+        kind="needs_input",
+        reason="Set CLOUDFLARE_TOKEN=cf_1234567890abcdefghijklmnopqrstuvwxyz and https://x.test?a=1&token=supersecretvalue1234567890",
+        config={"secure_drop_url": "https://drop.example/one"},
+    )
+
+    assert "cf_1234567890abcdefghijklmnopqrstuvwxyz" not in msg
+    assert "supersecretvalue1234567890" not in msg
+    assert "CLOUDFLARE_TOKEN=[redacted]" in msg
+    assert "token=[redacted]" in msg
+    assert "secure-drop: https://drop.example/one" in msg
+
+
+def test_skips_review_required_and_dependency_blocks():
+    mod = _load_plugin_module()
+
+    assert not mod._is_human_block("needs_input", "review-required: tests pass", {})
+    assert not mod._is_human_block("dependency", "waiting for parent", {})
+    assert mod._is_human_block("needs_input", "need DNS choice", {})
+    assert mod._is_human_block("capability", "missing access", {})
+    assert mod._is_human_block(None, "Cloudflare DNS choice needed", {})
+
+
+def test_dedupes_same_blocker_per_target(tmp_path, monkeypatch):
+    mod = _load_plugin_module()
+    sent: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(mod, "_plugin_config", lambda: {"state_db": str(tmp_path / "state.sqlite3"), "targets": ["telegram:test"]})
+    monkeypatch.setattr(
+        mod,
+        "_fetch_task",
+        lambda board, task_id: SimpleNamespace(
+            id=task_id,
+            title="Blocked task",
+            assignee="developer",
+            block_kind="needs_input",
+        ),
+    )
+    monkeypatch.setattr(mod, "_send", lambda target, message, config: sent.append((target, message)))
+
+    kwargs = {"board": "proj", "task_id": "t_deadbeef", "reason": "Need DNS decision"}
+    mod._on_kanban_task_blocked(**kwargs)
+    mod._on_kanban_task_blocked(**kwargs)
+
+    assert len(sent) == 1
+    assert sent[0][0] == "telegram:test"
+    assert "Need DNS decision" in sent[0][1]
+
+
+def test_real_kanban_block_event_sends_once(tmp_path, monkeypatch):
+    mod = _load_plugin_module()
+    sent: list[tuple[str, str]] = []
+    home = tmp_path / "kanban-home"
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setattr(mod, "_plugin_config", lambda: {"state_db": str(tmp_path / "state.sqlite3"), "targets": ["telegram:test"]})
+    monkeypatch.setattr(mod, "_send", lambda target, message, config: sent.append((target, message)))
+
+    from hermes_cli import kanban_db as kb
+    import hermes_cli.plugins as plugins
+
+    monkeypatch.setattr(
+        plugins,
+        "invoke_hook",
+        lambda event, **kwargs: mod._on_kanban_task_blocked(**kwargs) if event == "kanban_task_blocked" else None,
+    )
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="Configure HTTPS", assignee="developer", initial_status="running")
+        assert kb.block_task(conn, tid, reason="Need DNS decision", kind="needs_input")
+        # Same blocker fired again through the lifecycle callback should be deduped.
+        mod._on_kanban_task_blocked(board="default", task_id=tid, reason="Need DNS decision")
+    finally:
+        conn.close()
+
+    assert len(sent) == 1
+    assert "Configure HTTPS" in sent[0][1]
+    assert "Need DNS decision" in sent[0][1]
+
+
+def test_retries_after_send_failure(tmp_path, monkeypatch):
+    mod = _load_plugin_module()
+    attempts = {"count": 0}
+
+    monkeypatch.setattr(mod, "_plugin_config", lambda: {"state_db": str(tmp_path / "state.sqlite3"), "targets": ["telegram:test"]})
+    monkeypatch.setattr(
+        mod,
+        "_fetch_task",
+        lambda board, task_id: SimpleNamespace(
+            id=task_id,
+            title="Blocked task",
+            assignee="developer",
+            block_kind="needs_input",
+        ),
+    )
+
+    def flaky_send(target, message, config):
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(mod, "_send", flaky_send)
+
+    kwargs = {"board": "proj", "task_id": "t_deadbeef", "reason": "Need DNS decision"}
+    mod._on_kanban_task_blocked(**kwargs)
+    mod._on_kanban_task_blocked(**kwargs)
+
+    assert attempts["count"] == 2

--- a/website/docs/user-guide/features/kanban-block-notifier.md
+++ b/website/docs/user-guide/features/kanban-block-notifier.md
@@ -46,8 +46,9 @@ Why it is not a cron/watchdog:
 
 - no periodic scan of all `blocked` tasks is performed;
 - the plugin runs only when a block transition happens;
-- deduplication is persisted in a tiny SQLite sidecar so repeated identical
-  blocker events do not spam the user.
+- deduplication is persisted in a tiny SQLite sidecar and keyed to the Kanban
+  block event/occurrence, so callback replay does not spam the user while a
+  later unblock → re-run → re-block for the same reason still notifies again.
 
 ## Routing rules
 
@@ -65,10 +66,12 @@ It suppresses:
 - `dependency` blocks;
 - `transient` blocks.
 
-Secret-related reasons are redacted before delivery. If the reason looks like a
-secret/token/access request, the message tells the user not to paste secrets into
-chat and includes `secure_drop_url` when configured; otherwise it explicitly says
-that secure-drop is not configured.
+Secret-related reasons are redacted before delivery. This is a baseline safety
+filter for common URL tokens, environment-variable assignments, long token-like
+strings, and English/Russian secret keywords; it is not a full DLP system. If the
+reason looks like a secret/token/access request, the message tells the user not
+to paste secrets into chat and includes `secure_drop_url` when configured;
+otherwise it explicitly says that secure-drop is not configured.
 
 ## Configuration
 
@@ -93,9 +96,19 @@ plugins:
         - capability
       suppress_review_required: true
       secure_drop_url: "https://your-secure-drop.example/one-time"
+      send_timeout_seconds: 10
       # Optional override; default is <kanban-home>/kanban/kanban-block-notifier.sqlite3
       # state_db: /path/to/kanban-block-notifier.sqlite3
 ```
+
+The default sidecar database path is:
+
+```text
+<kanban-home>/kanban/kanban-block-notifier.sqlite3
+```
+
+For a standard default profile this resolves under the shared Kanban home; for a
+profile or test run it follows `HERMES_KANBAN_HOME` / the active Hermes profile.
 
 `hermes send --to telegram` must work for the gateway/home Telegram target. Test
 it directly before enabling the plugin in production:
@@ -104,11 +117,29 @@ it directly before enabling the plugin in production:
 hermes send --to telegram "Kanban notifier smoke test"
 ```
 
+## Disable and rollback
+
+Disable the plugin without touching Kanban data:
+
+```bash
+hermes plugins disable kanban-block-notifier
+```
+
+Rollback plan:
+
+1. Run the disable command above in the profile where the plugin was enabled.
+2. Restart the gateway/profile process if it was already running, so plugin
+   registration is refreshed.
+3. Leave the sidecar database in place for audit/debugging, or move it aside
+   after confirming no rollback investigation needs it.
+4. Kanban task state is unaffected; only future blocker notification sends stop.
+
 ## Smoke/regression test
 
-On a temporary board/home, create a task, block it with `kind="needs_input"`, and
-assert exactly one send is attempted for two identical hook invocations. The unit
-suite covers this behavior in:
+On a temporary board/home, create a task, block it with `kind="needs_input"`,
+replay the same hook event, then unblock/re-block with the same reason. Assert
+that the replay is suppressed and the later real re-block sends another message.
+The unit suite covers this behavior in:
 
 ```bash
 scripts/run_tests.sh tests/plugins/test_kanban_block_notifier.py
@@ -117,9 +148,14 @@ scripts/run_tests.sh tests/plugins/test_kanban_block_notifier.py
 Manual production smoke test after review:
 
 1. Enable the plugin in the Telegram-orchestrator profile.
-2. Create a throwaway task on a non-production board.
-3. Run a worker or CLI action that blocks it with `kind="needs_input"`.
-4. Confirm a single Telegram message arrives.
-5. Re-run the same blocker and confirm no duplicate message arrives.
-6. Disable the plugin with `hermes plugins disable kanban-block-notifier` if it
+2. Verify delivery with `hermes send --to telegram "Kanban notifier smoke test"`.
+3. Create a throwaway task on a non-production/project board.
+4. Run a worker or CLI action that blocks it with `kind="needs_input"`.
+5. Confirm a single Telegram message arrives and includes the board slug.
+6. Replay the same hook/event in a test harness or repeat the same callback input
+   and confirm no duplicate message arrives.
+7. Unblock/promote the task, re-run/re-block it with the same reason, and confirm
+   a second Telegram message arrives.
+8. Block a throwaway task with `review-required:` and confirm it does not notify.
+9. Disable the plugin with `hermes plugins disable kanban-block-notifier` if it
    misbehaves; existing Kanban behavior remains unchanged.

--- a/website/docs/user-guide/features/kanban-block-notifier.md
+++ b/website/docs/user-guide/features/kanban-block-notifier.md
@@ -1,0 +1,125 @@
+# Kanban blocker notifications without cron polling
+
+This note documents the supported path for notifying a human when a Kanban task
+enters a human-facing blocked state (`needs_input` / `capability`) without a
+separate cron job that repeatedly scans blocked tasks.
+
+## Current architecture
+
+Kanban state is stored in SQLite board databases:
+
+- the legacy default board: `<hermes-root>/kanban.db`;
+- project boards: `<hermes-root>/kanban/boards/<slug>/kanban.db`;
+- task transition history: `task_events`;
+- gateway subscriptions: `kanban_notify_subs`.
+
+The gateway already has a notifier watcher that tails `task_events` for
+subscribed tasks and deduplicates delivery with `kanban_notify_subs.last_event_id`.
+That closes the loop for tasks created from a chat, but it does not guarantee a
+user-visible ping for every worker-originated `kanban_block(kind="needs_input")`
+when no chat subscription exists.
+
+Hermes also exposes Kanban lifecycle plugin hooks from `hermes_cli.kanban_db`:
+
+- `kanban_task_claimed`;
+- `kanban_task_completed`;
+- `kanban_task_blocked`.
+
+Those hooks fire after the SQLite transaction commits, so observers never hold
+the board write lock and always observe durable state.
+
+## Chosen approach
+
+Use an opt-in plugin, `kanban-block-notifier`, that listens to
+`kanban_task_blocked` and sends a one-shot message via `hermes send` for only
+human-facing blockers.
+
+Why this survives `hermes update`:
+
+- the integration uses the public plugin and lifecycle-hook surface;
+- it does not patch a local installed copy of core files;
+- if shipped with Hermes, it is enabled through `plugins.enabled`; if installed
+  as a user plugin, it lives in `<HERMES_HOME>/plugins/`, which updates do not
+  overwrite.
+
+Why it is not a cron/watchdog:
+
+- no periodic scan of all `blocked` tasks is performed;
+- the plugin runs only when a block transition happens;
+- deduplication is persisted in a tiny SQLite sidecar so repeated identical
+  blocker events do not spam the user.
+
+## Routing rules
+
+The plugin notifies targets configured under
+`plugins.entries.kanban-block-notifier.targets` (default: `telegram`, meaning the
+Telegram home target known to `hermes send`). It sends only when:
+
+- `task.block_kind` is `needs_input` or `capability`; or
+- a legacy untyped block reason contains strong human-input keywords such as
+  `secret`, `token`, `access`, `DNS`, `Cloudflare`, `HTTPS`, or `decision`.
+
+It suppresses:
+
+- `review-required` blocks, which should route to an internal reviewer gate;
+- `dependency` blocks;
+- `transient` blocks.
+
+Secret-related reasons are redacted before delivery. If the reason looks like a
+secret/token/access request, the message tells the user not to paste secrets into
+chat and includes `secure_drop_url` when configured; otherwise it explicitly says
+that secure-drop is not configured.
+
+## Configuration
+
+Enable the plugin:
+
+```bash
+hermes plugins enable kanban-block-notifier
+```
+
+Optional config:
+
+```yaml
+plugins:
+  enabled:
+    - kanban-block-notifier
+  entries:
+    kanban-block-notifier:
+      targets:
+        - telegram
+      notify_kinds:
+        - needs_input
+        - capability
+      suppress_review_required: true
+      secure_drop_url: "https://your-secure-drop.example/one-time"
+      # Optional override; default is <kanban-home>/kanban/kanban-block-notifier.sqlite3
+      # state_db: /path/to/kanban-block-notifier.sqlite3
+```
+
+`hermes send --to telegram` must work for the gateway/home Telegram target. Test
+it directly before enabling the plugin in production:
+
+```bash
+hermes send --to telegram "Kanban notifier smoke test"
+```
+
+## Smoke/regression test
+
+On a temporary board/home, create a task, block it with `kind="needs_input"`, and
+assert exactly one send is attempted for two identical hook invocations. The unit
+suite covers this behavior in:
+
+```bash
+scripts/run_tests.sh tests/plugins/test_kanban_block_notifier.py
+```
+
+Manual production smoke test after review:
+
+1. Enable the plugin in the Telegram-orchestrator profile.
+2. Create a throwaway task on a non-production board.
+3. Run a worker or CLI action that blocks it with `kind="needs_input"`.
+4. Confirm a single Telegram message arrives.
+5. Re-run the same blocker and confirm no duplicate message arrives.
+6. Disable the plugin with `hermes plugins disable kanban-block-notifier` if it
+   misbehaves; existing Kanban behavior remains unchanged.


### PR DESCRIPTION
## Summary
- passes Kanban blocked event_id through the lifecycle hook and keys notifier dedupe by board/task/event/target
- preserves a run/hash fallback for older/manual callbacks while allowing unblock -> rerun -> re-block with the same reason to notify again
- extends blocker notifier regression coverage for event replay, project board slugs, same-reason re-blocks, URL/env/long/Russian secret redaction
- documents disable, sidecar DB path, production smoke, rollback, and baseline-not-full-DLP redaction

## Test plan
- scripts/run_tests.sh tests/plugins/test_kanban_block_notifier.py tests/hermes_cli/test_kanban_notify.py tests/gateway/test_kanban_notifier.py tests/gateway/test_kanban_notifier_watcher_dispatch_gate.py -q
- python3 -m py_compile plugins/kanban-block-notifier/__init__.py hermes_cli/kanban_db.py tests/plugins/test_kanban_block_notifier.py
- git diff --check

## Sonar
- Blocked locally: SONAR_HOST_URL/SONAR_TOKEN are present, but sonar-scanner is not installed in this worker environment (`sonar-scanner unavailable`).

## Production
- Do not enable in production from this PR/task. Production enablement remains gated on reviewer approval and Telegram-orchestrator smoke testing.