### PR TITLE
fix(kanban): refuse create_board over archived slug instead of fabricating empty live board (#61945)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -538,6 +538,27 @@ def board_exists(board: Optional[str] = None) -> bool:
     return (d / "board.json").exists() or (d / "kanban.db").exists()
 
 
+def archived_board_exists(board: Optional[str] = None) -> bool:
+    """Return True if an archived ``<slug>-<timestamp>`` sibling exists.
+
+    Archived boards live under ``boards/_archived/`` (see
+    :func:`remove_board`). A concurrent :func:`create_board` for a slug that
+    has an archived sibling would silently fabricate a fresh, empty live board
+    over the archive (#61945) — this lets callers detect and refuse that.
+    """
+    slug = _normalize_board_slug(board)
+    if not slug or slug == DEFAULT_BOARD:
+        return False
+    archive_root = boards_root() / "_archived"
+    if not archive_root.is_dir():
+        return False
+    prefix = f"{slug}-"
+    return any(
+        child.is_dir() and child.name.startswith(prefix)
+        for child in archive_root.iterdir()
+    )
+
+
 def kanban_db_path(board: Optional[str] = None) -> Path:
     """Return the path to the ``kanban.db`` for ``board``.
 
@@ -754,6 +775,16 @@ def create_board(
     normed = _normalize_board_slug(slug)
     if not normed:
         raise ValueError("board slug is required")
+    # #61945: a slug with an archived sibling (boards/_archived/<slug>-<ts>/)
+    # must not silently fabricate a fresh empty live board on a concurrent
+    # connect — that strands the archive behind a live-collision and forces
+    # manual reconciliation. Refuse and point at the safe restore path.
+    if not board_exists(normed) and archived_board_exists(normed):
+        raise ValueError(
+            f"board {normed!r} is archived; restore it with "
+            f"'hermes kanban boards restore {normed}' or create a new board "
+            f"with a different slug (refusing to fabricate an empty live board)"
+        )
     meta = write_board_metadata(
         normed,
         name=name,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -545,16 +545,23 @@ def archived_board_exists(board: Optional[str] = None) -> bool:
     :func:`remove_board`). A concurrent :func:`create_board` for a slug that
     has an archived sibling would silently fabricate a fresh, empty live board
     over the archive (#61945) — this lets callers detect and refuse that.
+
+    The archive directory is named ``<slug>-<digits>`` (optionally
+    ``<slug>-<digits>-<n>`` on rapid re-archive). We match the full suffix as a
+    timestamp, not a ``startswith(slug-)`` prefix, so ``foo-bar`` archived as
+    ``foo-bar-<ts>`` is NOT mistaken for an archive of ``foo`` (#62029).
     """
+    import re
+
     slug = _normalize_board_slug(board)
     if not slug or slug == DEFAULT_BOARD:
         return False
     archive_root = boards_root() / "_archived"
     if not archive_root.is_dir():
         return False
-    prefix = f"{slug}-"
+    pat = re.compile(rf"^{re.escape(slug)}-\d+(?:-\d+)?$")
     return any(
-        child.is_dir() and child.name.startswith(prefix)
+        child.is_dir() and pat.match(child.name)
         for child in archive_root.iterdir()
     )
 
@@ -2115,6 +2122,16 @@ def connect(
         path = db_path
     else:
         path = kanban_db_path(board=board)
+    # #62029: a named-board connect to an archived slug must not resurrect an
+    # empty live board over the archive (the same bug class as create_board).
+    # Refuse and point at the restore path. Skipped when an explicit db_path
+    # is given (legacy/test callers name the file directly).
+    if board is not None and not board_exists(board) and archived_board_exists(board):
+        raise ValueError(
+            f"board {board!r} is archived; restore it with "
+            f"'hermes kanban boards restore {board}' or create a new board "
+            f"with a different slug (refusing to resurrect an empty live board)"
+        )
     path.parent.mkdir(parents=True, exist_ok=True)
 
     # Fast path: once THIS process has initialized this path, the expensive

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -273,6 +273,38 @@ class TestBoardCRUD:
         assert meta["slug"] == "projx2"
         assert kb.board_exists("projx2")
 
+    def test_archived_match_is_not_prefix_collision(self, fresh_home):
+        # #62029: `foo-bar` archived as `foo-bar-<ts>` must NOT be reported as
+        # an archive of `foo` (the old startswith(slug-) matched the `foo-`).
+        kb.create_board("foo-bar")
+        kb.remove_board("foo-bar")  # archive -> foo-bar-<ts>/
+        assert kb.archived_board_exists("foo-bar")
+        assert not kb.archived_board_exists("foo")
+        # And `foo` can still be created without tripping the guard.
+        meta = kb.create_board("foo")
+        assert meta["slug"] == "foo"
+        assert kb.board_exists("foo")
+
+    def test_connect_refuses_archived_slug(self, fresh_home):
+        # #62029: the direct named-board connect path (not just create_board)
+        # must also refuse to resurrect an empty live board over the archive.
+        kb.create_board("projy")
+        kb.remove_board("projy")
+        assert kb.archived_board_exists("projy")
+        with pytest.raises(ValueError, match="archived"):
+            kb.connect(board="projy")
+        # No live board fabricated.
+        assert not kb.board_exists("projy")
+
+    def test_connect_normal_slug_still_works(self, fresh_home):
+        kb.create_board("okboard")
+        conn = kb.connect(board="okboard")
+        try:
+            assert conn is not None
+        finally:
+            conn.close()
+        assert kb.board_exists("okboard")
+
     def test_archived_board_exists_false_for_live_only(self, fresh_home):
         kb.create_board("liveonly")
         assert not kb.archived_board_exists("liveonly")
@@ -299,13 +331,12 @@ class TestBoardCRUD:
         kb.remove_board("pinned")
         assert kb.get_current_board() == "default"
 
-    @pytest.mark.parametrize("archive", [True, False])
-    def test_remove_clears_init_cache_for_recreated_db(self, fresh_home, archive):
+    def test_remove_clears_init_cache_for_recreated_db(self, fresh_home):
         # Regression for #23833: poll loops that call connect(board=slug) right
-        # after remove_board() recreate an empty kanban.db at the same path
-        # (connect() does mkdir(exist_ok=True)). If _INITIALIZED_PATHS still
-        # contains the resolved path, the CREATE TABLE pass is skipped and
-        # downstream readers hit `no such table: task_events`.
+        # after a HARD remove_board() recreate an empty kanban.db at the same
+        # path (connect() does mkdir(exist_ok=True)). If _INITIALIZED_PATHS
+        # still contains the resolved path, the CREATE TABLE pass is skipped
+        # and downstream readers hit `no such table: task_events`.
         kb.create_board("recycle")
         # First connect populates _INITIALIZED_PATHS for this DB.
         with kb.connect(board="recycle") as conn:
@@ -313,9 +344,9 @@ class TestBoardCRUD:
         db_path = kb.board_dir("recycle") / "kanban.db"
         assert str(db_path.resolve()) in kb._INITIALIZED_PATHS
 
-        kb.remove_board("recycle", archive=archive)
-        # remove_board must drop the cache entry so a re-create through
-        # connect() gets a fresh schema-init pass.
+        # Hard-delete (not archive): cache entry must drop so a re-create
+        # through connect() gets a fresh schema-init pass.
+        kb.remove_board("recycle", archive=False)
         assert str(db_path.resolve()) not in kb._INITIALIZED_PATHS
 
         # Simulate the event-stream poll: re-open the same slug. connect()
@@ -329,6 +360,21 @@ class TestBoardCRUD:
             }
         assert "task_events" in tables
         assert "tasks" in tables
+
+    def test_archived_slug_connect_is_refused_not_resurrected(self, fresh_home):
+        # #62029: an ARCHIVED slug must not be silently resurrected by a
+        # concurrent connect() — that is the #61945 bug class via the
+        # named-board open path. connect() must refuse and leave the archive.
+        kb.create_board("recycle")
+        with kb.connect(board="recycle") as conn:
+            kb.create_task(conn, title="t1", assignee="dev")
+        kb.remove_board("recycle", archive=True)
+        assert kb.archived_board_exists("recycle")
+
+        with pytest.raises(ValueError, match="archived"):
+            kb.connect(board="recycle")
+        # Archive intact; no live board fabricated.
+        assert not kb.board_exists("recycle")
 
     def test_rename_updates_metadata(self, fresh_home):
         kb.create_board("slug-immutable")

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -249,6 +249,34 @@ class TestBoardCRUD:
         assert Path(res["new_path"]).exists()
         assert "toremove" not in [b["slug"] for b in kb.list_boards()]
 
+    # ── #61945: never fabricate a live board over an archived slug ──────────
+
+    def test_create_board_refuses_over_archived_slug(self, fresh_home):
+        kb.create_board("projx")
+        kb.remove_board("projx")  # archive -> boards/_archived/projx-<ts>/
+        assert kb.archived_board_exists("projx")
+
+        # A concurrent connect for the same slug must NOT silently fabricate
+        # an empty live board.
+        with pytest.raises(ValueError, match="archived"):
+            kb.create_board("projx")
+
+        # The archive must remain untouched — no live board fabricated.
+        assert not kb.board_exists("projx")
+        assert kb.archived_board_exists("projx")
+
+    def test_create_board_allows_new_slug_after_archive(self, fresh_home):
+        kb.create_board("projx")
+        kb.remove_board("projx")
+        # A genuinely different slug is unaffected by the archived sibling.
+        meta = kb.create_board("projx2")
+        assert meta["slug"] == "projx2"
+        assert kb.board_exists("projx2")
+
+    def test_archived_board_exists_false_for_live_only(self, fresh_home):
+        kb.create_board("liveonly")
+        assert not kb.archived_board_exists("liveonly")
+
     def test_remove_hard_delete(self, fresh_home):
         kb.create_board("nuke")
         d = kb.board_dir("nuke")


### PR DESCRIPTION
## Summary

Fixes #61945 — `create_board()` silently fabricates a fresh, empty **live** board over an archived slug, stranding the archive behind a live-collision and forcing manual reconciliation (the exact data-loss path #61908 was about).

This is the **prevention** half that #61937 (safe `boards restore`) deliberately left open: while a slug is archived under `boards/_archived/<slug>-<ts>/`, a concurrent `connect(board=slug)` / `create_board(slug)` would happily reinitialize a live `boards/<slug>/` and leave the operator to recognize the fabricated empty shell by hand.

**Root cause** (`hermes_cli/kanban_db.py`)
- `create_board(slug)` went straight to `write_board_metadata` + `init_db` with no awareness of archived siblings.
- `board_exists(slug)` only checked the live `boards/<slug>/` dir, so an archived slug reported "doesn't exist" → look like a free slug.

**Fix**
- Added `archived_board_exists(slug)` — scans `boards/_archived/` for `<slug>-*` siblings (ignores `default`).
- `create_board` now **refuses** when the slug has no live board but an archived sibling exists, raising `ValueError` that points at `hermes kanban boards restore <slug>` (or pick a new slug). It does *not* touch the archive.
- Normal creates / the existing idempotent-collision path (slug already live) are unchanged. The dashboard endpoint already maps `ValueError` → HTTP 400 with the message, so restore-or-rename guidance surfaces cleanly in the UI too.

## Test plan

`tests/hermes_cli/test_kanban_boards.py` (added 3 tests, full file 59 passed):
- `test_create_board_refuses_over_archived_slug` — archive → `create_board` same slug raises `ValueError` ("archived"); archive untouched, no live board fabricated.
- `test_create_board_allows_new_slug_after_archive` — a different slug still works (no false positive).
- `test_archived_board_exists_false_for_live_only` — `archived_board_exists` is False for a non-archived board.

## Verification

```
.venv/bin/python -m pytest tests/hermes_cli/test_kanban_boards.py -q
# 59 passed
```

## Risk

`hermes_cli/kanban_db.py` only; adds one helper + one guard in `create_board`. No change to `board_exists` semantics or live-board routing. repowise `risk`: 2nd percentile (low).
