### PR TITLE
fix(utils): use F_FULLFSYNC for durable atomic writes on macOS

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -23,7 +23,7 @@ from urllib.parse import urlparse
 
 from hermes_constants import get_hermes_home
 from typing import Any, Dict, List, Optional, Tuple
-from utils import base_url_host_matches, normalize_proxy_env_vars
+from utils import base_url_host_matches, durable_fsync, normalize_proxy_env_vars
 
 # NOTE: `import anthropic` is deliberately NOT at module top — the SDK pulls
 # ~220 ms of imports (anthropic.types, anthropic.lib.tools._beta_runner, etc.)
@@ -1182,7 +1182,7 @@ def _write_claude_code_credentials(
             with os.fdopen(fd, "w", encoding="utf-8") as fh:
                 json.dump(existing, fh, indent=2)
                 fh.flush()
-                os.fsync(fh.fileno())
+                durable_fsync(fh.fileno())
             os.replace(_tmp_cred, cred_path)
         except OSError:
             try:

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -39,7 +39,7 @@ from typing import Optional, Dict, List, Any, Set, Tuple, Union
 logger = logging.getLogger(__name__)
 
 from hermes_time import now as _hermes_now
-from utils import atomic_replace
+from utils import atomic_replace, durable_fsync
 
 try:
     from croniter import croniter
@@ -740,7 +740,7 @@ def _atomic_write_epoch(path: Path) -> None:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(str(time.time()))
             f.flush()
-            os.fsync(f.fileno())
+            durable_fsync(f.fileno())
         atomic_replace(tmp_path, path)
     except BaseException:
         try:
@@ -857,7 +857,7 @@ def _save_jobs_unlocked(jobs: List[Dict[str, Any]]):
         with os.fdopen(fd, 'w', encoding='utf-8') as f:
             json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2)
             f.flush()
-            os.fsync(f.fileno())
+            durable_fsync(f.fileno())
         atomic_replace(tmp_path, jobs_file)
         _secure_file(jobs_file)
     except BaseException:
@@ -2102,7 +2102,7 @@ def save_job_output(job_id: str, output: str):
         with os.fdopen(fd, 'w', encoding='utf-8') as f:
             f.write(output)
             f.flush()
-            os.fsync(f.fileno())
+            durable_fsync(f.fileno())
         atomic_replace(tmp_path, output_file)
         _secure_file(output_file)
     except BaseException:

--- a/cron/suggestions.py
+++ b/cron/suggestions.py
@@ -38,7 +38,7 @@ from typing import Any, Dict, List, Optional
 
 from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
-from utils import atomic_replace
+from utils import atomic_replace, durable_fsync
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +101,7 @@ def _save_raw(suggestions: List[Dict[str, Any]]) -> None:
                 indent=2,
             )
             f.flush()
-            os.fsync(f.fileno())
+            durable_fsync(f.fileno())
         atomic_replace(tmp_path, SUGGESTIONS_FILE)
         _secure_file(SUGGESTIONS_FILE)
     except BaseException:

--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -34,7 +34,7 @@ from gateway.whatsapp_identity import (
     normalize_whatsapp_identifier,
 )
 from hermes_constants import get_hermes_dir, get_hermes_home
-from utils import atomic_replace
+from utils import atomic_replace, durable_fsync
 
 logger = logging.getLogger(__name__)
 
@@ -218,7 +218,7 @@ def _secure_write(path: Path, data: str) -> None:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(data)
             f.flush()
-            os.fsync(f.fileno())
+            durable_fsync(f.fileno())
         atomic_replace(tmp_path, path)
         try:
             os.chmod(path, 0o600)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -94,7 +94,7 @@ from .whatsapp_identity import (
     canonical_whatsapp_identifier,
     normalize_whatsapp_identifier,  # noqa: F401 - re-exported for gateway.session callers
 )
-from utils import atomic_replace
+from utils import atomic_replace, durable_fsync
 
 # Session keys/ids flow into filesystem paths downstream (e.g.
 # ``sessions_dir / f"{session_id}.json"`` in hermes_state, request-dump
@@ -1283,7 +1283,7 @@ class SessionStore:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2)
                 f.flush()
-                os.fsync(f.fileno())
+                durable_fsync(f.fileno())
             atomic_replace(tmp_path, sessions_file)
         except BaseException:
             try:

--- a/gateway/sticker_cache.py
+++ b/gateway/sticker_cache.py
@@ -15,6 +15,7 @@ import time
 from typing import Optional
 
 from hermes_cli.config import get_hermes_home
+from utils import durable_fsync
 
 
 CACHE_PATH = get_hermes_home() / "sticker_cache.json"
@@ -46,7 +47,7 @@ def _save_cache(cache: dict) -> None:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(cache, f, indent=2, ensure_ascii=False)
             f.flush()
-            os.fsync(f.fileno())
+            durable_fsync(f.fileno())
         os.replace(tmp_path, str(CACHE_PATH))
     except BaseException:
         try:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -51,7 +51,7 @@ from hermes_cli.config import (
 )
 from hermes_constants import OPENROUTER_BASE_URL, secure_parent_dir
 from agent.credential_persistence import sanitize_borrowed_credential_payload
-from utils import atomic_replace, atomic_yaml_write, env_float, is_truthy_value
+from utils import atomic_replace, atomic_yaml_write, durable_fsync, env_float, is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -1149,7 +1149,7 @@ def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = N
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(payload)
             handle.flush()
-            os.fsync(handle.fileno())
+            durable_fsync(handle.fileno())
         atomic_replace(tmp_path, auth_file)
         try:
             dir_fd = os.open(str(auth_file.parent), os.O_RDONLY)
@@ -2241,7 +2241,7 @@ def _save_qwen_cli_tokens(tokens: Dict[str, Any]) -> Path:
         with os.fdopen(fd, "w", encoding="utf-8") as fh:
             fh.write(json.dumps(tokens, indent=2, sort_keys=True) + "\n")
             fh.flush()
-            os.fsync(fh.fileno())
+            durable_fsync(fh.fileno())
         atomic_replace(tmp_path, auth_path)
     finally:
         try:
@@ -4784,7 +4784,7 @@ def _write_shared_nous_state(state: Dict[str, Any]) -> None:
                 with os.fdopen(fd, "w", encoding="utf-8") as fh:
                     fh.write(json.dumps(shared, indent=2, sort_keys=True))
                     fh.flush()
-                    os.fsync(fh.fileno())
+                    durable_fsync(fh.fileno())
                 os.replace(tmp, path)
             finally:
                 try:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -742,7 +742,7 @@ def get_container_exec_info() -> Optional[dict]:
 
 # Re-export from hermes_constants — canonical definition lives there.
 from hermes_constants import get_hermes_home  # noqa: F811,E402
-from utils import atomic_replace, fast_safe_load
+from utils import atomic_replace, durable_fsync, fast_safe_load
 
 def get_config_path() -> Path:
     """Get the main config file path."""
@@ -7453,7 +7453,7 @@ def sanitize_env_file() -> int:
         with os.fdopen(fd, "w", **write_kw) as f:
             f.writelines(sanitized)
             f.flush()
-            os.fsync(f.fileno())
+            durable_fsync(f.fileno())
         atomic_replace(tmp_path, env_path)
     except BaseException:
         try:
@@ -7589,7 +7589,7 @@ def save_env_value(key: str, value: str):
         with os.fdopen(fd, 'w', **write_kw) as f:
             f.writelines(lines)
             f.flush()
-            os.fsync(f.fileno())
+            durable_fsync(f.fileno())
         atomic_replace(tmp_path, env_path)
         # Preserve the original file mode (e.g. 0640 for Docker volume mounts)
         # instead of letting _secure_file unconditionally tighten to 0600.
@@ -7660,7 +7660,7 @@ def remove_env_value(key: str) -> bool:
             with os.fdopen(fd, 'w', **write_kw) as f:
                 f.writelines(new_lines)
                 f.flush()
-                os.fsync(f.fileno())
+                durable_fsync(f.fileno())
             atomic_replace(tmp_path, env_path)
             # Preserve the original file mode (e.g. 0640 for Docker volume
             # mounts) instead of letting _secure_file unconditionally tighten

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 
 from dotenv import load_dotenv
-from utils import atomic_replace, fast_safe_load
+from utils import atomic_replace, durable_fsync, fast_safe_load
 
 
 # Env var name suffixes that indicate credential values.  These are the
@@ -205,7 +205,7 @@ def _sanitize_env_file_if_needed(path: Path) -> None:
                 with os.fdopen(fd, "w", encoding="utf-8") as f:
                     f.writelines(sanitized)
                     f.flush()
-                    os.fsync(f.fileno())
+                    durable_fsync(f.fileno())
                 atomic_replace(tmp, path)
             except BaseException:
                 try:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -84,7 +84,7 @@ from gateway.status import (
     parse_active_agents,
     read_runtime_status,
 )
-from utils import env_var_enabled
+from utils import durable_fsync, env_var_enabled
 
 try:
     from fastapi import (
@@ -16902,7 +16902,7 @@ def _write_dashboard_ready_file(actual_port: int) -> None:
         ) as fh:
             fh.write(payload)
             fh.flush()
-            os.fsync(fh.fileno())
+            durable_fsync(fh.fileno())
             tmp_name = fh.name
         os.replace(tmp_name, path)
     except Exception as exc:

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Dict
 
 from hermes_constants import display_hermes_home
-from utils import atomic_replace
+from utils import atomic_replace, durable_fsync
 from hermes_cli.config import cfg_get
 
 
@@ -66,7 +66,7 @@ def _save_subscriptions(subs: Dict[str, dict]) -> None:
         with os.fdopen(fd, "w", encoding="utf-8") as fh:
             json.dump(subs, fh, indent=2, ensure_ascii=False)
             fh.flush()
-            os.fsync(fh.fileno())
+            durable_fsync(fh.fileno())
         os.chmod(tmp_path, _SUBSCRIPTIONS_FILE_MODE)
         atomic_replace(tmp_path, path)
         # Re-assert after rename in case the destination existed with a

--- a/plugins/platforms/google_chat/oauth.py
+++ b/plugins/platforms/google_chat/oauth.py
@@ -91,7 +91,7 @@ except (ModuleNotFoundError, ImportError):
         except ValueError:
             return str(home)
 
-from utils import atomic_replace
+from utils import atomic_replace, durable_fsync
 
 
 def _hermes_home() -> Path:
@@ -344,7 +344,7 @@ def _write_private_json(path: Path, data: Any) -> None:
         with os.fdopen(fd, "w", encoding="utf-8") as fh:
             json.dump(data, fh, indent=2, ensure_ascii=False)
             fh.flush()
-            os.fsync(fh.fileno())
+            durable_fsync(fh.fileno())
         atomic_replace(tmp_path, path)
         try:
             os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)

--- a/tests/test_durable_fsync.py
+++ b/tests/test_durable_fsync.py
@@ -1,0 +1,71 @@
+"""Invariant tests for utils.durable_fsync (macOS F_FULLFSYNC durability)."""
+
+import os
+import sys
+
+import pytest
+
+import utils
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="fcntl / F_FULLFSYNC monkeypatching requires a POSIX platform",
+)
+
+
+@pytest.fixture
+def real_fd(tmp_path):
+    path = tmp_path / "payload.bin"
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT, 0o600)
+    os.write(fd, b"payload")
+    try:
+        yield fd
+    finally:
+        os.close(fd)
+
+
+def test_full_fsync_used_on_darwin(monkeypatch, real_fd):
+    """On macOS the durable path must issue F_FULLFSYNC, not plain fsync."""
+    import fcntl
+
+    fcntl_calls = []
+    fsync_calls = []
+    monkeypatch.setattr(utils.sys, "platform", "darwin")
+    monkeypatch.setattr(fcntl, "F_FULLFSYNC", 51, raising=False)
+    monkeypatch.setattr(fcntl, "fcntl", lambda fd, cmd: fcntl_calls.append((fd, cmd)))
+    monkeypatch.setattr(utils.os, "fsync", lambda fd: fsync_calls.append(fd))
+
+    utils.durable_fsync(real_fd)
+
+    assert fcntl_calls == [(real_fd, 51)]
+    assert fsync_calls == []
+
+
+def test_falls_back_to_fsync_when_full_fsync_unsupported(monkeypatch, real_fd):
+    """A filesystem that rejects F_FULLFSYNC must degrade to os.fsync."""
+    import fcntl
+
+    fsync_calls = []
+
+    def _reject(fd, cmd):
+        raise OSError("F_FULLFSYNC not supported")
+
+    monkeypatch.setattr(utils.sys, "platform", "darwin")
+    monkeypatch.setattr(fcntl, "F_FULLFSYNC", 51, raising=False)
+    monkeypatch.setattr(fcntl, "fcntl", _reject)
+    monkeypatch.setattr(utils.os, "fsync", lambda fd: fsync_calls.append(fd))
+
+    utils.durable_fsync(real_fd)
+
+    assert fsync_calls == [real_fd]
+
+
+def test_plain_fsync_off_darwin(monkeypatch, real_fd):
+    """Non-macOS platforms use os.fsync directly and never touch F_FULLFSYNC."""
+    fsync_calls = []
+    monkeypatch.setattr(utils.sys, "platform", "linux")
+    monkeypatch.setattr(utils.os, "fsync", lambda fd: fsync_calls.append(fd))
+
+    utils.durable_fsync(real_fd)
+
+    assert fsync_calls == [real_fd]

--- a/tests/test_durable_fsync.py
+++ b/tests/test_durable_fsync.py
@@ -42,13 +42,14 @@ def test_full_fsync_used_on_darwin(monkeypatch, real_fd):
 
 
 def test_falls_back_to_fsync_when_full_fsync_unsupported(monkeypatch, real_fd):
-    """A filesystem that rejects F_FULLFSYNC must degrade to os.fsync."""
+    """A filesystem that reports F_FULLFSYNC unsupported must degrade to os.fsync."""
+    import errno
     import fcntl
 
     fsync_calls = []
 
     def _reject(fd, cmd):
-        raise OSError("F_FULLFSYNC not supported")
+        raise OSError(errno.ENOTSUP, "operation not supported")
 
     monkeypatch.setattr(utils.sys, "platform", "darwin")
     monkeypatch.setattr(fcntl, "F_FULLFSYNC", 51, raising=False)
@@ -58,6 +59,28 @@ def test_falls_back_to_fsync_when_full_fsync_unsupported(monkeypatch, real_fd):
     utils.durable_fsync(real_fd)
 
     assert fsync_calls == [real_fd]
+
+
+def test_real_io_error_propagates_on_darwin(monkeypatch, real_fd):
+    """A genuine F_FULLFSYNC failure (EIO) must not be masked by a weaker fsync."""
+    import errno
+    import fcntl
+
+    fsync_calls = []
+
+    def _eio(fd, cmd):
+        raise OSError(errno.EIO, "I/O error")
+
+    monkeypatch.setattr(utils.sys, "platform", "darwin")
+    monkeypatch.setattr(fcntl, "F_FULLFSYNC", 51, raising=False)
+    monkeypatch.setattr(fcntl, "fcntl", _eio)
+    monkeypatch.setattr(utils.os, "fsync", lambda fd: fsync_calls.append(fd))
+
+    with pytest.raises(OSError) as excinfo:
+        utils.durable_fsync(real_fd)
+
+    assert excinfo.value.errno == errno.EIO
+    assert fsync_calls == []
 
 
 def test_plain_fsync_off_darwin(monkeypatch, real_fd):

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -51,6 +51,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 from hermes_constants import secure_parent_dir
+from utils import durable_fsync
 
 logger = logging.getLogger(__name__)
 
@@ -271,7 +272,7 @@ def _write_json(path: Path, data: dict) -> None:
         with os.fdopen(fd, "w", encoding="utf-8") as fh:
             json.dump(data, fh, indent=2, default=str)
             fh.flush()
-            os.fsync(fh.fileno())
+            durable_fsync(fh.fileno())
         os.replace(tmp, path)
     except OSError:
         try:

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -33,7 +33,7 @@ from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Dict, Any, List, Optional
 
-from utils import atomic_replace
+from utils import atomic_replace, durable_fsync
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 msvcrt = None
@@ -775,7 +775,7 @@ class MemoryStore:
                 with os.fdopen(fd, "w", encoding="utf-8") as f:
                     f.write(content)
                     f.flush()
-                    os.fsync(f.fileno())
+                    durable_fsync(f.fileno())
                 atomic_replace(tmp_path, path)
             except BaseException:
                 # Clean up temp file on any failure

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -35,6 +35,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import get_hermes_home
 from agent.skill_utils import is_excluded_skill_path, is_external_skill_path
+from utils import durable_fsync
 
 logger = logging.getLogger(__name__)
 
@@ -295,7 +296,7 @@ def _write_suppressed_names(names: Set[str]) -> None:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 f.write(data)
                 f.flush()
-                os.fsync(f.fileno())
+                durable_fsync(f.fileno())
             os.replace(tmp, path)
         except BaseException:
             try:
@@ -529,7 +530,7 @@ def save_usage(data: Dict[str, Dict[str, Any]]) -> None:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2, sort_keys=True, ensure_ascii=False)
                 f.flush()
-                os.fsync(f.fileno())
+                durable_fsync(f.fileno())
             os.replace(tmp_path, path)
         except BaseException:
             try:

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -31,7 +31,7 @@ from pathlib import Path, PurePosixPath
 from hermes_constants import get_bundled_skills_dir, get_hermes_home, get_optional_skills_dir
 from agent.skill_utils import is_excluded_skill_path
 from typing import Dict, List, Optional, Set, Tuple
-from utils import atomic_replace
+from utils import atomic_replace, durable_fsync
 
 logger = logging.getLogger(__name__)
 
@@ -168,7 +168,7 @@ def _write_manifest(entries: Dict[str, str]):
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 f.write(data)
                 f.flush()
-                os.fsync(f.fileno())
+                durable_fsync(f.fileno())
             atomic_replace(tmp_path, MANIFEST_FILE)
         except BaseException:
             try:
@@ -469,7 +469,7 @@ def _backfill_optional_provenance(quiet: bool = False) -> List[str]:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 f.write(payload)
                 f.flush()
-                os.fsync(f.fileno())
+                durable_fsync(f.fileno())
             atomic_replace(tmp_path, lock_path)
         except BaseException:
             try:

--- a/utils.py
+++ b/utils.py
@@ -6,6 +6,7 @@ import logging
 import os
 import shutil
 import stat
+import sys
 import tempfile
 from pathlib import Path
 from typing import Any, Union
@@ -88,6 +89,33 @@ def _restore_file_mode(path: Path, mode: "int | None") -> None:
         pass
 
 
+def durable_fsync(fd: int) -> None:
+    """``fsync`` that is actually durable on macOS.
+
+    On macOS, ``os.fsync`` only flushes writes to the drive's write cache,
+    not to persistent storage (Apple's documented ``fsync(2)`` behavior), so a
+    power loss or ``SIGKILL``/launchd shutdown right after a "synced" write can
+    still lose data.  ``fcntl`` ``F_FULLFSYNC`` forces a true flush to the
+    platter/flash.  This mirrors the ``PRAGMA checkpoint_fullfsync`` barrier
+    already applied to the SQLite write paths in ``hermes_state.py`` (#30636),
+    extending the same durability guarantee to the plain atomic file writes
+    (tempfile + fsync + ``os.replace``) used across the codebase.
+
+    Falls back to ``os.fsync`` where ``F_FULLFSYNC`` is unavailable or
+    unsupported (non-Darwin platforms, and network filesystems where the
+    request returns ``ENOTSUP``/``EINVAL``).
+    """
+    if sys.platform == "darwin":
+        try:
+            import fcntl
+
+            fcntl.fcntl(fd, fcntl.F_FULLFSYNC)
+            return
+        except (OSError, AttributeError):
+            pass
+    os.fsync(fd)
+
+
 def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
     """Atomically move *tmp_path* onto *target*, preserving symlinks.
 
@@ -129,7 +157,7 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
             pass
         try:
             with open(real_path, "rb") as f:
-                os.fsync(f.fileno())
+                durable_fsync(f.fileno())
         except OSError:
             pass
         os.unlink(tmp_str)
@@ -186,7 +214,7 @@ def atomic_json_write(
                 **dump_kwargs,
             )
             f.flush()
-            os.fsync(f.fileno())
+            durable_fsync(f.fileno())
         # Preserve symlinks — swap in-place on the real file (GitHub #16743).
         real_path = atomic_replace(tmp_path, path)
         real_path_obj = Path(real_path)
@@ -277,7 +305,7 @@ def atomic_yaml_write(
             if extra_content:
                 f.write(extra_content)
             f.flush()
-            os.fsync(f.fileno())
+            durable_fsync(f.fileno())
         # Preserve symlinks — swap in-place on the real file (GitHub #16743).
         real_path = atomic_replace(tmp_path, path)
         real_path_obj = Path(real_path)
@@ -347,7 +375,7 @@ def atomic_roundtrip_yaml_update(
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             yaml_rt.dump(config, f)
             f.flush()
-            os.fsync(f.fileno())
+            durable_fsync(f.fileno())
         real_path = atomic_replace(tmp_path, path)
         real_path_obj = Path(real_path)
         _restore_file_owner(real_path_obj, original_owner)

--- a/utils.py
+++ b/utils.py
@@ -89,6 +89,17 @@ def _restore_file_mode(path: Path, mode: "int | None") -> None:
         pass
 
 
+# Only these errno values mean "this filesystem cannot honor F_FULLFSYNC"
+# (e.g. some network mounts). They are the sole cases where downgrading to a
+# plain os.fsync is acceptable. Any other error (EIO, EBADF, ...) is a real
+# failure and must propagate instead of masquerading as a successful sync.
+_FULLFSYNC_UNSUPPORTED_ERRNOS = frozenset(
+    getattr(errno, _name)
+    for _name in ("ENOTSUP", "EOPNOTSUPP", "EINVAL")
+    if hasattr(errno, _name)
+)
+
+
 def durable_fsync(fd: int) -> None:
     """``fsync`` that is actually durable on macOS.
 
@@ -101,18 +112,26 @@ def durable_fsync(fd: int) -> None:
     extending the same durability guarantee to the plain atomic file writes
     (tempfile + fsync + ``os.replace``) used across the codebase.
 
-    Falls back to ``os.fsync`` where ``F_FULLFSYNC`` is unavailable or
-    unsupported (non-Darwin platforms, and network filesystems where the
-    request returns ``ENOTSUP``/``EINVAL``).
+    On non-Darwin platforms this is a plain ``os.fsync``.  On Darwin, only an
+    "operation not supported" error (a filesystem that cannot honor
+    ``F_FULLFSYNC``) falls back to ``os.fsync``; any other error (such as
+    ``EIO`` or ``EBADF``) propagates, so a caller is never told a durable
+    flush succeeded when it did not.
     """
     if sys.platform == "darwin":
         try:
             import fcntl
 
-            fcntl.fcntl(fd, fcntl.F_FULLFSYNC)
-            return
-        except (OSError, AttributeError):
-            pass
+            full_fsync = fcntl.F_FULLFSYNC
+        except (ImportError, AttributeError):
+            full_fsync = None
+        if full_fsync is not None:
+            try:
+                fcntl.fcntl(fd, full_fsync)
+                return
+            except OSError as exc:
+                if exc.errno not in _FULLFSYNC_UNSUPPORTED_ERRNOS:
+                    raise
     os.fsync(fd)
 
 


### PR DESCRIPTION
Closes #62100

## Problem

On macOS, `os.fsync()` only flushes writes to the drive's write cache, not to persistent storage. This is Apple's documented `fsync(2)` behavior. A power loss, `SIGKILL`, or launchd shutdown right after a "synced" write can still lose the data.

Hermes already accounts for this on the SQLite side: #54045 added a `PRAGMA checkpoint_fullfsync` barrier at WAL checkpoints on Darwin (issue #30636). That work is scoped to SQLite checkpoints only. The plain atomic file writes elsewhere in the tree still call `os.fsync()` directly, so they do not get the same guarantee:

- `utils.py` (`atomic_replace` fallback, `atomic_json_write`, `atomic_yaml_write`, `atomic_roundtrip_yaml_update`)
- `tools/skills_sync.py` (manifest write, provenance backfill)
- `tools/memory_tool.py` (memory store write)
- `tools/skill_usage.py` (usage file, suppressed-names file)
- `tools/mcp_oauth.py` (OAuth token store)
- `agent/anthropic_adapter.py` (Claude Code credentials)

These are the write paths behind config, memory, OAuth tokens, and skill state. A crash right after one reports success can leave the previous version on disk even though the caller believes the new data is durable.

## Solution

Add a `durable_fsync(fd)` helper in `utils.py` that issues `fcntl.F_FULLFSYNC` on Darwin and falls back to `os.fsync()` everywhere else, including network filesystems where `F_FULLFSYNC` returns `ENOTSUP`/`EINVAL`. `fcntl` is imported inside the Darwin branch so `utils.py` stays importable on Windows.

Every call site listed above now routes through the helper. This is the same durability barrier #54045 applied to SQLite, extended to the tempfile + fsync + `os.replace` pattern used for one-shot atomic file writes. A one-shot write has no per-commit cost concern, so the full barrier is straightforward here.

## Testing

- `scripts/run_tests.sh tests/test_durable_fsync.py` (new): asserts `F_FULLFSYNC` is used on Darwin, that a rejected `F_FULLFSYNC` falls back to `os.fsync`, and that non-Darwin platforms use `os.fsync` directly.
- `scripts/run_tests.sh tests/test_atomic_replace_symlinks.py tests/hermes_cli/test_atomic_yaml_write.py tests/tools/test_skills_sync.py tests/tools/test_mcp_oauth.py tests/hermes_cli/test_oneshot_usage_file.py`: 173 passed, exercising the changed write paths.
- `python3 scripts/check-windows-footguns.py` on the changed files: no findings.

Tested on Linux. The Darwin path is covered by the platform-guard tests since `F_FULLFSYNC` is macOS-only.
