### PR TITLE
fix(memory): default setup picker to active provider

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -236,7 +236,7 @@ def cmd_setup_provider(provider_name: str) -> None:
 
 def cmd_setup(args) -> None:
     """Interactive memory provider setup wizard."""
-    from hermes_cli.config import load_config, save_config
+    from hermes_cli.config import load_config, load_config_readonly, save_config
 
     providers = _get_available_providers()
 
@@ -245,14 +245,26 @@ def cmd_setup(args) -> None:
         print("  Install a plugin to ~/.hermes/plugins/ and try again.\n")
         return
 
+    picker_config = load_config_readonly()
+    mem_config = (
+        picker_config.get("memory", {})
+        if isinstance(picker_config.get("memory"), dict)
+        else {}
+    )
+    active_provider = str(mem_config.get("provider", "") or "")
+
     # Build picker items
     items = []
-    for name, desc, _ in providers:
+    active_idx = None
+    for idx, (name, desc, _) in enumerate(providers):
+        if name == active_provider:
+            active_idx = idx
         items.append((name, f"— {desc}"))
     items.append(("Built-in only", "— MEMORY.md / USER.md (default)"))
 
     builtin_idx = len(items) - 1
-    selected = _curses_select("Memory provider setup", items, default=builtin_idx, cancel_returns=_CANCELLED)
+    default_idx = active_idx if active_idx is not None else builtin_idx
+    selected = _curses_select("Memory provider setup", items, default=default_idx, cancel_returns=_CANCELLED)
     if selected == _CANCELLED:
         _print_cancelled_setup()
         return

--- a/tests/hermes_cli/test_memory_setup.py
+++ b/tests/hermes_cli/test_memory_setup.py
@@ -63,15 +63,18 @@ def test_curses_select_clears_after_picker_returns(monkeypatch):
 
 def test_cmd_setup_top_level_cancel_writes_nothing(monkeypatch):
     save_config = MagicMock()
-    load_config = MagicMock(side_effect=AssertionError("cancel should not load config"))
+    load_config = MagicMock(side_effect=AssertionError("cancel should not load mutable config"))
+    load_config_readonly = MagicMock(return_value={"memory": {"provider": "fake"}})
 
     monkeypatch.setattr(memory_setup, "_get_available_providers", lambda: [("fake", "local", object())])
     monkeypatch.setattr(memory_setup, "_curses_select", lambda *args, **kwargs: kwargs["cancel_returns"])
     monkeypatch.setattr("hermes_cli.config.load_config", load_config)
+    monkeypatch.setattr("hermes_cli.config.load_config_readonly", load_config_readonly)
     monkeypatch.setattr("hermes_cli.config.save_config", save_config)
 
     memory_setup.cmd_setup(SimpleNamespace())
 
+    load_config_readonly.assert_called_once_with()
     load_config.assert_not_called()
     save_config.assert_not_called()
 

--- a/tests/hermes_cli/test_memory_setup_provider_arg.py
+++ b/tests/hermes_cli/test_memory_setup_provider_arg.py
@@ -41,6 +41,63 @@ class TestMemorySetupProviderRouting:
         picker.assert_called_once_with(args)
         direct.assert_not_called()
 
+    def test_picker_defaults_to_active_provider(self):
+        """The interactive picker should highlight the configured provider,
+        not always fall back to the Built-in only entry."""
+        providers = [
+            ("honcho", "API key / local", object()),
+            ("holographic", "local", object()),
+        ]
+        expected_items = [
+            ("honcho", "— API key / local"),
+            ("holographic", "— local"),
+            ("Built-in only", "— MEMORY.md / USER.md (default)"),
+        ]
+
+        with patch.object(memory_setup, "_get_available_providers", return_value=providers), \
+             patch.object(memory_setup, "_curses_select", return_value=memory_setup._CANCELLED) as picker, \
+             patch.object(memory_setup, "_print_cancelled_setup"), \
+             patch("hermes_cli.config.load_config_readonly", return_value={"memory": {"provider": "holographic"}}):
+            memory_setup.cmd_setup(SimpleNamespace())
+
+        picker.assert_called_once_with(
+            "Memory provider setup",
+            expected_items,
+            default=1,
+            cancel_returns=memory_setup._CANCELLED,
+        )
+
+    def test_picker_defaults_to_builtin_when_active_provider_is_unavailable_or_malformed(self):
+        """Missing, unavailable, and malformed provider config use the safe fallback."""
+        providers = [
+            ("honcho", "API key / local", object()),
+            ("holographic", "local", object()),
+        ]
+        expected_items = [
+            ("honcho", "— API key / local"),
+            ("holographic", "— local"),
+            ("Built-in only", "— MEMORY.md / USER.md (default)"),
+        ]
+        configs = [
+            {},
+            {"memory": {"provider": "unavailable"}},
+            {"memory": "malformed"},
+        ]
+
+        for config in configs:
+            with patch.object(memory_setup, "_get_available_providers", return_value=providers), \
+                 patch.object(memory_setup, "_curses_select", return_value=memory_setup._CANCELLED) as picker, \
+                 patch.object(memory_setup, "_print_cancelled_setup"), \
+                 patch("hermes_cli.config.load_config_readonly", return_value=config):
+                memory_setup.cmd_setup(SimpleNamespace())
+
+            picker.assert_called_once_with(
+                "Memory provider setup",
+                expected_items,
+                default=2,
+                cancel_returns=memory_setup._CANCELLED,
+            )
+
     def test_unknown_provider_reports_and_returns_early(self, capsys):
         """An unknown provider name surfaces a helpful message and returns
         before any config load/save (the not-found guard precedes those imports)."""


### PR DESCRIPTION
## Summary

- make `hermes memory setup` highlight the currently configured memory provider
- keep `Built-in only` as the fallback when the configured provider is missing, malformed, or unavailable
- preserve cancel behavior by using the read-only config path for picker initialization and loading mutable config only after a selection
- add regression coverage for active-provider selection and fallback cases

## Problem

The interactive memory setup picker always defaults to `Built-in only`, even when a plugin-backed provider is already active. Pressing Enter in that state can unintentionally disable the configured provider.

## Test plan

- [x] Confirm the regression test fails against upstream behavior
- [x] Run `scripts/run_tests.sh tests/hermes_cli/test_memory_setup.py tests/hermes_cli/test_memory_setup_provider_arg.py -q --tb=short`
- [x] Run Python compilation checks for the changed source and test files
- [x] Run `git diff --check`

### Results

- Focused canonical tests: `18 passed`
- Python compilation: passed
- Diff whitespace validation: passed

## Platform tested

- WSL2 / Linux
