### PR TITLE
feat(ci): add /assign self-assign workflow for issues

### DIFF
--- a/.github/workflows/issue-assign.yml
+++ b/.github/workflows/issue-assign.yml
@@ -1,0 +1,179 @@
+name: Issue Self-Assign
+
+# Opt-in, degrades-gracefully issue-claim tooling.
+#
+# Contributors comment `/assign` to assign an open issue to themselves and
+# `/unassign` to release it. GitHub's native Assignees field is the source of
+# truth; this only lets a contributor self-serve it instead of waiting on a
+# maintainer. A daily sweep releases claims that never turned into a PR so an
+# abandoned claim never blocks an issue for good.
+
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    # Daily stale-claim sweep at 07:00 UTC.
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+    inputs:
+      stale_days:
+        description: "Days of inactivity before an unclaimed assignment is released"
+        required: false
+        default: "14"
+
+permissions:
+  issues: write
+  contents: read
+
+concurrency:
+  group: issue-self-assign-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  assign:
+    name: Handle /assign and /unassign
+    if: >-
+      github.repository == 'NousResearch/hermes-agent' &&
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request == null &&
+      (startsWith(github.event.comment.body, '/assign') || startsWith(github.event.comment.body, '/unassign'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const body = context.payload.comment.body.trim();
+            const isAssign = /^\/assign\s*$/i.test(body);
+            const isUnassign = /^\/unassign\s*$/i.test(body);
+            if (!isAssign && !isUnassign) {
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.issue.number;
+            const commenter = context.payload.comment.user.login;
+            const current = (context.payload.issue.assignees || []).map((a) => a.login);
+
+            const react = async (content) => {
+              try {
+                await github.rest.reactions.createForIssueComment({
+                  owner,
+                  repo,
+                  comment_id: context.payload.comment.id,
+                  content,
+                });
+              } catch (err) {
+                core.warning(`Could not add reaction: ${err.message}`);
+              }
+            };
+
+            if (isUnassign) {
+              if (current.includes(commenter)) {
+                await github.rest.issues.removeAssignees({
+                  owner,
+                  repo,
+                  issue_number,
+                  assignees: [commenter],
+                });
+                await react("+1");
+              }
+              return;
+            }
+
+            const others = current.filter((login) => login !== commenter);
+            if (others.length > 0) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body:
+                  `This issue is already assigned to @${others[0]}. ` +
+                  `If that claim looks stale, comment here and a maintainer can reassign it — ` +
+                  `unclaimed assignments are released automatically after a period of inactivity.`,
+              });
+              return;
+            }
+
+            if (current.includes(commenter)) {
+              await react("+1");
+              return;
+            }
+
+            await github.rest.issues.addAssignees({
+              owner,
+              repo,
+              issue_number,
+              assignees: [commenter],
+            });
+            await react("rocket");
+
+  expire-stale-claims:
+    name: Release stale claims
+    if: >-
+      github.repository == 'NousResearch/hermes-agent' &&
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const staleDays = parseInt(
+              (context.payload.inputs && context.payload.inputs.stale_days) || "14",
+              10,
+            ) || 14;
+            const cutoff = Date.now() - staleDays * 24 * 60 * 60 * 1000;
+            const { owner, repo } = context.repo;
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: "open",
+              assignee: "*",
+              per_page: 100,
+            });
+
+            for (const issue of issues) {
+              if (issue.pull_request) {
+                continue;
+              }
+              const assignees = (issue.assignees || []).map((a) => a.login);
+              if (assignees.length === 0) {
+                continue;
+              }
+              if (new Date(issue.updated_at).getTime() >= cutoff) {
+                continue;
+              }
+
+              const timeline = await github.paginate(
+                github.rest.issues.listEventsForTimeline,
+                { owner, repo, issue_number: issue.number, per_page: 100 },
+              );
+              const hasLinkedPR = timeline.some(
+                (e) =>
+                  e.event === "cross-referenced" &&
+                  e.source &&
+                  e.source.issue &&
+                  e.source.issue.pull_request,
+              );
+              if (hasLinkedPR) {
+                continue;
+              }
+
+              await github.rest.issues.removeAssignees({
+                owner,
+                repo,
+                issue_number: issue.number,
+                assignees,
+              });
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issue.number,
+                body:
+                  `Releasing this claim: no linked pull request and no activity for ` +
+                  `${staleDays}+ days. ${assignees.map((a) => "@" + a).join(", ")}, ` +
+                  `comment \`/assign\` to pick it back up.`,
+              });
+            }

--- a/.github/workflows/issue-assign.yml
+++ b/.github/workflows/issue-assign.yml
@@ -100,6 +100,40 @@ jobs:
               return;
             }
 
+            // GitHub's Assignees field only accepts users it considers
+            // assignable (collaborators / prior assignees). For everyone else
+            // `addAssignees` fails with a 404, so preflight eligibility and
+            // degrade gracefully instead of surfacing a red workflow run.
+            let assignable = false;
+            try {
+              await github.rest.issues.checkUserCanBeAssigned({
+                owner,
+                repo,
+                assignee: commenter,
+              });
+              assignable = true;
+            } catch (err) {
+              if (err.status !== 404) {
+                throw err;
+              }
+            }
+
+            if (!assignable) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body:
+                  `Thanks for offering to take this on, @${commenter}! GitHub only lets ` +
+                  `accounts with repository access be set in the Assignees field, so I can't ` +
+                  `assign it to you directly — but your claim is recorded right here. Open a ` +
+                  `pull request that references this issue (e.g. \`Closes #${issue_number}\`) ` +
+                  `and a maintainer can formalize the assignment.`,
+              });
+              await react("+1");
+              return;
+            }
+
             await github.rest.issues.addAssignees({
               owner,
               repo,
@@ -150,12 +184,19 @@ jobs:
                 github.rest.issues.listEventsForTimeline,
                 { owner, repo, issue_number: issue.number, per_page: 100 },
               );
+              // A PR referenced from a comment/description surfaces as a
+              // `cross-referenced` event carrying the source PR; a PR linked
+              // through the "Development" sidebar surfaces as a `connected`
+              // event, which the REST timeline does not expand into a source.
+              // Treat either form as a live link so a manually linked PR keeps
+              // the claim from being swept.
               const hasLinkedPR = timeline.some(
                 (e) =>
-                  e.event === "cross-referenced" &&
-                  e.source &&
-                  e.source.issue &&
-                  e.source.issue.pull_request,
+                  (e.event === "cross-referenced" &&
+                    e.source &&
+                    e.source.issue &&
+                    e.source.issue.pull_request) ||
+                  e.event === "connected",
               );
               if (hasLinkedPR) {
                 continue;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ A quick search before you build saves your time and keeps the PR queue clean —
   Or use the web UI: [issues](https://github.com/NousResearch/hermes-agent/issues?q=) · [PRs (all states)](https://github.com/NousResearch/hermes-agent/pulls?q=is%3Apr).
 - **The issue tracker can lag the code.** Many requested features are already implemented in-tree, so also search the source (`search_files`, or your editor's grep) for the capability before proposing it.
 - **If an open PR already addresses it**, consider reviewing or improving that one instead of opening a competing duplicate.
-- **For larger work**, comment on the issue to signal you're working on it, so others don't start the same thing. Comment `/assign` to assign the issue to yourself (and `/unassign` to release it); claims with no linked PR and no activity for 14 days are released automatically so nothing stays blocked by an abandoned claim.
+- **For larger work**, comment on the issue to signal you're working on it, so others don't start the same thing. Comment `/assign` to claim it (and `/unassign` to release it): if your account has repository access it goes straight into the Assignees field, otherwise the claim is recorded as a comment and a maintainer can formalize it. Either way, claims with no linked PR and no activity for 14 days are released automatically so nothing stays blocked by an abandoned claim.
 
 Related: #38284 covers the agent-side analog — Hermes itself checking existing issues and PRs before deep self-troubleshooting. This section is the human-contributor complement.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ A quick search before you build saves your time and keeps the PR queue clean —
   Or use the web UI: [issues](https://github.com/NousResearch/hermes-agent/issues?q=) · [PRs (all states)](https://github.com/NousResearch/hermes-agent/pulls?q=is%3Apr).
 - **The issue tracker can lag the code.** Many requested features are already implemented in-tree, so also search the source (`search_files`, or your editor's grep) for the capability before proposing it.
 - **If an open PR already addresses it**, consider reviewing or improving that one instead of opening a competing duplicate.
-- **For larger work**, comment on the issue to signal you're working on it, so others don't start the same thing.
+- **For larger work**, comment on the issue to signal you're working on it, so others don't start the same thing. Comment `/assign` to assign the issue to yourself (and `/unassign` to release it); claims with no linked PR and no activity for 14 days are released automatically so nothing stays blocked by an abandoned claim.
 
 Related: #38284 covers the agent-side analog — Hermes itself checking existing issues and PRs before deep self-troubleshooting. This section is the human-contributor complement.
 


### PR DESCRIPTION
## Problem

Only a maintainer can set the Assignees field on an issue today. A contributor who wants to pick up an issue has no way to claim it themselves, so two people can start the same work and race to open a PR. `CONTRIBUTING.md` documents a comment-only norm for this, but a free-text comment carries no structured state and is easy to miss.

## Solution

Add `.github/workflows/issue-assign.yml`, an opt-in workflow that lets contributors manage their own claim through issue comments:

- `/assign` assigns the issue to the commenter.
- `/unassign` removes the commenter's own assignment.
- If the issue is already assigned to someone else, the workflow posts a short reply pointing at the current assignee instead of silently double-assigning.

A separate daily job releases a claim when the assigned issue has no linked pull request and no activity for a configurable number of days (default 14, exposed as a `workflow_dispatch` input). It only clears the assignment and never closes the issue, so a stale claim cannot block an issue for good.

The change also adds one line to `CONTRIBUTING.md` documenting the `/assign` and `/unassign` commands next to the existing "signal you're working on it" guidance.

Design choices match this repo's posture:

- No third-party marketplace action. The logic runs in `actions/github-script`, SHA-pinned to `3a2844b7e9c422d3c10d287c895573f7108da1b3` (v9.0.0) per the dependency-pinning policy.
- Minimal permissions: `issues: write` and `contents: read`.
- Gated to the upstream repo with `if: github.repository == 'NousResearch/hermes-agent'` so forks do not run it, matching `skills-index.yml`.
- Both jobs set `timeout-minutes`, consistent with the other workflows.

## Testing

- Validated the workflow parses: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/issue-assign.yml'))"`.
- Syntax-checked both embedded `github-script` bodies with `node --check`.
- Confirmed no existing workflow, issue, or PR covers self-serve issue assignment before writing this.

Full end-to-end behavior (comment triggers, the double-assign guard, and the daily sweep) needs the workflow living on the default branch to fire, so it is best verified on a maintainer's throwaway issue once this lands, or on a fork with the workflow enabled.

This is a contributor-workflow decision rather than a bug fix, so I opened an issue first to get a maintainer's read on whether the behavior and defaults are wanted.

Closes #62113
