### PR TITLE
perf(curator): trim dead tool-schema from the LLM review fork

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1921,6 +1921,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
             credential_pool=_credential_pool,
             request_overrides=_request_overrides,
             **_agent_kwargs,
+            enabled_toolsets=["skills", "terminal"],
             # Umbrella-building over a large skill collection is worth a
             # high iteration ceiling — the pass typically takes 50-100
             # API calls against hundreds of candidate skills. The

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -1494,12 +1494,14 @@ def test_review_fork_restricts_toolsets_to_skills_and_terminal(curator_env, monk
 
 
 def test_review_fork_toolset_surface_is_skills_plus_terminal():
-    """Documentary pin on the static surface the fork's kwarg resolves to.
+    """Documentary check on the static surface the fork's kwarg resolves to.
 
     Registry-independent (include_registry=False) so a plugin-registered tool
-    tagged into these toolsets cannot flake the exact-set pin. This documents
-    the intended surface (the four prompt-named tools present, dead default
-    and lcm_* schema absent) but does not itself guard the call-site kwarg.
+    tagged into these toolsets cannot flake the membership checks. This
+    documents the intended surface (the four prompt-named tools present, dead
+    default and lcm_* schema absent) but does not itself guard the call-site
+    kwarg. No exact-set pin: intentional additions to either toolset must not
+    fail this test.
     """
     from toolsets import resolve_toolset
 
@@ -1517,8 +1519,3 @@ def test_review_fork_toolset_surface_is_skills_plus_terminal():
     assert "read_file" not in surface
     assert "web_search" not in surface
     assert "lcm_grep" not in surface
-
-    # Exact source-of-truth pin: terminal pulls in "process" (5 tools, not 4).
-    assert sorted(surface) == sorted(
-        {"skills_list", "skill_view", "skill_manage", "terminal", "process"}
-    )

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -1442,3 +1442,83 @@ def test_review_fork_merges_slot_extra_body_over_runtime(curator_env, monkeypatc
         },
         "service_tier": "priority",
     }
+
+
+def test_review_fork_restricts_toolsets_to_skills_and_terminal(curator_env, monkeypatch):
+    """The curator LLM fork must advertise only the skills + terminal toolsets.
+
+    Without ``enabled_toolsets=["skills", "terminal"]`` on the AIAgent(...) call
+    in ``_run_llm_review``, ``enabled_toolsets`` defaults to None and init_agent
+    grants the fork the full default catalog (~30 tools) plus the context_engine
+    (lcm_*) tools, billing ~7K wasted schema tokens on every one of the fork's
+    50-100 API calls per consolidation pass. The prompt (curator.py:509-523)
+    confines the model to four tools in natural language, but only this kwarg
+    filters the advertised request schema. Capturing the constructor kwarg is
+    the sole assertion that distinguishes fixed from unfixed code.
+    """
+    curator = curator_env["curator"]
+
+    # curator_env stubs _run_llm_review wholesale; exercise the real
+    # implementation, so reload the module to restore it.
+    import importlib
+    importlib.reload(curator)
+
+    captured = {}
+
+    class _StubAgent:
+        def __init__(self, *args, **kwargs):
+            captured["enabled_toolsets"] = kwargs.get("enabled_toolsets", "UNSET")
+            self._memory_write_origin = "assistant_tool"
+            self._memory_nudge_interval = 0
+            self._skill_nudge_interval = 0
+            self._session_messages = []
+
+        def run_conversation(self, user_message=None, **kwargs):
+            return {"final_response": "no change"}
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("run_agent.AIAgent", _StubAgent)
+
+    meta = curator._run_llm_review("review prompt")
+
+    # error is None proves the fork was actually constructed (capture ran).
+    assert meta.get("error") is None, meta.get("error")
+    assert captured.get("enabled_toolsets") == ["skills", "terminal"], (
+        "curator review fork did not pass enabled_toolsets=['skills', "
+        "'terminal'] to AIAgent; the full default tool catalog (plus lcm_* "
+        "context_engine tools) would be advertised; got "
+        f"{captured.get('enabled_toolsets')!r}"
+    )
+
+
+def test_review_fork_toolset_surface_is_skills_plus_terminal():
+    """Documentary pin on the static surface the fork's kwarg resolves to.
+
+    Registry-independent (include_registry=False) so a plugin-registered tool
+    tagged into these toolsets cannot flake the exact-set pin. This documents
+    the intended surface (the four prompt-named tools present, dead default
+    and lcm_* schema absent) but does not itself guard the call-site kwarg.
+    """
+    from toolsets import resolve_toolset
+
+    surface = set(resolve_toolset("skills", include_registry=False)) | set(
+        resolve_toolset("terminal", include_registry=False)
+    )
+
+    # The four prompt-named tools are all present.
+    assert "skills_list" in surface
+    assert "skill_view" in surface
+    assert "skill_manage" in surface
+    assert "terminal" in surface
+
+    # Representative dropped default + context_engine tools are absent.
+    assert "read_file" not in surface
+    assert "web_search" not in surface
+    assert "lcm_grep" not in surface
+
+    # Exact source-of-truth pin: terminal pulls in "process" (5 tools, not 4).
+    assert sorted(surface) == sorted(
+        {"skills_list", "skill_view", "skill_manage", "terminal", "process"}
+    )


### PR DESCRIPTION
The curator's LLM review loop (`_run_llm_review` in `agent/curator.py`) builds its `AIAgent` without `enabled_toolsets`, so it advertises every enabled toolset: the full default catalog plus the `context_engine` (`lcm_*`) tools. The fork only ever uses four tools, fixed by its own system prompt (`curator.py:509-523`), and nothing routes calls to the others. Every other tool schema ships on each request and does nothing.

This restricts the fork to the tools it uses:

```python
enabled_toolsets=["skills", "terminal"],
```

`"skills"` is `skills_list / skill_view / skill_manage`, `"terminal"` is `terminal / process`. The same four tools the prompt already names.

Measured with `get_tool_definitions(...)`, the fork's advertised tool-schema payload drops from 21.5 KB to 6.6 KB of JSON, about 15 KB (69%) off every request, on the order of 3.7K tokens per call by a chars/4 estimate. That is a lower bound: it excludes the `context_engine` (`lcm_*`) tools, which are appended separately when `enabled_toolsets` is None and are suppressed by this change too. The figure scales with how many toolsets an install enables (browser, vision, web, image, and plugin toolsets all add more), so a full deployment saves more than the baseline measured here. The loop makes 50-100 model calls per consolidation pass and the tool schema rides on every one, so the saving compounds across a pass and repeats each pass.

The change is behavior-neutral. The prompt already held the model to these four tools and no dispatch path reached the rest, so this drops surface the fork never touched. The background-review fork already restricts itself the same way (`background_review.py:788-794`); the curator fork never got the same treatment. `AIAgent` already accepts and forwards `enabled_toolsets` (`run_agent.py`), so it is a one-line call-site change with no new plumbing.

The fork runs on opted-in consolidation passes (`curator.consolidate: true` or `hermes curator run --consolidate`); `curator.enabled` alone runs only the deterministic prune.

Tests: `test_review_fork_restricts_toolsets_to_skills_and_terminal` captures the constructor kwarg, `test_review_fork_toolset_surface_is_skills_plus_terminal` pins the resolved surface. Full `tests/agent/test_curator.py` passes: 72 tests.
