### PR TITLE
fix(compressor): handle dict content in _summarize_tool_result

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -623,7 +623,12 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
 
     if tool_name == "write_file":
         path = args.get("path", "?")
-        written_lines = args.get("content", "").count("\n") + 1 if args.get("content") else "?"
+        _content = args.get("content", "")
+        if isinstance(_content, dict):
+            _content = json.dumps(_content)
+        elif not isinstance(_content, str):
+            _content = str(_content)
+        written_lines = _content.count("\n") + 1 if _content else "?"
         return f"[write_file] wrote to {path} ({written_lines} lines)"
 
     if tool_name == "search_files":


### PR DESCRIPTION
## Fix

When `write_file` receives `content` as a `dict` (nested JSON), `args.get("content")` returns a dict, not a str. Calling `.count("\n")` on a dict crashes context compression with `AttributeError: 'dict' object has no attribute 'count'`.

This blocks compression entirely — the session grows past the threshold and every subsequent compression attempt hits the same crash.

## Patch

```python
# agent/context_compressor.py, _summarize_tool_result(), write_file branch
_content = args.get("content", "")
if isinstance(_content, dict):
    _content = json.dumps(_content)
elif not isinstance(_content, str):
    _content = str(_content)
written_lines = _content.count("\n") + 1 if _content else "?"
```

Uses `json.dumps` for dicts (preserves readable structure in the summary) and `str()` as fallback for any other non-string type (lists, ints, etc.).

## Verification

- **151 existing tests** in `tests/agent/test_context_compressor.py` — all pass (15s)
- **4 manual edge cases**:

| Input type | Result |
|---|---|
| `dict` (the bug) | `[write_file] wrote to /test.txt (1 lines)` ✅ |
| `str` with 3 lines | `[write_file] wrote to /test.txt (3 lines)` ✅ |
| empty / missing | `[write_file] wrote to /test.txt (? lines)` ✅ |
| `list` | `[write_file] wrote to /test.txt (1 lines)` ✅ |

## Note

The same pattern (`args.get(...)` assumed to be `str`, then `.count()`/`[:N]`/`len()`) exists for other tool branches in the same function. A defensive `_safe_str()` helper could fix the whole class at once.

Fixes #58317
