### PR TITLE
fix(email): add splits_long_messages = True to prevent hard-truncation at 4000 chars (#61990)

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -422,6 +422,8 @@ def _extract_attachments(
 class EmailAdapter(BasePlatformAdapter):
     """Email gateway adapter using IMAP (receive) and SMTP (send)."""
 
+    splits_long_messages = True  # send() delivers full payload without hard truncation
+
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.EMAIL)
 


### PR DESCRIPTION
## Summary
Email delivery was hard-truncating outgoing messages at ~4000 characters because `EmailAdapter` did not declare `splits_long_messages = True`. SMTP has no practical per-message limit at that scale — the adapter itself defines `MAX_MESSAGE_LENGTH = 50_000`.

## Root Cause
`gateway/delivery.py` checks `adapter.splits_long_messages`: when False (default), content is hard-truncated to 4000 chars with a `[... truncated]` footer. All chat adapters (Telegram, Discord, Slack, etc.) set this to True; EmailAdapter was missing it.

## Change
Added `splits_long_messages = True` as a class attribute on `EmailAdapter`.

## Verification
Lint passes clean. No test suite exists for email adapter yet.