### PR TITLE
fix(agent): support Codex Responses Lite WebSocket transport

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -887,6 +887,96 @@ def _codex_model_capabilities(agent):
     return capabilities
 
 
+def _clone_responses_lite_input(value: Any) -> Any:
+    """Clone and normalize Responses input for Lite image constraints."""
+    if isinstance(value, dict):
+        is_input_image = value.get("type") == "input_image"
+        if is_input_image:
+            image_url = value.get("image_url")
+            if isinstance(image_url, str):
+                scheme = image_url.partition(":")[0].lower()
+                if scheme in {"http", "https"}:
+                    return {
+                        "type": "input_text",
+                        "text": (
+                            "image content omitted because remote image URLs "
+                            "are not supported"
+                        ),
+                    }
+                detail = value.get("detail")
+                if image_url[:5].lower() == "data:" and (
+                    isinstance(detail, str) and detail.lower() == "low"
+                ):
+                    return {
+                        "type": "input_text",
+                        "text": (
+                            "image content omitted because detail 'low' is not "
+                            "supported; use 'high', 'original', or 'auto'"
+                        ),
+                    }
+        return {
+            key: _clone_responses_lite_input(item)
+            for key, item in value.items()
+            if not (is_input_image and key == "detail")
+        }
+    if isinstance(value, list):
+        return [_clone_responses_lite_input(item) for item in value]
+    return value
+
+
+def _prepare_responses_lite_request_kwargs(api_kwargs: dict) -> dict:
+    """Return an idempotently Lite-shaped copy of Responses request kwargs."""
+    request_kwargs = dict(api_kwargs)
+
+    reasoning = request_kwargs.get("reasoning")
+    reasoning = dict(reasoning) if isinstance(reasoning, dict) else {}
+    reasoning["context"] = "all_turns"
+    request_kwargs["reasoning"] = reasoning
+    request_kwargs["parallel_tool_calls"] = False
+
+    raw_tools = request_kwargs.pop("tools", None)
+    tools = list(raw_tools) if isinstance(raw_tools, list) else []
+    input_items = request_kwargs.get("input")
+    if isinstance(input_items, list):
+        input_items = _clone_responses_lite_input(input_items)
+    elif isinstance(input_items, str):
+        input_items = [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": input_items}],
+            }
+        ]
+    elif isinstance(input_items, dict):
+        input_items = [_clone_responses_lite_input(input_items)]
+    else:
+        input_items = []
+
+    already_prepared = bool(
+        input_items
+        and isinstance(input_items[0], dict)
+        and input_items[0].get("type") == "additional_tools"
+    )
+    instructions = request_kwargs.pop("instructions", None)
+    if not already_prepared:
+        prefix = [
+            {
+                "type": "additional_tools",
+                "role": "developer",
+                "tools": tools,
+            }
+        ]
+        if isinstance(instructions, str) and instructions:
+            prefix.append({
+                "type": "message",
+                "role": "developer",
+                "content": [{"type": "input_text", "text": instructions}],
+            })
+        input_items = prefix + input_items
+    request_kwargs["input"] = input_items
+    return request_kwargs
+
+
 def _prepare_codex_request_kwargs(agent, api_kwargs: dict, capabilities) -> dict:
     """Add model-specific Lite routing without mutating conversation kwargs."""
     request_kwargs = dict(api_kwargs)
@@ -900,18 +990,11 @@ def _prepare_codex_request_kwargs(agent, api_kwargs: dict, capabilities) -> dict
         headers = request_kwargs.setdefault("extra_headers", {})
         headers["X-OpenAI-Internal-Codex-Responses-Lite"] = "true"
 
-        # Responses Lite requires the complete reasoning context to be sent
-        # on every turn. Preserve the caller's effort/summary values while
-        # forcing the Lite-specific context contract.
-        reasoning = request_kwargs.get("reasoning")
-        reasoning = dict(reasoning) if isinstance(reasoning, dict) else {}
-        reasoning["context"] = "all_turns"
-        request_kwargs["reasoning"] = reasoning
-
-        # Responses Lite does not support parallel tool calls. The normal
-        # Codex transport enables this whenever tools are present, so make
-        # the Lite override explicit at the final request boundary.
-        request_kwargs["parallel_tool_calls"] = False
+        # Lite carries both the static instructions and client-executed tool
+        # schemas as developer input items rather than top-level request
+        # fields. This matches the first-party Codex request contract and
+        # keeps the same payload shape on HTTP and WebSocket transports.
+        request_kwargs = _prepare_responses_lite_request_kwargs(request_kwargs)
     return request_kwargs
 
 

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -545,11 +545,10 @@ def run_codex_app_server_turn(
 #
 # We sidestep the whole class of failure by going one level lower:
 # ``client.responses.create(stream=True)`` returns the raw AsyncIterable of
-# SSE events, and we assemble the final response object purely from
-# ``response.output_item.done`` events as they arrive.  We never read
-# ``response.completed.response.output`` for content reconstruction, so the
-# backend can return ``null``, ``[]``, a string, or omit the field entirely
-# and we don't care.
+# SSE events, and we assemble the final response object from output-item
+# events as they arrive. If a Lite response omits those events, we fall back
+# to a valid list in ``response.completed.response.output``; null, ``[]``, a
+# string, or an omitted field remains harmless.
 #
 # This mirrors what the OpenClaw TS implementation does for the same backend
 # and is structurally immune to the bug class rather than patched.
@@ -577,6 +576,17 @@ def _item_field(item: Any, name: str, default: Any = None) -> Any:
     if value is None and isinstance(item, dict):
         value = item.get(name, default)
     return value if value is not None else default
+
+
+def _coerce_response_value(value: Any) -> Any:
+    """Convert raw WebSocket JSON objects into SDK-like response objects."""
+    if isinstance(value, dict):
+        return SimpleNamespace(
+            **{key: _coerce_response_value(item) for key, item in value.items()}
+        )
+    if isinstance(value, list):
+        return [_coerce_response_value(item) for item in value]
+    return value
 
 
 def _raise_stream_error(event: Any) -> None:
@@ -609,10 +619,10 @@ def _consume_codex_event_stream(
     The returned object is a ``SimpleNamespace`` shaped like the SDK's typed
     ``Response`` for the fields downstream code actually reads:
 
-    * ``output``: list of output items, assembled from ``response.output_item.done``.
-      For tool-call turns this contains the function_call items; for plain-text
-      turns it contains a synthesized ``message`` item built from streamed deltas
-      if no message item was emitted directly.
+    * ``output``: list of output items, assembled from
+      ``response.output_item.done`` or, when those are absent, the terminal
+      response output. For plain-text turns this can be a synthesized
+      ``message`` item built from streamed or terminal text.
     * ``output_text``: assembled text from ``response.output_text.delta`` deltas.
     * ``usage``: copied from the terminal event's ``response.usage`` (when present).
     * ``status``: ``completed`` / ``incomplete`` / ``failed`` (or ``completed`` if
@@ -622,9 +632,9 @@ def _consume_codex_event_stream(
     * ``error``: passed through for ``response.failed`` frames.
     * ``model``: from kwargs (the wire model name is not authoritative).
 
-    Critically, we never read ``response.output`` from the terminal event for
-    content reconstruction — only ``usage``, ``status``, ``id``.  That field
-    being ``null`` / ``[]`` / missing is fine.
+    A terminal ``response.output`` value is used only as a guarded fallback
+    when no output items were observed during the stream. ``null`` / ``[]`` /
+    missing values are fine.
 
     Callbacks:
 
@@ -647,6 +657,8 @@ def _consume_codex_event_stream(
     terminal_response_id: str = None
     terminal_incomplete_details: Any = None
     terminal_error: Any = None
+    terminal_output_items: List[Any] = []
+    terminal_output_text: str = ""
     saw_terminal = False
 
     for event in event_iter:
@@ -736,13 +748,21 @@ def _consume_codex_event_stream(
         if event_type == "response.output_item.done":
             done_item = _event_field(event, "item")
             if done_item is not None:
-                collected_output_items.append(done_item)
+                collected_output_items.append(_coerce_response_value(done_item))
             continue
 
         if event_type in _TERMINAL_EVENT_TYPES:
             saw_terminal = True
             resp_obj = _event_field(event, "response")
             if resp_obj is not None:
+                raw_output = _event_field(resp_obj, "output")
+                if isinstance(raw_output, list) and raw_output:
+                    terminal_output_items = [
+                        _coerce_response_value(item) for item in raw_output
+                    ]
+                raw_output_text = _event_field(resp_obj, "output_text", "")
+                if isinstance(raw_output_text, str):
+                    terminal_output_text = raw_output_text
                 terminal_usage = getattr(resp_obj, "usage", None)
                 if terminal_usage is None and isinstance(resp_obj, dict):
                     terminal_usage = resp_obj.get("usage")
@@ -777,6 +797,11 @@ def _consume_codex_event_stream(
     # a single message item so downstream normalization has something to work with.
     if collected_output_items:
         output = list(collected_output_items)
+    elif terminal_output_items:
+        # Some Lite responses omit output_item.done and only include the
+        # completed items on response.completed.response.output. Use that as
+        # a fallback; null/empty terminal output remains harmless.
+        output = list(terminal_output_items)
     elif collected_text_deltas and not has_tool_calls:
         assembled = "".join(collected_text_deltas)
         output = [SimpleNamespace(
@@ -784,6 +809,13 @@ def _consume_codex_event_stream(
             role="assistant",
             status="completed",
             content=[SimpleNamespace(type="output_text", text=assembled)],
+        )]
+    elif terminal_output_text.strip() and not has_tool_calls:
+        output = [SimpleNamespace(
+            type="message",
+            role="assistant",
+            status="completed",
+            content=[SimpleNamespace(type="output_text", text=terminal_output_text)],
         )]
     else:
         output = []
@@ -799,7 +831,7 @@ def _consume_codex_event_stream(
             "Codex Responses stream did not emit a terminal response"
         )
 
-    assembled_text = "".join(collected_text_deltas)
+    assembled_text = "".join(collected_text_deltas) or terminal_output_text
 
     final = SimpleNamespace(
         output=output,
@@ -814,19 +846,95 @@ def _consume_codex_event_stream(
     return final
 
 
+def _is_native_codex_backend(agent) -> bool:
+    """Return True only for the ChatGPT OAuth Codex backend."""
+    base_url_lower = str(getattr(agent, "_base_url_lower", "") or "").lower()
+    hostname = str(getattr(agent, "_base_url_hostname", "") or "").lower()
+    base_url = str(getattr(agent, "base_url", "") or "").lower()
+    return (
+        getattr(agent, "provider", None) == "openai-codex"
+        or (hostname == "chatgpt.com" and "/backend-api/codex" in base_url_lower)
+        or ("chatgpt.com/backend-api/codex" in base_url)
+    )
+
+
+def _codex_model_capabilities(agent):
+    """Resolve and cache model-level Codex transport metadata on the agent."""
+    model = str(getattr(agent, "model", "") or "").strip()
+    cached_model = getattr(agent, "_codex_capabilities_model", None)
+    cached = getattr(agent, "_codex_model_capabilities", None)
+    if cached is not None and cached_model == model:
+        return cached
+
+    from hermes_cli.codex_models import get_codex_model_capabilities
+
+    access_token = getattr(agent, "api_key", None)
+    try:
+        capabilities = get_codex_model_capabilities(model, access_token=access_token)
+    except Exception as exc:
+        logger.debug("Codex model capability lookup failed for %s: %s", model, exc)
+        capabilities = None
+    if capabilities is None:
+        # Keep the runtime safe if metadata is malformed or unavailable.
+        capabilities = SimpleNamespace(
+            slug=model,
+            use_responses_lite=False,
+            prefer_websockets=None,
+            should_use_websocket=False,
+        )
+    setattr(agent, "_codex_capabilities_model", model)
+    setattr(agent, "_codex_model_capabilities", capabilities)
+    return capabilities
+
+
+def _prepare_codex_request_kwargs(agent, api_kwargs: dict, capabilities) -> dict:
+    """Add model-specific Lite routing without mutating conversation kwargs."""
+    request_kwargs = dict(api_kwargs)
+    existing_headers = api_kwargs.get("extra_headers")
+    if isinstance(existing_headers, dict):
+        request_kwargs["extra_headers"] = dict(existing_headers)
+
+    if _is_native_codex_backend(agent) and bool(
+        getattr(capabilities, "use_responses_lite", False)
+    ):
+        headers = request_kwargs.setdefault("extra_headers", {})
+        headers["X-OpenAI-Internal-Codex-Responses-Lite"] = "true"
+
+        # Responses Lite requires the complete reasoning context to be sent
+        # on every turn. Preserve the caller's effort/summary values while
+        # forcing the Lite-specific context contract.
+        reasoning = request_kwargs.get("reasoning")
+        reasoning = dict(reasoning) if isinstance(reasoning, dict) else {}
+        reasoning["context"] = "all_turns"
+        request_kwargs["reasoning"] = reasoning
+
+        # Responses Lite does not support parallel tool calls. The normal
+        # Codex transport enables this whenever tools are present, so make
+        # the Lite override explicit at the final request boundary.
+        request_kwargs["parallel_tool_calls"] = False
+    return request_kwargs
+
+
+def _codex_transport_for_request(agent, capabilities) -> str:
+    """Choose the native Codex transport from the model capability metadata."""
+    if not _is_native_codex_backend(agent):
+        return "http"
+    if bool(getattr(capabilities, "should_use_websocket", False)):
+        return "websocket"
+    return "http"
+
+
 def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta=None):
     """Execute one streaming Responses API request and return the final response.
 
-    Uses ``responses.create(stream=True)`` (low-level raw event iteration)
-    rather than the high-level ``responses.stream(...)`` helper.  This makes
-    us structurally immune to backend drift in the ``response.completed``
-    payload shape — we never let the SDK reconstruct a typed object from
-    the terminal event's ``output`` field.
+    Uses the model-advertised Codex WebSocket transport when available and
+    falls back to ``responses.create(stream=True)`` (low-level raw event
+    iteration) before any response event has been observed.  Both paths feed
+    the same event consumer, keeping the runtime immune to backend drift in
+    the ``response.completed`` payload shape.
     """
     import httpx as _httpx
 
-    active_client = client or agent._ensure_primary_openai_client(reason="codex_stream_direct")
-    max_stream_retries = 1
     # Accumulate streamed text so callers / compat shims can read it.
     agent._codex_streamed_text_parts: list = []
 
@@ -845,11 +953,54 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
     def _interrupt_check() -> bool:
         return bool(agent._interrupt_requested)
 
+    capabilities = _codex_model_capabilities(agent)
+    request_kwargs = _prepare_codex_request_kwargs(agent, api_kwargs, capabilities)
+    transport = _codex_transport_for_request(agent, capabilities)
+
+    if transport == "websocket":
+        from agent.codex_websocket import CodexWebSocketError, run_codex_websocket
+
+        try:
+            logger.debug(
+                "Using Codex Responses WebSocket transport (model=%s, lite=%s). %s",
+                request_kwargs.get("model"),
+                bool(getattr(capabilities, "use_responses_lite", False)),
+                agent._client_log_context(),
+            )
+            return run_codex_websocket(
+                agent,
+                request_kwargs,
+                use_responses_lite=bool(getattr(capabilities, "use_responses_lite", False)),
+                on_text_delta=_on_text_delta,
+                on_reasoning_delta=_on_reasoning_delta,
+                on_first_delta=on_first_delta,
+                on_event=_on_event,
+                interrupt_check=_interrupt_check,
+            )
+        except CodexWebSocketError as exc:
+            # Once a response.create frame has been sent, a silent socket
+            # failure may still represent an in-flight request.  Only fall
+            # back when the handshake/request was never sent, or when the
+            # server explicitly rejected the request before starting output.
+            if not exc.safe_to_fallback:
+                raise
+            logger.warning(
+                "Codex Responses WebSocket unavailable before first event; "
+                "falling back to HTTP/SSE. model=%s status=%s error=%s. %s",
+                request_kwargs.get("model"),
+                exc.status_code,
+                exc,
+                agent._client_log_context(),
+            )
+
+    active_client = client or agent._ensure_primary_openai_client(reason="codex_stream_direct")
+    max_stream_retries = 1
+
     for attempt in range(max_stream_retries + 1):
         if agent._interrupt_requested:
             raise InterruptedError("Agent interrupted before Codex stream retry")
 
-        stream_kwargs = dict(api_kwargs)
+        stream_kwargs = dict(request_kwargs)
         stream_kwargs["stream"] = True
 
         try:

--- a/agent/codex_websocket.py
+++ b/agent/codex_websocket.py
@@ -191,6 +191,9 @@ def build_codex_websocket_request(
     # response.create frame.  Preserve caller metadata while adding the exact
     # marker used by the first-party transport.
     if use_responses_lite:
+        from agent.codex_runtime import _prepare_responses_lite_request_kwargs
+
+        payload = _prepare_responses_lite_request_kwargs(payload)
         client_metadata = payload.get("client_metadata")
         if isinstance(client_metadata, dict):
             client_metadata = dict(client_metadata)
@@ -198,15 +201,6 @@ def build_codex_websocket_request(
             client_metadata = {}
         client_metadata[CODEX_RESPONSES_LITE_CLIENT_METADATA_KEY] = "true"
         payload["client_metadata"] = client_metadata
-
-        # The Lite backend rejects the frame unless reasoning context is
-        # explicitly replayed across all turns. Keep any existing reasoning
-        # controls and add the required context selector.
-        reasoning = payload.get("reasoning")
-        reasoning = dict(reasoning) if isinstance(reasoning, dict) else {}
-        reasoning["context"] = "all_turns"
-        payload["reasoning"] = reasoning
-        payload["parallel_tool_calls"] = False
 
     # The upstream wire shape is a tagged ``response.create`` frame whose
     # remaining fields are the regular Responses request body.

--- a/agent/codex_websocket.py
+++ b/agent/codex_websocket.py
@@ -1,0 +1,411 @@
+"""Responses WebSocket transport for the OAuth-backed Codex endpoint.
+
+The public OpenAI Python client only knows about the HTTP/SSE Responses
+endpoint.  ChatGPT subscription models can advertise a WebSocket-first
+transport, while still emitting the same ``response.*`` events.  This module
+keeps the wire-specific code separate and feeds the existing Hermes event
+consumer from :mod:`agent.codex_runtime`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+import time
+from functools import lru_cache
+from typing import Any, Dict, Iterator, Optional
+
+logger = logging.getLogger(__name__)
+
+CODEX_RESPONSES_LITE_HEADER = "X-OpenAI-Internal-Codex-Responses-Lite"
+CODEX_RESPONSES_LITE_CLIENT_METADATA_KEY = (
+    "ws_request_header_x_openai_internal_codex_responses_lite"
+)
+CODEX_RESPONSES_WEBSOCKET_BETA = "responses_websockets=2026-02-06"
+
+
+class CodexWebSocketError(ConnectionError):
+    """A WebSocket failure with enough context to decide whether to fall back."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        started: bool = False,
+        status_code: Optional[int] = None,
+        safe_to_fallback: Optional[bool] = None,
+    ) -> None:
+        super().__init__(message)
+        self.started = bool(started)
+        self.status_code = status_code
+        self.safe_to_fallback = (
+            not self.started if safe_to_fallback is None else bool(safe_to_fallback)
+        )
+
+
+def responses_websocket_url(base_url: str) -> str:
+    """Convert a Codex HTTP base URL into its Responses WebSocket URL."""
+    url = str(base_url or "").strip().rstrip("/")
+    if not url:
+        raise ValueError("Codex WebSocket transport requires a base URL")
+    if url.endswith("/responses"):
+        response_url = url
+    else:
+        response_url = f"{url}/responses"
+    if response_url.startswith("https://"):
+        return "wss://" + response_url[len("https://") :]
+    if response_url.startswith("http://"):
+        return "ws://" + response_url[len("http://") :]
+    if response_url.startswith(("wss://", "ws://")):
+        return response_url
+    raise ValueError(f"Unsupported Codex WebSocket base URL: {base_url!r}")
+
+
+def _set_header(headers: Dict[str, str], name: str, value: str) -> None:
+    """Set a header without leaving a differently-cased duplicate behind."""
+    for existing in list(headers):
+        if existing.lower() == name.lower() and existing != name:
+            del headers[existing]
+    headers[name] = value
+
+
+def _get_header(headers: Dict[str, str], name: str) -> Optional[str]:
+    for key, value in headers.items():
+        if key.lower() == name.lower():
+            return str(value)
+    return None
+
+
+@lru_cache(maxsize=1)
+def _codex_client_version() -> str:
+    """Return the installed Codex CLI version for the WS edge header."""
+    override = os.getenv("CODEX_CLI_VERSION", "").strip()
+    if override:
+        return override
+    binary = shutil.which("codex")
+    if binary:
+        try:
+            completed = subprocess.run(
+                [binary, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=1,
+                check=False,
+            )
+            match = re.search(r"\b(\d+\.\d+\.\d+)\b", completed.stdout or "")
+            if match:
+                return match.group(1)
+        except Exception:
+            pass
+    return "0.0.0"
+
+
+def build_codex_websocket_headers(
+    agent: Any,
+    api_kwargs: Dict[str, Any],
+    *,
+    use_responses_lite: bool,
+) -> Dict[str, str]:
+    """Build the first-party headers required by the Codex WS handshake."""
+    headers: Dict[str, str] = {}
+    client_kwargs = getattr(agent, "_client_kwargs", {})
+    if isinstance(client_kwargs, dict):
+        defaults = client_kwargs.get("default_headers")
+        if isinstance(defaults, dict):
+            headers.update({str(k): str(v) for k, v in defaults.items() if v is not None})
+
+    # The default header builder is deliberately imported lazily: this module
+    # must remain importable in tests and on installations that never use
+    # OpenAI/Codex.
+    try:
+        from agent.auxiliary_client import _codex_cloudflare_headers
+
+        first_party = _codex_cloudflare_headers(str(getattr(agent, "api_key", "") or ""))
+        for key, value in first_party.items():
+            if _get_header(headers, key) is None:
+                _set_header(headers, key, str(value))
+    except Exception:
+        logger.debug("Could not build Codex first-party headers", exc_info=True)
+
+    request_headers = api_kwargs.get("extra_headers")
+    if isinstance(request_headers, dict):
+        for key, value in request_headers.items():
+            if value is not None:
+                _set_header(headers, str(key), str(value))
+
+    api_key = getattr(agent, "api_key", None)
+    if (
+        isinstance(api_key, str)
+        and api_key.strip()
+        and _get_header(headers, "Authorization") is None
+    ):
+        _set_header(headers, "Authorization", f"Bearer {api_key.strip()}")
+
+    # The upstream Codex client sends this beta marker on its Responses
+    # WebSocket handshake.  Preserve any caller-supplied beta values while
+    # ensuring the transport marker is present.
+    existing_beta = _get_header(headers, "OpenAI-Beta") or ""
+    if "responses_websockets=" not in existing_beta:
+        existing_beta = (
+            f"{existing_beta},{CODEX_RESPONSES_WEBSOCKET_BETA}"
+            if existing_beta
+            else CODEX_RESPONSES_WEBSOCKET_BETA
+        )
+        _set_header(headers, "OpenAI-Beta", existing_beta)
+
+    # Codex's edge expects a client version header on the WebSocket path.  The
+    # exact CLI build is not semantically important to Hermes' wire protocol;
+    # use the installed Codex CLI version when one is present so model catalog
+    # minimum-version gates behave like they do for the first-party client.
+    if _get_header(headers, "version") is None:
+        _set_header(headers, "version", _codex_client_version())
+
+    if use_responses_lite:
+        _set_header(headers, CODEX_RESPONSES_LITE_HEADER, "true")
+
+    return headers
+
+
+def build_codex_websocket_request(
+    api_kwargs: Dict[str, Any],
+    *,
+    use_responses_lite: bool = False,
+) -> Dict[str, Any]:
+    """Build the ``response.create`` JSON frame from Hermes request kwargs."""
+    excluded = {"stream", "extra_headers", "extra_body", "timeout"}
+    payload = {
+        key: value
+        for key, value in api_kwargs.items()
+        if key not in excluded
+    }
+    extra_body = api_kwargs.get("extra_body")
+    if isinstance(extra_body, dict):
+        payload.update(extra_body)
+
+    # Responses Lite is connection-scoped on the WebSocket upgrade, but the
+    # upstream Codex client also records that choice in client metadata on the
+    # response.create frame.  Preserve caller metadata while adding the exact
+    # marker used by the first-party transport.
+    if use_responses_lite:
+        client_metadata = payload.get("client_metadata")
+        if isinstance(client_metadata, dict):
+            client_metadata = dict(client_metadata)
+        else:
+            client_metadata = {}
+        client_metadata[CODEX_RESPONSES_LITE_CLIENT_METADATA_KEY] = "true"
+        payload["client_metadata"] = client_metadata
+
+        # The Lite backend rejects the frame unless reasoning context is
+        # explicitly replayed across all turns. Keep any existing reasoning
+        # controls and add the required context selector.
+        reasoning = payload.get("reasoning")
+        reasoning = dict(reasoning) if isinstance(reasoning, dict) else {}
+        reasoning["context"] = "all_turns"
+        payload["reasoning"] = reasoning
+        payload["parallel_tool_calls"] = False
+
+    # The upstream wire shape is a tagged ``response.create`` frame whose
+    # remaining fields are the regular Responses request body.
+    payload["type"] = "response.create"
+    payload["stream"] = True
+    return payload
+
+
+def _stream_idle_timeout(api_kwargs: Dict[str, Any]) -> float:
+    configured = api_kwargs.get("timeout")
+    if isinstance(configured, (int, float)) and not isinstance(configured, bool) and configured > 0:
+        return max(30.0, min(float(configured), 300.0))
+    return 120.0
+
+
+def run_codex_websocket(
+    agent: Any,
+    api_kwargs: Dict[str, Any],
+    *,
+    use_responses_lite: bool,
+    on_text_delta=None,
+    on_reasoning_delta=None,
+    on_first_delta=None,
+    on_event=None,
+    interrupt_check=None,
+) -> Any:
+    """Run one Codex Responses request over WebSocket.
+
+    The returned object has the same ``SimpleNamespace`` shape as the HTTP
+    path because both paths share ``_consume_codex_event_stream``.
+    """
+    try:
+        from websockets.exceptions import ConnectionClosed
+        from websockets.sync.client import connect
+    except ImportError as exc:  # pragma: no cover - dependency is core
+        raise CodexWebSocketError("websockets dependency is unavailable") from exc
+
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    base_url = getattr(agent, "base_url", None) or getattr(agent, "_base_url", None)
+    ws_url = responses_websocket_url(str(base_url or ""))
+    headers = build_codex_websocket_headers(
+        agent,
+        api_kwargs,
+        use_responses_lite=use_responses_lite,
+    )
+    wire_request = build_codex_websocket_request(
+        api_kwargs,
+        use_responses_lite=use_responses_lite,
+    )
+    idle_timeout = _stream_idle_timeout(api_kwargs)
+    state = {"started": False, "request_sent": False}
+
+    def _events() -> Iterator[Dict[str, Any]]:
+        connection = None
+        last_event_at = time.monotonic()
+        try:
+            connection = connect(
+                ws_url,
+                additional_headers=headers,
+                user_agent_header=None,
+                compression="deflate",
+                open_timeout=min(30.0, idle_timeout),
+                ping_interval=20.0,
+                ping_timeout=20.0,
+                close_timeout=10.0,
+            )
+            setattr(agent, "_codex_active_websocket", connection)
+            # Be conservative around partial writes: once send() is attempted,
+            # the server may have accepted the request even if the client gets
+            # an exception before send() returns.
+            state["request_sent"] = True
+            connection.send(json.dumps(wire_request, ensure_ascii=False, separators=(",", ":")))
+
+            while True:
+                if interrupt_check is not None and interrupt_check():
+                    raise InterruptedError("Agent interrupted during Codex WebSocket stream")
+                if getattr(agent, "_interrupt_requested", False):
+                    raise InterruptedError("Agent interrupted during Codex WebSocket stream")
+                if time.monotonic() - last_event_at > idle_timeout:
+                    raise CodexWebSocketError(
+                        f"Codex WebSocket idle timeout after {int(idle_timeout)}s",
+                        started=state["started"],
+                    )
+
+                try:
+                    raw = connection.recv(timeout=1.0)
+                except TimeoutError:
+                    continue
+                except ConnectionClosed as exc:
+                    raise CodexWebSocketError(
+                        f"Codex WebSocket closed before response.completed: {exc}",
+                        started=state["started"],
+                        safe_to_fallback=not state["request_sent"],
+                    ) from exc
+
+                if raw is None:
+                    raise CodexWebSocketError(
+                        "Codex WebSocket closed before response.completed",
+                        started=state["started"],
+                        safe_to_fallback=not state["request_sent"],
+                    )
+                if isinstance(raw, bytes):
+                    try:
+                        raw = raw.decode("utf-8")
+                    except UnicodeDecodeError:
+                        logger.debug("Ignoring non-UTF-8 Codex WebSocket frame")
+                        continue
+                if not isinstance(raw, str):
+                    continue
+                try:
+                    event = json.loads(raw)
+                except json.JSONDecodeError:
+                    logger.debug("Ignoring malformed Codex WebSocket event: %r", raw[:200])
+                    continue
+                if not isinstance(event, dict):
+                    continue
+
+                event_type = event.get("type")
+                if event_type == "error":
+                    error = event.get("error")
+                    if isinstance(error, dict):
+                        message = error.get("message") or error.get("code") or str(error)
+                    else:
+                        message = str(error or "Codex WebSocket returned an error")
+                    status = event.get("status", event.get("status_code"))
+                    status_code = int(status) if isinstance(status, (int, float)) else None
+                    prefix = f"HTTP {status_code}: " if status_code else ""
+                    raise CodexWebSocketError(
+                        f"{prefix}{message}",
+                        started=state["started"],
+                        status_code=status_code,
+                        # An explicit error frame means the server rejected
+                        # this request; replaying it over HTTP is safe when
+                        # no response event has started, even though the
+                        # response.create frame was sent.
+                        safe_to_fallback=not state["started"],
+                    )
+
+                state["started"] = True
+                last_event_at = time.monotonic()
+                yield event
+        except CodexWebSocketError:
+            raise
+        except InterruptedError:
+            raise
+        except Exception as exc:
+            if getattr(agent, "_interrupt_requested", False):
+                raise InterruptedError("Agent interrupted during Codex WebSocket stream") from exc
+            raise CodexWebSocketError(
+                f"Codex WebSocket transport failed: {exc}",
+                started=state["started"],
+                safe_to_fallback=not state["request_sent"],
+            ) from exc
+        finally:
+            if getattr(agent, "_codex_active_websocket", None) is connection:
+                setattr(agent, "_codex_active_websocket", None)
+            if connection is not None:
+                try:
+                    connection.close()
+                except Exception:
+                    pass
+
+    event_iter = _events()
+    try:
+        return _consume_codex_event_stream(
+            event_iter,
+            model=api_kwargs.get("model"),
+            on_text_delta=on_text_delta,
+            on_reasoning_delta=on_reasoning_delta,
+            on_first_delta=on_first_delta,
+            on_event=on_event,
+            interrupt_check=interrupt_check,
+        )
+    finally:
+        close_iter = getattr(event_iter, "close", None)
+        if callable(close_iter):
+            close_iter()
+
+
+def close_active_codex_websocket(agent: Any) -> None:
+    """Abort a request-local WebSocket from Hermes' watchdog/interrupt thread."""
+    connection = getattr(agent, "_codex_active_websocket", None)
+    if connection is None:
+        return
+    try:
+        connection.close()
+    except Exception:
+        logger.debug("Codex WebSocket abort failed", exc_info=True)
+
+
+__all__ = [
+    "CODEX_RESPONSES_LITE_HEADER",
+    "CODEX_RESPONSES_LITE_CLIENT_METADATA_KEY",
+    "CODEX_RESPONSES_WEBSOCKET_BETA",
+    "CodexWebSocketError",
+    "build_codex_websocket_headers",
+    "build_codex_websocket_request",
+    "close_active_codex_websocket",
+    "responses_websocket_url",
+    "run_codex_websocket",
+]

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -2,14 +2,91 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
-from pathlib import Path
-from typing import List, Optional
-
 import os
+import re
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+_CODEX_CAPABILITY_CACHE_TTL = 300.0
+_CODEX_LIVE_MODEL_ENTRY_CACHE: Dict[str, tuple[float, List[Dict[str, Any]]]] = {}
+
+
+@lru_cache(maxsize=1)
+def _codex_client_version() -> str:
+    """Return the installed Codex CLI version for catalog requests."""
+    override = os.getenv("CODEX_CLI_VERSION", "").strip()
+    if override:
+        return override
+    binary = shutil.which("codex")
+    if binary:
+        try:
+            completed = subprocess.run(
+                [binary, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=1,
+                check=False,
+            )
+            match = re.search(r"\b(\d+\.\d+\.\d+)\b", completed.stdout or "")
+            if match:
+                return match.group(1)
+        except Exception:
+            pass
+    return "0.0.0"
+
+
+@dataclass(frozen=True)
+class CodexModelCapabilities:
+    """Transport capabilities advertised by the OAuth-backed Codex catalog.
+
+    The catalog is also consumed by the Codex CLI.  Hermes historically kept
+    only the visible model slugs, which meant it silently lost the transport
+    hints needed by newer subscription models such as GPT-5.6 Luna.
+    """
+
+    slug: str
+    use_responses_lite: bool = False
+    prefer_websockets: Optional[bool] = None
+    minimal_client_version: Optional[str] = None
+
+    @property
+    def should_use_websocket(self) -> bool:
+        """Return the safe automatic WebSocket choice for this model.
+
+        Older ``models_cache.json`` files do not contain
+        ``prefer_websockets``.  The current Lite-backed Codex models are
+        WebSocket-first, so use that as a compatibility fallback while still
+        honoring an explicit catalog value when one is available.
+        """
+        if self.prefer_websockets is not None:
+            return self.prefer_websockets
+        return self.use_responses_lite
+
+
+# Keep a small forward-compatible fallback for the current GPT-5.6 preview.
+# The live catalog and Codex CLI cache remain authoritative; this only keeps a
+# manually configured model usable during a transient catalog/cache miss.
+_KNOWN_CODEX_TRANSPORT_CAPABILITIES: Dict[str, CodexModelCapabilities] = {
+    "gpt-5.6-sol": CodexModelCapabilities(
+        slug="gpt-5.6-sol", use_responses_lite=True, prefer_websockets=True,
+    ),
+    "gpt-5.6-terra": CodexModelCapabilities(
+        slug="gpt-5.6-terra", use_responses_lite=True, prefer_websockets=True,
+    ),
+    "gpt-5.6-luna": CodexModelCapabilities(
+        slug="gpt-5.6-luna", use_responses_lite=True, prefer_websockets=True,
+    ),
+}
 
 DEFAULT_CODEX_MODELS: List[str] = [
     # GPT-5.6 series (Sol/Terra/Luna + -pro high-effort modes) — GA 2026-07-09
@@ -93,24 +170,32 @@ def _add_forward_compat_models(model_ids: List[str]) -> List[str]:
     return ordered
 
 
-def _fetch_models_from_api(access_token: str) -> List[str]:
-    """Fetch available models from the Codex API. Returns visible models sorted by priority."""
+def _fetch_model_entries_from_api(access_token: str) -> List[Dict[str, Any]]:
+    """Fetch visible model entries from the OAuth-backed Codex API."""
     try:
         import httpx
+        client_version = _codex_client_version()
         resp = httpx.get(
-            "https://chatgpt.com/backend-api/codex/models?client_version=1.0.0",
-            headers={"Authorization": f"Bearer {access_token}"},
+            f"https://chatgpt.com/backend-api/codex/models?client_version={client_version}",
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "User-Agent": f"codex_cli_rs/{client_version} (Hermes Agent)",
+                "originator": "codex_cli_rs",
+                "version": client_version,
+            },
             timeout=10,
         )
         if resp.status_code != 200:
             return []
         data = resp.json()
         entries = data.get("models", []) if isinstance(data, dict) else []
+        if not isinstance(entries, list):
+            return []
     except Exception as exc:
         logger.debug("Failed to fetch Codex models from API: %s", exc)
         return []
 
-    sortable = []
+    sortable: List[tuple[int, Dict[str, Any]]] = []
     for item in entries:
         if not isinstance(item, dict):
             continue
@@ -127,10 +212,20 @@ def _fetch_models_from_api(access_token: str) -> List[str]:
             continue
         priority = item.get("priority")
         rank = int(priority) if isinstance(priority, (int, float)) else 10_000
-        sortable.append((rank, slug))
+        sortable.append((rank, dict(item, slug=slug)))
 
-    sortable.sort(key=lambda x: (x[0], x[1]))
-    return _add_forward_compat_models([slug for _, slug in sortable])
+    sortable.sort(key=lambda x: (x[0], str(x[1].get("slug", ""))))
+    return [entry for _, entry in sortable]
+
+
+def _fetch_models_from_api(access_token: str) -> List[str]:
+    """Fetch available model IDs from the Codex API."""
+    entries = _fetch_model_entries_from_api(access_token)
+    return _add_forward_compat_models([
+        str(entry["slug"])
+        for entry in entries
+        if isinstance(entry.get("slug"), str)
+    ])
 
 
 def _read_default_model(codex_home: Path) -> Optional[str]:
@@ -186,6 +281,106 @@ def _read_cache_models(codex_home: Path) -> List[str]:
         if slug not in deduped:
             deduped.append(slug)
     return deduped
+
+
+def _read_cache_model_entries(codex_home: Path) -> List[Dict[str, Any]]:
+    """Read full model entries from the Codex CLI capability cache."""
+    cache_path = codex_home / "models_cache.json"
+    if not cache_path.exists():
+        return []
+    try:
+        raw = json.loads(cache_path.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+
+    entries = raw.get("models") if isinstance(raw, dict) else None
+    sortable: List[tuple[int, Dict[str, Any]]] = []
+    if isinstance(entries, list):
+        for item in entries:
+            if not isinstance(item, dict):
+                continue
+            slug = item.get("slug")
+            if not isinstance(slug, str) or not slug.strip():
+                continue
+            slug = slug.strip()
+            visibility = item.get("visibility")
+            if isinstance(visibility, str) and visibility.strip().lower() in {"hide", "hidden"}:
+                continue
+            priority = item.get("priority")
+            rank = int(priority) if isinstance(priority, (int, float)) else 10_000
+            sortable.append((rank, dict(item, slug=slug)))
+
+    sortable.sort(key=lambda item: (item[0], str(item[1].get("slug", ""))))
+    return [entry for _, entry in sortable]
+
+
+def _capabilities_from_entry(entry: Dict[str, Any]) -> CodexModelCapabilities:
+    prefer_websockets = entry.get("prefer_websockets")
+    if not isinstance(prefer_websockets, bool):
+        prefer_websockets = None
+    use_responses_lite = entry.get("use_responses_lite")
+    if not isinstance(use_responses_lite, bool):
+        use_responses_lite = False
+    minimal_client_version = entry.get("minimal_client_version")
+    if not isinstance(minimal_client_version, str) or not minimal_client_version.strip():
+        minimal_client_version = None
+    return CodexModelCapabilities(
+        slug=str(entry.get("slug") or ""),
+        use_responses_lite=use_responses_lite,
+        prefer_websockets=prefer_websockets,
+        minimal_client_version=minimal_client_version,
+    )
+
+
+def get_codex_model_capabilities(
+    model: str,
+    access_token: Optional[str] = None,
+) -> CodexModelCapabilities:
+    """Resolve transport capabilities for one Codex model.
+
+    The local Codex cache is the fast path.  When the caller has a JWT-like
+    OAuth token, refresh the catalog as well so newly introduced fields such as
+    ``prefer_websockets`` are not lost on older local cache formats.  Failure
+    to refresh is deliberately non-fatal: the HTTP path remains available.
+    """
+    requested = str(model or "").strip()
+    slug = requested.rsplit("/", 1)[-1]
+    codex_home_str = os.getenv("CODEX_HOME", "").strip() or str(Path.home() / ".codex")
+    codex_home = Path(codex_home_str).expanduser()
+
+    local_entries = _read_cache_model_entries(codex_home)
+    local_entry = next(
+        (entry for entry in local_entries if str(entry.get("slug", "")).strip() == slug),
+        None,
+    )
+
+    # Access tokens from the Codex OAuth flow are JWTs.  Avoid a live catalog
+    # request for synthetic/test tokens and for ordinary API-key providers.
+    live_entries: List[Dict[str, Any]] = []
+    if isinstance(access_token, str) and access_token.count(".") >= 2:
+        token_key = hashlib.sha256(access_token.encode("utf-8")).hexdigest()
+        now = time.monotonic()
+        cached_live = _CODEX_LIVE_MODEL_ENTRY_CACHE.get(token_key)
+        if cached_live and now - cached_live[0] < _CODEX_CAPABILITY_CACHE_TTL:
+            live_entries = cached_live[1]
+        else:
+            live_entries = _fetch_model_entries_from_api(access_token)
+            _CODEX_LIVE_MODEL_ENTRY_CACHE[token_key] = (now, live_entries)
+    live_entry = next(
+        (entry for entry in live_entries if str(entry.get("slug", "")).strip() == slug),
+        None,
+    )
+
+    if local_entry is None and live_entry is None:
+        return _KNOWN_CODEX_TRANSPORT_CAPABILITIES.get(
+            slug,
+            CodexModelCapabilities(slug=slug),
+        )
+
+    entry = dict(local_entry or {})
+    if live_entry:
+        entry.update(live_entry)
+    return _capabilities_from_entry(entry)
 
 
 def get_codex_model_ids(access_token: Optional[str] = None) -> List[str]:

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -78,13 +78,22 @@ class CodexModelCapabilities:
 # manually configured model usable during a transient catalog/cache miss.
 _KNOWN_CODEX_TRANSPORT_CAPABILITIES: Dict[str, CodexModelCapabilities] = {
     "gpt-5.6-sol": CodexModelCapabilities(
-        slug="gpt-5.6-sol", use_responses_lite=True, prefer_websockets=True,
+        slug="gpt-5.6-sol",
+        use_responses_lite=True,
+        prefer_websockets=True,
+        minimal_client_version="0.144.0",
     ),
     "gpt-5.6-terra": CodexModelCapabilities(
-        slug="gpt-5.6-terra", use_responses_lite=True, prefer_websockets=True,
+        slug="gpt-5.6-terra",
+        use_responses_lite=True,
+        prefer_websockets=True,
+        minimal_client_version="0.144.0",
     ),
     "gpt-5.6-luna": CodexModelCapabilities(
-        slug="gpt-5.6-luna", use_responses_lite=True, prefer_websockets=True,
+        slug="gpt-5.6-luna",
+        use_responses_lite=True,
+        prefer_websockets=True,
+        minimal_client_version="0.144.0",
     ),
 }
 
@@ -338,10 +347,10 @@ def get_codex_model_capabilities(
 ) -> CodexModelCapabilities:
     """Resolve transport capabilities for one Codex model.
 
-    The local Codex cache is the fast path.  When the caller has a JWT-like
-    OAuth token, refresh the catalog as well so newly introduced fields such as
-    ``prefer_websockets`` are not lost on older local cache formats.  Failure
-    to refresh is deliberately non-fatal: the HTTP path remains available.
+    The local Codex cache is the fast path.  When it lacks Lite capability
+    metadata and the caller has a JWT-like OAuth token, refresh the catalog so
+    newly introduced fields are available. Failure to refresh is deliberately
+    non-fatal: known-model metadata and the HTTP path remain available.
     """
     requested = str(model or "").strip()
     slug = requested.rsplit("/", 1)[-1]
@@ -357,7 +366,14 @@ def get_codex_model_capabilities(
     # Access tokens from the Codex OAuth flow are JWTs.  Avoid a live catalog
     # request for synthetic/test tokens and for ordinary API-key providers.
     live_entries: List[Dict[str, Any]] = []
-    if isinstance(access_token, str) and access_token.count(".") >= 2:
+    local_has_lite_metadata = isinstance(
+        (local_entry or {}).get("use_responses_lite"), bool
+    )
+    if (
+        not local_has_lite_metadata
+        and isinstance(access_token, str)
+        and access_token.count(".") >= 2
+    ):
         token_key = hashlib.sha256(access_token.encode("utf-8")).hexdigest()
         now = time.monotonic()
         cached_live = _CODEX_LIVE_MODEL_ENTRY_CACHE.get(token_key)
@@ -371,13 +387,16 @@ def get_codex_model_capabilities(
         None,
     )
 
-    if local_entry is None and live_entry is None:
-        return _KNOWN_CODEX_TRANSPORT_CAPABILITIES.get(
-            slug,
-            CodexModelCapabilities(slug=slug),
-        )
-
-    entry = dict(local_entry or {})
+    known = _KNOWN_CODEX_TRANSPORT_CAPABILITIES.get(slug)
+    entry: Dict[str, Any] = {"slug": slug}
+    if known is not None:
+        entry.update({
+            "use_responses_lite": known.use_responses_lite,
+            "prefer_websockets": known.prefer_websockets,
+            "minimal_client_version": known.minimal_client_version,
+        })
+    if local_entry:
+        entry.update(local_entry)
     if live_entry:
         entry.update(live_entry)
     return _capabilities_from_entry(entry)

--- a/run_agent.py
+++ b/run_agent.py
@@ -4148,6 +4148,16 @@ class AIAgent:
         """
         if client is None:
             return
+        # The native Codex subscription path may be using a request-local
+        # WebSocket rather than the OpenAI SDK's httpx client.  Watchdog and
+        # interrupt callers still arrive here, so close that socket as part of
+        # the same cross-thread abort path.
+        try:
+            from agent.codex_websocket import close_active_codex_websocket
+
+            close_active_codex_websocket(self)
+        except Exception:
+            logger.debug("Codex WebSocket abort hook failed", exc_info=True)
         try:
             shutdown_count = self._force_close_tcp_sockets(client)
             logger.info(

--- a/tests/agent/test_codex_runtime_transport.py
+++ b/tests/agent/test_codex_runtime_transport.py
@@ -72,9 +72,33 @@ def test_lite_capability_is_added_to_http_fallback_request(monkeypatch):
         captured.update(kwargs)
         return _completed_stream()
 
+    request = _request()
+    request["tools"] = [{"type": "function", "name": "terminal"}]
+    request["input"] = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_image",
+                    "image_url": "data:image/png;base64,abc",
+                    "detail": "high",
+                },
+                {
+                    "type": "input_image",
+                    "image_url": "https://example.com/image.png",
+                    "detail": "high",
+                },
+                {
+                    "type": "input_image",
+                    "image_url": "data:image/png;base64,def",
+                    "detail": "low",
+                },
+            ],
+        }
+    ]
     response = run_codex_stream(
         agent,
-        _request(),
+        request,
         client=SimpleNamespace(responses=SimpleNamespace(create=create)),
     )
 
@@ -82,6 +106,44 @@ def test_lite_capability_is_added_to_http_fallback_request(monkeypatch):
     assert captured["extra_headers"]["X-OpenAI-Internal-Codex-Responses-Lite"] == "true"
     assert captured["reasoning"]["context"] == "all_turns"
     assert captured["stream"] is True
+    assert "instructions" not in captured
+    assert "tools" not in captured
+    assert captured["input"][:2] == [
+        {
+            "type": "additional_tools",
+            "role": "developer",
+            "tools": [{"type": "function", "name": "terminal"}],
+        },
+        {
+            "type": "message",
+            "role": "developer",
+            "content": [{"type": "input_text", "text": "Be concise."}],
+        },
+    ]
+    assert captured["input"][2]["content"] == [
+        {
+            "type": "input_image",
+            "image_url": "data:image/png;base64,abc",
+        },
+        {
+            "type": "input_text",
+            "text": "image content omitted because remote image URLs are not supported",
+        },
+        {
+            "type": "input_text",
+            "text": (
+                "image content omitted because detail 'low' is not supported; "
+                "use 'high', 'original', or 'auto'"
+            ),
+        },
+    ]
+    # Preparing the wire payload must not mutate the reusable conversation
+    # request held by the agent loop.
+    assert request["instructions"] == "Be concise."
+    assert request["tools"] == [{"type": "function", "name": "terminal"}]
+    assert request["input"][0]["content"][0]["detail"] == "high"
+    assert request["input"][0]["content"][1]["image_url"].startswith("https://")
+    assert request["input"][0]["content"][2]["detail"] == "low"
 
 
 def test_lite_disables_parallel_tool_calls(monkeypatch):

--- a/tests/agent/test_codex_runtime_transport.py
+++ b/tests/agent/test_codex_runtime_transport.py
@@ -1,0 +1,213 @@
+from types import SimpleNamespace
+
+import pytest
+
+from agent.codex_websocket import CodexWebSocketError
+from agent.codex_runtime import run_codex_stream
+
+
+class _Stream:
+    def __init__(self, events):
+        self.events = list(events)
+        self.closed = False
+
+    def __iter__(self):
+        return iter(self.events)
+
+    def close(self):
+        self.closed = True
+
+
+def _agent():
+    return SimpleNamespace(
+        provider="openai-codex",
+        model="gpt-5.6-luna",
+        api_key="codex-token",
+        base_url="https://chatgpt.com/backend-api/codex",
+        _base_url_lower="https://chatgpt.com/backend-api/codex",
+        _base_url_hostname="chatgpt.com",
+        _interrupt_requested=False,
+        _codex_streamed_text_parts=[],
+        _fire_stream_delta=lambda text: None,
+        _fire_reasoning_delta=lambda text: None,
+        _touch_activity=lambda message: None,
+        _client_log_context=lambda: "test-context",
+    )
+
+
+def _request():
+    return {
+        "model": "gpt-5.6-luna",
+        "instructions": "Be concise.",
+        "input": [{"role": "user", "content": "hello"}],
+        "store": False,
+    }
+
+
+def _completed_stream():
+    return _Stream(
+        [
+            SimpleNamespace(type="response.output_text.delta", delta="hello"),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(id="resp-1", status="completed", usage=None),
+            ),
+        ]
+    )
+
+
+def test_lite_capability_is_added_to_http_fallback_request(monkeypatch):
+    agent = _agent()
+    captured = {}
+    monkeypatch.setattr(
+        "agent.codex_runtime._codex_model_capabilities",
+        lambda _agent: SimpleNamespace(
+            use_responses_lite=True,
+            prefer_websockets=False,
+            should_use_websocket=False,
+        ),
+    )
+
+    def create(**kwargs):
+        captured.update(kwargs)
+        return _completed_stream()
+
+    response = run_codex_stream(
+        agent,
+        _request(),
+        client=SimpleNamespace(responses=SimpleNamespace(create=create)),
+    )
+
+    assert response.output_text == "hello"
+    assert captured["extra_headers"]["X-OpenAI-Internal-Codex-Responses-Lite"] == "true"
+    assert captured["reasoning"]["context"] == "all_turns"
+    assert captured["stream"] is True
+
+
+def test_lite_disables_parallel_tool_calls(monkeypatch):
+    agent = _agent()
+    captured = {}
+    monkeypatch.setattr(
+        "agent.codex_runtime._codex_model_capabilities",
+        lambda _agent: SimpleNamespace(
+            use_responses_lite=True,
+            prefer_websockets=False,
+            should_use_websocket=False,
+        ),
+    )
+
+    def create(**kwargs):
+        captured.update(kwargs)
+        return _completed_stream()
+
+    request = _request()
+    request["parallel_tool_calls"] = True
+    response = run_codex_stream(
+        agent,
+        request,
+        client=SimpleNamespace(responses=SimpleNamespace(create=create)),
+    )
+
+    assert response.output_text == "hello"
+    assert captured["parallel_tool_calls"] is False
+
+
+def test_websocket_failure_before_events_falls_back_to_http(monkeypatch):
+    agent = _agent()
+    calls = {"websocket": 0, "http": 0}
+    monkeypatch.setattr(
+        "agent.codex_runtime._codex_model_capabilities",
+        lambda _agent: SimpleNamespace(
+            use_responses_lite=True,
+            prefer_websockets=True,
+            should_use_websocket=True,
+        ),
+    )
+
+    def websocket(*args, **kwargs):
+        calls["websocket"] += 1
+        raise CodexWebSocketError("policy rejected", started=False, status_code=403)
+
+    monkeypatch.setattr("agent.codex_websocket.run_codex_websocket", websocket)
+
+    def create(**kwargs):
+        calls["http"] += 1
+        assert kwargs["extra_headers"]["X-OpenAI-Internal-Codex-Responses-Lite"] == "true"
+        return _completed_stream()
+
+    response = run_codex_stream(
+        agent,
+        _request(),
+        client=SimpleNamespace(responses=SimpleNamespace(create=create)),
+    )
+
+    assert response.output_text == "hello"
+    assert calls == {"websocket": 1, "http": 1}
+
+
+def test_websocket_failure_after_events_is_not_replayed_over_http(monkeypatch):
+    agent = _agent()
+    calls = {"http": 0}
+    monkeypatch.setattr(
+        "agent.codex_runtime._codex_model_capabilities",
+        lambda _agent: SimpleNamespace(
+            use_responses_lite=True,
+            prefer_websockets=True,
+            should_use_websocket=True,
+        ),
+    )
+    monkeypatch.setattr(
+        "agent.codex_websocket.run_codex_websocket",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            CodexWebSocketError("stream dropped", started=True)
+        ),
+    )
+
+    def create(**kwargs):
+        calls["http"] += 1
+        return _completed_stream()
+
+    with pytest.raises(CodexWebSocketError, match="stream dropped"):
+        run_codex_stream(
+            agent,
+            _request(),
+            client=SimpleNamespace(responses=SimpleNamespace(create=create)),
+        )
+
+    assert calls["http"] == 0
+
+
+def test_websocket_failure_after_request_send_is_not_replayed_over_http(monkeypatch):
+    agent = _agent()
+    calls = {"http": 0}
+    monkeypatch.setattr(
+        "agent.codex_runtime._codex_model_capabilities",
+        lambda _agent: SimpleNamespace(
+            use_responses_lite=True,
+            prefer_websockets=True,
+            should_use_websocket=True,
+        ),
+    )
+    monkeypatch.setattr(
+        "agent.codex_websocket.run_codex_websocket",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            CodexWebSocketError(
+                "socket dropped after request send",
+                started=False,
+                safe_to_fallback=False,
+            )
+        ),
+    )
+
+    def create(**kwargs):
+        calls["http"] += 1
+        return _completed_stream()
+
+    with pytest.raises(CodexWebSocketError, match="socket dropped"):
+        run_codex_stream(
+            agent,
+            _request(),
+            client=SimpleNamespace(responses=SimpleNamespace(create=create)),
+        )
+
+    assert calls["http"] == 0

--- a/tests/agent/test_codex_websocket.py
+++ b/tests/agent/test_codex_websocket.py
@@ -46,6 +46,7 @@ def test_build_websocket_request_matches_response_create_shape():
             "model": "gpt-5.6-luna",
             "instructions": "Be concise.",
             "input": [{"role": "user", "content": "hello"}],
+            "tools": [{"type": "function", "name": "terminal"}],
             "store": False,
             "parallel_tool_calls": True,
             "stream": True,
@@ -61,6 +62,20 @@ def test_build_websocket_request_matches_response_create_shape():
     assert request["model"] == "gpt-5.6-luna"
     assert request["reasoning"] == {"context": "all_turns"}
     assert request["parallel_tool_calls"] is False
+    assert "instructions" not in request
+    assert "tools" not in request
+    assert request["input"][:2] == [
+        {
+            "type": "additional_tools",
+            "role": "developer",
+            "tools": [{"type": "function", "name": "terminal"}],
+        },
+        {
+            "type": "message",
+            "role": "developer",
+            "content": [{"type": "input_text", "text": "Be concise."}],
+        },
+    ]
     assert request["client_metadata"] == {
         "source": "test",
         CODEX_RESPONSES_LITE_CLIENT_METADATA_KEY: "true",
@@ -68,6 +83,25 @@ def test_build_websocket_request_matches_response_create_shape():
     assert "extra_headers" not in request
     assert "extra_body" not in request
     assert "timeout" not in request
+
+
+def test_build_websocket_request_does_not_duplicate_prepared_lite_input():
+    request = build_codex_websocket_request(
+        {
+            "model": "gpt-5.6-luna",
+            "instructions": "Be concise.",
+            "input": [{"role": "user", "content": "hello"}],
+            "tools": [{"type": "function", "name": "terminal"}],
+        },
+        use_responses_lite=True,
+    )
+
+    rebuilt = build_codex_websocket_request(request, use_responses_lite=True)
+
+    assert rebuilt["input"] == request["input"]
+    assert rebuilt["input"][0]["type"] == "additional_tools"
+    assert rebuilt["input"][1]["role"] == "developer"
+    assert rebuilt["input"][2] == {"role": "user", "content": "hello"}
 
 
 def test_build_websocket_headers_include_codex_transport_markers(monkeypatch):

--- a/tests/agent/test_codex_websocket.py
+++ b/tests/agent/test_codex_websocket.py
@@ -1,0 +1,216 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from agent.codex_websocket import (
+    CODEX_RESPONSES_LITE_CLIENT_METADATA_KEY,
+    CODEX_RESPONSES_LITE_HEADER,
+    CODEX_RESPONSES_WEBSOCKET_BETA,
+    CodexWebSocketError,
+    build_codex_websocket_headers,
+    build_codex_websocket_request,
+    responses_websocket_url,
+    run_codex_websocket,
+)
+
+
+def _agent():
+    return SimpleNamespace(
+        api_key="codex-token",
+        base_url="https://chatgpt.com/backend-api/codex",
+        _client_kwargs={
+            "default_headers": {
+                "User-Agent": "codex_cli_rs/0.144.1 (Hermes Agent)",
+                "originator": "codex_cli_rs",
+            }
+        },
+        _interrupt_requested=False,
+    )
+
+
+def test_responses_websocket_url_rewrites_http_scheme():
+    assert (
+        responses_websocket_url("https://chatgpt.com/backend-api/codex")
+        == "wss://chatgpt.com/backend-api/codex/responses"
+    )
+    assert (
+        responses_websocket_url("https://chatgpt.com/backend-api/codex/responses")
+        == "wss://chatgpt.com/backend-api/codex/responses"
+    )
+
+
+def test_build_websocket_request_matches_response_create_shape():
+    request = build_codex_websocket_request(
+        {
+            "model": "gpt-5.6-luna",
+            "instructions": "Be concise.",
+            "input": [{"role": "user", "content": "hello"}],
+            "store": False,
+            "parallel_tool_calls": True,
+            "stream": True,
+            "extra_headers": {"session_id": "session-1"},
+            "extra_body": {"client_metadata": {"source": "test"}},
+            "timeout": 30,
+        },
+        use_responses_lite=True,
+    )
+
+    assert request["type"] == "response.create"
+    assert request["stream"] is True
+    assert request["model"] == "gpt-5.6-luna"
+    assert request["reasoning"] == {"context": "all_turns"}
+    assert request["parallel_tool_calls"] is False
+    assert request["client_metadata"] == {
+        "source": "test",
+        CODEX_RESPONSES_LITE_CLIENT_METADATA_KEY: "true",
+    }
+    assert "extra_headers" not in request
+    assert "extra_body" not in request
+    assert "timeout" not in request
+
+
+def test_build_websocket_headers_include_codex_transport_markers(monkeypatch):
+    monkeypatch.setattr("agent.codex_websocket._codex_client_version", lambda: "0.144.1")
+
+    headers = build_codex_websocket_headers(
+        _agent(),
+        {"extra_headers": {"session_id": "session-1"}},
+        use_responses_lite=True,
+    )
+
+    assert headers["Authorization"] == "Bearer codex-token"
+    assert headers["originator"] == "codex_cli_rs"
+    assert headers["version"] == "0.144.1"
+    assert headers["OpenAI-Beta"] == CODEX_RESPONSES_WEBSOCKET_BETA
+    assert headers[CODEX_RESPONSES_LITE_HEADER] == "true"
+    assert headers["session_id"] == "session-1"
+
+
+class _FakeWebSocket:
+    def __init__(self, frames):
+        self.frames = list(frames)
+        self.sent = []
+        self.closed = False
+
+    def send(self, value):
+        self.sent.append(value)
+
+    def recv(self, timeout=None):
+        if not self.frames:
+            raise AssertionError("test server ran out of frames")
+        return self.frames.pop(0)
+
+    def close(self):
+        self.closed = True
+
+
+def test_run_codex_websocket_reuses_responses_event_consumer(monkeypatch):
+    ws = _FakeWebSocket(
+        [
+            json.dumps({"type": "response.created"}),
+            json.dumps({"type": "response.output_text.delta", "delta": "hello"}),
+            json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {"id": "resp-1", "status": "completed", "usage": None},
+                }
+            ),
+        ]
+    )
+    monkeypatch.setattr("websockets.sync.client.connect", lambda *args, **kwargs: ws)
+    agent = _agent()
+
+    response = run_codex_websocket(
+        agent,
+        {
+            "model": "gpt-5.6-luna",
+            "instructions": "Be concise.",
+            "input": [{"role": "user", "content": "hello"}],
+            "store": False,
+            "parallel_tool_calls": True,
+        },
+        use_responses_lite=True,
+    )
+
+    assert response.id == "resp-1"
+    assert response.output_text == "hello"
+    assert response.output[0].content[0].text == "hello"
+    assert ws.closed is True
+    sent = json.loads(ws.sent[0])
+    assert sent["type"] == "response.create"
+    assert sent["model"] == "gpt-5.6-luna"
+    assert sent["reasoning"]["context"] == "all_turns"
+    assert sent["parallel_tool_calls"] is False
+    assert sent["client_metadata"][CODEX_RESPONSES_LITE_CLIENT_METADATA_KEY] == "true"
+
+
+def test_run_codex_websocket_uses_terminal_output_when_done_event_is_missing(monkeypatch):
+    ws = _FakeWebSocket(
+        [
+            json.dumps({"type": "response.created"}),
+            json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp-terminal-output",
+                        "status": "completed",
+                        "output": [
+                            {
+                                "type": "message",
+                                "role": "assistant",
+                                "status": "completed",
+                                "content": [
+                                    {"type": "output_text", "text": "terminal hello"}
+                                ],
+                            }
+                        ],
+                    },
+                }
+            ),
+        ]
+    )
+    monkeypatch.setattr("websockets.sync.client.connect", lambda *args, **kwargs: ws)
+
+    response = run_codex_websocket(
+        _agent(),
+        {
+            "model": "gpt-5.6-luna",
+            "instructions": "Be concise.",
+            "input": [{"role": "user", "content": "hello"}],
+            "store": False,
+        },
+        use_responses_lite=True,
+    )
+
+    assert response.output[0].content[0].text == "terminal hello"
+
+
+def test_run_codex_websocket_marks_pre_response_errors_safe_to_fallback(monkeypatch):
+    ws = _FakeWebSocket(
+        [
+            json.dumps(
+                {
+                    "type": "error",
+                    "status": 403,
+                    "error": {"message": "websocket policy rejected"},
+                }
+            )
+        ]
+    )
+    monkeypatch.setattr("websockets.sync.client.connect", lambda *args, **kwargs: ws)
+
+    with pytest.raises(CodexWebSocketError) as exc_info:
+        run_codex_websocket(
+            _agent(),
+            {
+                "model": "gpt-5.6-luna",
+                "instructions": "Be concise.",
+                "input": [{"role": "user", "content": "hello"}],
+                "store": False,
+            },
+            use_responses_lite=True,
+        )
+
+    assert exc_info.value.started is False
+    assert exc_info.value.status_code == 403

--- a/tests/agent/test_codex_websocket.py
+++ b/tests/agent/test_codex_websocket.py
@@ -1,4 +1,5 @@
 import json
+import threading
 from types import SimpleNamespace
 
 import pytest
@@ -139,6 +140,29 @@ class _FakeWebSocket:
         self.closed = True
 
 
+class _BlockingFakeWebSocket(_FakeWebSocket):
+    """Socket that stays in recv until a cross-thread close wakes it."""
+
+    def __init__(self):
+        super().__init__([])
+        self.recv_started = threading.Event()
+        self.closed_event = threading.Event()
+        self.recv_thread_id = None
+        self.close_thread_ids = []
+
+    def recv(self, timeout=None):
+        self.recv_thread_id = threading.get_ident()
+        self.recv_started.set()
+        if not self.closed_event.wait(timeout=timeout):
+            raise TimeoutError
+        return None
+
+    def close(self):
+        self.close_thread_ids.append(threading.get_ident())
+        self.closed = True
+        self.closed_event.set()
+
+
 def test_run_codex_websocket_reuses_responses_event_consumer(monkeypatch):
     ws = _FakeWebSocket(
         [
@@ -248,3 +272,83 @@ def test_run_codex_websocket_marks_pre_response_errors_safe_to_fallback(monkeypa
 
     assert exc_info.value.started is False
     assert exc_info.value.status_code == 403
+
+
+def test_abort_hook_closes_active_websocket_without_http_replay(monkeypatch):
+    """A cross-thread abort must close, clear, and never replay a sent request."""
+    from agent.codex_runtime import run_codex_stream
+    from run_agent import AIAgent
+
+    ws = _BlockingFakeWebSocket()
+    monkeypatch.setattr("websockets.sync.client.connect", lambda *args, **kwargs: ws)
+    monkeypatch.setattr(
+        "agent.codex_runtime._codex_model_capabilities",
+        lambda _agent: SimpleNamespace(
+            use_responses_lite=True,
+            prefer_websockets=True,
+            should_use_websocket=True,
+        ),
+    )
+
+    agent = _agent()
+    agent.provider = "openai-codex"
+    agent.model = "gpt-5.6-luna"
+    agent._base_url_lower = agent.base_url
+    agent._base_url_hostname = "chatgpt.com"
+    agent._fire_stream_delta = lambda text: None
+    agent._fire_reasoning_delta = lambda text: None
+    agent._touch_activity = lambda message: None
+    agent._client_log_context = lambda: "test-context"
+    agent._force_close_tcp_sockets = lambda client: 0
+
+    http_calls = []
+
+    def create(**kwargs):
+        http_calls.append(kwargs)
+        raise AssertionError("a sent WebSocket request must not be replayed over HTTP")
+
+    client = SimpleNamespace(responses=SimpleNamespace(create=create))
+    outcome = {}
+
+    def run_request():
+        try:
+            outcome["response"] = run_codex_stream(
+                agent,
+                {
+                    "model": "gpt-5.6-luna",
+                    "instructions": "Be concise.",
+                    "input": [{"role": "user", "content": "hello"}],
+                    "store": False,
+                },
+                client=client,
+            )
+        except Exception as exc:
+            outcome["error"] = exc
+
+    worker = threading.Thread(target=run_request, daemon=True)
+    worker.start()
+    recv_started = ws.recv_started.wait(timeout=3.0)
+    if not recv_started:
+        ws.close()
+        worker.join(timeout=3.0)
+    assert recv_started, f"WebSocket request did not reach recv: {outcome!r}"
+
+    abort_thread_id = threading.get_ident()
+    close_count_before_abort = len(ws.close_thread_ids)
+    AIAgent._abort_request_openai_client(agent, client, reason="interrupt_abort")
+    abort_close_thread_ids = ws.close_thread_ids[close_count_before_abort:]
+    worker.join(timeout=3.0)
+    stopped_by_abort = not worker.is_alive()
+    if not stopped_by_abort:
+        ws.close()
+        worker.join(timeout=3.0)
+
+    assert stopped_by_abort
+    assert len(ws.sent) == 1
+    assert ws.closed is True
+    assert abort_thread_id in abort_close_thread_ids
+    assert ws.recv_thread_id != abort_thread_id
+    assert getattr(agent, "_codex_active_websocket", None) is None
+    assert http_calls == []
+    assert isinstance(outcome.get("error"), CodexWebSocketError)
+    assert outcome["error"].safe_to_fallback is False

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -1,7 +1,11 @@
 import json
 from unittest.mock import patch
 
-from hermes_cli.codex_models import DEFAULT_CODEX_MODELS, get_codex_model_ids
+from hermes_cli.codex_models import (
+    DEFAULT_CODEX_MODELS,
+    get_codex_model_capabilities,
+    get_codex_model_ids,
+)
 
 
 def test_get_codex_model_ids_prioritizes_default_and_cache(tmp_path, monkeypatch):
@@ -111,6 +115,91 @@ def test_fetch_from_api_keeps_supported_in_api_false_models(monkeypatch):
     assert "gpt-5.5" in models
     assert "gpt-5.3-codex-spark" in models
     assert "gpt-5-internal" not in models
+
+
+def test_fetch_from_api_uses_codex_client_version(monkeypatch):
+    import sys
+    from hermes_cli import codex_models
+
+    captured = {}
+
+    class _FakeResp:
+        status_code = 200
+
+        def json(self):
+            return {"models": [{"slug": "gpt-5.6-luna"}]}
+
+    class _FakeHttpx:
+        @staticmethod
+        def get(url, headers=None, timeout=None):
+            captured.update(url=url, headers=headers, timeout=timeout)
+            return _FakeResp()
+
+    monkeypatch.setattr(codex_models, "_codex_client_version", lambda: "0.144.1")
+    monkeypatch.setitem(sys.modules, "httpx", _FakeHttpx)
+
+    entries = codex_models._fetch_model_entries_from_api("tok")
+
+    assert entries[0]["slug"] == "gpt-5.6-luna"
+    assert "client_version=0.144.1" in captured["url"]
+    assert captured["headers"]["version"] == "0.144.1"
+    assert captured["headers"]["User-Agent"].startswith("codex_cli_rs/0.144.1")
+
+
+def test_get_codex_model_capabilities_preserves_transport_metadata(tmp_path, monkeypatch):
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir(parents=True, exist_ok=True)
+    (codex_home / "models_cache.json").write_text(
+        json.dumps(
+            {
+                "models": [
+                    {
+                        "slug": "gpt-5.6-luna",
+                        "use_responses_lite": True,
+                        "minimal_client_version": "0.144.0",
+                    },
+                    {
+                        "slug": "gpt-hidden",
+                        "visibility": "hidden",
+                        "use_responses_lite": True,
+                    },
+                ]
+            }
+        )
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    capabilities = get_codex_model_capabilities("openai/gpt-5.6-luna")
+
+    assert capabilities.slug == "gpt-5.6-luna"
+    assert capabilities.use_responses_lite is True
+    # Older cache files omit the explicit preference; Lite models retain the
+    # WebSocket-first behavior as a compatibility fallback.
+    assert capabilities.prefer_websockets is None
+    assert capabilities.should_use_websocket is True
+    assert capabilities.minimal_client_version == "0.144.0"
+
+
+def test_get_codex_model_capabilities_prefers_live_transport_metadata(monkeypatch, tmp_path):
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setattr(
+        "hermes_cli.codex_models._fetch_model_entries_from_api",
+        lambda access_token: [
+            {
+                "slug": "gpt-5.6-luna",
+                "use_responses_lite": True,
+                "prefer_websockets": False,
+            }
+        ],
+    )
+
+    capabilities = get_codex_model_capabilities("gpt-5.6-luna", access_token="a.b.c")
+
+    assert capabilities.use_responses_lite is True
+    assert capabilities.prefer_websockets is False
+    assert capabilities.should_use_websocket is False
 
 
 def test_model_command_uses_runtime_access_token_for_codex_list(monkeypatch):

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -173,11 +173,55 @@ def test_get_codex_model_capabilities_preserves_transport_metadata(tmp_path, mon
 
     assert capabilities.slug == "gpt-5.6-luna"
     assert capabilities.use_responses_lite is True
-    # Older cache files omit the explicit preference; Lite models retain the
-    # WebSocket-first behavior as a compatibility fallback.
-    assert capabilities.prefer_websockets is None
+    # The known-model fallback fills metadata omitted by an older cache.
+    assert capabilities.prefer_websockets is True
     assert capabilities.should_use_websocket is True
     assert capabilities.minimal_client_version == "0.144.0"
+
+
+def test_known_lite_capability_survives_legacy_cache_entry(tmp_path, monkeypatch):
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir(parents=True, exist_ok=True)
+    (codex_home / "models_cache.json").write_text(
+        json.dumps({"models": [{"slug": "gpt-5.6-luna"}]})
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    capabilities = get_codex_model_capabilities("gpt-5.6-luna")
+
+    assert capabilities.use_responses_lite is True
+    assert capabilities.prefer_websockets is True
+    assert capabilities.should_use_websocket is True
+    assert capabilities.minimal_client_version == "0.144.0"
+
+
+def test_complete_local_capabilities_skip_live_catalog_fetch(tmp_path, monkeypatch):
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir(parents=True, exist_ok=True)
+    (codex_home / "models_cache.json").write_text(
+        json.dumps({
+            "models": [
+                {
+                    "slug": "gpt-local-lite",
+                    "use_responses_lite": True,
+                    "prefer_websockets": False,
+                }
+            ]
+        })
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setattr(
+        "hermes_cli.codex_models._fetch_model_entries_from_api",
+        lambda access_token: (_ for _ in ()).throw(AssertionError("unexpected fetch")),
+    )
+
+    capabilities = get_codex_model_capabilities(
+        "gpt-local-lite",
+        access_token="a.b.c",
+    )
+
+    assert capabilities.use_responses_lite is True
+    assert capabilities.should_use_websocket is False
 
 
 def test_get_codex_model_capabilities_prefers_live_transport_metadata(monkeypatch, tmp_path):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -750,15 +750,9 @@ def test_run_codex_stream_parses_create_stream_events(monkeypatch):
     response = agent._run_codex_stream(_codex_request_kwargs())
     assert calls["create"] == 1
     assert create_stream.closed is True
-    # The wire's response.completed.response.output is a list with the message item,
-    # but the event-driven path reconstructs from response.output_item.done.
-    # _codex_message_response returns a SimpleNamespace whose .output is a list of
-    # items — we don't read those directly, we read the items via output_item.done,
-    # but this fixture doesn't emit output_item.done. So the consumer assembles a
-    # message from streamed text deltas if present, or returns the items it has.
-    # For backward compatibility with the helper that builds _codex_message_response,
-    # we just assert status is completed and id propagated.
     assert response.status == "completed"
+    assert response.output
+    assert response.output[0].content[0].text == "streamed create ok"
 
 
 def test_run_codex_stream_ignores_completed_response_with_null_output(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Adds the transport and request-shape support Hermes needs for OAuth-backed Codex Responses Lite models such as GPT-5.6 Luna. It matches the first-party Lite payload contract, uses the advertised WebSocket transport with a safe pre-response HTTP fallback, and preserves final text when a stream omits `response.output_item.done` events.

## Related Issue

No single upstream issue covers the combined failure mode. This follows the GPT-5.6 rollout and the related Codex transport work already merged or under review upstream; it is not a duplicate of the model-registration PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Preserve Codex model capability metadata from the live catalog and local cache, with known GPT-5.6 fallback metadata for legacy cache entries.
- Mark Responses Lite requests with the required header, `reasoning.context = "all_turns"`, and `parallel_tool_calls = false`.
- Move Lite instructions and tool schemas into developer input items, normalize unsupported image inputs, and keep the transformation idempotent across HTTP and WebSocket request builders.
- Add the synchronous Codex Responses WebSocket transport, headers, request framing, event handling, interruption cleanup, and guarded HTTP fallback.
- Recover assistant output from terminal response objects when output-item events are missing, including raw WebSocket JSON objects.
- Add regression coverage for model metadata, Lite request constraints, WebSocket framing/fallback, interruption behavior, and terminal-output recovery.

## How to Test

1. Run the focused repository wrapper suite:
   `scripts/run_tests.sh tests/agent/test_codex_websocket.py tests/agent/test_codex_runtime_transport.py tests/run_agent/test_run_agent_codex_responses.py tests/hermes_cli/test_codex_models.py tests/agent/transports/test_codex_transport.py tests/agent/test_codex_responses_adapter.py -q`
   Result: 198 passed.
2. Run the full repository suite against upstream `a0972b974` plus this PR's commits:
   `scripts/run_tests.sh tests/ -q`
   Result: 40,109 passed, 0 failed across 1,960 files.
3. Run Ruff on the changed Python files.
   Result: all checks passed.
4. Run the cross-platform scan:
   `python scripts/check-windows-footguns.py agent/codex_runtime.py agent/codex_websocket.py hermes_cli/codex_models.py`
   Result: no Windows footguns found.

The transport tests exercise mocked HTTP/SSE and WebSocket event streams, including Lite payload shaping, pre-response fallback, interrupted requests, multimodal normalization, and missing terminal output-item events.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable; this is a backend transport fix.

