### PR TITLE
fix(voice_mode): add timeout to post-kill proc.wait() in audio playback

### DIFF
--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1106,7 +1106,10 @@ def play_audio_file(file_path: str) -> bool:
             except subprocess.TimeoutExpired:
                 logger.warning("System player %s timed out, killing process", cmd[0])
                 proc.kill()
-                proc.wait()
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    pass
                 with _playback_lock:
                     _active_playback = None
             except Exception as e:


### PR DESCRIPTION
## Summary

Add a 10-second timeout to the bare `proc.wait()` call in the audio playback fallback path (`_play_system_audio`).

## Problem

When a system audio player (afplay, mpv, etc.) times out after 300s and is killed via `proc.kill()\), the subsequent `proc.wait()` call has no timeout. If the killed process fails to terminate promptly (e.g., zombie, hung IO), this permanently blocks the current thread and agent turn — the same bug class already fixed in browser_tool.py, computer_use/doctor.py, and several other locations.

## Fix

Wrap the post-kill `proc.wait()` in a try/except with `timeout=10`. If the process still hasn't exited after 10 seconds, silently continue — a leaked dead process is strictly preferable to a permanently frozen agent turn.

## Testing
- Syntax check passed (py_compile)
- Behavior verified