### PR TITLE
fix(moa): keep MoA presets in explicit-only desktop pickers (#61889)

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -339,8 +339,12 @@ def _filter_explicit_provider_rows(rows: list[dict], ctx: ConfigContext) -> list
             continue
         if slug == "moa":
             # MoA is a virtual routing mode, not an independently configured
-            # provider. Hide it from explicit-only pickers unless it is the
-            # current provider (handled above).
+            # provider. But its presets are user-authored config (named presets
+            # created via the MoA settings panel), so they are "explicit" in the
+            # user's intent — surface them in explicit-only pickers the same way
+            # user-defined providers are, rather than hiding them like ambient
+            # auto-seeded credentials (e.g. GitHub CLI -> Copilot).
+            kept.append(row)
             continue
         if is_provider_explicitly_configured(slug):
             kept.append(row)

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -196,6 +196,32 @@ def test_build_models_payload_returns_expected_shape():
     assert payload["providers"][1:] == rows
 
 
+def test_build_models_payload_explicit_only_keeps_moa_presets():
+    """Regression: PR #37a4cf900 added an explicit_only filter to desktop
+    chat pickers and hard-dropped the ``moa`` virtual provider. MoA presets are
+    user-authored config (named presets from the MoA settings panel), so they
+    must remain selectable in explicit-only pickers — the same way user-defined
+    providers are — instead of being hidden like ambient auto-seeded credentials
+    (e.g. GitHub CLI -> Copilot). Verifies the chat model menu still lists the
+    Mixture of Agents provider and its presets.
+    """
+    rows = [
+        {"slug": "openrouter", "name": "OpenRouter", "models": ["m1"],
+         "total_models": 1, "is_current": False, "is_user_defined": False,
+         "source": "built-in"},
+        {"slug": "moa", "name": "Mixture of Agents", "models": ["default",
+         "Free MOA Gemini build"], "total_models": 2, "is_current": False,
+         "is_user_defined": False, "source": "virtual"},
+    ]
+    ctx = _empty_ctx(provider="openrouter", model="m1", base_url="")
+    with _list_auth_returning(rows):
+        payload = build_models_payload(ctx, explicit_only=True)
+    moa_rows = [r for r in payload["providers"] if r["slug"] == "moa"]
+    assert moa_rows, "moa virtual provider must survive explicit_only filter"
+    assert isinstance(moa_rows[0].get("models"), list) and moa_rows[0]["models"], \
+        "moa row must surface at least one preset in explicit-only pickers"
+
+
 def test_build_models_payload_does_not_call_provider_model_ids():
     """``build_models_payload`` is a thin shape adapter — it delegates the
     actual curation to ``list_authenticated_providers`` (which DOES call
@@ -410,6 +436,7 @@ def test_explicit_only_filters_ambient_credentials_but_keeps_current_and_custom_
         payload = build_models_payload(ctx, explicit_only=True)
 
     assert [row["slug"] for row in payload["providers"]] == [
+        "moa",
         "openai-codex",
         "gemini",
         "custom:lab",

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -204,22 +204,47 @@ def test_build_models_payload_explicit_only_keeps_moa_presets():
     providers are — instead of being hidden like ambient auto-seeded credentials
     (e.g. GitHub CLI -> Copilot). Verifies the chat model menu still lists the
     Mixture of Agents provider and its presets.
+
+    ``_moa_provider_row`` is patched so the test is deterministic and does not
+    leak the host machine's real MoA config into the assertion.
+    """
+    moa_row = {
+        "slug": "moa", "name": "Mixture of Agents",
+        "models": ["default", "Free MOA Gemini build"], "total_models": 2,
+        "is_current": False, "is_user_defined": False, "source": "virtual",
+    }
+    rows = [
+        {"slug": "openrouter", "name": "OpenRouter", "models": ["m1"],
+         "total_models": 1, "is_current": False, "is_user_defined": False,
+         "source": "built-in"},
+        moa_row,
+    ]
+    ctx = _empty_ctx(provider="openrouter", model="m1", base_url="")
+    with _list_auth_returning(rows), \
+         patch("hermes_cli.inventory._moa_provider_row", return_value=moa_row):
+        payload = build_models_payload(ctx, explicit_only=True)
+    moa_rows = [r for r in payload["providers"] if r["slug"] == "moa"]
+    assert len(moa_rows) == 1, "moa virtual provider must survive explicit_only filter"
+    assert moa_rows[0]["models"] == ["default", "Free MOA Gemini build"], \
+        "moa row must surface the exact configured presets in explicit-only pickers"
+
+
+def test_build_models_payload_explicit_only_drops_moa_with_no_presets():
+    """Complement to the regression test above: when the user has NO MoA
+    presets configured, ``_moa_provider_row`` returns None and the moa row must
+    NOT appear in explicit-only pickers (no ambient clutter). Guards the fix
+    against over-keeping an empty/unconfigured routing mode.
     """
     rows = [
         {"slug": "openrouter", "name": "OpenRouter", "models": ["m1"],
          "total_models": 1, "is_current": False, "is_user_defined": False,
          "source": "built-in"},
-        {"slug": "moa", "name": "Mixture of Agents", "models": ["default",
-         "Free MOA Gemini build"], "total_models": 2, "is_current": False,
-         "is_user_defined": False, "source": "virtual"},
     ]
     ctx = _empty_ctx(provider="openrouter", model="m1", base_url="")
-    with _list_auth_returning(rows):
+    with _list_auth_returning(rows), \
+         patch("hermes_cli.inventory._moa_provider_row", return_value=None):
         payload = build_models_payload(ctx, explicit_only=True)
-    moa_rows = [r for r in payload["providers"] if r["slug"] == "moa"]
-    assert moa_rows, "moa virtual provider must survive explicit_only filter"
-    assert isinstance(moa_rows[0].get("models"), list) and moa_rows[0]["models"], \
-        "moa row must surface at least one preset in explicit-only pickers"
+    assert [r["slug"] for r in payload["providers"]] == ["openrouter"]
 
 
 def test_build_models_payload_does_not_call_provider_model_ids():


### PR DESCRIPTION
## What does this PR do?

Fixes a regression introduced by #37a4cf900 ("fix: limit desktop model pickers to explicit providers", merged Jul 2). That PR added an `explicit_only` filter to desktop model pickers and hard-dropped the `moa` virtual provider in `_filter_explicit_provider_rows`, treating it like ambient auto-seeded credentials (e.g. GitHub CLI -> Copilot). But MoA presets are **user-authored config** created via the MoA settings panel — so they must remain selectable in explicit-only pickers, the same way `is_user_defined` providers are.

Symptom reported: after updating Hermes Desktop, named MoA presets (e.g. "Free MOA Gemini build") vanished from both the chat model-picker pill and the Settings provider list. The `moa:` config block was never lost — the picker filter hid it.

Fix: keep the `moa` row in `_filter_explicit_provider_rows` instead of skipping it. One-line change. This restores MoA visibility on every surface that consumes `/api/model/options` (chat pill + Settings), since both route through `build_models_payload(..., explicit_only=True)`.

## Related Issue

Fixes #61889

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/inventory.py` — in `_filter_explicit_provider_rows`, the `slug == "moa"` branch now appends the row (`kept.append(row)`) instead of `continue`-ing past it.
- `tests/hermes_cli/test_inventory.py` — added `test_build_models_payload_explicit_only_keeps_moa_presets` (exercises the `explicit_only=True` path the original suite never covered; patches `_moa_provider_row` for determinism) and `test_build_models_payload_explicit_only_drops_moa_with_no_presets` (guards against over-keeping an unconfigured routing mode). Updated the existing `test_explicit_only_filters_ambient_credentials_but_keeps_current_and_custom_rows` to expect MoA present (it had encoded the buggy behavior).

## How to Test

1. Configure a MoA preset (Settings -> Models -> Configure Mixture of Agents presets).
2. Open the chat model-picker pill and type "moa" — before the fix only ambient providers appear; after, a "MOA PRESETS" section lists the presets.
3. Open Settings -> Models provider dropdown — "Mixture of Agents" is listed again.
4. `pytest tests/hermes_cli/test_inventory.py -q` — 41 passed (including the new regression tests).

Verified live on macOS against the reporter's real profile config: with `explicit_only=True`, the `moa` virtual provider now survives the filter and carries the configured presets.

## Review

Cross-vendor review dispatched (Gemini 3.1 Pro High + GPT-OSS 120B Medium) on the issue + this PR:

- Both confirmed the root-cause analysis and the fix's correctness. `_moa_provider_row` returns `None` when no presets exist, so `build_models_payload` never produces a moa row — the "empty-presets clutter" BLOCKER one reviewer raised was rejected against source (the fix cannot surface a nonexistent row).
- Both agreed the regression test needed isolation: it now patches `_moa_provider_row` and asserts the exact preset list, plus a companion test proving the moa row is dropped when no presets are configured.
- Title reference corrected from the stale `#61974` to the real issue `#61889`.

## Design decision (resolves the earlier open question)

The earlier draft asked whether MoA should instead be gated by `is_provider_explicitly_configured`. **No** — that check is always `False` for `moa` (MoA presets have no API key / provider-specific env), so gating on it would re-introduce this exact bug. The correct rule is: keep the `moa` row whenever it exists, because `_moa_provider_row` only ever returns a row when the user has configured ≥1 preset (returns `None` otherwise). So "row exists" already means "user-authored config present" — there is no ambient-clutter risk, and no separate gate is needed. This is why the fix is a plain `kept.append(row)` rather than a `row.get("models")` guard.

## References

- Regressing PR #37a4cf900 ("fix: limit desktop model pickers to explicit providers", merged Jul 2). Legitimate intent — it closed #56974 (ambient providers like Copilot via `gh_cli` shown as configured) and #55790 (stale `auth.json` `env:` pool entry kept a removed provider in the picker; the PR hardened `is_provider_explicitly_configured` to count only explicit pool sources and live `env:` vars). The MoA drop was a category error: MoA is user-authored config but has no env/key, so it was misclassified as ambient.
- Issue #61889 (root-cause writeup + the `is_provider_explicitly_configured("moa") == False` detail).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1 (Desktop)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [x] This section N/A (no skill added)

## Screenshots / Logs

Reporter confirmed before/after: chat picker showed only `KILO GATEWAY -> Hy3:Free High` for "moa"; after the fix it shows a "MOA PRESETS" section with `MoA: default` and `MoA: Free MOA Gemini build`, and the Settings provider dropdown lists "Mixture of Agents" again.

