### PR TITLE
fix(cli): register shell hooks in hermes serve sessions by adding 'serve' to _AGENT_COMMANDS (#61806)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12384,7 +12384,7 @@ def _plugin_cli_discovery_needed() -> bool:
     return True
 
 
-_AGENT_COMMANDS = {None, "chat", "acp", "rl"}
+_AGENT_COMMANDS = {None, "chat", "acp", "rl", "serve"}
 _AGENT_SUBCOMMANDS = {
     "cron": ("cron_command", {"run", "tick"}),
     "gateway": ("gateway_command", {"run"}),


### PR DESCRIPTION
## Summary
Shell hooks (pre_tool_call) were never registered in `hermes serve` sessions, allowing Desktop app / dashboard API sessions to bypass all hook policies.

## Root Cause
`_prepare_agent_startup()` gates shell hook registration on `args.command in _AGENT_COMMANDS`. `"serve"` was missing from that set, so serve sessions never called `agent.shell_hooks.register_from_config()`.

## Change
Added `"serve"` to `_AGENT_COMMANDS` in `hermes_cli/main.py`.

## Verification
731 serve-related tests pass.