### PR TITLE
chore(ci): add concurrency group to skills-index workflow

### DIFF
--- a/.github/workflows/skills-index.yml
+++ b/.github/workflows/skills-index.yml
@@ -18,7 +18,10 @@ permissions:
 concurrency:
   group: skills-index-${{ github.ref }}
   # Never cancel an in-flight index build: the deploy trigger downstream
-  # depends on a complete run, so we queue duplicates instead of dropping one.
+  # depends on a complete run. queue: max lets every duplicate wait its turn
+  # (up to 100) instead of the default single-pending slot silently dropping
+  # all but the newest queued run.
+  queue: max
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/skills-index.yml
+++ b/.github/workflows/skills-index.yml
@@ -15,6 +15,12 @@ permissions:
   contents: read
   actions: write # to trigger deploy-site.yml on schedule
 
+concurrency:
+  group: skills-index-${{ github.ref }}
+  # Never cancel an in-flight index build: the deploy trigger downstream
+  # depends on a complete run, so we queue duplicates instead of dropping one.
+  cancel-in-progress: false
+
 jobs:
   build-index:
     # Only run on the upstream repository, not on forks


### PR DESCRIPTION
## What does this PR do?

`skills-index.yml` is the only workflow with its own standalone triggers (push to `main`, a twice-daily schedule, and `workflow_dispatch`) that has no `concurrency:` group. Every other standalone-triggered workflow in the repo (`ci`, `docker`, `deploy-site`, `lint`, `tests`, `docker-lint`, `upload_to_pypi`, `uv-lockfile-check`) already sets one.

Without a group, overlapping runs can build the skills index twice in parallel:

- a manual dispatch fired during a scheduled run,
- a schedule tick landing while a dispatch is still in flight,
- two quick pushes to `main` that touch `scripts/build_skills_index.py`.

Those duplicate builds also race the downstream `deploy-site.yml` trigger that the `trigger-deploy` job kicks off, so two runs can fight over which index lands on the live site.

This adds a `concurrency:` group keyed on `github.ref` with `cancel-in-progress: false`, so a second run waits for the in-flight index build to finish instead of cancelling it partway through. Cancelling mid-build is the wrong choice here because the deploy step depends on a complete run.

## Related Issue

Fixes #62086

## Type of Change

- [x] CI hardening (no runtime code changed; workflow config only)

## Changes Made

- `.github/workflows/skills-index.yml`: added a `concurrency:` block after `permissions:`, matching the top-level key order (`on:` -> `permissions:` -> `concurrency:` -> `jobs:`) used by every other workflow in the repo.

## How to Test

1. Parse the workflow: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/skills-index.yml'))"` returns without error.
2. Confirm the key order is `on:` -> `permissions:` -> `concurrency:` -> `jobs:`, consistent with the other workflows.
3. Trigger two runs for the same ref (for example a `workflow_dispatch` while a scheduled run is active). The second run queues and waits for the first to finish instead of starting a parallel index build.

## Checklist

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits (`chore(ci):`).
- [x] I searched existing PRs and issues to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this fix (single-file workflow change).
- [x] Tests: N/A, this changes CI workflow config only; no Python runtime code is touched. Validated with `yaml.safe_load`.
- [x] Cross-platform impact: N/A (GitHub Actions config).
