### PR TITLE
fix(tui): discover MCP tools in slash workers

### DIFF
--- a/tests/tui_gateway/test_slash_worker_mcp_discovery.py
+++ b/tests/tui_gateway/test_slash_worker_mcp_discovery.py
@@ -1,0 +1,105 @@
+"""Integration coverage for profile-local MCP discovery in slash workers."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import queue
+import subprocess
+import sys
+import textwrap
+import threading
+
+import pytest
+import yaml
+
+pytest.importorskip("mcp.server.fastmcp")
+
+
+def test_profile_local_mcp_tool_is_visible_in_slash_worker(tmp_path):
+    profile_home = tmp_path / "profile-home"
+    profile_home.mkdir()
+    marker = "profile-local-61922"
+    server = tmp_path / "fastmcp_probe.py"
+    server.write_text(
+        textwrap.dedent(
+            f"""
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("profileprobe")
+
+            @mcp.tool()
+            def hermes_61922_profile_probe() -> str:
+                return {marker!r}
+
+            if __name__ == "__main__":
+                mcp.run(transport="stdio")
+            """
+        ),
+        encoding="utf-8",
+    )
+    (profile_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "mcp_servers": {
+                    "profileprobe": {
+                        "enabled": True,
+                        "command": sys.executable,
+                        "args": [str(server)],
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    for key in list(env):
+        if key.endswith("_API_KEY") or key.endswith("_TOKEN"):
+            env.pop(key)
+    env["HERMES_HOME"] = str(profile_home)
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2])
+    env["HERMES_SLASH_WATCHDOG_GRACE_S"] = "0"
+    env["HERMES_SLASH_WATCHDOG_POLL_S"] = "0.05"
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-u",
+            "-m",
+            "tui_gateway.slash_worker",
+            "--session-key",
+            "agent:main:tui:dm:mcp-profile-test",
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+        cwd=tmp_path,
+    )
+    output: queue.Queue[str] = queue.Queue()
+    try:
+        assert proc.stdin is not None
+        assert proc.stdout is not None
+        stdout = proc.stdout
+        threading.Thread(
+            target=lambda: output.put(stdout.readline()),
+            daemon=True,
+        ).start()
+        proc.stdin.write(json.dumps({"id": 1, "command": "/tools"}) + "\n")
+        proc.stdin.flush()
+        try:
+            line = output.get(timeout=10)
+        except queue.Empty:
+            pytest.fail("slash worker produced no /tools response within 10 seconds")
+        response = json.loads(line)
+        assert response["ok"] is True
+        assert "mcp__profileprobe__hermes_61922_profile_probe" in response["output"]
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -65,6 +65,27 @@ def _is_orphaned(original_ppid, parent_create_time, getppid=os.getppid) -> bool:
         return True
 
 
+def _prepare_slash_worker_runtime() -> None:
+    """Start bounded MCP discovery before HermesCLI snapshots tools.
+
+    Each slash_worker child is its own process — the parent ``hermes serve``
+    discovery thread does not populate this registry (issue #61891).
+    """
+    import logging
+
+    from hermes_cli.mcp_startup import (
+        start_background_mcp_discovery,
+        wait_for_mcp_discovery,
+    )
+
+    logger = logging.getLogger(__name__)
+    start_background_mcp_discovery(
+        logger=logger,
+        thread_name="slash-worker-mcp-discovery",
+    )
+    wait_for_mcp_discovery()
+
+
 def _start_parent_death_watchdog(original_ppid, parent_create_time) -> None:
     def _loop():
         while not _is_orphaned(original_ppid, parent_create_time):
@@ -129,6 +150,7 @@ def main():
     except psutil.Error:
         parent_create_time = 0.0
     _start_parent_death_watchdog(orig_ppid, parent_create_time)
+    _prepare_slash_worker_runtime()
 
     with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
         cli = HermesCLI(model=args.model or None, compact=True, resume=args.session_key, verbose=False)


### PR DESCRIPTION
## Summary
Desktop/TUI slash-command workers now discover profile-local MCP tools inside their own subprocess before `HermesCLI` snapshots the tool registry.

The parent gateway's in-memory MCP registry cannot cross the process boundary, so workers previously reported configured servers as enabled while exposing none of their tools.

## Changes
- `tui_gateway/slash_worker.py`: start the existing bounded, config-gated MCP discovery helper before constructing `HermesCLI`.
- Integration test: launch a real profile-local FastMCP stdio server and assert its tool appears through the actual worker's `/tools` response.

## Deliberately not included
The original PR also started discovery from `tui_gateway.server._make_agent()`. That hunk was dropped because dashboard/WS startup already owns discovery, stdio TUI has a separate owner, and a thread started from a profile-scoped build does not inherit the profile `ContextVar`. Keeping it could duplicate server connections or discover the launch profile instead.

## Validation
- 46 targeted MCP/TUI/slash-worker tests passed.
- New subprocess regression fails on current `main` and passes here.
- Real profile-local FastMCP tool registration and invocation verified.
- Ruff, compile, and diff checks passed.

Partial salvage of #61922 with @HexLab98's substantive commit authorship preserved.

Closes #61891.
