### PR TITLE
fix(telegram): send video metadata and thumbnail

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -10,6 +10,7 @@ Uses python-telegram-bot library for:
 import asyncio
 import dataclasses
 import inspect
+import io
 import json
 import logging
 import os
@@ -6175,6 +6176,83 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             return await super().send_document(chat_id, file_path, caption, file_name, reply_to, metadata=metadata)
 
+    @staticmethod
+    async def _probe_video_metadata(path: str) -> Optional[Dict[str, Any]]:
+        """Extract width, height, and duration from a local video via ffprobe.
+
+        Returns a dict with ``width``, ``height``, and ``duration`` (seconds, int)
+        keys, or ``None`` when ffprobe is missing / fails / finds no video stream.
+        """
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "ffprobe",
+                "-v", "error",
+                "-select_streams", "v:0",
+                "-show_entries", "stream=width,height,duration",
+                "-show_entries", "format=duration",
+                "-of", "json",
+                path,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5.0)
+            if proc.returncode != 0 or not stdout:
+                return None
+            data = json.loads(stdout.decode())
+            result: Dict[str, Any] = {}
+            streams = data.get("streams") or []
+            if streams:
+                s = streams[0]
+                if s.get("width"):
+                    result["width"] = int(s["width"])
+                if s.get("height"):
+                    result["height"] = int(s["height"])
+                # Prefer per-stream duration, fall back to format-level
+                dur = s.get("duration") or (data.get("format") or {}).get("duration")
+                if dur:
+                    result["duration"] = int(float(dur))
+            return result or None
+        except Exception:
+            return None
+
+    @staticmethod
+    async def _generate_video_thumbnail(path: str) -> Optional[io.BytesIO]:
+        """Extract a single JPEG frame from a video for use as a thumbnail.
+
+        Enforces Telegram thumbnail limits: JPEG format, max 320px per side,
+        under 200 kB.  Returns ``None`` when ffmpeg is unavailable, the
+        source cannot be decoded, or the generated frame exceeds any limit
+        — the upload proceeds without a thumbnail.
+        """
+        _THUMBNAIL_MAX_BYTES = 200 * 1024
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "ffmpeg",
+                "-y",
+                "-i", path,
+                "-vframes", "1",
+                "-ss", "0.5",
+                "-vf", "scale='min(320,iw)':'min(320,ih)':force_original_aspect_ratio=decrease",
+                "-f", "image2pipe",
+                "-vcodec", "mjpeg",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10.0)
+            if proc.returncode != 0 or not stdout:
+                return None
+            if len(stdout) > _THUMBNAIL_MAX_BYTES:
+                logger.debug(
+                    "Generated video thumbnail %d bytes exceeds %d kB limit — omitting",
+                    len(stdout), _THUMBNAIL_MAX_BYTES // 1024,
+                )
+                return None
+            buf = io.BytesIO(stdout)
+            buf.seek(0)
+            return buf
+        except Exception:
+            return None
+
     async def send_video(
         self,
         chat_id: str,
@@ -6184,7 +6262,14 @@ class TelegramAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
-        """Send a video natively as a Telegram video message."""
+        """Send a video natively as a Telegram video message.
+
+        For local MP4 files, extracts width/height/duration via ``ffprobe``
+        and generates a JPEG thumbnail via ``ffmpeg`` so Telegram can render
+        a correct aspect-ratio preview without server-side probing.  When
+        either tool is unavailable or fails, the video is sent without
+        metadata — the upload always succeeds.
+        """
         if not self._bot:
             return SendResult(success=False, error="Not connected")
 
@@ -6201,21 +6286,41 @@ class TelegramAdapter(BasePlatformAdapter):
                 reply_to_message_id=reply_to_id,
                 reply_to_mode=self._reply_to_mode
             )
+
+            video_meta = await self._probe_video_metadata(video_path)
+            thumb_buffer = await self._generate_video_thumbnail(video_path)
+
             with open(video_path, "rb") as f:
+                send_kwargs: Dict[str, Any] = {
+                    "chat_id": normalize_telegram_chat_id(chat_id),
+                    "video": f,
+                    "caption": caption[:1024] if caption else None,
+                    "reply_to_message_id": reply_to_id,
+                    **thread_kwargs,
+                    **self._notification_kwargs(metadata),
+                }
+                if video_meta:
+                    if "width" in video_meta:
+                        send_kwargs["width"] = video_meta["width"]
+                    if "height" in video_meta:
+                        send_kwargs["height"] = video_meta["height"]
+                    if "duration" in video_meta:
+                        send_kwargs["duration"] = video_meta["duration"]
+                if thumb_buffer is not None:
+                    send_kwargs["thumbnail"] = thumb_buffer
+
+                def _reset_media():
+                    f.seek(0)
+                    if thumb_buffer is not None:
+                        thumb_buffer.seek(0)
+
                 msg = await self._send_with_dm_topic_reply_anchor_retry(
                     self._bot.send_video,
-                    {
-                        "chat_id": normalize_telegram_chat_id(chat_id),
-                        "video": f,
-                        "caption": caption[:1024] if caption else None,
-                        "reply_to_message_id": reply_to_id,
-                        **thread_kwargs,
-                        **self._notification_kwargs(metadata),
-                    },
+                    send_kwargs,
                     metadata,
                     reply_to_id,
                     "video",
-                    reset_media=lambda: f.seek(0),
+                    reset_media=_reset_media,
                 )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -9,6 +9,7 @@ We mock the telegram module at import time to avoid collection errors.
 """
 
 import asyncio
+import io
 import os
 import sys
 from types import SimpleNamespace
@@ -969,3 +970,106 @@ class TestSendVideo:
 
         call_kwargs = connected_adapter._bot.send_video.call_args[1]
         assert call_kwargs["message_thread_id"] == 789
+
+
+class TestSendVideoMetadata:
+    """Tests for video aspect-ratio preview: width, height, and thumbnail."""
+
+    @pytest.fixture()
+    def connected_adapter(self, adapter):
+        bot = AsyncMock()
+        adapter._bot = bot
+        return adapter
+
+    @pytest.mark.asyncio
+    async def test_send_video_passes_dimensions_and_thumbnail(self, connected_adapter, tmp_path):
+        """Width, height, and JPEG thumbnail are forwarded for a 720x1280 video."""
+        test_file = tmp_path / "portrait.mp4"
+        test_file.write_bytes(b"\x00" * 200)
+
+        mock_msg = MagicMock()
+        mock_msg.message_id = 300
+        connected_adapter._bot.send_video = AsyncMock(return_value=mock_msg)
+
+        fake_jpeg = b"\xff\xd8\xff\xe0" + b"\x00" * 200  # JPEG SOI marker + padding
+
+        async def _fake_probe(path):
+            return {"width": 720, "height": 1280, "duration": 12}
+
+        async def _fake_thumb(path):
+            return io.BytesIO(fake_jpeg)
+
+        with patch.object(
+            TelegramAdapter, "_probe_video_metadata", staticmethod(_fake_probe)
+        ), patch.object(
+            TelegramAdapter, "_generate_video_thumbnail", staticmethod(_fake_thumb)
+        ):
+            result = await connected_adapter.send_video(
+                chat_id="12345",
+                video_path=str(test_file),
+                caption="Portrait clip",
+            )
+
+        assert result.success is True
+        assert result.message_id == "300"
+
+        call_kwargs = connected_adapter._bot.send_video.call_args[1]
+        assert call_kwargs["width"] == 720
+        assert call_kwargs["height"] == 1280
+        assert call_kwargs["duration"] == 12
+
+        thumb = call_kwargs["thumbnail"]
+        assert isinstance(thumb, io.BytesIO)
+        thumb.seek(0)
+        assert thumb.read(2) == b"\xff\xd8"  # JPEG SOI marker
+
+    @pytest.mark.asyncio
+    async def test_send_video_probe_failure_still_sends(self, connected_adapter, tmp_path):
+        """Video is sent without metadata when ffprobe/ffmpeg both fail."""
+        test_file = tmp_path / "clip.mp4"
+        test_file.write_bytes(b"\x00" * 200)
+
+        mock_msg = MagicMock()
+        mock_msg.message_id = 301
+        connected_adapter._bot.send_video = AsyncMock(return_value=mock_msg)
+
+        async def _fail_probe(path):
+            return None
+
+        async def _fail_thumb(path):
+            return None
+
+        with patch.object(
+            TelegramAdapter, "_probe_video_metadata", staticmethod(_fail_probe)
+        ), patch.object(
+            TelegramAdapter, "_generate_video_thumbnail", staticmethod(_fail_thumb)
+        ):
+            result = await connected_adapter.send_video(
+                chat_id="12345",
+                video_path=str(test_file),
+            )
+
+        assert result.success is True
+        assert result.message_id == "301"
+
+        call_kwargs = connected_adapter._bot.send_video.call_args[1]
+        assert "width" not in call_kwargs
+        assert "height" not in call_kwargs
+        assert "thumbnail" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_thumbnail_oversized_returns_none(self, adapter):
+        """_generate_video_thumbnail returns None when output exceeds 200 kB."""
+        oversized_jpeg = b"\xff\xd8\xff\xe0" + b"\x00" * (200 * 1024 + 1)
+
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate = AsyncMock(return_value=(oversized_jpeg, b""))
+
+        with (
+            patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=mock_proc)),
+            patch("asyncio.wait_for", new=lambda coro, timeout: coro),
+        ):
+            result = await TelegramAdapter._generate_video_thumbnail("/fake/path.mp4")
+
+        assert result is None, "Thumbnail >200 kB should return None"


### PR DESCRIPTION
## Summary
- pass explicit video width, height, and duration to Telegram
- generate a bounded JPEG thumbnail for reliable portrait previews
- gracefully fall back when ffprobe or ffmpeg is unavailable

## Validation
- scripts/run_tests.sh tests/gateway/test_telegram_documents.py -v --tb=short: 47 passed
- ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_documents.py: passed