### PR TITLE
fix: handle ACP interrupted turns without final response

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -890,7 +890,13 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
             except Exception:
                 logger.debug("Could not emit ACP provenance update after rotation for %s", session_id, exc_info=True)
 
-        final_response = result.get("final_response", "")
+        # ``final_response`` may be explicitly ``None`` on interrupted/cancelled
+        # turns.  Keep downstream text handling string-safe; otherwise the
+        # interrupt path below can crash with
+        # ``'NoneType' object has no attribute 'startswith'`` before ACP can
+        # return the cancellation metadata to the client.
+        final_response_raw = result.get("final_response", "")
+        final_response = final_response_raw if isinstance(final_response_raw, str) else ""
         cancelled = bool(state.cancel_event and state.cancel_event.is_set())
         # The local "waiting for model" interrupt status is metadata, not prose; stop_reason carries it.
         from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -38,6 +38,16 @@ class FakeAgent:
         return {"final_response": final, "messages": messages}
 
 
+class InterruptingAgent(FakeAgent):
+    def run_conversation(self, *, user_message, conversation_history, task_id, **kwargs):
+        self.runs.append(user_message)
+        return {
+            "final_response": None,
+            "interrupted": True,
+            "messages": list(conversation_history or []),
+        }
+
+
 class CaptureConn:
     def __init__(self):
         self.updates = []
@@ -167,3 +177,26 @@ async def test_acp_cancel_publishes_hard_stop_while_holding_runtime_lock():
 
 
 
+
+
+@pytest.mark.asyncio
+async def test_acp_interrupted_none_final_response_does_not_crash():
+    fake = InterruptingAgent()
+    manager = SessionManager(agent_factory=lambda **kwargs: fake, db=NoopDb())
+    acp_agent = HermesACPAgent(session_manager=manager)
+    state = manager.create_session(cwd=".")
+    conn = CaptureConn()
+    acp_agent.on_connect(conn)
+
+    response = await acp_agent.prompt(
+        session_id=state.session_id,
+        prompt=[TextContentBlock(type="text", text="start then interrupt")],
+    )
+
+    assert response.stop_reason == "end_turn"
+    assert fake.runs == ["start then interrupt"]
+    assert [
+        update
+        for _sid, update in conn.updates
+        if getattr(update, "session_update", None) == "agent_message_chunk"
+    ] == []


### PR DESCRIPTION
## Summary

- Normalize ACP `final_response` to a string before interrupt-suppression prefix checks.
- Prevent interrupted/cancelled ACP turns with `final_response=None` from crashing with `'NoneType' object has no attribute 'startswith'`.
- Preserve a focused regression that calls the ACP prompt path and asserts no visible agent message chunk is emitted.

## Current upstream verification

Rebased onto upstream `main` at `08b140d14e6c1d49f9b7ad02c9437fe940d54d65`; refreshed head: `a284a81d473fedfcffbd608a4b0434b0c97362bd`.

Current upstream still assigns `result.get("final_response", "")` and calls `.startswith(...)` when interrupted (`acp_adapter/server.py:893–899`). Executing those exact upstream statements with an interrupted result containing explicit `None` reproduces the AttributeError. This is a statement-level reproduction, not a live Zed test. Related merged interrupt/sentinel fixes have not normalized this value on the current path.

## Verification

Linux, refreshed head:
- `scripts/run_tests.sh tests/acp_adapter/test_acp_commands.py -q`: **4 passed, 0 failed**.
- Python compilation of both changed files: passed.
- `git diff --check origin/main..HEAD`: passed.
- Range-diff against the previous published patch: same behavior and regression, adapted surrounding upstream context.

Scope remains two files: `acp_adapter/server.py` and `tests/acp_adapter/test_acp_commands.py`. No fresh live Zed/manual test or full repository suite was run.

## Original symptom

Observed in Zed/ACP after interrupting an active turn, for example accidentally submitting a partial message while intending Shift+Enter. Interrupt metadata is not prose; the fix keeps the suppression check string-safe.
