### PR TITLE
fix(nix): allow auth = "header" in mcpServers.<name>

### DIFF
--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -364,11 +364,19 @@
 
             # Authentication
             auth = mkOption {
-              type = types.nullOr (types.enum [ "oauth" ]);
+              type = types.nullOr (types.enum [ "oauth" "header" ]);
               default = null;
               description = ''
-                Authentication method. Set to "oauth" for OAuth 2.1 PKCE flow
-                (remote MCP servers). Tokens are stored in $HERMES_HOME/mcp-tokens/.
+                Authentication method for remote (HTTP) MCP servers.
+
+                - "oauth"  — OAuth 2.1 PKCE flow. Tokens are stored in
+                             $HERMES_HOME/mcp-tokens/ and refreshed on demand.
+                - "header" — static bearer / API-key authentication. The
+                             actual credential lives in the `headers`
+                             attrset (typically as a `''${VAR}` placeholder
+                             interpolated from $HERMES_HOME/.env at
+                             MCP-client startup).
+                - null     — no authentication (public server).
               '';
             };
 
@@ -452,6 +460,11 @@
             remote-oauth = {
               url = "https://mcp.example.com/mcp";
               auth = "oauth";
+            };
+            remote-header = {
+              url = "https://mcp.vendor.com/mcp";
+              auth = "header";
+              headers."API-KEY" = "\''${VENDOR_API_KEY}";
             };
           }
         '';


### PR DESCRIPTION
## Summary

`services.hermes-agent.mcpServers.<name>.auth` in the NixOS module is
typed `nullOr (enum [ "oauth" ])`, but the Python runtime in
`tools/mcp_tool.py:2614` accepts any string and only branches on
`== "oauth"`. Everything else falls through to plain HTTP with the
`headers` attrset used verbatim — which is exactly the shape needed
for static bearer / API-key auth against remote MCP servers.

The strict enum forbids that shape at eval time even though the
runtime supports it, forcing operators to bypass the typed interface
and hand-write the whole server config under
`settings.mcp_servers.<name>` — losing type checking and duplicating
what the module's `mkIf cfg.mcpServers != { }` merge already does.

Widen the enum to `[ "oauth" "header" ]`, extend the description to
document all three cases (oauth / header / null), and add a
`remote-header` entry to the example next to `remote-oauth`.

## Compatibility

- Backwards compatible. Any existing config using `auth = "oauth"` or
  omitting `auth` evaluates identically. Enum strictly widened.
- No runtime change. `"header"` is documentation for the operator;
  the effect comes from `headers`.

## Motivating case

Deploying Dot (getdot.ai) MCP in a NixOS fleet where Dot's OAuth
server-side is currently broken (issues JWTs its own resource server
rejects — bug filed with Dot separately) but their MCP docs advertise
an `API-KEY` header alternative that works. Also covers n8n's remote
MCP endpoint and any vendor with static-bearer auth alongside or
instead of OAuth.
