### PR TITLE
fix(agent): distinguish plugin name mismatch from "not found" in context engine warning (#61839)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1730,6 +1730,7 @@ def init_agent(
     _selected_engine = None
     _copy_failed = False
     _engine_name = "compressor"  # default
+    _candidate = None
     try:
         _ctx_cfg = _agent_cfg.get("context", {}) if isinstance(_agent_cfg, dict) else {}
         _engine_name = _ctx_cfg.get("engine", "compressor") or "compressor"
@@ -1775,10 +1776,24 @@ def init_agent(
                     _selected_engine = None
 
         if _selected_engine is None and not _copy_failed:
-            _ra().logger.warning(
-                "Context engine '%s' not found — falling back to built-in compressor",
-                _engine_name,
-            )
+            # Distinguish "no engine at all" from "plugin system found an engine
+            # but its .name doesn't match the configured engine name" so the
+            # log message is accurate in both cases.  (#61839)
+            if _candidate is not None:
+                _ra().logger.warning(
+                    "Context engine '%s' configured but plugin system has "
+                    "engine '%s' (name mismatch) — falling back to built-in "
+                    "compressor. Set context.engine to '%s' to use the "
+                    "discovered engine.",
+                    _engine_name, getattr(_candidate, "name", "?"),
+                    getattr(_candidate, "name", "?"),
+                )
+            else:
+                _ra().logger.warning(
+                    "Context engine '%s' not found in native directory or "
+                    "plugin system — falling back to built-in compressor",
+                    _engine_name,
+                )
     # else: config says "compressor" — use built-in, don't auto-activate plugins
 
     if _selected_engine is not None:


### PR DESCRIPTION
## Problem

When `context.engine` is configured to a plugin engine (e.g. `context_chunking`) that lives in the user plugins directory (`/opt/data/plugins/`) rather than the native path (`plugins/context_engine/<name>/`), the first agent initialization emits a misleading warning:

```
Context engine 'context_chunking' not found — falling back to built-in compressor
```

The plugin system fallback successfully discovers the engine, but if the engine's `.name` property doesn't match the configured `context.engine` name, the generic "not found" message is logged, which is inaccurate and causes confusion.  See #61839.

## Fix

- Distinguish two failure modes in the warning message:
  - **Name mismatch:** the plugin system found an engine but its `.name` differs from the configured engine name → explain the mismatch and suggest the correct config value.
  - **Genuinely not found:** neither the native directory nor the plugin system has any engine → keep the original "not found" wording for clarity.
- Hoist `_candidate = None` before the `try` block to prevent a `NameError` when `_candidate` is referenced after the `if _engine_name != "compressor"` block and the exception handler set it.