### PR TITLE
fix: replace assert with runtime guards in tools/ and hermes_cli/ (4 files)

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -374,10 +374,7 @@ def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
 def _do_git_install(entry: CatalogEntry) -> Path:
     """Clone the entry's repo into ``~/.hermes/mcp-installs/<name>`` and run
     bootstrap commands. Returns the install directory."""
-    if entry.install is None or entry.install.type != "git":
-        raise RuntimeError(
-            f"_do_git_install called with install={entry.install!r} — expected git entry"
-        )
+    assert entry.install is not None and entry.install.type == "git"
     install = entry.install
     dest = _install_root() / entry.name
 

--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -374,7 +374,10 @@ def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
 def _do_git_install(entry: CatalogEntry) -> Path:
     """Clone the entry's repo into ``~/.hermes/mcp-installs/<name>`` and run
     bootstrap commands. Returns the install directory."""
-    assert entry.install is not None and entry.install.type == "git"
+    if entry.install is None or entry.install.type != "git":
+        raise RuntimeError(
+            f"_do_git_install called with install={entry.install!r} — expected git entry"
+        )
     install = entry.install
     dest = _install_root() / entry.name
 

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -201,8 +201,8 @@ async def _cdp_call(
     works for ``Target.*``, ``Browser.*``, ``Storage.*`` and a few other
     globally-scoped domains.
     """
-    assert websockets is not None  # guarded by _WS_AVAILABLE at call-site
-
+    if websockets is None:
+        raise RuntimeError("websockets package is required but not installed")
     async with websockets.connect(
         ws_url,
         max_size=None,  # CDP responses (e.g. DOM.getDocument) can be large

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -848,7 +848,8 @@ class CDPSupervisor:
 
     async def _read_loop(self) -> None:
         """Continuously dispatch incoming CDP frames."""
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("_read_loop called with no active WebSocket")
         try:
             async for raw in self._ws:
                 if self._stop_requested:

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -1058,7 +1058,8 @@ class DockerEnvironment(BaseEnvironment):
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
         """Spawn a bash process inside the Docker container."""
-        assert self._container_id, "Container not started"
+        if not self._container_id:
+            raise RuntimeError("Container not started — _run_bash called before start()")
         cmd = [self._docker_exe, "exec"]
         if stdin_data is not None:
             cmd.append("-i")


### PR DESCRIPTION
## Summary

`assert` statements are stripped when Python runs with `-O` (optimize flag), silently removing invariant checks in production. This PR replaces 3 `assert` statements across 3 files with explicit `if/raise` guards so violations surface as `RuntimeError` instead of passing silently.

## Changes

| File | Location | What was guarded |
|------|----------|-----------------|
| `tools/environments/docker.py` | `_run_bash()` | Container must be started before exec |
| `tools/browser_supervisor.py` | `_read_loop()` | WebSocket must be active |
| `tools/browser_cdp_tool.py` | `send_cdp()` | websockets package must be installed |

## Why this matters

- `python -O` strips all `assert` statements — the checks silently vanish
- Without these guards, failures would surface as confusing `AttributeError`, `TypeError`, or `subprocess` errors with no indication of root cause
- `docker.py` and `browser_supervisor.py` are in hot paths serving all Docker and browser tool operations

## Note

`hermes_cli/mcp_catalog.py` assert fix moved to PR #62006 (separate PR due to MCP catalog security review gate).

## Precedent

Follows the pattern established in:
- PR #56736 — fixed `assert` in `codex_app_server_session.py`
- PR #56866 — fixed `assert` in 7 other production files
- PR #61983 — fixed `assert` in `gateway/session.py`

## Test Plan

- [ ] `python -m py_compile` passes for all 3 files
- [ ] Existing tests pass
- [ ] No behavioral change when assertions were already true (the common case)
