### PR TITLE
session_search: honor session_search.protected profile config flag

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2203,6 +2203,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                     around_message_id=next_args.get("around_message_id"),
                     window=next_args.get("window", 5),
                     sort=next_args.get("sort"),
+                    profile=next_args.get("profile"),
                     db=session_db,
                     current_session_id=agent.session_id,
                 ),

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1198,6 +1198,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     around_message_id=next_args.get("around_message_id"),
                     window=next_args.get("window", 5),
                     sort=next_args.get("sort"),
+                    profile=next_args.get("profile"),
                     db=session_db,
                     current_session_id=agent.session_id,
                 )

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -762,3 +762,118 @@ class TestProtectedProfile:
         result = json.loads(session_search(session_id="s_bob", profile="bob", db=alice_db))
         assert result["success"] is True
         assert result["mode"] == "read"
+
+
+# =========================================================================
+# Real-HERMES_HOME integration tests (profile resolution via filesystem)
+# =========================================================================
+
+
+class TestProtectedProfileWithRealHome:
+    """Protected profile gating exercised through real HERMES_HOME filesystem
+    layout, avoiding monkeypatched profile helpers.
+
+    This exercises the ``_locate_session_db`` and ``_is_profile_protected``
+    code paths against real ``config.yaml`` files and ``SessionDB`` on disk,
+    verifying the integration boundary that the monkeypatched tests leave
+    untested.
+    """
+
+    def _setup_profiles(self, tmp_path):
+        from hermes_state import SessionDB
+
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir(parents=True)
+
+        # Alice profile
+        alice_dir = hermes_home / "profiles" / "alice"
+        alice_dir.mkdir(parents=True)
+        (alice_dir / "config.yaml").write_text("{}\n")
+        alice_db = SessionDB(alice_dir / "state.db")
+        alice_db.create_session("s_alice", source="cli")
+        alice_db.append_message("s_alice", role="user", content="hello from alice")
+
+        # Bob profile — protected
+        bob_dir = hermes_home / "profiles" / "bob"
+        bob_dir.mkdir(parents=True)
+        (bob_dir / "config.yaml").write_text(
+            "session_search:\n  protected: true\n"
+        )
+        bob_db = SessionDB(bob_dir / "state.db")
+        bob_db.create_session("s_bob", source="cli")
+        bob_db.append_message("s_bob", role="user", content="secret thought from bob")
+
+        return hermes_home, alice_dir, bob_dir, alice_db, bob_db
+
+    # ------------------------------------------------------------------
+    # session_search with explicit profile= — reads from filesystem
+    # ------------------------------------------------------------------
+
+    def test_alice_cannot_read_protected_bob_via_explicit_profile(self, tmp_path, monkeypatch):
+        """Alice CANNOT read Bob's session with explicit profile= — bob is protected."""
+        hermes_home, alice_dir, bob_dir, alice_db, bob_db = self._setup_profiles(tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        from hermes_cli import profiles as profiles_mod
+
+        monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+        monkeypatch.setattr(profiles_mod, "validate_profile_name", lambda n: None)
+
+        result = json.loads(
+            session_search(session_id="s_bob", profile="bob", db=alice_db)
+        )
+        assert result["success"] is False
+        assert "protected" in result.get("error", "")
+
+    def test_alice_cannot_read_protected_bob_through_locate(self, tmp_path, monkeypatch):
+        """Bare lookup (no profile=) on a protected profile must fail
+        via the real _locate_session_db path.
+        """
+        hermes_home, alice_dir, bob_dir, alice_db, bob_db = self._setup_profiles(tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        from hermes_cli import profiles as profiles_mod
+
+        monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+        monkeypatch.setattr(profiles_mod, "validate_profile_name", lambda n: None)
+        monkeypatch.setattr(profiles_mod, "get_active_profile_name", lambda: "alice")
+
+        result = json.loads(session_search(session_id="s_bob", db=alice_db))
+        assert result["success"] is False
+
+    def test_bob_reads_own_sessions_through_locate(self, tmp_path, monkeypatch):
+        """Protected profile can find own sessions via _locate."""
+        hermes_home, alice_dir, bob_dir, alice_db, bob_db = self._setup_profiles(tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        from hermes_cli import profiles as profiles_mod
+
+        monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+        monkeypatch.setattr(profiles_mod, "validate_profile_name", lambda n: None)
+        monkeypatch.setattr(profiles_mod, "get_active_profile_name", lambda: "bob")
+
+        # DB that does NOT contain s_bob — forces _locate fallback
+        from hermes_state import SessionDB
+        empty_db = SessionDB(tmp_path / "empty.db")
+
+        result = json.loads(session_search(session_id="s_bob", db=empty_db))
+        assert result["success"] is True
+        assert result.get("profile") == "bob"
+
+    def test_locate_bare_lookup_skips_protected_from_unprotected_active(self, tmp_path, monkeypatch):
+        """Bare lookup from alice must NOT find bob's session
+        through _locate_session_db."""
+        hermes_home, alice_dir, bob_dir, alice_db, bob_db = self._setup_profiles(tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        from hermes_cli import profiles as profiles_mod
+
+        monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+        monkeypatch.setattr(profiles_mod, "validate_profile_name", lambda n: None)
+        monkeypatch.setattr(profiles_mod, "get_active_profile_name", lambda: "alice")
+
+        from hermes_state import SessionDB
+        empty_db = SessionDB(tmp_path / "empty2.db")
+
+        result = json.loads(session_search(session_id="s_bob", db=empty_db))
+        assert result["success"] is False

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -638,3 +638,127 @@ class TestCronDemotion:
         # Interactive rows first, in original relative order; cron last, in
         # original relative order.
         assert [r["id"] for r in ordered] == [2, 4, 5, 1, 3]
+
+
+# =========================================================================
+# Protected profile gating (session_search.protected config flag)
+# =========================================================================
+
+class TestProtectedProfile:
+    """session_search.protected: true makes a profile invisible to other
+    profiles' session_search, but the protected profile can still read itself
+    and read other profiles.
+    """
+
+    def _setup_profiles(self, tmp_path):
+        """Create two fake profiles: 'alice' (caller) and 'bob' (protected)."""
+        from hermes_state import SessionDB
+
+        alice_home = tmp_path / "profiles" / "alice"
+        alice_home.mkdir(parents=True)
+        bob_home = tmp_path / "profiles" / "bob"
+        bob_home.mkdir(parents=True)
+
+        # Bob's config marks him as protected.
+        (bob_home / "config.yaml").write_text(
+            "session_search:\n  protected: true\n", encoding="utf-8"
+        )
+        # Alice has no such config (or an empty one).
+        (alice_home / "config.yaml").write_text("{}\n", encoding="utf-8")
+
+        # Seed Bob's DB with a session.
+        bob_db = SessionDB(bob_home / "state.db")
+        bob_db.create_session("s_bob", source="cli")
+        bob_db.append_message("s_bob", role="user", content="secret thought from bob")
+        bob_db._conn.commit()
+
+        # Seed Alice's DB with a session.
+        alice_db = SessionDB(alice_home / "state.db")
+        alice_db.create_session("s_alice", source="cli")
+        alice_db.append_message("s_alice", role="user", content="hello from alice")
+        alice_db._conn.commit()
+
+        return alice_home, bob_home, alice_db, bob_db
+
+    def _patch_profiles(self, monkeypatch, tmp_path, active_name="alice"):
+        """Patch hermes_cli.profiles to use the tmp_path layout."""
+        from collections import namedtuple
+        from hermes_cli import profiles as profiles_mod
+
+        profiles_root = tmp_path / "profiles"
+        Info = namedtuple("Info", "name path")
+
+        monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+        monkeypatch.setattr(profiles_mod, "validate_profile_name", lambda n: None)
+        monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: (profiles_root / n).exists())
+        monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: profiles_root / n)
+        monkeypatch.setattr(profiles_mod, "get_active_profile_name", lambda: active_name)
+        monkeypatch.setattr(
+            profiles_mod, "list_profiles",
+            lambda: [Info(d.name, d) for d in profiles_root.iterdir() if d.is_dir()],
+        )
+
+    def test_alice_cannot_read_protected_bob(self, tmp_path, monkeypatch):
+        """Profile A cannot read protected profile B via explicit profile param."""
+        alice_home, bob_home, alice_db, bob_db = self._setup_profiles(tmp_path)
+        self._patch_profiles(monkeypatch, tmp_path, active_name="alice")
+
+        result = json.loads(session_search(session_id="s_bob", profile="bob", db=alice_db))
+        assert result["success"] is False
+        assert "protected" in result.get("error", "")
+
+    def test_bob_can_read_own_profile(self, tmp_path, monkeypatch):
+        """Protected profile B can read itself without error."""
+        alice_home, bob_home, alice_db, bob_db = self._setup_profiles(tmp_path)
+        self._patch_profiles(monkeypatch, tmp_path, active_name="bob")
+
+        result = json.loads(session_search(session_id="s_bob", profile="bob", db=bob_db))
+        assert result["success"] is True
+        assert result["mode"] == "read"
+        assert result["session_id"] == "s_bob"
+
+    def test_bob_can_read_alice(self, tmp_path, monkeypatch):
+        """Protected profile B can read unprotected profile A."""
+        alice_home, bob_home, alice_db, bob_db = self._setup_profiles(tmp_path)
+        self._patch_profiles(monkeypatch, tmp_path, active_name="bob")
+
+        result = json.loads(session_search(session_id="s_alice", profile="alice", db=bob_db))
+        assert result["success"] is True
+        assert result["mode"] == "read"
+        assert result["session_id"] == "s_alice"
+
+    def test_locate_skips_protected_bob_when_caller_is_alice(self, tmp_path, monkeypatch):
+        """_locate_session_db must not find sessions inside protected profiles."""
+        alice_home, bob_home, alice_db, bob_db = self._setup_profiles(tmp_path)
+        self._patch_profiles(monkeypatch, tmp_path, active_name="alice")
+
+        # Bare id without profile — should NOT find bob's session.
+        result = json.loads(session_search(session_id="s_bob", db=alice_db))
+        assert result["success"] is False
+
+    def test_locate_finds_own_sessions_when_protected(self, tmp_path, monkeypatch):
+        """Protected profile can still locate its own sessions via bare id scan."""
+        alice_home, bob_home, alice_db, bob_db = self._setup_profiles(tmp_path)
+        self._patch_profiles(monkeypatch, tmp_path, active_name="bob")
+
+        # bob_db is the caller's DB; s_bob is in it directly, so read shape
+        # finds it without needing _locate_session_db. But let's test via a
+        # DB that does NOT contain s_bob — forcing fallback to _locate.
+        from hermes_state import SessionDB
+        empty_db = SessionDB(tmp_path / "empty.db")
+
+        result = json.loads(session_search(session_id="s_bob", db=empty_db))
+        assert result["success"] is True
+        assert result["profile"] == "bob"
+
+    def test_broken_config_treated_as_unprotected(self, tmp_path, monkeypatch):
+        """A profile whose config.yaml is broken is treated as NOT protected."""
+        alice_home, bob_home, alice_db, bob_db = self._setup_profiles(tmp_path)
+        # Corrupt bob's config
+        (bob_home / "config.yaml").write_text("{{{{invalid yaml", encoding="utf-8")
+        self._patch_profiles(monkeypatch, tmp_path, active_name="alice")
+
+        # Should succeed — broken config means bob is treated as unprotected.
+        result = json.loads(session_search(session_id="s_bob", profile="bob", db=alice_db))
+        assert result["success"] is True
+        assert result["mode"] == "read"

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -141,6 +141,33 @@ def _shape_message(m: Dict[str, Any], anchor_id: Optional[int] = None) -> Dict[s
     return {k: v for k, v in entry.items() if v is not None or k in ("content",)}
 
 
+def _is_profile_protected(name: str) -> bool:
+    """Check whether ``session_search.protected`` is set in a profile's config.
+
+    Returns False (unprotected) on any I/O or parse error so that a broken
+    config in someone else's profile doesn't break the caller's search.
+    Result is NOT cached globally — re-read every call so the flag takes
+    effect immediately after a config change.
+    """
+    try:
+        from hermes_cli import profiles as profiles_mod
+        import yaml
+
+        config_path = profiles_mod.get_profile_dir(name) / "config.yaml"
+        if not config_path.exists():
+            return False
+        raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            return False
+        ss = raw.get("session_search")
+        if not isinstance(ss, dict):
+            return False
+        return bool(ss.get("protected"))
+    except Exception as e:
+        logging.debug("_is_profile_protected(%r) failed: %s", name, e, exc_info=True)
+        return False
+
+
 def _resolve_profile_db(profile: str):
     """Open another profile's ``state.db`` read-only, or None for the current one.
 
@@ -161,6 +188,11 @@ def _resolve_profile_db(profile: str):
     if not profiles_mod.profile_exists(canon):
         raise ValueError(f"profile '{canon}' does not exist")
 
+    # Protected profiles are invisible to other profiles' session_search.
+    active = profiles_mod.get_active_profile_name()
+    if canon != active and _is_profile_protected(canon):
+        raise ValueError(f"profile '{canon}' is protected")
+
     return SessionDB(db_path=profiles_mod.get_profile_dir(canon) / "state.db", read_only=True)
 
 
@@ -172,6 +204,9 @@ def _locate_session_db(session_id: str):
     so the first hit is authoritative. This is the safety net for linked-session
     reads where the model dropped the owning profile from the link and passed a
     bare id — we find it wherever it actually lives instead of failing.
+
+    Protected profiles (``session_search.protected: true`` in their config) are
+    skipped unless the caller IS that profile.
     """
     from pathlib import Path
 
@@ -180,6 +215,8 @@ def _locate_session_db(session_id: str):
         from hermes_state import SessionDB
     except Exception:
         return None, None
+
+    active = profiles_mod.get_active_profile_name()
 
     targets = [("default", profiles_mod.get_profile_dir("default"))]
     try:
@@ -194,6 +231,9 @@ def _locate_session_db(session_id: str):
         if key in seen or not db_path.exists():
             continue
         seen.add(key)
+        # Skip protected profiles that are not the caller.
+        if name != active and _is_profile_protected(name):
+            continue
         try:
             pdb = SessionDB(db_path=db_path, read_only=True)
         except Exception:

--- a/website/docs/user-guide/profiles.md
+++ b/website/docs/user-guide/profiles.md
@@ -132,6 +132,8 @@ Profiles are often confused with workspaces or sandboxes, but they are different
 
 On the default `local` terminal backend, the agent still has the same filesystem access as your user account. A profile does not stop it from accessing folders outside the profile directory.
 
+Profile visibility (the `session_search.protected` config flag) controls only whether **session_search can discover and read another profile's session database**. It does NOT restrict filesystem, memory, or tool access. A profile with `session_search.protected: true` is invisible to other profiles' session_search, but another profile's agent can still read its files — protect sensitive data at the OS level, not with the profile flag.
+
 If you want a profile to start in a specific project folder, set an explicit absolute `terminal.cwd` in that profile's `config.yaml`:
 
 ```yaml


### PR DESCRIPTION
## What

A profile can now opt out of being visible to other profiles' `session_search` by declaring in its own `config.yaml`:

```yaml
session_search:
  protected: true
```

- `_resolve_profile_db` rejects direct reads of a protected profile by any other profile (same error channel as "profile does not exist").
- `_locate_session_db` skips protected profiles when scanning for a bare session id.
- The restriction hangs on the **target**, not the caller: the protected profile itself can still search everyone as before (one-way glass).
- A broken or missing target config counts as unprotected, so someone else's malformed YAML can never break your search (logged at debug level).

## Why

In multi-profile deployments some profiles hold conversations of a fundamentally different sensitivity class (e.g. a personal/mental-health assistant next to infra bots). Today every profile can read every other profile's `state.db` through `session_search` — there is no permission layer at all. This adds a minimal, config-driven one.

## Tests

New tests next to the existing `session_search` suite (tmp profiles-root + monkeypatched `HERMES_HOME`): caller→protected target rejected, target reads itself fine, protected caller reads others fine, locate-scan skips protected profiles, broken config treated as unprotected. Full file: 59 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)