### PR TITLE
fix: harden tui_gateway subprocess reads against Windows locale UnicodeDecodeError (#53137)

### DIFF
--- a/tests/tui_gateway/test_subprocess_encoding.py
+++ b/tests/tui_gateway/test_subprocess_encoding.py
@@ -1,0 +1,132 @@
+"""Regression tests for UTF-8 encoding hardening in tui_gateway/server.py (#53137).
+
+On Windows with a non-UTF-8 system locale (e.g. GBK on Chinese Windows),
+text-mode subprocess reads defaulted to the locale encoding. When a child
+process emitted bytes invalid in that locale, an unhandled UnicodeDecodeError
+crashed the reader thread / gateway thread.
+
+#53137 added encoding="utf-8", errors="replace" to every text-mode subprocess
+call in tui_gateway/server.py. These tests assert that the kwargs survive so
+the crash class cannot silently regress.
+
+# Test pattern adapted from @devorun's PR #52700 (salvage convention).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import tui_gateway.server as server
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+def _make_completed_process() -> MagicMock:
+    """A CompletedProcess-like mock with str stdout/stderr (text=True contract)."""
+    cp = MagicMock()
+    cp.stdout = ""
+    cp.stderr = ""
+    cp.returncode = 0
+    return cp
+
+
+# ── _SlashWorker.Popen path ──────────────────────────────────────────────
+
+def test_slash_worker_popen_uses_utf8_replace():
+    """The slash-worker subprocess.Popen must pass encoding="utf-8" and
+    errors="replace" so invalid bytes in child stdout/stderr don't raise
+    UnicodeDecodeError inside the drain threads (#53137).
+    """
+    with patch.dict("sys.modules", {
+        "hermes_constants": MagicMock(
+            get_hermes_home=MagicMock(return_value="/tmp/hermes_test")
+        ),
+    }):
+        with patch("subprocess.Popen") as mock_popen:
+            mock_popen.return_value.stdout = MagicMock()
+            mock_popen.return_value.stderr = MagicMock()
+
+            from tui_gateway.server import _SlashWorker
+
+            _SlashWorker(
+                session_key="test_key",
+                model="test-model",
+            )
+
+            assert mock_popen.called, "Popen was not invoked"
+            kwargs = mock_popen.call_args[1]
+            assert kwargs.get("encoding") == "utf-8", (
+                f"slash-worker Popen must set encoding='utf-8' (got {kwargs.get('encoding')!r})"
+            )
+            assert kwargs.get("errors") == "replace", (
+                f"slash-worker Popen must set errors='replace' (got {kwargs.get('errors')!r})"
+            )
+
+
+# ── cli.exec handler ─────────────────────────────────────────────────────
+
+def test_cli_exec_uses_utf8_replace():
+    """The cli.exec RPC handler runs `python -m hermes_cli.main` via
+    subprocess.run; it must pass encoding="utf-8" and errors="replace"
+    (#53137)."""
+    handler = server._methods["cli.exec"]
+    with patch("subprocess.run", return_value=_make_completed_process()) as mock_run:
+        # Non-interactive argv that passes _cli_exec_blocked.
+        resp = handler(1, {"argv": ["--version"]})
+        assert mock_run.called, "subprocess.run was not invoked"
+        kwargs = mock_run.call_args[1]
+        assert kwargs.get("encoding") == "utf-8", (
+            f"cli.exec subprocess.run must set encoding='utf-8' (got {kwargs.get('encoding')!r})"
+        )
+        assert kwargs.get("errors") == "replace", (
+            f"cli.exec subprocess.run must set errors='replace' (got {kwargs.get('errors')!r})"
+        )
+
+
+# ── shell.exec handler ───────────────────────────────────────────────────
+
+def test_shell_exec_uses_utf8_replace():
+    """The shell.exec RPC handler runs an arbitrary shell command via
+    subprocess.run; it must pass encoding="utf-8" and errors="replace"
+    (#53137)."""
+    handler = server._methods["shell.exec"]
+    with patch("subprocess.run", return_value=_make_completed_process()) as mock_run:
+        # A harmless, non-dangerous command that passes the approval gate.
+        with patch("tools.approval.detect_hardline_command", return_value=(False, "")), \
+             patch("tools.approval.detect_dangerous_command", return_value=(False, None, "")):
+            resp = handler(1, {"command": "echo hello"})
+        assert mock_run.called, "subprocess.run was not invoked"
+        kwargs = mock_run.call_args[1]
+        assert kwargs.get("encoding") == "utf-8", (
+            f"shell.exec subprocess.run must set encoding='utf-8' (got {kwargs.get('encoding')!r})"
+        )
+        assert kwargs.get("errors") == "replace", (
+            f"shell.exec subprocess.run must set errors='replace' (got {kwargs.get('errors')!r})"
+        )
+
+
+# ── quick-command exec path (via command.dispatch) ───────────────────────
+
+def test_quick_command_exec_uses_utf8_replace():
+    """A quick_command of type 'exec' is dispatched via command.dispatch;
+    the underlying subprocess.run must pass encoding="utf-8" and
+    errors="replace" (#53137)."""
+    handler = server._methods["command.dispatch"]
+    fake_cp = _make_completed_process()
+    with patch("subprocess.run", return_value=fake_cp) as mock_run, \
+         patch("tui_gateway.server._load_cfg", return_value={
+             "quick_commands": {"runcmd": {"type": "exec", "command": "echo hi"}}
+         }), \
+         patch("tools.environments.local._sanitize_subprocess_env", return_value={"PATH": "/usr/bin"}):
+        resp = handler(1, {"name": "runcmd", "arg": "", "session_id": ""})
+        assert mock_run.called, "subprocess.run was not invoked for quick-command exec"
+        kwargs = mock_run.call_args[1]
+        assert kwargs.get("encoding") == "utf-8", (
+            f"quick-command exec subprocess.run must set encoding='utf-8' (got {kwargs.get('encoding')!r})"
+        )
+        assert kwargs.get("errors") == "replace", (
+            f"quick-command exec subprocess.run must set errors='replace' (got {kwargs.get('errors')!r})"
+        )

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11754,9 +11754,7 @@ def _(rid, params: dict) -> dict:
         return _ok(rid, {"blocked": True, "hint": hint, "code": -1, "output": ""})
     try:
         r = subprocess.run(
-            [
-                sys.executable, "-m", "hermes_cli.main", *argv
-            ],
+            [sys.executable, "-m", "hermes_cli.main", *argv],
             capture_output=True,
             text=True,
             # Force UTF-8 + lossy decode so non-UTF-8 child output can't crash

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -317,6 +317,12 @@ class _SlashWorker:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            # Force UTF-8 with lossy decoding so child output containing bytes
+            # that are invalid in the system locale (e.g. GBK on Chinese
+            # Windows) can't raise UnicodeDecodeError inside the drain threads
+            # and crash the gateway. See #53137.
+            encoding="utf-8",
+            errors="replace",
             bufsize=1,
             cwd=os.getcwd(),
             env=env,
@@ -9695,6 +9701,9 @@ def _(rid, params: dict) -> dict:
         try:
             res = subprocess.run(
                 argv, capture_output=True, text=True, timeout=120, stdin=subprocess.DEVNULL,
+                # Force UTF-8 + lossy decode so non-UTF-8 child output can't
+                # crash the gateway thread on locale-mismatched Windows (#53137).
+                encoding="utf-8", errors="replace",
                 creationflags=windows_hide_flags(),
             )
         except subprocess.TimeoutExpired:
@@ -11745,9 +11754,15 @@ def _(rid, params: dict) -> dict:
         return _ok(rid, {"blocked": True, "hint": hint, "code": -1, "output": ""})
     try:
         r = subprocess.run(
-            [sys.executable, "-m", "hermes_cli.main", *argv],
+            [
+                sys.executable, "-m", "hermes_cli.main", *argv
+            ],
             capture_output=True,
             text=True,
+            # Force UTF-8 + lossy decode so non-UTF-8 child output can't crash
+            # the gateway thread on locale-mismatched Windows. See #53137.
+            encoding="utf-8",
+            errors="replace",
             timeout=min(int(params.get("timeout", 240)), 600),
             cwd=os.getcwd(),
             # cli.exec runs `python -m hermes_cli.main` (can drive the agent) →
@@ -11818,6 +11833,9 @@ def _(rid, params: dict) -> dict:
                 shell=True,
                 capture_output=True,
                 text=True,
+                # Force UTF-8 + lossy decode so non-UTF-8 child output can't
+                # crash the gateway thread on locale-mismatched Windows (#53137).
+                encoding="utf-8", errors="replace",
                 timeout=30,
                 stdin=subprocess.DEVNULL,
                 env=sanitized_env,
@@ -14298,6 +14316,9 @@ def _(rid, params: dict) -> dict:
     try:
         r = subprocess.run(
             cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=os.getcwd(),
+            # Force UTF-8 + lossy decode so non-UTF-8 child output can't crash
+            # the gateway thread on locale-mismatched Windows (#53137).
+            encoding="utf-8", errors="replace",
             stdin=subprocess.DEVNULL,
         )
         return _ok(


### PR DESCRIPTION
Fixes #53137
Closes #61595 (same crash class, labeled duplicate)

## Description

On Windows with a non-UTF-8 system locale (e.g. GBK on Chinese Windows), text-mode subprocess reads in `tui_gateway/server.py` defaulted to the locale encoding for their stdout/stderr reader threads. When a child process emitted bytes invalid in that locale, an unhandled `UnicodeDecodeError` crashed the reader thread and silently killed the gateway.

This forces `encoding="utf-8"`, `errors="replace"` on every text-mode subprocess read in `tui_gateway/server.py` (slash worker, cli.exec, pdftoppm, shell.exec, quick-command exec) so non-UTF-8 child output decodes lossily instead of crashing the gateway. `git_probe.py` already used this pattern; the rest did not.

## Relationship to #52700

PR #52700 by @devorun independently covered 2 of the 5 text-mode subprocess sites (slash-worker Popen + `_git_branch_for_cwd`) and contributed the regression test pattern. This PR covers all 5 sites that exist on current main. The test file (`tests/tui_gateway/test_subprocess_encoding.py`) is adapted from @devorun's test pattern per the repo's salvage convention.

## Verification

- Confirmed the premise on current origin/main: server.py spawned the slash worker with `text=True` and no explicit encoding.
- All text-mode subprocess calls in `tui_gateway/` now pass `encoding="utf-8"`, `errors="replace"` (verified by scan — no remaining gaps).
- `python -c compile(...)` passes for the changed files.
- Regression tests: `tests/tui_gateway/test_subprocess_encoding.py` — 4 passed (slash-worker, cli.exec, shell.exec, quick-command exec).
- Gates: S1 (secrets) clean, S2 (personal refs) clean, C1 (conventional commit) passes, F1 (diff focused to `tui_gateway/server.py` + test).