### PR TITLE
fix(api-server): preserve multimodal content in runs API

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4188,19 +4188,35 @@ class APIServerAdapter(BasePlatformAdapter):
             return web.json_response(_openai_error("Invalid JSON"), status=400)
 
         raw_input = body.get("input")
-        if not raw_input:
+        if raw_input is None:
             return web.json_response(_openai_error("Missing 'input' field"), status=400)
-
-        user_message = raw_input if isinstance(raw_input, str) else (raw_input[-1].get("content", "") if isinstance(raw_input, list) else "")
-        if not user_message:
-            return web.json_response(_openai_error("No user message found in input"), status=400)
 
         instructions = body.get("instructions")
         previous_response_id = body.get("previous_response_id")
 
+        input_messages: List[Dict[str, Any]] = []
+        if isinstance(raw_input, str):
+            input_messages = [{"role": "user", "content": raw_input}]
+        elif isinstance(raw_input, list):
+            for idx, item in enumerate(raw_input):
+                if isinstance(item, str):
+                    input_messages.append({"role": "user", "content": item})
+                elif isinstance(item, dict):
+                    role = item.get("role", "user")
+                    try:
+                        content = _normalize_multimodal_content(item.get("content", ""))
+                    except ValueError as exc:
+                        return _multimodal_validation_error(exc, param=f"input[{idx}].content")
+                    input_messages.append({"role": role, "content": content})
+        else:
+            return web.json_response(_openai_error("'input' must be a string or array"), status=400)
+
+        if not input_messages:
+            return web.json_response(_openai_error("No user message found in input"), status=400)
+
         # Accept explicit conversation_history from the request body.
         # Precedence: explicit conversation_history > previous_response_id.
-        conversation_history: List[Dict[str, str]] = []
+        conversation_history: List[Dict[str, Any]] = []
         raw_history = body.get("conversation_history")
         if raw_history:
             if not isinstance(raw_history, list):
@@ -4214,7 +4230,11 @@ class APIServerAdapter(BasePlatformAdapter):
                         _openai_error(f"conversation_history[{i}] must have 'role' and 'content' fields"),
                         status=400,
                     )
-                conversation_history.append({"role": str(entry["role"]), "content": str(entry["content"])})
+                try:
+                    entry_content = _normalize_multimodal_content(entry["content"])
+                except ValueError as exc:
+                    return _multimodal_validation_error(exc, param=f"conversation_history[{i}].content")
+                conversation_history.append({"role": str(entry["role"]), "content": entry_content})
             if previous_response_id:
                 logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
 
@@ -4227,20 +4247,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 if instructions is None:
                     instructions = stored.get("instructions")
 
-        # When input is a multi-message array, extract all but the last
-        # message as conversation history (the last becomes user_message).
-        # Only fires when no explicit history was provided.
-        if not conversation_history and isinstance(raw_input, list) and len(raw_input) > 1:
-            for msg in raw_input[:-1]:
-                if isinstance(msg, dict) and msg.get("role") and msg.get("content"):
-                    content = msg["content"]
-                    if isinstance(content, list):
-                        # Flatten multi-part content blocks to text
-                        content = " ".join(
-                            part.get("text", "") for part in content
-                            if isinstance(part, dict) and part.get("type") == "text"
-                        )
-                    conversation_history.append({"role": msg["role"], "content": str(content)})
+        if not conversation_history:
+            conversation_history.extend(input_messages[:-1])
+
+        user_message: Any = input_messages[-1].get("content", "")
+        if not _content_has_visible_payload(user_message):
+            return web.json_response(_openai_error("No user message found in input"), status=400)
 
         run_id = f"run_{uuid.uuid4().hex}"
         session_id = body.get("session_id") or stored_session_id or run_id

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -616,6 +616,7 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_post("/v1/responses", adapter._handle_responses)
     app.router.add_get("/v1/responses/{response_id}", adapter._handle_get_response)
     app.router.add_delete("/v1/responses/{response_id}", adapter._handle_delete_response)
+    app.router.add_post("/v1/runs", adapter._handle_runs)
     return app
 
 
@@ -1732,6 +1733,154 @@ class TestDeriveChatSessionId:
         """None system prompt doesn't crash."""
         sid = _derive_chat_session_id(None, "test")
         assert isinstance(sid, str) and len(sid) > 4
+
+
+# ---------------------------------------------------------------------------
+# /v1/runs endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestRunsEndpoint:
+    @staticmethod
+    async def _post_run_and_wait(cli, adapter, payload):
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "ok", "messages": [], "api_calls": 1}
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        with patch.object(adapter, "_create_agent", return_value=mock_agent):
+            resp = await cli.post("/v1/runs", json=payload)
+            data = await resp.json()
+            assert resp.status == 202
+
+            task = adapter._active_run_tasks.get(data["run_id"])
+            if task is not None:
+                await asyncio.wait_for(task, timeout=2)
+
+            assert mock_agent.run_conversation.called
+            return mock_agent.run_conversation.call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_multimodal_last_input_message_reaches_run_conversation(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            call_kwargs = await self._post_run_and_wait(
+                cli,
+                adapter,
+                {
+                    "model": "hermes-agent",
+                    "input": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "input_text", "text": "Describe this"},
+                                {"type": "input_image", "image_url": "data:image/png;base64,AAAA"},
+                            ],
+                        }
+                    ],
+                },
+            )
+
+        assert call_kwargs["conversation_history"] == []
+        assert call_kwargs["user_message"] == [
+            {"type": "text", "text": "Describe this"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_explicit_conversation_history_preserves_multimodal_content(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            call_kwargs = await self._post_run_and_wait(
+                cli,
+                adapter,
+                {
+                    "model": "hermes-agent",
+                    "input": "continue",
+                    "conversation_history": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "text", "text": "Earlier image"},
+                                {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+                            ],
+                        }
+                    ],
+                },
+            )
+
+        assert call_kwargs["user_message"] == "continue"
+        assert call_kwargs["conversation_history"] == [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Earlier image"},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+                ],
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_multimessage_input_history_preserves_multimodal_content(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            call_kwargs = await self._post_run_and_wait(
+                cli,
+                adapter,
+                {
+                    "model": "hermes-agent",
+                    "input": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "text", "text": "Remember this image"},
+                                {"type": "input_image", "image_url": "https://example.com/diagram.jpg"},
+                            ],
+                        },
+                        {"role": "assistant", "content": "noted"},
+                        {"role": "user", "content": "What did I send?"},
+                    ],
+                },
+            )
+
+        assert call_kwargs["user_message"] == "What did I send?"
+        assert call_kwargs["conversation_history"] == [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Remember this image"},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/diagram.jpg"}},
+                ],
+            },
+            {"role": "assistant", "content": "noted"},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_invalid_multimodal_input_returns_400(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "model": "hermes-agent",
+                        "input": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "input_image", "image_url": "file_123"},
+                                ],
+                            }
+                        ],
+                    },
+                )
+                data = await resp.json()
+
+        assert resp.status == 400
+        assert data["error"]["code"] == "invalid_image_url"
+        assert data["error"]["param"] == "input[0].content"
+        mock_create.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Preserves multimodal content on the `/v1/runs` API path.

  `/v1/runs` previously parsed `input` and `conversation_history` differently from `/v1/responses`:
  list-shaped multimodal content could be stringified or flattened to text-only history before
  reaching `run_conversation`. This updates `/v1/runs` to use the same
  `_normalize_multimodal_content()` validation/normalization path used by the other API server
  endpoints.

## Related Issue

## Type of Change

- [ *] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [* ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Normalize `/v1/runs` `input` message content with `_normalize_multimodal_content()`.
- Preserve multimodal parts in explicit `conversation_history`.
- Preserve multimodal parts from multi-message `input` history instead of flattening to text-only
content.
- Return a structured 400 response for invalid image inputs before creating an agent run.
- Add regression coverage for multimodal final input, explicit history, multi-message history,
and invalid image URLs.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_api_server.py`

## Checklist

### Code

- [ *] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ *] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ *] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ *] I've run `pytest tests/ -q` and all tests pass
- [ *] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ *] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ *] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [ *] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ *] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [ *] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A
- [ *] I've updated tool descriptions/schemas if I changed tool behavior — N/A