### PR TITLE
fix(kanban): add boards restore for archived boards

### DIFF
--- a/contributors/emails/seraphine@Seraphines-Mac-Studio.local
+++ b/contributors/emails/seraphine@Seraphines-Mac-Studio.local
@@ -1,0 +1,2 @@
+Bartok9
+# Seraphine Mac Studio local email on Bartok9 PR tips (per-PR attribution; Teknium/Daniel 2026-08-01)

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -300,6 +300,19 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                       help="Hard-delete the board directory instead of archiving it. "
                            "Default is to move it to boards/_archived/ so it's recoverable.")
 
+    b_restore = boards_sub.add_parser(
+        "restore",
+        aliases=["unarchive"],
+        help="Restore a board previously archived by `boards rm`",
+    )
+    b_restore.add_argument("slug", help="Slug of the archived board to restore")
+    b_restore.add_argument(
+        "--from",
+        dest="from_path",
+        default=None,
+        help="Explicit path under boards/_archived/ (default: newest match)",
+    )
+
     b_switch = boards_sub.add_parser(
         "switch", aliases=["use"],
         help="Set the active board for subsequent CLI calls",
@@ -1201,6 +1214,8 @@ def _dispatch_boards(args: argparse.Namespace) -> int:
         return _cmd_boards_rename(args)
     if sub == "set-default-workdir":
         return _cmd_boards_set_default_workdir(args)
+    if sub in {"restore", "unarchive"}:
+        return _cmd_boards_restore(args)
     print(f"kanban boards: unknown action {sub!r}", file=sys.stderr)
     return 2
 
@@ -1298,10 +1313,33 @@ def _cmd_boards_rm(args: argparse.Namespace) -> int:
         return 1
     if res["action"] == "archived":
         print(f"Board {res['slug']!r} archived → {res['new_path']}")
-        print("Recover by moving the directory back to "
-              "<root>/kanban/boards/<slug>/.")
+        print(
+            "Recover with "
+            f"`hermes kanban boards restore {res['slug']}` "
+            "(preferred) or by moving the directory back to "
+            "<root>/kanban/boards/<slug>/."
+        )
     else:
         print(f"Board {res['slug']!r} deleted.")
+    return 0
+
+
+def _cmd_boards_restore(args: argparse.Namespace) -> int:
+    """Restore a board previously archived by ``boards rm``.
+
+    Prefer this over manually moving directories: it refuses to clobber a
+    live board and picks the newest matching archive by default.
+    """
+    archive_path = getattr(args, "from_path", None) or None
+    try:
+        res = kb.restore_board(args.slug, archive_path=archive_path)
+    except ValueError as exc:
+        print(f"kanban boards restore: {exc}", file=sys.stderr)
+        return 1
+    print(
+        f"Board {res['slug']!r} restored from {res['from_path']} → {res['new_path']}"
+    )
+    print(f"  Use `hermes kanban boards switch {res['slug']}` to make it current.")
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -873,6 +873,145 @@ def remove_board(slug: str, *, archive: bool = True) -> dict:
         return {"slug": normed, "action": "deleted", "new_path": ""}
 
 
+def list_archived_board_dirs(slug: str | None = None) -> list[Path]:
+    """Return archived board directories under ``boards/_archived/``.
+
+    When ``slug`` is given, only entries whose name starts with
+    ``"<slug>-"`` (the prefix used by :func:`remove_board`) are returned.
+    Newest (lexicographically last / timestamped last) is first.
+    """
+    archive_root = boards_root() / "_archived"
+    if not archive_root.is_dir():
+        return []
+    prefix = None
+    if slug is not None:
+        normed = _normalize_board_slug(slug)
+        if not normed:
+            return []
+        prefix = f"{normed}-"
+    entries: list[Path] = []
+    for child in archive_root.iterdir():
+        if not child.is_dir():
+            continue
+        if prefix is not None and not child.name.startswith(prefix):
+            continue
+        # Require something that looks like a board (db or metadata).
+        if not ((child / "kanban.db").exists() or (child / "board.json").exists()):
+            continue
+        entries.append(child)
+    # Timestamps are embedded in the dir name (`slug-<unix>`); sort desc.
+    entries.sort(key=lambda p: p.name, reverse=True)
+    return entries
+
+
+def restore_board(slug: str, *, archive_path: str | Path | None = None) -> dict:
+    """Restore a board archived by :func:`remove_board`.
+
+    Moves the newest (or explicitly named) ``boards/_archived/<slug>-*``
+    directory back to ``boards/<slug>/``.
+
+    Raises :class:`ValueError` when:
+    - the slug is invalid / is ``default``
+    - a live board already exists at ``boards/<slug>/``
+    - no matching archive directory is found
+    """
+    normed = _normalize_board_slug(slug)
+    if not normed:
+        raise ValueError("board slug is required")
+    if normed == DEFAULT_BOARD:
+        raise ValueError("the 'default' board cannot be restored from _archived")
+
+    live = board_dir(normed)
+    if live.exists() and (
+        (live / "kanban.db").exists() or (live / "board.json").exists()
+    ):
+        raise ValueError(
+            f"board {normed!r} already exists at {live}. "
+            f"Remove or rename it before restoring an archive."
+        )
+
+    archive_root = (boards_root() / "_archived").resolve()
+    if archive_path is not None:
+        # Confine --from to boards/_archived/ so operators cannot point
+        # restore at an arbitrary local directory that only shares a basename.
+        try:
+            src = Path(archive_path).expanduser().resolve(strict=False)
+        except OSError as exc:
+            raise ValueError(f"invalid archive path: {archive_path}") from exc
+        try:
+            src.relative_to(archive_root)
+        except ValueError as exc:
+            raise ValueError(
+                f"archive path must be under {archive_root}; got {src}"
+            ) from exc
+        if not src.is_dir():
+            raise ValueError(f"archive path does not exist: {src}")
+        if not src.name.startswith(f"{normed}-"):
+            raise ValueError(
+                f"archive path {src.name!r} does not match slug {normed!r} "
+                f"(expected a directory named '{normed}-<timestamp>')"
+            )
+        if not ((src / "kanban.db").exists() or (src / "board.json").exists()):
+            raise ValueError(
+                f"archive path {src} does not look like a board "
+                f"(missing kanban.db / board.json)"
+            )
+    else:
+        candidates = list_archived_board_dirs(normed)
+        if not candidates:
+            raise ValueError(
+                f"no archived board found for slug {normed!r} under "
+                f"{boards_root() / '_archived'}"
+            )
+        src = candidates[0]
+
+    # Drop any stale init cache for the live path in case a concurrent
+    # process fabricated an empty db after the archive.
+    live_db = live / "kanban.db"
+    try:
+        _INITIALIZED_PATHS.discard(str(live_db.resolve()))
+    except Exception:
+        _INITIALIZED_PATHS.discard(str(live_db))
+
+    if live.exists() and not any(live.iterdir()):
+        # Empty shell left by a concurrent mkdir; remove so rename works.
+        live.rmdir()
+    elif live.exists():
+        # Non-board junk or partial path — refuse rather than clobber.
+        raise ValueError(
+            f"live path {live} already exists and is non-empty; "
+            f"move it aside before restoring"
+        )
+
+    live.parent.mkdir(parents=True, exist_ok=True)
+    # Final rename can still race with a concurrent create_board() that
+    # recreated boards/<slug>/ after the empty-shell sweep above. Convert
+    # the filesystem collision into the advertised user-facing refusal
+    # (ValueError) so the CLI path surfaces a collision instead of OSError.
+    try:
+        src.rename(live)
+    except OSError as exc:
+        if live.exists():
+            raise ValueError(
+                f"board {normed!r} already exists at {live}. "
+                f"Remove or rename it before restoring an archive."
+            ) from exc
+        raise ValueError(
+            f"failed to restore board {normed!r} from {src} to {live}: {exc}"
+        ) from exc
+    return {
+        "slug": normed,
+        "action": "restored",
+        "from_path": str(src),
+        "new_path": str(live),
+    }
+
+
+def has_archived_board(slug: str) -> bool:
+    """True if ``boards/_archived/`` holds at least one directory for ``slug``."""
+    return bool(list_archived_board_dirs(slug))
+
+
 # ---------------------------------------------------------------------------
 # Data classes
 # ---------------------------------------------------------------------------

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -606,6 +606,7 @@ Multi-profile, multi-project collaboration board. Each install can host many boa
 | `boards show` / `boards current` | Print the currently-active board's name, DB path, and task counts. |
 | `boards rename <slug> "<name>"` | Change a board's display name. Slug is immutable. |
 | `boards rm <slug>` | Archive (default) or hard-delete a board. `--delete` skips the archive step. Archived boards move to `boards/_archived/<slug>-<ts>/`. Refused for `default`. |
+| `boards restore <slug>` / `boards unarchive` | Restore a board previously archived by `boards rm`. Default: newest matching `boards/_archived/<slug>-*` entry. Optional `--from <path>` confines the source under `boards/_archived/` (external paths are rejected). Refuses if a live board already exists at `boards/<slug>/`. |
 | `create "<title>"` | Create a new task on the active board. Flags: `--body`, `--assignee`, `--parent` (repeatable), `--workspace scratch\|worktree\|dir:<path>`, `--tenant`, `--priority`, `--triage`, `--idempotency-key`, `--max-runtime`, `--max-retries`, `--skill` (repeatable). |
 | `list` / `ls` | List tasks on the active board. Filter with `--mine`, `--assignee`, `--status`, `--tenant`, `--archived`, `--json`. |
 | `show <id>` | Show a task with comments and events. `--json` for machine output. |
@@ -640,6 +641,10 @@ hermes kanban list                  # shows atm10-server tasks
 # Archive a board (recoverable) or hard-delete it.
 hermes kanban boards rm atm10-server
 hermes kanban boards rm atm10-server --delete
+
+# Restore an archived board (newest archive by default).
+hermes kanban boards restore atm10-server
+# hermes kanban boards restore atm10-server --from ~/.hermes/kanban/boards/_archived/atm10-server-1710000000
 ```
 
 Board resolution order (highest precedence first): `--board <slug>` flag → `HERMES_KANBAN_BOARD` env var → `~/.hermes/kanban/current` file → `default`.

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -113,8 +113,11 @@ hermes kanban boards show             # who's active right now?
 hermes kanban boards rename atm10-server "ATM10 (Prod)"
 
 # Archive (default) — moves the board's dir to boards/_archived/<slug>-<ts>/.
-# Recoverable by moving the dir back.
 hermes kanban boards rm atm10-server
+
+# Restore from the newest matching archive (preferred over hand-renaming dirs).
+# Refuses if boards/<slug>/ already exists. Optional: --from under boards/_archived/.
+hermes kanban boards restore atm10-server
 
 # Hard delete — `rm -rf` the board dir. No recovery.
 hermes kanban boards rm atm10-server --delete


### PR DESCRIPTION
## Summary

- Add kanban_db.restore_board / list_archived_board_dirs to reverse boards rm archives.
- Wire hermes kanban boards restore|unarchive CLI with optional --from archive path.
- Point boards rm recovery copy at the first-class restore command.

## Motivation

Closes #61908.

boards rm moved data under boards/_archived/<slug>-<timestamp>/ but only told operators to rename directories by hand. Concurrent board_exists/create_board could then mkdir a fresh empty live board for the same slug, so a manual restore races and can drop open tasks. A first-class restore path refuses live collisions and picks the newest archive by default.

## Verification

- python3 -m pytest tests/hermes_cli/test_kanban_boards.py -q — 60 passed
- Did NOT change: hard-delete (boards rm --delete) semantics or default-board removal rules
