### PR TITLE
fix(cron): close codex app-server session when a job run finishes

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -533,6 +533,26 @@ def run_codex_app_server_turn(
     }
 
 
+def close_codex_session(agent) -> None:
+    """Tear down the per-agent `codex app-server` subprocess, if any.
+
+    Ephemeral agents (cron jobs, gateway hygiene/summary agents) run inside
+    the long-lived gateway process, so the subprocess never exits with its
+    parent the way it does for a one-shot CLI run. The client's reader
+    threads keep the client object referenced, so GC never closes its pipes
+    either — without this explicit close, every such run leaks one
+    `codex app-server` process. Safe no-op for agents on other runtimes.
+    """
+    session = getattr(agent, "_codex_session", None)
+    if session is None:
+        return
+    try:
+        session.close()
+    except Exception:
+        logger.debug("codex app-server session close failed", exc_info=True)
+    agent._codex_session = None
+
+
 # ---------------------------------------------------------------------------
 # Event-driven Responses streaming
 #

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -397,8 +397,13 @@ class CodexAppServerSession:
             # turn re-spawns cleanly.
             result.should_retire = True
             return result
-        assert self._client is not None and self._thread_id is not None
-        result.thread_id = self._thread_id
+        # Retain stable references for this turn. close() may run concurrently
+        # on cron inactivity timeout and clears the session attributes, while
+        # the client object remains safe to inspect as it shuts down.
+        client = self._client
+        thread_id = self._thread_id
+        assert client is not None and thread_id is not None
+        result.thread_id = thread_id
 
         self._interrupt_event.clear()
         projector = CodexEventProjector()
@@ -408,10 +413,10 @@ class CodexAppServerSession:
         # Send turn/start with the user input. Text-only for now (codex
         # supports rich content but Hermes' text path is the common case).
         try:
-            ts = self._client.request(
+            ts = client.request(
                 "turn/start",
                 {
-                    "threadId": self._thread_id,
+                    "threadId": thread_id,
                     "input": [{"type": "text", "text": user_input_text}],
                 },
                 timeout=10,
@@ -419,7 +424,7 @@ class CodexAppServerSession:
         except CodexAppServerError as exc:
             # Classify auth/refresh failures so the user gets a clear
             # `codex login` pointer instead of a raw RPC error string.
-            stderr_blob = "\n".join(self._client.stderr_tail(40))
+            stderr_blob = "\n".join(client.stderr_tail(40))
             hint = _classify_oauth_failure(exc.message, stderr_blob)
             if hint is not None:
                 result.error = hint
@@ -435,7 +440,7 @@ class CodexAppServerSession:
             return result
         except TimeoutError as exc:
             # turn/start hanging is a strong signal the subprocess is wedged.
-            stderr_blob = "\n".join(self._client.stderr_tail(40))
+            stderr_blob = "\n".join(client.stderr_tail(40))
             hint = _classify_oauth_failure(stderr_blob)
             result.error = hint or self._format_error_with_stderr(
                 "turn/start timed out", exc
@@ -462,8 +467,8 @@ class CodexAppServerSession:
             # (e.g. crashed, segfaulted, or its auth refresh thread killed
             # the process), we won't get any more notifications — bail out
             # rather than waiting for the full turn deadline.
-            if not self._client.is_alive():
-                stderr_blob = "\n".join(self._client.stderr_tail(60))
+            if not client.is_alive():
+                stderr_blob = "\n".join(client.stderr_tail(60))
                 hint = _classify_oauth_failure(stderr_blob)
                 if hint is not None:
                     result.error = hint
@@ -495,14 +500,14 @@ class CodexAppServerSession:
 
             # Drain any server-initiated requests (approvals) before
             # reading notifications, so the codex side isn't blocked.
-            sreq = self._client.take_server_request(timeout=0)
+            sreq = client.take_server_request(timeout=0)
             if sreq is not None:
                 # Drain any pending notifications first so per-turn state
                 # (e.g. _pending_file_changes for fileChange approvals) is
                 # up to date when we make the approval decision. Bounded
                 # to avoid starving the server-request response.
                 for _ in range(8):
-                    pending = self._client.take_notification(timeout=0)
+                    pending = client.take_notification(timeout=0)
                     if pending is None:
                         break
                     _apply_token_usage_notification(result, pending)
@@ -529,7 +534,7 @@ class CodexAppServerSession:
                 last_tool_completion_at = None
                 continue
 
-            note = self._client.take_notification(
+            note = client.take_notification(
                 timeout=notification_poll_timeout
             )
             if note is None:
@@ -596,7 +601,7 @@ class CodexAppServerSession:
                         # rewrite the error into a re-auth hint AND mark
                         # the session for retirement.
                         stderr_blob = "\n".join(
-                            self._client.stderr_tail(40)
+                            client.stderr_tail(40)
                         )
                         hint = _classify_oauth_failure(err_msg, stderr_blob)
                         if hint is not None:
@@ -797,6 +802,10 @@ class CodexAppServerSession:
         except CodexAppServerError as exc:
             # "no active turn to interrupt" is fine — already done.
             logger.debug("turn/interrupt non-fatal: %s", exc)
+        except RuntimeError as exc:
+            # Concurrent session teardown may close stdin after the guards
+            # above but before request() writes. The turn is already stopping.
+            logger.debug("turn/interrupt skipped; transport closed: %s", exc)
         except TimeoutError:
             logger.warning("turn/interrupt timed out")
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3133,6 +3133,21 @@ def run_job(
             raise
         finally:
             _cron_pool.shutdown(wait=False, cancel_futures=True)
+            # The codex_app_server runtime spawns a `codex app-server`
+            # subprocess per agent. Cron agents are ephemeral but run inside
+            # the long-lived gateway process, so without an explicit close
+            # every job run leaks one app-server (its reader threads pin the
+            # client object, so GC never closes the pipes). On the
+            # inactivity-timeout path this also kills the hung subprocess,
+            # which is the intended outcome.
+            try:
+                from agent.codex_runtime import close_codex_session
+                close_codex_session(agent)
+            except Exception:
+                logger.debug(
+                    "Job '%s': codex session cleanup failed", job_id,
+                    exc_info=True,
+                )
 
         if _inactivity_timeout:
             # Build diagnostic summary from the agent's activity tracker.

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3133,21 +3133,6 @@ def run_job(
             raise
         finally:
             _cron_pool.shutdown(wait=False, cancel_futures=True)
-            # The codex_app_server runtime spawns a `codex app-server`
-            # subprocess per agent. Cron agents are ephemeral but run inside
-            # the long-lived gateway process, so without an explicit close
-            # every job run leaks one app-server (its reader threads pin the
-            # client object, so GC never closes the pipes). On the
-            # inactivity-timeout path this also kills the hung subprocess,
-            # which is the intended outcome.
-            try:
-                from agent.codex_runtime import close_codex_session
-                close_codex_session(agent)
-            except Exception:
-                logger.debug(
-                    "Job '%s': codex session cleanup failed", job_id,
-                    exc_info=True,
-                )
 
         if _inactivity_timeout:
             # Build diagnostic summary from the agent's activity tracker.
@@ -3351,6 +3336,15 @@ def _teardown_cron_agent(agent, job_id: str) -> None:
             agent.close()
     except (Exception, KeyboardInterrupt) as e:
         logger.debug("Job '%s': failed to close agent resources: %s", job_id, e)
+    # Codex app-server sessions are not currently owned by AIAgent.close().
+    # Close them from this centralized teardown path so both inline teardown
+    # and teardown deferred until after delivery release the subprocess.
+    try:
+        from agent.codex_runtime import close_codex_session
+        if agent is not None:
+            close_codex_session(agent)
+    except (Exception, KeyboardInterrupt) as e:
+        logger.debug("Job '%s': failed to close codex session: %s", job_id, e)
     # Each cron run spins up a short-lived worker thread whose event loop
     # dies as soon as the ``ThreadPoolExecutor`` shuts down. Any async
     # httpx clients cached under that loop are now unusable — reap them

--- a/tests/agent/test_codex_runtime_close.py
+++ b/tests/agent/test_codex_runtime_close.py
@@ -1,0 +1,38 @@
+"""Tests for explicit cleanup of per-agent Codex app-server sessions."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from agent.codex_runtime import close_codex_session
+
+
+def test_close_codex_session_closes_and_clears_session():
+    session = Mock()
+    agent = SimpleNamespace(_codex_session=session)
+
+    close_codex_session(agent)
+
+    session.close.assert_called_once_with()
+    assert agent._codex_session is None
+
+
+def test_close_codex_session_is_noop_without_session():
+    agent_without_attribute = SimpleNamespace()
+    agent_with_none = SimpleNamespace(_codex_session=None)
+
+    close_codex_session(agent_without_attribute)
+    close_codex_session(agent_with_none)
+
+    assert not hasattr(agent_without_attribute, "_codex_session")
+    assert agent_with_none._codex_session is None
+
+
+def test_close_codex_session_swallows_close_error_and_clears_session():
+    session = Mock()
+    session.close.side_effect = RuntimeError("close failed")
+    agent = SimpleNamespace(_codex_session=session)
+
+    close_codex_session(agent)
+
+    session.close.assert_called_once_with()
+    assert agent._codex_session is None

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -417,6 +417,52 @@ class TestRunTurn:
         assert r.interrupted is True
         assert r.error and "timed out" in r.error
 
+    def test_close_during_turn_retires_without_losing_active_client(self):
+        """Cron timeout teardown may close a session while run_turn is active."""
+        client = FakeClient()
+        s = make_session(client)
+        s.ensure_started()
+
+        def close_during_start(method: str, params: dict):
+            if method == "turn/start":
+                s.close()
+                return {"turn": {"id": "turn-fake-001"}}
+            return {}
+
+        client._request_handler = close_during_start
+
+        result = s.run_turn(
+            "x", turn_timeout=2.0, notification_poll_timeout=0.01
+        )
+
+        assert result.should_retire is True
+        assert result.error and "subprocess exited unexpectedly" in result.error
+
+    def test_deadline_interrupt_tolerates_closed_transport(self):
+        """A close racing turn/interrupt must not hide the timeout result."""
+        client = FakeClient()
+
+        def close_before_interrupt(method: str, params: dict):
+            if method == "thread/start":
+                return {"thread": {"id": "thread-fake-001"}}
+            if method == "turn/start":
+                return {"turn": {"id": "turn-fake-001"}}
+            if method == "turn/interrupt":
+                raise RuntimeError("codex app-server client is closed")
+            return {}
+
+        client._request_handler = close_before_interrupt
+
+        result = make_session(client).run_turn(
+            "never finishes",
+            turn_timeout=0.05,
+            notification_poll_timeout=0.01,
+        )
+
+        assert result.interrupted is True
+        assert result.should_retire is True
+        assert result.error and "timed out" in result.error
+
     def test_deadline_uses_monotonic_clock(self):
         client = FakeClient()
         s = make_session(client)

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -205,6 +205,36 @@ def test_run_one_job_delivers_before_agent_teardown(monkeypatch):
     assert order == ["run_job", "deliver", "agent.close", "cleanup_stale"], order
 
 
+def test_teardown_closes_codex_session_even_if_agent_close_fails(monkeypatch):
+    """The centralized cron teardown always releases the Codex subprocess."""
+    order = []
+
+    class FakeSession:
+        def close(self):
+            order.append("codex.close")
+
+    class FakeAgent:
+        def __init__(self):
+            self._codex_session = FakeSession()
+
+        def close(self):
+            order.append("agent.close")
+            raise RuntimeError("generic teardown failed")
+
+    import agent.auxiliary_client as aux
+    monkeypatch.setattr(
+        aux,
+        "cleanup_stale_async_clients",
+        lambda: order.append("cleanup_stale"),
+    )
+    agent = FakeAgent()
+
+    s._teardown_cron_agent(agent, "job-codex-cleanup")
+
+    assert order == ["agent.close", "codex.close", "cleanup_stale"]
+    assert agent._codex_session is None
+
+
 def test_run_one_job_tears_down_deferred_agent_when_delivery_raises(monkeypatch):
     """Even if _deliver_result raises, the deferred agent is still torn down
     (no fd/client leak — #10200). Teardown lives in a finally around delivery.


### PR DESCRIPTION
## What does this PR do?

Fixes a process leak when `model.openai_runtime: codex_app_server` is active: every cron run inside the long-lived gateway process could leave behind one `codex app-server` subprocess and its MCP children.

The fix now follows the cron agent's existing lifecycle boundary:

- `agent/codex_runtime.py` provides an idempotent, exception-safe `close_codex_session(agent)` helper.
- `cron/scheduler.py` invokes that helper from `_teardown_cron_agent()`, so cleanup happens on both inline and delivery-deferred teardown paths.
- `agent/transports/codex_app_server_session.py` retains stable client/thread references during `run_turn()`, allowing inactivity-timeout teardown to close the transport concurrently without a `NoneType` race.
- A closed transport racing `turn/interrupt` is treated as non-fatal because the turn is already stopping.

## Related Issue

Fixes #62101

## Why

Cron constructs a fresh `AIAgent` per run. The Codex runtime lazily attaches a `CodexAppServerSession`, but `AIAgent.close()` does not currently own that session. In a one-shot CLI process, parent exit masks the problem; in the long-lived gateway, the client reader threads keep the subprocess and its pipes alive indefinitely.

Cleanup originally landed immediately after `ThreadPoolExecutor.shutdown(wait=False)`. Review correctly identified that the worker can still be inside `run_turn()` at that point. This revision moves cleanup to the centralized cron teardown path and makes the active turn safe when close happens concurrently.

## Validation

- `pytest -o addopts='' tests/agent/test_codex_runtime_close.py tests/agent/transports/test_codex_app_server_session.py tests/cron/test_run_one_job.py -q` — **79 passed**
- `pytest -o addopts='' tests/cron/test_cron_inactivity_timeout.py tests/cron/test_codex_execution_paths.py -q` — **13 passed**
- `python -m py_compile` for all changed production and test modules — passed
- Mutation check: temporarily restoring the unsafe `self._client.is_alive()` dereference made the new concurrency regression fail with the original `AttributeError`; restoring the fix returned the suite to green.

The focused regressions cover:

- session close and reference clearing
- no-op cleanup without a session
- cleanup despite a session close error
- close racing an active `run_turn()`
- close racing `turn/interrupt`
- centralized scheduler teardown, including when `agent.close()` fails

## Manual verification

With `provider: openai-codex` and `openai_runtime: codex_app_server`, a triggered cron run returns the gateway's Codex child-process count to baseline after delivery/teardown instead of leaking one app-server per run.

## Checklist

- [x] Bug fix is scoped to Codex app-server cron lifecycle cleanup
- [x] Cleanup uses the existing centralized cron teardown path
- [x] Concurrent-close behavior has regression coverage
- [x] Focused agent/session/cron tests pass
- [x] Broader cron inactivity and Codex execution-path tests pass
- [x] Tested on macOS arm64 with Python 3.11
