### PR TITLE
fix: preserve custom Anthropic fallback configuration

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -832,7 +832,36 @@ def init_agent(
             # the third-party identity-injection bug.
             from agent.anthropic_adapter import _is_oauth_token as _is_oat
             agent._is_anthropic_oauth = _is_oat(effective_key) if (_is_native_anthropic and isinstance(effective_key, str)) else False
-            agent._anthropic_client = build_anthropic_client(effective_key, base_url, timeout=_provider_timeout)
+
+            # Custom Anthropic-compatible providers may require protocol
+            # headers (for example a Vertex ``anthropic-version`` override).
+            # Resolve them by endpoint and retain them for credential/client
+            # rebuilds; OpenAI-wire custom headers are handled separately.
+            _anthropic_extra_headers: Dict[str, str] = {}
+            try:
+                from hermes_cli.config import (
+                    get_compatible_custom_providers,
+                    get_custom_provider_extra_headers,
+                    load_config,
+                )
+
+                _cp_entries = get_compatible_custom_providers(load_config())
+                _anthropic_extra_headers = get_custom_provider_extra_headers(
+                    base_url,
+                    custom_providers=_cp_entries,
+                ) or {}
+            except Exception:
+                logger.debug(
+                    "custom Anthropic-provider extra_headers resolution skipped",
+                    exc_info=True,
+                )
+            agent._anthropic_extra_headers = _anthropic_extra_headers
+            agent._anthropic_client = build_anthropic_client(
+                effective_key,
+                base_url,
+                timeout=_provider_timeout,
+                extra_headers=_anthropic_extra_headers,
+            )
             # No OpenAI client needed for Anthropic mode
             agent.client = None
             agent._client_kwargs = {}

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -628,9 +628,10 @@ def _common_betas_for_base_url(
 def _build_anthropic_client_with_bearer_hook(
     token_provider,
     base_url: str = None,
-    timeout: float = None,
+    timeout: Optional[float] = None,
     *,
     drop_context_1m_beta: bool = False,
+    extra_headers: Optional[Dict[str, str]] = None,
 ):
     """Anthropic-on-Foundry Entra ID variant of :func:`build_anthropic_client`.
 
@@ -697,6 +698,11 @@ def _build_anthropic_client_with_bearer_hook(
     )
     if common_betas:
         kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
+    if extra_headers:
+        kwargs["default_headers"] = {
+            **dict(kwargs.get("default_headers") or {}),
+            **{str(k): str(v) for k, v in extra_headers.items() if v is not None},
+        }
 
     return _anthropic_sdk.Anthropic(**kwargs)
 
@@ -704,9 +710,10 @@ def _build_anthropic_client_with_bearer_hook(
 def build_anthropic_client(
     api_key,
     base_url: str = None,
-    timeout: float = None,
+    timeout: Optional[float] = None,
     *,
     drop_context_1m_beta: bool = False,
+    extra_headers: Optional[Dict[str, str]] = None,
 ):
     """Create an Anthropic client, auto-detecting setup-tokens vs API keys.
 
@@ -748,6 +755,7 @@ def build_anthropic_client(
         return _build_anthropic_client_with_bearer_hook(
             api_key, base_url, timeout,
             drop_context_1m_beta=drop_context_1m_beta,
+            extra_headers=extra_headers,
         )
 
     normalize_proxy_env_vars()
@@ -826,6 +834,15 @@ def build_anthropic_client(
         kwargs["api_key"] = api_key
         if common_betas:
             kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
+
+    # Per-provider headers are required by some Anthropic-compatible gateways
+    # (for example a Vertex-style ``anthropic-version`` override). Apply them
+    # last so explicit provider config wins over Hermes' common beta defaults.
+    if extra_headers:
+        kwargs["default_headers"] = {
+            **dict(kwargs.get("default_headers") or {}),
+            **{str(k): str(v) for k, v in extra_headers.items() if v is not None},
+        }
 
     return _anthropic_sdk.Anthropic(**kwargs)
 
@@ -2739,6 +2756,14 @@ def sanitize_anthropic_kwargs(api_kwargs: Any, *, log_prefix: str = "") -> Any:
 
 def _is_stream_unavailable_error(exc: Exception) -> bool:
     """Return True when an Anthropic stream call should fall back to create()."""
+    # Some Anthropic-compatible gateways ignore ``stream=true`` and return a
+    # complete JSON Message instead of SSE.  The Anthropic SDK then raises an
+    # empty AssertionError while entering/aggregating the stream.  A normal
+    # ``messages.create()`` call is still valid for those gateways, so treat
+    # this narrow SDK failure as stream unavailability rather than failing the
+    # whole provider.
+    if isinstance(exc, AssertionError) and not str(exc).strip():
+        return True
     err_lower = str(exc).lower()
     if "stream" in err_lower and "not supported" in err_lower:
         return True

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1500,16 +1500,21 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 fb_model, fb_provider, _norm_err,
             )
 
-        # Determine api_mode from provider / base URL / model
+        # Determine api_mode from provider / base URL / model.  Keep the
+        # resolved client URL authoritative for OpenAI-wire providers (their
+        # resolver intentionally normalizes ``/v1``), while using the raw
+        # configured URL to detect Anthropic-compatible endpoints whose
+        # protocol-signalling ``/anthropic`` suffix would otherwise be lost.
         fb_api_mode = "chat_completions"
         fb_base_url = str(fb_client.base_url)
+        fb_protocol_url = fb_base_url_hint or fb_base_url
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
         if fb_provider == "openai-codex":
             fb_api_mode = "codex_responses"
         elif (
             fb_provider == "anthropic"
-            or fb_base_url.rstrip("/").lower().endswith("/anthropic")
-            or base_url_hostname(fb_base_url) == "api.anthropic.com"
+            or fb_protocol_url.rstrip("/").lower().endswith("/anthropic")
+            or base_url_hostname(fb_protocol_url) == "api.anthropic.com"
         ):
             # Custom providers (e.g. cron-anthropic) point at the native
             # api.anthropic.com host with no "/anthropic" path suffix, so the
@@ -1518,6 +1523,9 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             # host the same way determine_api_mode() and _detect_api_mode_for_url()
             # do on the primary path. (#32243, #49247)
             fb_api_mode = "anthropic_messages"
+            # Anthropic SDK construction needs the un-normalized endpoint;
+            # it appends ``/v1/messages`` itself.
+            fb_base_url = fb_protocol_url
         elif _fb_is_azure:
             # Azure OpenAI serves gpt-5.x on /chat/completions — does NOT
             # support the Responses API. Stay on chat_completions.
@@ -1596,14 +1604,43 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         _fb_timeout = get_provider_request_timeout(fb_provider, fb_model)
 
         if fb_api_mode == "anthropic_messages":
-            # Build native Anthropic client instead of using OpenAI client
+            # Build native Anthropic client instead of using OpenAI client.
+            # Preserve custom protocol headers (for example a Vertex-style
+            # anthropic-version override) just as the primary-provider path
+            # does; otherwise a working custom provider can fail only when it
+            # is activated as a fallback.
             from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token, _is_oauth_token
             effective_key = (fb_client.api_key or resolve_anthropic_token() or "") if fb_provider == "anthropic" else (fb_client.api_key or "")
+            fb_extra_headers = fb.get("extra_headers")
+            if not isinstance(fb_extra_headers, dict):
+                fb_extra_headers = {}
+            if not fb_extra_headers:
+                try:
+                    from hermes_cli.config import (
+                        get_compatible_custom_providers,
+                        get_custom_provider_extra_headers,
+                        load_config,
+                    )
+
+                    fb_extra_headers = get_custom_provider_extra_headers(
+                        fb_base_url,
+                        custom_providers=get_compatible_custom_providers(load_config()),
+                    ) or {}
+                except Exception:
+                    logger.debug(
+                        "Fallback custom Anthropic extra_headers resolution skipped",
+                        exc_info=True,
+                    )
+                    fb_extra_headers = {}
             agent.api_key = effective_key
             agent._anthropic_api_key = effective_key
             agent._anthropic_base_url = fb_base_url
+            agent._anthropic_extra_headers = dict(fb_extra_headers)
             agent._anthropic_client = build_anthropic_client(
-                effective_key, agent._anthropic_base_url, timeout=_fb_timeout,
+                effective_key,
+                agent._anthropic_base_url,
+                timeout=_fb_timeout,
+                extra_headers=agent._anthropic_extra_headers,
             )
             agent._is_anthropic_oauth = _is_oauth_token(effective_key) if fb_provider == "anthropic" else False
             agent.client = None
@@ -3062,8 +3099,17 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     else:
                         _err_lower = str(e).lower()
                         _is_stream_unsupported = (
-                            "stream" in _err_lower
-                            and "not supported" in _err_lower
+                            ("stream" in _err_lower and "not supported" in _err_lower)
+                            # Some Anthropic-compatible proxies ignore
+                            # ``stream=true`` and return a complete JSON
+                            # Message. The Anthropic SDK then raises an empty
+                            # AssertionError from get_final_message(); retry
+                            # the session via the existing non-streaming path.
+                            or (
+                                agent.api_mode == "anthropic_messages"
+                                and isinstance(e, AssertionError)
+                                and not str(e).strip()
+                            )
                         )
                         # AWS Bedrock (AnthropicBedrock SDK path): IAM policies
                         # with bedrock:InvokeModel but not

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1348,6 +1348,58 @@ def _fallback_entry_key(fb: dict) -> tuple[str, str, str]:
     )
 
 
+def _fallback_explicit_api_mode(
+    fb: dict, fb_provider: str, *candidate_urls: str,
+) -> "tuple[Optional[str], str]":
+    """Resolve an explicitly configured wire protocol for a fallback entry.
+
+    Mirrors primary-path precedence (hermes_cli.runtime_provider): a
+    configured ``api_mode`` wins over provider-name and URL heuristics, so a
+    custom Anthropic-compatible gateway without an ``/anthropic`` path suffix
+    still routes to the Messages API when its config says so.  Reads the
+    fallback entry itself first (``api_mode`` / ``transport``), then the
+    ``providers`` / ``custom_providers`` entry matching the fallback's
+    provider name or endpoint.
+
+    Returns ``(api_mode, configured_base_url)``; ``api_mode`` is None when
+    nothing explicit is declared, and ``configured_base_url`` is the matched
+    config entry's endpoint ("" when the mode came from the fallback entry
+    itself), so callers can prefer the un-normalized configured URL for
+    Anthropic SDK construction.
+    """
+    from hermes_cli.runtime_provider import _parse_api_mode
+
+    mode = _parse_api_mode(fb.get("api_mode") or fb.get("transport"))
+    if mode:
+        return mode, ""
+    try:
+        from hermes_cli.config import get_compatible_custom_providers, load_config
+
+        entries = get_compatible_custom_providers(load_config())
+    except Exception:
+        logger.debug("Fallback custom-provider api_mode lookup skipped", exc_info=True)
+        return None, ""
+    urls = {u.rstrip("/").lower() for u in candidate_urls if u}
+    name_target = (fb_provider or "").strip().lower()
+    if name_target.startswith("custom:"):
+        name_target = name_target[len("custom:"):]
+    name_target = name_target.replace(" ", "-")
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        entry_name = str(entry.get("name") or "").strip().lower().replace(" ", "-")
+        entry_url = str(entry.get("base_url") or "").strip().rstrip("/")
+        if not (
+            (name_target and entry_name == name_target)
+            or (entry_url and entry_url.lower() in urls)
+        ):
+            continue
+        mode = _parse_api_mode(entry.get("api_mode"))
+        if mode:
+            return mode, entry_url
+    return None, ""
+
+
 def _fallback_entry_unavailable_without_network(agent, fb: dict) -> Optional[str]:
     """Return a skip reason for fallback entries known to be unusable locally."""
     fb_provider = (fb.get("provider") or "").strip().lower()
@@ -1509,10 +1561,17 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         fb_base_url = str(fb_client.base_url)
         fb_protocol_url = fb_base_url_hint or fb_base_url
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
+        # An explicit api_mode on the fallback entry or its matching custom
+        # provider takes precedence over the provider-name/URL heuristics
+        # below — same order as the primary path in runtime_provider.
+        fb_explicit_mode, fb_explicit_cfg_url = _fallback_explicit_api_mode(
+            fb, fb_provider, fb_protocol_url, fb_base_url,
+        )
         if fb_provider == "openai-codex":
             fb_api_mode = "codex_responses"
         elif (
-            fb_provider == "anthropic"
+            fb_explicit_mode == "anthropic_messages"
+            or fb_provider == "anthropic"
             or fb_protocol_url.rstrip("/").lower().endswith("/anthropic")
             or base_url_hostname(fb_protocol_url) == "api.anthropic.com"
         ):
@@ -1521,11 +1580,13 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             # name/suffix checks above miss them and they default to
             # chat_completions → POST /v1/chat/completions → 404. Match the
             # host the same way determine_api_mode() and _detect_api_mode_for_url()
-            # do on the primary path. (#32243, #49247)
+            # do on the primary path, and honor an explicitly declared
+            # anthropic_messages mode for gateways whose URL carries no
+            # Anthropic signal at all. (#32243, #49247)
             fb_api_mode = "anthropic_messages"
             # Anthropic SDK construction needs the un-normalized endpoint;
             # it appends ``/v1/messages`` itself.
-            fb_base_url = fb_protocol_url
+            fb_base_url = fb_base_url_hint or fb_explicit_cfg_url or fb_protocol_url
         elif _fb_is_azure:
             # Azure OpenAI serves gpt-5.x on /chat/completions — does NOT
             # support the Responses API. Stay on chat_completions.

--- a/run_agent.py
+++ b/run_agent.py
@@ -4610,6 +4610,7 @@ class AIAgent:
             self._anthropic_client = build_anthropic_client(
                 runtime_key, runtime_base,
                 timeout=get_provider_request_timeout(self.provider, self.model),
+                extra_headers=getattr(self, "_anthropic_extra_headers", None),
             )
             self._is_anthropic_oauth = _is_oauth_token(runtime_key) if self.provider == "anthropic" else False
             self.api_key = runtime_key
@@ -4680,6 +4681,7 @@ class AIAgent:
                 getattr(self, "_anthropic_base_url", None),
                 timeout=get_provider_request_timeout(self.provider, self.model),
                 drop_context_1m_beta=_drop_1m,
+                extra_headers=getattr(self, "_anthropic_extra_headers", None),
             )
 
     def _interruptible_api_call(self, api_kwargs: dict):

--- a/run_agent.py
+++ b/run_agent.py
@@ -4605,6 +4605,27 @@ class AIAgent:
             except Exception:
                 pass
 
+            # extra_headers are resolved per endpoint (providers[].extra_headers
+            # matches on base_url), so a pool entry that moves the runtime to a
+            # different endpoint must not carry the previous endpoint's headers
+            # along. Re-resolve for the new URL; empty when no config entry
+            # matches. Same-endpoint rotations keep the current headers, which
+            # may have been set inline by a fallback entry rather than config.
+            _prev_base = str(getattr(self, "_anthropic_base_url", "") or "").rstrip("/").lower()
+            _next_base = str(runtime_base or "").rstrip("/").lower()
+            if _next_base != _prev_base:
+                _rotated_headers: dict = {}
+                try:
+                    from hermes_cli.config import get_custom_provider_extra_headers
+
+                    _rotated_headers = get_custom_provider_extra_headers(runtime_base) or {}
+                except Exception:
+                    logger.debug(
+                        "custom Anthropic-provider extra_headers re-resolution skipped",
+                        exc_info=True,
+                    )
+                self._anthropic_extra_headers = _rotated_headers
+
             self._anthropic_api_key = runtime_key
             self._anthropic_base_url = runtime_base
             self._anthropic_client = build_anthropic_client(

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -116,11 +116,22 @@ class TestBuildAnthropicClient:
     def test_custom_base_url_strips_trailing_v1(self):
         with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
             build_anthropic_client(
-                "sk-ant-api03-x",
+                "sk-test",
                 base_url="https://proxy.example.com/anthropic/v1",
             )
             kwargs = mock_sdk.Anthropic.call_args[1]
             assert kwargs["base_url"] == "https://proxy.example.com/anthropic"
+
+    def test_custom_extra_headers_override_protocol_defaults(self):
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client(
+                "sk-test",
+                base_url="https://proxy.example.com/anthropic",
+                extra_headers={"anthropic-version": "vertex-2023-10-16"},
+            )
+            headers = mock_sdk.Anthropic.call_args[1]["default_headers"]
+            assert headers["anthropic-version"] == "vertex-2023-10-16"
+            assert "interleaved-thinking-2025-05-14" in headers["anthropic-beta"]
 
     def test_azure_anthropic_endpoint_keeps_context_1m_beta(self):
         with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -211,6 +211,70 @@ class TestFallbackChainAdvancement:
             assert agent._try_activate_fallback() is True
             assert agent.api_mode == "anthropic_messages"
 
+    def test_explicit_custom_anthropic_url_and_headers_survive_fallback(self):
+        explicit_url = "https://proxy.example.com/service/anthropic"
+        headers = {"anthropic-version": "vertex-2023-10-16"}
+        fbs = [
+            {
+                "provider": "custom",
+                "model": "claude-sonnet-4-6",
+                "base_url": explicit_url,
+                "key_env": "MY_FALLBACK_KEY",
+                "extra_headers": headers,
+            }
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        setattr(agent, "provider", "openai-codex")
+        setattr(agent, "model", "primary-model")
+        normalized_client = _mock_client(
+            base_url="https://proxy.example.com/service/v1/v1/",
+            api_key="env-secret",
+        )
+        with (
+            patch.dict("os.environ", {"MY_FALLBACK_KEY": "env-secret"}, clear=False),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(normalized_client, "claude-sonnet-4-6"),
+            ),
+            patch("hermes_cli.model_normalize.normalize_model_for_provider", side_effect=lambda m, p: m),
+            patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()) as build_client,
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert getattr(agent, "api_mode") == "anthropic_messages"
+        assert agent.base_url == explicit_url
+        assert getattr(agent, "_anthropic_extra_headers") == headers
+        assert build_client.call_args.args[0] == "env-secret"
+        assert build_client.call_args.kwargs["extra_headers"] == headers
+
+    def test_explicit_openai_wire_url_keeps_resolver_normalization(self):
+        """Anthropic URL preservation must not alter OpenAI-wire fallbacks."""
+        fbs = [{
+            "provider": "custom",
+            "model": "fallback-model",
+            "base_url": "https://proxy.example.com/service",
+            "api_key": "test-key",
+        }]
+        agent = _make_agent(fallback_model=fbs)
+        setattr(agent, "provider", "openai-codex")
+        setattr(agent, "model", "primary-model")
+        normalized_url = "https://proxy.example.com/service/v1/"
+        normalized_client = _mock_client(
+            base_url=normalized_url,
+            api_key="test-key",
+        )
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(normalized_client, "fallback-model"),
+            ),
+            patch("hermes_cli.model_normalize.normalize_model_for_provider", side_effect=lambda m, p: m),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert getattr(agent, "api_mode") == "chat_completions"
+        assert agent.base_url == normalized_url
+
 
 # ── Pool-rotation vs fallback gating (#11314) ────────────────────────────
 

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -247,6 +247,83 @@ class TestFallbackChainAdvancement:
         assert build_client.call_args.args[0] == "env-secret"
         assert build_client.call_args.kwargs["extra_headers"] == headers
 
+    def test_explicit_fallback_api_mode_wins_without_anthropic_url(self):
+        """A fallback entry declaring api_mode=anthropic_messages must route
+        to the Messages API even when the endpoint has no "/anthropic" path
+        suffix and is not the native Anthropic host — explicit config beats
+        the URL heuristics, matching primary-path precedence."""
+        explicit_url = "https://gateway.example.com/api"
+        fbs = [{
+            "provider": "custom",
+            "model": "claude-sonnet-4-6",
+            "base_url": explicit_url,
+            "api_key": "test-key",
+            "api_mode": "anthropic_messages",
+        }]
+        agent = _make_agent(fallback_model=fbs)
+        setattr(agent, "provider", "openai-codex")
+        setattr(agent, "model", "primary-model")
+        normalized_client = _mock_client(
+            base_url="https://gateway.example.com/api/v1/",
+            api_key="test-key",
+        )
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(normalized_client, "claude-sonnet-4-6"),
+            ),
+            patch("hermes_cli.model_normalize.normalize_model_for_provider", side_effect=lambda m, p: m),
+            patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()) as build_client,
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.api_mode == "anthropic_messages"
+        assert agent.base_url == explicit_url
+        assert build_client.call_args.args[1] == explicit_url
+
+    def test_custom_provider_config_api_mode_wins_without_anthropic_url(self):
+        """api_mode declared on the matching custom_providers entry (not on
+        the fallback entry itself) must also route to the Messages API for a
+        non-/anthropic endpoint, and its extra_headers must be applied."""
+        explicit_url = "https://gateway.example.com/api"
+        headers = {"anthropic-version": "vertex-2023-10-16"}
+        fbs = [{
+            "provider": "my-gateway",
+            "model": "claude-sonnet-4-6",
+            "base_url": explicit_url,
+            "api_key": "test-key",
+        }]
+        agent = _make_agent(fallback_model=fbs)
+        setattr(agent, "provider", "openai-codex")
+        setattr(agent, "model", "primary-model")
+        cfg = {
+            "custom_providers": [{
+                "name": "my-gateway",
+                "base_url": explicit_url,
+                "api_mode": "anthropic_messages",
+                "extra_headers": headers,
+            }]
+        }
+        normalized_client = _mock_client(
+            base_url="https://gateway.example.com/api/v1/",
+            api_key="test-key",
+        )
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(normalized_client, "claude-sonnet-4-6"),
+            ),
+            patch("hermes_cli.model_normalize.normalize_model_for_provider", side_effect=lambda m, p: m),
+            patch("hermes_cli.config.load_config", return_value=cfg),
+            patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()) as build_client,
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.api_mode == "anthropic_messages"
+        assert agent.base_url == explicit_url
+        assert agent._anthropic_extra_headers == headers
+        assert build_client.call_args.kwargs["extra_headers"] == headers
+
     def test_explicit_openai_wire_url_keeps_resolver_normalization(self):
         """Anthropic URL preservation must not alter OpenAI-wire fallbacks."""
         fbs = [{

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -7214,6 +7214,34 @@ class TestAnthropicCredentialRefresh:
         agent._anthropic_client.messages.create.assert_called_once_with(model="claude-sonnet-4-20250514")
         assert result is response
 
+    def test_anthropic_messages_create_falls_back_on_empty_stream_assertion(self):
+        """A complete-JSON proxy response can make the SDK stream path assert."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()),
+        ):
+            agent = AIAgent(
+                api_key="sk-test",
+                base_url="https://proxy.example.com/anthropic",
+                api_mode="anthropic_messages",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        response = SimpleNamespace(content=[])
+        agent._anthropic_client = MagicMock()
+        agent._anthropic_client.messages.stream.side_effect = AssertionError()
+        agent._anthropic_client.messages.create.return_value = response
+
+        with patch.object(agent, "_try_refresh_anthropic_client_credentials", return_value=False):
+            result = agent._anthropic_messages_create({"model": "claude-sonnet-4-20250514"})
+
+        agent._anthropic_client.messages.stream.assert_called_once_with(model="claude-sonnet-4-20250514")
+        agent._anthropic_client.messages.create.assert_called_once_with(model="claude-sonnet-4-20250514")
+        assert result is response
+
     def test_anthropic_messages_create_honors_disable_streaming(self):
         with (
             patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -7242,6 +7242,61 @@ class TestAnthropicCredentialRefresh:
         agent._anthropic_client.messages.create.assert_called_once_with(model="claude-sonnet-4-20250514")
         assert result is response
 
+    def test_swap_credential_reresolves_headers_on_endpoint_change(self):
+        """Pool rotation to a different endpoint must not carry the previous
+        endpoint's extra_headers along — they are matched per base_url, so
+        stale headers can break auth/protocol on the new gateway. Rotating
+        within the same endpoint keeps the current headers untouched."""
+        url_a = "https://gw-a.example.com/anthropic"
+        url_b = "https://gw-b.example.com/anthropic"
+        headers_a = {"anthropic-version": "vertex-2023-10-16"}
+        headers_b = {"x-gateway-b": "1"}
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()),
+        ):
+            agent = AIAgent(
+                api_key="sk-test",
+                base_url=url_a,
+                api_mode="anthropic_messages",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        agent._anthropic_client = MagicMock()
+        agent._anthropic_base_url = url_a
+        agent._anthropic_extra_headers = dict(headers_a)
+        by_url = {url_a: headers_a, url_b: headers_b}
+
+        def _headers_for(base_url, *args, **kwargs):
+            return dict(by_url.get(str(base_url).rstrip("/"), {}))
+
+        def _entry(key, url):
+            return SimpleNamespace(runtime_api_key=key, runtime_base_url=url)
+
+        with (
+            patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()) as build_client,
+            patch("hermes_cli.config.get_custom_provider_extra_headers", side_effect=_headers_for) as resolve_headers,
+        ):
+            agent._swap_credential(_entry("key-b", url_b))
+            assert agent._anthropic_extra_headers == headers_b
+            assert agent._anthropic_base_url == url_b
+            assert build_client.call_args.kwargs["extra_headers"] == headers_b
+
+            agent._swap_credential(_entry("key-a", url_a))
+            assert agent._anthropic_extra_headers == headers_a
+            assert build_client.call_args.kwargs["extra_headers"] == headers_a
+            assert resolve_headers.call_count == 2
+
+            # Same-endpoint rotation: headers preserved without re-resolution,
+            # so inline fallback-entry headers absent from config survive.
+            agent._swap_credential(_entry("key-a2", url_a))
+            assert agent._anthropic_extra_headers == headers_a
+            assert build_client.call_args.kwargs["extra_headers"] == headers_a
+            assert resolve_headers.call_count == 2
+
     def test_anthropic_messages_create_honors_disable_streaming(self):
         with (
             patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),


### PR DESCRIPTION
## Summary

Fix custom Anthropic-compatible providers so their configured protocol headers and endpoint survive initial client creation, credential refresh, and provider fallback.

## Problem

A custom provider using `api_mode: anthropic_messages` can require provider-specific headers such as an `anthropic-version` override. Hermes resolved `extra_headers` for OpenAI-wire clients, but did not pass them into native Anthropic SDK clients.

The fallback path had a second issue: `resolve_provider_client()` normalizes custom URLs as OpenAI-wire endpoints. For a configured Anthropic endpoint ending in `/anthropic`, that can erase the protocol-signalling suffix and produce an invalid `/v1/v1` route. Applying the raw URL globally would regress OpenAI-wire fallbacks, so this patch uses it only for Anthropic protocol detection/client construction while preserving resolver normalization for other providers.

Some Anthropic-compatible gateways also return a complete JSON Message when the SDK asks for streaming, which surfaces as an empty `AssertionError`. The existing non-streaming fallback is extended to cover that SDK failure shape.

## Changes

- Resolve custom-provider `extra_headers` during Anthropic agent initialization.
- Pass those headers into initial clients and credential-refresh rebuilds.
- Preserve explicit Anthropic fallback URLs without changing OpenAI-wire fallback normalization.
- Preserve fallback API keys and headers when building the native Anthropic client.
- Support provider headers in the callable bearer-token client path.
- Fall back to `messages.create()` when an Anthropic stream returns the SDK's empty-assertion failure shape.
- Add regression tests for headers, API-key propagation, explicit Anthropic URLs, OpenAI-wire URL normalization, and non-streaming fallback.

## Verification

- `python -m pytest tests/agent/test_anthropic_adapter.py tests/run_agent/test_provider_fallback.py tests/run_agent/test_run_agent.py -o 'addopts=' -q`
  - `616 passed`
- `git diff --check`
- Live custom-provider smoke test passed.
- Isolated broken-primary → custom-provider automatic fallback E2E passed.
- Independent Claude Code second-pass review verdict: `PASS`.
