### PR TITLE
cron: reliability guards for silent job loss, missed runs, delivery status

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -34,12 +34,12 @@ except ImportError:  # pragma: no cover - non-Windows
 from datetime import datetime, timedelta
 from pathlib import Path
 from hermes_constants import get_hermes_home
-from typing import Optional, Dict, List, Any, Set, Tuple, Union
+from typing import Optional, Dict, List, Any, Iterable, Set, Tuple, Union
 
 logger = logging.getLogger(__name__)
 
 from hermes_time import now as _hermes_now
-from utils import atomic_replace
+from utils import atomic_replace, atomic_json_write
 
 try:
     from croniter import croniter
@@ -195,6 +195,62 @@ def _oneshot_run_claim_ttl_seconds() -> float:
 def _jobs_lock_file() -> Path:
     """Return the advisory lock path for the current cron directory."""
     return _current_cron_store().cron_dir / ".jobs.lock"
+
+
+def _jobs_census_file() -> Path:
+    """Path to the job-id census for the active cron store.
+
+    The census records the id set of the last sanctioned ``save_jobs`` so that
+    job-loss detection can tell whether a job vanished from ``jobs.json``
+    out-of-band (external edit/truncation, corruption repair that dropped
+    records, a partial write) versus a legitimate removal that went through the
+    store API (which rewrites the census in the same call).
+    """
+    return _current_cron_store().cron_dir / "jobs_census.json"
+
+
+def update_jobs_census(job_ids: Iterable[str]) -> None:
+    """Persist the current known job-id set. Best-effort — never raises.
+
+    Called from ``save_jobs`` so the census mirrors the last sanctioned write.
+    Only rewrites when the id-set actually changed: the hot savers
+    (``mark_job_run`` per fire, ``advance_next_run`` per due job) mutate job
+    fields but not the id-set, so the steady state pays a cheap census read and
+    skips a second durable write. A census failure must never break a job save,
+    so all errors are swallowed (worst case: a stale census → a spurious/absent
+    loss signal, never lost jobs).
+    """
+    ids = sorted({str(j) for j in job_ids if j})
+    try:
+        if set(ids) == known_job_ids():
+            return
+        atomic_json_write(
+            _jobs_census_file(),
+            {"ids": ids, "updated_at": _hermes_now().isoformat()},
+        )
+    except Exception:
+        logger.debug("Failed to update cron jobs census", exc_info=True)
+
+
+def read_jobs_census() -> Dict[str, Any]:
+    """Return the persisted census dict, or ``{}`` if missing/unreadable."""
+    path = _jobs_census_file()
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            return data
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+    except Exception:
+        logger.debug("Failed to read cron jobs census", exc_info=True)
+    return {}
+
+
+def known_job_ids() -> set:
+    """The job-id set recorded by the last sanctioned save (from the census)."""
+    ids = read_jobs_census().get("ids", [])
+    return {str(i) for i in ids if i}
 
 
 @contextlib.contextmanager
@@ -866,6 +922,9 @@ def _save_jobs_unlocked(jobs: List[Dict[str, Any]]):
         except OSError:
             pass
         raise
+    # Refresh the job-loss census to mirror this sanctioned write. Best-effort
+    # and after the durable replace, so a census hiccup can never fail a save.
+    update_jobs_census(j.get("id") for j in jobs if isinstance(j, dict))
 
 
 def save_jobs(jobs: List[Dict[str, Any]]):
@@ -1446,15 +1505,22 @@ def remove_job(job_id: str) -> bool:
 
 
 def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
-                 delivery_error: Optional[str] = None):
+                 delivery_error: Optional[str] = None,
+                 delivered: Optional[bool] = None):
     """
     Mark a job as having been run.
-    
+
     Updates last_run_at, last_status, increments completed count,
     computes next_run_at, and auto-deletes if repeat limit reached.
 
     ``delivery_error`` is tracked separately from the agent error — a job
     can succeed (agent produced output) but fail delivery (platform down).
+
+    ``delivered`` records a *durable* delivery outcome so a silent delivery
+    failure is queryable and a successful delivery is positively confirmed
+    (``last_delivery_error`` alone can't distinguish "delivered fine" from
+    "never attempted"). ``True`` → a delivery was attempted; ``False`` → skipped
+    (local-only, [SILENT], empty response); ``None`` → the caller didn't say.
     """
     with _jobs_lock():
         jobs = load_jobs()
@@ -1466,6 +1532,17 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                 job["last_error"] = error if not success else None
                 # Track delivery failures separately — cleared on successful delivery
                 job["last_delivery_error"] = delivery_error
+                # Durable delivery status: a positive/negative record so a silent
+                # delivery failure is visible and a real delivery is confirmed.
+                if delivery_error:
+                    job["last_delivery_status"] = "failed"
+                elif delivered is True:
+                    job["last_delivery_status"] = "delivered"
+                    job["last_delivered_at"] = now
+                elif delivered is False:
+                    job["last_delivery_status"] = "skipped"
+                else:
+                    job["last_delivery_status"] = "unknown"
                 # Clear any external-fire claim so a re-armed recurring job can
                 # be claimed again on its next fire (Phase 4C CAS).
                 job["fire_claim"] = None

--- a/cron/reliability.py
+++ b/cron/reliability.py
@@ -1,0 +1,193 @@
+"""Cron reliability safeguards: detection helpers for the failure modes that
+let scheduled jobs silently disappear, stop firing, or fail without a trace.
+
+These are deliberately small, pure functions over plain job dicts (plus a
+persisted job *census* maintained by ``cron.jobs.save_jobs``) so they can be
+called cheaply from the ticker loop, ``hermes cron status``, or a dashboard,
+and unit-tested without touching the scheduler.
+
+Four dimensions, mirroring the incident that motivated them:
+
+* **job-loss detection** — jobs that vanished from ``jobs.json`` relative to the
+  last sanctioned save (``detect_dropped_jobs``).
+* **missed-run detection** — enabled jobs whose ``next_run_at`` is long past, so
+  the scheduler evidently never fired them (``find_missed_runs``).
+* **visible failure state** — jobs carrying a failure signal, surfaced even when
+  ``enabled=False`` (which ``list_jobs`` hides by default) (``find_failed_jobs``).
+* **durable delivery status** — recorded by ``cron.jobs.mark_job_run``; surfaced
+  here via the ``last_delivery_error`` / ``last_delivery_status`` failure signals.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, Iterable, List, Optional
+
+logger = logging.getLogger("cron.reliability")
+
+# A job whose next_run_at is older than this many seconds — after allowing for
+# the ticker interval and per-job schedule grace — is treated as a missed run.
+# 10 minutes is well above the 60s tick cadence and any legitimate between-tick
+# lag, so it fires only when the scheduler genuinely failed to run the job.
+DEFAULT_MISSED_RUN_GRACE_SECONDS = 600
+
+
+def _parse_dt(value: Any) -> Optional[datetime]:
+    """Parse a stored ISO timestamp into an aware datetime, or None.
+
+    Delegates timezone normalization to ``cron.jobs._ensure_aware`` — the single
+    tz-normalization point the rest of cron uses — so both naive and aware
+    values are normalized to the configured Hermes zone and comparisons never
+    mix offsets.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    from cron.jobs import _ensure_aware
+
+    return _ensure_aware(dt)
+
+
+def _is_schedulable(job: Dict[str, Any]) -> bool:
+    """True when a job is expected to keep firing (enabled and not paused)."""
+    if not job.get("enabled", True):
+        return False
+    if job.get("state") == "paused" or job.get("paused_at"):
+        return False
+    return True
+
+
+def find_missed_runs(
+    jobs: Iterable[Dict[str, Any]],
+    now: datetime,
+    grace_seconds: float = DEFAULT_MISSED_RUN_GRACE_SECONDS,
+) -> List[Dict[str, Any]]:
+    """Return recurring jobs whose ``next_run_at`` is overdue by > grace.
+
+    An overdue ``next_run_at`` on a *recurring* (cron/interval) job means the
+    ticker should have fired it and advanced the timestamp but did not — the
+    process was down, the tick wedged, or the job was skipped.
+
+    Excluded (their past ``next_run_at`` is normal, not a miss):
+      * paused/disabled jobs — nothing to be late for.
+      * jobs missing/with an unparseable ``next_run_at``.
+      * jobs currently in flight (a ``run_claim``/``fire_claim`` is stamped for
+        the duration of a run, and one-shot ``next_run_at`` is intentionally
+        left in the past while the agent runs), which would otherwise false-alarm
+        every tick for a healthy long-running job.
+      * one-shot (``kind == "once"``) jobs — single-fire; ``advance_next_run``
+        never moves their ``next_run_at`` forward, so a past value is expected.
+    """
+    missed: List[Dict[str, Any]] = []
+    for job in jobs:
+        if not _is_schedulable(job):
+            continue
+        if job.get("run_claim") or job.get("fire_claim"):
+            continue
+        if (job.get("schedule") or {}).get("kind") == "once":
+            continue
+        nxt = _parse_dt(job.get("next_run_at"))
+        if nxt is None:
+            continue
+        if (now - nxt).total_seconds() > grace_seconds:
+            missed.append(job)
+    return missed
+
+
+def find_failed_jobs(jobs: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Return jobs carrying a failure signal, regardless of ``enabled``.
+
+    ``list_jobs(include_disabled=False)`` hides ``enabled=False`` jobs, so a job
+    that failed and was auto-disabled/completed would silently drop off the
+    default listing. This surfaces every job whose last run errored, whose
+    delivery failed, or whose state is ``error`` — the visible-failure signal.
+    """
+    failed: List[Dict[str, Any]] = []
+    for job in jobs:
+        if (
+            job.get("state") == "error"
+            or job.get("last_status") == "error"
+            or job.get("last_error")
+            or job.get("last_delivery_error")
+        ):
+            failed.append(job)
+    return failed
+
+
+def detect_dropped_jobs(
+    expected_ids: Iterable[str],
+    current_jobs: Iterable[Dict[str, Any]],
+) -> List[str]:
+    """Return ids in ``expected_ids`` that are absent from ``current_jobs``.
+
+    ``expected_ids`` is normally the persisted census (``cron.jobs.known_job_ids``)
+    — the id set of the last sanctioned save. Any id missing from the live store
+    disappeared out-of-band (external edit/truncation, corruption repair that
+    dropped records, or a partial write), which is exactly the silent job loss
+    this guards against. Returned sorted and de-duplicated so the result (and the
+    log line built from it) is deterministic even though ``expected_ids`` is
+    typically an unordered set.
+    """
+    present = {j.get("id") for j in current_jobs if j.get("id")}
+    return sorted({jid for jid in expected_ids if jid and jid not in present})
+
+
+def audit_cron_health(
+    jobs: List[Dict[str, Any]],
+    now: datetime,
+    *,
+    expected_ids: Optional[Iterable[str]] = None,
+    grace_seconds: float = DEFAULT_MISSED_RUN_GRACE_SECONDS,
+) -> Dict[str, List[str]]:
+    """Summarize the three detectable failure modes as id lists (for logging)."""
+    return {
+        "missed_runs": [j["id"] for j in find_missed_runs(jobs, now, grace_seconds) if j.get("id")],
+        "failed": [j["id"] for j in find_failed_jobs(jobs) if j.get("id")],
+        "dropped": detect_dropped_jobs(expected_ids or [], jobs),
+    }
+
+
+_DIMENSION_MESSAGES = (
+    ("dropped", "cron job-loss detected: %d job(s) missing from jobs.json since last save: %s"),
+    ("missed_runs", "cron missed runs: %d job(s) overdue (next_run_at long past): %s"),
+    ("failed", "cron jobs in failure state: %d job(s): %s"),
+)
+
+# Per-store memory of the last-warned id-set for each dimension, so a persistent
+# condition (a job stuck in failure state, a lingering completed one-shot) is
+# logged when it appears/changes, not re-flooded every tick. Keyed by cron dir.
+_last_warned: Dict[str, Dict[str, frozenset]] = {}
+
+
+def log_cron_health() -> Dict[str, List[str]]:
+    """Best-effort health audit of the active cron store; warn on new findings.
+
+    Reads the live jobs plus the persisted census and emits a WARNING per
+    dimension only when its set of flagged ids *changes* since the last audit, so
+    a standing condition doesn't re-flood the log every tick. Never raises — the
+    ticker loop relies on this being fully inert on any failure (including a
+    corrupt jobs.json, which is exactly the input it exists to observe).
+    """
+    empty = {"missed_runs": [], "failed": [], "dropped": []}
+    try:
+        from cron.jobs import known_job_ids, load_jobs, _hermes_now, _current_cron_store
+
+        jobs = load_jobs()
+        report = audit_cron_health(jobs, _hermes_now(), expected_ids=known_job_ids())
+        key = str(_current_cron_store().cron_dir)
+        prev = _last_warned.get(key, {})
+        current: Dict[str, frozenset] = {}
+        for dim, message in _DIMENSION_MESSAGES:
+            ids = report[dim]
+            current[dim] = frozenset(ids)
+            if ids and current[dim] != prev.get(dim):
+                logger.warning(message, len(ids), ", ".join(str(i) for i in ids))
+        _last_warned[key] = current
+        return report
+    except Exception:
+        logger.debug("cron health audit failed", exc_info=True)
+        return empty

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3482,7 +3482,18 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
 
         if not _consume_interrupted_flag(job["id"]):
-            mark_job_run(job["id"], success, error, delivery_error=delivery_error)
+            # Durable delivery status: "delivered" only when a message was
+            # actually sent — i.e. content was deliverable AND a real target
+            # resolved. `should_deliver` alone is True for local-only / origin-
+            # less jobs (non-empty content), but `_deliver_result` sends nothing
+            # for them (no targets), so keying on it would falsely stamp those
+            # runs "delivered". A send that resolved a target but errored is
+            # caught by `delivery_error` (→ "failed") inside mark_job_run.
+            delivered = should_deliver and bool(_resolve_delivery_targets(job))
+            mark_job_run(
+                job["id"], success, error,
+                delivery_error=delivery_error, delivered=delivered,
+            )
         return True
 
     except Exception as e:

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -167,6 +167,7 @@ class InProcessCronScheduler(CronScheduler):
         import logging
         from cron.scheduler import tick as cron_tick
         from cron.jobs import record_ticker_heartbeat
+        from cron.reliability import log_cron_health
 
         logger = logging.getLogger("cron.scheduler_provider")
         logger.info("In-process cron scheduler started (interval=%ds)", interval)
@@ -191,4 +192,12 @@ class InProcessCronScheduler(CronScheduler):
             # clean tick, so status can tell "alive but failing every tick" from
             # "actually firing jobs" (#32612, #32895).
             record_ticker_heartbeat(success=ok)
+            # Surface reliability signals (job loss, missed runs, failure state)
+            # once per tick. log_cron_health is self-contained and never raises,
+            # but guard the call anyway so a future regression there can never
+            # unwind the ticker loop and stop all cron firing.
+            try:
+                log_cron_health()
+            except Exception:
+                logger.debug("cron health audit failed", exc_info=True)
             stop_event.wait(interval)

--- a/tests/cron/test_reliability.py
+++ b/tests/cron/test_reliability.py
@@ -1,0 +1,253 @@
+"""Regression tests for cron reliability safeguards (Kanban t_b934a5b3).
+
+Four safeguards, each proven independently:
+
+  1. job-loss detection      — a job that vanishes from jobs.json out-of-band
+                               is detectable against the persisted census.
+  2. missed-run detection    — an enabled job whose next_run_at is long past is
+                               surfaced (the scheduler never fired it).
+  3. durable delivery status — mark_job_run() persists a positive/negative
+                               delivery outcome, not just an error string.
+  4. visible failure state   — failing jobs are surfaced even when they are
+                               enabled=False (which list_jobs() hides by default).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from cron import jobs as cron_jobs
+from cron import reliability
+
+
+UTC = timezone.utc
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+# ---------------------------------------------------------------------------
+# 2. Missed-run detection (pure)
+# ---------------------------------------------------------------------------
+class TestFindMissedRuns:
+    def test_overdue_enabled_job_is_missed(self):
+        now = datetime(2026, 7, 10, 12, 0, tzinfo=UTC)
+        jobs = [
+            {"id": "a", "name": "old", "enabled": True,
+             "next_run_at": _iso(now - timedelta(hours=3))},
+        ]
+        missed = reliability.find_missed_runs(jobs, now, grace_seconds=600)
+        assert [j["id"] for j in missed] == ["a"]
+
+    def test_future_job_not_missed(self):
+        now = datetime(2026, 7, 10, 12, 0, tzinfo=UTC)
+        jobs = [{"id": "a", "enabled": True, "next_run_at": _iso(now + timedelta(hours=1))}]
+        assert reliability.find_missed_runs(jobs, now, grace_seconds=600) == []
+
+    def test_within_grace_not_missed(self):
+        now = datetime(2026, 7, 10, 12, 0, tzinfo=UTC)
+        jobs = [{"id": "a", "enabled": True, "next_run_at": _iso(now - timedelta(seconds=30))}]
+        assert reliability.find_missed_runs(jobs, now, grace_seconds=600) == []
+
+    def test_disabled_and_paused_not_missed(self):
+        now = datetime(2026, 7, 10, 12, 0, tzinfo=UTC)
+        past = _iso(now - timedelta(hours=3))
+        jobs = [
+            {"id": "disabled", "enabled": False, "next_run_at": past},
+            {"id": "paused", "enabled": True, "state": "paused", "next_run_at": past},
+        ]
+        assert reliability.find_missed_runs(jobs, now, grace_seconds=600) == []
+
+    def test_missing_or_unparseable_next_run_ignored(self):
+        now = datetime(2026, 7, 10, 12, 0, tzinfo=UTC)
+        jobs = [
+            {"id": "none", "enabled": True, "next_run_at": None},
+            {"id": "bad", "enabled": True, "next_run_at": "not-a-date"},
+        ]
+        assert reliability.find_missed_runs(jobs, now, grace_seconds=600) == []
+
+    def test_in_flight_job_not_missed(self):
+        """A job currently running (run_claim/fire_claim stamped) keeps its
+        next_run_at in the past for the duration of the run — not a miss."""
+        now = datetime(2026, 7, 10, 12, 0, tzinfo=UTC)
+        past = _iso(now - timedelta(hours=3))
+        jobs = [
+            {"id": "running", "enabled": True, "next_run_at": past,
+             "run_claim": {"at": past, "by": "host"}},
+            {"id": "firing", "enabled": True, "next_run_at": past,
+             "fire_claim": {"at": past, "by": "host"}},
+        ]
+        assert reliability.find_missed_runs(jobs, now, grace_seconds=600) == []
+
+    def test_once_job_not_missed(self):
+        """One-shot jobs never advance next_run_at, so a past value is expected,
+        not a missed run."""
+        now = datetime(2026, 7, 10, 12, 0, tzinfo=UTC)
+        jobs = [
+            {"id": "once", "enabled": True, "schedule": {"kind": "once"},
+             "next_run_at": _iso(now - timedelta(hours=3))},
+        ]
+        assert reliability.find_missed_runs(jobs, now, grace_seconds=600) == []
+
+    def test_recurring_overdue_still_missed(self):
+        """A recurring job that is not in flight and overdue is still a miss."""
+        now = datetime(2026, 7, 10, 12, 0, tzinfo=UTC)
+        jobs = [
+            {"id": "cronjob", "enabled": True, "schedule": {"kind": "interval"},
+             "next_run_at": _iso(now - timedelta(hours=3))},
+        ]
+        assert [j["id"] for j in reliability.find_missed_runs(jobs, now, grace_seconds=600)] == ["cronjob"]
+
+
+# ---------------------------------------------------------------------------
+# 4. Visible failure state (pure) — surfaces jobs list_jobs() hides
+# ---------------------------------------------------------------------------
+class TestFindFailedJobs:
+    def test_last_error_surfaced_even_when_disabled(self):
+        jobs = [
+            {"id": "ok", "enabled": True, "last_status": "ok"},
+            {"id": "err", "enabled": False, "last_status": "error",
+             "last_error": "boom"},
+        ]
+        assert [j["id"] for j in reliability.find_failed_jobs(jobs)] == ["err"]
+
+    def test_delivery_failure_surfaced(self):
+        jobs = [{"id": "d", "enabled": True, "last_status": "ok",
+                 "last_delivery_error": "telegram 500"}]
+        assert [j["id"] for j in reliability.find_failed_jobs(jobs)] == ["d"]
+
+    def test_error_state_surfaced(self):
+        jobs = [{"id": "s", "enabled": True, "state": "error"}]
+        assert [j["id"] for j in reliability.find_failed_jobs(jobs)] == ["s"]
+
+    def test_healthy_jobs_not_surfaced(self):
+        jobs = [{"id": "ok", "enabled": True, "last_status": "ok",
+                 "state": "scheduled", "last_error": None,
+                 "last_delivery_error": None}]
+        assert reliability.find_failed_jobs(jobs) == []
+
+
+# ---------------------------------------------------------------------------
+# 1. Job-loss detection
+# ---------------------------------------------------------------------------
+class TestDetectDroppedJobs:
+    def test_pure_diff_reports_missing_ids(self):
+        current = [{"id": "b"}, {"id": "c"}]
+        dropped = reliability.detect_dropped_jobs(["a", "b", "c"], current)
+        assert dropped == ["a"]
+
+    def test_no_loss_when_all_present(self):
+        current = [{"id": "a"}, {"id": "b"}]
+        assert reliability.detect_dropped_jobs(["a", "b"], current) == []
+
+    def test_census_written_on_save_and_detects_out_of_band_loss(self, tmp_path):
+        import json
+
+        with cron_jobs.use_cron_store(tmp_path):
+            cron_jobs.create_job(prompt="one", schedule="every 1h")
+            cron_jobs.create_job(prompt="two", schedule="every 2h")
+            saved_ids = {j["id"] for j in cron_jobs.load_jobs()}
+            # save_jobs() must persist a census of the known job ids.
+            census_ids = cron_jobs.known_job_ids()
+            assert census_ids == saved_ids
+
+            # Simulate silent out-of-band loss: a writer that bypassed the
+            # sanctioned API drops one job from jobs.json.
+            jobs_file = cron_jobs._current_cron_store().jobs_file
+            data = json.loads(jobs_file.read_text())
+            dropped_id = data["jobs"].pop()["id"]
+            jobs_file.write_text(json.dumps(data))
+
+            missing = reliability.detect_dropped_jobs(
+                cron_jobs.known_job_ids(), cron_jobs.load_jobs()
+            )
+            assert missing == [dropped_id]
+
+
+# ---------------------------------------------------------------------------
+# 3. Durable delivery status
+# ---------------------------------------------------------------------------
+class TestDurableDeliveryStatus:
+    def test_successful_delivery_recorded(self, tmp_path):
+        with cron_jobs.use_cron_store(tmp_path):
+            job = cron_jobs.create_job(prompt="x", schedule="every 1h")
+            cron_jobs.mark_job_run(job["id"], success=True, delivered=True)
+            stored = cron_jobs.get_job(job["id"])
+            assert stored["last_delivery_status"] == "delivered"
+            assert stored.get("last_delivered_at")
+
+    def test_delivery_failure_recorded(self, tmp_path):
+        with cron_jobs.use_cron_store(tmp_path):
+            job = cron_jobs.create_job(prompt="x", schedule="every 1h")
+            cron_jobs.mark_job_run(
+                job["id"], success=True, delivery_error="telegram 500", delivered=True
+            )
+            stored = cron_jobs.get_job(job["id"])
+            assert stored["last_delivery_status"] == "failed"
+
+    def test_skipped_delivery_recorded(self, tmp_path):
+        with cron_jobs.use_cron_store(tmp_path):
+            job = cron_jobs.create_job(prompt="x", schedule="every 1h")
+            cron_jobs.mark_job_run(job["id"], success=True, delivered=False)
+            stored = cron_jobs.get_job(job["id"])
+            assert stored["last_delivery_status"] == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# Combined health audit
+# ---------------------------------------------------------------------------
+class TestLogCronHealth:
+    def test_never_raises_on_non_string_id(self, tmp_path):
+        """A corrupt jobs.json (non-string id) is exactly the input this feature
+        observes; log_cron_health must audit it without raising (the ticker loop
+        depends on it being fully inert on failure)."""
+        import json
+
+        with cron_jobs.use_cron_store(tmp_path):
+            cron_jobs.ensure_dirs()
+            jobs_file = cron_jobs._current_cron_store().jobs_file
+            jobs_file.write_text(json.dumps(
+                {"jobs": [{"id": 123, "enabled": True, "last_status": "error"}]}
+            ))
+            report = reliability.log_cron_health()  # must not raise
+            assert 123 in report["failed"]
+
+    def test_persistent_condition_logged_once(self, tmp_path, caplog):
+        """A standing failure state is warned when it appears, not re-flooded
+        every tick."""
+        import json
+        import logging
+
+        with cron_jobs.use_cron_store(tmp_path):
+            cron_jobs.ensure_dirs()
+            jobs_file = cron_jobs._current_cron_store().jobs_file
+            jobs_file.write_text(json.dumps(
+                {"jobs": [{"id": "x", "enabled": True, "state": "error"}]}
+            ))
+            reliability._last_warned.clear()
+            with caplog.at_level(logging.WARNING, logger="cron.reliability"):
+                reliability.log_cron_health()
+                first = len([r for r in caplog.records if "failure state" in r.getMessage()])
+                reliability.log_cron_health()  # unchanged → should not re-warn
+                total = len([r for r in caplog.records if "failure state" in r.getMessage()])
+        assert first == 1
+        assert total == 1
+
+
+class TestAuditCronHealth:
+    def test_audit_reports_all_dimensions(self):
+        now = datetime(2026, 7, 10, 12, 0, tzinfo=UTC)
+        jobs = [
+            {"id": "missed", "enabled": True,
+             "next_run_at": _iso(now - timedelta(hours=3))},
+            {"id": "failed", "enabled": False, "last_delivery_error": "x"},
+        ]
+        report = reliability.audit_cron_health(
+            jobs, now, expected_ids=["missed", "failed", "gone"], grace_seconds=600
+        )
+        assert "missed" in report["missed_runs"]
+        assert "failed" in report["failed"]
+        assert "gone" in report["dropped"]

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -31,13 +31,19 @@ def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final res
         calls.append(("deliver", job["id"]))
         return None
 
-    def fake_mark(jid, ok, err=None, delivery_error=None):
-        calls.append(("mark", jid, ok))
+    def fake_mark(jid, ok, err=None, delivery_error=None, delivered=None):
+        calls.append(("mark", jid, ok, delivered))
 
     monkeypatch.setattr(s, "run_job", fake_run_job)
     monkeypatch.setattr(s, "save_job_output", fake_save)
     monkeypatch.setattr(s, "_deliver_result", fake_deliver)
     monkeypatch.setattr(s, "mark_job_run", fake_mark)
+    # A real delivery target so `delivered` reflects a genuine send; local-only /
+    # target-less jobs are covered separately (test_local_only_job_not_delivered).
+    monkeypatch.setattr(
+        s, "_resolve_delivery_targets",
+        lambda job: [{"platform": "test", "chat_id": "1"}],
+    )
     return calls
 
 
@@ -51,7 +57,7 @@ def test_tick_process_job_sequence(monkeypatch):
     s.tick(verbose=False, sync=True)
 
     assert [c[0] for c in calls] == ["run_job", "save", "deliver", "mark"]
-    assert calls[-1] == ("mark", "j1", True)
+    assert calls[-1] == ("mark", "j1", True, True)  # delivered
 
 
 def test_run_one_job_success_sequence(monkeypatch):
@@ -63,7 +69,7 @@ def test_run_one_job_success_sequence(monkeypatch):
 
     assert ok is True
     assert [c[0] for c in calls] == ["run_job", "save", "deliver", "mark"]
-    assert calls[-1] == ("mark", "j2", True)
+    assert calls[-1] == ("mark", "j2", True, True)  # delivered
 
 
 def test_run_one_job_silent_skips_delivery(monkeypatch):
@@ -85,7 +91,7 @@ def test_run_one_job_empty_response_is_soft_failure(monkeypatch):
     s.run_one_job({"id": "j4", "name": "t"})
 
     mark = [c for c in calls if c[0] == "mark"][0]
-    assert mark == ("mark", "j4", False)
+    assert mark == ("mark", "j4", False, False)  # empty response → not delivered
 
 
 def test_run_one_job_failed_job_delivers_error(monkeypatch):
@@ -97,7 +103,21 @@ def test_run_one_job_failed_job_delivers_error(monkeypatch):
     kinds = [c[0] for c in calls]
     assert "deliver" in kinds  # failures always deliver
     mark = [c for c in calls if c[0] == "mark"][0]
-    assert mark == ("mark", "j5", False)
+    assert mark == ("mark", "j5", False, True)  # failure notice delivered
+
+
+def test_local_only_job_not_marked_delivered(monkeypatch):
+    """A job whose delivery resolves no target (local-only / origin-less) must
+    NOT be recorded as delivered — `should_deliver` is True (non-empty content)
+    but nothing is actually sent, so delivered must be False (→ status skipped)."""
+    calls = _patch_pipeline(monkeypatch)
+    # Override: no delivery target resolves for this run.
+    monkeypatch.setattr(s, "_resolve_delivery_targets", lambda job: [])
+
+    s.run_one_job({"id": "jL", "name": "t", "deliver": "local"})
+
+    mark = [c for c in calls if c[0] == "mark"][0]
+    assert mark == ("mark", "jL", True, False)  # ran ok, but nothing delivered
 
 
 def test_run_one_job_exception_marks_failure(monkeypatch):

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2568,6 +2568,7 @@ class TestSilentDelivery:
             False,
             "Agent completed but produced empty response (model error, timeout, or misconfiguration)",
             delivery_error=None,
+            delivered=False,
         )
 
 


### PR DESCRIPTION
## Problem

Four scheduled cron jobs silently disappeared from `jobs.json` and had to be restored by hand. The cron store had no way to notice a job vanishing, a recurring job that stopped firing, or a delivery that silently failed — and jobs auto-disabled by a failure drop off the default `cron list`.

## What this adds (smallest safeguards, cron-only)

New `cron/reliability.py` with small pure detectors, plus minimal wiring:

- **Job-loss detection** — `save_jobs` maintains a `jobs_census.json` id-set (written only when the id-set changes); `detect_dropped_jobs` flags ids that vanished from `jobs.json` out-of-band.
- **Missed-run detection** — `find_missed_runs` reports recurring (cron/interval) jobs whose `next_run_at` is long overdue, excluding paused, in-flight (`run_claim`/`fire_claim`), and one-shot jobs so healthy long runs don't false-alarm.
- **Durable delivery status** — `mark_job_run` records `last_delivery_status` (`delivered`/`failed`/`skipped`/`unknown`) + `last_delivered_at`. `delivered` is set only when a real delivery target resolved, so local-only / origin-less jobs aren't falsely marked delivered.
- **Visible failure state** — `find_failed_jobs` surfaces failing jobs even when `enabled=False` (which `list_jobs` hides), without changing the listing default.

Detectors run once per tick via `log_cron_health` (fully exception-safe, guarded at the call site, and deduped so a standing condition is logged when it changes, not every 60s).

## Out of scope (follow-ups)

- The census catches out-of-band loss; the in-API degraded-lock stale-subset overwrite wants a save-time shrink invariant.
- Detectors are surfaced in the in-process ticker; wiring them into `cron status` would cover external providers.
- Per-target partial-delivery outcome isn't represented.

## Test plan

New `tests/cron/test_reliability.py` (missed-run exclusions, failure surfacing, census round-trip + out-of-band loss, delivery-status persistence, health-audit resilience on corrupt ids + log dedupe). Delivery test doubles updated for the `delivered` signal, incl. a local-only "not delivered" case.

Canonical runner (per-file isolation):
`scripts/run_tests.sh tests/cron/ tests/tools/test_cronjob_tools.py tests/hermes_cli/test_cron.py -q` → **785 passed, 0 failed**.