### PR TITLE
fix(vision): resolve image paths whose Unicode whitespace was flattened to U+0020

### DIFF
--- a/tests/tools/test_image_source_unicode_space.py
+++ b/tests/tools/test_image_source_unicode_space.py
@@ -100,3 +100,69 @@ class TestResolveImageSource:
 
         with pytest.raises(SourceNotFound):
             _resolve(tmp_path / "a b.png")
+
+    def test_leading_and_trailing_unicode_space_is_stripped_before_lookup(
+        self, tmp_path, monkeypatch,
+    ):
+        """``resolve_image_source`` strips the source first; U+202F is whitespace.
+
+        Pinned so nobody mistakes the strip for the fuzzy retry: a trailing NNBSP
+        never reaches ``_fuzzy_whitespace_match`` at all.
+        """
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        exact = tmp_path / "plain.png"
+        exact.write_bytes(PNG)
+        assert _resolve(f"{NNBSP}{exact}{NNBSP}").data == PNG
+
+    def test_internal_narrow_space_survives_the_strip(self, tmp_path, monkeypatch):
+        """The macOS case is an INTERNAL U+202F; only the retry can rescue it."""
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        (tmp_path / f"shot at 9.23.58{NNBSP}AM.png").write_bytes(PNG)
+        assert _resolve(tmp_path / "shot at 9.23.58 AM.png").data == PNG
+
+
+class TestCredentialGuardStillApplies:
+    def test_guard_receives_the_fuzzy_resolved_path(self, tmp_path, monkeypatch):
+        """The retry's target must go through raise_if_read_blocked, not around it."""
+        import agent.file_safety as fs
+
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        real = tmp_path / f"a{NNBSP}b.png"
+        real.write_bytes(PNG)
+
+        seen = []
+        monkeypatch.setattr(fs, "raise_if_read_blocked", lambda p: seen.append(p))
+
+        _resolve(tmp_path / "a b.png")
+
+        assert seen == [str(real)], (
+            "the guard must be handed the path the retry actually resolved to"
+        )
+
+    def test_guard_can_still_block_a_fuzzy_resolved_path(self, tmp_path, monkeypatch):
+        import agent.file_safety as fs
+        from tools.image_source import SourceUnsafe
+
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        (tmp_path / f"a{NNBSP}b.png").write_bytes(PNG)
+
+        def deny(_path):
+            raise ValueError("Access denied: test")
+
+        monkeypatch.setattr(fs, "raise_if_read_blocked", deny)
+
+        with pytest.raises(SourceUnsafe):
+            _resolve(tmp_path / "a b.png")
+
+    def test_no_blocked_basename_can_be_fabricated_by_flattening(self):
+        """A blocked name has no preimage but itself.
+
+        ``_flatten_unicode_spaces`` only maps Zs -> U+0020. No blocked basename
+        contains a Zs codepoint, so no *other* filename can flatten onto one and
+        be picked up by the retry.
+        """
+        from agent.file_safety import _BLOCKED_PROJECT_ENV_BASENAMES as blocked
+
+        assert blocked, "sanity: the denylist is non-empty"
+        for name in blocked:
+            assert _flatten_unicode_spaces(name) == name, name

--- a/tests/tools/test_image_source_unicode_space.py
+++ b/tests/tools/test_image_source_unicode_space.py
@@ -1,0 +1,102 @@
+"""Resolve image paths whose Unicode whitespace was flattened to U+0020.
+
+macOS names screenshots ``Screenshot 2026-07-10 at 9.23.58<U+202F>AM.png``, using a
+NARROW NO-BREAK SPACE before AM/PM. A model that lists the directory and echoes the
+name back almost always emits a plain space, so ``vision_analyze`` reported
+"image file not found" for a file it had just been shown.
+
+The retry is deliberately narrow: same directory, unique match only, local backend
+only. It must never resolve a genuinely missing file, and never pick between
+ambiguous candidates.
+"""
+import asyncio
+
+import pytest
+
+from tools.image_source import (
+    SourceNotFound,
+    _flatten_unicode_spaces,
+    _fuzzy_whitespace_match,
+    ResolveContext,
+    resolve_image_source,
+)
+
+NNBSP = "\u202f"  # NARROW NO-BREAK SPACE (macOS screenshot names)
+NBSP = "\u00a0"   # NO-BREAK SPACE
+PNG = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+def _resolve(path):
+    return asyncio.run(resolve_image_source(str(path), ResolveContext()))
+
+
+class TestFlattenUnicodeSpaces:
+    def test_folds_narrow_no_break_space(self):
+        assert _flatten_unicode_spaces(f"9.23.58{NNBSP}AM.png") == "9.23.58 AM.png"
+
+    def test_folds_no_break_space(self):
+        assert _flatten_unicode_spaces(f"a{NBSP}b") == "a b"
+
+    def test_leaves_ordinary_names_alone(self):
+        assert _flatten_unicode_spaces("plain name.png") == "plain name.png"
+
+
+class TestFuzzyWhitespaceMatch:
+    def test_finds_sibling_differing_only_by_narrow_space(self, tmp_path):
+        real = tmp_path / f"Screenshot at 9.23.58{NNBSP}AM.png"
+        real.write_bytes(PNG)
+        asked = tmp_path / "Screenshot at 9.23.58 AM.png"
+        assert _fuzzy_whitespace_match(asked) == real
+
+    def test_returns_none_when_no_sibling_matches(self, tmp_path):
+        (tmp_path / "other.png").write_bytes(PNG)
+        assert _fuzzy_whitespace_match(tmp_path / "missing.png") is None
+
+    def test_returns_none_when_ambiguous(self, tmp_path):
+        """Two candidates that both flatten to the request -> refuse to guess."""
+        (tmp_path / f"a{NNBSP}b.png").write_bytes(PNG)
+        (tmp_path / f"a{NBSP}b.png").write_bytes(PNG)
+        assert _fuzzy_whitespace_match(tmp_path / "a b.png") is None
+
+    def test_returns_none_when_parent_missing(self, tmp_path):
+        assert _fuzzy_whitespace_match(tmp_path / "nope" / "x.png") is None
+
+    def test_does_not_match_a_directory(self, tmp_path):
+        (tmp_path / f"a{NNBSP}b").mkdir()
+        assert _fuzzy_whitespace_match(tmp_path / "a b") is None
+
+
+class TestResolveImageSource:
+    def test_resolves_flattened_macos_screenshot_name(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        (tmp_path / f"Screenshot at 9.23.58{NNBSP}AM.png").write_bytes(PNG)
+
+        resolved = _resolve(tmp_path / "Screenshot at 9.23.58 AM.png")
+
+        assert resolved.mime == "image/png"
+        assert resolved.origin == "file"
+        assert resolved.data == PNG
+
+    def test_exact_match_is_preferred_and_unaffected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        exact = tmp_path / "plain.png"
+        exact.write_bytes(PNG)
+        assert _resolve(exact).data == PNG
+
+    def test_genuinely_missing_file_still_raises(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        (tmp_path / f"Screenshot at 9.23.58{NNBSP}AM.png").write_bytes(PNG)
+
+        with pytest.raises(SourceNotFound):
+            _resolve(tmp_path / "Screenshot at 9.99.99 AM.png")
+
+    def test_ambiguous_candidates_do_not_resolve(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        (tmp_path / f"a{NNBSP}b.png").write_bytes(PNG)
+        (tmp_path / f"a{NBSP}b.png").write_bytes(PNG)
+
+        with pytest.raises(SourceNotFound):
+            _resolve(tmp_path / "a b.png")

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -116,6 +116,17 @@ async def resolve_image_source(src: str, ctx: ResolveContext) -> ResolvedImage:
     # every other path is read inside the sandbox via exec-read, so a host
     # path outside the caches never yields the host's bytes.
     host_target = _permitted_host_read_target(p, ctx)
+    # Exact miss on the host: retry once against a sibling that differs only by
+    # Unicode whitespace (macOS' U+202F screenshot names). Local backend only —
+    # under a sandbox the miss must still fall through to the in-container read
+    # so the confinement boundary in this module's docstring holds.
+    if (
+        (host_target is None or not host_target.is_file())
+        and _is_local_terminal_backend()
+    ):
+        alt = _fuzzy_whitespace_match(p)
+        if alt is not None:
+            host_target = _permitted_host_read_target(alt, ctx)
     if host_target is not None and host_target.is_file():
         # Shared credential-read guard (agent.file_safety, #57698): refuse
         # secret-bearing files (.env, auth.json, ...) with an intentional,
@@ -196,6 +207,40 @@ async def _download_to_bytes(url: str) -> bytes:
         raise SourceUnsafe(str(exc), src=url, origin="http")
     finally:
         tmp.unlink(missing_ok=True)
+
+
+def _flatten_unicode_spaces(name: str) -> str:
+    """NFC-normalize and fold every Unicode space separator to U+0020."""
+    import unicodedata
+
+    return "".join(
+        " " if unicodedata.category(ch) == "Zs" else ch
+        for ch in unicodedata.normalize("NFC", name)
+    )
+
+
+def _fuzzy_whitespace_match(p: Path) -> Optional[Path]:
+    """Find a sibling file whose name differs from ``p`` only by Unicode whitespace.
+
+    macOS names screenshots with U+202F (NARROW NO-BREAK SPACE) before AM/PM.
+    A model that lists the directory and then echoes the name back almost always
+    emits a plain U+0020 instead, so the exact path misses a file the agent can
+    plainly see. Confined to ``p``'s own directory and to a unique match, so this
+    can never redirect a read to an unrelated file; the caller still applies the
+    media-cache confinement and credential-read guard to whatever comes back.
+    """
+    try:
+        parent = p.parent
+        if not parent.is_dir():
+            return None
+        target = _flatten_unicode_spaces(p.name)
+        matches = [
+            c for c in parent.iterdir()
+            if c.is_file() and _flatten_unicode_spaces(c.name) == target
+        ]
+    except OSError:
+        return None
+    return matches[0] if len(matches) == 1 else None
 
 
 def _is_local_terminal_backend() -> bool:


### PR DESCRIPTION
## Problem

macOS names screenshots with a NARROW NO-BREAK SPACE (U+202F) before AM/PM:

```
Screenshot 2026-07-10 at 9.23.58<U+202F>AM.png
```

A model lists the directory, sees the name, and passes it to `vision_analyze` — emitting a plain U+0020. `resolve_image_source()` then raises `image file not found` for a file the agent was **just shown**. In my session three screenshots failed back-to-back this way.

Reproducible on `main`:

```python
d = pathlib.Path(tempfile.mkdtemp())
(d / "Screenshot at 9.23.58 AM.png").write_bytes(PNG)
await resolve_image_source(str(d / "Screenshot at 9.23.58 AM.png"), ResolveContext())
# -> SourceNotFound
```

## Fix

On an exact miss, retry **once** against a sibling whose name is equal after NFC normalization and folding every Unicode space separator (category `Zs`) to U+0020.

The retry is deliberately narrow, so it cannot widen the read surface:

- **same directory only** — it can never redirect a read elsewhere;
- **unique match only** — ambiguous candidates (e.g. `a b.png` and `a b.png`) still fail rather than guess;
- **local backend only** — under a non-local backend the miss still falls through to the in-sandbox exec-read, so the confinement model documented in the module header (GHSA-gpxw-6wxv-w3qq) is unchanged;
- the resolved path still passes through `_permitted_host_read_target()` and the `raise_if_read_blocked()` credential guard.

## Tests

`tests/tools/test_image_source_unicode_space.py` — 12 cases: folding helper, sibling match, ambiguity refusal, missing parent, directory-not-matched, end-to-end resolve of a flattened macOS name, exact-match unaffected, genuinely-missing still raises, ambiguous still raises.

Driven with `asyncio.run` rather than `pytest.mark.asyncio` so they run without the `pytest-asyncio` plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)