### PR TITLE
fix(tools): strip terminal/web_extract cross-reference from browser_n…

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -492,25 +492,48 @@ def _compute_tool_definitions(
                         filtered_tools[i] = {"type": "function", "function": dynamic}
                         break
 
-    # Strip web tool cross-references from browser_navigate description when
-    # web_search / web_extract are not available.  The static schema says
-    # "prefer web_search or web_extract" which causes the model to hallucinate
-    # those tools when they're missing.
+    # Strip web/terminal tool cross-references from browser_navigate
+    # description when those tools are not available.  The static schema
+    # mentions "web_search", "web_extract", and "the terminal tool" in two
+    # separate sentences, which causes the model to hallucinate calls to
+    # those tools when they're missing (#43099).
     if "browser_navigate" in available_tool_names:
         web_tools_available = {"web_search", "web_extract"} & available_tool_names
-        if not web_tools_available:
+        web_extract_available = "web_extract" in available_tool_names
+        terminal_available = "terminal" in available_tool_names
+        if not web_tools_available or not (web_extract_available and terminal_available):
             for i, td in enumerate(filtered_tools):
-                if td.get("function", {}).get("name") == "browser_navigate":
-                    desc = td["function"].get("description", "")
+                if td.get("function", {}).get("name") != "browser_navigate":
+                    continue
+                desc = td["function"].get("description", "")
+                if not web_tools_available:
                     desc = desc.replace(
                         " For simple information retrieval, prefer web_search or web_extract (faster, cheaper).",
                         "",
                     )
-                    filtered_tools[i] = {
-                        "type": "function",
-                        "function": {**td["function"], "description": desc},
-                    }
-                    break
+                if not web_extract_available and not terminal_available:
+                    desc = desc.replace(
+                        " For plain-text endpoints — URLs ending in .md, .txt, .json, .yaml, "
+                        ".yml, .csv, .xml, raw.githubusercontent.com, or any documented API "
+                        "endpoint — prefer curl via the terminal tool or web_extract; the "
+                        "browser stack is overkill and much slower for these.",
+                        "",
+                    )
+                elif not web_extract_available:
+                    desc = desc.replace(
+                        "prefer curl via the terminal tool or web_extract;",
+                        "prefer curl via the terminal tool;",
+                    )
+                elif not terminal_available:
+                    desc = desc.replace(
+                        "prefer curl via the terminal tool or web_extract;",
+                        "prefer web_extract;",
+                    )
+                filtered_tools[i] = {
+                    "type": "function",
+                    "function": {**td["function"], "description": desc},
+                }
+                break
 
     if not quiet_mode:
         if filtered_tools:

--- a/model_tools.py
+++ b/model_tools.py
@@ -498,18 +498,28 @@ def _compute_tool_definitions(
     # separate sentences, which causes the model to hallucinate calls to
     # those tools when they're missing (#43099).
     if "browser_navigate" in available_tool_names:
-        web_tools_available = {"web_search", "web_extract"} & available_tool_names
+        web_search_available = "web_search" in available_tool_names
         web_extract_available = "web_extract" in available_tool_names
         terminal_available = "terminal" in available_tool_names
-        if not web_tools_available or not (web_extract_available and terminal_available):
+        if not (web_search_available and web_extract_available and terminal_available):
             for i, td in enumerate(filtered_tools):
                 if td.get("function", {}).get("name") != "browser_navigate":
                     continue
                 desc = td["function"].get("description", "")
-                if not web_tools_available:
+                if not web_search_available and not web_extract_available:
                     desc = desc.replace(
                         " For simple information retrieval, prefer web_search or web_extract (faster, cheaper).",
                         "",
+                    )
+                elif not web_extract_available:
+                    desc = desc.replace(
+                        "prefer web_search or web_extract (faster, cheaper).",
+                        "prefer web_search (faster, cheaper).",
+                    )
+                elif not web_search_available:
+                    desc = desc.replace(
+                        "prefer web_search or web_extract (faster, cheaper).",
+                        "prefer web_extract (faster, cheaper).",
                     )
                 if not web_extract_available and not terminal_available:
                     desc = desc.replace(

--- a/tests/tools/test_browser_navigate_cross_tool_refs.py
+++ b/tests/tools/test_browser_navigate_cross_tool_refs.py
@@ -3,19 +3,34 @@ in model_tools.py's get_tool_definitions().
 
 The static browser_navigate schema (tools/browser_tool.py) hardcodes two
 sentences that name other tools by name: "prefer web_search or web_extract"
-and "prefer curl via the terminal tool or web_extract". AGENTS.md's Known
-Pitfalls section forbids shipping schema descriptions that mention tools
-from other toolsets by name, because a model reading the description will
-attempt to call them even when they are unavailable (missing API key,
-disabled toolset), causing hallucinated tool calls.
+and "prefer curl via the terminal tool or web_extract". Shipping a schema
+description that names an unavailable tool causes the model to attempt
+calls to it, since the model has no other signal that the tool doesn't
+actually exist in this session's tool list.
 
 model_tools.py post-processes the description to strip references to
 whichever of {web_search, web_extract, terminal} are not actually available
 this session. This file locks in that behavior for every availability
-combination so a future edit to either sentence can't silently reintroduce
-a dangling cross-reference (as happened in the abandoned PR #43352, which
-fixed only the first sentence and was closed for "prefer web_search or
-web_extract" still remaining).
+combination -- including the "browser" toolset's own default shape, which
+bundles web_search but not web_extract or terminal (toolsets.py) -- so a
+future edit to either sentence can't silently reintroduce a dangling
+cross-reference. Two prior fixes were rejected for exactly this failure
+mode:
+
+  * PR #43352 fixed only the first sentence via a regex that broke on the
+    literal periods inside ".md, .txt, .json, ..." and
+    "raw.githubusercontent.com" in the second sentence, and was self-closed
+    for still leaving "prefer web_search or web_extract" in place.
+  * An earlier revision of this fix checked
+    ``{"web_search", "web_extract"} & available_tool_names`` (a set
+    intersection) to decide whether to touch the first sentence at all --
+    which is truthy whenever *either* tool is present. Because the
+    ``browser`` toolset bundles web_search but not web_extract, enabling
+    only ``browser`` left "web_extract" named in the schema despite it
+    being genuinely unavailable. This file's
+    ``test_browser_only_default_config_never_names_unavailable_web_extract``
+    and ``test_browser_plus_terminal_without_web_toolset_never_names_unavailable_web_extract``
+    cases pin that exact scenario.
 """
 
 from __future__ import annotations
@@ -33,6 +48,10 @@ _BROWSER_TOOL_NAMES = [
 ]
 _OTHER_TOOL_NAMES = ["web_search", "web_extract", "terminal", "process"]
 
+# Every cross-tool name that could plausibly appear in the browser_navigate
+# description. Used by the invariant check below.
+_CROSS_TOOL_NAMES = ("web_search", "web_extract", "terminal")
+
 
 def _force_available(monkeypatch, names):
     """Force check_fn() -> True for every registered tool in *names* that
@@ -44,19 +63,41 @@ def _force_available(monkeypatch, names):
             monkeypatch.setattr(entry, "check_fn", lambda: True)
 
 
-def _browser_navigate_description(enabled_toolsets, disabled_toolsets=None):
+def _get_definitions(enabled_toolsets, disabled_toolsets=None):
     model_tools._tool_defs_cache.clear()
-    defs = model_tools.get_tool_definitions(
+    return model_tools.get_tool_definitions(
         enabled_toolsets=enabled_toolsets,
         disabled_toolsets=disabled_toolsets,
         quiet_mode=True,
         skip_tool_search_assembly=True,
     )
+
+
+def _browser_navigate_description(enabled_toolsets, disabled_toolsets=None):
+    defs = _get_definitions(enabled_toolsets, disabled_toolsets)
     for tool_def in defs:
         fn = tool_def.get("function", {})
         if fn.get("name") == "browser_navigate":
             return fn.get("description", "")
     raise AssertionError("browser_navigate not present in tool definitions")
+
+
+def _assert_no_unavailable_tool_named(enabled_toolsets, disabled_toolsets=None):
+    """Invariant: every cross-tool name mentioned in the browser_navigate
+    description must correspond to a tool that is actually available."""
+    defs = _get_definitions(enabled_toolsets, disabled_toolsets)
+    available = {d["function"]["name"] for d in defs}
+    desc = next(
+        d["function"]["description"] for d in defs
+        if d["function"]["name"] == "browser_navigate"
+    )
+    for tool_name in _CROSS_TOOL_NAMES:
+        if tool_name in desc:
+            assert tool_name in available, (
+                f"browser_navigate description names {tool_name!r}, but it "
+                f"is not in the available tool set {sorted(available)!r}"
+            )
+    return desc
 
 
 @pytest.fixture(autouse=True)
@@ -70,8 +111,27 @@ def _clean_registry_state(monkeypatch):
 
 
 class TestBrowserNavigateCrossToolReferences:
-    def test_no_web_tools_no_terminal_strips_both_sentences(self):
-        desc = _browser_navigate_description(
+    def test_browser_only_default_config_never_names_unavailable_web_extract(self):
+        """The 'browser' toolset bundles web_search but NOT web_extract or
+        terminal (toolsets.py). This is the realistic default shape for a
+        browser-only session and must not leave web_extract named."""
+        desc = _assert_no_unavailable_tool_named(enabled_toolsets=["browser"])
+        assert "web_search" in desc
+        assert "prefer web_search (faster, cheaper)" in desc
+
+    def test_browser_plus_terminal_without_web_toolset_never_names_unavailable_web_extract(self):
+        """browser + terminal, with the 'web' toolset never enabled: terminal
+        is available but web_extract still is not (only web_search is,
+        bundled via the browser toolset)."""
+        desc = _assert_no_unavailable_tool_named(
+            enabled_toolsets=["browser", "terminal"],
+        )
+        assert "web_search" in desc
+        assert "prefer web_search (faster, cheaper)" in desc
+        assert "prefer curl via the terminal tool;" in desc
+
+    def test_web_toolset_disabled_strips_both_sentences(self):
+        desc = _assert_no_unavailable_tool_named(
             enabled_toolsets=["browser"], disabled_toolsets=["web"],
         )
         assert "web_search" not in desc
@@ -80,16 +140,16 @@ class TestBrowserNavigateCrossToolReferences:
         # The rest of the description must still read as a coherent sentence.
         assert "Use browser tools when you need to interact with a page" in desc
 
-    def test_terminal_available_no_web_tools_keeps_only_terminal_mention(self):
-        desc = _browser_navigate_description(
+    def test_terminal_available_web_toolset_disabled_keeps_only_terminal_mention(self):
+        desc = _assert_no_unavailable_tool_named(
             enabled_toolsets=["browser", "terminal"], disabled_toolsets=["web"],
         )
         assert "web_search" not in desc
         assert "web_extract" not in desc
         assert "prefer curl via the terminal tool;" in desc
 
-    def test_web_tools_available_no_terminal_keeps_only_web_extract_mention(self):
-        desc = _browser_navigate_description(
+    def test_web_toolset_available_no_terminal_keeps_only_web_extract_mention(self):
+        desc = _assert_no_unavailable_tool_named(
             enabled_toolsets=["browser", "web"],
         )
         assert "terminal" not in desc
@@ -97,7 +157,7 @@ class TestBrowserNavigateCrossToolReferences:
         assert "prefer web_extract;" in desc
 
     def test_everything_available_preserves_original_description(self):
-        desc = _browser_navigate_description(
+        desc = _assert_no_unavailable_tool_named(
             enabled_toolsets=["browser", "web", "terminal"],
         )
         assert "prefer web_search or web_extract (faster, cheaper)" in desc

--- a/tests/tools/test_browser_navigate_cross_tool_refs.py
+++ b/tests/tools/test_browser_navigate_cross_tool_refs.py
@@ -1,0 +1,104 @@
+"""Regression tests for the browser_navigate cross-tool-reference stripping
+in model_tools.py's get_tool_definitions().
+
+The static browser_navigate schema (tools/browser_tool.py) hardcodes two
+sentences that name other tools by name: "prefer web_search or web_extract"
+and "prefer curl via the terminal tool or web_extract". AGENTS.md's Known
+Pitfalls section forbids shipping schema descriptions that mention tools
+from other toolsets by name, because a model reading the description will
+attempt to call them even when they are unavailable (missing API key,
+disabled toolset), causing hallucinated tool calls.
+
+model_tools.py post-processes the description to strip references to
+whichever of {web_search, web_extract, terminal} are not actually available
+this session. This file locks in that behavior for every availability
+combination so a future edit to either sentence can't silently reintroduce
+a dangling cross-reference (as happened in the abandoned PR #43352, which
+fixed only the first sentence and was closed for "prefer web_search or
+web_extract" still remaining).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import model_tools
+from tools.registry import invalidate_check_fn_cache, registry
+
+_BROWSER_TOOL_NAMES = [
+    "browser_navigate", "browser_snapshot", "browser_click",
+    "browser_type", "browser_scroll", "browser_back",
+    "browser_press", "browser_get_images", "browser_vision",
+    "browser_console", "browser_cdp", "browser_dialog",
+]
+_OTHER_TOOL_NAMES = ["web_search", "web_extract", "terminal", "process"]
+
+
+def _force_available(monkeypatch, names):
+    """Force check_fn() -> True for every registered tool in *names* that
+    exists, so schema availability in this test doesn't depend on whether
+    the local environment has API keys / a browser backend installed."""
+    for name in names:
+        entry = registry.get_entry(name)
+        if entry is not None:
+            monkeypatch.setattr(entry, "check_fn", lambda: True)
+
+
+def _browser_navigate_description(enabled_toolsets, disabled_toolsets=None):
+    model_tools._tool_defs_cache.clear()
+    defs = model_tools.get_tool_definitions(
+        enabled_toolsets=enabled_toolsets,
+        disabled_toolsets=disabled_toolsets,
+        quiet_mode=True,
+        skip_tool_search_assembly=True,
+    )
+    for tool_def in defs:
+        fn = tool_def.get("function", {})
+        if fn.get("name") == "browser_navigate":
+            return fn.get("description", "")
+    raise AssertionError("browser_navigate not present in tool definitions")
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry_state(monkeypatch):
+    _force_available(monkeypatch, _BROWSER_TOOL_NAMES + _OTHER_TOOL_NAMES)
+    invalidate_check_fn_cache()
+    model_tools._tool_defs_cache.clear()
+    yield
+    model_tools._tool_defs_cache.clear()
+    invalidate_check_fn_cache()
+
+
+class TestBrowserNavigateCrossToolReferences:
+    def test_no_web_tools_no_terminal_strips_both_sentences(self):
+        desc = _browser_navigate_description(
+            enabled_toolsets=["browser"], disabled_toolsets=["web"],
+        )
+        assert "web_search" not in desc
+        assert "web_extract" not in desc
+        assert "terminal" not in desc
+        # The rest of the description must still read as a coherent sentence.
+        assert "Use browser tools when you need to interact with a page" in desc
+
+    def test_terminal_available_no_web_tools_keeps_only_terminal_mention(self):
+        desc = _browser_navigate_description(
+            enabled_toolsets=["browser", "terminal"], disabled_toolsets=["web"],
+        )
+        assert "web_search" not in desc
+        assert "web_extract" not in desc
+        assert "prefer curl via the terminal tool;" in desc
+
+    def test_web_tools_available_no_terminal_keeps_only_web_extract_mention(self):
+        desc = _browser_navigate_description(
+            enabled_toolsets=["browser", "web"],
+        )
+        assert "terminal" not in desc
+        assert "prefer web_search or web_extract (faster, cheaper)" in desc
+        assert "prefer web_extract;" in desc
+
+    def test_everything_available_preserves_original_description(self):
+        desc = _browser_navigate_description(
+            enabled_toolsets=["browser", "web", "terminal"],
+        )
+        assert "prefer web_search or web_extract (faster, cheaper)" in desc
+        assert "prefer curl via the terminal tool or web_extract;" in desc


### PR DESCRIPTION
## What changed and why

`get_tool_definitions()` in `model_tools.py` strips hardcoded cross-tool references from the `browser_navigate` schema description when the referenced tools are unavailable. However, only one of the two references was being removed. As a result, the schema could still instruct the model to use tools such as `web_extract` or `terminal` even when they were not available in the current session.


## Prior attempt

PR #43352 attempted to address this issue with a regex-based approach but was later closed. The pattern relied on `[^.]*` to determine sentence boundaries, which failed because the target sentence contains literal periods (for example, in file extensions such as `.md`, `.txt`, and `.json`, as well as `raw.githubusercontent.com`). This implementation instead uses exact-string matching, avoiding those edge cases while preserving the intended text.

## How to test

1. Run:
   ```bash
   pytest tests/tools/test_browser_navigate_cross_tool_refs.py -v
   ```
   Verifies all four `{web_extract, terminal}` availability combinations.

2. Run:
   ```bash
   pytest tests/test_model_tools.py -v
   ```
   Confirms there are no regressions.

## Platform tested

- Windows 11 25H2
- Python 3.11