### PR TITLE
docs(docker-compose): fix stale api-server doc path (add missing features/ segment)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@
 #     supervision tree before any service starts. Bypassing it skips
 #     all of that setup and the gateway will not work correctly.
 #   - The gateway's API server is off unless you uncomment API_SERVER_KEY
-#     and API_SERVER_HOST. See docs/user-guide/api-server.md before doing
+#     and API_SERVER_HOST. See docs/user-guide/features/api-server.md before doing
 #     this on an internet-facing host.
 #
 services:


### PR DESCRIPTION
﻿## Summary

The setup comment in `docker-compose.yml` points readers at a documentation path that is missing the `features/` segment:

```
#     and API_SERVER_HOST. See docs/user-guide/api-server.md before doing
```

The actual page lives at `website/docs/user-guide/features/api-server.md`, and every other reference to it in the repo uses the `user-guide/features/api-server` path (`website/sidebars.ts`, `website/docs/integrations/index.md`, `programmatic-integration.md`, `windows-wsl-quickstart.md`, `website/scripts/generate-llms-txt.py`). This comment is the only one missing `features/`, so a reader following it lands on a 404.

## Fix

```diff
-#     and API_SERVER_HOST. See docs/user-guide/api-server.md before doing
+#     and API_SERVER_HOST. See docs/user-guide/features/api-server.md before doing
```

## Validation

- Provable by file existence + majority pattern: the real file is at `.../user-guide/features/api-server.md`, and all other repo references include `features/`.
- Comment-only — zero runtime/container behavior change. 1 file, 1 line.
- Checked open PRs: no overlap on this file's comment.
