### PR TITLE
docs(memory): use https for the supermemory api key link

### DIFF
--- a/plugins/memory/supermemory/README.md
+++ b/plugins/memory/supermemory/README.md
@@ -5,7 +5,7 @@ Semantic long-term memory with profile recall, semantic search, explicit memory 
 ## Requirements
 
 - `pip install supermemory`
-- Supermemory API key from [app.supermemory.ai/integrations?connect=hermes](http://app.supermemory.ai/integrations?connect=hermes)
+- Supermemory API key from [app.supermemory.ai/integrations?connect=hermes](https://app.supermemory.ai/integrations?connect=hermes)
 
 ## Setup
 

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -32,7 +32,7 @@ _DEFAULT_API_TIMEOUT = 5.0
 _MIN_CAPTURE_LENGTH = 10
 _MAX_ENTITY_CONTEXT_LENGTH = 1500
 _CONVERSATIONS_URL = "https://api.supermemory.ai/v4/conversations"
-_API_KEY_URL = "http://app.supermemory.ai/integrations?connect=hermes"
+_API_KEY_URL = "https://app.supermemory.ai/integrations?connect=hermes"
 _TRIVIAL_RE = re.compile(
     r"^(ok|okay|thanks|thank you|got it|sure|yes|no|yep|nope|k|ty|thx|np)\.?$",
     re.IGNORECASE,

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -537,7 +537,7 @@ Semantic long-term memory with profile recall, semantic search, explicit memory 
 | | |
 |---|---|
 | **Best for** | Semantic recall with user profiling and session-level graph building |
-| **Requires** | `pip install supermemory` + [API key](http://app.supermemory.ai/integrations?connect=hermes) |
+| **Requires** | `pip install supermemory` + [API key](https://app.supermemory.ai/integrations?connect=hermes) |
 | **Data storage** | Supermemory Cloud |
 | **Cost** | Supermemory pricing |
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory-providers.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory-providers.md
@@ -467,7 +467,7 @@ hermes config set memory.provider byterover
 | | |
 |---|---|
 | **适合场景** | 带用户 profile 和会话级图谱构建的语义召回 |
-| **依赖** | `pip install supermemory` + [API key](http://app.supermemory.ai/integrations?connect=hermes) |
+| **依赖** | `pip install supermemory` + [API key](https://app.supermemory.ai/integrations?connect=hermes) |
 | **数据存储** | Supermemory Cloud |
 | **费用** | Supermemory 定价 |
 


### PR DESCRIPTION
## Problem

The Supermemory API-key link was served over plain `http://`. This showed up in the runtime setup constant (`_API_KEY_URL`), the provider README, and both the English and zh-Hans memory-provider docs. A plain-http link to fetch an API key is downgrade-prone and gets flagged by doc link-checkers.

## Solution

Upgrade `http://app.supermemory.ai` to `https://app.supermemory.ai` in all four sites. This is a scheme-only change; the constant is a displayed URL string, so there is no logic change.

- `plugins/memory/supermemory/__init__.py` (`_API_KEY_URL`)
- `plugins/memory/supermemory/README.md`
- `website/docs/user-guide/features/memory-providers.md`
- `website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory-providers.md`

## Testing

- Confirmed `https://app.supermemory.ai/integrations?connect=hermes` resolves (HTTP 200).
- `rg "http://app\.supermemory\.ai"` returns no tracked hits after the change.
- `python3 -c "import ast; ast.parse(...)"` confirms the plugin still parses.
- Verified the zh-Hans copy matches the English one.

Fixes #62093
