### PR TITLE
fix(model): discover no-key custom provider catalogs

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2213,6 +2213,7 @@ def list_authenticated_providers(
                     "api_url": api_url,
                     "api_key": api_key,
                     "models": [],
+                    "has_explicit_models": False,
                     "discover_models": discover,
                     "extra_headers": entry_extra_headers,
                 }
@@ -2238,6 +2239,7 @@ def list_authenticated_providers(
             for model_id in _declared_model_ids(entry.get("models", {})):
                 if model_id not in groups[group_key]["models"]:
                     groups[group_key]["models"].append(model_id)
+                    groups[group_key]["has_explicit_models"] = True
 
         _section4_emitted_slugs: set = set()
         _current_base_url_group_count = sum(
@@ -2298,11 +2300,13 @@ def list_authenticated_providers(
             #   the (possibly partial) ``models:`` subset configured for
             #   context-length overrides with the full live catalog.
             #   This is the Bifrost / aggregator-gateway case.
-            # - Without an api_key but with an explicit ``models:`` list
-            #   (or top-level ``model:``), the user is narrowing a public
-            #   endpoint to a specific subset (e.g. ollama.com /v1/models
-            #   returns 35 models but the user only wants 4). Preserve the
-            #   explicit list and skip live discovery.
+            # - Without an api_key but with an explicit ``models:`` list,
+            #   the user is narrowing a public endpoint to a specific subset
+            #   (e.g. ollama.com /v1/models returns 35 models but the user
+            #   only wants 4). Preserve the explicit list and skip live
+            #   discovery. The singular ``model:`` field is only the current
+            #   active selection and must not suppress discovery on local
+            #   no-key endpoints.
             # - Without an api_key AND no explicit models, fall through to
             #   live discovery so bare-endpoint custom providers (local
             #   llama.cpp / Ollama servers) still appear populated.
@@ -2320,7 +2324,7 @@ def list_authenticated_providers(
             should_probe = (
                 _can_probe_custom_provider(row_is_current=_grp_is_current)
                 and bool(api_url)
-                and (bool(api_key) or not grp["models"])
+                and (bool(api_key) or not grp.get("has_explicit_models"))
                 and grp.get("discover_models", True)
             )
             if should_probe:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2236,10 +2236,12 @@ def list_authenticated_providers(
             if default_model and default_model not in groups[group_key]["models"]:
                 groups[group_key]["models"].append(default_model)
 
-            for model_id in _declared_model_ids(entry.get("models", {})):
+            declared_models = _declared_model_ids(entry.get("models", {}))
+            if declared_models:
+                groups[group_key]["has_explicit_models"] = True
+            for model_id in declared_models:
                 if model_id not in groups[group_key]["models"]:
                     groups[group_key]["models"].append(model_id)
-                    groups[group_key]["has_explicit_models"] = True
 
         _section4_emitted_slugs: set = set()
         _current_base_url_group_count = sum(

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -371,11 +371,13 @@ def test_custom_provider_explicit_model_matching_default_skips_probe(monkeypatch
     """Explicitness comes from ``models:``, even when dedup adds no item."""
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    calls = []
 
-    def fail_fetch(*args, **kwargs):
-        raise AssertionError("explicit one-model catalog must not be probed")
+    def fetch(*args, **kwargs):
+        calls.append((args, kwargs))
+        return ["unexpected-live-model"]
 
-    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fail_fetch)
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fetch)
 
     providers = list_authenticated_providers(
         current_provider="custom:local-ollama",
@@ -391,6 +393,7 @@ def test_custom_provider_explicit_model_matching_default_skips_probe(monkeypatch
     )
 
     row = next(p for p in providers if p["name"] == "Local Ollama")
+    assert calls == []
     assert row["models"] == ["llama3"]
 
 
@@ -398,11 +401,13 @@ def test_custom_provider_group_explicit_duplicate_skips_probe(monkeypatch):
     """A later grouped entry can explicitly narrow to an existing model."""
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    calls = []
 
-    def fail_fetch(*args, **kwargs):
-        raise AssertionError("grouped explicit catalog must not be probed")
+    def fetch(*args, **kwargs):
+        calls.append((args, kwargs))
+        return ["unexpected-live-model"]
 
-    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fail_fetch)
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fetch)
 
     providers = list_authenticated_providers(
         current_provider="custom:local-ollama",
@@ -422,6 +427,7 @@ def test_custom_provider_group_explicit_duplicate_skips_probe(monkeypatch):
     )
 
     row = next(p for p in providers if p["name"] == "Local Ollama")
+    assert calls == []
     assert row["models"] == ["llama3"]
 
 

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -5,16 +5,9 @@ shared slash-command pipeline (`/model` in CLI/gateway/Telegram) historically
 only looked at `providers:`.
 """
 
-import pytest
-
 import hermes_cli.providers as providers_mod
 from hermes_cli.model_switch import list_authenticated_providers, switch_model
 from hermes_cli.providers import resolve_provider_full
-
-
-@pytest.fixture(autouse=True)
-def _no_live_custom_provider_model_fetch(monkeypatch):
-    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *args, **kwargs: [])
 
 
 _MOCK_VALIDATION = {
@@ -287,6 +280,8 @@ def test_list_groups_same_name_custom_providers_into_one_row(monkeypatch):
     with all models collected, not N duplicate rows."""
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    fetch = lambda *a, **k: (_ for _ in ()).throw(AssertionError("unexpected probe"))
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fetch)
 
     providers = list_authenticated_providers(
         current_provider="openrouter",
@@ -370,6 +365,109 @@ def test_custom_provider_no_key_singular_model_still_probes_live_models(monkeypa
     row = next(p for p in providers if p["name"] == "Local Ollama")
     assert row["models"] == ["llama3", "mistral", "qwen3-coder"]
     assert row["total_models"] == 3
+
+
+def test_custom_provider_explicit_model_matching_default_skips_probe(monkeypatch):
+    """Explicitness comes from ``models:``, even when dedup adds no item."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    def fail_fetch(*args, **kwargs):
+        raise AssertionError("explicit one-model catalog must not be probed")
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fail_fetch)
+
+    providers = list_authenticated_providers(
+        current_provider="custom:local-ollama",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "Local Ollama",
+                "base_url": "http://localhost:11434/v1",
+                "model": "llama3",
+                "models": {"llama3": {}},
+            }
+        ],
+    )
+
+    row = next(p for p in providers if p["name"] == "Local Ollama")
+    assert row["models"] == ["llama3"]
+
+
+def test_custom_provider_group_explicit_duplicate_skips_probe(monkeypatch):
+    """A later grouped entry can explicitly narrow to an existing model."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    def fail_fetch(*args, **kwargs):
+        raise AssertionError("grouped explicit catalog must not be probed")
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fail_fetch)
+
+    providers = list_authenticated_providers(
+        current_provider="custom:local-ollama",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "Local Ollama",
+                "base_url": "http://localhost:11434/v1",
+                "model": "llama3",
+            },
+            {
+                "name": "Local Ollama",
+                "base_url": "http://localhost:11434/v1",
+                "models": ["llama3"],
+            },
+        ],
+    )
+
+    row = next(p for p in providers if p["name"] == "Local Ollama")
+    assert row["models"] == ["llama3"]
+
+
+def test_custom_provider_current_only_probe_respects_explicit_catalog(monkeypatch):
+    """Normal GUI opens probe only the active singular-only provider."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    calls = []
+
+    def fetch(api_key, base_url, **kwargs):
+        calls.append((api_key, base_url, kwargs))
+        return ["live-a", "live-b"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fetch)
+
+    providers = list_authenticated_providers(
+        current_provider="custom:active",
+        current_base_url="http://active.local/v1",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "Active",
+                "base_url": "http://active.local/v1",
+                "model": "seed",
+            },
+            {
+                "name": "Offline",
+                "base_url": "http://offline.local/v1",
+                "model": "offline-seed",
+            },
+            {
+                "name": "Static",
+                "base_url": "http://static.local/v1",
+                "model": "only",
+                "models": ["only"],
+            },
+        ],
+        probe_custom_providers=False,
+        probe_current_custom_provider=True,
+    )
+
+    assert calls == [("", "http://active.local/v1", {"headers": None})]
+    rows = {row["name"]: row for row in providers if row.get("is_user_defined")}
+    assert rows["Active"]["models"] == ["live-a", "live-b"]
+    assert rows["Offline"]["models"] == ["offline-seed"]
+    assert rows["Static"]["models"] == ["only"]
 
 
 def test_list_enumerates_dict_format_models_alongside_default(monkeypatch):

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -22,6 +22,7 @@ def test_list_authenticated_providers_includes_custom_providers(monkeypatch):
     """No-args /model menus should include saved custom_providers entries."""
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *a, **k: [])
 
     providers = list_authenticated_providers(
         current_provider="openai-codex",
@@ -313,6 +314,7 @@ def test_list_deduplicates_same_model_in_group(monkeypatch):
     duplicate entries in the models list."""
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *a, **k: [])
 
     providers = list_authenticated_providers(
         current_provider="openrouter",
@@ -474,6 +476,70 @@ def test_custom_provider_current_only_probe_respects_explicit_catalog(monkeypatc
     assert rows["Active"]["models"] == ["live-a", "live-b"]
     assert rows["Offline"]["models"] == ["offline-seed"]
     assert rows["Static"]["models"] == ["only"]
+
+
+def test_custom_provider_current_explicit_catalog_skips_probe(monkeypatch):
+    """Current-only GUI probing must still honor an explicit catalog."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    calls = []
+
+    def fetch(*args, **kwargs):
+        calls.append((args, kwargs))
+        return ["unexpected-live-model"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fetch)
+
+    providers = list_authenticated_providers(
+        current_provider="custom:static",
+        current_base_url="http://static.local/v1",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "Static",
+                "base_url": "http://static.local/v1",
+                "model": "only",
+                "models": ["only"],
+            }
+        ],
+        probe_custom_providers=False,
+        probe_current_custom_provider=True,
+    )
+
+    assert calls == []
+    row = next(p for p in providers if p["name"] == "Static")
+    assert row["is_current"] is True
+    assert row["models"] == ["only"]
+
+
+def test_custom_provider_empty_explicit_list_allows_probe(monkeypatch):
+    """An empty ``models:`` declaration is not an explicit catalog."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    calls = []
+
+    def fetch(api_key, base_url, **kwargs):
+        calls.append((api_key, base_url, kwargs))
+        return ["live-a", "live-b"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fetch)
+
+    providers = list_authenticated_providers(
+        current_provider="custom:local",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "Local",
+                "base_url": "http://local.test/v1",
+                "model": "seed",
+                "models": [],
+            }
+        ],
+    )
+
+    assert calls == [("", "http://local.test/v1", {"headers": None})]
+    row = next(p for p in providers if p["name"] == "Local")
+    assert row["models"] == ["live-a", "live-b"]
 
 
 def test_list_enumerates_dict_format_models_alongside_default(monkeypatch):

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -5,9 +5,16 @@ shared slash-command pipeline (`/model` in CLI/gateway/Telegram) historically
 only looked at `providers:`.
 """
 
+import pytest
+
 import hermes_cli.providers as providers_mod
 from hermes_cli.model_switch import list_authenticated_providers, switch_model
 from hermes_cli.providers import resolve_provider_full
+
+
+@pytest.fixture(autouse=True)
+def _no_live_custom_provider_model_fetch(monkeypatch):
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *args, **kwargs: [])
 
 
 _MOCK_VALIDATION = {
@@ -327,6 +334,42 @@ def test_list_deduplicates_same_model_in_group(monkeypatch):
     assert len(my_rows) == 1
     assert my_rows[0]["models"] == ["llama3", "mistral"]
     assert my_rows[0]["total_models"] == 2
+
+
+def test_custom_provider_no_key_singular_model_still_probes_live_models(monkeypatch):
+    """A singular ``model:`` is the active selection, not an explicit catalog.
+
+    No-key local endpoints such as Ollama and llama.cpp should still be probed
+    so /model matches the terminal ``hermes model`` flow.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    calls = []
+
+    def fake_fetch_api_models(api_key, base_url, **kwargs):
+        calls.append((api_key, base_url, kwargs))
+        return ["llama3", "mistral", "qwen3-coder"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fake_fetch_api_models)
+
+    providers = list_authenticated_providers(
+        current_provider="openai-codex",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "Local Ollama",
+                "base_url": "http://localhost:11434/v1",
+                "model": "llama3",
+            }
+        ],
+        max_models=50,
+    )
+
+    assert calls == [("", "http://localhost:11434/v1", {"headers": None})]
+    row = next(p for p in providers if p["name"] == "Local Ollama")
+    assert row["models"] == ["llama3", "mistral", "qwen3-coder"]
+    assert row["total_models"] == 3
 
 
 def test_list_enumerates_dict_format_models_alongside_default(monkeypatch):


### PR DESCRIPTION
## Summary
No-key custom providers with only an active `model:` now discover their live catalog, while explicit `models:` catalogs remain authoritative.

## Changes
- Preserve @ooiuuii's focused fix from #55158 on current `main`.
- Derive explicit-catalog policy from declarations before display-list deduplication.
- Preserve current-only GUI probing and `discover_models: false` behavior.
- Replace the broad network stub with mutation-sensitive, per-test probe assertions.
- Cover same-entry/grouped duplicates, empty catalogs, and current explicit catalogs.

## Validation
- 107 targeted tests passed.
- Deterministic no-network E2E matrix: 8/8 scenarios passed.
- Mutation checks caught both the old probe gate and post-dedup explicitness bug.
- Ruff, ty diff, Windows footgun scan, and `git diff --check` passed.

## Credit
- @ooiuuii (#55158): focused source-tracking implementation and singular-only regression test; authorship preserved.
- @Morad37 (#40554): first submitted fix direction for #40542.
- @konsisumer (#60656): independently identified the declaration-before-dedup edge case; its separate provider-config gating remains outside this focused salvage.

Closes #40542.
