### PR TITLE
fix(delegation): inherit service tier in child agents

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -629,7 +629,16 @@ def init_agent(
     agent.max_tokens = max_tokens  # None = use model default
     agent.reasoning_config = reasoning_config  # None = use default (medium for OpenRouter)
     agent.service_tier = service_tier
-    agent.request_overrides = dict(request_overrides or {})
+    from hermes_cli.models import apply_fast_mode_request_overrides
+
+    agent.request_overrides = apply_fast_mode_request_overrides(
+        request_overrides,
+        service_tier=agent.service_tier,
+        model_id=agent.model,
+        provider=agent.provider,
+        api_mode=agent.api_mode,
+        base_url=agent.base_url,
+    )
     agent.prefill_messages = prefill_messages or []  # Prefilled conversation turns
     agent._force_ascii_payload = False
     

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1221,6 +1221,17 @@ def restore_primary_runtime(agent) -> bool:
             agent.api_mode == "anthropic_messages" and agent.provider == "anthropic",
         )
 
+        from hermes_cli.models import apply_fast_mode_request_overrides
+
+        agent.request_overrides = apply_fast_mode_request_overrides(
+            getattr(agent, "request_overrides", None),
+            service_tier=getattr(agent, "service_tier", None),
+            model_id=agent.model,
+            provider=agent.provider,
+            api_mode=agent.api_mode,
+            base_url=agent.base_url,
+        )
+
         # ── Rebuild client for the primary provider ──
         if agent.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client
@@ -1885,6 +1896,9 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     # _client_kwargs is a dict — snapshot a shallow copy so mutating the
     # live dict doesn't poison the rollback target.
     _snapshot["_client_kwargs"] = dict(getattr(agent, "_client_kwargs", {}) or {})
+    _snapshot["request_overrides"] = dict(
+        getattr(agent, "request_overrides", {}) or {}
+    )
     # Snapshot the credential pool reference so a failed client rebuild can
     # restore the original pool (issue #52727: pool reload is part of this
     # switch and must be reversible on rollback).
@@ -2049,6 +2063,17 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
                 reason="switch_model",
                 shared=True,
             )
+
+        from hermes_cli.models import apply_fast_mode_request_overrides
+
+        agent.request_overrides = apply_fast_mode_request_overrides(
+            getattr(agent, "request_overrides", None),
+            service_tier=getattr(agent, "service_tier", None),
+            model_id=agent.model,
+            provider=agent.provider,
+            api_mode=agent.api_mode,
+            base_url=agent.base_url,
+        )
     except Exception:
         # Rollback every mutated field to the pre-swap snapshot so the agent
         # is left consistent (old model + old provider + old client) and the

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -818,6 +818,19 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
 def build_api_kwargs(agent, api_messages: list) -> dict:
     """Build the keyword arguments dict for the active API mode."""
+    from hermes_cli.models import apply_fast_mode_request_overrides
+
+    # Derive Fast/Priority at request time as a final guard against any route
+    # mutation path that did not rebuild request_overrides itself.
+    agent.request_overrides = apply_fast_mode_request_overrides(
+        getattr(agent, "request_overrides", None),
+        service_tier=getattr(agent, "service_tier", None),
+        model_id=agent.model,
+        provider=agent.provider,
+        api_mode=agent.api_mode,
+        base_url=agent.base_url,
+    )
+
     tools_for_api = agent.tools
 
     if agent.api_mode == "anthropic_messages":
@@ -1552,6 +1565,17 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent._fallback_activated = True
+
+        from hermes_cli.models import apply_fast_mode_request_overrides
+
+        agent.request_overrides = apply_fast_mode_request_overrides(
+            getattr(agent, "request_overrides", None),
+            service_tier=getattr(agent, "service_tier", None),
+            model_id=agent.model,
+            provider=agent.provider,
+            api_mode=agent.api_mode,
+            base_url=agent.base_url,
+        )
 
         # Rebind the credential pool to the fallback provider when the provider
         # changes.  Keeping the primary pool attached would make downstream

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4042,7 +4042,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return route
 
         try:
-            overrides = resolve_fast_mode_overrides(route["model"])
+            overrides = resolve_fast_mode_overrides(
+                route["model"],
+                provider=runtime.get("provider"),
+                api_mode=runtime.get("api_mode"),
+                base_url=runtime.get("base_url"),
+            )
         except Exception:
             overrides = None
         route["request_overrides"] = overrides or {}

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -217,7 +217,12 @@ class CLIAgentSetupMixin:
             return route
 
         try:
-            overrides = resolve_fast_mode_overrides(route["model"])
+            overrides = resolve_fast_mode_overrides(
+                route["model"],
+                provider=runtime.get("provider"),
+                api_mode=runtime.get("api_mode"),
+                base_url=runtime.get("base_url"),
+            )
         except Exception:
             overrides = None
         route["request_overrides"] = overrides

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2262,22 +2262,128 @@ def _is_anthropic_fast_model(model_id: Optional[str]) -> bool:
     return "opus-4-6" in base or "opus-4.6" in base
 
 
-def resolve_fast_mode_overrides(model_id: Optional[str]) -> dict[str, Any] | None:
-    """Return request_overrides for fast/priority mode, or None if unsupported.
+def _fast_route_hostname(base_url: Optional[str]) -> str:
+    try:
+        return (urllib.parse.urlparse(str(base_url or "")).hostname or "").lower()
+    except (TypeError, ValueError):
+        return ""
+
+
+def _is_native_anthropic_fast_route(
+    *,
+    provider: Optional[str],
+    api_mode: Optional[str],
+    base_url: Optional[str],
+) -> bool:
+    """Return whether the active route is Anthropic's native Messages API."""
+    if str(api_mode or "").strip().lower() != "anthropic_messages":
+        return False
+    hostname = _fast_route_hostname(base_url)
+    if hostname:
+        return hostname == "api.anthropic.com"
+    return normalize_provider(provider) == "anthropic"
+
+
+def _is_openai_fast_route(
+    *,
+    provider: Optional[str],
+    api_mode: Optional[str],
+    base_url: Optional[str],
+) -> bool:
+    """Return whether the active OpenAI-compatible route can carry service_tier."""
+    if str(api_mode or "").strip().lower() not in {
+        "chat_completions",
+        "codex_responses",
+    }:
+        return False
+    if normalize_provider(provider) in {
+        "anthropic",
+        "bedrock",
+        "gemini",
+        "vertex",
+        "xai",
+        "xai-oauth",
+    }:
+        return False
+    return _fast_route_hostname(base_url) not in {
+        "api.anthropic.com",
+        "api.x.ai",
+    }
+
+
+def resolve_fast_mode_overrides(
+    model_id: Optional[str],
+    *,
+    provider: Optional[str] = None,
+    api_mode: Optional[str] = None,
+    base_url: Optional[str] = None,
+) -> dict[str, Any] | None:
+    """Return route-valid request overrides for fast/priority mode.
 
     Returns provider-appropriate overrides:
     - OpenAI models: ``{"service_tier": "priority"}`` (Priority Processing)
     - Anthropic models: ``{"speed": "fast"}`` (Anthropic Fast Mode beta)
 
-    The overrides are injected into the API request kwargs by
-    ``_build_api_kwargs`` in run_agent.py — each API path handles its own
-    keys (service_tier for OpenAI/Codex, speed for Anthropic Messages).
+    Callers that know the active runtime must pass its provider, API mode, and
+    base URL. Model-only calls retain the legacy capability lookup used by UI
+    discovery, but must not be used to construct wire kwargs.
     """
     if not model_supports_fast_mode(model_id):
         return None
+    has_route = provider is not None or api_mode is not None or base_url is not None
     if _is_anthropic_fast_model(model_id):
+        if has_route and not _is_native_anthropic_fast_route(
+            provider=provider,
+            api_mode=api_mode,
+            base_url=base_url,
+        ):
+            return None
         return {"speed": "fast"}
+    if has_route and not _is_openai_fast_route(
+        provider=provider,
+        api_mode=api_mode,
+        base_url=base_url,
+    ):
+        return None
     return {"service_tier": "priority"}
+
+
+def apply_fast_mode_request_overrides(
+    request_overrides: Optional[dict[str, Any]],
+    *,
+    service_tier: Optional[str],
+    model_id: Optional[str],
+    provider: Optional[str],
+    api_mode: Optional[str],
+    base_url: Optional[str],
+    clear_when_disabled: bool = False,
+) -> dict[str, Any]:
+    """Replace derived Fast-only keys with the option for the active route.
+
+    Explicit low-level request overrides remain authoritative when there is no
+    durable Fast preference. Callers handling an explicit user-visible Fast
+    disable can request removal with ``clear_when_disabled=True``.
+    """
+    merged = dict(request_overrides or {})
+
+    if str(service_tier or "").strip().lower() != "priority":
+        if clear_when_disabled:
+            merged.pop("service_tier", None)
+            merged.pop("speed", None)
+        return merged
+
+    merged.pop("service_tier", None)
+    merged.pop("speed", None)
+
+    fast_overrides = resolve_fast_mode_overrides(
+        model_id,
+        provider=provider,
+        api_mode=api_mode,
+        base_url=base_url,
+    )
+    if fast_overrides:
+        merged.update(fast_overrides)
+    return merged
 
 
 def _resolve_copilot_catalog_api_key() -> str:

--- a/tests/cli/test_fast_command.py
+++ b/tests/cli/test_fast_command.py
@@ -409,6 +409,26 @@ class TestAnthropicFastMode(unittest.TestCase):
         assert route["runtime"]["provider"] == "anthropic"
         assert route["request_overrides"] == {"speed": "fast"}
 
+    def test_turn_route_omits_anthropic_fast_on_openrouter_chat_completions(self):
+        cli_mod = _import_cli()
+        stub = SimpleNamespace(
+            model="anthropic/claude-opus-4.6",
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            provider="openrouter",
+            api_mode="chat_completions",
+            acp_command=None,
+            acp_args=[],
+            _credential_pool=None,
+            service_tier="priority",
+        )
+
+        route = cli_mod.HermesCLI._resolve_turn_agent_config(stub, "hi")
+
+        assert route["runtime"]["provider"] == "openrouter"
+        assert route["runtime"]["api_mode"] == "chat_completions"
+        assert route["request_overrides"] is None
+
 
 class TestAnthropicFastModeAdapter(unittest.TestCase):
     """Verify build_anthropic_kwargs handles fast_mode parameter."""

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -142,6 +142,31 @@ def test_turn_route_skips_priority_processing_for_unsupported_models():
     assert route["request_overrides"] == {}
 
 
+def test_turn_route_omits_anthropic_fast_on_openrouter_chat_completions():
+    runner = _make_runner()
+    runner._service_tier = "priority"
+    runtime_kwargs = {
+        "api_key": "***",
+        "base_url": "https://openrouter.ai/api/v1",
+        "provider": "openrouter",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+    }
+
+    route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+        runner,
+        "hi",
+        "anthropic/claude-opus-4.6",
+        runtime_kwargs,
+    )
+
+    assert route["runtime"]["provider"] == "openrouter"
+    assert route["runtime"]["api_mode"] == "chat_completions"
+    assert route["request_overrides"] == {}
+
+
 @pytest.mark.asyncio
 async def test_handle_fast_command_persists_config(monkeypatch, tmp_path):
     runner = _make_runner()

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -30,7 +30,12 @@ def _make_tool_defs(*names: str) -> list:
     ]
 
 
-def _make_agent(fallback_model=None, provider="custom", base_url="https://my-llm.example.com/v1"):
+def _make_agent(
+    fallback_model=None,
+    provider="custom",
+    base_url="https://my-llm.example.com/v1",
+    **agent_kwargs,
+):
     """Create a minimal AIAgent with optional fallback config."""
     with (
         patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
@@ -45,6 +50,7 @@ def _make_agent(fallback_model=None, provider="custom", base_url="https://my-llm
             skip_context_files=True,
             skip_memory=True,
             fallback_model=fallback_model,
+            **agent_kwargs,
         )
         agent.client = MagicMock()
         return agent
@@ -200,6 +206,113 @@ class TestRestorePrimaryRuntime:
             agent._restore_primary_runtime()
 
         assert agent._use_prompt_caching == original_caching
+
+    def test_openai_fast_override_clears_on_fallback_and_recomputes_on_restore(self):
+        unrelated = {"extra_body": {"trace": "keep"}}
+        agent = _make_agent(
+            provider="openai-api",
+            base_url="https://api.openai.com/v1",
+            model="gpt-5.5",
+            api_mode="codex_responses",
+            service_tier="priority",
+            request_overrides={**unrelated, "service_tier": "priority"},
+            fallback_model={
+                "provider": "deepseek",
+                "model": "deepseek-chat",
+            },
+        )
+
+        primary_kwargs = agent._build_api_kwargs(
+            [{"role": "user", "content": "test"}]
+        )
+        assert primary_kwargs["service_tier"] == "priority"
+        assert primary_kwargs["extra_body"]["trace"] == "keep"
+
+        fallback_client = _mock_resolve(base_url="https://api.deepseek.com/v1")
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(fallback_client, None),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.request_overrides == unrelated
+        fallback_kwargs = agent._build_api_kwargs(
+            [{"role": "user", "content": "test"}]
+        )
+        assert "service_tier" not in fallback_kwargs
+        assert "speed" not in fallback_kwargs
+        assert fallback_kwargs["extra_body"]["trace"] == "keep"
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            assert agent._restore_primary_runtime() is True
+
+        assert agent.request_overrides == {
+            **unrelated,
+            "service_tier": "priority",
+        }
+        restored_kwargs = agent._build_api_kwargs(
+            [{"role": "user", "content": "test"}]
+        )
+        assert restored_kwargs["service_tier"] == "priority"
+        assert restored_kwargs["extra_body"]["trace"] == "keep"
+
+    def test_anthropic_fast_override_translates_on_fallback_and_recomputes_on_restore(self):
+        from agent.anthropic_adapter import _FAST_MODE_BETA
+
+        unrelated = {"extra_body": {"trace": "keep"}}
+        agent = _make_agent(
+            provider="anthropic",
+            base_url="https://api.anthropic.com",
+            model="claude-opus-4-6",
+            api_mode="anthropic_messages",
+            service_tier="priority",
+            request_overrides={**unrelated, "speed": "fast"},
+            fallback_model={
+                "provider": "openai-api",
+                "model": "gpt-5.5",
+            },
+        )
+        agent.client = None
+
+        primary_kwargs = agent._build_api_kwargs(
+            [{"role": "user", "content": "test"}]
+        )
+        assert "speed" not in primary_kwargs
+        assert primary_kwargs["extra_body"]["speed"] == "fast"
+        assert _FAST_MODE_BETA in primary_kwargs["extra_headers"]["anthropic-beta"]
+
+        fallback_client = _mock_resolve(base_url="https://api.openai.com/v1")
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(fallback_client, None),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.request_overrides == {
+            **unrelated,
+            "service_tier": "priority",
+        }
+        fallback_kwargs = agent._build_api_kwargs(
+            [{"role": "user", "content": "test"}]
+        )
+        assert fallback_kwargs["service_tier"] == "priority"
+        assert "speed" not in fallback_kwargs
+        assert fallback_kwargs.get("extra_body", {}).get("speed") != "fast"
+        assert fallback_kwargs["extra_body"]["trace"] == "keep"
+
+        with patch(
+            "agent.anthropic_adapter.build_anthropic_client",
+            return_value=MagicMock(),
+        ):
+            assert agent._restore_primary_runtime() is True
+
+        assert agent.request_overrides == {**unrelated, "speed": "fast"}
+        restored_kwargs = agent._build_api_kwargs(
+            [{"role": "user", "content": "test"}]
+        )
+        assert "speed" not in restored_kwargs
+        assert restored_kwargs["extra_body"]["speed"] == "fast"
+        assert _FAST_MODE_BETA in restored_kwargs["extra_headers"]["anthropic-beta"]
 
     def test_restore_skips_cross_provider_pool_entry(self):
         """Restore must not swap in a fallback provider credential for the primary runtime."""

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3902,6 +3902,9 @@ def test_config_set_fast_updates_live_agent_and_config(monkeypatch):
     emits = []
     agent = types.SimpleNamespace(
         model="openai/gpt-5.4",
+        provider="openrouter",
+        api_mode="chat_completions",
+        base_url="https://openrouter.ai/api/v1",
         request_overrides={"foo": "bar", "speed": "slow"},
         service_tier=None,
     )
@@ -3914,7 +3917,7 @@ def test_config_set_fast_updates_live_agent_and_config(monkeypatch):
     monkeypatch.setattr(server, "_emit", lambda *args: emits.append(args))
     monkeypatch.setattr(
         "hermes_cli.models.resolve_fast_mode_overrides",
-        lambda _model_id: {"service_tier": "priority"},
+        lambda _model_id, **_route: {"service_tier": "priority"},
     )
 
     try:
@@ -3945,6 +3948,38 @@ def test_config_set_fast_updates_live_agent_and_config(monkeypatch):
         assert agent.service_tier is None
         assert agent.request_overrides == {"foo": "bar"}
         assert ("agent.service_tier", "normal") in writes
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_config_set_fast_rejects_anthropic_over_openrouter(monkeypatch):
+    writes = []
+    agent = types.SimpleNamespace(
+        model="anthropic/claude-opus-4.6",
+        provider="openrouter",
+        api_mode="chat_completions",
+        base_url="https://openrouter.ai/api/v1",
+        request_overrides={"foo": "bar"},
+        service_tier=None,
+    )
+    server._sessions["sid"] = _session(agent=agent)
+    monkeypatch.setattr(
+        server, "_write_config_key", lambda path, value: writes.append((path, value))
+    )
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "config.set",
+                "params": {"session_id": "sid", "key": "fast", "value": "fast"},
+            }
+        )
+
+        assert resp["error"]["code"] == 4002
+        assert agent.service_tier is None
+        assert agent.request_overrides == {"foo": "bar"}
+        assert writes == []
     finally:
         server._sessions.pop("sid", None)
 
@@ -3989,7 +4024,7 @@ def test_config_set_fast_rejects_unsupported_model(monkeypatch):
     )
     monkeypatch.setattr(
         "hermes_cli.models.resolve_fast_mode_overrides",
-        lambda _model_id: None,
+        lambda _model_id, **_route: None,
     )
 
     try:
@@ -6781,6 +6816,71 @@ def test_mirror_slash_side_effects_allowed_when_idle(monkeypatch):
     # Should NOT contain "session busy" — the switch went through.
     assert "session busy" not in warning
     assert applied["model"]
+
+
+@pytest.mark.parametrize(
+    ("agent", "expected_overrides"),
+    [
+        (
+            types.SimpleNamespace(
+                model="gpt-5.6-sol",
+                provider="openai-codex",
+                api_mode="codex_responses",
+                base_url="https://chatgpt.com/backend-api/codex",
+                service_tier="priority",
+                request_overrides={"service_tier": "priority", "timeout": 321.0},
+            ),
+            {"timeout": 321.0},
+        ),
+        (
+            types.SimpleNamespace(
+                model="claude-opus-4-6",
+                provider="anthropic",
+                api_mode="anthropic_messages",
+                base_url="https://api.anthropic.com",
+                service_tier="priority",
+                request_overrides={
+                    "speed": "fast",
+                    "extra_body": {"trace": "keep"},
+                },
+            ),
+            {"extra_body": {"trace": "keep"}},
+        ),
+    ],
+)
+def test_slash_exec_fast_normal_clears_derived_fast_overrides(
+    monkeypatch, agent, expected_overrides
+):
+    """The slash-worker mirror must update the live request path, not only config."""
+
+    class _Worker:
+        def run(self, command):
+            assert command == "fast normal"
+            return "Fast mode disabled"
+
+    persisted = []
+    monkeypatch.setattr(
+        server,
+        "_persist_live_session_runtime",
+        lambda session: persisted.append(session),
+    )
+    session = _session(agent=agent, slash_worker=_Worker())
+    server._sessions["sid"] = session
+    try:
+        response = server.handle_request(
+            {
+                "id": "1",
+                "method": "slash.exec",
+                "params": {"command": "fast normal", "session_id": "sid"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert response["result"]["output"] == "Fast mode disabled"
+    assert agent.service_tier is None
+    assert agent.request_overrides == expected_overrides
+    assert persisted == [session]
 
 
 def test_mirror_slash_compress_does_not_prelock_history(monkeypatch):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -46,6 +46,8 @@ def _make_mock_parent(depth=0):
     parent.provider = "openrouter"
     parent.api_mode = "chat_completions"
     parent.model = "anthropic/claude-sonnet-4"
+    parent.service_tier = None
+    parent.request_overrides = {}
     parent.platform = "cli"
     parent.providers_allowed = None
     parent.providers_ignored = None
@@ -412,6 +414,347 @@ class TestDelegateTask(unittest.TestCase):
             self.assertEqual(kwargs["api_key"], parent.api_key)
             self.assertEqual(kwargs["provider"], parent.provider)
             self.assertEqual(kwargs["api_mode"], parent.api_mode)
+
+    def _capture_child_agent_kwargs(
+        self,
+        parent,
+        *,
+        model=None,
+        override_provider=None,
+        override_base_url=None,
+        override_api_key=None,
+        override_api_mode=None,
+        override_request_overrides=None,
+    ):
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="Use fast processing",
+                context=None,
+                toolsets=None,
+                model=model,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+                override_provider=override_provider,
+                override_base_url=override_base_url,
+                override_api_key=override_api_key,
+                override_api_mode=override_api_mode,
+                override_request_overrides=override_request_overrides,
+            )
+        return MockAgent.call_args.kwargs
+
+    @staticmethod
+    def _real_agent_from_child_kwargs(kwargs):
+        from run_agent import AIAgent
+
+        return AIAgent(
+            api_key="test-key-12345678",
+            base_url=kwargs["base_url"],
+            provider=kwargs["provider"],
+            api_mode=kwargs["api_mode"],
+            model=kwargs["model"],
+            enabled_toolsets=[],
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            service_tier=kwargs["service_tier"],
+            request_overrides=kwargs["request_overrides"],
+        )
+
+    def test_child_fast_preference_reaches_supported_openai_wire_kwargs(self):
+        parent = _make_mock_parent(depth=0)
+        parent.model = "gpt-5.6-sol"
+        parent.provider = "openai-codex"
+        parent.api_mode = "codex_responses"
+        parent.base_url = "https://chatgpt.com/backend-api/codex"
+        parent.service_tier = "priority"
+        parent.request_overrides = {"extra_body": {"trace": "keep"}}
+
+        kwargs = self._capture_child_agent_kwargs(parent)
+
+        self.assertEqual(kwargs["service_tier"], "priority")
+        self.assertEqual(
+            kwargs["request_overrides"],
+            {"extra_body": {"trace": "keep"}, "service_tier": "priority"},
+        )
+        child = self._real_agent_from_child_kwargs(kwargs)
+        api_kwargs = child._build_api_kwargs(
+            [{"role": "user", "content": "test"}]
+        )
+        self.assertEqual(api_kwargs["service_tier"], "priority")
+        self.assertEqual(api_kwargs["extra_body"]["trace"], "keep")
+
+    def test_child_fast_preference_reaches_native_anthropic_wire_kwargs(self):
+        from agent.anthropic_adapter import _FAST_MODE_BETA
+
+        parent = _make_mock_parent(depth=0)
+        parent.model = "claude-opus-4-6"
+        parent.provider = "anthropic"
+        parent.api_mode = "anthropic_messages"
+        parent.base_url = "https://api.anthropic.com"
+        parent.service_tier = "priority"
+        parent.request_overrides = {"timeout": 321.0}
+
+        kwargs = self._capture_child_agent_kwargs(parent)
+
+        self.assertEqual(kwargs["service_tier"], "priority")
+        self.assertEqual(
+            kwargs["request_overrides"],
+            {"timeout": 321.0, "speed": "fast"},
+        )
+        child = self._real_agent_from_child_kwargs(kwargs)
+        api_kwargs = child._build_api_kwargs(
+            [{"role": "user", "content": "test"}]
+        )
+        self.assertNotIn("speed", api_kwargs)
+        self.assertEqual(api_kwargs["extra_body"]["speed"], "fast")
+        self.assertIn(
+            _FAST_MODE_BETA,
+            api_kwargs["extra_headers"]["anthropic-beta"],
+        )
+
+    def test_child_fast_preference_omits_anthropic_fields_on_openrouter(self):
+        from agent.anthropic_adapter import _FAST_MODE_BETA
+
+        parent = _make_mock_parent(depth=0)
+        parent.model = "anthropic/claude-opus-4.6"
+        parent.provider = "openrouter"
+        parent.api_mode = "chat_completions"
+        parent.base_url = "https://openrouter.ai/api/v1"
+        parent.service_tier = "priority"
+        parent.request_overrides = {
+            "speed": "fast",
+            "extra_body": {"trace": "keep"},
+        }
+
+        kwargs = self._capture_child_agent_kwargs(parent)
+
+        self.assertEqual(kwargs["service_tier"], "priority")
+        self.assertEqual(
+            kwargs["request_overrides"],
+            {"extra_body": {"trace": "keep"}},
+        )
+        child = self._real_agent_from_child_kwargs(kwargs)
+        api_kwargs = child._build_api_kwargs(
+            [{"role": "user", "content": "test"}]
+        )
+        self.assertNotIn("speed", api_kwargs)
+        self.assertNotEqual(api_kwargs.get("extra_body", {}).get("speed"), "fast")
+        self.assertEqual(api_kwargs["extra_body"]["trace"], "keep")
+        self.assertNotIn(
+            _FAST_MODE_BETA,
+            api_kwargs.get("extra_headers", {}).get("anthropic-beta", ""),
+        )
+
+    def test_standard_child_without_derived_fast_state_keeps_unrelated_overrides(self):
+        parent = _make_mock_parent(depth=0)
+        parent.model = "gpt-5.5"
+        parent.provider = "openai-api"
+        parent.api_mode = "codex_responses"
+        parent.base_url = "https://api.openai.com/v1"
+        parent.service_tier = None
+        parent.request_overrides = {"timeout": 321.0}
+
+        kwargs = self._capture_child_agent_kwargs(parent)
+
+        self.assertIsNone(kwargs["service_tier"])
+        self.assertEqual(kwargs["request_overrides"], {"timeout": 321.0})
+        child = self._real_agent_from_child_kwargs(kwargs)
+        api_kwargs = child._build_api_kwargs(
+            [{"role": "user", "content": "test"}]
+        )
+        self.assertNotIn("service_tier", api_kwargs)
+        self.assertNotIn("speed", api_kwargs)
+        self.assertEqual(api_kwargs["timeout"], 321.0)
+
+    def test_delegate_task_standard_preserves_explicit_low_level_overrides(self):
+        """No durable Fast marker means configured request overrides are explicit."""
+        parent = _make_mock_parent(depth=0)
+        parent.service_tier = None
+        parent.request_overrides = {"extra_body": {"parent_only": True}}
+        runtime_overrides = {
+            "service_tier": "flex",
+            "timeout": 321.0,
+            "extra_body": {"store": False},
+        }
+        runtime = {
+            "provider": "openai-api",
+            "model": "gpt-5.5",
+            "base_url": "https://api.openai.com/v1",
+            "api_key": "child-key-12345678",
+            "api_mode": "codex_responses",
+            "request_overrides": runtime_overrides,
+        }
+        cfg = {
+            "model": "gpt-5.5",
+            "provider": "openai-api",
+            "max_iterations": 10,
+        }
+        child_result = {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "done",
+            "error": None,
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+        }
+
+        with (
+            patch("tools.delegate_tool._load_config", return_value=cfg),
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value=runtime,
+            ),
+            patch("tools.delegate_tool._run_single_child", return_value=child_result),
+            patch("run_agent.AIAgent") as MockAgent,
+        ):
+            MockAgent.return_value = MagicMock()
+            result = json.loads(
+                delegate_task(goal="Preserve explicit overrides", parent_agent=parent)
+            )
+
+        self.assertEqual(result["results"][0]["status"], "completed")
+        kwargs = MockAgent.call_args.kwargs
+        self.assertIsNone(kwargs["service_tier"])
+        self.assertEqual(kwargs["request_overrides"], runtime_overrides)
+
+    def test_overridden_provider_keeps_its_overrides_without_fast_leakage(self):
+        parent = _make_mock_parent(depth=0)
+        parent.model = "claude-opus-4-6"
+        parent.provider = "anthropic"
+        parent.api_mode = "anthropic_messages"
+        parent.base_url = "https://api.anthropic.com"
+        parent.service_tier = "priority"
+        parent.request_overrides = {
+            "speed": "fast",
+            "extra_body": {"parent_only": True},
+        }
+
+        kwargs = self._capture_child_agent_kwargs(
+            parent,
+            model="deepseek-chat",
+            override_provider="deepseek",
+            override_base_url="https://api.deepseek.com/v1",
+            override_api_key="child-key-12345678",
+            override_api_mode="chat_completions",
+            override_request_overrides={"extra_body": {"child_only": True}},
+        )
+
+        self.assertEqual(kwargs["service_tier"], "priority")
+        self.assertEqual(
+            kwargs["request_overrides"],
+            {"extra_body": {"child_only": True}},
+        )
+        child = self._real_agent_from_child_kwargs(kwargs)
+        api_kwargs = child._build_api_kwargs(
+            [{"role": "user", "content": "test"}]
+        )
+        self.assertNotIn("service_tier", api_kwargs)
+        self.assertNotIn("speed", api_kwargs)
+        self.assertIs(api_kwargs["extra_body"]["child_only"], True)
+        self.assertNotIn("parent_only", api_kwargs["extra_body"])
+
+    def test_delegate_task_configured_provider_keeps_runtime_overrides_and_fast_wire(self):
+        """Configured provider metadata must survive the full delegate_task path."""
+        parent = _make_mock_parent(depth=0)
+        parent.model = "claude-opus-4-6"
+        parent.provider = "anthropic"
+        parent.api_mode = "anthropic_messages"
+        parent.base_url = "https://api.anthropic.com"
+        parent.service_tier = "priority"
+        parent.request_overrides = {
+            "speed": "fast",
+            "extra_body": {"parent_only": True},
+        }
+        runtime_overrides = {"extra_body": {"store": False}}
+        runtime = {
+            "provider": "openai-api",
+            "model": "gpt-5.5",
+            "base_url": "https://api.openai.com/v1",
+            "api_key": "child-key-12345678",
+            "api_mode": "codex_responses",
+            "request_overrides": runtime_overrides,
+        }
+        cfg = {
+            "model": "gpt-5.5",
+            "provider": "openai-api",
+            "max_iterations": 10,
+        }
+        child_result = {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "done",
+            "error": None,
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+        }
+
+        with (
+            patch("tools.delegate_tool._load_config", return_value=cfg),
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value=runtime,
+            ) as mock_resolve,
+            patch("tools.delegate_tool._run_single_child", return_value=child_result),
+            patch("run_agent.AIAgent") as MockAgent,
+        ):
+            MockAgent.return_value = MagicMock()
+            result = json.loads(
+                delegate_task(goal="Use configured provider", parent_agent=parent)
+            )
+
+        self.assertEqual(result["results"][0]["status"], "completed")
+        mock_resolve.assert_called_once_with(
+            requested="openai-api", target_model="gpt-5.5"
+        )
+        kwargs = MockAgent.call_args.kwargs
+        self.assertEqual(kwargs["provider"], "openai-api")
+        self.assertEqual(kwargs["api_mode"], "codex_responses")
+        self.assertEqual(kwargs["service_tier"], "priority")
+        self.assertEqual(
+            kwargs["request_overrides"],
+            {
+                "extra_body": {"store": False},
+                "service_tier": "priority",
+            },
+        )
+        child = self._real_agent_from_child_kwargs(kwargs)
+        api_kwargs = child._build_api_kwargs(
+            [{"role": "user", "content": "test"}]
+        )
+        self.assertEqual(api_kwargs["service_tier"], "priority")
+        self.assertIs(api_kwargs["extra_body"]["store"], False)
+        self.assertNotIn("parent_only", api_kwargs["extra_body"])
+
+    def test_fast_preference_is_inherited_by_nested_descendant(self):
+        parent = _make_mock_parent(depth=0)
+        parent.model = "gpt-5.5"
+        parent.provider = "openai-api"
+        parent.api_mode = "codex_responses"
+        parent.base_url = "https://api.openai.com/v1"
+        parent.service_tier = "priority"
+
+        child_kwargs = self._capture_child_agent_kwargs(parent)
+        child_parent = _make_mock_parent(depth=1)
+        for name in (
+            "model",
+            "provider",
+            "api_mode",
+            "base_url",
+            "service_tier",
+            "request_overrides",
+        ):
+            setattr(child_parent, name, child_kwargs[name])
+
+        grandchild_kwargs = self._capture_child_agent_kwargs(child_parent)
+
+        self.assertEqual(grandchild_kwargs["service_tier"], "priority")
+        self.assertEqual(
+            grandchild_kwargs["request_overrides"]["service_tier"],
+            "priority",
+        )
 
     def test_child_inherits_parent_print_fn(self):
         parent = _make_mock_parent(depth=0)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1317,6 +1317,27 @@ def _build_child_agent(
     if isinstance(child_max_tokens, int):
         child_optional_kwargs["max_tokens"] = child_max_tokens
 
+    # The durable Fast preference is provider-agnostic, but its wire option is
+    # not. Preserve current override semantics (a different configured provider
+    # gets only its own request overrides), then derive the Fast-only key from
+    # the child's complete route so parent-specific keys cannot leak across.
+    child_service_tier = getattr(parent_agent, "service_tier", None)
+    base_request_overrides = (
+        dict(override_request_overrides or {})
+        if override_provider
+        else dict(getattr(parent_agent, "request_overrides", {}) or {})
+    )
+    from hermes_cli.models import apply_fast_mode_request_overrides
+
+    child_request_overrides = apply_fast_mode_request_overrides(
+        base_request_overrides,
+        service_tier=child_service_tier,
+        model_id=effective_model,
+        provider=effective_provider,
+        api_mode=effective_api_mode,
+        base_url=effective_base_url,
+    )
+
     child = AIAgent(
         base_url=effective_base_url,
         api_key=effective_api_key,
@@ -1347,11 +1368,8 @@ def _build_child_agent(
         provider_sort=child_provider_sort,
         provider_require_parameters=child_provider_require_parameters,
         provider_data_collection=child_provider_data_collection,
-        request_overrides=(
-            dict(override_request_overrides or {})
-            if override_provider
-            else dict(getattr(parent_agent, "request_overrides", {}) or {})
-        ),
+        service_tier=child_service_tier,
+        request_overrides=child_request_overrides,
         openrouter_min_coding_score=child_openrouter_min_coding_score,
         tool_progress_callback=child_progress_cb,
         iteration_budget=None,  # fresh budget per subagent

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10777,7 +10777,14 @@ def _(rid, params: dict) -> dict:
                     4002,
                     "fast mode is not available without a selected model",
                 )
-            overrides = resolve_fast_mode_overrides(target_model)
+            route_kwargs = {}
+            if agent is not None:
+                route_kwargs = {
+                    "provider": getattr(agent, "provider", None),
+                    "api_mode": getattr(agent, "api_mode", None),
+                    "base_url": getattr(agent, "base_url", None),
+                }
+            overrides = resolve_fast_mode_overrides(target_model, **route_kwargs)
             if overrides is None:
                 return _err(
                     rid,
@@ -10787,13 +10794,7 @@ def _(rid, params: dict) -> dict:
 
         _write_config_key("agent.service_tier", nv)
         if agent is not None:
-            agent.service_tier = "priority" if nv == "fast" else None
-            current_overrides = dict(getattr(agent, "request_overrides", {}) or {})
-            current_overrides.pop("service_tier", None)
-            current_overrides.pop("speed", None)
-            if nv == "fast":
-                current_overrides.update(overrides)
-            agent.request_overrides = current_overrides
+            _set_live_agent_fast_mode(agent, enabled=nv == "fast")
             _persist_live_session_runtime(session)
             _emit(
                 "session.info",
@@ -13790,6 +13791,22 @@ def _live_slash_command_output(sid: str, session: Optional[dict], name: str, arg
     return None
 
 
+def _set_live_agent_fast_mode(agent, *, enabled: bool) -> None:
+    """Apply an explicit TUI Fast transition to marker and derived wire state."""
+
+    from hermes_cli.models import apply_fast_mode_request_overrides
+
+    agent.service_tier = "priority" if enabled else None
+    agent.request_overrides = apply_fast_mode_request_overrides(
+        getattr(agent, "request_overrides", None),
+        service_tier=agent.service_tier,
+        model_id=getattr(agent, "model", None),
+        provider=getattr(agent, "provider", None),
+        api_mode=getattr(agent, "api_mode", None),
+        base_url=getattr(agent, "base_url", None),
+        clear_when_disabled=True,
+    )
+
 
 def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
     """Apply side effects that must also hit the gateway's live agent."""
@@ -13889,9 +13906,11 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
         elif name == "fast" and agent:
             mode = arg.lower()
             if mode in {"fast", "on"}:
-                agent.service_tier = "priority"
+                _set_live_agent_fast_mode(agent, enabled=True)
+                _persist_live_session_runtime(session)
             elif mode in {"normal", "off"}:
-                agent.service_tier = None
+                _set_live_agent_fast_mode(agent, enabled=False)
+                _persist_live_session_runtime(session)
             _emit("session.info", sid, _session_info(agent, session))
         elif name == "reload-mcp" and agent and hasattr(agent, "reload_mcp_tools"):
             agent.reload_mcp_tools()


### PR DESCRIPTION
1|## Summary
2|
3|Repairs Fast-mode delegation against current `main` and makes derived Fast wire options depend on the complete active route rather than the model name alone.
4|
5|- Inherits the durable Fast preference into delegated children and nested descendants.
6|- Preserves configured-provider runtime overrides through the public `delegate_task` path.
7|- Recomputes derived Fast fields during initialization, request construction, fallback activation, primary restoration, model switching, and live TUI transitions.
8|- Preserves caller-owned explicit low-level request overrides when no durable Fast marker exists.
9|
10|## Route behavior
11|
12|- Supported OpenAI/Codex routes emit `service_tier="priority"`, including `gpt-5.6-sol` over `openai-codex`.
13|- Native Anthropic Messages for Claude Opus 4.6 emits adapter `extra_body.speed="fast"` with the required beta.
14|- Anthropic models over OpenRouter/chat-completions do not receive SDK-invalid top-level `speed`.
15|- Unsupported routes receive no derived Fast field.
16|- Supported cross-provider fallback translates the derived key (`speed` ↔ `service_tier`) instead of retaining stale provider-specific state.
17|- Explicit Standard/normal transitions clear derived Fast state while retaining unrelated overrides.
18|
19|## Review feedback addressed
20|
21|The updated branch derives Fast overrides from the child's complete effective route, preserves unrelated parent/runtime overrides, and includes a configured-provider regression through the public `delegate_task` path.
22|
23|## Fresh verification after rebase
24|
25|Rebased onto `7cb2d2cd4` on 2026-07-17.
26|
27|- Directly affected delegation/Fast/gateway/restore/TUI matrix: **249 passed**.
28|- Broader five-file matrix: **596 passed, 1 failed**; the single browser-connect failure reproduces unchanged on clean current `main` and is unrelated to this patch.
29|- Ruff over all 13 changed Python paths: passed.
30|- `git diff --check`: passed.
31|
32|The branch is intentionally route-aware rather than merely copying the parent marker: configured provider overrides and fallback/model-switch paths must not leak provider-specific Fast keys.
33|