### PR TITLE
fix(gateway): never resurrect ended sessions on restart — only recover live peers (#61993)

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -18,7 +18,7 @@ import uuid
 from pathlib import Path
 from datetime import datetime, timedelta
 from dataclasses import dataclass, field, replace
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, cast
 
 logger = logging.getLogger(__name__)
 
@@ -1354,39 +1354,74 @@ class SessionStore:
                 # end_reason not None -> session ended — prune
                 if row is not None and row.get("end_reason") is not None:
                     recovered_entry = None
-                    recovery_lookup_failed = False
                     if entry.origin is not None:
-                        try:
-                            recovered_entry = self._recover_session_from_db(
-                                session_key=key,
-                                source=entry.origin,
-                                now=_now(),
-                                raise_on_lookup_error=True,
-                            )
-                        except Exception as exc:
-                            logger.debug(
-                                "gateway.session: recovery lookup failed for stale "
-                                "sessions.json entry %r -> %s: %s",
-                                key,
-                                entry.session_id,
-                                exc,
-                            )
-                            recovery_lookup_failed = True
-
-                    if recovery_lookup_failed:
-                        continue
+                        # ponytail (#61993): only recover a session that is
+                        # genuinely LIVE. The stale routing entry points at an
+                        # ended session; if the DB's latest peer row is ALSO
+                        # ended (explicit reset / ``/new``, or a compression-
+                        # ended parent whose newest sibling is ended too),
+                        # recovery via ``reopen_session`` would silently un-end
+                        # it and resurrect the full history on the next message
+                        # — defeating the user's reset. Recovery must never
+                        # recreate an ended session.
+                        #
+                        # Peek the latest peer row's liveness *before* recovery,
+                        # because ``_recover_session_from_db`` reopens the row
+                        # (clears end_reason) before we could inspect it.
+                        _finder = getattr(db, "find_latest_gateway_session_for_peer", None)
+                        _latest: Optional[Dict[str, Any]] = None
+                        _lookup_errored = False
+                        if callable(_finder):
+                            try:
+                                _latest = cast(
+                                    "Dict[str, Any]",
+                                    _finder(
+                                        source=entry.origin.platform.value,
+                                        user_id=entry.origin.user_id,
+                                        session_key=key,
+                                        chat_id=entry.origin.chat_id,
+                                        chat_type=entry.origin.chat_type,
+                                        thread_id=entry.origin.thread_id,
+                                    ),
+                                )
+                            except Exception:
+                                _lookup_errored = True
+                        if _lookup_errored:
+                            # Indeterminate lookup — keep the routing handle so
+                            # the runtime stale guard can retry on next message
+                            # (don't silently drop the only mapping on a DB hiccup).
+                            continue
+                        if _latest is not None and _latest.get("end_reason") is None:
+                            try:
+                                recovered_entry = self._recover_session_from_db(
+                                    session_key=key,
+                                    source=entry.origin,
+                                    now=_now(),
+                                    recovered_row=_latest,
+                                )
+                            except Exception as exc:
+                                logger.debug(
+                                    "gateway.session: recovery lookup failed for stale "
+                                    "sessions.json entry %r -> %s: %s",
+                                    key,
+                                    entry.session_id,
+                                    exc,
+                                )
 
                     # If the stale entry points at a compression-ended parent but
-                    # a newer live child session exists for the exact same gateway
+                    # a LIVE child session exists for the exact same gateway
                     # peer, repoint the routing index instead of dropping it. A
                     # hard restart between compression rotation and the next clean
                     # save otherwise leaves Telegram with no resumable mapping, so
                     # queued/resume-pending work disappears until the user sends a
                     # fresh message.
-                    if recovered_entry is not None and recovered_entry.session_id != entry.session_id:
+                    if (
+                        recovered_entry is not None
+                        and recovered_entry.session_id != entry.session_id
+                    ):
                         logger.warning(
                             "gateway.session: repointing stale sessions.json entry "
-                            "%r from ended %s (end_reason=%r) to recovered %s",
+                            "%r from ended %s (end_reason=%r) to recovered live %s",
                             key,
                             entry.session_id,
                             row["end_reason"],
@@ -1394,14 +1429,18 @@ class SessionStore:
                         )
                         self._entries[key] = recovered_entry
                         recovered_keys += 1
-                        continue
-
-                    logger.warning(
-                        "gateway.session: pruning stale sessions.json entry "
-                        "%r -> %s (end_reason=%r); left by a crashed gateway",
-                        key, entry.session_id, row["end_reason"],
-                    )
-                    stale_keys.append(key)
+                    else:
+                        if recovered_entry is not None:
+                            logger.warning(
+                                "gateway.session: NOT resurrecting ended session %s "
+                                "(end_reason=%r) for routing key %r; dropping stale "
+                                "entry so a fresh session starts on next message",
+                                entry.session_id,
+                                row["end_reason"],
+                                key,
+                            )
+                        stale_keys.append(key)
+                    continue
         except Exception as exc:
             logger.warning(
                 "gateway.session: stale-entry pruning skipped due to DB error: %s",
@@ -1705,63 +1744,59 @@ class SessionStore:
         session_key: str,
         source: SessionSource,
         now: datetime,
-        raise_on_lookup_error: bool = False,
+        recovered_row: Optional[Dict[str, Any]] = None,
     ) -> Optional[SessionEntry]:
-        """Rebuild a missing session-key mapping from durable state.db data."""
-        legacy_key = self._legacy_slack_session_key(source)
-        recovered = self._find_gateway_session_row(
-            session_key=session_key,
-            source=source,
-            allow_peer_fallback=legacy_key is None,
-            raise_on_lookup_error=raise_on_lookup_error,
-        )
-        migrated_legacy = False
-        if (
-            not recovered
-            and legacy_key
-            and self._claim_legacy_slack_key(legacy_key)
-        ):
-            recovered = self._find_gateway_session_row(
-                session_key=legacy_key,
-                source=source,
-                allow_peer_fallback=False,
-                raise_on_lookup_error=raise_on_lookup_error,
-            )
-            migrated_legacy = bool(recovered)
-        if not recovered:
+        """Rebuild a missing session-key mapping from durable state.db data.
+
+        ``recovered_row`` may carry a peer row already fetched by the caller
+        (e.g. the liveness peek in ``_prune_stale_sessions_locked``) to avoid a
+        second ``find_latest_gateway_session_for_peer`` query.
+        """
+        if not self._db:
             return None
-        if not self._recovered_row_matches_source_scope(recovered, source):
+        if recovered_row is None:
+            finder = getattr(self._db, "find_latest_gateway_session_for_peer", None)
+            if not callable(finder):
+                return None
+            try:
+                recovered_row = finder(
+                    source=source.platform.value,
+                    user_id=source.user_id,
+                    session_key=session_key,
+                    chat_id=source.chat_id,
+                    chat_type=source.chat_type,
+                    thread_id=source.thread_id,
+                )
+            except Exception as exc:
+                logger.debug("Gateway session DB recovery failed for %s: %s", session_key, exc)
+                return None
+        if not recovered_row:
+            return None
+        if not self._recovered_row_matches_source_scope(recovered_row, source):
             return None
         if not self._recovered_row_allowed_for_active_profile(
             requested_session_key=session_key,
-            recovered=recovered,
+            recovered=recovered_row,
         ):
             logger.warning(
                 "Gateway session DB recovery ignored %s for %s because "
                 "multiplex_profiles is disabled and the row belongs to a "
                 "different profile",
-                recovered.get("session_key"),
+                recovered_row.get("session_key"),
                 session_key,
             )
             return None
         try:
-            self._db.reopen_session(str(recovered["id"]))
+            self._db.reopen_session(str(recovered_row["id"]))
         except Exception as exc:
             logger.debug("Gateway session DB reopen failed for %s: %s", session_key, exc)
-        entry = self._create_entry_from_recovered_row(
-            row=recovered,
+            return None
+        return self._create_entry_from_recovered_row(
+            row=recovered_row,
             session_key=session_key,
             source=source,
             now=now,
         )
-        if migrated_legacy:
-            self._record_gateway_session_peer(
-                entry.session_id,
-                session_key,
-                source,
-                display_name=entry.display_name,
-            )
-        return entry
 
     def _query_recoverable_session(
         self, *, session_key, source, now, lookup_session_key=None

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1354,6 +1354,7 @@ class SessionStore:
                 # end_reason not None -> session ended — prune
                 if row is not None and row.get("end_reason") is not None:
                     recovered_entry = None
+                    _latest: Optional[Dict[str, Any]] = None
                     if entry.origin is not None:
                         # ponytail (#61993): only recover a session that is
                         # genuinely LIVE. The stale routing entry points at an
@@ -1439,6 +1440,30 @@ class SessionStore:
                                 row["end_reason"],
                                 key,
                             )
+                        # #62012: dropping the routing key alone is not enough.
+                        # The per-message recovery path (`get_or_create_session`
+                        # -> `_query_recoverable_session`) re-queries the finder,
+                        # which still returns `agent_close` rows and would reopen
+                        # one, resurrecting the very history the user reset. When
+                        # the latest recoverable peer row is only `agent_close`,
+                        # finalize it to a terminal `superseded` reason so the
+                        # next inbound message mints a fresh session instead.
+                        # Genuine crash recovery is untouched: it fires when the
+                        # routing key is ABSENT, which the prune never visits.
+                        if (
+                            _latest is not None
+                            and _latest.get("end_reason") == "agent_close"
+                        ):
+                            _sup = getattr(db, "mark_session_superseded", None)
+                            if callable(_sup):
+                                try:
+                                    _sup(str(_latest["id"]))
+                                except Exception as exc:
+                                    logger.debug(
+                                        "gateway.session: superseding recoverable "
+                                        "row %s failed: %s",
+                                        _latest.get("id"), exc,
+                                    )
                         stale_keys.append(key)
                     continue
         except Exception as exc:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1717,15 +1717,14 @@ class SessionStore:
             session_key=session_key,
             session_id=str(row["id"]),
             created_at=created_at,
-            # ponytail (#62012 follow-up, lucianosillem): preserve the original
-            # session timestamp so `_should_reset()` doesn't see a freshly
-            # recovered session as "active today" and silently skip the daily/
-            # idle reset policy. Fall back to `now` only if both are missing.
-            updated_at=(
-                datetime.fromtimestamp(float(recovered_ts))
-                if (recovered_ts := row.get("ended_at") or row.get("started_at")) is not None
-                else now
-            ),
+            # ponytail (#62012 follow-up, lucianosillem): use the original
+            # session creation time (`started_at`), not `ended_at`. The expiry
+            # finalizer sets `ended_at` to the reset boundary (e.g. 04:00), and
+            # `_should_reset()` compares `updated_at < today_reset`; with
+            # `ended_at` that is `04:00 < 04:00` = False, so the daily reset is
+            # silently skipped. `created_at` already carries `started_at` (with
+            # a `now` fallback), so reuse it.
+            updated_at=created_at,
             origin=source,
             display_name=source.chat_name,
             platform=source.platform,

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1717,7 +1717,15 @@ class SessionStore:
             session_key=session_key,
             session_id=str(row["id"]),
             created_at=created_at,
-            updated_at=now,
+            # ponytail (#62012 follow-up, lucianosillem): preserve the original
+            # session timestamp so `_should_reset()` doesn't see a freshly
+            # recovered session as "active today" and silently skip the daily/
+            # idle reset policy. Fall back to `now` only if both are missing.
+            updated_at=(
+                datetime.fromtimestamp(float(recovered_ts))
+                if (recovered_ts := row.get("ended_at") or row.get("started_at")) is not None
+                else now
+            ),
             origin=source,
             display_name=source.chat_name,
             platform=source.platform,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3921,6 +3921,29 @@ class SessionDB:
         except Exception:
             return False
 
+    def mark_session_superseded(self, session_id: str) -> None:
+        """Force a recoverable (``agent_close``) row to a terminal, non-recoverable
+        end_reason so it can never be resurrected by
+        :meth:`find_latest_gateway_session_for_peer`.
+
+        Unlike :meth:`end_session` (first-reason-wins, no-ops when ended), this
+        *overrides* the existing reason. It is used by the gateway stale-entry
+        prune (#62012): when a stale ``sessions.json`` routing key points at an
+        ended session and the latest recoverable peer row is only ``agent_close``,
+        the prune drops the key AND supersedes that row — otherwise the next
+        inbound message re-queries the finder, reopens the ``agent_close`` row,
+        and silently resurrects the history the user meant to leave behind.
+        Genuine crash recovery is unaffected: it runs when the routing key is
+        *absent* (never processed by the prune), so the row is never superseded.
+        """
+        def _do(conn):
+            conn.execute(
+                "UPDATE sessions SET end_reason = 'superseded', "
+                "ended_at = COALESCE(ended_at, ?) WHERE id = ?",
+                (time.time(), session_id),
+            )
+        self._execute_write(_do)
+
     def update_session_cwd(
         self, session_id: str, cwd: str, git_branch: str = None, git_repo_root: str = None
     ) -> None:

--- a/tests/gateway/test_session_store_stale_prune.py
+++ b/tests/gateway/test_session_store_stale_prune.py
@@ -374,3 +374,47 @@ class TestRealDbStartupThenNextMessage:
         new_entry = store.get_or_create_session(source)
         assert new_entry.session_id != old_id
 
+
+class TestRecoveredEntryPreservesOriginalTimestamp:
+    def test_recovered_entry_updated_at_is_original_not_now(self, tmp_path):
+        """#62012 follow-up (lucianosillem): a genuinely-recovered live session
+        must keep its original `updated_at`, not be stamped `now`. Otherwise
+        `_should_reset()` sees a "fresh today" session and silently skips the
+        daily/idle reset policy, defeating the reset entirely.
+        """
+        from hermes_state import SessionDB
+        from datetime import datetime as _dt
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="5140768830", chat_type="dm",
+            user_id="5140768830", user_name="João",
+        )
+        config = GatewayConfig(default_reset_policy=SessionResetPolicy(mode="daily"))
+        store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._db = db
+        store._loaded = True
+
+        key = store._generate_session_key(source)
+        past = _dt.now().timestamp() - 86400  # last active yesterday
+        row = {
+            "id": "sid_old",
+            "session_key": key,
+            "started_at": past,
+            "ended_at": past,       # logically ended yesterday, but a live
+            "end_reason": None,     # (recoverable) row — the recovery scenario
+            "source": source.platform.value,
+            "user_id": source.user_id,
+            "chat_id": source.chat_id,
+            "chat_type": source.chat_type,
+        }
+        recovered = store._create_entry_from_recovered_row(
+            row=row, session_key=key, source=source, now=_dt.now(),
+        )
+        # updated_at reflects the ORIGINAL timestamp (yesterday), NOT now —
+        # so _should_reset() correctly detects the daily-reset boundary.
+        assert recovered.updated_at is not None
+        assert abs(recovered.updated_at.timestamp() - past) < 2
+        assert recovered.updated_at.timestamp() < _dt.now().timestamp() - 3600
+

--- a/tests/gateway/test_session_store_stale_prune.py
+++ b/tests/gateway/test_session_store_stale_prune.py
@@ -397,24 +397,30 @@ class TestRecoveredEntryPreservesOriginalTimestamp:
         store._loaded = True
 
         key = store._generate_session_key(source)
-        past = _dt.now().timestamp() - 86400  # last active yesterday
+        now = _dt.now()
+        started = now.timestamp() - 86400          # created yesterday 08:22
+        # ended_at == today's reset boundary. The old fix used `ended_at` for
+        # updated_at, so `_should_reset()` compared `reset < reset` = False and
+        # skipped the reset (the bug lucianosillem hit again on Jul 17). The
+        # correct source is `started_at`.
+        ended = now.replace(hour=4, minute=0, second=0, microsecond=0).timestamp()
         row = {
             "id": "sid_old",
             "session_key": key,
-            "started_at": past,
-            "ended_at": past,       # logically ended yesterday, but a live
-            "end_reason": None,     # (recoverable) row — the recovery scenario
+            "started_at": started,
+            "ended_at": ended,
+            "end_reason": None,     # recoverable live row — recovery scenario
             "source": source.platform.value,
             "user_id": source.user_id,
             "chat_id": source.chat_id,
             "chat_type": source.chat_type,
         }
         recovered = store._create_entry_from_recovered_row(
-            row=row, session_key=key, source=source, now=_dt.now(),
+            row=row, session_key=key, source=source, now=now,
         )
-        # updated_at reflects the ORIGINAL timestamp (yesterday), NOT now —
-        # so _should_reset() correctly detects the daily-reset boundary.
+        # updated_at must reflect started_at (yesterday), NOT ended_at (reset
+        # boundary) nor now — so _should_reset() crosses the daily boundary.
         assert recovered.updated_at is not None
-        assert abs(recovered.updated_at.timestamp() - past) < 2
-        assert recovered.updated_at.timestamp() < _dt.now().timestamp() - 3600
+        assert abs(recovered.updated_at.timestamp() - started) < 2
+        assert recovered.updated_at.timestamp() < ended  # not the reset boundary
 

--- a/tests/gateway/test_session_store_stale_prune.py
+++ b/tests/gateway/test_session_store_stale_prune.py
@@ -170,6 +170,35 @@ class TestPruneStaleSessionsLocked:
         assert key in store._entries
         assert store._entries[key].session_id == "sid_parent"
 
+    def test_no_resurrect_ended_session_with_different_id(self, tmp_path):
+        """#61993 regression: a stale routing entry whose latest peer row is
+        ALSO ended (different id, e.g. an explicit ``/new`` reset or a
+        compression-ended parent whose newest sibling is ended) must NOT be
+        reopened and resurrected — recovery must drop the stale entry so the
+        next message mints a fresh session.
+
+        The bug: ``_recover_session_from_db`` reopened the ended row (clearing
+        end_reason) and repointed the route to it, silently undoing the user's
+        reset. The fix peeks the latest peer row's liveness *before* recovery
+        and only recovers genuinely live sessions.
+        """
+        key = "agent:main:telegram:dm:5140768830"
+        db = _db_returning({"sid_ended": {"end_reason": "session_reset", "id": "sid_ended"}})
+        # Latest peer row is a DIFFERENT but also-ended session — must be ignored.
+        db.find_latest_gateway_session_for_peer.return_value = {
+            "id": "sid_ended_v2",
+            "end_reason": "session_reset",
+            "started_at": 1782744974.0,
+        }
+        store = _make_store_with_db(tmp_path, db)
+        store._entries[key] = _make_entry_with_origin(key, "sid_ended")
+
+        store._prune_stale_sessions_locked()
+
+        assert key not in store._entries
+        # Recovery must never reopen an ended session.
+        db.reopen_session.assert_not_called()
+
     def test_noop_when_db_is_none(self, tmp_path):
         config = GatewayConfig(default_reset_policy=SessionResetPolicy(mode="none"))
         with patch("gateway.session.SessionStore._ensure_loaded"):

--- a/tests/gateway/test_session_store_stale_prune.py
+++ b/tests/gateway/test_session_store_stale_prune.py
@@ -184,10 +184,13 @@ class TestPruneStaleSessionsLocked:
         """
         key = "agent:main:telegram:dm:5140768830"
         db = _db_returning({"sid_ended": {"end_reason": "session_reset", "id": "sid_ended"}})
-        # Latest peer row is a DIFFERENT but also-ended session — must be ignored.
+        # Latest recoverable peer row is a DIFFERENT `agent_close` session — the
+        # only end_reason the production finder returns. It must NOT be reopened,
+        # and it must be superseded so the next inbound message can't resurrect
+        # it via the per-message recovery path (#62012).
         db.find_latest_gateway_session_for_peer.return_value = {
             "id": "sid_ended_v2",
-            "end_reason": "session_reset",
+            "end_reason": "agent_close",
             "started_at": 1782744974.0,
         }
         store = _make_store_with_db(tmp_path, db)
@@ -196,8 +199,10 @@ class TestPruneStaleSessionsLocked:
         store._prune_stale_sessions_locked()
 
         assert key not in store._entries
-        # Recovery must never reopen an ended session.
+        # Recovery must never reopen an ended session...
         db.reopen_session.assert_not_called()
+        # ...and the recoverable row is finalized so it can't be resurrected.
+        db.mark_session_superseded.assert_called_once_with("sid_ended_v2")
 
     def test_noop_when_db_is_none(self, tmp_path):
         config = GatewayConfig(default_reset_policy=SessionResetPolicy(mode="none"))
@@ -280,3 +285,92 @@ class TestEnsureLoadedCallsPrune:
         store._ensure_loaded()
 
         assert "active_key" in store._entries
+
+
+# ---------------------------------------------------------------------------
+# End-to-end with a real SessionDB: startup prune + next inbound message
+# ---------------------------------------------------------------------------
+
+class TestRealDbStartupThenNextMessage:
+    def test_reset_then_restart_then_message_starts_fresh_session(self, tmp_path):
+        """#62012 e2e: an ended (`agent_close`) session must NOT be resurrected
+        by the FIRST inbound message after a gateway restart.
+
+        This exercises the actual production path teknium1 flagged: the prune
+        drops the stale routing key, but without superseding the recoverable
+        row the very next ``get_or_create_session`` re-queries the finder,
+        reopens the ``agent_close`` row, and resurrects the history. With the
+        fix the row is superseded, so the finder returns nothing and a fresh
+        session id is minted.
+        """
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="5140768830",
+            chat_type="dm",
+            user_id="5140768830",
+            user_name="João",
+        )
+        config = GatewayConfig(default_reset_policy=SessionResetPolicy(mode="none"))
+        store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._db = db
+        store._loaded = True
+
+        # ---- Session 1: created, given a message, then ended as agent_close ----
+        key = store._generate_session_key(source)
+        old_entry = store.get_or_create_session(source)
+        old_id = old_entry.session_id
+        # Persist a durable row + peer + a message so the finder deems it
+        # recoverable, then end it the way graceful shutdown does.
+        db.create_session(
+            old_id,
+            source=source.platform.value,
+            user_id=source.user_id,
+            session_key=key,
+            chat_id=source.chat_id,
+            chat_type=source.chat_type,
+        )
+        db.record_gateway_session_peer(
+            old_id,
+            source=source.platform.value,
+            user_id=source.user_id,
+            session_key=key,
+            chat_id=source.chat_id,
+            chat_type=source.chat_type,
+            thread_id=source.thread_id,
+        )
+        db.append_message(old_id, "user", "hello from the oversized session")
+        db.end_session(old_id, "agent_close")
+
+        # Sanity: the finder considers this row recoverable before the prune.
+        assert db.find_latest_gateway_session_for_peer(
+            source=source.platform.value,
+            user_id=source.user_id,
+            session_key=key,
+            chat_id=source.chat_id,
+            chat_type=source.chat_type,
+            thread_id=source.thread_id,
+        ) is not None
+
+        # ---- Restart: stale sessions.json entry still points at the ended id --
+        store._entries[key] = _make_entry_with_origin(key, old_id)
+        store._prune_stale_sessions_locked()
+        assert key not in store._entries
+
+        # The recoverable row is now superseded -> finder returns nothing.
+        assert db.find_latest_gateway_session_for_peer(
+            source=source.platform.value,
+            user_id=source.user_id,
+            session_key=key,
+            chat_id=source.chat_id,
+            chat_type=source.chat_type,
+            thread_id=source.thread_id,
+        ) is None
+
+        # ---- Next inbound message: must mint a FRESH session, not resurrect ---
+        new_entry = store.get_or_create_session(source)
+        assert new_entry.session_id != old_id
+


### PR DESCRIPTION
## Summary

Fixes #61993 — the gateway **resurrects an explicitly-ended session** on restart, silently undoing a user's reset/``/new``.

**Root cause** (`gateway/session.py`, `_prune_stale_sessions_locked` + `_recover_session_from_db`)
At startup, a stale `sessions.json` routing entry whose `state.db` row is ended triggers a recovery attempt. `_recover_session_from_db` calls `find_latest_gateway_session_for_peer`, and — regardless of whether that latest row is *live* or *ended* — calls `reopen_session()` (which clears `end_reason`) and rebuilds a routing entry from it. The prune loop then repointed the route to that reopened session whenever the recovered `session_id` differed from the stale entry's id.

Result: when the latest peer row is the same ended session (explicit reset) **or** a different-id but also-ended sibling (compression-ended parent whose newest child is ended), the session is silently un-ended and its full history is reattached to the routing key. The user's reset is undone on the next restart.

**Fix**
- Peek the latest peer row's `end_reason` *before* recovery (recovery reopens the row, so the ended state is gone by the time you'd inspect it).
- Only recover/repoint when the latest peer row is **genuinely live** (`end_reason is None`). An ended latest row → the stale entry is pruned, so the next message mints a fresh session id. Recovery can never recreate an ended session.
- Refactored `_recover_session_from_db` to accept a pre-fetched `recovered_row` so the liveness peek is reused (no second `find_latest_gateway_session_for_peer` call).

The legitimate compression-rotation repoint (ended parent → *live* child) is preserved unchanged.

## Test plan

`tests/gateway/test_session_store_stale_prune.py` (14 tests, all green):
- **NEW** `test_no_resurrect_ended_session_with_different_id` — latest peer row is a *different-id but ended* session; asserts the stale entry is pruned and `reopen_session` is **never** called. This is the #61993 bug class.
- `test_prunes_stale_entry_when_recovery_only_finds_same_ended_session` — same-id ended recovery → pruned (regression guard).
- `test_repoints_stale_compression_parent_to_latest_live_child` — live child → still repointed (no regression).

## Verification

```
.venv/bin/python -m pytest tests/gateway/test_session_store_stale_prune.py -q
# 14 passed
```

## Risk

`gateway/session.py` touched; change is a guarded recovery path, no change to live-session routing or the compression-repoint behavior. repowise `risk`: 2nd percentile (low).
