### PR TITLE
fix(desktop): isolate session routing across sidebar switches (#54527)

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
@@ -2,7 +2,13 @@ import { useAui, useAuiState, useComposerRuntime } from '@assistant-ui/react'
 import { type RefObject, useCallback, useEffect, useRef, useState } from 'react'
 
 import { SLASH_COMMAND_RE } from '@/lib/chat-runtime'
-import { $composerAttachments, type ComposerAttachment, stashSessionDraft, takeSessionDraft } from '@/store/composer'
+import {
+  $composerAttachments,
+  type ComposerAttachment,
+  migrateSessionDraft,
+  stashSessionDraft,
+  takeSessionDraft
+} from '@/store/composer'
 import { isBrowsingHistory } from '@/store/composer-input-history'
 
 import { cloneAttachments, DRAFT_PERSIST_DEBOUNCE_MS, type QueueEditState } from '../composer-utils'
@@ -23,6 +29,7 @@ interface UseComposerDraftArgs {
   focusKey: ChatBarProps['focusKey']
   inputDisabled: boolean
   queueEditRef: RefObject<QueueEditState | null>
+  queueSessionKey: ChatBarProps['queueSessionKey']
   sessionId: string | null | undefined
 }
 
@@ -41,6 +48,7 @@ export function useComposerDraft({
   focusKey,
   inputDisabled,
   queueEditRef,
+  queueSessionKey,
   sessionId
 }: UseComposerDraftArgs) {
   const aui = useAui()
@@ -75,8 +83,20 @@ export function useComposerDraft({
   const draftRef = useRef('')
   const pendingDraftPersistRef = useRef<{ scope: string | null; text: string } | null>(null)
   const draftPersistTimerRef = useRef<number | undefined>(undefined)
+  // Draft persistence must track the scope the swap effect owns, NOT the render-
+  // time queue key. activeQueueSessionKey updates on render while the editor still
+  // shows the previous session's text until the swap effect runs — debounced stashes
+  // keyed off the render ref mis-file drafts under the next session (#54527).
+  const draftScopeRef = useRef<string | null>(activeQueueSessionKey)
+  const prevDraftScopeRef = useRef<string | null>(activeQueueSessionKey)
   const activeQueueSessionKeyRef = useRef(activeQueueSessionKey)
   activeQueueSessionKeyRef.current = activeQueueSessionKey
+
+  const cancelPendingDraftPersist = () => {
+    window.clearTimeout(draftPersistTimerRef.current)
+    draftPersistTimerRef.current = undefined
+    pendingDraftPersistRef.current = null
+  }
   const sessionIdRef = useRef(sessionId)
   sessionIdRef.current = sessionId
   const queueEditStateRef = useRef<QueueEditState | null>(queueEditRef.current)
@@ -222,12 +242,18 @@ export function useComposerDraft({
         return
       }
 
-      const scope = activeQueueSessionKeyRef.current
+      const scope = draftScopeRef.current
       pendingDraftPersistRef.current = { scope, text }
       window.clearTimeout(draftPersistTimerRef.current)
       draftPersistTimerRef.current = window.setTimeout(() => {
+        const pending = pendingDraftPersistRef.current
+
+        if (!pending || pending.scope !== draftScopeRef.current) {
+          return
+        }
+
         pendingDraftPersistRef.current = null
-        stashAt(scope, text)
+        stashAt(pending.scope, pending.text)
       }, DRAFT_PERSIST_DEBOUNCE_MS)
     }
 
@@ -235,7 +261,7 @@ export function useComposerDraft({
 
     return () => {
       unsubscribe()
-      window.clearTimeout(draftPersistTimerRef.current)
+      cancelPendingDraftPersist()
     }
   }, [composerRuntime, queueEditRef])
 
@@ -285,17 +311,33 @@ export function useComposerDraft({
   // never clears composer state; this effect alone stashes on leave, restores
   // on enter. Keyed writes are idempotent, so no skip-sentinel.
   useEffect(() => {
+    cancelPendingDraftPersist()
+
+    const prev = prevDraftScopeRef.current
+    prevDraftScopeRef.current = activeQueueSessionKey
+
+    // Re-key when a fresh chat mints its first runtime id (or a resume bounce
+    // replaces a dead runtime id). Stable stored ids never churn — same rule as
+    // the queued-prompt migrator.
+    if (!queueSessionKey && prev && activeQueueSessionKey && prev !== activeQueueSessionKey) {
+      migrateSessionDraft(prev, activeQueueSessionKey)
+    }
+
+    draftScopeRef.current = activeQueueSessionKey
+
     const { attachments, text } = takeSessionDraft(activeQueueSessionKey)
     loadIntoComposer(text, attachments)
 
     return () => {
+      cancelPendingDraftPersist()
       const latestText = syncDraftFromEditor()
       const editing = queueEditStateRef.current
+      const scope = draftScopeRef.current
 
-      if (editing?.sessionKey === activeQueueSessionKey) {
-        stashAt(activeQueueSessionKey, editing.draft, editing.attachments)
+      if (editing?.sessionKey === scope) {
+        stashAt(scope, editing.draft, editing.attachments)
       } else if (!isBrowsingHistory(sessionId)) {
-        stashAt(activeQueueSessionKey, latestText)
+        stashAt(scope, latestText)
       }
     }
   }, [activeQueueSessionKey]) // eslint-disable-line react-hooks/exhaustive-deps
@@ -304,7 +346,7 @@ export function useComposerDraft({
   // inside the debounce/rAF window would drop trailing keystrokes without this.
   useEffect(() => {
     const flushPendingDraftPersist = () => {
-      const scope = activeQueueSessionKeyRef.current
+      const scope = draftScopeRef.current
       const editing = queueEditStateRef.current
 
       if (editing?.sessionKey === scope || isBrowsingHistory(sessionIdRef.current)) {

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -79,7 +79,7 @@ export function useComposerSubmit({
 
     const restore = () => {
       loadIntoComposer(text, submittedAttachments)
-      stashAt(activeQueueSessionKeyRef.current, text, submittedAttachments)
+      stashAt(submittedScope, text, submittedAttachments)
     }
 
     void Promise.resolve(attachments ? onSubmit(text, { attachments }) : onSubmit(text))

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -150,7 +150,7 @@ export function ChatBar({
     sessionIdRef,
     setComposerText,
     stashAt
-  } = useComposerDraft({ activeQueueSessionKey, focusKey, inputDisabled, queueEditRef, sessionId })
+  } = useComposerDraft({ activeQueueSessionKey, focusKey, inputDisabled, queueEditRef, queueSessionKey, sessionId })
 
   // "Add URL" dialog — open/value state, autofocus, and submit (host onAddUrl or
   // an @url: directive into the draft).

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -812,6 +812,7 @@ export function DesktopController() {
     branchCurrentSession: branchInNewChat,
     busyRef,
     createBackendSessionForSend,
+    getRouteToken,
     handleSkinCommand,
     openMemoryGraph: openStarmap,
     refreshSessions,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -51,7 +51,9 @@ interface HarnessHandle {
 }
 
 function Harness({
+  activeSessionIdRef: activeSessionIdRefProp,
   busyRef,
+  getRouteToken,
   onReady,
   onSeedState,
   openMemoryGraph,
@@ -59,11 +61,14 @@ function Harness({
   requestGateway,
   resumeStoredSession,
   seedMessages,
+  selectedStoredSessionIdRef: selectedStoredSessionIdRefProp,
   storedSessionId,
   activeSessionId,
   createBackendSessionForSend
 }: {
+  activeSessionIdRef?: MutableRefObject<string | null>
   busyRef?: MutableRefObject<boolean>
+  getRouteToken?: () => string
   onReady: (handle: HarnessHandle) => void
   onSeedState?: (state: Record<string, unknown>) => void
   openMemoryGraph?: () => void
@@ -71,15 +76,16 @@ function Harness({
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
   resumeStoredSession?: (storedSessionId: string) => Promise<void> | void
   seedMessages?: unknown[]
+  selectedStoredSessionIdRef?: MutableRefObject<string | null>
   storedSessionId?: null | string
   activeSessionId?: null | string
   createBackendSessionForSend?: () => Promise<null | string>
 }) {
-  const activeSessionIdRef: MutableRefObject<string | null> = {
+  const activeSessionIdRef: MutableRefObject<string | null> = activeSessionIdRefProp ?? {
     current: activeSessionId === undefined ? RUNTIME_SESSION_ID : activeSessionId
   }
 
-  const selectedStoredSessionIdRef: MutableRefObject<string | null> = {
+  const selectedStoredSessionIdRef: MutableRefObject<string | null> = selectedStoredSessionIdRefProp ?? {
     current: storedSessionId === undefined ? RUNTIME_SESSION_ID : storedSessionId
   }
 
@@ -98,6 +104,7 @@ function Harness({
     branchCurrentSession: async () => true,
     busyRef: localBusyRef,
     createBackendSessionForSend: createBackendSessionForSend ?? (async () => RUNTIME_SESSION_ID),
+    getRouteToken: getRouteToken ?? (() => 'token'),
     handleSkinCommand: () => '',
     openMemoryGraph: openMemoryGraph ?? (() => undefined),
     refreshSessions,
@@ -1239,7 +1246,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
 
     expect(ok).toBe(true)
     expect(calls.map(c => c.method)).toEqual(['prompt.submit', 'session.resume', 'prompt.submit'])
-    expect(calls[1]?.params).toEqual({ session_id: STORED_SESSION_ID })
+    expect(calls[1]?.params).toEqual({ session_id: STORED_SESSION_ID, source: 'desktop' })
     expect(calls[2]?.params).toEqual({
       session_id: RECOVERED_SESSION_ID,
       text: 'message during starved loop'
@@ -1313,6 +1320,125 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(ok).toBe(true)
     expect(createBackendSessionForSend).toHaveBeenCalledTimes(1)
     expect(calls).not.toContain('session.resume')
+  })
+})
+
+describe('usePromptActions submit session-context isolation (#54527)', () => {
+  const STORED_SESSION_A = 'stored-project-a'
+  const STORED_SESSION_B = 'stored-project-b'
+  const RUNTIME_SESSION_B = 'rt-session-b-wrong'
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('aborts submit when the user switches sessions during session.resume (no misroute)', async () => {
+    // Exact #54527 failure: user submits in Session A while its runtime binding
+    // is gone; before resume returns they switch to Session B. Without a pinned
+    // context the resumed runtime id belongs to B and A's text lands in the
+    // wrong chat — permanently lost from A.
+    let releaseResume: () => void = () => {}
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: STORED_SESSION_A }
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'session.resume') {
+        await new Promise<void>(resolve => {
+          releaseResume = resolve
+        })
+
+        // Simulate the user switching to Session B while resume is in flight.
+        selectedStoredSessionIdRef.current = STORED_SESSION_B
+        activeSessionIdRef.current = RUNTIME_SESSION_B
+
+        return { session_id: RUNTIME_SESSION_B } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={STORED_SESSION_A}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    const submitting = handle!.submitText('carefully composed prompt for project A')
+    await waitFor(() => expect(calls.some(c => c.method === 'session.resume')).toBe(true))
+    releaseResume()
+
+    expect(await submitting).toBe(false)
+    expect(calls.some(c => c.method === 'prompt.submit')).toBe(false)
+    expect(calls.find(c => c.method === 'session.resume')?.params).toEqual({
+      session_id: STORED_SESSION_A
+    })
+  })
+
+  it('aborts recovery submit when the user switches sessions during timeout resume', async () => {
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    let submitAttempts = 0
+    let releaseResume: () => void = () => {}
+
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: STORED_SESSION_A }
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'prompt.submit') {
+        submitAttempts += 1
+
+        if (submitAttempts === 1) {
+          throw new Error('request timed out: prompt.submit')
+        }
+      }
+
+      if (method === 'session.resume') {
+        await new Promise<void>(resolve => {
+          releaseResume = resolve
+        })
+        selectedStoredSessionIdRef.current = STORED_SESSION_B
+
+        return { session_id: RUNTIME_SESSION_B } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={STORED_SESSION_A}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    const submitting = handle!.submitText('message that must not land in session B')
+    await waitFor(() => expect(calls.some(c => c.method === 'session.resume')).toBe(true))
+    releaseResume()
+
+    expect(await submitting).toBe(false)
+    expect(submitAttempts).toBe(1)
+    expect(calls.filter(c => c.method === 'prompt.submit')).toHaveLength(1)
+    expect(calls.find(c => c.method === 'session.resume')?.params).toMatchObject({
+      session_id: STORED_SESSION_A
+    })
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -158,6 +158,7 @@ interface PromptActionsOptions {
   busyRef: MutableRefObject<boolean>
   branchCurrentSession: () => Promise<boolean>
   createBackendSessionForSend: (preview?: string | null) => Promise<string | null>
+  getRouteToken: () => string
   handleSkinCommand: (arg: string) => string
   openMemoryGraph: () => void
   refreshSessions: () => Promise<void>
@@ -186,6 +187,7 @@ export function usePromptActions({
   busyRef,
   branchCurrentSession,
   createBackendSessionForSend,
+  getRouteToken,
   handleSkinCommand,
   openMemoryGraph,
   refreshSessions,
@@ -354,6 +356,7 @@ export function usePromptActions({
     busyRef,
     copy,
     createBackendSessionForSend,
+    getRouteToken,
     requestGateway,
     selectedStoredSessionIdRef,
     syncAttachmentsForSubmit,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -35,6 +35,7 @@ interface SubmitPromptDeps {
   busyRef: MutableRefObject<boolean>
   copy: Translations['desktop']
   createBackendSessionForSend: (preview?: string | null) => Promise<string | null>
+  getRouteToken: () => string
   requestGateway: GatewayRequest
   selectedStoredSessionIdRef: MutableRefObject<string | null>
   syncAttachmentsForSubmit: (
@@ -57,6 +58,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
     busyRef,
     copy,
     createBackendSessionForSend,
+    getRouteToken,
     requestGateway,
     selectedStoredSessionIdRef,
     syncAttachmentsForSubmit,
@@ -113,9 +115,20 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         return false
       }
 
+      // Pin the session context for the whole async submit pipeline. Without
+      // this, a fast session switch during session.resume / file.attach can
+      // redirect the user's text into a different chat (#54527).
+      const startingActiveSessionId = activeSessionIdRef.current
+      const startingStoredSessionId = selectedStoredSessionIdRef.current
+      const startingRouteToken = getRouteToken()
+
+      const sessionContextDrifted = (): boolean =>
+        selectedStoredSessionIdRef.current !== startingStoredSessionId ||
+        getRouteToken() !== startingRouteToken
+
       // One submit in flight per session — drop any concurrent re-fire so a
       // stalled turn can't stack the same prompt into multiple real turns.
-      const submitLockKey = selectedStoredSessionIdRef.current || activeSessionId || '__pending_new__'
+      const submitLockKey = startingStoredSessionId || startingActiveSessionId || '__pending_new__'
 
       if (_submitInFlight.has(submitLockKey)) {
         return false
@@ -166,7 +179,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             // (what made drained-after-interrupt sends go silent).
             interrupted: false
           }),
-          selectedStoredSessionIdRef.current
+          startingStoredSessionId
         )
 
       // After sync rewrites refs, refresh the optimistic message in place so the
@@ -178,7 +191,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             ...state,
             messages: state.messages.map(message => (message.id === optimisticId ? buildUserMessage() : message))
           }),
-          selectedStoredSessionIdRef.current
+          startingStoredSessionId
         )
 
       const dropOptimistic = (sid: null | string) => {
@@ -197,8 +210,15 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             awaitingResponse: false,
             pendingBranchGroup: null
           }),
-          selectedStoredSessionIdRef.current
+          startingStoredSessionId
         )
+      }
+
+      const abortForSessionSwitch = (optimisticSessionId: null | string): false => {
+        dropOptimistic(optimisticSessionId)
+        releaseBusy()
+
+        return false
       }
 
       setMutableRef(busyRef, true)
@@ -214,7 +234,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         setMessages(current => [...current, buildUserMessage()])
       }
 
-      if (!sessionId && selectedStoredSessionIdRef.current) {
+      if (!sessionId && startingStoredSessionId) {
         // A stored session is SELECTED but its runtime binding is gone (the
         // live session was orphan-reaped, or a timeout/reconnect cleared
         // activeSessionId). Continuing the selected conversation must mean
@@ -224,8 +244,12 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         // new-chat draft).
         try {
           const resumed = await requestGateway<{ session_id: string }>('session.resume', {
-            session_id: selectedStoredSessionIdRef.current
+            session_id: startingStoredSessionId
           })
+
+          if (sessionContextDrifted()) {
+            return abortForSessionSwitch(sessionId)
+          }
 
           if (resumed?.session_id) {
             sessionId = resumed.session_id
@@ -235,6 +259,10 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           // Resume failed (session gone from state.db, gateway hiccup) —
           // fall through to creating a fresh session rather than dead-ending
           // the user's message.
+        }
+
+        if (sessionContextDrifted()) {
+          return abortForSessionSwitch(sessionId)
         }
 
         if (sessionId) {
@@ -253,6 +281,10 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           return false
         }
 
+        if (sessionContextDrifted()) {
+          return abortForSessionSwitch(sessionId)
+        }
+
         if (!sessionId) {
           dropOptimistic(null)
           releaseBusy()
@@ -268,6 +300,10 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         const syncedAttachments = await syncAttachmentsForSubmit(sessionId, attachments, {
           updateComposerAttachments: usingComposerAttachments
         })
+
+        if (sessionContextDrifted()) {
+          return abortForSessionSwitch(sessionId)
+        }
 
         // Rewrite the optimistic message + prompt text with the synced refs so
         // the gateway receives @file: paths that resolve in its workspace.
@@ -288,7 +324,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         } catch (firstErr) {
           if (
             (isSessionNotFoundError(firstErr) || isGatewayTimeoutError(firstErr)) &&
-            selectedStoredSessionIdRef.current
+            startingStoredSessionId
           ) {
             // Re-register the session in the gateway and get a fresh live ID.
             // Timeouts recover the same way as "session not found": a starved
@@ -296,9 +332,13 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             // the stored session is fine — resume + retry instead of erroring
             // out and losing the session binding.
             const resumed = await requestGateway<{ session_id: string }>('session.resume', {
-              session_id: selectedStoredSessionIdRef.current,
+              session_id: startingStoredSessionId,
               source: 'desktop'
             })
+
+            if (sessionContextDrifted()) {
+              return abortForSessionSwitch(sessionId)
+            }
 
             const recoveredId = resumed?.session_id
 
@@ -375,6 +415,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       busyRef,
       copy,
       createBackendSessionForSend,
+      getRouteToken,
       requestGateway,
       selectedStoredSessionIdRef,
       syncAttachmentsForSubmit,

--- a/apps/desktop/src/store/composer.test.ts
+++ b/apps/desktop/src/store/composer.test.ts
@@ -5,6 +5,7 @@ import {
   addComposerAttachment,
   clearSessionDraft,
   type ComposerAttachment,
+  migrateSessionDraft,
   removeComposerAttachment,
   SESSION_DRAFTS_STORAGE_KEY,
   stashSessionDraft,
@@ -105,5 +106,39 @@ describe('session drafts', () => {
     taken.attachments[0]!.label = 'mutated'
 
     expect(takeSessionDraft('session-a').attachments[0]?.label).toBe('doc.pdf')
+  })
+})
+
+describe('migrateSessionDraft', () => {
+  afterEach(() => {
+    for (const scope of ['session-a', 'session-b', null, 'rt-new']) {
+      clearSessionDraft(scope)
+    }
+
+    window.localStorage.clear()
+  })
+
+  it('moves a draft from the unsaved new-session key onto a runtime id', () => {
+    stashSessionDraft(null, 'fresh chat draft', [])
+
+    expect(migrateSessionDraft(null, 'rt-new')).toBe(true)
+    expect(takeSessionDraft(null).text).toBe('')
+    expect(takeSessionDraft('rt-new').text).toBe('fresh chat draft')
+  })
+
+  it('does not clobber an existing target draft', () => {
+    stashSessionDraft('rt-old', 'old runtime draft', [])
+    stashSessionDraft('rt-new', 'already here', [])
+
+    expect(migrateSessionDraft('rt-old', 'rt-new')).toBe(false)
+    expect(takeSessionDraft('rt-old').text).toBe('old runtime draft')
+    expect(takeSessionDraft('rt-new').text).toBe('already here')
+  })
+
+  it('no-ops when source and target resolve to the same key', () => {
+    stashSessionDraft('session-a', 'draft', [])
+
+    expect(migrateSessionDraft('session-a', 'session-a')).toBe(false)
+    expect(takeSessionDraft('session-a').text).toBe('draft')
   })
 })

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -99,6 +99,41 @@ export function takeSessionDraft(scope: string | null | undefined): SessionDraft
 
 export const clearSessionDraft = (scope: string | null | undefined) => stashSessionDraft(scope, '', [])
 
+/**
+ * Move a stashed draft from a dead scope onto a live one (e.g. `__new__` → the
+ * first runtime session id minted on send, or an old runtime id after resume).
+ * No-op unless the source has content and the target is empty — never clobber.
+ */
+export function migrateSessionDraft(
+  fromKey: string | null | undefined,
+  toKey: string | null | undefined
+): boolean {
+  const from = draftKey(fromKey)
+  const to = draftKey(toKey)
+
+  if (from === to) {
+    return false
+  }
+
+  const source = draftsBySession.get(from)
+
+  if (!source || (!source.text.trim() && source.attachments.length === 0)) {
+    return false
+  }
+
+  const target = draftsBySession.get(to) ?? EMPTY_SESSION_DRAFT
+
+  if (target.text.trim() || target.attachments.length > 0) {
+    return false
+  }
+
+  draftsBySession.delete(from)
+  draftsBySession.set(to, cloneDraft(source))
+  persistDraftTexts()
+
+  return true
+}
+
 export function setComposerDraft(value: string) {
   $composerDraft.set(value)
 }


### PR DESCRIPTION
## Summary

Fixes #54527 — user input could be lost or appear in the wrong Desktop session when switching chats mid-compose or mid-submit. Two independent bug classes, two commits:

1. **Composer draft isolation** — debounced draft persistence no longer keys off the render-time session ref while the editor still shows the previous session's text. Tracks draft scope in the swap effect, cancels stale timers, migrates fresh-chat drafts on runtime id assignment, and restores rejected submits to the submitted scope.
2. **Submit session-context pinning** — snapshots the selected stored session id and route token for the full async `session.resume` / `prompt.submit` pipeline. Aborts cleanly if the user switches sessions mid-flight instead of misrouting text into another chat.

Supersedes #62130 (composer-only PR, now included here).

Fixes #54527

## Test plan

- [x] `npm run test:ui -- src/store/composer.test.ts` (11/11)
- [x] `npm run test:ui -- src/app/session/hooks/use-prompt-actions/index.test.tsx` (42/42)
- [x] Verified #54527 regression tests fail without commit 2 and pass with both commits