### PR TITLE
fix(gateway): detect systemd-managed profile gateways via /proc/PID/environ

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -289,6 +289,14 @@ def _gateway_command_subcommand(command: str | None) -> str | None:
         if i + 1 >= len(filtered):
             return "run"  # bare `hermes gateway` defaults to `run`
         return filtered[i + 1]
+    # When the remaining token is just the bare `hermes`/`hermes.exe` entry-point
+    # binary (no `gateway` subcommand visible — common for systemd-managed
+    # gateways where `--profile` is set via the service file), treat it as a
+    # gateway run process.  Callers validate the profile via
+    # ``_command_line_belongs_to_profile`` (which checks HERMES_HOME in
+    # /proc/PID/environ), preventing false positives.
+    if len(filtered) == 1 and filtered[0] in ("hermes", "hermes.exe"):
+        return "run"
     return None
 
 

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -176,6 +176,33 @@ def get_process_start_time(pid: int) -> Optional[int]:
     return _get_process_start_time(pid)
 
 
+def _read_process_environ(pid: int) -> Optional[dict[str, str]]:
+    """Return the process environment as a dict of ``KEY=VALUE`` pairs.
+
+    On Linux, reads ``/proc/<pid>/environ`` directly.  Returns ``None`` on
+    platforms without /proc or when the file is not readable.
+    """
+    environ_path = Path(f"/proc/{pid}/environ")
+    try:
+        raw = environ_path.read_bytes()
+    except (FileNotFoundError, PermissionError, OSError):
+        return None
+    if not raw:
+        return None
+    result: dict[str, str] = {}
+    for entry in raw.split(b"\x00"):
+        if not entry:
+            continue
+        try:
+            decoded = entry.decode("utf-8", errors="ignore")
+        except Exception:
+            continue
+        if "=" in decoded:
+            key, _, value = decoded.partition("=")
+            result[key] = value
+    return result
+
+
 def _read_process_cmdline(pid: int) -> Optional[str]:
     """Return the process command line as a space-separated string.
 
@@ -417,9 +444,32 @@ def _record_matches_live_gateway_pid(
         if expected_home is not None and not _command_line_belongs_to_profile(
             live_cmdline, expected_home
         ):
-            return False
+            # Command-line check failed (common for systemd-managed gateways
+            # where --profile is set via the service file, not visible in
+            # /proc/PID/cmdline).  Fall back to checking the process
+            # environment for HERMES_HOME.
+            if not _pid_environ_matches_profile(pid, expected_home):
+                return False
         return True
     return _record_looks_like_gateway(record)
+
+
+def _pid_environ_matches_profile(pid: int, profile_home: Path) -> bool:
+    """Return True when the process environment's HERMES_HOME matches.
+
+    Used as a fallback when the command line carries no profile flag (bare
+    ``hermes`` entry-point binary started by a service manager).
+    """
+    environ = _read_process_environ(pid)
+    if environ is None:
+        return False
+    env_home = environ.get("HERMES_HOME")
+    if env_home is None:
+        return False
+    try:
+        return Path(env_home).resolve() == profile_home.resolve()
+    except OSError:
+        return False
 
 
 def _build_pid_record() -> dict:


### PR DESCRIPTION
## Summary

Systemd-managed profile gateways are reported as "stopped" by `hermes profile list` even when running, because the L2 `/proc` scan cannot identify bare `hermes` entry-point binaries or verify their profile membership.

Fixes #61981

## Root Cause

Two independent failures in `gateway/status.py`:

1. **`_gateway_command_subcommand()` rejects bare `hermes`.** Systemd gateways show only `hermes` in `/proc/PID/cmdline` — no `gateway` subcommand. The parser requires an explicit `gateway` token.

2. **`_command_line_belongs_to_profile()` cannot validate systemd gateways.** Profile membership is checked via `--profile` or `HERMES_HOME=` on the command line, but systemd services set these as environment variables, not cmdline arguments.

## Changes

**Commit 1: Recognize bare `hermes` as gateway run** (`gateway/status.py` +8 lines)

In `_gateway_command_subcommand()`: when `has_gateway_entry` is True but no `gateway` token exists, and the only remaining token is `hermes` / `hermes.exe`, treat it as `run`. The existing `_command_line_belongs_to_profile()` guard prevents false positives.

**Commit 2: Fall back to `/proc/PID/environ` for profile check** (`gateway/status.py` +51/-1 lines)

- Add `_read_process_environ()` to parse `/proc/<pid>/environ`.
- Add `_pid_environ_matches_profile()` as a fallback in `_record_matches_live_gateway_pid()` when the cmdline-level profile check fails.
- Works by matching the process's `HERMES_HOME` env var against the expected profile home.

## Verification

- `hermes profile list` correctly detects running systemd-managed gateways
- Does not affect non-systemd gateways (existing cmdline-based checks remain primary)
- Profile isolation is maintained (cross-profile false positives are rejected by the env check)
- No `/proc` dependency on non-Linux platforms (graceful `None` return)