### PR TITLE
fix(security): fail closed when terminal config bridge is unavailable

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3499,7 +3499,29 @@ def apply_terminal_config_to_env(
     file_has_terminal_config = isinstance(raw_terminal_cfg, dict)
     if not file_has_terminal_config:
         raw_terminal_cfg = {}
-    should_override = file_has_terminal_config if override is None else override
+
+    # Managed-scope terminal keys (administrator-pinned config in /etc/hermes)
+    # are authoritative on the same terms as explicit user keys.  Without this,
+    # an admin's ``terminal.backend: docker`` would lose to a stale
+    # ``TERMINAL_ENV=local`` in the process environment and silently downgrade
+    # an isolated backend to host execution — managed_scope §4.1 deliberately
+    # inverts the usual env-over-config precedence for pinned leaves, so the
+    # bridge must honor that inversion too.
+    from hermes_cli import managed_scope
+
+    managed_terminal_keys = {
+        key[len("terminal."):]
+        for key in managed_scope.managed_config_keys()
+        if key.startswith("terminal.")
+    }
+    managed_terminal_keys &= set(TERMINAL_CONFIG_ENV_MAP)
+    has_managed_terminal_config = bool(managed_terminal_keys)
+
+    should_override = (
+        (file_has_terminal_config or has_managed_terminal_config)
+        if override is None
+        else override
+    )
 
     cfg = config if config is not None else load_config_readonly()
     terminal_cfg = cfg.get("terminal", {}) if isinstance(cfg, dict) else {}
@@ -3507,11 +3529,19 @@ def apply_terminal_config_to_env(
         return target
 
     # A caller-supplied config is its own source of explicit keys.  For the
-    # normal merged-config path, only keys present in raw config.yaml may
-    # override existing env values; keys inherited from DEFAULT_CONFIG are
-    # backfill-only.
-    explicit_keys = terminal_cfg.keys() if config is not None else raw_terminal_cfg.keys()
-    backend_is_explicit = config is not None or "backend" in raw_terminal_cfg
+    # normal merged-config path, only keys present in raw config.yaml (user or
+    # managed) may override existing env values; keys inherited from
+    # DEFAULT_CONFIG are backfill-only.
+    explicit_keys = (
+        terminal_cfg.keys()
+        if config is not None
+        else set(raw_terminal_cfg.keys()) | managed_terminal_keys
+    )
+    backend_is_explicit = (
+        config is not None
+        or "backend" in raw_terminal_cfg
+        or "backend" in managed_terminal_keys
+    )
     if backend_is_explicit:
         terminal_backend = str(
             terminal_cfg.get("backend") or target.get("TERMINAL_ENV") or ""

--- a/tests/tools/test_browser_camofox_private_page_guard.py
+++ b/tests/tools/test_browser_camofox_private_page_guard.py
@@ -168,3 +168,139 @@ def test_guard_inactive_does_not_probe(monkeypatch, _session):
 
     assert out["success"] is True
     assert out["element_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Post-redirect SSRF guard on camofox_navigate (P1: redirect chain to
+# private/metadata leaks the auto-snapshot) and camofox_back guard (P2).
+# ---------------------------------------------------------------------------
+
+
+def _mock_navigate_http(monkeypatch, final_url, snapshot_body):
+    """Route navigate through a fake Camofox server that follows a redirect and
+    returns *final_url*, and whose /snapshot returns *snapshot_body*."""
+    monkeypatch.setattr(browser_camofox, "_get_session", lambda task_id: {"tab_id": "tab-1", "user_id": "user-1"})
+    monkeypatch.setattr(browser_camofox, "_ensure_tab", lambda task_id, url: {"tab_id": "tab-1", "user_id": "user-1"})
+
+    nav_calls = []
+
+    def fake_post(path, body=None, timeout=None):
+        if "navigate" in path:
+            nav_calls.append(body)
+            return {"ok": True, "url": final_url, "title": "redirected"}
+        return {"ok": True, "url": final_url}
+
+    monkeypatch.setattr(browser_camofox, "_post", fake_post)
+    monkeypatch.setattr(
+        browser_camofox,
+        "_get",
+        lambda path, params=None: {"snapshot": snapshot_body, "refsCount": 1},
+    )
+    return nav_calls
+
+
+def test_camofox_navigate_blocks_redirect_to_metadata(monkeypatch, _session):
+    """Public URL 302->IMDS: camofox_navigate must fail closed BEFORE the auto-snapshot.
+
+    Regression for the Camofox redirect-chain SSRF leak: browser_navigate routed
+    through camofox_navigate before any post-redirect check, and the auto-snapshot
+    returned the landing page content.
+    """
+    from tools import browser_tool
+
+    monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", lambda task_id: True)
+    nav_calls = _mock_navigate_http(
+        monkeypatch,
+        final_url="http://169.254.169.254/latest/meta-data/",
+        snapshot_body="<pre>arn:aws:iam::123456789012:role/leaked</pre>",
+    )
+
+    out = json.loads(browser_camofox.camofox_navigate("https://example.com/r", task_id="t1"))
+
+    assert out["success"] is False
+    assert "metadata endpoint" in out["error"]
+    assert "snapshot" not in out, "leaked snapshot must not be returned"
+    # The private page must be cleared (about:blank) to prevent later snapshot leaks.
+    assert nav_calls[-1]["url"] == "about:blank"
+
+
+def test_camofox_navigate_blocks_redirect_to_private(monkeypatch, _session):
+    """Public URL 302->RFC1918 with the SSRF guard active: blocked, no snapshot."""
+    from tools import browser_tool
+
+    monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", lambda task_id: True)
+    nav_calls = _mock_navigate_http(
+        monkeypatch,
+        final_url="http://10.0.0.5/admin",
+        snapshot_body="<h1>internal admin</h1>",
+    )
+
+    out = json.loads(browser_camofox.camofox_navigate("https://example.com/r", task_id="t1"))
+
+    assert out["success"] is False
+    assert "private/internal address" in out["error"]
+    assert "snapshot" not in out
+    assert nav_calls[-1]["url"] == "about:blank"
+
+
+def test_camofox_navigate_allows_public_redirect_when_guard_inactive(monkeypatch, _session):
+    """SSRF guard inactive (local terminal): redirect to private is allowed, matching
+    the local browser behavior; the auto-snapshot is returned."""
+    from tools import browser_tool
+
+    monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", lambda task_id: False)
+    _mock_navigate_http(
+        monkeypatch,
+        final_url="http://10.0.0.5/admin",
+        snapshot_body="<h1>internal admin</h1>",
+    )
+
+    out = json.loads(browser_camofox.camofox_navigate("https://example.com/r", task_id="t1"))
+
+    assert out["success"] is True
+    assert out["url"] == "http://10.0.0.5/admin"
+    assert "internal admin" in out["snapshot"]
+
+
+def test_camofox_back_blocks_private_post_back_page(monkeypatch, _session):
+    """camofox_back must apply the private-page guard like every other Camofox
+    content-returning action (snapshot/click/type/press)."""
+    from tools import browser_tool
+
+    monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(
+        browser_tool,
+        "_camofox_current_page_private_url",
+        lambda tab_id, user_id: "http://169.254.169.254/latest/meta-data/",
+    )
+
+    # The back HTTP call itself succeeds (matching browser_back: history nav runs,
+    # then the post-back page is re-checked), and the guard must block the result.
+    monkeypatch.setattr(
+        browser_camofox,
+        "_post",
+        lambda path, body=None, timeout=None: {"ok": True, "url": "http://169.254.169.254/latest/meta-data/"},
+    )
+
+    out = json.loads(browser_camofox.camofox_back(task_id="t1"))
+
+    assert out["success"] is False
+    assert "private or internal address" in out["error"]
+
+
+def test_camofox_back_still_runs_when_page_public(monkeypatch, _session):
+    """Post-back page public: camofox_back returns the URL normally."""
+    from tools import browser_tool
+
+    monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(browser_tool, "_camofox_current_page_private_url", lambda tab_id, user_id: None)
+
+    def fake_post(path, body=None, timeout=None):
+        return {"ok": True, "url": "https://example.com/prev"}
+
+    monkeypatch.setattr(browser_camofox, "_post", fake_post)
+
+    out = json.loads(browser_camofox.camofox_back(task_id="t1"))
+
+    assert out["success"] is True
+    assert out["url"] == "https://example.com/prev"

--- a/tests/tools/test_browser_ssrf_local.py
+++ b/tests/tools/test_browser_ssrf_local.py
@@ -97,6 +97,49 @@ class TestPreNavigationSsrf:
 
         assert result["success"] is True
 
+    # -- Camofox + container terminal: SSRF stays active (#61882 P1) ----------
+
+    def test_camofox_with_docker_terminal_blocks_private_url(
+        self, monkeypatch, _common_patches
+    ):
+        """A host-side Camofox service is NOT local when the terminal runs in
+        a container — SSRF protection must stay enabled so a model-controlled
+        navigation can't reach private/internal services on the host (#61882).
+        """
+        monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: True)
+        monkeypatch.setattr(browser_tool, "_get_cloud_provider", lambda: None)
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setattr(browser_tool, "_allow_private_urls", lambda: False)
+        monkeypatch.setattr(browser_tool, "_is_safe_url", lambda url: False)
+
+        result = json.loads(browser_tool.browser_navigate(self.PRIVATE_URL))
+
+        assert result["success"] is False
+        assert "private or internal address" in result["error"]
+
+    def test_camofox_with_local_terminal_allows_private_url(
+        self, monkeypatch, _common_patches
+    ):
+        """Camofox + local terminal is still a trusted local backend — the
+        Docker gate above must not over-block the pure-local case (#61882).
+        """
+        from tools import browser_camofox
+
+        monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: True)
+        monkeypatch.setattr(browser_tool, "_get_cloud_provider", lambda: None)
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.setattr(browser_tool, "_allow_private_urls", lambda: False)
+        monkeypatch.setattr(browser_tool, "_is_safe_url", lambda url: False)
+        monkeypatch.setattr(
+            browser_camofox,
+            "camofox_navigate",
+            lambda url, task_id: json.dumps(_make_browser_result(url)),
+        )
+
+        result = json.loads(browser_tool.browser_navigate(self.PRIVATE_URL))
+
+        assert result["success"] is True
+
     # -- Always-blocked floor: hybrid routing bypass regression (#16234) -------
 
     # Hybrid-routing feature flips auto_local_this_nav=True for private URLs,
@@ -175,13 +218,19 @@ class TestIsLocalBackend:
         assert browser_tool._is_local_backend() is True
 
 
-    def test_camofox_overrides_container_backend(self, monkeypatch):
-        """Camofox mode always counts as local, even with container terminal."""
+    def test_camofox_with_container_terminal_is_not_local(self, monkeypatch):
+        """Camofox is local ONLY when the terminal is also local.
+
+        A host-side Camofox service combined with a container terminal
+        (terminal.backend: docker) can reach internal networks the terminal
+        sandbox cannot, so it must not be classified as a trusted local
+        backend — otherwise SSRF protection would be skipped (#61882 P1).
+        """
         monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: True)
         monkeypatch.setattr(browser_tool, "_get_cloud_provider", lambda: None)
         monkeypatch.setenv("TERMINAL_ENV", "docker")
 
-        assert browser_tool._is_local_backend() is True
+        assert browser_tool._is_local_backend() is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_docker_cold_start_guard.py
+++ b/tests/tools/test_docker_cold_start_guard.py
@@ -1,0 +1,196 @@
+"""Regression tests for Docker cold-start sandbox escape (#54354).
+
+When ``TERMINAL_ENV`` is not set but ``terminal.backend`` is configured
+in config.yaml, ``_resolve_backend_type()`` must read the backend type
+directly from the config file instead of falling back to ``"local"``.
+
+When the config bridge fails for an isolated backend, ``_get_env_config()``
+must fail closed instead of silently downgrading to host-local execution.
+"""
+
+import sys
+from pathlib import Path
+import pytest
+
+_repo_root = Path(__file__).resolve().parent.parent.parent
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+try:
+    import tools.terminal_tool  # noqa: F401
+    _tt_mod = sys.modules["tools.terminal_tool"]
+except ImportError:
+    pytest.skip("hermes-agent tools not importable (missing deps)", allow_module_level=True)
+
+
+class TestResolveBackendType:
+    """_resolve_backend_type() must not silently downgrade Docker to local."""
+
+    def test_env_var_used_when_no_terminal_config_exists(self, monkeypatch):
+        """When config has no terminal section, TERMINAL_ENV remains usable."""
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", lambda: {})
+        monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: {})
+
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        assert _tt_mod._resolve_backend_type() == "docker"
+
+        monkeypatch.setenv("TERMINAL_ENV", "modal")
+        assert _tt_mod._resolve_backend_type() == "modal"
+
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        assert _tt_mod._resolve_backend_type() == "local"
+
+    def test_env_var_set_to_ssh_without_terminal_config(self, monkeypatch):
+        """Explicit TERMINAL_ENV=ssh must be honoured without terminal config."""
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", lambda: {})
+        monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: {})
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        assert _tt_mod._resolve_backend_type() == "ssh"
+
+    def test_falls_back_to_config_when_env_not_set(self, monkeypatch):
+        """When TERMINAL_ENV is not set, read terminal.backend from config.yaml."""
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+        def _mock_load_config():
+            return {"terminal": {"backend": "docker"}}
+
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", _mock_load_config)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly", _mock_load_config,
+        )
+        assert _tt_mod._resolve_backend_type() == "docker"
+
+    def test_config_backend_overrides_stale_env_var(self, monkeypatch):
+        """When config has terminal.backend, config.yaml is authoritative."""
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        def _mock_load_config():
+            return {"terminal": {"backend": "docker"}}
+
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", _mock_load_config)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly", _mock_load_config,
+        )
+        assert _tt_mod._resolve_backend_type() == "docker"
+
+    def test_falls_back_to_local_when_config_has_no_terminal_section(self, monkeypatch):
+        """When config.yaml has no terminal section, default to local."""
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+        def _mock_load_config():
+            return {}
+
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", _mock_load_config)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly", _mock_load_config,
+        )
+        assert _tt_mod._resolve_backend_type() == "local"
+
+    def test_falls_back_to_local_when_config_terminal_has_no_backend(self, monkeypatch):
+        """When terminal.backend is absent from config, default to local."""
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+        def _mock_load_config():
+            return {"terminal": {"cwd": "/home/user"}}
+
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", _mock_load_config)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly", _mock_load_config,
+        )
+        assert _tt_mod._resolve_backend_type() == "local"
+
+    def test_falls_back_to_local_when_config_load_fails(self, monkeypatch):
+        """When config.yaml is unreadable, default to local (no crash)."""
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+        def _mock_load_config():
+            raise OSError("Permission denied")
+
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", _mock_load_config)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly", _mock_load_config,
+        )
+        # Must not raise — falls back to local
+        assert _tt_mod._resolve_backend_type() == "local"
+
+    def test_docker_backend_flows_through_get_env_config_from_config(self, monkeypatch):
+        """End-to-end: _get_env_config() routes to Docker when config says so."""
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.setenv("TERMINAL_DOCKER_IMAGE", "stale-image")
+
+        cfg = {"terminal": {"backend": "docker", "docker_image": "python:3.12-slim"}}
+
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", lambda: cfg)
+        monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: cfg)
+        config = _tt_mod._get_env_config()
+
+        # Config backend overrides stale TERMINAL_ENV=local.
+        assert config["env_type"] == "docker"
+        # Stale env var is replaced by the config value.
+        assert config["docker_image"] == "python:3.12-slim"
+
+    def test_config_bridge_failure_raises_when_backend_is_docker(self, monkeypatch):
+        """When config bridge fails and config intends Docker, fail closed."""
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.setenv("TERMINAL_DOCKER_IMAGE", "stale-image")
+
+        # Simulate a config bridge failure.
+        monkeypatch.setattr(
+            "hermes_cli.config.apply_terminal_config_to_env",
+            lambda env=None: (_ for _ in ()).throw(RuntimeError("Bridge error")),
+        )
+        # load_config_readonly still returns the intended Docker config
+        # for the fallback check in _get_env_config.
+        cfg = {"terminal": {"backend": "docker"}}
+        monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: cfg)
+
+        with pytest.raises(RuntimeError, match="Refusing to downgrade"):
+            _tt_mod._get_env_config()
+
+    def test_config_bridge_failure_allows_local_when_backend_is_local(self, monkeypatch):
+        """When config bridge fails but config intends local, it is safe to proceed."""
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        monkeypatch.setattr(
+            "hermes_cli.config.apply_terminal_config_to_env",
+            lambda env=None: (_ for _ in ()).throw(RuntimeError("Bridge error")),
+        )
+        cfg = {"terminal": {"backend": "local"}}
+        monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: cfg)
+
+        # Must not raise — local → local is a safe fallback.
+        config = _tt_mod._get_env_config()
+        assert config["env_type"] == "local"
+
+    def test_config_bridge_failure_preserves_explicit_termin_env(self, monkeypatch):
+        """When bridge fails but TERMINAL_ENV=docker was explicitly set, keep it."""
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_DOCKER_IMAGE", "my-image")
+
+        monkeypatch.setattr(
+            "hermes_cli.config.apply_terminal_config_to_env",
+            lambda env=None: (_ for _ in ()).throw(RuntimeError("Bridge error")),
+        )
+        cfg = {"terminal": {"backend": "docker", "docker_image": "cfg-image"}}
+        monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: cfg)
+
+        # TERMINAL_ENV=docker is preserved; TERMINAL_DOCKER_IMAGE is wiped.
+        # config.yaml says docker → RuntimeError.
+        with pytest.raises(RuntimeError, match="Refusing to downgrade"):
+            _tt_mod._get_env_config()
+
+    def test_config_bridge_and_config_read_both_fail(self, monkeypatch):
+        """When both bridge and fallback config read fail, refuse to run."""
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        monkeypatch.setattr(
+            "hermes_cli.config.apply_terminal_config_to_env",
+            lambda env=None: (_ for _ in ()).throw(RuntimeError("Bridge error")),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: (_ for _ in ()).throw(OSError("Config unreadable")),
+        )
+
+        with pytest.raises(RuntimeError, match="config.yaml is unreadable"):
+            _tt_mod._get_env_config()

--- a/tests/tools/test_docker_cold_start_guard.py
+++ b/tests/tools/test_docker_cold_start_guard.py
@@ -248,3 +248,122 @@ class TestResolveBackendType:
 
         with pytest.raises(RuntimeError, match="config.yaml is unreadable"):
             _tt_mod._get_env_config()
+
+
+class TestProbeConfigUnreadableShapes:
+    """_probe_config_unreadable() must reject empty / non-mapping / invalid configs."""
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "",                       # empty document
+            "# comment only\n",        # comment-only document
+            "[]\n",                   # list root
+            "- a\n- b\n",             # list root with items
+            "just a string\n",        # scalar root
+            "42\n",                   # numeric scalar root
+        ],
+    )
+    def test_present_but_invalid_shape_is_unreadable(self, monkeypatch, tmp_path, raw):
+        """A present config that is empty/list/scalar cannot carry a backend."""
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(raw, encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        assert _tt_mod._probe_config_unreadable() is True
+
+    def test_non_mapping_terminal_section_is_unreadable(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("terminal: [docker]\n", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        assert _tt_mod._probe_config_unreadable() is True
+
+    def test_invalid_backend_value_is_unreadable(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "terminal:\n  backend: kubernetes\n", encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        assert _tt_mod._probe_config_unreadable() is True
+
+    def test_valid_terminal_section_is_readable(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "terminal:\n  backend: docker\n", encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        assert _tt_mod._probe_config_unreadable() is False
+
+    def test_terminal_section_without_backend_is_readable(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "terminal:\n  cwd: /home/user\n", encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        assert _tt_mod._probe_config_unreadable() is False
+
+    def test_absent_config_is_readable(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        assert _tt_mod._probe_config_unreadable() is False
+
+
+class TestResolveTerminalBackend:
+    """resolve_terminal_backend() must honor config on cold start and fail closed."""
+
+    def test_cold_start_docker_config_resolves_docker(self, monkeypatch):
+        """config.yaml terminal.backend: docker + stale TERMINAL_ENV=local."""
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        def _mock_load_config():
+            return {"terminal": {"backend": "docker"}}
+
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", _mock_load_config)
+        monkeypatch.setattr("hermes_cli.config.load_config_readonly", _mock_load_config)
+
+        assert _tt_mod.resolve_terminal_backend() == "docker"
+
+    def test_bridge_failure_returns_unknown_sentinel(self, monkeypatch):
+        """On an untrusted snapshot, return non-local sentinel (fail closed)."""
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.setattr(
+            "hermes_cli.config.apply_terminal_config_to_env",
+            lambda env=None: (_ for _ in ()).throw(RuntimeError("Bridge error")),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"terminal": {"backend": "docker"}},
+        )
+
+        assert _tt_mod.resolve_terminal_backend() == "unknown"
+
+    def test_image_source_host_reads_fail_closed_on_cold_start_docker(self, monkeypatch):
+        """image_source must deny host reads when config selects docker on cold start."""
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        def _mock_load_config():
+            return {"terminal": {"backend": "docker"}}
+
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", _mock_load_config)
+        monkeypatch.setattr("hermes_cli.config.load_config_readonly", _mock_load_config)
+
+        from tools.image_source import _is_local_terminal_backend
+
+        assert _is_local_terminal_backend() is False

--- a/tests/tools/test_docker_cold_start_guard.py
+++ b/tests/tools/test_docker_cold_start_guard.py
@@ -183,14 +183,68 @@ class TestResolveBackendType:
         """When both bridge and fallback config read fail, refuse to run."""
         monkeypatch.setenv("TERMINAL_ENV", "local")
 
+        # Simulate the config file being present but unparseable — the path
+        # that matches real production behavior (load_config_readonly absorbs
+        # parse errors via last-known-good fallback instead of raising).
+        monkeypatch.setattr(
+            _tt_mod,
+            "_probe_config_unreadable",
+            lambda: True,
+        )
         monkeypatch.setattr(
             "hermes_cli.config.apply_terminal_config_to_env",
             lambda env=None: (_ for _ in ()).throw(RuntimeError("Bridge error")),
         )
-        monkeypatch.setattr(
-            "hermes_cli.config.load_config_readonly",
-            lambda: (_ for _ in ()).throw(OSError("Config unreadable")),
+
+        with pytest.raises(RuntimeError, match="config.yaml is unreadable"):
+            _tt_mod._get_env_config()
+
+    def test_malformed_config_with_stale_local_env_fails_closed(
+        self, monkeypatch, tmp_path,
+    ):
+        """Regression: malformed YAML + stale TERMINAL_ENV=local must refuse.
+
+        When config.yaml exists but cannot be parsed (e.g. mid-edit broken
+        YAML) and TERMINAL_ENV=local, the bridge silently absorbs the parse
+        error via the last-known-good fallback.  Without the
+        _probe_config_unreadable guard this would downgrade a potentially
+        isolated backend to local execution.  Assert it fails closed.
+        """
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        config_file = hermes_home / "config.yaml"
+        config_file.write_text(
+            "terminal:\n  backend: docker\n  docker_image: python:3.12\n"
+            "  !!invalid yaml syntax here ~~~",
+            encoding="utf-8",
         )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        # Production functions now see the malformed config.yaml at HERMES_HOME.
+        # _probe_config_unreadable must detect it; _get_env_config must fail.
+        assert _tt_mod._probe_config_unreadable() is True
+
+        with pytest.raises(RuntimeError, match="config.yaml is unreadable"):
+            _tt_mod._get_env_config()
+
+    def test_malformed_config_absent_stale_docker_env_fails_closed(
+        self, monkeypatch, tmp_path,
+    ):
+        """Malformed config + explicit TERMINAL_ENV=docker: wipe stale vars, fail."""
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        config_file = hermes_home / "config.yaml"
+        config_file.write_text(
+            "terminal:\n  backend: docker\n  docker_image: python:3.12\n"
+            "  -- broken yaml : [",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_DOCKER_IMAGE", "stale-image")
+
+        assert _tt_mod._probe_config_unreadable() is True
 
         with pytest.raises(RuntimeError, match="config.yaml is unreadable"):
             _tt_mod._get_env_config()

--- a/tests/tools/test_docker_cold_start_guard.py
+++ b/tests/tools/test_docker_cold_start_guard.py
@@ -47,6 +47,45 @@ class TestResolveBackendType:
         monkeypatch.setenv("TERMINAL_ENV", "ssh")
         assert _tt_mod._resolve_backend_type() == "ssh"
 
+    def test_normalizes_case_and_whitespace(self, monkeypatch):
+        """Backend values must be normalized (strip + lowercase) like the validator.
+
+        Regression (CodeRabbit #61882): _probe_config_unreadable() accepts
+        terminal.backend: Docker / " docker", but _resolve_backend_type()
+        returned the value verbatim, so case-sensitive consumers (env_probe's
+        ``in _REMOTE_BACKENDS``, credential_files, _get_env_config's
+        ``in _CONTAINER_BACKENDS``) took host-local branches for a config that
+        requested an isolated backend.
+        """
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+        def _mock_load_config():
+            return {"terminal": {"backend": "Docker"}}
+
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", _mock_load_config)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly", _mock_load_config,
+        )
+        assert _tt_mod._resolve_backend_type() == "docker"
+
+        # Whitespace variant too.
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.read_raw_config",
+            lambda: {"terminal": {"backend": " docker "}},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"terminal": {"backend": " docker "}},
+        )
+        assert _tt_mod._resolve_backend_type() == "docker"
+
+        # Environment value is normalized the same way.
+        monkeypatch.setenv("TERMINAL_ENV", "  Modal ")
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", lambda: {})
+        monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: {})
+        assert _tt_mod._resolve_backend_type() == "modal"
+
     def test_falls_back_to_config_when_env_not_set(self, monkeypatch):
         """When TERMINAL_ENV is not set, read terminal.backend from config.yaml."""
         monkeypatch.delenv("TERMINAL_ENV", raising=False)
@@ -129,8 +168,20 @@ class TestResolveBackendType:
         # Stale env var is replaced by the config value.
         assert config["docker_image"] == "python:3.12-slim"
 
-    def test_config_bridge_failure_raises_when_backend_is_docker(self, monkeypatch):
+    def _isolate_hermes_home(self, monkeypatch, tmp_path):
+        """Point HERMES_HOME at an empty temp dir so _probe_config_unreadable()
+        can never read an inherited/ambient config.yaml and divert the test onto
+        the unreadable-config path (CodeRabbit #61882)."""
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("HERMES_MANAGED_DIR", raising=False)
+
+    def test_config_bridge_failure_raises_when_backend_is_docker(
+        self, monkeypatch, tmp_path,
+    ):
         """When config bridge fails and config intends Docker, fail closed."""
+        self._isolate_hermes_home(monkeypatch, tmp_path)
         monkeypatch.setenv("TERMINAL_ENV", "local")
         monkeypatch.setenv("TERMINAL_DOCKER_IMAGE", "stale-image")
 
@@ -147,8 +198,11 @@ class TestResolveBackendType:
         with pytest.raises(RuntimeError, match="Refusing to downgrade"):
             _tt_mod._get_env_config()
 
-    def test_config_bridge_failure_allows_local_when_backend_is_local(self, monkeypatch):
+    def test_config_bridge_failure_allows_local_when_backend_is_local(
+        self, monkeypatch, tmp_path,
+    ):
         """When config bridge fails but config intends local, it is safe to proceed."""
+        self._isolate_hermes_home(monkeypatch, tmp_path)
         monkeypatch.setenv("TERMINAL_ENV", "local")
 
         monkeypatch.setattr(
@@ -162,8 +216,11 @@ class TestResolveBackendType:
         config = _tt_mod._get_env_config()
         assert config["env_type"] == "local"
 
-    def test_config_bridge_failure_preserves_explicit_termin_env(self, monkeypatch):
+    def test_config_bridge_failure_preserves_explicit_termin_env(
+        self, monkeypatch, tmp_path,
+    ):
         """When bridge fails but TERMINAL_ENV=docker was explicitly set, keep it."""
+        self._isolate_hermes_home(monkeypatch, tmp_path)
         monkeypatch.setenv("TERMINAL_ENV", "docker")
         monkeypatch.setenv("TERMINAL_DOCKER_IMAGE", "my-image")
 
@@ -317,6 +374,67 @@ class TestProbeConfigUnreadableShapes:
         assert _tt_mod._probe_config_unreadable() is False
 
     def test_absent_config_is_readable(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        assert _tt_mod._probe_config_unreadable() is False
+
+
+class TestProbeManagedConfigUnreadable:
+    """_probe_config_unreadable() must also fail closed on a malformed MANAGED config.
+
+    Regression: ``managed_scope.load_managed_config()`` is fail-open (returns {} on a
+    parse error), so an admin-pinned ``terminal.backend: docker`` silently vanished
+    and a stale ``TERMINAL_ENV=local`` downgraded an isolated backend to host
+    execution — the managed-config counterpart of the user-config probe.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _managed(self, monkeypatch, tmp_path):
+        self._managed_dir = tmp_path / "managed"
+        self._managed_dir.mkdir()
+        monkeypatch.setenv("HERMES_MANAGED_DIR", str(self._managed_dir))
+        from hermes_cli import managed_scope
+
+        managed_scope.invalidate_managed_cache()
+        yield
+        monkeypatch.delenv("HERMES_MANAGED_DIR", raising=False)
+        managed_scope.invalidate_managed_cache()
+
+    def test_malformed_managed_config_is_unreadable(self, monkeypatch, tmp_path):
+        """A present-but-unparseable managed config.yaml must fail closed."""
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        (self._managed_dir / "config.yaml").write_text(
+            "terminal:\n  backend: docker\n  broken [[[ yaml", encoding="utf-8",
+        )
+
+        assert _tt_mod._probe_config_unreadable() is True
+        with pytest.raises(RuntimeError, match="config.yaml is unreadable"):
+            _tt_mod._get_env_config()
+
+    def test_managed_config_pins_docker_over_stale_local(self, monkeypatch, tmp_path):
+        """A clean managed terminal.backend: docker must override stale TERMINAL_ENV."""
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        (self._managed_dir / "config.yaml").write_text(
+            "terminal:\n  backend: docker\n  docker_image: python:3.12\n",
+            encoding="utf-8",
+        )
+
+        assert _tt_mod._probe_config_unreadable() is False
+        cfg = _tt_mod._get_env_config()
+        assert cfg["env_type"] == "docker"
+        assert cfg["docker_image"] == "python:3.12"
+
+    def test_absent_managed_config_stays_readable(self, monkeypatch, tmp_path):
+        """No managed file at all (or no managed scope) is the normal benign case."""
         hermes_home = tmp_path / "hermes_home"
         hermes_home.mkdir()
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))

--- a/tests/tools/test_docker_session_isolation.py
+++ b/tests/tools/test_docker_session_isolation.py
@@ -44,8 +44,6 @@ def _clean_state(monkeypatch):
     with terminal_tool._session_cwd_lock:
         before_cwd = dict(terminal_tool._session_cwd)
         terminal_tool._session_cwd.clear()
-    # The config→env bridge is one-shot; mark it done so tests control env vars.
-    monkeypatch.setattr(terminal_tool, "_terminal_config_bridge_attempted", True)
     yield
     terminal_tool._task_env_overrides.clear()
     terminal_tool._task_env_overrides.update(before_overrides)

--- a/tests/tools/test_env_probe.py
+++ b/tests/tools/test_env_probe.py
@@ -317,3 +317,15 @@ class TestRunBoundedByTimeout:
         assert elapsed < 3.0, f"_run blocked on grandchild for {elapsed:.1f}s"
         assert rc == 0, f"expected clean exit, got rc={rc} err={err!r}"
         assert out == "ok"
+
+
+class TestUnknownBackendSkipsHostProbe:
+    """When the backend is unconfirmed ("unknown" — config bridge failed),
+    the host-Python probe must not report host state as the agent's terminal."""
+
+    def test_unknown_returns_empty(self, monkeypatch):
+        import tools.terminal_tool as terminal_tool
+
+        monkeypatch.setattr(terminal_tool, "resolve_terminal_backend", lambda: "unknown")
+        monkeypatch.setattr(env_probe, "_python_version_of", lambda b: None)
+        assert env_probe.get_environment_probe_line() == ""

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -1000,3 +1000,33 @@ class TestNotFoundCache:
         assert _check_not_found_cache("read", "/tmp/never-exists-notify", tid) is None, (
             "notify_other_tool_call must clear cached misses"
         )
+
+
+class TestUnknownBackendFailsClosed:
+    """When the terminal backend cannot be confirmed (config bridge failed),
+    path resolution must fail closed to sandbox-relative handling rather than
+    dereferencing host paths for a possibly-isolated backend."""
+
+    def test_uses_container_paths_true_for_unknown(self, monkeypatch):
+        import tools.file_tools as file_tools
+
+        monkeypatch.setattr(
+            file_tools, "_terminal_env_type_for_task", lambda task_id="default": "unknown"
+        )
+        assert file_tools._uses_container_paths() is True
+
+    def test_uses_container_paths_false_for_local(self, monkeypatch):
+        import tools.file_tools as file_tools
+
+        monkeypatch.setattr(
+            file_tools, "_terminal_env_type_for_task", lambda task_id="default": "local"
+        )
+        assert file_tools._uses_container_paths() is False
+
+    def test_uses_container_paths_true_for_docker(self, monkeypatch):
+        import tools.file_tools as file_tools
+
+        monkeypatch.setattr(
+            file_tools, "_terminal_env_type_for_task", lambda task_id="default": "docker"
+        )
+        assert file_tools._uses_container_paths() is True

--- a/tests/tools/test_terminal_degraded_mode.py
+++ b/tests/tools/test_terminal_degraded_mode.py
@@ -27,9 +27,8 @@ def isolated_env(tmp_path, monkeypatch):
     import tools.terminal_tool as tt
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
-    # The one-shot config bridge would overwrite our TERMINAL_* test vars
-    # from the developer's real config.yaml; mark it as already attempted.
-    monkeypatch.setattr(tt, "_terminal_config_bridge_attempted", True)
+    # Isolated HERMES_HOME means no config.yaml exists, so the snapshot
+    # bridge cannot overwrite our TERMINAL_* test vars.
 
     def _clear():
         with tt._env_lock:

--- a/tests/tools/test_terminal_env_bridge.py
+++ b/tests/tools/test_terminal_env_bridge.py
@@ -1,9 +1,10 @@
-"""Behavioral regressions for the terminal config → env bridge.
+"""Behavioral regressions for the terminal config → env snapshot.
 
-``terminal_tool._get_env_config()`` reads TERMINAL_* variables.  The bridge
-must let explicitly configured terminal keys override stale launcher/.env
-values while preserving environment values for terminal keys omitted from
-config.yaml.
+``terminal_tool._get_env_config()`` reads TERMINAL_* variables through a
+bridged snapshot (``_terminal_env_snapshot()``) rather than process-global
+env.  Explicit terminal keys in config.yaml override stale launcher/.env
+values; environment values for keys omitted from config.yaml are preserved;
+process-global env is never mutated.
 """
 
 import os
@@ -15,9 +16,8 @@ from hermes_constants import get_hermes_home
 
 
 @pytest.fixture(autouse=True)
-def _reset_bridge_state(monkeypatch):
-    """Each test starts with an un-attempted bridge and clean mapped env."""
-    monkeypatch.setattr(terminal_tool, "_terminal_config_bridge_attempted", False)
+def _clean_env(monkeypatch):
+    """Each test starts with clean TERMINAL_* env."""
     for name in (
         "TERMINAL_ENV",
         "TERMINAL_CWD",
@@ -45,7 +45,8 @@ def test_unset_terminal_env_backfills_backend_from_config():
 
     assert config["env_type"] == "docker"
     assert config["docker_image"] == "custom/image:1"
-    assert os.environ["TERMINAL_ENV"] == "docker"
+    # Snapshot semantics: process-global env is not mutated.
+    assert "TERMINAL_ENV" not in os.environ
 
 
 def test_explicit_config_backend_overrides_stale_env(monkeypatch):
@@ -55,7 +56,7 @@ def test_explicit_config_backend_overrides_stale_env(monkeypatch):
     config = terminal_tool._get_env_config()
 
     assert config["env_type"] == "docker"
-    assert os.environ["TERMINAL_ENV"] == "docker"
+    assert os.environ["TERMINAL_ENV"] == "local"
 
 
 def test_partial_terminal_config_preserves_unrelated_env_values(monkeypatch):
@@ -93,8 +94,9 @@ def test_ssh_config_preserves_remote_tilde_cwd(monkeypatch):
 
     config = terminal_tool._get_env_config()
 
-    assert os.environ["TERMINAL_CWD"] == "~"
+    assert config["env_type"] == "ssh"
     assert config["cwd"] == "~"
+    assert "TERMINAL_CWD" not in os.environ
 
 
 def test_env_is_preserved_when_config_has_no_terminal_section(monkeypatch):
@@ -114,10 +116,16 @@ def test_defaults_backfill_when_neither_config_nor_env_selects_backend():
     config = terminal_tool._get_env_config()
 
     assert config["env_type"] == "local"
-    assert os.environ["TERMINAL_ENV"] == "local"
+    assert "TERMINAL_ENV" not in os.environ
 
 
-def test_bridge_only_attempted_once(monkeypatch):
+def test_snapshot_is_fresh_per_call(monkeypatch):
+    """Each ``_get_env_config()`` bridges a fresh snapshot; no global state.
+
+    The old process-global ``_ensure_terminal_env_bridged()`` ran at most once;
+    the snapshot design has no such optimization, so repeated calls stay
+    consistent without carrying state between them.
+    """
     calls = []
 
     import hermes_cli.config as config_mod
@@ -131,10 +139,11 @@ def test_bridge_only_attempted_once(monkeypatch):
     monkeypatch.setattr(config_mod, "apply_terminal_config_to_env", _counting)
     _write_config("{}\n")
 
-    terminal_tool._get_env_config()
-    terminal_tool._get_env_config()
+    first = terminal_tool._get_env_config()
+    second = terminal_tool._get_env_config()
 
-    assert len(calls) == 1
+    assert len(calls) == 2
+    assert first == second
 
 
 def test_bridge_config_failure_does_not_crash(monkeypatch):
@@ -150,5 +159,45 @@ def test_bridge_config_failure_does_not_crash(monkeypatch):
 
     config = terminal_tool._get_env_config()
 
+    # Fail-closed: TERMINAL_ENV (the backend selection) survives the bridge
+    # failure, but the remaining TERMINAL_* settings are stripped so stale
+    # values are never trusted.
     assert config["env_type"] == "ssh"
-    assert config["ssh_host"] == "example.test"
+    assert config["ssh_host"] == ""
+
+
+def test_worker_timeout_override_survives_bridge(monkeypatch):
+    """Explicit worker-scoped overrides beat config defaults.
+
+    Subprocess callers (e.g. kanban ``_default_spawn``) set
+    ``TERMINAL_TIMEOUT``/``TERMINAL_LIFETIME_SECONDS`` deliberately; the
+    snapshot must restore them after the bridge applies config defaults.
+    """
+    _write_config(
+        "terminal:\n"
+        "  backend: docker\n"
+        "  timeout: 180\n"
+        "  lifetime_seconds: 300\n"
+    )
+    monkeypatch.setenv("TERMINAL_TIMEOUT", "600")
+    monkeypatch.setenv("TERMINAL_LIFETIME_SECONDS", "900")
+
+    config = terminal_tool._get_env_config()
+
+    assert config["env_type"] == "docker"
+    assert config["timeout"] == 600
+    assert config["lifetime_seconds"] == 900
+
+
+def test_bridge_applies_config_default_when_no_worker_override(monkeypatch):
+    """Without an explicit worker override, config defaults apply."""
+    _write_config(
+        "terminal:\n"
+        "  backend: docker\n"
+        "  timeout: 240\n"
+    )
+    monkeypatch.delenv("TERMINAL_TIMEOUT", raising=False)
+
+    config = terminal_tool._get_env_config()
+
+    assert config["timeout"] == 240

--- a/tests/tools/test_terminal_env_bridge.py
+++ b/tests/tools/test_terminal_env_bridge.py
@@ -18,13 +18,9 @@ from hermes_constants import get_hermes_home
 @pytest.fixture(autouse=True)
 def _clean_env(monkeypatch):
     """Each test starts with clean TERMINAL_* env."""
-    for name in (
-        "TERMINAL_ENV",
-        "TERMINAL_CWD",
-        "TERMINAL_DOCKER_IMAGE",
-        "TERMINAL_SSH_HOST",
-    ):
-        monkeypatch.delenv(name, raising=False)
+    for name in tuple(os.environ):
+        if name.startswith("TERMINAL_"):
+            monkeypatch.delenv(name, raising=False)
     yield
 
 
@@ -187,6 +183,41 @@ def test_worker_timeout_override_survives_bridge(monkeypatch):
     assert config["env_type"] == "docker"
     assert config["timeout"] == 600
     assert config["lifetime_seconds"] == 900
+
+
+def test_managed_timeout_pin_beats_stale_process_env(monkeypatch, tmp_path):
+    """An administrator-pinned managed ``terminal.timeout`` must win over a stale
+    process-env ``TERMINAL_TIMEOUT``.
+
+    Regression: ``_terminal_env_snapshot()`` restored the worker-scoped
+    timeout/lifetime values from the process env unconditionally, clobbering a
+    managed-scope pin — the same precedence inversion the PR fixes for the
+    backend key.  A managed pin is administrator-forced (managed_scope §4.1), so
+    it must override even an explicitly-set env value.
+    """
+    managed_dir = tmp_path / "managed"
+    managed_dir.mkdir()
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_dir))
+    from hermes_cli import managed_scope
+
+    managed_scope.invalidate_managed_cache()
+    (managed_dir / "config.yaml").write_text(
+        "terminal:\n"
+        "  backend: docker\n"
+        "  timeout: 600\n"
+        "  lifetime_seconds: 900\n"
+    )
+    monkeypatch.setenv("TERMINAL_ENV", "local")       # stale, must lose
+    monkeypatch.setenv("TERMINAL_TIMEOUT", "180")     # stale, must lose
+    monkeypatch.setenv("TERMINAL_LIFETIME_SECONDS", "300")
+
+    config = terminal_tool._get_env_config()
+
+    assert config["env_type"] == "docker"
+    assert config["timeout"] == 600
+    assert config["lifetime_seconds"] == 900
+    managed_scope.invalidate_managed_cache()
+    monkeypatch.delenv("HERMES_MANAGED_DIR", raising=False)
 
 
 def test_bridge_applies_config_default_when_no_worker_override(monkeypatch):

--- a/tests/tools/test_terminal_env_bridge.py
+++ b/tests/tools/test_terminal_env_bridge.py
@@ -201,3 +201,63 @@ def test_bridge_applies_config_default_when_no_worker_override(monkeypatch):
     config = terminal_tool._get_env_config()
 
     assert config["timeout"] == 240
+
+
+# ---------------------------------------------------------------------------
+# Managed-scope backend precedence (#61882 P1)
+# ---------------------------------------------------------------------------
+
+
+def _write_managed_config(tmp_path, body):
+    """Create a managed-scope config.yaml and point HERMES_MANAGED_DIR at it."""
+    md = tmp_path / "managed"
+    md.mkdir()
+    (md / "config.yaml").write_text(body, encoding="utf-8")
+    import hermes_cli.managed_scope as managed_scope
+
+    managed_scope.invalidate_managed_cache()
+    return md
+
+
+def test_managed_backend_overrides_stale_env(monkeypatch, tmp_path):
+    """Admin-pinned terminal.backend beats a stale TERMINAL_ENV=local.
+
+    Managed-scope config is merged into the effective config by
+    ``load_config_readonly()``, but ``apply_terminal_config_to_env()`` only
+    treated user config.yaml keys as explicit — so a managed
+    ``terminal.backend: docker`` lost to a stale ``TERMINAL_ENV=local`` and
+    silently downgraded an isolated backend to host execution (#61882 P1).
+    """
+    md = _write_managed_config(tmp_path, "terminal:\n  backend: docker\n")
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(md))
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+
+    config = terminal_tool._get_env_config()
+
+    assert config["env_type"] == "docker"
+    # Process-global env is never mutated by the bridge.
+    assert os.environ["TERMINAL_ENV"] == "local"
+
+
+def test_managed_backend_resolves_docker_for_sibling_readers(monkeypatch, tmp_path):
+    """``resolve_terminal_backend()`` must report docker (not local) for a
+    managed docker backend, so sibling host-read/SSRF gates fail closed
+    rather than trusting the host-side browser/media helpers (#61882 P1).
+    """
+    md = _write_managed_config(tmp_path, "terminal:\n  backend: docker\n")
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(md))
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+
+    assert terminal_tool.resolve_terminal_backend() == "docker"
+
+
+def test_managed_backend_without_stale_env_still_wins(monkeypatch, tmp_path):
+    """A managed docker backend applies even with no launcher TERMINAL_ENV at
+    all (cold start) — the managed value is authoritative, not just a tiebreak.
+    """
+    md = _write_managed_config(tmp_path, "terminal:\n  backend: docker\n")
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(md))
+
+    config = terminal_tool._get_env_config()
+
+    assert config["env_type"] == "docker"

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -493,6 +493,32 @@ def _delete(path: str, body: dict = None, timeout: Optional[int] = None) -> dict
 # Tool implementations
 # ---------------------------------------------------------------------------
 
+def _navigate_redirect_block_reason(final_url: str, task_id: Optional[str]) -> Optional[str]:
+    """Return ``"metadata"`` / ``"private"`` when a navigated final URL must be blocked.
+
+    Mirrors the post-redirect SSRF logic in ``browser_tool.browser_navigate`` for
+    the Camofox path: the always-blocked cloud-metadata floor fires for every
+    backend, and the ordinary private-address check fires only when the SSRF
+    guard is active (non-local terminal backend, not a local sidecar,
+    ``allow_private_urls`` unset).  ``final_url`` is the URL the Camofox server
+    reports after following redirects.  Returns ``None`` when navigation may
+    proceed.  Imports are deferred to call time to avoid a circular import.
+    """
+    if not final_url:
+        return None
+    from tools.browser_tool import (
+        _eval_ssrf_guard_active,
+        _is_always_blocked_url,
+        _is_safe_url,
+    )
+
+    if _is_always_blocked_url(final_url):
+        return "metadata"
+    if _eval_ssrf_guard_active(task_id or "default") and not _is_safe_url(final_url):
+        return "private"
+    return None
+
+
 def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
     """Navigate to a URL via Camofox."""
     try:
@@ -535,6 +561,35 @@ def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
                 f"{rewrite_info['from']} -> {rewrite_info['to']}"
             )
         vnc = get_vnc_url()
+
+        # Post-redirect SSRF check — mirror browser_tool.browser_navigate.
+        # The Camofox browser runs on the host side, so a server-side redirect
+        # from a public URL can land on a private/internal/metadata address the
+        # terminal sandbox cannot reach.  The pre-nav check only saw the initial
+        # URL, so re-check the final URL the navigate returned BEFORE returning
+        # the auto-snapshot (which would otherwise leak the private content).
+        # The always-blocked floor (cloud metadata / IMDS) is unconditional;
+        # the private-address check applies only when the SSRF guard is active
+        # (non-local terminal backend, not a local sidecar, allow_private_urls
+        # unset), matching the non-Camofox path.
+        blocked_reason = _navigate_redirect_block_reason(result["url"], task_id)
+        if blocked_reason:
+            try:
+                _post(
+                    f"/tabs/{session['tab_id']}/navigate",
+                    {"userId": session["user_id"], "url": "about:blank"},
+                    timeout=10,
+                )
+            except Exception:
+                pass  # Best-effort: clearing the private page prevents snapshot leaks.
+            return json.dumps({
+                "success": False,
+                "error": (
+                    "Blocked: redirect landed on a cloud metadata endpoint"
+                    if blocked_reason == "metadata"
+                    else "Blocked: redirect landed on a private/internal address"
+                ),
+            }, ensure_ascii=False)
         if vnc:
             result["vnc_url"] = vnc
             result["vnc_hint"] = (
@@ -745,6 +800,13 @@ def camofox_back(task_id: Optional[str] = None) -> str:
             f"/tabs/{session['tab_id']}/back",
             {"userId": session["user_id"]},
         )
+        # Browser history can land on a private/internal/cloud-metadata address
+        # the pre-nav check never saw — re-check the post-back page, matching
+        # browser_tool.browser_back and every other content-returning entry
+        # point (snapshot/click/type/press all call _camofox_private_page_block).
+        blocked = _camofox_private_page_block(session, task_id, "go back")
+        if blocked:
+            return blocked
         return json.dumps({"success": True, "url": data.get("url", "")})
     except Exception as e:
         return tool_error(str(e), success=False)

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -977,8 +977,12 @@ def _is_local_backend() -> bool:
     if _get_cloud_provider() is not None:
         return False
     # When terminal runs in a container, browser on host can access
-    # internal networks the terminal can't → treat as non-local.
-    terminal_backend = os.getenv("TERMINAL_ENV", "local").strip().lower()
+    # internal networks the terminal can't → treat as non-local. Resolve
+    # through terminal_tool's bridged snapshot so a config.yaml
+    # terminal.backend: docker is honored on cold start; an uncertain
+    # backend fails closed (non-local) rather than skipping the SSRF gate.
+    from tools.terminal_tool import resolve_terminal_backend
+    terminal_backend = resolve_terminal_backend()
     return terminal_backend in ("local", "")
 
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -972,17 +972,23 @@ def _is_local_backend() -> bool:
     # non-local; keep the two helpers in agreement.
     if _get_cdp_override_raw():
         return False
+    # Resolve the terminal backend BEFORE the Camofox shortcut below.  Camofox
+    # runs as a host-side sidecar service, so it is only a trusted "local"
+    # backend when the terminal also runs locally.  With the terminal in a
+    # container (docker, modal, daytona, ssh, singularity), the host-side
+    # Camofox service can reach internal networks the terminal sandbox cannot,
+    # so SSRF protection must stay enabled for Camofox too.  Resolve through
+    # terminal_tool's bridged snapshot so a config.yaml terminal.backend:
+    # docker is honored on cold start; an uncertain backend fails closed
+    # (non-local) rather than skipping the SSRF gate.
+    from tools.terminal_tool import resolve_terminal_backend
+    terminal_backend = resolve_terminal_backend()
     if _is_camofox_mode():
-        return True
+        return terminal_backend in ("local", "")
     if _get_cloud_provider() is not None:
         return False
     # When terminal runs in a container, browser on host can access
-    # internal networks the terminal can't → treat as non-local. Resolve
-    # through terminal_tool's bridged snapshot so a config.yaml
-    # terminal.backend: docker is honored on cold start; an uncertain
-    # backend fails closed (non-local) rather than skipping the SSRF gate.
-    from tools.terminal_tool import resolve_terminal_backend
-    terminal_backend = resolve_terminal_backend()
+    # internal networks the terminal can't → treat as non-local.
     return terminal_backend in ("local", "")
 
 

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -505,7 +505,8 @@ def from_agent_visible_cache_path(
     auto-mounted cache directory — the caller then treats a still-container
     path as "no host file" and falls back to an in-container read.
     """
-    if os.environ.get("TERMINAL_ENV", "local") != "docker":
+    from tools.terminal_tool import resolve_terminal_backend
+    if resolve_terminal_backend() != "docker":
         return container_path
 
     path = Path(container_path)
@@ -546,7 +547,8 @@ def to_agent_visible_cache_path(
     Backend is identified by TERMINAL_ENV (same env var
     tools/terminal_tool.py reads in _get_environment_config).
     """
-    backend = (os.environ.get("TERMINAL_ENV") or "local").strip().lower()
+    from tools.terminal_tool import resolve_terminal_backend
+    backend = resolve_terminal_backend()
     if backend in ("docker", "modal"):
         pass  # /root/.hermes default
     elif backend in ("ssh", "daytona", "vercel_sandbox"):

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -544,8 +544,9 @@ def to_agent_visible_cache_path(
       the host path is directly readable and translation would dangle
       (cache dirs are not remapped into that sandbox).
 
-    Backend is identified by TERMINAL_ENV (same env var
-    tools/terminal_tool.py reads in _get_environment_config).
+    Backend is resolved through ``resolve_terminal_backend()`` — the bridged
+    config snapshot from ``tools/terminal_tool.py`` (config.yaml
+    ``terminal.backend`` wins over any process-level ``TERMINAL_ENV``).
     """
     from tools.terminal_tool import resolve_terminal_backend
     backend = resolve_terminal_backend()

--- a/tools/env_probe.py
+++ b/tools/env_probe.py
@@ -194,7 +194,8 @@ def _build_probe_line() -> str:
     """
     # Bail out if a remote terminal backend is configured; the host's
     # Python state isn't where the agent's tools run.
-    backend = (os.getenv("TERMINAL_ENV") or "local").strip().lower()
+    from tools.terminal_tool import resolve_terminal_backend
+    backend = resolve_terminal_backend()
     if backend in _REMOTE_BACKENDS:
         return ""
 

--- a/tools/env_probe.py
+++ b/tools/env_probe.py
@@ -196,7 +196,7 @@ def _build_probe_line() -> str:
     # Python state isn't where the agent's tools run.
     from tools.terminal_tool import resolve_terminal_backend
     backend = resolve_terminal_backend()
-    if backend in _REMOTE_BACKENDS:
+    if backend in _REMOTE_BACKENDS or backend == "unknown":
         return ""
 
     py3_ver = _python_version_of("python3")

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -203,9 +203,13 @@ def _terminal_env_type_for_task(task_id: str = "default") -> str:
             if "daytona" in name:
                 return "daytona"
         cfg = _get_env_config()
-        return str(cfg.get("env_type") or os.getenv("TERMINAL_ENV") or "local").lower()
+        return str(cfg.get("env_type") or "local").lower()
     except Exception:
-        return str(os.getenv("TERMINAL_ENV") or "local").lower()
+        try:
+            from tools.terminal_tool import resolve_terminal_backend
+            return resolve_terminal_backend()
+        except Exception:
+            return "unknown"
 
 
 def _uses_container_paths(task_id: str = "default") -> bool:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -218,7 +218,13 @@ def _uses_container_paths(task_id: str = "default") -> bool:
         container_backends = _CONTAINER_BACKENDS
     except Exception:
         container_backends = _CONTAINER_PATH_BACKENDS_FALLBACK
-    return _terminal_env_type_for_task(task_id) in container_backends
+    env_type = _terminal_env_type_for_task(task_id)
+    # Fail closed: when the backend cannot be confirmed ("unknown" sentinel,
+    # e.g. config bridge failed), treat paths as container/sandbox-relative so
+    # file tools never dereference host paths for a possibly-isolated backend.
+    if env_type == "unknown":
+        return True
+    return env_type in container_backends
 
 
 def _normalize_without_host_deref(path: str | Path | PurePosixPath) -> PurePosixPath:

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -1091,7 +1091,8 @@ def _agent_cache_base_for_env(env: Any) -> str | None:
     # Hermes cache roots can be translated without side effects. SSH can still
     # use a shell-visible tilde path; its first environment sync will upload
     # the cache file before the first command runs.
-    backend = (os.getenv("TERMINAL_ENV") or "local").strip().lower()
+    from tools.terminal_tool import resolve_terminal_backend
+    backend = resolve_terminal_backend()
     if backend in {"docker", "singularity", "modal"}:
         return "/root/.hermes"
     if backend == "ssh":
@@ -1863,7 +1864,8 @@ def _confine_source_images(
 
     Returns ``(image_url, reference_image_urls, error_json_or_None)``.
     """
-    backend = (os.getenv("TERMINAL_ENV") or "local").strip().lower()
+    from tools.terminal_tool import resolve_terminal_backend
+    backend = resolve_terminal_backend()
     if backend in ("", "local"):
         return image_url, reference_image_urls, None
 

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -213,9 +213,12 @@ def _is_local_terminal_backend() -> bool:
     """True when the terminal backend runs directly on the host.
 
     Mirrors ``tools.browser_tool._is_local_backend`` and terminal_tool's own
-    dispatch, which key off ``TERMINAL_ENV``.
+    dispatch.  Resolves through terminal_tool's bridged config snapshot so a
+    config.yaml ``terminal.backend: docker`` is honored on cold start; an
+    uncertain backend fails closed (non-local).
     """
-    return os.getenv("TERMINAL_ENV", "local").strip().lower() in ("local", "")
+    from tools.terminal_tool import resolve_terminal_backend
+    return resolve_terminal_backend() in ("local", "")
 
 
 def _media_cache_roots() -> list:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -492,7 +492,8 @@ def _is_gateway_surface() -> bool:
 
 
 def _get_terminal_backend_name() -> str:
-    return str(os.getenv("TERMINAL_ENV", "local")).strip().lower() or "local"
+    from tools.terminal_tool import resolve_terminal_backend
+    return resolve_terminal_backend()
 
 
 def _is_env_var_persisted(

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1533,7 +1533,10 @@ def _terminal_env_snapshot() -> Dict[str, str]:
     stripped and a ``_config_bridge_failed`` sentinel is set so callers can
     fail closed instead of silently downgrading an isolated backend to local.
     """
-    env = dict(os.environ)
+    # Save original process-env values so explicit worker overrides
+    # (e.g. kanban subprocess TERMINAL_TIMEOUT) survive the bridge.
+    orig = os.environ
+    env = dict(orig)
 
     try:
         from hermes_cli.config import apply_terminal_config_to_env
@@ -1546,6 +1549,14 @@ def _terminal_env_snapshot() -> Dict[str, str]:
             if key.startswith("TERMINAL_") and key != "TERMINAL_ENV":
                 env.pop(key, None)
         env["_config_bridge_failed"] = "1"
+        return env
+
+    # Restore explicit worker overrides for timeout/lifetime so that
+    # subprocess callers (e.g. kanban _default_spawn) that intentionally
+    # set a longer value are not clobbered by config defaults.
+    for key in ("TERMINAL_TIMEOUT", "TERMINAL_LIFETIME_SECONDS"):
+        if key in orig:
+            env[key] = orig[key]
 
     return env
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1532,11 +1532,25 @@ def _terminal_env_snapshot() -> Dict[str, str]:
     When the bridge fails, stale TERMINAL_* values (except TERMINAL_ENV) are
     stripped and a ``_config_bridge_failed`` sentinel is set so callers can
     fail closed instead of silently downgrading an isolated backend to local.
+
+    Also probes raw config readability before bridging to detect a present-but-
+    unparseable config.yaml that ``apply_terminal_config_to_env()`` may silently
+    absorb via its last-known-good fallback.  When the config file exists but
+    cannot be parsed, ``_config_unreadable`` is set alongside
+    ``_config_bridge_failed`` so ``_get_env_config()`` can fail closed.
     """
     # Save original process-env values so explicit worker overrides
     # (e.g. kanban subprocess TERMINAL_TIMEOUT) survive the bridge.
     orig = os.environ
     env = dict(orig)
+
+    # Probe raw config readability before bridging.  ``apply_terminal_config_to_env()``
+    # calls ``read_raw_config()`` and ``load_config_readonly()``, both of which handle
+    # parse errors gracefully (return ``{}`` / fall back to last-known-good) instead of
+    # raising.  A malformed config + stale ``TERMINAL_ENV=local`` would therefore
+    # silently downgrade an isolated backend to host execution.  Detect that case here
+    # so the sentinel is set regardless of whether the bridge raises.
+    config_unreadable = _probe_config_unreadable()
 
     try:
         from hermes_cli.config import apply_terminal_config_to_env
@@ -1549,6 +1563,20 @@ def _terminal_env_snapshot() -> Dict[str, str]:
             if key.startswith("TERMINAL_") and key != "TERMINAL_ENV":
                 env.pop(key, None)
         env["_config_bridge_failed"] = "1"
+        if config_unreadable:
+            env["_config_unreadable"] = "1"
+        return env
+
+    # The bridge succeeded (returned normally), but if the underlying config is
+    # unreadable the bridge silently fell back to last-known-good or defaults —
+    # the TERMINAL_* values in ``env`` are not trustworthy.  Wipe them and flag
+    # the failure so ``_get_env_config()`` can fail closed.
+    if config_unreadable:
+        for key in list(env.keys()):
+            if key.startswith("TERMINAL_") and key != "TERMINAL_ENV":
+                env.pop(key, None)
+        env["_config_bridge_failed"] = "1"
+        env["_config_unreadable"] = "1"
         return env
 
     # Restore explicit worker overrides for timeout/lifetime so that
@@ -1559,6 +1587,27 @@ def _terminal_env_snapshot() -> Dict[str, str]:
             env[key] = orig[key]
 
     return env
+
+
+def _probe_config_unreadable() -> bool:
+    """Return True when config.yaml *exists* but cannot be parsed.
+
+    ``read_raw_config()`` returns ``{}`` for both "file absent" and "parse
+    failure".  This helper distinguishes the two: a present-but-malformed
+    config is a security risk (it may carry ``terminal.backend: docker``),
+    while an absent config is safe (just use env vars).
+    """
+    try:
+        from hermes_cli.config import get_config_path, fast_safe_load
+        config_path = get_config_path()
+        config_path.stat()
+        with open(config_path, encoding="utf-8") as f:
+            fast_safe_load(f)
+        return False
+    except FileNotFoundError:
+        return False
+    except Exception:
+        return True
 
 
 def _resolve_backend_type(env: Optional[Dict[str, str]] = None) -> str:
@@ -1581,6 +1630,17 @@ def _get_env_config() -> Dict[str, Any]:
         # The config bridge failed — stale TERMINAL_* values were wiped.
         # Check whether config.yaml intends an isolated backend; if so, fail
         # closed instead of silently downgrading to host-local execution.
+        #
+        # When ``_config_unreadable`` is set, config.yaml exists but cannot be
+        # parsed — so we cannot confirm the intended backend at all.  Fail closed
+        # immediately; do NOT fall through to ``load_config_readonly()`` (which
+        # would silently return last-known-good/defaults and bypass the guard).
+        if terminal_env.get("_config_unreadable"):
+            raise RuntimeError(
+                "Terminal config bridge failed and config.yaml is unreadable. "
+                "Refusing to run terminal without confirmed backend. "
+                "Check hermes CLI config connectivity."
+            )
         config_readable = True
         try:
             from hermes_cli.config import load_config_readonly

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1327,10 +1327,9 @@ def _docker_session_isolation_enabled() -> bool:
     ``container_persistent: true`` the documented ONE-long-lived-container
     contract is unchanged.
     """
-    _ensure_terminal_env_bridged()
-    if os.getenv("TERMINAL_ENV", "local") != "docker":
+    if _resolve_backend_type() != "docker":
         return False
-    return os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() not in {"true", "1", "yes"}
+    return _terminal_env_snapshot().get("TERMINAL_CONTAINER_PERSISTENT", "true").lower() not in {"true", "1", "yes"}
 
 
 _ISOLATION_OVERRIDE_KEYS = frozenset({
@@ -1515,68 +1514,77 @@ def _is_unusable_container_cwd(cwd: str) -> bool:
     return False
 
 
-# One-shot guard for the config-fallback bridge below.  Purely an
-# optimization: after the first attempt either TERMINAL_ENV is set (bridge
-# succeeded — merged config always carries terminal.backend) or the import
-# failed and retrying every call would be wasted work.
-_terminal_config_bridge_attempted = False
+def _terminal_env_snapshot() -> Dict[str, str]:
+    """Return terminal env values with config.yaml bridged in.
 
+    ``apply_terminal_config_to_env()`` is normally called by launch paths
+    before terminal tools run.  A cold-start tool call can arrive before that
+    bridge has completed, so build a local snapshot here as the final guard.
+    Does not mutate process-global env.
 
-def _ensure_terminal_env_bridged() -> None:
-    """Backfill TERMINAL_* env vars from config.yaml when no launcher did.
-
-    terminal_tool reads ALL terminal settings from os.environ (TERMINAL_*).
-    The CLI (cli.py ``env_mappings``), the gateway (gateway/run.py
-    ``_terminal_env_map``), and TUI/dashboard PTY launches
-    (``apply_terminal_config_to_env``) bridge ``terminal.*`` config into env
-    vars at startup — but processes that skip all of those paths (``hermes
-    serve`` / the Desktop app backend's in-process agents, the desktop cron
-    ticker, ACP) used to silently fall back to the local backend even when
-    config.yaml selects ``terminal.backend: docker``, running commands on the
-    host the user intended to sandbox (#63141, #54449, #61115, #65696).
-
-    Explicit terminal config keys win: when config.yaml has a ``terminal``
-    section, each key present there overrides its matching env value (which may
-    be stale from ``hermes setup``). Environment values for omitted terminal
-    keys are preserved. When no terminal section exists, exported/.env values
-    keep working unchanged.
+    When the bridge fails, stale TERMINAL_* values (except TERMINAL_ENV) are
+    stripped and a ``_config_bridge_failed`` sentinel is set so callers can
+    fail closed instead of silently downgrading an isolated backend to local.
     """
-    global _terminal_config_bridge_attempted
-    if _terminal_config_bridge_attempted:
-        return
-    _terminal_config_bridge_attempted = True
+    env = dict(os.environ)
+
     try:
-        from hermes_cli.config import apply_terminal_config_to_env, read_raw_config
-
-        # If config.yaml has an explicit terminal section, bridge with
-        # override enabled. The helper only overrides env vars for keys present
-        # in that raw section; merged defaults remain backfill-only. Without a
-        # terminal section, preserve an existing TERMINAL_ENV selection or
-        # backfill defaults when no selection exists.
-        raw_config = read_raw_config()
-        has_terminal_section = isinstance(raw_config.get("terminal"), dict)
-
-        if has_terminal_section:
-            # Explicit terminal keys in config.yaml win over matching env values.
-            apply_terminal_config_to_env(env=None, override=True)
-        elif "TERMINAL_ENV" not in os.environ:
-            # No terminal section in config.yaml, TERMINAL_ENV not set —
-            # backfill from config defaults
-            apply_terminal_config_to_env(env=None, override=False)
+        from hermes_cli.config import apply_terminal_config_to_env
+        apply_terminal_config_to_env(env=env)
     except Exception:
-        # Never let a config problem take the terminal tool down — the
-        # historical local default still applies.
-        logger.debug("terminal config → env fallback bridge failed", exc_info=True)
+        logger.debug(
+            "Could not bridge terminal config into env snapshot", exc_info=True,
+        )
+        for key in list(env.keys()):
+            if key.startswith("TERMINAL_") and key != "TERMINAL_ENV":
+                env.pop(key, None)
+        env["_config_bridge_failed"] = "1"
+
+    return env
+
+
+def _resolve_backend_type(env: Optional[Dict[str, str]] = None) -> str:
+    """Return the terminal backend type after bridging config.yaml."""
+    source = _terminal_env_snapshot() if env is None else env
+    env_val = source.get("TERMINAL_ENV")
+    if env_val:
+        return env_val
+    return "local"
 
 
 def _get_env_config() -> Dict[str, Any]:
     """Get terminal environment configuration from environment variables."""
     # Default image with Python and Node.js for maximum compatibility
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
-    _ensure_terminal_env_bridged()
-    env_type = os.getenv("TERMINAL_ENV", "local")
-    
-    mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
+    terminal_env = _terminal_env_snapshot()
+    env_type = _resolve_backend_type(terminal_env)
+
+    if terminal_env.get("_config_bridge_failed"):
+        # The config bridge failed — stale TERMINAL_* values were wiped.
+        # Check whether config.yaml intends an isolated backend; if so, fail
+        # closed instead of silently downgrading to host-local execution.
+        config_readable = True
+        try:
+            from hermes_cli.config import load_config_readonly
+            cfg = load_config_readonly()
+            intended = cfg.get("terminal", {}).get("backend", "local")
+        except Exception:
+            config_readable = False
+            intended = "local"
+        if not config_readable:
+            raise RuntimeError(
+                "Terminal config bridge failed and config.yaml is unreadable. "
+                "Refusing to run terminal without confirmed backend. "
+                "Check hermes CLI config connectivity."
+            )
+        if intended != "local":
+            raise RuntimeError(
+                f"Terminal config bridge failed. Refusing to downgrade "
+                f"terminal.backend={intended} to local execution. "
+                f"Check hermes CLI config connectivity."
+            )
+
+    mount_docker_cwd = terminal_env.get("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
     container_backend = env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}
     docker_backend = env_type == "docker"
 
@@ -1622,13 +1630,13 @@ def _get_env_config() -> Dict[str, Any]:
     # If Docker cwd passthrough is explicitly enabled, remap the host path to
     # /workspace and track the original host path separately. Otherwise keep the
     # normal sandbox behavior and discard host paths.
-    cwd = os.getenv("TERMINAL_CWD", default_cwd)
+    cwd = terminal_env.get("TERMINAL_CWD", default_cwd)
     from hermes_cli.config import _is_ssh_remote_tilde_cwd
     if cwd and not _is_ssh_remote_tilde_cwd(env_type, cwd):
         cwd = os.path.expanduser(cwd)
     host_cwd = None
     if env_type == "docker" and mount_docker_cwd:
-        docker_cwd_source = os.getenv("TERMINAL_CWD") or _safe_getcwd()
+        docker_cwd_source = terminal_env.get("TERMINAL_CWD") or _safe_getcwd()
         candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
         if (
             any(candidate.startswith(p) for p in _HOST_CWD_PREFIXES)
@@ -1646,41 +1654,41 @@ def _get_env_config() -> Dict[str, Any]:
 
     return {
         "env_type": env_type,
-        "modal_mode": coerce_modal_mode(os.getenv("TERMINAL_MODAL_MODE", "auto")),
-        "docker_image": os.getenv("TERMINAL_DOCKER_IMAGE", default_image),
+        "modal_mode": coerce_modal_mode(terminal_env.get("TERMINAL_MODAL_MODE", "auto")),
+        "docker_image": terminal_env.get("TERMINAL_DOCKER_IMAGE", default_image),
         "docker_forward_env": docker_forward_env,
-        "singularity_image": os.getenv("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
-        "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", default_image),
-        "daytona_image": os.getenv("TERMINAL_DAYTONA_IMAGE", default_image),
-        "vercel_runtime": os.getenv("TERMINAL_VERCEL_RUNTIME", "").strip(),
+        "singularity_image": terminal_env.get("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
+        "modal_image": terminal_env.get("TERMINAL_MODAL_IMAGE", default_image),
+        "daytona_image": terminal_env.get("TERMINAL_DAYTONA_IMAGE", default_image),
+        "vercel_runtime": terminal_env.get("TERMINAL_VERCEL_RUNTIME", "").strip(),
         "cwd": cwd,
         "host_cwd": host_cwd,
         "docker_mount_cwd_to_workspace": mount_docker_cwd,
         "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180"),
         "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300"),
         # SSH-specific config
-        "ssh_host": os.getenv("TERMINAL_SSH_HOST", ""),
-        "ssh_user": os.getenv("TERMINAL_SSH_USER", ""),
+        "ssh_host": terminal_env.get("TERMINAL_SSH_HOST", ""),
+        "ssh_user": terminal_env.get("TERMINAL_SSH_USER", ""),
         "ssh_port": _parse_env_var("TERMINAL_SSH_PORT", "22"),
-        "ssh_key": os.getenv("TERMINAL_SSH_KEY", ""),
+        "ssh_key": terminal_env.get("TERMINAL_SSH_KEY", ""),
         # Persistent shell: SSH defaults to the config-level persistent_shell
         # setting (true by default for non-local backends); local is always opt-in.
         # Per-backend env vars override if explicitly set.
-        "ssh_persistent": os.getenv(
+        "ssh_persistent": terminal_env.get(
             "TERMINAL_SSH_PERSISTENT",
-            os.getenv("TERMINAL_PERSISTENT_SHELL", "true"),
+            terminal_env.get("TERMINAL_PERSISTENT_SHELL", "true"),
         ).lower() in {"true", "1", "yes"},
-        "local_persistent": os.getenv("TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
+        "local_persistent": terminal_env.get("TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
         # Container resource config (applies to docker, singularity, modal,
         # daytona, and vercel_sandbox -- ignored for local/ssh)
         "container_cpu": container_cpu,
         "container_memory": container_memory,     # MB (default 5GB)
         "container_disk": container_disk,        # MB (default 50GB)
-        "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
+        "container_persistent": terminal_env.get("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
         "docker_volumes": docker_volumes,
         "docker_env": docker_env,
-        "docker_run_as_host_user": os.getenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
-        "docker_network": os.getenv("TERMINAL_DOCKER_NETWORK", "true").lower() in {"true", "1", "yes"},
+        "docker_run_as_host_user": terminal_env.get("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
+        "docker_network": terminal_env.get("TERMINAL_DOCKER_NETWORK", "true").lower() in {"true", "1", "yes"},
         "docker_extra_args": docker_extra_args,
         "docker_shm_size": docker_shm_size,
         # Cross-process container reuse (issue #20561).  The docs claim
@@ -1689,14 +1697,14 @@ def _get_env_config() -> Dict[str, Any]:
         # attaching to it instead of always starting a fresh one.  Set to
         # ``false`` for hard per-process isolation (no reuse, container is
         # removed on exit).
-        "docker_persist_across_processes": os.getenv(
+        "docker_persist_across_processes": terminal_env.get(
             "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES", "true"
         ).lower() in {"true", "1", "yes"},
         # Startup orphan reaper for hermes-tagged containers left behind by
         # crashed / SIGKILL'd previous processes that bypassed atexit.
         # Conservative: only sweeps Exited containers older than 2× the
         # idle-reap window AND scoped to the current profile. Issue #20561.
-        "docker_orphan_reaper": os.getenv(
+        "docker_orphan_reaper": terminal_env.get(
             "TERMINAL_DOCKER_ORPHAN_REAPER", "true"
         ).lower() in {"true", "1", "yes"},
     }

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1454,13 +1454,20 @@ def _resolve_task_host_cwd(config: Dict[str, Any], task_id: Optional[str]) -> Op
 
 # Configuration from environment variables
 
-def _parse_env_var(name: str, default: str, converter: Any = int, type_label: str = "integer"):
+def _parse_env_var(
+    name: str,
+    default: str,
+    converter: Any = int,
+    type_label: str = "integer",
+    env: Optional[Dict[str, str]] = None,
+):
     """Parse an environment variable with *converter*, raising a clear error on bad values.
 
     Without this wrapper, a single malformed env var (e.g. TERMINAL_TIMEOUT=5m)
     causes an unhandled ValueError that kills every terminal command.
     """
-    raw = os.getenv(name, default)
+    source = os.environ if env is None else env
+    raw = source.get(name, default)
     try:
         return converter(raw)
     except (ValueError, json.JSONDecodeError):
@@ -1593,20 +1600,20 @@ def _get_env_config() -> Dict[str, Any]:
     # until a backend that can consume them is selected; a stale or invalid
     # Docker value should not make local terminal/execute_code unusable.
     if container_backend:
-        container_cpu = _parse_env_var("TERMINAL_CONTAINER_CPU", "1", float, "number")
-        container_memory = _parse_env_var("TERMINAL_CONTAINER_MEMORY", "5120")
-        container_disk = _parse_env_var("TERMINAL_CONTAINER_DISK", "51200")
+        container_cpu = _parse_env_var("TERMINAL_CONTAINER_CPU", "1", float, "number", env=terminal_env)
+        container_memory = _parse_env_var("TERMINAL_CONTAINER_MEMORY", "5120", env=terminal_env)
+        container_disk = _parse_env_var("TERMINAL_CONTAINER_DISK", "51200", env=terminal_env)
     else:
         container_cpu = 1.0
         container_memory = 5120
         container_disk = 51200
 
     if docker_backend:
-        docker_forward_env = _parse_env_var("TERMINAL_DOCKER_FORWARD_ENV", "[]", json.loads, "valid JSON")
-        docker_volumes = _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON")
-        docker_env = _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON")
-        docker_extra_args = _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON")
-        docker_shm_size = os.getenv("TERMINAL_DOCKER_SHM_SIZE", "1g")
+        docker_forward_env = _parse_env_var("TERMINAL_DOCKER_FORWARD_ENV", "[]", json.loads, "valid JSON", env=terminal_env)
+        docker_volumes = _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON", env=terminal_env)
+        docker_env = _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON", env=terminal_env)
+        docker_extra_args = _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON", env=terminal_env)
+        docker_shm_size = terminal_env.get("TERMINAL_DOCKER_SHM_SIZE", "1g")
     else:
         docker_forward_env = []
         docker_volumes = []
@@ -1664,12 +1671,12 @@ def _get_env_config() -> Dict[str, Any]:
         "cwd": cwd,
         "host_cwd": host_cwd,
         "docker_mount_cwd_to_workspace": mount_docker_cwd,
-        "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180"),
-        "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300"),
+        "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180", env=terminal_env),
+        "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300", env=terminal_env),
         # SSH-specific config
         "ssh_host": terminal_env.get("TERMINAL_SSH_HOST", ""),
         "ssh_user": terminal_env.get("TERMINAL_SSH_USER", ""),
-        "ssh_port": _parse_env_var("TERMINAL_SSH_PORT", "22"),
+        "ssh_port": _parse_env_var("TERMINAL_SSH_PORT", "22", env=terminal_env),
         "ssh_key": terminal_env.get("TERMINAL_SSH_KEY", ""),
         # Persistent shell: SSH defaults to the config-level persistent_shell
         # setting (true by default for non-local backends); local is always opt-in.

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -791,7 +791,11 @@ def _sudo_nopasswd_works() -> bool:
     cache) so an expired sudo timestamp cannot make a later command silently
     block waiting for a password.
     """
-    terminal_env = os.getenv("TERMINAL_ENV", "local").strip().lower() or "local"
+    # Resolve through the bridged config snapshot, not process-global env, so a
+    # config.yaml terminal.backend: docker on cold start does not probe the
+    # host's sudo state.  "unknown" (untrusted snapshot) is treated as
+    # non-local and fails closed (no sudo probe).
+    terminal_env = resolve_terminal_backend()
     if terminal_env != "local":
         return False
 
@@ -1327,9 +1331,10 @@ def _docker_session_isolation_enabled() -> bool:
     ``container_persistent: true`` the documented ONE-long-lived-container
     contract is unchanged.
     """
-    if _resolve_backend_type() != "docker":
+    snapshot = _terminal_env_snapshot()
+    if _resolve_backend_type(snapshot) != "docker":
         return False
-    return _terminal_env_snapshot().get("TERMINAL_CONTAINER_PERSISTENT", "true").lower() not in {"true", "1", "yes"}
+    return snapshot.get("TERMINAL_CONTAINER_PERSISTENT", "true").lower() not in {"true", "1", "yes"}
 
 
 _ISOLATION_OVERRIDE_KEYS = frozenset({
@@ -1548,6 +1553,13 @@ def _terminal_env_snapshot() -> Dict[str, str]:
     orig = os.environ
     env = dict(orig)
 
+    # Control sentinels must come from this function only, never from the
+    # inherited process environment: a pre-existing _config_bridge_failed /
+    # _config_unreadable variable would make resolve_terminal_backend() return
+    # "unknown" and _get_env_config() raise even when the bridge succeeds.
+    env.pop("_config_bridge_failed", None)
+    env.pop("_config_unreadable", None)
+
     # Probe raw config readability before bridging.  ``apply_terminal_config_to_env()``
     # calls ``read_raw_config()`` and ``load_config_readonly()``, both of which handle
     # parse errors gracefully (return ``{}`` / fall back to last-known-good) instead of
@@ -1585,12 +1597,47 @@ def _terminal_env_snapshot() -> Dict[str, str]:
 
     # Restore explicit worker overrides for timeout/lifetime so that
     # subprocess callers (e.g. kanban _default_spawn) that intentionally
-    # set a longer value are not clobbered by config defaults.
+    # set a longer value are not clobbered by config defaults.  The one
+    # exception: a key pinned by the MANAGED scope (administrator-forced,
+    # per managed_scope §4.1 the pinned leaf inverts env-over-config
+    # precedence) must win over a stale process-env value, exactly as the
+    # backend key does in this PR series.
+    pinned = _terminal_config_pinned_env_vars()
     for key in ("TERMINAL_TIMEOUT", "TERMINAL_LIFETIME_SECONDS"):
-        if key in orig:
+        if key in orig and key not in pinned:
             env[key] = orig[key]
 
     return env
+
+
+def _terminal_config_pinned_env_vars() -> set:
+    """Return the ``TERMINAL_*`` env vars pinned by the MANAGED config.
+
+    Only managed-scope pins count here: a worker's explicit env override must
+    still beat a *user* config value (that is the pre-existing contract the
+    restore loop implements), but it must NOT beat an administrator-forced
+    managed value (managed_scope §4.1).  Keys that only appear in
+    ``DEFAULT_CONFIG`` are backfill-only and never pinned.
+    """
+    pinned: set = set()
+    try:
+        from hermes_cli import managed_scope
+        from hermes_cli.config import TERMINAL_CONFIG_ENV_MAP
+
+        managed_keys = {
+            key[len("terminal."):]
+            for key in managed_scope.managed_config_keys()
+            if key.startswith("terminal.")
+        }
+        for cfg_key in managed_keys:
+            env_var = TERMINAL_CONFIG_ENV_MAP.get(cfg_key)
+            if env_var:
+                pinned.add(env_var)
+    except Exception:
+        # Fail open: if the managed scope can't be inspected, treat nothing as
+        # pinned so a worker override is preserved (safe availability default).
+        pass
+    return pinned
 
 
 def _probe_config_unreadable() -> bool:
@@ -1604,7 +1651,19 @@ def _probe_config_unreadable() -> bool:
     unrecognized ``terminal.backend`` — is a security risk (it may carry
     ``terminal.backend: docker``) and must fail closed rather than silently
     downgrading an isolated backend to host-local execution.
+
+    Both the user config (``HERMES_HOME/config.yaml``) and the managed-scope
+    config (``/etc/hermes/config.yaml`` or ``$HERMES_MANAGED_DIR``) are probed:
+    a malformed MANAGED file is fail-open in ``managed_scope.load_managed_config``
+    (it returns ``{}``), which would silently drop an administrator-pinned
+    ``terminal.backend: docker`` and downgrade to host execution — the same
+    fail-closed invariant the user-config probe protects.
     """
+    return _probe_user_config_unreadable() or _probe_managed_config_unreadable()
+
+
+def _probe_user_config_unreadable() -> bool:
+    """Probe the user-scope config.yaml (``get_config_path()``)."""
     try:
         from hermes_cli.config import get_config_path, fast_safe_load
         config_path = get_config_path()
@@ -1615,9 +1674,42 @@ def _probe_config_unreadable() -> bool:
         return False
     except Exception:
         return True
+    return _terminal_config_shape_unreadable(data)
 
-    # A present document that is empty, a list, or a scalar cannot carry a
-    # trustworthy terminal.backend — treat it as unreadable.
+
+def _probe_managed_config_unreadable() -> bool:
+    """Probe the managed-scope config.yaml when a managed scope is present.
+
+    ``managed_scope.load_managed_config()`` fails open on a malformed managed
+    file (returns ``{}`` and logs loudly), so an admin's pinned
+    ``terminal.backend`` silently vanishes on parse failure.  Detect that here
+    so ``_terminal_env_snapshot()`` fails closed instead of downgrading.
+    """
+    try:
+        import yaml
+
+        from hermes_cli import managed_scope
+
+        managed_dir = managed_scope.get_managed_dir()
+        if managed_dir is None:
+            return False
+        managed_path = managed_dir / "config.yaml"
+        managed_path.stat()
+        with open(managed_path, encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except FileNotFoundError:
+        return False
+    except Exception:
+        return True
+    return _terminal_config_shape_unreadable(data)
+
+
+def _terminal_config_shape_unreadable(data) -> bool:
+    """Return True when a parsed config root cannot carry a trustworthy backend.
+
+    A present document that is empty, a list, or a scalar cannot carry a
+    trustworthy terminal.backend — treat it as unreadable.
+    """
     if not isinstance(data, dict):
         return True
 
@@ -1635,7 +1727,7 @@ def _probe_config_unreadable() -> bool:
 def _resolve_backend_type(env: Optional[Dict[str, str]] = None) -> str:
     """Return the terminal backend type after bridging config.yaml."""
     source = _terminal_env_snapshot() if env is None else env
-    env_val = source.get("TERMINAL_ENV")
+    env_val = (source.get("TERMINAL_ENV") or "").strip().lower()
     if env_val:
         return env_val
     return "local"

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1499,6 +1499,10 @@ _HOST_CWD_PREFIXES = ("/Users/", "/home/", "C:\\", "C:/")
 
 _CONTAINER_BACKENDS = frozenset({"docker", "singularity", "modal", "daytona", "vercel_sandbox"})
 
+_VALID_TERMINAL_BACKENDS = frozenset({
+    "local", "docker", "singularity", "modal", "daytona", "vercel_sandbox", "ssh",
+})
+
 
 def _is_unusable_container_cwd(cwd: str) -> bool:
     """Return True if *cwd* is a host/relative path that won't work as the
@@ -1590,24 +1594,42 @@ def _terminal_env_snapshot() -> Dict[str, str]:
 
 
 def _probe_config_unreadable() -> bool:
-    """Return True when config.yaml *exists* but cannot be parsed.
+    """Return True when config.yaml *exists* but is not a trustworthy terminal config.
 
-    ``read_raw_config()`` returns ``{}`` for both "file absent" and "parse
-    failure".  This helper distinguishes the two: a present-but-malformed
-    config is a security risk (it may carry ``terminal.backend: docker``),
-    while an absent config is safe (just use env vars).
+    ``read_raw_config()`` normalizes "file absent", "empty document", a
+    non-mapping root (list/scalar), and "parse failure" all to ``{}``.  This
+    helper distinguishes a safe absent config from a present-but-corrupt one:
+    a config that exists but cannot be trusted — unparseable, an empty or
+    non-mapping document, a non-mapping ``terminal`` section, or an
+    unrecognized ``terminal.backend`` — is a security risk (it may carry
+    ``terminal.backend: docker``) and must fail closed rather than silently
+    downgrading an isolated backend to host-local execution.
     """
     try:
         from hermes_cli.config import get_config_path, fast_safe_load
         config_path = get_config_path()
         config_path.stat()
         with open(config_path, encoding="utf-8") as f:
-            fast_safe_load(f)
-        return False
+            data = fast_safe_load(f)
     except FileNotFoundError:
         return False
     except Exception:
         return True
+
+    # A present document that is empty, a list, or a scalar cannot carry a
+    # trustworthy terminal.backend — treat it as unreadable.
+    if not isinstance(data, dict):
+        return True
+
+    terminal = data.get("terminal")
+    if terminal is None:
+        return False
+    if not isinstance(terminal, dict):
+        return True
+    backend = terminal.get("backend")
+    if backend is None:
+        return False
+    return str(backend).strip().lower() not in _VALID_TERMINAL_BACKENDS
 
 
 def _resolve_backend_type(env: Optional[Dict[str, str]] = None) -> str:
@@ -1617,6 +1639,26 @@ def _resolve_backend_type(env: Optional[Dict[str, str]] = None) -> str:
     if env_val:
         return env_val
     return "local"
+
+
+def resolve_terminal_backend() -> str:
+    """Resolve the active terminal backend from the bridged config snapshot.
+
+    Public resolver for sibling tools (``image_source``, ``vision_tools``,
+    ``image_generation_tool``, ``browser_tool``, ``credential_files``, ...) that
+    need the same backend determination as terminal dispatch.  Goes through
+    :func:`_terminal_env_snapshot` so a config.yaml ``terminal.backend`` is
+    honored even on cold start, before the launch-time bridge has run.
+
+    On an untrusted snapshot (config bridge failed or config unreadable) this
+    returns the non-local sentinel ``"unknown"`` so callers that gate host-side
+    reads / SSRF exemptions on ``== "local"`` fail closed instead of silently
+    downgrading an isolated backend to host execution.
+    """
+    snapshot = _terminal_env_snapshot()
+    if snapshot.get("_config_bridge_failed"):
+        return "unknown"
+    return _resolve_backend_type(snapshot)
 
 
 def _get_env_config() -> Dict[str, Any]:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1531,7 +1531,10 @@ def _terminal_env_snapshot() -> Dict[str, str]:
     stripped and a ``_config_bridge_failed`` sentinel is set so callers can
     fail closed instead of silently downgrading an isolated backend to local.
     """
-    env = dict(os.environ)
+    # Save original process-env values so explicit worker overrides
+    # (e.g. kanban subprocess TERMINAL_TIMEOUT) survive the bridge.
+    orig = os.environ
+    env = dict(orig)
 
     try:
         from hermes_cli.config import apply_terminal_config_to_env
@@ -1544,6 +1547,14 @@ def _terminal_env_snapshot() -> Dict[str, str]:
             if key.startswith("TERMINAL_") and key != "TERMINAL_ENV":
                 env.pop(key, None)
         env["_config_bridge_failed"] = "1"
+        return env
+
+    # Restore explicit worker overrides for timeout/lifetime so that
+    # subprocess callers (e.g. kanban _default_spawn) that intentionally
+    # set a longer value are not clobbered by config defaults.
+    for key in ("TERMINAL_TIMEOUT", "TERMINAL_LIFETIME_SECONDS"):
+        if key in orig:
+            env[key] = orig[key]
 
     return env
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1530,11 +1530,25 @@ def _terminal_env_snapshot() -> Dict[str, str]:
     When the bridge fails, stale TERMINAL_* values (except TERMINAL_ENV) are
     stripped and a ``_config_bridge_failed`` sentinel is set so callers can
     fail closed instead of silently downgrading an isolated backend to local.
+
+    Also probes raw config readability before bridging to detect a present-but-
+    unparseable config.yaml that ``apply_terminal_config_to_env()`` may silently
+    absorb via its last-known-good fallback.  When the config file exists but
+    cannot be parsed, ``_config_unreadable`` is set alongside
+    ``_config_bridge_failed`` so ``_get_env_config()`` can fail closed.
     """
     # Save original process-env values so explicit worker overrides
     # (e.g. kanban subprocess TERMINAL_TIMEOUT) survive the bridge.
     orig = os.environ
     env = dict(orig)
+
+    # Probe raw config readability before bridging.  ``apply_terminal_config_to_env()``
+    # calls ``read_raw_config()`` and ``load_config_readonly()``, both of which handle
+    # parse errors gracefully (return ``{}`` / fall back to last-known-good) instead of
+    # raising.  A malformed config + stale ``TERMINAL_ENV=local`` would therefore
+    # silently downgrade an isolated backend to host execution.  Detect that case here
+    # so the sentinel is set regardless of whether the bridge raises.
+    config_unreadable = _probe_config_unreadable()
 
     try:
         from hermes_cli.config import apply_terminal_config_to_env
@@ -1547,6 +1561,20 @@ def _terminal_env_snapshot() -> Dict[str, str]:
             if key.startswith("TERMINAL_") and key != "TERMINAL_ENV":
                 env.pop(key, None)
         env["_config_bridge_failed"] = "1"
+        if config_unreadable:
+            env["_config_unreadable"] = "1"
+        return env
+
+    # The bridge succeeded (returned normally), but if the underlying config is
+    # unreadable the bridge silently fell back to last-known-good or defaults —
+    # the TERMINAL_* values in ``env`` are not trustworthy.  Wipe them and flag
+    # the failure so ``_get_env_config()`` can fail closed.
+    if config_unreadable:
+        for key in list(env.keys()):
+            if key.startswith("TERMINAL_") and key != "TERMINAL_ENV":
+                env.pop(key, None)
+        env["_config_bridge_failed"] = "1"
+        env["_config_unreadable"] = "1"
         return env
 
     # Restore explicit worker overrides for timeout/lifetime so that
@@ -1557,6 +1585,27 @@ def _terminal_env_snapshot() -> Dict[str, str]:
             env[key] = orig[key]
 
     return env
+
+
+def _probe_config_unreadable() -> bool:
+    """Return True when config.yaml *exists* but cannot be parsed.
+
+    ``read_raw_config()`` returns ``{}`` for both "file absent" and "parse
+    failure".  This helper distinguishes the two: a present-but-malformed
+    config is a security risk (it may carry ``terminal.backend: docker``),
+    while an absent config is safe (just use env vars).
+    """
+    try:
+        from hermes_cli.config import get_config_path, fast_safe_load
+        config_path = get_config_path()
+        config_path.stat()
+        with open(config_path, encoding="utf-8") as f:
+            fast_safe_load(f)
+        return False
+    except FileNotFoundError:
+        return False
+    except Exception:
+        return True
 
 
 def _resolve_backend_type(env: Optional[Dict[str, str]] = None) -> str:
@@ -1579,6 +1628,17 @@ def _get_env_config() -> Dict[str, Any]:
         # The config bridge failed — stale TERMINAL_* values were wiped.
         # Check whether config.yaml intends an isolated backend; if so, fail
         # closed instead of silently downgrading to host-local execution.
+        #
+        # When ``_config_unreadable`` is set, config.yaml exists but cannot be
+        # parsed — so we cannot confirm the intended backend at all.  Fail closed
+        # immediately; do NOT fall through to ``load_config_readonly()`` (which
+        # would silently return last-known-good/defaults and bypass the guard).
+        if terminal_env.get("_config_unreadable"):
+            raise RuntimeError(
+                "Terminal config bridge failed and config.yaml is unreadable. "
+                "Refusing to run terminal without confirmed backend. "
+                "Check hermes CLI config connectivity."
+            )
         config_readable = True
         try:
             from hermes_cli.config import load_config_readonly

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1325,10 +1325,9 @@ def _docker_session_isolation_enabled() -> bool:
     ``container_persistent: true`` the documented ONE-long-lived-container
     contract is unchanged.
     """
-    _ensure_terminal_env_bridged()
-    if os.getenv("TERMINAL_ENV", "local") != "docker":
+    if _resolve_backend_type() != "docker":
         return False
-    return os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() not in {"true", "1", "yes"}
+    return _terminal_env_snapshot().get("TERMINAL_CONTAINER_PERSISTENT", "true").lower() not in {"true", "1", "yes"}
 
 
 _ISOLATION_OVERRIDE_KEYS = frozenset({
@@ -1513,68 +1512,77 @@ def _is_unusable_container_cwd(cwd: str) -> bool:
     return False
 
 
-# One-shot guard for the config-fallback bridge below.  Purely an
-# optimization: after the first attempt either TERMINAL_ENV is set (bridge
-# succeeded — merged config always carries terminal.backend) or the import
-# failed and retrying every call would be wasted work.
-_terminal_config_bridge_attempted = False
+def _terminal_env_snapshot() -> Dict[str, str]:
+    """Return terminal env values with config.yaml bridged in.
 
+    ``apply_terminal_config_to_env()`` is normally called by launch paths
+    before terminal tools run.  A cold-start tool call can arrive before that
+    bridge has completed, so build a local snapshot here as the final guard.
+    Does not mutate process-global env.
 
-def _ensure_terminal_env_bridged() -> None:
-    """Backfill TERMINAL_* env vars from config.yaml when no launcher did.
-
-    terminal_tool reads ALL terminal settings from os.environ (TERMINAL_*).
-    The CLI (cli.py ``env_mappings``), the gateway (gateway/run.py
-    ``_terminal_env_map``), and TUI/dashboard PTY launches
-    (``apply_terminal_config_to_env``) bridge ``terminal.*`` config into env
-    vars at startup — but processes that skip all of those paths (``hermes
-    serve`` / the Desktop app backend's in-process agents, the desktop cron
-    ticker, ACP) used to silently fall back to the local backend even when
-    config.yaml selects ``terminal.backend: docker``, running commands on the
-    host the user intended to sandbox (#63141, #54449, #61115, #65696).
-
-    Explicit terminal config keys win: when config.yaml has a ``terminal``
-    section, each key present there overrides its matching env value (which may
-    be stale from ``hermes setup``). Environment values for omitted terminal
-    keys are preserved. When no terminal section exists, exported/.env values
-    keep working unchanged.
+    When the bridge fails, stale TERMINAL_* values (except TERMINAL_ENV) are
+    stripped and a ``_config_bridge_failed`` sentinel is set so callers can
+    fail closed instead of silently downgrading an isolated backend to local.
     """
-    global _terminal_config_bridge_attempted
-    if _terminal_config_bridge_attempted:
-        return
-    _terminal_config_bridge_attempted = True
+    env = dict(os.environ)
+
     try:
-        from hermes_cli.config import apply_terminal_config_to_env, read_raw_config
-
-        # If config.yaml has an explicit terminal section, bridge with
-        # override enabled. The helper only overrides env vars for keys present
-        # in that raw section; merged defaults remain backfill-only. Without a
-        # terminal section, preserve an existing TERMINAL_ENV selection or
-        # backfill defaults when no selection exists.
-        raw_config = read_raw_config()
-        has_terminal_section = isinstance(raw_config.get("terminal"), dict)
-
-        if has_terminal_section:
-            # Explicit terminal keys in config.yaml win over matching env values.
-            apply_terminal_config_to_env(env=None, override=True)
-        elif "TERMINAL_ENV" not in os.environ:
-            # No terminal section in config.yaml, TERMINAL_ENV not set —
-            # backfill from config defaults
-            apply_terminal_config_to_env(env=None, override=False)
+        from hermes_cli.config import apply_terminal_config_to_env
+        apply_terminal_config_to_env(env=env)
     except Exception:
-        # Never let a config problem take the terminal tool down — the
-        # historical local default still applies.
-        logger.debug("terminal config → env fallback bridge failed", exc_info=True)
+        logger.debug(
+            "Could not bridge terminal config into env snapshot", exc_info=True,
+        )
+        for key in list(env.keys()):
+            if key.startswith("TERMINAL_") and key != "TERMINAL_ENV":
+                env.pop(key, None)
+        env["_config_bridge_failed"] = "1"
+
+    return env
+
+
+def _resolve_backend_type(env: Optional[Dict[str, str]] = None) -> str:
+    """Return the terminal backend type after bridging config.yaml."""
+    source = _terminal_env_snapshot() if env is None else env
+    env_val = source.get("TERMINAL_ENV")
+    if env_val:
+        return env_val
+    return "local"
 
 
 def _get_env_config() -> Dict[str, Any]:
     """Get terminal environment configuration from environment variables."""
     # Default image with Python and Node.js for maximum compatibility
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
-    _ensure_terminal_env_bridged()
-    env_type = os.getenv("TERMINAL_ENV", "local")
-    
-    mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
+    terminal_env = _terminal_env_snapshot()
+    env_type = _resolve_backend_type(terminal_env)
+
+    if terminal_env.get("_config_bridge_failed"):
+        # The config bridge failed — stale TERMINAL_* values were wiped.
+        # Check whether config.yaml intends an isolated backend; if so, fail
+        # closed instead of silently downgrading to host-local execution.
+        config_readable = True
+        try:
+            from hermes_cli.config import load_config_readonly
+            cfg = load_config_readonly()
+            intended = cfg.get("terminal", {}).get("backend", "local")
+        except Exception:
+            config_readable = False
+            intended = "local"
+        if not config_readable:
+            raise RuntimeError(
+                "Terminal config bridge failed and config.yaml is unreadable. "
+                "Refusing to run terminal without confirmed backend. "
+                "Check hermes CLI config connectivity."
+            )
+        if intended != "local":
+            raise RuntimeError(
+                f"Terminal config bridge failed. Refusing to downgrade "
+                f"terminal.backend={intended} to local execution. "
+                f"Check hermes CLI config connectivity."
+            )
+
+    mount_docker_cwd = terminal_env.get("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
     container_backend = env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}
     docker_backend = env_type == "docker"
 
@@ -1620,13 +1628,13 @@ def _get_env_config() -> Dict[str, Any]:
     # If Docker cwd passthrough is explicitly enabled, remap the host path to
     # /workspace and track the original host path separately. Otherwise keep the
     # normal sandbox behavior and discard host paths.
-    cwd = os.getenv("TERMINAL_CWD", default_cwd)
+    cwd = terminal_env.get("TERMINAL_CWD", default_cwd)
     from hermes_cli.config import _is_ssh_remote_tilde_cwd
     if cwd and not _is_ssh_remote_tilde_cwd(env_type, cwd):
         cwd = os.path.expanduser(cwd)
     host_cwd = None
     if env_type == "docker" and mount_docker_cwd:
-        docker_cwd_source = os.getenv("TERMINAL_CWD") or _safe_getcwd()
+        docker_cwd_source = terminal_env.get("TERMINAL_CWD") or _safe_getcwd()
         candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
         if (
             any(candidate.startswith(p) for p in _HOST_CWD_PREFIXES)
@@ -1644,41 +1652,41 @@ def _get_env_config() -> Dict[str, Any]:
 
     return {
         "env_type": env_type,
-        "modal_mode": coerce_modal_mode(os.getenv("TERMINAL_MODAL_MODE", "auto")),
-        "docker_image": os.getenv("TERMINAL_DOCKER_IMAGE", default_image),
+        "modal_mode": coerce_modal_mode(terminal_env.get("TERMINAL_MODAL_MODE", "auto")),
+        "docker_image": terminal_env.get("TERMINAL_DOCKER_IMAGE", default_image),
         "docker_forward_env": docker_forward_env,
-        "singularity_image": os.getenv("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
-        "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", default_image),
-        "daytona_image": os.getenv("TERMINAL_DAYTONA_IMAGE", default_image),
-        "vercel_runtime": os.getenv("TERMINAL_VERCEL_RUNTIME", "").strip(),
+        "singularity_image": terminal_env.get("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
+        "modal_image": terminal_env.get("TERMINAL_MODAL_IMAGE", default_image),
+        "daytona_image": terminal_env.get("TERMINAL_DAYTONA_IMAGE", default_image),
+        "vercel_runtime": terminal_env.get("TERMINAL_VERCEL_RUNTIME", "").strip(),
         "cwd": cwd,
         "host_cwd": host_cwd,
         "docker_mount_cwd_to_workspace": mount_docker_cwd,
         "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180"),
         "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300"),
         # SSH-specific config
-        "ssh_host": os.getenv("TERMINAL_SSH_HOST", ""),
-        "ssh_user": os.getenv("TERMINAL_SSH_USER", ""),
+        "ssh_host": terminal_env.get("TERMINAL_SSH_HOST", ""),
+        "ssh_user": terminal_env.get("TERMINAL_SSH_USER", ""),
         "ssh_port": _parse_env_var("TERMINAL_SSH_PORT", "22"),
-        "ssh_key": os.getenv("TERMINAL_SSH_KEY", ""),
+        "ssh_key": terminal_env.get("TERMINAL_SSH_KEY", ""),
         # Persistent shell: SSH defaults to the config-level persistent_shell
         # setting (true by default for non-local backends); local is always opt-in.
         # Per-backend env vars override if explicitly set.
-        "ssh_persistent": os.getenv(
+        "ssh_persistent": terminal_env.get(
             "TERMINAL_SSH_PERSISTENT",
-            os.getenv("TERMINAL_PERSISTENT_SHELL", "true"),
+            terminal_env.get("TERMINAL_PERSISTENT_SHELL", "true"),
         ).lower() in {"true", "1", "yes"},
-        "local_persistent": os.getenv("TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
+        "local_persistent": terminal_env.get("TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
         # Container resource config (applies to docker, singularity, modal,
         # daytona, and vercel_sandbox -- ignored for local/ssh)
         "container_cpu": container_cpu,
         "container_memory": container_memory,     # MB (default 5GB)
         "container_disk": container_disk,        # MB (default 50GB)
-        "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
+        "container_persistent": terminal_env.get("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
         "docker_volumes": docker_volumes,
         "docker_env": docker_env,
-        "docker_run_as_host_user": os.getenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
-        "docker_network": os.getenv("TERMINAL_DOCKER_NETWORK", "true").lower() in {"true", "1", "yes"},
+        "docker_run_as_host_user": terminal_env.get("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
+        "docker_network": terminal_env.get("TERMINAL_DOCKER_NETWORK", "true").lower() in {"true", "1", "yes"},
         "docker_extra_args": docker_extra_args,
         "docker_shm_size": docker_shm_size,
         # Cross-process container reuse (issue #20561).  The docs claim
@@ -1687,14 +1695,14 @@ def _get_env_config() -> Dict[str, Any]:
         # attaching to it instead of always starting a fresh one.  Set to
         # ``false`` for hard per-process isolation (no reuse, container is
         # removed on exit).
-        "docker_persist_across_processes": os.getenv(
+        "docker_persist_across_processes": terminal_env.get(
             "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES", "true"
         ).lower() in {"true", "1", "yes"},
         # Startup orphan reaper for hermes-tagged containers left behind by
         # crashed / SIGKILL'd previous processes that bypassed atexit.
         # Conservative: only sweeps Exited containers older than 2× the
         # idle-reap window AND scoped to the current profile. Issue #20561.
-        "docker_orphan_reaper": os.getenv(
+        "docker_orphan_reaper": terminal_env.get(
             "TERMINAL_DOCKER_ORPHAN_REAPER", "true"
         ).lower() in {"true", "1", "yes"},
     }

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1452,13 +1452,20 @@ def _resolve_task_host_cwd(config: Dict[str, Any], task_id: Optional[str]) -> Op
 
 # Configuration from environment variables
 
-def _parse_env_var(name: str, default: str, converter: Any = int, type_label: str = "integer"):
+def _parse_env_var(
+    name: str,
+    default: str,
+    converter: Any = int,
+    type_label: str = "integer",
+    env: Optional[Dict[str, str]] = None,
+):
     """Parse an environment variable with *converter*, raising a clear error on bad values.
 
     Without this wrapper, a single malformed env var (e.g. TERMINAL_TIMEOUT=5m)
     causes an unhandled ValueError that kills every terminal command.
     """
-    raw = os.getenv(name, default)
+    source = os.environ if env is None else env
+    raw = source.get(name, default)
     try:
         return converter(raw)
     except (ValueError, json.JSONDecodeError):
@@ -1591,20 +1598,20 @@ def _get_env_config() -> Dict[str, Any]:
     # until a backend that can consume them is selected; a stale or invalid
     # Docker value should not make local terminal/execute_code unusable.
     if container_backend:
-        container_cpu = _parse_env_var("TERMINAL_CONTAINER_CPU", "1", float, "number")
-        container_memory = _parse_env_var("TERMINAL_CONTAINER_MEMORY", "5120")
-        container_disk = _parse_env_var("TERMINAL_CONTAINER_DISK", "51200")
+        container_cpu = _parse_env_var("TERMINAL_CONTAINER_CPU", "1", float, "number", env=terminal_env)
+        container_memory = _parse_env_var("TERMINAL_CONTAINER_MEMORY", "5120", env=terminal_env)
+        container_disk = _parse_env_var("TERMINAL_CONTAINER_DISK", "51200", env=terminal_env)
     else:
         container_cpu = 1.0
         container_memory = 5120
         container_disk = 51200
 
     if docker_backend:
-        docker_forward_env = _parse_env_var("TERMINAL_DOCKER_FORWARD_ENV", "[]", json.loads, "valid JSON")
-        docker_volumes = _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON")
-        docker_env = _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON")
-        docker_extra_args = _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON")
-        docker_shm_size = os.getenv("TERMINAL_DOCKER_SHM_SIZE", "1g")
+        docker_forward_env = _parse_env_var("TERMINAL_DOCKER_FORWARD_ENV", "[]", json.loads, "valid JSON", env=terminal_env)
+        docker_volumes = _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON", env=terminal_env)
+        docker_env = _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON", env=terminal_env)
+        docker_extra_args = _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON", env=terminal_env)
+        docker_shm_size = terminal_env.get("TERMINAL_DOCKER_SHM_SIZE", "1g")
     else:
         docker_forward_env = []
         docker_volumes = []
@@ -1662,12 +1669,12 @@ def _get_env_config() -> Dict[str, Any]:
         "cwd": cwd,
         "host_cwd": host_cwd,
         "docker_mount_cwd_to_workspace": mount_docker_cwd,
-        "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180"),
-        "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300"),
+        "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180", env=terminal_env),
+        "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300", env=terminal_env),
         # SSH-specific config
         "ssh_host": terminal_env.get("TERMINAL_SSH_HOST", ""),
         "ssh_user": terminal_env.get("TERMINAL_SSH_USER", ""),
-        "ssh_port": _parse_env_var("TERMINAL_SSH_PORT", "22"),
+        "ssh_port": _parse_env_var("TERMINAL_SSH_PORT", "22", env=terminal_env),
         "ssh_key": terminal_env.get("TERMINAL_SSH_KEY", ""),
         # Persistent shell: SSH defaults to the config-level persistent_shell
         # setting (true by default for non-local backends); local is always opt-in.

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1839,8 +1839,8 @@ def _video_to_base64_data_url(video_path: Path, mime_type: Optional[str] = None)
 
 
 def _terminal_backend_is_local() -> bool:
-    backend = os.getenv("TERMINAL_ENV", "local").strip().lower()
-    return backend in ("", "local")
+    from tools.terminal_tool import resolve_terminal_backend
+    return resolve_terminal_backend() in ("", "local")
 
 
 def _is_path_like_video_source(value: str) -> bool:


### PR DESCRIPTION
Closes #54354

## What Problem This Solves

When a cold-start terminal tool call arrives before the config bridge has run, stale env vars (TERMINAL_ENV=local, TERMINAL_DOCKER_IMAGE=old-image) can cause the terminal to silently run on the host instead of in the configured Docker container. This is a sandbox escape: the user thinks code runs in Docker but it actually runs on the host.

## Why This Change Was Made

Adds `_terminal_env_snapshot()` to bridge config.yaml into terminal env resolution during cold-start, and a fail-closed guard in `_get_env_config()`:

- When the config bridge fails, stale TERMINAL_* container vars are stripped (preserving explicit TERMINAL_ENV so env-only configuration is not regressed)
- `_get_env_config()` checks whether config.yaml intends an isolated backend (docker, modal, etc.)
- If yes → `RuntimeError` (fail closed, refuse to run on host)
- If config.yaml is also unreadable → `RuntimeError` (refuse to run without confirmed backend)
- If config intends local → safe to proceed

## User Impact

Users with Docker/container terminal backends are now protected against silent sandbox downgrades during cold-start tool calls. Previously, an unavailable config bridge could cause code to execute on the host without the user knowing.

## Evidence

- `pytest tests/tools/test_docker_cold_start_guard.py` — 12 tests passed
- Codex review approved by egilewski ("fully addressed")
- New tests cover: Docker bridge failure → RuntimeError, local bridge failure → safe proceed, env-only TERMINAL_ENV preserved, double-failure → RuntimeError

## Previous iterations

- Supersedes #54982 (stale branch, rebased cleanly on current main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal backend detection by honoring configured settings and environment overrides consistently.
  * Prevented unsafe fallback to local execution when Docker or SSH configuration is invalid, unavailable, or ambiguous.
  * Preserved explicit timeout and session lifetime settings during configuration updates.
  * Improved Docker session isolation and cache, image, browser, file, and vision tool routing.

* **Tests**
  * Added regression coverage for configuration precedence, malformed settings, bridge failures, and cold-start behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->