### PR TITLE
feat(matrix): emoji-reaction clarify prompts on the migrated adapter

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -337,6 +337,23 @@ class _MatrixModelPickerPrompt:
     bot_reaction_events: dict[str, str] = field(default_factory=dict)
 
 
+@dataclass
+class _MatrixClarifyPrompt:
+    """Tracks a pending Matrix reaction-based clarify prompt (#46490)."""
+
+    chat_id: str
+    message_id: str
+    session_key: str
+    clarify_id: str
+    choices: list[str]
+    emoji_to_index: dict[str, int]  # number emoji -> choice index
+    other_emoji: str
+    requester_user_id: str | None = None
+    expires_at: float | None = None
+    resolved: bool = False
+    bot_reaction_events: dict[str, str] = field(default_factory=dict)
+
+
 # Matrix message size limit (4000 chars practical, spec has no hard limit
 # but clients render poorly above this).
 MAX_MESSAGE_LENGTH = 4000
@@ -954,6 +971,11 @@ class MatrixAdapter(BasePlatformAdapter):
         except ValueError:
             self._approval_timeout_seconds = 300
         self._model_picker_prompts_by_event: Dict[str, _MatrixModelPickerPrompt] = {}
+        # Matrix reaction-based clarify prompts (#46490): number emojis pick a
+        # choice, ✏️ arms free-text capture (resolved by the gateway
+        # text-intercept, exactly like a text-fallback "Other" reply).
+        self._clarify_other_emoji = "✏️"
+        self._clarify_prompts_by_event: Dict[str, _MatrixClarifyPrompt] = {}
         allowed_users_raw = os.getenv("MATRIX_ALLOWED_USERS", "")
         self._allowed_user_ids: Set[str] = {
             u.strip() for u in allowed_users_raw.split(",") if u.strip()
@@ -2124,6 +2146,84 @@ class MatrixAdapter(BasePlatformAdapter):
                     prompt.bot_reaction_events[emoji] = str(reaction_event_id)
             except Exception as exc:
                 logger.debug("Matrix: failed to add model picker reaction %s: %s", emoji, exc)
+
+        return result
+
+    async def send_clarify(
+        self,
+        chat_id: str,
+        question: str,
+        choices: Optional[list],
+        clarify_id: str,
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Render a clarify prompt as reaction controls (#46490).
+
+        Multi-choice (``choices`` non-empty): post the question + a numbered
+        choice list, then self-react with 1️⃣..4️⃣ (one per choice) plus ✏️
+        for a free-text answer — mirroring the exec-approval / model-picker
+        reaction idiom.  A number reaction resolves the clarify primitive
+        directly; ✏️ flips the entry into text-capture mode so the gateway's
+        platform-agnostic text-intercept
+        (:meth:`GatewayRunner._maybe_intercept_clarify_text`) picks up the next
+        typed message — no Matrix-specific text machinery.  A typed reply
+        ("2" or the choice text) also resolves via that same intercept.
+
+        Open-ended (``choices`` empty): delegate to the base implementation,
+        which renders the plain question and arms the same text-intercept.
+        """
+        if not choices:
+            return await super().send_clarify(
+                chat_id=chat_id,
+                question=question,
+                choices=choices,
+                clarify_id=clarify_id,
+                session_key=session_key,
+                metadata=metadata,
+            )
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        # One number emoji per choice (clarify caps choices at 4; the model
+        # picker reaction tuple supplies 1️⃣..🔟 so a larger list degrades
+        # gracefully instead of raising).
+        number_emojis = _MATRIX_MODEL_PICKER_REACTIONS[: len(choices)]
+        emoji_to_index: dict[str, int] = {}
+        lines = [f"❓ **{question}**", ""]
+        for idx, choice in enumerate(choices):
+            emoji = number_emojis[idx]
+            emoji_to_index[emoji] = idx
+            lines.append(f"{emoji} {choice}")
+        other_emoji = self._clarify_other_emoji
+        lines.append(f"{other_emoji} Other (type your own answer)")
+        lines.append("")
+        lines.append("React to choose, or reply with the number or your own answer.")
+
+        result = await self.send(chat_id, "\n".join(lines), metadata=metadata)
+        if not result.success or not result.message_id:
+            return result
+
+        prompt = _MatrixClarifyPrompt(
+            chat_id=chat_id,
+            message_id=result.message_id,
+            session_key=session_key,
+            clarify_id=clarify_id,
+            choices=list(choices),
+            emoji_to_index=emoji_to_index,
+            other_emoji=other_emoji,
+            requester_user_id=str((metadata or {}).get("requester_user_id") or "") or None,
+            expires_at=time.monotonic() + max(self._approval_timeout_seconds, 0),
+        )
+        self._clarify_prompts_by_event[result.message_id] = prompt
+
+        for emoji in list(emoji_to_index) + [other_emoji]:
+            try:
+                reaction_event_id = await self._send_reaction(chat_id, result.message_id, emoji)
+                if reaction_event_id:
+                    prompt.bot_reaction_events[emoji] = str(reaction_event_id)
+            except Exception as exc:
+                logger.debug("Matrix: failed to add clarify reaction %s: %s", emoji, exc)
 
         return result
 
@@ -3318,6 +3418,109 @@ class MatrixAdapter(BasePlatformAdapter):
                         reply_to=reacts_to,
                     )
                 return
+
+            # Check if this reaction resolves a pending clarify prompt (#46490).
+            clarify_prompt = self._clarify_prompts_by_event.get(reacts_to)
+            if clarify_prompt and not clarify_prompt.resolved:
+                if room_id != clarify_prompt.chat_id:
+                    return
+                if self._matrix_prompt_expired(clarify_prompt):
+                    await self._expire_matrix_clarify_prompt(room_id, reacts_to, clarify_prompt)
+                    return
+                if not await self._validate_matrix_prompt_reactor(
+                    room_id, reacts_to, sender, clarify_prompt, "clarify"
+                ):
+                    return
+                await self._resolve_matrix_clarify_reaction(
+                    room_id, reacts_to, sender, key, clarify_prompt
+                )
+                return
+
+    async def _resolve_matrix_clarify_reaction(
+        self,
+        room_id: str,
+        target_event_id: str,
+        sender: str,
+        key: str,
+        prompt: "_MatrixClarifyPrompt",
+    ) -> None:
+        """Resolve a clarify reaction: a number picks a choice, ✏️ arms text."""
+        from tools import clarify_gateway as _clarify_mod
+
+        # ✏️ → enter text-capture mode.  The gateway's platform-agnostic
+        # text-intercept resolves the clarify from the user's next typed
+        # message, so there is no Matrix-side text bookkeeping.
+        if key == prompt.other_emoji:
+            if not _clarify_mod.mark_awaiting_text(prompt.clarify_id):
+                # Entry evicted (clarify_timeout) or gateway restarted between
+                # ask and tap — a typed answer would go nowhere.
+                await self._finalize_expired_clarify(room_id, target_event_id, prompt)
+                return
+            await self._send_invalid_reaction_feedback(
+                room_id,
+                target_event_id,
+                "✏️ Type your answer and I'll use it as your response.",
+            )
+            return
+
+        idx = prompt.emoji_to_index.get(key)
+        if idx is None or not (0 <= idx < len(prompt.choices)):
+            await self._send_invalid_reaction_feedback(
+                room_id,
+                target_event_id,
+                "That reaction is not one of the available choices.",
+            )
+            return
+
+        choice_text = str(prompt.choices[idx])
+        try:
+            if _clarify_mod.resolve_gateway_clarify(prompt.clarify_id, choice_text):
+                prompt.resolved = True
+                self._clarify_prompts_by_event.pop(target_event_id, None)
+                logger.info(
+                    "Matrix reaction resolved clarify for session %s (choice=%r, user=%s)",
+                    prompt.session_key, choice_text, sender,
+                )
+                # Redact the bot's seed reactions, leaving only the user's.
+                await self._redact_bot_clarify_reactions(room_id, prompt)
+            else:
+                # Entry evicted / gateway restarted — surface expiry.
+                await self._finalize_expired_clarify(room_id, target_event_id, prompt)
+        except Exception as exc:
+            logger.error("Failed to resolve gateway clarify from Matrix reaction: %s", exc)
+
+    async def _expire_matrix_clarify_prompt(
+        self,
+        room_id: str,
+        target_event_id: str,
+        prompt: "_MatrixClarifyPrompt",
+    ) -> None:
+        await self._finalize_expired_clarify(room_id, target_event_id, prompt)
+
+    async def _finalize_expired_clarify(
+        self,
+        room_id: str,
+        target_event_id: str,
+        prompt: "_MatrixClarifyPrompt",
+    ) -> None:
+        prompt.resolved = True
+        self._clarify_prompts_by_event.pop(target_event_id, None)
+        await self._redact_bot_clarify_reactions(room_id, prompt)
+        await self._send_invalid_reaction_feedback(
+            room_id,
+            target_event_id,
+            "This clarify prompt has expired. Send a new request if you still want to answer.",
+        )
+
+    async def _redact_bot_clarify_reactions(
+        self,
+        room_id: str,
+        prompt: "_MatrixClarifyPrompt",
+    ) -> None:
+        """Redact the bot's seeded clarify reactions, leaving only the user's."""
+        for emoji, evt_id in prompt.bot_reaction_events.items():
+            self._schedule_reaction_redaction(room_id, evt_id, "clarify resolved")
+            logger.debug("Matrix: scheduled bot clarify reaction redaction %s (%s)", emoji, evt_id)
 
     def _matrix_prompt_expired(self, prompt: Any) -> bool:
         expires_at = getattr(prompt, "expires_at", None)

--- a/tests/gateway/test_matrix_clarify_reactions.py
+++ b/tests/gateway/test_matrix_clarify_reactions.py
@@ -1,0 +1,195 @@
+"""Tests for Matrix reaction-based clarify (#46490).
+
+Mirrors test_matrix_exec_approval.py (harness) for the ``send_clarify``
+override and the clarify branch of ``_on_reaction``:
+
+  * render — question + numbered choices, self-reactions 1️⃣.. + ✏️,
+  * a number reaction resolves the clarify with the right choice string,
+  * ✏️ arms the gateway text-capture (``mark_awaiting_text``),
+  * an unauthorized reaction is ignored,
+  * open-ended (no choices) falls back to the base plain-text path.
+"""
+
+import types
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from gateway.config import PlatformConfig
+
+
+def _make_adapter(monkeypatch):
+    monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@liizfq:liizfq.top")
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    adapter = MatrixAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="tok",
+            extra={"homeserver": "https://matrix.example.org"},
+        )
+    )
+    adapter._client = types.SimpleNamespace()
+    # Resolve user_id so _is_self_sender doesn't defensively drop all traffic.
+    adapter._user_id = "@bot:example.org"
+    return adapter
+
+
+def _number_emojis(count):
+    from plugins.platforms.matrix.adapter import _MATRIX_MODEL_PICKER_REACTIONS
+
+    return list(_MATRIX_MODEL_PICKER_REACTIONS[:count])
+
+
+def _reaction_event(sender, reacts_to, key):
+    return types.SimpleNamespace(
+        sender=sender,
+        event_id="$react1",
+        room_id="!room:example.org",
+        content={"m.relates_to": {"event_id": reacts_to, "key": key}},
+    )
+
+
+class TestMatrixClarifyReactions:
+    @pytest.mark.asyncio
+    async def test_send_clarify_renders_and_seeds_reactions(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter.send = AsyncMock(
+            return_value=types.SimpleNamespace(success=True, message_id="$clar1")
+        )
+        adapter._send_reaction = AsyncMock(return_value="$r")
+
+        result = await adapter.send_clarify(
+            chat_id="!room:example.org",
+            question="Which fruit?",
+            choices=["Apple", "Banana"],
+            clarify_id="c1",
+            session_key="sess-1",
+        )
+
+        assert result.success is True
+        # Message body carries the question + numbered choices.
+        body = adapter.send.await_args.args[1]
+        assert "Which fruit?" in body
+        assert "Apple" in body and "Banana" in body
+        # Prompt is tracked by the message event_id for the reaction handler.
+        prompt = adapter._clarify_prompts_by_event["$clar1"]
+        assert prompt.clarify_id == "c1"
+        assert prompt.session_key == "sess-1"
+        # Self-reactions: one number per choice + the ✏️ "Other" control.
+        emojis = [call.args[2] for call in adapter._send_reaction.await_args_list]
+        assert emojis == _number_emojis(2) + ["✏️"]
+
+    @pytest.mark.asyncio
+    async def test_reaction_resolves_choice(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        from plugins.platforms.matrix.adapter import _MatrixClarifyPrompt
+        from tools import clarify_gateway
+
+        number_emojis = _number_emojis(2)
+        clarify_gateway.register(
+            clarify_id="c1",
+            session_key="sess-1",
+            question="Which fruit?",
+            choices=["Apple", "Banana"],
+        )
+        try:
+            adapter._clarify_prompts_by_event["$clar1"] = _MatrixClarifyPrompt(
+                chat_id="!room:example.org",
+                message_id="$clar1",
+                session_key="sess-1",
+                clarify_id="c1",
+                choices=["Apple", "Banana"],
+                emoji_to_index={number_emojis[0]: 0, number_emojis[1]: 1},
+                other_emoji="✏️",
+            )
+
+            event = _reaction_event("@liizfq:liizfq.top", "$clar1", number_emojis[1])
+            await adapter._on_reaction(event)
+
+            # The exact chosen string crosses into the gateway primitive.
+            entry = clarify_gateway._entries["c1"]
+            assert entry.response == "Banana"
+            assert entry.event.is_set()
+            assert "$clar1" not in adapter._clarify_prompts_by_event
+        finally:
+            clarify_gateway.clear_session("sess-1")
+
+    @pytest.mark.asyncio
+    async def test_other_reaction_arms_text_capture(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        from plugins.platforms.matrix.adapter import _MatrixClarifyPrompt
+
+        adapter._clarify_prompts_by_event["$clar1"] = _MatrixClarifyPrompt(
+            chat_id="!room:example.org",
+            message_id="$clar1",
+            session_key="sess-1",
+            clarify_id="c1",
+            choices=["Apple", "Banana"],
+            emoji_to_index={e: i for i, e in enumerate(_number_emojis(2))},
+            other_emoji="✏️",
+        )
+        adapter._send_invalid_reaction_feedback = AsyncMock()
+
+        event = _reaction_event("@liizfq:liizfq.top", "$clar1", "✏️")
+        with patch(
+            "tools.clarify_gateway.mark_awaiting_text", return_value=True
+        ) as mock_arm:
+            await adapter._on_reaction(event)
+
+        mock_arm.assert_called_once_with("c1")
+        # Prompt stays pending — the typed reply resolves it via the gateway
+        # text-intercept, not a second reaction.
+        assert "$clar1" in adapter._clarify_prompts_by_event
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_reaction_ignored(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        from plugins.platforms.matrix.adapter import _MatrixClarifyPrompt
+
+        number_emojis = _number_emojis(2)
+        adapter._clarify_prompts_by_event["$clar1"] = _MatrixClarifyPrompt(
+            chat_id="!room:example.org",
+            message_id="$clar1",
+            session_key="sess-1",
+            clarify_id="c1",
+            choices=["Apple", "Banana"],
+            emoji_to_index={number_emojis[0]: 0, number_emojis[1]: 1},
+            other_emoji="✏️",
+        )
+        adapter._send_invalid_reaction_feedback = AsyncMock()
+
+        event = _reaction_event("@stranger:example.org", "$clar1", number_emojis[1])
+        with patch("tools.clarify_gateway.resolve_gateway_clarify") as mock_resolve:
+            await adapter._on_reaction(event)
+
+        mock_resolve.assert_not_called()
+        # Prompt is left pending; only the auth-denied feedback fires.
+        assert "$clar1" in adapter._clarify_prompts_by_event
+        assert not adapter._clarify_prompts_by_event["$clar1"].resolved
+
+    @pytest.mark.asyncio
+    async def test_open_ended_falls_back_to_base(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter.send = AsyncMock(
+            return_value=types.SimpleNamespace(success=True, message_id="$open1")
+        )
+        adapter._send_reaction = AsyncMock(return_value="$r")
+
+        result = await adapter.send_clarify(
+            chat_id="!room:example.org",
+            question="Anything else?",
+            choices=None,
+            clarify_id="c2",
+            session_key="sess-2",
+        )
+
+        assert result.success is True
+        # Base path renders a plain question and seeds no reactions / prompt.
+        adapter._send_reaction.assert_not_awaited()
+        assert "$open1" not in adapter._clarify_prompts_by_event
+        # Base send_clarify calls self.send(content=...) by keyword.
+        sent = adapter.send.await_args
+        body = sent.kwargs.get("content") or sent.args[1]
+        assert "Anything else?" in body


### PR DESCRIPTION
Fixes #46490

## What this does

Ports the emoji-reaction clarify UX to the **current** Matrix adapter (`plugins/platforms/matrix/adapter.py`) — multiple-choice `clarify` prompts render as numbered reactions (1️⃣…4️⃣) the user taps to answer, plus ✏️ for a free-form reply, matching the reaction idiom Matrix already uses for exec-approval and the model picker.

Credit where due: **#46495 (@rusty4444) pioneered exactly this approach** — same emoji-keyed options, same `mark_awaiting_text` free-form path. That PR targets `gateway/platforms/matrix.py`, which no longer exists after the adapter migration, so this PR re-implements the design against the migrated adapter and folds in the surrounding idioms the new location provides. If #46495 is rebased instead, happy to close this in its favor — the goal is #46490 landing, not authorship.

## How it works

- `send_clarify` override: posts the question + numbered option lines, then self-reacts with the option emojis (reusing the model-picker's `_MATRIX_MODEL_PICKER_REACTIONS` tuple) + ✏️; prompt tracked by message `event_id` like the approval flow.
- The existing reaction-event handler gains a clarify branch: an authorized user's reaction resolves via `resolve_gateway_clarify` with the exact choice string; ✏️ calls `mark_awaiting_text` so the gateway's platform-agnostic text-intercept resolves the next typed message (no new machinery).
- **Authorization**: reuses `_validate_matrix_prompt_reactor` verbatim — the same fail-closed `MATRIX_ALLOWED_USERS` / requester gating as approval reactions, plus room-match and expiry checks.
- On resolve, the bot's seed reactions are redacted (the approval idiom), leaving the user's choice visible.
- Open-ended clarify (no choices) falls back to the base text path unchanged; typed "2"-style replies to a multi-choice prompt still work via the existing intercept.

Message as rendered:
```
❓ Which environment should I deploy to?
1️⃣ staging
2️⃣ production
3️⃣ both, staging first
✏️ Other (type your answer)
```

## Tests

5 new tests in `tests/gateway/test_matrix_clarify_reactions.py` (render + self-reactions · reaction resolves the exact choice string into the real gateway primitive · ✏️ arms text-capture · unauthorized reaction ignored, prompt stays pending · open-ended falls back to base). Full Matrix suite + `test_clarify_gateway` green via `scripts/run_tests.sh` (one pre-existing markdown-table failure verified identical on clean main).
