### PR TITLE
feat(transport): enable NVIDIA NIM thinking mode for GLM-5.2 and similar models

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -400,6 +400,30 @@ class ChatCompletionsTransport(ProviderTransport):
                         _tokenhub_effort = _e
                 api_kwargs["reasoning_effort"] = _tokenhub_effort
 
+        # NVIDIA NIM: GLM-5.2 等 thinking 模式。NVIDIA 端点用 thinking.type 参数
+        # (enabled/disabled/adaptive)，不走 reasoning_effort。
+        # adaptive = 模型自动决定简单/复杂问题是否思考，类似 HY3 的自动快慢融合。
+        # 注：thinking 参数放进 extra_body（非 OpenAI 标准参数，顶层传会 400）。
+        if is_nvidia_nim:
+            _nim_thinking_off = bool(
+                reasoning_config
+                and isinstance(reasoning_config, dict)
+                and reasoning_config.get("enabled") is False
+            )
+            if not _nim_thinking_off:
+                _nim_type = "adaptive"
+                if reasoning_config and isinstance(reasoning_config, dict):
+                    _e = (reasoning_config.get("effort") or "").strip().lower()
+                    if _e in {"none", "false", "disabled"}:
+                        _nim_type = "disabled"
+                    elif _e == "high" or _e == "xhigh" or _e == "max":
+                        _nim_type = "enabled"
+                _nvidia_nim_thinking = {"type": _nim_type}
+            else:
+                _nvidia_nim_thinking = None
+        else:
+            _nvidia_nim_thinking = None
+
         # LM Studio: top-level reasoning_effort. Only emit when the model
         # declares reasoning support via /api/v1/models capabilities (gated
         # upstream by params["supports_reasoning"]). resolve_lmstudio_effort
@@ -418,6 +442,10 @@ class ChatCompletionsTransport(ProviderTransport):
         is_openrouter = params.get("is_openrouter", False)
         is_nous = params.get("is_nous", False)
         is_github_models = params.get("is_github_models", False)
+
+        # NVIDIA NIM thinking: 放进 extra_body（非 OpenAI 标准参数）
+        if _nvidia_nim_thinking:
+            extra_body["thinking"] = _nvidia_nim_thinking
         provider_name = str(params.get("provider_name") or "").strip().lower()
         base_url = params.get("base_url")
 


### PR DESCRIPTION
## Problem

NVIDIA NIM endpoints (`integrate.api.nvidia.com`) use a `thinking.type` parameter (`enabled`/`disabled`/`adaptive`) to control reasoning — not the `reasoning_effort` field used by other providers.

The transport already detects `is_nvidia_nim` (line 361 in `chat_completions.py`, line 803 in `chat_completion_helpers.py`) and passes it to `build_kwargs`, but never uses it to inject the thinking parameter. As a result, models like `z-ai/glm-5.2` silently run **without reasoning** — `reasoning_content` is always `null`.

## Fix

Inject `thinking` into `extra_body` when `is_nvidia_nim` is true, following the same pattern as the Kimi and TokenHub reasoning_effort blocks:

| `reasoning_config.effort` | `thinking.type` |
|---|---|
| *(unset/empty/medium/low/minimal)* → `adaptive` | Model auto-decides: simple questions skip thinking, complex ones reason first |
| `high`/`xhigh`/`max` → `enabled` | Force thinking on |
| `none`/`false`/`disabled` → `disabled` | Thinking off |

### Why `extra_body`?
`thinking` is not a standard OpenAI Chat Completions parameter. Sending it as a top-level kwarg to `client.chat.completions.create()` causes a 400 from the OpenAI client. Putting it in `extra_body` lets the OpenAI SDK forward it verbatim to NVIDIA's endpoint.

## Verification

**Before (no thinking parameter):**
```json
"reasoning_content": null
```

**After (thinking.type=adaptive, complex question):**
```json
"reasoning_content": "1. 分析请求：... (1462 chars of reasoning)"
"content": "同时开需要 13小时20分钟 注满。..."
```

Test command:
```bash
curl -s https://integrate.api.nvidia.com/v1/chat/completions \
  -H "Authorization: Bearer $NVIDIA_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"z-ai/glm-5.2","messages":[{"role":"user","content":"证明根号2是无理数"}],"max_tokens":2000,"thinking":{"type":"adaptive"}}'
```

## Scope

- 1 file changed, 28 insertions
- No changes to existing behavior for non-NVIDIA providers
- `is_nvidia_nim` detection was already wired — this just uses the flag it sets