### PR TITLE
fix(gateway): scope authz allowlist reads to the routed profile

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -315,7 +315,6 @@ class GatewayAuthorizationMixin:
         4. Global allow-all (GATEWAY_ALLOW_ALL_USERS=true)
         5. Default: deny
         """
-        from gateway.run import logger
         # Home Assistant events are system-generated (state changes), not
         # user-initiated messages.  The HASS_TOKEN already authenticates the
         # connection, so HA events are always authorized.
@@ -369,6 +368,7 @@ class GatewayAuthorizationMixin:
         ``_is_user_authorized`` only for that scope entry — the logic below
         is unchanged.
         """
+        from gateway.run import logger
         user_id = source.user_id
 
         # Telegram (and similar) authorize entire group/forum/channel chats

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -30,12 +30,27 @@ from gateway.whatsapp_identity import (
 
 
 def _auth_env(name: str, default: str = "") -> str:
-    """Read allowlist/auth env; prefer profile secret_scope under multiplex."""
+    """Read allowlist/auth env; prefer profile secret_scope under multiplex.
+
+    When a profile secret scope is installed, that scope is AUTHORITATIVE: a var
+    the routed profile does not define resolves to ``default``, never to
+    ``os.environ``. In a multiplexer ``os.environ`` holds whichever profile
+    started the process, so falling back there would authorize the routed
+    profile's traffic against another profile's allowlist — the cross-profile
+    leak this scoping exists to prevent. ``get_secret`` applies the same rule
+    (see ``agent.secret_scope``); this mirrors it for the blank-value case.
+
+    Outside any scope (single-profile gateways) the read is plain ``os.getenv``,
+    identical to the legacy behavior every caller had before.
+    """
     if not name:
         return default
     try:
-        from agent.secret_scope import get_secret
+        from agent.secret_scope import current_secret_scope, get_secret
 
+        if current_secret_scope() is not None:
+            val = get_secret(name)
+            return str(val).strip() if val is not None else default
         val = get_secret(name)
         if val is not None and str(val).strip():
             return str(val).strip()

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -18,6 +18,7 @@ import time -> no import cycle. The lazy import preserves the exact logger name
 from __future__ import annotations
 
 import os
+from contextlib import nullcontext
 from typing import Optional
 
 from gateway.config import Platform
@@ -276,6 +277,33 @@ class GatewayAuthorizationMixin:
             return per_profile[profile]
         return getattr(self, "pairing_store", None)
 
+    def _profile_scope_for(self, profile: Optional[str]):
+        """Enter the named profile's secret scope for one authz decision.
+
+        Multiplexed gateways serve every profile from one process; without
+        this, an authz check for a secondary profile's message would read
+        allowlist env vars from the *active* profile's ``.env`` (loaded into
+        process-global ``os.environ`` at startup) instead of its own — the
+        same class of bug ``_profile_runtime_scope`` fixes for credentials
+        and ``_pairing_store_for`` (above) fixes for pairing whitelists.
+
+        No-op (``nullcontext``) for single-profile gateways, mirroring the
+        same ``if multiplex_profiles: with _profile_runtime_scope(...)`` guard
+        already used elsewhere in the gateway (e.g. ``_run_agent``) — zero
+        behavior or performance change when multiplexing is off.
+        """
+        if not getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            return nullcontext()
+        from gateway.run import _profile_runtime_scope
+        from hermes_cli.profiles import get_active_profile_name, get_profile_dir
+        try:
+            name = (profile or "").strip() or get_active_profile_name() or "default"
+            profile_home = get_profile_dir(name)
+        except Exception:
+            from hermes_constants import get_hermes_home
+            profile_home = get_hermes_home()
+        return _profile_runtime_scope(profile_home)
+
     def _is_user_authorized(self, source: SessionSource) -> bool:
         """
         Check if a user is authorized to use the bot.
@@ -329,6 +357,18 @@ class GatewayAuthorizationMixin:
         ):
             return True
 
+        with self._profile_scope_for(source.profile):
+            return self._is_user_authorized_scoped(source)
+
+    def _is_user_authorized_scoped(self, source: SessionSource) -> bool:
+        """Env-allowlist / pairing identity checks for ``_is_user_authorized``.
+
+        Runs inside the routed profile's secret scope (entered by the caller
+        via ``_profile_scope_for``) so ``_auth_env`` resolves *this* profile's
+        allowlist vars instead of the process-global ones. Split out of
+        ``_is_user_authorized`` only for that scope entry — the logic below
+        is unchanged.
+        """
         user_id = source.user_id
 
         # Telegram (and similar) authorize entire group/forum/channel chats
@@ -347,7 +387,7 @@ class GatewayAuthorizationMixin:
                 Platform.QQBOT: "QQ_GROUP_ALLOWED_USERS",
             }.get(source.platform, "")
             if chat_allowlist_env:
-                raw_chat_allowlist = os.getenv(chat_allowlist_env, "").strip()
+                raw_chat_allowlist = _auth_env(chat_allowlist_env)
                 if raw_chat_allowlist:
                     allowed_group_ids = {
                         cid.strip()
@@ -371,7 +411,7 @@ class GatewayAuthorizationMixin:
         }
         if getattr(source, "is_bot", False):
             allow_bots_var = platform_allow_bots_map.get(source.platform)
-            if allow_bots_var and os.getenv(allow_bots_var, "none").lower().strip() in {"mentions", "all"}:
+            if allow_bots_var and _auth_env(allow_bots_var, "none").lower() in {"mentions", "all"}:
                 return True
 
         if not user_id:
@@ -643,6 +683,22 @@ class GatewayAuthorizationMixin:
            and a potential info-leak. (#9337)
         6. No allowlist and no explicit config → ``"pair"`` (open-gateway default).
         """
+        with self._profile_scope_for(profile):
+            return self._get_unauthorized_dm_behavior_scoped(platform, profile=profile)
+
+    def _get_unauthorized_dm_behavior_scoped(
+        self,
+        platform: Optional[Platform],
+        *,
+        profile: Optional[str] = None,
+    ) -> str:
+        """Env-allowlist checks for ``_get_unauthorized_dm_behavior``.
+
+        Runs inside the routed profile's secret scope (entered by the caller
+        via ``_profile_scope_for``) so ``_auth_env`` resolves *this* profile's
+        allowlist vars instead of the process-global ones. Split out only for
+        that scope entry — the logic below is unchanged.
+        """
         config = getattr(self, "config", None)
 
         # Check for an explicit per-platform override first.
@@ -713,13 +769,13 @@ class GatewayAuthorizationMixin:
                 ),
                 Platform.QQBOT: ("QQ_GROUP_ALLOWED_USERS",),
             }
-            if os.getenv(platform_env_map.get(platform, ""), "").strip():
+            if _auth_env(platform_env_map.get(platform, "")):
                 return "ignore"
             for env_key in platform_group_env_map.get(platform, ()):
-                if os.getenv(env_key, "").strip():
+                if _auth_env(env_key):
                     return "ignore"
 
-        if os.getenv("GATEWAY_ALLOWED_USERS", "").strip():
+        if _auth_env("GATEWAY_ALLOWED_USERS"):
             return "ignore"
 
         return "pair"

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2884,6 +2884,10 @@ class BasePlatformAdapter(ABC):
         user_id: Optional[str],
         chat_type: Optional[str] = None,
         chat_id: Optional[str] = None,
+        *,
+        guild_id: Optional[str] = None,
+        thread_id: Optional[str] = None,
+        parent_chat_id: Optional[str] = None,
     ) -> Optional[bool]:
         """Return whether ``user_id`` is on the allowlist, if a check is configured.
 
@@ -2891,10 +2895,25 @@ class BasePlatformAdapter(ABC):
         registered via :meth:`set_authorization_check`. Returns ``None``
         when no check is registered (caller should treat as "trust unknown"
         and preserve legacy behaviour).
+
+        The optional routing context (``guild_id`` / ``thread_id`` /
+        ``parent_chat_id``) lets a multiplexing gateway resolve which profile's
+        allowlist governs this chat — ``gateway.profile_routes`` matches
+        conjunctively, so a guild- or thread-scoped route needs those fields to
+        match at all. It is forwarded only to callbacks marked
+        ``_accepts_route_ctx``; callbacks registered as plain 3-arg callables
+        keep the legacy call and are unaffected.
         """
         if not user_id or self._authorization_check is None:
             return None
         try:
+            if getattr(self._authorization_check, "_accepts_route_ctx", False):
+                return bool(self._authorization_check(
+                    user_id, chat_type, chat_id,
+                    guild_id=guild_id,
+                    thread_id=thread_id,
+                    parent_chat_id=parent_chat_id,
+                ))
             return bool(self._authorization_check(user_id, chat_type, chat_id))
         except Exception:
             logger.warning(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9109,11 +9109,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ``profile_name`` binds the callback to the secondary adapter's own
         multiplex profile, so its ``SessionSource`` resolves that profile's
         secret scope instead of falling back to the active profile.
+
+        The primary adapter is shared across profiles and registers without a
+        ``profile_name``: a channel it serves may still be routed elsewhere by
+        ``gateway.profile_routes``. So when no profile is bound, resolve the
+        route from the caller's routing context — otherwise the check reads the
+        *active* profile's allowlist for a routed channel, marking that
+        profile's own users ``[unverified]`` while treating default-profile
+        users as verified. ``_profile_name_for_source`` returns ``None``
+        (default profile) when multiplexing is off or no route matches, so
+        unrouted gateways are unaffected.
         """
         def check(
             user_id: str,
             chat_type: Optional[str] = None,
             chat_id: Optional[str] = None,
+            *,
+            guild_id: Optional[str] = None,
+            thread_id: Optional[str] = None,
+            parent_chat_id: Optional[str] = None,
         ) -> bool:
             if not user_id:
                 return False
@@ -9123,8 +9137,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 chat_type=chat_type or "group",
                 user_id=user_id,
                 profile=profile_name,
+                guild_id=guild_id,
+                thread_id=thread_id,
+                parent_chat_id=parent_chat_id,
             )
+            if not profile_name:
+                routed = self._profile_name_for_source(source)
+                if routed:
+                    source.profile = routed
             return self._is_user_authorized(source)
+
+        # Tells ``BasePlatformAdapter._is_sender_authorized`` it may forward the
+        # routing context above; callbacks without this marker (e.g. plugin or
+        # test-registered 3-arg callables) keep the legacy positional call.
+        check._accepts_route_ctx = True  # type: ignore[attr-defined]
         return check
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8873,7 +8873,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter.set_session_store(self.session_store)
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
             adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
-            adapter.set_authorization_check(self._make_adapter_auth_check(adapter.platform))
+            adapter.set_authorization_check(
+                self._make_adapter_auth_check(adapter.platform, profile_name=profile_name)
+            )
             adapter._busy_text_mode = self._busy_text_mode
 
             try:
@@ -9090,6 +9092,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     def _make_adapter_auth_check(
         self,
         platform: Platform,
+        profile_name: Optional[str] = None,
     ) -> Callable[[str, Optional[str], Optional[str]], bool]:
         """Build a platform-bound auth callback for adapter use.
 
@@ -9102,6 +9105,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         The returned callback delegates to :meth:`_is_user_authorized` so the
         full auth chain — platform allowlists, group allowlists, pairing
         store, allow-all flags — stays the single source of truth.
+
+        ``profile_name`` binds the callback to the secondary adapter's own
+        multiplex profile, so its ``SessionSource`` resolves that profile's
+        secret scope instead of falling back to the active profile.
         """
         def check(
             user_id: str,
@@ -9115,6 +9122,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 chat_id=chat_id or "",
                 chat_type=chat_type or "group",
                 user_id=user_id,
+                profile=profile_name,
             )
             return self._is_user_authorized(source)
         return check

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5046,6 +5046,17 @@ class DiscordAdapter(BasePlatformAdapter):
         is_thread_channel = isinstance(channel, discord.Thread)
         has_unverified = False
 
+        # Routing context for the gateway's authorization check: a channel here
+        # may be routed to another profile by ``gateway.profile_routes``, whose
+        # guild-/thread-scoped shapes only match when these are supplied.
+        _guild_obj_id = getattr(getattr(channel, "guild", None), "id", None)
+        _route_guild_id = str(_guild_obj_id) if _guild_obj_id is not None else None
+        _route_thread_id = channel_id if is_thread_channel else None
+        _route_parent_chat_id = (
+            str(getattr(channel, "parent_id", "") or "") or None
+            if is_thread_channel else None
+        )
+
         try:
             def _keep(msg) -> Optional[str]:
                 """Return a formatted ``[name] content`` line, or None to skip.
@@ -5097,6 +5108,9 @@ class DiscordAdapter(BasePlatformAdapter):
                         author_id,
                         chat_type="thread" if is_thread_channel else "group",
                         chat_id=channel_id,
+                        guild_id=_route_guild_id,
+                        thread_id=_route_thread_id,
+                        parent_chat_id=_route_parent_chat_id,
                     )
                     if is_authorized is False:
                         trust_tag = "[unverified] "

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -4402,8 +4402,16 @@ class SlackAdapter(BasePlatformAdapter):
                 # check; the auth check is configured by GatewayRunner.
                 trust_tag = ""
                 if not is_bot and msg_user:
+                    # Pass the routing context so a channel routed to another
+                    # profile by ``gateway.profile_routes`` is checked against
+                    # that profile's allowlist. ``guild_id`` carries the
+                    # workspace, mirroring the ``scope_id=team_id`` the normal
+                    # inbound path sets (the two are aliases, reconciled in
+                    # ``SessionSource.__post_init__``).
                     is_authorized = self._is_sender_authorized(
                         msg_user, chat_type="thread", chat_id=channel_id,
+                        guild_id=team_id or None,
+                        thread_id=thread_ts,
                     )
                     if is_authorized is False:
                         trust_tag = "[unverified] "

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -139,6 +139,56 @@ def test_secondary_allowlist_dm_behavior_ignores_unauthorized(monkeypatch):
     assert runner._get_unauthorized_dm_behavior(Platform.WECOM) == "ignore"
 
 
+def test_adapter_auth_check_stamps_secondary_profile(monkeypatch):
+    """The adapter auth-check callback must stamp its own secondary profile.
+
+    Regression for the gap where ``_make_adapter_auth_check`` built a
+    profile-less ``SessionSource``, so a secondary adapter's external-context
+    authorization (e.g. Slack/Discord thread-reply lookups) silently
+    resolved the *active* profile's allowlist scope instead of its own.
+    """
+    from gateway.run import GatewayRunner
+
+    _clear_auth_env(monkeypatch)
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+
+    captured: dict = {}
+
+    def fake_is_user_authorized(source):
+        captured["profile"] = source.profile
+        return True
+
+    runner._is_user_authorized = fake_is_user_authorized
+
+    check = runner._make_adapter_auth_check(Platform.WECOM, profile_name="coder")
+    assert check("some-user", "dm", "dm-chat") is True
+    assert captured["profile"] == "coder"
+
+
+def test_adapter_auth_check_defaults_to_active_profile(monkeypatch):
+    """Primary-adapter callbacks (no profile_name) still resolve the active profile."""
+    from gateway.run import GatewayRunner
+
+    _clear_auth_env(monkeypatch)
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+
+    captured: dict = {}
+
+    def fake_is_user_authorized(source):
+        captured["profile"] = source.profile
+        return True
+
+    runner._is_user_authorized = fake_is_user_authorized
+
+    check = runner._make_adapter_auth_check(Platform.WECOM)
+    assert check("some-user", "dm", "dm-chat") is True
+    assert captured["profile"] is None
+
+
 def test_secondary_open_policy_fails_startup_guard(monkeypatch):
     """Secondary profiles must pass the same open-policy startup guard."""
     from gateway.run import _own_policy_open_startup_violation

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -207,3 +207,100 @@ def test_secondary_open_policy_fails_startup_guard(monkeypatch):
     assert violation is not None
     assert "wecom" in violation
     assert "open policy" in violation
+
+def _routed_runner(monkeypatch, routes):
+    """Runner whose Discord/Slack channels are routed by ``profile_routes``."""
+    from gateway.profile_routing import parse_profile_routes
+    from gateway.run import GatewayRunner
+
+    _clear_auth_env(monkeypatch)
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner.config.profile_routes = parse_profile_routes(routes)
+    return runner
+
+
+def _capture_authorized_profile(runner):
+    """Record the profile each authz decision is scoped to."""
+    seen = {}
+
+    def _fake_is_user_authorized(source):
+        seen["profile"] = source.profile
+        return True
+
+    runner._is_user_authorized = _fake_is_user_authorized
+    return seen
+
+
+def test_primary_adapter_callback_resolves_channel_route(monkeypatch):
+    """A shared primary adapter must authorize against the ROUTED profile.
+
+    The primary adapter registers without a ``profile_name``, but a channel it
+    serves may be routed elsewhere. Without route resolution the check reads the
+    active profile's allowlist — marking the routed profile's own users
+    ``[unverified]`` while trusting default-profile users.
+    """
+    runner = _routed_runner(monkeypatch, [
+        {
+            "name": "coder-channel",
+            "platform": "slack",
+            "chat_id": "C-CODER",
+            "profile": "coder",
+        },
+    ])
+    seen = _capture_authorized_profile(runner)
+
+    check = runner._make_adapter_auth_check(Platform.SLACK)
+    assert check("u1", "thread", "C-CODER") is True
+    assert seen["profile"] == "coder"
+
+
+def test_primary_adapter_callback_matches_guild_scoped_route(monkeypatch):
+    """Guild-scoped routes match conjunctively — the callback must pass guild_id."""
+    runner = _routed_runner(monkeypatch, [
+        {
+            "name": "coder-guild",
+            "platform": "discord",
+            "guild_id": "G-CODER",
+            "profile": "coder",
+        },
+    ])
+    seen = _capture_authorized_profile(runner)
+
+    check = runner._make_adapter_auth_check(Platform.DISCORD)
+    assert check("u1", "group", "chan-1", guild_id="G-CODER") is True
+    assert seen["profile"] == "coder"
+
+
+def test_primary_adapter_callback_unrouted_channel_uses_default(monkeypatch):
+    """A channel with no matching route stays on the default profile."""
+    runner = _routed_runner(monkeypatch, [
+        {
+            "name": "coder-channel",
+            "platform": "slack",
+            "chat_id": "C-CODER",
+            "profile": "coder",
+        },
+    ])
+    seen = _capture_authorized_profile(runner)
+
+    check = runner._make_adapter_auth_check(Platform.SLACK)
+    assert check("u1", "thread", "C-OTHER") is True
+    assert seen["profile"] is None
+
+
+def test_secondary_adapter_profile_wins_over_routes(monkeypatch):
+    """An explicitly bound profile is authoritative — routes must not override it."""
+    runner = _routed_runner(monkeypatch, [
+        {
+            "name": "coder-channel",
+            "platform": "slack",
+            "chat_id": "C-CODER",
+            "profile": "coder",
+        },
+    ])
+    seen = _capture_authorized_profile(runner)
+
+    check = runner._make_adapter_auth_check(Platform.SLACK, profile_name="ops")
+    assert check("u1", "thread", "C-CODER") is True
+    assert seen["profile"] == "ops"

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -304,3 +304,45 @@ def test_secondary_adapter_profile_wins_over_routes(monkeypatch):
     check = runner._make_adapter_auth_check(Platform.SLACK, profile_name="ops")
     assert check("u1", "thread", "C-CODER") is True
     assert seen["profile"] == "ops"
+
+
+def test_auth_env_scope_is_authoritative_for_undefined_var(monkeypatch):
+    """A var the routed profile does not define must not leak from os.environ.
+
+    In a multiplexer ``os.environ`` holds whichever profile started the process.
+    Falling back there for a routed profile that simply omits the var would
+    authorize its traffic against another profile's allowlist.
+    """
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+    from gateway.authz_mixin import _auth_env
+
+    monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "default-user")
+
+    token = set_secret_scope({"SOME_OTHER_SECRET": "x"})
+    try:
+        assert _auth_env("GATEWAY_ALLOWED_USERS") == ""
+    finally:
+        reset_secret_scope(token)
+
+
+def test_auth_env_scope_value_wins_over_process_env(monkeypatch):
+    """The routed profile's own value is used, not the process-global one."""
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+    from gateway.authz_mixin import _auth_env
+
+    monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "default-user")
+
+    token = set_secret_scope({"GATEWAY_ALLOWED_USERS": "coder-user"})
+    try:
+        assert _auth_env("GATEWAY_ALLOWED_USERS") == "coder-user"
+    finally:
+        reset_secret_scope(token)
+
+
+def test_auth_env_unscoped_reads_process_env(monkeypatch):
+    """Single-profile gateways keep the legacy os.getenv behavior."""
+    from gateway.authz_mixin import _auth_env
+
+    monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "default-user")
+    assert _auth_env("GATEWAY_ALLOWED_USERS") == "default-user"
+    assert _auth_env("UNSET_VAR_XYZ", "fallback") == "fallback"


### PR DESCRIPTION
## Summary

- `_is_user_authorized` and `_get_unauthorized_dm_behavior` read `*_ALLOWED_USERS` / `*_ALLOW_ALL_USERS` / `GATEWAY_ALLOWED_USERS` via raw `os.getenv`, which only ever sees the process-global environment.
- Under `gateway.multiplex_profiles`, a secondary profile's `.env` is intentionally never merged into `os.environ` (`_profile_runtime_scope` only installs a per-turn secret scope, to keep credentials isolated) — so a secondary profile's own allowlist configuration was silently ignored, and the allowlist actually enforced was whichever profile started the gateway process.
- This is an authz **isolation** gap, not a credential-leak issue: #57417 already fixed per-profile *credential* (token) resolution; this PR closes a separate gap in *request-time authorization* allowlist resolution that #57417 doesn't touch (it doesn't modify `authz_mixin.py`'s env-reading logic).

## Reproduction (before this fix)

Two profiles (`default`, `coder`), each configuring a distinct `MATTERMOST_ALLOWED_USERS`:

- `default/.env`: `MATTERMOST_ALLOWED_USERS=user-a`
- `coder/.env`: `MATTERMOST_ALLOWED_USERS=user-b`

With multiplexing on, `user-b` messaging the `coder` profile's bot was rejected ("Unauthorized user"), while `user-a` was authorized on *both* bots — the `coder` profile's own allowlist was never consulted.

## Fix

- Add `_profile_scope_for(profile)`: enters the routed profile's secret scope for one authz decision, mirroring the existing `_pairing_store_for` per-profile isolation pattern and the `if multiplex_profiles: with _profile_runtime_scope(...)` guard already used elsewhere in the gateway. No-op (`nullcontext`) when multiplexing is off, so single-profile gateways are unaffected.
- Add a scope-aware `_getenv` local to this module, mirroring `gateway.config._getenv` / `hermes_cli.runtime_provider._getenv` (the existing convention for this in the codebase).
- Split `_is_user_authorized` / `_get_unauthorized_dm_behavior` so the allowlist-reading portion runs inside that scope, and replace their `os.getenv` calls with `_getenv`.

## How to test

I wasn't able to get a Python 3.11–3.13 environment running locally to run `scripts/run_tests.sh` end-to-end (the checkout I had available was on 3.10). Rather than add pytest coverage I couldn't actually execute against the full suite, I verified the real, unmodified code path with a standalone script that stubs only `gateway.run.logger` (the one thing `authz_mixin` imports from that module at call time) and exercises `GatewayAuthorizationMixin._is_user_authorized` under a manually-installed `agent.secret_scope` scope per profile:

```python
runner._profile_scope_for = <stub installing {"MATTERMOST_ALLOWED_USERS": ...} per profile via agent.secret_scope>

assert runner._is_user_authorized(source(user_id="user-a", profile=None))    is True   # default's own user
assert runner._is_user_authorized(source(user_id="user-b", profile=None))    is False  # not in default's allowlist
assert runner._is_user_authorized(source(user_id="user-b", profile="coder")) is True   # coder's own user
assert runner._is_user_authorized(source(user_id="user-a", profile="coder")) is False  # no longer leaks in via default's allowlist

# non-multiplex regression check
runner2.config.multiplex_profiles = False
assert runner2._is_user_authorized(source(user_id="user-a", profile=None)) is True  # legacy os.environ path unchanged
```

All assertions pass. Happy to add this as a proper `tests/gateway/` pytest module (following the existing `test_multiplex_profile_authz.py` / `test_multiplex_credential_isolation.py` patterns) if a maintainer wants it before merge — I only left it out of the diff because I couldn't run it against the full suite myself in this environment.

## Platforms tested

The changed logic is platform-agnostic (same `os.getenv` pattern applied to every `*_ALLOWED_USERS` var); verified with `Platform.MATTERMOST` on Linux (WSL2).

Related: #57417 (fixes credential isolation; this PR addresses the separate authz-allowlist isolation gap it doesn't cover).
