### PR TITLE
fix: replace assert with runtime guards in gateway/session.py

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1803,7 +1803,10 @@ class SessionStore:
             slot.event.wait()
             if slot.error is not None:
                 raise slot.error
-            assert slot.result is not None
+            if slot.result is None:
+                raise RuntimeError(
+                    "slot.result is None after event.wait() — owner did not set result"
+                )
             return slot.result
 
         try:
@@ -1980,7 +1983,10 @@ class SessionStore:
                     published = candidate
                 else:
                     published = current
-            assert published is not None
+            if published is None:
+                raise RuntimeError(
+                    "published is None — neither candidate nor current was assigned"
+                )
             entry = published
             _needs_save = True
             if entry is candidate:


### PR DESCRIPTION
## Summary

`assert` statements in `gateway/session.py` are stripped when Python runs with `-O` (optimize flag), silently removing invariant checks in production. This PR replaces two `assert` statements with explicit `if/raise` guards so violations surface as `RuntimeError` instead of passing silently.

## Changes

**`gateway/session.py`** — 2 locations in `SessionStore.get_or_create_session()`:

1. **Line 1806** — `assert slot.result is not None` after `event.wait()`:
   Replaced with `if slot.result is None: raise RuntimeError(...)`. If the owning thread fails to set `slot.result` before signalling the event, callers now get a clear error instead of `None` propagating.

2. **Line 1983** — `assert published is not None` after candidate/current assignment:
   Replaced with `if published is None: raise RuntimeError(...)`. If neither `candidate` nor `current` was assigned to `published` (defensive), callers now get a clear error.

## Why this matters

- `python -O` strips all `assert` statements — the checks would silently vanish
- `gateway/session.py` is in the critical session management path — silent `None` propagation could cause downstream `AttributeError` or `TypeError` crashes with no indication of root cause
- The gateway serves all platform adapters (Telegram, Discord, Slack, etc.) — a silent failure here affects every connected user

## Precedent

Follows the pattern established in PR #56866 which fixed the same `assert`-in-production issue in 7 other files (`codex_app_server_session.py`, `api_server.py`, `bluebubbles.py`, `weixin.py`, `ws_transport.py`, `main.py`, `mcp_picker.py`). This PR covers the remaining file.

## Test Plan

- [ ] `python -m py_compile gateway/session.py` passes
- [ ] Existing session tests pass
- [ ] No behavioral change when assertions were already true (the common case)
