### PR TITLE
fix(mcp): finalize async generators before loop close

### DIFF
--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -3,6 +3,7 @@
 import asyncio
 import os
 import signal
+import threading
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -82,6 +83,42 @@ class TestMCPLoopExceptionHandler:
                 mcp_mod._servers.clear()
                 mcp_mod._server_connecting.clear()
             mcp_mod._stop_mcp_loop()
+
+    def test_shutdown_finalizes_async_generators_before_closing_loop(self):
+        """Stopping the MCP loop drains async generators on its owner thread."""
+        import tools.mcp_tool as mcp_mod
+
+        finalized = threading.Event()
+
+        async def _stream():
+            try:
+                yield "ready"
+            finally:
+                finalized.set()
+
+        with mcp_mod._lock:
+            mcp_mod._servers.clear()
+            mcp_mod._server_connecting.clear()
+
+        mcp_mod._ensure_mcp_loop()
+        with mcp_mod._lock:
+            loop = mcp_mod._mcp_loop
+
+        streams = []
+
+        async def _start_stream():
+            # Construct and first-iterate the generator on the MCP loop so it
+            # is registered with that loop's async-generator hooks.
+            stream = _stream()
+            streams.append(stream)
+            return await stream.__anext__()
+
+        first_item = asyncio.run_coroutine_threadsafe(_start_stream(), loop)
+        assert first_item.result(timeout=2) == "ready"
+
+        assert mcp_mod._stop_mcp_loop() is True
+        assert finalized.wait(timeout=2)
+        assert loop.is_closed()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -120,6 +120,32 @@ class TestMCPLoopExceptionHandler:
         assert finalized.wait(timeout=2)
         assert loop.is_closed()
 
+    def test_shutdown_closes_loop_when_recorded_thread_is_already_dead(self):
+        """A stale non-null thread record still takes the defensive fallback."""
+        import tools.mcp_tool as mcp_mod
+
+        loop = asyncio.new_event_loop()
+        dead_thread = threading.Thread(target=lambda: None)
+        dead_thread.start()
+        dead_thread.join(timeout=2)
+        assert not dead_thread.is_alive()
+
+        with mcp_mod._lock:
+            mcp_mod._servers.clear()
+            mcp_mod._server_connecting.clear()
+            mcp_mod._mcp_loop = loop
+            mcp_mod._mcp_thread = dead_thread
+
+        try:
+            assert mcp_mod._stop_mcp_loop() is True
+            assert loop.is_closed()
+        finally:
+            with mcp_mod._lock:
+                mcp_mod._mcp_loop = None
+                mcp_mod._mcp_thread = None
+            if not loop.is_closed():
+                loop.close()
+
 
 # ---------------------------------------------------------------------------
 # Fix 2: stdio PID tracking

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5645,7 +5645,7 @@ def _stop_mcp_loop(*, only_if_idle: bool = False) -> bool:
             and thread.is_alive()
         ):
             logger.warning("MCP event loop thread did not stop within 5 seconds")
-        elif thread is None and not loop.is_closed():
+        elif (thread is None or not thread.is_alive()) and not loop.is_closed():
             # Defensive fallback for partially initialized test/runtime state.
             try:
                 loop.run_until_complete(loop.shutdown_asyncgens())

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3564,6 +3564,28 @@ def _mcp_loop_exception_handler(loop, context):
     loop.default_exception_handler(context)
 
 
+def _run_mcp_loop(loop: asyncio.AbstractEventLoop) -> None:
+    """Own the MCP loop for its full lifecycle in the background thread.
+
+    Async generators must be finalized before the loop is closed. Closing the
+    loop from the caller thread immediately after ``run_forever`` stops leaves
+    transports such as httpx/httpcore's ``PoolByteStream`` pending and emits
+    ``RuntimeWarning: async generator ... was never awaited`` at process exit.
+    Keeping shutdown and close on the loop's owner thread also avoids a race
+    where the caller closes a loop whose thread has not quite exited yet.
+    """
+    asyncio.set_event_loop(loop)
+    try:
+        loop.run_forever()
+    finally:
+        try:
+            loop.run_until_complete(loop.shutdown_asyncgens())
+        except Exception:
+            logger.warning("Failed to finalize MCP async generators", exc_info=True)
+        finally:
+            loop.close()
+
+
 def _ensure_mcp_loop():
     """Start the background event loop thread if not already running."""
     global _mcp_loop, _mcp_thread
@@ -3573,7 +3595,8 @@ def _ensure_mcp_loop():
         _mcp_loop = asyncio.new_event_loop()
         _mcp_loop.set_exception_handler(_mcp_loop_exception_handler)
         _mcp_thread = threading.Thread(
-            target=_mcp_loop.run_forever,
+            target=_run_mcp_loop,
+            args=(_mcp_loop,),
             name="mcp-event-loop",
             daemon=True,
         )
@@ -5614,12 +5637,22 @@ def _stop_mcp_loop(*, only_if_idle: bool = False) -> bool:
         _mcp_thread = None
     if loop is not None:
         loop.call_soon_threadsafe(loop.stop)
-        if thread is not None:
+        if thread is not None and thread is not threading.current_thread():
             thread.join(timeout=5)
-        try:
-            loop.close()
-        except Exception:
-            pass
+        if (
+            thread is not None
+            and thread is not threading.current_thread()
+            and thread.is_alive()
+        ):
+            logger.warning("MCP event loop thread did not stop within 5 seconds")
+        elif thread is None and not loop.is_closed():
+            # Defensive fallback for partially initialized test/runtime state.
+            try:
+                loop.run_until_complete(loop.shutdown_asyncgens())
+            except Exception:
+                logger.warning("Failed to finalize MCP async generators", exc_info=True)
+            finally:
+                loop.close()
         # After closing the loop, any stdio subprocesses that survived the
         # graceful shutdown are now orphaned — include active PIDs too
         # since the loop is gone and no session can still be in flight.


### PR DESCRIPTION
## Summary

- keep the MCP event loop lifecycle on its owner thread
- run `shutdown_asyncgens()` before closing the loop
- avoid racing `loop.close()` from the caller thread
- retain a defensive path for partially initialized loop state

This prevents pending httpx/httpcore async generators from producing `RuntimeWarning: async generator ... was never awaited` during MCP shutdown.

## Verification

- `uv run --extra dev pytest -q tests/tools/test_mcp_stability.py`
- 25 passed

The regression test creates an async generator on the MCP loop and verifies its finalizer runs before the loop closes.