### PR TITLE
fix(install): re-enable errexit inside stage protocol subshell

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1321,7 +1321,7 @@ setup_venv() {
 
     log_info "Creating virtual environment with Python $PYTHON_VERSION..."
 
-    if [ -d "venv" ]; then
+    if [ -e "venv" ] || [ -L "venv" ]; then
         log_info "Virtual environment already exists, recreating..."
         rm -rf venv
     fi
@@ -3067,7 +3067,7 @@ run_stage_protocol() {
     # before emitting the frame and the Rust/Electron parser would see "no
     # result frame" instead of a clean {ok:false} contract response.
     set +e
-    ( run_stage_body "$stage" )
+    ( set -e; run_stage_body "$stage" )
     local code=$?
     set -e
 


### PR DESCRIPTION
## Summary

Fixes #61828

`run_stage_protocol()` in `scripts/install.sh` disables `set -e` before spawning the stage body subshell, so helpers like `setup_venv`, `install_deps`, and `clone_repo` — all written for the monolithic `set -e` flow — silently swallow failures. A hard-failing `uv venv` was reporting `✓ SUCCESS`.

## Changes

**Primary fix (run_stage_protocol, line 3070):**
Add `set -e;` before `run_stage_body` inside the subshell so the helper gets the failure semantics it expects while the parent survives `exit 1` calls to emit the JSON result frame.

```diff
-    ( run_stage_body "$stage" )
+    ( set -e; run_stage_body "$stage" )
```

**Secondary fix (setup_venv stale-venv detection, line 1324):**
`[ -d "venv" ]` is false for dangling symlinks (e.g. `venv -> ./venv`), so self-referential broken symlinks are silently skipped. Use `[ -e "venv" ] || [ -L "venv" ]` instead to catch them.

```diff
-    if [ -d "venv" ]; then
+    if [ -e "venv" ] || [ -L "venv" ]; then
```

## Verification

A reproducer script validates all three aspects:
1. **Subshell errexit mechanism** — without `set -e` inside the subshell, a `false` command is silently swallowed (exit 0). With `set -e`, the error properly propagates (exit 1).
2. **run_stage_protocol failure reporting** — the subshell correctly captures `ok:false` and non-zero exit code for failing stage helpers.
3. **Symlink detection** — the fix changes `[ -d ]` to `[ -e ] || [ -L ]` to catch broken symlinks.

All tests pass for both the fixed version and correctly fail for the original.