### PR TITLE
fix(feishu): require explicit bot mention for @all

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4329,10 +4329,8 @@ class FeishuAdapter(BasePlatformAdapter):
     # --- Mention detection ----------------------------------------------------
 
     def _mentions_self(self, message: Any) -> bool:
-        # @_all is Feishu's @everyone placeholder.
+        # @_all is Feishu's @everyone placeholder, not an explicit bot mention.
         raw_content = getattr(message, "content", "") or ""
-        if "@_all" in raw_content:
-            return True
         mentions = getattr(message, "mentions", None) or []
         if mentions and self._message_mentions_bot(mentions):
             return True

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -3540,7 +3540,7 @@ class TestGroupMentionAtAll(unittest.TestCase):
     """Tests for @_all (Feishu @everyone) group mention routing."""
 
     @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
-    def test_at_all_in_content_accepts_without_explicit_bot_mention(self):
+    def test_at_all_does_not_count_as_explicit_bot_mention(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter
 
@@ -3550,20 +3550,28 @@ class TestGroupMentionAtAll(unittest.TestCase):
             mentions=[],
         )
         sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
-        self.assertTrue(_admits_group(adapter, message, sender_id, ""))
+        self.assertFalse(_admits_group(adapter, message, sender_id, ""))
 
-    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "allowlist", "FEISHU_ALLOWED_USERS": "ou_allowed"}, clear=True)
-    def test_at_all_still_requires_policy_gate(self):
-        """@_all bypasses mention gating but NOT the allowlist policy."""
+    @patch.dict(
+        os.environ,
+        {
+            "FEISHU_GROUP_POLICY": "allowlist",
+            "FEISHU_ALLOWED_USERS": "ou_allowed",
+            "FEISHU_REQUIRE_MENTION": "false",
+        },
+        clear=True,
+    )
+    def test_at_all_still_requires_policy_when_mention_gate_disabled(self):
+        """@_all is only admitted when mention gating is disabled and policy allows it."""
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter
 
         adapter = FeishuAdapter(PlatformConfig())
         message = SimpleNamespace(content='{"text":"@_all attention"}', mentions=[])
-        # Non-allowlisted user — should be blocked even with @_all.
+        # Non-allowlisted user — should be blocked even if mention gating is disabled.
         blocked_sender = SimpleNamespace(open_id="ou_blocked", user_id=None)
         self.assertFalse(_admits_group(adapter, message, blocked_sender, ""))
-        # Allowlisted user — should pass.
+        # Allowlisted user — should pass only because FEISHU_REQUIRE_MENTION=false.
         allowed_sender = SimpleNamespace(open_id="ou_allowed", user_id=None)
         self.assertTrue(_admits_group(adapter, message, allowed_sender, ""))
 

--- a/tests/gateway/test_feishu_bot_admission.py
+++ b/tests/gateway/test_feishu_bot_admission.py
@@ -385,6 +385,49 @@ def test_admit_pipeline(case):
     assert adapter._admit(sender, message) == case["expected"]
 
 
+def test_mentions_self_ignores_feishu_at_all_placeholder():
+    adapter = make_adapter_skeleton(bot_open_id="ou_self", group_policy="open")
+    message = make_message(chat_type="group")
+    message.content = '{"text":"@_all 請留意"}'
+
+    assert adapter._mentions_self(message) is False
+
+
+def test_admit_rejects_group_at_all_when_explicit_mention_required():
+    adapter = make_adapter_skeleton(
+        bot_open_id="ou_self",
+        require_mention=True,
+        group_policy="open",
+    )
+    sender = make_sender(sender_type="user", open_id="ou_human")
+    message = make_message(chat_type="group")
+    message.content = '{"text":"@_all 請留意"}'
+
+    assert adapter._admit(sender, message) == "group_policy_rejected"
+
+
+def test_admit_accepts_explicit_bot_mention_when_mention_required():
+    adapter = make_adapter_skeleton(
+        bot_open_id="ou_self",
+        require_mention=True,
+        group_policy="open",
+    )
+    sender = make_sender(sender_type="user", open_id="ou_human")
+    message = make_message(
+        chat_type="group",
+        mentions=[
+            SimpleNamespace(
+                key="@_user_1",
+                id=SimpleNamespace(open_id="ou_self", user_id=""),
+                name="Hermes",
+            )
+        ],
+    )
+    message.content = '{"text":"@_user_1 幫我查"}'
+
+    assert adapter._admit(sender, message) is None
+
+
 # --- Mention call-count semantics ------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- stop treating Feishu/Lark @_all as an explicit bot mention in mention-gated groups
- preserve explicit bot mention admission by open_id/user_id/name
- keep intentional no-mention groups as configuration exceptions (sandbox + multiprofit remain require_mention=false outside this PR)
- update/add regression tests for @all mention gating

## Tests
- python -m pytest tests/gateway/test_feishu_bot_admission.py tests/gateway/test_feishu.py::TestGroupMentionAtAll -q

## Local runtime note
- production config currently has global require_mention=true with only the intentional sandbox/multiprofit no-mention exceptions
- local verification script confirms @_all is not considered a self mention while explicit @bot still is