### PR TITLE
fix(dashboard): guard against malformed plugin manifests and add integrity passthrough (#61471)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -16238,6 +16238,7 @@ def _discover_dashboard_plugins() -> list:
                     "slots": slots,
                     "entry": data.get("entry", "dist/index.js"),
                     "css": data.get("css"),
+                    "integrity": data.get("integrity"),
                     "has_api": bool(safe_api),
                     "source": source,
                     "_dir": str(dashboard_dir),

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -237,12 +237,14 @@ function buildNavItems(
   const items = [...builtIn];
 
   for (const manifest of manifests) {
+    // Guard against malformed manifests: require a valid tab object.
+    if (!manifest.tab || typeof manifest.tab !== "object") continue;
     if (manifest.tab.override) continue;
     if (manifest.tab.hidden) continue;
 
     const pluginItem: NavItem = {
-      path: manifest.tab.path,
-      label: manifest.label,
+      path: manifest.tab.path || `/${manifest.name}`,
+      label: manifest.label || manifest.name,
       icon: resolveIcon(manifest.icon),
     };
 
@@ -293,6 +295,8 @@ function buildRoutes(
   const addons: PluginManifest[] = [];
 
   for (const m of manifests) {
+    // Guard against malformed manifests: require a valid tab object.
+    if (!m.tab || typeof m.tab !== "object") continue;
     if (m.tab.override) {
       byOverride.set(m.tab.override, m);
     } else {
@@ -446,10 +450,10 @@ export default function App() {
   const pluginTabMeta = useMemo(
     () =>
       manifests
-        .filter((m) => !m.tab.hidden)
+        .filter((m) => m.tab && typeof m.tab === "object" && !m.tab.hidden)
         .map((m) => ({
-          path: m.tab.override ?? m.tab.path,
-          label: m.label,
+          path: m.tab.override ?? m.tab.path ?? `/${m.name}`,
+          label: m.label ?? m.name,
         })),
     [manifests],
   );

--- a/web/src/plugins/usePlugins.ts
+++ b/web/src/plugins/usePlugins.ts
@@ -28,7 +28,12 @@ export function usePlugins() {
     api
       .getPlugins()
       .then((list) => {
-        setManifests(list);
+        // Defensive: ensure every manifest has a valid tab object.
+        const cleaned = (list ?? []).map((m) => ({
+          ...m,
+          tab: m.tab && typeof m.tab === "object" ? m.tab : { path: `/${m.name}` },
+        }));
+        setManifests(cleaned);
         if (list.length === 0) setLoading(false);
       })
       .catch(() => setLoading(false));


### PR DESCRIPTION
## Problem

When any user-installed dashboard plugin has `tab.hidden: false`, the SPA delivers HTML but the root React mount never renders, leaving `/sessions` and `/system` as blank white pages.  Even a 546-byte no-op placeholder plugin reproduces this at 100% rate.

Browser console shows no plugin-loader errors. The crash occurs in the minified route-building code when a plugin manifest has missing or malformed `tab` data.  (#61471)

## Fix

**Backend** (`hermes_cli/web_server.py`):
- Pass the `integrity` field from plugin `manifest.json` to the frontend (was previously dropped before serialising the plugin list for the SPA).

**Frontend** (`web/src/App.tsx`, `web/src/plugins/usePlugins.ts`):
- Guard malformed manifests in `buildNavItems`, `buildRoutes`, and `pluginTabMeta` — skip plugins without a valid `tab` object instead of crashing.
- Fall back to a default path (`/<name>`) when `tab.path` is missing.
- Fall back to `manifest.name` when `tab.label` is missing.
- Sanitize manifest data in `usePlugins()` before setting state, ensuring every manifest has a valid `tab` object.