### PR TITLE
fix(backup): reject mixed archive wrapper prefixes

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -507,9 +507,11 @@ def _detect_prefix(zf: zipfile.ZipFile) -> str:
 
     # Find common prefix
     parts_list = [Path(n).parts for n in names]
+    if any(len(parts) < 2 for parts in parts_list):
+        return ""
 
     # Check if all entries share a common first directory
-    first_parts = {p[0] for p in parts_list if len(p) > 1}
+    first_parts = {p[0] for p in parts_list}
     if len(first_parts) == 1:
         prefix = first_parts.pop()
         # Only strip if it looks like a hermes dir name

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -906,9 +906,11 @@ def _detect_prefix(zf: zipfile.ZipFile) -> str:
 
     # Find common prefix
     parts_list = [Path(n).parts for n in names]
+    if any(len(parts) < 2 for parts in parts_list):
+        return ""
 
     # Check if all entries share a common first directory
-    first_parts = {p[0] for p in parts_list if len(p) > 1}
+    first_parts = {p[0] for p in parts_list}
     if len(first_parts) == 1:
         prefix = first_parts.pop()
         # Only strip if it looks like a hermes dir name

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -547,6 +547,24 @@ class TestImport:
         assert (hermes_home / "config.yaml").read_text() == "model: test\n"
         assert (hermes_home / "skills" / "a" / "SKILL.md").read_text() == "# A\n"
 
+    def test_mixed_wrapped_and_root_entries_do_not_collide(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        zip_path = tmp_path / "backup.zip"
+        self._make_backup_zip(zip_path, {
+            "hermes/config.yaml": "wrapped\n",
+            "config.yaml": "root\n",
+        })
+
+        from hermes_cli.backup import run_import
+        run_import(Namespace(zipfile=str(zip_path), force=True))
+
+        assert (hermes_home / "config.yaml").read_text() == "root\n"
+        assert (hermes_home / "hermes" / "config.yaml").read_text() == "wrapped\n"
+
     def test_rejects_empty_zip(self, tmp_path, monkeypatch):
         """Import rejects an empty zip."""
         hermes_home = tmp_path / ".hermes"
@@ -943,6 +961,18 @@ class TestValidation:
         with zipfile.ZipFile(buf, "w") as zf:
             zf.writestr("config.yaml", "test")
             zf.writestr("skills/a/SKILL.md", "skill")
+        buf.seek(0)
+        with zipfile.ZipFile(buf, "r") as zf:
+            assert _detect_prefix(zf) == ""
+
+    def test_detect_prefix_none_with_mixed_root_and_wrapper_entries(self):
+        import io
+        from hermes_cli.backup import _detect_prefix
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("hermes/config.yaml", "wrapped")
+            zf.writestr("config.yaml", "root")
         buf.seek(0)
         with zipfile.ZipFile(buf, "r") as zf:
             assert _detect_prefix(zf) == ""

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -368,6 +368,24 @@ class TestImport:
 
         assert not calls
 
+    def test_mixed_wrapped_and_root_entries_do_not_collide(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        zip_path = tmp_path / "backup.zip"
+        self._make_backup_zip(zip_path, {
+            "hermes/config.yaml": "wrapped\n",
+            "config.yaml": "root\n",
+        })
+
+        from hermes_cli.backup import run_import
+        run_import(Namespace(zipfile=str(zip_path), force=True))
+
+        assert (hermes_home / "config.yaml").read_text() == "root\n"
+        assert (hermes_home / "hermes" / "config.yaml").read_text() == "wrapped\n"
+
     def test_import_survives_service_layer_import_failure(self, tmp_path, monkeypatch, capsys):
         """If the service helpers can't even be reached, import still completes
         and prints the manual fallback."""
@@ -572,6 +590,18 @@ class TestValidation:
         assert ok
 
 
+
+    def test_detect_prefix_none_with_mixed_root_and_wrapper_entries(self):
+        import io
+        from hermes_cli.backup import _detect_prefix
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("hermes/config.yaml", "wrapped")
+            zf.writestr("config.yaml", "root")
+        buf.seek(0)
+        with zipfile.ZipFile(buf, "r") as zf:
+            assert _detect_prefix(zf) == ""
 
     def test_detect_prefix_only_dirs(self):
         """Prefix detection returns empty for zip with only directory entries."""


### PR DESCRIPTION
## Summary

- Treat a Hermes directory as a strip-prefix only when every file is nested beneath it.
- Preserve root-level and wrapped entries as distinct paths in mixed archives.
- Add unit and end-to-end import regressions for the collision.

## Problem

Prefix detection collected first path segments only from entries with more than one component. For an archive containing both hermes/config.yaml and config.yaml, the root-level entry was ignored during detection, hermes/ was stripped, and both members were restored to config.yaml. One silently overwrote the other.

## Fix

Return no strip-prefix whenever any non-directory archive member is already at the root. The existing .hermes/ and hermes/ convenience behavior remains unchanged when all members genuinely share that wrapper.

## Duplicate review

Searched the current PR queue for mixed root/wrapper archives, prefix collisions, and duplicate config.yaml restores. PR #11224 only adds case-insensitive wrapper-name matching; it does not cover mixed root entries or output collisions.

## Validation

- Regression proof before fix: 2 failed
- uv run --extra dev python -m pytest tests/hermes_cli/test_backup.py -k "detect_prefix or strips_hermes_prefix or mixed_wrapped_and_root_entries_do_not_collide" -q (6 passed)
- uv run --extra dev ruff check hermes_cli/backup.py tests/hermes_cli/test_backup.py
- Broader backup suite: 140 passed, 3 skipped, 4 pre-existing Windows-only failures unrelated to prefix handling
- git diff upstream/main...HEAD --check
- Rebased on upstream 97e9c64664

## Agent disclosure

Prepared with Codex; scope is limited to upstream backup import behavior and its focused tests.