### PR TITLE
fix: stale update overlay + SSH fast-path fallthrough

### DIFF
--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -80,11 +80,13 @@ export function UpdatesOverlay() {
 
     setUpdateOverlayOpen(next)
 
-    if (
-      !next &&
-      (apply.stage === 'error' || apply.stage === 'restart' || apply.stage === 'manual' || apply.stage === 'guiSkew')
-    ) {
+    if (!next) {
       resetUpdateApplyState()
+      if (isBackend) {
+        $backendUpdateStatus.set(null)
+      } else {
+        $updateStatus.set(null)
+      }
     }
   }
 

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -197,9 +197,14 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     if _is_official_ssh_remote(origin_url):
         head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
         checked = _check_via_rev(head_rev) if head_rev else None
-        if checked == UPDATE_AVAILABLE_NO_COUNT:
-            return 1
-        return checked
+        if checked is not None:
+            if checked == UPDATE_AVAILABLE_NO_COUNT:
+                return 1
+            return checked
+        # HTTPS ls-remote failed (network restrictions, rate-limiting, etc.).
+        # Fall through to the local git-based count below — we already have
+        # origin/main from the last fetch, so we don't need the network
+        # round-trip to answer "are we behind?".
 
     # Installer checkouts are shallow (`git clone --depth 1`). On a shallow
     # clone the history stops at a single commit, so a plain `git fetch` would


### PR DESCRIPTION
## Problem

After `hermes update` completes, the desktop overlay keeps showing "Improvements and fixes" even though `hermes update --check` reports "Already up to date". Two root causes:

### 1. banner.py — SSH fast-path returns None instead of falling through

When the repo uses an SSH remote, `_check_via_local_git()` calls `_check_via_rev()` which uses `git ls-remote https://...`. In network-restricted environments, HTTPS to GitHub fails, returning `None`.

Before: returns `None` immediately, never falls through to local git count.
After: falls through to `rev-list --count HEAD..origin/main` when HTTPS fails.

### 2. updates-overlay.tsx — stale update status on overlay close

The overlay `handleClose` only cleared state on error stages. Normal close left `$updateStatus` / `$backendUpdateStatus` stale — reopening skipped refetch (useEffect guard: `open && !status`).

After: both atoms cleared on ANY close, ensuring fresh fetch on next open.

## Test Plan

- [x] `hermes update --check` correctly reports "Already up to date"
- [x] Desktop overlay no longer shows stale results after close + reopen
- [x] No regression: SSH fast-path works when HTTPS is available
- [x] No regression: overlay shows error/restart/manual stages on failure
