### PR TITLE
fix(auxiliary): discard stale credentials after auth refresh

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8007,9 +8007,13 @@ def call_llm(
                     resolved_provider=auth_refresh_provider,
                     resolved_model=resolved_model or final_model,
                     resolved_base_url=resolved_base_url,
-                    resolved_api_key=resolved_api_key,
+                    # Refresh succeeded, so any request-scoped key or main
+                    # runtime snapshot is stale by definition. Re-resolve the
+                    # credential from the refreshed auth store instead of
+                    # replaying the token that just received a 401.
+                    resolved_api_key=None,
                     resolved_api_mode=resolved_api_mode,
-                    main_runtime=main_runtime,
+                    main_runtime=None,
                     final_model=final_model,
                     messages=messages,
                     temperature=temperature,
@@ -8598,7 +8602,9 @@ async def async_call_llm(
                     resolved_provider=auth_refresh_provider,
                     resolved_model=resolved_model or final_model,
                     resolved_base_url=resolved_base_url,
-                    resolved_api_key=resolved_api_key,
+                    # Do not replay the credential that just failed. The
+                    # refresh helper has already updated the provider store.
+                    resolved_api_key=None,
                     resolved_api_mode=resolved_api_mode,
                     final_model=final_model,
                     messages=messages,

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4319,9 +4319,9 @@ class TestAuxiliaryAuthRefreshRetry:
         assert fresh_client.chat.completions.create.call_count == 1
 
     def test_call_llm_refreshes_codex_when_auto_routes_to_codex_on_401(self):
-        # Preflight compression's exact failure (#23670): provider auto →
-        # Codex OAuth backend 401s → before the fix, no refresh was attempted
-        # because resolved_provider stayed "auto".
+        # Follow-up to #23670: refresh can succeed but the same 401 recurs if
+        # the retry inherits either request-scoped credentials or the main
+        # agent's stale startup-time runtime snapshot.
         stale_client = MagicMock()
         stale_client.base_url = "https://chatgpt.com/backend-api/codex"
         stale_client.chat.completions.create.side_effect = _AuxAuth401("User not found.")
@@ -4331,7 +4331,10 @@ class TestAuxiliaryAuthRefreshRetry:
         fresh_client.chat.completions.create.return_value = _DummyResponse("fresh-auto-codex")
 
         with (
-            patch("agent.auxiliary_client._resolve_task_provider_model", return_value=("auto", None, None, None, None)),
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=("auto", None, None, "stale-resolved-token", None),
+            ),
             patch("agent.auxiliary_client._get_cached_client", side_effect=[(stale_client, "gpt-5.5"), (fresh_client, "gpt-5.5")]) as mock_get_client,
             patch("agent.auxiliary_client._refresh_provider_credentials", return_value=True) as mock_refresh,
             patch("agent.auxiliary_client._evict_cached_clients") as mock_evict,
@@ -4339,15 +4342,69 @@ class TestAuxiliaryAuthRefreshRetry:
             resp = call_llm(
                 task="compression",
                 messages=[{"role": "user", "content": "summarize"}],
-                main_runtime={"provider": "openai-codex", "model": "gpt-5.5"},
+                main_runtime={
+                    "provider": "openai-codex",
+                    "model": "gpt-5.5",
+                    "api_key": "stale-session-token",
+                },
             )
 
         assert resp.choices[0].message.content == "fresh-auto-codex"
         mock_refresh.assert_called_once_with("openai-codex")
         mock_evict.assert_called_once_with("auto")
         assert mock_get_client.call_args_list[1].args[0] == "openai-codex"
+        retry_kwargs = mock_get_client.call_args_list[1].kwargs
+        assert retry_kwargs["api_key"] is None
+        assert retry_kwargs["main_runtime"] is None
         assert stale_client.chat.completions.create.call_count == 1
         assert fresh_client.chat.completions.create.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_async_call_llm_refreshes_codex_when_auto_routes_to_codex_on_401(self):
+        stale_client = MagicMock()
+        stale_client.base_url = "https://chatgpt.com/backend-api/codex"
+        stale_client.chat.completions.create = AsyncMock(
+            side_effect=_AuxAuth401("User not found.")
+        )
+
+        fresh_client = MagicMock()
+        fresh_client.base_url = "https://chatgpt.com/backend-api/codex"
+        fresh_client.chat.completions.create = AsyncMock(
+            return_value=_DummyResponse("fresh-async-auto-codex")
+        )
+
+        with (
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=("auto", None, None, "stale-resolved-token", None),
+            ),
+            patch(
+                "agent.auxiliary_client._get_cached_client",
+                side_effect=[
+                    (stale_client, "gpt-5.5"),
+                    (fresh_client, "gpt-5.5"),
+                ],
+            ) as mock_get_client,
+            patch(
+                "agent.auxiliary_client._refresh_provider_credentials",
+                return_value=True,
+            ) as mock_refresh,
+            patch(
+                "agent.auxiliary_client._evict_cached_clients"
+            ) as mock_evict,
+        ):
+            resp = await async_call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+            )
+
+        assert resp.choices[0].message.content == "fresh-async-auto-codex"
+        mock_refresh.assert_called_once_with("openai-codex")
+        mock_evict.assert_called_once_with("auto")
+        assert mock_get_client.call_args_list[1].args[0] == "openai-codex"
+        assert mock_get_client.call_args_list[1].kwargs["api_key"] is None
+        assert stale_client.chat.completions.create.await_count == 1
+        assert fresh_client.chat.completions.create.await_count == 1
 
     def test_call_llm_refreshes_anthropic_on_401_for_non_vision(self):
         stale_client = MagicMock()
@@ -4506,8 +4563,17 @@ class TestAuxiliaryAuthRefreshRetry:
         fresh_client.chat.completions.create = AsyncMock(return_value=_DummyResponse("fresh-async-anthropic"))
 
         with (
-            patch("agent.auxiliary_client._resolve_task_provider_model", return_value=("anthropic", "claude-haiku-4-5-20251001", None, None, None)),
-            patch("agent.auxiliary_client._get_cached_client", side_effect=[(stale_client, "claude-haiku-4-5-20251001"), (fresh_client, "claude-haiku-4-5-20251001")]),
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=(
+                    "anthropic",
+                    "claude-haiku-4-5-20251001",
+                    None,
+                    "stale-resolved-token",
+                    None,
+                ),
+            ),
+            patch("agent.auxiliary_client._get_cached_client", side_effect=[(stale_client, "claude-haiku-4-5-20251001"), (fresh_client, "claude-haiku-4-5-20251001")]) as mock_get_client,
             patch("agent.auxiliary_client._refresh_provider_credentials", return_value=True) as mock_refresh,
         ):
             resp = await async_call_llm(
@@ -4519,6 +4585,7 @@ class TestAuxiliaryAuthRefreshRetry:
 
         assert resp.choices[0].message.content == "fresh-async-anthropic"
         mock_refresh.assert_called_once_with("anthropic")
+        assert mock_get_client.call_args_list[1].kwargs["api_key"] is None
         assert stale_client.chat.completions.create.await_count == 1
         assert fresh_client.chat.completions.create.await_count == 1
 


### PR DESCRIPTION
## What does this PR do?

Prevents auxiliary OAuth auth-recovery retries from replaying the credential that just received a 401.

`call_llm()` already refreshes an auto-routed OAuth provider and rebuilds its client. However, the sync retry still passed both `resolved_api_key` and `main_runtime` into `_get_cached_client()`. A long-lived main-agent runtime can retain its startup-time token after the main request path rotates credentials. The retry therefore rebuilt a "fresh" client with the stale token and received the same 401 again.

For context compression, that creates a damaging loop: compression starts, OAuth refresh succeeds, the retry reuses the rejected token, compression aborts/cools down, and the conversation continues growing toward the model limit.

After a successful provider credential refresh, the retry now resolves credentials from the refreshed auth store:

- synchronous retry drops both the request-scoped API key and stale main-runtime snapshot;
- asynchronous retry drops the request-scoped API key as well.

This is a narrow follow-up to the auto-route auth recovery added in #59837.

## Related Issue

Follow-up to #23670 and #59837.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/auxiliary_client.py`
  - discard stale credential inputs after a successful synchronous OAuth refresh;
  - mirror the request-key behavior in the asynchronous refresh path.
- `tests/agent/test_auxiliary_client.py`
  - extend the synchronous auto-routed Codex compression regression test with stale request and main-runtime tokens;
  - add asynchronous auto-routed Codex coverage for the stale request-token path;
  - verify the async Anthropic retry also drops its stale request token.

## How to Test

1. Run the focused auth-recovery tests:
   ```bash
   pytest -q tests/agent/test_auxiliary_client.py::TestAuxiliaryAuthRefreshRetry
   ```
2. Run the auxiliary-client coverage:
   ```bash
   pytest -q tests/agent/test_*auxiliary*.py tests/hermes_cli/test_plugin_auxiliary_tasks.py
   ```
3. Confirm the synchronous Codex test rebuilds the retry client with `api_key=None` and `main_runtime=None`, while the asynchronous Codex and Anthropic tests rebuild with `api_key=None`.

Validation on this branch:

- Current-main full auxiliary-client module: `370 passed`.
- `ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_client.py` passed.
- GitHub CI on the rebased branch is authoritative for the repository-wide result: all required checks passed, including all eight Python slices, e2e, desktop Playwright, amd64/arm64 Docker builds, and supply-chain checks.

Observed on current `main` before the fix: an auto-routed Codex compression call refreshed an expired OAuth credential, then immediately repeated the same 401 on every retry until the conversation exceeded its context window. The regression test fails before this patch because the second `_get_cached_client()` call receives the stale `main_runtime` token.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] Current GitHub CI passes the full required repository matrix; the focused auxiliary-client module also passes 370/370 locally
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1, Python 3.11.15, OpenAI SDK 2.24.0

### Documentation & Housekeeping

- [x] Documentation update: N/A — internal retry correction with regression coverage
- [x] `cli-config.yaml.example`: N/A — no config changes
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A — no architecture or workflow changes
- [x] Cross-platform impact considered: provider-resolution logic is platform-independent
- [x] Tool descriptions/schemas: N/A — no tool surface changes

## Screenshots / Logs

Not applicable. The behavior is covered by the sync and async credential-retry regression tests.