### PR TITLE
fix(agent): scope model.context_length override to config default model

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -257,6 +257,31 @@ def _merge_custom_provider_extra_body(agent, custom_providers: List[Dict[str, An
     agent.request_overrides = overrides
 
 
+def _scope_config_context_length_to_default_model(
+    model_cfg: Any, agent_model: Any, config_context_length: Optional[int]
+) -> Optional[int]:
+    """Drop model.context_length unless it was written for this session's model.
+
+    The override in config.yaml is tied to model.default — the model the
+    config's author configured — not necessarily the model this particular
+    session ends up on (e.g. a per-session model_override to a different
+    provider/model). Read the config default the same way
+    hermes_cli.web_server.get_model_info does (`default`, falling back to
+    `name`); if it names a model and this session's model differs, drop the
+    override so auto-detection resolves the real window for the actual
+    model instead. Mirrors the /model switch guard in
+    agent_runtime_helpers.py, which clears _config_context_length on swap
+    for the same reason.
+    """
+    if config_context_length is None or not isinstance(model_cfg, dict):
+        return config_context_length
+    _default_model = str(model_cfg.get("default", model_cfg.get("name", "")) or "").strip()
+    _agent_model = str(agent_model or "").strip()
+    if _default_model and _agent_model and _agent_model != _default_model:
+        return None
+    return config_context_length
+
+
 def init_agent(
     agent,
     base_url: str = None,
@@ -1651,6 +1676,12 @@ def init_agent(
                 file=sys.stderr,
             )
             _config_context_length = None
+
+    # Scope the override to the config's default model — see
+    # _scope_config_context_length_to_default_model for why.
+    _config_context_length = _scope_config_context_length_to_default_model(
+        _model_cfg, agent.model, _config_context_length
+    )
 
     # Resolve custom_providers list once for reuse below (startup
     # context-length override and plugin context-engine init).

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -258,7 +258,7 @@ def _merge_custom_provider_extra_body(agent, custom_providers: List[Dict[str, An
 
 
 def _scope_config_context_length_to_default_model(
-    model_cfg: Any, agent_model: Any, config_context_length: Optional[int]
+    model_cfg: Any, agent_model: Any, config_context_length: Optional[int], provider: Any = None
 ) -> Optional[int]:
     """Drop model.context_length unless it was written for this session's model.
 
@@ -272,13 +272,35 @@ def _scope_config_context_length_to_default_model(
     model instead. Mirrors the /model switch guard in
     agent_runtime_helpers.py, which clears _config_context_length on swap
     for the same reason.
+
+    ``agent_model`` has already gone through the provider-aware
+    normalization applied near the top of ``init_agent`` (stripping a
+    matching provider prefix, e.g. ``zai/glm-4.6`` -> ``glm-4.6``) for
+    non-aggregator providers. The raw config default has not, so a
+    legitimately-configured ``default: zai/glm-4.6`` would otherwise
+    compare unequal to the normalized ``glm-4.6`` and lose its override.
+    Run the config default through the same normalization here so the
+    comparison is apples-to-apples.
     """
     if config_context_length is None or not isinstance(model_cfg, dict):
         return config_context_length
     _default_model = str(model_cfg.get("default", model_cfg.get("name", "")) or "").strip()
     _agent_model = str(agent_model or "").strip()
-    if _default_model and _agent_model and _agent_model != _default_model:
-        return None
+    if _default_model and _agent_model:
+        _normalized_default = _default_model
+        try:
+            from hermes_cli.model_normalize import (
+                _AGGREGATOR_PROVIDERS,
+                normalize_model_for_provider,
+            )
+
+            _provider = str(provider or "").strip().lower()
+            if _provider not in _AGGREGATOR_PROVIDERS:
+                _normalized_default = normalize_model_for_provider(_default_model, _provider)
+        except Exception:
+            pass
+        if _agent_model != _normalized_default:
+            return None
     return config_context_length
 
 
@@ -1680,7 +1702,7 @@ def init_agent(
     # Scope the override to the config's default model — see
     # _scope_config_context_length_to_default_model for why.
     _config_context_length = _scope_config_context_length_to_default_model(
-        _model_cfg, agent.model, _config_context_length
+        _model_cfg, agent.model, _config_context_length, agent.provider
     )
 
     # Resolve custom_providers list once for reuse below (startup

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11038,11 +11038,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _hyg_base_url = None
             _hyg_api_key = None
             _hyg_data = {}
+            _hyg_model_cfg = None
             try:
                 _hyg_data = _load_gateway_config()
                 if _hyg_data:
                     # Resolve model name (same logic as run_sync)
                     _model_cfg = _hyg_data.get("model", {})
+                    # Keep the raw config model block around (past this `if`)
+                    # so it can be re-consulted after session-runtime
+                    # resolution below, to scope _hyg_config_context_length
+                    # to whichever model the session actually ends up on.
+                    _hyg_model_cfg = _model_cfg
                     if isinstance(_model_cfg, str):
                         _hyg_model = _model_cfg
                     elif isinstance(_model_cfg, dict):
@@ -11085,6 +11091,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _hyg_provider = _hyg_runtime.get("provider") or _hyg_provider
                     _hyg_base_url = _hyg_runtime.get("base_url") or _hyg_base_url
                     _hyg_api_key = _hyg_runtime.get("api_key") or _hyg_api_key
+                except Exception:
+                    pass
+
+                # Scope the config's model.context_length override to the
+                # resolved SESSION model, not the config's default model.
+                # The override read above comes from the raw config's model
+                # block (config.yaml's model.default), but a session can be
+                # running a different model via a per-session /model
+                # override or channel override — _resolve_session_agent_runtime
+                # just resolved that above. Without this, pre-agent hygiene
+                # compression for an overridden session was sized against the
+                # DEFAULT model's context window instead of the model the
+                # session is actually on. Mirrors the same scoping applied at
+                # agent build time in agent.agent_init.init_agent.
+                try:
+                    from agent.agent_init import _scope_config_context_length_to_default_model
+                    _hyg_config_context_length = _scope_config_context_length_to_default_model(
+                        _hyg_model_cfg, _hyg_model, _hyg_config_context_length, _hyg_provider
+                    )
                 except Exception:
                     pass
 

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -1171,3 +1171,273 @@ async def test_session_hygiene_default_hard_message_limit_does_not_fire_at_12_me
     assert FakeCompressAgent.last_instance is None, (
         "Compression should NOT fire at 12 messages with default hard_limit=5000"
     )
+
+
+@pytest.mark.asyncio
+async def test_session_hygiene_context_override_does_not_leak_onto_session_model_override(
+    monkeypatch, tmp_path
+):
+    """Regression: model.context_length in config.yaml is written for the
+    config's default model, but the gateway hygiene pre-check used to read
+    it from the raw config BEFORE resolving which model the session is
+    actually running on. A session with a per-session model override
+    (different provider/model, e.g. the desktop/mobile picker) still got
+    sized against the DEFAULT model's window instead of its own.
+
+    Mirrors the agent-build-time fix in agent.agent_init
+    (_scope_config_context_length_to_default_model) — the gateway hygiene
+    path must apply the same scoping, using the model
+    _resolve_session_agent_runtime actually resolved for this session."""
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    class FakeCompressAgent:
+        last_instance = None
+
+        def __init__(self, **kwargs):
+            self.model = kwargs.get("model")
+            self.session_id = kwargs.get("session_id", "fake-session")
+            self._print_fn = None
+            self.shutdown_memory_provider = MagicMock()
+            self.close = MagicMock()
+            type(self).last_instance = self
+
+        def _compress_context(self, messages, *_args, **_kwargs):
+            self.session_id = f"{self.session_id}_compressed"
+            return ([{"role": "assistant", "content": "compressed"}], None)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeCompressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    # config.yaml: model.default names "config-default-model" with an
+    # explicit context_length override written for it.
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        "model:\n"
+        "  default: config-default-model\n"
+        "  context_length: 131072\n"
+        "compression:\n"
+        "  enabled: true\n"
+    )
+
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    # The session is actually running "override-model" on a different
+    # provider — e.g. a per-session /model or channel override away from
+    # the config default. Stub _resolve_session_agent_runtime directly so
+    # this test targets only how its result is consumed by the hygiene
+    # block, not the override-key-computation logic exercised elsewhere.
+    monkeypatch.setattr(
+        GatewayRunner,
+        "_resolve_session_agent_runtime",
+        lambda self, **kwargs: (
+            "override-model",
+            {
+                "provider": "openai-codex",
+                "base_url": "https://example.test/v1",
+                "api_key": "override-key",
+            },
+        ),
+    )
+
+    _ctx_calls = []
+
+    def _record_get_model_context_length(model, **kwargs):
+        _ctx_calls.append({"model": model, **kwargs})
+        return 372_000
+
+    adapter = HygieneCaptureAdapter()
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token")}
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:telegram:private:12345",
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="private",
+    )
+    runner.session_store.load_transcript.return_value = _make_history(6, content_size=400)
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.append_to_transcript = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        _record_get_model_context_length,
+    )
+    monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "795544298")
+
+    event = MessageEvent(
+        text="hello",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="private",
+            user_id="12345",
+        ),
+        message_id="1",
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result == "ok"
+    assert _ctx_calls, "expected the hygiene pre-check to resolve a context length"
+    hygiene_call = _ctx_calls[0]
+    # Sized against the session's actual model ("override-model"), not the
+    # config default ("config-default-model").
+    assert hygiene_call["model"] == "override-model"
+    # The 131072 override written for the config default must NOT have
+    # leaked onto this session's different model.
+    assert hygiene_call.get("config_context_length") is None
+    assert hygiene_call.get("config_context_length") != 131072
+
+
+@pytest.mark.asyncio
+async def test_session_hygiene_context_override_applies_when_session_matches_default(
+    monkeypatch, tmp_path
+):
+    """Companion to the leak regression above: when the resolved session
+    model DOES match the config's default model, the explicit
+    model.context_length override must still apply to hygiene sizing."""
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    class FakeCompressAgent:
+        last_instance = None
+
+        def __init__(self, **kwargs):
+            self.model = kwargs.get("model")
+            self.session_id = kwargs.get("session_id", "fake-session")
+            self._print_fn = None
+            self.shutdown_memory_provider = MagicMock()
+            self.close = MagicMock()
+            type(self).last_instance = self
+
+        def _compress_context(self, messages, *_args, **_kwargs):
+            self.session_id = f"{self.session_id}_compressed"
+            return ([{"role": "assistant", "content": "compressed"}], None)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeCompressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        "model:\n"
+        "  default: config-default-model\n"
+        "  context_length: 131072\n"
+        "compression:\n"
+        "  enabled: true\n"
+    )
+
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    # The session is running the SAME model as the config default —
+    # no per-session override in play.
+    monkeypatch.setattr(
+        GatewayRunner,
+        "_resolve_session_agent_runtime",
+        lambda self, **kwargs: (
+            "config-default-model",
+            {"provider": None, "base_url": None, "api_key": "fake"},
+        ),
+    )
+
+    _ctx_calls = []
+
+    def _record_get_model_context_length(model, **kwargs):
+        _ctx_calls.append({"model": model, **kwargs})
+        return kwargs.get("config_context_length") or 372_000
+
+    adapter = HygieneCaptureAdapter()
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token")}
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:telegram:private:12345",
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="private",
+    )
+    runner.session_store.load_transcript.return_value = _make_history(6, content_size=400)
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.append_to_transcript = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        _record_get_model_context_length,
+    )
+    monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "795544298")
+
+    event = MessageEvent(
+        text="hello",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="private",
+            user_id="12345",
+        ),
+        message_id="1",
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result == "ok"
+    assert _ctx_calls, "expected the hygiene pre-check to resolve a context length"
+    hygiene_call = _ctx_calls[0]
+    assert hygiene_call["model"] == "config-default-model"
+    assert hygiene_call.get("config_context_length") == 131072

--- a/tests/run_agent/test_config_context_length_model_scoping.py
+++ b/tests/run_agent/test_config_context_length_model_scoping.py
@@ -1,0 +1,159 @@
+"""Tests that model.context_length in config.yaml is scoped to model.default.
+
+Regression coverage for the leak where a global context_length override
+written for the config's default model applied to *every* model a session
+could run — including a per-session model_override to a completely
+different provider/model (e.g. mobile/desktop picking a model other than
+the local default). See _scope_config_context_length_to_default_model in
+agent/agent_init.py, and the analogous /model switch guard in
+agent_runtime_helpers.py (agent._config_context_length = None on swap).
+"""
+
+from unittest.mock import patch
+
+from agent.agent_init import _scope_config_context_length_to_default_model
+
+
+def _fake_get_model_context_length(*args, config_context_length=None, **kwargs):
+    """Stand-in for agent.model_metadata.get_model_context_length: honors an
+    explicit config override (step-0 resolution in the real function), else
+    falls back to a fixed "auto-detected" window distinct from the override
+    under test (131072) so the two are easy to tell apart in assertions."""
+    if config_context_length is not None:
+        return config_context_length
+    return 372_000
+
+
+def _build_agent(model_cfg, model, base_url="http://localhost:8090/v1"):
+    """Build a real AIAgent with the given model config, mirroring the
+    pattern in tests/run_agent/test_invalid_context_length_warning.py."""
+    cfg = {"model": model_cfg}
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch(
+            "agent.model_metadata.get_model_context_length",
+            side_effect=_fake_get_model_context_length,
+        ),
+        # context_compressor.py imports get_model_context_length at module
+        # load time, so it needs its own patch target.
+        patch(
+            "agent.context_compressor.get_model_context_length",
+            side_effect=_fake_get_model_context_length,
+        ),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            model=model,
+            api_key="test-key-1234567890",
+            base_url=base_url,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    return agent
+
+
+# ── init_agent integration tests ─────────────────────────────────────────
+
+
+def test_override_applies_when_session_model_matches_config_default():
+    """agent.model == config default → the explicit override still applies."""
+    model_cfg = {
+        "default": "Qwen3.6-27B-NVFP4-MTP-GGUF.gguf",
+        "provider": "custom:trainlocal-qwen36-27b",
+        "base_url": "http://localhost:8090/v1",
+        "context_length": 131072,
+    }
+    agent = _build_agent(model_cfg, model="Qwen3.6-27B-NVFP4-MTP-GGUF.gguf")
+    assert agent._config_context_length == 131072
+    assert agent.context_compressor.context_length == 131072
+
+
+def test_override_does_not_leak_onto_session_model_override():
+    """agent.model != config default (e.g. per-session model_override to a
+    different provider/model) → the override must not apply; auto-detection
+    resolves the real window for the actual model instead."""
+    model_cfg = {
+        "default": "Qwen3.6-27B-NVFP4-MTP-GGUF.gguf",
+        "provider": "custom:trainlocal-qwen36-27b",
+        "base_url": "http://localhost:8090/v1",
+        "context_length": 131072,
+    }
+    agent = _build_agent(
+        model_cfg,
+        model="some-other-model",
+        base_url="http://localhost:8080/v1",
+    )
+    assert agent._config_context_length is None
+    # Auto-detected window (mocked get_model_context_length) is used, not
+    # the stale 131072 written for the local default model.
+    assert agent.context_compressor.context_length == 372_000
+    assert agent.context_compressor.context_length != 131072
+
+
+def test_plain_string_model_config_unchanged():
+    """A plain-string model config (no dict) never had an override to
+    begin with — behavior is unchanged by the scoping."""
+    agent = _build_agent("Qwen3.6-27B-NVFP4-MTP-GGUF.gguf", model="Qwen3.6-27B-NVFP4-MTP-GGUF.gguf")
+    assert agent._config_context_length is None
+
+
+# ── unit tests for the pure scoping helper ───────────────────────────────
+
+
+def test_scope_helper_returns_none_unchanged():
+    assert _scope_config_context_length_to_default_model(
+        {"default": "model-a"}, "model-a", None
+    ) is None
+
+
+def test_scope_helper_non_dict_config_returns_value_unchanged():
+    assert _scope_config_context_length_to_default_model(
+        "model-a", "model-b", 131072
+    ) == 131072
+
+
+def test_scope_helper_matching_model_keeps_override():
+    assert _scope_config_context_length_to_default_model(
+        {"default": "model-a"}, "model-a", 131072
+    ) == 131072
+
+
+def test_scope_helper_mismatched_model_drops_override():
+    assert _scope_config_context_length_to_default_model(
+        {"default": "model-a"}, "model-b", 131072
+    ) is None
+
+
+def test_scope_helper_falls_back_to_name_key():
+    assert _scope_config_context_length_to_default_model(
+        {"name": "model-a"}, "model-a", 131072
+    ) == 131072
+    assert _scope_config_context_length_to_default_model(
+        {"name": "model-a"}, "model-b", 131072
+    ) is None
+
+
+def test_scope_helper_strips_whitespace():
+    assert _scope_config_context_length_to_default_model(
+        {"default": " model-a "}, "model-a", 131072
+    ) == 131072
+
+
+def test_scope_helper_no_default_name_keeps_override():
+    """If the config block names no default/name at all, there is nothing
+    to compare against — leave existing behavior alone."""
+    assert _scope_config_context_length_to_default_model(
+        {"provider": "custom"}, "model-a", 131072
+    ) == 131072
+
+
+def test_scope_helper_no_agent_model_keeps_override():
+    assert _scope_config_context_length_to_default_model(
+        {"default": "model-a"}, None, 131072
+    ) == 131072

--- a/tests/run_agent/test_config_context_length_model_scoping.py
+++ b/tests/run_agent/test_config_context_length_model_scoping.py
@@ -24,7 +24,7 @@ def _fake_get_model_context_length(*args, config_context_length=None, **kwargs):
     return 372_000
 
 
-def _build_agent(model_cfg, model, base_url="http://localhost:8090/v1"):
+def _build_agent(model_cfg, model, base_url="http://localhost:8090/v1", provider=None):
     """Build a real AIAgent with the given model config, mirroring the
     pattern in tests/run_agent/test_invalid_context_length_warning.py."""
     cfg = {"model": model_cfg}
@@ -51,6 +51,7 @@ def _build_agent(model_cfg, model, base_url="http://localhost:8090/v1"):
             model=model,
             api_key="test-key-1234567890",
             base_url=base_url,
+            provider=provider,
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,
@@ -101,6 +102,52 @@ def test_plain_string_model_config_unchanged():
     begin with — behavior is unchanged by the scoping."""
     agent = _build_agent("Qwen3.6-27B-NVFP4-MTP-GGUF.gguf", model="Qwen3.6-27B-NVFP4-MTP-GGUF.gguf")
     assert agent._config_context_length is None
+
+
+def test_override_applies_when_default_has_provider_prefix_agent_model_normalized():
+    """A legitimately-configured ``default: zai/glm-4.6`` must not lose its
+    override just because init_agent's own provider-aware normalization
+    (agent/agent_init.py, near the top of init_agent) strips the matching
+    ``zai/`` prefix from agent.model before this scoping runs. The config
+    default and the normalized agent.model refer to the same model and the
+    override must be kept."""
+    model_cfg = {
+        "default": "zai/glm-4.6",
+        "provider": "zai",
+        "base_url": "https://api.z.ai/api/coding/paas/v4",
+        "context_length": 131072,
+    }
+    agent = _build_agent(
+        model_cfg,
+        model="zai/glm-4.6",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        provider="zai",
+    )
+    # init_agent's own normalization strips the provider prefix for
+    # non-aggregator providers.
+    assert agent.model == "glm-4.6"
+    assert agent._config_context_length == 131072
+    assert agent.context_compressor.context_length == 131072
+
+
+def test_override_drops_for_genuinely_different_model_with_provider_prefix():
+    """A per-session override to a genuinely different model on the same
+    provider must still drop the config default's context_length."""
+    model_cfg = {
+        "default": "zai/glm-4.6",
+        "provider": "zai",
+        "base_url": "https://api.z.ai/api/coding/paas/v4",
+        "context_length": 131072,
+    }
+    agent = _build_agent(
+        model_cfg,
+        model="zai/glm-4.5-air",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        provider="zai",
+    )
+    assert agent.model == "glm-4.5-air"
+    assert agent._config_context_length is None
+    assert agent.context_compressor.context_length == 372_000
 
 
 # ── unit tests for the pure scoping helper ───────────────────────────────
@@ -156,4 +203,33 @@ def test_scope_helper_no_default_name_keeps_override():
 def test_scope_helper_no_agent_model_keeps_override():
     assert _scope_config_context_length_to_default_model(
         {"default": "model-a"}, None, 131072
+    ) == 131072
+
+
+def test_scope_helper_normalizes_provider_prefixed_default():
+    """config default `zai/glm-4.6` compared against the already-normalized
+    agent.model `glm-4.6` (same provider-aware normalization init_agent
+    applies to agent.model for non-aggregator providers) must be treated as
+    the same model and keep the override."""
+    assert _scope_config_context_length_to_default_model(
+        {"default": "zai/glm-4.6"}, "glm-4.6", 131072, "zai"
+    ) == 131072
+
+
+def test_scope_helper_normalized_default_still_drops_for_different_model():
+    assert _scope_config_context_length_to_default_model(
+        {"default": "zai/glm-4.6"}, "glm-4.5-air", 131072, "zai"
+    ) is None
+
+
+def test_scope_helper_aggregator_provider_keeps_vendor_prefix_form():
+    """Aggregator providers (openrouter/nous/kilocode) consume vendor/model
+    slugs, so init_agent does not strip the prefix from agent.model for
+    them; the helper must not strip it from the default either, or a
+    genuinely aggregator-qualified default would spuriously match."""
+    assert _scope_config_context_length_to_default_model(
+        {"default": "anthropic/claude-sonnet-4.6"},
+        "anthropic/claude-sonnet-4.6",
+        131072,
+        "openrouter",
     ) == 131072

--- a/tests/run_agent/test_invalid_context_length_warning.py
+++ b/tests/run_agent/test_invalid_context_length_warning.py
@@ -33,10 +33,13 @@ def _build_agent(model_cfg, custom_providers=None, model="anthropic/claude-opus-
 
 def test_valid_integer_context_length_no_warning():
     """Plain integer context_length should work silently."""
+    # model must match config default — the override is scoped to it (see
+    # _scope_config_context_length_to_default_model in agent/agent_init.py).
     with patch("run_agent.logger") as mock_logger:
         agent = _build_agent({"default": "gpt5.4", "provider": "custom",
                               "base_url": "http://localhost:4000/v1",
-                              "context_length": 256000})
+                              "context_length": 256000},
+                             model="gpt5.4")
     assert agent._config_context_length == 256000
     # No warning about invalid context_length
     for c in mock_logger.warning.call_args_list:
@@ -59,10 +62,13 @@ def test_string_k_suffix_context_length_warns():
 
 def test_string_numeric_context_length_works():
     """context_length: '256000' (string) should parse fine via int()."""
+    # model must match config default — the override is scoped to it (see
+    # _scope_config_context_length_to_default_model in agent/agent_init.py).
     with patch("run_agent.logger") as mock_logger:
         agent = _build_agent({"default": "gpt5.4", "provider": "custom",
                               "base_url": "http://localhost:4000/v1",
-                              "context_length": "256000"})
+                              "context_length": "256000"},
+                             model="gpt5.4")
     assert agent._config_context_length == 256000
     for c in mock_logger.warning.call_args_list:
         assert "Invalid" not in str(c)


### PR DESCRIPTION
Closes #62152

## Problem

The explicit `model.context_length` in config.yaml is written for the config's default model, but `init_agent` applied it to every agent build unconditionally. A new session created with a per-session model override (desktop/mobile picker choosing a different provider/model) inherited the override and reported the wrong context window: e.g. a Codex gpt-5.6 session (real window 372k) showing a local default model's 131072, with the compressor threshold firing accordingly.

The in-session `/model` switch path already guards against exactly this by clearing `_config_context_length` on swap (`agent_runtime_helpers.py`). The build path had no equivalent, so switching mid-session gave the correct window while picking the same model for a new chat did not.

## Fix

New pure helper `_scope_config_context_length_to_default_model` in `agent/agent_init.py`, wired in right after the existing int-parse of the override:

* reads the config default the same way `hermes_cli/web_server.py::get_model_info` does (`default`, falling back to `name`)
* if the config names a default model and `agent.model` differs, returns None so `get_model_context_length()` auto-detects the real window for the actual model
* conservative otherwise: non-dict model config, no named default, or empty agent model all keep current behavior

Per-model `context_length` entries under `custom_providers` are untouched and still resolve after the scoped override falls through to None (that block already keys on model + base_url).

## Tests

`tests/run_agent/test_config_context_length_model_scoping.py` (new, 11 tests):

* integration (real `AIAgent`, mirroring `test_invalid_context_length_warning.py`): override applies when the session model matches the config default; override does not leak onto a session with a different model (auto-detection wins); plain-string model config unchanged
* unit coverage of the helper: match/mismatch, `name` fallback, whitespace, missing default, missing agent model, non-dict config

`tests/run_agent/test_invalid_context_length_warning.py`: two tests incidentally built the agent with a model that mismatched the config default while asserting the override applied; they now pass the matching model explicitly, with a comment noting the scoping constraint.

`python3 -m pytest tests/run_agent/test_config_context_length_model_scoping.py tests/run_agent/test_invalid_context_length_warning.py` passes 16/16 on this branch. `ruff check` clean on the touched files.
