### PR TITLE
feat(desktop): run bang-prefixed shell commands

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { textPart } from '@/lib/chat-messages'
 import { $composerAttachments, $composerDraft, type ComposerAttachment, setComposerDraft } from '@/store/composer'
-import { $busy, $connection, $messages, $sessions, setSessions } from '@/store/session'
+import { $busy, $connection, $currentCwd, $messages, $sessions, setSessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
 import { uploadComposerAttachment, usePromptActions } from '.'
@@ -46,6 +46,7 @@ function sessionInfo(overrides: Partial<SessionInfo> = {}): SessionInfo {
 interface HarnessHandle {
   cancelRun: () => Promise<void>
   restoreToMessage: (messageId: string, target?: { text?: string; userOrdinal?: number | null }) => Promise<void>
+  selectStoredSession: (storedSessionId: null | string) => void
   steerPrompt: (text: string) => Promise<boolean>
   submitText: (text: string, options?: { attachments?: ComposerAttachment[]; fromQueue?: boolean }) => Promise<boolean>
 }
@@ -56,9 +57,11 @@ function Harness({
   getRouteToken,
   onReady,
   onSeedState,
+  onUpdateSessionBinding,
   openMemoryGraph,
   refreshSessions,
   requestGateway,
+  resumedSessionId,
   resumeStoredSession,
   seedMessages,
   selectedStoredSessionIdRef: selectedStoredSessionIdRefProp,
@@ -71,9 +74,11 @@ function Harness({
   getRouteToken?: () => string
   onReady: (handle: HarnessHandle) => void
   onSeedState?: (state: Record<string, unknown>) => void
+  onUpdateSessionBinding?: (runtimeSessionId: string, storedSessionId?: null | string) => void
   openMemoryGraph?: () => void
   refreshSessions: () => Promise<void>
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+  resumedSessionId?: string
   resumeStoredSession?: (storedSessionId: string) => Promise<void> | void
   seedMessages?: unknown[]
   selectedStoredSessionIdRef?: MutableRefObject<string | null>
@@ -109,15 +114,19 @@ function Harness({
     openMemoryGraph: openMemoryGraph ?? (() => undefined),
     refreshSessions,
     requestGateway,
-    resumeStoredSession: resumeStoredSession ?? (() => undefined),
+    resumeStoredSession: async storedId => {
+      await resumeStoredSession?.(storedId)
+      activeSessionIdRef.current = resumedSessionId ?? RUNTIME_SESSION_ID
+    },
     selectedStoredSessionIdRef,
     startFreshSessionDraft: () => undefined,
     sttEnabled: false,
-    updateSessionState: (_sessionId, updater) => {
+    updateSessionState: (runtimeSessionId, updater, boundStoredSessionId) => {
       // Seed with interrupted:true so we can prove a fresh submit clears it.
       const next = updater(stateRef.current) as unknown as Record<string, unknown>
       stateRef.current = next as never
       onSeedState?.(next)
+      onUpdateSessionBinding?.(runtimeSessionId, boundStoredSessionId)
 
       return next as never
     }
@@ -127,10 +136,20 @@ function Harness({
     onReady({
       cancelRun: actions.cancelRun,
       restoreToMessage: actions.restoreToMessage,
+      selectStoredSession: storedId => {
+        selectedStoredSessionIdRef.current = storedId
+      },
       steerPrompt: actions.steerPrompt,
       submitText: actions.submitText
     })
-  }, [actions.cancelRun, actions.restoreToMessage, actions.steerPrompt, actions.submitText, onReady])
+  }, [
+    actions.cancelRun,
+    actions.restoreToMessage,
+    actions.steerPrompt,
+    actions.submitText,
+    onReady,
+    selectedStoredSessionIdRef
+  ])
 
   return null
 }
@@ -353,6 +372,240 @@ describe('usePromptActions slash.exec dispatch payloads', () => {
 
     expect($composerDraft.get()).toBe('/ pasted context that must not vanish')
     expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
+  })
+})
+
+describe('usePromptActions direct shell commands', () => {
+  afterEach(() => {
+    cleanup()
+    $currentCwd.set('')
+    vi.restoreAllMocks()
+  })
+
+  it('leaves a bare bang as a normal prompt instead of executing a shell command', async () => {
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+    )
+
+    await handle!.submitText('!')
+
+    expect(requestGateway).toHaveBeenCalledWith(
+      'prompt.submit',
+      { session_id: RUNTIME_SESSION_ID, text: '!' },
+      1_800_000
+    )
+    expect(requestGateway).not.toHaveBeenCalledWith('shell.exec', expect.anything())
+  })
+
+  it('runs a bang command through shell.exec in the active project and renders its result without prompting the model', async () => {
+    $currentCwd.set('/active/worktree')
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    const states: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'shell.exec') {
+        return { code: 7, stderr: 'warning', stdout: 'branch-a' } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => states.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('! git branch --show-current')
+
+    expect(calls).toEqual([
+      {
+        method: 'shell.exec',
+        params: {
+          command: 'git branch --show-current',
+          cwd: '/active/worktree',
+          session_id: RUNTIME_SESSION_ID
+        }
+      }
+    ])
+
+    const renderedText = states
+      .flatMap(state => {
+        const messages = Array.isArray(state.messages)
+          ? (state.messages as Array<{ parts?: Array<{ text?: string }> }>)
+          : []
+
+        return messages.flatMap(message => (message.parts ?? []).map(part => part.text ?? ''))
+      })
+      .join('\n')
+
+    expect(renderedText).toContain('$ git branch --show-current')
+    expect(renderedText).toContain('stdout:\nbranch-a')
+    expect(renderedText).toContain('stderr:\nwarning')
+    expect(renderedText).toContain('Exit status: 7')
+    expect(requestGateway).not.toHaveBeenCalledWith('prompt.submit', expect.anything())
+  })
+
+  it('keeps bang-prefixed messages with attachments on the normal prompt path', async () => {
+    const attachment: ComposerAttachment = {
+      id: 'file:notes',
+      kind: 'file',
+      label: 'notes.txt',
+      refText: '@file:`/tmp/notes.txt`'
+    }
+
+    const requestGateway = vi.fn(async (_method: string, _params?: Record<string, unknown>) => ({}) as never)
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+    )
+
+    await handle!.submitText('! summarize this file', { attachments: [attachment] })
+
+    expect(requestGateway.mock.calls.map(call => call[0])).toEqual(['prompt.submit'])
+    expect(requestGateway).not.toHaveBeenCalledWith('shell.exec', expect.anything())
+  })
+
+  it('resumes the selected stored session before running a command without a live runtime id', async () => {
+    const createBackendSessionForSend = vi.fn(async () => 'unexpected-new-session')
+    const resumeStoredSession = vi.fn()
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      return { code: 0, stderr: '', stdout: '/repo\n' } as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={null}
+        createBackendSessionForSend={createBackendSessionForSend}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        resumedSessionId="resumed-runtime"
+        resumeStoredSession={resumeStoredSession}
+        storedSessionId="stored-session"
+      />
+    )
+
+    await handle!.submitText('!pwd')
+
+    expect(calls.map(call => call.method)).toEqual(['shell.exec'])
+    expect(calls[0]?.params?.session_id).toBe('resumed-runtime')
+    expect(resumeStoredSession).toHaveBeenCalledWith('stored-session')
+    expect(createBackendSessionForSend).not.toHaveBeenCalled()
+  })
+
+  it('resumes and retries once when shell.exec rejects a stale runtime session', async () => {
+    let shellAttempts = 0
+    const calls: string[] = []
+    const resumeStoredSession = vi.fn()
+
+    const requestGateway = vi.fn(async (method: string) => {
+      calls.push(method)
+      shellAttempts += 1
+
+      if (shellAttempts === 1) {
+        throw new Error('session not found')
+      }
+
+      return { code: 0, stderr: '', stdout: 'ok\n' } as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        resumedSessionId="fresh-runtime"
+        resumeStoredSession={resumeStoredSession}
+      />
+    )
+
+    await handle!.submitText('!pwd')
+
+    expect(calls).toEqual(['shell.exec', 'shell.exec'])
+    expect(resumeStoredSession).toHaveBeenCalledWith(RUNTIME_SESSION_ID)
+  })
+
+  it('does not resume a different session after selection changes during stale-runtime recovery', async () => {
+    let rejectShell: ((reason: Error) => void) | undefined
+    const bindings: Array<[string, null | string | undefined]> = []
+    const resumeStoredSession = vi.fn()
+
+    const requestGateway = vi.fn(
+      async () =>
+        await new Promise<never>((_resolve, reject) => {
+          rejectShell = reject
+        })
+    )
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        onUpdateSessionBinding={(runtimeId, storedId) => bindings.push([runtimeId, storedId])}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        resumeStoredSession={resumeStoredSession}
+        storedSessionId="stored-a"
+      />
+    )
+
+    const pending = handle!.submitText('!pwd')
+    await Promise.resolve()
+    handle!.selectStoredSession('stored-b')
+    rejectShell?.(new Error('session not found'))
+
+    expect(await pending).toBe(true)
+    expect(requestGateway).toHaveBeenCalledTimes(1)
+    expect(resumeStoredSession).not.toHaveBeenCalled()
+    expect(bindings.at(-1)).toEqual([RUNTIME_SESSION_ID, 'stored-a'])
+  })
+
+  it('rejects a second submission while a shell command is still in flight', async () => {
+    let finishShell: ((value: { code: number; stderr: string; stdout: string }) => void) | undefined
+    const bindings: Array<[string, null | string | undefined]> = []
+
+    const requestGateway = async <T,>(_method: string, _params?: Record<string, unknown>): Promise<T> =>
+      (await new Promise<{ code: number; stderr: string; stdout: string }>(resolve => {
+        finishShell = resolve
+      })) as T
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        onUpdateSessionBinding={(runtimeId, storedId) => bindings.push([runtimeId, storedId])}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        storedSessionId="stored-a"
+      />
+    )
+
+    const first = handle!.submitText('!sleep 1')
+    await Promise.resolve()
+
+    expect(await handle!.submitText('normal prompt')).toBe(false)
+    handle!.selectStoredSession('stored-b')
+
+    finishShell?.({ code: 0, stderr: '', stdout: 'done\n' })
+    expect(await first).toBe(true)
+    expect(bindings.at(-1)).toEqual([RUNTIME_SESSION_ID, 'stored-a'])
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -21,7 +21,7 @@ import { resetSessionBackground } from '@/store/composer-status'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { clearPreviewArtifacts } from '@/store/preview-status'
 import { clearAllPrompts } from '@/store/prompts'
-import { $busy, $connection, $messages, setAwaitingResponse, setBusy, setMessages } from '@/store/session'
+import { $busy, $connection, $currentCwd, $messages, setAwaitingResponse, setBusy, setMessages } from '@/store/session'
 import { clearSessionSubagents } from '@/store/subagents'
 import { clearSessionTodos } from '@/store/todos'
 
@@ -57,6 +57,12 @@ import {
 interface HandoffResult {
   ok: boolean
   error?: string
+}
+
+interface ShellExecResponse {
+  code: number
+  stderr: string
+  stdout: string
 }
 
 /**
@@ -200,9 +206,10 @@ export function usePromptActions({
 }: PromptActionsOptions) {
   const { t } = useI18n()
   const copy = t.desktop
+  const shellBusyRef = useRef(false)
 
   const appendSessionTextMessage = useCallback(
-    (sessionId: string, role: ChatMessage['role'], text: string) => {
+    (sessionId: string, role: ChatMessage['role'], text: string, storedSessionId = selectedStoredSessionIdRef.current) => {
       // Strip ANSI: slash-command output from the backend worker carries SGR
       // color codes (e.g. "Unknown command" in red). The ESC byte is invisible
       // in the chat panel, so without this the `[1;31m…[0m` payload leaks as
@@ -226,7 +233,7 @@ export function usePromptActions({
             }
           ]
         }),
-        selectedStoredSessionIdRef.current
+        storedSessionId
       )
     },
     [selectedStoredSessionIdRef, updateSessionState]
@@ -461,10 +468,120 @@ export function usePromptActions({
     submitPromptText
   })
 
+  const executeDirectShellCommand = useCallback(
+    async (command: string) => {
+      if (busyRef.current || shellBusyRef.current) {
+        return false
+      }
+
+      shellBusyRef.current = true
+      let sessionId = activeSessionIdRef.current
+      let storedSessionId = selectedStoredSessionIdRef.current
+
+      try {
+        const resumeSession = async (storedSessionId: string): Promise<null | string> => {
+          await resumeStoredSession(storedSessionId)
+
+          return activeSessionIdRef.current
+        }
+
+        if (!sessionId && storedSessionId) {
+          sessionId = await resumeSession(storedSessionId).catch(() => null)
+        }
+
+        if (!sessionId) {
+          sessionId = await createBackendSessionForSend(`!${command}`)
+        }
+
+        if (!sessionId) {
+          return false
+        }
+
+        storedSessionId = selectedStoredSessionIdRef.current
+
+        const cwd = $currentCwd.get().trim()
+
+        const run = (runtimeSessionId: string) =>
+          requestGateway<ShellExecResponse>('shell.exec', {
+            command,
+            ...(cwd ? { cwd } : {}),
+            session_id: runtimeSessionId
+          })
+
+        let result: ShellExecResponse
+
+        try {
+          result = await run(sessionId)
+        } catch (err) {
+          if (
+            !isSessionNotFoundError(err) ||
+            !storedSessionId ||
+            selectedStoredSessionIdRef.current !== storedSessionId
+          ) {
+            throw err
+          }
+
+          const resumedSessionId = await resumeSession(storedSessionId)
+
+          if (!resumedSessionId) {
+            throw err
+          }
+
+          sessionId = resumedSessionId
+          result = await run(sessionId)
+        }
+
+        const parts = [
+          `$ ${command}`,
+          `stdout:\n${result.stdout || '(no output)'}`,
+          `stderr:\n${result.stderr || '(no output)'}`,
+          `Exit status: ${result.code}`
+        ]
+
+        appendSessionTextMessage(sessionId, 'system', parts.join('\n\n'), storedSessionId)
+
+        return true
+      } catch (err) {
+        if (sessionId) {
+          appendSessionTextMessage(
+            sessionId,
+            'system',
+            `$ ${command}\n\nError: ${inlineErrorMessage(err, 'shell command failed')}`,
+            storedSessionId
+          )
+        }
+
+        return true
+      } finally {
+        shellBusyRef.current = false
+      }
+    },
+    [
+      activeSessionIdRef,
+      appendSessionTextMessage,
+      busyRef,
+      createBackendSessionForSend,
+      requestGateway,
+      resumeStoredSession,
+      selectedStoredSessionIdRef
+    ]
+  )
+
   const submitText = useCallback(
     async (rawText: string, options?: SubmitTextOptions) => {
+      if (shellBusyRef.current) {
+        return false
+      }
+
       const visibleText = rawText.trim()
       const attachments = options?.attachments ?? $composerAttachments.get()
+      const directShellCommand = visibleText.startsWith('!') ? visibleText.slice(1).trim() : ''
+
+      // Never discard attachments implicitly: a bang-prefixed message with
+      // files remains a normal prompt so the regular attachment pipeline owns it.
+      if (!attachments.length && directShellCommand) {
+        return await executeDirectShellCommand(directShellCommand)
+      }
 
       if (!attachments.length && SLASH_COMMAND_RE.test(visibleText)) {
         triggerHaptic('selection')
@@ -475,7 +592,7 @@ export function usePromptActions({
 
       return await submitPromptText(rawText, options)
     },
-    [executeSlashCommand, submitPromptText]
+    [executeDirectShellCommand, executeSlashCommand, submitPromptText]
   )
 
   const transcribeVoiceAudio = useCallback(

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -481,6 +481,70 @@ def test_dispatch_rejects_non_object_params():
     }
 
 
+def test_shell_exec_uses_requested_project_cwd_without_local_path_validation(monkeypatch):
+    remote_project_cwd = "/remote-host/worktree"
+    calls: list[tuple[str, dict]] = []
+
+    def fake_run(command: str, **kwargs):
+        calls.append((command, kwargs))
+        return types.SimpleNamespace(returncode=0, stderr="", stdout="ready\n")
+
+    monkeypatch.setattr(server.subprocess, "run", fake_run)
+
+    response = server.handle_request(
+        {
+            "id": "shell-cwd",
+            "method": "shell.exec",
+            "params": {"command": "echo ready", "cwd": remote_project_cwd},
+        }
+    )
+
+    assert response is not None
+    assert response["result"] == {"code": 0, "stderr": "", "stdout": "ready\n"}
+    assert calls[0][0] == "echo ready"
+    assert calls[0][1]["cwd"] == remote_project_cwd
+    assert calls[0][1]["timeout"] == 30
+
+
+def test_shell_exec_rejects_unknown_runtime_session():
+    response = server.handle_request(
+        {
+            "id": "shell-stale-session",
+            "method": "shell.exec",
+            "params": {"command": "pwd", "session_id": "missing-runtime-session"},
+        }
+    )
+
+    assert response is not None
+    assert response["error"] == {"code": 4001, "message": "session not found"}
+
+
+def test_shell_exec_sanitizes_child_env_and_redacts_output(monkeypatch):
+    secret = "sk-proj-shell-secret-sentinel-value-1234567890"
+    calls: list[dict] = []
+
+    monkeypatch.setenv("OPENAI_API_KEY", secret)
+
+    def fake_run(_command: str, **kwargs):
+        calls.append(kwargs)
+        return types.SimpleNamespace(returncode=0, stderr=f"err:{secret}", stdout=f"out:{secret}")
+
+    monkeypatch.setattr(server.subprocess, "run", fake_run)
+
+    response = server.handle_request(
+        {
+            "id": "shell-secret-boundary",
+            "method": "shell.exec",
+            "params": {"command": "printenv OPENAI_API_KEY"},
+        }
+    )
+
+    assert response is not None
+    assert "OPENAI_API_KEY" not in calls[0]["env"]
+    assert secret not in response["result"]["stdout"]
+    assert secret not in response["result"]["stderr"]
+
+
 def test_voice_toggle_returns_configured_record_key(monkeypatch):
     monkeypatch.setattr(
         server,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -14309,15 +14309,25 @@ def _(rid, params: dict) -> dict:
     except ImportError:
         return _err(rid, 5001, "shell.exec unavailable: approval safety module not importable")
     try:
+        session_id = params.get("session_id") or ""
+        session = _sessions.get(session_id) if session_id else None
+        if session_id and session is None:
+            return _err(rid, 4001, "session not found")
+
+        from agent.redact import redact_sensitive_text
+        from tools.environments.local import _sanitize_subprocess_env
+
+        cwd = str(params.get("cwd") or _session_cwd(session) or os.getcwd())
+        sanitized_env = _sanitize_subprocess_env(os.environ.copy())
         r = subprocess.run(
-            cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=os.getcwd(),
-            stdin=subprocess.DEVNULL,
+            cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=cwd,
+            stdin=subprocess.DEVNULL, env=sanitized_env,
         )
         return _ok(
             rid,
             {
-                "stdout": r.stdout[-4000:],
-                "stderr": r.stderr[-2000:],
+                "stdout": redact_sensitive_text(r.stdout or "", force=True)[-4000:],
+                "stderr": redact_sensitive_text(r.stderr or "", force=True)[-2000:],
                 "code": r.returncode,
             },
         )


### PR DESCRIPTION
## Summary

- Treat attachment-free composer input beginning with `!` as a direct shell command instead of sending it to the model.
- Reuse the gateway `shell.exec` RPC with the active session and project cwd.
- Preserve normal prompt behavior for a bare `!` and bang-prefixed messages with attachments.
- Resume stored sessions through the existing Desktop hydration path and keep in-flight output bound to the originating session across session switches.
- Harden `shell.exec` by validating session IDs, sanitizing the subprocess environment, redacting output, and retaining the existing dangerous-command checks.

## Safety and compatibility

- Commands still pass through the gateway's hardline and dangerous-command detectors.
- Provider, messaging, and gateway credentials are stripped from the child environment.
- stdout/stderr are redacted and remain bounded to the existing response limits.
- No new dependencies or persistent configuration are introduced.

## Verification

- Desktop ESLint: passed for the changed hook and tests.
- Desktop typecheck: passed.
- Targeted Vitest: 7 passed (`direct shell commands`).
- Targeted gateway pytest: 3 passed, 315 deselected (`shell_exec`).
- Ruff: passed for the changed Python files.
- Desktop production build: passed.
- Independent blocking-focused review: resolved stale-session hydration, session-switch binding, and retry race findings.
