### PR TITLE
fix(desktop): isolate composer drafts across session switches (#54527)

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
@@ -2,7 +2,13 @@ import { useAui, useAuiState, useComposerRuntime } from '@assistant-ui/react'
 import { type RefObject, useCallback, useEffect, useRef, useState } from 'react'
 
 import { SLASH_COMMAND_RE } from '@/lib/chat-runtime'
-import { $composerAttachments, type ComposerAttachment, stashSessionDraft, takeSessionDraft } from '@/store/composer'
+import {
+  $composerAttachments,
+  type ComposerAttachment,
+  migrateSessionDraft,
+  stashSessionDraft,
+  takeSessionDraft
+} from '@/store/composer'
 import { isBrowsingHistory } from '@/store/composer-input-history'
 
 import { cloneAttachments, DRAFT_PERSIST_DEBOUNCE_MS, type QueueEditState } from '../composer-utils'
@@ -23,6 +29,7 @@ interface UseComposerDraftArgs {
   focusKey: ChatBarProps['focusKey']
   inputDisabled: boolean
   queueEditRef: RefObject<QueueEditState | null>
+  queueSessionKey: ChatBarProps['queueSessionKey']
   sessionId: string | null | undefined
 }
 
@@ -41,6 +48,7 @@ export function useComposerDraft({
   focusKey,
   inputDisabled,
   queueEditRef,
+  queueSessionKey,
   sessionId
 }: UseComposerDraftArgs) {
   const aui = useAui()
@@ -75,8 +83,20 @@ export function useComposerDraft({
   const draftRef = useRef('')
   const pendingDraftPersistRef = useRef<{ scope: string | null; text: string } | null>(null)
   const draftPersistTimerRef = useRef<number | undefined>(undefined)
+  // Draft persistence must track the scope the swap effect owns, NOT the render-
+  // time queue key. activeQueueSessionKey updates on render while the editor still
+  // shows the previous session's text until the swap effect runs — debounced stashes
+  // keyed off the render ref mis-file drafts under the next session (#54527).
+  const draftScopeRef = useRef<string | null>(activeQueueSessionKey)
+  const prevDraftScopeRef = useRef<string | null>(activeQueueSessionKey)
   const activeQueueSessionKeyRef = useRef(activeQueueSessionKey)
   activeQueueSessionKeyRef.current = activeQueueSessionKey
+
+  const cancelPendingDraftPersist = () => {
+    window.clearTimeout(draftPersistTimerRef.current)
+    draftPersistTimerRef.current = undefined
+    pendingDraftPersistRef.current = null
+  }
   const sessionIdRef = useRef(sessionId)
   sessionIdRef.current = sessionId
   const queueEditStateRef = useRef<QueueEditState | null>(queueEditRef.current)
@@ -222,12 +242,18 @@ export function useComposerDraft({
         return
       }
 
-      const scope = activeQueueSessionKeyRef.current
+      const scope = draftScopeRef.current
       pendingDraftPersistRef.current = { scope, text }
       window.clearTimeout(draftPersistTimerRef.current)
       draftPersistTimerRef.current = window.setTimeout(() => {
+        const pending = pendingDraftPersistRef.current
+
+        if (!pending || pending.scope !== draftScopeRef.current) {
+          return
+        }
+
         pendingDraftPersistRef.current = null
-        stashAt(scope, text)
+        stashAt(pending.scope, pending.text)
       }, DRAFT_PERSIST_DEBOUNCE_MS)
     }
 
@@ -235,7 +261,7 @@ export function useComposerDraft({
 
     return () => {
       unsubscribe()
-      window.clearTimeout(draftPersistTimerRef.current)
+      cancelPendingDraftPersist()
     }
   }, [composerRuntime, queueEditRef])
 
@@ -285,17 +311,33 @@ export function useComposerDraft({
   // never clears composer state; this effect alone stashes on leave, restores
   // on enter. Keyed writes are idempotent, so no skip-sentinel.
   useEffect(() => {
+    cancelPendingDraftPersist()
+
+    const prev = prevDraftScopeRef.current
+    prevDraftScopeRef.current = activeQueueSessionKey
+
+    // Re-key when a fresh chat mints its first runtime id (or a resume bounce
+    // replaces a dead runtime id). Stable stored ids never churn — same rule as
+    // the queued-prompt migrator.
+    if (!queueSessionKey && prev && activeQueueSessionKey && prev !== activeQueueSessionKey) {
+      migrateSessionDraft(prev, activeQueueSessionKey)
+    }
+
+    draftScopeRef.current = activeQueueSessionKey
+
     const { attachments, text } = takeSessionDraft(activeQueueSessionKey)
     loadIntoComposer(text, attachments)
 
     return () => {
+      cancelPendingDraftPersist()
       const latestText = syncDraftFromEditor()
       const editing = queueEditStateRef.current
+      const scope = draftScopeRef.current
 
-      if (editing?.sessionKey === activeQueueSessionKey) {
-        stashAt(activeQueueSessionKey, editing.draft, editing.attachments)
+      if (editing?.sessionKey === scope) {
+        stashAt(scope, editing.draft, editing.attachments)
       } else if (!isBrowsingHistory(sessionId)) {
-        stashAt(activeQueueSessionKey, latestText)
+        stashAt(scope, latestText)
       }
     }
   }, [activeQueueSessionKey]) // eslint-disable-line react-hooks/exhaustive-deps
@@ -304,7 +346,7 @@ export function useComposerDraft({
   // inside the debounce/rAF window would drop trailing keystrokes without this.
   useEffect(() => {
     const flushPendingDraftPersist = () => {
-      const scope = activeQueueSessionKeyRef.current
+      const scope = draftScopeRef.current
       const editing = queueEditStateRef.current
 
       if (editing?.sessionKey === scope || isBrowsingHistory(sessionIdRef.current)) {

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -79,7 +79,7 @@ export function useComposerSubmit({
 
     const restore = () => {
       loadIntoComposer(text, submittedAttachments)
-      stashAt(activeQueueSessionKeyRef.current, text, submittedAttachments)
+      stashAt(submittedScope, text, submittedAttachments)
     }
 
     void Promise.resolve(attachments ? onSubmit(text, { attachments }) : onSubmit(text))

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -150,7 +150,7 @@ export function ChatBar({
     sessionIdRef,
     setComposerText,
     stashAt
-  } = useComposerDraft({ activeQueueSessionKey, focusKey, inputDisabled, queueEditRef, sessionId })
+  } = useComposerDraft({ activeQueueSessionKey, focusKey, inputDisabled, queueEditRef, queueSessionKey, sessionId })
 
   // "Add URL" dialog — open/value state, autofocus, and submit (host onAddUrl or
   // an @url: directive into the draft).

--- a/apps/desktop/src/store/composer.test.ts
+++ b/apps/desktop/src/store/composer.test.ts
@@ -5,6 +5,7 @@ import {
   addComposerAttachment,
   clearSessionDraft,
   type ComposerAttachment,
+  migrateSessionDraft,
   removeComposerAttachment,
   SESSION_DRAFTS_STORAGE_KEY,
   stashSessionDraft,
@@ -105,5 +106,39 @@ describe('session drafts', () => {
     taken.attachments[0]!.label = 'mutated'
 
     expect(takeSessionDraft('session-a').attachments[0]?.label).toBe('doc.pdf')
+  })
+})
+
+describe('migrateSessionDraft', () => {
+  afterEach(() => {
+    for (const scope of ['session-a', 'session-b', null, 'rt-new']) {
+      clearSessionDraft(scope)
+    }
+
+    window.localStorage.clear()
+  })
+
+  it('moves a draft from the unsaved new-session key onto a runtime id', () => {
+    stashSessionDraft(null, 'fresh chat draft', [])
+
+    expect(migrateSessionDraft(null, 'rt-new')).toBe(true)
+    expect(takeSessionDraft(null).text).toBe('')
+    expect(takeSessionDraft('rt-new').text).toBe('fresh chat draft')
+  })
+
+  it('does not clobber an existing target draft', () => {
+    stashSessionDraft('rt-old', 'old runtime draft', [])
+    stashSessionDraft('rt-new', 'already here', [])
+
+    expect(migrateSessionDraft('rt-old', 'rt-new')).toBe(false)
+    expect(takeSessionDraft('rt-old').text).toBe('old runtime draft')
+    expect(takeSessionDraft('rt-new').text).toBe('already here')
+  })
+
+  it('no-ops when source and target resolve to the same key', () => {
+    stashSessionDraft('session-a', 'draft', [])
+
+    expect(migrateSessionDraft('session-a', 'session-a')).toBe(false)
+    expect(takeSessionDraft('session-a').text).toBe('draft')
   })
 })

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -99,6 +99,41 @@ export function takeSessionDraft(scope: string | null | undefined): SessionDraft
 
 export const clearSessionDraft = (scope: string | null | undefined) => stashSessionDraft(scope, '', [])
 
+/**
+ * Move a stashed draft from a dead scope onto a live one (e.g. `__new__` → the
+ * first runtime session id minted on send, or an old runtime id after resume).
+ * No-op unless the source has content and the target is empty — never clobber.
+ */
+export function migrateSessionDraft(
+  fromKey: string | null | undefined,
+  toKey: string | null | undefined
+): boolean {
+  const from = draftKey(fromKey)
+  const to = draftKey(toKey)
+
+  if (from === to) {
+    return false
+  }
+
+  const source = draftsBySession.get(from)
+
+  if (!source || (!source.text.trim() && source.attachments.length === 0)) {
+    return false
+  }
+
+  const target = draftsBySession.get(to) ?? EMPTY_SESSION_DRAFT
+
+  if (target.text.trim() || target.attachments.length > 0) {
+    return false
+  }
+
+  draftsBySession.delete(from)
+  draftsBySession.set(to, cloneDraft(source))
+  persistDraftTexts()
+
+  return true
+}
+
 export function setComposerDraft(value: string) {
   $composerDraft.set(value)
 }


### PR DESCRIPTION
## Summary

- Fix cross-session composer draft bleed when switching chats in the Desktop sidebar (#54527): debounced draft persistence no longer keys off the render-time session ref while the editor still shows the previous session's text.
- Track draft scope in the swap effect, cancel stale debounce timers on scope change, and ignore pending persists whose scope no longer matches.
- Migrate unsaved new-chat drafts when a fresh session mints its first runtime id (mirrors queued-prompt re-keying).
- Restore rejected submits back to the submitted scope instead of whichever session is focused when the gateway rejects.

## Root cause

`activeQueueSessionKeyRef` updates synchronously on render, but the contentEditable composer still holds the **previous** session's text until the draft-swap effect runs. A trailing debounced `stashSessionDraft` could therefore file Session A's in-progress text under Session B's key — matching the reporter symptom where a draft "follows" across a sidebar switch and the typed prompt is lost.

## Test plan

- [x] `npm run test:ui -- src/store/composer.test.ts` (includes new `migrateSessionDraft` cases)
- [ ] Open Session A (existing), type a long draft, switch to Session B (new) — B's composer should be empty / B's own draft, not A's text
- [ ] Type in Session B, switch back to A — each session retains its own draft
- [ ] Start a fresh chat, type before first send, send once — draft should survive runtime id assignment
- [ ] Submit a prompt, simulate gateway rejection — composer restores to the session that sent, not the currently focused one

Fixes #54527