### PR TITLE
fix(pairing): reset the failed-approval counter on a successful approval

### DIFF
--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -527,6 +527,14 @@ class PairingStore:
             del pending[matched_key]
             self._save_json(self._pending_path(platform), pending)
 
+            # A successful approval proves the requester is legitimate, so the
+            # brute-force failure streak must not carry over. Without this,
+            # isolated mistyped codes accumulate across the gateway's lifetime
+            # (the counter is persisted in _rate_limits.json and only ever
+            # reset when a lockout fires) and eventually trip a spurious
+            # lockout on a single fresh typo — rejecting even a valid code.
+            self._reset_failed_attempts(platform)
+
             # Add to approved list
             self._approve_user(platform, matched_entry["user_id"],
                                matched_entry.get("user_name", ""))
@@ -621,6 +629,19 @@ class PairingStore:
             print(f"[pairing] Platform {platform} locked out for {LOCKOUT_SECONDS}s "
                   f"after {MAX_FAILED_ATTEMPTS} failed attempts", flush=True)
         self._save_json(self._rate_limit_path(), limits)
+
+    def _reset_failed_attempts(self, platform: str) -> None:
+        """Clear the accumulated failed-approval counter after a success.
+
+        Called from the ``approve_code`` success path so that a legitimate
+        approval resets the brute-force streak (standard lockout semantics:
+        the counter tracks *consecutive* failures, not lifetime ones).
+        """
+        limits = self._load_json(self._rate_limit_path())
+        fail_key = f"_failures:{platform}"
+        if limits.get(fail_key):
+            limits[fail_key] = 0
+            self._save_json(self._rate_limit_path(), limits)
 
     # ----- Cleanup -----
 

--- a/tests/gateway/test_pairing.py
+++ b/tests/gateway/test_pairing.py
@@ -540,6 +540,30 @@ class TestLockout:
             code = store.generate_code("telegram", "newuser")
         assert code is None
 
+    def test_successful_approval_resets_failure_counter(self, tmp_path):
+        """A successful approval clears the brute-force streak, so isolated
+        typos across the gateway's lifetime don't accumulate into a spurious
+        lockout that rejects a valid code.
+        """
+        with patch("gateway.pairing.PAIRING_DIR", tmp_path):
+            store = PairingStore()
+
+            # One short of the lockout threshold — not locked out yet.
+            for _ in range(MAX_FAILED_ATTEMPTS - 1):
+                assert store.approve_code("telegram", "WRONGCODE") is None
+            assert store._is_locked_out("telegram") is False
+
+            # A legitimate approval must reset the accumulated failures.
+            code = store.generate_code("telegram", "user1", "Alice")
+            assert store.approve_code("telegram", code) is not None
+            limits = store._load_json(store._rate_limit_path())
+            assert limits.get("_failures:telegram", 0) == 0
+
+            # Because the streak was cleared, a single fresh typo afterwards
+            # must NOT trip the lockout (it would have with the stale count).
+            assert store.approve_code("telegram", "WRONGCODE") is None
+            assert store._is_locked_out("telegram") is False
+
     def test_lockout_blocks_code_approval(self, tmp_path):
         """Regression guard for #10195: lockout must also gate approve_code.
 


### PR DESCRIPTION
## Problem

`PairingStore.approve_code()`'s **success** path never clears `_failures:{platform}`. The counter is incremented on every non-matching code (`_record_failed_attempt`), persisted in `_rate_limits.json`, and only ever reset to `0` when it reaches `MAX_FAILED_ATTEMPTS` (which fires the 1-hour lockout). So it counts failures over the gateway's **entire lifetime**, not consecutive ones — and the sibling guard `_is_rate_limited` in the same class correctly uses a time window, so this counter is the odd one out.

### Concrete failure (normal operation)

Pairing codes are 8 random chars, so mistyping one is common. An owner who pairs users over time and fat-fingers the code on 4 separate occasions — each time immediately retyping it correctly and **successfully** pairing — accumulates `_failures:telegram = 4` (never reset, survives restarts).

A later single fresh typo → `_record_failed_attempt` → `fails = 5` → **lockout for 1 hour**. The owner now types the **correct** code, but `_is_locked_out` gates `approve_code` (the #10195 fix) and returns `None` — the valid pairing is rejected and all approval on that platform is dead for an hour, from five *non-consecutive* typos.

## Fix

Reset the counter on a successful approval — standard brute-force-guard semantics, where the counter tracks *consecutive* failures. Added `_reset_failed_attempts()` (mirrors `_record_failed_attempt`) and call it from the `approve_code` success path.

This does **not** weaken protection: an attacker cannot produce a success without a valid code, and 5 *consecutive* wrong attempts still lock out exactly as before. It only stops isolated, interleaved-with-success typos from accumulating.

## Tests

Added `test_successful_approval_resets_failure_counter` to `TestLockout`: `MAX_FAILED_ATTEMPTS - 1` wrong attempts, then a valid approval, asserts `_failures` is cleared and a subsequent single typo does **not** trip the lockout. Fails on current code (counter stays at 4), passes with the fix.

`python -m pytest tests/gateway/test_pairing.py` — 52 passed, 1 skipped.

## Dedup

`#21325` (merged) and `#10248` (closed) added/duplicated the *lockout check* in `approve_code`; neither resets the failure counter on success. This is a distinct defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)