### PR TITLE
fix(desktop): increase backend probe timeout from 5s to 15s to prevent death-loop

### DIFF
--- a/apps/desktop/electron/backend-probes.ts
+++ b/apps/desktop/electron/backend-probes.ts
@@ -20,7 +20,7 @@
  * actually works.
  *
  * Both probes are deliberately fast and forgiving:
- *   - 5s timeout (a hung interpreter beats forever, but we still give
+ *   - 15s timeout (a hung interpreter beats forever, but we still give
  *     slow disks / cold caches room to breathe)
  *   - stdio ignored (we only care about exit code; stdout/stderr are
  *     not surfaced to the user, just to recentHermesLog for forensics
@@ -34,7 +34,7 @@
 
 import { execFileSync } from 'node:child_process'
 
-const PROBE_TIMEOUT_MS = 5000
+const PROBE_TIMEOUT_MS = 15000
 
 /**
  * Return the Python snippet used to verify Hermes can import far enough to


### PR DESCRIPTION
Fixes #61764

## Problem
The desktop launcher probes candidate Python backends with a 5s timeout on `execFileSync`. On slow disks / cold caches the probe can timeout before Hermes finishes its initial Python import chain, causing the resolver to fall through all rungs with no backend found. The launcher immediately retries, producing an infinite death-loop.

## Fix
Bump `PROBE_TIMEOUT_MS` from 5000 to 15000 — 3× headroom for cold boot without making genuinely dead paths wait 30s.

## Changes
```
apps/desktop/electron/backend-probes.ts | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```
- Line 23: comment updated (5s → 15s)
- Line 37: `const PROBE_TIMEOUT_MS = 5000` → `15000`