### PR TITLE
fix(desktop): hide PowerShell windows during Windows update and fix update race condition

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2501,7 +2501,9 @@ async function applyUpdates(opts = {}) {
       // whole update itself: `hermes update` (backend) + `hermes desktop
       // --build-only` (OS-aware GUI rebuild), then swap the running .app bundle
       // with the freshly built one and relaunch.
-      return await applyUpdatesPosixInApp(opts)
+      const result = await applyUpdatesPosixInApp(opts)
+      updateInFlight = false
+      return result
     }
 
     if (!updater) {
@@ -2535,6 +2537,7 @@ async function applyUpdates(opts = {}) {
       rememberLog(`[updates] no staged updater; surfacing manual \`${command}\` for CLI install at ${updateRoot}`)
       emitUpdateProgress({ stage: 'manual', message: command, percent: null })
 
+      updateInFlight = false
       return { ok: true, manual: true, command, hermesRoot: updateRoot }
     }
 
@@ -2591,7 +2594,7 @@ async function applyUpdates(opts = {}) {
       },
       detached: true,
       stdio: 'ignore',
-      windowsHide: false
+      windowsHide: true
     })
 
     child.unref()
@@ -2620,8 +2623,9 @@ async function applyUpdates(opts = {}) {
     }, UPDATE_HANDOFF_DWELL_MS)
 
     return { ok: true, handedOff: true, updater }
-  } finally {
+  } catch (error) {
     updateInFlight = false
+    throw error
   }
 }
 
@@ -2630,9 +2634,15 @@ async function handOffWindowsBootstrapRecovery(reason) {
     return false
   }
 
+  if (updateInFlight) {
+    return false
+  }
+  updateInFlight = true
+
   const updater = resolveUpdaterBinary()
 
   if (!updater) {
+    updateInFlight = false
     return false
   }
 
@@ -2669,7 +2679,7 @@ async function handOffWindowsBootstrapRecovery(reason) {
     },
     detached: true,
     stdio: 'ignore',
-    windowsHide: false
+    windowsHide: true
   })
 
   child.unref()


### PR DESCRIPTION
### Summary

Fixes two related issues in the Windows update flow (`apps/desktop/electron/main.ts`) that cause multiple PowerShell windows to appear on screen during an update. See #61898.

### Problems

1. **Visible PowerShell windows**: When spawning `hermes-setup.exe` in `applyUpdates` and `handOffWindowsBootstrapRecovery`, `windowsHide` was set to `false`, so PowerShell windows became visible.

2. **Race condition**: `applyUpdates` used a `finally` block that reset `updateInFlight` to `false` immediately on return. But the app waits `UPDATE_HANDOFF_DWELL_MS` (2.5s) before quitting. In that window a re-triggered update saw `updateInFlight === false` and spawned another updater process  producing many stacked PowerShell windows.

### Changes

- Set `windowsHide: true` in both spawn sites.
- Replace the `finally` block with a `catch` block so `updateInFlight` is only reset on error, keeping the guard held through the 2.5s quit dwell on the success path.
- Reset `updateInFlight` explicitly on the POSIX in-app and manual-command early-return paths (which do not quit the app).
- Add an `updateInFlight` guard to `handOffWindowsBootstrapRecovery` to prevent concurrent recovery hand-offs.

### Notes

The Rust updater (`apps/bootstrap-installer/src-tauri/src/update.rs`) already uses `CREATE_NO_WINDOW` (0x08000000); this change brings `main.ts` in line with that behavior.