### PR TITLE
fix(desktop): prevent event loop stalls on Windows cold start

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -159,6 +159,26 @@ def _warm_gateway_module() -> None:
         import hermes_cli.gateway  # noqa: F401
     except Exception:
         pass
+    # gateway.config 和 hermes_state 也在 /api/status 中 inline import，
+    # 冷启动时同样会阻塞事件循环。一并预热。
+    try:
+        import gateway.config  # noqa: F401
+    except Exception:
+        pass
+    try:
+        import hermes_state  # noqa: F401
+    except Exception:
+        pass
+    # /api/status 中还 inline import 了 dashboard_auth 和 auth，
+    # 虽然比 gateway.config 轻量，一并预热避免任何阻塞可能。
+    try:
+        import hermes_cli.dashboard_auth  # noqa: F401
+    except Exception:
+        pass
+    try:
+        import hermes_cli.auth  # noqa: F401
+    except Exception:
+        pass
 
 
 def _resolve_restart_drain_timeout() -> float:
@@ -181,13 +201,25 @@ async def _lifespan(app: "FastAPI"):
     # event loop during lifespan startup — see _get_event_state's docstring.
     app.state.chat_argv_lock = asyncio.Lock()
 
-    # Fire hermes_cli.gateway import into a background thread so the event
-    # loop is not blocked and HERMES_DASHBOARD_READY fires without delay.
+    # Fire hermes_cli.gateway + gateway.config + hermes_state import into a
+    # background thread so the event loop is not blocked and
+    # HERMES_DASHBOARD_READY fires without delay on server mode.
     # On a cold Windows install the module chain triggers .pyc compilation
     # and Defender real-time scans that can stall the event loop for 15-30s.
     # Running in an executor means the cost is paid in a worker thread while
     # the server socket is already open and accepting probes.
-    asyncio.get_event_loop().run_in_executor(None, _warm_gateway_module)
+    #
+    # Desktop mode (HERMES_DESKTOP=1): await the warmup before announcing
+    # readiness.  Without this, HERMES(BACKEND|DASHBOARD)_READY fires too
+    # early — the Electron frontend immediately polls /api/status which
+    # still has cold imports that block the event loop, causing a 15-90s
+    # timeout and repeated backend restarts.
+    warm_future = asyncio.get_event_loop().run_in_executor(None, _warm_gateway_module)
+    if os.getenv("HERMES_DESKTOP") == "1":
+        try:
+            await asyncio.wait_for(warm_future, timeout=120.0)
+        except (asyncio.TimeoutError, Exception):
+            pass
 
     # Desktop-spawned backends (HERMES_DESKTOP=1) fire cron jobs themselves,
     # since the app has no gateway running the scheduler. Server `hermes
@@ -17059,10 +17091,19 @@ def start_server(
             app.state.bound_port = actual_port
 
             _write_dashboard_ready_file(actual_port)
-            # Port-discovery sentinel parsed by the desktop spawn. `serve` is a
-            # plain backend, not a dashboard, so it announces a neutral token;
-            # `dashboard` keeps the legacy one. The desktop matches either.
-            ready_token = "HERMES_BACKEND_READY" if headless else "HERMES_DASHBOARD_READY"
+            # Port-discovery sentinel parsed by the desktop spawn. The `serve`
+            # command was designed to announce HERMES_BACKEND_READY (a neutral
+            # token), but the packaged Electron desktop app (app.asar) only
+            # recognizes HERMES_DASHBOARD_READY. When the desktop spawns the
+            # backend, use the legacy token so the packaged app can find the
+            # port without a rebuild.
+            # See backend-ready.ts / backend-ready.cjs `_READY_RE`.
+            if os.getenv("HERMES_DESKTOP") == "1":
+                ready_token = "HERMES_DASHBOARD_READY"
+            elif headless:
+                ready_token = "HERMES_BACKEND_READY"
+            else:
+                ready_token = "HERMES_DASHBOARD_READY"
             print(f"{ready_token} port={actual_port}", flush=True)
             if headless:
                 # No SPA, and the JSON-RPC/WS endpoints are auth-gated — don't


### PR DESCRIPTION
Three changes in hermes_cli/web_server.py:

1. _warm_gateway_module() extended — pre-import gateway.config, hermes_state, hermes_cli.dashboard_auth, and hermes_cli.auth alongside the existing hermes_cli.gateway. These modules are imported inline in /api/status and would block the event loop for 30-78s on first access on a cold Windows install.

2. _lifespan now awaits the warmup in desktop mode (HERMES_DESKTOP=1) with a 120s timeout before announcing HERMES_DASHBOARD_READY. Without this, the Electron frontend polls /api/status immediately and hits the cold imports, causing a 15-90s timeout and repeated backend restarts.

3. READY token compatibility — use HERMES_DASHBOARD_READY instead of HERMES_BACKEND_READY when HERMES_DESKTOP=1, because the packaged Electron app (app.asar) only recognizes the legacy token. The headless serve command retains HERMES_BACKEND_READY for non-desktop use.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

