### PR TITLE
fix(telegram): route PTB NetworkError to reconnect ladder in polling heartbeat

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2177,6 +2177,18 @@ class TelegramAdapter(BasePlatformAdapter):
         HEARTBEAT_INTERVAL = 90   # seconds between probes
         PROBE_TIMEOUT = 15        # seconds before declaring the path dead
 
+        def _trigger_reconnect(err: Exception) -> None:
+            logger.warning(
+                "[%s] Polling heartbeat probe failed (%s); triggering reconnect",
+                self.name, err,
+            )
+            if self._polling_error_task and not self._polling_error_task.done():
+                return   # reconnect already in progress
+            loop = asyncio.get_running_loop()
+            self._polling_error_task = loop.create_task(
+                self._handle_polling_network_error(err)
+            )
+
         while True:
             try:
                 await asyncio.sleep(HEARTBEAT_INTERVAL)
@@ -2204,17 +2216,21 @@ class TelegramAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 return
             except (asyncio.TimeoutError, OSError) as probe_err:
-                logger.warning(
-                    "[%s] Polling heartbeat probe failed (%s); triggering reconnect",
-                    self.name, probe_err,
-                )
-                if self._polling_error_task and not self._polling_error_task.done():
-                    continue   # reconnect already in progress
-                loop = asyncio.get_running_loop()
-                self._polling_error_task = loop.create_task(
-                    self._handle_polling_network_error(probe_err)
-                )
-            except Exception:
+                _trigger_reconnect(probe_err)
+            except Exception as probe_err:
+                # python-telegram-bot wraps network failures in TelegramError,
+                # which is not an OSError. We must explicitly check for PTB
+                # connectivity errors (NetworkError, TimedOut) and route them
+                # to the reconnect ladder.
+                try:
+                    from telegram.error import NetworkError, TimedOut
+                except ImportError:
+                    # PTB not available or version mismatch; fall through to pass.
+                    pass
+                else:
+                    if isinstance(probe_err, (NetworkError, TimedOut)):
+                        _trigger_reconnect(probe_err)
+                        continue
                 # Non-connectivity errors (e.g. TelegramError 401) are not
                 # CLOSE-WAIT symptoms — let PTB's own handlers surface them.
                 pass

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -679,6 +679,114 @@ async def test_heartbeat_loop_ignores_non_connectivity_errors():
 
 
 @pytest.mark.asyncio
+async def test_heartbeat_loop_triggers_reconnect_on_ptb_network_error():
+    """python-telegram-bot NetworkError must trigger reconnect, not be swallowed."""
+    # Import the real PTB exception classes if available, otherwise mock them.
+    try:
+        from telegram.error import NetworkError, TimedOut
+    except ImportError:
+        NetworkError = type("NetworkError", (Exception,), {})
+        TimedOut = type("TimedOut", (NetworkError,), {})
+
+    adapter = _make_adapter()
+    adapter._handle_polling_network_error = AsyncMock()
+
+    mock_app = MagicMock()
+    adapter._app = mock_app
+
+    sleep_call = 0
+
+    async def fast_sleep(seconds):
+        nonlocal sleep_call
+        sleep_call += 1
+        if sleep_call >= 3:
+            raise asyncio.CancelledError()
+
+    async def network_error_wait_for(coro, timeout):
+        if asyncio.iscoroutine(coro):
+            coro.close()
+        raise NetworkError("Network error from PTB")
+
+    with patch("asyncio.sleep", side_effect=fast_sleep):
+        with patch("plugins.platforms.telegram.adapter.asyncio.wait_for", side_effect=network_error_wait_for):
+            await adapter._polling_heartbeat_loop()
+
+    # A reconnect task must have been created for PTB NetworkError.
+    assert adapter._polling_error_task is not None
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_loop_triggers_reconnect_on_ptb_timed_out():
+    """python-telegram-bot TimedOut (subclass of NetworkError) must trigger reconnect."""
+    try:
+        from telegram.error import TimedOut
+    except ImportError:
+        NetworkError = type("NetworkError", (Exception,), {})
+        TimedOut = type("TimedOut", (NetworkError,), {})
+
+    adapter = _make_adapter()
+    adapter._handle_polling_network_error = AsyncMock()
+
+    mock_app = MagicMock()
+    adapter._app = mock_app
+
+    sleep_call = 0
+
+    async def fast_sleep(seconds):
+        nonlocal sleep_call
+        sleep_call += 1
+        if sleep_call >= 3:
+            raise asyncio.CancelledError()
+
+    async def timed_out_wait_for(coro, timeout):
+        if asyncio.iscoroutine(coro):
+            coro.close()
+        raise TimedOut("Timed out from PTB")
+
+    with patch("asyncio.sleep", side_effect=fast_sleep):
+        with patch("plugins.platforms.telegram.adapter.asyncio.wait_for", side_effect=timed_out_wait_for):
+            await adapter._polling_heartbeat_loop()
+
+    # A reconnect task must have been created for PTB TimedOut.
+    assert adapter._polling_error_task is not None
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_loop_ignores_ptb_bad_request():
+    """PTB BadRequest (non-connectivity) must not trigger reconnect."""
+    try:
+        from telegram.error import BadRequest
+    except ImportError:
+        BadRequest = type("BadRequest", (Exception,), {})
+
+    adapter = _make_adapter()
+    adapter._handle_polling_network_error = AsyncMock()
+
+    mock_app = MagicMock()
+    adapter._app = mock_app
+
+    sleep_call = 0
+
+    async def fast_sleep(seconds):
+        nonlocal sleep_call
+        sleep_call += 1
+        if sleep_call >= 3:
+            raise asyncio.CancelledError()
+
+    async def bad_request_wait_for(coro, timeout):
+        if asyncio.iscoroutine(coro):
+            coro.close()
+        raise BadRequest("Bad request from PTB")
+
+    with patch("asyncio.sleep", side_effect=fast_sleep):
+        with patch("plugins.platforms.telegram.adapter.asyncio.wait_for", side_effect=bad_request_wait_for):
+            await adapter._polling_heartbeat_loop()
+
+    # No reconnect should have been triggered for BadRequest.
+    adapter._handle_polling_network_error.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_heartbeat_loop_exits_on_fatal_error():
     """A fatal error short-circuits the loop before probing get_me()."""
     adapter = _make_adapter()


### PR DESCRIPTION
## What does this PR do?

The persistent Telegram polling heartbeat (`_polling_heartbeat_loop`) did not recognize python-telegram-bot (PTB) `NetworkError` or `TimedOut` exceptions as connectivity failures. These PTB exceptions inherit from `TelegramError`, not `OSError`, so the existing handler `(asyncio.TimeoutError, OSError)` missed them. A broad `except Exception` block subsequently swallowed these errors silently, preventing the gateway from detecting and recovering dead TCP connections.

This fix extracts the reconnect trigger logic into a helper and explicitly checks for PTB `NetworkError` / `TimedOut` in the exception handler, routing them to the existing reconnect ladder. Non-connectivity PTB errors (e.g., `BadRequest`, `InvalidToken`) remain swallowed as before.


## Related Issue

Fixes #62047


## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)


## Changes Made

- `plugins/platforms/telegram/adapter.py`: Modified `_polling_heartbeat_loop` to catch and handle `telegram.error.NetworkError` and `telegram.error.TimedOut` as connectivity failures. Added a local helper `_trigger_reconnect` to deduplicate the reconnect scheduling logic.
- `tests/gateway/test_telegram_network_reconnect.py`: Added regression tests for PTB `NetworkError`, `TimedOut` (trigger reconnect) and `BadRequest` (ignore).


## How to Test

1. Run the new regression tests: `pytest tests/gateway/test_telegram_network_reconnect.py::test_heartbeat_loop_triggers_reconnect_on_ptb_network_error tests/gateway/test_telegram_network_reconnect.py::test_heartbeat_loop_triggers_reconnect_on_ptb_timed_out tests/gateway/test_telegram_network_reconnect.py::test_heartbeat_loop_ignores_ptb_bad_request`
2. Run the full Telegram network reconnect test suite to ensure existing behavior is preserved: `pytest tests/gateway/test_telegram_network_reconnect.py`
3. Observed result: All 3 new tests pass, confirming that PTB `NetworkError` and `TimedOut` now trigger `_handle_polling_network_error` (task created), while `BadRequest` does not. Existing tests for `OSError` and `asyncio.TimeoutError` continue to pass.


## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (ran subset for gateway/telegram).
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (via local pytest run).

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (added comments in code)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (platform-agnostic exception handling)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A