### PR TITLE
fix(tui): resubscribe virtual history after ScrollBox remount

### DIFF
--- a/ui-tui/scripts/bench-history-scroll.tsx
+++ b/ui-tui/scripts/bench-history-scroll.tsx
@@ -14,7 +14,7 @@
 import { PassThrough } from 'stream'
 
 import { Box, renderSync, ScrollBox, type ScrollBoxHandle, Text } from '@hermes/ink'
-import React, { useLayoutEffect, useRef } from 'react'
+import React, { useCallback, useLayoutEffect, useRef, useState } from 'react'
 
 import { useVirtualHistory } from '../src/hooks/useVirtualHistory.js'
 
@@ -129,8 +129,14 @@ function makeItems(count: number): BenchItem[] {
 
 function Harness({ expose, items }: { expose: React.MutableRefObject<Exposed | null>; items: readonly BenchItem[] }) {
   const scrollRef = useRef<ScrollBoxHandle | null>(null)
+  const [scrollHandle, setScrollHandle] = useState<ScrollBoxHandle | null>(null)
 
-  const virtual = useVirtualHistory(scrollRef, items, COLUMNS, {
+  const bindScrollRef = useCallback((next: ScrollBoxHandle | null) => {
+    scrollRef.current = next
+    setScrollHandle(current => (current === next ? current : next))
+  }, [])
+
+  const virtual = useVirtualHistory(scrollHandle, items, COLUMNS, {
     coldStartCount: 30,
     estimateHeight: index => items[index]?.height ?? 1,
     maxMounted: MAX_MOUNTED,
@@ -142,7 +148,7 @@ function Harness({ expose, items }: { expose: React.MutableRefObject<Exposed | n
   })
 
   return (
-    <ScrollBox flexDirection="column" height={ROWS} ref={scrollRef} stickyScroll>
+    <ScrollBox flexDirection="column" height={ROWS} ref={bindScrollRef} stickyScroll>
       <Box flexDirection="column" width="100%">
         {virtual.topSpacer > 0 ? <Box height={virtual.topSpacer} /> : null}
         {items.slice(virtual.start, virtual.end).map(item => (

--- a/ui-tui/src/__tests__/scrollBoxRendererBounds.test.ts
+++ b/ui-tui/src/__tests__/scrollBoxRendererBounds.test.ts
@@ -1,7 +1,7 @@
 import { PassThrough } from 'stream'
 
 import { Box, renderSync, ScrollBox, type ScrollBoxHandle, Text } from '@hermes/ink'
-import React, { useLayoutEffect, useRef } from 'react'
+import React, { useCallback, useLayoutEffect, useRef, useState } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 
 import SourceBox from '../../packages/hermes-ink/src/ink/components/Box.js'
@@ -61,8 +61,14 @@ function Harness({
   maxMounted?: number
 }) {
   const scrollRef = useRef<ScrollBoxHandle | null>(null)
+  const [scrollHandle, setScrollHandle] = useState<ScrollBoxHandle | null>(null)
 
-  const virtualHistory = useVirtualHistory(scrollRef, items, columns, {
+  const bindScrollRef = useCallback((next: ScrollBoxHandle | null) => {
+    scrollRef.current = next
+    setScrollHandle(current => (current === next ? current : next))
+  }, [])
+
+  const virtualHistory = useVirtualHistory(scrollHandle, items, columns, {
     coldStartCount: 16,
     estimateHeight: index => itemHeightForColumns(items[index], columns),
     generation,
@@ -77,7 +83,7 @@ function Harness({
 
   return React.createElement(
     ScrollBox,
-    { flexDirection: 'column', height, ref: scrollRef, stickyScroll: true },
+    { flexDirection: 'column', height, ref: bindScrollRef, stickyScroll: true },
     React.createElement(
       Box,
       { flexDirection: 'column', width: '100%' },

--- a/ui-tui/src/__tests__/virtualHistoryOffsetCache.test.ts
+++ b/ui-tui/src/__tests__/virtualHistoryOffsetCache.test.ts
@@ -1,7 +1,7 @@
 import { PassThrough } from 'stream'
 
 import { Box, renderSync, ScrollBox, type ScrollBoxHandle, Text } from '@hermes/ink'
-import React, { useLayoutEffect, useRef } from 'react'
+import React, { useCallback, useLayoutEffect, useRef, useState } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 
 import { MAX_HISTORY } from '../config/limits.js'
@@ -66,7 +66,8 @@ function Harness({
   generation = 0,
   initialHeights,
   items,
-  maxMounted = 16
+  maxMounted = 16,
+  scrollBoxKey = 'default'
 }: {
   columns?: number
   expose: React.MutableRefObject<Exposed | null>
@@ -75,10 +76,17 @@ function Harness({
   initialHeights?: ReadonlyMap<string, number>
   items: readonly Item[]
   maxMounted?: number
+  scrollBoxKey?: string
 }) {
   const scrollRef = useRef<ScrollBoxHandle | null>(null)
+  const [scrollHandle, setScrollHandle] = useState<ScrollBoxHandle | null>(null)
 
-  const virtualHistory = useVirtualHistory(scrollRef, items, columns, {
+  const bindScrollRef = useCallback((next: ScrollBoxHandle | null) => {
+    scrollRef.current = next
+    setScrollHandle(current => (current === next ? current : next))
+  }, [])
+
+  const virtualHistory = useVirtualHistory(scrollHandle, items, columns, {
     coldStartCount: 16,
     estimateHeight: index => itemHeightForColumns(items[index], columns),
     generation,
@@ -93,7 +101,7 @@ function Harness({
 
   return React.createElement(
     ScrollBox,
-    { flexDirection: 'column', height, ref: scrollRef, stickyScroll: true },
+    { flexDirection: 'column', height, key: scrollBoxKey, ref: bindScrollRef, stickyScroll: true },
     React.createElement(
       Box,
       { flexDirection: 'column', width: '100%' },
@@ -144,6 +152,108 @@ describe('useVirtualHistory offset cache reuse', () => {
     } as ScrollBoxHandle)
 
     expect(short).not.toBe(tall)
+  })
+
+  it('resubscribes when ScrollBox remounts while virtual history stays mounted', async () => {
+    const items = Array.from({ length: 200 }, (_, index) => ({ height: 4, key: `item-${index}` }))
+    const expose = { current: null as Exposed | null }
+    const streams = makeStreams()
+
+    const instance = renderSync(
+      React.createElement(Harness, { expose, items, maxMounted: 40, scrollBoxKey: 'first' }),
+      {
+        patchConsole: false,
+        stderr: streams.stderr as NodeJS.WriteStream,
+        stdin: streams.stdin as NodeJS.ReadStream,
+        stdout: streams.stdout as NodeJS.WriteStream
+      }
+    )
+
+    try {
+      await delay(80)
+
+      const firstScroll = expose.current!.scroll!
+
+      expect(expose.current!.virtualHistory.start).toBeGreaterThan(0)
+
+      instance.rerender(React.createElement(Harness, { expose, items, maxMounted: 40, scrollBoxKey: 'second' }))
+      await delay(80)
+
+      const secondScroll = expose.current!.scroll!
+
+      expect(secondScroll).not.toBe(firstScroll)
+
+      secondScroll.scrollTo(0)
+      await delay(120)
+
+      expect(secondScroll.getScrollTop()).toBe(0)
+      expect(expose.current!.virtualHistory.start).toBe(0)
+      expect(viewportIsMounted(items, expose.current!.virtualHistory, secondScroll)).toBe(true)
+
+      instance.rerender(React.createElement(Harness, { expose, items, maxMounted: 40, scrollBoxKey: 'third' }))
+      await delay(80)
+
+      const thirdScroll = expose.current!.scroll!
+
+      expect(thirdScroll).not.toBe(secondScroll)
+
+      thirdScroll.scrollTo(400)
+      await delay(120)
+
+      expect(thirdScroll.getScrollTop()).toBe(400)
+      expect(viewportIsMounted(items, expose.current!.virtualHistory, thirdScroll)).toBe(true)
+    } finally {
+      instance.unmount()
+      instance.cleanup()
+    }
+  })
+
+  it('uses the remounted ScrollBox for unmount compensation', async () => {
+    const items = Array.from({ length: 20 }, (_, index) => ({ height: 2, key: `item-${index}` }))
+    const initialHeights = new Map(items.map(item => [item.key, item.height]))
+    const expose = { current: null as Exposed | null }
+    const streams = makeStreams()
+
+    const instance = renderSync(
+      React.createElement(Harness, { expose, initialHeights, items, scrollBoxKey: 'first' }),
+      {
+        patchConsole: false,
+        stderr: streams.stderr as NodeJS.WriteStream,
+        stdin: streams.stdin as NodeJS.ReadStream,
+        stdout: streams.stdout as NodeJS.WriteStream
+      }
+    )
+
+    try {
+      await delay(40)
+      const firstScroll = expose.current!.scroll!
+      const firstAdjustScrollTop = vi.spyOn(firstScroll, 'adjustScrollTop')
+
+      instance.rerender(React.createElement(Harness, { expose, initialHeights, items, scrollBoxKey: 'second' }))
+      await delay(40)
+
+      const secondScroll = expose.current!.scroll!
+      const secondAdjustScrollTop = vi.spyOn(secondScroll, 'adjustScrollTop')
+
+      secondScroll.scrollTo(5)
+      await delay(40)
+
+      expect(secondScroll).not.toBe(firstScroll)
+      expect(secondScroll.getScrollTop()).toBe(5)
+      expect(secondScroll.isSticky()).toBe(false)
+
+      const compensatedIndex = expose.current!.virtualHistory.start
+      expect((compensatedIndex + 1) * 2).toBeLessThanOrEqual(5)
+      const ref = expose.current!.virtualHistory.measureRef(items[compensatedIndex]!.key)
+      ref({ yogaNode: { getComputedHeight: () => 5 } })
+      ref(null)
+
+      expect(firstAdjustScrollTop).not.toHaveBeenCalled()
+      expect(secondAdjustScrollTop).toHaveBeenCalledWith(3)
+    } finally {
+      instance.unmount()
+      instance.cleanup()
+    }
   })
 
   it('remounts enough tail rows after the scroll viewport grows', async () => {

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -594,6 +594,7 @@ export interface AppLayoutStatusProps {
 }
 
 export interface AppLayoutTranscriptProps {
+  bindScrollRef: (handle: null | ScrollBoxHandle) => void
   historyItems: Msg[]
   scrollRef: RefObject<null | ScrollBoxHandle>
   virtualHistory: VirtualHistoryState

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -222,6 +222,14 @@ export function useMainApp(gw: GatewayClient) {
   const slashRef = useRef<(cmd: string) => boolean>(() => false)
   const colsRef = useRef(cols)
   const scrollRef = useRef<null | ScrollBoxHandle>(null)
+  // Keep imperative callers on a ref while making mount identity reactive for subscriptions.
+  const [scrollHandle, setScrollHandle] = useState<null | ScrollBoxHandle>(null)
+
+  const bindScrollRef = useCallback((next: null | ScrollBoxHandle) => {
+    scrollRef.current = next
+    setScrollHandle(current => (current === next ? current : next))
+  }, [])
+
   const onEventRef = useRef<(ev: GatewayEvent) => void>(() => {})
   const sysRef = useRef<(text: string) => void>(() => {})
   const submitRef = useRef<(value: string) => void>(() => {})
@@ -423,7 +431,7 @@ export function useMainApp(gw: GatewayClient) {
     [activeHeightCache, virtualRows]
   )
 
-  const virtualHistory = useVirtualHistory(scrollRef, virtualRows, cols, {
+  const virtualHistory = useVirtualHistory(scrollHandle, virtualRows, cols, {
     estimateHeight: estimateRowHeight,
     generation: historyGeneration,
     initialHeights: activeHeightCache,
@@ -1201,8 +1209,8 @@ export function useMainApp(gw: GatewayClient) {
   )
 
   const appTranscript = useMemo(
-    () => ({ historyItems, scrollRef, virtualHistory, virtualRows }),
-    [historyItems, virtualHistory, virtualRows]
+    () => ({ bindScrollRef, historyItems, scrollRef, virtualHistory, virtualRows }),
+    [bindScrollRef, historyItems, virtualHistory, virtualRows]
   )
 
   return { appActions, appComposer, appProgress, appStatus, appTranscript, gateway }

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -189,7 +189,7 @@ const TranscriptPane = memo(function TranscriptPane({
             actions.clearSelection()
           }
         }}
-        ref={transcript.scrollRef}
+        ref={transcript.bindScrollRef}
         stickyScroll
       >
         <Box flexDirection="column" paddingX={1}>

--- a/ui-tui/src/hooks/useVirtualHistory.ts
+++ b/ui-tui/src/hooks/useVirtualHistory.ts
@@ -1,6 +1,5 @@
 import type { ScrollBoxHandle } from '@hermes/ink'
 import {
-  type RefObject,
   useCallback,
   useDeferredValue,
   useEffect,
@@ -136,7 +135,7 @@ export const ensureVirtualItemHeight = (
 }
 
 export function useVirtualHistory(
-  scrollRef: RefObject<ScrollBoxHandle | null>,
+  scrollHandle: ScrollBoxHandle | null,
   items: readonly { key: string }[],
   columns: number,
   {
@@ -158,6 +157,8 @@ export function useVirtualHistory(
   const measuredBottoms = useRef(new Map<string, number>())
   const unmountViewport = useRef<{ sticky: boolean; top: number } | null>(null)
   const onHeightsChangeRef = useRef(onHeightsChange)
+  // Measurement refs are cached by item key, so read the latest mounted box at callback time.
+  const scrollHandleRef = useRef(scrollHandle)
   // Bump whenever heightCache mutates so offsets rebuild on next read.
   // Ref (not state) — checked during render phase, zero extra commits.
   const offsetVersion = useRef(0)
@@ -171,7 +172,6 @@ export function useVirtualHistory(
     version: -1
   })
 
-  const [hasScrollRef, setHasScrollRef] = useState(false)
   // Height cache writes happen in layout effects; bump once so offsets and
   // clamp bounds rebuild without waiting for the next scroll/input event.
   const [measuredHeightVersion, bumpMeasuredHeightVersion] = useState(0)
@@ -191,6 +191,7 @@ export function useVirtualHistory(
   const generationRef = useRef<number | string>(generation)
 
   onHeightsChangeRef.current = onHeightsChange
+  scrollHandleRef.current = scrollHandle
 
   if (generationRef.current !== generation) {
     generationRef.current = generation
@@ -233,22 +234,18 @@ export function useVirtualHistory(
     freezeRenders.current = FREEZE_RENDERS
   }
 
-  useLayoutEffect(() => {
-    setHasScrollRef(Boolean(scrollRef.current))
-  }, [scrollRef])
-
   // Quantized snapshot: same-bin scrolls (most wheel ticks) produce the same
   // key → React.Object.is short-circuits the commit entirely. The key includes
   // sticky state, target scroll position, and viewport height so resize-only
   // changes still recompute the mounted transcript window.
   const subscribe = useCallback(
-    (cb: () => void) => (hasScrollRef ? scrollRef.current?.subscribe(cb) : null) ?? NOOP,
-    [hasScrollRef, scrollRef]
+    (cb: () => void) => scrollHandle?.subscribe(cb) ?? NOOP,
+    [scrollHandle]
   )
 
   useSyncExternalStore(
     subscribe,
-    () => virtualHistorySnapshotKey(scrollRef.current),
+    () => virtualHistorySnapshotKey(scrollHandle),
     () => 'none'
   )
 
@@ -291,12 +288,12 @@ export function useVirtualHistory(
 
   const offsets = offsetsCache.current.arr
   const total = offsets[n] ?? 0
-  const top = safeUnsignedGeometry(scrollRef.current?.getScrollTop() ?? 0)
-  const pendingDelta = safeSignedGeometry(scrollRef.current?.getPendingDelta() ?? 0)
+  const top = safeUnsignedGeometry(scrollHandle?.getScrollTop() ?? 0)
+  const pendingDelta = safeSignedGeometry(scrollHandle?.getPendingDelta() ?? 0)
   const target = safeUnsignedGeometry(top + pendingDelta)
-  const vp = safeUnsignedGeometry(scrollRef.current?.getViewportHeight() ?? 0)
-  const sticky = scrollRef.current?.isSticky() ?? true
-  const recentManual = Date.now() - (scrollRef.current?.getLastManualScrollAt() ?? 0) < 1200
+  const vp = safeUnsignedGeometry(scrollHandle?.getViewportHeight() ?? 0)
+  const sticky = scrollHandle?.isSticky() ?? true
+  const recentManual = Date.now() - (scrollHandle?.getLastManualScrollAt() ?? 0) < 1200
 
   // During a freeze, drop the frozen range if items shrank past its start
   // (/clear, compaction) — clamping would collapse to an empty mount and
@@ -509,7 +506,7 @@ export function useVirtualHistory(
           const previousHeight = heights.current.get(key)
 
           if (validVirtualItemHeight(h) && previousHeight !== h) {
-            const s = scrollRef.current
+            const s = scrollHandleRef.current
             const measuredBottom = measuredBottoms.current.get(key)
 
             // All null refs in this commit share the viewport boundary captured
@@ -545,12 +542,12 @@ export function useVirtualHistory(
 
       return fn
     },
-    [scrollRef]
+    []
   )
 
   useLayoutEffect(() => {
     unmountViewport.current = null
-    const s = scrollRef.current
+    const s = scrollHandle
     let dirty = false
     let heightDirty = false
     let anchorDelta = 0
@@ -660,7 +657,7 @@ export function useVirtualHistory(
     if (heightDirty) {
       bumpMeasuredHeightVersion(n => n + 1)
     }
-  }, [effEnd, effStart, items, liveTailActive, measuredHeightVersion, n, offsets, scrollRef, sticky, top, total, vp])
+  }, [effEnd, effStart, items, liveTailActive, measuredHeightVersion, n, offsets, scrollHandle, sticky, top, total, vp])
 
   return {
     bottomSpacer: Math.max(0, total - (offsets[effEnd] ?? total)),


### PR DESCRIPTION
## What does this PR do?

Fixes transcript scrolling getting stuck after closing a TUI overlay such as `/agents` or `/journey`.

Opening an overlay unmounts the transcript `ScrollBox`, but `useVirtualHistory` stays mounted in `useMainApp`. It previously subscribed through `scrollRef`; the ref object itself does not change when `scrollRef.current` points to a new handle, so `useSyncExternalStore` kept listening to the old `ScrollBox`.

The fix tracks the active handle in state through a callback ref and passes that handle to `useVirtualHistory`. Existing imperative callers still use `scrollRef` as before.

## Changes

- Re-subscribe virtual history whenever the transcript `ScrollBox` is recreated.
- Keep the existing imperative scroll ref API unchanged.
- Make cached row-measurement callbacks read the latest active handle, so post-remount scroll compensation cannot target a stale `ScrollBox`.
- Adapt all current hook call sites, including renderer-bound tests and the history-scroll benchmark.
- Add regression coverage for two consecutive `ScrollBox` remounts while `useVirtualHistory` remains mounted.
- Add regression coverage proving unmount compensation targets the remounted handle rather than the stale one.

## Testing

Run from the repository root:

```bash
NODE_ENV=test npm test --workspace ui-tui -- \
  src/__tests__/virtualHistoryOffsetCache.test.ts \
  src/__tests__/scrollBoxRendererBounds.test.ts

NODE_ENV=test npm test --workspace ui-tui
NODE_ENV=development npm run typecheck --workspace ui-tui
NODE_ENV=development npm run lint --workspace ui-tui
NODE_ENV=production npm run build --workspace ui-tui
```

Results on current `main` (`e400dca96e`):

- Targeted virtual-history and renderer tests: **23 passed**.
- Full TUI suite: **1543 passed, 4 skipped, 1 pre-existing failure**.
- All tests except that known baseline failure: **1543 passed, 5 skipped**.
- TypeScript typecheck: passed.
- ESLint: 0 errors; one pre-existing warning in untouched `useSessionLifecycle.ts`.
- Production build: passed.
- History-scroll benchmark smoke: 0 invalid offsets, 0 non-monotone offsets, maximum anchor error 0.
- `git diff --check`: passed.

The sole full-suite failure is:

```text
createGatewayEventHandler.test.ts
picks the polarity-matching paired palette from gateway.ready skins
```

It reproduces with the same `#00e57a` versus `#8B0000` assertion in a clean detached worktree at `e400dca96e`, so it is unrelated to this PR.

The original overlay scenario was also verified manually by opening and closing `/agents` and `/journey` in a long session, then scrolling in both directions.

## Checklist

- [x] Read the contributing guide
- [x] Searched for existing PRs covering the same issue
- [x] Added regression tests
- [x] Kept the PR limited to this fix
- [x] Tested on macOS
