### PR TITLE
fix(whatsapp-bridge): drop redelivered messages with durable ingress receipts

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -31,6 +31,7 @@ import { execFileSync } from 'child_process';
 import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
+import { createIngressReceipts } from './ingress_receipts.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
 import {
@@ -261,6 +262,15 @@ const logger = pino({ level: 'warn' });
 // Message queue for polling
 const messageQueue = [];
 const MAX_QUEUE_SIZE = 100;
+
+// Durable ingress dedup: Baileys redelivers messages on reconnects and
+// history sync (especially right after a re-pair), and each duplicate that
+// reaches the adapter becomes a model-facing event with real token cost.
+// Receipts live OUTSIDE the session dir so re-pairing keeps them.
+const ingressReceipts = createIngressReceipts({
+  filePath: process.env.WHATSAPP_INGRESS_RECEIPTS_FILE
+    || path.join(path.dirname(SESSION_DIR), 'ingress-receipts.log'),
+});
 
 // Track recently sent message IDs.  Two purposes:
 //   1. Prevent echo-back loops with media in self-chat mode.
@@ -542,6 +552,19 @@ async function startSocket() {
         senderId: redactWhatsAppId(senderId),
         messageKeys: Object.keys(msg.message || {}),
       });
+
+      // Drop redelivered messages before any further work (media download,
+      // gates, queueing). The receipt is recorded durably on first sight, so
+      // reconnect storms and post-re-pair history replay cost nothing.
+      if (msg.key.id && !ingressReceipts.record(chatId, msg.key.id)) {
+        emitDebugEvent({
+          stage: 'ignored',
+          reason: 'duplicate_ingress',
+          chatId: redactWhatsAppId(chatId),
+          messageId: msg.key.id,
+        });
+        continue;
+      }
 
       // Handle fromMe messages based on mode
       let fromOwner = false;

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -268,8 +268,8 @@ const MAX_QUEUE_SIZE = 100;
 // reaches the adapter becomes a model-facing event with real token cost.
 // Receipts live OUTSIDE the session dir so re-pairing keeps them.
 const ingressReceipts = createIngressReceipts({
-  filePath: process.env.WHATSAPP_INGRESS_RECEIPTS_FILE
-    || path.join(path.dirname(SESSION_DIR), 'ingress-receipts.log'),
+  dirPath: process.env.WHATSAPP_INGRESS_RECEIPTS_DIR
+    || path.join(path.dirname(SESSION_DIR), 'ingress-receipts'),
 });
 
 // Track recently sent message IDs.  Two purposes:

--- a/scripts/whatsapp-bridge/ingress_receipts.js
+++ b/scripts/whatsapp-bridge/ingress_receipts.js
@@ -1,0 +1,105 @@
+/**
+ * Persistent ingress receipts for the WhatsApp bridge.
+ *
+ * Baileys can redeliver the same inbound message many times: connection
+ * flaps, history sync after a re-pair, and `messages.upsert` replays all
+ * produce events whose `(remoteJid, key.id)` pair was already processed.
+ * The in-memory echo filter (`outbound_ids.js`) only covers our own sends
+ * and does not survive a bridge restart, so a restart in the middle of a
+ * redelivery storm forwards every duplicate to the Python adapter — and
+ * from there each one becomes a model-facing event with real token cost.
+ *
+ * This tracker records a durable receipt per `(chatId, messageId)` BEFORE
+ * the message is processed. The receipt is appended to disk first and only
+ * then added to the in-memory set, so a crash between the two never lets a
+ * message through twice. Duplicates are dropped at the bridge door without
+ * media downloads or queue traffic.
+ *
+ * Storage is a newline-delimited key log next to the session directory
+ * (deliberately OUTSIDE it: deleting the session to re-pair must not erase
+ * receipts, because re-pairing is exactly when history replay happens).
+ * When the log exceeds `maxEntries` it is compacted in place to the newest
+ * `compactTo` keys via a tmp-file + atomic rename.
+ */
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'fs';
+import path from 'path';
+
+const KEY_SEPARATOR = ' ';
+
+export function receiptKey(chatId, messageId) {
+  return `${chatId}${KEY_SEPARATOR}${messageId}`;
+}
+
+export function createIngressReceipts({
+  filePath,
+  maxEntries = 50000,
+  compactTo = 25000,
+  logger = console,
+} = {}) {
+  if (!filePath) throw new Error('ingress receipts: filePath is required');
+  if (compactTo >= maxEntries) throw new Error('ingress receipts: compactTo must be < maxEntries');
+
+  // Insertion-ordered by construction; JS Sets iterate in insertion order,
+  // which is what compaction relies on to keep the newest keys.
+  let seen = new Set();
+
+  function load() {
+    seen = new Set();
+    if (!existsSync(filePath)) return;
+    try {
+      for (const line of readFileSync(filePath, 'utf8').split('\n')) {
+        if (line) seen.add(line);
+      }
+    } catch (err) {
+      // A damaged receipts file must not take the bridge down; starting
+      // empty only risks duplicate delivery, never message loss.
+      logger.warn?.(`[bridge] ingress receipts unreadable, starting empty: ${err.message}`);
+      seen = new Set();
+    }
+  }
+
+  function compact() {
+    const keep = [...seen].slice(-compactTo);
+    const tmpPath = `${filePath}.tmp`;
+    writeFileSync(tmpPath, keep.length ? keep.join('\n') + '\n' : '');
+    renameSync(tmpPath, filePath);
+    seen = new Set(keep);
+  }
+
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  load();
+  if (seen.size > maxEntries) compact();
+
+  return {
+    /** True when this (chatId, messageId) was already recorded. */
+    has(chatId, messageId) {
+      return seen.has(receiptKey(chatId, messageId));
+    },
+
+    /**
+     * Record a receipt. Returns true when the message is new (caller should
+     * process it) and false when it is a duplicate (caller should drop it).
+     * The durable append happens before the in-memory add.
+     */
+    record(chatId, messageId) {
+      const key = receiptKey(chatId, messageId);
+      if (seen.has(key)) return false;
+      try {
+        appendFileSync(filePath, key + '\n');
+      } catch (err) {
+        // Fail open on write errors: forwarding a rare duplicate is cheaper
+        // than silently dropping real messages when the disk hiccups.
+        logger.warn?.(`[bridge] ingress receipt write failed: ${err.message}`);
+      }
+      seen.add(key);
+      if (seen.size > maxEntries) compact();
+      return true;
+    },
+
+    /** Number of receipts currently tracked (for tests/diagnostics). */
+    size() {
+      return seen.size;
+    },
+  };
+}

--- a/scripts/whatsapp-bridge/ingress_receipts.js
+++ b/scripts/whatsapp-bridge/ingress_receipts.js
@@ -1,5 +1,5 @@
 /**
- * Persistent ingress receipts for the WhatsApp bridge.
+ * Persistent, inter-process-safe ingress receipts for the WhatsApp bridge.
  *
  * Baileys can redeliver the same inbound message many times: connection
  * flaps, history sync after a re-pair, and `messages.upsert` replays all
@@ -8,21 +8,27 @@
  * and does not survive a bridge restart, so a restart in the middle of a
  * redelivery storm forwards every duplicate to the Python adapter — and
  * from there each one becomes a model-facing event with real token cost.
+ * The incident that motivated this involved 24 concurrent bridge
+ * processes, so the claim must be atomic ACROSS processes, not just
+ * within one.
  *
- * This tracker records a durable receipt per `(chatId, messageId)` BEFORE
- * the message is processed. The receipt is appended to disk first and only
- * then added to the in-memory set, so a crash between the two never lets a
- * message through twice. Duplicates are dropped at the bridge door without
- * media downloads or queue traffic.
+ * Storage is one empty claim file per `(chatId, messageId)` inside a
+ * receipts directory. The claim is an exclusive create (`O_CREAT|O_EXCL`),
+ * which the kernel arbitrates: when several bridge processes race on the
+ * same message, exactly one create succeeds and every other process sees
+ * `EEXIST` and drops its copy. The directory lives OUTSIDE the session dir
+ * (deleting the session to re-pair must not erase receipts, because
+ * re-pairing is exactly when history replay happens). Past `maxEntries`
+ * claims, the directory is compacted down to the newest `compactTo` by
+ * file mtime.
  *
- * Storage is a newline-delimited key log next to the session directory
- * (deliberately OUTSIDE it: deleting the session to re-pair must not erase
- * receipts, because re-pairing is exactly when history replay happens).
- * When the log exceeds `maxEntries` it is compacted in place to the newest
- * `compactTo` keys via a tmp-file + atomic rename.
+ * Every storage failure fails open: the message is forwarded and the key
+ * is NOT remembered, so a later replay is only dropped once a durable
+ * receipt actually exists. A rare duplicate is cheaper than silently
+ * dropping real messages while the disk misbehaves.
  */
 
-import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'fs';
+import { closeSync, existsSync, mkdirSync, openSync, readdirSync, statSync, unlinkSync } from 'fs';
 import path from 'path';
 
 const KEY_SEPARATOR = ' ';
@@ -31,68 +37,105 @@ export function receiptKey(chatId, messageId) {
   return `${chatId}${KEY_SEPARATOR}${messageId}`;
 }
 
+/** Claim files are the encoded key; `seen` stores encoded names only. */
+function claimName(chatId, messageId) {
+  return encodeURIComponent(receiptKey(chatId, messageId));
+}
+
 export function createIngressReceipts({
-  filePath,
+  dirPath,
   maxEntries = 50000,
   compactTo = 25000,
   logger = console,
 } = {}) {
-  if (!filePath) throw new Error('ingress receipts: filePath is required');
+  if (!dirPath) throw new Error('ingress receipts: dirPath is required');
   if (compactTo >= maxEntries) throw new Error('ingress receipts: compactTo must be < maxEntries');
 
-  // Insertion-ordered by construction; JS Sets iterate in insertion order,
-  // which is what compaction relies on to keep the newest keys.
+  // Fast path only; the durable claim below is what other processes see.
   let seen = new Set();
+
+  function warn(message, err) {
+    logger.warn?.(`[bridge] ${message}: ${err.message}`);
+  }
 
   function load() {
     seen = new Set();
-    if (!existsSync(filePath)) return;
     try {
-      for (const line of readFileSync(filePath, 'utf8').split('\n')) {
-        if (line) seen.add(line);
-      }
+      mkdirSync(dirPath, { recursive: true });
+      for (const name of readdirSync(dirPath)) seen.add(name);
     } catch (err) {
-      // A damaged receipts file must not take the bridge down; starting
-      // empty only risks duplicate delivery, never message loss.
-      logger.warn?.(`[bridge] ingress receipts unreadable, starting empty: ${err.message}`);
-      seen = new Set();
+      // A damaged receipts dir must not take the bridge down; running
+      // without receipts only risks duplicate delivery, never message loss.
+      warn('ingress receipts dir unusable, deduplication degraded', err);
     }
   }
 
   function compact() {
-    const keep = [...seen].slice(-compactTo);
-    const tmpPath = `${filePath}.tmp`;
-    writeFileSync(tmpPath, keep.length ? keep.join('\n') + '\n' : '');
-    renameSync(tmpPath, filePath);
-    seen = new Set(keep);
+    try {
+      const entries = [];
+      for (const name of readdirSync(dirPath)) {
+        try {
+          entries.push([name, statSync(path.join(dirPath, name)).mtimeMs]);
+        } catch {
+          // Removed by a concurrent compaction; already gone is fine.
+        }
+      }
+      entries.sort((a, b) => a[1] - b[1]);
+      for (const [name] of entries.slice(0, Math.max(0, entries.length - compactTo))) {
+        try {
+          unlinkSync(path.join(dirPath, name));
+        } catch {
+          // Same: losing the race to delete an old claim is harmless.
+        }
+      }
+      seen = new Set(entries.slice(-compactTo).map(([name]) => name));
+    } catch (err) {
+      warn('ingress receipts compaction failed, keeping current receipts', err);
+    }
   }
 
-  mkdirSync(path.dirname(filePath), { recursive: true });
   load();
   if (seen.size > maxEntries) compact();
 
   return {
     /** True when this (chatId, messageId) was already recorded. */
     has(chatId, messageId) {
-      return seen.has(receiptKey(chatId, messageId));
+      const name = claimName(chatId, messageId);
+      return seen.has(name) || existsSync(path.join(dirPath, name));
     },
 
     /**
-     * Record a receipt. Returns true when the message is new (caller should
-     * process it) and false when it is a duplicate (caller should drop it).
-     * The durable append happens before the in-memory add.
+     * Claim a message. Returns true when this call won the claim (caller
+     * should process the message) and false when it is a duplicate (caller
+     * should drop it). The claim is durable and atomic across processes:
+     * it exists on disk before this returns true.
      */
     record(chatId, messageId) {
-      const key = receiptKey(chatId, messageId);
-      if (seen.has(key)) return false;
+      const name = claimName(chatId, messageId);
+      if (seen.has(name)) return false;
+      const claimPath = path.join(dirPath, name);
       try {
-        appendFileSync(filePath, key + '\n');
+        try {
+          closeSync(openSync(claimPath, 'wx'));
+        } catch (err) {
+          if (err.code !== 'ENOENT') throw err;
+          // The receipts dir vanished or never got created; one recreate
+          // attempt so a transient gap does not disable dedup for good.
+          mkdirSync(dirPath, { recursive: true });
+          closeSync(openSync(claimPath, 'wx'));
+        }
       } catch (err) {
-        // Fail open on write errors: forwarding a rare duplicate is cheaper
-        // than silently dropping real messages when the disk hiccups.
-        logger.warn?.(`[bridge] ingress receipt write failed: ${err.message}`);
+        if (err.code === 'EEXIST') {
+          // Another process (or an earlier run) holds the claim.
+          seen.add(name);
+          return false;
+        }
+        // Fail open without remembering the key: a key retained here would
+        // silently drop replays that no durable receipt ever covered.
+        warn('ingress receipt write failed, forwarding without dedup', err);
+        return true;
       }
-      seen.add(key);
+      seen.add(name);
       if (seen.size > maxEntries) compact();
       return true;
     },

--- a/scripts/whatsapp-bridge/ingress_receipts.test.mjs
+++ b/scripts/whatsapp-bridge/ingress_receipts.test.mjs
@@ -1,0 +1,66 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+
+import { createIngressReceipts, receiptKey } from './ingress_receipts.js';
+
+function tempFile() {
+  return path.join(mkdtempSync(path.join(tmpdir(), 'ingress-receipts-')), 'receipts.log');
+}
+
+test('first sight records, second sight is a duplicate', () => {
+  const receipts = createIngressReceipts({ filePath: tempFile() });
+  assert.equal(receipts.record('123@s.whatsapp.net', 'ABC1'), true);
+  assert.equal(receipts.record('123@s.whatsapp.net', 'ABC1'), false);
+  assert.equal(receipts.has('123@s.whatsapp.net', 'ABC1'), true);
+});
+
+test('same message id in different chats is not a duplicate', () => {
+  const receipts = createIngressReceipts({ filePath: tempFile() });
+  assert.equal(receipts.record('123@s.whatsapp.net', 'ABC1'), true);
+  assert.equal(receipts.record('456@g.us', 'ABC1'), true);
+});
+
+test('incident regression: 100 replays of one message process exactly once', () => {
+  const receipts = createIngressReceipts({ filePath: tempFile() });
+  let processed = 0;
+  for (let i = 0; i < 100; i += 1) {
+    if (receipts.record('40750000000@s.whatsapp.net', '3EB0REPLAYED')) processed += 1;
+  }
+  assert.equal(processed, 1);
+});
+
+test('receipts survive a bridge restart (new instance, same file)', () => {
+  const filePath = tempFile();
+  createIngressReceipts({ filePath }).record('123@s.whatsapp.net', 'ABC1');
+  const reloaded = createIngressReceipts({ filePath });
+  assert.equal(reloaded.has('123@s.whatsapp.net', 'ABC1'), true);
+  assert.equal(reloaded.record('123@s.whatsapp.net', 'ABC1'), false);
+});
+
+test('receipt is durable before the in-memory add (crash-safety ordering)', () => {
+  const filePath = tempFile();
+  createIngressReceipts({ filePath }).record('123@s.whatsapp.net', 'ABC1');
+  assert.ok(readFileSync(filePath, 'utf8').includes(receiptKey('123@s.whatsapp.net', 'ABC1')));
+});
+
+test('compaction keeps the newest keys and drops the oldest', () => {
+  const filePath = tempFile();
+  const receipts = createIngressReceipts({ filePath, maxEntries: 10, compactTo: 5 });
+  for (let i = 0; i < 11; i += 1) receipts.record('c@s.whatsapp.net', `id-${i}`);
+  assert.ok(receipts.size() <= 6);
+  assert.equal(receipts.has('c@s.whatsapp.net', 'id-10'), true);
+  assert.equal(receipts.has('c@s.whatsapp.net', 'id-0'), false);
+  const reloaded = createIngressReceipts({ filePath, maxEntries: 10, compactTo: 5 });
+  assert.equal(reloaded.has('c@s.whatsapp.net', 'id-10'), true);
+  assert.equal(reloaded.has('c@s.whatsapp.net', 'id-0'), false);
+});
+
+test('a corrupt receipts file starts empty instead of crashing', () => {
+  const filePath = tempFile();
+  writeFileSync(filePath, 'not-a-log');
+  const receipts = createIngressReceipts({ filePath, logger: { warn: () => {} } });
+  assert.equal(receipts.record('123@s.whatsapp.net', 'ABC1'), true);
+});

--- a/scripts/whatsapp-bridge/ingress_receipts.test.mjs
+++ b/scripts/whatsapp-bridge/ingress_receipts.test.mjs
@@ -1,30 +1,41 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, writeFileSync } from 'fs';
+import { chmodSync, existsSync, mkdtempSync, utimesSync, writeFileSync } from 'fs';
+import { execFile } from 'child_process';
 import { tmpdir } from 'os';
 import path from 'path';
+import { promisify } from 'util';
 
 import { createIngressReceipts, receiptKey } from './ingress_receipts.js';
 
-function tempFile() {
-  return path.join(mkdtempSync(path.join(tmpdir(), 'ingress-receipts-')), 'receipts.log');
+const execFileAsync = promisify(execFile);
+
+// chmod-based failure injection is a no-op for root (e.g. some CI containers).
+const isRoot = process.getuid?.() === 0;
+
+function tempDir() {
+  return path.join(mkdtempSync(path.join(tmpdir(), 'ingress-receipts-')), 'receipts');
+}
+
+function claimPath(dirPath, chatId, messageId) {
+  return path.join(dirPath, encodeURIComponent(receiptKey(chatId, messageId)));
 }
 
 test('first sight records, second sight is a duplicate', () => {
-  const receipts = createIngressReceipts({ filePath: tempFile() });
+  const receipts = createIngressReceipts({ dirPath: tempDir() });
   assert.equal(receipts.record('123@s.whatsapp.net', 'ABC1'), true);
   assert.equal(receipts.record('123@s.whatsapp.net', 'ABC1'), false);
   assert.equal(receipts.has('123@s.whatsapp.net', 'ABC1'), true);
 });
 
 test('same message id in different chats is not a duplicate', () => {
-  const receipts = createIngressReceipts({ filePath: tempFile() });
+  const receipts = createIngressReceipts({ dirPath: tempDir() });
   assert.equal(receipts.record('123@s.whatsapp.net', 'ABC1'), true);
   assert.equal(receipts.record('456@g.us', 'ABC1'), true);
 });
 
 test('incident regression: 100 replays of one message process exactly once', () => {
-  const receipts = createIngressReceipts({ filePath: tempFile() });
+  const receipts = createIngressReceipts({ dirPath: tempDir() });
   let processed = 0;
   for (let i = 0; i < 100; i += 1) {
     if (receipts.record('40750000000@s.whatsapp.net', '3EB0REPLAYED')) processed += 1;
@@ -32,35 +43,118 @@ test('incident regression: 100 replays of one message process exactly once', () 
   assert.equal(processed, 1);
 });
 
-test('receipts survive a bridge restart (new instance, same file)', () => {
-  const filePath = tempFile();
-  createIngressReceipts({ filePath }).record('123@s.whatsapp.net', 'ABC1');
-  const reloaded = createIngressReceipts({ filePath });
+test('receipts survive a bridge restart (new instance, same dir)', () => {
+  const dirPath = tempDir();
+  createIngressReceipts({ dirPath }).record('123@s.whatsapp.net', 'ABC1');
+  const reloaded = createIngressReceipts({ dirPath });
   assert.equal(reloaded.has('123@s.whatsapp.net', 'ABC1'), true);
   assert.equal(reloaded.record('123@s.whatsapp.net', 'ABC1'), false);
 });
 
-test('receipt is durable before the in-memory add (crash-safety ordering)', () => {
-  const filePath = tempFile();
-  createIngressReceipts({ filePath }).record('123@s.whatsapp.net', 'ABC1');
-  assert.ok(readFileSync(filePath, 'utf8').includes(receiptKey('123@s.whatsapp.net', 'ABC1')));
+test('the claim is durable before record() reports a win (crash-safety ordering)', () => {
+  const dirPath = tempDir();
+  createIngressReceipts({ dirPath }).record('123@s.whatsapp.net', 'ABC1');
+  assert.ok(existsSync(claimPath(dirPath, '123@s.whatsapp.net', 'ABC1')));
 });
 
-test('compaction keeps the newest keys and drops the oldest', () => {
-  const filePath = tempFile();
-  const receipts = createIngressReceipts({ filePath, maxEntries: 10, compactTo: 5 });
-  for (let i = 0; i < 11; i += 1) receipts.record('c@s.whatsapp.net', `id-${i}`);
-  assert.ok(receipts.size() <= 6);
-  assert.equal(receipts.has('c@s.whatsapp.net', 'id-10'), true);
-  assert.equal(receipts.has('c@s.whatsapp.net', 'id-0'), false);
-  const reloaded = createIngressReceipts({ filePath, maxEntries: 10, compactTo: 5 });
+test('incident regression: concurrent processes claim a message exactly once', async () => {
+  const dirPath = tempDir();
+  const workerPath = path.join(path.dirname(dirPath), 'race_worker.mjs');
+  const moduleUrl = new URL('./ingress_receipts.js', import.meta.url).href;
+  writeFileSync(workerPath, [
+    `import { createIngressReceipts } from ${JSON.stringify(moduleUrl)};`,
+    'const receipts = createIngressReceipts({ dirPath: process.argv[2] });',
+    // Each worker starts with its own empty in-memory view, so only the
+    // on-disk exclusive create arbitrates the race.
+    "process.stdout.write(receipts.record('race@s.whatsapp.net', '3EB0RACE') ? '1' : '0');",
+  ].join('\n'));
+  const runs = await Promise.all(
+    Array.from({ length: 8 }, () => execFileAsync(process.execPath, [workerPath, dirPath])),
+  );
+  const wins = runs.reduce((sum, { stdout }) => sum + Number(stdout), 0);
+  assert.equal(wins, 1);
+});
+
+test('compaction keeps the newest receipts and drops the oldest', () => {
+  const dirPath = tempDir();
+  const first = createIngressReceipts({ dirPath });
+  for (let i = 0; i < 11; i += 1) first.record('c@s.whatsapp.net', `id-${i}`);
+  // Recency is judged by mtime; spread the claims out so it is well-defined.
+  const base = Date.now() / 1000 - 3600;
+  for (let i = 0; i < 11; i += 1) {
+    utimesSync(claimPath(dirPath, 'c@s.whatsapp.net', `id-${i}`), base + i, base + i);
+  }
+  const compacted = createIngressReceipts({ dirPath, maxEntries: 10, compactTo: 5 });
+  assert.equal(compacted.size(), 5);
+  assert.equal(compacted.has('c@s.whatsapp.net', 'id-10'), true);
+  assert.equal(compacted.has('c@s.whatsapp.net', 'id-0'), false);
+  const reloaded = createIngressReceipts({ dirPath, maxEntries: 10, compactTo: 5 });
   assert.equal(reloaded.has('c@s.whatsapp.net', 'id-10'), true);
   assert.equal(reloaded.has('c@s.whatsapp.net', 'id-0'), false);
 });
 
-test('a corrupt receipts file starts empty instead of crashing', () => {
-  const filePath = tempFile();
-  writeFileSync(filePath, 'not-a-log');
-  const receipts = createIngressReceipts({ filePath, logger: { warn: () => {} } });
+test('an unwritable receipts dir fails open and does not poison later replays', { skip: isRoot }, () => {
+  const dirPath = tempDir();
+  const warnings = [];
+  const receipts = createIngressReceipts({ dirPath, logger: { warn: (m) => warnings.push(m) } });
+  chmodSync(dirPath, 0o500);
+  try {
+    // No durable receipt could be written: forward, and do NOT remember the
+    // key — a replay must not be dropped on the strength of a failed write.
+    assert.equal(receipts.record('123@s.whatsapp.net', 'ABC1'), true);
+    assert.equal(receipts.record('123@s.whatsapp.net', 'ABC1'), true);
+    assert.equal(warnings.length, 2);
+  } finally {
+    chmodSync(dirPath, 0o700);
+  }
+  // Once storage recovers, deduplication resumes.
   assert.equal(receipts.record('123@s.whatsapp.net', 'ABC1'), true);
+  assert.equal(receipts.record('123@s.whatsapp.net', 'ABC1'), false);
+});
+
+test('an unreadable receipts dir degrades at load instead of crashing', { skip: isRoot }, () => {
+  const dirPath = tempDir();
+  createIngressReceipts({ dirPath }).record('123@s.whatsapp.net', 'ABC1');
+  chmodSync(dirPath, 0o000);
+  try {
+    const warnings = [];
+    const receipts = createIngressReceipts({ dirPath, logger: { warn: (m) => warnings.push(m) } });
+    assert.equal(warnings.length, 1);
+    // Degraded means forwarding, never dropping.
+    assert.equal(receipts.record('456@s.whatsapp.net', 'DEF2'), true);
+  } finally {
+    chmodSync(dirPath, 0o700);
+  }
+});
+
+test('a receipts dir that cannot be created does not take the bridge down', () => {
+  const blocker = path.join(mkdtempSync(path.join(tmpdir(), 'ingress-receipts-')), 'blocker');
+  writeFileSync(blocker, '');
+  const dirPath = path.join(blocker, 'receipts');
+  const receipts = createIngressReceipts({ dirPath, logger: { warn: () => {} } });
+  assert.equal(receipts.record('123@s.whatsapp.net', 'ABC1'), true);
+  assert.equal(receipts.record('123@s.whatsapp.net', 'ABC1'), true);
+});
+
+test('storage failure during a compaction-eligible claim keeps forwarding', { skip: isRoot }, () => {
+  const dirPath = tempDir();
+  const warnings = [];
+  const receipts = createIngressReceipts({
+    dirPath,
+    maxEntries: 3,
+    compactTo: 1,
+    logger: { warn: (m) => warnings.push(m) },
+  });
+  for (let i = 0; i < 3; i += 1) receipts.record('c@s.whatsapp.net', `id-${i}`);
+  chmodSync(dirPath, 0o500);
+  try {
+    assert.equal(receipts.record('c@s.whatsapp.net', 'id-3'), true);
+    assert.ok(warnings.length >= 1);
+  } finally {
+    chmodSync(dirPath, 0o700);
+  }
+  // Once writable again, the claim lands and compaction runs without a crash.
+  assert.equal(receipts.record('c@s.whatsapp.net', 'id-3'), true);
+  assert.equal(receipts.record('c@s.whatsapp.net', 'id-3'), false);
+  assert.ok(receipts.size() <= 2);
 });


### PR DESCRIPTION
## Problem

Baileys redelivers inbound messages on connection flaps and history sync — especially right after a re-pair. The bridge's only duplicate filter today is the in-memory echo tracker for our *own* sends (`outbound_ids.js`); redelivered messages from other people (or history replays) pass straight through to the adapter, and each copy becomes a model-facing event with real token cost.

Observed in production: a Signal/Baileys error storm replayed a single message id **2,004 times across 24 bridge processes**; the affected sessions consumed ~7.4M input tokens before manual containment.

## Fix

A small durable receipt store (`ingress_receipts.js`): the bridge claims each `(chatId, messageId)` at first sight — before media download, gating, or queueing — and drops any message whose claim already exists.

Design notes (revised after review):

- **Inter-process atomic claim**: one empty claim file per `(chatId, messageId)` in a receipts directory, created with `O_CREAT|O_EXCL`. The kernel arbitrates the race, so concurrent bridge processes (the 24-process incident case) cannot both win the same message. A regression test spawns 8 processes racing on one key and asserts exactly one winner.
- **Durable before the win**: `record()` only reports "new" after the claim file exists on disk, so a crash never lets a message through twice.
- **Receipts live outside the session dir**: deleting the session to re-pair must not erase receipts, because re-pairing is exactly when history replay happens.
- **Self-compacting**: past 50k claims the directory is compacted to the newest 25k by mtime.
- **Fails open, everywhere**: dir setup, load, claim writes, and compaction are all caught. On any storage failure the message is forwarded and the key is **not** retained in memory, so replays stay eligible until a durable receipt actually exists — a rare duplicate is cheaper than dropping real messages.
- Override path via `WHATSAPP_INGRESS_RECEIPTS_DIR` for tests/multi-instance setups.

## Tests

`node --test` in `scripts/whatsapp-bridge/` — 11 tests, including two incident regressions (**100 replays of one message process exactly once**, and **8 concurrent processes claim a message exactly once**), restart persistence, per-chat key scoping, mtime-based compaction, and real failure injection: unwritable dir (fail open without poisoning later replays, then recovery), unreadable dir at load, uncreatable dir, and storage failure around compaction. Full bridge suite (32 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)