### PR TITLE
fix(skills_hub): guard shutil.rmtree against OSError in install/uninstall paths

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3481,7 +3481,12 @@ def install_from_quarantine(
     install_dir = _resolve_lock_install_path(install_rel_path, safe_skill_name)
 
     if install_dir.exists():
-        shutil.rmtree(install_dir)
+        try:
+            shutil.rmtree(install_dir)
+        except OSError as exc:
+            raise OSError(
+                f"Failed to clear existing install dir '{install_dir}': {exc}"
+            ) from exc
 
     # Warn (but don't block) if SKILL.md is very large
     skill_md = quarantine_path / "SKILL.md"
@@ -3562,7 +3567,10 @@ def uninstall_skill(skill_name: str) -> Tuple[bool, str]:
         return False, f"Refusing to uninstall '{skill_name}': {exc}"
 
     if install_path.exists():
-        shutil.rmtree(install_path)
+        try:
+            shutil.rmtree(install_path)
+        except OSError as exc:
+            return False, f"Failed to remove skill directory '{install_path}': {exc}"
 
     lock.record_uninstall(skill_name)
     append_audit_log("UNINSTALL", skill_name, entry["source"], entry["trust_level"], "n/a", "user_request")


### PR DESCRIPTION
## Summary

Guard two unguarded `shutil.rmtree` calls in `tools/skills_hub.py` with try/except OSError.

## Problem

Two `shutil.rmtree` calls in the skills hub were unprotected:
- **`install_from_quarantine()`** (line 3484): If `rmtree` raises `OSError` (e.g. permission denied on a read-only file inside an existing install dir), the entire install flow crashes, leaving the quarantine path in an undefined state.
- **`uninstall_skill()`** (line 3565): If `rmtree` raises `OSError`, the lock record and audit log are never written, making the uninstall unrecoverable and inconsistent.

PR #60021 already added `ignore_errors=True` to the `quarantine_bundle` rmtree, and PR #60630 guards the `skill_manager_tool.py` rmtree/rmdir. This PR covers the two remaining unguarded calls in the same file.

## Fix

- `install_from_quarantine`: wraps rmtree in try/except, re-raises as OSError with context
- `uninstall_skill`: wraps rmtree in try/except, returns `False, error` tuple (matching the function's existing error-handling pattern)

## Testing
- Syntax check passed (py_compile)
- Behavior verified