### PR TITLE
fix(desktop): re-apply UI zoom on show/restore, scoped to chat windows (supersedes #61245)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -4743,7 +4743,13 @@ function installPreviewShortcut(window) {
 // survives reloads/restarts) rather than a main-process JSON file. The main
 // process owns setZoomLevel, so we mirror each change into localStorage and
 // read it back on did-finish-load to re-apply after reloads or crash recovery.
-import { clampZoomLevel, percentToZoomLevel, ZOOM_STORAGE_KEY, zoomLevelToPercent } from './zoom'
+import {
+  clampZoomLevel,
+  installZoomReassertOnWindowEvents,
+  percentToZoomLevel,
+  ZOOM_STORAGE_KEY,
+  zoomLevelToPercent
+} from './zoom'
 
 function setAndPersistZoomLevel(window, zoomLevel) {
   if (!window || window.isDestroyed()) {
@@ -6507,10 +6513,21 @@ async function startHermes() {
 // security posture: external links open in the OS browser, in-app navigation
 // stays confined to the dev server / packaged file URL, and the preview /
 // devtools / zoom / context-menu affordances behave identically everywhere.
-function wireCommonWindowHandlers(win) {
+//
+// `zoom` is opt-out for the pet overlay: it sizes its own OS window to fit the
+// sprite in unzoomed CSS px (overlayWindowSize -> setBounds) and has its own
+// Alt+wheel scale, so inheriting the global UI zoom would render the mascot
+// larger than its window and crop it. Chat windows keep zoom on.
+function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {}) {
   installPreviewShortcut(win)
   installDevToolsShortcut(win)
-  installZoomShortcuts(win)
+  if (zoom) {
+    installZoomShortcuts(win)
+    // Re-apply persisted zoom on show/restore (Windows drops webContents zoom on
+    // minimize/restore) and on first load (reloads / crash recovery).
+    installZoomReassertOnWindowEvents(win, () => restorePersistedZoomLevel(win))
+    win.webContents.once('did-finish-load', () => restorePersistedZoomLevel(win))
+  }
   installContextMenu(win)
   win.webContents.setWindowOpenHandler(details => {
     openExternalUrl(details.url)
@@ -6702,7 +6719,9 @@ function spawnPetOverlayWindow(bounds) {
     // Not supported everywhere — best effort.
   }
 
-  wireCommonWindowHandlers(win)
+  // Pet overlay opts out of global UI zoom (see wireCommonWindowHandlers): it
+  // owns its window-fit + scale, and inheriting zoom would crop the sprite.
+  wireCommonWindowHandlers(win, { zoom: false })
 
   win.once('ready-to-show', () => {
     if (!win.isDestroyed()) {
@@ -6893,7 +6912,8 @@ function createWindow() {
   }
 
   mainWindow.webContents.once('did-finish-load', () => {
-    restorePersistedZoomLevel(mainWindow)
+    // Zoom restore is handled by wireCommonWindowHandlers (shared with session
+    // windows); no need to reapply it here.
     broadcastBootProgress()
     sendWindowStateChanged()
     startHermes().catch(error => rememberLog(error.stack || error.message))

--- a/apps/desktop/electron/zoom.test.ts
+++ b/apps/desktop/electron/zoom.test.ts
@@ -5,9 +5,19 @@
  */
 
 import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
 import test from 'node:test'
+import { fileURLToPath } from 'node:url'
 
-import { clampZoomLevel, percentToZoomLevel, ZOOM_STORAGE_KEY, zoomLevelToPercent } from './zoom'
+import {
+  clampZoomLevel,
+  installZoomReassertOnWindowEvents,
+  percentToZoomLevel,
+  ZOOM_REASSERT_WINDOW_EVENTS,
+  ZOOM_STORAGE_KEY,
+  zoomLevelToPercent
+} from './zoom'
 
 test('storage key stays stable so persisted zoom survives upgrades', () => {
   assert.equal(ZOOM_STORAGE_KEY, 'hermes:desktop:zoomLevel')
@@ -52,4 +62,64 @@ test('conversion is monotonic across the preset range', () => {
 test('extreme percentages clamp to the level bounds', () => {
   assert.equal(percentToZoomLevel(1), -9)
   assert.equal(percentToZoomLevel(1_000_000), 9)
+})
+
+test('installZoomReassertOnWindowEvents wires show and restore', () => {
+  const handlers = new Map()
+  const win = {
+    isDestroyed: () => false,
+    on(event, listener) {
+      handlers.set(event, listener)
+    }
+  }
+  let calls = 0
+  installZoomReassertOnWindowEvents(win, () => {
+    calls += 1
+  })
+
+  assert.deepEqual([...handlers.keys()], [...ZOOM_REASSERT_WINDOW_EVENTS])
+  handlers.get('show')()
+  handlers.get('restore')()
+  assert.equal(calls, 2)
+})
+
+test('installZoomReassertOnWindowEvents skips destroyed windows', () => {
+  const handlers = new Map()
+  let destroyed = false
+  const win = {
+    isDestroyed: () => destroyed,
+    on(event, listener) {
+      handlers.set(event, listener)
+    }
+  }
+  let calls = 0
+  installZoomReassertOnWindowEvents(win, () => {
+    calls += 1
+  })
+  destroyed = true
+  handlers.get('show')()
+  assert.equal(calls, 0)
+})
+
+// Source assertion (see windows-child-process.test.ts for the established
+// pattern): wireCommonWindowHandlers lives in the electron main entry with heavy
+// Electron deps, so we assert the wiring contract against source rather than
+// booting a BrowserWindow. Locks in that the pet overlay opts OUT of global UI
+// zoom while chat windows keep it — the whole reason this fix is scoped.
+test('pet overlay opts out of global UI zoom; chat windows keep it', () => {
+  const electronDir = path.dirname(fileURLToPath(import.meta.url))
+  const source = fs.readFileSync(path.join(electronDir, 'main.ts'), 'utf8').replace(/\r\n/g, '\n')
+
+  // The shared helper gates all zoom wiring behind an opt-out flag.
+  assert.match(source, /function wireCommonWindowHandlers\(win, \{ zoom = true \}/)
+
+  // The pet overlay window is the only caller that disables zoom.
+  assert.match(source, /wireCommonWindowHandlers\(win, \{ zoom: false \}\)/)
+
+  // Zoom restore now flows through the shared helper, so createWindow must not
+  // reassert it directly (that would double-fire and drift from session windows).
+  const finishLoad = source.indexOf("mainWindow.webContents.once('did-finish-load'")
+  assert.notEqual(finishLoad, -1, 'missing mainWindow did-finish-load handler')
+  const snippet = source.slice(finishLoad, finishLoad + 300)
+  assert.doesNotMatch(snippet, /restorePersistedZoomLevel\(mainWindow\)/)
 })

--- a/apps/desktop/electron/zoom.ts
+++ b/apps/desktop/electron/zoom.ts
@@ -31,3 +31,22 @@ export function percentToZoomLevel(percent) {
 
   return clampZoomLevel(Math.log(percent / 100) / Math.log(ZOOM_FACTOR_BASE))
 }
+
+// Chromium on Windows can drop webContents zoom when a BrowserWindow is minimized
+// and restored. Re-apply the persisted level on these lifecycle transitions.
+export const ZOOM_REASSERT_WINDOW_EVENTS = ['show', 'restore']
+
+export function installZoomReassertOnWindowEvents(win, reassert) {
+  if (!win?.on) {
+    return
+  }
+
+  for (const event of ZOOM_REASSERT_WINDOW_EVENTS) {
+    win.on(event, () => {
+      if (win.isDestroyed?.()) {
+        return
+      }
+      reassert()
+    })
+  }
+}


### PR DESCRIPTION
## Summary

Supersedes #61245.

On Windows, Chromium drops `webContents` zoom on minimize→restore, so the UI snapped back to 100% while Settings still read 125% ([#61081](https://github.com/NousResearch/hermes-agent/issues/61081)). Zoom was only reasserted on the main window's `did-finish-load` — never on `show`/`restore`, and never for secondary session windows.

This reasserts the persisted zoom on `show` + `restore` + first load, wired once in `wireCommonWindowHandlers` so the main window and session windows share the fix.

## What this changes vs #61245

#61245 wired the reassert through `wireCommonWindowHandlers`, which is **also** used by the pet overlay — the open question Gille raised in the report thread. Letting the pet inherit global UI zoom is a bug, not a nicety:

- The overlay sizes its **own** OS window to fit the sprite in **unzoomed CSS px** (`overlayWindowSize` → `setBounds`). `setZoomLevel` scales rendered content but not window bounds, so at 125% the sprite renders larger than the window that contains it and gets **cropped** at the edges (breaking that helper's own "never cropped by the window edge" invariant; the `right:0/top:0` mail button can clip off too).
- The pet already has its **own** scale system (Alt+wheel gesture + settings slider); global zoom double-scales it and desyncs the fit math.
- The overlay shares the renderer origin (`…/index.html?win=overlay`), so it reads the same `hermes:desktop:zoomLevel` key — #61245 would newly pull the main window's 125% into the mascot on spawn.

So zoom is now **opt-out**: `wireCommonWindowHandlers(win, { zoom: false })` for the pet overlay; chat windows keep it on. (Click-through alpha hit-testing itself stays correct — it's all one CSS-px space — but window-fit + the screen/CSS coordinate mixing in drag/pop-out is where zoom bites.)

## Files
- `electron/zoom.ts` — `installZoomReassertOnWindowEvents` + `ZOOM_REASSERT_WINDOW_EVENTS` (from #61245).
- `electron/main.ts` — `wireCommonWindowHandlers(win, { zoom })` gate; pet passes `{ zoom: false }`; drop the now-redundant `restorePersistedZoomLevel(mainWindow)` in `createWindow` (shared helper handles it).
- `electron/zoom.test.ts` — #61245's pure-helper tests + a scope assertion (pet opts out, chat windows keep zoom, no double-restore in `createWindow`).

## Test plan
- [x] `npx tsx --test electron/zoom.test.ts` → 10 passed
- [x] `tsc -p apps/desktop --noEmit` → no errors in changed files
- [ ] Windows: set UI Scale 125%, minimize→restore → stays 125%; open a session window → inherits 125%; pop out the pet → renders 1× and uncropped

Credit: @HexLab98 (original fix + helper tests), preserved via `Co-authored-by`. Closes the pet-scope review question from the report thread.