### PR TITLE
fix(scripts): re-enable errexit inside stage subshell to prevent masked failures in install.sh --stage (#61828)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3067,7 +3067,7 @@ run_stage_protocol() {
     # before emitting the frame and the Rust/Electron parser would see "no
     # result frame" instead of a clean {ok:false} contract response.
     set +e
-    ( run_stage_body "$stage" )
+    ( set -e; run_stage_body "$stage" )
     local code=$?
     set -e
 


### PR DESCRIPTION
## Summary
`run_stage_protocol()` in `scripts/install.sh` disables `set -e` before spawning the stage subshell. The subshell inherits errexit-OFF, so hard failures mid-helper (e.g. `uv venv` hard-failing) are silently swallowed and the stage reports success.

## Root Cause
```bash
set +e          # errexit OFF inherited by subshell
( run_stage_body "$stage" )
local code=$?
set -e
```

## Change
Re-enable errexit inside the subshell so helpers get the semantics they were written for:
```bash
set +e
( set -e; run_stage_body "$stage" )
local code=$?
set -e
```

## Verification
Fix matches the minimal repro in the issue: the success line no longer prints after a hard failure, and the subshell returns the correct exit code.