### PR TITLE
fix: clarify tool flattens choices emitted with 'value' key (#62146)

### DIFF
--- a/tests/test_clarify_flatten.py
+++ b/tests/test_clarify_flatten.py
@@ -1,0 +1,39 @@
+"""Regression tests for clarify_tool._flatten_choice (issue #62146).
+
+Some models (GLM-5.2 via xiaomi) emit choices as [{"value": "A. Option text"}]
+instead of the canonical label/text keys. _flatten_choice must surface the
+human-readable text from `value` as a last-resort fallback without breaking
+models that use the canonical keys.
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from tools.clarify_tool import _flatten_choice
+
+
+def test_canonical_label_wins_over_value():
+    assert _flatten_choice({"label": "L", "value": "V"}) == "L"
+
+
+def test_value_fallback_for_glm_style_choices():
+    # The reported bug: GLM-5.2 emits value-only choice dicts.
+    assert _flatten_choice({"value": "A. Option text"}) == "A. Option text"
+
+
+def test_bare_string_passthrough():
+    assert _flatten_choice("plain") == "plain"
+
+
+def test_unknown_key_dropped():
+    assert _flatten_choice({"unknown": "x"}) == ""
+
+
+def test_mixed_list_flattened():
+    assert _flatten_choice([{"value": "X"}, "Y"]) == "X Y"
+
+
+def test_none_dropped():
+    assert _flatten_choice(None) == ""

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -32,18 +32,21 @@ def _flatten_choice(c) -> str:
     fixes the whole class in one place instead of per-adapter.
 
     Dict unwrap order is the canonical LLM tool-call user-facing keys:
-    ``label`` → ``description`` → ``text`` → ``title``. ``name`` and ``value``
-    are deliberately excluded — they're component-shaped fields that could
-    carry raw enum values or short identifiers, not human-readable labels. A
-    dict with none of the canonical keys is dropped (returns ""), since a
-    garbage label is worse than no choice at all.
+    ``label`` → ``description`` → ``text`` → ``title`` → ``value``. ``name``
+    is still excluded (raw enum / short identifier). ``value`` was added as a
+    last-resort fallback because some models (e.g. GLM-5.2 via the xiaomi
+    provider) emit the human-readable choice text in ``value``
+    (``[{"value": "A. Option text"}]``) rather than ``label``/``text``. It
+    stays last so canonical keys still win when present. A dict with none of
+    these keys is dropped (returns ""), since a garbage label is worse than no
+    choice at all.
     """
     if c is None:
         return ""
     if isinstance(c, str):
         return c.strip()
     if isinstance(c, dict):
-        for key in ("label", "description", "text", "title"):
+        for key in ("label", "description", "text", "title", "value"):
             v = c.get(key)
             if isinstance(v, str) and v.strip():
                 return v.strip()


### PR DESCRIPTION
## What
Fixes #62146: the `clarify` tool rendered blank options when a model emits choices as `[{"value": "A. Option text"}]` (e.g. GLM-5.2 via the xiaomi provider).

`_flatten_choice` only checked `label`/`description`/`text`/`title`, so the `value` key flattened to an empty string and the interactive selection showed blank choices.

## Changes
- `tools/clarify_tool.py`: add `"value"` as the **last** key in the unwrap order, so canonical keys still win when present and `value` is a backward-compatible fallback. Updated docstring.
- `tests/test_clarify_flatten.py`: 6 regression tests (label-wins-over-value, value-fallback for GLM-style dicts, bare string, unknown-key dropped, mixed list, None).

## Verification
`pytest tests/test_clarify_flatten.py` → 6 passed. Also verified directly: label still wins over value, `{"value": "A. Option text"}` → `"A. Option text"`.

## Scope
One-function fix + test. No behavior change for models using canonical keys.

Closes #62146. Revertible: `git revert <sha>`.