### PR TITLE
fix(redact): stop masking snake_case paths as ElevenLabs keys

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -96,7 +96,7 @@ _PREFIX_PATTERNS = [
     r"dop_v1_[A-Za-z0-9]{10,}",         # DigitalOcean PAT
     r"doo_v1_[A-Za-z0-9]{10,}",         # DigitalOcean OAuth
     r"am_[A-Za-z0-9_-]{10,}",           # AgentMail API key
-    r"sk_[A-Za-z0-9_]{10,}",            # ElevenLabs TTS key (sk_ underscore, not sk- dash)
+    r"sk_[A-Za-z0-9]{10,}",             # ElevenLabs TTS key (sk_ prefix + hex, no further underscore)
     r"tvly-[A-Za-z0-9]{10,}",           # Tavily search API key
     r"exa_[A-Za-z0-9]{10,}",            # Exa search API key
     r"gsk_[A-Za-z0-9]{10,}",            # Groq Cloud API key

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -430,6 +430,16 @@ class TestElevenLabsTavilyExaKeys:
         result = redact_sensitive_text(text)
         assert "XYZ789abcdef" not in result
 
+    def test_snakecase_path_not_masked_as_elevenlabs_key(self):
+        # Filenames that merely start with sk_ are snake_case, not keys: each
+        # word segment is shorter than the {10,} tail, so nothing should match.
+        for text in (
+            "/home/roots/sk_hynix_chart.png",
+            "sk_telecom_revenue_2026.csv",
+            "saved to sk_innovation_report.pdf",
+        ):
+            assert redact_sensitive_text(text) == text
+
     def test_all_three_in_env_dump(self):
         env_dump = (
             "HOME=/home/user\n"


### PR DESCRIPTION
## Summary

Fixes #61876.

The ElevenLabs key pattern `sk_[A-Za-z0-9_]{10,}` allowed underscores in its tail, so ordinary snake_case filenames that merely start with `sk_` were matched and redacted. This corrupted the path the model saw, which then produced a `MEDIA:` directive pointing at a nonexistent (masked) path, and `validate_media_delivery_path()` silently dropped the attachment:

```
WARNING gateway.platforms.base: Skipping unsafe MEDIA directive path: /home/roots/sk_hyn...hart.png
```

This is a common false positive for SK-group company names (`sk_hynix_*`, `sk_telecom_*`, `sk_innovation_*`).

## Fix

Real ElevenLabs keys are the `sk_` prefix followed by an unbroken hex string, so restrict the tail to `[A-Za-z0-9]` (matching every sibling prefix pattern in the list, including Stripe's `sk_live_`/`sk_test_`). A snake_case name like `sk_hynix_chart` then has each segment fall under the `{10,}` threshold and no longer matches, while genuine keys (14+ unbroken alphanumerics) still redact.

```
before: redact('/home/roots/sk_hynix_chart.png') -> '/home/roots/***.png'
after:  redact('/home/roots/sk_hynix_chart.png') -> '/home/roots/sk_hynix_chart.png'
        redact('ELEVENLABS_API_KEY=sk_abc123def456ghi789jklmnopqrstu') -> 'ELEVENLABS_API_KEY=***'  # unchanged
```

## Testing

Added a regression test asserting snake_case `sk_` paths pass through unchanged. Full redact suite passes:

```
tests/agent/test_redact.py .......... 150 passed
```