### PR TITLE
fix(slack): truncate section text when updating approval messages

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -62,6 +62,17 @@ except ImportError:  # pragma: no cover - plugin loaded outside package context
 
 logger = logging.getLogger(__name__)
 
+_SLACK_SECTION_TEXT_MAX = 3000
+
+
+def _fit_slack_section_text(text: str) -> str:
+    """Clamp mrkdwn section text to Slack's Block Kit section limit."""
+    if len(text) <= _SLACK_SECTION_TEXT_MAX:
+        return text
+    return text[: _SLACK_SECTION_TEXT_MAX - 3].rstrip() + "..."
+
+
+
 # ContextVar carrying the user_id of the slash-command invoker.
 # Set in _handle_slash_command, read in send() to match the correct
 # stashed response_url when multiple users issue commands on the same
@@ -3519,7 +3530,7 @@ class SlackAdapter(BasePlatformAdapter):
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": original_text or "Confirmation prompt",
+                    "text": _fit_slack_section_text(original_text or "Confirmation prompt"),
                 },
             },
             {
@@ -3641,7 +3652,7 @@ class SlackAdapter(BasePlatformAdapter):
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": original_text or "Command approval request",
+                    "text": _fit_slack_section_text(original_text or "Command approval request"),
                 },
             },
             {

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -207,6 +207,46 @@ class TestSlackApprovalAction:
         update_kwargs = mock_client.chat_update.call_args[1]
         assert "Approved once by norbert" in update_kwargs["text"]
 
+
+    @pytest.mark.asyncio
+    async def test_update_truncates_long_original_text(self):
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        adapter._approval_resolved["1234.5678"] = False
+
+        long_original = "x" * 3500
+        ack = AsyncMock()
+        body = {
+            "message": {
+                "ts": "1234.5678",
+                "blocks": [
+                    {
+                        "type": "section",
+                        "text": {"type": "mrkdwn", "text": long_original},
+                    },
+                    {"type": "actions", "elements": []},
+                ],
+            },
+            "channel": {"id": "C1"},
+            "user": {"name": "norbert", "id": "U_NORBERT"},
+        }
+        action = {
+            "action_id": "hermes_approve_once",
+            "value": "agent:main:slack:group:C1:1111",
+        }
+
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=1):
+            await adapter._handle_approval_action(ack, body, action)
+
+        update_kwargs = mock_client.chat_update.call_args[1]
+        section_text = update_kwargs["blocks"][0]["text"]["text"]
+        assert len(section_text) <= 3000
+        assert section_text.endswith("...")
+        assert "Approved once by norbert" in update_kwargs["blocks"][1]["elements"][0]["text"]
+
     @pytest.mark.asyncio
     async def test_prevents_double_click(self):
         adapter = _make_adapter()


### PR DESCRIPTION
Fixes #62054

## What
Slack `chat.update` fails with `invalid_blocks` when updating approval or slash-confirm messages after a button click — the section block text exceeds Slack's 3000-character limit.

## Why
`send_exec_approval` and `send_slash_confirm` budget content on send, but `_handle_approval_action` and `_handle_slash_confirm_action` copy `original_text` verbatim when rebuilding blocks after a button click.

## Fix
Add `_fit_slack_section_text()` to clamp section mrkdwn to 3000 chars before `chat.update`.

## How to test
```bash
pytest tests/gateway/test_slack_approval_buttons.py::TestSlackApprovalAction -v
```

Manual repro (production symptom):
1. Trigger a command approval with a large `execute_code` script.
2. Click "Allow Once".
3. Message should update to show the decision; buttons removed.

Previously: `invalid_blocks` / `must be less than 3001 characters [json-pointer:/blocks/0/text/text]` — approval still resolved but UI did not update.

## Platforms tested
- macOS (pytest)