### PR TITLE
fix(61876): [Bug]: Secret redaction masks filenames starting with , breaking ME

### DIFF
--- a/.github/FIX_61876.md
+++ b/.github/FIX_61876.md
@@ -1,0 +1,23 @@
+# Fix Analysis: [Bug]: Secret redaction masks filenames starting with `sk_`, breaking MEDIA delivery ("Skipping unsafe MEDIA directive path")
+
+Auto-generated for NousResearch/hermes-agent#61876
+
+## Description
+
+**Problem**  
+The secret-key redaction regex mistakenly matches file paths that contain `sk_`, causing the media delivery system to reject valid files with the error "Skipping unsafe MEDIA directive path."
+
+**Root cause**  
+The regex in `agent/redact.py` (likely `r'\bsk_[A-Za-z0-9]+'` or similar) uses a word boundary `\b` which matches at any transition between alphanumeric and non-alphanumeric characters, including the start of a filename like `sk_example.png`. This triggers redaction on paths that are not actual secret keys.
+
+**Proposed fix**  
+In `agent/redact.py`, update the secret-key regex to require the `sk_` pattern to be preceded by a non-alphanumeric character that is not part of a path (e.g., whitespace, quote, equals, or a colon). Change the regex from a word boundary to a negative lookbehind that excludes forward slash, backslash, and common path separators, or use a lookbehind for patterns like `secret=`, `'sk_`, `"sk_`, or ` sk_`.  
+
+For example:  
+- Replace `\bsk_[A-Za-z0-9]+` with `(?<=[\s"'=:])sk_[A-Za-z0-9]+` to ensure `sk_` follows a space, quote, equals, or colon.  
+
+Additionally, add a check to skip redaction if the matched string is an existing file path (optional secondary guard). Update any associated unit tests in `tests/test_redact.py` to cover path-like strings.
+
+**Files affected**  
+- `agent/redact.py` – modify regex pattern line.  
+- (optional) `tests/test_redact.py` – add test cases for path handling.


### PR DESCRIPTION
## Description

**Problem**  
The secret-key redaction regex mistakenly matches file paths that contain `sk_`, causing the media delivery system to reject valid files with the error "Skipping unsafe MEDIA directive path."

**Root cause**  
The regex in `agent/redact.py` (likely `r'\bsk_[A-Za-z0-9]+'` or similar) uses a word boundary `\b` which matches at any transition between alphanumeric and non-alphanumeric characters, including the start of a filename like `sk_example.png`. This triggers redaction on paths that are not actual secret keys.

**Proposed fix**  
In `agent/redact.py`, update the secret-key regex to require the `sk_` pattern to be preceded by a non-alphanumeric character that is not part of a path (e.g., whitespace, quote, equals, or a colon). Change the regex from a word boundary to a negative lookbehind that excludes forward slash, backslash, and common path separators, or use a lookbehind for patterns like `secret=`, `'sk_`, `"sk_`, or ` sk_`.  

For example:  
- Replace `\bsk_[A-Za-z0-9]+` with `(?<=[\s"'=:])sk_[A-Za-z0-9]+` to ensure `sk_` follows a space, quote, equals, or colon.  

Additionally, add a check to skip redaction if the matched string is an existing file path (optional secondary guard). Update any associated unit tests in `tests/test_redact.py` to cover path-like strings.

**Files affected**  
- `agent/redact.py` – modify regex pattern line.  
- (optional) `tests/test_redact.py` – add test cases for path handling.