### PR TITLE
fix(cron): avoid gateway API deadlock on 2nd+ LLM call (#62151)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -236,6 +236,75 @@ def _check_stale_giveup(agent) -> None:
         )
 
 
+def should_use_direct_api_call(agent) -> bool:
+    """True when the non-streaming path should skip the interrupt worker thread.
+
+    Cron jobs run inside nested gateway thread pools (cron-scheduler →
+    cron-parallel → per-job pool → ``interruptible_api_call`` worker). That
+    extra daemon thread can wedge before HTTP on the 2nd+ API call of a
+    tool-using turn (#62151) while the same job succeeds via ``hermes cron
+    tick``. Cron has no interactive interrupt surface, so synchronous calls
+    on the conversation thread are safe and avoid the deadlock class.
+    """
+    return getattr(agent, "platform", None) == "cron"
+
+
+def _execute_nonstreaming_api_request(agent, api_kwargs: dict):
+    """Dispatch one non-streaming LLM request on the calling thread."""
+    request_client = None
+    try:
+        if agent.api_mode == "codex_responses":
+            request_client = agent._create_request_openai_client(
+                reason="codex_stream_request",
+                api_kwargs=api_kwargs,
+            )
+            return agent._run_codex_stream(
+                api_kwargs,
+                client=request_client,
+                on_first_delta=getattr(agent, "_codex_on_first_delta", None),
+            )
+        if agent.api_mode == "anthropic_messages":
+            return agent._anthropic_messages_create(api_kwargs)
+        if agent.api_mode == "bedrock_converse":
+            from agent.bedrock_adapter import (
+                _get_bedrock_runtime_client,
+                invalidate_runtime_client,
+                is_stale_connection_error,
+                normalize_converse_response,
+            )
+
+            region = api_kwargs.pop("__bedrock_region__", "us-east-1")
+            api_kwargs.pop("__bedrock_converse__", None)
+            client = _get_bedrock_runtime_client(region)
+            try:
+                raw_response = client.converse(**api_kwargs)
+            except Exception as bedrock_exc:
+                if is_stale_connection_error(bedrock_exc):
+                    invalidate_runtime_client(region)
+                raise
+            return normalize_converse_response(raw_response)
+
+        request_client = agent._create_request_openai_client(
+            reason="chat_completion_request",
+            api_kwargs=api_kwargs,
+        )
+        return request_client.chat.completions.create(**api_kwargs)
+    finally:
+        if request_client is not None:
+            agent._close_request_openai_client(
+                request_client, reason="request_complete"
+            )
+
+
+def direct_api_call(agent, api_kwargs: dict):
+    """Run a non-streaming API call synchronously on the conversation thread."""
+    _check_stale_giveup(agent)
+    agent._touch_activity("waiting for non-streaming API response")
+    response = _execute_nonstreaming_api_request(agent, api_kwargs)
+    _reset_stale_streak(agent)
+    return response
+
+
 def interruptible_api_call(agent, api_kwargs: dict):
     """
     Run the API call in a background thread so the main conversation loop

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1318,6 +1318,13 @@ def run_conversation(
                         return agent._interruptible_streaming_api_call(
                             next_api_kwargs, on_first_delta=_stop_spinner
                         )
+                    from agent.chat_completion_helpers import (
+                        direct_api_call,
+                        should_use_direct_api_call,
+                    )
+
+                    if should_use_direct_api_call(agent):
+                        return direct_api_call(agent, next_api_kwargs)
                     return agent._interruptible_api_call(next_api_kwargs)
 
                 from hermes_cli.middleware import run_llm_execution_middleware

--- a/tests/cron/test_cron_direct_api_call_62151.py
+++ b/tests/cron/test_cron_direct_api_call_62151.py
@@ -1,0 +1,60 @@
+"""Regression guard for #62151 — gateway cron must not wedge on 2nd+ API call.
+
+Gateway-fired cron jobs hung forever on the 2nd+ non-streaming API call when
+``interruptible_api_call`` spawned a daemon worker inside nested cron thread
+pools. The worker logged client creation but never opened a TCP connection.
+The same job succeeded via ``hermes cron tick``. Cron has no interactive
+interrupt surface, so the fix routes cron through a synchronous direct call on
+the conversation thread instead of the interrupt worker.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from agent.chat_completion_helpers import (
+    direct_api_call,
+    should_use_direct_api_call,
+)
+
+
+def _make_agent(*, platform="cron"):
+    agent = MagicMock()
+    agent.platform = platform
+    agent.api_mode = "chat_completions"
+    agent._touch_activity = MagicMock()
+    agent._create_request_openai_client = MagicMock()
+    agent._close_request_openai_client = MagicMock()
+    return agent
+
+
+def test_should_use_direct_api_call_only_for_cron_platform():
+    assert should_use_direct_api_call(_make_agent(platform="cron")) is True
+    assert should_use_direct_api_call(_make_agent(platform="cli")) is False
+    assert should_use_direct_api_call(_make_agent(platform="telegram")) is False
+    assert should_use_direct_api_call(_make_agent(platform=None)) is False
+
+
+def test_direct_api_call_runs_two_sequential_requests_on_same_thread():
+    """Mirror the 2nd+ call failure mode: two back-to-back completions.create."""
+    agent = _make_agent()
+    calls = {"n": 0}
+    fake_client = MagicMock()
+
+    def _create(**_kwargs):
+        calls["n"] += 1
+        return fake_client
+
+    fake_client.chat.completions.create.side_effect = [
+        SimpleNamespace(id="first"),
+        SimpleNamespace(id="second"),
+    ]
+    agent._create_request_openai_client.side_effect = _create
+
+    first = direct_api_call(agent, {"model": "m", "messages": []})
+    second = direct_api_call(agent, {"model": "m", "messages": []})
+
+    assert first.id == "first"
+    assert second.id == "second"
+    assert calls["n"] == 2
+    assert fake_client.chat.completions.create.call_count == 2
+    assert agent._close_request_openai_client.call_count == 2


### PR DESCRIPTION
## Summary
- Route cron-platform non-streaming LLM calls through a synchronous `direct_api_call` on the conversation thread instead of `interruptible_api_call`'s daemon worker.
- Fixes gateway-fired cron jobs that wedged before HTTP on the 2nd+ API call of a tool-using turn while the same job succeeded via `hermes cron tick` ([#62151](https://github.com/NousResearch/hermes-agent/issues/62151)).
- Cron has no interactive interrupt surface, so skipping the extra worker thread is safe and removes the nested-thread deadlock class inside the gateway process.

## Test plan
- [x] `scripts/run_tests.sh tests/cron/test_cron_direct_api_call_62151.py`
- [x] `scripts/run_tests.sh tests/agent/test_cascading_interrupt_6600.py`
- [ ] Reproduce on a VPS: gateway-fired cron job with tools completes API call #2+ and delivers