### PR TITLE
fix(background-review): surface terminal failures after partial action summaries

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -637,6 +637,7 @@ def _run_review_in_thread(
 
     review_agent = None
     review_messages: List[Dict] = []
+    review_failure: Optional[RuntimeError] = None
     try:
         # Silence stdout/stderr for THIS worker thread only.  A process-global
         # ``contextlib.redirect_stdout(devnull)`` here would also blank
@@ -817,7 +818,7 @@ def _run_review_in_thread(
                     _digest_history(messages_snapshot) if _routed
                     else messages_snapshot
                 )
-                review_agent.run_conversation(
+                result = review_agent.run_conversation(
                     user_message=(
                         prompt
                         + "\n\nYou can only call memory and skill "
@@ -826,6 +827,20 @@ def _run_review_in_thread(
                     ),
                     conversation_history=_review_history,
                 )
+                if isinstance(result, dict) and result.get("failed"):
+                    if result.get("compaction_disabled"):
+                        detail = (
+                            "Background review exceeded the model context window. "
+                            "Review forks do not compact their own history by design, "
+                            "so the review may be incomplete."
+                        )
+                    else:
+                        detail = (
+                            result.get("error")
+                            or result.get("final_response")
+                            or "Background review did not complete."
+                        )
+                    review_failure = RuntimeError(str(detail))
             finally:
                 clear_thread_tool_whitelist()
 
@@ -891,6 +906,28 @@ def _run_review_in_thread(
                     )
                 except Exception:
                     pass
+
+        # A terminal review failure can happen after earlier memory/skill tool
+        # calls have already committed their writes. Surface those real actions
+        # above, then report that the overall review was incomplete. Raising at
+        # the run_conversation boundary would skip the action summary entirely.
+        #
+        # The emit is wrapped: _emit_auxiliary_failure reaches the user through
+        # _emit_warning -> status callback, which a host is free to raise from.
+        # Unwrapped, that raise lands in the outer ``except`` below, which calls
+        # _emit_auxiliary_failure a second time and logs the same review twice.
+        if review_failure is not None:
+            logger.warning(
+                "Background memory/skill review incomplete: %s",
+                review_failure,
+            )
+            try:
+                agent._emit_auxiliary_failure("background review", review_failure)
+            except Exception:
+                logger.warning(
+                    "Failed to surface background-review failure to the user",
+                    exc_info=True,
+                )
 
     except Exception as e:
         logger.warning("Background memory/skill review failed: %s", e)

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -278,7 +278,7 @@ def test_background_review_summary_is_attributed_to_self_improvement_loop(monkey
             ]
 
         def run_conversation(self, **kwargs):
-            pass
+            return {"failed": False, "completed": True}
 
         def shutdown_memory_provider(self):
             pass
@@ -311,6 +311,195 @@ def test_background_review_summary_is_attributed_to_self_improvement_loop(monkey
     assert captured_bg_callback[0].startswith("💾 Self-improvement review:"), (
         captured_bg_callback[0]
     )
+
+
+def test_background_review_terminal_failure_reports_partial_actions_first(monkeypatch):
+    """Committed actions survive a later terminal failure in the review fork."""
+    import json
+
+    events: list[tuple[str, str]] = []
+    cleanup_events: list[str] = []
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            self._session_messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_before_overflow",
+                    "content": json.dumps(
+                        {"success": True, "message": "Entry added", "target": "memory"}
+                    ),
+                }
+            )
+            return {
+                "failed": True,
+                "compaction_disabled": True,
+                "error": (
+                    "Context overflow and auto-compaction is disabled "
+                    "(compression.enabled: false). Run /compress to compact manually."
+                ),
+            }
+
+        def shutdown_memory_provider(self):
+            cleanup_events.append("shutdown")
+
+        def close(self):
+            cleanup_events.append("close")
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+    agent._safe_print = lambda message: events.append(("summary", message))
+    agent.background_review_callback = lambda message: events.append(
+        ("callback", message)
+    )
+    agent._emit_auxiliary_failure = lambda task, exc: events.append(
+        ("failure", f"{task}: {exc}")
+    )
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hi"}],
+        review_memory=True,
+    )
+
+    assert [kind for kind, _ in events] == ["summary", "callback", "failure"]
+    assert "Memory updated" in events[0][1]
+    assert "Memory updated" in events[1][1]
+    warning = events[2][1]
+    assert "may be incomplete" in warning
+    assert "/compress" not in warning
+    assert "compression.enabled" not in warning
+    assert cleanup_events == ["shutdown", "close"]
+
+
+def test_background_review_terminal_failure_without_actions_only_warns(monkeypatch):
+    """A failed review with no committed actions emits no success summary."""
+    events: list[tuple[str, str]] = []
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            return {"failed": True, "error": "provider rejected the request"}
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+    agent._safe_print = lambda message: events.append(("summary", message))
+    agent._emit_auxiliary_failure = lambda task, exc: events.append(
+        ("failure", f"{task}: {exc}")
+    )
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hi"}],
+        review_memory=True,
+    )
+
+    assert events == [
+        ("failure", "background review: provider rejected the request")
+    ]
+
+
+def test_background_review_terminal_failure_without_error_key_uses_final_response(
+    monkeypatch,
+):
+    """Failures that fall through finalize_turn() carry no ``error`` key.
+
+    ``finalize_turn()`` never sets ``error`` on its result dictionary, so a
+    conversation that breaks out of the tool loop with ``failed = True`` — the
+    Ollama runtime-context path is the reachable example — reaches the caller
+    with only ``final_response`` to describe it.
+    """
+    events: list[tuple[str, str]] = []
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            return {
+                "failed": True,
+                "completed": False,
+                "final_response": "Ollama runtime context is too small for Hermes tool use",
+            }
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+    agent._safe_print = lambda message: events.append(("summary", message))
+    agent._emit_auxiliary_failure = lambda task, exc: events.append(
+        ("failure", f"{task}: {exc}")
+    )
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hi"}],
+        review_memory=True,
+    )
+
+    assert events == [
+        (
+            "failure",
+            "background review: Ollama runtime context is too small for Hermes tool use",
+        )
+    ]
+
+
+def test_background_review_failure_emit_is_not_reported_twice(monkeypatch):
+    """A raising status callback must not turn one failure into two warnings."""
+    emitted: list[str] = []
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            return {"failed": True, "error": "provider rejected the request"}
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    def _raising_emit(task, exc):
+        emitted.append(f"{task}: {exc}")
+        raise RuntimeError("status callback exploded")
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+    agent._emit_auxiliary_failure = _raising_emit
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hi"}],
+        review_memory=True,
+    )
+
+    assert emitted == ["background review: provider rejected the request"]
 
 
 def test_background_review_fork_skips_external_memory_plugins(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Background reviews suppress their fork's status output, and previously ignored the terminal `failed: true` result that `run_conversation()` returns instead of raising. An incomplete review was therefore silent, or showed already-committed memory/skill actions as if the whole review had succeeded.

This PR captures the terminal failure without raising at the boundary. The review still snapshots `_session_messages`, tears down the fork, and summarizes any memory/skill writes that completed before the failure. It then emits the auxiliary failure warning after those real results have been delivered.

Raising at the boundary would be the smaller diff, but it skips the action summary and hides writes that already landed on disk — the partial-result loss #59437 fixed.

Two result shapes are handled:

- early returns with an explicit `error` key (context overflow, content policy, terminal API errors);
- failures that fall through `finalize_turn()` with **no** `error` key (the Ollama runtime-context path), falling back to `final_response`.

For the fork's intentional `compression_enabled = False` overflow, the foreground-session advice (`/compress`, `compression.enabled: false`) is replaced with a review-scoped explanation.

## Related Issue

Fixes #61962

Orthogonal to #54115 / PR #54255 (concurrency guard on pre-spawn path; this PR changes post-return behavior).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/background_review.py` — inspect the returned terminal-failure contract; preserve partial action collection and summary delivery; emit the auxiliary failure only after summaries (wrapped to prevent double-reporting if the status callback raises); derive the message from `error`, falling back to `final_response`; replace fork-internal overflow remediation with user-actionable review context.
- `tests/run_agent/test_background_review.py` — four new tests covering partial action survival, no-action failure, `final_response` fallback, and double-report guard.

## How to Test

```bash
scripts/run_tests.sh \
  tests/run_agent/test_background_review.py \
  tests/run_agent/test_background_review_cache_parity.py \
  tests/run_agent/test_background_review_toolset_restriction.py -q
```

All four new tests fail on unpatched `main` (the regression they guard).

`cache_parity` and `toolset_restriction` are included on purpose: they pin the prefix-cache invariant from #25322 and the review tool whitelist. Both stay green, so this change does not perturb the same-model warm-cache path.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits: `fix(background-review): surface terminal failures after partial summaries`.
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains **only** changes related to this fix.
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run locally.** The full suite does not collect in my environment (186 collection errors from missing optional dependencies). I ran the background-review subset above instead: 23 passed. Relying on CI for the full run.
- [x] I've added tests for my changes.
- [x] I've tested on my platform: Windows 11, Python 3.14.3, Hermes 0.18.2.

### Documentation & Housekeeping

- [x] Documentation: N/A — no user-facing configuration or API changed.
- [x] `cli-config.yaml.example`: N/A — no config keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A — no workflow or architecture changed.
- [x] Cross-platform impact considered: shared Python control flow only.
- [x] Tool descriptions/schemas: N/A — no tool contract changed.

## Screenshots / Logs

Not applicable. The regression is asserted through emitted-event ordering and warning content in unit tests.
