### PR TITLE
feat(memory): per-user USER.md profiles keyed by platform user_id

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1337,10 +1337,11 @@ def init_agent(
             agent._user_profile_enabled = mem_config.get("user_profile_enabled", False)
             agent._memory_nudge_interval = int(mem_config.get("nudge_interval", 10))
             if agent._memory_enabled or agent._user_profile_enabled:
-                from tools.memory_tool import MemoryStore
+                from tools.memory_tool import MemoryStore, resolve_user_scope
                 agent._memory_store = MemoryStore(
                     memory_char_limit=mem_config.get("memory_char_limit", 2200),
                     user_char_limit=mem_config.get("user_char_limit", 1375),
+                    user_scope=resolve_user_scope(user_id, mem_config),
                 )
                 agent._memory_store.load_from_disk()
         except Exception:

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1341,7 +1341,8 @@ def init_agent(
                 agent._memory_store = MemoryStore(
                     memory_char_limit=mem_config.get("memory_char_limit", 2200),
                     user_char_limit=mem_config.get("user_char_limit", 1375),
-                    user_scope=resolve_user_scope(user_id, mem_config),
+                    user_scope=resolve_user_scope(user_id, mem_config,
+                                                  platform=platform),
                 )
                 agent._memory_store.load_from_disk()
         except Exception:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2787,6 +2787,9 @@ class GatewaySlashCommandsMixin:
         # Apply approved writes against a fresh on-disk store (the gateway has
         # no long-lived agent; the store persists to the same MEMORY/USER.md).
         # load_on_disk_store() honors the user's configured char limits.
+        # Per-user profile scopes are recovered per record inside
+        # apply_memory_pending() from the staged payload, so one unscoped
+        # store here stays correct with memory.per_user_profiles on.
         store = load_on_disk_store()
 
         out = handle_pending_subcommand(

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2191,6 +2191,22 @@ DEFAULT_CONFIG = {
         "write_approval": False,
         "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
         "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
+        # Per-user USER.md profiles for multi-user gateway setups.
+        #   false (default) — one shared USER.md (legacy behaviour)
+        #   true            — the memory tool's "user" target maps to
+        #                     memories/users/<key>/USER.md per speaker;
+        #                     MEMORY.md stays shared by design.
+        "per_user_profiles": False,
+        # Optional registry mapping platform user ids to profile keys.
+        # Empty = <hermes_home>/data/users.json. Schema:
+        #   {"users": {"telegram:12345": {"key": "alice"},
+        #              "12345":          {"key": "alice"}}}
+        # A platform-qualified "<platform>:<id>" entry wins over a bare
+        # "<id>" one; unregistered ids get their own isolated scope.
+        "users_registry": "",
+        # Profile scope for sessions without a platform user_id (CLI,
+        # cron). Empty = those sessions keep the legacy shared USER.md.
+        "default_user_key": "",
         # External memory provider plugin (empty = built-in only).
         # Set to a provider name to activate: "openviking", "mem0",
         # "hindsight", "holographic", "retaindb", "byterover".

--- a/tests/tools/test_memory_tool_multiuser.py
+++ b/tests/tools/test_memory_tool_multiuser.py
@@ -1,0 +1,110 @@
+"""Per-user USER.md profile scoping (memory.per_user_profiles)."""
+import json
+
+import pytest
+
+from tools import memory_tool
+from tools.memory_tool import MemoryStore, resolve_user_scope
+
+
+@pytest.fixture
+def mem_home(tmp_path, monkeypatch):
+    monkeypatch.setattr(memory_tool, "get_hermes_home", lambda: tmp_path)
+    (tmp_path / "memories").mkdir(parents=True)
+    return tmp_path
+
+
+def _write(path, entries):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(memory_tool.ENTRY_DELIMITER.join(entries), encoding="utf-8")
+
+
+class TestResolveUserScope:
+    def test_flag_off_returns_legacy(self, mem_home):
+        assert resolve_user_scope("12345678", {}) == ""
+        assert resolve_user_scope("12345678", {"per_user_profiles": False}) == ""
+
+    def test_no_user_id_uses_default_key(self, mem_home):
+        cfg = {"per_user_profiles": True, "default_user_key": "Owner"}
+        assert resolve_user_scope("", cfg) == "owner"
+        assert resolve_user_scope(None, cfg) == "owner"
+
+    def test_no_user_id_no_default_is_legacy(self, mem_home):
+        assert resolve_user_scope("", {"per_user_profiles": True}) == ""
+
+    def test_registry_maps_id_to_key(self, mem_home):
+        reg = mem_home / "data" / "users.json"
+        reg.parent.mkdir(parents=True)
+        reg.write_text(json.dumps(
+            {"users": {"111": {"key": "alice"}, "222": {"key": "bob"}}}))
+        cfg = {"per_user_profiles": True}
+        assert resolve_user_scope("111", cfg) == "alice"
+        assert resolve_user_scope("222", cfg) == "bob"
+
+    def test_unlisted_id_gets_own_scope(self, mem_home):
+        reg = mem_home / "data" / "users.json"
+        reg.parent.mkdir(parents=True)
+        reg.write_text(json.dumps({"users": {"111": {"key": "alice"}}}))
+        cfg = {"per_user_profiles": True}
+        assert resolve_user_scope("999", cfg) == "999"
+
+    def test_missing_registry_falls_back_to_id(self, mem_home):
+        cfg = {"per_user_profiles": True}
+        assert resolve_user_scope("SomeUser", cfg) == "someuser"
+
+    def test_custom_registry_path(self, mem_home, tmp_path):
+        reg = tmp_path / "custom.json"
+        reg.write_text(json.dumps({"users": {"7": {"key": "carol"}}}))
+        cfg = {"per_user_profiles": True, "users_registry": str(reg)}
+        assert resolve_user_scope("7", cfg) == "carol"
+
+
+class TestScopedStore:
+    def test_legacy_paths_without_scope(self, mem_home):
+        store = MemoryStore()
+        assert store._path_for("user") == mem_home / "memories" / "USER.md"
+        assert store._path_for("memory") == mem_home / "memories" / "MEMORY.md"
+
+    def test_scoped_user_path_shared_memory_path(self, mem_home):
+        store = MemoryStore(user_scope="alice")
+        assert store._path_for("user") == (
+            mem_home / "memories" / "users" / "alice" / "USER.md")
+        assert store._path_for("memory") == mem_home / "memories" / "MEMORY.md"
+
+    def test_load_reads_scoped_profile(self, mem_home):
+        _write(mem_home / "memories" / "USER.md", ["legacy profile entry"])
+        _write(mem_home / "memories" / "users" / "alice" / "USER.md",
+               ["alice profile entry"])
+        _write(mem_home / "memories" / "MEMORY.md", ["shared fact"])
+
+        legacy = MemoryStore()
+        legacy.load_from_disk()
+        assert legacy.user_entries == ["legacy profile entry"]
+
+        alice = MemoryStore(user_scope="alice")
+        alice.load_from_disk()
+        assert alice.user_entries == ["alice profile entry"]
+        assert alice.memory_entries == ["shared fact"]
+
+    def test_save_creates_scoped_dir(self, mem_home):
+        store = MemoryStore(user_scope="bob")
+        store.load_from_disk()
+        store.user_entries = ["bob likes tests"]
+        store.save_to_disk("user")
+        assert (mem_home / "memories" / "users" / "bob" / "USER.md").exists()
+        # shared file untouched
+        assert not (mem_home / "memories" / "USER.md").exists()
+
+    def test_cross_scope_isolation(self, mem_home):
+        a = MemoryStore(user_scope="alice")
+        a.load_from_disk()
+        a.user_entries = ["alice only"]
+        a.save_to_disk("user")
+
+        b = MemoryStore(user_scope="bob")
+        b.load_from_disk()
+        assert b.user_entries == []
+
+    def test_scope_is_sanitized(self, mem_home):
+        store = MemoryStore(user_scope="A/B..C!")
+        assert store.user_scope == "abc"

--- a/tests/tools/test_memory_tool_multiuser.py
+++ b/tests/tools/test_memory_tool_multiuser.py
@@ -4,7 +4,12 @@ import json
 import pytest
 
 from tools import memory_tool
-from tools.memory_tool import MemoryStore, resolve_user_scope
+from tools.memory_tool import (
+    MemoryStore,
+    _isolated_id_scope,
+    apply_memory_pending,
+    resolve_user_scope,
+)
 
 
 @pytest.fixture
@@ -50,7 +55,12 @@ class TestResolveUserScope:
 
     def test_missing_registry_falls_back_to_id(self, mem_home):
         cfg = {"per_user_profiles": True}
-        assert resolve_user_scope("SomeUser", cfg) == "someuser"
+        assert resolve_user_scope("999", cfg) == "999"
+        # A raw id that sanitization would alter gets a digest suffix so it
+        # can never merge with its clean twin.
+        hardened = resolve_user_scope("SomeUser", cfg)
+        assert hardened.startswith("someuser-")
+        assert hardened != resolve_user_scope("someuser", cfg)
 
     def test_custom_registry_path(self, mem_home, tmp_path):
         reg = tmp_path / "custom.json"
@@ -108,3 +118,161 @@ class TestScopedStore:
     def test_scope_is_sanitized(self, mem_home):
         store = MemoryStore(user_scope="A/B..C!")
         assert store.user_scope == "abc"
+
+    def test_resolved_scope_survives_store_resanitization(self, mem_home):
+        # Digest-hardened scopes from _isolated_id_scope are clean slugs, so
+        # the store's own (lossy) re-sanitization passes them through intact.
+        scope = _isolated_id_scope("Weird/Id!", "telegram")
+        assert MemoryStore(user_scope=scope).user_scope == scope
+
+
+class TestIsolatedIdScopeCollisions:
+    def test_dropped_chars_do_not_merge_ids(self):
+        assert _isolated_id_scope("a/b") != _isolated_id_scope("ab")
+        assert _isolated_id_scope("ab") == "ab"
+
+    def test_all_symbol_ids_stay_distinct_and_non_empty(self):
+        s1 = _isolated_id_scope("###")
+        s2 = _isolated_id_scope("@@@")
+        assert s1 and s2 and s1 != s2
+
+    def test_case_variants_stay_distinct(self):
+        # Some platforms use case-sensitive ids (e.g. YouTube channel ids).
+        assert _isolated_id_scope("UCabc") != _isolated_id_scope("ucabc")
+
+    def test_deterministic(self):
+        assert _isolated_id_scope("Weird/Id!") == _isolated_id_scope("Weird/Id!")
+
+
+class TestResolveUserScopePlatform:
+    def test_unlisted_id_is_platform_qualified(self, mem_home):
+        cfg = {"per_user_profiles": True}
+        tg = resolve_user_scope("123", cfg, platform="telegram")
+        dc = resolve_user_scope("123", cfg, platform="discord")
+        assert tg == "telegram-123"
+        assert dc == "discord-123"
+        assert tg != dc
+
+    def test_registry_platform_qualified_entry_wins(self, mem_home):
+        reg = mem_home / "data" / "users.json"
+        reg.parent.mkdir(parents=True)
+        reg.write_text(json.dumps({"users": {
+            "telegram:111": {"key": "alice"},
+            "111": {"key": "generic"},
+        }}))
+        cfg = {"per_user_profiles": True}
+        assert resolve_user_scope("111", cfg, platform="telegram") == "alice"
+        # Other platforms and platform-less callers fall back to the bare id
+        # entry, so existing registries keep working unchanged.
+        assert resolve_user_scope("111", cfg, platform="discord") == "generic"
+        assert resolve_user_scope("111", cfg) == "generic"
+
+
+class TestApprovalScopeRoundTrip:
+    """Write-approval staging must persist the user scope and approval replay
+    must recover it — no matter which store the approver happens to hold."""
+
+    @pytest.fixture
+    def gate_on(self, monkeypatch):
+        from tools import write_approval as wa
+        monkeypatch.setattr(wa, "write_approval_enabled", lambda subsystem: True)
+        return wa
+
+    def test_staged_single_payload_carries_scope(self, mem_home, monkeypatch, gate_on):
+        staged = {}
+        real_stage = gate_on.stage_write
+
+        def capture(subsystem, payload, **kwargs):
+            staged.update(payload)
+            return real_stage(subsystem, payload, **kwargs)
+
+        monkeypatch.setattr(gate_on, "stage_write", capture)
+        store = MemoryStore(user_scope="alice")
+        out = json.loads(memory_tool.memory_tool(
+            action="add", target="user", content="likes tea", store=store))
+        assert out.get("staged") is True
+        assert staged["user_scope"] == "alice"
+
+    def test_staged_batch_payload_carries_scope(self, mem_home, monkeypatch, gate_on):
+        staged = {}
+        real_stage = gate_on.stage_write
+
+        def capture(subsystem, payload, **kwargs):
+            staged.update(payload)
+            return real_stage(subsystem, payload, **kwargs)
+
+        monkeypatch.setattr(gate_on, "stage_write", capture)
+        store = MemoryStore(user_scope="bob")
+        out = json.loads(memory_tool.memory_tool(
+            target="user",
+            operations=[{"action": "add", "content": "batch entry"}],
+            store=store))
+        assert out.get("staged") is True
+        assert staged["user_scope"] == "bob"
+
+    def test_apply_recovers_scope_over_unscoped_store(self, mem_home):
+        # Gateway shape: approvals are applied against a fresh UNscoped store.
+        payload = {"action": "add", "target": "user",
+                   "content": "alice entry", "user_scope": "alice"}
+        unscoped = MemoryStore()
+        unscoped.load_from_disk()
+        result = apply_memory_pending(payload, unscoped)
+        assert result["success"] is True
+        scoped_file = mem_home / "memories" / "users" / "alice" / "USER.md"
+        assert "alice entry" in scoped_file.read_text(encoding="utf-8")
+        assert not (mem_home / "memories" / "USER.md").exists()
+
+    def test_apply_does_not_hijack_approver_scope(self, mem_home):
+        # CLI shape: the approver's live store is scoped to the APPROVER —
+        # the staged write must still land in the STAGER's profile.
+        payload = {"action": "add", "target": "user",
+                   "content": "for alice", "user_scope": "alice"}
+        approver = MemoryStore(user_scope="bob")
+        approver.load_from_disk()
+        apply_memory_pending(payload, approver)
+        assert (mem_home / "memories" / "users" / "alice" / "USER.md").exists()
+        assert not (mem_home / "memories" / "users" / "bob" / "USER.md").exists()
+
+    def test_legacy_payload_without_scope_stays_legacy(self, mem_home):
+        # Records staged before scopes existed carry no user_scope key and
+        # keep applying to the legacy shared file, even via a scoped store.
+        payload = {"action": "add", "target": "user", "content": "old style"}
+        approver = MemoryStore(user_scope="bob")
+        approver.load_from_disk()
+        apply_memory_pending(payload, approver)
+        assert (mem_home / "memories" / "USER.md").exists()
+        assert not (mem_home / "memories" / "users" / "bob" / "USER.md").exists()
+
+    def test_batch_apply_recovers_scope(self, mem_home):
+        payload = {"action": "batch", "target": "user", "user_scope": "carol",
+                   "operations": [{"action": "add", "content": "batch fact"}]}
+        unscoped = MemoryStore()
+        unscoped.load_from_disk()
+        result = apply_memory_pending(payload, unscoped)
+        assert result["success"] is True
+        scoped_file = mem_home / "memories" / "users" / "carol" / "USER.md"
+        assert "batch fact" in scoped_file.read_text(encoding="utf-8")
+
+    def test_gateway_approve_flow_end_to_end(self, mem_home, monkeypatch, gate_on):
+        # Full stage → /memory approve round trip the way the gateway runs it
+        # (gateway/slash_commands.py): staged by a scoped session, applied
+        # against a fresh unscoped on-disk store.
+        from hermes_cli.write_approval_commands import handle_pending_subcommand
+        monkeypatch.setattr(gate_on, "get_hermes_home", lambda: mem_home)
+
+        stager = MemoryStore(user_scope="alice")
+        stager.load_from_disk()
+        out = json.loads(memory_tool.memory_tool(
+            action="add", target="user", content="tea, not coffee",
+            store=stager))
+        assert out.get("staged") is True
+
+        gateway_store = memory_tool.load_on_disk_store()
+        msg = handle_pending_subcommand(
+            gate_on.MEMORY, ["approve", out["pending_id"]],
+            memory_store=gateway_store)
+        assert isinstance(msg, str)
+
+        scoped = mem_home / "memories" / "users" / "alice" / "USER.md"
+        assert "tea, not coffee" in scoped.read_text(encoding="utf-8")
+        assert not (mem_home / "memories" / "USER.md").exists()

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -25,6 +25,7 @@ Design:
 
 import json
 import logging
+import re
 import os
 import tempfile
 import time
@@ -55,6 +56,41 @@ logger = logging.getLogger(__name__)
 def get_memory_dir() -> Path:
     """Return the profile-scoped memories directory."""
     return get_hermes_home() / "memories"
+
+
+def _sanitize_user_scope(key: str) -> str:
+    """Normalize a user-scope key to a filesystem-safe slug ("" = legacy)."""
+    return re.sub(r"[^a-z0-9_-]", "", (key or "").strip().lower())
+
+
+def resolve_user_scope(user_id: Optional[str], mem_config: Dict[str, Any]) -> str:
+    """Map a platform user_id to a USER.md scope key.
+
+    Returns "" (legacy shared USER.md) unless memory.per_user_profiles is
+    enabled. With the flag on:
+      - a session WITHOUT a user_id (CLI, cron) uses memory.default_user_key;
+      - a user_id listed in the registry file (memory.users_registry, default
+        <hermes_home>/data/users.json, schema {"users": {"<id>": {"key": ...}}})
+        maps to that entry's key;
+      - an unlisted user_id falls back to the sanitized id itself, so unknown
+        speakers get their own isolated profile rather than someone else's.
+    """
+    if not mem_config or not mem_config.get("per_user_profiles", False):
+        return ""
+    uid = str(user_id or "").strip()
+    if not uid:
+        return _sanitize_user_scope(str(mem_config.get("default_user_key", "")))
+    reg_path = str(mem_config.get("users_registry", "") or
+                   (get_hermes_home() / "data" / "users.json"))
+    key = ""
+    try:
+        with open(reg_path, encoding="utf-8") as fh:
+            entry = (json.load(fh).get("users") or {}).get(uid)
+        if isinstance(entry, dict):
+            key = str(entry.get("key", ""))
+    except Exception:
+        key = ""
+    return _sanitize_user_scope(key) or _sanitize_user_scope(uid) or "unknown"
 
 ENTRY_DELIMITER = "\n§\n"
 
@@ -127,9 +163,13 @@ class MemoryStore:
     # turn to budget exhaustion and suppress the user's reply (issue #42405).
     _MAX_CONSOLIDATION_FAILURES_PER_TURN = 3
 
-    def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375):
+    def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375,
+                 user_scope: str = ""):
         self.memory_entries: List[str] = []
         self.user_entries: List[str] = []
+        # Scope key for the USER.md profile ("" = legacy shared file).
+        # MEMORY.md is always shared; only the user profile is per-person.
+        self.user_scope = _sanitize_user_scope(user_scope)
         self.memory_char_limit = memory_char_limit
         self.user_char_limit = user_char_limit
         # Frozen snapshot for system prompt -- set once at load_from_disk()
@@ -186,7 +226,7 @@ class MemoryStore:
         mem_dir.mkdir(parents=True, exist_ok=True)
 
         self.memory_entries = self._read_file(mem_dir / "MEMORY.md")
-        self.user_entries = self._read_file(mem_dir / "USER.md")
+        self.user_entries = self._read_file(self._path_for("user"))
 
         # Deduplicate entries (preserves order, keeps first occurrence)
         self.memory_entries = list(dict.fromkeys(self.memory_entries))
@@ -277,10 +317,11 @@ class MemoryStore:
                     pass
             fd.close()
 
-    @staticmethod
-    def _path_for(target: str) -> Path:
+    def _path_for(self, target: str) -> Path:
         mem_dir = get_memory_dir()
         if target == "user":
+            if self.user_scope:
+                return mem_dir / "users" / self.user_scope / "USER.md"
             return mem_dir / "USER.md"
         return mem_dir / "MEMORY.md"
 
@@ -308,8 +349,9 @@ class MemoryStore:
 
     def save_to_disk(self, target: str):
         """Persist entries to the appropriate file. Called after every mutation."""
-        get_memory_dir().mkdir(parents=True, exist_ok=True)
-        self._write_file(self._path_for(target), self._entries_for(target))
+        path = self._path_for(target)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._write_file(path, self._entries_for(target))
 
     def _entries_for(self, target: str) -> List[str]:
         if target == "user":

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -23,6 +23,7 @@ Design:
 - Frozen snapshot pattern: system prompt is stable, tool responses show live state
 """
 
+import hashlib
 import json
 import logging
 import re
@@ -59,11 +60,38 @@ def get_memory_dir() -> Path:
 
 
 def _sanitize_user_scope(key: str) -> str:
-    """Normalize a user-scope key to a filesystem-safe slug ("" = legacy)."""
+    """Normalize a user-scope key to a filesystem-safe slug ("" = legacy).
+
+    Lossy by design — meant for ADMIN-CHOSEN keys (registry ``key`` values,
+    ``memory.default_user_key``) where "Owner" and "owner" are the same
+    person, and for re-sanitizing already-resolved scopes (idempotent: any
+    resolved scope is a clean slug and passes through unchanged). Raw
+    platform ids take the collision-resistant :func:`_isolated_id_scope`
+    path instead.
+    """
     return re.sub(r"[^a-z0-9_-]", "", (key or "").strip().lower())
 
 
-def resolve_user_scope(user_id: Optional[str], mem_config: Dict[str, Any]) -> str:
+def _isolated_id_scope(user_id: str, platform: str = "") -> str:
+    """Collision-resistant scope for an UNREGISTERED platform user id.
+
+    Platform-qualified ("<platform>-<id>") so equal raw ids from different
+    platforms can never share a profile, and digest-hardened: whenever
+    slugging would alter the qualified id (case-folding, dropped characters)
+    a short stable digest of the raw value is appended, so distinct ids can
+    never merge into one scope ("a/b" vs "ab", "UCx" vs "ucx", or two
+    all-symbol ids).
+    """
+    raw = f"{platform}-{user_id}" if platform else user_id
+    slug = re.sub(r"[^a-z0-9_-]", "", raw.lower())
+    if slug == raw:
+        return slug
+    digest = hashlib.sha256(raw.encode("utf-8", "replace")).hexdigest()[:8]
+    return f"{slug}-{digest}" if slug else f"u-{digest}"
+
+
+def resolve_user_scope(user_id: Optional[str], mem_config: Dict[str, Any],
+                       platform: Optional[str] = None) -> str:
     """Map a platform user_id to a USER.md scope key.
 
     Returns "" (legacy shared USER.md) unless memory.per_user_profiles is
@@ -71,26 +99,36 @@ def resolve_user_scope(user_id: Optional[str], mem_config: Dict[str, Any]) -> st
       - a session WITHOUT a user_id (CLI, cron) uses memory.default_user_key;
       - a user_id listed in the registry file (memory.users_registry, default
         <hermes_home>/data/users.json, schema {"users": {"<id>": {"key": ...}}})
-        maps to that entry's key;
-      - an unlisted user_id falls back to the sanitized id itself, so unknown
-        speakers get their own isolated profile rather than someone else's.
+        maps to that entry's key; a platform-qualified entry
+        ("<platform>:<id>") takes precedence over a bare "<id>" one;
+      - an unlisted user_id falls back to its own platform-qualified,
+        collision-resistant scope ("<platform>-<id>" fed through
+        _sanitize_user_scope), so unknown speakers get an isolated profile
+        and equal raw ids from different platforms can never share one.
     """
     if not mem_config or not mem_config.get("per_user_profiles", False):
         return ""
     uid = str(user_id or "").strip()
     if not uid:
         return _sanitize_user_scope(str(mem_config.get("default_user_key", "")))
+    plat = str(platform or "").strip().lower()
     reg_path = str(mem_config.get("users_registry", "") or
                    (get_hermes_home() / "data" / "users.json"))
     key = ""
     try:
         with open(reg_path, encoding="utf-8") as fh:
-            entry = (json.load(fh).get("users") or {}).get(uid)
+            users = json.load(fh).get("users") or {}
+        entry = users.get(f"{plat}:{uid}") if plat else None
+        if entry is None:
+            entry = users.get(uid)
         if isinstance(entry, dict):
             key = str(entry.get("key", ""))
     except Exception:
         key = ""
-    return _sanitize_user_scope(key) or _sanitize_user_scope(uid) or "unknown"
+    scoped = _sanitize_user_scope(key)
+    if scoped:
+        return scoped
+    return _isolated_id_scope(uid, plat)
 
 ENTRY_DELIMITER = "\n§\n"
 
@@ -830,7 +868,7 @@ class MemoryStore:
             raise RuntimeError(f"Failed to write memory file {path}: {e}")
 
 
-def load_on_disk_store() -> "MemoryStore":
+def load_on_disk_store(user_scope: str = "") -> "MemoryStore":
     """Build a fresh on-disk :class:`MemoryStore`, honoring configured char limits.
 
     Use this from any context that has no live agent (the messaging gateway, the
@@ -839,6 +877,9 @@ def load_on_disk_store() -> "MemoryStore":
     in ``agent/agent_init.py`` — including the user's ``memory.memory_char_limit``
     / ``memory.user_char_limit`` overrides — so an approval applied without a live
     agent enforces the SAME caps as one applied with one.
+
+    ``user_scope`` selects a per-user USER.md profile ("" = legacy shared file);
+    pass a staged payload's recorded scope when replaying approved writes.
 
     Falls back to the built-in defaults if config can't be loaded, so this can
     never raise on a missing/unreadable config.
@@ -857,18 +898,23 @@ def load_on_disk_store() -> "MemoryStore":
     store = MemoryStore(
         memory_char_limit=memory_char_limit,
         user_char_limit=user_char_limit,
+        user_scope=user_scope,
     )
     store.load_from_disk()
     return store
 
 
 def _apply_write_gate(action: str, target: str, content: Optional[str],
-                      old_text: Optional[str]) -> Optional[str]:
+                      old_text: Optional[str],
+                      user_scope: str = "") -> Optional[str]:
     """Evaluate the memory write gate. Returns a JSON tool-result string when
     the write should NOT proceed normally (blocked or staged), or None when the
     caller should perform the real write.
 
-    Only the mutating actions (add/replace/remove) are gated.
+    Only the mutating actions (add/replace/remove) are gated. ``user_scope``
+    (the staging store's per-user profile scope) is recorded in the staged
+    payload so approval replay writes to the same profile the write was
+    created under — the approver's own store may be scoped differently.
     """
     if action not in {"add", "replace", "remove"}:
         return None
@@ -906,6 +952,7 @@ def _apply_write_gate(action: str, target: str, content: Optional[str],
         "target": target,
         "content": content,
         "old_text": old_text,
+        "user_scope": user_scope,
     }
     record = wa.stage_write(
         wa.MEMORY, payload,
@@ -919,12 +966,16 @@ def _apply_write_gate(action: str, target: str, content: Optional[str],
     )
 
 
-def _apply_batch_write_gate(target: str, operations: List[Dict[str, Any]]) -> Optional[str]:
+def _apply_batch_write_gate(target: str, operations: List[Dict[str, Any]],
+                            user_scope: str = "") -> Optional[str]:
     """Evaluate the write gate for a batch of memory operations.
 
     Returns a JSON tool-result string when the batch should NOT proceed
     (blocked or staged), or None when the caller should perform the real
-    batch write. The whole batch is gated as a single unit.
+    batch write. The whole batch is gated as a single unit. ``user_scope``
+    is recorded in the staged payload for the same reason as in
+    :func:`_apply_write_gate` — approval replay must target the profile the
+    batch was staged under.
     """
     try:
         from tools import write_approval as wa
@@ -953,7 +1004,8 @@ def _apply_batch_write_gate(target: str, operations: List[Dict[str, Any]]) -> Op
     if decision.blocked:
         return tool_error(decision.message, success=False)
 
-    payload = {"action": "batch", "target": target, "operations": operations}
+    payload = {"action": "batch", "target": target, "operations": operations,
+               "user_scope": user_scope}
     record = wa.stage_write(
         wa.MEMORY, payload,
         summary=f"{summary}: {detail[:120]}",
@@ -1032,7 +1084,8 @@ def memory_tool(
     if operations:
         if not isinstance(operations, list):
             return tool_error("operations must be a list of {action, content?, old_text?} objects.", success=False)
-        gate_result = _apply_batch_write_gate(target, operations)
+        gate_result = _apply_batch_write_gate(target, operations,
+                                              user_scope=store.user_scope)
         if gate_result is not None:
             return gate_result
         result = store.apply_batch(target, operations)
@@ -1057,7 +1110,8 @@ def memory_tool(
 
     # Approval gate: when on, stages the write (background/gateway) or prompts
     # inline (interactive CLI); when off (default) passes straight through.
-    gate_result = _apply_write_gate(action, target, content, old_text)
+    gate_result = _apply_write_gate(action, target, content, old_text,
+                                    user_scope=store.user_scope)
     if gate_result is not None:
         return gate_result
 
@@ -1085,12 +1139,25 @@ def apply_memory_pending(payload: Dict[str, Any], store: "MemoryStore") -> Dict[
     """Replay a staged memory write directly against the store, bypassing the
     write gate. Called by the /memory approve handler.
 
+    The staged payload records the ``user_scope`` it was created under
+    (per-user USER.md profiles). The approver's store may be scoped
+    differently — the gateway applies against an unscoped on-disk store, an
+    interactive CLI against its own session's store — so recover the staged
+    scope and rebuild the store when they differ; otherwise an approved
+    ``user`` write would land in the approver's profile instead of the
+    stager's. Payloads staged before scopes existed carry no ``user_scope``
+    and keep applying to the legacy shared USER.md.
+
     Returns the store's result dict.
     """
     action = payload.get("action")
     target = payload.get("target", "memory")
     content = payload.get("content") or ""
     old_text = payload.get("old_text") or ""
+    if target == "user":
+        staged_scope = _sanitize_user_scope(str(payload.get("user_scope", "") or ""))
+        if staged_scope != getattr(store, "user_scope", ""):
+            store = load_on_disk_store(user_scope=staged_scope)
     if action == "batch":
         return store.apply_batch(target, payload.get("operations") or [])
     if action == "add":

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -612,9 +612,14 @@ memory:
   memory_char_limit: 2200   # ~800 tokens
   user_char_limit: 1375     # ~500 tokens
   write_approval: false     # true = require approval before any memory write
+  per_user_profiles: false  # true = per-user USER.md profiles on multi-user gateways
+  users_registry: ""        # optional id→key registry; empty = ~/.hermes/data/users.json
+  default_user_key: ""      # profile scope for sessions without a user_id (CLI, cron)
 ```
 
 With `memory.write_approval: true`, memory writes need your approval before they land: interactive CLI turns prompt inline; messaging sessions and the background self-improvement review stage the write for `/memory pending` → `/memory approve <id>` / `/memory reject <id>` review. Toggle at runtime with `/memory approval on|off`. See [Controlling memory writes](/user-guide/features/memory#controlling-memory-writes-write_approval).
+
+With `memory.per_user_profiles: true`, the memory tool's `user` target becomes per person: each platform user id maps to `memories/users/<key>/USER.md`, while `MEMORY.md` stays shared. `<key>` resolves from the registry file (schema `{"users": {"telegram:12345": {"key": "alice"}}}`; a platform-qualified `"<platform>:<id>"` entry wins over a bare `"<id>"` one). Ids not in the registry get their own isolated, collision-resistant scope — an unknown speaker never inherits someone else's profile — and sessions without a user id (CLI, cron) use `memory.default_user_key` (empty = legacy shared file). Staged writes record the scope they were created under, so approving them later from another session or platform still lands them in the right profile.
 
 ## Context File Truncation
 


### PR DESCRIPTION
## What

Per-user `USER.md` profiles for multi-user gateway setups, behind a config flag.

The gateway already isolates sessions per sender and plumbs `user_id` into
`initialize_agent`, but the built-in curated memory still keeps ONE
`memories/USER.md`. When several trusted people DM the same agent, the profile
of whoever came first gets applied to everyone: user A's preferences,
communication style and habits leak into answers for user B, and
`background_review` distills observations about both people into the same
profile file.

With `memory.per_user_profiles: true` the user-profile target of the built-in
memory tool becomes per person:

```
memories/users/<key>/USER.md
```

while `MEMORY.md` stays shared. `<key>` resolves from the session's platform
`user_id` via an optional registry file (`memory.users_registry`, default
`<hermes_home>/data/users.json`, schema
`{"users": {"<platform id>": {"key": "alice"}}}`). An id without a registry
entry gets its own sanitized-id scope, so an unknown speaker never inherits
someone else's profile. Sessions without a `user_id` (CLI, cron) use
`memory.default_user_key`. With the flag off (default) or an empty key the
legacy shared `USER.md` path is used - behavior is unchanged.

## Config

```yaml
memory:
  per_user_profiles: false   # feature flag (default: off, legacy behavior)
  users_registry: ""         # optional; default <hermes_home>/data/users.json
  default_user_key: ""       # scope for sessions without a platform user_id
```

## Notes

- `MEMORY.md` intentionally stays shared - household/global facts should not
  be duplicated per person. Only the user profile is scoped.
- No overlap with #61941 (it touches `hermes_cli/memory_api`; this PR touches
  `agent/agent_init.py` + `tools/memory_tool.py` only).
- Follows the user-scoping direction of #61650 and #61639.

## Tests

- New `tests/tools/test_memory_tool_multiuser.py`: 13 cases - flag off/on,
  registry mapping, unlisted-id isolation, default key, scoped vs legacy
  paths, cross-scope isolation, scope sanitization.
- Existing memory-tool suites pass unchanged (89 tests).
