### PR TITLE
docs(batch_runner): correct documented CLI defaults for model and log_prefix_chars

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -568,7 +568,7 @@ class BatchRunner:
             num_workers (int): Number of parallel workers
             verbose (bool): Enable verbose logging
             ephemeral_system_prompt (str): System prompt used during agent execution but NOT saved to trajectories (optional)
-            log_prefix_chars (int): Number of characters to show in log previews for tool calls/responses (default: 20)
+            log_prefix_chars (int): Number of characters to show in log previews for tool calls/responses (default: 100)
             providers_allowed (List[str]): OpenRouter providers to allow (optional)
             providers_ignored (List[str]): OpenRouter providers to ignore (optional)
             providers_order (List[str]): OpenRouter providers to try in order (optional)
@@ -1177,7 +1177,7 @@ def main(
         batch_size (int): Number of prompts per batch
         run_name (str): Name for this run (used for output and checkpointing)
         distribution (str): Toolset distribution to use (default: "default")
-        model (str): Model name to use (default: "claude-opus-4-20250514")
+        model (str): Model name to use (default: "anthropic/claude-sonnet-4.6")
         api_key (str): API key for model authentication
         base_url (str): Base URL for model API
         max_turns (int): Maximum number of tool calling iterations per prompt (default: 10)
@@ -1186,7 +1186,7 @@ def main(
         verbose (bool): Enable verbose logging (default: False)
         list_distributions (bool): List available toolset distributions and exit
         ephemeral_system_prompt (str): System prompt used during agent execution but NOT saved to trajectories (optional)
-        log_prefix_chars (int): Number of characters to show in log previews for tool calls/responses (default: 20)
+        log_prefix_chars (int): Number of characters to show in log previews for tool calls/responses (default: 100)
         providers_allowed (str): Comma-separated list of OpenRouter providers to allow (e.g. "anthropic,openai")
         providers_ignored (str): Comma-separated list of OpenRouter providers to ignore (e.g. "together,deepinfra")
         providers_order (str): Comma-separated list of OpenRouter providers to try in order (e.g. "anthropic,openai,google")

--- a/website/docs/user-guide/features/batch-processing.md
+++ b/website/docs/user-guide/features/batch-processing.md
@@ -60,7 +60,7 @@ Entries can optionally include:
 | `--batch_size` | (required) | Prompts per batch |
 | `--run_name` | (required) | Name for this run (used for output dir and checkpointing) |
 | `--distribution` | `"default"` | Toolset distribution to sample from |
-| `--model` | `claude-sonnet-4.6` | Model to use |
+| `--model` | `anthropic/claude-sonnet-4.6` | Model to use |
 | `--base_url` | `https://openrouter.ai/api/v1` | API base URL |
 | `--api_key` | (env var) | API key for model |
 | `--max_turns` | `10` | Maximum tool-calling iterations per prompt |


### PR DESCRIPTION
## Problem

`batch_runner.py` exposes `main()` through `fire.Fire(main)`, so its docstring **is** the CLI `--help` text. Two documented defaults don't match the actual signatures:

| Arg | Docstring says | Actual default |
|-----|----------------|----------------|
| `model` (main, L1180) | `"claude-opus-4-20250514"` | `"anthropic/claude-sonnet-4.6"` (L1152) |
| `log_prefix_chars` (main L1189 **and** `BatchRunner.__init__` L571) | `20` | `100` (L1161 / L545) |

The `model` mismatch is the meaningful one: a user who reads `--help` and relies on the documented default expects **Opus 4**, but the run actually uses **Sonnet 4.6** — a different model, provider, and cost. The Opus id is the real default on `BatchRunner.__init__` (L541); the `main()` docstring was copied from there without updating when `main()`'s default was changed to the OpenRouter Sonnet id.

## Fix

Docstring-only change so the documented defaults match the code (`main.model` → `anthropic/claude-sonnet-4.6`; both `log_prefix_chars` docstrings → `100`). No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)