### PR TITLE
fix(email): enable splits_long_messages to avoid 4000-char truncation cap

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -422,6 +422,12 @@ def _extract_attachments(
 class EmailAdapter(BasePlatformAdapter):
     """Email gateway adapter using IMAP (receive) and SMTP (send)."""
 
+    # Email preserves full payload without chunking: SMTP handles arbitrary
+    # lengths (adapter internally limits to MAX_MESSAGE_LENGTH=50_000).
+    # When True, the delivery router skips gateway-level truncation at
+    # MAX_PLATFORM_OUTPUT (4000 chars) and passes the full content to send().
+    splits_long_messages = True
+
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.EMAIL)
 

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1775,5 +1775,74 @@ class TestSenderAuthentication(unittest.TestCase):
         self.assertFalse(ok, reason)
 
 
+class TestEmailAdapterSplitsLongMessages(unittest.TestCase):
+    """Verify EmailAdapter declares splits_long_messages=True to avoid truncation."""
+
+    def test_splits_long_messages_enabled(self):
+        """EmailAdapter should declare splits_long_messages=True."""
+        from plugins.platforms.email.adapter import EmailAdapter
+
+        self.assertTrue(
+            EmailAdapter.splits_long_messages,
+            "EmailAdapter must declare splits_long_messages=True to avoid "
+            "gateway/delivery.py's MAX_PLATFORM_OUTPUT (4000 chars) truncation cap."
+        )
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_IMAP_HOST": "imap.test.com",
+        "EMAIL_SMTP_HOST": "smtp.test.com",
+    }, clear=False)
+    def test_long_content_reaches_email_send_intact(self):
+        """Regression test: >4000-char content reaches EmailAdapter.send() without truncation."""
+        from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+        from gateway.delivery import DeliveryRouter, DeliveryTarget
+        from plugins.platforms.email.adapter import EmailAdapter
+        from email.mime.text import MIMEText
+        import base64
+
+        # Mock the actual SMTP send to avoid network calls
+        with patch.object(EmailAdapter, '_connect_smtp') as mock_smtp:
+            mock_smtp_client = MagicMock()
+            mock_smtp.return_value = mock_smtp_client
+
+            # Set up adapter
+            config = GatewayConfig()
+            _apply_env_overrides(config)
+            adapter = EmailAdapter(config.platforms[Platform.EMAIL])
+            router = DeliveryRouter(config, adapters={Platform.EMAIL: adapter})
+
+            # Send content longer than MAX_PLATFORM_OUTPUT (4000 chars)
+            long_content = "x" * 5000
+            target = DeliveryTarget.parse("email:user@test.com")
+
+            import asyncio
+            asyncio.run(router._deliver_to_platform(target, long_content, metadata={"job_id": "test-email-job"}))
+
+            # Verify the full 5000 chars reached send() (no truncation)
+            mock_smtp_client.send_message.assert_called_once()
+            sent_msg = mock_smtp_client.send_message.call_args[0][0]
+            
+            # MIMEText encodes long text as base64; decode to verify
+            payload = sent_msg.get_payload(0).get_payload()
+            if sent_msg.get_payload(0).get_content_type() == "text/plain" and sent_msg.get_payload(0).get("Content-Transfer-Encoding") == "base64":
+                decoded = base64.b64decode(payload).decode('utf-8')
+            else:
+                decoded = payload
+            
+            self.assertEqual(
+                len(decoded),
+                5000,
+                "EmailAdapter.send() should receive the full 5000-char payload; "
+                "router should not truncate for splits_long_messages=True adapters."
+            )
+            self.assertEqual(
+                decoded,
+                long_content,
+                "EmailAdapter.send() should receive the exact original content."
+            )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What does this PR do?

Adds `splits_long_messages = True` to `EmailAdapter` class attributes.

The delivery router (`gateway/delivery.py`) checks `adapter.splits_long_messages` at line 431 to decide whether to truncate content at `MAX_PLATFORM_OUTPUT` (4000 chars) or deliver the full payload. When `True`, the full content passes to the adapter's `send()` method, which can chunk natively. When `False` (the default), content above the cap is truncated with a footer pointing to a saved file.

`EmailAdapter` was missing this declaration, causing all email delivery to hit the truncation path even though:
- SMTP has no practical message length limit at 4000 chars
- The adapter's `send()` method handles the full payload via `MIMEText(body, "plain", "utf-8")`
- The adapter internally defines `MAX_MESSAGE_LENGTH = 50_000`, indicating intent to support much longer messages

All other platform adapters (Telegram, Discord, Slack, Matrix, WhatsApp, etc.) already declare `splits_long_messages = True`. This change aligns email with their behavior and fixes the silent truncation bug where cron job output was cut off mid-content.

## Related Issue

Fixes #61990

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/email/adapter.py`: Added `splits_long_messages = True` class attribute with explanatory comment
- `tests/gateway/test_email.py`: Added `TestEmailAdapterSplitsLongMessages` test class to verify the attribute is declared

## How to Test

1. Verify the test passes: `pytest tests/gateway/test_email.py::TestEmailAdapterSplitsLongMessages -v`
2. Check that the adapter declares the attribute: `python -c "from plugins.platforms.email.adapter import EmailAdapter; print(EmailAdapter.splits_long_messages)"` should print `True`
3. (Integration test) Configure email gateway adapter, create a cron job that generates output longer than 4000 characters (e.g., a daily briefing), and verify the received email contains the full output without truncation

Observed result: The test passes, confirming that `EmailAdapter.splits_long_messages` is `True`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
