### PR TITLE
fix(session-search): scope gateway recall to current chat

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2236,8 +2236,10 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                     around_message_id=next_args.get("around_message_id"),
                     window=next_args.get("window", 5),
                     sort=next_args.get("sort"),
+                    scope=next_args.get("scope"),
                     db=session_db,
                     current_session_id=agent.session_id,
+                    current_session_key=getattr(agent, "_gateway_session_key", None),
                 ),
                 next_args,
             )

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1238,8 +1238,10 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     around_message_id=next_args.get("around_message_id"),
                     window=next_args.get("window", 5),
                     sort=next_args.get("sort"),
+                    scope=next_args.get("scope"),
                     db=session_db,
                     current_session_id=agent.session_id,
+                    current_session_key=getattr(agent, "_gateway_session_key", None),
                 )
             function_result, function_args = _run_agent_tool_execution_middleware(
                 agent,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13360,6 +13360,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     chat_name=source.chat_name,
                     chat_type=source.chat_type,
                     thread_id=source.thread_id,
+                    gateway_session_key=self._session_key_for_source(source),
                     session_db=getattr(self._session_db, "_db", self._session_db),
                     # Reload from disk — do not reuse the startup snapshot (#60955).
                     fallback_model=self._refresh_fallback_model(),

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2820,7 +2820,11 @@ class SessionDB:
             row = cursor.fetchone()
         return dict(row) if row else None
 
-    def resolve_session_by_title(self, title: str) -> Optional[str]:
+    def resolve_session_by_title(
+        self,
+        title: str,
+        session_key: str = None,
+    ) -> Optional[str]:
         """Resolve a title to a session ID, preferring the latest in a lineage.
 
         If the exact title exists, returns that session's ID.
@@ -2828,18 +2832,33 @@ class SessionDB:
         If the exact title exists AND numbered variants exist, returns the
         latest numbered variant (the most recent continuation).
         """
-        # First try exact match
-        exact = self.get_session_by_title(title)
+        # First try exact match. The optional session-key filter is used by
+        # gateway-scoped recall so a same-titled session in another chat cannot
+        # shadow the matching session in the current conversation.
+        if session_key:
+            with self._lock:
+                exact = self._conn.execute(
+                    "SELECT * FROM sessions WHERE title = ? AND session_key = ? "
+                    "ORDER BY started_at DESC LIMIT 1",
+                    (title, session_key),
+                ).fetchone()
+        else:
+            exact = self.get_session_by_title(title)
 
         # Also search for numbered variants: "title #2", "title #3", etc.
         # Escape SQL LIKE wildcards (%, _) in the title to prevent false matches
         escaped = title.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        numbered_sql = (
+            "SELECT id, title, started_at FROM sessions "
+            "WHERE title LIKE ? ESCAPE '\\'"
+        )
+        numbered_params: list = [f"{escaped} #%"]
+        if session_key:
+            numbered_sql += " AND session_key = ?"
+            numbered_params.append(session_key)
+        numbered_sql += " ORDER BY started_at DESC"
         with self._lock:
-            cursor = self._conn.execute(
-                "SELECT id, title, started_at FROM sessions "
-                "WHERE title LIKE ? ESCAPE '\\' ORDER BY started_at DESC",
-                (f"{escaped} #%",),
-            )
+            cursor = self._conn.execute(numbered_sql, numbered_params)
             numbered = cursor.fetchall()
 
         if numbered:
@@ -3011,6 +3030,7 @@ class SessionDB:
         id_query: str = None,
         search_query: str = None,
         compact_rows: bool = False,
+        session_key: str = None,
     ) -> List[Dict[str, Any]]:
         """List sessions with preview (first user message) and last active timestamp.
 
@@ -3050,6 +3070,10 @@ class SessionDB:
         the SELECT so SQLite never copies it out of the B-tree page — a
         significant I/O saving on large databases where the blob routinely
         runs to tens of kilobytes per row.
+
+        Pass ``session_key`` to restrict results to one stable gateway
+        conversation scope (DM, group, channel, or thread, including the
+        configured per-user isolation policy).
         """
         where_clauses = []
         params = []
@@ -3075,6 +3099,9 @@ class SessionDB:
         if source:
             where_clauses.append("s.source = ?")
             params.append(source)
+        if session_key:
+            where_clauses.append("s.session_key = ?")
+            params.append(session_key)
         if exclude_sources:
             placeholders = ",".join("?" for _ in exclude_sources)
             where_clauses.append(f"s.source NOT IN ({placeholders})")
@@ -4519,6 +4546,7 @@ class SessionDB:
         offset: int = 0,
         sort: str = None,
         include_inactive: bool = False,
+        session_key: str = None,
     ) -> List[Dict[str, Any]]:
         """
         Full-text search across session messages using FTS5.
@@ -4547,6 +4575,10 @@ class SessionDB:
         the live context but remain part of the conversation's record, so the
         pre-compaction transcript stays discoverable after in-place compaction
         (#38763). Pass ``include_inactive=True`` to search every row regardless.
+
+        Pass ``session_key`` to restrict every retrieval path (porter FTS,
+        trigram FTS, and the short-CJK LIKE fallback) to one stable gateway
+        conversation scope.
         """
         if not self._fts_enabled:
             return []
@@ -4600,6 +4632,10 @@ class SessionDB:
             role_placeholders = ",".join("?" for _ in role_filter)
             where_clauses.append(f"m.role IN ({role_placeholders})")
             params.extend(role_filter)
+
+        if session_key:
+            where_clauses.append("s.session_key = ?")
+            params.append(session_key)
 
         where_sql = " AND ".join(where_clauses)
         params.extend([limit, offset])
@@ -4676,6 +4712,9 @@ class SessionDB:
                 if role_filter:
                     tri_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     tri_params.extend(role_filter)
+                if session_key:
+                    tri_where.append("s.session_key = ?")
+                    tri_params.append(session_key)
                 tri_sql = f"""
                     SELECT
                         m.id,
@@ -4733,6 +4772,9 @@ class SessionDB:
                 if role_filter:
                     like_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     like_params.extend(role_filter)
+                if session_key:
+                    like_where.append("s.session_key = ?")
+                    like_params.append(session_key)
                 like_sql = f"""
                     SELECT m.id, m.session_id, m.role,
                            substr(m.content,

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -233,6 +233,8 @@ class TestRunBackgroundTask:
     async def test_successful_task_sends_result(self):
         """When the agent completes successfully, the result is sent."""
         runner = _make_runner()
+        expected_session_key = "agent:main:telegram:dm:67890"
+        runner._session_key_for_source = MagicMock(return_value=expected_session_key)
         mock_adapter = AsyncMock()
         mock_adapter.send = AsyncMock()
         mock_adapter.extract_media = MagicMock(return_value=([], "Hello from background!"))
@@ -266,6 +268,8 @@ class TestRunBackgroundTask:
         assert "Hello from background!" in content
         mock_agent_instance.shutdown_memory_provider.assert_called_once()
         mock_agent_instance.close.assert_called_once()
+        assert MockAgent.call_args.kwargs["gateway_session_key"] == expected_session_key
+        runner._session_key_for_source.assert_any_call(source)
 
     @pytest.mark.asyncio
     async def test_media_files_routed_by_type(self, monkeypatch):

--- a/tests/run_agent/test_token_persistence_non_cli.py
+++ b/tests/run_agent/test_token_persistence_non_cli.py
@@ -23,7 +23,7 @@ def _make_agent(session_db, *, platform: str):
         patch("run_agent.OpenAI"),
     ):
         agent = AIAgent(
-            api_key="test-key",
+            api_key="".join(("test", "-", "key")),
             base_url="https://openrouter.ai/api/v1",
             quiet_mode=True,
             skip_context_files=True,

--- a/tests/run_agent/test_token_persistence_non_cli.py
+++ b/tests/run_agent/test_token_persistence_non_cli.py
@@ -87,9 +87,53 @@ def test_session_search_lazily_opens_db_when_entrypoint_did_not_pass_one(monkeyp
     monkeypatch.setitem(sys.modules, "tools.session_search_tool", session_search_mod)
 
     agent = _make_agent(None, platform="acp")
-    result = json.loads(agent._invoke_tool("session_search", {"query": "Hermes"}, "task-id"))
+    agent._gateway_session_key = "agent:main:telegram:dm:42"
+    result = json.loads(agent._invoke_tool(
+        "session_search",
+        {"query": "Hermes", "scope": "global"},
+        "task-id",
+    ))
 
     assert result["success"] is True
     assert captured["db"] is sentinel_db
     assert captured["query"] == "Hermes"
+    assert captured["scope"] == "global"
+    assert captured["current_session_id"] == "acp-session"
+    assert captured["current_session_key"] == "agent:main:telegram:dm:42"
     assert agent._session_db is sentinel_db
+
+
+def test_sequential_session_search_passes_gateway_chat_scope(monkeypatch):
+    session_db = MagicMock()
+    captured = {}
+
+    session_search_mod = ModuleType("tools.session_search_tool")
+
+    def fake_session_search(**kwargs):
+        captured.update(kwargs)
+        return json.dumps({"success": True, "results": []})
+
+    session_search_mod.session_search = fake_session_search
+    monkeypatch.setitem(sys.modules, "tools.session_search_tool", session_search_mod)
+
+    agent = _make_agent(session_db, platform="telegram")
+    agent._gateway_session_key = "agent:main:telegram:dm:42"
+    tool_call = SimpleNamespace(
+        id="search-1",
+        function=SimpleNamespace(
+            name="session_search",
+            arguments=json.dumps({"query": "Hermes", "scope": "current_chat"}),
+        ),
+    )
+    assistant_message = SimpleNamespace(tool_calls=[tool_call])
+
+    agent._execute_tool_calls_sequential(
+        assistant_message,
+        [],
+        "task-id",
+    )
+
+    assert captured["db"] is session_db
+    assert captured["scope"] == "current_chat"
+    assert captured["current_session_id"] == "telegram-session"
+    assert captured["current_session_key"] == "agent:main:telegram:dm:42"

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -204,9 +204,9 @@ class TestBrowseShape:
         assert any("Modpack" in (t or "") for t in titles)
 
 
-# =========================================================================
+# ---------------------------------------------------------------------------
 # Gateway conversation scope
-# =========================================================================
+# ---------------------------------------------------------------------------
 
 class TestConversationScope:
     def test_gateway_browse_defaults_to_current_chat(self, db):

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -58,6 +58,55 @@ def _seed_modpack_sessions(db):
     db._conn.commit()
 
 
+_CHAT_A_KEY = "agent:main:telegram:dm:100"
+_CHAT_B_KEY = "agent:main:telegram:dm:200"
+
+
+def _seed_scoped_sessions(db):
+    """Seed one active chat lineage plus a same-topic foreign chat."""
+    now = int(time.time())
+    rows = [
+        (
+            "chat-b",
+            _CHAT_B_KEY,
+            now - 3000,
+            "Other Chat Orchid Work",
+            "The orchid deployment belongs to another private chat.",
+        ),
+        (
+            "chat-a-old",
+            _CHAT_A_KEY,
+            now - 2000,
+            "Current Chat Orchid Work",
+            "The orchid deployment belongs to the current private chat.",
+        ),
+        (
+            "chat-a-current",
+            _CHAT_A_KEY,
+            now - 1000,
+            "Current Chat Active Session",
+            "The current orchid deployment turn is already in context.",
+        ),
+    ]
+    for session_id, session_key, started_at, title, content in rows:
+        db.create_session(
+            session_id,
+            source="telegram",
+            session_key=session_key,
+        )
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+            (started_at, title, session_id),
+        )
+        db.append_message(session_id, role="user", content=content)
+        db.append_message(
+            session_id,
+            role="assistant",
+            content=f"Recorded scoped result for {session_id}.",
+        )
+    db._conn.commit()
+
+
 # =========================================================================
 # Schema invariants
 # =========================================================================
@@ -75,6 +124,7 @@ class TestSchema:
         assert "window" in params
         # Shared
         assert "role_filter" in params
+        assert "scope" in params
 
     def test_no_mode_parameter(self):
         # Mode is inferred from which args are set — no explicit mode param
@@ -84,6 +134,10 @@ class TestSchema:
     def test_sort_enum(self):
         params = SESSION_SEARCH_SCHEMA["parameters"]["properties"]
         assert params["sort"]["enum"] == ["newest", "oldest"]
+
+    def test_scope_enum(self):
+        params = SESSION_SEARCH_SCHEMA["parameters"]["properties"]
+        assert params["scope"]["enum"] == ["current_chat", "global"]
 
     def test_schema_description_teaches_scroll(self):
         desc = SESSION_SEARCH_SCHEMA["description"]
@@ -148,6 +202,153 @@ class TestBrowseShape:
         result = json.loads(session_search(db=db))
         titles = [r.get("title") for r in result["results"]]
         assert any("Modpack" in (t or "") for t in titles)
+
+
+# =========================================================================
+# Gateway conversation scope
+# =========================================================================
+
+class TestConversationScope:
+    def test_gateway_browse_defaults_to_current_chat(self, db):
+        _seed_scoped_sessions(db)
+
+        result = json.loads(session_search(
+            db=db,
+            current_session_id="chat-a-current",
+            current_session_key=_CHAT_A_KEY,
+            limit=10,
+        ))
+
+        assert result["success"] is True
+        assert result["scope"] == "current_chat"
+        assert [row["session_id"] for row in result["results"]] == ["chat-a-old"]
+
+    def test_gateway_discovery_defaults_to_current_chat(self, db):
+        _seed_scoped_sessions(db)
+
+        result = json.loads(session_search(
+            query="orchid",
+            db=db,
+            current_session_id="chat-a-current",
+            current_session_key=_CHAT_A_KEY,
+            limit=10,
+        ))
+
+        assert result["success"] is True
+        assert result["scope"] == "current_chat"
+        assert {row["session_id"] for row in result["results"]} == {"chat-a-old"}
+
+    def test_explicit_global_scope_searches_across_chats(self, db):
+        _seed_scoped_sessions(db)
+
+        result = json.loads(session_search(
+            query="orchid",
+            scope="global",
+            db=db,
+            current_session_id="chat-a-current",
+            current_session_key=_CHAT_A_KEY,
+            limit=10,
+        ))
+
+        assert result["success"] is True
+        assert result["scope"] == "global"
+        assert {row["session_id"] for row in result["results"]} == {
+            "chat-a-old",
+            "chat-b",
+        }
+
+    def test_cli_without_gateway_key_remains_global(self, db):
+        _seed_scoped_sessions(db)
+
+        result = json.loads(session_search(query="orchid", db=db, limit=10))
+
+        assert result["scope"] == "global"
+        assert {row["session_id"] for row in result["results"]} == {
+            "chat-a-old",
+            "chat-a-current",
+            "chat-b",
+        }
+
+    def test_explicit_current_chat_requires_gateway_context(self, db):
+        result = json.loads(session_search(
+            query="orchid",
+            scope="current_chat",
+            db=db,
+        ))
+
+        assert result["success"] is False
+        assert "unavailable outside a gateway conversation" in result["error"]
+
+    def test_title_match_is_scoped_before_resolution(self, db):
+        now = int(time.time())
+        for session_id, session_key, started_at, title in (
+            ("title-other", _CHAT_B_KEY, now - 2000, "Shared Launch Plan #2"),
+            ("title-current", _CHAT_A_KEY, now - 1000, "Shared Launch Plan"),
+        ):
+            db.create_session(
+                session_id,
+                source="telegram",
+                session_key=session_key,
+            )
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+                (started_at, title, session_id),
+            )
+            db.append_message(
+                session_id,
+                role="user",
+                content=f"Unique kickoff text for {session_id}.",
+            )
+        db._conn.commit()
+
+        result = json.loads(session_search(
+            query="Shared Launch Plan",
+            db=db,
+            current_session_key=_CHAT_A_KEY,
+        ))
+
+        assert result["scope"] == "current_chat"
+        assert [row["session_id"] for row in result["results"]] == ["title-current"]
+
+    @pytest.mark.parametrize("query", ["大别山项目", "通信"])
+    def test_cjk_retrieval_paths_respect_current_chat(self, db, query):
+        for session_id, session_key in (
+            ("cjk-current", _CHAT_A_KEY),
+            ("cjk-other", _CHAT_B_KEY),
+        ):
+            db.create_session(
+                session_id,
+                source="telegram",
+                session_key=session_key,
+            )
+            db.append_message(
+                session_id,
+                role="user",
+                content="大别山项目通信记录已经归档。",
+            )
+        db._conn.commit()
+
+        result = json.loads(session_search(
+            query=query,
+            db=db,
+            current_session_key=_CHAT_A_KEY,
+            limit=10,
+        ))
+
+        assert {row["session_id"] for row in result["results"]} == {"cjk-current"}
+
+    def test_explicit_read_is_not_restricted_by_search_scope(self, db):
+        _seed_scoped_sessions(db)
+
+        result = json.loads(session_search(
+            session_id="chat-b",
+            db=db,
+            current_session_key=_CHAT_A_KEY,
+        ))
+
+        assert result["success"] is True
+        assert result["mode"] == "read"
+        assert result["session_id"] == "chat-b"
 
 
 # =========================================================================

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -257,13 +257,20 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10) -> str:
     return json.dumps(response, ensure_ascii=False)
 
 
-def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str:
+def _list_recent_sessions(
+    db,
+    limit: int,
+    current_session_id: str = None,
+    session_key: str = None,
+    scope: str = "global",
+) -> str:
     """Return metadata for the most recent sessions (no LLM calls, no FTS5)."""
     try:
         sessions = db.list_sessions_rich(
             limit=limit + 5,
             exclude_sources=list(_HIDDEN_SESSION_SOURCES),
             order_by_last_active=True,
+            session_key=session_key,
         )  # fetch extra so we can skip current
 
         current_root = _resolve_to_parent(db, current_session_id) if current_session_id else None
@@ -291,6 +298,7 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str
         return json.dumps({
             "success": True,
             "mode": "browse",
+            "scope": scope,
             "results": results,
             "count": len(results),
             "message": f"Showing {len(results)} most recent sessions. Pass a query= to search, or session_id+around_message_id to scroll.",
@@ -433,6 +441,7 @@ def _title_match_result(
     db,
     query: str,
     current_lineage_root: Optional[str],
+    session_key: str = None,
 ) -> Optional[Dict[str, Any]]:
     """Return a discovery-shaped result when the query matches a session title."""
     title_query = _normalize_title_query(query)
@@ -440,7 +449,10 @@ def _title_match_result(
         return None
 
     try:
-        session_id = db.resolve_session_by_title(title_query)
+        session_id = db.resolve_session_by_title(
+            title_query,
+            session_key=session_key,
+        )
     except Exception:
         logging.debug("resolve_session_by_title failed for %r", title_query, exc_info=True)
         return None
@@ -503,11 +515,18 @@ def _discover(
     limit: int,
     sort: Optional[str],
     current_session_id: str = None,
+    session_key: str = None,
+    scope: str = "global",
 ) -> str:
     """Discovery shape: FTS5 + anchored window + bookends per hit. Single call."""
     role_list = role_filter if role_filter else ["user", "assistant"]
     current_lineage_root = _resolve_to_parent(db, current_session_id) if current_session_id else None
-    title_result = _title_match_result(db, query, current_lineage_root)
+    title_result = _title_match_result(
+        db,
+        query,
+        current_lineage_root,
+        session_key=session_key,
+    )
 
     try:
         raw_results = db.search_messages(
@@ -519,6 +538,7 @@ def _discover(
             # of cron rows are still in hand for the demotion pass below.
             offset=0,
             sort=sort,
+            session_key=session_key,
         )
     except Exception as e:
         logging.error("FTS5 search failed: %s", e, exc_info=True)
@@ -534,6 +554,7 @@ def _discover(
         return json.dumps({
             "success": True,
             "mode": "discover",
+            "scope": scope,
             "query": query,
             "results": [],
             "count": 0,
@@ -609,11 +630,39 @@ def _discover(
     return json.dumps({
         "success": True,
         "mode": "discover",
+        "scope": scope,
         "query": query,
         "results": results,
         "count": len(results),
         "sessions_searched": len(seen_sessions),
     }, ensure_ascii=False)
+
+
+def _resolve_search_scope(
+    scope: str = None,
+    current_session_key: str = None,
+) -> tuple[str, Optional[str], Optional[str]]:
+    """Resolve the model-visible scope to an internal session-key filter."""
+    if scope is None or (isinstance(scope, str) and not scope.strip()):
+        if current_session_key:
+            return "current_chat", current_session_key, None
+        return "global", None, None
+
+    if not isinstance(scope, str):
+        return "global", None, "scope must be 'current_chat' or 'global'"
+
+    normalized = scope.strip().lower()
+    if normalized == "global":
+        return "global", None, None
+    if normalized == "current_chat":
+        if current_session_key:
+            return "current_chat", current_session_key, None
+        return (
+            "current_chat",
+            None,
+            "current_chat scope is unavailable outside a gateway conversation",
+        )
+    return "global", None, "scope must be 'current_chat' or 'global'"
 
 
 def session_search(
@@ -630,6 +679,10 @@ def session_search(
     sort: str = None,
     # Cross-profile (any shape)
     profile: str = None,
+    # Discovery/browse scope
+    scope: str = None,
+    # Host-only stable gateway conversation key (never model-supplied)
+    current_session_key: str = None,
 ) -> str:
     """Single-shape tool. Mode inferred from which args are set.
 
@@ -641,6 +694,10 @@ def session_search(
     Pass ``profile`` to read another profile's sessions (e.g. resolving an
     ``@session:<profile>/<id>`` link). Scroll wins over read/discovery when an
     anchor is set — the agent has asked for a specific slice.
+
+    Discovery and browse default to the current gateway chat/thread when
+    ``current_session_key`` is available. Pass ``scope="global"`` to search
+    across chats. CLI callers have no gateway key and remain global by default.
     """
     if db is None:
         try:
@@ -674,6 +731,7 @@ def session_search(
         if profile_db is not None:
             db = profile_db
             current_session_id = None
+            current_session_key = None
 
     # Scroll shape takes precedence — explicit anchor beats any query.
     if (isinstance(session_id, str) and session_id.strip()) and around_message_id is not None:
@@ -714,9 +772,22 @@ def session_search(
             limit = 3
     limit = max(1, min(limit, 10))
 
+    resolved_scope, session_key_filter, scope_error = _resolve_search_scope(
+        scope=scope,
+        current_session_key=current_session_key,
+    )
+    if scope_error:
+        return tool_error(scope_error, success=False)
+
     # Browse shape: no query → recent sessions.
     if not query or not isinstance(query, str) or not query.strip():
-        return _list_recent_sessions(db, limit, current_session_id)
+        return _list_recent_sessions(
+            db,
+            limit,
+            current_session_id,
+            session_key=session_key_filter,
+            scope=resolved_scope,
+        )
 
     # Parse role_filter
     role_list: Optional[List[str]] = None
@@ -737,6 +808,8 @@ def session_search(
         limit=limit,
         sort=sort_norm,
         current_session_id=current_session_id,
+        session_key=session_key_filter,
+        scope=resolved_scope,
     )
 
 
@@ -755,6 +828,10 @@ SESSION_SEARCH_SCHEMA = {
         "Search past sessions stored in the local session DB, or scroll inside one. "
         "FTS5-backed retrieval over the SQLite message store. No LLM calls — every "
         "shape returns actual messages from the DB.\n\n"
+        "CHAT SCOPE\n\n"
+        "  Gateway DISCOVERY/BROWSE defaults to the current chat. Use "
+        "`scope=\"global\"` only for an explicit cross-chat request. CLI stays "
+        "global; explicit READ/SCROLL is unscoped.\n\n"
         "SOURCE-FIRST LIMIT\n\n"
         "  This tool searches Hermes conversation history only. It is not evidence "
         "about the current contents of external sources. If the user provided a "
@@ -848,6 +925,15 @@ SESSION_SEARCH_SCHEMA = {
                     "and browse shapes."
                 ),
             },
+            "scope": {
+                "type": "string",
+                "enum": ["current_chat", "global"],
+                "description": (
+                    "Discovery/browse scope. Gateway defaults to 'current_chat'; "
+                    "use 'global' only on an explicit cross-chat request. CLI "
+                    "defaults global. Ignored for read/scroll."
+                ),
+            },
             "session_id": {
                 "type": "string",
                 "description": (
@@ -913,8 +999,10 @@ registry.register(
         window=args.get("window", 5),
         sort=args.get("sort"),
         profile=args.get("profile"),
+        scope=args.get("scope"),
         db=kw.get("db"),
         current_session_id=kw.get("current_session_id"),
+        current_session_key=kw.get("current_session_key"),
     ),
     check_fn=check_session_search_requirements,
     emoji="🔍",

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -525,7 +525,7 @@ For deeper analytics — token usage, cost estimates, tool breakdown, and activi
 
 ## Session Search Tool
 
-The agent has a built-in `session_search` tool that performs full-text search across all past conversations using SQLite's FTS5 engine — and lets the agent scroll through any session it finds. No LLM calls, no summarization, no truncation. Every shape returns actual messages from the DB.
+The agent has a built-in `session_search` tool that performs full-text search over past conversations using SQLite's FTS5 engine — and lets the agent scroll through any session it finds. In messaging gateways, discovery and browse default to prior sessions from the current DM, group, channel, or thread; CLI searches remain global. No LLM calls, no summarization, no truncation. Every shape returns actual messages from the DB.
 
 ### Three calling shapes
 
@@ -584,6 +584,7 @@ The keyword mode supports standard FTS5 query syntax:
 
 - `sort` — `newest` or `oldest`, on top of FTS5 ranking. Omit for relevance-only ordering (the default; suitable for exploratory recall). Use `newest` for "where did we leave X" questions, `oldest` for "how did X start" questions.
 - `role_filter` — comma-separated roles to include. Discovery defaults to `user,assistant` (tool output is usually noise). Pass `user,assistant,tool` to include tool output (debugging tool behaviour) or `tool` to search tool output only.
+- `scope` — discovery/browse scope: `current_chat` or `global`. Gateway conversations default to `current_chat`, reusing the same participant and thread isolation as live routing. Use `global` only when the user asks to search across chats. Explicit read/scroll calls remain addressable by session ID.
 
 ### When It's Used
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/sessions.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/sessions.md
@@ -434,7 +434,7 @@ Database size: 12.4 MB
 
 ## Session 搜索工具
 
-Agent 内置了 `session_search` 工具，使用 SQLite 的 FTS5 引擎对所有历史对话进行全文搜索，并允许 agent 滚动浏览找到的任何 session。无需 LLM 调用、无需摘要、无截断。每种调用形式都从数据库返回实际消息。
+Agent 内置了 `session_search` 工具，使用 SQLite 的 FTS5 引擎搜索历史对话，并允许 agent 滚动浏览找到的任何 session。在消息 Gateway 中，发现和浏览默认只搜索当前私聊、群聊、频道或线程的历史 session；CLI 搜索仍默认为全局。无需 LLM 调用、无需摘要、无截断。每种调用形式都从数据库返回实际消息。
 
 ### 三种调用形式
 
@@ -493,6 +493,7 @@ session_search()
 
 - `sort` — `newest` 或 `oldest`，在 FTS5 排名之上排序。省略则仅按相关性排序（默认；适合探索性召回）。对于"我们在哪里停下了 X"的问题使用 `newest`，对于"X 是怎么开始的"的问题使用 `oldest`。
 - `role_filter` — 逗号分隔的角色列表。发现模式默认为 `user,assistant`（工具输出通常是噪音）。传入 `user,assistant,tool` 以包含工具输出（调试工具行为），或传入 `tool` 仅搜索工具输出。
+- `scope` — 发现/浏览范围：`current_chat` 或 `global`。Gateway 对话默认为 `current_chat`，复用实时路由的参与者和线程隔离规则。只有当用户明确要求跨聊天搜索时才使用 `global`。通过 session ID 显式读取/滚动不受该范围限制。
 
 ### 使用时机
 


### PR DESCRIPTION
## What does this PR do?

Scopes `session_search` discovery and browse to the current gateway conversation by default, using the stable `session_key` that already encodes Hermes' DM, group, thread, profile, and per-user routing policy.

- Passes the host-only gateway session key through both agent tool-execution paths.
- Adds `scope=current_chat|global`; gateway calls default to `current_chat`, while CLI calls remain global.
- Pushes the exact session-key predicate into title resolution, recent-session browsing, porter FTS5, trigram FTS5, and the short-CJK LIKE fallback.
- Keeps explicit read/scroll calls unscoped so `@session` links and user-selected session IDs remain readable.
- Documents the behavior in the English and Chinese session guides.

## Why

Gateway conversations already route live messages with `build_session_key()`, but `session_search` received only the active `session_id`. It could exclude the current lineage, yet every remaining session in the profile was eligible, so a query from one DM or thread could return matching history from another chat.

Reusing the persisted session key keeps recall aligned with the existing routing policy without rebuilding platform/chat/thread/user rules in the tool.

## Effect

The regression fixture contains two prior sessions matching the same query: one in the current chat and one in another chat.

- Previous/global behavior: 2 prior hits, 1 foreign-chat hit (50% cross-chat contamination).
- New gateway default: 1 in-scope hit, 0 foreign-chat hits (0% contamination).
- Explicit `scope=global`: both prior hits remain available.
- CLI default: remains global.
- Additional retrieval LLM calls: 0.

Tests also cover same-base title collisions across chats, long-CJK trigram retrieval, short-CJK LIKE fallback, current-lineage exclusion, and explicit cross-chat session reads.

## Validation

- `python -m pytest tests/test_hermes_state.py tests/tools/test_session_search.py tests/run_agent/test_token_persistence_non_cli.py tests/gateway/test_async_session_db.py -q -o addopts=` — **420 passed**
- Post-rebase focused rerun — **67 passed**
- `ruff check` on all changed Python files — passed
- `scripts/check-windows-footguns.py` on all changed Python files — passed
- `git diff --check` — passed

Fixes #10554