### PR TITLE
fix(docs): upgrade Supermemory API-key link from http to https

### DIFF
--- a/plugins/memory/supermemory/README.md
+++ b/plugins/memory/supermemory/README.md
@@ -5,7 +5,7 @@ Semantic long-term memory with profile recall, semantic search, explicit memory 
 ## Requirements
 
 - `pip install supermemory`
-- Supermemory API key from [app.supermemory.ai/integrations?connect=hermes](http://app.supermemory.ai/integrations?connect=hermes)
+- Supermemory API key from [app.supermemory.ai/integrations?connect=hermes](https://app.supermemory.ai/integrations?connect=hermes)
 
 ## Setup
 

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -32,7 +32,7 @@ _DEFAULT_API_TIMEOUT = 5.0
 _MIN_CAPTURE_LENGTH = 10
 _MAX_ENTITY_CONTEXT_LENGTH = 1500
 _CONVERSATIONS_URL = "https://api.supermemory.ai/v4/conversations"
-_API_KEY_URL = "http://app.supermemory.ai/integrations?connect=hermes"
+_API_KEY_URL = "https://app.supermemory.ai/integrations?connect=hermes"
 _TRIVIAL_RE = re.compile(
     r"^(ok|okay|thanks|thank you|got it|sure|yes|no|yep|nope|k|ty|thx|np)\.?$",
     re.IGNORECASE,

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -513,7 +513,7 @@ Semantic long-term memory with profile recall, semantic search, explicit memory 
 | | |
 |---|---|
 | **Best for** | Semantic recall with user profiling and session-level graph building |
-| **Requires** | `pip install supermemory` + [API key](http://app.supermemory.ai/integrations?connect=hermes) |
+| **Requires** | `pip install supermemory` + [API key](https://app.supermemory.ai/integrations?connect=hermes) |
 | **Data storage** | Supermemory Cloud |
 | **Cost** | Supermemory pricing |
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory-providers.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory-providers.md
@@ -467,7 +467,7 @@ hermes config set memory.provider byterover
 | | |
 |---|---|
 | **适合场景** | 带用户 profile 和会话级图谱构建的语义召回 |
-| **依赖** | `pip install supermemory` + [API key](http://app.supermemory.ai/integrations?connect=hermes) |
+| **依赖** | `pip install supermemory` + [API key](https://app.supermemory.ai/integrations?connect=hermes) |
 | **数据存储** | Supermemory Cloud |
 | **费用** | Supermemory 定价 |
 


### PR DESCRIPTION
## Problem

The Supermemory API-key link is served over plain http in several user-facing places. The most important is the runtime constant shown to users during setup:

    _API_KEY_URL = "http://app.supermemory.ai/integrations?connect=hermes"

A clickable link to fetch an API key should not start on plain http. It is downgrade-prone, and doc link-checkers flag insecure schemes. https://app.supermemory.ai/integrations?connect=hermes resolves directly (HTTP 200), so there is no reason to keep the plain-http form.

## Changes

- plugins/memory/supermemory/__init__.py - _API_KEY_URL constant
- plugins/memory/supermemory/README.md
- website/docs/user-guide/features/memory-providers.md
- website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory-providers.md

No logic change - only URL scheme upgrade from http to https.

Closes #62093