### PR TITLE
fix(tui): MCP discovery for slash_worker and TUI agent builds (#61891)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7488,10 +7488,16 @@ def test_make_agent_reads_nested_max_turns(monkeypatch):
 
 def test_make_agent_waits_for_shared_mcp_discovery(monkeypatch):
     _setup_make_agent_mocks(monkeypatch, {})
+    started = []
     waited = []
 
     from hermes_cli import mcp_startup
 
+    monkeypatch.setattr(
+        mcp_startup,
+        "start_background_mcp_discovery",
+        lambda **kwargs: started.append(kwargs),
+    )
     monkeypatch.setattr(
         mcp_startup,
         "wait_for_mcp_discovery",
@@ -7501,6 +7507,9 @@ def test_make_agent_waits_for_shared_mcp_discovery(monkeypatch):
     with patch("run_agent.AIAgent"):
         server._make_agent("sid1", "key1")
 
+    assert started == [
+        {"logger": server.logger, "thread_name": "tui-agent-mcp-discovery"}
+    ]
     assert waited == [0.75]
 
 

--- a/tests/tui_gateway/test_slash_worker_mcp_discovery.py
+++ b/tests/tui_gateway/test_slash_worker_mcp_discovery.py
@@ -1,0 +1,103 @@
+"""Regression tests for MCP discovery in tui_gateway.slash_worker (#61891).
+
+The slash-command worker is a per-session child process. MCP tools discovered
+in the parent ``hermes serve`` / dashboard process do not populate the worker's
+in-memory registry, so ``HermesCLI`` must start its own bounded discovery
+before the first tool snapshot.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_prepare_runtime_runs_before_hermes_cli_in_main():
+    """MCP discovery must be armed before ``HermesCLI`` construction."""
+    src = (PROJECT_ROOT / "tui_gateway" / "slash_worker.py").read_text()
+    tree = ast.parse(src)
+
+    prepare_line = None
+    cli_call_line = None
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_prepare_slash_worker_runtime"
+        ):
+            if prepare_line is None:
+                prepare_line = node.lineno
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "HermesCLI"
+        ):
+            if cli_call_line is None:
+                cli_call_line = node.lineno
+
+    assert prepare_line is not None, "slash_worker must call _prepare_slash_worker_runtime()"
+    assert cli_call_line is not None, "slash_worker must construct HermesCLI"
+    assert prepare_line < cli_call_line, (
+        "_prepare_slash_worker_runtime() must run before HermesCLI() (issue #61891)"
+    )
+
+
+def test_prepare_slash_worker_runtime_starts_and_waits(monkeypatch):
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        "hermes_cli.mcp_startup.start_background_mcp_discovery",
+        lambda **kwargs: calls.append("start"),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.mcp_startup.wait_for_mcp_discovery",
+        lambda timeout=None: calls.append("wait"),
+    )
+
+    from tui_gateway.slash_worker import _prepare_slash_worker_runtime
+
+    _prepare_slash_worker_runtime()
+
+    assert calls == ["start", "wait"]
+
+
+def test_main_invokes_mcp_prepare_before_cli(monkeypatch):
+    """main() wires discovery ahead of the expensive HermesCLI build."""
+    calls: list[str] = []
+
+    class _FakeProc:
+        def create_time(self):
+            return 0.0
+
+    monkeypatch.setattr(
+        "tui_gateway.slash_worker._start_parent_death_watchdog",
+        lambda *args, **kwargs: calls.append("watchdog"),
+    )
+    monkeypatch.setattr(
+        "tui_gateway.slash_worker._prepare_slash_worker_runtime",
+        lambda: calls.append("mcp"),
+    )
+    monkeypatch.setattr(
+        "tui_gateway.slash_worker.HermesCLI",
+        lambda **kwargs: calls.append("cli") or object(),
+    )
+    monkeypatch.setattr(
+        "tui_gateway.slash_worker.psutil.Process",
+        lambda pid: _FakeProc(),
+    )
+    monkeypatch.setattr(
+        "sys.argv",
+        ["slash_worker", "--session-key", "test-key"],
+    )
+
+    with patch("sys.stdin", []):
+        from tui_gateway import slash_worker
+
+        slash_worker.main()
+
+    assert calls[:3] == ["watchdog", "mcp", "cli"]

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4476,10 +4476,19 @@ def _make_agent(
     # once here and never re-reads it, so briefly wait for in-flight discovery
     # to land before building — bounded, so a slow/dead server still can't
     # block. Dashboard /api/ws uses hermes_cli.mcp_startup; TUI stdio keeps
-    # its existing tui_gateway.entry-owned thread.
+    # its existing tui_gateway.entry-owned thread.  Start discovery here too
+    # (idempotent) so a missed dashboard/ws startup or a profile-scoped build
+    # still registers MCP tools before the snapshot (issue #61891).
     try:
-        from hermes_cli.mcp_startup import wait_for_mcp_discovery
+        from hermes_cli.mcp_startup import (
+            start_background_mcp_discovery,
+            wait_for_mcp_discovery,
+        )
 
+        start_background_mcp_discovery(
+            logger=logger,
+            thread_name="tui-agent-mcp-discovery",
+        )
         wait_for_mcp_discovery()
     except Exception:
         pass

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -65,6 +65,27 @@ def _is_orphaned(original_ppid, parent_create_time, getppid=os.getppid) -> bool:
         return True
 
 
+def _prepare_slash_worker_runtime() -> None:
+    """Start bounded MCP discovery before HermesCLI snapshots tools.
+
+    Each slash_worker child is its own process — the parent ``hermes serve``
+    discovery thread does not populate this registry (issue #61891).
+    """
+    import logging
+
+    from hermes_cli.mcp_startup import (
+        start_background_mcp_discovery,
+        wait_for_mcp_discovery,
+    )
+
+    logger = logging.getLogger(__name__)
+    start_background_mcp_discovery(
+        logger=logger,
+        thread_name="slash-worker-mcp-discovery",
+    )
+    wait_for_mcp_discovery()
+
+
 def _start_parent_death_watchdog(original_ppid, parent_create_time) -> None:
     def _loop():
         while not _is_orphaned(original_ppid, parent_create_time):
@@ -129,6 +150,7 @@ def main():
     except psutil.Error:
         parent_create_time = 0.0
     _start_parent_death_watchdog(orig_ppid, parent_create_time)
+    _prepare_slash_worker_runtime()
 
     with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
         cli = HermesCLI(model=args.model or None, compact=True, resume=args.session_key, verbose=False)


### PR DESCRIPTION
## Summary

- Start bounded background MCP discovery in `tui_gateway.slash_worker` before `HermesCLI` construction — each slash-command worker is a separate process, so the parent `hermes serve` registry never reaches it ([#61891](https://github.com/NousResearch/hermes-agent/issues/61891)).
- Arm idempotent `start_background_mcp_discovery()` in `tui_gateway.server._make_agent` before the existing bounded `wait_for_mcp_discovery()` join, so TUI/desktop agent builds still snapshot MCP tools when dashboard startup raced ahead or never started a discovery thread.

## Root cause

`hermes chat` starts MCP discovery in-process before tool snapshots. Desktop/TUI sessions run agent turns through `tui_gateway`, which only waited on an existing discovery thread. The per-session `slash_worker` subprocess never started discovery at all, and `_make_agent` could no-op when no thread was armed yet.

## Test plan

- [x] `scripts/run_tests.sh tests/tui_gateway/test_slash_worker_mcp_discovery.py -q`
- [x] `scripts/run_tests.sh tests/test_tui_gateway_server.py -k test_make_agent_waits_for_shared_mcp_discovery -q`
- [ ] Manual: configure an MCP server, run `hermes serve`, open desktop/TUI chat, confirm MCP tools appear in session info and are callable

Fixes #61891
