### PR TITLE
fix(wecom): heartbeat-triggered reconnect + 846609 retryable

### DIFF
--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -374,11 +374,20 @@ class WeComAdapter(BasePlatformAdapter):
                 raise RuntimeError("WeCom websocket closed")
 
     async def _heartbeat_loop(self) -> None:
-        """Send lightweight application-level pings."""
+        """Send lightweight application-level pings.
+
+        Consecutive ping failures indicate a dead connection.  After
+        ``_PING_FAIL_THRESHOLD`` failures in a row, we proactively close
+        the websocket so ``_listen_loop`` detects the break and reconnects.
+        This shrinks the "subscribe vacuum" window from minutes to seconds.
+        """
+        _PING_FAIL_THRESHOLD = 3
+        _consecutive_failures = 0
         try:
             while self._running:
                 await asyncio.sleep(HEARTBEAT_INTERVAL_SECONDS)
                 if not self._ws or self._ws.closed:
+                    _consecutive_failures = 0
                     continue
                 try:
                     await self._send_json(
@@ -388,8 +397,19 @@ class WeComAdapter(BasePlatformAdapter):
                             "body": {},
                         }
                     )
+                    _consecutive_failures = 0
                 except Exception as exc:
-                    logger.debug("[%s] Heartbeat send failed: %s", self.name, exc)
+                    _consecutive_failures += 1
+                    if _consecutive_failures >= _PING_FAIL_THRESHOLD:
+                        logger.warning(
+                            "[%s] %d consecutive heartbeat failures — closing WS to trigger reconnect",
+                            self.name, _consecutive_failures,
+                        )
+                        _consecutive_failures = 0
+                        await self._cleanup_ws()
+                        # _listen_loop will detect ws.closed and enter reconnect cycle
+                    else:
+                        logger.debug("[%s] Heartbeat send failed (%d/%d): %s", self.name, _consecutive_failures, _PING_FAIL_THRESHOLD, exc)
         except asyncio.CancelledError:
             pass
 
@@ -1416,11 +1436,16 @@ class WeComAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Timeout sending message to WeCom")
         except Exception as exc:
             logger.error("[%s] Send failed: %s", self.name, exc)
-            return SendResult(success=False, error=str(exc))
+            # WebSocket not connected / subscribe vacuum — transient, safe to retry
+            error_str = str(exc)
+            is_transient = "websocket is not connected" in error_str.lower() or "not subscribed" in error_str.lower()
+            return SendResult(success=False, error=error_str, retryable=is_transient)
 
         error = self._response_error(response)
         if error:
-            return SendResult(success=False, error=error)
+            # errcode 846609 = "aibot websocket not subscribed" — transient during reconnect
+            is_transient = "846609" in error
+            return SendResult(success=False, error=error, retryable=is_transient)
 
         return SendResult(
             success=True,


### PR DESCRIPTION
## Problem

WeCom WebSocket connections can enter a "subscribe vacuum" state where the bot is connected but cannot send or receive messages. The existing heartbeat mechanism detected failures but did not proactively reconnect — the connection could remain dead for minutes before recovery.

Additionally, when sending fails with `errcode 846609` ("aibot websocket not subscribed") or "websocket is not connected", the error was marked as non-retryable, causing messages to be silently dropped during transient reconnection windows.

## Changes

### 1. Heartbeat-triggered proactive reconnect
After 3 consecutive heartbeat ping failures, proactively close the WebSocket so the listen loop detects the break and enters the reconnect cycle. This shrinks the subscribe vacuum window from minutes to seconds.

### 2. Mark transient send errors as retryable
- `846609` (aibot websocket not subscribed) → retryable
- "websocket is not connected" → retryable

This lets the scheduler retry the message after the reconnect completes instead of permanently dropping it.

## Testing
- Verified heartbeat failure counting and threshold trigger
- Confirmed retryable marking for both error patterns
- Existing test suite passes