### PR TITLE
fix(mcp): stop retrying wrapped OAuth failures

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -2032,12 +2032,16 @@ class TestReconnection:
         asyncio.run(_test())
 
     def test_initial_oauth_failure_does_not_retry(self):
-        """Initial OAuth failures stop immediately to avoid repeated browser prompts."""
+        """Wrapped OAuth failures stop immediately to avoid repeated browser prompts."""
         from tools.mcp_tool import MCPServerTask
+        from tools.mcp_oauth import OAuthNonInteractiveError
 
         run_count = 0
         target_server = None
-        oauth_error = RuntimeError("Token exchange failed (400): Unknown client_id")
+        oauth_error = ExceptionGroup(
+            "unhandled errors in a TaskGroup",
+            [OAuthNonInteractiveError("user_skipped")],
+        )
 
         original_run_stdio = MCPServerTask._run_stdio
 
@@ -2054,14 +2058,19 @@ class TestReconnection:
             target_server = server
 
             with patch.object(MCPServerTask, "_run_stdio", patched_run_stdio), \
-                 patch("tools.mcp_tool._is_auth_error", return_value=True), \
                  patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
-                await server.run({"command": "test"})
+                await asyncio.wait_for(server.run({"command": "test"}), timeout=1)
 
             assert run_count == 1
             assert server._error is oauth_error
             assert server._ready.is_set()
             assert mock_sleep.await_count == 0
+            pending = [
+                task
+                for task in asyncio.all_tasks()
+                if task is not asyncio.current_task() and not task.done()
+            ]
+            assert pending == []
 
         asyncio.run(_test())
 

--- a/tests/tools/test_mcp_tool_401_handling.py
+++ b/tests/tools/test_mcp_tool_401_handling.py
@@ -30,6 +30,38 @@ def test_is_auth_error_detects_oauth_non_interactive():
     assert _is_auth_error(OAuthNonInteractiveError("no browser")) is True
 
 
+def test_is_auth_error_detects_nested_oauth_non_interactive():
+    from tools.mcp_tool import _is_auth_error
+    from tools.mcp_oauth import OAuthNonInteractiveError
+
+    exc = ExceptionGroup(
+        "transport task group",
+        [ExceptionGroup("oauth callback", [OAuthNonInteractiveError("user_skipped")])],
+    )
+    assert _is_auth_error(exc) is True
+
+
+def test_is_auth_error_detects_auth_leaf_in_mixed_group():
+    from tools.mcp_tool import _is_auth_error
+    from tools.mcp_oauth import OAuthNonInteractiveError
+
+    exc = ExceptionGroup(
+        "transport teardown",
+        [RuntimeError("cleanup failed"), OAuthNonInteractiveError("user_skipped")],
+    )
+    assert _is_auth_error(exc) is True
+
+
+def test_is_auth_error_rejects_all_non_auth_group():
+    from tools.mcp_tool import _is_auth_error
+
+    exc = ExceptionGroup(
+        "transport failures",
+        [RuntimeError("closed"), ValueError("bad config")],
+    )
+    assert _is_auth_error(exc) is False
+
+
 def test_is_auth_error_detects_httpx_401():
     from tools.mcp_tool import _is_auth_error
     import httpx
@@ -40,6 +72,16 @@ def test_is_auth_error_detects_httpx_401():
     assert _is_auth_error(exc) is True
 
 
+def test_is_auth_error_detects_nested_httpx_401():
+    from tools.mcp_tool import _is_auth_error
+    import httpx
+
+    response = MagicMock()
+    response.status_code = 401
+    leaf = httpx.HTTPStatusError("unauth", request=MagicMock(), response=response)
+    assert _is_auth_error(ExceptionGroup("transport", [leaf])) is True
+
+
 def test_is_auth_error_rejects_httpx_500():
     from tools.mcp_tool import _is_auth_error
     import httpx
@@ -48,6 +90,16 @@ def test_is_auth_error_rejects_httpx_500():
     response.status_code = 500
     exc = httpx.HTTPStatusError("oops", request=MagicMock(), response=response)
     assert _is_auth_error(exc) is False
+
+
+def test_is_auth_error_rejects_nested_httpx_500():
+    from tools.mcp_tool import _is_auth_error
+    import httpx
+
+    response = MagicMock()
+    response.status_code = 500
+    leaf = httpx.HTTPStatusError("oops", request=MagicMock(), response=response)
+    assert _is_auth_error(ExceptionGroup("transport", [leaf])) is False
 
 
 def test_is_auth_error_rejects_generic_exception():

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3176,10 +3176,17 @@ def _get_auth_error_types() -> tuple:
 def _is_auth_error(exc: BaseException) -> bool:
     """Return True if ``exc`` indicates an MCP OAuth failure.
 
+    Async transport libraries may wrap the underlying OAuth exception in a
+    nested ``BaseExceptionGroup``.  Treat a group as auth-related when any
+    leaf is auth-related so startup does not retry the entire browser flow.
+
     ``httpx.HTTPStatusError`` is only treated as auth-related when the
     response status code is 401. Other HTTP errors fall through to the
     generic error path in the tool handlers.
     """
+    if isinstance(exc, BaseExceptionGroup):
+        return any(_is_auth_error(child) for child in exc.exceptions)
+
     types = _get_auth_error_types()
     if not types or not isinstance(exc, types):
         return False


### PR DESCRIPTION
## Summary

- treat auth failures wrapped in nested `BaseExceptionGroup` / `ExceptionGroup` instances as terminal auth failures
- stop the initial MCP connection retry loop from relaunching an interactive OAuth flow after the user skips it
- add regression coverage for nested/mixed groups, HTTP 401 vs 500, one transport attempt, zero backoff sleeps, and no detached tasks

## Root cause

The MCP SDK's async transport can wrap `OAuthNonInteractiveError("user_skipped")` in an `ExceptionGroup`. `_is_auth_error()` only inspected the top-level exception, so `MCPServerTask.run()` misclassified the wrapped auth abort as a transient connection failure.

That reran the whole transport four times (initial attempt plus three configured retries), producing repeated authorization URLs/browser prompts. After the retry budget was exhausted, the task parked for reconnect; cancellation during that parked wait reproduced the reported `RuntimeError: Event loop is closed` cleanup traceback.

This change recursively classifies a group as auth-related when **any nested leaf** is already auth-related. The original group is preserved in `server._error`; the change only prevents automatic restart of an interactive auth flow. Direct HTTP policy remains unchanged: 401 is auth-related, 500 is not.

## Reference behavior

OpenCode represents authorization-required as an explicit terminal MCP state rather than a generic transport retry. Qwen Code similarly excludes auth failures from generic transient retry policy and owns a single callback-server lifecycle.

## Tests

Relevant suites after rebasing onto current `origin/main`:

- `10 passed, 3 deselected` — focused wrapped-auth/classifier matrix with `PytestUnraisableExceptionWarning` promoted to error
- `373 passed` — MCP tool, OAuth, OAuth manager, and CLI MCP config modules
- `ruff check` — passed for all touched files
- `git diff --check` — passed

A full repository xdist run completed with `39656 passed, 226 skipped, 536 failed, 18 errors` in 12m51s. The failures/errors are broad pre-existing environment/global-state failures (including web-provider, Hindsight, and website-policy suites); all touched and directly relevant MCP/OAuth/CLI modules are green.

No live OAuth provider, browser callback, credentials, config, gateway, or runtime rollout was used or changed.
