### PR TITLE
fix(desktop): prevent TypeScript source emission

### DIFF
--- a/apps/desktop/tsconfig.electron.json
+++ b/apps/desktop/tsconfig.electron.json
@@ -12,6 +12,7 @@
     "exactOptionalPropertyTypes": false,
     "ignoreDeprecations": "6.0",
     "composite": true,
+    "noEmit": false,
     "declaration": true,
     "outDir": "build/electron-types"
   },

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -14,6 +14,7 @@
     "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "noEmit": true,
     "jsx": "react-jsx",
     "paths": {
       "@/*": ["./src/*"],


### PR DESCRIPTION
## Summary

- prevent the desktop renderer TypeScript project from emitting JavaScript beside its source files
- preserve declaration output for the referenced Electron project

## Root cause

The desktop production build runs `tsc -b` before Vite. The renderer `tsconfig.json` did not set `noEmit`, so TypeScript wrote compiled `.js` files directly into `apps/desktop/src` and `apps/shared/src`. A stock desktop rebuild generated 694 untracked source-tree files.

The renderer is bundled by Vite and does not need TypeScript output. The Electron reference does need declarations, so it explicitly overrides the inherited setting with `noEmit: false` and keeps its existing `build/electron-types` output directory.

## Validation

- `npm run --prefix apps/desktop typecheck`
- `npm run --prefix apps/desktop build`
- direct `tsc -b apps/desktop/tsconfig.json` reproduction: 694 generated source-tree `.js` files before the fix, zero after
- all 68 Electron declaration outputs remain present
