### PR TITLE
fix(codex): refresh GPT-5.6 context metadata

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -77,9 +77,15 @@ def _build_codex_gpt5_autoraise_notice(autoraise: Dict[str, Any]) -> str:
     include the exact opt-back-out command.
     """
     model = str(autoraise.get("model") or "gpt-5.4/5.5").strip().lower().rsplit("/", 1)[-1]
-    # gpt-5.3-codex-spark has a native 128K window; the gpt-5.4/5.5/5.6 family
-    # is capped at 272K by the Codex OAuth backend.
-    cap = "128K" if model.startswith("gpt-5.3-codex-spark") else "272K"
+    # Codex OAuth exposes route-specific windows that differ from the direct
+    # OpenAI API. Keep the notice aligned with the same model families used by
+    # the context resolver and compaction override.
+    if model.startswith("gpt-5.3-codex-spark"):
+        cap = "128K"
+    elif model.startswith("gpt-5.6"):
+        cap = "372K"
+    else:
+        cap = "272K"
     from_pct = int(round(autoraise["from"] * 100))
     to_pct = int(round(autoraise["to"] * 100))
     return (
@@ -101,8 +107,9 @@ def _resolve_compression_threshold(
 
     Returns ``(effective_threshold, autoraise_notice)``. ``autoraise_notice`` is
     ``{"model": <slug>, "from": <old>, "to": <new>}`` only when a Codex
-    autoraise (gpt-5.4/5.5 272K family or gpt-5.3-codex-spark) actually raises
-    the threshold, otherwise ``None``.
+    autoraise (gpt-5.4/5.5 at 85%, gpt-5.6 at 95%, or
+    gpt-5.3-codex-spark at 70%) actually raises the threshold, otherwise
+    ``None``.
 
     The Codex overrides are *autoraises*: they must never LOWER a higher
     user-configured threshold. A user who already set ``compression.threshold``
@@ -1504,8 +1511,8 @@ def init_agent(
         _compression_cfg = {}
     compression_threshold = float(_compression_cfg.get("threshold", 0.50))
     # Per-model/route compaction-threshold override. Codex gpt-5.4 / gpt-5.5
-    # raise to 85% (the Codex backend caps both families at 272K, so the
-    # default 50% would compact at ~136K — half the usable context). Gated by
+    # raise to 85% of their 272K windows; gpt-5.6 raises to 95% of its 372K
+    # window, matching Codex's 353.4K effective boundary. Gated by
     # an opt-out config flag so the user can fall back to the global threshold;
     # when the override fires we stash a one-time notification (replayed on the
     # first turn) that tells the user what changed and how to revert. The
@@ -1522,6 +1529,7 @@ def init_agent(
         from agent.auxiliary_client import (
             _compression_threshold_for_model as _cthresh_fn,
             _is_codex_gpt54_or_gpt55 as _is_codex_gpt54_or_gpt55_fn,
+            _is_codex_gpt56 as _is_codex_gpt56_fn,
             _is_codex_spark as _is_codex_spark_fn,
         )
         _model_cthresh = _cthresh_fn(
@@ -1529,11 +1537,11 @@ def init_agent(
             agent.provider,
             allow_codex_gpt55_autoraise=_codex_gpt55_autoraise,
         )
-        # The Codex autoraises (gpt-5.4/5.5 272K family and gpt-5.3-codex-spark)
-        # apply only when they RAISE (never lower a user's higher global
-        # threshold). The notice is populated only when it actually fires, and
-        # carries the model slug so the banner names the right family. Arcee
-        # Trinity keeps its long-standing unconditional behaviour.
+        # The Codex autoraises apply only when they RAISE (never lower a user's
+        # higher global threshold). The notice is populated only when it
+        # actually fires, and carries the model slug so the banner names the
+        # right family. Arcee Trinity keeps its long-standing unconditional
+        # behaviour.
         compression_threshold, agent._compression_threshold_autoraised = (
             _resolve_compression_threshold(
                 compression_threshold,
@@ -1541,6 +1549,7 @@ def init_agent(
                 model=agent.model,
                 is_codex_autoraise=(
                     _is_codex_gpt54_or_gpt55_fn(agent.model, agent.provider)
+                    or _is_codex_gpt56_fn(agent.model, agent.provider)
                     or _is_codex_spark_fn(agent.model, agent.provider)
                 ),
             )

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -315,18 +315,21 @@ def _is_arcee_trinity_thinking(model: Optional[str]) -> bool:
 
 
 # Context window enforced by ChatGPT's Codex OAuth backend for the
-# gpt-5.4 / gpt-5.5 / gpt-5.6 families. The raw OpenAI API and OpenRouter
-# expose 1.05M for the same slugs, but the Codex backend hard-caps at 272K
-# (verified live for 5.4/5.5: a ~330K-token request to
+# gpt-5.4 / gpt-5.5 families. The raw OpenAI API and OpenRouter expose 1.05M
+# for the same slugs, but the Codex backend hard-caps these families at 272K
+# (verified live: a ~330K-token request to
 # chatgpt.com/backend-api/codex/responses is rejected with
-# ``context_length_exceeded`` while ~250K succeeds; gpt-5.6 shares the same
-# 272K Codex cap — see _CODEX_OAUTH_CONTEXT_FALLBACK in model_metadata.py).
+# ``context_length_exceeded`` while ~250K succeeds).
 # With a 272K ceiling the default 50% compaction trigger fires at ~136K —
 # wasteful, since the model can hold far more raw context before
 # summarization actually buys anything. We raise the trigger to 85% (~231K)
-# on this exact route so Codex gpt-5.4 / gpt-5.5 / gpt-5.6 sessions use the
-# window they actually have.
+# on this exact route so Codex gpt-5.4 / gpt-5.5 sessions use the window they
+# actually have.
 _CODEX_GPT54_GPT55_COMPACTION_THRESHOLD = 0.85
+
+# GPT-5.6 exposes a 372K total window on Codex OAuth. Codex applies a 95%
+# effective-window safety margin, so compact at the matching 353.4K boundary.
+_CODEX_GPT56_COMPACTION_THRESHOLD = 0.95
 
 # gpt-5.3-codex-spark is Codex-OAuth-only (ChatGPT Pro entitlement) with a
 # native 128K context window.  The default 50% compaction trigger fires at
@@ -339,16 +342,14 @@ _CODEX_SPARK_COMPACTION_THRESHOLD = 0.70
 
 
 def _is_codex_gpt54_or_gpt55(model: Optional[str], provider: Optional[str] = None) -> bool:
-    """True for gpt-5.4 / gpt-5.5 / gpt-5.6 on the ChatGPT Codex OAuth backend.
+    """True for gpt-5.4 / gpt-5.5 on the ChatGPT Codex OAuth backend.
 
     Matches only the Codex OAuth route (provider ``openai-codex``), not the
     direct OpenAI API, OpenRouter, or GitHub Copilot paths — those expose a
     larger context window for the same slug and must keep the user's default
     compaction threshold. ``-pro`` variants and dated snapshots are matched
-    via prefix so the override tracks every 272K-capped family (5.4, 5.5,
-    5.6 sol/terra/luna incl. their ``-pro`` modes) without re-listing every
-    variant. (Name kept for backward compatibility with the
-    ``compression.codex_gpt55_autoraise`` config key.)
+    via prefix so the override tracks both 272K-capped families without
+    re-listing every variant.
     """
     prov = (provider or "").strip().lower()
     if prov != "openai-codex":
@@ -361,7 +362,17 @@ def _is_codex_gpt54_or_gpt55(model: Optional[str], provider: Optional[str] = Non
         or bare == "gpt-5.5"
         or bare.startswith("gpt-5.5-")
         or bare.startswith("gpt-5.5.")
-        or bare == "gpt-5.6"
+    )
+
+
+def _is_codex_gpt56(model: Optional[str], provider: Optional[str] = None) -> bool:
+    """True for GPT-5.6 variants on the ChatGPT Codex OAuth backend."""
+    prov = (provider or "").strip().lower()
+    if prov != "openai-codex":
+        return False
+    bare = (model or "").strip().lower().rsplit("/", 1)[-1]
+    return (
+        bare == "gpt-5.6"
         or bare.startswith("gpt-5.6-")
         or bare.startswith("gpt-5.6.")
     )
@@ -418,9 +429,12 @@ def _compression_threshold_for_model(
 
     Per-model/route overrides:
       - Arcee Trinity Large Thinking → 0.75 (preserve reasoning context).
-      - gpt-5.4 / gpt-5.5 / gpt-5.6 on the Codex OAuth route → 0.85, because
-        Codex caps all three families at 272K and the default 50% trigger
-        would compact at ~136K. Gated by ``allow_codex_gpt55_autoraise``
+      - gpt-5.4 / gpt-5.5 on the Codex OAuth route → 0.85, because Codex caps
+        both families at 272K and the default 50% trigger would compact at
+        ~136K.
+      - gpt-5.6 on the Codex OAuth route → 0.95, matching Codex's 5% safety
+        margin on its 372K total window (353.4K effective).
+        Both overrides are gated by ``allow_codex_gpt55_autoraise``
         (historical config-key name kept for backward compatibility) so the
         user can opt back down to the global default (the caller passes the
         config flag through here).
@@ -435,6 +449,8 @@ def _compression_threshold_for_model(
     """
     if _is_arcee_trinity_thinking(model):
         return 0.75
+    if allow_codex_gpt55_autoraise and _is_codex_gpt56(model, provider):
+        return _CODEX_GPT56_COMPACTION_THRESHOLD
     if allow_codex_gpt55_autoraise and _is_codex_gpt54_or_gpt55(model, provider):
         return _CODEX_GPT54_GPT55_COMPACTION_THRESHOLD
     if _is_codex_spark(model, provider):

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -230,7 +230,8 @@ DEFAULT_CONTEXT_LENGTHS = {
     # provider-aware branches (_resolve_codex_oauth_context_length + models.dev).
     # This hardcoded value is only reached when every probe misses.
     # GPT-5.6 series (Sol/Terra/Luna, GA 2026-07-09) — 1.05M on the direct
-    # OpenAI API (same as gpt-5.5). Codex OAuth caps these at 272K.
+    # OpenAI API (same as gpt-5.5). Codex OAuth exposes a 372K total window
+    # with a 353.4K effective budget after its 5% safety margin.
     # (Lookups length-sort keys at match time, so dict order is cosmetic.)
     "gpt-5.6-luna": 1050000,
     "gpt-5.6-terra": 1050000,
@@ -534,8 +535,13 @@ def _skip_persistent_context_cache(base_url: str, provider: str) -> bool:
 
     LM Studio excludes caching because loaded context is transient — the user
     can reload the model with a different context_length at any time.
+
+    Codex OAuth also exposes authoritative, evolving per-model limits from its
+    own ``/models`` endpoint. Keep writing successful probes for diagnostics,
+    but do not let a fallback cached during an outage permanently mask a later
+    catalog update (for example GPT-5.6 moving from 272k fallback to 372k).
    """
-    return provider == "lmstudio"
+    return provider in {"lmstudio", "openai-codex"}
 
 
 def _maybe_cache_local_context_length(
@@ -1843,9 +1849,11 @@ _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
     "gpt-5.3-codex-spark": 128_000,
     "gpt-5.2-codex": 272_000,
     "gpt-5.4-mini": 272_000,
-    "gpt-5.6-sol": 272_000,
-    "gpt-5.6-terra": 272_000,
-    "gpt-5.6-luna": 272_000,
+    # GPT-5.6 exposes a 372k total window on Codex OAuth. Codex reserves a
+    # 5% safety margin at runtime, leaving a 353.4k effective input budget.
+    "gpt-5.6-sol": 372_000,
+    "gpt-5.6-terra": 372_000,
+    "gpt-5.6-luna": 372_000,
     "gpt-5.5": 272_000,
     "gpt-5.4": 272_000,
     "gpt-5.2": 272_000,
@@ -2106,24 +2114,23 @@ def get_model_context_length(
     # LM Studio is excluded — its loaded context length is transient (the
     # user can reload the model with a different context_length at any time
     # via /api/v1/models/load), so a stale cached value would mask reloads.
-    if base_url and not _skip_persistent_context_cache(base_url, provider):
+    # Codex likewise never returns a persisted value, but still removes the
+    # known pre-provider-aware direct-API values so the cache remains useful
+    # for diagnostics.
+    if base_url and provider == "openai-codex":
+        cached = get_cached_context_length(model, base_url)
+        if cached is not None and cached >= 400_000:
+            logger.info(
+                "Dropping stale Codex cache entry %s@%s -> %s (pre-fix value); "
+                "re-resolving via live /models probe",
+                model, base_url, f"{cached:,}",
+            )
+            _invalidate_cached_context_length(model, base_url)
+    elif base_url and not _skip_persistent_context_cache(base_url, provider):
         cached = get_cached_context_length(model, base_url)
         if cached is not None:
-            # Invalidate stale Codex OAuth cache entries: pre-PR #14935 builds
-            # resolved gpt-5.x to the direct-API value (e.g. 1.05M) via
-            # models.dev and persisted it. Codex OAuth caps at 272K for every
-            # slug, so any cached Codex entry at or above 400K is a leftover
-            # from the old resolution path. Drop it and fall through to the
-            # live /models probe in step 5 below.
-            if provider == "openai-codex" and cached >= 400_000:
-                logger.info(
-                    "Dropping stale Codex cache entry %s@%s -> %s (pre-fix value); "
-                    "re-resolving via live /models probe",
-                    model, base_url, f"{cached:,}",
-                )
-                _invalidate_cached_context_length(model, base_url)
             # Invalidate stale 32k cache entries for Kimi-family models.
-            elif cached <= 32768 and _model_name_suggests_kimi(model):
+            if cached <= 32768 and _model_name_suggests_kimi(model):
                 logger.info(
                     "Dropping stale Kimi cache entry %s@%s -> %s (OpenRouter underreport); "
                     "re-resolving via hardcoded defaults",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1437,12 +1437,10 @@ DEFAULT_CONFIG = {
                                       # True if you'd rather pause than silently lose
                                       # context turns when your aux model is flaky.
         "codex_gpt55_autoraise": True,  # Historical key name kept for compatibility.
-                                      # When True, gpt-5.4 / gpt-5.5 / gpt-5.6 on the
-                                      # ChatGPT Codex OAuth route raise their compaction
-                                      # trigger to 85% (vs the global `threshold` above).
-                                      # Codex hard-caps these families at a 272K window, so
-                                      # the default 50% would compact at ~136K and waste half
-                                      # the usable context. Set to False to opt back down to
+                                      # When True, gpt-5.4 / gpt-5.5 on the ChatGPT Codex
+                                      # OAuth route raise their compaction trigger to 85%
+                                      # of 272K, while gpt-5.6 raises to 95% of 372K
+                                      # (353.4K effective). Set to False to opt back down to
                                       # the global threshold (e.g. 0.50) for those Codex
                                       # sessions. Only this exact route is affected —
                                       # gpt-5.4 / 5.5 / 5.6 on OpenAI's direct API,
@@ -1450,7 +1448,7 @@ DEFAULT_CONFIG = {
                                       # regardless.
         "codex_gpt55_autoraise_notice": True,  # Display the one-time Codex gpt-5.4/5.5/5.6
                                       # autoraise banner. Set False to keep the
-                                      # 85% threshold autoraise but suppress the
+                                      # model-specific threshold autoraise but suppress the
                                       # user-facing notice in CLI/gateway output.
         "codex_app_server_auto": "native",  # Codex app-server (codex CLI runtime) thread
                                       # compaction mode. The codex agent owns the real

--- a/tests/agent/test_codex_gpt55_autoraise_notice.py
+++ b/tests/agent/test_codex_gpt55_autoraise_notice.py
@@ -54,11 +54,27 @@ def _config(*, show_notice: bool) -> dict:
     }
 
 
-def _make_codex_agent(monkeypatch, tmp_path: Path, *, show_notice: bool):
-    """Construct a real Codex gpt-5.5 agent under an isolated config."""
+def _make_codex_agent(
+    monkeypatch,
+    tmp_path: Path,
+    *,
+    show_notice: bool,
+    model: str = "gpt-5.5",
+    context_length: int = 272_000,
+):
+    """Construct a real Codex agent under an isolated config."""
+    import run_agent
+
     from hermes_cli import config as config_mod
+    from agent import context_compressor as compressor_mod
 
     monkeypatch.setattr(config_mod, "load_config", lambda: _config(show_notice=show_notice))
+    monkeypatch.setattr(run_agent, "_hermes_home", get_hermes_home())
+    monkeypatch.setattr(
+        compressor_mod,
+        "get_model_context_length",
+        lambda *args, **kwargs: context_length,
+    )
     db = SessionDB(db_path=tmp_path / "state.db")
     stdout = io.StringIO()
 
@@ -67,7 +83,7 @@ def _make_codex_agent(monkeypatch, tmp_path: Path, *, show_notice: bool):
             base_url="https://chatgpt.com/backend-api/codex",
             api_key="test-key",
             provider="openai-codex",
-            model="gpt-5.5",
+            model=model,
             enabled_toolsets=[],
             disabled_toolsets=[],
             quiet_mode=False,
@@ -105,6 +121,23 @@ def test_codex_gpt55_autoraise_notice_can_be_suppressed_without_disabling_autora
     assert _threshold_ratio(agent) == 0.85
     assert getattr(agent, "_compression_warning") is None
     assert "auto-compaction was raised" not in stdout
+
+
+def test_codex_gpt56_uses_372k_window_and_95_percent_autoraise(monkeypatch, tmp_path):
+    agent, stdout = _make_codex_agent(
+        monkeypatch,
+        tmp_path,
+        show_notice=True,
+        model="gpt-5.6-sol",
+        context_length=372_000,
+    )
+
+    assert agent.context_compressor.context_length == 372_000
+    assert _threshold_ratio(agent) == 0.95
+    warning = getattr(agent, "_compression_warning")
+    assert "372K" in warning
+    assert "95%" in warning
+    assert "372K" in stdout
 
 
 def test_codex_gpt55_autoraise_notice_deduped_across_agent_inits(monkeypatch, tmp_path):

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -359,7 +359,8 @@ class TestCodexOAuthContextLength:
     OpenAI API for the same slugs. Verified Apr 2026 via live probe of
     chatgpt.com/backend-api/codex/models: most models return 272k, while
     models.dev reports 1.05M for gpt-5.5/gpt-5.4 and 400k for the rest.
-    (Known exception: gpt-5.3-codex-spark is 128k.)
+    Known exceptions include gpt-5.3-codex-spark at 128k and GPT-5.6 at
+    372k total / 353.4k effective.
     """
 
     def setup_method(self):
@@ -374,6 +375,12 @@ class TestCodexOAuthContextLength:
         from agent.model_metadata import get_model_context_length
 
         expected = {
+            "gpt-5.6-sol": 372_000,
+            "gpt-5.6-sol-pro": 372_000,
+            "gpt-5.6-terra": 372_000,
+            "gpt-5.6-terra-pro": 372_000,
+            "gpt-5.6-luna": 372_000,
+            "gpt-5.6-luna-pro": 372_000,
             "gpt-5.5": 272_000,
             "gpt-5.4": 272_000,
             "gpt-5.4-mini": 272_000,
@@ -479,8 +486,8 @@ class TestCodexOAuthContextLength:
         """Pre-PR #14935 builds cached gpt-5.5 at 1.05M (from models.dev)
         before the Codex-aware branch existed. Upgrading users keep that
         stale entry on disk and the cache-first lookup returns it forever.
-        Codex OAuth caps at 272k for every slug, so any cached Codex
-        entry >= 400k must be dropped and re-resolved via the live probe.
+        Values >= 400k came from direct-API metadata, so they must be dropped
+        and re-resolved via the Codex route's live probe.
         """
         from agent import model_metadata as mm
 
@@ -520,9 +527,13 @@ class TestCodexOAuthContextLength:
         assert stale_key not in remaining, "Stale entry was not invalidated from the cache file"
         assert remaining.get(other_key) == 128_000, "Unrelated cache entries must not be touched"
 
-    def test_fresh_codex_cache_under_400k_is_respected(self, tmp_path, monkeypatch):
-        """Codex entries at the correct 272k must NOT be invalidated —
-        only stale pre-fix values (>= 400k) get dropped."""
+    def test_codex_live_probe_reconciles_stale_lower_cache(self, tmp_path, monkeypatch):
+        """Codex model metadata can grow without crossing the old 400k guard.
+
+        GPT-5.6 launched at 372k after Hermes had already cached its 272k
+        fallback, so the provider-authoritative live value must win even when
+        the cached value looks otherwise plausible.
+        """
         from agent import model_metadata as mm
 
         cache_file = tmp_path / "context_length_cache.yaml"
@@ -531,19 +542,25 @@ class TestCodexOAuthContextLength:
         base_url = "https://chatgpt.com/backend-api/codex/"
         import yaml as _yaml
         cache_file.write_text(_yaml.dump({"context_lengths": {
-            f"gpt-5.5@{base_url}": 272_000,
+            f"gpt-5.6-sol@{base_url}": 272_000,
         }}))
 
-        # If the invalidation incorrectly fired, this would be called; assert it isn't.
-        with patch("agent.model_metadata.requests.get") as mock_get:
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_response.json.return_value = {
+            "models": [{"slug": "gpt-5.6-sol", "context_window": 372_000}]
+        }
+
+        with patch("agent.model_metadata.requests.get", return_value=fake_response), \
+             patch("agent.model_metadata.save_context_length") as mock_save:
             ctx = mm.get_model_context_length(
-                model="gpt-5.5",
+                model="gpt-5.6-sol",
                 base_url=base_url,
                 api_key="fake-token",
                 provider="openai-codex",
             )
-        assert ctx == 272_000
-        mock_get.assert_not_called()
+        assert ctx == 372_000
+        mock_save.assert_called_with("gpt-5.6-sol", base_url, 372_000)
 
     def test_stale_invalidation_scoped_to_codex_provider(self, tmp_path, monkeypatch):
         """A cached 1M entry for a non-Codex provider (e.g. Anthropic opus on

--- a/tests/hermes_cli/test_gpt56_registration.py
+++ b/tests/hermes_cli/test_gpt56_registration.py
@@ -84,11 +84,10 @@ class TestGpt56PricingRoute:
 
 
 class TestGpt56CodexCompaction:
-    """Codex OAuth caps the whole gpt-5.6 family at 272K, same as 5.4/5.5, so
-    the compaction auto-raise (0.85) must fire for every 5.6 variant on the
-    openai-codex route and NOT on the direct-API/OpenRouter routes."""
+    """Codex OAuth gives GPT-5.6 a 372K total window and reserves 5% headroom,
+    so Hermes should compact at the same 353.4K effective boundary."""
 
-    def test_autoraise_applies_to_all_56_on_codex(self):
+    def test_autoraise_uses_effective_window_for_all_56_on_codex(self):
         from agent.auxiliary_client import _compression_threshold_for_model
 
         for slug in (
@@ -101,14 +100,16 @@ class TestGpt56CodexCompaction:
         ):
             assert (
                 _compression_threshold_for_model(slug, provider="openai-codex")
-                == 0.85
+                == 0.95
             ), slug
+
+        assert int(372_000 * 0.95) == 353_400
 
     def test_no_autoraise_on_direct_api_route(self):
         from agent.auxiliary_client import _compression_threshold_for_model
 
         # Direct OpenAI API / OpenRouter expose the full 1.05M window, so the
-        # 272K-cap override must NOT apply there.
+        # Codex-route override must NOT apply there.
         assert (
             _compression_threshold_for_model("gpt-5.6-sol", provider="openai")
             is None


### PR DESCRIPTION
## Summary

- treat the Codex OAuth `/models` response as authoritative instead of returning a persisted context-length cache entry first
- update GPT-5.6 Sol/Terra/Luna Codex fallbacks from 272K to the 372K total window reported by the Codex model catalog
- compact GPT-5.6 Codex sessions at 95% (353.4K), matching Codex's effective-window headroom, while preserving the existing 85% behavior for GPT-5.4/5.5
- update the one-time autoraise notice and config documentation to show the correct GPT-5.6 values

## Root cause

`context_length: 0` correctly selects automatic resolution, but the persistent `model@base_url` cache was consulted before the provider-specific Codex probe. A 272K fallback cached before GPT-5.6 metadata was available therefore masked the later 372K value indefinitely.

The OpenAI Codex model catalog currently reports `context_window: 372000` for GPT-5.6 Sol, Terra, and Luna. Codex applies a 95% effective-window margin, yielding the 353,400-token boundary users see.

Catalog reference: https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json

## Tests

- `137 passed` - model metadata and Codex autoraise notice suites
- `81 passed` - GPT-5.6 registration and compaction override suites
- `11 passed` - model-switch context display/application suites
- Ruff, `py_compile`, and `git diff --check` pass

The regression tests cover a stale 272K disk cache being reconciled to a live 372K response, no-token fallback behavior for all GPT-5.6 variants, route scoping, opt-out behavior, and real `AIAgent` initialization with a 372K/95% notice.
