### PR TITLE
fix(cron): classify local script timeouts separately

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -58,6 +58,16 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     text = (error or "unknown error").strip()
     lower = text.lower()
 
+    # _run_job_script emits this exact envelope for local subprocess
+    # timeouts. Classify it before broad provider-keyword checks so a script
+    # path containing "429" or "rate-limit" cannot shadow the real cause.
+    if re.match(r"^script timed out after \d+(?:\.\d+)?s:", lower):
+        return (
+            f"⚠️ Cron '{job_name}' failed: local script timeout. "
+            "The pre-run script exceeded its execution limit. "
+            "Full details saved in cron output."
+        )
+
     # Provider/API failures are the common noisy path. Keep these short.
     if "429" in text or "rate limit" in lower or "usage limit" in lower:
         reason = "rate limit"

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -195,6 +195,35 @@ class TestRunJobScript:
         assert success is False
         assert "timed out" in output.lower()
 
+    def test_script_timeout_delivery_summary_stays_local(self, cron_env, monkeypatch):
+        import subprocess
+
+        from cron import scheduler as sched_mod
+        from cron.scheduler import (
+            _run_job_script,
+            _summarize_cron_failure_for_delivery,
+        )
+
+        script = cron_env / "scripts" / "429-rate-limit-report.py"
+        script.write_text("print('never runs')\n")
+
+        def raise_timeout(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs["timeout"])
+
+        monkeypatch.setattr(sched_mod.subprocess, "run", raise_timeout)
+        success, error = _run_job_script(str(script))
+
+        assert success is False
+        assert error.startswith("Script timed out after ")
+        summary = _summarize_cron_failure_for_delivery(
+            {"name": "nightly-report"}, error
+        )
+        assert "local script timeout" in summary
+        assert "provider timeout" not in summary
+        assert "provider rate limit" not in summary
+        assert "Fallback chain" not in summary
+        assert str(script) not in summary
+
     def test_script_json_output(self, cron_env):
         """Scripts can output structured JSON for the LLM to parse."""
         from cron.scheduler import _run_job_script

--- a/tests/cron/test_scheduler_failure_summary.py
+++ b/tests/cron/test_scheduler_failure_summary.py
@@ -1,0 +1,61 @@
+"""Regression tests for concise cron failure delivery summaries."""
+
+from cron.scheduler import _summarize_cron_failure_for_delivery
+
+
+JOB = {"id": "job-1", "name": "nightly-report"}
+
+
+def summarize(error: str) -> str:
+    return _summarize_cron_failure_for_delivery(JOB, error)
+
+
+def test_local_script_timeout_is_not_labelled_as_provider_failure():
+    result = summarize("Script timed out after 120s: /tmp/foo.py")
+
+    assert "local script timeout" in result
+    assert "provider timeout" not in result
+    assert "Fallback chain" not in result
+    assert "/tmp/foo.py" not in result
+
+
+def test_decimal_local_script_timeout_is_classified_locally():
+    result = summarize("Script timed out after 1.5s: /tmp/foo.py")
+
+    assert "local script timeout" in result
+    assert "provider timeout" not in result
+
+
+def test_local_timeout_path_containing_429_does_not_become_rate_limit():
+    result = summarize("Script timed out after 30s: /tmp/429-report.py")
+
+    assert "local script timeout" in result
+    assert "provider rate limit" not in result
+
+
+def test_local_timeout_path_containing_rate_limit_stays_local():
+    result = summarize("Script timed out after 30s: /tmp/rate-limit-report.py")
+
+    assert "local script timeout" in result
+    assert "provider rate limit" not in result
+
+
+def test_readtimeout_remains_a_provider_timeout():
+    result = summarize("ReadTimeout: request timed out")
+
+    assert "provider timeout" in result
+    assert "Fallback chain" in result
+
+
+def test_normal_script_failure_remains_generic_and_sanitized():
+    result = summarize("Script execution failed: permission denied")
+
+    assert result == "⚠️ Cron 'nightly-report' failed: Script execution failed: permission denied"
+    assert "provider timeout" not in result
+
+
+def test_incidental_timeout_wording_does_not_match_local_script_envelope():
+    result = summarize("Script reported timeout statistics")
+
+    assert "local script timeout" not in result
+    assert "provider timeout" in result


### PR DESCRIPTION
## What does this PR do?

Cron delivery summaries can misclassify a **local pre-run script timeout** as a provider failure. `_run_job_script()` emits an exact envelope such as `Script timed out after 120s: ...`, but broad keyword checks for `429`, `rate limit`, and `timeout` can shadow the real cause when those terms appear in the script path or error text.

This change classifies the exact local-script timeout envelope before provider/API keyword checks. Provider timeout and rate-limit behavior remains unchanged for genuine provider failures.

No matching open/closed issue or pull request was found in the pre-submission search.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/scheduler.py`: classify the exact local script-timeout envelope before broad provider-keyword checks.
- `tests/cron/test_scheduler_failure_summary.py`: add precedence and sanitization regressions for integer/decimal local timeouts, paths containing `429`/`rate-limit`, genuine provider timeouts, and generic script failures.
- `tests/cron/test_cron_script.py`: add an integration regression from `_run_job_script()` timeout output through the delivery-summary classifier.

## How to Test

1. Run `python -m pytest -o 'addopts=' -q tests/cron/test_scheduler_failure_summary.py`.
2. Run `python -m pytest -o 'addopts=' -q tests/cron/test_cron_script.py`.
3. Run `python -m pytest -o 'addopts=' -q tests/cron` with an isolated process-level `HOME`, `HERMES_HOME`, XDG config/cache paths, and `TMPDIR`.

Local verification on macOS:

- Failure-summary tests: **7 passed**
- Script tests: **39 passed**
- Complete cron suite: **678 passed, 2 warnings**
- `py_compile`: passed
- `git diff --check`: passed
- Live default cron registry before/after the sandboxed complete cron-suite run: **106 jobs, identical IDs and byte-for-byte identical registry hash**

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1, Python 3.11

The full repository test suite was not run locally. The complete `tests/cron` suite was run and passed as documented above.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is internal and covered by code comments/tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python classification logic; no platform-specific behavior added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable. The change affects text classification in cron failure delivery summaries and is covered by focused and integration regression tests.
