### PR TITLE
fix(desktop): keep active-session indicators across compression rotations

### DIFF
--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -27,6 +27,7 @@ import {
   toRuntimeMessage
 } from '@/lib/chat-runtime'
 import { useIncrementalExternalStoreRuntime } from '@/lib/incremental-external-store-runtime'
+import { sessionMatchesStoredId } from '@/lib/session-identity'
 import { cn } from '@/lib/utils'
 import type { ComposerAttachment } from '@/store/composer'
 import { $pinnedSessionIds } from '@/store/layout'
@@ -118,8 +119,7 @@ function ChatHeader({
   const sessions = useStore($sessions)
   const pinnedSessionIds = useStore($pinnedSessionIds)
 
-  const activeStoredSession =
-    sessions.find(session => session.id === selectedSessionId || session._lineage_root_id === selectedSessionId) || null
+  const activeStoredSession = sessions.find(session => sessionMatchesStoredId(session, selectedSessionId)) || null
 
   const title = activeStoredSession ? sessionTitle(activeStoredSession) : 'New session'
 

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -23,6 +23,7 @@ import { searchSessions, type SessionInfo, type SessionSearchResult } from '@/he
 import { useI18n } from '@/i18n'
 import { comboTokens } from '@/lib/keybinds/combo'
 import { profileColor } from '@/lib/profile-color'
+import { sessionIdentityIds } from '@/lib/session-identity'
 import { sessionMatchesSearch } from '@/lib/session-search'
 import { normalizeSessionSource, sessionSourceLabel } from '@/lib/session-source'
 import { cn } from '@/lib/utils'
@@ -341,8 +342,8 @@ export function ChatSidebar({
 
   const workingSessionIdSet = useMemo(() => new Set(workingSessionIds), [workingSessionIds])
 
-  // Index sessions by both their live id and their lineage-root id so a pin
-  // stored as the pre-compression root resolves to the live continuation tip.
+  // Index sessions by every compression-segment id so pins, search hits, and
+  // active turns resolve to the one projected live conversation row.
   const sessionByAnyId = useMemo(() => {
     const map = new Map<string, SessionInfo>()
 
@@ -350,10 +351,10 @@ export function ChatSidebar({
     // them too — otherwise a pinned cron job can't resolve into the Pinned
     // section. Recents take precedence on id collisions (set last).
     for (const s of [...cronSessions, ...visibleSessions]) {
-      map.set(s.id, s)
-
-      if (s._lineage_root_id && !map.has(s._lineage_root_id)) {
-        map.set(s._lineage_root_id, s)
+      for (const id of sessionIdentityIds(s)) {
+        if (id === s.id || !map.has(id)) {
+          map.set(id, s)
+        }
       }
     }
 

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -8,6 +8,7 @@ import { SidebarGroup, SidebarGroupContent } from '@/components/ui/sidebar'
 import type { HermesGitWorktree } from '@/global'
 import type { SessionInfo } from '@/hermes'
 import { flattenSessionsWithBranches } from '@/lib/session-branch-tree'
+import { sessionMatchesAnyId, sessionMatchesStoredId } from '@/lib/session-identity'
 import { cn } from '@/lib/utils'
 import { sessionPinId } from '@/store/session'
 
@@ -195,8 +196,8 @@ export function SidebarSessionsSection({
     const rowProps = {
       branchStem,
       isPinned: pinned,
-      isSelected: session.id === activeSessionId,
-      isWorking: workingSessionIdSet.has(session.id),
+      isSelected: sessionMatchesStoredId(session, activeSessionId),
+      isWorking: sessionMatchesAnyId(session, workingSessionIdSet),
       onArchive: () => onArchiveSession(session.id),
       onBranch: onBranchSession ? () => onBranchSession(session.id, session.profile) : undefined,
       onDelete: () => onDeleteSession(session.id),

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -5,6 +5,7 @@ import { type FC, useCallback, useRef } from 'react'
 
 import type { SessionInfo } from '@/hermes'
 import { type SidebarSessionEntry } from '@/lib/session-branch-tree'
+import { sessionMatchesAnyId, sessionMatchesStoredId } from '@/lib/session-identity'
 import { cn } from '@/lib/utils'
 import { sessionPinId } from '@/store/session'
 
@@ -83,8 +84,8 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
     const commonProps: SessionRowCommonProps = {
       branchStem,
       isPinned: pinned,
-      isSelected: session.id === activeSessionId,
-      isWorking: workingSessionIdSet.has(session.id),
+      isSelected: sessionMatchesStoredId(session, activeSessionId),
+      isWorking: sessionMatchesAnyId(session, workingSessionIdSet),
       onArchive: () => onArchiveSession(session.id),
       onBranch: onBranchSession ? () => onBranchSession(session.id, session.profile) : undefined,
       onDelete: () => onDeleteSession(session.id),

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -17,6 +17,7 @@ import { useSkinCommand } from '@/themes/use-skin-command'
 import { formatRefValue } from '../components/assistant-ui/directive-text'
 import { getSessionMessages, type SessionMessage, triggerCronJob } from '../hermes'
 import { type ChatMessage, chatMessageText, preserveLocalAssistantErrors, toChatMessages } from '../lib/chat-messages'
+import { sessionMatchesStoredId } from '../lib/session-identity'
 import { storedSessionIdForNotification } from '../lib/session-ids'
 import { isMessagingSource } from '../lib/session-source'
 import { latestSessionTodos } from '../lib/todos'
@@ -149,10 +150,6 @@ const CRON_POLL_INTERVAL_MS = 30_000
 // appears without requiring a manual refresh or route change.
 const MESSAGING_POLL_INTERVAL_MS = 10_000
 const ACTIVE_MESSAGING_SESSION_POLL_INTERVAL_MS = 5_000
-
-function sessionMatchesStoredId(session: { id: string; _lineage_root_id?: null | string }, id: string): boolean {
-  return session.id === id || session._lineage_root_id === id
-}
 
 function hashString(hash: number, value: string): number {
   let next = hash
@@ -419,7 +416,7 @@ export function DesktopController() {
     }
 
     // Pin on the durable lineage-root id so the pin survives auto-compression.
-    const session = $sessions.get().find(s => s.id === sessionId || s._lineage_root_id === sessionId)
+    const session = $sessions.get().find(s => sessionMatchesStoredId(s, sessionId))
     const pinId = session ? sessionPinId(session) : sessionId
 
     if ($pinnedSessionIds.get().includes(pinId)) {
@@ -500,9 +497,7 @@ export function DesktopController() {
         return
       }
 
-      const storedProfile = $sessions
-        .get()
-        .find(session => session.id === storedSessionId || session._lineage_root_id === storedSessionId)?.profile
+      const storedProfile = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))?.profile
 
       for (let index = 0; index < Math.max(1, attempts); index += 1) {
         try {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -11,6 +11,7 @@ import { playCompletionSound } from '@/lib/completion-sound'
 import { gatewayEventRequiresSessionId } from '@/lib/gateway-events'
 import { triggerHaptic } from '@/lib/haptics'
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
+import { sessionMatchesStoredId } from '@/lib/session-identity'
 import { clearClarifyRequest, setClarifyRequest } from '@/store/clarify'
 import { setSessionCompacting } from '@/store/compaction'
 import { refreshBackgroundProcesses } from '@/store/composer-status'
@@ -354,9 +355,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         const nextTitle = typeof payload?.title === 'string' ? payload.title.trim() : ''
 
         if (storedId && nextTitle) {
-          setSessions(prev =>
-            prev.map(s => (s.id === storedId || s._lineage_root_id === storedId ? { ...s, title: nextTitle } : s))
-          )
+          setSessions(prev => prev.map(s => (sessionMatchesStoredId(s, storedId) ? { ...s, title: nextTitle } : s)))
         }
       } else if (event.type === 'tool.start' || event.type === 'tool.progress' || event.type === 'tool.generating') {
         if (!sessionId) {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -2,6 +2,7 @@ import { getSession } from '@/hermes'
 import { type ChatMessage, chatMessageText } from '@/lib/chat-messages'
 import { normalizePersonalityValue } from '@/lib/chat-runtime'
 import { embeddedImageUrls, textWithoutEmbeddedImages } from '@/lib/embedded-images'
+import { sessionMatchesStoredId } from '@/lib/session-identity'
 import { requestDesktopOnboarding } from '@/store/onboarding'
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
 import {
@@ -182,9 +183,7 @@ export function patchSessionWorkspace(sessionId: string, cwd: string | undefined
   setSessions(prev => prev.map(session => (session.id === sessionId ? { ...session, cwd } : session)))
 }
 
-export function sessionMatchesStoredId(session: SessionInfo, storedSessionId: string): boolean {
-  return session.id === storedSessionId || session._lineage_root_id === storedSessionId
-}
+export { sessionMatchesStoredId } from '@/lib/session-identity'
 
 export function sessionShouldHaveTranscript(session: SessionInfo | undefined): boolean {
   return (session?.message_count ?? 0) > 0

--- a/apps/desktop/src/lib/session-identity.test.ts
+++ b/apps/desktop/src/lib/session-identity.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SessionInfo } from '@/types/hermes'
+
+import { sessionIdentityIds, sessionMatchesAnyId, sessionMatchesStoredId } from './session-identity'
+
+const session = (over: Partial<SessionInfo>): SessionInfo => over as SessionInfo
+
+describe('session identity across compression', () => {
+  const projected = session({
+    id: 'tip-3',
+    _lineage_root_id: 'root',
+    _lineage_ids: ['root', 'tip-1', 'tip-2', 'tip-3']
+  })
+
+  it('matches the live tip, root, and intermediate runtime ids', () => {
+    expect(sessionMatchesStoredId(projected, 'tip-3')).toBe(true)
+    expect(sessionMatchesStoredId(projected, 'root')).toBe(true)
+    expect(sessionMatchesStoredId(projected, 'tip-2')).toBe(true)
+    expect(sessionMatchesStoredId(projected, 'other')).toBe(false)
+  })
+
+  it('keeps backward-compatible tip/root matching without lineage aliases', () => {
+    const legacy = session({ id: 'tip', _lineage_root_id: 'root' })
+
+    expect(sessionMatchesStoredId(legacy, 'tip')).toBe(true)
+    expect(sessionMatchesStoredId(legacy, 'root')).toBe(true)
+    expect(sessionMatchesStoredId(legacy, 'mid')).toBe(false)
+  })
+
+  it('matches a working-id set through an intermediate segment', () => {
+    expect(sessionMatchesAnyId(projected, new Set(['tip-1']))).toBe(true)
+    expect(sessionMatchesAnyId(projected, new Set(['other']))).toBe(false)
+  })
+
+  it('returns unique aliases for lookup maps', () => {
+    expect(sessionIdentityIds(projected)).toEqual(['tip-3', 'root', 'tip-1', 'tip-2'])
+  })
+})

--- a/apps/desktop/src/lib/session-identity.ts
+++ b/apps/desktop/src/lib/session-identity.ts
@@ -1,0 +1,31 @@
+import type { SessionInfo } from '@/types/hermes'
+
+type SessionIdentity = Pick<SessionInfo, '_lineage_ids' | '_lineage_root_id' | 'id'>
+
+/** True when an id belongs to this logical conversation.
+ *
+ * Auto-compression rotates the live session id. A turn may therefore remain
+ * keyed by an intermediate segment while the sidebar already projects a newer
+ * tip. Matching the complete lineage keeps selection and working indicators
+ * attached to the one visible conversation row. */
+export function sessionMatchesStoredId(session: SessionIdentity, id: null | string | undefined): boolean {
+  if (!id) {
+    return false
+  }
+
+  return session.id === id || session._lineage_root_id === id || Boolean(session._lineage_ids?.includes(id))
+}
+
+export function sessionMatchesAnyId(session: SessionIdentity, ids: ReadonlySet<string>): boolean {
+  if (ids.has(session.id) || (session._lineage_root_id != null && ids.has(session._lineage_root_id))) {
+    return true
+  }
+
+  return Boolean(session._lineage_ids?.some(id => ids.has(id)))
+}
+
+export function sessionIdentityIds(session: SessionIdentity): string[] {
+  return [
+    ...new Set([session.id, session._lineage_root_id, ...(session._lineage_ids ?? [])].filter(Boolean) as string[])
+  ]
+}

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -7,6 +7,7 @@ import { desktopDefaultCwd, selectDesktopPaths, writeDesktopFileText } from '@/l
 import { desktopGit } from '@/lib/desktop-git'
 import { isMissingRpcMethod } from '@/lib/gateway-rpc'
 import { persistentAtom } from '@/lib/persisted'
+import { sessionMatchesStoredId } from '@/lib/session-identity'
 import { activeGateway, ensureActiveGatewayOpen } from '@/store/gateway'
 import { setSidebarAgentsGrouped } from '@/store/layout'
 import { notify } from '@/store/notifications'
@@ -585,7 +586,7 @@ function openSessionBelongsToProject(projectId: string, projects: ProjectInfo[])
     return false
   }
 
-  const open = $sessions.get().find(s => s.id === openId || s._lineage_root_id === openId)
+  const open = $sessions.get().find(s => sessionMatchesStoredId(s, openId))
 
   return Boolean(open && liveSessionProjectId(open, projects) === projectId)
 }

--- a/apps/desktop/src/store/session-switcher.ts
+++ b/apps/desktop/src/store/session-switcher.ts
@@ -1,5 +1,6 @@
 import { atom } from 'nanostores'
 
+import { sessionMatchesStoredId } from '@/lib/session-identity'
 import type { SessionInfo } from '@/types/hermes'
 
 import { $selectedStoredSessionId, $sessions } from './session'
@@ -74,7 +75,7 @@ export function openOrAdvanceSwitcher(direction: 1 | -1): string | null {
     return null
   }
 
-  const current = sessions.findIndex(session => session.id === $selectedStoredSessionId.get())
+  const current = sessions.findIndex(session => sessionMatchesStoredId(session, $selectedStoredSessionId.get()))
   const start = current === -1 ? (direction === 1 ? -1 : 0) : current
   const nextIndex = wrap(start + direction, sessions.length)
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -334,6 +334,8 @@ export interface SessionInfo {
    *  continuation tip. Stable across compressions — used as the durable id for
    *  pins so a pinned conversation survives auto-compression. */
   _lineage_root_id?: null | string
+  /** Every persisted segment in this projected compression conversation. */
+  _lineage_ids?: null | string[]
   input_tokens: number
   is_active: boolean
   last_active: number

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1644,7 +1644,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "output_tokens", "cache_read_tokens", "cache_write_tokens",
             "reasoning_tokens", "estimated_cost_usd", "actual_cost_usd",
             "api_call_count", "parent_session_id", "last_active", "preview",
-            "_lineage_root_id",
+            "_lineage_root_id", "_lineage_ids",
         )
         payload = {key: session.get(key) for key in safe_keys if key in session}
         # Avoid exposing full system prompts/model_config through the client API;

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3264,7 +3264,7 @@ class SessionDB:
                     projected.append(s)
                     continue
                 tip_id = self.get_compression_tip(s["id"])
-                if tip_id == s["id"]:
+                if not tip_id or tip_id == s["id"]:
                     projected.append(s)
                     continue
                 tip_row = self._get_session_rich_row(tip_id, compact_rows=compact_rows)
@@ -3282,6 +3282,20 @@ class SessionDB:
                     if key in tip_row:
                         merged[key] = tip_row[key]
                 merged["_lineage_root_id"] = s["id"]
+                # A live turn may still be keyed by any segment that was the
+                # tip when the turn started. Surface the complete compression
+                # chain so clients can reconcile that runtime id with this
+                # single projected conversation row after later rotations.
+                # `_session_lineage_root_to_tip` also includes a branch root's
+                # non-compression parent, so trim to this projected root.
+                lineage_ids = self._session_lineage_root_to_tip(tip_id)
+                try:
+                    lineage_ids = lineage_ids[lineage_ids.index(s["id"]):]
+                except ValueError:
+                    # Defensive fallback for an inconsistent parent chain. The
+                    # projected root and tip are still valid reconciliation ids.
+                    lineage_ids = list(dict.fromkeys((s["id"], tip_id)))
+                merged["_lineage_ids"] = lineage_ids
                 projected.append(merged)
             sessions = projected
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -51,6 +51,19 @@ class TestCheckRequirements:
         assert check_api_server_requirements() is False
 
 
+class TestSessionResponse:
+    def test_preserves_compression_lineage_aliases(self):
+        payload = APIServerAdapter._session_response({
+            "id": "tip",
+            "_lineage_root_id": "root",
+            "_lineage_ids": ["root", "mid", "tip"],
+            "system_prompt": "private",
+        })
+
+        assert payload["_lineage_ids"] == ["root", "mid", "tip"]
+        assert "system_prompt" not in payload
+
+
 # ---------------------------------------------------------------------------
 # _redact_api_error_text — guards every outward error site (envelopes, SSE
 # error events, cron-endpoint 500 bodies) that routes raw exception text to

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3861,9 +3861,33 @@ class TestCompressionChainProjection:
         # The row surfaces the tip's identity but preserves the root's start
         # timestamp for stable ordering and lineage tracking.
         assert tip_row["_lineage_root_id"] == "root1"
+        assert tip_row["_lineage_ids"] == ["root1", "mid1", "tip1"]
         assert tip_row["preview"].startswith("latest message")
         assert tip_row["ended_at"] is None  # tip is still live
         assert tip_row["end_reason"] is None
+
+    def test_projected_branch_lineage_excludes_non_compression_parent(self, db):
+        """Lineage aliases must not make a branch match its source session."""
+        db.create_session("parent", "cli")
+        db.end_session("parent", "branched")
+        db.create_session(
+            "branch-root",
+            "cli",
+            parent_session_id="parent",
+            model_config={"_branched_from": "parent"},
+        )
+        db.append_message("branch-root", "user", "explore an alternative")
+        db.end_session("branch-root", "compression")
+        db.create_session("branch-tip", "cli", parent_session_id="branch-root")
+        db.append_message("branch-tip", "user", "continue the branch")
+        db._conn.commit()
+
+        sessions = db.list_sessions_rich(source="cli", limit=20)
+        branch_row = next(s for s in sessions if s["id"] == "branch-tip")
+
+        assert branch_row["_lineage_root_id"] == "branch-root"
+        assert branch_row["_lineage_ids"] == ["branch-root", "branch-tip"]
+        assert "parent" not in branch_row["_lineage_ids"]
 
     def test_list_projection_uses_tip_cwd(self, db):
         """Projected lineage rows should carry cwd from the live tip row.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11032,6 +11032,7 @@ def _project_tree_row(r: dict) -> dict:
     return {
         "id": r.get("id"),
         "_lineage_root_id": r.get("_lineage_root_id"),
+        "_lineage_ids": r.get("_lineage_ids"),
         # The sidebar nests branch/fork sessions under their parent
         # (flattenSessionsWithBranches keys on this); without it, lane rows can't
         # draw the └─ connector the flat Recents list shows.


### PR DESCRIPTION
# PR title

`fix(desktop): keep active-session indicators across compression rotations`

## Summary

- keep Desktop sidebar selection and working outlines attached to the same logical conversation after repeated auto-compression
- expose the projected conversation's persisted compression-segment aliases as `_lineage_ids`
- centralize Desktop session-identity matching across sidebar rows, headers, pin/search lookup, session switching, and related session updates

## Problem

A long-running Desktop conversation can rotate through several persisted session IDs during auto-compression:

```text
root -> continuation #2 -> continuation #3 -> current tip
```

`SessionDB.list_sessions_rich()` correctly projects that chain to one visible row at the latest tip. Before this change, however, the projection exposed only the latest tip ID and `_lineage_root_id`. Desktop's selected/working state can still be keyed by an intermediate segment that was current when the turn started.

After a later rotation, neither of the existing comparisons matches:

```text
working/selected id = continuation #2
visible row id      = continuation #3
visible root id     = root
```

The turn is still live, but the sidebar loses its working outline and the chat header can fall back to `New session`.

A live Desktop example on this machine had rotated through eight persisted segments while its `slash_worker` remained active on the latest segment, confirming that this is a real long-running-session shape rather than a synthetic two-node edge case.

This is the same general lineage-reconciliation class as #43483, but affects active/selected identity rather than duplicate-row merging.

## Fix

1. `list_sessions_rich()` now adds `_lineage_ids` to projected compression rows, containing every persisted compression segment from that projected root through the latest tip.
2. The REST session response and Desktop project-tree payload preserve that field.
3. Desktop uses shared lineage-aware helpers to resolve exact tip IDs, durable root IDs, and intermediate compression IDs.
4. Sidebar selected/working states, header resolution, pin/search lookup, session switcher selection, workspace lookup, and session update paths use the same identity rule.
5. Branch roots trim non-compression parents from `_lineage_ids`, preventing a branch from matching its source conversation.

## Regression coverage

- backend projection returns `[root, intermediate, tip]`
- branch projection excludes its non-compression source parent
- API session response preserves `_lineage_ids` without exposing protected fields
- Desktop identity helpers match tip, root, and intermediate IDs and retain backward compatibility with payloads lacking `_lineage_ids`
- selected/working sidebar matching uses the centralized helper in both normal and virtualized lists

## Verification

```text
Desktop targeted Vitest: 47 passed
Desktop TypeScript: typecheck passed
SessionDB tests: 340 passed
API server tests: 194 passed
TUI targeted regression: 1 passed
```

A full TUI run was also attempted; 3 existing environment/source-label expectations failed because the suite expected `tui` while this Desktop worktree runs under `desktop`. A full Desktop Vitest run also contains pre-existing unrelated failures; targeted affected suites and typecheck pass.

## Related

- #43483 — duplicate sidebar rows after compression lineage rotation (fixed)
- #50192 — treat compressed lineages as one logical Desktop chat
- #51058 — broader Desktop/TUI session identity mix-up after compression/reconnect
