### PR TITLE
fix(gateway): guard null skill description in /help and /commands

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1333,7 +1333,8 @@ class GatewaySlashCommandsMixin:
                 # Show first 10, then point to /commands for the rest
                 sorted_cmds = sorted(skill_cmds)
                 for cmd in sorted_cmds[:10]:
-                    lines.append(f"`{cmd}` — {skill_cmds[cmd]['description']}")
+                    desc = skill_cmds[cmd].get("description") or t("gateway.commands.default_desc")
+                    lines.append(f"`{cmd}` — {desc}")
                 if len(sorted_cmds) > 10:
                     lines.append(t("gateway.help.more_use_commands", count=len(sorted_cmds) - 10))
         except Exception:
@@ -1365,7 +1366,7 @@ class GatewaySlashCommandsMixin:
                 entries.append("")
                 entries.append(t("gateway.commands.skill_header"))
                 for cmd in sorted(skill_cmds):
-                    desc = skill_cmds[cmd].get("description", "").strip() or t("gateway.commands.default_desc")
+                    desc = (skill_cmds[cmd].get("description") or "").strip() or t("gateway.commands.default_desc")
                     entries.append(f"`{cmd}` — {desc}")
         except Exception:
             pass

--- a/tests/gateway/test_gateway_command_help.py
+++ b/tests/gateway/test_gateway_command_help.py
@@ -86,3 +86,52 @@ async def test_help_keeps_non_telegram_slash_command_mentions_unchanged(monkeypa
     )
 
     assert "`/Linear`" in result
+
+
+@pytest.mark.asyncio
+async def test_commands_survives_null_skill_description(monkeypatch):
+    """A skill whose SKILL.md frontmatter has a blank/null ``description:``
+    parses as ``description: None`` and must not take down the *entire*
+    skill-commands section of /commands for every other skill.
+
+    ``tools/skill_manager_tool.py::_validate_frontmatter`` only checks
+    ``"description" not in parsed`` (key absence), not falsiness, so such a
+    manifest is accepted today and reaches ``get_skill_commands()`` with a
+    ``None`` description.
+    """
+    monkeypatch.setattr(
+        "agent.skill_commands.get_skill_commands",
+        lambda: {
+            "/broken": {"description": None},
+            "/fine": {"description": "Does something useful"},
+        },
+    )
+
+    result = await _make_runner()._handle_commands_command(
+        _make_event("/commands 999", Platform.DISCORD)
+    )
+
+    assert "`/fine`" in result
+    assert "Does something useful" in result
+    assert "`/broken`" in result
+
+
+@pytest.mark.asyncio
+async def test_help_survives_null_skill_description(monkeypatch):
+    """Same null-description tolerance for /help's skill listing."""
+    monkeypatch.setattr(
+        "agent.skill_commands.get_skill_commands",
+        lambda: {
+            "/broken": {"description": None},
+            "/fine": {"description": "Does something useful"},
+        },
+    )
+
+    result = await _make_runner()._handle_help_command(
+        _make_event("/help", Platform.DISCORD)
+    )
+
+    assert "`/fine`" in result
+    assert "Does something useful" in result
+    assert "`/broken`" in result
+    assert "None" not in result


### PR DESCRIPTION
## What does this PR do?
`get_skill_commands()` sources its `description` field from each skill's `SKILL.md` frontmatter. `tools/skill_manager_tool.py::_validate_frontmatter` only checks that the `description` key exists (`"description" not in parsed`), not that its value is non-empty, so a manifest with a blank `description:` (parses as YAML `null`) passes validation and is accepted today.

Two call sites in `gateway/slash_commands.py` then read that field unsafely:

- **`_handle_commands_command`** (`/commands`): `skill_cmds[cmd].get("description", "").strip()` raises `AttributeError` on `None`. The whole `for cmd in sorted(skill_cmds)` loop is wrapped in a bare `except: pass`, so this silently deletes the **entire** skill-commands section from the output — for every other installed skill, not just the broken one.
- **`_handle_help_command`** (`/help`): `skill_cmds[cmd]['description']` doesn't crash on `None`, but renders the literal string `"None"` as the command's description.

Both are reachable through community/third-party skill installs (a skill author leaving `description:` blank in frontmatter), not just local config hand-editing.

## Related Issue
N/A — found while investigating whether a null-description skill manifest is actually reachable today. Confirmed it is: `_validate_frontmatter`'s existence-only check doesn't reject it.

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- `gateway/slash_commands.py`: both sites now fall back to the existing `gateway.commands.default_desc` locale string ("Skill command") when the description is null/empty, matching the fallback `_handle_commands_command` already used for an empty (non-null) description.
- `tests/gateway/test_gateway_command_help.py`: add `test_commands_survives_null_skill_description` and `test_help_survives_null_skill_description`.

## How to Test
```
pytest tests/gateway/test_gateway_command_help.py -v
```
All 6 tests in the file pass. Mutation-verified: reverting the two-line fix reproduces both failures — `AttributeError` (entire skill section silently dropped) for `/commands`, and the literal string `"None"` appearing in `/help` output.

## Checklist
- [x] Read the Contributing Guide
- [x] Conventional Commits format
- [x] No duplicate PR
- [x] Single logical change
- [x] Tests added
- [x] Cross-platform: N/A