### PR TITLE
fix(install): detect silent git SSH clone failure and fall back to HTTPS

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1636,14 +1636,19 @@ function Install-Repository {
         $env:GIT_CONFIG_VALUE_0 = "false"
         git config --global windows.appendAtomically false 2>$null
 
-        # Try SSH first, then HTTPS, with -c flag for atomic write fix
+        # Try SSH first, then HTTPS, with -c flag for atomic write fix.
+        # GitHub has no anonymous SSH, so a keyless machine fails the SSH clone.
+        # Rather than trust only the exit code we verify a real git repo with a
+        # checked-out commit landed in $InstallDir; otherwise we fall back to
+        # HTTPS, which clones the public repo with no GitHub account and no key.
         Write-Info "Trying SSH clone..."
         $env:GIT_SSH_COMMAND = "ssh -o BatchMode=yes -o ConnectTimeout=5"
         try {
             Invoke-NativeWithRelaxedErrorAction { git -c windows.appendAtomically=false clone --depth 1 --branch $Branch $RepoUrlSsh $InstallDir }
-            if ($LASTEXITCODE -eq 0) { $cloneSuccess = $true }
         } catch { }
         $env:GIT_SSH_COMMAND = $null
+        $null = git -C $InstallDir rev-parse HEAD 2>$null
+        if ($LASTEXITCODE -eq 0 -and (Test-Path "$InstallDir\.git")) { $cloneSuccess = $true }
 
         if (-not $cloneSuccess) {
             if (Test-Path $InstallDir) { Remove-Item -Recurse -Force $InstallDir -ErrorAction SilentlyContinue }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2245,14 +2245,19 @@ function Install-Repository {
         $env:GIT_CONFIG_VALUE_0 = "false"
         git config --global windows.appendAtomically false 2>$null
 
-        # Try SSH first, then HTTPS, with -c flag for atomic write fix
+        # Try SSH first, then HTTPS, with -c flag for atomic write fix.
+        # GitHub has no anonymous SSH, so a keyless machine fails the SSH clone.
+        # Rather than trust only the exit code we verify a real git repo with a
+        # checked-out commit landed in $InstallDir; otherwise we fall back to
+        # HTTPS, which clones the public repo with no GitHub account and no key.
         Write-Info "Trying SSH clone..."
         $env:GIT_SSH_COMMAND = "ssh -o BatchMode=yes -o ConnectTimeout=5"
         try {
             Invoke-NativeWithRelaxedErrorAction { git -c windows.appendAtomically=false clone --depth 1 --branch $Branch $RepoUrlSsh $InstallDir }
-            if ($LASTEXITCODE -eq 0) { $cloneSuccess = $true }
         } catch { }
         $env:GIT_SSH_COMMAND = $null
+        $null = git -C $InstallDir rev-parse HEAD 2>$null
+        if ($LASTEXITCODE -eq 0 -and (Test-Path "$InstallDir\.git")) { $cloneSuccess = $true }
 
         if (-not $cloneSuccess) {
             if (Test-Path $InstallDir) { Remove-Item -Recurse -Force $InstallDir -ErrorAction SilentlyContinue }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1293,11 +1293,17 @@ EOF
         fi
     else
         # Try SSH first (for private repo access), fall back to HTTPS
-        # GIT_SSH_COMMAND disables interactive prompts and sets a short timeout
-        # so SSH fails fast instead of hanging when no key is configured.
+        # GitHub has no anonymous SSH and a keyless machine will fail the clone
+        # - so we just attempt it and then verify the result. If a real git repo
+        # with a checked-out commit landed in INSTALL_DIR we're done; otherwise
+        # we clean up and fall back to HTTPS, which clones the public repo with
+        # no GitHub account and no key. GIT_SSH_COMMAND disables interactive
+        # prompts and sets a short timeout so a missing key fails fast instead
+        # of hanging.
         log_info "Trying SSH clone..."
         if GIT_SSH_COMMAND="ssh -o BatchMode=yes -o ConnectTimeout=5" \
-           git clone --depth 1 --branch "$BRANCH" "$REPO_URL_SSH" "$INSTALL_DIR" 2>/dev/null; then
+            git clone --depth 1 --branch "$BRANCH" "$REPO_URL_SSH" "$INSTALL_DIR" 2>/dev/null && \
+           [ -d "$INSTALL_DIR/.git" ] && git -C "$INSTALL_DIR" rev-parse HEAD 2>/dev/null; then
             log_success "Cloned via SSH"
         else
             rm -rf "$INSTALL_DIR" 2>/dev/null  # Clean up partial SSH clone

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1363,11 +1363,17 @@ EOF
         fi
     else
         # Try SSH first (for private repo access), fall back to HTTPS
-        # GIT_SSH_COMMAND disables interactive prompts and sets a short timeout
-        # so SSH fails fast instead of hanging when no key is configured.
+        # GitHub has no anonymous SSH and a keyless machine will fail the clone
+        # - so we just attempt it and then verify the result. If a real git repo
+        # with a checked-out commit landed in INSTALL_DIR we're done; otherwise
+        # we clean up and fall back to HTTPS, which clones the public repo with
+        # no GitHub account and no key. GIT_SSH_COMMAND disables interactive
+        # prompts and sets a short timeout so a missing key fails fast instead
+        # of hanging.
         log_info "Trying SSH clone..."
         if GIT_SSH_COMMAND="ssh -o BatchMode=yes -o ConnectTimeout=5" \
-           git clone --depth 1 --branch "$BRANCH" "$REPO_URL_SSH" "$INSTALL_DIR" 2>/dev/null; then
+            git clone --depth 1 --branch "$BRANCH" "$REPO_URL_SSH" "$INSTALL_DIR" 2>/dev/null && \
+           [ -d "$INSTALL_DIR/.git" ] && git -C "$INSTALL_DIR" rev-parse HEAD 2>/dev/null; then
             log_success "Cloned via SSH"
         else
             rm -rf "$INSTALL_DIR" 2>/dev/null  # Clean up partial SSH clone


### PR DESCRIPTION
## What does this PR do?

The SSH clone fallback in the installer trusts git clone's exit code to decide whether the clone succeeded. On some environments (e.g. Lightning.ai Ubuntu VMs), git clone via SSH exits 0 but doesn't actually clone the repo — the script then skips the HTTPS fallback and the install fails.

This PR adds post-clone validation: it checks `.git` directory exists and `git rev-parse HEAD` succeeds before accepting the SSH clone. If either check fails, the script falls back to HTTPS, which clones the public repo without credentials.

## Related Issue

Fixes #62132

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- scripts/install.sh — appended `&& [ -d "$INSTALL_DIR/.git" ] && git -C "$INSTALL_DIR" rev-parse HEAD` to the SSH clone condition
- scripts/install.ps1 — added `git -C $InstallDir rev-parse HEAD` and `Test-Path "$InstallDir\.git"` checks after the SSH clone attempt

## How to Test

I encountered this issue on https://lightning.ai/ Ubuntu VM studios.

1. Using the default install command on a newly created studio should fail after repo cloning step: `curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash`.
2. Now, using the install script from my branch should correctly clone the repo and proceed with the full installation: `curl -fsSL https://raw.githubusercontent.com/codeaditya/hermes-agent/refs/heads/fix/git-ssh-clone-fallback/scripts/install.sh | bash`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [N/A] I've run `pytest tests/ -q` and all tests pass
- [N/A] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [N/A] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
