### PR TITLE
fix(gateway): prevent duplicate Photon sidecar storms

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9079,14 +9079,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         active = get_active_profile_name() or "default"
         connected = 0
-        # (platform, token-fingerprint) -> profile that claimed it. Detects two
-        # profiles trying to poll the same bot credential (impossible to do
-        # concurrently). Seed with the active profile's adapters.
+        # Resource claim -> profile that owns it. Credential claims prevent two
+        # profiles polling the same account; listener claims prevent sidecars
+        # with distinct credentials from binding the same endpoint.
         claimed: Dict[tuple, str] = {}
         for _plat, _ad in self.adapters.items():
             fp = self._adapter_credential_fingerprint(_ad)
             if fp is not None:
                 claimed[(_plat, fp)] = active
+            listener_claim = self._adapter_listener_claim(_plat, _ad)
+            if listener_claim is not None:
+                claimed[listener_claim] = active
 
         for profile_name, profile_home in profiles_to_serve(multiplex=True):
             if profile_name == active:
@@ -9212,6 +9215,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # adapter, shut down the primary profile's live sidecar.
                     continue
                 claimed[(platform, fp)] = profile_name
+
+            listener_claim = self._adapter_listener_claim(platform, adapter)
+            if listener_claim is not None:
+                owner = claimed.get(listener_claim)
+                if owner is not None:
+                    bind, port = listener_claim[-2:]
+                    logger.error(
+                        "Profile '%s' and '%s' both configure %s sidecars on "
+                        "%s:%s — refusing to start the duplicate listener. "
+                        "Set platforms.%s.extra.sidecar_port to a distinct port "
+                        "for profile '%s'.",
+                        owner,
+                        profile_name,
+                        platform.value,
+                        bind,
+                        port,
+                        platform.value,
+                        profile_name,
+                    )
+                    # Like credential conflicts, this adapter never connected
+                    # and owns no resources that should be disconnected.
+                    continue
+                claimed[listener_claim] = profile_name
 
             self._configure_profile_adapter(adapter, profile_name, platform)
 
@@ -9443,6 +9469,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return await self._handle_message(event)
 
         return _handler
+
+    @staticmethod
+    def _adapter_listener_claim(platform: Platform, adapter: Any) -> Optional[tuple]:
+        """Return the exclusive listener resource claimed by an adapter.
+
+        Photon sidecars are per-profile processes. Even when two profiles use
+        different project credentials, their sidecars cannot share a bind and
+        port. Represent that endpoint as a claim so multiplex startup rejects
+        the later adapter before either ``connect()`` or ``disconnect()`` can
+        disturb the first profile.
+        """
+        if getattr(platform, "value", None) != "photon":
+            return None
+        bind = getattr(adapter, "_sidecar_bind", None)
+        port = getattr(adapter, "_sidecar_port", None)
+        if not isinstance(bind, str) or not bind.strip():
+            return None
+        try:
+            port = int(port)
+        except (TypeError, ValueError):
+            return None
+        return ("listener", "photon", bind.strip().lower(), port)
 
     @staticmethod
     def _adapter_credential_fingerprint(adapter: Any) -> Optional[str]:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9199,8 +9199,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             # Same-token conflict detection — refuse a duplicate poll.
             fp = self._adapter_credential_fingerprint(adapter)
-            if fp is not None:
-                owner = claimed.get((platform, fp))
+            credential_claim = (platform, fp) if fp is not None else None
+            if credential_claim is not None:
+                owner = claimed.get(credential_claim)
                 if owner is not None:
                     logger.error(
                         "Profile '%s' and '%s' both configure %s with the same "
@@ -9214,7 +9215,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # the shared platform state and, for a same-credential Photon
                     # adapter, shut down the primary profile's live sidecar.
                     continue
-                claimed[(platform, fp)] = profile_name
 
             listener_claim = self._adapter_listener_claim(platform, adapter)
             if listener_claim is not None:
@@ -9237,7 +9237,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # Like credential conflicts, this adapter never connected
                     # and owns no resources that should be disconnected.
                     continue
-                claimed[listener_claim] = profile_name
 
             self._configure_profile_adapter(adapter, profile_name, platform)
 
@@ -9246,6 +9245,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     success = await self._connect_adapter_with_timeout(adapter, platform)
                 if success:
                     profile_map[platform] = adapter
+                    if credential_claim is not None:
+                        claimed[credential_claim] = profile_name
+                    if listener_claim is not None:
+                        claimed[listener_claim] = profile_name
                     connected += 1
                     logger.info("✓ %s connected (profile: %s)", platform.value, profile_name)
                 else:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9201,12 +9201,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if owner is not None:
                     logger.error(
                         "Profile '%s' and '%s' both configure %s with the same "
-                        "credential — refusing to start the duplicate (a single "
-                        "bot token cannot be polled twice). Give each profile its "
-                        "own %s credential.",
+                        "credential — refusing to start the duplicate (one "
+                        "credential cannot be consumed twice). Give each profile "
+                        "its own %s credential.",
                         owner, profile_name, platform.value, platform.value,
                     )
-                    await self._safe_adapter_disconnect(adapter, platform)
+                    # This adapter has not connected and therefore owns no
+                    # resources to clean up. Calling disconnect here can mutate
+                    # the shared platform state and, for a same-credential Photon
+                    # adapter, shut down the primary profile's live sidecar.
                     continue
                 claimed[(platform, fp)] = profile_name
 
@@ -9445,13 +9448,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     def _adapter_credential_fingerprint(adapter: Any) -> Optional[str]:
         """Return a stable, log-safe fingerprint of an adapter's credential.
 
-        Used only to detect two profiles claiming the same bot token. Returns a
-        salted hash (never the token itself) of the adapter's primary
-        credential, or None when no credential is discoverable (in which case
-        we don't attempt conflict detection for it).
+        Used only to detect two profiles claiming the same platform credential.
+        Returns a salted hash (never the credential itself) of the adapter's
+        primary credential, or None when no credential is discoverable (in
+        which case we don't attempt conflict detection for it).
         """
         token = None
-        for attr in ("token", "bot_token", "_token", "api_token", "_bot_token"):
+        for attr in (
+            "token",
+            "bot_token",
+            "_token",
+            "api_token",
+            "_bot_token",
+            # Photon/Spectrum authenticates with project credentials instead
+            # of a bot token. Including its secret keeps multiplexed profiles
+            # from spawning competing sidecars for the same account and port.
+            "_project_secret",
+        ):
             val = getattr(adapter, attr, None)
             if isinstance(val, str) and val.strip():
                 token = val.strip()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7451,6 +7451,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 "config": platform_config,
                                 "attempts": 1,
                                 "next_retry": time.monotonic() + 30,
+                                "credential_claim": self._adapter_credential_claim(
+                                    platform, adapter
+                                ),
+                                "listener_claim": self._adapter_listener_claim(
+                                    platform, adapter
+                                ),
                             }
                     else:
                         self._update_platform_runtime_status(
@@ -7467,6 +7473,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "config": platform_config,
                             "attempts": 1,
                             "next_retry": time.monotonic() + 30,
+                            "credential_claim": self._adapter_credential_claim(
+                                platform, adapter
+                            ),
+                            "listener_claim": self._adapter_listener_claim(
+                                platform, adapter
+                            ),
                         }
             except Exception as e:
                 logger.error("✗ %s error: %s", platform.value, e)
@@ -7486,6 +7498,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "config": platform_config,
                     "attempts": 1,
                     "next_retry": time.monotonic() + 30,
+                    "credential_claim": self._adapter_credential_claim(
+                        platform, adapter
+                    ),
+                    "listener_claim": self._adapter_listener_claim(
+                        platform, adapter
+                    ),
                 }
             if await self._abort_startup_if_shutdown_requested():
                 return True
@@ -9090,6 +9108,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             listener_claim = self._adapter_listener_claim(_plat, _ad)
             if listener_claim is not None:
                 claimed[listener_claim] = active
+        # A retryable primary still owns its configured credential and listener.
+        # Reserve both while it is queued so a secondary cannot take the endpoint
+        # before the reconnect watcher retries the primary adapter.
+        for retry_info in getattr(self, "_failed_platforms", {}).values():
+            for claim_name in ("credential_claim", "listener_claim"):
+                retry_claim = retry_info.get(claim_name)
+                if isinstance(retry_claim, tuple):
+                    claimed[retry_claim] = active
 
         for profile_name, profile_home in profiles_to_serve(multiplex=True):
             if profile_name == active:
@@ -9198,8 +9224,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 continue
 
             # Same-token conflict detection — refuse a duplicate poll.
-            fp = self._adapter_credential_fingerprint(adapter)
-            credential_claim = (platform, fp) if fp is not None else None
+            credential_claim = self._adapter_credential_claim(platform, adapter)
             if credential_claim is not None:
                 owner = claimed.get(credential_claim)
                 if owner is not None:
@@ -9472,6 +9497,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return await self._handle_message(event)
 
         return _handler
+
+    @staticmethod
+    def _adapter_credential_claim(
+        platform: Platform, adapter: Any
+    ) -> Optional[tuple]:
+        """Return the exclusive credential resource claimed by an adapter."""
+        fingerprint = GatewayRunner._adapter_credential_fingerprint(adapter)
+        if fingerprint is None:
+            return None
+        return (platform, fingerprint)
 
     @staticmethod
     def _adapter_listener_claim(platform: Platform, adapter: Any) -> Optional[tuple]:

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -889,6 +889,61 @@ class TestSecondaryProfileConfigHandling:
         assert secondary.disconnected is False
         assert runner._profile_adapters["reviewer"][photon] is secondary
 
+    @pytest.mark.asyncio
+    async def test_failed_photon_connect_releases_listener_for_later_profile(
+        self, monkeypatch
+    ):
+        """A failed sidecar must not reserve an endpoint it never owned."""
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+        class _PhotonAdapter:
+            def __init__(self, secret, should_connect):
+                self._project_secret = secret
+                self._sidecar_bind = "127.0.0.1"
+                self._sidecar_port = 8789
+                self.platform = Platform("photon")
+                self.should_connect = should_connect
+                self.disconnected = False
+                self.config = PlatformConfig(enabled=True)
+
+            def __getattr__(self, name):
+                if name.startswith("set_"):
+                    return lambda *args, **kwargs: None
+                raise AttributeError(name)
+
+            async def disconnect(self):
+                self.disconnected = True
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._profile_adapters = {}
+        runner.session_store = None
+        runner._busy_text_mode = "queue"
+
+        photon = Platform("photon")
+        profile_cfg = GatewayConfig(multiplex_profiles=True)
+        profile_cfg.platforms = {photon: PlatformConfig(enabled=True)}
+        failed = _PhotonAdapter("failed-secret", False)
+        later = _PhotonAdapter("later-secret", True)
+        adapters = iter((failed, later))
+        claimed = {}
+
+        async def _connect(adapter, platform):
+            return adapter.should_connect
+
+        monkeypatch.setattr("gateway.config.load_gateway_config", lambda: profile_cfg)
+        monkeypatch.setattr(runner, "_create_adapter", lambda p, c: next(adapters))
+        monkeypatch.setattr(runner, "_connect_adapter_with_timeout", _connect)
+        monkeypatch.setattr(runner, "_make_adapter_auth_check", lambda p: None)
+
+        first = await runner._start_one_profile_adapters("broken", "/tmp/x", claimed)
+        second = await runner._start_one_profile_adapters("later", "/tmp/y", claimed)
+
+        assert first == 0
+        assert failed.disconnected is True
+        assert second == 1
+        assert runner._profile_adapters["later"][photon] is later
+
     def test_port_binding_set_covers_known_listeners(self):
         from gateway.run import _PORT_BINDING_PLATFORM_VALUES
         # Every adapter that binds a TCP port must be in the guard set.

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -783,6 +783,112 @@ class TestSecondaryProfileConfigHandling:
         assert duplicate.disconnected is False
         assert runner._profile_adapters["reviewer"] == {}
 
+    @pytest.mark.asyncio
+    async def test_secondary_distinct_photon_credentials_same_port_are_refused(
+        self, monkeypatch
+    ):
+        """The sidecar listener is exclusive even when credentials differ."""
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+        class _PhotonAdapter:
+            def __init__(self, secret, port=8789):
+                self._project_secret = secret
+                self._sidecar_bind = "127.0.0.1"
+                self._sidecar_port = port
+                self.platform = Platform("photon")
+                self.connected = False
+                self.disconnected = False
+
+            async def connect(self):
+                self.connected = True
+                raise AssertionError("conflicting sidecar must not connect")
+
+            async def disconnect(self):
+                self.disconnected = True
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._profile_adapters = {}
+
+        photon = Platform("photon")
+        reviewer_cfg = GatewayConfig(multiplex_profiles=True)
+        reviewer_cfg.platforms = {photon: PlatformConfig(enabled=True)}
+        primary = _PhotonAdapter("primary-secret")
+        duplicate = _PhotonAdapter("different-secret")
+        claimed = {
+            GatewayRunner._adapter_listener_claim(photon, primary): "default"
+        }
+
+        monkeypatch.setattr("gateway.config.load_gateway_config", lambda: reviewer_cfg)
+        monkeypatch.setattr(runner, "_create_adapter", lambda p, c: duplicate)
+
+        connected = await runner._start_one_profile_adapters(
+            "reviewer", "/tmp/x", claimed
+        )
+
+        assert connected == 0
+        assert duplicate.connected is False
+        assert duplicate.disconnected is False
+        assert runner._profile_adapters["reviewer"] == {}
+
+    @pytest.mark.asyncio
+    async def test_secondary_distinct_photon_credentials_distinct_ports_connect(
+        self, monkeypatch
+    ):
+        """Multiplexing remains supported when Photon sidecars cannot collide."""
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+        class _PhotonAdapter:
+            def __init__(self, secret, port):
+                self._project_secret = secret
+                self._sidecar_bind = "127.0.0.1"
+                self._sidecar_port = port
+                self.platform = Platform("photon")
+                self.connected = False
+                self.disconnected = False
+                self.config = PlatformConfig(enabled=True)
+
+            def __getattr__(self, name):
+                if name.startswith("set_"):
+                    return lambda *args, **kwargs: None
+                raise AttributeError(name)
+
+            async def disconnect(self):
+                self.disconnected = True
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._profile_adapters = {}
+        runner.session_store = None
+        runner._busy_text_mode = "queue"
+
+        photon = Platform("photon")
+        reviewer_cfg = GatewayConfig(multiplex_profiles=True)
+        reviewer_cfg.platforms = {photon: PlatformConfig(enabled=True)}
+        primary = _PhotonAdapter("primary-secret", 8789)
+        secondary = _PhotonAdapter("different-secret", 8790)
+        claimed = {
+            GatewayRunner._adapter_listener_claim(photon, primary): "default"
+        }
+
+        async def _connect(adapter, platform):
+            adapter.connected = True
+            return True
+
+        monkeypatch.setattr("gateway.config.load_gateway_config", lambda: reviewer_cfg)
+        monkeypatch.setattr(runner, "_create_adapter", lambda p, c: secondary)
+        monkeypatch.setattr(runner, "_connect_adapter_with_timeout", _connect)
+        monkeypatch.setattr(runner, "_make_adapter_auth_check", lambda p: None)
+
+        connected = await runner._start_one_profile_adapters(
+            "reviewer", "/tmp/x", claimed
+        )
+
+        assert connected == 1
+        assert secondary.connected is True
+        assert secondary.disconnected is False
+        assert runner._profile_adapters["reviewer"][photon] is secondary
+
     def test_port_binding_set_covers_known_listeners(self):
         from gateway.run import _PORT_BINDING_PLATFORM_VALUES
         # Every adapter that binds a TCP port must be in the guard set.

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -878,7 +878,9 @@ class TestSecondaryProfileConfigHandling:
         monkeypatch.setattr("gateway.config.load_gateway_config", lambda: reviewer_cfg)
         monkeypatch.setattr(runner, "_create_adapter", lambda p, c: secondary)
         monkeypatch.setattr(runner, "_connect_adapter_with_timeout", _connect)
-        monkeypatch.setattr(runner, "_make_adapter_auth_check", lambda p: None)
+        monkeypatch.setattr(
+            runner, "_make_adapter_auth_check", lambda p, **kwargs: None
+        )
 
         connected = await runner._start_one_profile_adapters(
             "reviewer", "/tmp/x", claimed
@@ -934,7 +936,9 @@ class TestSecondaryProfileConfigHandling:
         monkeypatch.setattr("gateway.config.load_gateway_config", lambda: profile_cfg)
         monkeypatch.setattr(runner, "_create_adapter", lambda p, c: next(adapters))
         monkeypatch.setattr(runner, "_connect_adapter_with_timeout", _connect)
-        monkeypatch.setattr(runner, "_make_adapter_auth_check", lambda p: None)
+        monkeypatch.setattr(
+            runner, "_make_adapter_auth_check", lambda p, **kwargs: None
+        )
 
         first = await runner._start_one_profile_adapters("broken", "/tmp/x", claimed)
         second = await runner._start_one_profile_adapters("later", "/tmp/y", claimed)
@@ -943,6 +947,50 @@ class TestSecondaryProfileConfigHandling:
         assert failed.disconnected is True
         assert second == 1
         assert runner._profile_adapters["later"][photon] is later
+
+    @pytest.mark.asyncio
+    async def test_failed_primary_photon_listener_is_reserved_for_retry(
+        self, monkeypatch
+    ):
+        """A retrying primary keeps secondaries off its sidecar endpoint."""
+        from gateway.config import GatewayConfig, Platform
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner.adapters = {}
+        runner._profile_adapters = {}
+        runner.pairing_stores = {}
+
+        photon = Platform("photon")
+        listener_claim = ("listener", "photon", "127.0.0.1", 8789)
+        runner._failed_platforms = {
+            photon: {
+                "config": object(),
+                "attempts": 1,
+                "next_retry": 0,
+                "listener_claim": listener_claim,
+            }
+        }
+        seen = {}
+
+        async def _start(profile_name, profile_home, claimed):
+            seen.update(claimed)
+            return 0
+
+        monkeypatch.setattr(
+            "hermes_cli.profiles.profiles_to_serve",
+            lambda multiplex=True: (("default", "/tmp/default"), ("reviewer", "/tmp/reviewer")),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "default"
+        )
+        monkeypatch.setattr("gateway.status.write_runtime_status", lambda **kwargs: None)
+        monkeypatch.setattr(runner, "_start_one_profile_adapters", _start)
+
+        connected = await runner._start_secondary_profile_adapters()
+
+        assert connected == 0
+        assert seen[listener_claim] == "default"
 
     def test_port_binding_set_covers_known_listeners(self):
         from gateway.run import _PORT_BINDING_PLATFORM_VALUES

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -41,6 +41,22 @@ class TestCredentialFingerprint:
                 self.bot_token = "alt-token"
         assert GatewayRunner._adapter_credential_fingerprint(_AltAdapter()) is not None
 
+    def test_reads_photon_project_secret(self):
+        class _PhotonAdapter:
+            def __init__(self, secret):
+                self._project_secret = secret
+
+        fp1 = GatewayRunner._adapter_credential_fingerprint(
+            _PhotonAdapter("shared-project-secret")
+        )
+        fp2 = GatewayRunner._adapter_credential_fingerprint(
+            _PhotonAdapter("shared-project-secret")
+        )
+
+        assert fp1 == fp2
+        assert fp1 is not None
+        assert "shared-project-secret" not in fp1
+
     def test_reads_platform_config_token(self):
         class _Config:
             token = "config-token"
@@ -718,8 +734,10 @@ class TestSecondaryProfileConfigHandling:
         assert connect_calls == [(relay, Platform.RELAY)]
 
     @pytest.mark.asyncio
-    async def test_secondary_same_config_token_is_refused(self, monkeypatch):
-        """Adapters that keep their token on config still trip the mux guard."""
+    async def test_secondary_same_config_token_is_refused_without_disconnect(
+        self, monkeypatch
+    ):
+        """A never-connected duplicate must not disturb shared live state."""
         from gateway.config import GatewayConfig, Platform, PlatformConfig
 
         class _ConfigTokenAdapter:
@@ -762,7 +780,7 @@ class TestSecondaryProfileConfigHandling:
         )
 
         assert connected == 0
-        assert duplicate.disconnected is True
+        assert duplicate.disconnected is False
         assert runner._profile_adapters["reviewer"] == {}
 
     def test_port_binding_set_covers_known_listeners(self):


### PR DESCRIPTION
## What does this PR do?

Prevents multiplexed gateways from launching duplicate Photon sidecars and from marking a healthy shared platform disconnected during duplicate rejection.

When `gateway.multiplex_profiles` is enabled, credential-backed platforms can be discovered for every served profile. The duplicate guard recognized bot-token fields but not Photon/Spectrum's `_project_secret`, so each profile attempted to launch a Node sidecar on the same `127.0.0.1:8789` listener. The rejection path also called `disconnect()` on freshly constructed adapters that had never connected; for shared-credential adapters that could mutate aggregate platform state and shut down the primary Photon sidecar.

This change makes Photon credentials participate in the existing log-safe fingerprint and treats a rejected, never-connected adapter as owning no resources to disconnect.

## Related Issue

No tracking issue filed.

Companion: #54565 handles the separate Windows `CREATE_NO_WINDOW` hardening for Photon subprocesses. This PR intentionally does not duplicate that contributor's work.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`
  - Include Photon/Spectrum project secrets in multiplex credential fingerprints.
  - Do not call `disconnect()` for duplicates rejected before `connect()`.
  - Generalize the duplicate diagnostic beyond bot tokens.
- `tests/gateway/test_multiplex_adapter_registry.py`
  - Verify Photon project-secret fingerprints are stable and log-safe.
  - Verify a duplicate adapter is neither connected nor disconnected and cannot disturb shared live state.

## Sweeper Feedback Follow-up

The automated review correctly identified that credential fingerprints alone do not prevent two different Photon projects from binding the same sidecar endpoint. Follow-up commits preserve the original fix and additionally:

- Claim Photon sidecar listeners independently by normalized bind + port.
- Reject distinct credentials sharing one listener before `connect()` or `disconnect()`.
- Continue allowing distinct credentials when each profile uses a distinct sidecar port.
- Publish claims only after a successful secondary connection, so a failed start cannot block a later valid profile.
- Reserve retryable primary credential/listener ownership so the reconnect watcher cannot collide with a secondary sidecar.
- Cover same credentials, distinct credentials on the default port, distinct ports, failed-secondary recovery, and retrying-primary ownership.

## How to Test

1. Configure a default profile plus secondary profiles with `gateway.multiplex_profiles: true` and shared Photon credentials.
2. Start the gateway.
3. Confirm one primary Photon adapter connects, secondary duplicates are rejected before spawning, and the primary Photon/Telegram platform states remain `connected`.
4. Run:
   - `scripts/run_tests.sh tests/gateway/test_multiplex_adapter_registry.py -q`
   - `python scripts/check-windows-footguns.py --all`
   - `ruff check .`

Validation completed:

- Follow-up focused Windows suite after the sweeper remediation: **16 passed**.
- Repository wrapper in an isolated Linux/CI-parity container: **12 passed**.
- Native Windows 11 focused pytest: **12 passed**.
- Windows footgun scanner: **753 files scanned, no findings**.
- Full Ruff: **passed**.
- Python compilation and `git diff --check`: **passed**.
- Live Windows 11 gateway: one Photon sidecar, zero post-fix `EADDRINUSE`/sidecar-exit events, Telegram + Photon + API server connected, and repeated five-minute watchdog checks returned 0 without a restart storm.

Native-Windows wrapper note: the unmodified wrapper currently fails before collection under Git Bash because `env -i` drops Windows home variables and the progress renderer uses CP1252. The same wrapper passed unchanged in the Linux container, and the focused tests passed directly in the native Windows environment. The advisory full-tree `ty` scan is also not claimed green: `ty 0.0.21` panicked on an unrelated existing file and reported the repository's baseline diagnostics.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — focused wrapper/native suites passed; full matrix is delegated to CI
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 and Linux container

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is internal and documented inline
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before, one restart produced ten secondary Photon sidecar exits on the shared port and duplicate cleanup left aggregate platform state disconnected. After the fix:

```text
photon_node_count=1
startup_eaddrinuse=0
startup_sidecar_exits=0
telegram=connected
photon=connected
watchdog_result=0
```