### PR TITLE
fix(copilot_acp): read/write ACP files as UTF-8

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -703,7 +703,11 @@ class CopilotACPClient:
                 if block_error:
                     raise PermissionError(block_error)
                 try:
-                    content = path.read_text()
+                    # Force UTF-8: read_text() with no encoding falls back to
+                    # the system locale (cp1252/GBK on Windows) and raises
+                    # UnicodeDecodeError on any non-ASCII source/doc the peer
+                    # asked to read. The codebase treats all text files as UTF-8.
+                    content = path.read_text(encoding="utf-8")
                 except FileNotFoundError:
                     content = ""
                 line = params.get("line")
@@ -732,7 +736,13 @@ class CopilotACPClient:
                         f"Write denied: '{path}' is a protected system/credential file."
                     )
                 path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_text(str(params.get("content") or ""))
+                # Force UTF-8: write_text() with no encoding falls back to the
+                # system locale (cp1252/GBK on Windows) and raises
+                # UnicodeEncodeError on any non-ASCII content the peer asked to
+                # write (unicode in source, docs, emoji, CJK).
+                path.write_text(
+                    str(params.get("content") or ""), encoding="utf-8"
+                )
                 response = {
                     "jsonrpc": "2.0",
                     "id": message_id,

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -226,6 +226,53 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
         self.assertIn("error", response)
         self.assertFalse(target.exists())
 
+    def test_write_text_file_writes_utf8(self) -> None:
+        """Non-ASCII content must persist as UTF-8, not the system locale
+        (cp1252/GBK on Windows would raise UnicodeEncodeError)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            target = root / "note.md"
+            payload = "# Заголовок ✅\nステータス: 完了\n"
+
+            response = self._dispatch(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 6,
+                    "method": "fs/write_text_file",
+                    "params": {"path": str(target), "content": payload},
+                },
+                cwd=str(root),
+            )
+
+            self.assertNotIn("error", response)
+            # Decode as UTF-8 and normalise platform newline translation
+            # (text-mode write turns \n into \r\n on Windows) — the point is
+            # that the non-ASCII bytes survived, not the line ending.
+            written = target.read_bytes().decode("utf-8").replace("\r\n", "\n")
+            self.assertEqual(written, payload)
+
+    def test_read_text_file_reads_utf8(self) -> None:
+        """A UTF-8 file with non-ASCII content must decode regardless of the
+        host locale."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            src = root / "src.txt"
+            payload = "переменная = '完了' # ✅\n"
+            src.write_bytes(payload.encode("utf-8"))
+
+            response = self._dispatch(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 7,
+                    "method": "fs/read_text_file",
+                    "params": {"path": str(src)},
+                },
+                cwd=str(root),
+            )
+
+            content = ((response.get("result") or {}).get("content") or "")
+            self.assertEqual(content, payload)
+
     def test_write_text_file_respects_safe_root(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)


### PR DESCRIPTION
## Problem

The ACP JSON-RPC client's file handlers in `agent/copilot_acp_client.py` read and write with no explicit encoding:

```python
# fs/read_text_file
content = path.read_text()                              # L706
# fs/write_text_file
path.write_text(str(params.get("content") or ""))       # L735
```

This is the file-I/O surface the ACP peer uses to **read and edit real project files** — `content` is arbitrary text (source code, markdown, any language). `read_text()`/`write_text()` with no `encoding` fall back to the system locale (cp1252/GBK on Windows). On a non-UTF-8 host:

- writing a file whose content has any non-ASCII char (unicode identifiers, comments, emoji, CJK) raises `UnicodeEncodeError`;
- reading such a file raises `UnicodeDecodeError`.

Both are caught by the handler's `except Exception` and returned to the peer as a JSON-RPC `-32602` error — so the agent simply **fails to read or edit non-ASCII files** on Windows. The codebase treats all text files as UTF-8 (see `hermes_cli/doctor.py` / `config.py`), and the tool-side file I/O in `tools/` already pins `encoding="utf-8"`; these two ACP handlers diverged.

## Repro (Windows, cp1251)

```python
p.write_text("完了 ✅")                       # UnicodeEncodeError: 'charmap' codec can't encode
p.write_bytes("完了".encode("utf-8")); p.read_text()   # UnicodeDecodeError
p.write_text("完了 ✅", encoding="utf-8")     # ok
```

## Fix

Pin `encoding="utf-8"` on both calls.

## Tests

Added round-trip regression tests to `tests/agent/test_copilot_acp_client.py`:
- `test_write_text_file_writes_utf8` — Cyrillic/CJK/emoji content persists as UTF-8;
- `test_read_text_file_reads_utf8` — a UTF-8 file with non-ASCII content decodes back intact.

Both fail on the pre-fix handlers and pass after. `python -m pytest tests/agent/test_copilot_acp_client.py` — 13 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)