### PR TITLE
fix(gateway): prioritize user interrupts over internal events

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8323,11 +8323,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 return
 
+            # Album/media follow-ups must keep merging into the (user-owned)
+            # head slot even when internal events sit in the overflow: the
+            # head is already ahead of every internal event, and inserting the
+            # photo into the overflow instead would split a burst into
+            # separate turns.
+            merges_into_head = (
+                getattr(existing, "message_type", None) == MessageType.PHOTO
+                or event.message_type == MessageType.PHOTO
+                or bool(getattr(existing, "media_urls", None))
+                or bool(getattr(event, "media_urls", None))
+            )
             first_internal = next(
                 (index for index, queued in enumerate(overflow) if getattr(queued, "internal", False)),
                 None,
             )
-            if first_internal is not None:
+            if first_internal is not None and not merges_into_head:
                 if self._queue_depth(session_key, adapter=adapter) >= self._BUSY_QUEUE_MAX_PENDING:
                     # Remove the last synthetic event to make room without
                     # reordering or discarding any real user follow-up.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8285,6 +8285,71 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # semantics); everything else appends to the overflow tail.
         pending_slot = getattr(adapter, "_pending_messages", None)
         existing = pending_slot.get(session_key) if isinstance(pending_slot, dict) else None
+
+        # Real user input must outrank synthetic completion notifications.
+        # Internal events deliberately queue without interrupting a busy turn,
+        # so one can already occupy the head slot when a user sends an
+        # interrupting follow-up. Plain FIFO would abort the active model call
+        # but then run the older internal notification first — making the
+        # truthful-looking "Interrupting current task" ack a priority inversion
+        # and delaying the user's steering by an entire extra agent turn.
+        # Preserve order within each class, but place real user input before
+        # queued internal events.
+        incoming_internal = bool(getattr(event, "internal", False))
+        if existing is not None and not incoming_internal:
+            queued_events = getattr(self, "_queued_events", None)
+            if queued_events is None:
+                queued_events = {}
+                self._queued_events = queued_events
+            overflow = queued_events.setdefault(session_key, [])
+            existing_internal = bool(getattr(existing, "internal", False))
+
+            if existing_internal:
+                if self._queue_depth(session_key, adapter=adapter) >= self._BUSY_QUEUE_MAX_PENDING:
+                    # Prefer dropping one synthetic notification over dropping
+                    # live operator steering when the bounded queue is full.
+                    logger.warning(
+                        "Replacing queued internal event with user input for session %s — "
+                        "pending queue at cap (%d).",
+                        session_key,
+                        self._BUSY_QUEUE_MAX_PENDING,
+                    )
+                else:
+                    overflow.insert(0, existing)
+                adapter._pending_messages[session_key] = event
+                logger.info(
+                    "Prioritized user input ahead of queued internal event for session %s.",
+                    session_key,
+                )
+                return
+
+            first_internal = next(
+                (index for index, queued in enumerate(overflow) if getattr(queued, "internal", False)),
+                None,
+            )
+            if first_internal is not None:
+                if self._queue_depth(session_key, adapter=adapter) >= self._BUSY_QUEUE_MAX_PENDING:
+                    # Remove the last synthetic event to make room without
+                    # reordering or discarding any real user follow-up.
+                    last_internal = next(
+                        (
+                            index
+                            for index in range(len(overflow) - 1, -1, -1)
+                            if getattr(overflow[index], "internal", False)
+                        ),
+                        None,
+                    )
+                    if last_internal is not None:
+                        overflow.pop(last_internal)
+                        if last_internal < first_internal:
+                            first_internal -= 1
+                overflow.insert(first_internal, event)
+                logger.info(
+                    "Prioritized user input ahead of queued internal overflow for session %s.",
+                    session_key,
+                )
+                return
+
         if existing is not None and (
             getattr(existing, "message_type", None) == MessageType.PHOTO
             or event.message_type == MessageType.PHOTO

--- a/tests/gateway/test_internal_event_never_interrupts_busy_session.py
+++ b/tests/gateway/test_internal_event_never_interrupts_busy_session.py
@@ -69,6 +69,7 @@ def _make_runner() -> GatewayRunner:
     runner._running_agents = {}
     runner._running_agents_ts = {}
     runner._pending_messages = {}
+    runner._queued_events = {}
     runner._busy_ack_ts = {}
     runner._draining = False
     runner.adapters = {}
@@ -127,3 +128,25 @@ async def test_internal_event_does_not_interrupt_busy_session() -> None:
     adapter._send_with_retry.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_non_internal_event_still_interrupts() -> None:
+    """A real user message still interrupts, and becomes the next queued turn."""
+    runner = _make_runner()
+    runner._busy_input_mode = "interrupt"
+    adapter = _make_adapter()
+    internal = _make_internal_event(text="[background process completed]")
+    event = _make_internal_event(text="please stop")
+    object.__setattr__(event, "internal", False)
+    object.__setattr__(event, "source", internal.source)
+    sk = build_session_key(event.source)
+    adapter._pending_messages[sk] = internal
+    parent = _make_running_parent()
+    runner._running_agents[sk] = parent
+    runner.adapters[event.source.platform] = adapter
+
+    handled = await runner._handle_active_session_busy_message(event, sk)
+
+    assert handled is True
+    parent.interrupt.assert_called_once_with("please stop")
+    assert adapter._pending_messages[sk] is event
+    assert runner._queued_events[sk] == [internal]

--- a/tests/gateway/test_internal_event_never_interrupts_busy_session.py
+++ b/tests/gateway/test_internal_event_never_interrupts_busy_session.py
@@ -129,6 +129,28 @@ async def test_internal_event_does_not_interrupt_busy_session() -> None:
 
 
 @pytest.mark.asyncio
+async def test_user_interrupt_replaces_queued_internal_completion() -> None:
+    """User steering becomes the next turn rather than waiting behind a synthetic completion."""
+    runner = _make_runner()
+    runner._busy_input_mode = "interrupt"
+    adapter = _make_adapter()
+    internal = _make_internal_event(text="[background process completed]")
+    user_event = _make_internal_event(text="please stop")
+    object.__setattr__(user_event, "internal", False)
+    object.__setattr__(user_event, "source", internal.source)
+    session_key = build_session_key(user_event.source)
+    adapter._pending_messages[session_key] = internal
+    parent = _make_running_parent()
+    runner._running_agents[session_key] = parent
+    runner.adapters[user_event.source.platform] = adapter
+
+    assert await runner._handle_active_session_busy_message(user_event, session_key) is True
+    parent.interrupt.assert_called_once_with("please stop")
+    assert adapter._pending_messages[session_key] is user_event
+    assert runner._queued_events[session_key] == [internal]
+
+
+@pytest.mark.asyncio
 async def test_non_internal_event_still_interrupts() -> None:
     """A real user message still interrupts, and becomes the next queued turn."""
     runner = _make_runner()
@@ -150,3 +172,35 @@ async def test_non_internal_event_still_interrupts() -> None:
     parent.interrupt.assert_called_once_with("please stop")
     assert adapter._pending_messages[sk] is event
     assert runner._queued_events[sk] == [internal]
+
+
+@pytest.mark.asyncio
+async def test_user_interrupt_outranks_multiple_queued_internal_events() -> None:
+    """With one internal completion in the head slot AND another already in
+    the overflow, a user interrupt takes the head slot and both internal
+    events cascade after it in their original arrival order."""
+    runner = _make_runner()
+    runner._busy_input_mode = "interrupt"
+    adapter = _make_adapter()
+
+    internal_head = _make_internal_event(text="[background process 1 completed]")
+    internal_tail = _make_internal_event(text="[background process 2 completed]")
+    object.__setattr__(internal_tail, "message_id", "msg2")
+    user_event = _make_internal_event(text="pivot to the other approach")
+    object.__setattr__(user_event, "internal", False)
+    object.__setattr__(user_event, "source", internal_head.source)
+    object.__setattr__(user_event, "message_id", "user-msg")
+
+    sk = build_session_key(user_event.source)
+    adapter._pending_messages[sk] = internal_head
+    runner._queued_events[sk] = [internal_tail]
+    parent = _make_running_parent()
+    runner._running_agents[sk] = parent
+    runner.adapters[user_event.source.platform] = adapter
+
+    handled = await runner._handle_active_session_busy_message(user_event, sk)
+
+    assert handled is True
+    parent.interrupt.assert_called_once_with("pivot to the other approach")
+    assert adapter._pending_messages[sk] is user_event
+    assert runner._queued_events[sk] == [internal_head, internal_tail]

--- a/tests/gateway/test_queue_consumption.py
+++ b/tests/gateway/test_queue_consumption.py
@@ -220,3 +220,49 @@ class TestBusyInputModeQueueFifo:
         assert runner._queue_depth(session_key, adapter=adapter) == len(texts)
 
 
+class TestUserPriorityOverInternalEvents:
+    def _make_runner_and_adapter(self):
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner._queued_events = {}
+        adapter = _StubAdapter()
+        runner.adapters = {Platform.TELEGRAM: adapter}
+        return runner, adapter
+
+    @staticmethod
+    def _event(text: str, *, internal: bool = False) -> MessageEvent:
+        source = MagicMock(chat_id="c1", platform=Platform.TELEGRAM, profile=None)
+        return MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id=f"m-{text}",
+            internal=internal,
+        )
+
+    def test_users_run_before_internal_events_in_arrival_order(self):
+        runner, adapter = self._make_runner_and_adapter()
+        session_key = "telegram:user:priority"
+        for text, internal in (("internal-1", True), ("user-1", False), ("internal-2", True), ("user-2", False)):
+            runner._queue_or_replace_pending_event(session_key, self._event(text, internal=internal))
+
+        assert adapter._pending_messages[session_key].text == "user-1"
+        assert [event.text for event in runner._queued_events[session_key]] == [
+            "user-2", "internal-1", "internal-2"
+        ]
+
+    def test_full_queue_replaces_internal_not_user_input(self):
+        from gateway.run import GatewayRunner
+
+        runner, adapter = self._make_runner_and_adapter()
+        session_key = "telegram:user:priority-cap"
+        for index in range(GatewayRunner._BUSY_QUEUE_MAX_PENDING):
+            runner._queue_or_replace_pending_event(session_key, self._event(f"internal-{index}", internal=True))
+
+        runner._queue_or_replace_pending_event(session_key, self._event("user-steer"))
+
+        assert adapter._pending_messages[session_key].text == "user-steer"
+        assert runner._queue_depth(session_key, adapter=adapter) == GatewayRunner._BUSY_QUEUE_MAX_PENDING
+        assert all(event.internal for event in runner._queued_events[session_key])
+


### PR DESCRIPTION
## Summary

When a gateway session is busy, synthetic `internal=True` completion events intentionally queue without interrupting the active turn. If one reaches the pending head before a real user follow-up, the user message can still abort the model call but remain behind that internal event in the FIFO. The recursive next turn then handles the synthetic notification first, delaying the user's steering despite the interrupt acknowledgement.

This change gives real user events priority over queued internal events while preserving arrival order within each class. When the bounded queue is full, it prefers dropping a synthetic notification rather than live operator input.

Related follow-ups to #49738 (internal completions do not interrupt busy sessions) and #49776 (busy-session FIFO queueing). I searched existing issues and PRs and did not find an equivalent fix.

## Reproduction

1. Start a gateway turn with `busy_input_mode: interrupt`.
2. While it is running, enqueue a background/delegation completion (`internal=True`).
3. Send a real user follow-up before the active model call completes.
4. The model call is interrupted, but plain FIFO dequeues the older internal completion first instead of the user message.

## Changes

- Reorder a newly queued real user event ahead of pending internal events.
- Preserve user-to-user and internal-to-internal ordering.
- Preserve existing media merge behavior and the queue depth cap.
- Add a regression test covering an internal completion already occupying the head slot when a user interrupt arrives.

## Test plan

- `scripts/run_tests.sh tests/gateway/test_internal_event_never_interrupts_busy_session.py tests/gateway/test_queue_consumption.py tests/gateway/test_queue_command.py tests/gateway/test_busy_session_ack.py tests/gateway/test_session_race_guard.py`
  - 67 passed, 0 failed
- `uv run --extra dev ruff check .`
  - passed
- `python3 scripts/check-windows-footguns.py --all`
  - passed (753 files scanned)
- `git diff --check origin/main...HEAD`
  - passed

## Risk and rollback

Risk is limited to ordering in a busy session when real and internal events coexist in the same pending queue. Media-only merging, all-user FIFO ordering, and all-internal FIFO ordering are unchanged. The focused queue tests cover the surrounding interrupt and dequeue paths.

Rollback is a single-commit revert; no configuration, migration, or persistent data changes are involved.
