### PR TITLE
fix(installer): write code-scoped .install_method stamp in install.ps1 to fix false-positive unsupported install method banner

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -3458,6 +3458,20 @@ function Invoke-PostInstallMode {
 function Main {
     Write-Banner
     Invoke-AllStages
+
+    # Write code-scoped install method stamp
+    # This must come AFTER Invoke-AllStages (which runs the "dependencies" stage)
+    # to overwrite any "pip" stamp written by the postinstall hook triggered by uv.
+    # The install.ps1 + uv-based install is a Tier-1 supported method and should
+    # be marked as "installer", not "pip". See issue #61827.
+    try {
+        $methodStamp = "$InstallDir\.install_method"
+        "installer" | Out-File -FilePath $methodStamp -Encoding utf8 -NoNewline
+    } catch {
+        # Best-effort: if the install tree is read-only, silently skip
+        Write-Debug "Failed to write .install_method stamp: $_"
+    }
+
     if (-not $Json) {
         Write-Completion
     } else {


### PR DESCRIPTION
## What does this PR do?

Fixes the false-positive "Unsupported install method: pip installs are no longer an officially supported platform and will not receive further updates" warning banner that appears in Hermes Desktop for users who installed Hermes via the official `install.ps1` bootstrap flow with uv-based dependency management.

**Root cause:**
- `install.ps1` uses `uv` to create the venv and install `hermes-agent` from `uv.lock`
- The `hermes postinstall` hook (triggered by pip/uv package installation) calls `stamp_install_method("pip")`, writing "pip" to `<install tree>/.install_method`
- The Desktop app reads `.install_method` and shows the unsupported-install-method banner for any "pip" value
- However, `install.ps1 + uv` is a Tier-1 supported installation method (documented at https://hermes-agent.nousresearch.com/docs/getting-started/platform-support), not an unsupported pip install

**Fix:**
- After `Invoke-AllStages` completes in `install.ps1`, write a code-scoped `.install_method` stamp with value "installer"
- This overwrites the "pip" stamp written by the postinstall hook, correctly identifying the installation as an official installer-based install
- The "installer" value is not in `_UNSUPPORTED_INSTALL_METHODS`, so no banner is shown

## Related Issue

Fixes #61827

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/install.ps1`: Added code-scoped `.install_method` stamp write in `Main()` function after `Invoke-AllStages()` completes, with value "installer" to correctly identify install.ps1 + uv-based installs

## How to Test

1. On Windows, install Hermes via the official installer:
   ```powershell
   irm https://hermes-agent.nousresearch.com/install.ps1 | iex
   ```
2. Let the installer complete (uses uv to create venv and install from uv.lock)
3. Verify `.install_method` file exists in the install tree with content "installer":
   ```powershell
   Get-Content "$env:LOCALAPPDATA\hermes\hermes-agent\.install_method"
   ```
   Expected output: `installer`
4. Open Hermes Desktop — the "Unsupported install method" banner should NOT appear
5. Verify via CLI that the install method is detected correctly:
   ```powershell
   hermes config get install_method
   ```
   Expected output: `installer` (not "pip")

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (N/A: no Python changes)
- [ ] I've added tests for my changes (N/A: shell script change, manual testing path documented)
- [ ] I've tested on my platform: N/A (macOS environment, fix is Windows-specific)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — fix is Windows-specific, no impact on other platforms
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A