### PR TITLE
fix(tools): resolve MSYS paths in file tools on Windows (supersedes #50488)

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -428,6 +428,69 @@ class TestSearchHandler:
 
 
 # ---------------------------------------------------------------------------
+# Windows MSYS path resolution (salvage of #50488 / #46995)
+# ---------------------------------------------------------------------------
+
+class TestWindowsMsysPathResolution:
+    """File tools must translate Git Bash drive paths before Path resolution."""
+
+    def test_absolute_msys_path_normalized_before_windows_resolve(self, monkeypatch):
+        import tools.environments.local as local_mod
+        import tools.file_tools as file_tools
+
+        monkeypatch.setattr(file_tools.sys, "platform", "win32")
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(file_tools, "_uses_container_paths", lambda task_id="default": False)
+
+        resolved = file_tools._resolve_path_for_task("/c/Users/Mark/project/app.py")
+        assert str(resolved) == r"C:\Users\Mark\project\app.py"
+
+    def test_cygdrive_path_normalized(self, monkeypatch):
+        import tools.environments.local as local_mod
+        import tools.file_tools as file_tools
+
+        monkeypatch.setattr(file_tools.sys, "platform", "win32")
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(file_tools, "_uses_container_paths", lambda task_id="default": False)
+
+        resolved = file_tools._resolve_path_for_task("/cygdrive/d/code/main.py")
+        assert str(resolved) == r"D:\code\main.py"
+
+    def test_relative_path_uses_normalized_msys_cwd(self, monkeypatch):
+        import tools.environments.local as local_mod
+        import tools.file_tools as file_tools
+
+        monkeypatch.setattr(file_tools.sys, "platform", "win32")
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(file_tools, "_uses_container_paths", lambda task_id="default": False)
+        monkeypatch.setattr(
+            file_tools,
+            "_authoritative_workspace_root",
+            lambda task_id="default": "/c/Users/Mark/project",
+        )
+
+        resolved = file_tools._resolve_path_for_task("src/app.py", task_id="msys")
+        assert str(resolved) == r"C:\Users\Mark\project\src\app.py"
+
+    def test_container_paths_skip_msys_translation(self, monkeypatch):
+        """WSL/docker Linux paths must not be rewritten as Windows drives."""
+        import tools.environments.local as local_mod
+        import tools.file_tools as file_tools
+
+        monkeypatch.setattr(file_tools.sys, "platform", "win32")
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(file_tools, "_uses_container_paths", lambda task_id="default": True)
+        monkeypatch.setattr(
+            file_tools,
+            "_authoritative_workspace_root",
+            lambda task_id="default": "/home/don/project",
+        )
+
+        resolved = file_tools._resolve_path_for_task("/home/don/.env")
+        assert str(resolved) == "/home/don/.env"
+
+
+# ---------------------------------------------------------------------------
 # Tool result hint tests (#722)
 # ---------------------------------------------------------------------------
 

--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -68,6 +68,15 @@ class TestMsysToWindowsPath:
         monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
         assert _msys_to_windows_path("/tmp/foo") == "/tmp/foo"
         assert _msys_to_windows_path("/home/x") == "/home/x"
+        # /mnt/<name>/... only translates when <name> is a single drive letter.
+        assert _msys_to_windows_path("/mnt/home/x") == "/mnt/home/x"
+
+    def test_translates_cygdrive_and_wsl_mnt_forms(self, monkeypatch):
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        assert _msys_to_windows_path("/cygdrive/c/Users/NVIDIA") == r"C:\Users\NVIDIA"
+        assert _msys_to_windows_path("/mnt/d/Projects/foo") == r"D:\Projects\foo"
+        assert _msys_to_windows_path("/cygdrive/c") == "C:\\"
+        assert _msys_to_windows_path("/mnt/c/") == "C:\\"
 
     def test_empty_string(self, monkeypatch):
         monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -25,16 +25,24 @@ def _msys_to_windows_path(cwd: str) -> str:
     native Windows form (``C:\\Users\\x``) so ``os.path.isdir`` and
     ``subprocess.Popen(..., cwd=...)`` can find it.
 
+    Also accepts the Cygwin (``/cygdrive/c/...``) and WSL-mount
+    (``/mnt/c/...``) spellings of a drive root. Multi-segment POSIX paths
+    like ``/home/x`` or ``/tmp/foo`` are left untouched.
+
     No-ops on non-Windows hosts or for paths that aren't in MSYS form.
     Returns the input unchanged when no translation applies. This is
     idempotent — calling it on an already-Windows path returns it as-is.
     """
     if not _IS_WINDOWS or not cwd:
         return cwd
-    # Match leading "/<single letter>/" or exactly "/<letter>" (bare drive root).
-    m = re.match(r'^/([a-zA-Z])(/.*)?$', cwd)
+    # Match leading "/<single letter>/" or exactly "/<letter>" (bare drive root),
+    # plus /cygdrive/<letter>/... and /mnt/<letter>/... variants.
+    m = re.match(r'^/(?:(?:cygdrive|mnt)/)?([a-zA-Z])(/.*)?$', cwd)
     if not m:
         return cwd
+    # Reject /cygdrive or /mnt with no drive letter — the optional group above
+    # already requires the letter. Multi-char first segments (/home, /tmp)
+    # fail the single-letter capture and fall through as no-ops.
     drive = m.group(1).upper()
     tail = (m.group(2) or "").replace('/', '\\')
     return f"{drive}:{tail or chr(92)}"  # chr(92) = backslash, avoid raw-string escape

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import posixpath
+import sys
 import threading
 from pathlib import Path, PurePosixPath
 
@@ -406,6 +407,17 @@ def _resolve_base_dir(
         if not posixpath.isabs(base_text):
             base_text = posixpath.join(os.getcwd(), base_text)
         return _normalize_without_host_deref(base_text)
+    # Git Bash ``pwd -P`` reports ``/c/Users/...``; translate before Path so
+    # relative file-tool paths don't anchor under a nonexistent ``\\c\\Users``.
+    from tools.environments.local import _msys_to_windows_path
+
+    base_text = _msys_to_windows_path(base_text)
+    if sys.platform == "win32":
+        import ntpath
+
+        if not ntpath.isabs(base_text):
+            base_text = ntpath.join(os.getcwd(), base_text)
+        return Path(ntpath.normpath(base_text))
     base = Path(base_text)
     if not base.is_absolute():
         # Last-resort anchoring: a live cwd should already be absolute, but if a
@@ -420,14 +432,31 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | Pu
 
     See :func:`_resolve_base_dir` for how the base is chosen. Absolute input
     paths are returned resolved-but-unanchored.
+
+    On native Windows, Git Bash / MSYS drive paths (``/c/Users/...``) are
+    translated to ``C:\\Users\\...`` before resolution so file tools don't
+    treat them as relative ``\\c\\Users\\...`` under the process cwd.
     """
     container_paths = _uses_container_paths(task_id)
-    expanded = _expand_tilde(filepath)
     if container_paths:
+        expanded = _expand_tilde(filepath)
         if posixpath.isabs(expanded):
             return _normalize_without_host_deref(expanded)
         resolved = _resolve_base_dir(task_id, container_paths=True) / expanded
         return _normalize_without_host_deref(resolved)
+
+    # Host paths only — never rewrite Linux paths inside a container/WSL env.
+    from tools.environments.local import _msys_to_windows_path
+
+    expanded = _expand_tilde(_msys_to_windows_path(filepath))
+    if sys.platform == "win32":
+        import ntpath
+
+        if ntpath.isabs(expanded):
+            return Path(ntpath.normpath(expanded))
+        joined = ntpath.join(str(_resolve_base_dir(task_id, container_paths=False)), expanded)
+        return Path(ntpath.normpath(joined))
+
     p = Path(expanded)
     if p.is_absolute():
         return p.resolve()


### PR DESCRIPTION
## Summary

Supersedes #50488 (and consolidates the same fix class from #44735 / #46995).

On native Windows + Git Bash, the agent passes MSYS drive paths like `/c/Users/...` into `read_file` / `write_file` / `search_files`. Python's `Path("/c/Users/...")` becomes relative `\\c\\Users\\...` under the process cwd, so edits miss the real file (or land in the wrong place).

`LocalEnvironment` already had `_msys_to_windows_path` for terminal cwd. File tools did not call it.

### What this PR does
- Reuse `tools.environments.local._msys_to_windows_path` from `_resolve_path_for_task` / `_resolve_base_dir` (no duplicated helper).
- Extend that helper to also accept `/cygdrive/c/...` and `/mnt/c/...` drive spellings; leave `/home/...`, `/tmp/...`, `/mnt/home/...` alone.
- Use `ntpath` on `win32` so absolute-after-translation checks are correct.
- Skip translation when `_uses_container_paths` is true (WSL/docker Linux paths must not become `H:\\ome\\...`).
- Add regression coverage (`TestWindowsMsysPathResolution` + cygdrive/mnt unit cases).

### What was dropped from #50488
- Unrelated desktop "artifact sidecar" HTML-preview commit (`apps/desktop/src/store/preview.ts`).
- Incorrect `Closes #40138` (that issue is WSL host-prefix mangling — opposite bug class).
- Copy-pasted private helper in `file_tools.py`.

### Discord / `\drivers\etc` note
The Windows Desktop report that surfaces `Directory \drivers\etc does not exist; exiting` / "update your msys package" on **both** `write_file` and `terminal` after `init_session` snapshot bootstrap failure is a broken Git-Bash cwd/spawn path, not only Python `Path` resolution. This PR fixes the file-tool MSYS→native half. The bash-side native→MSYS rewrite tracked in #55481 is still worth a separate look for that symptom.

## Test plan
- [x] `pytest tests/tools/test_local_env_windows_msys.py tests/tools/test_file_tools.py::TestWindowsMsysPathResolution -q` → 30 passed
- [ ] On Windows + Git Bash: `write_file` / `read_file` with `/c/Users/...` paths land on `C:\Users\...`
- [ ] WSL/container backend: Linux absolute paths like `/home/...` are unchanged

Credit: @lEWFkRAD (primary), tests adapted from @LeonSGP43 (#46995). Related: #44735, #37180, #55481.