### PR TITLE
fix(approvals): make cron-session classification task-local, not process-global

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2680,11 +2680,6 @@ def run_job(
 
     agent = None
 
-    # Mark this as a cron session so the approval system can apply cron_mode.
-    # This env var is process-wide and persists for the lifetime of the
-    # scheduler process — every job this process runs is a cron job.
-    os.environ["HERMES_CRON_SESSION"] = "1"
-
     # Use ContextVars for per-job session/delivery state so parallel jobs
     # don't clobber each other's targets (os.environ is process-global).
     from gateway.session_context import set_session_vars, clear_session_vars, _VAR_MAP
@@ -2722,6 +2717,15 @@ def run_job(
     )
     for _var_name in _cron_delivery_vars:
         _VAR_MAP[_var_name].set("")
+
+    # Mark this task as a cron session so the approval system applies
+    # cron_mode. Task-local on purpose: the in-process scheduler
+    # (gateway/run.py::_start_cron_ticker) shares its process with the live
+    # gateway, so the old process-wide os.environ flag reclassified every
+    # interactive session after the first tick as cron — hard-denying (or
+    # with cron_mode: approve, silently auto-approving) commands that should
+    # have gone through interactive gateway approval.
+    _VAR_MAP["HERMES_CRON_SESSION"].set("1")
 
     # Per-job working directory.  When set (and validated at create/update
     # time), we point TERMINAL_CWD at it so:

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -120,6 +120,17 @@ _CRON_AUTO_DELIVER_PLATFORM: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_P
 _CRON_AUTO_DELIVER_CHAT_ID: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_CHAT_ID", default=_UNSET)
 _CRON_AUTO_DELIVER_THREAD_ID: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_THREAD_ID", default=_UNSET)
 
+# Whether the current task is executing a scheduled cron job. Set per-job in
+# run_job() — NOT via os.environ, which is process-global: the in-process
+# scheduler (gateway/run.py::_start_cron_ticker) shares its process with the
+# live gateway, so a process-wide flag set by the first cron tick would
+# reclassify every subsequent interactive session as cron and route its
+# approvals through ``approvals.cron_mode`` (hard-deny or, worse,
+# auto-approve) instead of the interactive gateway approval flow. The
+# ``os.environ`` fallback in get_session_env still honors a process-level
+# HERMES_CRON_SESSION for dedicated cron worker processes and tests.
+_CRON_SESSION: ContextVar = ContextVar("HERMES_CRON_SESSION", default=_UNSET)
+
 _VAR_MAP = {
     "HERMES_SESSION_PLATFORM": _SESSION_PLATFORM,
     "HERMES_SESSION_SOURCE": _SESSION_SOURCE,
@@ -136,6 +147,7 @@ _VAR_MAP = {
     "HERMES_CRON_AUTO_DELIVER_PLATFORM": _CRON_AUTO_DELIVER_PLATFORM,
     "HERMES_CRON_AUTO_DELIVER_CHAT_ID": _CRON_AUTO_DELIVER_CHAT_ID,
     "HERMES_CRON_AUTO_DELIVER_THREAD_ID": _CRON_AUTO_DELIVER_THREAD_ID,
+    "HERMES_CRON_SESSION": _CRON_SESSION,
 }
 
 

--- a/tests/tools/test_cron_approval_mode.py
+++ b/tests/tools/test_cron_approval_mode.py
@@ -1,13 +1,26 @@
 """Tests for approvals.cron_mode — configurable approval behavior for cron jobs."""
 
+import contextvars
+import os
+
 import pytest
 
 import tools.approval as approval_module
 from tools.approval import (
     _get_cron_approval_mode,
+    _is_cron_session,
+    _is_gateway_approval_context,
     check_all_command_guards,
     check_dangerous_command,
+    check_execute_code_guard,
     detect_dangerous_command,
+)
+from gateway.session_context import (
+    _UNSET,
+    _VAR_MAP,
+    clear_session_vars,
+    reset_session_vars,
+    set_session_vars,
 )
 
 
@@ -432,3 +445,134 @@ class TestCronWithGatewayOrigin:
                 assert result.get("status") != "approval_required"
         finally:
             clear_session_vars(tokens)
+
+
+# ---------------------------------------------------------------------------
+# HERMES_CRON_SESSION: ContextVar (task-local) vs. the old os.environ leak
+# ---------------------------------------------------------------------------
+#
+# Regression coverage for the fix: run_job() (cron/scheduler.py) used to set
+# os.environ["HERMES_CRON_SESSION"] = "1" process-wide and never clear it.
+# Because the in-process cron scheduler shares its process with the live
+# gateway (gateway/run.py::_start_cron_ticker -> InProcessCronScheduler),
+# every interactive session (e.g. Telegram) after the FIRST cron tick was
+# permanently misclassified as a cron session — approvals took the
+# ``approvals.cron_mode`` branch (hard-deny, or silent auto-approve) instead
+# of the interactive gateway flow.
+#
+# The fix: gateway/session_context._CRON_SESSION is a task-local ContextVar,
+# set per-job by run_job() via ``_VAR_MAP["HERMES_CRON_SESSION"].set("1")``
+# instead of mutating os.environ. tools.approval._is_cron_session() reads it
+# through get_session_env (contextvar-first, os.environ fallback preserved
+# for dedicated cron worker processes / legacy tests that never touch the
+# contextvar at all).
+
+class TestCronSessionContextVar:
+    """Task-local HERMES_CRON_SESSION contextvar replaces the process-wide env leak."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_cron_session_contextvar(self, monkeypatch):
+        # ContextVar.set() calls made directly in a test function (i.e. NOT
+        # inside a contextvars.copy_context().run(...) call) mutate the
+        # thread's ambient context and persist into whatever test runs next
+        # in the same thread. Reset to the "never set" sentinel before and
+        # after every test in this class, and make sure the legacy env var
+        # doesn't leak in either direction.
+        _VAR_MAP["HERMES_CRON_SESSION"].set(_UNSET)
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        yield
+        _VAR_MAP["HERMES_CRON_SESSION"].set(_UNSET)
+
+    def test_contextvar_set_makes_is_cron_session_true(self):
+        """What run_job() now does: bind the contextvar, task-local, no env write."""
+        _VAR_MAP["HERMES_CRON_SESSION"].set("1")
+        assert _is_cron_session() is True
+        # No process-global mutation accompanies the contextvar bind.
+        assert "HERMES_CRON_SESSION" not in os.environ
+
+    def test_contextvar_set_drives_cron_deny_branch_for_dangerous_command(self):
+        _VAR_MAP["HERMES_CRON_SESSION"].set("1")
+
+        from unittest.mock import patch as mock_patch
+        with mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"):
+            result = check_all_command_guards("rm -rf /tmp/stuff", "local")
+            assert not result["approved"]
+            assert "BLOCKED" in result["message"]
+            assert "cron_mode" in result["message"]
+
+    def test_contextvar_set_drives_cron_deny_branch_for_execute_code(self):
+        """check_execute_code_guard's cron branch also reads the contextvar
+        (the fourth of the four former env_var_enabled call sites)."""
+        _VAR_MAP["HERMES_CRON_SESSION"].set("1")
+
+        from unittest.mock import patch as mock_patch
+        with mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"):
+            result = check_execute_code_guard(
+                "import os\nos.system('rm -rf /tmp/stuff')", "local"
+            )
+            assert not result["approved"]
+            assert "BLOCKED" in result["message"]
+            assert result.get("pattern_key") == "execute_code"
+
+    def test_env_fallback_preserved_when_contextvar_never_set(self, monkeypatch):
+        """Dedicated cron worker processes / legacy tests that never touch the
+        contextvar at all still classify via the os.environ fallback."""
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        assert _is_cron_session() is True
+
+    def test_reset_session_vars_returns_to_unset_then_env_fallback_reapplies(self, monkeypatch):
+        _VAR_MAP["HERMES_CRON_SESSION"].set("1")
+        assert _is_cron_session() is True
+
+        reset_session_vars()
+        assert _VAR_MAP["HERMES_CRON_SESSION"].get() is _UNSET
+
+        # Contextvar back to "never set in this context" -> os.environ fallback.
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        assert _is_cron_session() is True
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        assert _is_cron_session() is False
+
+    def test_cron_context_does_not_leak_into_fresh_interactive_context(self):
+        """THE CORE REGRESSION.
+
+        Before the fix, a cron tick's os.environ["HERMES_CRON_SESSION"] = "1"
+        was process-wide and permanent, so every interactive session running
+        afterwards in the SAME PROCESS was misclassified as cron. Simulate the
+        cron job the way run_job() actually executes — in its own task, i.e.
+        a copied contextvars.Context — and prove:
+
+          1. os.environ is never written to (the leak vector is gone).
+          2. A separately-copied context that binds a real interactive gateway
+             session (set_session_vars(platform="telegram", ...)) sees NO
+             cron classification and IS treated as a gateway approval context.
+        """
+        assert "HERMES_CRON_SESSION" not in os.environ
+
+        def _cron_job_body():
+            # Task-local bind, exactly like run_job() in cron/scheduler.py.
+            _VAR_MAP["HERMES_CRON_SESSION"].set("1")
+            assert _is_cron_session() is True
+
+        cron_ctx = contextvars.copy_context()
+        cron_ctx.run(_cron_job_body)
+
+        # The cron job's bind must not have escaped into os.environ or into
+        # this (the spawning) context.
+        assert "HERMES_CRON_SESSION" not in os.environ
+        assert _VAR_MAP["HERMES_CRON_SESSION"].get() is _UNSET
+
+        def _interactive_body():
+            tokens = set_session_vars(platform="telegram", chat_id="123", user_id="u1")
+            try:
+                assert _is_cron_session() is False
+                assert _is_gateway_approval_context() is True
+            finally:
+                clear_session_vars(tokens)
+
+        interactive_ctx = contextvars.copy_context()
+        interactive_ctx.run(_interactive_body)

--- a/tests/tools/test_request_tool_approval.py
+++ b/tests/tools/test_request_tool_approval.py
@@ -103,6 +103,12 @@ class TestRequestToolApproval:
     def test_cron_deny_mode_blocks(self, monkeypatch):
         monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)
         monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
+        # Cron classification now goes through _is_cron_session(), which reads
+        # the HERMES_CRON_SESSION contextvar with an os.environ fallback (not
+        # env_var_enabled directly) — set the real env var to simulate a
+        # dedicated cron worker process. Keep env_var_enabled patched so other
+        # process-level flags (HERMES_EXEC_ASK, ...) stay off deterministically.
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
         monkeypatch.setattr(approval, "env_var_enabled",
                             lambda v: v == "HERMES_CRON_SESSION")
         monkeypatch.setattr(approval, "_get_cron_approval_mode", lambda: "deny")
@@ -113,6 +119,7 @@ class TestRequestToolApproval:
     def test_cron_approve_mode_allows(self, monkeypatch):
         monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)
         monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
         monkeypatch.setattr(approval, "env_var_enabled",
                             lambda v: v == "HERMES_CRON_SESSION")
         monkeypatch.setattr(approval, "_get_cron_approval_mode", lambda: "approve")

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -176,6 +176,25 @@ def _get_session_platform() -> str:
         return os.getenv("HERMES_SESSION_PLATFORM", "") or ""
 
 
+def _is_cron_session() -> bool:
+    """True when the current task is executing a scheduled cron job.
+
+    Reads the task-local contextvar bound per-job by cron's run_job()
+    (gateway/session_context), falling back to a process-level
+    HERMES_CRON_SESSION env var for dedicated cron worker processes and
+    tests. The contextvar is authoritative on purpose: the in-process
+    scheduler shares its process with the live gateway, so a process-global
+    flag would reclassify every interactive session after the first cron
+    tick as cron (see run_job).
+    """
+    try:
+        from gateway.session_context import get_session_env
+
+        return is_truthy_value(get_session_env("HERMES_CRON_SESSION", ""))
+    except Exception:
+        return _is_cron_session()
+
+
 def _is_gateway_approval_context() -> bool:
     """True when this call is inside a gateway/API session.
 
@@ -190,7 +209,7 @@ def _is_gateway_approval_context() -> bool:
     fall through to the gateway branch would submit a pending approval
     with no listener and block the job indefinitely.
     """
-    if env_var_enabled("HERMES_CRON_SESSION"):
+    if _is_cron_session():
         return False
     if env_var_enabled("HERMES_GATEWAY_SESSION"):
         return True
@@ -2069,7 +2088,7 @@ def _run_approval_gate(
 
     if not is_cli and not is_gateway:
         # Cron sessions: respect cron_mode config
-        if env_var_enabled("HERMES_CRON_SESSION"):
+        if _is_cron_session():
             if _get_cron_approval_mode() == "deny":
                 return {
                     "approved": False,
@@ -2599,7 +2618,7 @@ def check_all_command_guards(command: str, env_type: str,
     # flows, we do not block on approvals and we skip external guard work.
     if not is_cli and not is_gateway and not is_ask:
         # Cron sessions: respect cron_mode config
-        if env_var_enabled("HERMES_CRON_SESSION"):
+        if _is_cron_session():
             if _get_cron_approval_mode() == "deny":
                 # Run detection to get a description for the block message
                 is_dangerous, _pk, description = detect_dangerous_command(command)
@@ -2994,7 +3013,7 @@ def check_execute_code_guard(code: str, env_type: str,
     is_ask = env_var_enabled("HERMES_EXEC_ASK")
 
     # Cron: no user is present to approve arbitrary code.
-    if env_var_enabled("HERMES_CRON_SESSION"):
+    if _is_cron_session():
         if _get_cron_approval_mode() == "deny":
             return {
                 "approved": False,


### PR DESCRIPTION
## What does this PR do?

Fixes a process-global state leak that makes the approval system misclassify every interactive gateway session as a cron session once any scheduled job has run.

`run_job()` marks cron execution by setting `HERMES_CRON_SESSION=1` in `os.environ` and never clears it. The env var is process-wide, and the in-process scheduler (`gateway/run.py::_start_cron_ticker`) shares its process with the live gateway. So from the first cron tick onward, every interactive Telegram/Discord/Slack session in that gateway process is classified as cron by all four approval checks — including `_is_gateway_approval_context()`, which returns `False` for cron and therefore knocks the session out of the interactive approval flow entirely.

Observed effect depends on `approvals.cron_mode`:
- `deny` (the default): ordinary interactive requests that need approval (`execute_code`, dangerous terminal commands) are hard-blocked with a message claiming "Cron jobs run without a user present to approve it" — while a user is right there in the chat.
- `approve`: those same requests would be **silently auto-approved** without the user ever being asked.

With a frequent cron job (e.g. every few minutes), the leak window is effectively the whole gateway uptime.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/session_context.py`: new `HERMES_CRON_SESSION` ContextVar registered in `_VAR_MAP` — the same task-local mechanism run_job() already uses for the `HERMES_CRON_AUTO_DELIVER_*` delivery vars (which were moved off `os.environ` for exactly this concurrency reason). Covered automatically by `reset_session_vars()`.
- `cron/scheduler.py`: `run_job()` binds the flag per-job via the contextvar instead of writing `os.environ`.
- `tools/approval.py`: new `_is_cron_session()` helper reads the flag through `get_session_env()` (contextvar-first, `os.environ` fallback) and replaces the four `env_var_enabled("HERMES_CRON_SESSION")` call sites. The env fallback keeps dedicated cron worker processes and existing tests that export the env var classifying correctly.
- `tests/tools/test_cron_approval_mode.py`: new `TestCronSessionContextVar` class — contextvar drives the cron-deny branch for dangerous commands and `execute_code`; env fallback preserved when the contextvar was never set; `reset_session_vars()` restores fallback semantics; and the core regression: a cron context does not leak into a fresh interactive gateway context, and `os.environ` stays clean.
- `tests/tools/test_request_tool_approval.py`: the two cron-mode tests now export the real env var (simulating a dedicated cron worker) since classification no longer goes through the patched `env_var_enabled`.

## Testing

- `pytest tests/tools/test_cron_approval_mode.py tests/tools/test_execute_code_approval_cluster.py tests/tools/test_approval.py tests/tools/test_approval_deny_rules.py tests/tools/test_hardline_blocklist.py tests/tools/test_request_tool_approval.py` — 568 passed.
- `pytest tests/gateway/` — identical results with and without this change (the handful of failures there fail the same way on a clean checkout of `main`).
