### PR TITLE
fix(cli): gate pet animation behind TTY check to prevent Docker log flooding (#61964)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4988,6 +4988,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
     def _pet_start_anim(self) -> None:
         if self._pet_anim_running:
             return
+        # Don't start the pet animation when stdout is not a TTY (e.g. in a
+        # Docker container with the json-file logging driver).  Every redraw
+        # frame would otherwise be captured by the logging driver and written
+        # to the container's log file, causing ~4 GB/day of log growth
+        # (#61964).
+        if not os.isatty(sys.stdout.fileno()):
+            return
         self._pet_resolve_config()
         self._pet_anim_running = True
         self._pet_anim_thread = threading.Thread(target=self._pet_anim_loop, daemon=True)


### PR DESCRIPTION
## Summary
When the `pet` feature is enabled, the terminal animation redraws continuously to stdout. In Docker containers, every redrawn frame gets captured by the `json-file` logging driver, causing the container log to grow ~4GB/day.

## Root Cause
`_pet_start_anim()` in `cli.py` starts a daemon thread that calls `app.invalidate()` every 0.16 seconds regardless of whether stdout is a TTY. Docker captures all stdout bytes, so each redraw frame is logged. Two other code paths (`resolve_mode` in `agent/pet/render.py` and `_cmd_show` in `hermes_cli/pets.py`) already gate on TTY correctly, but the CLI TUI animation path bypassed them.

## Change
Added `os.isatty(sys.stdout.fileno())` check at the top of `_pet_start_anim()`. When stdout is not a TTY (e.g. Docker), the animation thread never starts and the pet widget collapses to zero height — a clean no-op.

## Verification
36 pet-related tests pass (test_cli_pet_pane, test_pet_toggle, test_pet_engine).