### PR TITLE
fix(config): null web/backend and known_plugin_toolsets values no longer crash (#61142, #53196 salvage)

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1980,7 +1980,10 @@ def _save_platform_tools(config: dict, platform: str, enabled_toolset_keys: Set[
     # Track which plugin toolsets are "known" for this platform so we can
     # distinguish "new plugin, default enabled" from "user disabled it".
     if plugin_keys:
-        config.setdefault("known_plugin_toolsets", {})
+        # setdefault does NOT replace a present-but-null key ("known_plugin_toolsets:"
+        # in config.yaml parses to None) — normalize before indexing into it.
+        if not isinstance(config.get("known_plugin_toolsets"), dict):
+            config["known_plugin_toolsets"] = {}
         config["known_plugin_toolsets"][platform] = sorted(plugin_keys)
 
     # Reconcile with agent.disabled_toolsets. _get_platform_tools() applies

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1830,8 +1830,8 @@ def _get_platform_tools(
     # has been saved for that platform (tracked via known_plugin_toolsets).
     # Unknown plugins default to enabled; known-but-absent = disabled.
     if plugin_ts_keys:
-        known_map = config.get("known_plugin_toolsets", {})
-        known_for_platform = set(known_map.get(platform, []))
+        known_map = config.get("known_plugin_toolsets", {}) or {}
+        known_for_platform = set(known_map.get(platform, []) or [])
         for pts in plugin_ts_keys:
             if pts in toolset_names:
                 # Explicitly listed in config — enabled

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,8 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "humphreysun98@gmail.com": "HumphreySun98",  # PR #61142 salvage (web: null web/backend config value guards)
+    "sonxi@nous.local": "17324393074",  # PR #53196 salvage (tools_config: known_plugin_toolsets null guard; commit under unlinked local identity)
     "lemonwan@users.noreply.github.com": "lemonwan",  # PR #59430 sibling salvage (adapter reconnect contract guard)
     "luxuguangno1@163.com": "luxuguang-leo",  # PR #52966 salvage (QQBot reconnect contract)
     "grace@weeb.onl": "evelynburger",  # PR #57544 salvage (gateway: webhook payload filters + route scripts; commit under unlinked identity)

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -576,6 +576,22 @@ class TestCheckWebApiKey:
             from tools.web_tools import check_web_api_key
             assert check_web_api_key() is True
 
+    def test_null_backend_value_does_not_crash(self):
+        # config.yaml with ``web:\n  backend:`` yields backend=None. The gate
+        # must not raise AttributeError on None.lower() — mirrors _get_backend.
+        with patch("tools.web_tools._load_web_config", return_value={"backend": None}):
+            from tools.web_tools import check_web_api_key
+            assert check_web_api_key() is False
+
+    def test_null_web_section_does_not_crash(self):
+        # config.yaml with a present-but-null ``web:`` section makes the raw
+        # ``.get("web", {})`` return None; _load_web_config must still yield a
+        # dict so no caller does None.get(...).
+        with patch("hermes_cli.config.load_config", return_value={"web": None}):
+            from tools.web_tools import _load_web_config, check_web_api_key
+            assert _load_web_config() == {}
+            assert check_web_api_key() is False
+
     def test_firecrawl_key_only(self):
         with patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test"}):
             from tools.web_tools import check_web_api_key

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -132,7 +132,11 @@ def _load_web_config() -> dict:
     """Load the ``web:`` section from ~/.hermes/config.yaml."""
     try:
         from hermes_cli.config import load_config
-        return load_config().get("web", {})
+        # ``or {}``: a present-but-null ``web:`` section (YAML ``web:`` with no
+        # body) makes ``.get("web", {})`` return None, which would break every
+        # caller that does ``_load_web_config().get(...)``. Honor the ``-> dict``
+        # contract so callers never see None.
+        return load_config().get("web") or {}
     except (ImportError, Exception):
         return {}
 
@@ -1004,7 +1008,9 @@ def check_web_api_key() -> bool:
     :func:`_is_backend_available`, which delegates non-legacy names to the
     registry.
     """
-    configured = _load_web_config().get("backend", "").lower().strip()
+    # ``or ""``: a null ``web.backend`` value yields None from ``.get``, and
+    # ``None.lower()`` would raise. Mirrors ``_get_backend``.
+    configured = (_load_web_config().get("backend") or "").lower().strip()
     if configured and _is_backend_available(configured):
         return True
     # Any built-in backend with credentials present. This is a boolean OR, so


### PR DESCRIPTION
## Summary

Final two live members of the YAML-null config bug class: a null `web:`/`web.backend:` value no longer crashes web tools, and a null `known_plugin_toolsets:` no longer breaks `hermes tools` on both its read and write paths.

Salvages @HumphreySun98's #61142 and @17324393074's #53196 (authorship preserved), with one sibling-site follow-up.

## Changes

- `tools/web_tools.py` (#61142, cherry-picked): `_load_web_config()` honors its `-> dict` contract on a null `web:` section; `check_web_api_key()` guards `None.lower()` on a null backend. +2 tests.
- `hermes_cli/tools_config.py` (#53196, cherry-picked): read path guards `known_plugin_toolsets: null` in `_get_platform_tools()`
- Follow-up: write path in the same module — `setdefault()` does not replace a present-but-null key, so saving platform tools crashed indexing into None; normalized with an isinstance check
- `scripts/release.py`: AUTHOR_MAP entries for both contributors (#53196's commit is under an unlinked local identity)

## Validation

| | Before | After |
|---|---|---|
| `web:` null → `_load_web_config()` | `None` (contract violation) | `{}` |
| `web.backend:` null → `check_web_api_key()` | AttributeError | clean boolean |
| `known_plugin_toolsets:` null, read | AttributeError | defaults |
| `known_plugin_toolsets:` null, write | TypeError on save | normalized dict |
| test_web_tools_config.py + test_tools_config.py | — | green |

Both premises reproduced live on current main before salvage.

## Infographic

![null-config-stragglers](https://v3b.fal.media/files/b/0aa1a397/sWNt1o0-rdNxRDk__KzJM_tn0gFsAv.png)
