### PR TITLE
fix(copilot): preserve supported xhigh reasoning effort

### DIFF
--- a/plugins/model-providers/copilot/__init__.py
+++ b/plugins/model-providers/copilot/__init__.py
@@ -35,9 +35,25 @@ class CopilotProfile(ProviderProfile):
                 supported_efforts = github_model_reasoning_efforts(model)
                 if supported_efforts and reasoning_config:
                     effort = reasoning_config.get("effort", "medium")
-                    # Normalize stronger generic levels to the nearest supported.
-                    if effort in {"xhigh", "max", "ultra"}:
-                        effort = "high"
+                    # Honor the requested level when the live Copilot catalog
+                    # lists it as supported: gpt-5.5/gpt-5.4 DO support
+                    # ``xhigh``. Only downgrade levels the catalog does NOT
+                    # list (e.g. ``xhigh``/``max`` on models capped lower, or
+                    # ``minimal`` where unsupported), choosing the nearest
+                    # weaker supported level rather than forwarding verbatim.
+                    #
+                    # (Previously this unconditionally mapped xhigh->high, a
+                    #  stale guard that silently capped models which do support
+                    #  the higher level.)
+                    if effort not in supported_efforts:
+                        if effort == "xhigh" and "high" in supported_efforts:
+                            effort = "high"
+                        elif effort == "minimal" and "low" in supported_efforts:
+                            effort = "low"
+                        elif "medium" in supported_efforts:
+                            effort = "medium"
+                        else:
+                            effort = supported_efforts[0]
                     if effort in supported_efforts:
                         extra_body["reasoning"] = {"effort": effort}
                 elif supported_efforts:

--- a/run_agent.py
+++ b/run_agent.py
@@ -5451,7 +5451,7 @@ class AIAgent:
         else:
             requested_effort = "medium"
 
-        if requested_effort == "xhigh" and "high" in supported_efforts:
+        if requested_effort == "xhigh" and "xhigh" not in supported_efforts and "high" in supported_efforts:
             requested_effort = "high"
         elif requested_effort not in supported_efforts:
             if requested_effort == "minimal" and "low" in supported_efforts:

--- a/tests/plugins/model_providers/test_copilot_profile.py
+++ b/tests/plugins/model_providers/test_copilot_profile.py
@@ -1,0 +1,102 @@
+"""Unit tests for the Copilot provider profile's reasoning-effort wiring.
+
+GitHub Copilot serves different models with different supported reasoning-effort
+sets (the live ``/models`` catalog reports them per model). The profile must
+forward the requested effort when the catalog lists it as supported, and only
+downgrade to the nearest weaker supported level when it does not, rather than
+unconditionally collapsing ``xhigh`` to ``high`` (which silently capped models
+that actually support the higher level).
+
+These tests pin that contract without going live, by stubbing the catalog
+lookup ``github_model_reasoning_efforts``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def copilot_profile():
+    """Resolve the registered Copilot profile.
+
+    Importing ``model_tools`` triggers plugin discovery, which registers the
+    Copilot profile. Going through ``get_provider_profile`` keeps the test
+    honest: if the registered class is ever swapped for a plain
+    ``ProviderProfile`` the assertions below collapse.
+    """
+    import model_tools  # noqa: F401
+    import providers
+
+    profile = providers.get_provider_profile("copilot")
+    assert profile is not None, "copilot provider profile must be registered"
+    return profile
+
+
+def _patch_efforts(monkeypatch, efforts):
+    """Stub the catalog lookup the profile calls for supported efforts."""
+    import hermes_cli.models as models_mod
+    monkeypatch.setattr(
+        models_mod, "github_model_reasoning_efforts", lambda model: list(efforts)
+    )
+
+
+class TestCopilotReasoningEffortClamp:
+    def test_supported_effort_forwarded_verbatim(self, copilot_profile, monkeypatch):
+        """xhigh is forwarded unchanged when the catalog lists it."""
+        _patch_efforts(monkeypatch, ["minimal", "low", "medium", "high", "xhigh"])
+        extra_body, _ = copilot_profile.build_api_kwargs_extras(
+            model="gpt-5.5",
+            reasoning_config={"effort": "xhigh"},
+            supports_reasoning=True,
+        )
+        assert extra_body["reasoning"] == {"effort": "xhigh"}
+
+    def test_xhigh_downgrades_to_high_when_unsupported(self, copilot_profile, monkeypatch):
+        """A model whose catalog lacks xhigh gets the nearest weaker level."""
+        _patch_efforts(monkeypatch, ["low", "medium", "high"])
+        extra_body, _ = copilot_profile.build_api_kwargs_extras(
+            model="o-series-model",
+            reasoning_config={"effort": "xhigh"},
+            supports_reasoning=True,
+        )
+        assert extra_body["reasoning"] == {"effort": "high"}
+
+    def test_minimal_downgrades_to_low_when_unsupported(self, copilot_profile, monkeypatch):
+        _patch_efforts(monkeypatch, ["low", "medium", "high"])
+        extra_body, _ = copilot_profile.build_api_kwargs_extras(
+            model="o-series-model",
+            reasoning_config={"effort": "minimal"},
+            supports_reasoning=True,
+        )
+        assert extra_body["reasoning"] == {"effort": "low"}
+
+    def test_unsupported_effort_falls_back_to_medium(self, copilot_profile, monkeypatch):
+        """An effort not in the set, with no specific rule, falls to medium."""
+        _patch_efforts(monkeypatch, ["low", "medium", "high"])
+        extra_body, _ = copilot_profile.build_api_kwargs_extras(
+            model="some-model",
+            reasoning_config={"effort": "garbage"},
+            supports_reasoning=True,
+        )
+        assert extra_body["reasoning"] == {"effort": "medium"}
+
+    def test_falls_back_to_first_supported_when_no_medium(self, copilot_profile, monkeypatch):
+        """If medium isn't supported either, pick the first supported level."""
+        _patch_efforts(monkeypatch, ["low", "high"])
+        extra_body, _ = copilot_profile.build_api_kwargs_extras(
+            model="weird-model",
+            reasoning_config={"effort": "xhigh"},
+            supports_reasoning=True,
+        )
+        # xhigh not supported, high IS supported → high wins via the xhigh rule.
+        assert extra_body["reasoning"] == {"effort": "high"}
+
+    def test_first_supported_when_no_rule_matches(self, copilot_profile, monkeypatch):
+        _patch_efforts(monkeypatch, ["low", "high"])
+        extra_body, _ = copilot_profile.build_api_kwargs_extras(
+            model="weird-model",
+            reasoning_config={"effort": "garbage"},
+            supports_reasoning=True,
+        )
+        assert extra_body["reasoning"] == {"effort": "low"}

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1900,23 +1900,38 @@ class TestBuildApiKwargs:
         )
         assert kwargs["extra_body"]["reasoning"] == {"effort": "medium"}
 
-    def test_reasoning_xhigh_normalized_for_copilot(self, agent):
-        """xhigh effort should normalize to high for Copilot GitHub Models."""
+    def test_reasoning_xhigh_preserved_for_copilot_when_supported(self, agent, monkeypatch):
+        """The registered Copilot profile must preserve a supported xhigh."""
         from agent.transports import get_transport
         from providers import get_provider_profile
 
+        monkeypatch.setattr(
+            "hermes_cli.models.github_model_reasoning_efforts",
+            lambda _model: ["none", "low", "medium", "high", "xhigh"],
+        )
         transport = get_transport("chat_completions")
         profile = get_provider_profile("copilot")
         msgs = [{"role": "user", "content": "hi"}]
         kwargs = transport.build_kwargs(
-            model="gpt-5.4",
+            model="gpt-5.5",
             messages=msgs,
             tools=None,
             supports_reasoning=True,
             reasoning_config={"enabled": True, "effort": "xhigh"},
             provider_profile=profile,
         )
-        assert kwargs["extra_body"]["reasoning"] == {"effort": "high"}
+        assert kwargs["extra_body"]["reasoning"] == {"effort": "xhigh"}
+
+    def test_core_responses_preserves_supported_xhigh(self, agent, monkeypatch):
+        """The core GitHub Responses path must preserve a supported xhigh."""
+        monkeypatch.setattr(
+            "hermes_cli.models.github_model_reasoning_efforts",
+            lambda _model: ["none", "low", "medium", "high", "xhigh"],
+        )
+        agent.model = "gpt-5.5"
+        agent.reasoning_config = {"enabled": True, "effort": "xhigh"}
+
+        assert agent._github_models_reasoning_extra_body() == {"effort": "xhigh"}
 
     def test_reasoning_omitted_for_non_reasoning_copilot_model(self, agent):
         agent.base_url = "https://api.githubcopilot.com"


### PR DESCRIPTION
## Summary

- preserve `xhigh` when Copilot's supported-effort set includes it
- downgrade only when the requested effort is unsupported
- cover both Copilot request paths on current `main`: the registered provider profile and core GitHub Responses path

## Scope

This PR deliberately stays focused on effort negotiation. Live Copilot catalog loading/caching is handled by the complementary #51953; once that resolver supplies `xhigh`, this PR ensures neither request path silently collapses it to `high`.

The branch preserves the original commits and authorship from #10391 and #51480, with a small current-main regression-test commit added by @hydraxman.

## Tests

- `9 passed` in focused Copilot reasoning tests
- `git diff --check`
- `ruff check` on changed Python files
- `compileall` on changed Python files

Related: #31702, #51953, #52384
Supersedes: #10391, #51480
