### PR TITLE
feat(desktop): add composer.dictation keybind for voice dictation

### DIFF
--- a/apps/desktop/src/app/chat/composer/focus.ts
+++ b/apps/desktop/src/app/chat/composer/focus.ts
@@ -164,3 +164,10 @@ export const blurComposerInput = () => {
     el.blur()
   }
 }
+
+/** Toggle dictation — the `composer.dictation` hotkey reaching into the
+ *  composer that owns the voice recorder state. */
+const DICTATION_TOGGLE_EVENT = 'hermes:composer-dictation-toggle'
+export const requestDictationToggle = () => dispatch<{ at: number }>(DICTATION_TOGGLE_EVENT, { at: Date.now() })
+export const onComposerDictationToggleRequest = (handler: () => void) =>
+  subscribe<{ at: number }>(DICTATION_TOGGLE_EVENT, () => handler())

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -8,7 +8,7 @@ import { notifyError } from '@/store/notifications'
 import { $messages } from '@/store/session'
 import { $autoSpeakReplies, setAutoSpeakReplies } from '@/store/voice-prefs'
 
-import { onComposerVoiceToggleRequest } from '../focus'
+import { onComposerDictationToggleRequest, onComposerVoiceToggleRequest } from '../focus'
 import type { ChatBarProps } from '../types'
 
 import { useAutoSpeakReplies } from './use-auto-speak-replies'
@@ -123,6 +123,7 @@ export function useComposerVoice({
   }, [conversation, disabled, voiceConversationActive])
 
   useEffect(() => onComposerVoiceToggleRequest(toggleVoiceConversation), [toggleVoiceConversation])
+  useEffect(() => onComposerDictationToggleRequest(dictate), [dictate])
 
   // Explicit start/end for the on-screen conversation controls (the hotkey uses
   // the gated toggle above).

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -123,7 +123,14 @@ export function useComposerVoice({
   }, [conversation, disabled, voiceConversationActive])
 
   useEffect(() => onComposerVoiceToggleRequest(toggleVoiceConversation), [toggleVoiceConversation])
-  useEffect(() => onComposerDictationToggleRequest(dictate), [dictate])
+  const toggleDictation = useCallback(() => {
+    if (disabled) {
+      return
+    }
+    dictate()
+  }, [dictate, disabled])
+
+  useEffect(() => onComposerDictationToggleRequest(toggleDictation), [toggleDictation])
 
   // Explicit start/end for the on-screen conversation controls (the hotkey uses
   // the gated toggle above).

--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -44,7 +44,7 @@ import {
 import { openNewSessionInNewWindow } from '@/store/windows'
 import { useTheme } from '@/themes/context'
 
-import { requestComposerFocus, requestVoiceToggle } from '../chat/composer/focus'
+import { requestComposerFocus, requestDictationToggle, requestVoiceToggle } from '../chat/composer/focus'
 import { SIDEBAR_COLLAPSE_MEDIA_QUERY } from '../layout-constants'
 import {
   AGENTS_ROUTE,
@@ -119,6 +119,7 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
     'composer.focus': () => requestComposerFocus('main'),
     'composer.modelPicker': () => setModelPickerOpen(true),
     'composer.voice': requestVoiceToggle,
+    'composer.dictation': requestDictationToggle,
 
     'nav.commandPalette': toggleCommandPalette,
     'nav.commandCenter': deps.toggleCommandCenter,

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -234,6 +234,7 @@ export const en: Translations = {
       'composer.focus': 'Focus composer',
       'composer.modelPicker': 'Open model picker',
       'composer.voice': 'Start / stop voice conversation',
+      'composer.dictation': 'Start / stop voice dictation',
       'view.toggleSidebar': 'Toggle sessions sidebar',
       'view.toggleRightSidebar': 'Toggle file browser',
       'view.toggleReview': 'Toggle review pane',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -229,6 +229,7 @@ export const zh: Translations = {
       'composer.focus': '聚焦输入框',
       'composer.modelPicker': '打开模型选择器',
       'composer.voice': '开始 / 停止语音对话',
+      'composer.dictation': '开始 / 停止语音听写',
       'view.toggleSidebar': '切换会话侧边栏',
       'view.toggleRightSidebar': '切换文件浏览器',
       'view.toggleReview': '切换审查面板',

--- a/apps/desktop/src/lib/keybinds/actions.ts
+++ b/apps/desktop/src/lib/keybinds/actions.ts
@@ -58,6 +58,7 @@ export const KEYBIND_ACTIONS: readonly KeybindActionMeta[] = [
   // chord, so ship it unbound there (rebindable in the panel) rather than
   // stealing the long-standing sidebar binding.
   { id: 'composer.voice', category: 'composer', defaults: IS_MAC ? ['ctrl+b'] : [] },
+  { id: 'composer.dictation', category: 'composer', defaults: [] },
 
   // ── Profiles ─────────────────────────────────────────────────────────────
   { id: 'profile.default', category: 'profiles', defaults: ['mod+d'] },

--- a/plugins/platforms/wecom/callback_adapter.py
+++ b/plugins/platforms/wecom/callback_adapter.py
@@ -116,12 +116,15 @@ class WecomCallbackAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
+<<<<<<< Updated upstream
         # ``is_reconnect`` is forwarded by GatewayRunner on every retry per
         # the BasePlatformAdapter.connect contract. Callback adapters have
         # no server-side queue to preserve, so the flag is accepted-and-
         # ignored — but the kwarg MUST be present or the reconnect watcher
         # dies with TypeError and the platform silently stays offline.
         del is_reconnect
+=======
+>>>>>>> Stashed changes
         if not self._apps:
             logger.warning("[WecomCallback] No callback apps configured")
             return False

--- a/plugins/platforms/wecom/callback_adapter.py
+++ b/plugins/platforms/wecom/callback_adapter.py
@@ -116,15 +116,12 @@ class WecomCallbackAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
-<<<<<<< Updated upstream
         # ``is_reconnect`` is forwarded by GatewayRunner on every retry per
         # the BasePlatformAdapter.connect contract. Callback adapters have
         # no server-side queue to preserve, so the flag is accepted-and-
         # ignored — but the kwarg MUST be present or the reconnect watcher
         # dies with TypeError and the platform silently stays offline.
         del is_reconnect
-=======
->>>>>>> Stashed changes
         if not self._apps:
             logger.warning("[WecomCallback] No callback apps configured")
             return False


### PR DESCRIPTION
## Summary

Add a rebindable hotkey for voice dictation in the desktop composer, separate from the existing voice conversation toggle (`composer.voice` / Ctrl+B).

Currently, voice dictation (transcript → draft) is only accessible by clicking the DictationButton in the UI. Voice conversation has a keybind (`composer.voice`), but dictation does not. This PR adds `composer.dictation` so users can bind it to any combo in the keybinds panel (⌘/).

## Changes

| File | Change |
|------|--------|
| `actions.ts` | Register `composer.dictation` action (default: unbound) |
| `focus.ts` | Add `requestDictationToggle` event bus |
| `use-keybinds.ts` | Wire handler to dispatch dictation toggle |
| `use-composer-voice.ts` | Subscribe to dictation toggle event |
| `i18n/zh.ts` | Chinese label: 开始 / 停止语音听写 |
| `i18n/en.ts` | English label: Start / stop voice dictation |

## Usage

1. Open keybinds panel (⌘/)
2. Find **Composer → Start / stop voice dictation**
3. Bind to desired key combo
4. Press the combo to toggle dictation (same as clicking the mic icon)

## Motivation

Voice dictation and voice conversation serve different use cases:
- **Dictation**: speak → text inserted into draft (user sends manually)
- **Conversation**: continuous voice loop (auto-sends, auto-speaks replies)

Having a keybind for dictation lets users quickly dictate text without reaching for the mouse.