### PR TITLE
feat(gemini): improve request context for support and compatibility

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -32,6 +32,13 @@ from agent.gemini_schema import sanitize_gemini_tool_parameters
 
 logger = logging.getLogger(__name__)
 
+try:
+    import hermes_cli as _hermes_cli
+
+    _HERMES_VERSION = str(_hermes_cli.__version__)
+except Exception:
+    _HERMES_VERSION = "0.0.0"
+
 DEFAULT_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
 
 # Published max output-token ceiling shared by every current Gemini text model
@@ -99,7 +106,10 @@ def probe_gemini_tier(
                 url,
                 params={"key": key},
                 json=payload,
-                headers={"Content-Type": "application/json"},
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Goog-Api-Client": f"hermes-agent/{_HERMES_VERSION}",
+                },
             )
     except Exception as exc:
         logger.debug("probe_gemini_tier: network error: %s", exc)
@@ -901,7 +911,11 @@ class GeminiNativeClient:
             "Content-Type": "application/json",
             "Accept": "application/json",
             "x-goog-api-key": self.api_key,
-            "User-Agent": "hermes-agent (gemini-native)",
+            # Include Hermes client context following Gemini's partner
+            # integration guidance.
+            # See https://ai.google.dev/gemini-api/docs/partner-integration
+            "User-Agent": f"hermes-agent/{_HERMES_VERSION} (gemini-native)",
+            "X-Goog-Api-Client": f"hermes-agent/{_HERMES_VERSION}",
         }
         headers.update(self._default_headers)
         return headers

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3574,6 +3574,8 @@ def probe_api_models(
 
     tried: list[str] = []
     headers: dict[str, str] = {"User-Agent": _HERMES_USER_AGENT}
+    if urllib.parse.urlparse(normalized).hostname == "generativelanguage.googleapis.com":
+        headers["X-Goog-Api-Client"] = f"hermes-agent/{_HERMES_VERSION}"
     if api_key and api_mode == "anthropic_messages":
         headers["x-api-key"] = api_key
         headers["anthropic-version"] = "2023-06-01"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -758,6 +758,7 @@ AUTHOR_MAP = {
     "bzarnitz13@gmail.com": "Beandon13",
     "tony@tonysimons.dev": "asimons81",
     "jetha@google.com": "jethac",
+    "vishal.dharm@gmail.com": "vishal-dharm",
     "jani@0xhoneyjar.xyz": "deep-name",
     # LINE messaging plugin (synthesis PR)
     "32443648+leepoweii@users.noreply.github.com": "leepoweii",

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -461,3 +461,53 @@ def test_explicit_max_tokens_is_respected():
 
     req = build_gemini_request(messages=[{"role": "user", "content": "hi"}], max_tokens=4096)
     assert req["generationConfig"]["maxOutputTokens"] == 4096
+
+
+# ---------------------------------------------------------------------------
+# X-Goog-Api-Client header tests
+# ---------------------------------------------------------------------------
+
+
+def test_x_goog_api_client_header_is_set():
+    """The X-Goog-Api-Client header should be set on inference requests."""
+    from agent.gemini_native_adapter import GeminiNativeClient
+
+    client = GeminiNativeClient(api_key="fake-key", model="gemini-2.0-flash")
+    headers = client._headers()
+
+    assert "X-Goog-Api-Client" in headers, "X-Goog-Api-Client header missing"
+    assert "hermes-agent/" in headers["X-Goog-Api-Client"], (
+        "hermes-agent not found in X-Goog-Api-Client header"
+    )
+
+
+def test_x_goog_api_client_header_format():
+    """Header value should be 'hermes-agent/<version>' matching the package version."""
+    from agent.gemini_native_adapter import GeminiNativeClient, _HERMES_VERSION
+
+    client = GeminiNativeClient(api_key="fake-key", model="gemini-2.0-flash")
+    headers = client._headers()
+
+    expected = f"hermes-agent/{_HERMES_VERSION}"
+    assert headers["X-Goog-Api-Client"] == expected
+
+
+def test_user_agent_contains_version():
+    """User-Agent should include the hermes-agent version."""
+    from agent.gemini_native_adapter import GeminiNativeClient, _HERMES_VERSION
+
+    client = GeminiNativeClient(api_key="fake-key", model="gemini-2.0-flash")
+    headers = client._headers()
+
+    assert f"hermes-agent/{_HERMES_VERSION}" in headers["User-Agent"]
+
+
+def test_hermes_version_is_valid():
+    """_HERMES_VERSION should be a non-empty string."""
+    from agent.gemini_native_adapter import _HERMES_VERSION
+
+    assert isinstance(_HERMES_VERSION, str)
+    assert len(_HERMES_VERSION) > 0
+    assert _HERMES_VERSION != "0.0.0", (
+        "Version should resolve from hermes_cli.__version__, not the fallback"
+    )

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -942,3 +942,33 @@ class TestProbeApiModelsUserAgent:
         assert ua and ua.startswith("hermes-cli/")
         # No Authorization was set, but UA must still be present.
         assert req.get_header("Authorization") is None
+
+    def test_probe_sends_client_context_to_gemini(self):
+        from unittest.mock import patch
+        from hermes_cli.models import _HERMES_VERSION
+
+        body = b'{"data":[]}'
+        with patch(
+            "hermes_cli.models.urllib.request.urlopen",
+            return_value=self._make_mock_response(body),
+        ) as mock_urlopen:
+            probe_api_models(
+                "gemini-key",
+                "https://generativelanguage.googleapis.com/v1beta/openai",
+            )
+
+        req = mock_urlopen.call_args[0][0]
+        assert req.get_header("X-goog-api-client") == f"hermes-agent/{_HERMES_VERSION}"
+
+    def test_probe_omits_gemini_client_context_for_other_providers(self):
+        from unittest.mock import patch
+
+        body = b'{"data":[]}'
+        with patch(
+            "hermes_cli.models.urllib.request.urlopen",
+            return_value=self._make_mock_response(body),
+        ) as mock_urlopen:
+            probe_api_models("provider-key", "https://api.example.com/v1")
+
+        req = mock_urlopen.call_args[0][0]
+        assert req.get_header("X-goog-api-client") is None

--- a/tests/tools/test_tts_gemini.py
+++ b/tests/tools/test_tts_gemini.py
@@ -117,6 +117,7 @@ class TestGenerateGeminiTts:
 
     def test_x_goog_api_client_header_is_set(self, tmp_path, monkeypatch, mock_gemini_response):
         """Gemini TTS requests should include Hermes client context."""
+        from hermes_cli import __version__
         from tools.tts_tool import _generate_gemini_tts
 
         monkeypatch.setenv("GEMINI_API_KEY", "test-key")
@@ -125,8 +126,7 @@ class TestGenerateGeminiTts:
             _generate_gemini_tts("Hi", str(tmp_path / "test.wav"), {})
 
         headers = mock_post.call_args[1]["headers"]
-        assert "X-Goog-Api-Client" in headers
-        assert headers["X-Goog-Api-Client"].startswith("hermes-agent/")
+        assert headers["X-Goog-Api-Client"] == f"hermes-agent/{__version__}"
 
     def test_default_voice_and_model(self, tmp_path, monkeypatch, mock_gemini_response):
         from tools.tts_tool import (
@@ -268,6 +268,22 @@ class TestGenerateGeminiTts:
             _generate_gemini_tts("Hi", str(tmp_path / "test.wav"), {})
 
         assert mock_post.call_args[0][0].startswith("https://custom-gemini.example.com/v1beta/")
+        assert "X-Goog-Api-Client" not in mock_post.call_args[1]["headers"]
+
+    def test_lookalike_base_url_omits_client_context(
+        self, tmp_path, monkeypatch, mock_gemini_response
+    ):
+        from tools.tts_tool import _generate_gemini_tts
+
+        lookalike = "https://generativelanguage.googleapis.com.evil.example/v1beta"
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        monkeypatch.setenv("GEMINI_BASE_URL", lookalike)
+
+        with patch("requests.post", return_value=mock_gemini_response) as mock_post:
+            _generate_gemini_tts("Hi", str(tmp_path / "test.wav"), {})
+
+        assert mock_post.call_args[0][0].startswith(f"{lookalike}/")
+        assert "X-Goog-Api-Client" not in mock_post.call_args[1]["headers"]
 
     def test_persona_prompt_file_appends_labeled_transcript(
         self, tmp_path, monkeypatch, mock_gemini_response

--- a/tests/tools/test_tts_gemini.py
+++ b/tests/tools/test_tts_gemini.py
@@ -115,6 +115,19 @@ class TestGenerateGeminiTts:
         # Audio payload should match the PCM we put in
         assert data[44:] == fake_pcm_bytes
 
+    def test_x_goog_api_client_header_is_set(self, tmp_path, monkeypatch, mock_gemini_response):
+        """Gemini TTS requests should include Hermes client context."""
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+
+        with patch("requests.post", return_value=mock_gemini_response) as mock_post:
+            _generate_gemini_tts("Hi", str(tmp_path / "test.wav"), {})
+
+        headers = mock_post.call_args[1]["headers"]
+        assert "X-Goog-Api-Client" in headers
+        assert headers["X-Goog-Api-Client"].startswith("hermes-agent/")
+
     def test_default_voice_and_model(self, tmp_path, monkeypatch, mock_gemini_response):
         from tools.tts_tool import (
             DEFAULT_GEMINI_TTS_MODEL,

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1732,11 +1732,24 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         },
     }
 
+    try:
+        import hermes_cli as _hermes_cli
+
+        _hermes_version = str(_hermes_cli.__version__)
+    except Exception:
+        _hermes_version = "0.0.0"
+
     endpoint = f"{base_url}/models/{model}:generateContent"
     response = requests.post(
         endpoint,
         params={"key": api_key},
-        headers={"Content-Type": "application/json"},
+        headers={
+            "Content-Type": "application/json",
+            # Include Hermes client context following Gemini's partner
+            # integration guidance:
+            # https://ai.google.dev/gemini-api/docs/partner-integration
+            "X-Goog-Api-Client": f"hermes-agent/{_hermes_version}",
+        },
         json=payload,
         timeout=60,
     )

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -50,7 +50,7 @@ import threading
 import uuid
 from pathlib import Path
 from typing import Callable, Dict, Any, Optional
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_constants import display_hermes_home
@@ -1732,24 +1732,24 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         },
     }
 
-    try:
-        import hermes_cli as _hermes_cli
+    headers = {"Content-Type": "application/json"}
+    if urlparse(base_url).hostname == "generativelanguage.googleapis.com":
+        try:
+            import hermes_cli as _hermes_cli
 
-        _hermes_version = str(_hermes_cli.__version__)
-    except Exception:
-        _hermes_version = "0.0.0"
+            _hermes_version = str(_hermes_cli.__version__)
+        except Exception:
+            _hermes_version = "0.0.0"
+        # Include Hermes client context following Gemini's partner
+        # integration guidance:
+        # https://ai.google.dev/gemini-api/docs/partner-integration
+        headers["X-Goog-Api-Client"] = f"hermes-agent/{_hermes_version}"
 
     endpoint = f"{base_url}/models/{model}:generateContent"
     response = requests.post(
         endpoint,
         params={"key": api_key},
-        headers={
-            "Content-Type": "application/json",
-            # Include Hermes client context following Gemini's partner
-            # integration guidance:
-            # https://ai.google.dev/gemini-api/docs/partner-integration
-            "X-Goog-Api-Client": f"hermes-agent/{_hermes_version}",
-        },
+        headers=headers,
         json=payload,
         timeout=60,
     )


### PR DESCRIPTION
## **Summary**

This change includes the Hermes client name and version with requests sent directly to the Gemini API:

x-goog-api-client: hermes-agent/\<version\>

This additional context can help identify Hermes-specific compatibility issues when users need support with Gemini.

## **What users can expect**

There are no new settings or changes to the way Gemini is configured in Hermes. Existing API keys, models, and request flows continue to work as before.

The header contains only the Hermes client name and version. It does not include prompts, responses, API keys, user or account identifiers, or information about the user's Hermes configuration.

For example:

x-goog-api-client: hermes-agent/0.16.0

## **Changes**

- Include the Hermes client name and version with Gemini inference requests.
- Include the same context with Gemini model and tier checks.
- Apply it consistently to Gemini TTS requests.
- Add coverage for the updated request headers.

## **Why this is useful**

When a Gemini issue depends on the client or version being used, this gives maintainers and the provider enough context to investigate it more effectively. It can make compatibility problems easier to distinguish without requiring users to provide additional setup details.

Gemini partner integration guidance: [https://ai.google.dev/gemini-api/docs/partner-integration](https://ai.google.dev/gemini-api/docs/partner-integration)

## **Related work**

This PR supersedes #48761 and continues the Gemini client-context work from #47385.

## **Type of change**

- [x] New feature (non-breaking change that adds functionality)

## **How to test**

Run the focused request-header coverage:

```bash
scripts/run_tests.sh \
  tests/agent/test_gemini_native_adapter.py \
  tests/hermes_cli/test_model_validation.py \
  tests/tools/test_tts_gemini.py -q
```

The tests verify that:

- Gemini inference, tier checks, model checks, and TTS requests include `x-goog-api-client: hermes-agent/<version>`.
- Model checks for non-Gemini providers do not receive the Gemini-specific header.
- Existing Gemini request construction and TTS behavior continue to work.

## **Validation**

- Focused Gemini and model-validation suites: 138 passed.
- Ruff checks for all changed Python files: passed.
- Windows compatibility scan for the PR diff: passed.
- Full repository suite: all tests covering the changed files passed. The local macOS run completed with 39,995 passed and 21 unrelated failures across nine platform- or environment-sensitive test files.

Tested on macOS 26.3.1 with Python 3.11.15.

## **Checklist**

- [x] Commit message follows Conventional Commits.
- [x] The PR contains only Gemini request-context changes and their tests.
- [x] Tests were added for the updated request headers.
- [x] No configuration keys, tool schemas, or user documentation require updates.
- [x] Cross-platform impact was considered and the Windows compatibility scan passed.
