### PR TITLE
fix(fallback): accept provider:model string entries from the desktop settings field

### DIFF
--- a/contributors/emails/giuseppe.capaldo@t-systems.com
+++ b/contributors/emails/giuseppe.capaldo@t-systems.com
@@ -1,0 +1,2 @@
+GiuseppeCapaldo93
+# PR #62083 (fallback: accept provider:model string entries from the desktop Fallback Models field)

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -31,17 +31,85 @@ def resolve_entry_api_key(entry: dict[str, Any] | None) -> str | None:
     return None
 
 
-def _iter_fallback_entries(raw: Any) -> list[dict[str, Any]]:
+def _split_provider_model(text: str) -> tuple[str, str] | None:
+    """Split a ``provider:model`` string into ``(provider, model)``.
+
+    Mirrors the ``provider:model`` grammar of
+    :func:`hermes_cli.models.parse_model_input`: the split is anchored to the
+    **first** colon so model ids that themselves contain colons stay intact
+    (``ollama-cloud:nemotron-3-nano:30b`` → provider ``ollama-cloud``, model
+    ``nemotron-3-nano:30b``; ``openrouter:qwen/qwen3.6-plus:free`` → provider
+    ``openrouter``, model ``qwen/qwen3.6-plus:free``).
+
+    The ``custom:<name>:<model>`` triple is special-cased so a qualified custom
+    endpoint id keeps its ``custom:<name>`` prefix
+    (``custom:my-endpoint:claude-sonnet-4.6`` → provider ``custom:my-endpoint``,
+    model ``claude-sonnet-4.6``).
+
+    Returns ``None`` when the string can't be interpreted as ``provider:model``
+    (no colon, or an empty provider/model half).
+    """
+    colon = text.find(":")
+    if colon <= 0:
+        return None
+    provider = text[:colon].strip()
+    model = text[colon + 1:].strip()
+    if not provider or not model:
+        return None
+    # custom:<name>:<model> → provider "custom:<name>", model "<model>",
+    # matching the named-custom-provider case in parse_model_input.
+    if provider.lower() == "custom" and ":" in model:
+        second = model.find(":")
+        custom_name = model[:second].strip()
+        actual_model = model[second + 1:].strip()
+        if custom_name and actual_model:
+            return (f"custom:{custom_name}", actual_model)
+    return (provider, model)
+
+
+def _coerce_entry(entry: Any, *, allow_strings: bool) -> dict[str, Any] | None:
+    """Coerce a single raw fallback entry into a ``{provider, model, ...}`` dict.
+
+    Two on-disk shapes are accepted:
+
+    * ``dict`` — the canonical form written by ``hermes fallback`` and the CLI,
+      and the only shape the config validator accepts for either key.
+    * ``"provider:model"`` string — only when ``allow_strings`` is set. This is
+      the shape produced by the desktop *Model → Fallback Models* settings
+      field, which is rendered by the generic comma-separated ``list`` editor
+      and whose help text reads *"Backup provider:model entries to try if the
+      default model fails."* String coercion is scoped to ``fallback_providers``
+      (the desktop list field); the legacy ``fallback_model`` key stays
+      dict-only to match its documented, validated contract.
+
+    Returns ``None`` for shapes that can't be interpreted (e.g. a bare model
+    with no ``provider:`` prefix, or a non-string/non-dict value).
+    """
+    if isinstance(entry, dict):
+        return entry
+    if allow_strings and isinstance(entry, str):
+        split = _split_provider_model(entry.strip())
+        if split is None:
+            return None
+        provider, model = split
+        return {"provider": provider, "model": model}
+    return None
+
+
+def _iter_fallback_entries(raw: Any, *, allow_strings: bool = False) -> list[dict[str, Any]]:
     if isinstance(raw, dict):
-        candidates = [raw]
+        candidates: list[Any] = [raw]
+    elif isinstance(raw, str):
+        candidates = [raw] if allow_strings else []
     elif isinstance(raw, list):
-        candidates = raw
+        candidates = list(raw)
     else:
         return []
 
     entries: list[dict[str, Any]] = []
-    for entry in candidates:
-        if not isinstance(entry, dict):
+    for raw_entry in candidates:
+        entry = _coerce_entry(raw_entry, allow_strings=allow_strings)
+        if entry is None:
             continue
         provider = str(entry.get("provider") or "").strip()
         model = str(entry.get("model") or "").strip()
@@ -75,14 +143,19 @@ def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
     order. Legacy ``fallback_model`` entries are appended afterwards unless
     they target the same provider/model/base_url route as an earlier entry.
     The returned list always contains fresh dict copies.
+
+    ``"provider:model"`` string entries are only honored for the
+    ``fallback_providers`` list — the shape the desktop settings field writes.
+    ``fallback_model`` stays dict-only to match its documented/validated
+    contract.
     """
 
     config = config or {}
     chain: list[dict[str, Any]] = []
     seen: set[tuple[str, str, str]] = set()
 
-    for key in ("fallback_providers", "fallback_model"):
-        for entry in _iter_fallback_entries(config.get(key)):
+    for key, allow_strings in (("fallback_providers", True), ("fallback_model", False)):
+        for entry in _iter_fallback_entries(config.get(key), allow_strings=allow_strings):
             identity = _entry_identity(entry)
             if identity in seen:
                 continue

--- a/tests/test_fallback_config.py
+++ b/tests/test_fallback_config.py
@@ -1,0 +1,151 @@
+"""Tests for :mod:`hermes_cli.fallback_config`.
+
+Covers both on-disk shapes of the fallback chain:
+
+* dict entries — the canonical form written by ``hermes fallback`` / the CLI.
+* ``"provider:model"`` strings — the shape produced by the desktop
+  *Model → Fallback Models* settings field (a generic comma-separated ``list``
+  editor whose help text reads "Backup provider:model entries ...").
+"""
+from __future__ import annotations
+
+from hermes_cli.fallback_config import _iter_fallback_entries, get_fallback_chain
+
+
+class TestIterFallbackEntriesDicts:
+    def test_single_dict(self):
+        assert _iter_fallback_entries({"provider": "custom", "model": "m1"}) == [
+            {"provider": "custom", "model": "m1"}
+        ]
+
+    def test_list_of_dicts_preserves_order(self):
+        raw = [
+            {"provider": "a", "model": "m1"},
+            {"provider": "b", "model": "m2"},
+        ]
+        out = _iter_fallback_entries(raw)
+        assert [(e["provider"], e["model"]) for e in out] == [("a", "m1"), ("b", "m2")]
+
+    def test_dict_missing_provider_or_model_is_skipped(self):
+        assert _iter_fallback_entries({"model": "m1"}) == []
+        assert _iter_fallback_entries({"provider": "a"}) == []
+
+    def test_base_url_is_normalized(self):
+        out = _iter_fallback_entries(
+            {"provider": "a", "model": "m", "base_url": "https://x.test/v1/  "}
+        )
+        assert out[0]["base_url"] == "https://x.test/v1"
+
+    def test_non_iterable_returns_empty(self):
+        assert _iter_fallback_entries(None) == []
+        assert _iter_fallback_entries(123) == []
+
+
+class TestIterFallbackEntriesStrings:
+    """The desktop settings field persists ``provider:model`` strings.
+
+    String coercion is opt-in via ``allow_strings`` (only ``fallback_providers``
+    enables it), so these direct-helper cases pass the flag explicitly.
+    """
+
+    def test_simple_provider_model_string(self):
+        assert _iter_fallback_entries(
+            ["openrouter:anthropic/claude-3.5"], allow_strings=True
+        ) == [{"provider": "openrouter", "model": "anthropic/claude-3.5"}]
+
+    def test_qualified_custom_provider_keeps_full_provider(self):
+        # custom:<name>:<model> is special-cased so the qualified custom
+        # endpoint id keeps its "custom:<name>" prefix.
+        assert _iter_fallback_entries(
+            ["custom:my-endpoint:claude-sonnet-4.6"], allow_strings=True
+        ) == [{"provider": "custom:my-endpoint", "model": "claude-sonnet-4.6"}]
+
+    def test_model_id_with_colon_suffix_keeps_full_model(self):
+        # First-colon split: the model half may itself contain colons
+        # (e.g. an Ollama Cloud size suffix), which must survive intact rather
+        # than being swallowed by a last-colon split.
+        assert _iter_fallback_entries(
+            ["ollama-cloud:nemotron-3-nano:30b"], allow_strings=True
+        ) == [{"provider": "ollama-cloud", "model": "nemotron-3-nano:30b"}]
+
+    def test_openrouter_free_suffix_keeps_full_model(self):
+        assert _iter_fallback_entries(
+            ["openrouter:qwen/qwen3.6-plus:free"], allow_strings=True
+        ) == [{"provider": "openrouter", "model": "qwen/qwen3.6-plus:free"}]
+
+    def test_whitespace_is_trimmed(self):
+        assert _iter_fallback_entries([" openai : gpt-5.2 "], allow_strings=True) == [
+            {"provider": "openai", "model": "gpt-5.2"}
+        ]
+
+    def test_bare_model_without_provider_is_skipped(self):
+        # No colon -> the provider can't be inferred -> dropped, matching the
+        # "provider:model" contract advertised by the field's help text.
+        assert _iter_fallback_entries(["gpt-5.2"], allow_strings=True) == []
+
+    def test_top_level_string(self):
+        assert _iter_fallback_entries("custom:m1", allow_strings=True) == [
+            {"provider": "custom", "model": "m1"}
+        ]
+
+    def test_strings_dropped_when_not_allowed(self):
+        # Default (allow_strings=False) is used for the dict-only fallback_model
+        # key -- strings must be ignored there.
+        assert _iter_fallback_entries(["a:m1"]) == []
+        assert _iter_fallback_entries("a:m1") == []
+
+    def test_mixed_strings_and_dicts(self):
+        raw = ["a:m1", {"provider": "b", "model": "m2"}]
+        out = _iter_fallback_entries(raw, allow_strings=True)
+        assert [(e["provider"], e["model"]) for e in out] == [("a", "m1"), ("b", "m2")]
+
+
+class TestGetFallbackChain:
+    def test_string_entries_now_participate(self):
+        # Regression: string entries from the desktop field used to be silently
+        # dropped, leaving the effective chain empty.
+        cfg = {
+            "fallback_providers": [
+                "custom:llmhub:claude-sonnet-4.6",
+                "openai:gpt-5.2",
+            ]
+        }
+        chain = get_fallback_chain(cfg)
+        assert [(e["provider"], e["model"]) for e in chain] == [
+            ("custom:llmhub", "claude-sonnet-4.6"),
+            ("openai", "gpt-5.2"),
+        ]
+
+    def test_colon_suffix_model_string_participates(self):
+        # First-colon split end to end: an Ollama Cloud size suffix survives.
+        cfg = {"fallback_providers": ["ollama-cloud:nemotron-3-nano:30b"]}
+        chain = get_fallback_chain(cfg)
+        assert [(e["provider"], e["model"]) for e in chain] == [
+            ("ollama-cloud", "nemotron-3-nano:30b"),
+        ]
+
+    def test_string_fallback_model_is_not_coerced(self):
+        # fallback_model is dict-only (documented + validated). A bare string
+        # there must NOT be coerced -- string coercion is scoped to the
+        # fallback_providers desktop list field.
+        cfg = {"fallback_model": "openai:gpt-5.2"}
+        assert get_fallback_chain(cfg) == []
+
+    def test_providers_stay_before_legacy_fallback_model(self):
+        cfg = {
+            "fallback_providers": [{"provider": "a", "model": "m1"}],
+            "fallback_model": {"provider": "b", "model": "m2"},
+        }
+        chain = get_fallback_chain(cfg)
+        assert [(e["provider"], e["model"]) for e in chain] == [("a", "m1"), ("b", "m2")]
+
+    def test_duplicate_route_is_deduped_across_keys(self):
+        cfg = {
+            "fallback_providers": [{"provider": "a", "model": "m1"}],
+            "fallback_model": {"provider": "a", "model": "m1"},
+        }
+        assert len(get_fallback_chain(cfg)) == 1
+
+    def test_empty_config(self):
+        assert get_fallback_chain({}) == []
+        assert get_fallback_chain(None) == []


### PR DESCRIPTION
## Summary

The desktop **Model → Fallback Models** settings field is a no-op: entries typed
there never take effect, so the fallback chain silently stays empty.

## Root cause

That field is rendered by the generic comma-separated `list` editor
(`apps/desktop/src/app/settings/config-settings.tsx`), which serializes its
value as an **array of plain `"provider:model"` strings** — exactly the shape
its own help text advertises:

> Backup provider:model entries to try if the default model fails.

But the backend reader `_iter_fallback_entries`
(`hermes_cli/fallback_config.py`) only accepts **dict** entries and `continue`s
past anything else. So every string the GUI writes to `fallback_providers` is
dropped and `get_fallback_chain()` returns an empty chain — the field is a dead
end end to end.

The shared `list` editor can't be changed to emit dicts without breaking the
other list-type settings that legitimately use string arrays, so the fix
belongs in the backend reader (which already normalizes entries).

## Fix

`_iter_fallback_entries` now coerces `"provider:model"` strings into
`{provider, model}` dicts via a small `_coerce_entry` helper. The split is
anchored to the **last** colon so qualified custom providers keep their full id:

- `openrouter:anthropic/claude-3.5` → `{provider: "openrouter", model: "anthropic/claude-3.5"}`
- `custom:my-endpoint:claude-sonnet-4.6` → `{provider: "custom:my-endpoint", model: "claude-sonnet-4.6"}`

Dict entries and the legacy `fallback_model` key are unchanged; a bare model
with no `provider:` prefix is skipped (the provider can't be inferred).

## Tests

Adds `tests/test_fallback_config.py` (15 cases): dict handling, string handling,
the qualified-custom split, whitespace trimming, mixed string/dict lists,
dedupe/order across `fallback_providers` + `fallback_model`, and the bare-model
skip contract.

```
$ pytest tests/test_fallback_config.py -q
15 passed
```
