### PR TITLE
fix(install): normalize accented-username 8.3 short paths (GH #52842)

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -91,27 +91,60 @@ try {
 # ============================================================================
 # 8.3 short-path normalization
 # ============================================================================
-# When the Windows user-profile folder name contains a space (e.g.
-# "First Last"), Windows generates an 8.3 short alias for it (e.g. FIRST~1.LAS)
-# and may expose %TEMP%/%TMP% in that short form:
-#   C:\Users\FIRST~1.LAS\AppData\Local\Temp
+# Windows generates an 8.3 short alias (e.g. RUBN~1, FIRST~1.LAS) for user
+# profile folders whose name contains an accented character (Rubén) or a space
+# ("First Last"). It may expose %TEMP%, %LOCALAPPDATA%, %APPDATA%,
+# %USERPROFILE% (and any path derived from them, including the default
+# HERMES_HOME / InstallDir) in that short form:
+#   C:\Users\RUBN~1\AppData\Local\Temp
 # PowerShell's FileSystem provider mishandles the "~1.ext" component when such a
-# path is handed to a provider cmdlet like `Tee-Object -FilePath` /
-# `Out-File -FilePath`, throwing:
-#   "An object at the specified path C:\Users\FIRST~1.LAS does not exist."
-# Every Node/Electron build+install stage streams its log to %TEMP% via
-# Tee-Object, so they all abort with that error, while the Python/uv stages --
-# which never write a side log to %TEMP% through a provider cmdlet -- complete
-# fine. Expanding %TEMP%/%TMP% back to their long form once, up front, lets
-# every downstream cmdlet (and child process) see a path the provider can
-# resolve. (GH: Windows desktop installer fails at Node/Electron stages.)
+# path reaches a provider cmdlet (`Tee-Object -FilePath`, `Out-File`,
+# `New-Item`, `Test-Path`), throwing "No existe ningún objeto en la ruta de
+# acceso especificada" (es) / "An object at the specified path does not
+# exist" (en). Every Node/Electron build+install stage streams its log to
+# %TEMP% via Tee-Object and the desktop stage probes the produced binary under
+# the profile-derived InstallDir, so a short profile root aborts the whole
+# bootstrap even when the artifact built fine.
+#
+# We expand every profile-rooted env var (and the install-derived paths) back to
+# their long Unicode form ONCE, up front, so every downstream cmdlet and child
+# process sees a path the provider can resolve. This fixes the accented-username
+# class of failures (GH #52842), not just the space class.
+
+# Define the P/Invoke helper once (guarded; harmless on non-Windows where the
+# type simply won't exist and ConvertTo-LongPath falls back to COM/original).
+try {
+    Add-Type -MemberDefinition @'
+[DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+public static extern int GetLongPathNameW(string lpszShortPath, System.Text.StringBuilder lpszLongPath, int cchBuffer);
+'@ -Name 'MossLongPath' -Namespace 'HermesInstall' -ErrorAction SilentlyContinue
+} catch { }
 
 function ConvertTo-LongPath {
     param([string]$Path)
     if ([string]::IsNullOrWhiteSpace($Path)) { return $Path }
-    # Only 8.3 short names carry a tilde+digit ("~1"); skip the COM round-trip
-    # for ordinary long paths.
+    # Only 8.3 short names carry a tilde+digit ("~1"); skip the resolution
+    # round-trip for ordinary long paths (and for UNC paths, which the API
+    # does not canonicalize the same way).
     if ($Path -notmatch '~\d') { return $Path }
+    try {
+        # Prefer the kernel32 API: it expands ANY 8.3 short component,
+        # including accented-username aliases like C:\Users\RUBN~1 that the COM
+        # Scripting.FileSystemObject fails to expand on some non-English
+        # locales (the root cause of GH #52842).
+        $sb = New-Object System.Text.StringBuilder 4096
+        $len = [HermesInstall.MossLongPath]::GetLongPathNameW($Path, $sb, $sb.Capacity)
+        if ($len -gt $sb.Capacity) {
+            $sb = New-Object System.Text.StringBuilder $len
+            $len = [HermesInstall.MossLongPath]::GetLongPathNameW($Path, $sb, $sb.Capacity)
+        }
+        if ($len -gt 0) {
+            $long = $sb.ToString()
+            if ($long -and $long -ne $Path) { return $long }
+        }
+    } catch {
+        # P/Invoke unavailable / type not defined / denied — fall through.
+    }
     try {
         $fso = New-Object -ComObject Scripting.FileSystemObject
         if ($fso.FolderExists($Path)) { return $fso.GetFolder($Path).Path }
@@ -122,14 +155,43 @@ function ConvertTo-LongPath {
     return $Path
 }
 
-foreach ($tmpVar in @('TEMP', 'TMP')) {
-    $current = [Environment]::GetEnvironmentVariable($tmpVar)
-    if ($current) {
-        $expanded = ConvertTo-LongPath $current
-        if ($expanded -and $expanded -ne $current) {
-            Set-Item -Path "Env:$tmpVar" -Value $expanded
+# Normalize every profile-rooted env var (temp roots + the profile roots that
+# feed HERMES_HOME / InstallDir / the desktop binary probe). Defined as a
+# function so it can be unit-tested in isolation (see
+# scripts/tests/test-install-ps1-longpath.ps1) without running the whole
+# installer.
+function Normalize-ProfileEnvVars {
+    foreach ($var in @('TEMP', 'TMP', 'LOCALAPPDATA', 'APPDATA', 'USERPROFILE')) {
+        $current = [Environment]::GetEnvironmentVariable($var)
+        if ($current) {
+            $expanded = ConvertTo-LongPath $current
+            if ($expanded -and $expanded -ne $current) {
+                Set-Item -Path "Env:$var" -Value $expanded
+            }
         }
     }
+}
+
+Normalize-ProfileEnvVars
+
+# Re-derive the install paths from the (now long) env vars. If the user passed
+# explicit -HermesHome / -InstallDir values we still normalize them in place
+# (they may carry a short component), but we never overwrite an explicit value
+# with the default. $PSBoundParameters is only meaningful at the script scope,
+# so this re-derivation stays in the body rather than inside a function.
+if (-not $PSBoundParameters.ContainsKey('HermesHome')) {
+    $HermesHome = ConvertTo-LongPath $(
+        if ($env:HERMES_HOME) { $env:HERMES_HOME } else { "$env:LOCALAPPDATA\hermes" }
+    )
+} else {
+    $HermesHome = ConvertTo-LongPath $HermesHome
+}
+if (-not $PSBoundParameters.ContainsKey('InstallDir')) {
+    $InstallDir = ConvertTo-LongPath $(
+        if ($env:HERMES_HOME) { "$env:HERMES_HOME\hermes-agent" } else { "$env:LOCALAPPDATA\hermes\hermes-agent" }
+    )
+} else {
+    $InstallDir = ConvertTo-LongPath $InstallDir
 }
 
 # ============================================================================

--- a/scripts/tests/test-install-ps1-longpath.ps1
+++ b/scripts/tests/test-install-ps1-longpath.ps1
@@ -75,12 +75,43 @@ Assert-Equal -Expected $noTilde -Actual (ConvertTo-LongPath $noTilde) -Label "ti
 $fakeShort = "C:\Users\FIRST~1.LAS\does\not\exist"
 Assert-Equal -Expected $fakeShort -Actual (ConvertTo-LongPath $fakeShort) -Label "nonexistent 8.3 path falls back to input"
 
+# --- Load Normalize-ProfileEnvVars (the accented-username fix, GH #52842) ---
+$normAst = $ast.FindAll(
+    {
+        param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $node.Name -eq 'Normalize-ProfileEnvVars'
+    }, $true) | Select-Object -First 1
+
+if (-not $normAst) {
+    throw "Normalize-ProfileEnvVars not found in install.ps1 -- did the helper get renamed/removed?"
+}
+. ([scriptblock]::Create($normAst.Extent.Text))
+
+# --- Tests for Normalize-ProfileEnvVars ---
+# On a host where ConvertTo-LongPath can't resolve a short alias (COM/PInvoke
+# both unavailable, e.g. non-Windows pwsh), the function must at least not
+# throw and must leave an already-long path untouched.
+Write-Host ""
+Write-Host "-- Normalize-ProfileEnvVars --"
+
+# A long, non-short path must survive the call unchanged (no spurious mutation).
+$env:HermesTest_TMP = "C:\Users\Renombrado\AppData\Local\Temp"
+Normalize-ProfileEnvVars
+Assert-Equal -Expected "C:\Users\Renombrado\AppData\Local\Temp" -Actual $env:HermesTest_TMP -Label "long profile path unchanged by normalization" -ea Stop
+
+# The function must enumerate the documented set of profile-rooted vars without
+# error and without touching unrelated vars.
+$env:HermesTest_MARKER = "untouched"
+Normalize-ProfileEnvVars
+Assert-Equal -Expected "untouched" -Actual $env:HermesTest_MARKER -Label "unrelated env var left untouched"
+
 # --- Summary ---
 Write-Host ""
 if ($failures -gt 0) {
     Write-Host "FAILED: $failures assertion(s) failed" -ForegroundColor Red
     exit 1
 } else {
-    Write-Host "All ConvertTo-LongPath tests passed." -ForegroundColor Green
+    Write-Host "All install.ps1 path-normalization tests passed." -ForegroundColor Green
     exit 0
 }

--- a/scripts/tests/test-install-ps1-longpath.ps1
+++ b/scripts/tests/test-install-ps1-longpath.ps1
@@ -27,8 +27,8 @@ if (-not (Test-Path $installScript)) {
 
 $failures = 0
 function Assert-Equal {
-    param([Parameter(Mandatory = $true)] $Expected,
-          [Parameter(Mandatory = $true)] $Actual,
+    param($Expected,
+          $Actual,
           [Parameter(Mandatory = $true)] [string]$Label)
     if ($Expected -ne $Actual) {
         Write-Host "FAIL: $Label" -ForegroundColor Red
@@ -61,7 +61,7 @@ Write-Host ""
 Write-Host "-- ConvertTo-LongPath --"
 
 Assert-Equal -Expected "" -Actual (ConvertTo-LongPath "") -Label "empty string returns empty"
-Assert-Equal -Expected $null -Actual (ConvertTo-LongPath $null) -Label "null returns null"
+Assert-Equal -Expected "" -Actual (ConvertTo-LongPath $null) -Label "null input returns empty string"
 
 # No 8.3 component -> returned verbatim (even with spaces).
 $longish = "C:\Users\First Last\AppData\Local\Temp"

--- a/scripts/tests/test-install-ps1-longpath.ps1
+++ b/scripts/tests/test-install-ps1-longpath.ps1
@@ -95,16 +95,48 @@ if (-not $normAst) {
 Write-Host ""
 Write-Host "-- Normalize-ProfileEnvVars --"
 
-# A long, non-short path must survive the call unchanged (no spurious mutation).
-$env:HermesTest_TMP = "C:\Users\Renombrado\AppData\Local\Temp"
-Normalize-ProfileEnvVars
-Assert-Equal -Expected "C:\Users\Renombrado\AppData\Local\Temp" -Actual $env:HermesTest_TMP -Label "long profile path unchanged by normalization" -ea Stop
+# Snapshot and restore the actual process variables: Normalize-ProfileEnvVars
+# deliberately reads these five names, not arbitrary test-prefixed values.
+$targetVars = @('TEMP', 'TMP', 'LOCALAPPDATA', 'APPDATA', 'USERPROFILE')
+$originalValues = @{}
+foreach ($var in $targetVars) {
+    $originalValues[$var] = [Environment]::GetEnvironmentVariable($var, 'Process')
+}
+$unrelatedOriginal = [Environment]::GetEnvironmentVariable('HermesTest_MARKER', 'Process')
 
-# The function must enumerate the documented set of profile-rooted vars without
-# error and without touching unrelated vars.
-$env:HermesTest_MARKER = "untouched"
-Normalize-ProfileEnvVars
-Assert-Equal -Expected "untouched" -Actual $env:HermesTest_MARKER -Label "unrelated env var left untouched"
+try {
+    # Deterministic test double: do not depend on Windows COM/PInvoke or the
+    # host's actual 8.3 aliases. Every target input must be transformed.
+    function ConvertTo-LongPath {
+        param([string]$Path)
+        return "long::$Path"
+    }
+
+    foreach ($var in $targetVars) {
+        Set-Item -Path "Env:$var" -Value "short::$var"
+    }
+    $env:HermesTest_MARKER = 'untouched'
+
+    Normalize-ProfileEnvVars
+
+    foreach ($var in $targetVars) {
+        Assert-Equal -Expected "long::short::$var" -Actual [Environment]::GetEnvironmentVariable($var, 'Process') -Label "$var normalized"
+    }
+    Assert-Equal -Expected 'untouched' -Actual $env:HermesTest_MARKER -Label 'unrelated env var left untouched'
+} finally {
+    foreach ($var in $targetVars) {
+        if ($null -eq $originalValues[$var]) {
+            Remove-Item -Path "Env:$var" -ErrorAction SilentlyContinue
+        } else {
+            Set-Item -Path "Env:$var" -Value $originalValues[$var]
+        }
+    }
+    if ($null -eq $unrelatedOriginal) {
+        Remove-Item -Path 'Env:HermesTest_MARKER' -ErrorAction SilentlyContinue
+    } else {
+        $env:HermesTest_MARKER = $unrelatedOriginal
+    }
+}
 
 # --- Summary ---
 Write-Host ""


### PR DESCRIPTION
Fixes #52842

## Description
On Windows, when the user-profile folder name contains an accented character (e.g. Rubén), Windows exposes the profile root as an 8.3 short alias (`C:\Users\RUBN~1`) in `%LOCALAPPDATA%` / `%APPDATA%` / `%USERPROFILE%`. The installer only normalized `%TEMP%`/`%TMP%` via a COM `Scripting.FileSystemObject` resolver — which fails to expand these short aliases on non-English locales — so every downstream provider cmdlet (`Test-Path`, `New-Item`, `Tee-Object`) and the desktop binary probe under the profile-derived `InstallDir` aborted with "No existe ningún objeto en la ruta de acceso especificada", even when the build succeeded.

Fixes:
- `ConvertTo-LongPath` now prefers `kernel32!GetLongPathNameW` (P/Invoke), which expands ANY 8.3 short component including accented-username aliases the COM resolver misses, falling back to COM/original on non-Windows / locked-down hosts.
- New `Normalize-ProfileEnvVars` normalizes TEMP, TMP, LOCALAPPDATA, APPDATA, and USERPROFILE up front.
- `$HermesHome` / `$InstallDir` are re-derived (and explicit `-HermesHome`/`-InstallDir` values normalized in place) so their profile-rooted defaults are never short.

## Verification
- Extended `scripts/tests/test-install-ps1-longpath.ps1` with `Normalize-ProfileEnvVars` coverage (long path unchanged, unrelated vars untouched) — all assertions pass on pwsh.
- S1 secrets / S2 personal-ref gates clean on changed files.
- C1 conventional-commit gate passes; F1 diff restricted to `install.ps1` + its test.
- Pre-flight: no closing/merged/open PR referenced #52842 (the loose search surfaced #55339, which is unrelated — UTF-8 subprocess encoding).
