### PR TITLE
fix(file-sync): make sync-back portable on Windows

### DIFF
--- a/tests/tools/test_file_sync_windows_tempfile.py
+++ b/tests/tools/test_file_sync_windows_tempfile.py
@@ -32,3 +32,34 @@ def test_sync_back_download_receives_reopenable_path(tmp_path):
 
     assert host_file.read_bytes() == b"remote_version"
     assert archive_paths and not archive_paths[0].exists()
+
+
+def test_sync_back_maps_files_when_relpath_uses_windows_separators(
+    tmp_path, monkeypatch
+):
+    host_file = tmp_path / "host_skill.md"
+    host_file.write_bytes(b"original")
+
+    def download(dest: Path) -> None:
+        with tarfile.open(dest, "w") as archive:
+            data = b"remote_version"
+            member = tarfile.TarInfo("root/.hermes/skill.md")
+            member.size = len(data)
+            archive.addfile(member, io.BytesIO(data))
+
+    monkeypatch.setattr(
+        "tools.environments.file_sync.os.path.relpath",
+        lambda *_args: r"root\.hermes\skill.md",
+    )
+
+    manager = FileSyncManager(
+        get_files_fn=lambda: [(str(host_file), "/root/.hermes/skill.md")],
+        upload_fn=MagicMock(),
+        delete_fn=MagicMock(),
+        bulk_download_fn=download,
+    )
+    manager._pushed_hashes["/root/.hermes/skill.md"] = "0" * 64
+
+    manager._sync_back_impl()
+
+    assert host_file.read_bytes() == b"remote_version"

--- a/tests/tools/test_file_sync_windows_tempfile.py
+++ b/tests/tools/test_file_sync_windows_tempfile.py
@@ -1,0 +1,34 @@
+import io
+import tarfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from tools.environments.file_sync import FileSyncManager
+
+
+def test_sync_back_download_receives_reopenable_path(tmp_path):
+    host_file = tmp_path / "host_skill.md"
+    host_file.write_bytes(b"original")
+    archive_paths: list[Path] = []
+
+    def download(dest: Path) -> None:
+        archive_paths.append(dest)
+        assert not dest.exists()
+        with tarfile.open(dest, "w") as archive:
+            data = b"remote_version"
+            member = tarfile.TarInfo("root/.hermes/skill.md")
+            member.size = len(data)
+            archive.addfile(member, io.BytesIO(data))
+
+    manager = FileSyncManager(
+        get_files_fn=lambda: [(str(host_file), "/root/.hermes/skill.md")],
+        upload_fn=MagicMock(),
+        delete_fn=MagicMock(),
+        bulk_download_fn=download,
+    )
+    manager._pushed_hashes["/root/.hermes/skill.md"] = "0" * 64
+
+    manager._sync_back_impl()
+
+    assert host_file.read_bytes() == b"remote_version"
+    assert archive_paths and not archive_paths[0].exists()

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -342,13 +342,14 @@ class FileSyncManager:
         except Exception:
             file_mapping = []
 
-        with tempfile.NamedTemporaryFile(suffix=".tar") as tf:
-            self._bulk_download_fn(Path(tf.name))
+        with tempfile.TemporaryDirectory(prefix="hermes-sync-back-download-") as download_dir:
+            archive_path = Path(download_dir) / "remote.tar"
+            self._bulk_download_fn(archive_path)
 
             # Defensive size cap: a misbehaving sandbox could produce an
             # arbitrarily large tar. Refuse to extract if it exceeds the cap.
             try:
-                tar_size = os.path.getsize(tf.name)
+                tar_size = os.path.getsize(archive_path)
             except OSError:
                 tar_size = 0
             if tar_size > _SYNC_BACK_MAX_BYTES:
@@ -359,7 +360,7 @@ class FileSyncManager:
                 return
 
             with tempfile.TemporaryDirectory(prefix="hermes-sync-back-") as staging:
-                with tarfile.open(tf.name) as tar:
+                with tarfile.open(archive_path) as tar:
                     tar.extractall(staging, filter="data")
 
                 applied = 0
@@ -369,7 +370,7 @@ class FileSyncManager:
                 for dirpath, _dirnames, filenames in os.walk(staging):
                     for fname in filenames:
                         staged_file = os.path.join(dirpath, fname)
-                        rel = os.path.relpath(staged_file, staging)
+                        rel = Path(staged_file).relative_to(staging).as_posix()
                         remote_path = "/" + rel
 
                         pushed_hash = self._pushed_hashes.get(remote_path)

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -361,13 +361,14 @@ class FileSyncManager:
         except Exception:
             file_mapping = []
 
-        with tempfile.NamedTemporaryFile(suffix=".tar") as tf:
-            self._bulk_download_fn(Path(tf.name))
+        with tempfile.TemporaryDirectory(prefix="hermes-sync-back-download-") as download_dir:
+            archive_path = Path(download_dir) / "remote.tar"
+            self._bulk_download_fn(archive_path)
 
             # Defensive size cap: a misbehaving sandbox could produce an
             # arbitrarily large tar. Refuse to extract if it exceeds the cap.
             try:
-                tar_size = os.path.getsize(tf.name)
+                tar_size = os.path.getsize(archive_path)
             except OSError:
                 tar_size = 0
             if tar_size > _SYNC_BACK_MAX_BYTES:
@@ -378,7 +379,7 @@ class FileSyncManager:
                 return
 
             with tempfile.TemporaryDirectory(prefix="hermes-sync-back-") as staging:
-                with tarfile.open(tf.name) as tar:
+                with tarfile.open(archive_path) as tar:
                     tar.extractall(staging, filter="data")
 
                 applied = 0
@@ -388,7 +389,7 @@ class FileSyncManager:
                 for dirpath, _dirnames, filenames in os.walk(staging):
                     for fname in filenames:
                         staged_file = os.path.join(dirpath, fname)
-                        rel = os.path.relpath(staged_file, staging)
+                        rel = Path(staged_file).relative_to(staging).as_posix()
                         remote_path = "/" + rel
 
                         pushed_hash = self._pushed_hashes.get(remote_path)


### PR DESCRIPTION
## Summary

- Download sync-back archives into a fresh path inside a temporary directory.
- Avoid reopening a still-open NamedTemporaryFile on Windows.
- Normalize staged archive paths to POSIX form before matching remote paths.

## Problem

On Windows, the downloader could not reliably reopen the already-open temporary file. Even when extraction succeeded, os.path.relpath() produced backslashes, so extracted paths did not match POSIX remote paths and updates were silently skipped.

## Duplicate review

Searched the current upstream PR and issue queue for sync-back Windows temporary-file, reopen, and path-separator fixes. No overlapping open change was found.

## Validation

- uv run --extra dev python -m pytest tests/tools/test_file_sync_windows_tempfile.py tests/tools/test_file_sync.py -q (17 passed)
- uv run --extra dev ruff check tools/environments/file_sync.py tests/tools/test_file_sync_windows_tempfile.py
- git diff upstream/main...HEAD --check
- Rebased on upstream dfdc3156fbeb3e1d67c7173101d836fcfee0be85

## Agent disclosure

Prepared with Codex; scope is limited to upstream file-sync portability and focused tests.