### PR TITLE
Add memkeeper to the MCP catalog

### DIFF
--- a/optional-mcps/memkeeper/manifest.yaml
+++ b/optional-mcps/memkeeper/manifest.yaml
@@ -1,0 +1,73 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: memkeeper
+description: Keep durable agent memory locally in a portable SQLite store.
+source: https://github.com/teflon07/memkeeper
+
+# memkeeper is a local stdio server. Launching through Cargo keeps the command
+# cross-platform (including the Windows .exe suffix) while transport.env makes
+# semantic retrieval fail closed if no embeddings backend is available.
+transport:
+  type: stdio
+  command: cargo
+  args:
+    - run
+    - --quiet
+    - --release
+    - --locked
+    - --offline
+    - --manifest-path
+    - "${INSTALL_DIR}/Cargo.toml"
+    - --
+    - mcp
+  env:
+    MEMKEEPER_REQUIRE_SEMANTIC: "1"
+
+# Clone an immutable source revision and build its reviewed Cargo.lock. This
+# avoids trusting a mutable release URL (or a checksum downloaded beside the
+# artifact) and supplies the supported native Windows path. Cargo and a native
+# C/C++ toolchain are required; the upstream Windows support remains experimental.
+install:
+  type: git
+  url: https://github.com/teflon07/memkeeper.git
+  ref: 8f8b775431d1aa8e69b542973a88feb360998918
+  bootstrap:
+    - "cargo build --release --locked"
+
+auth:
+  type: none
+
+# Default to recall, context assembly, and intentional durable writes. Keep
+# destructive and graph-mutating actions opt-in through `hermes mcp configure`.
+tools:
+  default_enabled:
+    - stats
+    - search
+    - get
+    - memory_list
+    - entity_search
+    - graph_neighbors
+    - graph_context
+    - dream_graph
+    - remember
+    - pack
+    - candidate_submit
+    - candidate_list
+
+post_install: |
+  memkeeper stores data locally in ~/.memkeeper/store.sqlite by default.
+  This source build requires Rust plus the platform's native C/C++ build tools.
+  Windows support is experimental but the stdio server is supported there.
+
+  Before use, run this from the MCP install directory shown above:
+
+    cargo run --release --locked --offline -- pull-models
+
+  This entry requires semantic retrieval. Until the on-device models are
+  installed, requests fail rather than silently serving lexical-only search.
+
+  An OpenAI-compatible embeddings API is also supported. To use it instead of
+  local models, add the documented MEMKEEPER_EMBED_* settings to this server's
+  config env block, then re-embed the store before use.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -333,6 +333,7 @@ locales = ["locales/*.yaml"]
 # manifests into one colliding optional-mcps/manifest.yaml). One target per
 # entry; tests/test_packaging_metadata.py enforces an entry per optional-mcps/<name>.
 "optional-mcps/linear" = ["optional-mcps/linear/manifest.yaml"]
+"optional-mcps/memkeeper" = ["optional-mcps/memkeeper/manifest.yaml"]
 "optional-mcps/n8n" = ["optional-mcps/n8n/manifest.yaml"]
 
 [tool.setuptools.package-data]

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -267,6 +267,18 @@ def test_locale_catalogs_ship_in_both_wheel_and_sdist():
     assert on_disk, "expected locales/*.yaml catalogs on disk"
 
 
+def test_memkeeper_manifest_is_declared_as_wheel_data_file():
+    """The memkeeper catalog entry must retain its directory in built wheels."""
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    data_files = data["tool"]["setuptools"].get("data-files", {})
+    assert data_files.get("optional-mcps/memkeeper") == [
+        "optional-mcps/memkeeper/manifest.yaml"
+    ], (
+        "pyproject [tool.setuptools.data-files] must declare memkeeper's "
+        "manifest so wheels ship this catalog entry"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Dependency-pin consistency: pyproject extras <-> tools/lazy_deps.py
 #


### PR DESCRIPTION
## Summary

Adds a Nous-catalog candidate for [memkeeper](https://github.com/teflon07/memkeeper): a local-first, stdio MCP server for durable agent memory stored in SQLite.

The entry:

- pins an immutable memkeeper source commit for the `v0.2.13` release;
- uses memkeeper's release installer, which verifies the downloaded binary archive SHA-256;
- starts the server with `MEMKEEPER_REQUIRE_SEMANTIC=1`, so a missing semantic model fails closed rather than silently using lexical-only search;
- defaults to 12 recall/context/intentional-write tools and leaves destructive or graph-mutating tools opt-in via `hermes mcp configure memkeeper`.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py -q` — 35 passed.
- Fresh `HERMES_HOME` integration run: `hermes mcp install memkeeper` installed the pinned release, then `hermes mcp test memkeeper` connected over stdio and discovered 16 tools.
- On a Mac mini M4 with 16 GB unified memory, a cold local semantic search with embedding and rerank models loaded completed in 1.44 s with 2.53 GB peak RSS.

## Deployment choices

The catalog path is local-first: users run `bin/memkeeper pull-models` once for fully on-device semantic retrieval. Memkeeper also supports OpenAI-compatible embeddings APIs for users who prefer that path; the post-install guidance calls out the required explicit MCP `env` configuration and re-embedding step.
