### PR TITLE
feat(plugins): add opt-in required pre-tool policies

### DIFF
--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -62,6 +62,32 @@ behavior-affecting hooks:
 Telemetry plugins should treat these behavior-affecting returns as optional
 compatibility features, not as observability requirements.
 
+### Required Tool Policies
+
+`pre_tool_call` hooks remain fail-open by default. Operators can require a
+specific plugin to return a policy decision for selected tool-name globs:
+
+```yaml
+plugins:
+  enabled:
+    - github-policy
+  entries:
+    github-policy:
+      required_pre_tool_call:
+        tools:
+          - "github_*"
+          - terminal
+```
+
+`required_pre_tool_call: true` protects every tool. For a matching tool, each
+`pre_tool_call` callback registered by that plugin must return an explicit
+`{"action": "allow"}`, a valid `block` directive, or a valid `approve`
+directive. Hermes blocks the call when the plugin is unavailable, a callback
+raises, or a callback returns an empty or malformed decision. Other plugins
+and unprotected tools keep the ordinary fail-open behavior. A malformed
+`required_pre_tool_call` configuration cannot identify its intended tool
+scope, so Hermes blocks tool dispatch until the entry is corrected or removed.
+
 ## Correlation IDs
 
 Observer payloads use stable IDs so plugins can join events without relying on

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -245,7 +245,10 @@ _LAST_EXPANDED_CONFIG_BY_PATH: Dict[str, Any] = {}
 # editing the managed-scope config.yaml invalidates the cache (see
 # managed_scope), and the env snapshot invalidates it when a referenced ${VAR}
 # changes value (late .env load, in-process rotation — #58514).
-_LOAD_CONFIG_CACHE: Dict[str, Tuple[int, int, int, int, Dict[str, Any], Dict[str, Optional[str]]]] = {}
+_LOAD_CONFIG_CACHE: Dict[
+    str,
+    Tuple[int, int, int, int, Dict[str, Any], Dict[str, Optional[str]], bool],
+] = {}
 # (path, mtime_ns, size) -> cached raw yaml dict. Same pattern as
 # _LOAD_CONFIG_CACHE but for read_raw_config() — used when callers want
 # the user's on-disk values without defaults merged in.
@@ -3152,6 +3155,16 @@ def load_config_readonly() -> Dict[str, Any]:
     return _load_config_impl(want_deepcopy=False)
 
 
+def load_config_readonly_strict() -> Dict[str, Any]:
+    """Read config without silently substituting defaults or stale values.
+
+    Security gates use this path when an existing malformed or unreadable
+    source must disable execution until the operator repairs it. Missing user
+    and managed config files remain valid and resolve to normal defaults.
+    """
+    return _load_config_impl(want_deepcopy=False, strict_sources=True)
+
+
 def write_platform_config_field(
     platform_key: str,
     field_key: str,
@@ -3280,7 +3293,9 @@ def apply_terminal_config_to_env(
     return target
 
 
-def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
+def _load_config_impl(
+    *, want_deepcopy: bool, strict_sources: bool = False
+) -> Dict[str, Any]:
     with _CONFIG_LOCK:
         ensure_hermes_home()
         config_path = get_config_path()
@@ -3321,14 +3336,15 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
 
         cached = _LOAD_CONFIG_CACHE.get(path_key)
         if cached is not None and cache_sig is not None and cached[:4] == cache_sig:
-            # File signatures match, but the cached expansion is only valid if
-            # every ${VAR} it was expanded against still has the same value.
-            # Without this, a load_config() that ran before load_hermes_dotenv()
-            # pins unexpanded literals (e.g. auxiliary.<task>.api_key) for the
-            # life of the process (#58514).
-            env_snapshot = cached[5] if len(cached) > 5 else {}
-            if all(os.environ.get(k) == v for k, v in env_snapshot.items()):
-                return copy.deepcopy(cached[4]) if want_deepcopy else cached[4]
+            strict_validated = len(cached) > 6 and cached[6] is True
+            if not strict_sources or strict_validated:
+                # File signatures match, but the cached expansion is only valid
+                # if every ${VAR} it was expanded against still has the same
+                # value. Without this, a load_config() that ran before
+                # load_hermes_dotenv() pins unexpanded literals for the process.
+                env_snapshot = cached[5] if len(cached) > 5 else {}
+                if all(os.environ.get(k) == v for k, v in env_snapshot.items()):
+                    return copy.deepcopy(cached[4]) if want_deepcopy else cached[4]
 
         config = copy.deepcopy(DEFAULT_CONFIG)
 
@@ -3364,6 +3380,8 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                     e,
                     fallback="last-known-good" if lkg is not None else "defaults",
                 )
+                if strict_sources:
+                    raise
                 if lkg is not None:
                     # save_config() stores the pre-expansion normalized dict
                     # (env-ref templates preserved); the load path stores the
@@ -3382,7 +3400,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                         _LOAD_CONFIG_CACHE[path_key] = (
                             cache_sig[0], cache_sig[1],
                             cache_sig[2], cache_sig[3],
-                            lkg_copy, _empty_env,
+                            lkg_copy, _empty_env, False,
                         )
                     return copy.deepcopy(lkg_copy) if want_deepcopy else lkg_copy
 
@@ -3393,7 +3411,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
         # against the process environment, never against user-config-defined refs.
         # This deliberately inverts the usual env-over-config precedence for the
         # keys the managed layer pins — see docs/design/managed-scope.md §4.1.
-        managed_config = managed_scope.load_managed_config()
+        managed_config = managed_scope.load_managed_config(strict=strict_sources)
         if managed_config:
             managed_expanded = _expand_env_vars(managed_config)
             expanded = _deep_merge(expanded, managed_expanded)
@@ -3404,14 +3422,19 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
             # cached value, and ``load_config_readonly()`` (deepcopy=False)
             # callers all see the same stable cached object. The cached tuple is
             # (user_mtime, user_size, managed_mtime, managed_size, value,
-            # env_ref_snapshot). The snapshot records the environment values
-            # this expansion was made against so later loads can detect env
-            # drift (late .env load, in-process rotation) — see cache hit above.
+            # env_ref_snapshot, strict_validated). The snapshot records the
+            # environment values this expansion was made against so later loads
+            # can detect env drift (late .env load, in-process rotation).
             cached_copy = copy.deepcopy(expanded)
             env_snapshot = _env_ref_snapshot(normalized)
             if managed_config:
                 _env_ref_snapshot(managed_config, env_snapshot)
-            _LOAD_CONFIG_CACHE[path_key] = (*cache_sig, cached_copy, env_snapshot)
+            _LOAD_CONFIG_CACHE[path_key] = (
+                *cache_sig,
+                cached_copy,
+                env_snapshot,
+                strict_sources,
+            )
             # On the readonly path return the same cached object subsequent
             # calls will see — keeps "two readonly calls return the same
             # object" invariant that callers may rely on for identity checks.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -246,7 +246,10 @@ _LAST_EXPANDED_CONFIG_BY_PATH: Dict[str, Any] = {}
 # editing the managed-scope config.yaml invalidates the cache (see
 # managed_scope), and the env snapshot invalidates it when a referenced ${VAR}
 # changes value (late .env load, in-process rotation — #58514).
-_LOAD_CONFIG_CACHE: Dict[str, Tuple[int, int, int, int, Dict[str, Any], Dict[str, Optional[str]]]] = {}
+_LOAD_CONFIG_CACHE: Dict[
+    str,
+    Tuple[int, int, int, int, Dict[str, Any], Dict[str, Optional[str]], bool],
+] = {}
 # (path, mtime_ns, size) -> cached raw yaml dict. Same pattern as
 # _LOAD_CONFIG_CACHE but for read_raw_config() — used when callers want
 # the user's on-disk values without defaults merged in.
@@ -3342,6 +3345,16 @@ def load_config_readonly() -> Dict[str, Any]:
     return _load_config_impl(want_deepcopy=False)
 
 
+def load_config_readonly_strict() -> Dict[str, Any]:
+    """Read config without silently substituting defaults or stale values.
+
+    Security gates use this path when an existing malformed or unreadable
+    source must disable execution until the operator repairs it. Missing user
+    and managed config files remain valid and resolve to normal defaults.
+    """
+    return _load_config_impl(want_deepcopy=False, strict_sources=True)
+
+
 def write_platform_config_field(
     platform_key: str,
     field_key: str,
@@ -3494,7 +3507,9 @@ def apply_terminal_config_to_env(
     return target
 
 
-def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
+def _load_config_impl(
+    *, want_deepcopy: bool, strict_sources: bool = False
+) -> Dict[str, Any]:
     with _CONFIG_LOCK:
         ensure_hermes_home()
         config_path = get_config_path()
@@ -3535,14 +3550,15 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
 
         cached = _LOAD_CONFIG_CACHE.get(path_key)
         if cached is not None and cache_sig is not None and cached[:4] == cache_sig:
-            # File signatures match, but the cached expansion is only valid if
-            # every ${VAR} it was expanded against still has the same value.
-            # Without this, a load_config() that ran before load_hermes_dotenv()
-            # pins unexpanded literals (e.g. auxiliary.<task>.api_key) for the
-            # life of the process (#58514).
-            env_snapshot = cached[5] if len(cached) > 5 else {}
-            if all(os.environ.get(k) == v for k, v in env_snapshot.items()):
-                return copy.deepcopy(cached[4]) if want_deepcopy else cached[4]
+            strict_validated = len(cached) > 6 and cached[6] is True
+            if not strict_sources or strict_validated:
+                # File signatures match, but the cached expansion is only valid
+                # if every ${VAR} it was expanded against still has the same
+                # value. Without this, a load_config() that ran before
+                # load_hermes_dotenv() pins unexpanded literals for the process.
+                env_snapshot = cached[5] if len(cached) > 5 else {}
+                if all(os.environ.get(k) == v for k, v in env_snapshot.items()):
+                    return copy.deepcopy(cached[4]) if want_deepcopy else cached[4]
 
         config = copy.deepcopy(DEFAULT_CONFIG)
 
@@ -3578,6 +3594,8 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                     e,
                     fallback="last-known-good" if lkg is not None else "defaults",
                 )
+                if strict_sources:
+                    raise
                 if lkg is not None:
                     # save_config() stores the pre-expansion normalized dict
                     # (env-ref templates preserved); the load path stores the
@@ -3596,7 +3614,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                         _LOAD_CONFIG_CACHE[path_key] = (
                             cache_sig[0], cache_sig[1],
                             cache_sig[2], cache_sig[3],
-                            lkg_copy, _empty_env,
+                            lkg_copy, _empty_env, False,
                         )
                     return copy.deepcopy(lkg_copy) if want_deepcopy else lkg_copy
 
@@ -3607,7 +3625,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
         # against the process environment, never against user-config-defined refs.
         # This deliberately inverts the usual env-over-config precedence for the
         # keys the managed layer pins — see docs/design/managed-scope.md §4.1.
-        managed_config = managed_scope.load_managed_config()
+        managed_config = managed_scope.load_managed_config(strict=strict_sources)
         if managed_config:
             # Normalize the managed overlay through the same canonicalization as
             # the user config BEFORE merging (parity with
@@ -3629,14 +3647,19 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
             # cached value, and ``load_config_readonly()`` (deepcopy=False)
             # callers all see the same stable cached object. The cached tuple is
             # (user_mtime, user_size, managed_mtime, managed_size, value,
-            # env_ref_snapshot). The snapshot records the environment values
-            # this expansion was made against so later loads can detect env
-            # drift (late .env load, in-process rotation) — see cache hit above.
+            # env_ref_snapshot, strict_validated). The snapshot records the
+            # environment values this expansion was made against so later loads
+            # can detect env drift (late .env load, in-process rotation).
             cached_copy = copy.deepcopy(expanded)
             env_snapshot = _env_ref_snapshot(normalized)
             if managed_config:
                 _env_ref_snapshot(managed_config, env_snapshot)
-            _LOAD_CONFIG_CACHE[path_key] = (*cache_sig, cached_copy, env_snapshot)
+            _LOAD_CONFIG_CACHE[path_key] = (
+                *cache_sig,
+                cached_copy,
+                env_snapshot,
+                strict_sources,
+            )
             # On the readonly path return the same cached object subsequent
             # calls will see — keeps "two readonly calls return the same
             # object" invariant that callers may rely on for identity checks.

--- a/hermes_cli/lifecycle.py
+++ b/hermes_cli/lifecycle.py
@@ -8,14 +8,19 @@ from typing import Any, List
 logger = logging.getLogger(__name__)
 
 
-def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
-    """Notify first-party observers, then invoke compatibility plugin hooks."""
+def observe_hook(hook_name: str, **kwargs: Any) -> None:
+    """Notify first-party observers without dispatching compatibility plugins."""
     try:
         from hermes_cli.observability import observe_lifecycle
 
         observe_lifecycle(hook_name, **kwargs)
     except Exception:
         logger.warning("Built-in observability hook failed", exc_info=True)
+
+
+def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
+    """Notify first-party observers, then invoke compatibility plugin hooks."""
+    observe_hook(hook_name, **kwargs)
 
     from hermes_cli import plugins
 

--- a/hermes_cli/managed_scope.py
+++ b/hermes_cli/managed_scope.py
@@ -78,7 +78,7 @@ def invalidate_managed_cache() -> None:
         _ENV_CACHE.clear()
 
 
-def _cached_read(path: Path, cache: Dict[str, tuple], parse):
+def _cached_read(path: Path, cache: Dict[str, tuple], parse, *, strict: bool = False):
     """Shared (mtime_ns, size)-keyed read. Returns a deepcopy of the parsed value.
 
     Returns ``None`` when the file is absent or fails to parse (fail-open). A
@@ -88,8 +88,12 @@ def _cached_read(path: Path, cache: Dict[str, tuple], parse):
     """
     try:
         st = path.stat()
-    except OSError:
+    except FileNotFoundError:
         return None  # absent
+    except OSError:
+        if strict:
+            raise
+        return None
     key = (st.st_mtime_ns, st.st_size)
     path_key = str(path)
     with _CACHE_LOCK:
@@ -106,14 +110,16 @@ def _cached_read(path: Path, cache: Dict[str, tuple], parse):
             path,
             exc,
         )
+        if strict:
+            raise
         return None
     with _CACHE_LOCK:
         cache[path_key] = (key[0], key[1], copy.deepcopy(parsed))
     return parsed
 
 
-def load_managed_config() -> dict:
-    """Parsed managed config.yaml, or {} when absent/malformed (fail-open)."""
+def load_managed_config(*, strict: bool = False) -> dict:
+    """Parse managed config.yaml, optionally rejecting an invalid source."""
     managed_dir = get_managed_dir()
     if managed_dir is None:
         return {}
@@ -121,8 +127,15 @@ def load_managed_config() -> dict:
         managed_dir / "config.yaml",
         _CONFIG_CACHE,
         lambda f: yaml.safe_load(f) or {},
+        strict=strict,
     )
-    return parsed if isinstance(parsed, dict) else {}
+    if parsed is None:
+        return {}
+    if not isinstance(parsed, dict):
+        if strict:
+            raise ValueError("managed config.yaml root must be a mapping")
+        return {}
+    return parsed
 
 
 def load_managed_env() -> Dict[str, str]:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -44,6 +44,7 @@ import asyncio
 import importlib.metadata
 import importlib.util
 import inspect
+import json
 import logging
 import os
 import sys
@@ -648,6 +649,33 @@ class PluginContext:
             agent = getattr(cli, "agent", None) if cli else None
             if agent is not None:
                 kwargs["parent_agent"] = agent
+
+        parent_agent = kwargs.get("parent_agent")
+        middleware_trace = kwargs.get("middleware_trace")
+        try:
+            block_message = resolve_pre_tool_block(
+                tool_name,
+                args,
+                task_id=str(kwargs.get("task_id") or ""),
+                session_id=str(
+                    kwargs.get("session_id")
+                    or getattr(parent_agent, "session_id", "")
+                    or ""
+                ),
+                tool_call_id=str(kwargs.get("tool_call_id") or ""),
+                turn_id=str(kwargs.get("turn_id") or ""),
+                api_request_id=str(kwargs.get("api_request_id") or ""),
+                middleware_trace=(
+                    list(middleware_trace) if isinstance(middleware_trace, list) else None
+                ),
+            )
+        except Exception:
+            # Preserve fail-open behavior for ordinary observer-hook failures.
+            # Required-policy failures are converted to block messages inside
+            # resolve_pre_tool_block().
+            block_message = None
+        if block_message is not None:
+            return json.dumps({"error": block_message}, ensure_ascii=False)
 
         return registry.dispatch(tool_name, args, **kwargs)
 
@@ -2153,6 +2181,7 @@ class _PreToolCallDirective:
 class _RequiredPreToolPolicies:
     plugin_ids: tuple[str, ...] = ()
     invalid_plugin_ids: tuple[str, ...] = ()
+    configuration_error: bool = False
 
 
 def _required_pre_tool_policies(tool_name: str) -> _RequiredPreToolPolicies:
@@ -2171,23 +2200,31 @@ def _required_pre_tool_policies(tool_name: str) -> _RequiredPreToolPolicies:
     the operator's intended guard.
     """
     try:
-        from hermes_cli.config import load_config_readonly
+        from hermes_cli.config import load_config_readonly_strict
 
-        config = load_config_readonly() or {}
+        config = load_config_readonly_strict() or {}
     except Exception:
-        return _RequiredPreToolPolicies()
+        logger.exception("Required pre_tool_call policy configuration is unreadable")
+        return _RequiredPreToolPolicies(configuration_error=True)
 
-    entries = cfg_get(config, "plugins", "entries", default={})
-    if not isinstance(entries, dict):
+    plugins_config = config.get("plugins", {})
+    if not isinstance(plugins_config, dict):
+        return _RequiredPreToolPolicies(configuration_error=True)
+    if "entries" not in plugins_config:
         return _RequiredPreToolPolicies()
+    entries = plugins_config.get("entries")
+    if not isinstance(entries, dict):
+        return _RequiredPreToolPolicies(configuration_error=True)
 
     required: List[str] = []
     invalid: List[str] = []
     for raw_plugin_id, entry in entries.items():
         if not isinstance(raw_plugin_id, str) or not raw_plugin_id.strip():
-            continue
+            return _RequiredPreToolPolicies(configuration_error=True)
         plugin_id = raw_plugin_id.strip()
-        if not isinstance(entry, dict) or "required_pre_tool_call" not in entry:
+        if not isinstance(entry, dict):
+            return _RequiredPreToolPolicies(configuration_error=True)
+        if "required_pre_tool_call" not in entry:
             continue
         setting = entry.get("required_pre_tool_call")
         if setting is False or setting is None:
@@ -2215,6 +2252,8 @@ def _required_pre_tool_policies(tool_name: str) -> _RequiredPreToolPolicies:
 def required_pre_tool_policy_failure(tool_name: str) -> Optional[str]:
     """Return a sanitized fail-closed message if *tool_name* is protected."""
     policies = _required_pre_tool_policies(tool_name)
+    if policies.configuration_error:
+        return "BLOCKED: required pre_tool_call policy configuration is unavailable"
     if not policies.plugin_ids and not policies.invalid_plugin_ids:
         return None
     return f"BLOCKED: required pre_tool_call policy evaluation failed for {tool_name}"
@@ -2225,6 +2264,14 @@ def _required_policy_block(plugin_id: str, reason: str) -> _PreToolCallDirective
     return _PreToolCallDirective(
         action="block",
         message=f"BLOCKED: required pre_tool_call policy '{plugin_id}' {reason}",
+    )
+
+
+def _required_policy_configuration_block() -> _PreToolCallDirective:
+    logger.error("Required pre_tool_call policy configuration is unavailable")
+    return _PreToolCallDirective(
+        action="block",
+        message="BLOCKED: required pre_tool_call policy configuration is unavailable",
     )
 
 
@@ -2319,16 +2366,18 @@ def _get_pre_tool_call_directive_details(
         "api_request_id": api_request_id,
         "middleware_trace": list(middleware_trace or []),
     }
+    from hermes_cli.lifecycle import observe_hook
+
+    observe_hook("pre_tool_call", **hook_kwargs)
     policies = _required_pre_tool_policies(tool_name)
+    if policies.configuration_error:
+        return _required_policy_configuration_block()
     if policies.invalid_plugin_ids:
         return _required_policy_block(
             policies.invalid_plugin_ids[0], "has invalid configuration"
         )
 
     if policies.plugin_ids:
-        from hermes_cli.lifecycle import observe_hook
-
-        observe_hook("pre_tool_call", **hook_kwargs)
         manager = get_plugin_manager()
         invocations = manager.invoke_hook_detailed("pre_tool_call", **hook_kwargs)
         for plugin_id in policies.plugin_ids:
@@ -2362,9 +2411,7 @@ def _get_pre_tool_call_directive_details(
             if invocation.error is None and invocation.result is not None
         ]
     else:
-        from hermes_cli.lifecycle import invoke_hook as invoke_lifecycle_hook
-
-        hook_results = invoke_lifecycle_hook("pre_tool_call", **hook_kwargs)
+        hook_results = invoke_hook("pre_tool_call", **hook_kwargs)
 
     for result in hook_results:
         valid, directive = _parse_pre_tool_call_result(result)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -25,6 +25,13 @@ Plugins may register callbacks for any of the hooks in ``VALID_HOOKS``.
 The agent core calls ``invoke_hook(name, **kwargs)`` at the appropriate
 points.
 
+Operators can make a plugin's ``pre_tool_call`` hook mandatory for selected
+tool-name globs with
+``plugins.entries.<plugin_id>.required_pre_tool_call.tools``. Mandatory hooks
+must return an explicit ``allow``, ``block``, or ``approve`` decision; missing,
+failed, or malformed policy hooks fail closed for matching tools. Ordinary
+observer hooks retain their fail-open behavior.
+
 Tool registration
 -----------------
 ``PluginContext.register_tool()`` delegates to ``tools.registry.register()``
@@ -43,6 +50,7 @@ import sys
 import threading
 import types
 from dataclasses import dataclass, field
+from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set, Union
 
@@ -330,6 +338,19 @@ class LoadedPlugin:
     # imported) loader. The module loads on first real use via the
     # platform_registry; see PluginManager._register_deferred_platform.
     deferred: bool = False
+
+
+@dataclass(frozen=True)
+class _RegisteredHook:
+    plugin_id: str
+    callback: Callable
+
+
+@dataclass(frozen=True)
+class _HookInvocation:
+    plugin_id: Optional[str]
+    result: Any = None
+    error: Optional[Exception] = None
 
 
 # ---------------------------------------------------------------------------
@@ -1188,7 +1209,12 @@ class PluginContext:
                 hook_name,
                 ", ".join(sorted(VALID_HOOKS)),
             )
-        self._manager._hooks.setdefault(hook_name, []).append(callback)
+        self._manager._hooks.setdefault(hook_name, []).append(
+            _RegisteredHook(
+                plugin_id=self.manifest.key or self.manifest.name,
+                callback=callback,
+            )
+        )
         logger.debug("Plugin %s registered hook: %s", self.manifest.name, hook_name)
 
     # -- middleware registration -------------------------------------------
@@ -1269,7 +1295,7 @@ class PluginManager:
 
     def __init__(self) -> None:
         self._plugins: Dict[str, LoadedPlugin] = {}
-        self._hooks: Dict[str, List[Callable]] = {}
+        self._hooks: Dict[str, List[Union[Callable, _RegisteredHook]]] = {}
         self._middleware: Dict[str, List[Callable]] = {}
         self._plugin_tool_names: Set[str] = set()
         self._plugin_platform_names: Set[str] = set()
@@ -1908,6 +1934,35 @@ class PluginManager:
     # Hook invocation
     # -----------------------------------------------------------------------
 
+    def invoke_hook_detailed(
+        self, hook_name: str, **kwargs: Any
+    ) -> List[_HookInvocation]:
+        """Call hooks while retaining owner and failure state for policy gates."""
+        kwargs.setdefault("telemetry_schema_version", OBSERVER_SCHEMA_VERSION)
+        invocations: List[_HookInvocation] = []
+        for registered in self._hooks.get(hook_name, []):
+            if isinstance(registered, _RegisteredHook):
+                plugin_id = registered.plugin_id
+                callback = registered.callback
+            else:
+                plugin_id = None
+                callback = registered
+            try:
+                invocations.append(
+                    _HookInvocation(plugin_id=plugin_id, result=callback(**kwargs))
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Hook '%s' callback %s raised: %s",
+                    hook_name,
+                    getattr(callback, "__name__", repr(callback)),
+                    exc,
+                )
+                invocations.append(
+                    _HookInvocation(plugin_id=plugin_id, error=exc)
+                )
+        return invocations
+
     def invoke_hook(self, hook_name: str, **kwargs: Any) -> List[Any]:
         """Call all registered callbacks for *hook_name*.
 
@@ -1928,22 +1983,11 @@ class PluginManager:
         are reused.  All injected context is ephemeral — never
         persisted to session DB.
         """
-        kwargs.setdefault("telemetry_schema_version", OBSERVER_SCHEMA_VERSION)
-        callbacks = self._hooks.get(hook_name, [])
-        results: List[Any] = []
-        for cb in callbacks:
-            try:
-                ret = cb(**kwargs)
-                if ret is not None:
-                    results.append(ret)
-            except Exception as exc:
-                logger.warning(
-                    "Hook '%s' callback %s raised: %s",
-                    hook_name,
-                    getattr(cb, "__name__", repr(cb)),
-                    exc,
-                )
-        return results
+        return [
+            invocation.result
+            for invocation in self.invoke_hook_detailed(hook_name, **kwargs)
+            if invocation.error is None and invocation.result is not None
+        ]
 
     def has_hook(self, hook_name: str) -> bool:
         """Return True when at least one callback is registered for a hook."""
@@ -2105,6 +2149,110 @@ class _PreToolCallDirective:
     rule_key: Optional[str] = None
 
 
+@dataclass(frozen=True)
+class _RequiredPreToolPolicies:
+    plugin_ids: tuple[str, ...] = ()
+    invalid_plugin_ids: tuple[str, ...] = ()
+
+
+def _required_pre_tool_policies(tool_name: str) -> _RequiredPreToolPolicies:
+    """Return strict policy plugins configured for this runtime tool name.
+
+    Configuration lives under each plugin's existing trust entry::
+
+        plugins:
+          entries:
+            github-policy:
+              required_pre_tool_call:
+                tools: ["github_*", "terminal"]
+
+    ``true`` is shorthand for all tools. Once the opt-in key is present,
+    malformed policy configuration fails closed instead of silently disabling
+    the operator's intended guard.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        config = load_config_readonly() or {}
+    except Exception:
+        return _RequiredPreToolPolicies()
+
+    entries = cfg_get(config, "plugins", "entries", default={})
+    if not isinstance(entries, dict):
+        return _RequiredPreToolPolicies()
+
+    required: List[str] = []
+    invalid: List[str] = []
+    for raw_plugin_id, entry in entries.items():
+        if not isinstance(raw_plugin_id, str) or not raw_plugin_id.strip():
+            continue
+        plugin_id = raw_plugin_id.strip()
+        if not isinstance(entry, dict) or "required_pre_tool_call" not in entry:
+            continue
+        setting = entry.get("required_pre_tool_call")
+        if setting is False or setting is None:
+            continue
+        if setting is True:
+            patterns = ["*"]
+        elif isinstance(setting, dict):
+            patterns = setting.get("tools")
+            if not (
+                isinstance(patterns, list)
+                and patterns
+                and all(isinstance(pattern, str) and pattern.strip() for pattern in patterns)
+            ):
+                invalid.append(plugin_id)
+                continue
+            patterns = [pattern.strip() for pattern in patterns]
+        else:
+            invalid.append(plugin_id)
+            continue
+        if any(fnmatchcase(tool_name, pattern) for pattern in patterns):
+            required.append(plugin_id)
+    return _RequiredPreToolPolicies(tuple(required), tuple(invalid))
+
+
+def required_pre_tool_policy_failure(tool_name: str) -> Optional[str]:
+    """Return a sanitized fail-closed message if *tool_name* is protected."""
+    policies = _required_pre_tool_policies(tool_name)
+    if not policies.plugin_ids and not policies.invalid_plugin_ids:
+        return None
+    return f"BLOCKED: required pre_tool_call policy evaluation failed for {tool_name}"
+
+
+def _required_policy_block(plugin_id: str, reason: str) -> _PreToolCallDirective:
+    logger.error("Required pre_tool_call policy %r %s", plugin_id, reason)
+    return _PreToolCallDirective(
+        action="block",
+        message=f"BLOCKED: required pre_tool_call policy '{plugin_id}' {reason}",
+    )
+
+
+def _parse_pre_tool_call_result(
+    result: Any, *, explicit_allow: bool = False
+) -> tuple[bool, _PreToolCallDirective]:
+    if not isinstance(result, dict):
+        return False, _PreToolCallDirective()
+    action = result.get("action")
+    if action == "allow" and explicit_allow:
+        return True, _PreToolCallDirective()
+    if action not in ("block", "approve"):
+        return False, _PreToolCallDirective()
+    message = result.get("message")
+    message = message if isinstance(message, str) and message else None
+    if action == "block" and not message:
+        return False, _PreToolCallDirective()
+    rule_key = result.get("rule_key") if action == "approve" else None
+    rule_key = rule_key.strip() if isinstance(rule_key, str) else None
+    if not rule_key:
+        rule_key = None
+    return True, _PreToolCallDirective(
+        action=action,
+        message=message,
+        rule_key=rule_key,
+    )
+
+
 def set_thread_tool_whitelist(
     allowed: Optional[Set[str]],
     deny_msg_fmt: str = "Tool '{tool_name}' denied: not in this thread's tool whitelist",
@@ -2161,37 +2309,67 @@ def _get_pre_tool_call_directive_details(
             message=fmt.format(tool_name=tool_name),
         )
 
-    from hermes_cli.lifecycle import invoke_hook as invoke_lifecycle_hook
+    hook_kwargs = {
+        "tool_name": tool_name,
+        "args": args if isinstance(args, dict) else {},
+        "task_id": task_id,
+        "session_id": session_id,
+        "tool_call_id": tool_call_id,
+        "turn_id": turn_id,
+        "api_request_id": api_request_id,
+        "middleware_trace": list(middleware_trace or []),
+    }
+    policies = _required_pre_tool_policies(tool_name)
+    if policies.invalid_plugin_ids:
+        return _required_policy_block(
+            policies.invalid_plugin_ids[0], "has invalid configuration"
+        )
 
-    hook_results = invoke_lifecycle_hook(
-        "pre_tool_call",
-        tool_name=tool_name,
-        args=args if isinstance(args, dict) else {},
-        task_id=task_id,
-        session_id=session_id,
-        tool_call_id=tool_call_id,
-        turn_id=turn_id,
-        api_request_id=api_request_id,
-        middleware_trace=list(middleware_trace or []),
-    )
+    if policies.plugin_ids:
+        from hermes_cli.lifecycle import observe_hook
+
+        observe_hook("pre_tool_call", **hook_kwargs)
+        manager = get_plugin_manager()
+        invocations = manager.invoke_hook_detailed("pre_tool_call", **hook_kwargs)
+        for plugin_id in policies.plugin_ids:
+            loaded = manager._plugins.get(plugin_id)
+            if loaded is None or not loaded.enabled or loaded.error:
+                return _required_policy_block(plugin_id, "is unavailable")
+            owned = [
+                invocation
+                for invocation in invocations
+                if invocation.plugin_id == plugin_id
+            ]
+            if not owned:
+                return _required_policy_block(
+                    plugin_id, "did not register a pre_tool_call hook"
+                )
+            for invocation in owned:
+                if invocation.error is not None:
+                    return _required_policy_block(plugin_id, "callback failed")
+                valid, directive = _parse_pre_tool_call_result(
+                    invocation.result, explicit_allow=True
+                )
+                if not valid:
+                    return _required_policy_block(
+                        plugin_id, "returned an invalid decision"
+                    )
+                if directive.action == "block":
+                    return directive
+        hook_results = [
+            invocation.result
+            for invocation in invocations
+            if invocation.error is None and invocation.result is not None
+        ]
+    else:
+        from hermes_cli.lifecycle import invoke_hook as invoke_lifecycle_hook
+
+        hook_results = invoke_lifecycle_hook("pre_tool_call", **hook_kwargs)
 
     for result in hook_results:
-        if not isinstance(result, dict):
-            continue
-        action = result.get("action")
-        if action not in ("block", "approve"):
-            continue
-        message = result.get("message")
-        message = message if isinstance(message, str) and message else None
-        # A block directive requires a message (it becomes the tool result);
-        # an approve directive can carry an optional reason.
-        if action == "block" and not message:
-            continue
-        rule_key = result.get("rule_key") if action == "approve" else None
-        rule_key = rule_key.strip() if isinstance(rule_key, str) else None
-        if not rule_key:
-            rule_key = None
-        return _PreToolCallDirective(action=action, message=message, rule_key=rule_key)
+        valid, directive = _parse_pre_tool_call_result(result)
+        if valid:
+            return directive
 
     return _PreToolCallDirective()
 
@@ -2246,7 +2424,7 @@ def get_pre_tool_call_block_message(
     return message if directive == "block" else None
 
 
-def resolve_pre_tool_block(
+def _resolve_pre_tool_block(
     tool_name: str,
     args: Optional[Dict[str, Any]],
     task_id: str = "",
@@ -2315,6 +2493,39 @@ def resolve_pre_tool_block(
                 or f"BLOCKED: plugin approval required for {tool_name}"
             )
     return None
+
+
+def resolve_pre_tool_block(
+    tool_name: str,
+    args: Optional[Dict[str, Any]],
+    task_id: str = "",
+    session_id: str = "",
+    tool_call_id: str = "",
+    turn_id: str = "",
+    api_request_id: str = "",
+    middleware_trace: Optional[List[Dict[str, Any]]] = None,
+) -> Optional[str]:
+    """Fail closed on resolver errors only for explicitly protected tools."""
+    try:
+        return _resolve_pre_tool_block(
+            tool_name,
+            args,
+            task_id=task_id,
+            session_id=session_id,
+            tool_call_id=tool_call_id,
+            turn_id=turn_id,
+            api_request_id=api_request_id,
+            middleware_trace=middleware_trace,
+        )
+    except Exception:
+        block_message = required_pre_tool_policy_failure(tool_name)
+        if block_message is not None:
+            logger.exception(
+                "Required pre_tool_call policy resolution crashed for %s",
+                tool_name,
+            )
+            return block_message
+        raise
 
 
 def get_pre_verify_continue_message(

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2216,6 +2216,33 @@ class PluginContext:
             if agent is not None:
                 kwargs["parent_agent"] = agent
 
+        parent_agent = kwargs.get("parent_agent")
+        middleware_trace = kwargs.get("middleware_trace")
+        try:
+            block_message = resolve_pre_tool_block(
+                tool_name,
+                args,
+                task_id=str(kwargs.get("task_id") or ""),
+                session_id=str(
+                    kwargs.get("session_id")
+                    or getattr(parent_agent, "session_id", "")
+                    or ""
+                ),
+                tool_call_id=str(kwargs.get("tool_call_id") or ""),
+                turn_id=str(kwargs.get("turn_id") or ""),
+                api_request_id=str(kwargs.get("api_request_id") or ""),
+                middleware_trace=(
+                    list(middleware_trace) if isinstance(middleware_trace, list) else None
+                ),
+            )
+        except Exception:
+            # Preserve fail-open behavior for ordinary observer-hook failures.
+            # Required-policy failures are converted to block messages inside
+            # resolve_pre_tool_block().
+            block_message = None
+        if block_message is not None:
+            return json.dumps({"error": block_message}, ensure_ascii=False)
+
         return registry.dispatch(
             tool_name, args, scope=self._manager.scope_key, **kwargs
         )
@@ -6004,6 +6031,7 @@ class _PreToolCallDirective:
 class _RequiredPreToolPolicies:
     plugin_ids: tuple[str, ...] = ()
     invalid_plugin_ids: tuple[str, ...] = ()
+    configuration_error: bool = False
 
 
 def _required_pre_tool_policies(tool_name: str) -> _RequiredPreToolPolicies:
@@ -6022,23 +6050,31 @@ def _required_pre_tool_policies(tool_name: str) -> _RequiredPreToolPolicies:
     the operator's intended guard.
     """
     try:
-        from hermes_cli.config import load_config_readonly
+        from hermes_cli.config import load_config_readonly_strict
 
-        config = load_config_readonly() or {}
+        config = load_config_readonly_strict() or {}
     except Exception:
-        return _RequiredPreToolPolicies()
+        logger.exception("Required pre_tool_call policy configuration is unreadable")
+        return _RequiredPreToolPolicies(configuration_error=True)
 
-    entries = cfg_get(config, "plugins", "entries", default={})
-    if not isinstance(entries, dict):
+    plugins_config = config.get("plugins", {})
+    if not isinstance(plugins_config, dict):
+        return _RequiredPreToolPolicies(configuration_error=True)
+    if "entries" not in plugins_config:
         return _RequiredPreToolPolicies()
+    entries = plugins_config.get("entries")
+    if not isinstance(entries, dict):
+        return _RequiredPreToolPolicies(configuration_error=True)
 
     required: List[str] = []
     invalid: List[str] = []
     for raw_plugin_id, entry in entries.items():
         if not isinstance(raw_plugin_id, str) or not raw_plugin_id.strip():
-            continue
+            return _RequiredPreToolPolicies(configuration_error=True)
         plugin_id = raw_plugin_id.strip()
-        if not isinstance(entry, dict) or "required_pre_tool_call" not in entry:
+        if not isinstance(entry, dict):
+            return _RequiredPreToolPolicies(configuration_error=True)
+        if "required_pre_tool_call" not in entry:
             continue
         setting = entry.get("required_pre_tool_call")
         if setting is False or setting is None:
@@ -6066,6 +6102,8 @@ def _required_pre_tool_policies(tool_name: str) -> _RequiredPreToolPolicies:
 def required_pre_tool_policy_failure(tool_name: str) -> Optional[str]:
     """Return a sanitized fail-closed message if *tool_name* is protected."""
     policies = _required_pre_tool_policies(tool_name)
+    if policies.configuration_error:
+        return "BLOCKED: required pre_tool_call policy configuration is unavailable"
     if not policies.plugin_ids and not policies.invalid_plugin_ids:
         return None
     return f"BLOCKED: required pre_tool_call policy evaluation failed for {tool_name}"
@@ -6076,6 +6114,14 @@ def _required_policy_block(plugin_id: str, reason: str) -> _PreToolCallDirective
     return _PreToolCallDirective(
         action="block",
         message=f"BLOCKED: required pre_tool_call policy '{plugin_id}' {reason}",
+    )
+
+
+def _required_policy_configuration_block() -> _PreToolCallDirective:
+    logger.error("Required pre_tool_call policy configuration is unavailable")
+    return _PreToolCallDirective(
+        action="block",
+        message="BLOCKED: required pre_tool_call policy configuration is unavailable",
     )
 
 
@@ -6170,16 +6216,18 @@ def _get_pre_tool_call_directive_details(
         "api_request_id": api_request_id,
         "middleware_trace": list(middleware_trace or []),
     }
+    from hermes_cli.lifecycle import observe_hook
+
+    observe_hook("pre_tool_call", **hook_kwargs)
     policies = _required_pre_tool_policies(tool_name)
+    if policies.configuration_error:
+        return _required_policy_configuration_block()
     if policies.invalid_plugin_ids:
         return _required_policy_block(
             policies.invalid_plugin_ids[0], "has invalid configuration"
         )
 
     if policies.plugin_ids:
-        from hermes_cli.lifecycle import observe_hook
-
-        observe_hook("pre_tool_call", **hook_kwargs)
         manager = get_plugin_manager()
         invocations = manager.invoke_hook_detailed("pre_tool_call", **hook_kwargs)
         for plugin_id in policies.plugin_ids:
@@ -6213,9 +6261,7 @@ def _get_pre_tool_call_directive_details(
             if invocation.error is None and invocation.result is not None
         ]
     else:
-        from hermes_cli.lifecycle import invoke_hook as invoke_lifecycle_hook
-
-        hook_results = invoke_lifecycle_hook("pre_tool_call", **hook_kwargs)
+        hook_results = invoke_hook("pre_tool_call", **hook_kwargs)
 
     modified_args: Optional[Dict[str, Any]] = None
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -25,6 +25,13 @@ Plugins may register callbacks for any of the hooks in ``VALID_HOOKS``.
 The agent core calls ``invoke_hook(name, **kwargs)`` at the appropriate
 points.
 
+Operators can make a plugin's ``pre_tool_call`` hook mandatory for selected
+tool-name globs with
+``plugins.entries.<plugin_id>.required_pre_tool_call.tools``. Mandatory hooks
+must return an explicit ``allow``, ``block``, or ``approve`` decision; missing,
+failed, or malformed policy hooks fail closed for matching tools. Ordinary
+observer hooks retain their fail-open behavior.
+
 Tool registration
 -----------------
 ``PluginContext.register_tool()`` delegates to ``tools.registry.register()``
@@ -50,6 +57,7 @@ import types
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from functools import wraps
+from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import (Any, Callable, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Type, Union)
 
@@ -1198,6 +1206,19 @@ class PluginRegistration:
         finally:
             if self._on_dispose is not None:
                 self._on_dispose(self)
+
+
+@dataclass(frozen=True)
+class _RegisteredHook:
+    plugin_id: str
+    callback: Callable
+
+
+@dataclass(frozen=True)
+class _HookInvocation:
+    plugin_id: Optional[str]
+    result: Any = None
+    error: Optional[Exception] = None
 
 
 # ---------------------------------------------------------------------------
@@ -3121,11 +3142,15 @@ class PluginContext:
                 ", ".join(sorted(VALID_HOOKS)),
             )
         callbacks = self._manager._hooks.setdefault(hook_name, [])
-        callbacks.append(callback)
+        registered = _RegisteredHook(
+            plugin_id=self.manifest.key or self.manifest.name,
+            callback=callback,
+        )
+        callbacks.append(registered)
         handle = self._track(
             "hook", hook_name,
             lambda: self._manager._remove_callback(
-                self._manager._hooks, hook_name, callback
+                self._manager._hooks, hook_name, registered
             ),
         )
         logger.debug("Plugin %s registered hook: %s", self.manifest.name, hook_name)
@@ -3396,7 +3421,7 @@ class PluginManager:
         self.home_path = Path(self.scope_key)
         self._discovery_lock = threading.RLock()
         self._plugins: Dict[str, LoadedPlugin] = {}
-        self._hooks: Dict[str, List[Callable]] = {}
+        self._hooks: Dict[str, List[Union[Callable, _RegisteredHook]]] = {}
         self._middleware: Dict[str, List[Callable]] = {}
         self._plugin_tool_names: Set[str] = set()
         self._plugin_platform_names: Set[str] = set()
@@ -5068,6 +5093,39 @@ class PluginManager:
         }
         return callback(**accepted_payload)
 
+    def invoke_hook_detailed(
+        self, hook_name: str, **kwargs: Any
+    ) -> List[_HookInvocation]:
+        """Call hooks while retaining owner and failure state for policy gates."""
+        if hook_name != "gateway_platform_event":
+            kwargs.setdefault("telemetry_schema_version", OBSERVER_SCHEMA_VERSION)
+        invocations: List[_HookInvocation] = []
+        for registered in self._hooks.get(hook_name, []):
+            if isinstance(registered, _RegisteredHook):
+                plugin_id = registered.plugin_id
+                callback = registered.callback
+            else:
+                plugin_id = None
+                callback = registered
+            try:
+                invocations.append(
+                    _HookInvocation(
+                        plugin_id=plugin_id,
+                        result=self._invoke_hook_callback(callback, kwargs),
+                    )
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Hook '%s' callback %s raised: %s",
+                    hook_name,
+                    getattr(callback, "__name__", repr(callback)),
+                    exc,
+                )
+                invocations.append(
+                    _HookInvocation(plugin_id=plugin_id, error=exc)
+                )
+        return invocations
+
     def invoke_hook(self, hook_name: str, **kwargs: Any) -> List[Any]:
         """Call all registered callbacks for *hook_name*.
 
@@ -5091,27 +5149,11 @@ class PluginManager:
         are reused.  All injected context is ephemeral — never
         persisted to session DB.
         """
-        # Most legacy observer hooks carry the shared telemetry marker. Gateway
-        # platform events define event-local additive envelopes instead: injecting
-        # a bus-wide version here would turn unrelated adapter payloads into one
-        # monolithic compatibility contract (#64176).
-        if hook_name != "gateway_platform_event":
-            kwargs.setdefault("telemetry_schema_version", OBSERVER_SCHEMA_VERSION)
-        callbacks = self._hooks.get(hook_name, [])
-        results: List[Any] = []
-        for cb in callbacks:
-            try:
-                ret = self._invoke_hook_callback(cb, kwargs)
-                if ret is not None:
-                    results.append(ret)
-            except Exception as exc:
-                logger.warning(
-                    "Hook '%s' callback %s raised: %s",
-                    hook_name,
-                    getattr(cb, "__name__", repr(cb)),
-                    exc,
-                )
-        return results
+        return [
+            invocation.result
+            for invocation in self.invoke_hook_detailed(hook_name, **kwargs)
+            if invocation.error is None and invocation.result is not None
+        ]
 
     def _subscribe_event(
         self,
@@ -5316,7 +5358,12 @@ class PluginManager:
 
     def iter_hook_callbacks(self, hook_name: str) -> tuple[Callable, ...]:
         """Return a stable snapshot of callbacks registered for a hook."""
-        return tuple(self._hooks.get(hook_name, ()))
+        return tuple(
+            registered.callback
+            if isinstance(registered, _RegisteredHook)
+            else registered
+            for registered in self._hooks.get(hook_name, ())
+        )
 
     def render_system_prompt_sections(
         self, session_info: Mapping[str, Any]
@@ -5953,6 +6000,110 @@ class _PreToolCallDirective:
     modified_args: Optional[Dict[str, Any]] = None
 
 
+@dataclass(frozen=True)
+class _RequiredPreToolPolicies:
+    plugin_ids: tuple[str, ...] = ()
+    invalid_plugin_ids: tuple[str, ...] = ()
+
+
+def _required_pre_tool_policies(tool_name: str) -> _RequiredPreToolPolicies:
+    """Return strict policy plugins configured for this runtime tool name.
+
+    Configuration lives under each plugin's existing trust entry::
+
+        plugins:
+          entries:
+            github-policy:
+              required_pre_tool_call:
+                tools: ["github_*", "terminal"]
+
+    ``true`` is shorthand for all tools. Once the opt-in key is present,
+    malformed policy configuration fails closed instead of silently disabling
+    the operator's intended guard.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        config = load_config_readonly() or {}
+    except Exception:
+        return _RequiredPreToolPolicies()
+
+    entries = cfg_get(config, "plugins", "entries", default={})
+    if not isinstance(entries, dict):
+        return _RequiredPreToolPolicies()
+
+    required: List[str] = []
+    invalid: List[str] = []
+    for raw_plugin_id, entry in entries.items():
+        if not isinstance(raw_plugin_id, str) or not raw_plugin_id.strip():
+            continue
+        plugin_id = raw_plugin_id.strip()
+        if not isinstance(entry, dict) or "required_pre_tool_call" not in entry:
+            continue
+        setting = entry.get("required_pre_tool_call")
+        if setting is False or setting is None:
+            continue
+        if setting is True:
+            patterns = ["*"]
+        elif isinstance(setting, dict):
+            patterns = setting.get("tools")
+            if not (
+                isinstance(patterns, list)
+                and patterns
+                and all(isinstance(pattern, str) and pattern.strip() for pattern in patterns)
+            ):
+                invalid.append(plugin_id)
+                continue
+            patterns = [pattern.strip() for pattern in patterns]
+        else:
+            invalid.append(plugin_id)
+            continue
+        if any(fnmatchcase(tool_name, pattern) for pattern in patterns):
+            required.append(plugin_id)
+    return _RequiredPreToolPolicies(tuple(required), tuple(invalid))
+
+
+def required_pre_tool_policy_failure(tool_name: str) -> Optional[str]:
+    """Return a sanitized fail-closed message if *tool_name* is protected."""
+    policies = _required_pre_tool_policies(tool_name)
+    if not policies.plugin_ids and not policies.invalid_plugin_ids:
+        return None
+    return f"BLOCKED: required pre_tool_call policy evaluation failed for {tool_name}"
+
+
+def _required_policy_block(plugin_id: str, reason: str) -> _PreToolCallDirective:
+    logger.error("Required pre_tool_call policy %r %s", plugin_id, reason)
+    return _PreToolCallDirective(
+        action="block",
+        message=f"BLOCKED: required pre_tool_call policy '{plugin_id}' {reason}",
+    )
+
+
+def _parse_pre_tool_call_result(
+    result: Any, *, explicit_allow: bool = False
+) -> tuple[bool, _PreToolCallDirective]:
+    if not isinstance(result, dict):
+        return False, _PreToolCallDirective()
+    action = result.get("action")
+    if action == "allow" and explicit_allow:
+        return True, _PreToolCallDirective()
+    if action not in ("block", "approve"):
+        return False, _PreToolCallDirective()
+    message = result.get("message")
+    message = message if isinstance(message, str) and message else None
+    if action == "block" and not message:
+        return False, _PreToolCallDirective()
+    rule_key = result.get("rule_key") if action == "approve" else None
+    rule_key = rule_key.strip() if isinstance(rule_key, str) else None
+    if not rule_key:
+        rule_key = None
+    return True, _PreToolCallDirective(
+        action=action,
+        message=message,
+        rule_key=rule_key,
+    )
+
+
 def set_thread_tool_whitelist(
     allowed: Optional[Set[str]],
     deny_msg_fmt: str = "Tool '{tool_name}' denied: not in this thread's tool whitelist",
@@ -6009,21 +6160,63 @@ def _get_pre_tool_call_directive_details(
             message=fmt.format(tool_name=tool_name),
         )
 
-    from hermes_cli.lifecycle import invoke_hook as invoke_lifecycle_hook
+    hook_kwargs = {
+        "tool_name": tool_name,
+        "args": args if isinstance(args, dict) else {},
+        "task_id": task_id,
+        "session_id": session_id,
+        "tool_call_id": tool_call_id,
+        "turn_id": turn_id,
+        "api_request_id": api_request_id,
+        "middleware_trace": list(middleware_trace or []),
+    }
+    policies = _required_pre_tool_policies(tool_name)
+    if policies.invalid_plugin_ids:
+        return _required_policy_block(
+            policies.invalid_plugin_ids[0], "has invalid configuration"
+        )
 
-    hook_results = invoke_lifecycle_hook(
-        "pre_tool_call",
-        tool_name=tool_name,
-        args=args if isinstance(args, dict) else {},
-        task_id=task_id,
-        session_id=session_id,
-        tool_call_id=tool_call_id,
-        turn_id=turn_id,
-        api_request_id=api_request_id,
-        middleware_trace=list(middleware_trace or []),
-    )
+    if policies.plugin_ids:
+        from hermes_cli.lifecycle import observe_hook
 
-    block_msg: Optional[str] = None
+        observe_hook("pre_tool_call", **hook_kwargs)
+        manager = get_plugin_manager()
+        invocations = manager.invoke_hook_detailed("pre_tool_call", **hook_kwargs)
+        for plugin_id in policies.plugin_ids:
+            loaded = manager._plugins.get(plugin_id)
+            if loaded is None or not loaded.enabled or loaded.error:
+                return _required_policy_block(plugin_id, "is unavailable")
+            owned = [
+                invocation
+                for invocation in invocations
+                if invocation.plugin_id == plugin_id
+            ]
+            if not owned:
+                return _required_policy_block(
+                    plugin_id, "did not register a pre_tool_call hook"
+                )
+            for invocation in owned:
+                if invocation.error is not None:
+                    return _required_policy_block(plugin_id, "callback failed")
+                valid, directive = _parse_pre_tool_call_result(
+                    invocation.result, explicit_allow=True
+                )
+                if not valid:
+                    return _required_policy_block(
+                        plugin_id, "returned an invalid decision"
+                    )
+                if directive.action == "block":
+                    return directive
+        hook_results = [
+            invocation.result
+            for invocation in invocations
+            if invocation.error is None and invocation.result is not None
+        ]
+    else:
+        from hermes_cli.lifecycle import invoke_hook as invoke_lifecycle_hook
+
+        hook_results = invoke_lifecycle_hook("pre_tool_call", **hook_kwargs)
+
     modified_args: Optional[Dict[str, Any]] = None
 
     for result in hook_results:
@@ -6112,7 +6305,7 @@ def get_pre_tool_call_block_message(
     return message if directive == "block" else None
 
 
-def resolve_pre_tool_block(
+def _resolve_pre_tool_block(
     tool_name: str,
     args: Optional[Dict[str, Any]],
     task_id: str = "",
@@ -6207,6 +6400,39 @@ def _resolve_block_from_details(
     return None
 
 
+def resolve_pre_tool_block(
+    tool_name: str,
+    args: Optional[Dict[str, Any]],
+    task_id: str = "",
+    session_id: str = "",
+    tool_call_id: str = "",
+    turn_id: str = "",
+    api_request_id: str = "",
+    middleware_trace: Optional[List[Dict[str, Any]]] = None,
+) -> Optional[str]:
+    """Fail closed on resolver errors only for explicitly protected tools."""
+    try:
+        return _resolve_pre_tool_block(
+            tool_name,
+            args,
+            task_id=task_id,
+            session_id=session_id,
+            tool_call_id=tool_call_id,
+            turn_id=turn_id,
+            api_request_id=api_request_id,
+            middleware_trace=middleware_trace,
+        )
+    except Exception:
+        block_message = required_pre_tool_policy_failure(tool_name)
+        if block_message is not None:
+            logger.exception(
+                "Required pre_tool_call policy resolution crashed for %s",
+                tool_name,
+            )
+            return block_message
+        raise
+
+
 def _dispatch_pre_tool_call_hooks(
     tool_name: str,
     args: Optional[Dict[str, Any]],
@@ -6235,16 +6461,26 @@ def _dispatch_pre_tool_call_hooks(
     Callers that also need input transformation should call this
     function and apply ``modified_args`` if not ``None``.
     """
-    details = _get_pre_tool_call_directive_details(
-        tool_name, args, task_id=task_id, session_id=session_id,
-        tool_call_id=tool_call_id, turn_id=turn_id,
-        api_request_id=api_request_id, middleware_trace=middleware_trace,
-    )
-    block_msg = _resolve_block_from_details(
-        details, tool_name,
-        turn_id=turn_id, tool_call_id=tool_call_id, session_id=session_id,
-    )
-    return (block_msg, details.modified_args)
+    try:
+        details = _get_pre_tool_call_directive_details(
+            tool_name, args, task_id=task_id, session_id=session_id,
+            tool_call_id=tool_call_id, turn_id=turn_id,
+            api_request_id=api_request_id, middleware_trace=middleware_trace,
+        )
+        block_msg = _resolve_block_from_details(
+            details, tool_name,
+            turn_id=turn_id, tool_call_id=tool_call_id, session_id=session_id,
+        )
+        return (block_msg, details.modified_args)
+    except Exception:
+        block_message = required_pre_tool_policy_failure(tool_name)
+        if block_message is not None:
+            logger.exception(
+                "Required pre_tool_call policy resolution crashed for %s",
+                tool_name,
+            )
+            return (block_message, None)
+        raise
 
 
 def get_pre_verify_continue_message(

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -17,6 +17,7 @@ from hermes_cli.config import (
     _normalize_max_turns_config,
     is_provider_enabled,
     load_config,
+    load_config_readonly_strict,
     load_env,
     migrate_config,
     read_raw_config,
@@ -169,8 +170,20 @@ class TestLoadConfigParseFailure:
             err = capsys.readouterr().err
             assert "previously loaded config" in err
 
+    def test_strict_read_rejects_corruption_despite_last_known_good(self, tmp_path):
+        from hermes_cli import config as cfg_mod
 
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            cfg = tmp_path / "config.yaml"
+            cfg.write_text("plugins:\n  entries: {}\n")
+            assert isinstance(load_config_readonly_strict(), dict)
 
+            cfg.write_text("plugins:\n  entries: [broken and deliberately longer\n")
+            assert load_config()["plugins"]["entries"] == {}
+            with pytest.raises(Exception):
+                load_config_readonly_strict()
+
+            cfg_mod._LOAD_CONFIG_CACHE.pop(str(cfg), None)
 
 
 class TestEmptyConfigSections:
@@ -1356,7 +1369,6 @@ class TestCodexAppServerAutoConfig:
 
             raw = yaml.safe_load((tmp_path / "config.yaml").read_text())
             assert raw["compression"]["codex_app_server_auto"] == "hermes"
-
 
 class TestIsProviderEnabled:
     """``is_provider_enabled`` gates ``providers.<name>`` blocks for the

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -17,6 +17,7 @@ from hermes_cli.config import (
     _normalize_max_turns_config,
     is_provider_enabled,
     load_config,
+    load_config_readonly_strict,
     load_env,
     migrate_config,
     read_raw_config,
@@ -169,8 +170,20 @@ class TestLoadConfigParseFailure:
             err = capsys.readouterr().err
             assert "previously loaded config" in err
 
+    def test_strict_read_rejects_corruption_despite_last_known_good(self, tmp_path):
+        from hermes_cli import config as cfg_mod
 
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            cfg = tmp_path / "config.yaml"
+            cfg.write_text("plugins:\n  entries: {}\n")
+            assert isinstance(load_config_readonly_strict(), dict)
 
+            cfg.write_text("plugins:\n  entries: [broken and deliberately longer\n")
+            assert load_config()["plugins"]["entries"] == {}
+            with pytest.raises(Exception):
+                load_config_readonly_strict()
+
+            cfg_mod._LOAD_CONFIG_CACHE.pop(str(cfg), None)
 
 
 class TestEmptyConfigSections:
@@ -1417,7 +1430,6 @@ class TestCodexAppServerAutoConfig:
 
             raw = yaml.safe_load((tmp_path / "config.yaml").read_text())
             assert raw["compression"]["codex_app_server_auto"] == "hermes"
-
 
 class TestIsProviderEnabled:
     """``is_provider_enabled`` gates ``providers.<name>`` blocks for the

--- a/tests/hermes_cli/test_managed_scope_loaders.py
+++ b/tests/hermes_cli/test_managed_scope_loaders.py
@@ -82,3 +82,18 @@ def test_gateway_env_bridge_honors_managed(homes, monkeypatch):
     raw = yaml.safe_load((home / "config.yaml").read_text())
     bridged = managed_scope.apply_managed_overlay(raw)
     assert bridged.get("timezone") == "Asia/Tokyo"
+
+
+def test_strict_config_read_rejects_malformed_managed_source(homes):
+    home, managed = homes
+    _seed(
+        home,
+        managed,
+        user="plugins:\n  entries: {}\n",
+        mgd="plugins:\n  entries: [unterminated\n",
+    )
+    from hermes_cli.config import load_config_readonly, load_config_readonly_strict
+
+    assert isinstance(load_config_readonly(), dict)
+    with pytest.raises(Exception):
+        load_config_readonly_strict()

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -518,6 +518,232 @@ class TestResolvePreToolBlock:
         msg = resolve_pre_tool_block("terminal", {})
         assert msg is not None and "gate failed" in msg  # fail-closed
 
+    @staticmethod
+    def _configure_required_policy(home, plugin_id, tools):
+        config_path = home / "config.yaml"
+        config = yaml.safe_load(config_path.read_text()) if config_path.exists() else {}
+        config = config or {}
+        plugins = config.setdefault("plugins", {})
+        plugins.setdefault("enabled", [])
+        plugins.setdefault("entries", {})[plugin_id] = {
+            "required_pre_tool_call": {"tools": tools}
+        }
+        config_path.write_text(yaml.safe_dump(config))
+
+    def test_required_policy_callback_exception_blocks_with_sanitized_reason(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.plugins as plugins_mod
+
+        home = tmp_path / "hermes"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _make_plugin_dir(
+            home / "plugins",
+            "required_guard",
+            register_body=(
+                'ctx.register_hook("pre_tool_call", '
+                'lambda **kw: (_ for _ in ()).throw(RuntimeError("secret detail")))'
+            ),
+        )
+        self._configure_required_policy(home, "required_guard", ["terminal"])
+        manager = PluginManager()
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+        manager.discover_and_load()
+
+        message = plugins_mod.resolve_pre_tool_block("terminal", {"command": "pwd"})
+
+        assert message is not None
+        assert "required_guard" in message
+        assert "secret detail" not in message
+
+    def test_missing_required_policy_plugin_blocks(self, tmp_path, monkeypatch):
+        import hermes_cli.plugins as plugins_mod
+
+        home = tmp_path / "hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        self._configure_required_policy(home, "missing_guard", ["github_*"])
+        manager = PluginManager()
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+        manager.discover_and_load()
+
+        message = plugins_mod.resolve_pre_tool_block("github_merge", {})
+
+        assert message is not None
+        assert "missing_guard" in message
+
+    def test_required_policy_malformed_result_blocks_but_unprotected_tool_allows(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.plugins as plugins_mod
+
+        home = tmp_path / "hermes"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _make_plugin_dir(
+            home / "plugins",
+            "malformed_guard",
+            register_body=(
+                'ctx.register_hook("pre_tool_call", '
+                'lambda **kw: {"action": "maybe"})'
+            ),
+        )
+        self._configure_required_policy(home, "malformed_guard", ["terminal"])
+        manager = PluginManager()
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+        manager.discover_and_load()
+
+        assert plugins_mod.resolve_pre_tool_block("terminal", {}) is not None
+        assert plugins_mod.resolve_pre_tool_block("read_file", {}) is None
+
+    def test_required_policy_explicit_allow_permits_matching_tool(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.plugins as plugins_mod
+
+        home = tmp_path / "hermes"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _make_plugin_dir(
+            home / "plugins",
+            "allow_guard",
+            register_body=(
+                'ctx.register_hook("pre_tool_call", '
+                'lambda **kw: {"action": "allow"})'
+            ),
+        )
+        self._configure_required_policy(home, "allow_guard", ["github_*"])
+        manager = PluginManager()
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+        manager.discover_and_load()
+
+        assert plugins_mod.resolve_pre_tool_block("github_merge", {}) is None
+
+    def test_required_policy_preserves_first_party_observation(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli import observability
+        import hermes_cli.plugins as plugins_mod
+
+        home = tmp_path / "hermes"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _make_plugin_dir(
+            home / "plugins",
+            "allow_guard",
+            register_body=(
+                'ctx.register_hook("pre_tool_call", '
+                'lambda **kw: {"action": "allow"})'
+            ),
+        )
+        self._configure_required_policy(home, "allow_guard", ["github_*"])
+        manager = PluginManager()
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+        manager.discover_and_load()
+        observed = []
+        monkeypatch.setattr(
+            observability,
+            "observe_lifecycle",
+            lambda hook_name, **kwargs: observed.append((hook_name, kwargs)),
+        )
+
+        assert plugins_mod.resolve_pre_tool_block("github_merge", {}) is None
+        assert [name for name, _kwargs in observed] == ["pre_tool_call"]
+        assert observed[0][1]["tool_name"] == "github_merge"
+
+    def test_required_policy_approve_uses_fail_closed_gate(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.plugins as plugins_mod
+
+        home = tmp_path / "hermes"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _make_plugin_dir(
+            home / "plugins",
+            "approval_guard",
+            register_body=(
+                'ctx.register_hook("pre_tool_call", '
+                'lambda **kw: {"action": "approve", "message": "review"})'
+            ),
+        )
+        self._configure_required_policy(home, "approval_guard", ["terminal"])
+        manager = PluginManager()
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+        manager.discover_and_load()
+        monkeypatch.setattr(
+            "tools.approval.request_tool_approval",
+            lambda *args, **kwargs: {"approved": False, "message": "denied"},
+        )
+
+        assert plugins_mod.resolve_pre_tool_block("terminal", {}) == "denied"
+
+    def test_required_policy_plugin_load_failure_blocks(self, tmp_path, monkeypatch):
+        import hermes_cli.plugins as plugins_mod
+
+        home = tmp_path / "hermes"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _make_plugin_dir(
+            home / "plugins",
+            "broken_guard",
+            register_body=(
+                'ctx.register_hook("pre_tool_call", '
+                'lambda **kw: {"action": "allow"}); '
+                'raise RuntimeError("load secret")'
+            ),
+        )
+        self._configure_required_policy(home, "broken_guard", ["terminal"])
+        manager = PluginManager()
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+        manager.discover_and_load()
+
+        message = plugins_mod.resolve_pre_tool_block("terminal", {})
+
+        assert message is not None
+        assert "broken_guard" in message
+        assert "load secret" not in message
+
+    def test_required_policy_resolver_crash_fails_closed_only_for_protected_tool(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.plugins as plugins_mod
+
+        home = tmp_path / "hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        self._configure_required_policy(home, "guard", ["terminal"])
+        monkeypatch.setattr(
+            plugins_mod,
+            "_resolve_pre_tool_block",
+            lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("secret")),
+        )
+
+        message = plugins_mod.resolve_pre_tool_block("terminal", {})
+        assert message is not None
+        assert "secret" not in message
+        with pytest.raises(RuntimeError, match="secret"):
+            plugins_mod.resolve_pre_tool_block("read_file", {})
+
+    def test_malformed_required_policy_configuration_fails_closed(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.plugins as plugins_mod
+
+        home = tmp_path / "hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        config = {
+            "plugins": {
+                "entries": {
+                    "guard": {
+                        "required_pre_tool_call": {"tools": "terminal"}
+                    }
+                }
+            }
+        }
+        (home / "config.yaml").write_text(yaml.safe_dump(config))
+
+        message = plugins_mod.resolve_pre_tool_block("read_file", {})
+
+        assert message is not None
+        assert "invalid configuration" in message
+
 
 class TestGetPreVerifyContinueMessage:
     """`pre_verify` directive aggregation — mirrors the pre_tool_call block path."""

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1,5 +1,6 @@
 """Tests for the Hermes plugin system (hermes_cli.plugins)."""
 
+import json
 import logging
 import sys
 import types
@@ -620,8 +621,8 @@ class TestResolvePreToolBlock:
     def test_required_policy_preserves_first_party_observation(
         self, tmp_path, monkeypatch
     ):
-        from hermes_cli import observability
         import hermes_cli.plugins as plugins_mod
+        from hermes_cli import observability
 
         home = tmp_path / "hermes"
         monkeypatch.setenv("HERMES_HOME", str(home))
@@ -1290,6 +1291,200 @@ class TestPluginCommandResultResolution:
 
 class TestPluginDispatchTool:
     """Tests for PluginContext.dispatch_tool() — tool dispatch with agent context."""
+
+    @staticmethod
+    def _configure_required_policy(home: Path, plugin_id: str = "guard") -> None:
+        config_path = home / "config.yaml"
+        config = yaml.safe_load(config_path.read_text()) if config_path.exists() else {}
+        config = config or {}
+        plugins = config.setdefault("plugins", {})
+        plugins.setdefault("enabled", []).append(plugin_id)
+        plugins.setdefault("entries", {})[plugin_id] = {
+            "required_pre_tool_call": {"tools": ["terminal"]}
+        }
+        plugins["enabled"] = list(dict.fromkeys(plugins["enabled"]))
+        config_path.write_text(yaml.safe_dump(config))
+
+    @pytest.mark.parametrize("has_cli_ref", [False, True])
+    @pytest.mark.parametrize(
+        ("outcome", "register_body", "approval_result"),
+        [
+            (
+                "block",
+                'ctx.register_hook("pre_tool_call", '
+                'lambda **kw: {"action": "block", "message": "denied"})',
+                None,
+            ),
+            (
+                "callback_failure",
+                'ctx.register_hook("pre_tool_call", lambda **kw: '
+                '(_ for _ in ()).throw(RuntimeError("callback secret")))',
+                None,
+            ),
+            (
+                "malformed_result",
+                'ctx.register_hook("pre_tool_call", '
+                'lambda **kw: {"action": "maybe"})',
+                None,
+            ),
+            ("unavailable", None, None),
+            (
+                "approval_denial",
+                'ctx.register_hook("pre_tool_call", '
+                'lambda **kw: {"action": "approve", "message": "review"})',
+                {"approved": False, "message": "denied"},
+            ),
+            (
+                "approval_error",
+                'ctx.register_hook("pre_tool_call", '
+                'lambda **kw: {"action": "approve", "message": "review"})',
+                RuntimeError("approval secret"),
+            ),
+            (
+                "approval_timeout",
+                'ctx.register_hook("pre_tool_call", '
+                'lambda **kw: {"action": "approve", "message": "review"})',
+                {"approved": False, "message": "timed out"},
+            ),
+        ],
+    )
+    def test_dispatch_tool_enforces_required_policy_failures(
+        self,
+        tmp_path,
+        monkeypatch,
+        has_cli_ref,
+        outcome,
+        register_body,
+        approval_result,
+    ):
+        import hermes_cli.plugins as plugins_mod
+
+        home = tmp_path / f"hermes-{outcome}-{has_cli_ref}"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        if register_body is not None:
+            _make_plugin_dir(
+                home / "plugins",
+                "guard",
+                register_body=register_body,
+            )
+        self._configure_required_policy(home)
+
+        manager = PluginManager()
+        manager.discover_and_load()
+        if has_cli_ref:
+            manager._cli_ref = types.SimpleNamespace(
+                agent=types.SimpleNamespace(session_id="cli-session")
+            )
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+        hook_spy = MagicMock(wraps=manager.invoke_hook_detailed)
+        monkeypatch.setattr(manager, "invoke_hook_detailed", hook_spy)
+
+        if isinstance(approval_result, Exception):
+            approval = MagicMock(side_effect=approval_result)
+        else:
+            approval = MagicMock(return_value=approval_result)
+        monkeypatch.setattr("tools.approval.request_tool_approval", approval)
+
+        context = PluginContext(
+            PluginManifest(name="command-plugin", source="user"), manager
+        )
+        mock_registry = MagicMock()
+        with patch("tools.registry.registry", mock_registry):
+            result = context.dispatch_tool("terminal", {"command": "rm target"})
+
+        error = json.loads(result)["error"]
+        assert error
+        assert "secret" not in error
+        mock_registry.dispatch.assert_not_called()
+        hook_spy.assert_called_once()
+        if outcome.startswith("approval_"):
+            approval.assert_called_once()
+        else:
+            approval.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "config_text",
+        [
+            "plugins:\n  entries: [unterminated\n",
+            yaml.safe_dump({"plugins": {"entries": []}}),
+        ],
+    )
+    def test_dispatch_tool_blocks_invalid_existing_config(
+        self, tmp_path, monkeypatch, config_text
+    ):
+        home = tmp_path / "hermes"
+        home.mkdir()
+        (home / "config.yaml").write_text(config_text)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        context = PluginContext(
+            PluginManifest(name="command-plugin", source="user"), PluginManager()
+        )
+        mock_registry = MagicMock()
+
+        with patch("tools.registry.registry", mock_registry):
+            result = context.dispatch_tool("terminal", {"command": "rm target"})
+
+        assert "configuration is unavailable" in json.loads(result)["error"]
+        mock_registry.dispatch.assert_not_called()
+
+    def test_dispatch_tool_blocks_unreadable_existing_config(
+        self, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "hermes"
+        home.mkdir()
+        (home / "config.yaml").write_text("plugins: {}\n")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        context = PluginContext(
+            PluginManifest(name="command-plugin", source="user"), PluginManager()
+        )
+        mock_registry = MagicMock()
+
+        with patch("tools.registry.registry", mock_registry):
+            with patch("builtins.open", side_effect=PermissionError("denied")):
+                result = context.dispatch_tool("terminal", {"command": "rm target"})
+
+        assert "configuration is unavailable" in json.loads(result)["error"]
+        mock_registry.dispatch.assert_not_called()
+
+    def test_dispatch_tool_blocks_when_valid_config_becomes_malformed(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.plugins as plugins_mod
+
+        home = tmp_path / "hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _make_plugin_dir(
+            home / "plugins",
+            "guard",
+            register_body=(
+                'ctx.register_hook("pre_tool_call", '
+                'lambda **kw: {"action": "allow"})'
+            ),
+        )
+        self._configure_required_policy(home)
+        manager = PluginManager()
+        manager.discover_and_load()
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+        context = PluginContext(
+            PluginManifest(name="command-plugin", source="user"), manager
+        )
+        mock_registry = MagicMock()
+        mock_registry.dispatch.return_value = '{"ok": true}'
+
+        with patch("tools.registry.registry", mock_registry):
+            assert context.dispatch_tool("terminal", {"command": "pwd"}) == '{"ok": true}'
+            mock_registry.dispatch.assert_called_once()
+            mock_registry.reset_mock()
+
+            (home / "config.yaml").write_text(
+                "plugins:\n  entries: [now malformed and deliberately longer\n"
+            )
+            result = context.dispatch_tool("terminal", {"command": "rm target"})
+
+        assert "configuration is unavailable" in json.loads(result)["error"]
+        mock_registry.dispatch.assert_not_called()
 
     def test_dispatch_tool_calls_registry(self):
         """dispatch_tool() delegates to registry.dispatch()."""

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1,5 +1,6 @@
 """Tests for the Hermes plugin system (hermes_cli.plugins)."""
 
+import json
 import logging
 import json
 import sys
@@ -1224,8 +1225,8 @@ class TestResolvePreToolBlock:
     def test_required_policy_preserves_first_party_observation(
         self, tmp_path, monkeypatch
     ):
-        from hermes_cli import observability
         import hermes_cli.plugins as plugins_mod
+        from hermes_cli import observability
 
         home = tmp_path / "hermes"
         monkeypatch.setenv("HERMES_HOME", str(home))
@@ -2170,6 +2171,200 @@ class TestPluginCommandResultResolution:
 
 class TestPluginDispatchTool:
     """Tests for PluginContext.dispatch_tool() — tool dispatch with agent context."""
+
+    @staticmethod
+    def _configure_required_policy(home: Path, plugin_id: str = "guard") -> None:
+        config_path = home / "config.yaml"
+        config = yaml.safe_load(config_path.read_text()) if config_path.exists() else {}
+        config = config or {}
+        plugins = config.setdefault("plugins", {})
+        plugins.setdefault("enabled", []).append(plugin_id)
+        plugins.setdefault("entries", {})[plugin_id] = {
+            "required_pre_tool_call": {"tools": ["terminal"]}
+        }
+        plugins["enabled"] = list(dict.fromkeys(plugins["enabled"]))
+        config_path.write_text(yaml.safe_dump(config))
+
+    @pytest.mark.parametrize("has_cli_ref", [False, True])
+    @pytest.mark.parametrize(
+        ("outcome", "register_body", "approval_result"),
+        [
+            (
+                "block",
+                'ctx.register_hook("pre_tool_call", '
+                'lambda **kw: {"action": "block", "message": "denied"})',
+                None,
+            ),
+            (
+                "callback_failure",
+                'ctx.register_hook("pre_tool_call", lambda **kw: '
+                '(_ for _ in ()).throw(RuntimeError("callback secret")))',
+                None,
+            ),
+            (
+                "malformed_result",
+                'ctx.register_hook("pre_tool_call", '
+                'lambda **kw: {"action": "maybe"})',
+                None,
+            ),
+            ("unavailable", None, None),
+            (
+                "approval_denial",
+                'ctx.register_hook("pre_tool_call", '
+                'lambda **kw: {"action": "approve", "message": "review"})',
+                {"approved": False, "message": "denied"},
+            ),
+            (
+                "approval_error",
+                'ctx.register_hook("pre_tool_call", '
+                'lambda **kw: {"action": "approve", "message": "review"})',
+                RuntimeError("approval secret"),
+            ),
+            (
+                "approval_timeout",
+                'ctx.register_hook("pre_tool_call", '
+                'lambda **kw: {"action": "approve", "message": "review"})',
+                {"approved": False, "message": "timed out"},
+            ),
+        ],
+    )
+    def test_dispatch_tool_enforces_required_policy_failures(
+        self,
+        tmp_path,
+        monkeypatch,
+        has_cli_ref,
+        outcome,
+        register_body,
+        approval_result,
+    ):
+        import hermes_cli.plugins as plugins_mod
+
+        home = tmp_path / f"hermes-{outcome}-{has_cli_ref}"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        if register_body is not None:
+            _make_plugin_dir(
+                home / "plugins",
+                "guard",
+                register_body=register_body,
+            )
+        self._configure_required_policy(home)
+
+        manager = PluginManager()
+        manager.discover_and_load()
+        if has_cli_ref:
+            manager._cli_ref = types.SimpleNamespace(
+                agent=types.SimpleNamespace(session_id="cli-session")
+            )
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+        hook_spy = MagicMock(wraps=manager.invoke_hook_detailed)
+        monkeypatch.setattr(manager, "invoke_hook_detailed", hook_spy)
+
+        if isinstance(approval_result, Exception):
+            approval = MagicMock(side_effect=approval_result)
+        else:
+            approval = MagicMock(return_value=approval_result)
+        monkeypatch.setattr("tools.approval.request_tool_approval", approval)
+
+        context = PluginContext(
+            PluginManifest(name="command-plugin", source="user"), manager
+        )
+        mock_registry = MagicMock()
+        with patch("tools.registry.registry", mock_registry):
+            result = context.dispatch_tool("terminal", {"command": "rm target"})
+
+        error = json.loads(result)["error"]
+        assert error
+        assert "secret" not in error
+        mock_registry.dispatch.assert_not_called()
+        hook_spy.assert_called_once()
+        if outcome.startswith("approval_"):
+            approval.assert_called_once()
+        else:
+            approval.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "config_text",
+        [
+            "plugins:\n  entries: [unterminated\n",
+            yaml.safe_dump({"plugins": {"entries": []}}),
+        ],
+    )
+    def test_dispatch_tool_blocks_invalid_existing_config(
+        self, tmp_path, monkeypatch, config_text
+    ):
+        home = tmp_path / "hermes"
+        home.mkdir()
+        (home / "config.yaml").write_text(config_text)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        context = PluginContext(
+            PluginManifest(name="command-plugin", source="user"), PluginManager()
+        )
+        mock_registry = MagicMock()
+
+        with patch("tools.registry.registry", mock_registry):
+            result = context.dispatch_tool("terminal", {"command": "rm target"})
+
+        assert "configuration is unavailable" in json.loads(result)["error"]
+        mock_registry.dispatch.assert_not_called()
+
+    def test_dispatch_tool_blocks_unreadable_existing_config(
+        self, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "hermes"
+        home.mkdir()
+        (home / "config.yaml").write_text("plugins: {}\n")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        context = PluginContext(
+            PluginManifest(name="command-plugin", source="user"), PluginManager()
+        )
+        mock_registry = MagicMock()
+
+        with patch("tools.registry.registry", mock_registry):
+            with patch("builtins.open", side_effect=PermissionError("denied")):
+                result = context.dispatch_tool("terminal", {"command": "rm target"})
+
+        assert "configuration is unavailable" in json.loads(result)["error"]
+        mock_registry.dispatch.assert_not_called()
+
+    def test_dispatch_tool_blocks_when_valid_config_becomes_malformed(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.plugins as plugins_mod
+
+        home = tmp_path / "hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _make_plugin_dir(
+            home / "plugins",
+            "guard",
+            register_body=(
+                'ctx.register_hook("pre_tool_call", '
+                'lambda **kw: {"action": "allow"})'
+            ),
+        )
+        self._configure_required_policy(home)
+        manager = PluginManager()
+        manager.discover_and_load()
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+        context = PluginContext(
+            PluginManifest(name="command-plugin", source="user"), manager
+        )
+        mock_registry = MagicMock()
+        mock_registry.dispatch.return_value = '{"ok": true}'
+
+        with patch("tools.registry.registry", mock_registry):
+            assert context.dispatch_tool("terminal", {"command": "pwd"}) == '{"ok": true}'
+            mock_registry.dispatch.assert_called_once()
+            mock_registry.reset_mock()
+
+            (home / "config.yaml").write_text(
+                "plugins:\n  entries: [now malformed and deliberately longer\n"
+            )
+            result = context.dispatch_tool("terminal", {"command": "rm target"})
+
+        assert "configuration is unavailable" in json.loads(result)["error"]
+        mock_registry.dispatch.assert_not_called()
 
     def test_dispatch_tool_calls_registry(self):
         """dispatch_tool() delegates to registry.dispatch()."""

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1325,6 +1325,30 @@ class TestResolvePreToolBlock:
         with pytest.raises(RuntimeError, match="secret"):
             plugins_mod.resolve_pre_tool_block("read_file", {})
 
+    def test_required_policy_dispatch_crash_fails_closed_only_for_protected_tool(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.plugins as plugins_mod
+
+        home = tmp_path / "hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        self._configure_required_policy(home, "guard", ["terminal"])
+        monkeypatch.setattr(
+            plugins_mod,
+            "_get_pre_tool_call_directive_details",
+            lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("secret")),
+        )
+
+        message, modified = plugins_mod._dispatch_pre_tool_call_hooks(
+            "terminal", {}
+        )
+        assert message is not None
+        assert "secret" not in message
+        assert modified is None
+        with pytest.raises(RuntimeError, match="secret"):
+            plugins_mod._dispatch_pre_tool_call_hooks("read_file", {})
+
     def test_malformed_required_policy_configuration_fails_closed(
         self, tmp_path, monkeypatch
     ):
@@ -1381,6 +1405,44 @@ class TestPreToolCallModify:
         )
         assert block_msg is None
         assert modified == {"path": "/safe", "content": "fixed"}
+
+    def test_required_allow_policy_preserves_other_plugin_modification(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.plugins as plugins_mod
+
+        home = tmp_path / "hermes"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _make_plugin_dir(
+            home / "plugins",
+            "required_guard",
+            register_body=(
+                'ctx.register_hook("pre_tool_call", '
+                'lambda **kw: {"action": "allow"})'
+            ),
+        )
+        _make_plugin_dir(
+            home / "plugins",
+            "modifier",
+            register_body=(
+                'ctx.register_hook("pre_tool_call", '
+                'lambda **kw: {"action": "modify", '
+                '"args": {"path": "/safe"}})'
+            ),
+        )
+        TestResolvePreToolBlock._configure_required_policy(
+            home, "required_guard", ["write_file"]
+        )
+        manager = PluginManager()
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+        manager.discover_and_load()
+
+        block_msg, modified = plugins_mod._dispatch_pre_tool_call_hooks(
+            "write_file", {"path": "/unsafe", "content": "x"}
+        )
+
+        assert block_msg is None
+        assert modified == {"path": "/safe", "content": "x"}
 
     def test_modify_last_wins_on_same_key(self, monkeypatch):
         """When two hooks modify the same key, the later hook wins."""

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1122,6 +1122,232 @@ class TestResolvePreToolBlock:
         msg = resolve_pre_tool_block("terminal", {})
         assert msg is not None and "gate failed" in msg  # fail-closed
 
+    @staticmethod
+    def _configure_required_policy(home, plugin_id, tools):
+        config_path = home / "config.yaml"
+        config = yaml.safe_load(config_path.read_text()) if config_path.exists() else {}
+        config = config or {}
+        plugins = config.setdefault("plugins", {})
+        plugins.setdefault("enabled", [])
+        plugins.setdefault("entries", {})[plugin_id] = {
+            "required_pre_tool_call": {"tools": tools}
+        }
+        config_path.write_text(yaml.safe_dump(config))
+
+    def test_required_policy_callback_exception_blocks_with_sanitized_reason(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.plugins as plugins_mod
+
+        home = tmp_path / "hermes"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _make_plugin_dir(
+            home / "plugins",
+            "required_guard",
+            register_body=(
+                'ctx.register_hook("pre_tool_call", '
+                'lambda **kw: (_ for _ in ()).throw(RuntimeError("secret detail")))'
+            ),
+        )
+        self._configure_required_policy(home, "required_guard", ["terminal"])
+        manager = PluginManager()
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+        manager.discover_and_load()
+
+        message = plugins_mod.resolve_pre_tool_block("terminal", {"command": "pwd"})
+
+        assert message is not None
+        assert "required_guard" in message
+        assert "secret detail" not in message
+
+    def test_missing_required_policy_plugin_blocks(self, tmp_path, monkeypatch):
+        import hermes_cli.plugins as plugins_mod
+
+        home = tmp_path / "hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        self._configure_required_policy(home, "missing_guard", ["github_*"])
+        manager = PluginManager()
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+        manager.discover_and_load()
+
+        message = plugins_mod.resolve_pre_tool_block("github_merge", {})
+
+        assert message is not None
+        assert "missing_guard" in message
+
+    def test_required_policy_malformed_result_blocks_but_unprotected_tool_allows(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.plugins as plugins_mod
+
+        home = tmp_path / "hermes"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _make_plugin_dir(
+            home / "plugins",
+            "malformed_guard",
+            register_body=(
+                'ctx.register_hook("pre_tool_call", '
+                'lambda **kw: {"action": "maybe"})'
+            ),
+        )
+        self._configure_required_policy(home, "malformed_guard", ["terminal"])
+        manager = PluginManager()
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+        manager.discover_and_load()
+
+        assert plugins_mod.resolve_pre_tool_block("terminal", {}) is not None
+        assert plugins_mod.resolve_pre_tool_block("read_file", {}) is None
+
+    def test_required_policy_explicit_allow_permits_matching_tool(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.plugins as plugins_mod
+
+        home = tmp_path / "hermes"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _make_plugin_dir(
+            home / "plugins",
+            "allow_guard",
+            register_body=(
+                'ctx.register_hook("pre_tool_call", '
+                'lambda **kw: {"action": "allow"})'
+            ),
+        )
+        self._configure_required_policy(home, "allow_guard", ["github_*"])
+        manager = PluginManager()
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+        manager.discover_and_load()
+
+        assert plugins_mod.resolve_pre_tool_block("github_merge", {}) is None
+
+    def test_required_policy_preserves_first_party_observation(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli import observability
+        import hermes_cli.plugins as plugins_mod
+
+        home = tmp_path / "hermes"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _make_plugin_dir(
+            home / "plugins",
+            "allow_guard",
+            register_body=(
+                'ctx.register_hook("pre_tool_call", '
+                'lambda **kw: {"action": "allow"})'
+            ),
+        )
+        self._configure_required_policy(home, "allow_guard", ["github_*"])
+        manager = PluginManager()
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+        manager.discover_and_load()
+        observed = []
+        monkeypatch.setattr(
+            observability,
+            "observe_lifecycle",
+            lambda hook_name, **kwargs: observed.append((hook_name, kwargs)),
+        )
+
+        assert plugins_mod.resolve_pre_tool_block("github_merge", {}) is None
+        assert [name for name, _kwargs in observed] == ["pre_tool_call"]
+        assert observed[0][1]["tool_name"] == "github_merge"
+
+    def test_required_policy_approve_uses_fail_closed_gate(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.plugins as plugins_mod
+
+        home = tmp_path / "hermes"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _make_plugin_dir(
+            home / "plugins",
+            "approval_guard",
+            register_body=(
+                'ctx.register_hook("pre_tool_call", '
+                'lambda **kw: {"action": "approve", "message": "review"})'
+            ),
+        )
+        self._configure_required_policy(home, "approval_guard", ["terminal"])
+        manager = PluginManager()
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+        manager.discover_and_load()
+        monkeypatch.setattr(
+            "tools.approval.request_tool_approval",
+            lambda *args, **kwargs: {"approved": False, "message": "denied"},
+        )
+
+        assert plugins_mod.resolve_pre_tool_block("terminal", {}) == "denied"
+
+    def test_required_policy_plugin_load_failure_blocks(self, tmp_path, monkeypatch):
+        import hermes_cli.plugins as plugins_mod
+
+        home = tmp_path / "hermes"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _make_plugin_dir(
+            home / "plugins",
+            "broken_guard",
+            register_body=(
+                'ctx.register_hook("pre_tool_call", '
+                'lambda **kw: {"action": "allow"}); '
+                'raise RuntimeError("load secret")'
+            ),
+        )
+        self._configure_required_policy(home, "broken_guard", ["terminal"])
+        manager = PluginManager()
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+        manager.discover_and_load()
+
+        message = plugins_mod.resolve_pre_tool_block("terminal", {})
+
+        assert message is not None
+        assert "broken_guard" in message
+        assert "load secret" not in message
+
+    def test_required_policy_resolver_crash_fails_closed_only_for_protected_tool(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.plugins as plugins_mod
+
+        home = tmp_path / "hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        self._configure_required_policy(home, "guard", ["terminal"])
+        monkeypatch.setattr(
+            plugins_mod,
+            "_resolve_pre_tool_block",
+            lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("secret")),
+        )
+
+        message = plugins_mod.resolve_pre_tool_block("terminal", {})
+        assert message is not None
+        assert "secret" not in message
+        with pytest.raises(RuntimeError, match="secret"):
+            plugins_mod.resolve_pre_tool_block("read_file", {})
+
+    def test_malformed_required_policy_configuration_fails_closed(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.plugins as plugins_mod
+
+        home = tmp_path / "hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        config = {
+            "plugins": {
+                "entries": {
+                    "guard": {
+                        "required_pre_tool_call": {"tools": "terminal"}
+                    }
+                }
+            }
+        }
+        (home / "config.yaml").write_text(yaml.safe_dump(config))
+
+        message = plugins_mod.resolve_pre_tool_block("read_file", {})
+
+        assert message is not None
+        assert "invalid configuration" in message
+
 
 class TestPreToolCallModify:
     """Tests for the modify action — transforming tool args before dispatch."""

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -3,6 +3,7 @@
 import json
 from unittest.mock import ANY, call, patch
 
+import yaml
 
 from model_tools import (
     handle_function_call,
@@ -310,6 +311,42 @@ class TestPreToolCallBlocking:
         result = json.loads(handle_function_call("read_file", {"path": "test.txt"}, task_id="t1"))
         assert result == {"ok": True}
 
+    def test_missing_required_policy_blocks_at_dispatch_boundary(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.plugins as plugins_mod
+
+        home = tmp_path / "hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        (home / "config.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "plugins": {
+                        "entries": {
+                            "required_guard": {
+                                "required_pre_tool_call": {
+                                    "tools": ["read_file"]
+                                }
+                            }
+                        }
+                    }
+                }
+            )
+        )
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", plugins_mod.PluginManager())
+        monkeypatch.setattr(
+            "model_tools.registry.dispatch",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("protected tool must not dispatch")
+            ),
+        )
+
+        result = json.loads(
+            handle_function_call("read_file", {"path": "test.txt"}, task_id="t1")
+        )
+
+        assert "required_guard" in result["error"]
 
     def test_relay_rewrite_is_visible_to_pre_tool_authorization(self, monkeypatch):
         observed = {}


### PR DESCRIPTION
Closes #61656

## Summary

- add an opt-in `plugins.entries.<plugin_id>.required_pre_tool_call` contract for protected tool-name globs
- retain hook ownership and detailed callback outcomes so required plugins fail closed on missing registration, load failure, exceptions, and malformed or empty decisions
- preserve existing fail-open behavior for ordinary observer hooks and unprotected tools
- route strict `approve` decisions through the existing fail-closed human approval gate
- fail closed when an existing user or managed config is malformed, unreadable, or contains an invalid plugin-entry structure
- enforce the same policy gate for plugin-command `PluginContext.dispatch_tool()` calls
- document the operator configuration and decision contract

## Security behavior

A matching required policy must be loaded and enabled, must own at least one `pre_tool_call` callback, and every owned callback must return an explicit `allow`, valid `block`, or valid `approve` decision. Failure responses are sanitized; callback, loader, and approval exception details are logged but not returned to the model.

An absent config remains valid. Once a config source exists, policy evaluation uses a strict read and does not substitute defaults or last-known-good data for malformed or unreadable current content.

All current dispatch paths converge on `resolve_pre_tool_block`, including direct model dispatch, sequential/concurrent executors, runtime helpers, tool-search resolved calls, and plugin-command dispatch.

## Validation

- `uv run pytest -q tests/plugins` (1801 passed)
- focused plugin-dispatch and managed-scope regression suite (45 passed)
- broad plugin/config/managed-scope suite (344 passed)
- adjacent model-tool, runtime-guardrail, registry, dispatch-session, transform-hook, and shell/verify-hook suite (161 passed)
- `uv run ruff check .`
- `uv run python scripts/check-windows-footguns.py --all` (761 files clean)
- `uv run python -m py_compile hermes_cli/config.py hermes_cli/managed_scope.py hermes_cli/plugins.py`
- `git diff --check`

Tests use temporary Hermes homes and mocked approval/dispatch boundaries; no live providers, gateways, credentials, or MCP servers were used.
