### PR TITLE
ci: add timeout-minutes to workflow jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
   detect:
     name: Detect affected areas
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       python: ${{ steps.classify.outputs.python }}
       frontend: ${{ steps.classify.outputs.frontend }}
@@ -151,6 +152,7 @@ jobs:
       # - docker
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Evaluate job results
         env:
@@ -177,6 +179,7 @@ jobs:
     needs: [all-checks-pass, docker]
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/contributor-check.yml
+++ b/.github/workflows/contributor-check.yml
@@ -9,6 +9,7 @@ permissions:
 jobs:
   check-attribution:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -41,6 +41,7 @@ jobs:
     # doesn't auto-deploy via the deploy-docs path.
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Trigger Vercel Deploy
         run: curl -X POST "${{ secrets.VERCEL_DEPLOY_HOOK }}"
@@ -48,6 +49,7 @@ jobs:
   deploy-docs:
     if: github.repository == 'NousResearch/hermes-agent'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}

--- a/.github/workflows/docs-site-checks.yml
+++ b/.github/workflows/docs-site-checks.yml
@@ -9,6 +9,7 @@ permissions:
 jobs:
   docs-site-checks:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/history-check.yml
+++ b/.github/workflows/history-check.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   check-common-ancestor:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/skills-index-freshness.yml
+++ b/.github/workflows/skills-index-freshness.yml
@@ -20,6 +20,7 @@ jobs:
   check-freshness:
     if: github.repository == 'NousResearch/hermes-agent'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Probe live index
         id: probe

--- a/.github/workflows/skills-index.yml
+++ b/.github/workflows/skills-index.yml
@@ -20,6 +20,7 @@ jobs:
     # Only run on the upstream repository, not on forks
     if: github.repository == 'NousResearch/hermes-agent'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -49,6 +50,7 @@ jobs:
     needs: build-index
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Trigger Deploy Site workflow
         env:

--- a/.github/workflows/supply-chain-audit.yml
+++ b/.github/workflows/supply-chain-audit.yml
@@ -43,6 +43,7 @@ jobs:
     name: Scan PR for critical supply chain risks
     if: inputs.scan
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -164,6 +165,7 @@ jobs:
     name: Check PyPI dependency upper bounds
     if: inputs.deps
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -229,6 +231,7 @@ jobs:
     name: MCP catalog security review
     if: inputs.mcp_catalog
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
   generate:
     name: "Generate slices"
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
@@ -126,6 +127,7 @@ jobs:
     needs: test
     if: needs.test.result == 'success' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Download all slice durations
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -26,6 +26,7 @@ jobs:
   build:
     name: Build distribution 📦
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -90,6 +91,7 @@ jobs:
     name: Publish to PyPI
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     environment:
       name: pypi
       url: https://pypi.org/p/hermes-agent
@@ -115,6 +117,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     needs: publish
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write # attach assets to the existing release
       id-token: write # sigstore signing


### PR DESCRIPTION
Closes #62103

## Problem

Most jobs across the repo's GitHub Actions workflows have no `timeout-minutes` set. A job without one inherits the platform default of 6 hours, so a step that hangs (a stuck network call, a deadlocked test, a wedged subprocess) keeps a runner busy for hours before the run is cancelled. Some workflows already set it (`lint.yml`, `docker.yml`, `docker-lint.yml`, the `test`/`e2e` jobs in `tests.yml`, `uv-lockfile-check.yml`), so the gap was inconsistent coverage rather than a deliberate policy.

## Solution

Add a `timeout-minutes` cap to every job that was missing one, sized to the work each job does:

| Workflow | Job(s) | timeout-minutes |
|---|---|---|
| `ci.yml` | `detect`, `all-checks-pass` | 5 |
| `ci.yml` | `ci-timings` | 10 |
| `contributor-check.yml` | `check-attribution` | 10 |
| `docs-site-checks.yml` | `docs-site-checks` | 10 |
| `history-check.yml` | `check-common-ancestor` | 10 |
| `skills-index-freshness.yml` | `check-freshness` | 10 |
| `deploy-site.yml` | `deploy-vercel`, `deploy-docs` | 15 |
| `skills-index.yml` | `build-index`, `trigger-deploy` | 15 |
| `supply-chain-audit.yml` | `scan`, `dep-bounds`, `mcp-catalog-review` | 15 |
| `tests.yml` | `generate`, `save-durations` | 15 |
| `upload_to_pypi.yml` | `build`, `publish`, `sign` | 20 |

`typecheck.yml` is intentionally left out. Its read-only `permissions` change is already in flight in #45731, and the remaining `concurrency` plus `timeout-minutes` work for that file is tracked on its own, so editing it here would only create a conflict.

## Testing

- Parsed every `.github/workflows/*.yml` with `yaml.safe_load` before and after the change. All files parse, and the only job still without a `timeout-minutes` is in `typecheck.yml`, which is the intended exclusion.
- Confirmed the diff is additive only: 19 lines across 10 files, one per job, with nothing else touched.
