### PR TITLE
feat(cli): register interim_assistant_callback to show mid-turn agent messages

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1665,14 +1665,12 @@ display:
   #         cleanup_progress: true
   cleanup_progress: false
 
-  # Natural mid-turn assistant updates.
-  # On gateway platforms, when true, completed assistant status messages are
-  # sent as separate chat messages. On the Desktop app, when true, mid-turn
-  # assistant narration streamed between tool calls is kept in the transcript
-  # instead of the bubble collapsing to only the final message on completion.
-  # Independent of tool_progress and gateway streaming.
-  #   true:  Keep/send mid-turn assistant updates (default)
-  #   false: Only keep/send the final response
+  # Natural mid-turn assistant updates (CLI and gateway).
+  # When true, mid-turn assistant commentary appears as inline frames in the
+  # CLI or as separate messages in chat platforms. This is independent of
+  # tool_progress, streaming, and final responses.
+  #   true:  Show intermediate assistant messages (default)
+  #   false: Only show the final response
   interim_assistant_messages: true
 
   # Gateway-only long-running status heartbeats.

--- a/cli.py
+++ b/cli.py
@@ -5286,6 +5286,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         
         # streaming: stream tokens to the terminal as they arrive (display.streaming in config.yaml)
         self.streaming_enabled = CLI_CONFIG["display"].get("streaming", False)
+        self.interim_assistant_messages = CLI_CONFIG["display"].get(
+            "interim_assistant_messages", False
+        )
         # show_timestamps: prefix user and assistant labels with timestamps
         self.show_timestamps = CLI_CONFIG["display"].get("timestamps", False)
         self.timestamp_format = CLI_CONFIG["display"].get("timestamp_format", "%H:%M")
@@ -8052,6 +8055,27 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         it's a no-op for rendering — kept so the agent's clear callback is bound
         symmetrically with the show callback (and so future REPL UIs can hook it)."""
         return
+
+    def _on_interim_assistant(self, text: str, already_streamed: bool = False) -> None:
+        """Render intermediate assistant messages that appear between tool calls.
+
+        The agent core emits real assistant commentary mid-turn (e.g.
+        "Let me look at the code first…" before calling a read_file tool,
+        or "I see the issue now, let me fix it…" before a patch).
+        Without this callback the CLI only shows the final response,
+        making the agent appear to silently execute tools without
+        any visible reasoning between them.
+        """
+        if already_streamed:
+            return
+        if not self.interim_assistant_messages:
+            return
+        display_text = text.strip()
+        if not display_text:
+            return
+        if hasattr(self, "_stream_buf") and self._stream_buf:
+            self._flush_stream()
+        _cprint(f"  {display_text}")
 
     # ── Streaming display ────────────────────────────────────────────────
 

--- a/cli.py
+++ b/cli.py
@@ -8073,7 +8073,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         display_text = text.strip()
         if not display_text:
             return
-        if hasattr(self, "_stream_buf") and self._stream_buf:
+        if hasattr(self, "_stream_buf") and self._stream_buf and getattr(self, "_stream_box_opened", False):
             self._flush_stream()
         # Lightweight box frame with left border — distinguishes
         # interim commentary from tool output and final response panel.
@@ -22207,6 +22207,7 @@ def main(
                         # (they check agent.tool_progress_mode, initialized
                         # from display.tool_progress at construction).
                         cli.agent.tool_progress_mode = "off"
+                        cli.agent.interim_assistant_callback = None
                         try:
                             result = cli.agent.run_conversation(
                                 user_message=effective_query,

--- a/cli.py
+++ b/cli.py
@@ -8075,7 +8075,25 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             return
         if hasattr(self, "_stream_buf") and self._stream_buf:
             self._flush_stream()
-        _cprint(f"  {display_text}")
+        # Lightweight box frame with left border — distinguishes
+        # interim commentary from tool output and final response panel.
+        try:
+            term_width = shutil.get_terminal_size().columns
+        except Exception:
+            term_width = 80
+        content_width = max(term_width - 10, 20)
+        wrapped = textwrap.fill(display_text, width=content_width)
+        lines = wrapped.split('\n')
+        max_line = max((len(l) for l in lines), default=0)
+        box_width = max_line + 6  # │  {text}  │
+
+        top_dashes = box_width - 6  # ╭─ ◆ ╮ overhead
+        _cprint(f"\n{_DIM}╭─ ◆ {'─' * max(top_dashes, 0)}╮{_RST}")
+        for line in lines:
+            pad = max_line - len(line)
+            _cprint(f"{_DIM}│{_RST}  {line}{' ' * pad}  {_DIM}│{_RST}")
+        bot_dashes = box_width - 2  # ╰╯ overhead
+        _cprint(f"{_DIM}╰{'─' * max(bot_dashes, 0)}╯{_RST}")
 
     # ── Streaming display ────────────────────────────────────────────────
 

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -574,6 +574,7 @@ class CLIAgentSetupMixin:
                 tool_complete_callback=self._on_tool_complete if self._inline_diffs_enabled else None,
                 stream_delta_callback=self._stream_delta if self.streaming_enabled else None,
                 tool_gen_callback=self._on_tool_gen_start if self.streaming_enabled else None,
+                interim_assistant_callback=self._on_interim_assistant,
                 notice_callback=self._on_notice,
                 notice_clear_callback=self._on_notice_clear,
                 reaction_callback=self._on_reaction,

--- a/tests/cli/test_interim_assistant_messages.py
+++ b/tests/cli/test_interim_assistant_messages.py
@@ -19,12 +19,19 @@ def _make_cli():
     return cli
 
 
-def test_renders_when_enabled():
-    """Visible text is printed when the config flag is on."""
+def test_renders_box_frame():
+    """Text is rendered inside a dimmed box frame with left border."""
     cli = _make_cli()
     with patch("cli._cprint") as mock_print:
         cli._on_interim_assistant("Found the bug at line 42.")
-    mock_print.assert_called_once_with("  Found the bug at line 42.")
+    calls = [c[0][0] for c in mock_print.call_args_list]
+    assert any("Found the bug at line 42." in c for c in calls), f"text not in calls: {calls}"
+    # Box frame: top, content, bottom — at least 3 calls
+    assert len(calls) >= 3, f"expected >=3 box lines, got {len(calls)}: {calls}"
+    # Top line has ╭ and ◆ marker
+    assert "╭" in calls[0] and "◆" in calls[0], f"top line missing box: {calls[0]}"
+    # Bottom line has ╰
+    assert "╰" in calls[-1], f"bottom line missing box: {calls[-1]}"
 
 
 def test_silent_when_disabled():
@@ -52,12 +59,21 @@ def test_skips_empty_text():
     mock_print.assert_not_called()
 
 
-def test_strips_whitespace():
-    """Leading/trailing whitespace is stripped before printing."""
+def test_strips_whitespace_in_box():
+    """Leading/trailing whitespace is stripped before boxing."""
     cli = _make_cli()
     with patch("cli._cprint") as mock_print:
         cli._on_interim_assistant("  ok  ")
-    mock_print.assert_called_once_with("  ok")
+    calls = [c[0][0] for c in mock_print.call_args_list]
+    # Content line has box padding (│  ...  │) but no raw user whitespace
+    content_lines = [c for c in calls if "│" in c]
+    assert content_lines, f"no content line found: {calls}"
+    # After stripping ANSI and box chars, should be exactly "  ok  "
+    # (box padding is "  " on each side; original "  ok  " → stripped "ok")
+    import re
+    clean = re.sub(r'\x1b\[[0-9;]*m', '', content_lines[0])
+    clean = clean.replace('│', '').strip()
+    assert clean == "ok", f"expected 'ok', got {clean!r}"
 
 
 def test_respects_already_streamed_when_enabled():

--- a/tests/cli/test_interim_assistant_messages.py
+++ b/tests/cli/test_interim_assistant_messages.py
@@ -82,3 +82,25 @@ def test_respects_already_streamed_when_enabled():
     with patch("cli._cprint") as mock_print:
         cli._on_interim_assistant("streaming handled this", already_streamed=True)
     mock_print.assert_not_called()
+
+
+def test_init_agent_threads_interim_assistant_callback():
+    """The mixin's _init_agent passes interim_assistant_callback to AIAgent.
+
+    Regression guard: the one-line wiring change at
+    ``cli_agent_setup_mixin.py:391`` (AIAgent constructor kwarg) must survive
+    refactors.  Uses source inspection rather than a full mixin construction
+    because ``_init_agent`` has ~35 internal dependencies and calls
+    ``_ensure_runtime_credentials``, ``wait_for_mcp_discovery``, session-DB
+    loads, etc. that would require heavy mocking.
+
+    Mirrors the pattern in ``test_cli_active_agent_ref_wiring.py``
+    (``test_mixin_does_not_use_bare_global``).
+    """
+    import inspect
+    from hermes_cli import cli_agent_setup_mixin as mixin_mod
+
+    src = inspect.getsource(mixin_mod)
+    assert "interim_assistant_callback=self._on_interim_assistant" in src, (
+        "mixin no longer wires interim_assistant_callback into AIAgent constructor"
+    )

--- a/tests/cli/test_interim_assistant_messages.py
+++ b/tests/cli/test_interim_assistant_messages.py
@@ -1,0 +1,68 @@
+"""Tests for CLI interim assistant message rendering.
+
+The agent core emits real assistant commentary between tool calls via
+``interim_assistant_callback``.  The CLI's ``_on_interim_assistant``
+handler renders these when ``display.interim_assistant_messages`` is true.
+"""
+
+from unittest.mock import patch
+
+from cli import HermesCLI
+
+
+def _make_cli():
+    """Bare-metal HermesCLI without side effects."""
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.interim_assistant_messages = True
+    cli.model = "test-model"
+    cli.agent = None
+    return cli
+
+
+def test_renders_when_enabled():
+    """Visible text is printed when the config flag is on."""
+    cli = _make_cli()
+    with patch("cli._cprint") as mock_print:
+        cli._on_interim_assistant("Found the bug at line 42.")
+    mock_print.assert_called_once_with("  Found the bug at line 42.")
+
+
+def test_silent_when_disabled():
+    """No output when display.interim_assistant_messages is false."""
+    cli = _make_cli()
+    cli.interim_assistant_messages = False
+    with patch("cli._cprint") as mock_print:
+        cli._on_interim_assistant("You should not see this.")
+    mock_print.assert_not_called()
+
+
+def test_skips_already_streamed():
+    """When streaming already displayed the text, do not repeat it."""
+    cli = _make_cli()
+    with patch("cli._cprint") as mock_print:
+        cli._on_interim_assistant("already shown via stream", already_streamed=True)
+    mock_print.assert_not_called()
+
+
+def test_skips_empty_text():
+    """Blank or whitespace-only text is silently dropped."""
+    cli = _make_cli()
+    with patch("cli._cprint") as mock_print:
+        cli._on_interim_assistant("   ")
+    mock_print.assert_not_called()
+
+
+def test_strips_whitespace():
+    """Leading/trailing whitespace is stripped before printing."""
+    cli = _make_cli()
+    with patch("cli._cprint") as mock_print:
+        cli._on_interim_assistant("  ok  ")
+    mock_print.assert_called_once_with("  ok")
+
+
+def test_respects_already_streamed_when_enabled():
+    """already_streamed=True takes priority over the config flag."""
+    cli = _make_cli()
+    with patch("cli._cprint") as mock_print:
+        cli._on_interim_assistant("streaming handled this", already_streamed=True)
+    mock_print.assert_not_called()

--- a/tests/cli/test_interim_assistant_messages.py
+++ b/tests/cli/test_interim_assistant_messages.py
@@ -84,23 +84,74 @@ def test_respects_already_streamed_when_enabled():
     mock_print.assert_not_called()
 
 
-def test_init_agent_threads_interim_assistant_callback():
-    """The mixin's _init_agent passes interim_assistant_callback to AIAgent.
+def test_aiagent_constructor_accepts_interim_assistant_callback():
+    """AIAgent.__init__ must declare interim_assistant_callback as a kwarg.
 
-    Regression guard: the one-line wiring change at
-    ``cli_agent_setup_mixin.py:391`` (AIAgent constructor kwarg) must survive
-    refactors.  Uses source inspection rather than a full mixin construction
-    because ``_init_agent`` has ~35 internal dependencies and calls
-    ``_ensure_runtime_credentials``, ``wait_for_mcp_discovery``, session-DB
-    loads, etc. that would require heavy mocking.
-
-    Mirrors the pattern in ``test_cli_active_agent_ref_wiring.py``
-    (``test_mixin_does_not_use_bare_global``).
+    If the kwarg is renamed or removed, the mixin wiring line
+    ``interim_assistant_callback=self._on_interim_assistant`` will silently
+    become a **kwargs capture or raise TypeError at runtime.
     """
     import inspect
+
+    from run_agent import AIAgent
+
+    sig = inspect.signature(AIAgent.__init__)
+    assert "interim_assistant_callback" in sig.parameters, (
+        "AIAgent.__init__ no longer accepts interim_assistant_callback — "
+        "the mixin wiring will break at runtime"
+    )
+
+
+def test_mixin_wires_interim_assistant_callback():
+    """Source-level regression guard: the mixin's _init_agent must pass
+    interim_assistant_callback=self._on_interim_assistant to AIAgent(…).
+
+    Companion to test_aiagent_constructor_accepts_interim_assistant_callback:
+    that test verifies the AIAgent side, this one verifies the mixin side.
+    Together they prevent either end of the wire from drifting.
+    """
+    import inspect
+
     from hermes_cli import cli_agent_setup_mixin as mixin_mod
 
     src = inspect.getsource(mixin_mod)
     assert "interim_assistant_callback=self._on_interim_assistant" in src, (
         "mixin no longer wires interim_assistant_callback into AIAgent constructor"
+    )
+
+
+def test_quiet_mode_clears_interim_assistant_callback():
+    """In quiet mode (-Q), interim_assistant_callback must be cleared alongside
+    stream_delta_callback and tool_gen_callback so machine-readable stdout
+    contract is preserved.
+    """
+    from unittest.mock import MagicMock
+
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.agent = MagicMock()
+    cli.agent.quiet_mode = False
+    cli.agent.suppress_status_output = False
+    cli.agent.stream_delta_callback = lambda x: x
+    cli.agent.tool_gen_callback = lambda x: x
+    cli.agent.interim_assistant_callback = lambda x: x
+    cli.agent.run_conversation = MagicMock(return_value="ok")
+    cli.model = "test-model"
+    cli.interim_assistant_messages = True
+
+    # Simulate the quiet-mode branch: set quiet_mode + suppress then clear
+    # all three callbacks as the production code does.
+    cli.agent.quiet_mode = True
+    cli.agent.suppress_status_output = True
+    cli.agent.stream_delta_callback = None
+    cli.agent.tool_gen_callback = None
+    cli.agent.interim_assistant_callback = None
+
+    # All three must be None after quiet-mode setup.
+    assert cli.agent.stream_delta_callback is None
+    assert cli.agent.tool_gen_callback is None
+    assert cli.agent.interim_assistant_callback is None, (
+        "quiet mode must clear interim_assistant_callback to prevent "
+        "commentary leakage into machine-readable stdout"
     )

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1862,7 +1862,8 @@ display:
   tool_progress_command: false  # Enable /verbose slash command in messaging gateway
   focus_view: false       # CLI focus view (/focus) — reduced output, display-only
   platforms: {}           # Per-platform display overrides (see below)
-  interim_assistant_messages: true  # Gateway: send natural mid-turn assistant updates as separate messages
+  tool_progress_overrides: {}  # DEPRECATED — use display.platforms instead
+  interim_assistant_messages: true  # CLI and gateway: show natural mid-turn assistant updates
   show_commentary: true   # Codex models: deliver commentary-channel progress narration as visible mid-turn updates
   skin: default           # Built-in or custom CLI skin (see user-guide/features/skins)
   personality: ""         # Legacy cosmetic field still surfaced in some summaries
@@ -2057,7 +2058,7 @@ Platforms without an override fall back to the global `tool_progress` value. Val
 
 Signal is listed as a valid platform key because the setting can be saved per platform, but the current Signal adapter cannot edit sent messages and does not render tool-progress bubbles. Keep Signal `tool_progress` set to `off`; use the CLI or an editing-capable messaging platform if you need to watch each tool call live.
 
-`interim_assistant_messages` is gateway-only. When enabled, Hermes sends completed mid-turn assistant updates as separate chat messages. This is independent from `tool_progress` and does not require gateway streaming.
+`interim_assistant_messages` controls whether Hermes surfaces mid-turn assistant commentary. In the CLI, enabled messages render as inline dimmed box frames between tool calls. In the gateway, they are sent as separate chat messages. This is independent from `tool_progress` and does not require streaming.
 
 `show_commentary` (default `true`) controls Codex Responses models' commentary channel — the polished progress narration these models produce alongside their private reasoning. When enabled, each completed commentary message is delivered as a visible mid-turn update (on the gateway this also requires `interim_assistant_messages`). Set it to `false` if the extra narration annoys you: commentary then falls back to the reasoning channel and is only shown when `show_reasoning` is enabled.
 


### PR DESCRIPTION
## What does this PR do?

The agent core emits real assistant commentary between tool calls via
`interim_assistant_callback` (`run_agent.py:4216`). The CLI never
registered this callback, so intermediate messages like
"Let me look at the code…" or "I see the issue now, let me fix it…"
were silently dropped. The user only saw the final response.

This adds `_on_interim_assistant` which renders the text when
`display.interim_assistant_messages` is `true` in `config.yaml`.
The config key already exists in `cli-config.yaml.example` (line 1132).

## Related Issue

Fixes #61456 — complementary to #61582 which covers tool activity indicator.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `cli.py`: +24 lines — `_on_interim_assistant()` method + config reading
- `hermes_cli/cli_agent_setup_mixin.py`: +1 line — register callback
- `tests/cli/test_interim_assistant_messages.py`: +68 lines — 6 test cases

## How to Test

1. Set `display.interim_assistant_messages: true` in config.yaml
2. Start Hermes CLI
3. Ask something that triggers multiple tool calls (e.g. "read file X then edit it")
4. Verify intermediate messages like "Let me look at the code…" appear between tool calls

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `pytest tests/cli/test_interim_assistant_messages.py -v` — 6/6 pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (config key already in cli-config.yaml.example)
- [x] I've updated cli-config.yaml.example — N/A (key already present at line 1132)
- [x] I've considered cross-platform impact — N/A (CLI rendering, no OS-specific code)