### PR TITLE
fix(api-server): keep stopped runs tracked until executor exits

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -884,6 +884,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # Active run agent/task references for stop support
         self._active_run_agents: Dict[str, Any] = {}
         self._active_run_tasks: Dict[str, "asyncio.Task"] = {}
+        self._stopping_run_ids: set[str] = set()
         # Pollable run status for dashboards and external control-plane UIs.
         self._run_statuses: Dict[str, Dict[str, Any]] = {}
         # Active approval session key for each run_id.  The approval core
@@ -4372,10 +4373,21 @@ class APIServerAdapter(BasePlatformAdapter):
                     return r, u
 
                 result, usage = await asyncio.get_running_loop().run_in_executor(None, _run_sync)
+                if run_id in self._stopping_run_ids:
+                    q.put_nowait({
+                        "event": "run.cancelled",
+                        "run_id": run_id,
+                        "timestamp": time.time(),
+                    })
+                    self._set_run_status(
+                        run_id,
+                        "cancelled",
+                        last_event="run.cancelled",
+                    )
                 # Check for structured failure (non-retryable client errors like
                 # 401/400 return failed=True instead of raising, so the except
                 # block below never fires — issue #15561).
-                if isinstance(result, dict) and result.get("failed"):
+                elif isinstance(result, dict) and result.get("failed"):
                     error_msg = _redact_api_error_text(result.get("error") or "agent run failed")
                     q.put_nowait({
                         "event": "run.failed",
@@ -4457,6 +4469,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._active_run_agents.pop(run_id, None)
                 self._active_run_tasks.pop(run_id, None)
                 self._run_approval_sessions.pop(run_id, None)
+                self._stopping_run_ids.discard(run_id)
 
         task = asyncio.create_task(_run_and_close())
         self._active_run_tasks[run_id] = task
@@ -4643,28 +4656,12 @@ class APIServerAdapter(BasePlatformAdapter):
             return web.json_response(_openai_error(f"Run not found: {run_id}", code="run_not_found"), status=404)
 
         self._set_run_status(run_id, "stopping", last_event="run.stopping")
+        self._stopping_run_ids.add(run_id)
 
         if agent is not None:
             try:
                 agent.interrupt("Stop requested via API")
             except Exception:
-                pass
-
-        if task is not None and not task.done():
-            task.cancel()
-            # Bounded wait: run_conversation() executes in the default
-            # executor thread which task.cancel() cannot preempt — we rely on
-            # agent.interrupt() above to break the loop. Cap the wait so a
-            # slow/unresponsive interrupt can't hang this handler.
-            try:
-                await asyncio.wait_for(asyncio.shield(task), timeout=5.0)
-            except asyncio.TimeoutError:
-                logger.warning(
-                    "[api_server] stop for run %s timed out after 5s; "
-                    "agent may still be finishing the current step",
-                    run_id,
-                )
-            except (asyncio.CancelledError, Exception):
                 pass
 
         return web.json_response({"run_id": run_id, "status": "stopping"})
@@ -4694,6 +4691,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._active_run_agents.pop(run_id, None)
                 self._active_run_tasks.pop(run_id, None)
                 self._run_approval_sessions.pop(run_id, None)
+                self._stopping_run_ids.discard(run_id)
 
             stale_statuses = [
                 run_id

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4289,6 +4289,18 @@ class APIServerAdapter(BasePlatformAdapter):
         async def _run_and_close():
             try:
                 self._set_run_status(run_id, "running")
+                if run_id in self._stopping_run_ids:
+                    q.put_nowait({
+                        "event": "run.cancelled",
+                        "run_id": run_id,
+                        "timestamp": time.time(),
+                    })
+                    self._set_run_status(
+                        run_id,
+                        "cancelled",
+                        last_event="run.cancelled",
+                    )
+                    return
                 agent = self._create_agent(
                     ephemeral_system_prompt=ephemeral_system_prompt,
                     session_id=session_id,
@@ -4670,14 +4682,22 @@ class APIServerAdapter(BasePlatformAdapter):
         """Periodically clean up run streams that were never consumed."""
         while True:
             await asyncio.sleep(60)
+            self._sweep_orphaned_runs_once(time.time())
+
+    def _sweep_orphaned_runs_once(self, now: Optional[float] = None) -> None:
+        """Clean up stale run streams/statuses without detaching live workers."""
+        if now is None:
             now = time.time()
-            stale = [
-                run_id
-                for run_id, created_at in list(self._run_streams_created.items())
-                if now - created_at > self._RUN_STREAM_TTL
-            ]
-            for run_id in stale:
-                logger.debug("[api_server] sweeping orphaned run %s", run_id)
+        stale = [
+            run_id
+            for run_id, created_at in list(self._run_streams_created.items())
+            if now - created_at > self._RUN_STREAM_TTL
+        ]
+        for run_id in stale:
+            logger.debug("[api_server] sweeping orphaned run %s", run_id)
+            task = self._active_run_tasks.get(run_id)
+            task_done = task is None or task.done()
+            if task_done:
                 try:
                     from tools.approval import unregister_gateway_notify
 
@@ -4686,21 +4706,22 @@ class APIServerAdapter(BasePlatformAdapter):
                         unregister_gateway_notify(approval_session_key)
                 except Exception:
                     pass
-                self._run_streams.pop(run_id, None)
-                self._run_streams_created.pop(run_id, None)
+            self._run_streams.pop(run_id, None)
+            self._run_streams_created.pop(run_id, None)
+            if task_done:
                 self._active_run_agents.pop(run_id, None)
                 self._active_run_tasks.pop(run_id, None)
                 self._run_approval_sessions.pop(run_id, None)
                 self._stopping_run_ids.discard(run_id)
 
-            stale_statuses = [
-                run_id
-                for run_id, status in list(self._run_statuses.items())
-                if status.get("status") in {"completed", "failed", "cancelled"}
-                and now - float(status.get("updated_at", 0) or 0) > self._RUN_STATUS_TTL
-            ]
-            for run_id in stale_statuses:
-                self._run_statuses.pop(run_id, None)
+        stale_statuses = [
+            run_id
+            for run_id, status in list(self._run_statuses.items())
+            if status.get("status") in {"completed", "failed", "cancelled"}
+            and now - float(status.get("updated_at", 0) or 0) > self._RUN_STATUS_TTL
+        ]
+        for run_id in stale_statuses:
+            self._run_statuses.pop(run_id, None)
 
     # ------------------------------------------------------------------
     # BasePlatformAdapter interface

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -616,6 +616,9 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_post("/v1/responses", adapter._handle_responses)
     app.router.add_get("/v1/responses/{response_id}", adapter._handle_get_response)
     app.router.add_delete("/v1/responses/{response_id}", adapter._handle_delete_response)
+    app.router.add_post("/v1/runs", adapter._handle_runs)
+    app.router.add_get("/v1/runs/{run_id}", adapter._handle_get_run)
+    app.router.add_post("/v1/runs/{run_id}/stop", adapter._handle_stop_run)
     return app
 
 
@@ -662,6 +665,62 @@ class TestAgentExecution:
             conversation_history=[],
             task_id="session-123",
         )
+
+
+class TestRunStopLifecycle:
+    @pytest.mark.asyncio
+    async def test_pre_start_stop_marker_cancels_before_agent_creation(self, adapter, monkeypatch):
+        run_hex = "a" * 32
+        run_id = f"run_{run_hex}"
+        adapter._stopping_run_ids.add(run_id)
+
+        fake_uuid = MagicMock()
+        fake_uuid.hex = run_hex
+        monkeypatch.setattr("gateway.platforms.api_server.uuid.uuid4", lambda: fake_uuid)
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", side_effect=AssertionError("agent should not start")) as create_agent:
+                resp = await cli.post("/v1/runs", json={"input": "stop before start"})
+                assert resp.status == 202
+                data = await resp.json()
+                assert data["run_id"] == run_id
+
+                for _ in range(20):
+                    if adapter._run_statuses.get(run_id, {}).get("status") == "cancelled":
+                        break
+                    await asyncio.sleep(0.01)
+
+                create_agent.assert_not_called()
+                assert adapter._run_statuses[run_id]["status"] == "cancelled"
+                assert adapter._run_statuses[run_id]["last_event"] == "run.cancelled"
+
+    @pytest.mark.asyncio
+    async def test_orphan_sweep_keeps_active_stopped_worker_tracking(self, adapter):
+        run_id = "run_live_worker"
+        task = asyncio.create_task(asyncio.sleep(60))
+        agent = object()
+        q = asyncio.Queue()
+        try:
+            adapter._run_streams[run_id] = q
+            adapter._run_streams_created[run_id] = 1000.0
+            adapter._active_run_agents[run_id] = agent
+            adapter._active_run_tasks[run_id] = task
+            adapter._run_approval_sessions[run_id] = "approval-key"
+            adapter._stopping_run_ids.add(run_id)
+
+            adapter._sweep_orphaned_runs_once(now=1000.0 + adapter._RUN_STREAM_TTL + 1)
+
+            assert run_id not in adapter._run_streams
+            assert run_id not in adapter._run_streams_created
+            assert adapter._active_run_agents[run_id] is agent
+            assert adapter._active_run_tasks[run_id] is task
+            assert adapter._run_approval_sessions[run_id] == "approval-key"
+            assert run_id in adapter._stopping_run_ids
+        finally:
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -449,6 +449,56 @@ class TestRunEvents:
 
 class TestStopRun:
     @pytest.mark.asyncio
+    async def test_stop_does_not_detach_still_running_executor_agent(self, adapter):
+        """Stopping a run must not hide an executor thread that continues work."""
+        app = _create_runs_app(adapter)
+        run_can_finish = threading.Event()
+        run_finished = threading.Event()
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+
+                started = threading.Event()
+
+                def _run_conversation(*_args, **_kwargs):
+                    started.set()
+                    run_can_finish.wait(timeout=5)
+                    run_finished.set()
+                    return {"final_response": "late side effect"}
+
+                mock_agent.run_conversation.side_effect = _run_conversation
+                mock_agent.interrupt = MagicMock()
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+
+                assert started.wait(timeout=3)
+
+                stop_resp = await cli.post(f"/v1/runs/{run_id}/stop")
+                assert stop_resp.status == 200
+
+                await asyncio.sleep(0.2)
+                assert not run_finished.is_set()
+                assert run_id in adapter._active_run_agents
+                assert run_id in adapter._active_run_tasks
+
+                run_can_finish.set()
+                for _ in range(20):
+                    if run_id not in adapter._active_run_agents:
+                        break
+                    await asyncio.sleep(0.05)
+
+                assert run_id not in adapter._active_run_agents
+                assert run_id not in adapter._active_run_tasks
+                assert adapter._run_statuses[run_id]["status"] == "cancelled"
+
+    @pytest.mark.asyncio
     async def test_stop_running_agent(self, adapter):
         """Stop should interrupt the agent and cancel the task."""
         app = _create_runs_app(adapter)


### PR DESCRIPTION
## Summary

`POST /v1/runs/{run_id}/stop` cancelled the asyncio wrapper task even though the agent work is running inside `run_in_executor()`. Cancelling that wrapper cannot stop the executor thread. It only runs the wrapper's `finally` block, which removes the run from `_active_run_agents`, `_active_run_tasks`, and `_run_approval_sessions` while the underlying `agent.run_conversation()` may still be executing.

That leaves a stopped/untracked run continuing in the background.

## Why

`/v1/runs` is an external control-plane API. After a client asks Hermes to stop a run, Hermes must not hide a still-running worker thread from the run registry. Otherwise a run can keep executing tools or other agent work after the API surface says it is stopping/cancelled and after later `/stop` calls can no longer find it.

## Changes

- Track run IDs that have received a stop request.
- Do not `task.cancel()` the asyncio wrapper for executor-backed runs.
- Keep the run registered while the executor thread is still alive.
- When the executor returns after a stop request, emit `run.cancelled` and mark the run `cancelled` instead of `completed`.
- Clean up run tracking only after the executor-backed work has actually exited.
- Add a regression test proving a stopped but still-running executor-backed run remains tracked until it finishes.

## Tests

```text
python -m pytest tests/gateway/test_api_server_runs.py -q --tb=short --basetemp C:\tmp\hermes-runs-stop-pytest4
24 passed