### PR TITLE
fix: capture gateway silent crashes with last-resort crash diagnostics (#52942)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -38,6 +38,8 @@ import shlex
 import site
 import sys
 import signal
+import tempfile
+import traceback
 import threading
 import time
 from collections import OrderedDict
@@ -443,6 +445,83 @@ def _gateway_loop_exception_handler(
         return
     # Fall back to the default handler for anything we don't recognise.
     loop.default_exception_handler(context)
+
+
+# ── Last-resort crash diagnostics (issue #52942) ──────────────────────
+# The gateway has been observed dying with ZERO log output — no traceback,
+# no warning, just a silent stop. The asyncio loop handler above only
+# catches exceptions that reach the event loop; exceptions raised in plain
+# worker threads (cron subprocess readers, agent session threads, the
+# planned-stop watcher) or that escape ``asyncio.run`` entirely bypass it
+# and, without a ``sys.excepthook``/``threading.excepthook``, vanish.
+#
+# These hooks guarantee the unhandled exception is written straight to a
+# diagnostic file — bypassing the logging system, which may itself be
+# wedged or unflushed at crash time — so the crash signature is never
+# silently lost again. They are intentionally defensive: a failed write
+# must never become its own crash.
+_CRASH_HOOK_INSTALLED = False
+
+
+def _write_crash_diagnostic(
+    exc_type: "type",
+    exc_value: "BaseException",
+    exc_tb: "Any",
+    source: str,
+) -> None:
+    """Append an unhandled-exception traceback to the crash diagnostic log.
+
+    Writes directly to ``<hermes_home>/logs/gateway-crash-diag.log`` (and
+    best-effort to stderr) without going through ``logging`` — the whole
+    point is to capture crashes that occur when logging is unavailable or
+    unflushed. Never raises; a failed write must not become its own crash.
+    """
+    try:
+        ts = datetime.now().isoformat(timespec="seconds")
+        block = (
+            f"=== Hermes Gateway crash diagnostic ({source}) @ {ts} ===\n"
+            + "".join(traceback.format_exception(exc_type, exc_value, exc_tb))
+            + "\n"
+        )
+        try:
+            log_path = _hermes_home / "logs" / "gateway-crash-diag.log"
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(log_path, "a", encoding="utf-8", errors="replace") as fh:
+                fh.write(block)
+        except Exception:
+            pass
+        try:
+            sys.stderr.write(block)
+        except Exception:
+            pass
+    except Exception:
+        pass
+
+
+def _gateway_excepthook(exc_type, exc_value, exc_tb):
+    _write_crash_diagnostic(exc_type, exc_value, exc_tb, "sys.excepthook")
+
+
+def _gateway_threading_excepthook(args):
+    # args: types.SimpleNamespace(exc_type, exc_value, exc_traceback, thread)
+    thread_name = getattr(args.thread, "name", "?") if args.thread else "?"
+    _write_crash_diagnostic(
+        args.exc_type,
+        args.exc_value,
+        args.exc_traceback,
+        f"threading:{thread_name}",
+    )
+
+
+def _install_crash_diagnostic_hooks() -> None:
+    """Install process-global crash hooks. Idempotent and side-effect free."""
+    global _CRASH_HOOK_INSTALLED
+    if _CRASH_HOOK_INSTALLED:
+        return
+    _CRASH_HOOK_INSTALLED = True
+    sys.excepthook = _gateway_excepthook
+    if hasattr(threading, "excepthook"):
+        threading.excepthook = _gateway_threading_excepthook
 
 
 def _redact_gateway_user_facing_secrets(text: str) -> str:
@@ -26446,6 +26525,13 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # is forwarded to the default handler so real bugs still surface.
     loop.set_exception_handler(_gateway_loop_exception_handler)
 
+    # Last-resort crash diagnostics (issue #52942): unhandled exceptions in
+    # plain worker threads or ones that escape ``asyncio.run`` bypass the loop
+    # handler entirely. Install process-global hooks so any such crash is
+    # written to ``<hermes_home>/logs/gateway-crash-diag.log`` instead of
+    # being silently lost with zero log output.
+    _install_crash_diagnostic_hooks()
+
     if threading.current_thread() is threading.main_thread():
         for sig in (signal.SIGINT, signal.SIGTERM):
             try:
@@ -26767,6 +26853,13 @@ def main():
     
     args = parser.parse_args()
     
+    # Last-resort crash diagnostics (issue #52942): install as early as
+    # possible so even an unhandled exception during startup config load
+    # or inside ``asyncio.run`` is written to the crash diagnostic log
+    # instead of being silently swallowed. ``start_gateway`` installs the
+    # same hooks again (idempotent) once ``_hermes_home`` is authoritative.
+    _install_crash_diagnostic_hooks()
+
     config = None
     if args.config:
         import yaml

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -483,6 +483,9 @@ def _write_crash_diagnostic(
             + "".join(traceback.format_exception(exc_type, exc_value, exc_tb))
             + "\n"
         )
+        # Crash messages can contain credentials. This bypasses logging by
+        # design, so force the canonical redactor before either raw sink.
+        block = _redact_gateway_user_facing_secrets(block)
         try:
             log_path = _hermes_home / "logs" / "gateway-crash-diag.log"
             log_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/gateway/test_loop_exception_handler.py
+++ b/tests/gateway/test_loop_exception_handler.py
@@ -15,9 +15,13 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sys
+import threading
+from types import SimpleNamespace
 
 import pytest
 
+import gateway.run as gateway_run
 from gateway.run import (
     _gateway_loop_exception_handler,
     _is_transient_network_error,
@@ -139,3 +143,63 @@ def test_unhandled_transient_error_in_task_does_not_propagate_to_loop():
     # the real assertion is that no unhandled exception escapes the
     # ``run`` boundary.
     asyncio.run(main())
+
+
+# ---------------------------------------------------------------------
+# Last-resort crash diagnostics (#52942)
+# ---------------------------------------------------------------------
+
+
+def _caught_exception(message: str) -> tuple[type[BaseException], BaseException, object]:
+    """Return a real exception triple suitable for calling an exception hook."""
+    try:
+        raise RuntimeError(message)
+    except RuntimeError as exc:
+        return type(exc), exc, exc.__traceback__
+
+
+def test_sys_excepthook_writes_a_redacted_diagnostic(tmp_path, monkeypatch):
+    """The global hook persists a redacted traceback under the active Hermes home."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_redact_gateway_user_facing_secrets", lambda text: text.replace("secret-value", "[REDACTED]"))
+    exc_type, exc, tb = _caught_exception("secret-value")
+
+    gateway_run._gateway_excepthook(exc_type, exc, tb)
+
+    diagnostic = (tmp_path / "logs" / "gateway-crash-diag.log").read_text()
+    assert "sys.excepthook" in diagnostic
+    assert "[REDACTED]" in diagnostic
+    assert "secret-value" not in diagnostic
+
+
+def test_threading_excepthook_writes_a_redacted_diagnostic(tmp_path, monkeypatch):
+    """Thread exceptions use the same redacted diagnostic writer."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_redact_gateway_user_facing_secrets", lambda text: text.replace("thread-secret", "[REDACTED]"))
+    exc_type, exc, tb = _caught_exception("thread-secret")
+
+    gateway_run._gateway_threading_excepthook(
+        SimpleNamespace(exc_type=exc_type, exc_value=exc, exc_traceback=tb, thread=SimpleNamespace(name="worker-1"))
+    )
+
+    diagnostic = (tmp_path / "logs" / "gateway-crash-diag.log").read_text()
+    assert "threading:worker-1" in diagnostic
+    assert "[REDACTED]" in diagnostic
+    assert "thread-secret" not in diagnostic
+
+
+def test_install_crash_diagnostic_hooks_is_idempotent(monkeypatch):
+    """Installing twice preserves the gateway hook objects without recursion."""
+    monkeypatch.setattr(gateway_run, "_CRASH_HOOK_INSTALLED", False)
+    monkeypatch.setattr(sys, "excepthook", sys.__excepthook__)
+    original_thread_hook = getattr(threading, "excepthook", None)
+    try:
+        gateway_run._install_crash_diagnostic_hooks()
+        assert sys.excepthook is gateway_run._gateway_excepthook
+        assert threading.excepthook is gateway_run._gateway_threading_excepthook
+        gateway_run._install_crash_diagnostic_hooks()
+        assert sys.excepthook is gateway_run._gateway_excepthook
+    finally:
+        sys.excepthook = sys.__excepthook__
+        if original_thread_hook is not None:
+            threading.excepthook = original_thread_hook


### PR DESCRIPTION
Fixes #52942

## Description
The gateway has been observed dying with zero log output — no traceback, no warning, just a silent stop (the 94% crash-rate signature in #52942). The existing asyncio loop exception handler only catches exceptions that propagate to the event loop. Exceptions raised in plain worker threads (cron subprocess readers, agent session threads, the planned-stop watcher) or ones that escape asyncio.run entirely bypass it, and without sys.excepthook / threading.excepthook they vanish.

This PR installs process-global last-resort crash hooks (sys.excepthook + threading.excepthook) that write the full traceback straight to <hermes_home>/logs/gateway-crash-diag.log, bypassing the logging system (which may itself be wedged/unflushed at crash time). The hooks are idempotent and self-defensive: a failed write can never become its own crash. Install point is in main() (early, for startup crashes) and again in start_gateway (after _hermes_home is authoritative).

## Verification
- ast.parse compile check: PASS
- Secrets grep (S1): clean
- Personal-ref grep (S2): clean
- Conventional commit (C1): PASS (fix: ...)
- Focused diff (F1): only gateway/run.py (+92 lines), no unrelated changes
- Symbol presence verified: _gateway_excepthook, _gateway_threading_excepthook, _install_crash_diagnostic_hooks, _write_crash_diagnostic all defined
