### PR TITLE
fix(redact): narrow ElevenLabs key pattern to prevent sk_ filename false positives

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -96,7 +96,7 @@ _PREFIX_PATTERNS = [
     r"dop_v1_[A-Za-z0-9]{10,}",         # DigitalOcean PAT
     r"doo_v1_[A-Za-z0-9]{10,}",         # DigitalOcean OAuth
     r"am_[A-Za-z0-9_-]{10,}",           # AgentMail API key
-    r"sk_[A-Za-z0-9_]{10,}",            # ElevenLabs TTS key (sk_ underscore, not sk- dash)
+    r"sk_[A-Za-z0-9]{10,}",             # ElevenLabs TTS key (sk_ prefix, body is alpha+numeric only)
     r"tvly-[A-Za-z0-9]{10,}",           # Tavily search API key
     r"exa_[A-Za-z0-9]{10,}",            # Exa search API key
     r"gsk_[A-Za-z0-9]{10,}",            # Groq Cloud API key

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -445,6 +445,30 @@ class TestElevenLabsTavilyExaKeys:
         assert "HOME=/home/user" in result
         assert "SHELL=/bin/bash" in result
 
+    def test_sk_filepath_not_redacted_in_code(self):
+        """Regression: sk_ filenames (e.g. sk_hynix_*.png) must not be
+        redacted by the ElevenLabs pattern — the body char class excludes
+        underscore so snake_case filenames don't match.  Issue #61876."""
+        text = "Chart saved to /home/roots/sk_hynix_screenshot.png"
+        result = redact_sensitive_text(text, force=True, code_file=True)
+        assert result == text, f"File path was corrupted: {result!r}"
+
+    def test_sk_filepath_not_redacted_in_general(self):
+        """Same as above but without code_file=True — the prefix pattern
+        should not match snake_case sk_ filenames in any context."""
+        text = "Data written to sk_telecom_report_july.csv"
+        result = redact_sensitive_text(text, force=True)
+        assert result == text, f"CSV path was corrupted: {result!r}"
+
+    def test_elevenlabs_bare_key_still_redacted(self):
+        """Verify the fix still redacts real ElevenLabs keys (no underscores
+        in the body after sk_). Issue #61876 regression."""
+        key = "sk_aabbccddeeffgghhiijjkkllmmnnoopp"
+        text = f"elevenlabs key: {key}"
+        result = redact_sensitive_text(text, force=True)
+        assert key not in result, f"ElevenLabs key leaked: {result!r}"
+        assert "sk_" in result, "Prefix should survive in head/tail mask"
+
 
 class TestJWTTokens:
     """JWT tokens start with eyJ (base64 for '{') and have dot-separated parts."""


### PR DESCRIPTION
## Problem

The ElevenLabs API key pattern `sk_[A-Za-z0-9_]{10,}` matched filenames starting with `sk_` followed by snake_case components (e.g. `sk_hynix_`, `sk_telecom_`), because the body character class allowed underscores. This is a common false positive for Korean users (SK Group companies).

When such a filename appeared in `execute_code` stdout, the redacted path no longer existed on disk, causing `validate_media_delivery_path()` to fail with:
```
WARNING gateway.platforms.base: Skipping unsafe MEDIA directive path: /home/roots/sk_hyn...hart.png
```

Fixes #61876

## Fix

Changed the body character class from `[A-Za-z0-9_]` to `[A-Za-z0-9]` for the ElevenLabs key pattern only. ElevenLabs API keys use only alphanumeric characters after the `sk_` prefix, so removing underscore from the body class is safe and eliminates this false positive class.

## Verification

- All 152 existing tests pass (149 original + 3 new regression tests)
- Manually verified that `sk_hynix_screenshot.png` paths pass through unchanged
- Manually verified that real ElevenLabs keys (`sk_aabbcc...`) are still redacted
- Ran both `code_file=True` and default contexts