### PR TITLE
feat(skills): add configurable SKILL.md size ratchet

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2330,6 +2330,22 @@ DEFAULT_CONFIG = {
         "inline_shell": False,
         # Timeout (seconds) for each !`cmd` snippet when inline_shell is on.
         "inline_shell_timeout": 10,
+        # Keep SKILL.md as a lean trigger/authority/router while allowing rich
+        # references/templates/scripts in the same bundle.  The absolute agent-
+        # write ceiling remains 100k; this is a prompt-efficiency ratchet:
+        #   auto    — warn foreground writes; block background-review growth
+        #   warn    — warn all writes but allow them
+        #   enforce — block triggering foreground and background writes
+        #   off     — hard 100k ceiling only (legacy behavior)
+        # Shrinking edits are always allowed.  A write triggers when SKILL.md
+        # grows while already above the soft limit, crosses that limit, or adds
+        # more than max_growth_chars in one edit. Supporting files are exempt.
+        "skill_md_size_guard": "auto",
+        "skill_md_soft_limit_chars": 20_000,
+        "skill_md_max_growth_chars": 5_000,
+        # Optional exact skill-name overrides. Each mapping may set ``mode``,
+        # ``soft_limit_chars``, and/or ``max_growth_chars``.
+        "skill_md_size_overrides": {},
         # Run the keyword/pattern security scanner on skills the agent
         # writes via skill_manage (create/edit/patch).  Off by default
         # because the agent can already execute the same code paths via

--- a/skills/software-development/hermes-agent-skill-authoring/SKILL.md
+++ b/skills/software-development/hermes-agent-skill-authoring/SKILL.md
@@ -58,7 +58,8 @@ metadata:
 ## Size Limits
 
 - Description: ≤ 1024 chars (enforced).
-- Full SKILL.md: ≤ 100,000 chars (enforced as `MAX_SKILL_CONTENT_CHARS`, ~36k tokens).
+- Full SKILL.md: ≤ 100,000 chars (hard limit for agent writes; `MAX_SKILL_CONTENT_CHARS`).
+- Agent-managed writes also use the configurable `skills.skill_md_size_guard` ratchet: default `auto` warns foreground growth and blocks background-review growth above 20k or beyond +5k in one edit. Supporting files are exempt and shrinking edits always pass.
 - Peer skills in `software-development/` sit at **8-14k chars**. Aim for that range. If you're pushing past 20k, split into `references/*.md` and reference them from SKILL.md.
 
 ## Writing Quality Principles

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -490,6 +490,15 @@ class TestRemoveFile:
         assert result["success"] is True
         assert not (tmp_path / "my-skill" / "references" / "api.md").exists()
 
+    def test_remove_main_skill_file_is_rejected(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _remove_file("my-skill", "SKILL.md")
+
+        assert result["success"] is False
+        assert "action='delete'" in result["error"]
+        assert (tmp_path / "my-skill" / "SKILL.md").exists()
+
     def test_remove_nonexistent_file(self, tmp_path):
         with _skill_dir(tmp_path):
             _create_skill("my-skill", VALID_SKILL_CONTENT)

--- a/tests/tools/test_skill_size_limits.py
+++ b/tests/tools/test_skill_size_limits.py
@@ -1,11 +1,12 @@
 """Tests for skill content size limits.
 
-Agent writes (create/edit/patch/write_file) are constrained to
-MAX_SKILL_CONTENT_CHARS (100k) and MAX_SKILL_FILE_BYTES (1 MiB).
-Hand-placed and hub-installed skills have no hard limit.
+Agent writes keep the 100k hard ceiling and apply a configurable soft SKILL.md
+ratchet. Supporting files retain the hard character/byte limits only.
+Hand-placed and hub-installed skills have no storage hard limit.
 """
 
 import json
+from unittest.mock import patch
 
 import pytest
 
@@ -13,6 +14,10 @@ from tools.skill_manager_tool import (
     MAX_SKILL_CONTENT_CHARS,
     _validate_content_size,
     skill_manage,
+)
+from tools.skill_size_guard import (
+    DEFAULT_SKILL_MD_MAX_GROWTH_CHARS,
+    DEFAULT_SKILL_MD_SOFT_LIMIT_CHARS,
 )
 
 
@@ -190,6 +195,233 @@ class TestWriteFileSizeLimit:
             file_content="# Normal\n\n" + ("x" * 5000),
         ))
         assert result["success"] is True
+
+
+class TestSkillMdSizeGuard:
+    """The soft guard warns foreground writes and ratchets automatic growth."""
+
+    def test_auto_warns_foreground_create_above_soft_limit(self, isolate_skills):
+        content = _make_skill_content(DEFAULT_SKILL_MD_SOFT_LIMIT_CHARS + 500)
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"skills": {"skill_md_size_guard": "auto"}},
+        ):
+            result = json.loads(
+                skill_manage(action="create", name="large-foreground", content=content)
+            )
+
+        assert result["success"] is True
+        advisory = result["size_advisory"]
+        assert advisory["effective_mode"] == "warn"
+        assert advisory["after_chars"] == len(content)
+        assert advisory["soft_limit_chars"] == DEFAULT_SKILL_MD_SOFT_LIMIT_CHARS
+        assert "references/" in advisory["message"]
+
+    def test_auto_blocks_background_create_above_soft_limit(self, isolate_skills):
+        content = _make_skill_content(DEFAULT_SKILL_MD_SOFT_LIMIT_CHARS + 500)
+
+        with (
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"skills": {"skill_md_size_guard": "auto"}},
+            ),
+            patch("tools.skill_provenance.is_background_review", return_value=True),
+        ):
+            result = json.loads(
+                skill_manage(action="create", name="large-background", content=content)
+            )
+
+        assert result["success"] is False
+        assert result["size_guard"]["effective_mode"] == "enforce"
+        assert result["size_guard"]["after_chars"] == len(content)
+        assert not (isolate_skills / "large-background").exists()
+
+    def test_enforce_blocks_large_single_patch_and_preserves_file(self, isolate_skills):
+        content = _make_skill_content(5_000)
+        created = json.loads(
+            skill_manage(action="create", name="patch-ratchet", content=content)
+        )
+        skill_md = isolate_skills / created["path"] / "SKILL.md"
+        before = skill_md.read_text(encoding="utf-8")
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={
+                "skills": {
+                    "skill_md_size_guard": "enforce",
+                    "skill_md_soft_limit_chars": DEFAULT_SKILL_MD_SOFT_LIMIT_CHARS,
+                    "skill_md_max_growth_chars": DEFAULT_SKILL_MD_MAX_GROWTH_CHARS,
+                }
+            },
+        ):
+            result = json.loads(
+                skill_manage(
+                    action="patch",
+                    name="patch-ratchet",
+                    old_string="# Test Skill",
+                    new_string="# Test Skill\n" + ("y" * (DEFAULT_SKILL_MD_MAX_GROWTH_CHARS + 1)),
+                )
+            )
+
+        assert result["success"] is False
+        assert "single-write growth" in result["error"]
+        assert skill_md.read_text(encoding="utf-8") == before
+
+    def test_enforce_allows_shrinking_an_oversized_skill(self, isolate_skills):
+        skill_dir = isolate_skills / "legacy-large"
+        skill_dir.mkdir()
+        content = _make_skill_content(DEFAULT_SKILL_MD_SOFT_LIMIT_CHARS + 5_000)
+        content = content.replace("name: test-skill", "name: legacy-large")
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text(content, encoding="utf-8")
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"skills": {"skill_md_size_guard": "enforce"}},
+        ):
+            result = json.loads(
+                skill_manage(
+                    action="patch",
+                    name="legacy-large",
+                    old_string="x" * 100,
+                    new_string="y",
+                    replace_all=True,
+                )
+            )
+
+        assert result["success"] is True
+        assert len(skill_md.read_text(encoding="utf-8")) < len(content)
+        assert "size_advisory" not in result
+
+    @pytest.mark.parametrize(
+        "file_path",
+        ["SKILL.md", "explicit-main-patch/SKILL.md"],
+    )
+    def test_explicit_skill_md_patch_cannot_bypass_guard(
+        self, isolate_skills, file_path
+    ):
+        content = _make_skill_content(5_000)
+        created = json.loads(
+            skill_manage(action="create", name="explicit-main-patch", content=content)
+        )
+        skill_md = isolate_skills / created["path"] / "SKILL.md"
+        before = skill_md.read_text(encoding="utf-8")
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"skills": {"skill_md_size_guard": "enforce"}},
+        ):
+            result = json.loads(
+                skill_manage(
+                    action="patch",
+                    name="explicit-main-patch",
+                    file_path=file_path,
+                    old_string="# Test Skill",
+                    new_string="# Test Skill\n" + ("z" * (DEFAULT_SKILL_MD_MAX_GROWTH_CHARS + 1)),
+                )
+            )
+
+        assert result["success"] is False
+        assert skill_md.read_text(encoding="utf-8") == before
+
+    def test_explicit_skill_md_write_cannot_bypass_guard(self, isolate_skills):
+        content = _make_skill_content(1_000)
+        created = json.loads(
+            skill_manage(action="create", name="explicit-main-write", content=content)
+        )
+        skill_md = isolate_skills / created["path"] / "SKILL.md"
+        before = skill_md.read_text(encoding="utf-8")
+        replacement = _make_skill_content(DEFAULT_SKILL_MD_SOFT_LIMIT_CHARS + 500)
+        replacement = replacement.replace("name: test-skill", "name: explicit-main-write")
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"skills": {"skill_md_size_guard": "enforce"}},
+        ):
+            result = json.loads(
+                skill_manage(
+                    action="write_file",
+                    name="explicit-main-write",
+                    file_path="SKILL.md",
+                    file_content=replacement,
+                )
+            )
+
+        assert result["success"] is False
+        assert skill_md.read_text(encoding="utf-8") == before
+
+    def test_guard_does_not_apply_to_support_file_growth(self, isolate_skills):
+        content = _make_skill_content(1_000)
+        json.loads(skill_manage(action="create", name="large-reference", content=content))
+        json.loads(
+            skill_manage(
+                action="write_file",
+                name="large-reference",
+                file_path="references/data.md",
+                file_content="small",
+            )
+        )
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"skills": {"skill_md_size_guard": "enforce"}},
+        ):
+            result = json.loads(
+                skill_manage(
+                    action="patch",
+                    name="large-reference",
+                    file_path="references/data.md",
+                    old_string="small",
+                    new_string="x" * (DEFAULT_SKILL_MD_MAX_GROWTH_CHARS + 1),
+                )
+            )
+
+        assert result["success"] is True
+        assert "size_advisory" not in result
+
+    def test_exact_skill_override_can_enforce_a_stricter_policy(self, isolate_skills):
+        content = _make_skill_content(1_500)
+        config = {
+            "skills": {
+                "skill_md_size_guard": "auto",
+                "skill_md_soft_limit_chars": DEFAULT_SKILL_MD_SOFT_LIMIT_CHARS,
+                "skill_md_size_overrides": {
+                    "strict-skill": {
+                        "mode": "enforce",
+                        "soft_limit_chars": 1_000,
+                    }
+                },
+            }
+        }
+
+        with patch("hermes_cli.config.load_config", return_value=config):
+            strict = json.loads(
+                skill_manage(action="create", name="strict-skill", content=content)
+            )
+            ordinary = json.loads(
+                skill_manage(action="create", name="ordinary-skill", content=content)
+            )
+
+        assert strict["success"] is False
+        assert strict["size_guard"]["policy_source"] == "override:strict-skill"
+        assert strict["size_guard"]["soft_limit_chars"] == 1_000
+        assert ordinary["success"] is True
+        assert "size_advisory" not in ordinary
+
+    def test_off_mode_suppresses_foreground_advisory(self, isolate_skills):
+        content = _make_skill_content(DEFAULT_SKILL_MD_SOFT_LIMIT_CHARS + 500)
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"skills": {"skill_md_size_guard": "off"}},
+        ):
+            result = json.loads(
+                skill_manage(action="create", name="large-opt-out", content=content)
+            )
+
+        assert result["success"] is True
+        assert "size_advisory" not in result
 
 
 class TestHandPlacedSkillsNoLimit:

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -45,6 +45,11 @@ from typing import Any, Dict, List, Optional, Tuple
 from hermes_constants import get_hermes_home, display_hermes_home
 from utils import atomic_replace, is_truthy_value
 from hermes_cli.config import cfg_get
+from tools.skill_size_guard import (
+    attach_skill_md_size_advisory as _attach_skill_md_size_advisory,
+    blocked_by_skill_md_size_guard as _blocked_by_skill_md_size_guard,
+    evaluate_skill_md_size_guard as _evaluate_skill_md_size_guard,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -743,11 +748,28 @@ def _validate_file_path(file_path: str) -> Optional[str]:
     return None
 
 
+def _is_skill_md_file_path(file_path: Optional[str]) -> bool:
+    """Return True for the accepted explicit spellings of the main skill file."""
+    if not file_path:
+        return False
+    normalized = Path(file_path)
+    return (
+        normalized.name == "SKILL.md"
+        and len(normalized.parts) in {1, 2}
+    )
+
+
 def _resolve_skill_target(skill_dir: Path, file_path: str) -> Tuple[Optional[Path], Optional[str]]:
-    """Resolve a supporting-file path and ensure it stays within the skill directory."""
+    """Resolve a skill file path and ensure it stays within the skill directory."""
     from tools.path_security import validate_within_dir
 
-    target = skill_dir / file_path
+    # _validate_file_path accepts both SKILL.md and <name>/SKILL.md for the
+    # canonical main file. Normalize both to the actual root SKILL.md instead
+    # of accidentally creating a nested copy that bypasses main-file checks.
+    if _is_skill_md_file_path(file_path):
+        target = skill_dir / "SKILL.md"
+    else:
+        target = skill_dir / file_path
     error = validate_within_dir(target, skill_dir)
     if error:
         return None, error
@@ -810,6 +832,10 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
     if err:
         return {"success": False, "error": err}
 
+    size_guard = _evaluate_skill_md_size_guard(name, None, content)
+    if size_guard and size_guard.get("effective_mode") == "enforce":
+        return _blocked_by_skill_md_size_guard(size_guard)
+
     # Check for name collisions across all directories
     existing = _find_skill(name)
     if existing:
@@ -855,7 +881,7 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
         "To add reference files, templates, or scripts, use "
         "skill_manage(action='write_file', name='{}', file_path='references/example.md', file_content='...')".format(name)
     )
-    return result
+    return _attach_skill_md_size_advisory(result, size_guard)
 
 
 def _edit_skill(name: str, content: str) -> Dict[str, Any]:
@@ -884,6 +910,9 @@ def _edit_skill(name: str, content: str) -> Dict[str, Any]:
 
     # Back up original content for rollback
     original_content = skill_md.read_text(encoding="utf-8") if skill_md.exists() else None
+    size_guard = _evaluate_skill_md_size_guard(name, original_content, content)
+    if size_guard and size_guard.get("effective_mode") == "enforce":
+        return _blocked_by_skill_md_size_guard(size_guard)
     _atomic_write_text(skill_md, content)
 
     # Security scan — roll back on block
@@ -903,12 +932,13 @@ def _edit_skill(name: str, content: str) -> Dict[str, Any]:
     except Exception:
         pass
 
-    return {
+    result = {
         "success": True,
         "message": f"Skill '{name}' updated (full rewrite).",
         "path": str(existing["path"]),
         "_change": {"description": _desc},
     }
+    return _attach_skill_md_size_advisory(result, size_guard)
 
 
 def _patch_skill(
@@ -937,8 +967,8 @@ def _patch_skill(
     if guard:
         return guard
 
+    is_skill_md = not file_path or _is_skill_md_file_path(file_path)
     if file_path:
-        # Patching a supporting file
         err = _validate_file_path(file_path)
         if err:
             return {"success": False, "error": err}
@@ -989,19 +1019,25 @@ def _patch_skill(
         }
 
     # Check size limit on the result
-    target_label = "SKILL.md" if not file_path else file_path
+    target_label = "SKILL.md" if is_skill_md else file_path
     err = _validate_content_size(new_content, label=target_label)
     if err:
         return {"success": False, "error": err}
 
     # If patching SKILL.md, validate frontmatter is still intact
-    if not file_path:
+    if is_skill_md:
         err = _validate_frontmatter(new_content)
         if err:
             return {
                 "success": False,
                 "error": f"Patch would break SKILL.md structure: {err}",
             }
+
+    size_guard = None
+    if is_skill_md:
+        size_guard = _evaluate_skill_md_size_guard(name, content, new_content)
+        if size_guard and size_guard.get("effective_mode") == "enforce":
+            return _blocked_by_skill_md_size_guard(size_guard)
 
     original_content = content  # for rollback
     _atomic_write_text(target, new_content)
@@ -1014,14 +1050,14 @@ def _patch_skill(
 
     result = {
         "success": True,
-        "message": f"Patched {'SKILL.md' if not file_path else file_path} in skill '{name}' ({match_count} replacement{'s' if match_count > 1 else ''}).",
+        "message": f"Patched {'SKILL.md' if is_skill_md else file_path} in skill '{name}' ({match_count} replacement{'s' if match_count > 1 else ''}).",
     }
     # Include change previews for verbose notifications
     result["_change"] = {
         "old": old_string[:200] + ("…" if len(old_string) > 200 else ""),
         "new": new_string[:200] + ("…" if len(new_string) > 200 else ""),
     }
-    return result
+    return _attach_skill_md_size_advisory(result, size_guard)
 
 
 def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, Any]:
@@ -1130,10 +1166,11 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
 
 
 def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
-    """Add or overwrite a supporting file within any skill directory."""
+    """Add or overwrite a skill file; main-file writes retain SKILL.md checks."""
     err = _validate_file_path(file_path)
     if err:
         return {"success": False, "error": err}
+    is_skill_md = _is_skill_md_file_path(file_path)
 
     if not file_content and file_content != "":
         return {"success": False, "error": "file_content is required."}
@@ -1152,6 +1189,10 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     err = _validate_content_size(file_content, label=file_path)
     if err:
         return {"success": False, "error": err}
+    if is_skill_md:
+        err = _validate_frontmatter(file_content)
+        if err:
+            return {"success": False, "error": err}
 
     existing = _find_skill(name)
     if not existing:
@@ -1173,6 +1214,11 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     target.parent.mkdir(parents=True, exist_ok=True)
     # Back up for rollback
     original_content = target.read_text(encoding="utf-8") if target.exists() else None
+    size_guard = None
+    if is_skill_md:
+        size_guard = _evaluate_skill_md_size_guard(name, original_content, file_content)
+        if size_guard and size_guard.get("effective_mode") == "enforce":
+            return _blocked_by_skill_md_size_guard(size_guard)
     _atomic_write_text(target, file_content)
 
     # Security scan — roll back on block
@@ -1184,11 +1230,12 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
             target.unlink(missing_ok=True)
         return {"success": False, "error": scan_error}
 
-    return {
+    result = {
         "success": True,
         "message": f"File '{file_path}' written to skill '{name}'.",
         "path": str(target),
     }
+    return _attach_skill_md_size_advisory(result, size_guard)
 
 
 def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
@@ -1196,6 +1243,14 @@ def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
     err = _validate_file_path(file_path)
     if err:
         return {"success": False, "error": err}
+    if _is_skill_md_file_path(file_path):
+        return {
+            "success": False,
+            "error": (
+                "SKILL.md cannot be removed with remove_file. Use "
+                "action='delete' to remove the skill with its safety checks."
+            ),
+        }
 
     existing = _find_skill(name)
     if not existing:

--- a/tools/skill_size_guard.py
+++ b/tools/skill_size_guard.py
@@ -1,0 +1,170 @@
+"""Configurable prompt-efficiency ratchet for agent-managed SKILL.md files.
+
+The storage hard limit remains in ``skill_manager_tool``.  This module owns the
+softer policy that keeps the main skill body lean while allowing rich support
+files under references/, templates/, scripts/, and assets/.
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from hermes_cli.config import cfg_get
+
+DEFAULT_SKILL_MD_SOFT_LIMIT_CHARS = 20_000
+DEFAULT_SKILL_MD_MAX_GROWTH_CHARS = 5_000
+_SKILL_MD_SIZE_GUARD_MODES = {"off", "auto", "warn", "enforce"}
+
+
+def _positive_int_config(value: Any, default: int) -> int:
+    """Return a positive integer config value or *default*.
+
+    ``bool`` is deliberately rejected even though it is an ``int`` subclass;
+    ``true`` should never become a one-character skill limit.
+    """
+    if isinstance(value, bool):
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _skill_md_size_guard_settings(skill_name: str) -> Tuple[str, int, int, str]:
+    """Load the profile-scoped SKILL.md size policy.
+
+    ``auto`` is deliberately non-breaking for foreground/user-directed work:
+    it emits an advisory there, but enforces the same ratchet in autonomous
+    background review. Explicit ``enforce`` blocks both origins; ``warn``
+    advises both; ``off`` preserves the historical hard-limit-only behavior.
+    """
+    mode = "auto"
+    soft_limit = DEFAULT_SKILL_MD_SOFT_LIMIT_CHARS
+    growth_limit = DEFAULT_SKILL_MD_MAX_GROWTH_CHARS
+    policy_source = "default"
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        raw_mode = cfg_get(cfg, "skills", "skill_md_size_guard")
+        if raw_mode is not None:
+            candidate = str(raw_mode).strip().lower()
+            if candidate in _SKILL_MD_SIZE_GUARD_MODES:
+                mode = candidate
+        soft_limit = _positive_int_config(
+            cfg_get(cfg, "skills", "skill_md_soft_limit_chars"),
+            DEFAULT_SKILL_MD_SOFT_LIMIT_CHARS,
+        )
+        growth_limit = _positive_int_config(
+            cfg_get(cfg, "skills", "skill_md_max_growth_chars"),
+            DEFAULT_SKILL_MD_MAX_GROWTH_CHARS,
+        )
+
+        overrides = cfg_get(cfg, "skills", "skill_md_size_overrides")
+        override = overrides.get(skill_name) if isinstance(overrides, dict) else None
+        if isinstance(override, dict):
+            policy_source = f"override:{skill_name}"
+            raw_override_mode = override.get("mode")
+            if raw_override_mode is not None:
+                candidate = str(raw_override_mode).strip().lower()
+                if candidate in _SKILL_MD_SIZE_GUARD_MODES:
+                    mode = candidate
+            soft_limit = _positive_int_config(
+                override.get("soft_limit_chars"), soft_limit
+            )
+            growth_limit = _positive_int_config(
+                override.get("max_growth_chars"), growth_limit
+            )
+    except Exception:
+        # The hard 100k validation still applies. Config-read failures must not
+        # make all skill writes unavailable, so fall back to the safe default.
+        pass
+    return mode, soft_limit, growth_limit, policy_source
+
+
+def _background_review_origin() -> bool:
+    try:
+        from tools.skill_provenance import is_background_review
+
+        return bool(is_background_review())
+    except Exception:
+        return False
+
+
+def evaluate_skill_md_size_guard(
+    skill_name: str,
+    original_content: Optional[str],
+    new_content: str,
+) -> Optional[Dict[str, Any]]:
+    """Return size-guard details when a SKILL.md write deserves action.
+
+    Creation is judged against the soft total-size limit. Existing skills are
+    also ratcheted on single-write growth. Shrinks are always allowed, even
+    when a legacy SKILL.md remains above the soft limit.
+    """
+    configured_mode, soft_limit, growth_limit, policy_source = (
+        _skill_md_size_guard_settings(skill_name)
+    )
+    if configured_mode == "off":
+        return None
+
+    before_chars = len(original_content) if original_content is not None else 0
+    after_chars = len(new_content)
+    delta_chars = after_chars - before_chars
+    reasons: List[str] = []
+
+    if after_chars > soft_limit and (original_content is None or delta_chars > 0):
+        reasons.append(
+            f"total size {after_chars:,} exceeds the {soft_limit:,}-character soft limit"
+        )
+    if original_content is not None and delta_chars > growth_limit:
+        reasons.append(
+            f"single-write growth +{delta_chars:,} exceeds the {growth_limit:,}-character limit"
+        )
+    if not reasons:
+        return None
+
+    if configured_mode == "auto":
+        effective_mode = "enforce" if _background_review_origin() else "warn"
+    else:
+        effective_mode = configured_mode
+
+    reason_text = "; ".join(reasons)
+    message = (
+        f"{reason_text}. Keep SKILL.md as a lean trigger/authority/router file; "
+        "move session-specific detail, long examples, endpoint quirks, and "
+        "incident notes into references/ (or templates/scripts) and leave a "
+        "concise pointer in SKILL.md. Shrinking edits remain allowed."
+    )
+    return {
+        "skill": skill_name,
+        "policy_source": policy_source,
+        "configured_mode": configured_mode,
+        "effective_mode": effective_mode,
+        "before_chars": before_chars,
+        "after_chars": after_chars,
+        "delta_chars": delta_chars,
+        "soft_limit_chars": soft_limit,
+        "max_growth_chars": growth_limit,
+        "reasons": reasons,
+        "message": message,
+    }
+
+
+def blocked_by_skill_md_size_guard(details: Dict[str, Any]) -> Dict[str, Any]:
+    """Build the standard fail-closed tool result for an enforced policy."""
+    return {
+        "success": False,
+        "error": f"SKILL.md size guard blocked this write: {details['message']}",
+        "size_guard": details,
+        "_fail_closed": True,
+    }
+
+
+def attach_skill_md_size_advisory(
+    result: Dict[str, Any],
+    details: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Attach a structured advisory to a successful warn-mode tool result."""
+    if details and details.get("effective_mode") == "warn":
+        result["size_advisory"] = details
+    return result

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -592,6 +592,33 @@ skills:
 
 When on, any flagged `skill_manage` write surfaces as an approval prompt with the scanner's rationale. Accepted writes land; denied writes return an explanatory error to the agent.
 
+### SKILL.md size ratchet
+
+Hermes keeps the existing 100,000-character hard ceiling for agent-written skill files, but `SKILL.md` also has a softer prompt-efficiency ratchet. Supporting files under `references/`, `templates/`, `scripts/`, and `assets/` are not subject to this soft guard.
+
+```yaml
+skills:
+  skill_md_size_guard: auto          # off | auto | warn | enforce
+  skill_md_soft_limit_chars: 20000   # default
+  skill_md_max_growth_chars: 5000    # default; existing skills only
+  skill_md_size_overrides:           # optional; exact skill directory names
+    production-deployments:
+      mode: enforce
+      soft_limit_chars: 20000
+      max_growth_chars: 2000
+```
+
+A write triggers the guard when it creates or grows a `SKILL.md` above the soft limit, crosses that limit, or adds more than the configured growth allowance in one edit. Shrinking edits are always allowed, including edits that reduce a legacy oversized skill but leave it above the soft limit. Exact-name overrides inherit any omitted values from the global policy, so strict operational skills can be ratcheted without imposing the same ceiling on creative, research, or model-specific skills.
+
+Modes:
+
+- `auto` (default) — warn on foreground/user-directed writes, but block autonomous background-review growth.
+- `warn` — allow the write and return a structured `size_advisory` to the agent.
+- `enforce` — block triggering foreground and background writes before touching the file.
+- `off` — keep only the historical 100,000-character hard ceiling.
+
+The warning/error directs the agent to keep triggers, authority boundaries, and routing in `SKILL.md`, move branch-specific detail into support files, and leave concise pointers behind. Direct filesystem edits and hand-placed skills remain outside `skill_manage` enforcement.
+
 ### Write approval for skill writes
 
 Independent of the content scanner above, `skills.write_approval` gates **every** agent skill write (create / edit / patch / delete / supporting files) behind your explicit approval — the same approve/deny mechanism as dangerous commands:

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -463,6 +463,12 @@ below lets you require human review before those changes land.
 The `patch` action is preferred for updates — it's more token-efficient than `edit` because only the changed text appears in the tool call.
 :::
 
+### Keeping SKILL.md lean
+
+`skill_manage` applies a configurable size ratchet to the main `SKILL.md` body while leaving `references/`, `templates/`, `scripts/`, and `assets/` available for rich support material. By default (`skills.skill_md_size_guard: auto`), foreground growth above 20,000 characters or a single edit above 5,000 added characters returns a warning; the same growth from autonomous background review is blocked. Shrinking edits always pass.
+
+Use `skills.skill_md_size_guard: enforce` to block triggering foreground writes too, `warn` to advise without blocking, or `off` for the historical 100,000-character hard ceiling only. Exact-name entries under `skills.skill_md_size_overrides` can make selected safety-critical skills stricter without forcing the same policy on every category. See [SKILL.md size ratchet](/user-guide/configuration#skillmd-size-ratchet) for all settings and exact behavior.
+
 ### Gating agent skill writes (`skills.write_approval`)
 
 By default the agent writes skills freely — including from the [background


### PR DESCRIPTION
## Summary

- add a configurable soft size ratchet for agent-managed `SKILL.md` files while keeping the existing 100,000-character hard ceiling
- default to `auto`: foreground writes receive a structured advisory, while autonomous background-review growth is blocked
- support exact skill-name overrides so safety-critical skills can use stricter limits without imposing one global ceiling on creative or research skills
- keep `references/`, `templates/`, `scripts/`, and `assets/` exempt so detailed knowledge stays in the same skill bundle
- normalize explicit `SKILL.md` paths through the same frontmatter and size checks, and prevent `remove_file` from bypassing skill deletion safeguards
- document configuration and authoring guidance

## Behavior

A write triggers when it:

- creates or grows a main `SKILL.md` above the configured soft limit (default 20,000 chars), or
- adds more than the configured single-write allowance (default 5,000 chars)

Shrinking edits always pass, including reductions of already-oversized legacy skills.

Modes:

- `auto` (default): warn foreground writes, enforce background-review writes
- `warn`: return `size_advisory` but allow the write
- `enforce`: block before touching the file
- `off`: retain only the historical hard ceiling

## Test plan

- `scripts/run_tests.sh tests/tools/test_skill_size_limits.py tests/tools/test_skill_manager_tool.py tests/website/test_generate_skill_docs.py -q` — 139 passed
- `python -m ruff check tools/skill_manager_tool.py tools/skill_size_guard.py tests/tools/test_skill_size_limits.py tests/tools/test_skill_manager_tool.py hermes_cli/config.py` — passed
- `git diff --check origin/main...HEAD` — passed
- full suite executed: unrelated environment/platform failures remained (missing optional `acp`, macOS `/tmp` versus `/private/tmp`, system-service assumptions, and process/file-descriptor limits); the same failure classes reproduced from an untouched `origin/main` worktree

## Review note

A read-only Claude review identified that explicit `file_path="SKILL.md"` could bypass the first implementation. The final patch normalizes both accepted main-file spellings, applies the ratchet and frontmatter validation to patch/write paths, blocks `remove_file` for the main file, and includes regression tests for each path.
