### PR TITLE
fix(subdirectory-hints): never let hint discovery abort the agent turn

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -81,7 +81,28 @@ class SubdirectoryHintTracker:
         """Check tool call arguments for new directories and load any hint files.
 
         Returns formatted hint text to append to the tool result, or None.
+
+        Never raises: hint discovery is a best-effort enrichment, and both
+        tool_executor call sites run it after the tool result has already
+        been computed — an exception escaping here aborts the entire agent
+        turn and loses that result (see the ``Path.expanduser()``
+        RuntimeError class of crashes). Any failure is logged and swallowed.
         """
+        try:
+            return self._check_tool_call(tool_name, tool_args)
+        except Exception:
+            logger.debug(
+                "Subdirectory hint discovery failed for tool %r; skipping",
+                tool_name,
+                exc_info=True,
+            )
+            return None
+
+    def _check_tool_call(
+        self,
+        tool_name: str,
+        tool_args: Dict[str, Any],
+    ) -> Optional[str]:
         dirs = self._extract_directories(tool_name, tool_args)
         if not dirs:
             return None

--- a/tests/agent/test_subdirectory_hints_never_raise.py
+++ b/tests/agent/test_subdirectory_hints_never_raise.py
@@ -1,0 +1,59 @@
+"""Regression tests: ``check_tool_call`` must never raise.
+
+Subdirectory hint discovery is a best-effort enrichment. Both call sites in
+``agent/tool_executor.py`` (sequential and parallel tool paths) invoke it
+*after* the tool result has already been computed, and neither wraps the
+call — so any exception escaping ``check_tool_call`` aborts the entire
+agent turn and discards a perfectly good tool result.
+
+That is exactly how the ``Path.expanduser()`` RuntimeError class of crashes
+(fixed in ``test_subdirectory_hints_tilde.py``'s target change) took down
+live agent turns: the specific ``except`` tuples inside the walker missed
+one exception type. Rather than keep chasing individual exception types at
+each internal site, this change guards the public entrypoint: the internal
+logic moves to ``_check_tool_call`` and ``check_tool_call`` logs and
+swallows anything that escapes, returning ``None``.
+
+These tests intentionally use ``tmp_path`` only, so the file is runnable
+standalone (same convention as ``test_subdirectory_hints_tilde.py``).
+"""
+
+import pytest
+
+from agent.subdirectory_hints import SubdirectoryHintTracker
+
+
+class TestCheckToolCallNeverRaises:
+    """The public entrypoint absorbs arbitrary internal failures."""
+
+    @pytest.mark.parametrize(
+        "exc",
+        [RuntimeError("Could not determine home directory."),
+         KeyError("user"),
+         TypeError("unexpected argument shape"),
+         Exception("anything else")],
+        ids=["runtime-error", "key-error", "type-error", "bare-exception"],
+    )
+    def test_internal_failure_returns_none(self, tmp_path, monkeypatch, exc):
+        """Any exception from the internal walker is logged and swallowed."""
+        tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
+
+        def boom(*args, **kwargs):
+            raise exc
+
+        monkeypatch.setattr(tracker, "_extract_directories", boom)
+        result = tracker.check_tool_call("terminal", {"command": "ls ."})
+        assert result is None
+
+    def test_happy_path_still_returns_hints(self, tmp_path):
+        """The guard must not regress normal hint discovery."""
+        sub = tmp_path / "backend"
+        sub.mkdir()
+        (sub / "AGENTS.md").write_text("Backend instructions")
+        tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
+
+        result = tracker.check_tool_call(
+            "read_file", {"path": str(sub / "app.py")}
+        )
+        assert result is not None
+        assert "Backend instructions" in result


### PR DESCRIPTION
## What happened

`SubdirectoryHintTracker.check_tool_call()` is a best-effort enrichment, but both call sites in `agent/tool_executor.py` (sequential and parallel tool paths) invoke it **unguarded**, after the tool result has already been computed:

```python
subdir_hints = agent._subdirectory_hints.check_tool_call(name, args)
```

Any exception escaping the tracker therefore aborts the entire agent turn and discards a perfectly good tool result. That is exactly how the `Path.expanduser()` `RuntimeError` class of crashes (#43963, #45401) played out in production: in one long-running deployment we observed dozens of aborted turns across multiple agent profiles before the specific `except` tuples were widened, because LLMs routinely emit prose tokens like `~2.5x` or `~45,000` inside terminal commands.

## Why guard the entrypoint instead of more except tuples

The tilde fix widened three internal `except` clauses — correct, but it treats one exception type at one layer. The tracker walks the filesystem with many failure modes (`resolve()`, `is_dir()`, hint-file reads), and history shows each missed type costs a whole agent turn. Since the feature is explicitly best-effort and its result is only ever *appended* to a tool result, the public entrypoint should uphold a never-raises contract.

## Change

- Move the existing body of `check_tool_call()` to `_check_tool_call()` (unchanged).
- `check_tool_call()` now wraps it: on any exception, log at debug with traceback and return `None`.
- No behavior change on the happy path; internal except tuples are left as-is (they still short-circuit cheaply per-candidate).

## Tests

New standalone `tests/agent/test_subdirectory_hints_never_raise.py` following the `test_subdirectory_hints_tilde.py` conventions:

- parametrized internal failures (`RuntimeError`, `KeyError`, `TypeError`, bare `Exception`) → returns `None`, never raises
- happy path still returns hint text through the wrapper

`tests/agent/test_subdirectory_hints*.py`: **33 passed** (28 existing + 5 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)