### PR TITLE
fix(skill-manager): guard shutil.rmtree/rmdir against OSError in _delete_skill

### DIFF
--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1112,12 +1112,18 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
             message += f" Content absorbed into '{absorbed_target}'."
         return {"success": True, "message": message, "_archived": True}
 
-    shutil.rmtree(skill_dir)
+    try:
+        shutil.rmtree(skill_dir)
+    except OSError as e:
+        return {"success": False, "error": f"failed to remove '{name}': {e}"}
 
     # Clean up empty category directories (don't remove the skills root itself)
     parent = skill_dir.parent
     if parent != skills_root and parent.exists() and not any(parent.iterdir()):
-        parent.rmdir()
+        try:
+            parent.rmdir()
+        except OSError:
+            pass
 
     message = f"Skill '{name}' deleted."
     if is_consolidation:


### PR DESCRIPTION
## Summary

Added OSError guards around `shutil.rmtree()` and `parent.rmdir()` in the `_delete_skill()` function.

## Problem

`tools/skill_manager_tool.py:1115` calls `shutil.rmtree(skill_dir)` and line 1120 calls `parent.rmdir()` without any error handling. If the skill directory contains read-only files, files held open by a security scanner, or has other permission issues, the call raises `PermissionError`/`OSError` and crashes the entire skill delete tool.

This mirrors the same class of bug already addressed in PRs #60630 (curator_backup), #60021 (skills_hub quarantine_bundle), and the existing pattern at the top of this file (`_validate_delete_target` defense-in-depth).

## Fix

- Wrapped `shutil.rmtree(skill_dir)` in a try/except that returns a clean error dict: `{"success": False, "error": "..."}`
- Wrapped `parent.rmdir()` in a try/except/pass (empty parent dir cleanup is best-effort)

## Testing
- Syntax check passed (py_compile)
- Behavior verified: error path now returns structured error instead of crashing