### PR TITLE
fix(kanban): require completion evidence for coding tasks

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3975,6 +3975,220 @@ class HallucinatedCardsError(ValueError):
         )
 
 
+class CompletionEvidenceError(ValueError):
+    """Raised when a coding task tries to close without verifiable evidence."""
+
+    def __init__(self, task_id: str, reason: str):
+        self.task_id = task_id
+        self.reason = reason
+        super().__init__(f"completion blocked for {task_id}: {reason}")
+
+
+_GITHUB_PR_URL_RE = re.compile(
+    r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/\d+\b"
+)
+_CI_PASSING_RE = re.compile(
+    r"\b(?:ci|checks?|github actions?)\b[^\n.;]{0,80}"
+    r"\b(?:pass(?:ed|ing)?|success(?:ful)?|green|clean)\b"
+    r"|\b(?:pass(?:ed|ing)?|success(?:ful)?|green|clean)\b"
+    r"[^\n.;]{0,80}\b(?:ci|checks?|github actions?)\b",
+    re.IGNORECASE,
+)
+_PASSING_STATUS_VALUES = {
+    "clean",
+    "green",
+    "pass",
+    "passed",
+    "passing",
+    "success",
+    "successful",
+}
+_CODING_ASSIGNEES = {
+    "coder",
+    "developer",
+    "engineer",
+    "programmer",
+    "software-developer",
+}
+_CODING_METADATA_KEYS = {
+    "branch",
+    "changed_files",
+    "checks_status",
+    "ci_status",
+    "diff_path",
+    "pr_number",
+    "pr_url",
+    "tests_passed",
+    "tests_run",
+    "worktree_path",
+}
+_CODING_TASK_RE = re.compile(
+    r"\b(?:api|backend|branch|bug|build|ci|code|commit|diff|fix|flutter|"
+    r"frontend|github|implement|migration|patch|pr|pull request|refactor|"
+    r"regression|repo|schema|test|tests|worktree)\b",
+    re.IGNORECASE,
+)
+
+
+def _metadata_strings(value: Any) -> list[str]:
+    """Flatten JSON-like metadata into strings for lightweight evidence scans."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, (bool, int, float)):
+        return [str(value)]
+    if isinstance(value, dict):
+        out: list[str] = []
+        for key, item in value.items():
+            out.append(str(key))
+            out.extend(_metadata_strings(item))
+        return out
+    if isinstance(value, (list, tuple, set)):
+        out: list[str] = []
+        for item in value:
+            out.extend(_metadata_strings(item))
+        return out
+    return [str(value)]
+
+
+def _metadata_status_is_passing(metadata: Optional[dict]) -> bool:
+    if not isinstance(metadata, dict):
+        return False
+    for key in ("ci_status", "checks_status", "github_checks", "checks", "ci"):
+        value = metadata.get(key)
+        if value is True:
+            return True
+        if isinstance(value, str):
+            normalized = value.strip().lower().replace("_", "-")
+            if normalized in _PASSING_STATUS_VALUES:
+                return True
+    for key in ("ci_passing", "checks_passing", "github_checks_passing"):
+        if metadata.get(key) is True:
+            return True
+    return False
+
+
+def _completion_has_pr_and_passing_checks(
+    text_blob: str,
+    metadata: Optional[dict],
+) -> bool:
+    has_pr_url = bool(_GITHUB_PR_URL_RE.search(text_blob))
+    if isinstance(metadata, dict):
+        pr_url = metadata.get("pr_url") or metadata.get("pull_request_url")
+        if isinstance(pr_url, str) and _GITHUB_PR_URL_RE.search(pr_url):
+            has_pr_url = True
+    if not has_pr_url:
+        return False
+    return _metadata_status_is_passing(metadata) or bool(_CI_PASSING_RE.search(text_blob))
+
+
+def _completion_has_auditable_human_waiver(metadata: Optional[dict]) -> bool:
+    """Return True only for an explicit waiver record in completion metadata."""
+    if not isinstance(metadata, dict):
+        return False
+    waiver = metadata.get("human_waiver")
+    if isinstance(waiver, dict):
+        approved_by = str(
+            waiver.get("approved_by") or waiver.get("approver") or ""
+        ).strip()
+        reason = str(waiver.get("reason") or waiver.get("rationale") or "").strip()
+        return bool(approved_by and reason)
+    if waiver is True:
+        approved_by = str(
+            metadata.get("human_waiver_approved_by")
+            or metadata.get("waiver_approved_by")
+            or ""
+        ).strip()
+        reason = str(
+            metadata.get("human_waiver_reason") or metadata.get("waiver_reason") or ""
+        ).strip()
+        return bool(approved_by and reason)
+    return False
+
+
+def _task_requires_completion_evidence(
+    row: sqlite3.Row,
+    metadata: Optional[dict],
+) -> bool:
+    if row["workspace_kind"] == "worktree":
+        return True
+    keys = set(row.keys())
+    if "project_id" in keys and row["project_id"]:
+        return True
+    metadata_has_coding_shape = (
+        isinstance(metadata, dict)
+        and any(key in metadata for key in _CODING_METADATA_KEYS)
+    )
+    assignee = (row["assignee"] or "").strip().lower()
+    text = f"{row['title'] or ''}\n{row['body'] or ''}"
+    return assignee in _CODING_ASSIGNEES and (
+        metadata_has_coding_shape or bool(_CODING_TASK_RE.search(text))
+    )
+
+
+def _completion_evidence_error(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    summary: Optional[str],
+    result: Optional[str],
+    metadata: Optional[dict],
+    reason: str,
+) -> CompletionEvidenceError:
+    with write_txn(conn):
+        _append_event(
+            conn,
+            task_id,
+            "completion_blocked_evidence",
+            {
+                "reason": reason,
+                "summary_preview": (
+                    (summary or result or "").strip().splitlines()[0][:200]
+                    if (summary or result)
+                    else None
+                ),
+                "metadata_keys": sorted(metadata.keys()) if isinstance(metadata, dict) else [],
+            },
+        )
+    return CompletionEvidenceError(task_id, reason)
+
+
+def _enforce_completion_evidence(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    summary: Optional[str],
+    result: Optional[str],
+    metadata: Optional[dict],
+) -> None:
+    row = conn.execute(
+        "SELECT id, title, body, assignee, workspace_kind, project_id "
+        "FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if row is None or not _task_requires_completion_evidence(row, metadata):
+        return
+    if _completion_has_auditable_human_waiver(metadata):
+        return
+    text_blob = "\n".join(
+        str(x) for x in [summary, result, *_metadata_strings(metadata)] if x
+    )
+    if _completion_has_pr_and_passing_checks(text_blob, metadata):
+        return
+    raise _completion_evidence_error(
+        conn,
+        task_id,
+        summary=summary,
+        result=result,
+        metadata=metadata,
+        reason=(
+            "coding tasks require a GitHub PR URL plus passing CI/checks, "
+            "or an explicit auditable human waiver in metadata"
+        ),
+    )
+
+
 def complete_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4041,6 +4255,14 @@ def complete_task(
             raise HallucinatedCardsError(phantom_cards, task_id)
     else:
         verified_cards = []
+
+    _enforce_completion_evidence(
+        conn,
+        task_id,
+        summary=summary,
+        result=result,
+        metadata=metadata,
+    )
 
     with write_txn(conn):
         if expected_run_id is None:

--- a/tests/hermes_cli/test_kanban_completion_evidence.py
+++ b/tests/hermes_cli/test_kanban_completion_evidence.py
@@ -1,0 +1,154 @@
+"""Regression coverage for coding-task completion evidence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    return home
+
+
+def _running_coding_task(conn):
+    task_id = kb.create_task(
+        conn,
+        title="fix API persistence bug",
+        body="Change repository code, run tests, and open a pull request.",
+        assignee="programmer",
+        workspace_kind="worktree",
+        workspace_path="/tmp/hermes-test-worktree",
+    )
+    assert kb.claim_task(conn, task_id) is not None
+    return task_id
+
+
+def test_coding_task_completion_without_evidence_is_rejected_and_audited(kanban_home):
+    with kb.connect() as conn:
+        task_id = _running_coding_task(conn)
+
+        with pytest.raises(kb.CompletionEvidenceError) as exc_info:
+            kb.complete_task(
+                conn,
+                task_id,
+                summary="Code changed locally; tests pass; PR can be opened later.",
+                metadata={
+                    "changed_files": ["hermes_cli/kanban_db.py"],
+                    "tests_run": ["python -m pytest tests/hermes_cli/test_kanban_completion_evidence.py -q"],
+                },
+            )
+
+        task = kb.get_task(conn, task_id)
+        events = kb.list_events(conn, task_id)
+
+    assert "GitHub PR URL plus passing CI/checks" in exc_info.value.reason
+    assert task is not None
+    assert task.status == "running"
+    assert "completed" not in [event.kind for event in events]
+    evidence_events = [event for event in events if event.kind == "completion_blocked_evidence"]
+    assert len(evidence_events) == 1
+    evidence_payload = evidence_events[0].payload or {}
+    assert "changed_files" in evidence_payload["metadata_keys"]
+
+
+def test_coding_task_completion_accepts_pr_url_with_passing_checks(kanban_home):
+    with kb.connect() as conn:
+        task_id = _running_coding_task(conn)
+
+        assert kb.complete_task(
+            conn,
+            task_id,
+            summary=(
+                "PR https://github.com/NousResearch/hermes-agent/pull/123 "
+                "has passing checks."
+            ),
+            metadata={
+                "pr_url": "https://github.com/NousResearch/hermes-agent/pull/123",
+                "ci_status": "passed",
+            },
+        )
+        task = kb.get_task(conn, task_id)
+
+    assert task is not None
+    assert task.status == "done"
+
+
+def test_coding_task_completion_rejects_incomplete_evidence_shapes(kanban_home):
+    with kb.connect() as conn:
+        pr_only = _running_coding_task(conn)
+        with pytest.raises(kb.CompletionEvidenceError):
+            kb.complete_task(
+                conn,
+                pr_only,
+                summary="PR https://github.com/NousResearch/hermes-agent/pull/123 is open.",
+                metadata={"pr_url": "https://github.com/NousResearch/hermes-agent/pull/123"},
+            )
+        pr_task = kb.get_task(conn, pr_only)
+        assert pr_task is not None
+        assert pr_task.status == "running"
+
+        bare_waiver = _running_coding_task(conn)
+        with pytest.raises(kb.CompletionEvidenceError):
+            kb.complete_task(
+                conn,
+                bare_waiver,
+                summary="Done under waiver.",
+                metadata={"human_waiver": True},
+            )
+        waiver_task = kb.get_task(conn, bare_waiver)
+        assert waiver_task is not None
+        assert waiver_task.status == "running"
+
+
+def test_coding_task_completion_accepts_auditable_human_waiver(kanban_home):
+    with kb.connect() as conn:
+        task_id = _running_coding_task(conn)
+
+        assert kb.complete_task(
+            conn,
+            task_id,
+            summary="Done under explicit human waiver.",
+            metadata={
+                "human_waiver": {
+                    "approved_by": "maintainer",
+                    "reason": "Maintainer accepted out-of-band completion proof.",
+                },
+            },
+        )
+        task = kb.get_task(conn, task_id)
+        run = kb.latest_run(conn, task_id)
+
+    assert task is not None
+    assert run is not None
+    assert task.status == "done"
+    assert run.metadata["human_waiver"]["approved_by"] == "maintainer"
+
+
+def test_non_coding_task_completion_does_not_require_pr_evidence(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="summarize source notes",
+            body="Produce a short read-only research summary.",
+            assignee="researcher",
+        )
+        assert kb.claim_task(conn, task_id) is not None
+
+        assert kb.complete_task(conn, task_id, summary="Summary written.")
+        task = kb.get_task(conn, task_id)
+
+    assert task is not None
+    assert task.status == "done"

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -650,6 +650,14 @@ def _handle_complete(args: dict, **kw) -> str:
                     f"and either drop these ids from created_cards, or pass "
                     f"created_cards=[] to skip the card-claim check entirely."
                 )
+            except kb.CompletionEvidenceError as evidence_err:
+                return tool_error(
+                    f"kanban_complete blocked: {evidence_err.reason}. "
+                    f"Your task is still in-flight (no state change). Retry "
+                    f"with metadata/summary containing a GitHub PR URL plus "
+                    f"passing CI/checks, or metadata.human_waiver with "
+                    f"approved_by and reason."
+                )
             if not ok:
                 return tool_error(
                     f"could not complete {tid} (unknown id or already terminal)"


### PR DESCRIPTION
## Summary
- Add a Kanban DB completion guard that applies to coding/worktree cards before the `running|ready|blocked -> done` write.
- Reuse completion summary/metadata evidence: accept a GitHub PR URL only when paired with passing CI/checks, or accept an explicit auditable `metadata.human_waiver` record with `approved_by` and `reason`.
- Record rejected attempts as `completion_blocked_evidence` events and surface a retryable `kanban_complete` tool error without mutating task state.

## Test Plan
- RED: `python -m pytest tests/hermes_cli/test_kanban_completion_evidence.py -q` failed before implementation with missing `CompletionEvidenceError`.
- `python -m pytest tests/hermes_cli/test_kanban_completion_evidence.py -q` — 5 passed.
- `python -m py_compile hermes_cli/kanban_db.py tools/kanban_tools.py` — passed.
- `python -m pytest tests/hermes_cli/test_kanban_completion_evidence.py tests/tools/test_kanban_tools.py -q` — 102 passed.
- `python -m pytest tests/hermes_cli/test_kanban_db.py -q` — 224 passed.
- `git diff --check` — passed.

## Scope notes
- Limited to Phase 1B evidence-on-done enforcement in the existing completion path.
- Does not add review-stage behavior, transition whitelist changes, reviewer logic, dispatcher env changes, or GitHub merge automation.
