### PR TITLE
fix(kanban): stop zombie workers after complete (#61923)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -644,6 +644,33 @@ def run_conversation(
         # Reset per-turn checkpoint dedup so each iteration can take one snapshot
         agent._checkpoint_mgr.new_turn()
 
+        # Kanban worker terminal transition (#61923): after a successful
+        # kanban_complete / kanban_block the tool sets a process flag (and
+        # may also promote it to agent._interrupt_requested so remaining
+        # tools in the current batch are skipped). Check this *before* the
+        # generic interrupt path so we exit as a clean completion, not as
+        # a user interrupt.
+        try:
+            from tools.kanban_tools import worker_stop_requested
+
+            if worker_stop_requested():
+                _turn_exit_reason = "kanban_terminal_transition"
+                if final_response is None:
+                    final_response = (
+                        "Kanban task closed; worker stopping further tool calls."
+                    )
+                if not agent.quiet_mode:
+                    agent._safe_print(
+                        "\n✔ Kanban terminal transition — ending worker tool loop..."
+                    )
+                # Clear the interrupt we may have set only to skip sibling
+                # tools so turn finalization treats this as a normal stop.
+                if agent._interrupt_requested:
+                    agent.clear_interrupt()
+                break
+        except Exception:
+            pass
+
         # Check for interrupt request (e.g., user sent new message)
         if agent._interrupt_requested:
             interrupted = True

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -769,6 +769,17 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                                 pass
                         break
 
+                    # Promote kanban terminal-transition stop into an agent
+                    # interrupt so concurrent siblings are cancelled (#61923).
+                    if not agent._interrupt_requested:
+                        try:
+                            from tools.kanban_tools import worker_stop_requested
+
+                            if worker_stop_requested():
+                                agent._interrupt_requested = True
+                        except Exception:
+                            pass
+
                     # Check for interrupt — the per-thread interrupt signal
                     # already causes individual tools (terminal, execute_code)
                     # to abort, but tools without interrupt checks (web_search,
@@ -1645,6 +1656,19 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 _fr_str = function_result if isinstance(function_result, str) else str(function_result)
                 response_preview = _fr_str[:agent.log_prefix_chars] + "..." if len(_fr_str) > agent.log_prefix_chars else _fr_str
                 print(f"  ✅ Tool {i} completed in {tool_duration:.2f}s - {response_preview}")
+
+        # Kanban worker terminal tools (#61923) set a process flag so no
+        # further tools run after complete/block — promote that to the
+        # agent interrupt so remaining calls in this sequential batch
+        # are skipped the same way as a user interrupt.
+        if not agent._interrupt_requested:
+            try:
+                from tools.kanban_tools import worker_stop_requested
+
+                if worker_stop_requested():
+                    agent._interrupt_requested = True
+            except Exception:
+                pass
 
         if agent._interrupt_requested and i < len(assistant_message.tool_calls):
             remaining = len(assistant_message.tool_calls) - i

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1006,12 +1006,12 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     """Execute tool calls sequentially (original behavior). Used for single calls or interactive tools."""
     # Resolve the context-scaled tool-output budget once per turn.
     _tool_budget = _budget_for_agent(agent)
-    for i, tool_call in enumerate(assistant_message.tool_calls, 1):
+    for i, tool_call in enumerate(assistant_message.tool_calls):
         # SAFETY: check interrupt BEFORE starting each tool.
         # If the user sent "stop" during a previous tool's execution,
         # do NOT start any more tools -- skip them all immediately.
         if agent._interrupt_requested:
-            remaining_calls = assistant_message.tool_calls[i-1:]
+            remaining_calls = assistant_message.tool_calls[i:]
             if remaining_calls:
                 agent._vprint(f"{agent.log_prefix}⚡ Interrupt: skipping {len(remaining_calls)} tool call(s)", force=True)
             for skipped_tc in remaining_calls:
@@ -1121,11 +1121,11 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             display_args = _redact_tool_args_for_display(function_name, function_args) or function_args
             args_str = json.dumps(display_args, ensure_ascii=False)
             if agent.verbose_logging:
-                print(f"  📞 Tool {i}: {function_name}({list(display_args.keys())})")
+                print(f"  📞 Tool {i + 1}: {function_name}({list(display_args.keys())})")
                 print(agent._wrap_verbose("Args: ", json.dumps(display_args, indent=2, ensure_ascii=False)))
             else:
                 args_preview = args_str[:agent.log_prefix_chars] + "..." if len(args_str) > agent.log_prefix_chars else args_str
-                print(f"  📞 Tool {i}: {function_name}({list(function_args.keys())}) - {args_preview}")
+                print(f"  📞 Tool {i + 1}: {function_name}({list(function_args.keys())}) - {args_preview}")
 
         if not _execution_blocked:
             agent._current_tool = function_name
@@ -1650,12 +1650,12 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
 
         if not agent.quiet_mode and getattr(agent, "tool_progress_mode", "all") != "off":
             if agent.verbose_logging:
-                print(f"  ✅ Tool {i} completed in {tool_duration:.2f}s")
+                print(f"  ✅ Tool {i + 1} completed in {tool_duration:.2f}s")
                 print(agent._wrap_verbose("Result: ", function_result))
             else:
                 _fr_str = function_result if isinstance(function_result, str) else str(function_result)
                 response_preview = _fr_str[:agent.log_prefix_chars] + "..." if len(_fr_str) > agent.log_prefix_chars else _fr_str
-                print(f"  ✅ Tool {i} completed in {tool_duration:.2f}s - {response_preview}")
+                print(f"  ✅ Tool {i + 1} completed in {tool_duration:.2f}s - {response_preview}")
 
         # Kanban worker terminal tools (#61923) set a process flag so no
         # further tools run after complete/block — promote that to the
@@ -1670,10 +1670,10 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             except Exception:
                 pass
 
-        if agent._interrupt_requested and i < len(assistant_message.tool_calls):
-            remaining = len(assistant_message.tool_calls) - i
+        if agent._interrupt_requested and i + 1 < len(assistant_message.tool_calls):
+            remaining = len(assistant_message.tool_calls) - i - 1
             agent._vprint(f"{agent.log_prefix}⚡ Interrupt: skipping {remaining} remaining tool call(s)", force=True)
-            for skipped_tc in assistant_message.tool_calls[i:]:
+            for skipped_tc in assistant_message.tool_calls[i + 1:]:
                 skipped_name = skipped_tc.function.name
                 messages.append(make_tool_result_message(
                     skipped_name,
@@ -1687,7 +1687,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 )
             break
 
-        if agent.tool_delay > 0 and i < len(assistant_message.tool_calls):
+        if agent.tool_delay > 0 and i + 1 < len(assistant_message.tool_calls):
             time.sleep(agent.tool_delay)
 
     # ── Per-turn aggregate budget enforcement ─────────────────────────

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3984,6 +3984,7 @@ def complete_task(
     metadata: Optional[dict] = None,
     created_cards: Optional[Iterable[str]] = None,
     expected_run_id: Optional[int] = None,
+    signal_fn=None,
 ) -> bool:
     """Transition ``running|ready -> done`` and record ``result``.
 
@@ -4041,6 +4042,17 @@ def complete_task(
             raise HallucinatedCardsError(phantom_cards, task_id)
     else:
         verified_cards = []
+
+    # Kill a host-local foreign worker before clearing worker_pid so
+    # operator/dashboard completion cannot leave a live process mutating
+    # the workspace after the task is marked done (#61923). Self-complete
+    # (the worker closing its own run) is skipped here; the tool layer
+    # requests a clean process exit after the tool returns.
+    _terminate_running_task_for_manual_exit(
+        conn, task_id,
+        expected_run_id=expected_run_id,
+        signal_fn=signal_fn,
+    )
 
     with write_txn(conn):
         if expected_run_id is None:
@@ -4545,6 +4557,7 @@ def block_task(
     reason: Optional[str] = None,
     kind: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    signal_fn=None,
 ) -> bool:
     """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
 
@@ -4577,6 +4590,12 @@ def block_task(
         raise ValueError(
             f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None"
         )
+    # Same foreign-worker kill as complete_task (#61923).
+    _terminate_running_task_for_manual_exit(
+        conn, task_id,
+        expected_run_id=expected_run_id,
+        signal_fn=signal_fn,
+    )
     routed_to = "blocked"
     recurrences = 0
     with write_txn(conn):
@@ -5204,7 +5223,15 @@ def decompose_triage_task(
     return child_ids
 
 
-def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
+def archive_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    signal_fn=None,
+) -> bool:
+    # Terminate a live host-local worker before clearing claim metadata so
+    # archive does not orphan the OS process (#61923 / #42858 class).
+    _terminate_running_task_for_manual_exit(conn, task_id, signal_fn=signal_fn)
     with write_txn(conn):
         cur = conn.execute(
             "UPDATE tasks SET status = 'archived', "
@@ -5591,6 +5618,7 @@ def schedule_task(
     *,
     reason: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    signal_fn=None,
 ) -> bool:
     """Park a task in ``scheduled`` so it is waiting on time, not human input.
 
@@ -5598,6 +5626,11 @@ def schedule_task(
     human action, or automation can later call ``unblock_task`` to re-gate them
     to ``ready`` (or ``todo`` if parents are still incomplete).
     """
+    _terminate_running_task_for_manual_exit(
+        conn, task_id,
+        expected_run_id=expected_run_id,
+        signal_fn=signal_fn,
+    )
     with write_txn(conn):
         params: list[Any] = [task_id]
         sql = """
@@ -5758,6 +5791,43 @@ _RECENT_WORKER_EXIT_TTL_SECONDS = 600
 _RECENT_WORKER_EXITS_MAX = 4096
 _recent_worker_exits: "dict[int, tuple[int, float]]" = {}
 
+# Host-local spawn registry: pid → task_id for workers this process started.
+# ``complete_task`` / ``block_task`` clear ``worker_pid`` in the DB while the
+# OS process may still be alive (self-complete continues tool calls; Windows
+# has no waitpid zombie reap). ``reap_orphaned_terminal_workers`` uses this
+# map to detect "DB says terminal, process still running" and kill the tree
+# (#61923 process-state sync).
+_SPAWNED_WORKERS: "dict[int, str]" = {}
+_SPAWNED_WORKERS_LOCK = threading.Lock()
+_SPAWNED_WORKERS_MAX = 4096
+
+
+def _track_spawned_worker(pid: int, task_id: str) -> None:
+    """Remember a worker this dispatcher process started."""
+    if not pid or pid <= 0 or not task_id:
+        return
+    with _SPAWNED_WORKERS_LOCK:
+        _SPAWNED_WORKERS[int(pid)] = str(task_id)
+        if len(_SPAWNED_WORKERS) > _SPAWNED_WORKERS_MAX:
+            # Drop arbitrary oldest half if the registry somehow balloons
+            # (pid reuse / never-reaped hosts). Insertion order is preserved
+            # on 3.7+ so first half ≈ oldest.
+            for drop_pid in list(_SPAWNED_WORKERS.keys())[: len(_SPAWNED_WORKERS) // 2]:
+                _SPAWNED_WORKERS.pop(drop_pid, None)
+
+
+def _untrack_spawned_worker(pid: Optional[int]) -> None:
+    if not pid or pid <= 0:
+        return
+    with _SPAWNED_WORKERS_LOCK:
+        _SPAWNED_WORKERS.pop(int(pid), None)
+
+
+def clear_spawned_worker_registry() -> None:
+    """Test helper — reset the in-process spawn tracker."""
+    with _SPAWNED_WORKERS_LOCK:
+        _SPAWNED_WORKERS.clear()
+
 
 def _record_worker_exit(pid: int, raw_status: int) -> None:
     """Record a reaped child's exit status for later classification.
@@ -5829,7 +5899,10 @@ def reap_worker_zombies() -> "list[int]":
     """Reap all zombie children of this process without blocking.
 
     Returns the list of reaped PIDs. Safe to call when there are no
-    children (returns []). No-op on Windows.
+    children (returns []). No-op on Windows: native Windows has no Unix
+    zombie/waitpid model. Live post-completion orphans on every platform
+    (including Windows) are handled by
+    :func:`reap_orphaned_terminal_workers` using the spawn registry.
     """
     reaped: "list[int]" = []
     if os.name != "nt":
@@ -5843,9 +5916,69 @@ def reap_worker_zombies() -> "list[int]":
                     break
                 _record_worker_exit(pid, status)
                 reaped.append(pid)
+                _untrack_spawned_worker(pid)
         except Exception:
             pass
     return reaped
+
+
+def reap_orphaned_terminal_workers(
+    conn: sqlite3.Connection,
+    *,
+    signal_fn=None,
+) -> "list[dict[str, Any]]":
+    """Kill host-local workers whose task is no longer ``running``.
+
+    Closes the process-state gap from #61923: ``complete_task`` /
+    ``block_task`` / ``archive_task`` clear ``worker_pid`` in the DB, so
+    monitors that only read task status stop caring — even when the OS
+    process is still alive and may keep calling tools (browser, file
+    deletes). The spawn registry retains the PID so this pass can detect
+    ``DB terminal + process still alive`` and terminate the tree.
+
+    Returns a list of termination payloads (one per killed / attempted
+    orphan). Safe to call every dispatcher tick; no-ops when the registry
+    is empty.
+    """
+    with _SPAWNED_WORKERS_LOCK:
+        snapshot = list(_SPAWNED_WORKERS.items())
+    if not snapshot:
+        return []
+
+    results: "list[dict[str, Any]]" = []
+    for pid, task_id in snapshot:
+        if not _pid_alive(pid):
+            _untrack_spawned_worker(pid)
+            continue
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        # Unknown / deleted task with a live tracked worker → treat as orphan.
+        status = row["status"] if row is not None else None
+        if status == "running":
+            continue
+        termination = _terminate_worker_pid(int(pid), signal_fn=signal_fn)
+        payload = {
+            "task_id": task_id,
+            "status": status,
+            "worker_pid": int(pid),
+        }
+        payload.update(termination)
+        results.append(payload)
+        if termination.get("terminated") or not _pid_alive(pid):
+            _untrack_spawned_worker(pid)
+            try:
+                with write_txn(conn):
+                    _append_event(
+                        conn, task_id, "orphan_worker_terminated", payload,
+                    )
+            except Exception:
+                _log.debug(
+                    "orphan_worker_terminated event failed for %s",
+                    task_id, exc_info=True,
+                )
+    return results
 
 
 def _pid_alive(pid: Optional[int]) -> bool:
@@ -5912,29 +6045,59 @@ def _pid_alive(pid: Optional[int]) -> bool:
     return True
 
 
-def _terminate_reclaimed_worker(
-    pid: Optional[int],
-    claim_lock: Optional[str],
+def _terminate_worker_pid(
+    pid: int,
     *,
     signal_fn=None,
 ) -> dict[str, Any]:
-    """Best-effort host-local worker termination for reclaim paths."""
+    """Terminate a Kanban worker OS process (and its tree on Windows).
+
+    ``os.kill(pid, SIGTERM)`` on Windows maps to ``TerminateProcess`` for only
+    the direct process. Workers often own browser / MCP / Node children;
+    killing only the parent leaves those orphans (#61923). Prefer
+    ``taskkill /T /F`` on Windows (via ``gateway.status.terminate_pid``),
+    while preserving the ``signal_fn`` hook for unit tests.
+    """
     import signal
 
     info: dict[str, Any] = {
-        "prev_pid": int(pid) if pid else None,
-        "host_local": False,
         "termination_attempted": False,
         "terminated": False,
         "sigkill": False,
+        "process_tree": False,
+        "termination_method": None,
     }
-    if not pid or pid <= 0 or not claim_lock:
+    if pid <= 0:
         return info
 
-    host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
-    if not str(claim_lock).startswith(host_prefix):
-        return info
-    info["host_local"] = True
+    # Windows process-tree kill when not under a test signal hook.
+    if signal_fn is None and _IS_WINDOWS:
+        info["termination_attempted"] = True
+        info["process_tree"] = True
+        info["termination_method"] = "taskkill_tree"
+        try:
+            from gateway.status import terminate_pid
+
+            terminate_pid(int(pid), force=True)
+        except Exception as exc:
+            # Fall through to the stdlib kill path when taskkill is missing
+            # or fails for any reason (permissions, already gone, …).
+            info["termination_method"] = f"taskkill_tree_failed:{type(exc).__name__}"
+            _log.debug(
+                "taskkill tree terminate failed for pid %s: %s",
+                pid, exc, exc_info=True,
+            )
+        else:
+            for _ in range(10):
+                if not _pid_alive(pid):
+                    info["terminated"] = True
+                    _untrack_spawned_worker(pid)
+                    return info
+                time.sleep(0.5)
+            info["terminated"] = not _pid_alive(pid)
+            if info["terminated"]:
+                _untrack_spawned_worker(pid)
+            return info
 
     kill = signal_fn if signal_fn is not None else (
         os.kill if hasattr(os, "kill") else None
@@ -5943,6 +6106,8 @@ def _terminate_reclaimed_worker(
         return info
 
     info["termination_attempted"] = True
+    if info["termination_method"] is None:
+        info["termination_method"] = "signal"
     try:
         kill(int(pid), signal.SIGTERM)
     except ProcessLookupError:
@@ -5950,6 +6115,7 @@ def _terminate_reclaimed_worker(
         # survival. Leaving terminated=False here would make the reclaim guard
         # misread a dead worker as still-alive and defer forever.
         info["terminated"] = True
+        _untrack_spawned_worker(pid)
         return info
     except OSError:
         return info
@@ -5957,6 +6123,7 @@ def _terminate_reclaimed_worker(
     for _ in range(10):
         if not _pid_alive(pid):
             info["terminated"] = True
+            _untrack_spawned_worker(pid)
             return info
         time.sleep(0.5)
 
@@ -5971,7 +6138,95 @@ def _terminate_reclaimed_worker(
             return info
 
     info["terminated"] = not _pid_alive(pid)
+    if info["terminated"]:
+        _untrack_spawned_worker(pid)
     return info
+
+
+def _terminate_reclaimed_worker(
+    pid: Optional[int],
+    claim_lock: Optional[str],
+    *,
+    signal_fn=None,
+) -> dict[str, Any]:
+    """Best-effort host-local worker termination for reclaim paths."""
+    info: dict[str, Any] = {
+        "prev_pid": int(pid) if pid else None,
+        "host_local": False,
+        "termination_attempted": False,
+        "terminated": False,
+        "sigkill": False,
+        "process_tree": False,
+        "termination_method": None,
+    }
+    if not pid or pid <= 0 or not claim_lock:
+        return info
+
+    host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
+    if not str(claim_lock).startswith(host_prefix):
+        return info
+    info["host_local"] = True
+    info.update(_terminate_worker_pid(int(pid), signal_fn=signal_fn))
+    return info
+
+
+def _terminate_running_task_for_manual_exit(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    expected_run_id: Optional[int] = None,
+    signal_fn=None,
+) -> dict[str, Any]:
+    """Best-effort termination for operator-forced exits from ``running``.
+
+    Manual transitions like complete/archive/block/schedule must not leave a
+    live worker behind (#61923). The exception is the in-band worker path:
+    when the worker itself is completing or blocking its own run, killing the
+    current process would abort the transition mid-flight — that case is
+    skipped here and the tool layer requests a clean process exit after the
+    tool returns.
+    """
+    info: dict[str, Any] = {
+        "prev_pid": None,
+        "host_local": False,
+        "termination_attempted": False,
+        "terminated": False,
+        "sigkill": False,
+        "process_tree": False,
+        "termination_method": None,
+    }
+    row = conn.execute(
+        "SELECT status, claim_lock, worker_pid, current_run_id "
+        "FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if row is None or row["status"] != "running":
+        return info
+
+    if (
+        expected_run_id is not None
+        and row["current_run_id"] is not None
+        and int(row["current_run_id"]) != int(expected_run_id)
+    ):
+        return info
+
+    pid = row["worker_pid"]
+    if pid is None:
+        return info
+
+    info["prev_pid"] = int(pid)
+    # Never kill the current process. Self-complete / self-block (worker
+    # closing its own run) and tests that pin worker_pid to os.getpid()
+    # would otherwise SIGTERM the caller mid-flight. The tool layer
+    # requests a clean process exit after the tool returns for real
+    # dispatcher-spawned workers.
+    if int(pid) == os.getpid():
+        info["self_skipped"] = True
+        return info
+
+    return _terminate_reclaimed_worker(
+        pid, row["claim_lock"], signal_fn=signal_fn,
+    )
 
 
 def _worker_survived_termination(termination: dict) -> bool:
@@ -6731,6 +6986,9 @@ def _set_worker_pid(conn: sqlite3.Connection, task_id: str, pid: int) -> None:
                 (int(pid), run_id),
             )
         _append_event(conn, task_id, "spawned", {"pid": int(pid)}, run_id=run_id)
+    # Track outside the txn so a later terminal transition that NULLS
+    # worker_pid can still be matched to a live OS process (#61923).
+    _track_spawned_worker(int(pid), task_id)
 
 
 def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
@@ -7058,6 +7316,13 @@ def _dispatch_once_locked(
     # Reap zombie children from previously spawned workers. See
     # reap_worker_zombies() for the full rationale.
     reap_worker_zombies()
+    # Kill live workers whose task is already terminal but whose OS
+    # process is still running (self-complete lag / Windows). See
+    # reap_orphaned_terminal_workers() / #61923.
+    try:
+        reap_orphaned_terminal_workers(conn)
+    except Exception:
+        _log.debug("reap_orphaned_terminal_workers failed", exc_info=True)
 
     result = DispatchResult()
     result.reclaimed = release_stale_claims(conn)

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -990,6 +990,18 @@ def _set_status_direct(
     orphaned. ``running -> ready`` via drag-drop is the common case
     (user yanking a stuck worker back to the queue).
     """
+    # Kill the host-local worker *before* clearing claim/pid columns so a
+    # dashboard drag-drop off running cannot leave a live process behind
+    # (#61923).
+    prev_status = conn.execute(
+        "SELECT status FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if prev_status is None:
+        return False
+    if prev_status["status"] == "running" and new_status != "running":
+        kanban_db._terminate_running_task_for_manual_exit(conn, task_id)
+
     with kanban_db.write_txn(conn):
         # Snapshot current state so we know whether to close a run.
         prev = conn.execute(

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1170,6 +1170,168 @@ def test_complete_records_result(kanban_home):
     assert task.completed_at is not None
 
 
+def test_complete_task_terminates_foreign_running_worker(kanban_home, monkeypatch):
+    """Operator complete of a running task must kill the host-local worker
+    before clearing worker_pid (#61923)."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="worker")
+        kb.claim_task(conn, t)
+        kb._set_worker_pid(conn, t, 424242)
+
+        calls = []
+
+        def _fake_terminate(pid, claim_lock, *, signal_fn=None):
+            calls.append((pid, claim_lock))
+            return {
+                "prev_pid": int(pid),
+                "host_local": True,
+                "termination_attempted": True,
+                "terminated": True,
+                "sigkill": False,
+            }
+
+        monkeypatch.setattr(kb, "_terminate_reclaimed_worker", _fake_terminate)
+
+        assert kb.complete_task(conn, t, summary="closed by operator") is True
+        assert kb.get_task(conn, t).status == "done"
+        assert calls and calls[0][0] == 424242
+        assert calls[0][1]
+
+
+def test_complete_task_skips_terminating_self_worker(kanban_home, monkeypatch):
+    """Self-complete (worker closing its own run) must not kill mid-flight."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="worker")
+        claimed = kb.claim_task(conn, t)
+        assert claimed is not None
+        kb._set_worker_pid(conn, t, os.getpid())
+        run_id = kb.latest_run(conn, t).id
+
+        def _unexpected(*_args, **_kwargs):
+            raise AssertionError("self-complete should not terminate current worker")
+
+        monkeypatch.setattr(kb, "_terminate_reclaimed_worker", _unexpected)
+
+        assert kb.complete_task(
+            conn, t,
+            summary="worker finished cleanly",
+            expected_run_id=run_id,
+        ) is True
+        assert kb.get_task(conn, t).status == "done"
+
+
+def test_archive_task_terminates_foreign_running_worker(kanban_home, monkeypatch):
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="worker")
+        kb.claim_task(conn, t)
+        kb._set_worker_pid(conn, t, 434343)
+
+        calls = []
+
+        def _fake_terminate(pid, claim_lock, *, signal_fn=None):
+            calls.append((pid, claim_lock))
+            return {
+                "prev_pid": int(pid),
+                "host_local": True,
+                "termination_attempted": True,
+                "terminated": True,
+                "sigkill": False,
+            }
+
+        monkeypatch.setattr(kb, "_terminate_reclaimed_worker", _fake_terminate)
+
+        assert kb.archive_task(conn, t) is True
+        task = kb.get_task(conn, t)
+        assert task.status == "archived"
+        assert task.current_run_id is None
+        assert calls and calls[0][0] == 434343
+
+
+def test_reap_orphaned_terminal_workers_kills_live_pid_after_complete(
+    kanban_home, monkeypatch,
+):
+    """Process-state sync: done task + still-alive tracked pid → kill (#61923)."""
+    kb.clear_spawned_worker_registry()
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="worker")
+        kb.claim_task(conn, t)
+        # Skip real terminate during complete so the spawn registry keeps
+        # a live pid associated with a now-terminal task.
+        monkeypatch.setattr(
+            kb, "_terminate_running_task_for_manual_exit",
+            lambda *a, **k: {},
+        )
+        kb._set_worker_pid(conn, t, 515151)
+        assert kb.complete_task(conn, t, summary="done") is True
+        assert kb.get_task(conn, t).status == "done"
+        # worker_pid cleared in DB but spawn registry still tracks 515151
+        assert 515151 in kb._SPAWNED_WORKERS
+
+        killed = []
+
+        def _fake_kill(pid, *, signal_fn=None):
+            killed.append(pid)
+            return {
+                "termination_attempted": True,
+                "terminated": True,
+                "sigkill": False,
+                "process_tree": False,
+                "termination_method": "signal",
+            }
+
+        monkeypatch.setattr(kb, "_pid_alive", lambda p: int(p) == 515151)
+        monkeypatch.setattr(kb, "_terminate_worker_pid", _fake_kill)
+
+        results = kb.reap_orphaned_terminal_workers(conn)
+        assert len(results) == 1
+        assert results[0]["worker_pid"] == 515151
+        assert results[0]["task_id"] == t
+        assert killed == [515151]
+        assert 515151 not in kb._SPAWNED_WORKERS
+
+        kinds = [
+            r["kind"] for r in conn.execute(
+                "SELECT kind FROM task_events WHERE task_id = ?", (t,),
+            ).fetchall()
+        ]
+        assert "orphan_worker_terminated" in kinds
+    kb.clear_spawned_worker_registry()
+
+
+def test_reap_orphaned_terminal_workers_skips_running(kanban_home, monkeypatch):
+    kb.clear_spawned_worker_registry()
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="worker")
+        kb.claim_task(conn, t)
+        kb._set_worker_pid(conn, t, 616161)
+        monkeypatch.setattr(kb, "_pid_alive", lambda p: True)
+
+        def _unexpected(*_a, **_k):
+            raise AssertionError("must not kill a still-running task worker")
+
+        monkeypatch.setattr(kb, "_terminate_worker_pid", _unexpected)
+        assert kb.reap_orphaned_terminal_workers(conn) == []
+    kb.clear_spawned_worker_registry()
+
+
+def test_terminate_worker_pid_uses_taskkill_on_windows(monkeypatch):
+    """Windows force-kill must tree-kill via terminate_pid (#61923)."""
+    monkeypatch.setattr(kb, "_IS_WINDOWS", True)
+    calls = []
+
+    def _fake_terminate_pid(pid, *, force=False):
+        calls.append((pid, force))
+
+    monkeypatch.setattr("gateway.status.terminate_pid", _fake_terminate_pid)
+    monkeypatch.setattr(kb, "_pid_alive", lambda p: False)
+    info = kb._terminate_worker_pid(999001)
+    assert info["termination_attempted"] is True
+    assert info["process_tree"] is True
+    assert info["termination_method"] == "taskkill_tree"
+    assert info["terminated"] is True
+    assert calls == [(999001, True)]
+
+
 def test_block_then_unblock(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="x", assignee="a")

--- a/tests/run_agent/test_tool_call_incremental_persistence.py
+++ b/tests/run_agent/test_tool_call_incremental_persistence.py
@@ -198,6 +198,36 @@ def test_execute_tool_calls_sequential_flushes_each_tool_result_before_next_disp
     ]
 
 
+def test_kanban_complete_stops_sequential_batch_without_duplicate_results():
+    """A terminal kanban transition keeps one result per requested call."""
+    agent = _make_agent()
+    tool_calls = [
+        _mock_tool_call(name="kanban_complete", call_id="complete-call"),
+        _mock_tool_call(name="web_search", call_id="later-call"),
+    ]
+    messages: list = []
+    assistant_message = SimpleNamespace(content="", tool_calls=tool_calls)
+
+    with (
+        patch("run_agent.handle_function_call", return_value='{"ok": true}') as disp,
+        patch("tools.kanban_tools.worker_stop_requested", return_value=True),
+        patch(
+            "agent.tool_executor.maybe_persist_tool_result",
+            side_effect=lambda **kwargs: kwargs["content"],
+        ),
+    ):
+        agent._execute_tool_calls_sequential(assistant_message, messages, "task-1")
+
+    assert disp.call_count == 1
+    assert disp.call_args.args[0] == "kanban_complete"
+    assert [message["tool_call_id"] for message in messages] == [
+        "complete-call",
+        "later-call",
+    ]
+    assert len({message["tool_call_id"] for message in messages}) == 2
+    assert "not started" in messages[1]["content"]
+
+
 # ---------------------------------------------------------------------------
 # Contract 3: the CONCURRENT path flushes each collected tool result in append
 # order.  Dispatch goes through agent._invoke_tool (the real concurrent

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -311,6 +311,31 @@ def test_complete_happy_path(worker_env):
         conn.close()
 
 
+def test_complete_requests_worker_stop_after_terminal(worker_env):
+    """After kanban_complete the worker must stop further tool calls (#61923)."""
+    from tools import kanban_tools as kt
+
+    kt.clear_worker_stop_request()
+    try:
+        out = kt._handle_complete({"summary": "closing and stopping"})
+        assert json.loads(out)["ok"] is True
+        assert kt.worker_stop_requested() is True
+    finally:
+        kt.clear_worker_stop_request()
+
+
+def test_request_worker_stop_noop_without_kanban_env(monkeypatch):
+    from tools import kanban_tools as kt
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    kt.clear_worker_stop_request()
+    try:
+        kt.request_worker_stop_after_terminal()
+        assert kt.worker_stop_requested() is False
+    finally:
+        kt.clear_worker_stop_request()
+
+
 def test_complete_metadata_round_trips_through_show(worker_env):
     """Structured completion metadata should be visible to downstream agents."""
     from tools import kanban_tools as kt

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -31,6 +31,8 @@ from __future__ import annotations
 import json
 import logging
 import os
+import threading
+import time
 from typing import Any, Optional
 
 from agent.redact import redact_sensitive_text
@@ -39,6 +41,87 @@ from tools.registry import registry, tool_error
 from hermes_cli.config import cfg_get, load_config
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Worker process exit after terminal lifecycle tools (#61923)
+# ---------------------------------------------------------------------------
+# When a dispatcher-spawned worker calls kanban_complete / kanban_block, the
+# DB transition succeeds but the agent loop can keep issuing more tool calls
+# (file deletes, browser CDP, …). That is the zombie-worker class that
+# corrupted shared workspaces on Windows. After a successful terminal
+# transition we:
+#   1. Raise a process-level flag the conversation loop checks to stop the
+#      tool loop cleanly on the next iteration.
+#   2. Arm a short delayed os._exit backstop so a wedged cleanup path still
+#      reclaims the OS process (and any process-group children).
+# Never arm the hard exit under pytest — tests invoke the tools in-process.
+
+_worker_stop_requested = False
+_WORKER_HARD_EXIT_GRACE_S = 3.0
+
+
+def worker_stop_requested() -> bool:
+    """True when a kanban terminal tool asked the agent loop to stop."""
+    return _worker_stop_requested
+
+
+def clear_worker_stop_request() -> None:
+    """Test helper — reset the stop flag between cases."""
+    global _worker_stop_requested
+    _worker_stop_requested = False
+
+
+def request_worker_stop_after_terminal() -> None:
+    """Stop the agent loop (and eventually the process) after complete/block.
+
+    No-op unless this process is a dispatcher-spawned worker
+    (``HERMES_KANBAN_TASK`` set). Safe to call multiple times.
+    """
+    global _worker_stop_requested
+    if not (os.environ.get("HERMES_KANBAN_TASK") or "").strip():
+        return
+    _worker_stop_requested = True
+    # Nudge tools that poll is_interrupted() so concurrent work aborts.
+    try:
+        from tools.interrupt import set_interrupt
+
+        set_interrupt(True)
+    except Exception:
+        logger.debug("kanban worker stop: set_interrupt failed", exc_info=True)
+
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        return
+
+    def _hard_exit() -> None:
+        try:
+            time.sleep(_WORKER_HARD_EXIT_GRACE_S)
+        except Exception:
+            pass
+        try:
+            import logging as _lg
+
+            _lg.shutdown()
+        except Exception:
+            pass
+        for stream in (getattr(__import__("sys"), "stdout", None),
+                       getattr(__import__("sys"), "stderr", None)):
+            if stream is None:
+                continue
+            try:
+                stream.flush()
+            except Exception:
+                pass
+        os._exit(0)
+
+    try:
+        threading.Thread(
+            target=_hard_exit,
+            daemon=True,
+            name="kanban-worker-exit",
+        ).start()
+    except Exception:
+        logger.debug("kanban worker stop: hard-exit arm failed", exc_info=True)
 
 
 # ---------------------------------------------------------------------------
@@ -655,6 +738,9 @@ def _handle_complete(args: dict, **kw) -> str:
                     f"could not complete {tid} (unknown id or already terminal)"
                 )
             run = kb.latest_run(conn, tid)
+            # Task is durable-done; stop further tool calls from this worker
+            # so it cannot keep mutating the workspace (#61923).
+            request_worker_stop_after_terminal()
             return _ok(task_id=tid, run_id=run.id if run else None)
         finally:
             conn.close()
@@ -728,6 +814,10 @@ def _handle_block(args: dict, **kw) -> str:
             # Tell the worker where the task actually landed so it doesn't
             # assume it's sitting in 'blocked' when routing sent it elsewhere.
             landed = kb.get_task(conn, tid)
+            # Terminal for this worker run — same post-complete stop as
+            # kanban_complete so a blocked worker cannot keep running tools
+            # (#61923).
+            request_worker_stop_after_terminal()
             return _ok(
                 task_id=tid,
                 run_id=run.id if run else None,


### PR DESCRIPTION
## Summary

Fixes #61923 — Kanban workers that call `kanban_complete` (or are completed/archived from outside) could keep running as OS processes after the DB said `done`, especially on Windows where `reap_worker_zombies()` is a no-op. That left browser/file tools free to mutate shared workspaces after the card looked finished.

### Root causes addressed

1. **`complete_task` only wrote DB state** — set `status=done` + `worker_pid=NULL` without terminating the host-local process.
2. **Windows has no waitpid zombie reap** — so completed children never got cleaned up by the existing reap path.
3. **No process-state sync** — once `worker_pid` was cleared, monitors only saw DB status and stopped caring about the still-live process.

### Fix (belt-and-suspenders)

| Layer | Behavior |
|-------|----------|
| Manual lifecycle exits | `complete_task` / `archive_task` / `block_task` / `schedule_task` + dashboard drag-drop off `running` terminate the host-local foreign worker **before** clearing claim/pid metadata. Self-pid is skipped so the transition can finish. |
| Windows tree kill | `_terminate_worker_pid` uses `gateway.status.terminate_pid(..., force=True)` → `taskkill /T /F` so browser/MCP children die with the worker. |
| Self-complete stop | After successful `kanban_complete` / `kanban_block` in a dispatcher-spawned worker, request agent-loop stop (skip remaining tools) + arm a 3s `os._exit` backstop. |
| Process-state sync | Spawn registry tracks pids; each dispatcher tick runs `reap_orphaned_terminal_workers()` to kill live processes whose task is no longer `running` and emit `orphan_worker_terminated`. |

Salvages the intent of concurrent PRs #31365 (manual-exit terminate) and #49374 (Windows tree kill) without their unrelated/stale surface, and closes the self-complete gap those PRs left open.

## Verification

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/tools/test_kanban_tools.py -q
# 329 passed
```

Focused cases:

- `test_complete_task_terminates_foreign_running_worker`
- `test_complete_task_skips_terminating_self_worker`
- `test_archive_task_terminates_foreign_running_worker`
- `test_reap_orphaned_terminal_workers_kills_live_pid_after_complete`
- `test_reap_orphaned_terminal_workers_skips_running`
- `test_terminate_worker_pid_uses_taskkill_on_windows`
- `test_complete_requests_worker_stop_after_terminal`
- `test_request_worker_stop_noop_without_kanban_env`

## Manual reproduction notes

1. On Windows (or Linux), spawn a kanban browser-profile worker and let it call `kanban_complete`.
2. Before this fix: task shows `done`, process still alive and may keep tool calls.
3. After this fix: agent tool loop ends immediately after complete; process exits within ~3s; if it somehow survives, the next dispatcher tick kills it via the spawn registry.

## Concurrent PRs

Overlaps #31365 (manual terminate) and #49374 (Windows taskkill tree). This PR is a full fix for #61923 including self-complete stop + orphan reaper; those can close as superseded once this lands.