### PR TITLE
feat(ci): add DCO sign-off check for pull requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -44,6 +44,7 @@ Fixes #
 
 - [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
 - [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
+- [ ] My commits are signed off (`git commit -s`) per the [DCO](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#sign-off-your-commits-dco)
 - [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
 - [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
 - [ ] I've run `pytest tests/ -q` and all tests pass

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,12 @@ jobs:
     if: needs.detect.outputs.python == 'true'
     uses: ./.github/workflows/contributor-check.yml
 
+  dco:
+    name: Check DCO sign-off
+    needs: detect
+    if: needs.detect.outputs.event_name == 'pull_request'
+    uses: ./.github/workflows/dco.yml
+
   uv-lockfile:
     name: Check uv.lock
     needs: detect
@@ -143,6 +149,7 @@ jobs:
       - docs-site
       - history-check
       - contributor-check
+      - dco
       - uv-lockfile
       - docker-lint
       - supply-chain

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,8 +1,9 @@
 name: DCO Sign-off Check
 
 # Verifies every non-merge, non-bot commit in a pull request carries a
-# `Signed-off-by:` trailer matching its author, per the Developer Certificate
-# of Origin (https://developercertificate.org). Contributors add it with
+# `Signed-off-by:` trailer (parsed with `git interpret-trailers`, not matched
+# in prose) matching its author OR committer, per the Developer Certificate of
+# Origin (https://developercertificate.org). Contributors add it with
 # `git commit -s`. Mirrors the bot-exemption logic in contributor-check.yml.
 
 on:
@@ -22,55 +23,4 @@ jobs:
           fetch-depth: 0  # Full history needed for git log over the PR range
 
       - name: Verify Signed-off-by trailer on each commit
-        run: |
-          # Range of commits this PR adds on top of main.
-          MERGE_BASE=$(git merge-base origin/main HEAD)
-          COMMITS=$(git rev-list --no-merges "${MERGE_BASE}..HEAD")
-
-          if [ -z "$COMMITS" ]; then
-            echo "No commits to check."
-            exit 0
-          fi
-
-          MISSING=""
-          for sha in $COMMITS; do
-            author_name=$(git show -s --format='%an' "$sha")
-            author_email=$(git show -s --format='%ae' "$sha")
-
-            # Exempt bots the same way contributor-check.yml does.
-            case "$author_email" in
-              *noreply@github.com*|*dependabot*|*github-actions*)
-                echo "skip (bot)  ${sha:0:9}  ${author_email}"
-                continue ;;
-            esac
-
-            expected="Signed-off-by: ${author_name} <${author_email}>"
-            if git show -s --format='%B' "$sha" | grep -qiF "$expected"; then
-              echo "ok          ${sha:0:9}  $(git show -s --format='%s' "$sha")"
-            else
-              subject=$(git show -s --format='%s' "$sha")
-              MISSING="${MISSING}\n  ${sha:0:9}  ${subject}\n      missing: ${expected}"
-            fi
-          done
-
-          if [ -n "$MISSING" ]; then
-            echo ""
-            echo "❌ Commit(s) missing a matching Signed-off-by trailer:"
-            echo -e "$MISSING"
-            echo ""
-            echo "Sign off your commits to certify the Developer Certificate of Origin"
-            echo "(https://developercertificate.org):"
-            echo ""
-            echo "  # sign the most recent commit"
-            echo "  git commit --amend --no-edit -s"
-            echo ""
-            echo "  # sign every commit on this branch, then force-push"
-            echo "  git rebase --exec 'git commit --amend --no-edit -s' origin/main"
-            echo "  git push --force-with-lease"
-            echo ""
-            echo "Add -s to future commits (git commit -s) to sign off automatically."
-            exit 1
-          fi
-
-          echo ""
-          echo "✅ All commits are signed off."
+        run: python3 scripts/ci/check_dco.py origin/main HEAD

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,76 @@
+name: DCO Sign-off Check
+
+# Verifies every non-merge, non-bot commit in a pull request carries a
+# `Signed-off-by:` trailer matching its author, per the Developer Certificate
+# of Origin (https://developercertificate.org). Contributors add it with
+# `git commit -s`. Mirrors the bot-exemption logic in contributor-check.yml.
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  dco:
+    name: Check DCO sign-off
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0  # Full history needed for git log over the PR range
+
+      - name: Verify Signed-off-by trailer on each commit
+        run: |
+          # Range of commits this PR adds on top of main.
+          MERGE_BASE=$(git merge-base origin/main HEAD)
+          COMMITS=$(git rev-list --no-merges "${MERGE_BASE}..HEAD")
+
+          if [ -z "$COMMITS" ]; then
+            echo "No commits to check."
+            exit 0
+          fi
+
+          MISSING=""
+          for sha in $COMMITS; do
+            author_name=$(git show -s --format='%an' "$sha")
+            author_email=$(git show -s --format='%ae' "$sha")
+
+            # Exempt bots the same way contributor-check.yml does.
+            case "$author_email" in
+              *noreply@github.com*|*dependabot*|*github-actions*)
+                echo "skip (bot)  ${sha:0:9}  ${author_email}"
+                continue ;;
+            esac
+
+            expected="Signed-off-by: ${author_name} <${author_email}>"
+            if git show -s --format='%B' "$sha" | grep -qiF "$expected"; then
+              echo "ok          ${sha:0:9}  $(git show -s --format='%s' "$sha")"
+            else
+              subject=$(git show -s --format='%s' "$sha")
+              MISSING="${MISSING}\n  ${sha:0:9}  ${subject}\n      missing: ${expected}"
+            fi
+          done
+
+          if [ -n "$MISSING" ]; then
+            echo ""
+            echo "❌ Commit(s) missing a matching Signed-off-by trailer:"
+            echo -e "$MISSING"
+            echo ""
+            echo "Sign off your commits to certify the Developer Certificate of Origin"
+            echo "(https://developercertificate.org):"
+            echo ""
+            echo "  # sign the most recent commit"
+            echo "  git commit --amend --no-edit -s"
+            echo ""
+            echo "  # sign every commit on this branch, then force-push"
+            echo "  git rebase --exec 'git commit --amend --no-edit -s' origin/main"
+            echo "  git push --force-with-lease"
+            echo ""
+            echo "Add -s to future commits (git commit -s) to sign off automatically."
+            exit 1
+          fi
+
+          echo ""
+          echo "✅ All commits are signed off."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -999,7 +999,7 @@ That appends a trailer matching your git identity:
 Signed-off-by: Your Name <you@example.com>
 ```
 
-The trailer must match the commit author's name and email. Bot commits (Dependabot, GitHub Actions) are exempt.
+`git commit -s` signs off as the **committer**. The check accepts a trailer matching either the commit's author or its committer, so `git commit --author="Someone Else <them@example.com>" -s` (you commit, they authored) still passes on your sign-off. Bot commits (Dependabot, GitHub Actions) are exempt.
 
 Forgot to sign off? Retrofit before pushing:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -983,6 +983,37 @@ fix(security): prevent shell injection in sudo password piping
 test(tools): add unit tests for file_operations
 ```
 
+### Sign off your commits (DCO)
+
+Every commit must carry a `Signed-off-by:` trailer. Signing off certifies the [Developer Certificate of Origin](https://developercertificate.org) — you confirm you wrote the change (or have the right to submit it) and agree to contribute it under the project's [MIT License](LICENSE). There is no separate agreement to sign; the trailer is the whole attestation.
+
+Add it automatically with `-s`:
+
+```bash
+git commit -s -m "fix(cli): prevent crash on empty model string"
+```
+
+That appends a trailer matching your git identity:
+
+```
+Signed-off-by: Your Name <you@example.com>
+```
+
+The trailer must match the commit author's name and email. Bot commits (Dependabot, GitHub Actions) are exempt.
+
+Forgot to sign off? Retrofit before pushing:
+
+```bash
+# most recent commit
+git commit --amend --no-edit -s
+
+# every commit on the branch, then force-push
+git rebase --exec 'git commit --amend --no-edit -s' origin/main
+git push --force-with-lease
+```
+
+CI runs a DCO check on every pull request; an unsigned commit fails the check with the exact command to fix it.
+
 ---
 
 ## Reporting Issues

--- a/scripts/ci/check_dco.py
+++ b/scripts/ci/check_dco.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Verify every non-merge, non-bot commit in a range carries a DCO sign-off.
+
+A commit satisfies the Developer Certificate of Origin
+(https://developercertificate.org) when it has a ``Signed-off-by:`` *trailer*
+whose ``Name <email>`` identity matches **either the commit's author or its
+committer**.
+
+Two deliberate choices, both prompted by review of the first draft of this
+check:
+
+* **Author *or* committer.** ``git commit -s`` appends the sign-off for the
+  *committer*, which is not always the author (e.g. ``git commit --author=... -s``
+  or an applied patch). Requiring the trailer to match only the author would
+  reject those documented, valid workflows, so a sign-off from either identity
+  is accepted — the same rule the reference DCO GitHub App uses.
+* **Parsed trailer, not a substring.** Sign-offs are extracted with
+  ``git interpret-trailers --parse`` so only a real trailer in the message's
+  trailer block counts. A ``Signed-off-by:`` line sitting in ordinary prose
+  does not satisfy the check.
+
+Bot commits (Dependabot, GitHub Actions, GitHub noreply) are exempt, mirroring
+``contributor-check.yml``.
+
+Usage::
+
+    python3 scripts/ci/check_dco.py [<base-ref>] [<head-ref>]
+
+Defaults to ``origin/main`` and ``HEAD``. Exits non-zero (and prints the exact
+remediation commands) when any commit is missing a matching sign-off trailer.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+# Author/committer emails we never require a sign-off from, matched as
+# substrings the same way contributor-check.yml exempts them.
+_BOT_EMAIL_MARKERS = ("noreply@github.com", "dependabot", "github-actions")
+
+
+def format_identity(name: str, email: str) -> str:
+    """Render a git identity the way a ``Signed-off-by`` trailer does."""
+    return f"{name} <{email}>"
+
+
+def is_bot_email(email: str) -> bool:
+    """True for automation identities that are exempt from sign-off."""
+    lowered = email.lower()
+    return any(marker in lowered for marker in _BOT_EMAIL_MARKERS)
+
+
+def parse_signoff_trailers(parsed_trailers: str) -> list[str]:
+    """Pull ``Signed-off-by`` values out of ``git interpret-trailers --parse`` output.
+
+    The input is the newline-separated ``Key: Value`` block that
+    ``git interpret-trailers --parse`` emits — only real trailers appear there,
+    so a ``Signed-off-by:`` line buried in prose never reaches this function.
+    """
+    signoffs: list[str] = []
+    for line in parsed_trailers.splitlines():
+        key, sep, value = line.partition(":")
+        if sep and key.strip().lower() == "signed-off-by":
+            signoffs.append(value.strip())
+    return signoffs
+
+
+def is_signed_off(author_identity: str, committer_identity: str, signoffs: list[str]) -> bool:
+    """True when a sign-off matches the author or committer (case-insensitively)."""
+    accepted = {author_identity.strip().lower(), committer_identity.strip().lower()}
+    return any(s.strip().lower() in accepted for s in signoffs)
+
+
+def _git(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def _signoffs_for(sha: str) -> list[str]:
+    body = _git("show", "-s", "--format=%B", sha)
+    parsed = subprocess.run(
+        ["git", "interpret-trailers", "--parse"],
+        input=body,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    return parse_signoff_trailers(parsed)
+
+
+def load_commit(sha: str) -> dict:
+    """Collect the identity, subject, and sign-off trailers for one commit."""
+    fields = _git(
+        "show", "-s", "--format=%an%x00%ae%x00%cn%x00%ce%x00%s", sha
+    ).rstrip("\n")
+    an, ae, cn, ce, subject = fields.split("\x00", 4)
+    return {
+        "sha": sha,
+        "subject": subject,
+        "author_identity": format_identity(an, ae),
+        "committer_identity": format_identity(cn, ce),
+        "author_email": ae,
+        "committer_email": ce,
+        "signoffs": _signoffs_for(sha),
+    }
+
+
+def commit_range(base_ref: str, head_ref: str) -> list[str]:
+    merge_base = _git("merge-base", base_ref, head_ref).strip()
+    revs = _git("rev-list", "--no-merges", f"{merge_base}..{head_ref}").split()
+    return revs
+
+
+def main(argv: list[str]) -> int:
+    base_ref = argv[1] if len(argv) > 1 else "origin/main"
+    head_ref = argv[2] if len(argv) > 2 else "HEAD"
+
+    shas = commit_range(base_ref, head_ref)
+    if not shas:
+        print("No commits to check.")
+        return 0
+
+    missing: list[dict] = []
+    for sha in shas:
+        commit = load_commit(sha)
+        is_bot = is_bot_email(commit["author_email"]) or is_bot_email(commit["committer_email"])
+        signed_off = is_signed_off(
+            commit["author_identity"], commit["committer_identity"], commit["signoffs"]
+        )
+        if is_bot:
+            print(f"skip (bot)  {sha[:9]}  {commit['author_email']}")
+        elif signed_off:
+            print(f"ok          {sha[:9]}  {commit['subject']}")
+        else:
+            missing.append(commit)
+
+    if missing:
+        print("")
+        print("Commit(s) missing a matching Signed-off-by trailer:")
+        for commit in missing:
+            print(f"  {commit['sha'][:9]}  {commit['subject']}")
+            print(f"      expected a trailer matching: {commit['author_identity']}")
+            print(f"      or the committer:            {commit['committer_identity']}")
+        print("")
+        print("Sign off your commits to certify the Developer Certificate of Origin")
+        print("(https://developercertificate.org):")
+        print("")
+        print("  # sign the most recent commit")
+        print("  git commit --amend --no-edit -s")
+        print("")
+        print("  # sign every commit on this branch, then force-push")
+        print("  git rebase --exec 'git commit --amend --no-edit -s' origin/main")
+        print("  git push --force-with-lease")
+        print("")
+        print("Add -s to future commits (git commit -s) to sign off automatically.")
+        return 1
+
+    print("")
+    print("All commits are signed off.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/ci/test_check_dco.py
+++ b/tests/ci/test_check_dco.py
@@ -1,0 +1,189 @@
+"""Tests for scripts/ci/check_dco.py.
+
+Two things the DCO check must get right (both raised in review of the first
+draft):
+
+* A sign-off is accepted when it matches the **author or the committer** —
+  ``git commit -s`` signs off as the committer, so ``--author=... -s`` must pass.
+* A ``Signed-off-by:`` line only counts when it is a real trailer, not prose
+  sitting in the commit body.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_PATH = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "check_dco.py"
+_spec = importlib.util.spec_from_file_location("check_dco", _PATH)
+if _spec is None or _spec.loader is None:
+    raise ImportError("Failed to load check_dco.py")
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+
+# --- pure helpers ---------------------------------------------------------
+
+
+def test_parse_signoff_trailers_extracts_only_signoff_keys():
+    parsed = "Signed-off-by: Real Person <real@example.com>\nReviewed-by: Someone <s@example.com>"
+    assert _mod.parse_signoff_trailers(parsed) == ["Real Person <real@example.com>"]
+
+
+def test_parse_signoff_trailers_empty_when_no_trailers():
+    assert _mod.parse_signoff_trailers("") == []
+
+
+def test_is_signed_off_matches_author():
+    author = "Ann Author <ann@example.com>"
+    committer = "Ann Author <ann@example.com>"
+    assert _mod.is_signed_off(author, committer, [author])
+
+
+def test_is_signed_off_matches_committer_when_author_differs():
+    # git commit --author="Ann" -s  →  author is Ann, committer + sign-off are Cody.
+    author = "Ann Author <ann@example.com>"
+    committer = "Cody Committer <cody@example.com>"
+    assert _mod.is_signed_off(author, committer, [committer])
+
+
+def test_is_signed_off_case_insensitive():
+    author = "Ann Author <Ann@Example.com>"
+    committer = author
+    assert _mod.is_signed_off(author, committer, ["ann author <ann@example.com>"])
+
+
+def test_is_signed_off_false_when_signoff_matches_nobody():
+    author = "Ann Author <ann@example.com>"
+    committer = "Cody Committer <cody@example.com>"
+    assert not _mod.is_signed_off(author, committer, ["Ghost <ghost@example.com>"])
+
+
+def test_is_signed_off_false_when_no_signoffs():
+    assert not _mod.is_signed_off("A <a@x>", "A <a@x>", [])
+
+
+@pytest.mark.parametrize(
+    "email",
+    [
+        "49699333+dependabot[bot]@users.noreply.github.com",
+        "github-actions[bot]@users.noreply.github.com",
+        "12345+bot@noreply@github.com",
+    ],
+)
+def test_is_bot_email_true(email):
+    assert _mod.is_bot_email(email)
+
+
+@pytest.mark.parametrize(
+    "email",
+    [
+        "real@example.com",
+        # A human using GitHub's noreply address is not a bot and must sign off.
+        "octocat@users.noreply.github.com",
+    ],
+)
+def test_is_bot_email_false_for_human(email):
+    assert not _mod.is_bot_email(email)
+
+
+# --- end-to-end against a real git repo -----------------------------------
+
+
+def _run_git(repo: Path, *args: str, env: dict | None = None) -> str:
+    result = subprocess.run(
+        ["git", "-c", "commit.gpgsign=false", *args],
+        cwd=repo,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def _commit(repo, message, *, author, committer=None, signoff=False) -> None:
+    committer = committer or author
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": author[0],
+        "GIT_AUTHOR_EMAIL": author[1],
+        "GIT_COMMITTER_NAME": committer[0],
+        "GIT_COMMITTER_EMAIL": committer[1],
+    }
+    args = ["commit", "--allow-empty", "-m", message]
+    if signoff:
+        args.append("-s")  # signs off as the committer, per git docs
+    _run_git(repo, *args, env=env)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A git repo with one base commit; yields (path, base_sha).
+
+    ``base_sha`` is captured before any test commit so the checked range
+    (``base_sha..HEAD``) is exactly the commits the test adds.
+    """
+    _run_git(tmp_path, "init", "-q", "-b", "main")
+    _commit(tmp_path, "chore: base", author=("Base", "base@example.com"), signoff=True)
+    base_sha = _run_git(tmp_path, "rev-parse", "HEAD").strip()
+    return tmp_path, base_sha
+
+
+def _check(repo, monkeypatch) -> int:
+    path, base_sha = repo
+    monkeypatch.chdir(path)
+    return _mod.main(["check_dco.py", base_sha, "HEAD"])
+
+
+def test_signed_off_commit_passes(repo, monkeypatch):
+    _commit(repo[0], "feat: thing", author=("Ann", "ann@example.com"), signoff=True)
+    assert _check(repo, monkeypatch) == 0
+
+
+def test_author_committer_divergence_passes_on_committer_signoff(repo, monkeypatch):
+    # The exact workflow the review flagged: author != committer, `-s` signs
+    # off as the committer. This must pass.
+    _commit(
+        repo[0],
+        "feat: applied patch",
+        author=("Ann Author", "ann@example.com"),
+        committer=("Cody Committer", "cody@example.com"),
+        signoff=True,
+    )
+    assert _check(repo, monkeypatch) == 0
+
+
+def test_unsigned_commit_fails(repo, monkeypatch):
+    _commit(repo[0], "feat: unsigned", author=("Ann", "ann@example.com"), signoff=False)
+    assert _check(repo, monkeypatch) == 1
+
+
+def test_prose_decoy_is_not_a_trailer(repo, monkeypatch):
+    # "Signed-off-by:" in the body, but followed by another paragraph, so it is
+    # not in the trailer block. It must NOT satisfy the check.
+    message = (
+        "feat: sneaky\n\n"
+        "Signed-off-by: Ann <ann@example.com>\n\n"
+        "This trailing paragraph makes the line above prose, not a trailer."
+    )
+    _commit(repo[0], message, author=("Ann", "ann@example.com"), signoff=False)
+    assert _check(repo, monkeypatch) == 1
+
+
+def test_bot_commit_exempt_without_signoff(repo, monkeypatch):
+    _commit(
+        repo[0],
+        "chore(deps): bump thing",
+        author=("dependabot[bot]", "49699333+dependabot[bot]@users.noreply.github.com"),
+        signoff=False,
+    )
+    assert _check(repo, monkeypatch) == 0
+
+
+def test_empty_range_passes(repo, monkeypatch):
+    assert _check(repo, monkeypatch) == 0


### PR DESCRIPTION
## What does this PR do?

Adds a Developer Certificate of Origin (DCO) sign-off check so every contribution carries an explicit per-commit license attestation. Today the only outbound-license statement is one implicit line in `CONTRIBUTING.md`; there is no commit trailer and no automated check.

This is a governance call (DCO vs CLA vs neither), so it is filed as a proposal with a reference implementation rather than an assertion of policy. The linked issue lays out the DCO-vs-CLA framing. A maintainer can accept, adjust, or close it.

## Related Issue

Closes #62119

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `.github/workflows/dco.yml`: reusable `workflow_call` check. Walks the PR commit range and verifies each non-merge, non-bot commit has a `Signed-off-by:` trailer matching its author. Bots (Dependabot, GitHub Actions) are exempt, mirroring `contributor-check.yml`. The checkout action is SHA-pinned per the repo's dependency policy.
- `.github/workflows/ci.yml`: wires the `dco` job into the orchestrator (gated to `pull_request`) and adds it to the `all-checks-pass` gate.
- `CONTRIBUTING.md`: adds a "Sign off your commits (DCO)" section covering `git commit -s` and the amend/rebase retrofit.
- `.github/PULL_REQUEST_TEMPLATE.md`: adds a sign-off checklist item.

## How to Test

1. Parse the workflows: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/dco.yml')); yaml.safe_load(open('.github/workflows/ci.yml'))"`.
2. Match logic: a commit whose body contains `Signed-off-by: <author name> <author email>` passes; a commit without it fails and prints the exact remediation command.
3. The commit in this PR is signed off, so the check passes on its own range.

## Notes

- The check runs only on `pull_request` events, so it does not run on direct pushes to `main`.
- Matching is strict: the trailer must match the commit author, which follows the standard DCO behavior. The exemption list and strictness are easy to adjust if maintainers prefer.
- The new workflow file does not run on this PR yet, because GitHub executes workflows from the base branch for `pull_request` events. It takes effect once merged to `main`.
