### PR TITLE
fix(desktop,tui): preserve link labels over fetched titles

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.links.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.links.test.tsx
@@ -1,0 +1,66 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { __resetLinkTitleCache } from '@/lib/external-link'
+
+import { MarkdownTextContent } from './markdown-text'
+
+const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
+const initialHermesDesktop = desktopWindow.hermesDesktop
+
+afterEach(() => {
+  __resetLinkTitleCache()
+  cleanup()
+
+  if (initialHermesDesktop) {
+    desktopWindow.hermesDesktop = initialHermesDesktop
+  } else {
+    delete desktopWindow.hermesDesktop
+  }
+})
+
+describe('MarkdownTextContent links', () => {
+  it('preserves an explicit markdown URL label after it normalizes to the target', async () => {
+    const label = 'forgejo.example.com/issues/101'
+    const target = `https://${label}`
+    const fetchLinkTitle = vi.fn().mockResolvedValue('Fetched Forgejo title')
+
+    desktopWindow.hermesDesktop = { fetchLinkTitle } as unknown as Window['hermesDesktop']
+
+    render(<MarkdownTextContent isRunning={false} text={`[${label}](${target})`} />)
+
+    const link = screen.getByTitle(target)
+    await waitFor(() => {
+      expect(link.textContent).toContain(label)
+    })
+    expect(fetchLinkTitle).not.toHaveBeenCalled()
+  })
+
+  it('does not turn an explicit markdown URL label into an embed', async () => {
+    const label = 'www.youtube.com/watch?v=dQw4w9WgXcQ'
+    const target = `https://${label}`
+    const fetchLinkTitle = vi.fn().mockResolvedValue('Fetched YouTube title')
+
+    desktopWindow.hermesDesktop = { fetchLinkTitle } as unknown as Window['hermesDesktop']
+
+    render(<MarkdownTextContent isRunning={false} text={`[${label}](${target})`} />)
+
+    const link = screen.getByTitle(target)
+    await waitFor(() => {
+      expect(link.textContent).toContain(label)
+    })
+    expect(fetchLinkTitle).not.toHaveBeenCalled()
+  })
+
+  it('fetches titles for bare and angle-bracket autolinks', async () => {
+    const fetchLinkTitle = vi.fn().mockResolvedValue('Fetched title')
+
+    desktopWindow.hermesDesktop = { fetchLinkTitle } as unknown as Window['hermesDesktop']
+
+    render(<MarkdownTextContent isRunning={false} text="https://example.com/bare <https://example.com/angle>" />)
+
+    await waitFor(() => {
+      expect(fetchLinkTitle).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -8,7 +8,7 @@ import {
   tailBoundedRemend
 } from '@assistant-ui/react-streamdown'
 import { code } from '@streamdown/code'
-import { type ComponentProps, memo, useEffect, useMemo, useState } from 'react'
+import { type ComponentProps, createContext, memo, useContext, useEffect, useMemo, useState } from 'react'
 
 import { ExpandableBlock } from '@/components/chat/expandable-block'
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
@@ -220,7 +220,20 @@ function childrenToText(children: unknown): string {
   return ''
 }
 
-function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a'>) {
+interface MarkdownLinkProps extends ComponentProps<'a'> {
+  node?: { position?: { start?: { offset?: number } } }
+}
+
+const MarkdownSourceContext = createContext('')
+
+function isExplicitMarkdownLink(markdown: string, node: MarkdownLinkProps['node']): boolean {
+  const start = node?.position?.start?.offset
+
+  return typeof start === 'number' && markdown.slice(start).trimStart().startsWith('[')
+}
+
+function MarkdownLink({ children, className, href, node, ...props }: MarkdownLinkProps) {
+  const markdown = useContext(MarkdownSourceContext)
   const mediaPath = mediaPathFromMarkdownHref(href)
 
   if (mediaPath) {
@@ -253,10 +266,11 @@ function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a
   }
 
   const text = childrenToText(children)
+  const explicitMarkdownLink = Boolean(text && isExplicitMarkdownLink(markdown, node))
 
   // Bare autolink → inline rich embed when a provider matches. Labeled links
   // (`[watch](url)`) stay plain. Desktop only (webview / iframe renderers).
-  if (window.hermesDesktop && text && normalizeExternalUrl(text) === target) {
+  if (window.hermesDesktop && !explicitMarkdownLink && text && normalizeExternalUrl(text) === target) {
     const embed = detectEmbed(target)
 
     if (embed) {
@@ -264,7 +278,7 @@ function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a
     }
   }
 
-  const fallbackLabel = text && normalizeExternalUrl(text) !== target ? text : undefined
+  const fallbackLabel = explicitMarkdownLink ? text : undefined
 
   return (
     <PrettyLink className={cn('wrap-anywhere', className)} fallbackLabel={fallbackLabel} href={target} {...props} />
@@ -522,23 +536,25 @@ function MarkdownTextSurface({ containerClassName, containerProps, defer }: Mark
   }
 
   return (
-    <StreamdownTextPrimitive
-      components={components}
-      containerClassName={cn(MARKDOWN_CONTAINER_CLASS_NAME, containerClassName)}
-      containerProps={containerProps}
-      defer={defer}
-      lineNumbers={false}
-      mode="streaming"
-      // Incomplete-markdown repair runs in preprocessWithTailRepair on the
-      // full accumulated text; the built-in tail-bounded remend is disabled
-      // because a custom parseMarkdownIntoBlocksFn is supplied, and
-      // parseIncompleteMarkdown stays false to avoid a second full-text
-      // remend pass.
-      parseIncompleteMarkdown={false}
-      parseMarkdownIntoBlocksFn={parseMarkdownIntoBlocksCached}
-      plugins={plugins}
-      preprocess={preprocessWithTailRepair}
-    />
+    <MarkdownSourceContext.Provider value={text}>
+      <StreamdownTextPrimitive
+        components={components}
+        containerClassName={cn(MARKDOWN_CONTAINER_CLASS_NAME, containerClassName)}
+        containerProps={containerProps}
+        defer={defer}
+        lineNumbers={false}
+        mode="streaming"
+        // Incomplete-markdown repair runs in preprocessWithTailRepair on the
+        // full accumulated text; the built-in tail-bounded remend is disabled
+        // because a custom parseMarkdownIntoBlocksFn is supplied, and
+        // parseIncompleteMarkdown stays false to avoid a second full-text
+        // remend pass.
+        parseIncompleteMarkdown={false}
+        parseMarkdownIntoBlocksFn={parseMarkdownIntoBlocksCached}
+        plugins={plugins}
+        preprocess={preprocessWithTailRepair}
+      />
+    </MarkdownSourceContext.Provider>
   )
 }
 

--- a/apps/desktop/src/lib/external-link.test.tsx
+++ b/apps/desktop/src/lib/external-link.test.tsx
@@ -155,6 +155,29 @@ describe('external link helpers', () => {
     })
   })
 
+  it('treats not-found fetched titles as unusable', async () => {
+    const bridge = vi.fn().mockResolvedValue('Page not found - Kinkolino Forgejo')
+    installDesktopBridge({ fetchLinkTitle: bridge as unknown as Window['hermesDesktop']['fetchLinkTitle'] })
+
+    await expect(fetchLinkTitle('https://forgejo.home.example/homelab/homelab-ops/issues/101')).resolves.toBe('')
+    expect(bridge).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps explicit fallback labels ahead of fetched page titles', async () => {
+    const bridge = vi.fn().mockResolvedValue('Kinkolino Forgejo')
+    installDesktopBridge({ fetchLinkTitle: bridge as unknown as Window['hermesDesktop']['fetchLinkTitle'] })
+
+    const url = 'https://forgejo.home.example/homelab/homelab-ops/issues/101'
+
+    render(<PrettyLink fallbackLabel="FJ #101" href={url} />)
+
+    const link = screen.getByTitle(url)
+    await waitFor(() => {
+      expect(link.textContent).toContain('FJ #101')
+    })
+    expect(bridge).not.toHaveBeenCalled()
+  })
+
   it('normalizes scheme-less links before opening', () => {
     installDesktopBridge()
 

--- a/apps/desktop/src/lib/external-link.tsx
+++ b/apps/desktop/src/lib/external-link.tsx
@@ -23,7 +23,7 @@ const SKIP_PROTO_RE = /^(?:file|data|mailto|javascript|blob|chrome|about|hermes)
 const LOCAL_HOST_RE = /^(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::\d+)?$/i
 
 const ERROR_TITLE_RE =
-  /\b(?:access denied|attention required|captcha|error|forbidden|just a moment|request blocked|too many requests)\b/i
+  /\b(?:access denied|attention required|captcha|error|forbidden|just a moment|not found|page not found|request blocked|too many requests)\b/i
 
 export function normalizeExternalUrl(value: string): string {
   const trimmed = value.trim()
@@ -253,8 +253,9 @@ interface PrettyLinkProps extends Omit<ComponentProps<'a'>, 'href' | 'target'> {
 
 export function PrettyLink({ className, fallbackLabel, href, label, ...rest }: PrettyLinkProps) {
   const target = useMemo(() => normalizeExternalUrl(href), [href])
-  const fetched = useLinkTitle(label ? null : target)
-  const display = fetched || label?.trim() || fallbackLabel?.trim() || urlSlugTitleLabel(target)
+  const explicitLabel = label?.trim() || fallbackLabel?.trim()
+  const fetched = useLinkTitle(explicitLabel ? null : target)
+  const display = explicitLabel || fetched || urlSlugTitleLabel(target)
 
   return (
     <ExternalLink className={cn('wrap-break-word', className)} href={target} title={target} {...rest}>

--- a/ui-tui/src/__tests__/markdown.test.ts
+++ b/ui-tui/src/__tests__/markdown.test.ts
@@ -2,9 +2,10 @@ import { PassThrough } from 'stream'
 
 import { Box, renderSync } from '@hermes/ink'
 import React from 'react'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { AUDIO_DIRECTIVE_RE, INLINE_RE, Md, MEDIA_LINE_RE, stripInlineMarkup } from '../components/markdown.js'
+import { __resetLinkTitleCache } from '../lib/externalLink.js'
 import { stripAnsi } from '../lib/text.js'
 import { DEFAULT_THEME } from '../theme.js'
 
@@ -13,6 +14,12 @@ const BEL = String.fromCharCode(7)
 const ESC = String.fromCharCode(27)
 const CSI_RE = new RegExp(`${ESC}\\[[0-?]*[ -/]*[@-~]`, 'g')
 const OSC_RE = new RegExp(`${ESC}\\][\\s\\S]*?(?:${BEL}|${ESC}\\\\)`, 'g')
+
+afterEach(() => {
+  __resetLinkTitleCache()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
 
 const renderPlain = (node: React.ReactNode) => {
   const stdout = new PassThrough()
@@ -196,6 +203,31 @@ describe('protocol sentinels', () => {
 })
 
 describe('Md wrapping', () => {
+  it('keeps explicit link labels without fetching page titles', () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('<html><head><title>Page not found - Forgejo</title></head></html>', {
+        headers: { 'content-type': 'text/html' },
+        status: 200
+      })
+    )
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const lines = renderPlain(
+      React.createElement(
+        Box,
+        { width: 40 },
+        React.createElement(Md, {
+          t: DEFAULT_THEME,
+          text: '[FJ #101](https://forgejo.example.com/issues/101)'
+        })
+      )
+    )
+
+    expect(lines.join('\n')).toContain('FJ #101')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('trims spaces from word-wrap continuation lines', () => {
     const lines = renderPlain(
       React.createElement(Box, { width: 5 }, React.createElement(Md, { t: DEFAULT_THEME, text: 'Let me' }))
@@ -248,6 +280,55 @@ describe('Md wrapping', () => {
 })
 
 describe('Md link labels', () => {
+  it('preserves an explicit markdown URL label after it normalizes to the target', () => {
+    const label = 'forgejo.example.com/issues/101'
+    const target = `https://${label}`
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('<html><head><title>Fetched Forgejo title</title></head></html>', {
+        headers: { 'content-type': 'text/html' },
+        status: 200
+      })
+    )
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const lines = renderPlain(
+      React.createElement(
+        Box,
+        { width: 120 },
+        React.createElement(Md, { t: DEFAULT_THEME, text: `[${label}](${target})` })
+      )
+    )
+
+    expect(lines.join('\n')).toContain(label)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('fetches titles for bare and angle-bracket autolinks', () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('<html><head><title>Fetched title</title></head></html>', {
+        headers: { 'content-type': 'text/html' },
+        status: 200
+      })
+    )
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPlain(
+      React.createElement(
+        Box,
+        { width: 120 },
+        React.createElement(Md, {
+          t: DEFAULT_THEME,
+          text: 'https://example.com/bare <https://example.com/angle>'
+        })
+      )
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
   it('renders bare URLs with readable slug labels', () => {
     const lines = renderPlain(
       React.createElement(

--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -153,14 +153,14 @@ const autolinkUrl = (raw: string) =>
 const defaultLinkLabel = (url: string) =>
   url.startsWith('mailto:') ? url.replace(/^mailto:/, '') : /^https?:\/\//i.test(url) ? urlSlugTitleLabel(url) : url
 
-const pickFallbackLabel = (label: string | undefined, target: string): string | undefined => {
+const pickFallbackLabel = (label: string | undefined): string | undefined => {
   const trimmed = label?.trim()
 
   if (!trimmed) {
     return undefined
   }
 
-  return normalizeExternalUrl(trimmed) === target ? undefined : trimmed
+  return trimmed
 }
 
 interface ResolvedLinkProps {
@@ -170,8 +170,9 @@ interface ResolvedLinkProps {
 }
 
 function ResolvedLink({ fallbackLabel, t, url }: ResolvedLinkProps) {
-  const fetched = useLinkTitle(url)
-  const display = fetched || fallbackLabel || defaultLinkLabel(url)
+  const explicitLabel = fallbackLabel?.trim()
+  const fetched = useLinkTitle(explicitLabel ? null : url)
+  const display = explicitLabel || fetched || defaultLinkLabel(url)
 
   return (
     <Link url={url}>
@@ -185,7 +186,7 @@ function ResolvedLink({ fallbackLabel, t, url }: ResolvedLinkProps) {
 const renderResolvedLink = (k: number, t: Theme, rawUrl: string, label?: string) => {
   const target = normalizeExternalUrl(rawUrl)
 
-  return <ResolvedLink fallbackLabel={pickFallbackLabel(label, target)} key={k} t={t} url={target} />
+  return <ResolvedLink fallbackLabel={pickFallbackLabel(label)} key={k} t={t} url={target} />
 }
 
 export const stripInlineMarkup = (v: string) =>
@@ -561,7 +562,7 @@ function MdInline({ t, text }: { t: Theme; text: string }) {
     } else if (m[3] && m[4]) {
       parts.push(renderResolvedLink(parts.length, t, m[4], m[3]))
     } else if (m[5]) {
-      parts.push(renderResolvedLink(parts.length, t, autolinkUrl(m[5]), m[5].replace(/^mailto:/, '')))
+      parts.push(renderResolvedLink(parts.length, t, autolinkUrl(m[5])))
     } else if (m[6]) {
       parts.push(
         <Text key={parts.length} strikethrough>


### PR DESCRIPTION
## Summary

- Preserve explicit Desktop and TUI link labels/fallback labels instead of replacing them with fetched page titles.
- Skip background title fetching when either chat surface already has an explicit label.
- Treat fetched `not found` / `page not found` titles as unusable error-like titles in Desktop.
- Add regressions for a Forgejo-style not-found title and for labeled links that must not trigger title fetching.

## Root cause

Both chat renderers preferred fetched titles over explicit labels. Desktop used:

```ts
const display = fetched || label?.trim() || fallbackLabel?.trim() || urlSlugTitleLabel(target)
```

TUI independently used the same ordering and always called `useLinkTitle(url)` even when Markdown supplied a deliberate label. A private/self-hosted link could therefore replace a clean label such as `FJ #101` with an error-page title, and TUI performed an unnecessary fetch even before that replacement occurred.

The fix now makes explicit labels authoritative in both surfaces and passes `null` to the title hook when no fetch is needed. Unlabeled links retain fetched-title and URL-slug fallback behavior.

## Duplicate / related PR check

Checked upstream before opening this PR:

- #52707 was the closest prior work (`fix: preserve desktop link labels across ports`) but is closed and unmerged.
- #54796 is related title hygiene but does not cover not-found titles or the label-priority issue.
- #49857 covers Markdown autolink corruption; different bug class.
- #59659 resolves private GitHub link titles; different resolver scope.

## TDD / verification

Desktop RED on current `main`:

```text
npm --workspace apps/desktop run test:ui -- src/lib/external-link.test.tsx
# 2 failed: not-found title hygiene and explicit-label priority
```

TUI RED before the parity fix:

```text
npm --workspace ui-tui test -- src/__tests__/markdown.test.ts
# explicit labeled Markdown link still called fetch() once
```

GREEN after the fixes:

```text
npm --workspace apps/desktop run test:ui -- src/lib/external-link.test.tsx
# 15 passed

npm --workspace ui-tui test -- src/__tests__/markdown.test.ts src/__tests__/externalLink.test.ts
# 40 passed

npm --workspace apps/desktop run typecheck
npm --workspace ui-tui run typecheck
npm --workspace apps/desktop exec eslint src/lib/external-link.tsx src/lib/external-link.test.tsx
npm --workspace ui-tui exec eslint src/components/markdown.tsx src/__tests__/markdown.test.ts
npm --workspace ui-tui run build
# all passed
```

The full TUI suite reached 1113 passing tests and exposed four unrelated baseline failures in cursor-drift/status-rule/virtual-height tests. Re-running those files with this PR's TUI changes stashed produced the same four failures.

## Safety / boundaries

- Rendering-only changes in Desktop and TUI.
- No production config, credentials, service restarts, or local install hotfixes are changed by this PR.
- Existing behavior for unlabeled links with good fetched titles is preserved.
