### PR TITLE
fix(yuanbao): preserve archived transcript rows during recall redaction

### DIFF
--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -1424,7 +1424,15 @@ class RecallGuardMiddleware(InboundMiddleware):
                     if entry.get("role") == "user" and entry.get("content") == recalled_text:
                         entry["content"] = cls._REDACTED
                         try:
-                            store.rewrite_transcript(sid, transcript)
+                            # load_transcript() returns only the active view;
+                            # rewrite_transcript() is destructive by default
+                            # and would DELETE any soft-archived rows a prior
+                            # in-place compaction kept on disk. Preserve them.
+                            try:
+                                has_archived = store.has_archived_messages(sid)
+                            except Exception:
+                                has_archived = False
+                            store.rewrite_transcript(sid, transcript, active_only=has_archived)
                             logger.info("[%s] Recall redact: session %s", adapter.name, session_key[:30])
                         except Exception as exc:
                             logger.warning("[%s] Recall redact failed: %s", adapter.name, exc)
@@ -1484,7 +1492,15 @@ class RecallGuardMiddleware(InboundMiddleware):
         if target is not None:
             target["content"] = cls._REDACTED
             try:
-                store.rewrite_transcript(sid, transcript)
+                # load_transcript() returns only the active view;
+                # rewrite_transcript() is destructive by default and would
+                # DELETE any soft-archived rows a prior in-place compaction
+                # kept on disk. Preserve them.
+                try:
+                    has_archived = store.has_archived_messages(sid)
+                except Exception:
+                    has_archived = False
+                store.rewrite_transcript(sid, transcript, active_only=has_archived)
                 logger.info("[%s] Recall: redacted msg_id=%s (%s)", adapter.name, recalled_id, branch_label)
             except Exception as exc:
                 logger.warning("[%s] Recall: rewrite_transcript failed: %s", adapter.name, exc)

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -1428,10 +1428,15 @@ class RecallGuardMiddleware(InboundMiddleware):
                             # rewrite_transcript() is destructive by default
                             # and would DELETE any soft-archived rows a prior
                             # in-place compaction kept on disk. Preserve them.
+                            # A failed probe means we genuinely don't know
+                            # whether archived rows exist, so fail safe:
+                            # active_only=True is a no-op when nothing is
+                            # archived, and only ever *preserves* data the
+                            # False default would otherwise destroy.
                             try:
                                 has_archived = store.has_archived_messages(sid)
                             except Exception:
-                                has_archived = False
+                                has_archived = True
                             store.rewrite_transcript(sid, transcript, active_only=has_archived)
                             logger.info("[%s] Recall redact: session %s", adapter.name, session_key[:30])
                         except Exception as exc:
@@ -1496,10 +1501,14 @@ class RecallGuardMiddleware(InboundMiddleware):
                 # rewrite_transcript() is destructive by default and would
                 # DELETE any soft-archived rows a prior in-place compaction
                 # kept on disk. Preserve them.
+                # A failed probe means we genuinely don't know whether
+                # archived rows exist, so fail safe: active_only=True is a
+                # no-op when nothing is archived, and only ever *preserves*
+                # data the False default would otherwise destroy.
                 try:
                     has_archived = store.has_archived_messages(sid)
                 except Exception:
-                    has_archived = False
+                    has_archived = True
                 store.rewrite_transcript(sid, transcript, active_only=has_archived)
                 logger.info("[%s] Recall: redacted msg_id=%s (%s)", adapter.name, recalled_id, branch_label)
             except Exception as exc:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -2446,11 +2446,22 @@ class SessionStore:
             logger.debug("has_platform_message_id lookup failed", exc_info=True)
             return False
 
-    def rewrite_transcript(self, session_id: str, messages: List[Dict[str, Any]]) -> bool:
+    def rewrite_transcript(
+        self, session_id: str, messages: List[Dict[str, Any]], active_only: bool = False,
+    ) -> bool:
         """Replace the entire transcript for a session with new messages.
 
         Used by /retry, /undo, and /compress to persist modified conversation
         history. state.db is the canonical store.
+
+        DESTRUCTIVE by default (``active_only=False``): every row for the
+        session is deleted, including any soft-archived (``active = 0``)
+        turns that in-place compaction keeps on disk for durability. Callers
+        that share a session id with an agent that may have compacted
+        in-place must probe :meth:`has_archived_messages` first and pass
+        ``active_only=True`` when it returns True, mirroring the ACP
+        adapter's ``_persist`` guard — otherwise the archived pre-compaction
+        history is silently destroyed.
 
         Returns ``True`` when the write lands (or there is no DB to write to)
         and ``False`` when the canonical write fails. Most callers can ignore
@@ -2462,10 +2473,24 @@ class SessionStore:
         if not self._db:
             return True
         try:
-            self._db.replace_messages(session_id, messages)
+            self._db.replace_messages(session_id, messages, active_only=active_only)
             return True
         except Exception as e:
             logger.debug("Failed to rewrite transcript in DB: %s", e)
+            return False
+
+    def has_archived_messages(self, session_id: str) -> bool:
+        """Return True if the session has any soft-archived (``active = 0``) rows.
+
+        Used by callers of :meth:`rewrite_transcript` to decide whether a
+        full-history rewrite would destroy durably archived compaction turns.
+        """
+        if not self._db:
+            return False
+        try:
+            return bool(self._db.has_archived_messages(session_id))
+        except Exception as e:
+            logger.debug("Could not check archived messages in DB: %s", e)
             return False
 
     def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:

--- a/tests/gateway/platforms/test_yuanbao_recall_db_only.py
+++ b/tests/gateway/platforms/test_yuanbao_recall_db_only.py
@@ -8,8 +8,11 @@ JSONL file gone.  When a row has no platform id (e.g. agent-processed
 @bot messages whose adapter didn't carry a msg_id, or pre-column legacy
 rows), recall falls through to content-match.
 """
-from gateway.session import SessionStore
-from gateway.config import GatewayConfig
+from types import SimpleNamespace
+
+from gateway.platforms.yuanbao import RecallGuardMiddleware
+from gateway.session import SessionSource, SessionStore
+from gateway.config import GatewayConfig, Platform
 
 
 def _pin_db(monkeypatch, tmp_path):
@@ -86,3 +89,110 @@ def test_recall_branch_a2_content_match_when_no_platform_id(tmp_path, monkeypatc
         None,
     )
     assert target is not None
+
+
+def _make_adapter(store, group_code: str, from_account: str):
+    """Minimal adapter stub: only what RecallGuardMiddleware touches."""
+    source = SessionSource(
+        platform=Platform.YUANBAO,
+        chat_id=(f"group:{group_code}" if group_code else f"direct:{from_account}"),
+        chat_type="group" if group_code else "dm",
+        user_id=from_account or None,
+        thread_id="main" if group_code else None,
+    )
+    return SimpleNamespace(
+        name="yuanbao",
+        _session_store=store,
+        build_source=lambda **kw: source,
+    )
+
+
+class TestRecallPreservesArchivedTranscript:
+    """A recall/redaction must not destroy in-place-compacted (archived) history.
+
+    ``_patch_transcript`` loads the ACTIVE-only view via ``load_transcript()``
+    and rewrites it via ``rewrite_transcript()``, which defaults to a full
+    DELETE of every row for the session (see gateway/session.py). A session
+    that has already been in-place-compacted has soft-archived (active=0)
+    rows sitting alongside the live ones; without checking
+    ``has_archived_messages()`` first, a recall event on such a session
+    silently wipes that archived pre-compaction history — the same
+    destructive-rewrite class fixed for the hygiene/``/compress`` paths.
+    """
+
+    def test_patch_transcript_preserves_archived_rows(self, tmp_path, monkeypatch):
+        _pin_db(monkeypatch, tmp_path)
+        config = GatewayConfig()
+        store = SessionStore(sessions_dir=tmp_path, config=config)
+
+        sid = "test-yuanbao-recall-archive"
+        store._db.create_session(session_id=sid, source="yuanbao:direct:acct1")
+        # Simulate a prior in-place compaction: archive the original turns,
+        # then insert a compacted summary as the new active set.
+        store.append_to_transcript(sid, {"role": "user", "content": "pre-compaction turn"})
+        store.append_to_transcript(sid, {"role": "assistant", "content": "pre-compaction reply"})
+        store._db.archive_and_compact(sid, [
+            {"role": "system", "content": "[compacted summary]"},
+        ])
+        assert store.has_archived_messages(sid) is True
+
+        # Now a recall event arrives for a message in the (post-compaction)
+        # active transcript.
+        store.append_to_transcript(sid, {
+            "role": "user",
+            "content": "sensitive content",
+            "message_id": "platform-msg-recall",
+        })
+
+        # _patch_transcript resolves the session via get_or_create_session(),
+        # which keys off the routing table, not the literal session_id we
+        # created directly through store._db. Point it at our session so the
+        # test targets the transcript-rewrite behavior, not routing.
+        monkeypatch.setattr(store, "get_or_create_session", lambda source: SimpleNamespace(session_id=sid))
+
+        adapter = _make_adapter(store, group_code="", from_account="acct1")
+        RecallGuardMiddleware._patch_transcript(
+            adapter, recalled_id="platform-msg-recall",
+            group_code="", from_account="acct1",
+        )
+
+        # The archived pre-compaction turns must survive the rewrite.
+        assert store.has_archived_messages(sid) is True
+        full_history = store._db.get_messages_as_conversation(sid, include_inactive=True)
+        contents = [m["content"] for m in full_history]
+        assert "pre-compaction turn" in contents
+        assert "pre-compaction reply" in contents
+
+        # And the redaction itself must still have taken effect on the
+        # active view.
+        active_history = store.load_transcript(sid)
+        redacted = next(m for m in active_history if m.get("message_id") == "platform-msg-recall")
+        assert redacted["content"] != "sensitive content"
+
+    def test_patch_transcript_no_archived_rows_still_wipes_correctly(self, tmp_path, monkeypatch):
+        """Sessions with NO archived history keep the simple full-replace
+        behavior (active_only=False is a no-op when nothing is archived)."""
+        _pin_db(monkeypatch, tmp_path)
+        config = GatewayConfig()
+        store = SessionStore(sessions_dir=tmp_path, config=config)
+
+        sid = "test-yuanbao-recall-no-archive"
+        store._db.create_session(session_id=sid, source="yuanbao:direct:acct2")
+        store.append_to_transcript(sid, {
+            "role": "user",
+            "content": "sensitive content",
+            "message_id": "platform-msg-recall-2",
+        })
+        assert store.has_archived_messages(sid) is False
+
+        monkeypatch.setattr(store, "get_or_create_session", lambda source: SimpleNamespace(session_id=sid))
+
+        adapter = _make_adapter(store, group_code="", from_account="acct2")
+        RecallGuardMiddleware._patch_transcript(
+            adapter, recalled_id="platform-msg-recall-2",
+            group_code="", from_account="acct2",
+        )
+
+        active_history = store.load_transcript(sid)
+        assert len(active_history) == 1
+        assert active_history[0]["content"] != "sensitive content"

--- a/tests/gateway/platforms/test_yuanbao_recall_db_only.py
+++ b/tests/gateway/platforms/test_yuanbao_recall_db_only.py
@@ -196,3 +196,55 @@ class TestRecallPreservesArchivedTranscript:
         active_history = store.load_transcript(sid)
         assert len(active_history) == 1
         assert active_history[0]["content"] != "sensitive content"
+
+    def test_patch_transcript_fails_safe_when_archive_probe_raises(self, tmp_path, monkeypatch):
+        """If has_archived_messages() itself raises, the rewrite must not
+        assume "no archived rows" (active_only=False) — that would destroy
+        real archived history whenever the probe merely failed to answer.
+        The safe default is active_only=True: a no-op when nothing is
+        archived, and preserves data whenever something actually is.
+        """
+        _pin_db(monkeypatch, tmp_path)
+        config = GatewayConfig()
+        store = SessionStore(sessions_dir=tmp_path, config=config)
+
+        sid = "test-yuanbao-recall-probe-failure"
+        store._db.create_session(session_id=sid, source="yuanbao:direct:acct3")
+        store.append_to_transcript(sid, {"role": "user", "content": "pre-compaction turn"})
+        store.append_to_transcript(sid, {"role": "assistant", "content": "pre-compaction reply"})
+        store._db.archive_and_compact(sid, [
+            {"role": "system", "content": "[compacted summary]"},
+        ])
+        assert store.has_archived_messages(sid) is True
+
+        store.append_to_transcript(sid, {
+            "role": "user",
+            "content": "sensitive content",
+            "message_id": "platform-msg-recall-3",
+        })
+
+        monkeypatch.setattr(store, "get_or_create_session", lambda source: SimpleNamespace(session_id=sid))
+        # Simulate the probe itself failing (e.g. a transient DB error),
+        # rather than genuinely reporting "no archived rows".
+        monkeypatch.setattr(
+            store, "has_archived_messages",
+            lambda session_id: (_ for _ in ()).throw(RuntimeError("db probe failed")),
+        )
+
+        adapter = _make_adapter(store, group_code="", from_account="acct3")
+        RecallGuardMiddleware._patch_transcript(
+            adapter, recalled_id="platform-msg-recall-3",
+            group_code="", from_account="acct3",
+        )
+
+        # The archived pre-compaction turns must survive despite the probe
+        # failure — the rewrite must not have defaulted to destructive mode.
+        full_history = store._db.get_messages_as_conversation(sid, include_inactive=True)
+        contents = [m["content"] for m in full_history]
+        assert "pre-compaction turn" in contents
+        assert "pre-compaction reply" in contents
+
+        # And the redaction itself must still have taken effect.
+        active_history = store.load_transcript(sid)
+        redacted = next(m for m in active_history if m.get("message_id") == "platform-msg-recall-3")
+        assert redacted["content"] != "sensitive content"


### PR DESCRIPTION
## What does this PR do?
`RecallGuardMiddleware._schedule_content_redact()` and `_patch_transcript()` (`gateway/platforms/yuanbao.py`) redact a recalled/deleted Yuanbao message by loading the transcript via `load_transcript()` (active rows only) and writing it back via `rewrite_transcript()`. `rewrite_transcript()` is destructive by default: it deletes **every** row for the session, including any soft-archived (`active = 0`) rows that in-place compaction (`compression.in_place`, #38763) keeps on disk for durability.

Any Yuanbao session that had ever been compressed in-place, followed later by a user recalling/deleting a message, silently lost its entire pre-compaction history — same failure mode merged today in #61716 for the hygiene/`/compress` rewrite paths in `gateway/run.py`, and the same class the ACP adapter (`acp_adapter/session.py::_persist`) already guards against by probing `has_archived_messages()` before deciding `active_only`.

Related open PR #57803 proposes fixing this at the `hermes_state.py::replace_messages()` default-value layer, covering `gateway/session.py` and `tui_gateway/server.py`'s callers — it does not touch `gateway/platforms/yuanbao.py`, so this remains uncovered either way.

## Related Issue
N/A — found via a sibling-site sweep of the `rewrite_transcript()` destructive-default pattern after today's #61716 fix.

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- `gateway/session.py`: add `active_only: bool = False` passthrough parameter to `SessionStore.rewrite_transcript()` (forwarded to `replace_messages`); add `SessionStore.has_archived_messages()` passthrough. Both are additive — the three existing callers (hygiene handler, `/compress`, `/retry`+`/undo`) pass no `active_only` and are unaffected.
- `gateway/platforms/yuanbao.py`: both `rewrite_transcript()` call sites now probe `has_archived_messages(sid)` first and pass `active_only=has_archived`, mirroring the ACP adapter's existing guard exactly.
- `tests/gateway/platforms/test_yuanbao_recall_db_only.py`: add `TestRecallPreservesArchivedTranscript` — one test simulating a prior in-place compaction (via `archive_and_compact`) and verifying the archived rows survive a recall redaction; one test verifying the plain (no archived history) case is unchanged.

## How to Test
```
pytest tests/gateway/platforms/test_yuanbao_recall_db_only.py tests/gateway/test_session.py -v
```
112 passed. Also ran the wider yuanbao + compress/hygiene + `hermes_state.py` suites (530 tests) — all pass, no regressions.

Mutation-verified: reverting only the `yuanbao.py` call-site change (keeping the new `SessionStore` API) reproduces the exact bug — `has_archived_messages(sid)` flips from `True` to `False` after a recall redaction, i.e. the archived pre-compaction rows are actually deleted.

## Checklist
- [x] Read the Contributing Guide
- [x] Conventional Commits format
- [x] No duplicate PR
- [x] Single logical change
- [x] Tests added
- [x] Platform tested: macOS
- [x] Docs: N/A
- [x] Cross-platform: N/A