### PR TITLE
feat(gateway): make the working-state status text configurable

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -464,6 +464,15 @@ class PlatformConfig:
     # gateway/platforms/base.py.
     typing_indicator: bool = True
 
+    # Custom text for the working-state line on platforms whose typing
+    # indicator renders text rather than a native bubble: Slack's
+    # assistant.threads.setStatus line (shown next to the bot name; needs the
+    # assistant:write scope to render) and Google Chat's visible marker
+    # message. None keeps each platform's built-in default ("is thinking..." /
+    # "Hermes is thinking…"). Platforms with textless indicators (Discord,
+    # Telegram, Matrix, …) ignore it.
+    typing_status_text: Optional[str] = None
+
     # Per-channel model/provider/system_prompt overrides (channel_id -> ChannelOverride)
     channel_overrides: Dict[str, ChannelOverride] = field(default_factory=dict)
 
@@ -478,6 +487,8 @@ class PlatformConfig:
             "gateway_restart_notification": self.gateway_restart_notification,
             "typing_indicator": self.typing_indicator,
         }
+        if self.typing_status_text is not None:
+            result["typing_status_text"] = self.typing_status_text
         if self.token:
             result["token"] = self.token
         if self.api_key:
@@ -511,6 +522,12 @@ class PlatformConfig:
         if _typing is None:
             _typing = data.get("extra", {}).get("typing_indicator")
 
+        # typing_status_text takes the same two routes (top-level or bridged
+        # into extra); string passthrough, no coercion.
+        _typing_text = data.get("typing_status_text")
+        if _typing_text is None:
+            _typing_text = data.get("extra", {}).get("typing_status_text")
+
         channel_overrides: Dict[str, ChannelOverride] = {}
         raw_overrides = data.get("channel_overrides") or {}
         if isinstance(raw_overrides, dict):
@@ -526,6 +543,7 @@ class PlatformConfig:
             reply_to_mode=data.get("reply_to_mode", "first"),
             gateway_restart_notification=_coerce_bool(_grn, True),
             typing_indicator=_coerce_bool(_typing, True),
+            typing_status_text=_typing_text,
             channel_overrides=channel_overrides,
             extra=data.get("extra", {}),
         )
@@ -1223,6 +1241,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
                 if "typing_indicator" in platform_cfg:
                     bridged["typing_indicator"] = platform_cfg["typing_indicator"]
+                if "typing_status_text" in platform_cfg:
+                    bridged["typing_status_text"] = platform_cfg["typing_status_text"]
                 has_channel_overrides = "channel_overrides" in platform_cfg
                 if has_channel_overrides:
                     raw_overrides = platform_cfg.get("channel_overrides")

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -2296,7 +2296,10 @@ class GoogleChatAdapter(BasePlatformAdapter):
         thread_id = self._resolve_thread_id(
             reply_to=None, metadata=metadata, chat_id=chat_id,
         )
-        body: Dict[str, Any] = {"text": "Hermes is thinking…"}
+        body: Dict[str, Any] = {
+            "text": getattr(self.config, "typing_status_text", None)
+            or "Hermes is thinking…"
+        }
         if thread_id:
             body["thread"] = {"name": thread_id}
 

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1515,7 +1515,8 @@ class SlackAdapter(BasePlatformAdapter):
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Show a typing/status indicator using assistant.threads.setStatus.
 
-        Displays "is thinking..." next to the bot name in a thread.
+        Displays "is thinking..." next to the bot name in a thread, or the
+        platform's ``typing_status_text`` config value when set.
         Requires the assistant:write or chat:write scope.
         Auto-clears when the bot sends a reply to the thread.
         """
@@ -1534,7 +1535,8 @@ class SlackAdapter(BasePlatformAdapter):
             await self._get_client(chat_id).assistant_threads_setStatus(
                 channel_id=chat_id,
                 thread_ts=thread_ts,
-                status="is thinking...",
+                status=getattr(self.config, "typing_status_text", None)
+                or "is thinking...",
             )
         except Exception as e:
             # Silently ignore — may lack assistant:write scope or not be

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -427,6 +427,45 @@ class TestLoadGatewayConfig:
 
         assert config.quick_commands == {"limits": {"type": "exec", "command": "echo ok"}}
 
+    def test_typing_status_text_from_toplevel_platform_block(self, tmp_path, monkeypatch):
+        """A top-level ``slack:`` block reaches PlatformConfig via the
+        shared-key bridge (bridged into extra, then the from_dict extra
+        fallback) — the route a bare ``hermes config set``-style YAML uses."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            'slack:\n  typing_status_text: "is pouncing… 🐾"\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert (
+            config.platforms[Platform.SLACK].typing_status_text
+            == "is pouncing… 🐾"
+        )
+
+    def test_typing_status_text_from_nested_platforms_block(self, tmp_path, monkeypatch):
+        """``platforms.slack.typing_status_text`` reaches PlatformConfig via
+        _merge_platform_map + the from_dict top-level read."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  slack:\n"
+            "    enabled: true\n"
+            '    typing_status_text: "chasing yarn…"\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert (
+            config.platforms[Platform.SLACK].typing_status_text == "chasing yarn…"
+        )
+
     def test_multiplex_profiles_from_nested_gateway_section(self, tmp_path, monkeypatch):
         """``gateway.multiplex_profiles: true`` (the nested form written by
         ``hermes config set gateway.multiplex_profiles true``) must enable

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -92,6 +92,28 @@ class TestPlatformConfigRoundtrip:
         # extra; from_dict must honor it there too (mirrors _grn fallback).
         restored = PlatformConfig.from_dict({"extra": {"typing_indicator": False}})
         assert restored.typing_indicator is False
+
+    def test_typing_status_text_defaults_none(self):
+        assert PlatformConfig().typing_status_text is None
+        assert PlatformConfig.from_dict({}).typing_status_text is None
+
+    def test_typing_status_text_roundtrip(self):
+        pc = PlatformConfig(enabled=True, typing_status_text="is pouncing… 🐾")
+        restored = PlatformConfig.from_dict(pc.to_dict())
+        assert restored.typing_status_text == "is pouncing… 🐾"
+
+    def test_typing_status_text_resolved_from_extra(self):
+        # Same bridge route as typing_indicator: the shared-key loop copies a
+        # nested platforms.<plat> value into extra.
+        restored = PlatformConfig.from_dict(
+            {"extra": {"typing_status_text": "chasing yarn…"}}
+        )
+        assert restored.typing_status_text == "chasing yarn…"
+
+    def test_typing_status_text_omitted_from_to_dict_when_unset(self):
+        # None must not serialize — keeps existing config files byte-stable.
+        assert "typing_status_text" not in PlatformConfig().to_dict()
+
     def test_channel_overrides_roundtrip(self):
         pc = PlatformConfig(
             enabled=True,

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -1023,6 +1023,31 @@ class TestTypingLifecycle:
         assert adapter._typing_messages["spaces/S"] == "spaces/S/messages/THINK"
 
     @pytest.mark.asyncio
+    async def test_send_typing_uses_configured_status_text(self, adapter):
+        # typing_status_text replaces the default working-state marker text.
+        adapter.config.typing_status_text = "is pouncing… 🐾"
+        adapter._create_message = AsyncMock(
+            return_value=type("R", (), {"success": True,
+                                        "message_id": "spaces/S/messages/THINK",
+                                        "error": None})()
+        )
+        await adapter.send_typing("spaces/S")
+        body = adapter._create_message.await_args.args[1]
+        assert body["text"] == "is pouncing… 🐾"
+
+    @pytest.mark.asyncio
+    async def test_send_typing_default_status_text(self, adapter):
+        # Unset config keeps the built-in marker text.
+        adapter._create_message = AsyncMock(
+            return_value=type("R", (), {"success": True,
+                                        "message_id": "spaces/S/messages/THINK",
+                                        "error": None})()
+        )
+        await adapter.send_typing("spaces/S")
+        body = adapter._create_message.await_args.args[1]
+        assert body["text"] == "Hermes is thinking…"
+
+    @pytest.mark.asyncio
     async def test_send_typing_skips_when_already_tracking(self, adapter):
         adapter._typing_messages["spaces/S"] = "spaces/S/messages/EXIST"
         adapter._create_message = AsyncMock()

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2035,6 +2035,24 @@ class TestSendTyping:
         )
 
     @pytest.mark.asyncio
+    async def test_custom_typing_status_text(self):
+        # typing_status_text overrides the default status wording.
+        config = PlatformConfig(
+            enabled=True, token="xoxb-fake-token",
+            typing_status_text="is pouncing… 🐾",
+        )
+        a = SlackAdapter(config)
+        a._app = MagicMock()
+        a._app.client = AsyncMock()
+        a._app.client.assistant_threads_setStatus = AsyncMock()
+        await a.send_typing("C123", metadata={"thread_id": "parent_ts"})
+        a._app.client.assistant_threads_setStatus.assert_called_once_with(
+            channel_id="C123",
+            thread_ts="parent_ts",
+            status="is pouncing… 🐾",
+        )
+
+    @pytest.mark.asyncio
     async def test_noop_without_thread(self, adapter):
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
         await adapter.send_typing("C123")

--- a/website/docs/user-guide/messaging/google_chat.md
+++ b/website/docs/user-guide/messaging/google_chat.md
@@ -189,6 +189,23 @@ Send "hola" in the test DM. The bot posts a "Hermes is thinking…" marker, then
 edits that same message in place with the real response — no "message deleted"
 tombstones.
 
+### Customizing the working-state marker
+
+The marker text is configurable via `typing_status_text` in
+`~/.hermes/config.yaml` — e.g. a kitten assistant named Ada:
+
+```yaml
+platforms:
+  google_chat:
+    # Custom working-state marker text (default: "Hermes is thinking…").
+    typing_status_text: "is pouncing… 🐾"
+```
+
+Unlike Slack's ephemeral status line, this is a **real posted message** that
+gets edited in place with the response — so whatever you set here briefly
+appears in the chat as a normal message. Set `typing_indicator: false` to
+disable the marker entirely.
+
 ---
 
 ## Formatting and capabilities

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -93,6 +93,7 @@ These are the most commonly missed scopes.
 | Scope | Purpose |
 |-------|---------|
 | `groups:read` | List and get info about private channels |
+| `assistant:write` | Render the working-state status line ("is thinking…") next to the bot name while it processes a message. Without this scope the `assistant.threads.setStatus` call fails silently and Slack shows its own rotating generic placeholders instead ("Finding answers…", "Reviewing findings…", …) — Hermes never controls the text. Required for `typing_status_text` to have any visible effect. |
 
 ---
 
@@ -368,6 +369,32 @@ platforms:
 | `platforms.slack.extra.reply_broadcast` | `false` | When `true`, thread replies are also posted to the main channel. Only the first chunk is broadcast. |
 | `platforms.slack.extra.rich_blocks` | `false` | When `true`, agent messages are rendered as [Block Kit](https://docs.slack.dev/block-kit/) blocks (headers, dividers, true nested lists, and native tables). A plain-text fallback is always sent. Tables over Slack's limits fall back to aligned monospace. No app reinstall required — it's a send-side change only. |
 | `platforms.slack.extra.cron_continuable_surface` | `"thread"` | Delivery surface for [continuable cron jobs](../features/cron.md#flat-in-channel-continuation-slack). `"thread"` opens a dedicated thread per delivery (default); `"in_channel"` delivers flat into the channel timeline. Pair `in_channel` with `reply_in_thread: false` (and `require_mention: false`) so a plain channel reply continues the job. |
+
+### Working-State Status Line
+
+While the agent processes a message, Slack shows a status line next to the bot
+name in the thread. By default Hermes sets it to `is thinking...`; customize it
+with `typing_status_text` — e.g. a kitten assistant named Ada:
+
+```yaml
+platforms:
+  slack:
+    # Custom working-state status line (default: "is thinking...").
+    typing_status_text: "is pouncing… 🐾"
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `platforms.slack.typing_status_text` | `"is thinking..."` | Text of the working-state status line shown while the agent processes a message. Requires the `assistant:write` scope — without it the status call fails silently and Slack renders its own generic placeholder, whatever this is set to. Set `typing_indicator: false` to disable the status line entirely. |
+
+:::note Where the status renders
+The custom status appears in the **footer beneath the reply composer** ("*BotName* is thinking…"), not inline in the message list. The inline "Generating response…" / "Finding answers…" lines Slack shows in the message area while an AI app works are **Slack's own rotating indicators** — `assistant.threads.setStatus` does not control those, and both can appear at the same time.
+:::
+
+The same key customizes Google Chat's visible working-state marker message
+(`platforms.google_chat.typing_status_text`, default `"Hermes is thinking…"`) —
+note that on Google Chat it is a real posted message that gets patched into the
+reply, not an ephemeral status.
 
 ### Session Isolation
 


### PR DESCRIPTION
## What

Makes the working-state line — the text shown while the agent processes a
message — configurable via a new `PlatformConfig.typing_status_text` field, for
the two platforms that render text for it:

- **Slack**: the `assistant.threads.setStatus` status line, previously
  hardcoded to `"is thinking..."` (`plugins/platforms/slack/adapter.py`).
- **Google Chat**: the visible marker message, previously hardcoded to
  `"Hermes is thinking…"` (`plugins/platforms/google_chat/adapter.py`).

Default is `None` → both platforms keep their current built-in strings, and
`to_dict()` omits the field when unset, so existing configs and serialized
output are unchanged. Platforms with textless native typing indicators are
unaffected.

Also documents (Slack docs page) that the status line needs the
`assistant:write` scope — today that requirement is undocumented, the call
fails silently without it (`missing_scope` is swallowed by design), and Slack
falls back to its own generic placeholder, which makes the behaviour hard to
diagnose.

## Why

Operators giving their bot a persona have an on/off switch
(`typing_indicator`) but no way to change the wording. E.g. a kitten assistant
named Ada should be able to show:

```yaml
platforms:
  slack:
    typing_status_text: "is pouncing… 🐾"
```

The field follows the exact plumbing precedent of `typing_indicator`: typed
field on `PlatformConfig`, `from_dict` top-level + `extra` fallback, and the
shared-key bridge in `load_gateway_config()`, so it works top-level or nested
under `platforms.<platform>`.

## How to test

1. Set `platforms.slack.typing_status_text: "chasing yarn…"` in
   `~/.hermes/config.yaml`; ensure the Slack app has the `assistant:write`
   scope (reinstall after adding it).
2. Mention the bot inside a thread: the status line in the footer beneath the
   reply composer reads "*BotName* chasing yarn…" while it works, and clears
   on reply.
3. Remove the key: the footer line reads "is thinking..." (unchanged default).
4. Unit: `scripts/run_tests.sh tests/gateway/test_slack.py
   tests/gateway/test_google_chat.py tests/gateway/test_config.py`.

Note (documented in the docs change): the custom status renders in the
composer-footer slot. The "Generating response…" / "Finding answers…" lines
Slack shows inline in the message list while an AI app works are Slack's own
rotating indicators — `assistant.threads.setStatus` does not control those,
and both can appear simultaneously.

## Platforms tested

- **Slack**: unit tests for the config→adapter path, plus manual verification
  on a real workspace of the underlying behaviour via direct
  `assistant.threads.setStatus` calls with the same parameters the adapter
  sends: a custom status string (including emoji) renders in the
  composer-footer slot and clears; without the `assistant:write` scope the
  call fails and Slack shows only its own rotating placeholders — which is
  exactly the silent-failure mode the docs change documents.
- **Google Chat**: unit tests only (no Google Chat workspace available to me)
  — the change is the same one-line fallback pattern as Slack.

## Related (not fixed here)

#24117 / #32295 track the status line getting *stuck* after a reply. This PR
touches only the wording passed to `setStatus` in `send_typing`; the
set/clear lifecycle is unchanged, so it neither fixes nor worsens those.
