### PR TITLE
fix(agent): pass docker_network config to backend-probe container

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -993,6 +993,7 @@ def _probe_remote_backend(env_type: str) -> str | None:
                 "docker_extra_args": config.get("docker_extra_args", []),
                 "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
                 "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
+                "docker_network": config.get("docker_network", True),
             }
 
         env = _create_environment(

--- a/tests/tools/test_docker_network_config.py
+++ b/tests/tools/test_docker_network_config.py
@@ -95,8 +95,9 @@ def test_sibling_container_config_sites_carry_docker_network():
 
     import tools.code_execution_tool as code_execution_tool
     import tools.file_tools as file_tools
+    import agent.prompt_builder as prompt_builder
 
-    for module in (terminal_tool, file_tools, code_execution_tool):
+    for module in (terminal_tool, file_tools, code_execution_tool, prompt_builder):
         tree = ast.parse(inspect.getsource(module))
         sites = 0
         for node in ast.walk(tree):


### PR DESCRIPTION
The backend probe in prompt_builder.py builds its own container_config dict but omitted docker_network, so the probe container always launched with the default bridge network regardless of the operator's docker_network: false setting (issue #46358 introduced the toggle but only wired it through terminal_tool.py/code_execution_tool.py/file_tools.py).

Also extends test_sibling_container_config_sites_carry_docker_network to cover agent.prompt_builder, closing the gap that regression guard was meant to catch.

## What

Fixes a `docker_network` config gap in the backend probe (`agent/prompt_builder.py`). When `terminal.docker_network: false` is set, the probe container spawned by `_probe_remote_backend()` still launched with the default `NetworkMode: bridge`, ignoring the operator's egress lockdown.

## Why

#46358 introduced `terminal.docker_network` and wired it through `tools/terminal_tool.py`, `tools/code_execution_tool.py`, and `tools/file_tools.py`. The backend probe in `agent/prompt_builder.py` builds its own `container_config` dict for `_create_environment(...)` but was never updated to include `docker_network`, so it silently falls back to `DockerEnvironment`'s default (`network=True`).

In practice this means an operator running with `docker_network: false` for a fully air-gapped Docker sandbox still gets one bridged, internet-reachable container per model backend on disk (labeled `hermes-task-id:prompt-backend-probe`). The probe itself only runs a fixed `uname`/`whoami`/`pwd` command today, so there's no immediate exploit path, but it breaks the operator's stated intent and the existing regression guard (`test_sibling_container_config_sites_carry_docker_network`) didn't catch it because it didn't check `agent.prompt_builder`.

## Changes

- `agent/prompt_builder.py`: add `"docker_network": config.get("docker_network", True)` to the probe's `container_config` dict, matching the pattern already used in `terminal_tool.py` / `code_execution_tool.py` / `file_tools.py`.
- `tests/tools/test_docker_network_config.py`: extend `test_sibling_container_config_sites_carry_docker_network` to also walk `agent.prompt_builder`, so this asymmetry can't reappear silently.

## How to test

1. Set `terminal.backend: docker` and `terminal.docker_network: false`.
2. Remove any existing `hermes-*` containers.
3. Trigger a normal turn that uses `execute_code` — its container correctly gets `NetworkMode: none`.
4. Before this fix: the sibling container labeled `hermes-task-id:prompt-backend-probe` still comes up as `NetworkMode: bridge`. After this fix: it comes up as `none` too.

Automated:
```
pytest tests/tools/test_docker_network_config.py -v   # 8 passed
pytest tests/agent/test_prompt_builder.py -v           # 160 passed, 1 skipped (unrelated, filesystem-case-sensitivity skip)
```

## Platforms tested

Windows 11 (PowerShell), Python 3.12.

## Related

Follow-up to #46358, closing the gap flagged in that PR's own regression-guard test docstring ("the probe/exec asymmetry reported on issue #46358").

