### PR TITLE
fix(gateway): tighten clarify text response to prevent arbitrary prose from resolving multi-choice clarifies (#62034)

### DIFF
--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -81,14 +81,17 @@ class TestClarifyPrimitive:
         assert cm.resolve_text_response_for_session("sk3c", "2") is True
         assert cm.wait_for_response("id3c", timeout=0.1) == "Y"
 
-    def test_resolve_text_response_accepts_custom_other_text(self):
-        """Arbitrary typed text should resolve as a custom Other answer."""
+    def test_resolve_text_response_rejects_custom_other_text(self):
+        """Arbitrary typed text should NOT resolve multi-choice clarifies automatically.
+
+        Only numeric choices and exact label matches auto-resolve.  Prose
+        passes through as a normal turn instead.
+        """
         from tools import clarify_gateway as cm
 
         cm.register("id3d", "sk3d", "Pick", ["X", "Y"])
         custom = "None of those are valid options"
-        assert cm.resolve_text_response_for_session("sk3d", custom) is True
-        assert cm.wait_for_response("id3d", timeout=0.1) == custom
+        assert cm.resolve_text_response_for_session("sk3d", custom) is False
 
     def test_other_button_flips_to_text_mode(self):
         """mark_awaiting_text makes get_pending_for_session find the entry."""

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -187,8 +187,14 @@ def get_pending_for_session(
         return None
 
 
-def _coerce_text_response(entry: _ClarifyEntry, response: str) -> str:
-    """Map typed choice replies to canonical choice text, otherwise keep custom text."""
+def _coerce_text_response(entry: _ClarifyEntry, response: str) -> Optional[str]:
+    """Map typed choice replies to canonical choice text, or None if the text doesn't match.
+
+    For multi-choice clarifies, only numeric choices and exact label matches
+    auto-resolve.  Arbitrary prose returns None so it is NOT consumed as a
+    clarify answer and proceeds as a normal turn instead.
+    For open-ended clarifies (no choices), any text is accepted.
+    """
     text = str(response).strip()
     if entry.choices:
         try:
@@ -200,18 +206,25 @@ def _coerce_text_response(entry: _ClarifyEntry, response: str) -> str:
         for choice in entry.choices:
             if text.casefold() == str(choice).strip().casefold():
                 return str(choice).strip()
+        # Multi-choice with no match → don't consume the message.
+        return None
     return text
 
 
 def resolve_text_response_for_session(session_key: str, response: str) -> bool:
-    """Resolve the oldest pending clarify in ``session_key`` from typed text."""
+    """Resolve the oldest pending clarify in ``session_key`` from typed text.
+
+    For multi-choice clarifies, only numeric choices and exact label matches
+    resolve the clarify.  Arbitrary prose returns False so the message proceeds
+    as a normal turn instead of being swallowed.
+    """
     entry = get_pending_for_session(session_key, include_choice_prompts=True)
     if entry is None:
         return False
-    return resolve_gateway_clarify(
-        entry.clarify_id,
-        _coerce_text_response(entry, response),
-    )
+    coerced = _coerce_text_response(entry, response)
+    if coerced is None:
+        return False
+    return resolve_gateway_clarify(entry.clarify_id, coerced)
 
 
 def mark_awaiting_text(clarify_id: str) -> bool:


### PR DESCRIPTION
## Summary
In Slack threads, when Hermes has a pending multi-choice clarify, subsequent ordinary thread messages could be intercepted and resolved as clarify answers instead of being treated as normal turns.

## Root Cause
`_coerce_text_response()` in `tools/clarify_gateway.py` accepted arbitrary prose as a valid clarify answer for multi-choice clarifies. Any follow-up message text would fall through the choice-matching logic and be consumed as a clarify answer.

## Change
- `_coerce_text_response()` now returns `None` for multi-choice clarifies when text doesn't match a numeric choice or exact label
- `resolve_text_response_for_session()` treats `None` as "not consumed" so the message proceeds as a normal turn
- Open-ended clarifies (no choices) remain unaffected

## Verification
19 tests pass (clarify_gateway + active_session_bypass).