### PR TITLE
fix: make Slack platform capability note tool-aware

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -497,11 +497,15 @@ def build_session_context_prompt(
         lines.append("")
         lines.append(
             "**Platform notes:** You are running inside Slack. "
-            "You do NOT have access to Slack-specific APIs — you cannot search "
-            "channel history, pin/unpin messages, manage channels, or list users. "
-            "Do not promise to perform these actions. The gateway may inline the "
-            "current message's Slack block/attachment payload when available, but "
-            "you still cannot call Slack APIs yourself."
+            "Slack does not automatically expose a native Slack API tool. Do not "
+            "claim that channel history, member lookup, pinning, or admin actions "
+            "are available unless a loaded tool, plugin, or profile-provided bounded "
+            "helper supports them. For read-only requests such as channel history, "
+            "thread context, or member lookup, inspect the available tools and skills "
+            "first and use a bounded helper when present; do not infer lack of access "
+            "from this generic note. Never promise write or admin actions without an "
+            "explicit supporting tool. The gateway may also inline the current "
+            "message's Slack block/attachment payload when available."
         )
     elif context.source.platform == Platform.DISCORD:
         # Inject the Discord IDs block only when the agent actually has

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -294,8 +294,11 @@ class TestBuildSessionContextPrompt:
         prompt = build_session_context_prompt(ctx)
 
         assert "Slack" in prompt
-        assert "cannot search" in prompt.lower()
-        assert "pin" in prompt.lower()
+        assert "does not automatically expose a native slack api tool" in prompt.lower()
+        assert "inspect the available tools and skills first" in prompt.lower()
+        assert "bounded helper when present" in prompt.lower()
+        assert "do not infer lack of access" in prompt.lower()
+        assert "write or admin actions" in prompt.lower()
         assert "current message's slack block/attachment payload" in prompt.lower()
 
     def test_discord_prompt_with_channel_topic(self):


### PR DESCRIPTION
## What changed
- replace the absolute Slack API denial with capability-aware guidance
- tell agents to inspect loaded tools, plugins, and bounded helpers before claiming read access is unavailable
- preserve the guard against unsupported write/admin actions

## Why
Profiles can provide bounded read-only Slack helpers even when Hermes has no native Slack tool. The previous absolute note caused an agent to incorrectly refuse a channel-history summary despite a working helper.

## Verification
- direct `build_session_context_prompt` runtime assertion passed
- `py_compile` passed for changed Python files
- `git diff --check` passed
- canonical pytest runner unavailable in this air-gapped workspace because no test venv/pytest cache is installed