### PR TITLE
fix(web_server): close log_file fd on Popen failure in _spawn_hermes_action

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3228,7 +3228,11 @@ def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
     else:
         popen_kwargs["start_new_session"] = True
 
-    proc = subprocess.Popen(cmd, **popen_kwargs)
+    try:
+        proc = subprocess.Popen(cmd, **popen_kwargs)
+    except Exception:
+        log_file.close()
+        raise
     # The child inherits its own duplicated fd for stdout/stderr, so the
     # parent's handle can be released immediately — otherwise we leak one
     # fd per spawned action.


### PR DESCRIPTION
## Summary

Close the log file descriptor when `subprocess.Popen` raises in `_spawn_hermes_action`, preventing a fd leak on every failed spawn attempt.

## Problem

In `hermes_cli/web_server.py`, `_spawn_hermes_action()` opens a log file (line 3212) and then calls `subprocess.Popen` (line 3231). If `Popen` raises (e.g. `FileNotFoundError` for a missing executable, or `OSError`), the function propagates the exception without closing `log_file`. Each failed spawn attempt leaks one file descriptor. Over time, repeated failures exhaust the process fd limit.

## Fix

Wrap the `Popen` call in a try/except: if it raises, close `log_file` before re-raising. This mirrors the existing close-after-inherit pattern already present on line 3235, just moved to cover the error path too. Minimal diff: 5 lines added.

## Testing
- Syntax check passed (py_compile)
- Behavior verified