### PR TITLE
fix(file-sync): bound sync-back archive expansion

### DIFF
--- a/tests/tools/test_file_sync_archive_limits.py
+++ b/tests/tools/test_file_sync_archive_limits.py
@@ -1,0 +1,210 @@
+import io
+import logging
+import tarfile
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.environments.file_sync import FileSyncManager, _extract_sync_back_archive
+
+
+def _download_with(files: dict[str, bytes]):
+    def download(dest: Path) -> None:
+        with tarfile.open(dest, "w") as archive:
+            for name, data in files.items():
+                member = tarfile.TarInfo(name)
+                member.size = len(data)
+                archive.addfile(member, io.BytesIO(data))
+
+    return download
+
+
+def _manager(host_file: Path, files: dict[str, bytes]) -> FileSyncManager:
+    return FileSyncManager(
+        get_files_fn=lambda: [(str(host_file), "/root/.hermes/skill.md")],
+        upload_fn=MagicMock(),
+        delete_fn=MagicMock(),
+        bulk_download_fn=_download_with(files),
+    )
+
+
+def _download_members(members: list[tuple[tarfile.TarInfo, bytes | None]]):
+    def download(dest: Path) -> None:
+        with tarfile.open(dest, "w") as archive:
+            for member, data in members:
+                archive.addfile(member, io.BytesIO(data) if data is not None else None)
+
+    return download
+
+
+@contextmanager
+def _temporary_archive(path: Path):
+    try:
+        yield SimpleNamespace(name=str(path))
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def _run_sync_back(manager: FileSyncManager, archive_path: Path) -> list[Path]:
+    staging_paths: list[Path] = []
+    real_temporary_directory = tempfile.TemporaryDirectory
+
+    def recording_temporary_directory(*args, **kwargs):
+        directory = real_temporary_directory(*args, **kwargs)
+        staging_paths.append(Path(directory.name))
+        return directory
+
+    with patch(
+        "tools.environments.file_sync.tempfile.NamedTemporaryFile",
+        return_value=_temporary_archive(archive_path),
+    ), patch(
+        "tools.environments.file_sync.tempfile.TemporaryDirectory",
+        side_effect=recording_temporary_directory,
+    ):
+        manager._sync_back_impl()
+    assert not archive_path.exists()
+    assert all(not path.exists() for path in staging_paths)
+    return staging_paths
+
+
+def _assert_rejected(
+    manager: FileSyncManager,
+    host_file: Path,
+    archive_path: Path,
+    *,
+    expect_staging: bool = True,
+) -> None:
+    staging_paths = _run_sync_back(manager, archive_path)
+    assert bool(staging_paths) is expect_staging
+    assert host_file.read_bytes() == b"original"
+
+
+def test_sync_back_refuses_excessive_member_count(tmp_path, caplog):
+    host_file = tmp_path / "host_skill.md"
+    host_file.write_bytes(b"original")
+    manager = _manager(host_file, {
+        "root/.hermes/skill.md": b"remote_version",
+        "root/.hermes/extra.md": b"extra",
+    })
+
+    with caplog.at_level(logging.WARNING, logger="tools.environments.file_sync"):
+        with patch("tools.environments.file_sync._SYNC_BACK_MAX_MEMBERS", 1):
+            _assert_rejected(manager, host_file, tmp_path / "members.tar")
+
+    assert any("member" in record.message.lower() for record in caplog.records)
+
+
+def test_sync_back_refuses_excessive_expanded_size(tmp_path, caplog):
+    host_file = tmp_path / "host_skill.md"
+    host_file.write_bytes(b"original")
+    manager = _manager(host_file, {
+        "root/.hermes/skill.md": b"ab",
+        "root/.hermes/extra.md": b"cd",
+    })
+
+    with caplog.at_level(logging.WARNING, logger="tools.environments.file_sync"):
+        with patch("tools.environments.file_sync._SYNC_BACK_MAX_EXPANDED_BYTES", 3):
+            _assert_rejected(manager, host_file, tmp_path / "expanded.tar")
+
+    assert any("expanded" in record.message.lower() for record in caplog.records)
+
+
+def test_sync_back_refuses_excessive_per_member_size(tmp_path, caplog):
+    host_file = tmp_path / "host_skill.md"
+    host_file.write_bytes(b"original")
+    manager = _manager(host_file, {
+        "root/.hermes/skill.md": b"remote_version",
+    })
+
+    with caplog.at_level(logging.WARNING, logger="tools.environments.file_sync"):
+        with patch("tools.environments.file_sync._SYNC_BACK_MAX_MEMBER_BYTES", 1):
+            _assert_rejected(manager, host_file, tmp_path / "member-size.tar")
+
+    assert any("member" in record.message.lower() for record in caplog.records)
+    assert any("cap" in record.message.lower() for record in caplog.records)
+
+
+def test_sync_back_refuses_oversized_downloaded_archive(tmp_path, caplog):
+    host_file = tmp_path / "host_skill.md"
+    host_file.write_bytes(b"original")
+    manager = _manager(host_file, {
+        "root/.hermes/skill.md": b"remote_version",
+    })
+
+    with caplog.at_level(logging.WARNING, logger="tools.environments.file_sync"):
+        with patch("tools.environments.file_sync._SYNC_BACK_MAX_BYTES", 1):
+            _assert_rejected(
+                manager,
+                host_file,
+                tmp_path / "download.tar",
+                expect_staging=False,
+            )
+
+    assert any("remote tar is" in record.message.lower() for record in caplog.records)
+
+
+@pytest.mark.parametrize(
+    "member_name",
+    [
+        "../escape.md",
+        "..\\escape.md",
+        "/absolute/escape.md",
+        "C:\\absolute\\escape.md",
+    ],
+)
+def test_sync_back_refuses_traversal_and_absolute_paths(
+    tmp_path, caplog, member_name
+):
+    host_file = tmp_path / "host_skill.md"
+    host_file.write_bytes(b"original")
+    manager = _manager(host_file, {member_name: b"remote_version"})
+
+    with caplog.at_level(logging.WARNING, logger="tools.environments.file_sync"):
+        _assert_rejected(manager, host_file, tmp_path / "unsafe-path.tar")
+
+    assert not (tmp_path / "escape.md").exists()
+    assert any("unsafe" in record.message.lower() for record in caplog.records)
+
+
+@pytest.mark.parametrize(
+    "member_type",
+    [tarfile.SYMTYPE, tarfile.LNKTYPE],
+)
+def test_sync_back_refuses_link_members(tmp_path, caplog, member_type):
+    host_file = tmp_path / "host_skill.md"
+    host_file.write_bytes(b"original")
+    member = tarfile.TarInfo("root/.hermes/alias.md")
+    member.type = member_type
+    member.linkname = "root/.hermes/skill.md"
+    manager = FileSyncManager(
+        get_files_fn=lambda: [(str(host_file), "/root/.hermes/skill.md")],
+        upload_fn=MagicMock(),
+        delete_fn=MagicMock(),
+        bulk_download_fn=_download_members([(member, None)]),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="tools.environments.file_sync"):
+        _assert_rejected(manager, host_file, tmp_path / "unsafe-member.tar")
+
+    assert any("link" in record.message.lower() for record in caplog.records)
+
+
+def test_safe_archive_extracts_regular_files_and_directories(tmp_path):
+    archive_path = tmp_path / "valid.tar"
+    directory = tarfile.TarInfo("root/.hermes")
+    directory.type = tarfile.DIRTYPE
+    file_member = tarfile.TarInfo("root/.hermes/skill.md")
+    payload = b"remote_version"
+    file_member.size = len(payload)
+    _download_members([(directory, None), (file_member, payload)])(archive_path)
+
+    destination = tmp_path / "out"
+    destination.mkdir()
+    with tarfile.open(archive_path) as archive:
+        _extract_sync_back_archive(archive, str(destination))
+
+    assert (destination / "root" / ".hermes" / "skill.md").read_bytes() == payload

--- a/tests/tools/test_file_sync_archive_limits.py
+++ b/tests/tools/test_file_sync_archive_limits.py
@@ -193,6 +193,30 @@ def test_sync_back_refuses_link_members(tmp_path, caplog, member_type):
     assert any("link" in record.message.lower() for record in caplog.records)
 
 
+@pytest.mark.parametrize("member_type", [tarfile.FIFOTYPE, tarfile.CHRTYPE, tarfile.BLKTYPE])
+def test_sync_back_refuses_special_members(tmp_path, caplog, member_type):
+    host_file = tmp_path / "host_skill.md"
+    host_file.write_bytes(b"original")
+    regular_member = tarfile.TarInfo("root/.hermes/skill.md")
+    regular_payload = b"remote_version"
+    regular_member.size = len(regular_payload)
+    special_member = tarfile.TarInfo("root/.hermes/special")
+    special_member.type = member_type
+    manager = FileSyncManager(
+        get_files_fn=lambda: [(str(host_file), "/root/.hermes/skill.md")],
+        upload_fn=MagicMock(),
+        delete_fn=MagicMock(),
+        bulk_download_fn=_download_members(
+            [(regular_member, regular_payload), (special_member, None)]
+        ),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="tools.environments.file_sync"):
+        _assert_rejected(manager, host_file, tmp_path / "special-member.tar")
+
+    assert any("unsupported member type" in record.message.lower() for record in caplog.records)
+
+
 def test_safe_archive_extracts_regular_files_and_directories(tmp_path):
     archive_path = tmp_path / "valid.tar"
     directory = tarfile.TarInfo("root/.hermes")

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -22,7 +22,7 @@ try:
     import fcntl
 except ImportError:
     fcntl = None  # Windows — file locking skipped
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Callable
 
 from hermes_constants import get_hermes_home
@@ -129,6 +129,75 @@ def _sha256_file(path: str) -> str:
 _SYNC_BACK_MAX_RETRIES = 3
 _SYNC_BACK_BACKOFF = (2, 4, 8)  # seconds between retries
 _SYNC_BACK_MAX_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB — refuse to extract larger tars
+_SYNC_BACK_MAX_EXPANDED_BYTES = _SYNC_BACK_MAX_BYTES
+_SYNC_BACK_MAX_MEMBER_BYTES = _SYNC_BACK_MAX_EXPANDED_BYTES
+_SYNC_BACK_MAX_MEMBERS = 100_000
+
+
+class _SyncBackArchiveRejected(Exception):
+    pass
+
+
+def _validated_sync_back_members(tar: tarfile.TarFile) -> list[tarfile.TarInfo]:
+    members: list[tarfile.TarInfo] = []
+    expanded_size = 0
+
+    for member in tar:
+        if len(members) >= _SYNC_BACK_MAX_MEMBERS:
+            raise _SyncBackArchiveRejected(
+                f"remote tar has more than {_SYNC_BACK_MAX_MEMBERS} members"
+            )
+
+        normalized_name = member.name.replace("\\", "/")
+        member_path = PurePosixPath(normalized_name)
+        windows_path = PureWindowsPath(member.name)
+        if (
+            member_path.is_absolute()
+            or windows_path.anchor
+            or ".." in member_path.parts
+        ):
+            raise _SyncBackArchiveRejected(
+                f"remote tar has unsafe member path {member.name!r}"
+            )
+        if not member_path.parts and not member.isdir():
+            raise _SyncBackArchiveRejected(
+                f"remote tar has unsafe empty member path {member.name!r}"
+            )
+
+        if member.issym() or member.islnk():
+            raise _SyncBackArchiveRejected(
+                f"remote tar has unsupported link member {member.name!r}"
+            )
+        if not (member.isfile() or member.isdir()):
+            raise _SyncBackArchiveRejected(
+                f"remote tar has unsupported member type for {member.name!r}"
+            )
+
+        if member.isfile():
+            if member.size < 0:
+                raise _SyncBackArchiveRejected(
+                    f"remote tar member {member.name!r} has a negative size"
+                )
+            if member.size > _SYNC_BACK_MAX_MEMBER_BYTES:
+                raise _SyncBackArchiveRejected(
+                    f"remote tar member {member.name!r} is {member.size} bytes "
+                    f"(cap {_SYNC_BACK_MAX_MEMBER_BYTES})"
+                )
+            expanded_size += member.size
+            if expanded_size > _SYNC_BACK_MAX_EXPANDED_BYTES:
+                raise _SyncBackArchiveRejected(
+                    "remote tar expanded size exceeds "
+                    f"{_SYNC_BACK_MAX_EXPANDED_BYTES} bytes"
+                )
+
+        members.append(member)
+
+    return members
+
+
+def _extract_sync_back_archive(tar: tarfile.TarFile, destination: str) -> None:
+    members = _validated_sync_back_members(tar)
+    tar.extractall(destination, members=members, filter="data")
 
 
 class FileSyncManager:
@@ -368,7 +437,11 @@ class FileSyncManager:
 
             with tempfile.TemporaryDirectory(prefix="hermes-sync-back-") as staging:
                 with tarfile.open(tf.name) as tar:
-                    tar.extractall(staging, filter="data")
+                    try:
+                        _extract_sync_back_archive(tar, staging)
+                    except _SyncBackArchiveRejected as exc:
+                        logger.warning("sync_back: %s — skipping extraction", exc)
+                        return
 
                 applied = 0
                 upload_only_host_paths = (

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -22,7 +22,7 @@ try:
     import fcntl
 except ImportError:
     fcntl = None  # Windows — file locking skipped
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Callable
 
 from hermes_constants import get_hermes_home
@@ -129,6 +129,75 @@ def _sha256_file(path: str) -> str:
 _SYNC_BACK_MAX_RETRIES = 3
 _SYNC_BACK_BACKOFF = (2, 4, 8)  # seconds between retries
 _SYNC_BACK_MAX_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB — refuse to extract larger tars
+_SYNC_BACK_MAX_EXPANDED_BYTES = _SYNC_BACK_MAX_BYTES
+_SYNC_BACK_MAX_MEMBER_BYTES = _SYNC_BACK_MAX_EXPANDED_BYTES
+_SYNC_BACK_MAX_MEMBERS = 100_000
+
+
+class _SyncBackArchiveRejected(Exception):
+    pass
+
+
+def _validated_sync_back_members(tar: tarfile.TarFile) -> list[tarfile.TarInfo]:
+    members: list[tarfile.TarInfo] = []
+    expanded_size = 0
+
+    for member in tar:
+        if len(members) >= _SYNC_BACK_MAX_MEMBERS:
+            raise _SyncBackArchiveRejected(
+                f"remote tar has more than {_SYNC_BACK_MAX_MEMBERS} members"
+            )
+
+        normalized_name = member.name.replace("\\", "/")
+        member_path = PurePosixPath(normalized_name)
+        windows_path = PureWindowsPath(member.name)
+        if (
+            member_path.is_absolute()
+            or windows_path.anchor
+            or ".." in member_path.parts
+        ):
+            raise _SyncBackArchiveRejected(
+                f"remote tar has unsafe member path {member.name!r}"
+            )
+        if not member_path.parts and not member.isdir():
+            raise _SyncBackArchiveRejected(
+                f"remote tar has unsafe empty member path {member.name!r}"
+            )
+
+        if member.issym() or member.islnk():
+            raise _SyncBackArchiveRejected(
+                f"remote tar has unsupported link member {member.name!r}"
+            )
+        if not (member.isfile() or member.isdir()):
+            raise _SyncBackArchiveRejected(
+                f"remote tar has unsupported member type for {member.name!r}"
+            )
+
+        if member.isfile():
+            if member.size < 0:
+                raise _SyncBackArchiveRejected(
+                    f"remote tar member {member.name!r} has a negative size"
+                )
+            if member.size > _SYNC_BACK_MAX_MEMBER_BYTES:
+                raise _SyncBackArchiveRejected(
+                    f"remote tar member {member.name!r} is {member.size} bytes "
+                    f"(cap {_SYNC_BACK_MAX_MEMBER_BYTES})"
+                )
+            expanded_size += member.size
+            if expanded_size > _SYNC_BACK_MAX_EXPANDED_BYTES:
+                raise _SyncBackArchiveRejected(
+                    "remote tar expanded size exceeds "
+                    f"{_SYNC_BACK_MAX_EXPANDED_BYTES} bytes"
+                )
+
+        members.append(member)
+
+    return members
+
+
+def _extract_sync_back_archive(tar: tarfile.TarFile, destination: str) -> None:
+    members = _validated_sync_back_members(tar)
+    tar.extractall(destination, members=members, filter="data")
 
 
 class FileSyncManager:
@@ -379,7 +448,11 @@ class FileSyncManager:
 
             with tempfile.TemporaryDirectory(prefix="hermes-sync-back-") as staging:
                 with tarfile.open(tf.name) as tar:
-                    tar.extractall(staging, filter="data")
+                    try:
+                        _extract_sync_back_archive(tar, staging)
+                    except _SyncBackArchiveRejected as exc:
+                        logger.warning("sync_back: %s — skipping extraction", exc)
+                        return
 
                 applied = 0
                 upload_only_host_paths = (


### PR DESCRIPTION
## Summary

- Refuse sync-back archives with excessive member counts before extraction.
- Bound the total declared size of regular-file members to the existing 2 GiB sync-back limit.
- Keep Python tarfile data filtering in place for path and link safety.

## Problem

The downloaded tar had an on-disk size check, but extraction did not bound member count or declared expanded content. A sandbox-controlled archive could therefore consume excessive filesystem or inode resources during sync-back.

## Duplicate review

Searched the current upstream PR and issue queue for sync-back archive expansion, member-count, and tar extraction-limit fixes. No overlapping open change was found.

## Validation

- uv run --extra dev python -m pytest tests/tools/test_file_sync_archive_limits.py -q (2 passed)
- uv run --extra dev ruff check tools/environments/file_sync.py tests/tools/test_file_sync_archive_limits.py
- git diff upstream/main...HEAD --check
- Rebased on upstream dfdc3156fbeb3e1d67c7173101d836fcfee0be85

## Agent disclosure

Prepared with Codex; scope is limited to upstream file-sync code and focused tests.