### PR TITLE
Add session_id and tool_call_id to transform_terminal_output hook

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -1266,6 +1266,7 @@ def handle_function_call(
                         function_name, next_args,
                         task_id=task_id,
                         session_id=session_id,
+                        tool_call_id=tool_call_id,
                         enabled_tools=sandbox_enabled,
                     )
             else:
@@ -1274,6 +1275,7 @@ def handle_function_call(
                         function_name, next_args,
                         task_id=task_id,
                         session_id=session_id,
+                        tool_call_id=tool_call_id,
                         user_task=user_task,
                     )
             from hermes_cli.middleware import run_tool_execution_middleware

--- a/tests/test_dispatch_session_id.py
+++ b/tests/test_dispatch_session_id.py
@@ -73,3 +73,51 @@ class TestSessionIdForwarding:
                 skip_pre_tool_call_hook=True,
             )
         assert captured.get("task_id") == "task-999"
+
+
+class TestToolCallIdForwarding:
+    """tool_call_id must reach registry.dispatch so tools (e.g. terminal) can
+    attribute their output to the originating tool call."""
+
+    def test_standard_path_forwards_tool_call_id(self):
+        captured = {}
+        with patch("model_tools.registry", _make_registry(captured)):
+            from model_tools import handle_function_call
+            handle_function_call(
+                "web_search",
+                {"query": "test"},
+                task_id="t1",
+                session_id="sess-abc",
+                tool_call_id="call-abc",
+                skip_pre_tool_call_hook=True,
+            )
+        assert captured.get("tool_call_id") == "call-abc"
+
+    def test_execute_code_path_forwards_tool_call_id(self):
+        captured = {}
+        with patch("model_tools.registry", _make_registry(captured)):
+            from model_tools import handle_function_call
+            handle_function_call(
+                "execute_code",
+                {"code": "print(1)"},
+                task_id="t1",
+                session_id="sess-xyz",
+                tool_call_id="call-xyz",
+                skip_pre_tool_call_hook=True,
+            )
+        assert captured.get("tool_call_id") == "call-xyz"
+
+    def test_tool_call_id_default_is_none(self):
+        """When tool_call_id is omitted, dispatch receives None (the tool's own
+        fire site normalizes it to '')."""
+        captured = {}
+        with patch("model_tools.registry", _make_registry(captured)):
+            from model_tools import handle_function_call
+            handle_function_call(
+                "web_search",
+                {"query": "test"},
+                task_id="t1",
+                skip_pre_tool_call_hook=True,
+            )
+        assert "tool_call_id" in captured
+        assert captured["tool_call_id"] is None

--- a/tests/tools/test_terminal_output_transform_hook.py
+++ b/tests/tools/test_terminal_output_transform_hook.py
@@ -35,6 +35,8 @@ def _run_terminal(
     invoke_hook=_UNSET,
     approval=None,
     command="echo hello",
+    session_id=_UNSET,
+    tool_call_id=_UNSET,
 ):
     mock_env = MagicMock()
     mock_env.execute.return_value = {"output": output, "returncode": returncode}
@@ -54,8 +56,28 @@ def _run_terminal(
     if invoke_hook is not _UNSET:
         monkeypatch.setattr("hermes_cli.plugins.invoke_hook", invoke_hook)
 
-    result = json.loads(terminal_tool_module.terminal_tool(command=command))
+    call_kwargs = {"command": command}
+    if session_id is not _UNSET:
+        call_kwargs["session_id"] = session_id
+    if tool_call_id is not _UNSET:
+        call_kwargs["tool_call_id"] = tool_call_id
+
+    result = json.loads(terminal_tool_module.terminal_tool(**call_kwargs))
     return result, mock_env
+
+
+def _capturing_hook(store, *, ret=None):
+    """Return an invoke_hook stand-in that records the payload kwargs.
+
+    ``ret`` is the hook result list (default ``[]`` — no output mutation).
+    """
+
+    def _hook(hook_name, **kwargs):
+        store["hook_name"] = hook_name
+        store["payload"] = kwargs
+        return [] if ret is None else ret
+
+    return _hook
 
 
 def test_terminal_output_unchanged_when_transform_hook_not_registered(monkeypatch, tmp_path):
@@ -212,3 +234,99 @@ def test_terminal_output_transform_integration_with_real_plugin(monkeypatch, tmp
     assert "PLUGIN-HEAD" in result["output"]
     assert "PLUGIN-TAIL" in result["output"]
     assert "[OUTPUT TRUNCATED" in result["output"]
+
+
+def test_transform_hook_payload_carries_session_and_tool_call_id(monkeypatch, tmp_path):
+    """The hook payload includes session_id and tool_call_id so observers can
+    attribute terminal output to a session and a specific tool call."""
+    store = {}
+    result, _mock_env = _run_terminal(
+        monkeypatch,
+        tmp_path,
+        output="plain output",
+        invoke_hook=_capturing_hook(store),
+        session_id="sess-REAL-123",
+        tool_call_id="call-REAL-abc",
+    )
+
+    payload = store["payload"]
+    assert store["hook_name"] == "transform_terminal_output"
+    # The two newly-threaded fields, populated with real values.
+    assert payload["session_id"] == "sess-REAL-123"
+    assert payload["tool_call_id"] == "call-REAL-abc"
+    # Pre-existing payload fields are unchanged (purely additive).
+    assert payload["command"] == "echo hello"
+    assert payload["output"] == "plain output"
+    assert payload["returncode"] == 0
+    assert "task_id" in payload
+    assert "env_type" in payload
+    # No output-mutation behavior change: returning [] leaves output as-is.
+    assert result["output"] == "plain output"
+
+
+def test_transform_hook_session_and_tool_call_id_default_to_empty_string(monkeypatch, tmp_path):
+    """When the tool is invoked without correlation IDs, the payload carries
+    empty strings (never missing keys, never None) so consumers using
+    ``kwargs["session_id"]`` don't KeyError."""
+    store = {}
+    _run_terminal(
+        monkeypatch,
+        tmp_path,
+        output="plain output",
+        invoke_hook=_capturing_hook(store),
+    )
+
+    payload = store["payload"]
+    assert payload["session_id"] == ""
+    assert payload["tool_call_id"] == ""
+
+
+def test_transform_hook_ids_survive_full_dispatch_chain(monkeypatch, tmp_path):
+    """End-to-end guard: the ids must survive the REAL dispatch wiring, not just
+    a direct terminal_tool() call.
+
+    Exercises handle_function_call -> registry.dispatch -> _handle_terminal ->
+    terminal_tool -> transform_terminal_output, with the real registry (no mock),
+    proving neither model_tools' dispatch forwarding nor the _handle_terminal
+    adapter silently drops session_id/tool_call_id.
+    """
+    import model_tools
+
+    mock_env = MagicMock()
+    mock_env.execute.return_value = {"output": "plain output", "returncode": 0}
+    monkeypatch.setattr(
+        terminal_tool_module, "_get_env_config", lambda: _make_env_config(tmp_path)
+    )
+    monkeypatch.setattr(terminal_tool_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool_module,
+        "_check_all_guards",
+        lambda *_args, **_kwargs: {"approved": True},
+    )
+    monkeypatch.setitem(terminal_tool_module._active_environments, "default", mock_env)
+    monkeypatch.setitem(terminal_tool_module._last_activity, "default", 0.0)
+
+    # Several hooks fire on this path (transform_terminal_output, post_tool_call,
+    # ...); capture only the one under test and no-op the rest.
+    captured = {}
+
+    def _capture(hook_name, **kwargs):
+        if hook_name == "transform_terminal_output":
+            captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _capture)
+
+    model_tools.handle_function_call(
+        "terminal",
+        {"command": "echo hello"},
+        task_id="task-XYZ",
+        session_id="sess-REAL-123",
+        tool_call_id="call-REAL-abc",
+        skip_pre_tool_call_hook=True,
+        skip_tool_request_middleware=True,
+    )
+
+    assert captured, "transform_terminal_output hook never fired via dispatch"
+    assert captured["session_id"] == "sess-REAL-123"
+    assert captured["tool_call_id"] == "call-REAL-abc"

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2018,6 +2018,7 @@ def terminal_tool(
     pty: bool = False,
     notify_on_complete: bool = False,
     watch_patterns: Optional[List[str]] = None,
+    tool_call_id: Optional[str] = None,
 ) -> str:
     """
     Execute a command in the configured terminal environment.
@@ -2033,6 +2034,10 @@ def terminal_tool(
         pty: If True, use pseudo-terminal for interactive CLI tools (local backend only)
         notify_on_complete: If True and background=True, you'll be notified exactly once when the process exits. The right choice for almost every long task. MUTUALLY EXCLUSIVE with watch_patterns.
         watch_patterns: List of strings to watch for in background output. HARD rate limit: 1 notification per 15s per process. After 3 strike windows in a row, watch_patterns is disabled and the session is auto-promoted to notify_on_complete. Use ONLY for rare, one-shot mid-process signals on long-lived processes (server readiness, migration-done markers). NEVER use in loops/batch jobs — error patterns there will hit the strike limit and get disabled. MUTUALLY EXCLUSIVE with notify_on_complete — set one, not both.
+        tool_call_id: Identifier of the originating tool call, so observers can
+            attribute terminal output to a specific tool invocation. Appended
+            at the end of the signature to keep this change purely additive for
+            any positional caller (must not shift the ``force`` safety gate).
 
     Returns:
         str: JSON string with output, exit_code, and error fields
@@ -2695,6 +2700,12 @@ def terminal_tool(
                     returncode=returncode,
                     task_id=effective_task_id or "",
                     env_type=env_type,
+                    # session_id/tool_call_id let observers attribute terminal
+                    # output to the session and originating tool call without a
+                    # thread-local/task_id shim (effective_task_id collapses to
+                    # "default" for most sessions, so it isn't a reliable key).
+                    session_id=session_id or "",
+                    tool_call_id=tool_call_id or "",
                 )
                 for hook_result in hook_results:
                     if isinstance(hook_result, str):
@@ -3011,6 +3022,7 @@ def _handle_terminal(args, **kw):
         timeout=args.get("timeout"),
         task_id=kw.get("task_id"),
         session_id=kw.get("session_id"),
+        tool_call_id=kw.get("tool_call_id"),
         workdir=args.get("workdir"),
         pty=args.get("pty", False),
         notify_on_complete=args.get("notify_on_complete", False),

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -1203,9 +1203,11 @@ Fires inside the `terminal` tool's foreground-output pipeline, **before** the de
 def my_callback(
     command: str,
     output: str,
-    exit_code: int,
-    cwd: str,
-    task_id: str | None,
+    returncode: int,
+    task_id: str,
+    env_type: str,
+    session_id: str,
+    tool_call_id: str,
     **kwargs,
 ) -> str | None:
 ```
@@ -1213,9 +1215,12 @@ def my_callback(
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `command` | `str` | The shell command that produced the output. |
-| `output` | `str` | Raw combined stdout/stderr (may be very large — truncation happens after the hook). |
-| `exit_code` | `int` | Process exit code. |
-| `cwd` | `str` | Working directory the command ran in. |
+| `output` | `str` | Raw combined stdout/stderr (may be very large; truncation happens after the hook). |
+| `returncode` | `int` | Process exit code. |
+| `task_id` | `str` | Environment/isolation identifier. Collapses to `"default"` for most sessions, so it does not uniquely identify a conversation. |
+| `env_type` | `str` | Terminal backend the command ran in (`local`, `docker`, `modal`, etc.). |
+| `session_id` | `str` | Conversation the command belongs to. Empty string when unset. |
+| `tool_call_id` | `str` | Identifier of the tool call that produced this output. Empty string when unset. |
 
 **Return value:** `str` to replace the output, `None` to leave it unchanged.
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/hooks.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/hooks.md
@@ -1060,9 +1060,11 @@ def register(ctx):
 def my_callback(
     command: str,
     output: str,
-    exit_code: int,
-    cwd: str,
-    task_id: str | None,
+    returncode: int,
+    task_id: str,
+    env_type: str,
+    session_id: str,
+    tool_call_id: str,
     **kwargs,
 ) -> str | None:
 ```
@@ -1070,9 +1072,12 @@ def my_callback(
 | 参数 | 类型 | 描述 |
 |-----|------|------|
 | `command` | `str` | 产生输出的 shell 命令。 |
-| `output` | `str` | 原始合并的 stdout/stderr（可能非常大——截断在 hook 之后发生）。 |
-| `exit_code` | `int` | 进程退出码。 |
-| `cwd` | `str` | 命令运行的工作目录。 |
+| `output` | `str` | 原始合并的 stdout/stderr（可能非常大；截断在 hook 之后发生）。 |
+| `returncode` | `int` | 进程退出码。 |
+| `task_id` | `str` | 环境/隔离标识符。大多数会话会归并为 `"default"`，因此无法唯一标识某个会话。 |
+| `env_type` | `str` | 命令运行所在的终端后端（`local`、`docker`、`modal` 等）。 |
+| `session_id` | `str` | 该命令所属的会话。未设置时为空字符串。 |
+| `tool_call_id` | `str` | 产生此输出的工具调用标识。未设置时为空字符串。 |
 
 **返回值：** `str` 替换输出，`None` 保持不变。
 


### PR DESCRIPTION
## Problem

A plugin observing terminal output through `transform_terminal_output` can't tell which conversation or tool call produced it. The payload carries `command, output, returncode, task_id, env_type`, and `task_id` is no help: it collapses to the literal `"default"` for almost every session. Today plugins stash session identity in a thread-local and correlate out-of-band. That's fragile, and it races once several conversations share one gateway process.

The sibling hooks `pre_tool_call` and `post_tool_call` already receive `session_id` and `tool_call_id`. This hook is the only one of the three that doesn't.

## Fix

Add both fields to the payload. `session_id` is already in scope; `tool_call_id` is threaded from the dispatcher, same as the sibling hooks. Purely additive: plugins accept `**kwargs`, so nothing breaks. Truncation, redaction, and the return-a-string-to-replace-output behavior are untouched. Tests added.

In plain terms: when Hermes runs a shell command, plugins get to inspect the output, but until now they weren't told which chat or which command it came from. This adds those two labels.

Related: #19921 adds `cwd` to this hook (same additive pattern); #53642 already emits `tool_call_id` in run events.
