### PR TITLE
fix: replace assert with runtime guard in hermes_cli/mcp_catalog.py

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -374,7 +374,10 @@ def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
 def _do_git_install(entry: CatalogEntry) -> Path:
     """Clone the entry's repo into ``~/.hermes/mcp-installs/<name>`` and run
     bootstrap commands. Returns the install directory."""
-    assert entry.install is not None and entry.install.type == "git"
+    if entry.install is None or entry.install.type != "git":
+        raise RuntimeError(
+            f"_do_git_install called with install={entry.install!r} — expected git entry"
+        )
     install = entry.install
     dest = _install_root() / entry.name
 


### PR DESCRIPTION
## Summary

`assert` statement in `hermes_cli/mcp_catalog.py::_do_git_install()` is stripped when Python runs with `-O` (optimize flag), silently removing the invariant check. Replace with explicit `if/raise` guard so violations surface as `RuntimeError` instead of passing silently.

## Change

**`hermes_cli/mcp_catalog.py`** — `_do_git_install()`:

```python
# Before:
assert entry.install is not None and entry.install.type == "git"

# After:
if entry.install is None or entry.install.type != "git":
    raise RuntimeError(
        f"_do_git_install called with install={entry.install!r} — expected git entry"
    )
```

## Why separate PR

This file is covered by the MCP catalog security review gate (`mcp-catalog-reviewed` label). Submitting it as a standalone PR so it can be reviewed independently of other assert fixes.

## Precedent

Follows the pattern established in PRs #56736, #56866, #61983, #62001.

## Test Plan

- [ ] `python -m py_compile hermes_cli/mcp_catalog.py` passes
- [ ] Existing MCP catalog tests pass
