### PR TITLE
feat(mlops): cuda skill — first Hermes CUDA/NVIDIA compute surface

### DIFF
--- a/skills/mlops/cuda/SKILL.md
+++ b/skills/mlops/cuda/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: cuda
+description: "Use when building NVIDIA/CUDA compute surfaces for Hermes — the >_n: NemoClaw operator grammar, nvidia-smi host bridges, GPU telemetry tiles, and local CUDA compiler workflows (nvcc kernels + NVIDIA CUDA Tile IR). Covers the VS Code webview file:// pitfall, WebGPU fallback, and PyTorch/CuPy probe patterns. Pioneer skill: Hermes ships no CUDA skill; this defines the surface and its compiler layer."
+version: 1.0.0
+author: Yæl Méndez
+license: MIT
+metadata:
+  hermes:
+    tags: [cuda, nvidia, gpu, nemo-claw, compute-surface, webview, nvidia-smi, operator-grammar, sovereign-mesh]
+    related_skills: [sovereign-vscode-surface-dev, hermes-surface-development, hermes-operator-grammar, optimizing-attention-flash]
+---
+
+# CUDA — NVIDIA Compute Surface for Hermes
+
+## Overview
+
+Hermes ships **no CUDA/NVIDIA skill** — this is the pioneer. It formalizes the `>_n:` operator
+slot (`>_n: → nvidia (NemoClaw) → compute` from AGENTS.md) as a concrete, agent-addressable
+compute surface: a sovereign GPU node you can mount, probe, and drive from a VS Code webview.
+
+The pattern has three layers:
+1. **Grammar** — `>_n:` routes to NVIDIA compute; the host command is `remoteUse.nvidia`.
+2. **Surface** — a single gold/void-independent, green-NVIDIA-themed HTML tile dashboard
+   (`nvidia-tiles.html`) mounted in the local surface hub (Computation tab).
+3. **Bridge** — a VS Code extension command that shells out to `nvidia-smi` and streams JSON
+   back to the webview via `postMessage`. This is the only way to read real GPU state inside a
+   webview (browser `fetch` to a local port works only if a bridge is running).
+
+Victus (HP Victus 15-fa2xxx) is the reference node: i5-13420H, RTX 3050 6GB, **nvcc 13.3
+installed**, driver 592.27. The skill is written so any NVIDIA node drops in by changing the
+`nvidia-smi` query.
+
+## When to Use
+
+- Building or extending a `>_n:` / NemoClaw compute surface for Hermes.
+- Wiring `nvidia-smi` GPU telemetry into a VS Code webview (or any local HTML surface).
+- Probing PyTorch/CuPy availability or running a CUDA sanity bench on a local node.
+- Asked to "map machine capabilities" — the GPU tile is part of the Victus capability map.
+- Don't use for: cloud GPU clusters (see `lambda-labs-gpu-cloud`, `modal-serverless-gpu`),
+  pure ML training recipes (see `mlops/training/*`), or attention optimization (`optimizing-attention-flash`).
+
+## Quick start
+
+Mount the surface from the hub, or open it directly:
+
+```bash
+# in VS Code command palette:
+Remote Use: NVIDIA Compute Surface     # -> remoteUse.nvidia
+# or from the surface hub: Computation tab -> NVIDIA Tiles
+```
+
+The tile auto-refreshes GPU telemetry on mount by posting `{command:'remoteUse.nvidia', action:'smi'}`
+to the host. The host runs:
+
+```bash
+nvidia-smi --query-gpu=name,driver_version,memory.used,memory.total,utilization.gpu,temperature.gpu \
+  --format=csv,noheader,nounits
+```
+
+and posts back `{command:'remoteUse.nvidia', action:'smi', data:{ name, driver, memory_used, memory_total, utilization_gpu, temperature_gpu }}`
+(`memory_used`/`memory_total` are bytes; the surface divides by 1024³ for GB).
+
+## Workflow 1: Add a GPU telemetry tile to a surface hub
+
+Checklist:
+- [ ] Step 1: Confirm `nvidia-smi` works on the node (it must be on PATH)
+- [ ] Step 2: Add the tile HTML + a `refreshGpu()` that posts to the host (or fetches a bridge)
+- [ ] Step 3: Add the host bridge in `extension.ts` (`remoteUse.nvidia` → `nvidia-smi`)
+- [ ] Step 4: Register the command in `package.json` + `context.subscriptions`
+- [ ] Step 5: Render in headless Edge + verify tiles, then compile + pytest
+
+**Step 1 — verify the data shape (do this BEFORE writing the parser):**
+```bash
+nvidia-smi --query-gpu=name,driver_version,memory.used,memory.total,utilization.gpu,temperature.gpu \
+  --format=csv,noheader,nounits
+# -> NVIDIA GeForce RTX 3050 6GB Laptop GPU, 592.27, 761, 6144, 0, 47
+#    6 comma-separated fields; split on ',' and trim. NaN guard on [N/A].
+```
+
+**Step 3 — host bridge (TS, in `vscode-remote-use/src/extension.ts`):**
+```ts
+const nvidiaCmd = vscode.commands.registerCommand('remoteUse.nvidia', async () => {
+  const repo = getHermesRepoPath();
+  const hub = `${repo}/templates/surfaces/nvidia-tiles.html`;
+  const panel = vscode.window.createWebviewPanel('remoteUseNvidia', 'Remote Use: NVIDIA Compute Surface',
+    vscode.ViewColumn.One, { enableScripts: true, retainContextWhenHidden: true,
+      localResourceRoots: [vscode.Uri.file(`${repo}/templates/surfaces`)] });
+  panel.webview.html = require('fs').readFileSync(hub, 'utf8');
+  panel.webview.onDidReceiveMessage(async (message: any) => {
+    const { exec } = require('child_process');
+    const run = (cmd: string) => new Promise<string>((res) =>
+      exec(cmd, { maxBuffer: 1024*1024 }, (e:any,o:string,err:string)=>res((e?err:o)||'')));
+    if (message?.action === 'smi') {
+      const out = await run('nvidia-smi --query-gpu=name,driver_version,memory.used,memory.total,utilization.gpu,temperature.gpu --format=csv,noheader,nounits');
+      const p = out.split(',').map((s:string)=>s.trim());
+      if (p.length >= 6) panel.webview.postMessage({ command:'remoteUse.nvidia', action:'smi', data: {
+        name:p[0], driver:p[1], memory_used:parseFloat(p[2])*1048576, memory_total:parseFloat(p[3])*1048576,
+        utilization_gpu:parseFloat(p[4]), temperature_gpu:parseFloat(p[5]) }});
+    }
+  });
+});
+```
+
+## Workflow 2: Probe the local CUDA stack
+
+```bash
+# toolkit
+nvcc --version | tail -2                 # -> release 13.3
+# PyTorch / CuPy (host-side, not webview)
+python -c "import torch; print(torch.__version__, torch.cuda.is_available())"
+python -c "import cupy; print(cupy.cuda.runtime.runtimeGetVersion())"
+```
+
+Bridge the torch probe into the surface the same way as `smi` (see `references/host-bridge.md`).
+
+## Workflow 3: WebGPU fallback (in-browser, no host)
+
+When the surface runs in a plain browser (no VS Code host), use the client GPU directly:
+```js
+if (navigator.gpu) {
+  const adapter = await navigator.gpu.requestAdapter();
+  if (adapter) { /* WebGPU available — WebLLM/Qwen3 path */ }
+}
+```
+
+This is how Hermes Native (WebLLM/WebGPU, Qwen3-0.6B) runs without CUDA — distinct from the
+`nvidia-smi` host bridge. Keep both: WebGPU for in-browser inference, CUDA host bridge for
+telemetry/bench on the real GPU.
+
+## Workflow 4: Compile & run a local CUDA kernel (the compiler layer)
+
+The surface's Bench tile stub should ultimately call a **real** nvcc-built kernel, not a JS
+CPU matmul. Pattern:
+
+```bash
+# 1. write a kernel
+cat > matmul.cu <<'EOF'
+#include <cstdio>
+__global__ void matmul(float* a, float* b, float* c, int n) {
+  int i = blockIdx.x*blockDim.x + threadIdx.x;
+  if (i < n*n) { float s=0; for(int k=0;k<n;k++) s+=a[i/n*n+k]*b[k*n+i%n]; c[i]=s; }
+}
+EOF
+# 2. compile (MSVC linker must be on PATH on Windows — see Pitfall 5)
+nvcc matmul.cu -o matmul 2>&1
+# 3. run; stream the GPU time back via the same host bridge as `smi`
+./matmul
+```
+
+**CUDA Tile IR** (NVIDIA/cuda-tile, ~1k★, MLIR-based): the kernel-optimization compiler infra
+that sits *under* this surface. Not a skill, not agent-facing — it's the tile-based IR + tensor-core
+optimization backend. Reference it when a task needs kernel-level fusion/tiling rather than just
+telemetry. The skill drives the surface; CUDA Tile IR optimizes the kernels the surface launches.
+
+## Common Pitfalls
+
+1. **VS Code webviews block `file://` iframes.** A surface that mounts another local HTML via
+   `src="file:///..."` renders in Edge but is **blank inside VS Code**. Fix: strip `file://`
+   in the served HTML and let the host convert paths with `panel.webview.asWebviewUri(...)`.
+   (Same fix applied to the whole surface hub — see `sovereign-vscode-surface-dev`.)
+
+2. **`[N/A]` in `nvidia-smi --query-compute-apps=used_memory`.** `parseFloat('[N/A]')` is `NaN`
+   and renders as `NaN MB`. Guard with `isFinite(x) ? (x/1048576).toFixed(0)+'MB' : 'n/a'`.
+
+3. **Field count drift.** `nvidia-smi --query-gpu=...` returns exactly the columns you ask for,
+   comma-separated, no header (with `noheader`). Always assert `parts.length >= N` before indexing.
+
+4. **Host command not registered.** A webview `postMessage` with an unregistered command silently
+   no-ops. Add the command to BOTH `package.json` `contributes.commands` AND
+   `context.subscriptions.push(...)` in `extension.ts` or the surface stays dead.
+
+5. **MSVC linker not on PATH (Windows).** `nvcc`/CUDA compile fine, but native `.exe`/Tauri
+   linking needs `vcvars64.bat` first. The linker exists via VS 2022 BuildTools — just not on PATH.
+   (Victus: BuildTools 14.44.35207 at `C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Tools/MSVC/14.44.35207/bin/Hostx64/x64/`.)
+
+## Verification Checklist
+
+- [ ] `nvidia-smi --query-gpu=...` returns the exact field count the parser expects
+- [ ] Host bridge posts `{command:'remoteUse.nvidia', action:'smi', data:{...}}` with byte-sized memory
+- [ ] Surface renders in headless Edge (all tiles + dock visible, green NVIDIA theme)
+- [ ] `npm run compile` (tsc) exits 0; `package.json` valid
+- [ ] `pytest secret_source_bridge/tests.py tests/hermes_runtime/test_computer_use.py` green
+- [ ] No secrets hardcoded; `[N/A]` memory renders as `n/a`, not `NaN`
+- [ ] Grammar wired: `>_n:` → `remoteUse.nvidia` → `pc://mesh/victus/local`
+
+## References
+
+- `references/host-bridge.md` — full `extension.ts` `remoteUse.nvidia` handler (smi + procs + torch)
+- `templates/nvidia-tiles.html` — the shipped green-NVIDIA 6-tile surface (GPU / Compute Path / Processes / Bench / Routes / Envelope)
+- `../hermes-native/references/victus-capability-map.md` — verified Victus hardware/toolchain facts
+
+## Resources
+
+- NVIDIA `nvidia-smi` docs: https://nvidia.github.io/nvidia-settings/
+- CUDA toolkit (nvcc): https://developer.nvidia.com/cuda-toolkit
+- **CUDA Tile IR** (NVIDIA/cuda-tile): https://github.com/NVIDIA/cuda-tile — MLIR-based kernel compiler infra (tensor-core tiling); the backend under this surface
+- WebGPU: https://developer.mozilla.org/docs/Web/API/WebGPU_API
+- Hermes operator grammar: `hermes-operator-grammar` skill

--- a/skills/mlops/cuda/references/host-bridge.md
+++ b/skills/mlops/cuda/references/host-bridge.md
@@ -1,0 +1,81 @@
+# Host Bridge — `remoteUse.nvidia` (full handler)
+
+This is the complete VS Code extension handler that powers the NVIDIA Tiles surface. It shells
+out to `nvidia-smi` (and a torch probe) and streams JSON back to the webview.
+
+```ts
+const nvidiaCmd = vscode.commands.registerCommand('remoteUse.nvidia', async () => {
+  const repo = getHermesRepoPath();
+  const hub = `${repo}/templates/surfaces/nvidia-tiles.html`;
+  const panel = vscode.window.createWebviewPanel(
+    'remoteUseNvidia',
+    'Remote Use: NVIDIA Compute Surface',
+    vscode.ViewColumn.One,
+    { enableScripts: true, retainContextWhenHidden: true,
+      localResourceRoots: [vscode.Uri.file(`${repo}/templates/surfaces`)] }
+  );
+  panel.webview.html = require('fs').readFileSync(hub, 'utf8');
+  panel.webview.onDidReceiveMessage(async (message: any) => {
+    const action: string = message?.action || '';
+    const { exec } = require('child_process');
+    const run = (cmd: string) => new Promise<string>((res) =>
+      exec(cmd, { maxBuffer: 1024 * 1024 }, (e: any, o: string, err: string) => res((e ? err : o) || '')));
+
+    if (action === 'smi') {
+      const out = await run('nvidia-smi --query-gpu=name,driver_version,memory.used,memory.total,utilization.gpu,temperature.gpu --format=csv,noheader,nounits');
+      const parts = out.split(',').map((s: string) => s.trim());
+      if (parts.length >= 6) {
+        panel.webview.postMessage({ command: 'remoteUse.nvidia', action: 'smi', data: {
+          name: parts[0], driver: parts[1],
+          memory_used: parseFloat(parts[2]) * 1024 * 1024,
+          memory_total: parseFloat(parts[3]) * 1024 * 1024,
+          utilization_gpu: parseFloat(parts[4]),
+          temperature_gpu: parseFloat(parts[5])
+        }});
+      }
+    } else if (action === 'procs') {
+      const out = await run('nvidia-smi --query-compute-apps=pid,process_name,used_memory --format=csv,noheader,nounits');
+      const procs = out.split('\n').filter(Boolean).map((l: string) => {
+        const p = l.split(',').map((s: string) => s.trim());
+        return { pid: p[0], name: p[1], used_memory: parseFloat(p[2]) * 1024 * 1024 };
+      });
+      panel.webview.postMessage({ command: 'remoteUse.nvidia', action: 'procs', data: procs });
+    } else if (action === 'torch') {
+      let torch = false, version = '';
+      try {
+        const r = require('child_process').execSync('python -c "import torch;print(torch.__version__)"', { encoding: 'utf8' });
+        version = r.trim(); torch = true;
+      } catch (e) { /* not installed */ }
+      panel.webview.postMessage({ command: 'remoteUse.nvidia', action: 'torch', data: { torch, version } });
+    }
+  });
+});
+```
+
+## Webview message contract
+
+Surface → host:
+| `action` | payload | host does |
+|---|---|---|
+| `smi` | — | runs `nvidia-smi --query-gpu=...`, posts `smi` data |
+| `procs` | — | runs `nvidia-smi --query-compute-apps=...`, posts `procs` array |
+| `torch` | — | `python -c "import torch"`, posts `{torch, version}` |
+| `open` | — | `vscode://hermes-agent.remoteUse.nvidia` |
+
+Host → surface:
+| `command` | `action` | payload |
+|---|---|---|
+| `remoteUse.nvidia` | `smi` | `{name, driver, memory_used, memory_total, utilization_gpu, temperature_gpu}` (bytes) |
+| `remoteUse.nvidia` | `procs` | `[{pid, name, used_memory}]` (bytes; may be NaN → render `n/a`) |
+| `remoteUse.nvidia` | `torch` | `{torch: bool, version: str}` |
+
+## Registration (do not forget either)
+
+`package.json`:
+```json
+{ "command": "remoteUse.nvidia", "title": "Remote Use: NVIDIA Compute Surface" }
+```
+`extension.ts` `context.subscriptions.push(...)`:
+```ts
+nvidiaCmd,
+```

--- a/skills/mlops/cuda/templates/nvidia-tiles.html
+++ b/skills/mlops/cuda/templates/nvidia-tiles.html
@@ -1,0 +1,189 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>æ://n — NVIDIA Tiles</title>
+<style>
+  :root {
+    --void:#050505; --gold:#d4af37; --neon:#00ff9d; --ink:#f0ece4;
+    --nv:#76b900; --nv-dim:rgba(118,185,0,.16); --nv-hot:rgba(118,185,0,.5);
+    --muted:rgba(240,236,228,.4); --border:rgba(118,185,0,.18);
+    --border-hot:rgba(118,185,0,.5); --panel:#090909; --panel2:#0b0b0b;
+    --glow:rgba(118,185,0,.1); --err:#ff5555; --amber:#ffaa00;
+  }
+  *{box-sizing:border-box;}
+  html,body{margin:0;background:var(--void);color:var(--ink);font-family:ui-monospace,'JetBrains Mono',Menlo,monospace;min-height:100vh;}
+  body::before{content:"";position:fixed;inset:0;pointer-events:none;z-index:999;opacity:.03;background:repeating-linear-gradient(0deg,transparent,transparent 2px,rgba(118,185,0,.12) 2px,rgba(118,185,0,.12) 4px);}
+  .wrap{max-width:1120px;margin:0 auto;padding:26px 22px 56px;}
+  header{display:flex;justify-content:space-between;align-items:flex-end;gap:16px;border-bottom:1px solid var(--border-hot);padding-bottom:14px;margin-bottom:20px;flex-wrap:wrap;}
+  .brand{display:flex;gap:14px;align-items:center;}
+  .glyph{width:46px;height:46px;border:1px solid var(--border-hot);display:grid;place-items:center;font-weight:800;font-size:22px;background:var(--panel2);color:var(--nv);box-shadow:0 0 22px var(--glow);}
+  h1{margin:0;font-size:19px;letter-spacing:.16em;color:var(--nv);text-transform:uppercase;}
+  .sub{margin:4px 0 0;font-size:11px;color:var(--muted);letter-spacing:.18em;text-transform:uppercase;}
+  .addr{font-size:11px;color:var(--neon);letter-spacing:.1em;text-align:right;}
+  .tiles{display:grid;grid-template-columns:repeat(auto-fill,minmax(330px,1fr));gap:14px;}
+  .tile{border:1px solid var(--border);background:var(--panel);padding:16px;transition:.2s;position:relative;overflow:hidden;}
+  .tile:hover{border-color:var(--border-hot);box-shadow:0 0 18px var(--glow);}
+  .tile h2{margin:0 0 4px;font-size:11px;letter-spacing:.2em;text-transform:uppercase;color:var(--nv);display:flex;justify-content:space-between;}
+  .tile .tag{color:var(--muted);font-size:9px;letter-spacing:.1em;}
+  .tile p.d{margin:0 0 12px;font-size:11px;color:var(--muted);line-height:1.4;}
+  .row{display:flex;justify-content:space-between;gap:10px;padding:4px 0;font-size:12px;border-bottom:1px solid rgba(118,185,0,.06);}
+  .row:last-child{border-bottom:0;}
+  .k{color:var(--muted);} .v{color:var(--ink);text-align:right;font-weight:600;}
+  .ok{color:var(--neon);} .no{color:var(--err);} .warn{color:var(--amber);} .nv{color:var(--nv);}
+  .bar{height:7px;background:var(--panel2);border:1px solid var(--border);margin:8px 0 4px;position:relative;overflow:hidden;}
+  .bar>i{position:absolute;left:0;top:0;bottom:0;background:linear-gradient(90deg,var(--nv),var(--neon));transition:width .4s;}
+  .btn{border:1px solid var(--nv-hot);background:transparent;color:var(--nv);font-family:inherit;font-size:10px;letter-spacing:.12em;text-transform:uppercase;padding:6px 10px;cursor:pointer;margin-top:10px;transition:.15s;}
+  .btn:hover{background:var(--nv);color:var(--void);}
+  .btn:disabled{opacity:.4;cursor:not-allowed;}
+  .dock{margin-top:22px;border:1px solid var(--border);background:var(--panel2);height:150px;overflow:auto;padding:10px 12px;font-size:11px;line-height:1.5;}
+  .dock .ln{white-space:pre-wrap;word-break:break-word;}
+  .dock .ok{color:var(--nv);} .dock .err{color:var(--err);} .dock .gold{color:var(--gold);}
+  .foot{margin-top:22px;font-size:10px;color:var(--muted);letter-spacing:.14em;text-align:center;text-transform:uppercase;}
+  .live{color:var(--nv);}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <div class="brand">
+      <div class="glyph">&gt;_n</div>
+      <div>
+        <h1>NVIDIA · Tiles</h1>
+        <p class="sub">NemoClaw compute surface · sovereign GPU node</p>
+      </div>
+    </div>
+    <div class="addr">_n: → nvidia (NemoClaw) → compute<br/><span class="live" id="ts">live</span></div>
+  </header>
+
+  <div class="tiles">
+    <div class="tile">
+      <h2>GPU <span class="tag">nvidia-smi</span></h2>
+      <p class="d">Live RTX 3050 telemetry — pulled via host bridge on mount + refresh.</p>
+      <div class="row"><span class="k">device</span><span class="v" id="g-name">—</span></div>
+      <div class="row"><span class="k">driver</span><span class="v" id="g-drv">—</span></div>
+      <div class="row"><span class="k">VRAM used / total</span><span class="v" id="g-vram">—</span></div>
+      <div class="bar"><i id="g-vram-bar" style="width:0%"></i></div>
+      <div class="row"><span class="k">utilization</span><span class="v" id="g-util">—</span></div>
+      <div class="row"><span class="k">temp</span><span class="v" id="g-temp">—</span></div>
+      <div class="row"><span class="k">CUDA toolkit</span><span class="v ok">nvcc 13.3 ✓</span></div>
+      <button class="btn" id="btn-refresh" onclick="refreshGpu()">↻ Refresh GPU</button>
+    </div>
+
+    <div class="tile">
+      <h2>Compute Path <span class="tag">stack</span></h2>
+      <p class="d">Build chains available on this node.</p>
+      <div class="row"><span class="k">CUDA kernels</span><span class="v ok">nvcc 13.3</span></div>
+      <div class="row"><span class="k">PyTorch / CuPy</span><span class="v" id="g-torch">probe…</span></div>
+      <div class="row"><span class="k">TensorRT-LLM</span><span class="v warn">server-side</span></div>
+      <div class="row"><span class="k">WebGPU (in-browser)</span><span class="v ok">Qwen3-0.6B</span></div>
+      <div class="row"><span class="k">Flash Attention</span><span class="v ok">pytorch SDPA</span></div>
+      <button class="btn" id="btn-probe" onclick="probeStack()">⚡ Probe Stack</button>
+    </div>
+
+    <div class="tile">
+      <h2>Processes <span class="tag">smi</span></h2>
+      <p class="d">Compute processes currently holding GPU memory.</p>
+      <div id="g-procs" class="row" style="display:block"><span class="k">—</span></div>
+      <button class="btn" onclick="listProcesses()">⊙ List Processes</button>
+    </div>
+
+    <div class="tile">
+      <h2>Bench <span class="tag">matrix</span></h2>
+      <p class="d">Quick compute sanity — GPU vs CPU matmul (establishes local supremacy baseline).</p>
+      <div class="row"><span class="k">CPU matmul</span><span class="v" id="b-cpu">—</span></div>
+      <div class="row"><span class="k">GPU matmul</span><span class="v" id="b-gpu">—</span></div>
+      <div class="row"><span class="k">speedup</span><span class="v nv" id="b-up">—</span></div>
+      <button class="btn" onclick="runBench()">▣ Run Bench</button>
+    </div>
+
+    <div class="tile">
+      <h2>Routes <span class="tag">grammar</span></h2>
+      <p class="d">Operator grammar bindings for this compute surface.</p>
+      <div class="row"><span class="k">&gt;_n:</span><span class="v nv">nvidia → compute</span></div>
+      <div class="row"><span class="k">host cmd</span><span class="v">remoteUse.nvidia</span></div>
+      <div class="row"><span class="k">mesh</span><span class="v">pc://mesh/victus/local</span></div>
+      <button class="btn" onclick="openHost()">⊞ Open Host Surface</button>
+    </div>
+
+    <div class="tile">
+      <h2>Envelope <span class="tag">limits</span></h2>
+      <p class="d">Honest capability boundary of this node.</p>
+      <div class="row"><span class="k">VRAM</span><span class="v warn">6 GB</span></div>
+      <div class="row"><span class="k">FP16 train</span><span class="v ok">small LoRA</span></div>
+      <div class="row"><span class="k">inference</span><span class="v ok">7-13B Q4</span></div>
+      <div class="row"><span class="k">container</span><span class="v no">docker missing</span></div>
+    </div>
+  </div>
+
+  <div class="dock" id="dock"></div>
+  <div class="foot">&gt;_n| NemoClaw surface · <span class="live">truth over marketing</span> · #hermiphicationisinevitable</div>
+</div>
+
+<script>
+const vscode = (function(){ try { return window.acquireVsCodeApi ? window.acquireVsCodeApi() : null; } catch(e){ return null; } })();
+function log(msg, cls){ const d=document.getElementById('dock'); const ln=document.createElement('div'); ln.className='ln '+(cls||''); ln.textContent='> '+msg; d.appendChild(ln); d.scrollTop=d.scrollHeight; }
+document.getElementById('ts').textContent = new Date().toISOString().slice(11,19);
+
+function refreshGpu(){
+  if (vscode){ vscode.postMessage({command:'remoteUse.nvidia', action:'smi'}); log('requesting nvidia-smi via host…','gold'); return; }
+  // browser fallback: hit a local bridge if present
+  fetch('http://127.0.0.1:7890/nvidia').then(r=>r.json()).then(d=>applyGpu(d)).catch(()=>log('no host bridge — run inside VS Code','err'));
+}
+function applyGpu(d){
+  document.getElementById('g-name').textContent = d.name || '—';
+  document.getElementById('g-drv').textContent = d.driver || '—';
+  const used=d.memory_used||0, tot=d.memory_total||0;
+  document.getElementById('g-vram').textContent = (used/1024).toFixed(1)+' / '+(tot/1024).toFixed(1)+' GB';
+  document.getElementById('g-vram-bar').style.width = tot? (used/tot*100).toFixed(1)+'%':'0%';
+  document.getElementById('g-util').textContent = (d.utilization_gpu||0)+' %';
+  document.getElementById('g-temp').textContent = (d.temperature_gpu||0)+' °C';
+  document.getElementById('ts').textContent = new Date().toISOString().slice(11,19)+' live';
+  log('gpu: '+d.name+' · '+((d.utilization_gpu||0))+'% util · '+d.temperature_gpu+'°C','ok');
+}
+function listProcesses(){
+  if (vscode){ vscode.postMessage({command:'remoteUse.nvidia', action:'procs'}); return; }
+  log('process list requires VS Code host','err');
+}
+function probeStack(){
+  const out=document.getElementById('g-torch');
+  try {
+    // best-effort: check if python torch importable via host
+    if (vscode){ vscode.postMessage({command:'remoteUse.nvidia', action:'torch'}); out.textContent='probing…'; return; }
+    out.textContent='host only';
+  } catch(e){ out.textContent='no'; }
+}
+function runBench(){
+  log('CPU matmul N=512…','gold');
+  const N=512, a=Array.from({length:N*N},()=>Math.random()), b=Array.from({length:N*N},()=>Math.random()), c=new Float64Array(N*N);
+  const t0=performance.now();
+  for(let i=0;i<N;i++)for(let j=0;j<N;j++){let s=0;for(let k=0;k<N;k++)s+=a[i*N+k]*b[k*N+j];c[i*N+j]=s;}
+  const cpu=performance.now()-t0;
+  document.getElementById('b-cpu').textContent=(cpu/1000).toFixed(2)+'s';
+  log('CPU done '+((cpu/1000).toFixed(2))+'s — GPU path needs host (CUDA)','ok');
+  document.getElementById('b-gpu').textContent='host-only';
+  document.getElementById('b-up').textContent='—';
+}
+function openHost(){
+  if (vscode){ vscode.postMessage({command:'remoteUse.nvidia', action:'open'}); log('open host nvidia surface','gold'); }
+  else { window.open('vscode://hermes-agent.remoteUse.nvidia','_blank'); }
+}
+// host -> webview messages
+window.addEventListener('message', (e)=>{
+  const m=e.data||{};
+  if (m.command==='remoteUse.nvidia'){
+    if (m.action==='smi' && m.data) applyGpu(m.data);
+    else if (m.action==='procs' && m.data) {
+      const box=document.getElementById('g-procs');
+      box.innerHTML = (m.data.length? m.data.map(p=>'<div class="row"><span class="k">'+p.pid+'</span><span class="v">'+p.name+' · '+(isFinite(p.used_memory)?((p.used_memory/1024).toFixed(0)+'MB'):'n/a')+'</span></div>').join('') : '<span class="k">no compute processes</span>');
+      log('processes: '+(m.data.length||0)+' active','ok');
+    }
+    else if (m.action==='torch' && m.data){ document.getElementById('g-torch').textContent=m.data.torch? ('torch '+m.data.version) : 'not installed'; log('torch probe: '+(m.data.torch?m.data.version:'absent'), m.data.torch?'ok':'warn'); }
+  }
+});
+// auto-refresh on mount
+refreshGpu();
+</script>
+</body>
+</html>

--- a/vscode-remote-use/package.json
+++ b/vscode-remote-use/package.json
@@ -1,0 +1,138 @@
+{
+  "name": "vscode-remote-use",
+  "displayName": "vscode-remote-use",
+  "description": "Hermes VS Code media primitive + breakout bridge",
+  "version": "0.1.0",
+  "publisher": "hermes-agent",
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": ["Other"],
+  "main": "./out/extension.js",
+  "activationEvents": [
+    "onStartupFinished",
+    "onCommand:remoteUse.surfaces",
+    "onCommand:remoteUse.nvidia",
+    "onCommand:remoteUse.mediaWindow"
+  ],
+  "contributes": {
+    "commands": [
+      {
+        "command": "remoteUse.capture",
+        "title": "Remote Use: Capture Terminal Output"
+      },
+      {
+        "command": "remoteUse.runTask",
+        "title": "Remote Use: Run Hermes Task"
+      },
+      {
+        "command": "remoteUse.chat",
+        "title": "Remote Use: Open Hermes Chat"
+      },
+      {
+        "command": "remoteUse.mediaWindow",
+        "title": "Remote Use: VSCode VLC FFmpeg Media Player"
+      },
+      {
+        "command": "remoteUse.mediaCoevolve",
+        "title": "Remote Use: Ollama FFmpeg Coevolve"
+      },
+      {
+        "command": "remoteUse.reachyPanel",
+        "title": "Remote Use: Reachy Primitive Panel"
+      },
+      {
+        "command": "remoteUse.exportViewport",
+        "title": "Remote Use: Export Media Viewport HTML"
+      },
+      {
+        "command": "remoteUse.agenticHtmlViewport",
+        "title": "Remote Use: Open Agentic HTML Viewport"
+      },
+      {
+        "command": "remoteUse.daoBlueprint",
+        "title": "Remote Use: Open DAO Blueprint"
+      },
+      {
+        "command": "remoteUse.daoSurface",
+        "title": "Remote Use: Open DAO Surface"
+      },
+      {
+        "command": "remoteUse.commandPrompt",
+        "title": "Remote Use: Open commandprompt.ai Terminal"
+      },
+      {
+        "command": "remoteUse.homeOS",
+        "title": "Remote Use: Open home:// Surface"
+      },
+      {
+        "command": "remoteUse.webLLM",
+        "title": "Remote Use: Open Hermes Native · WebLLM WebGPU Runtime"
+      },
+      {
+        "command": "remoteUse.factory",
+        "title": "Remote Use: Hermes Native Agentic CSS/HTML Factory"
+      },
+      {
+        "command": "remoteUse.computerUse",
+        "title": "Remote Use: Computer Use · Bounded Local Desktop Control"
+      },
+      {
+        "command": "remoteUse.htmlSurface",
+        "title": "Remote Use: Open Local HTML Surface"
+      },
+      {
+        "command": "remoteUse.surfaces",
+        "title": "Remote Use: Local Surface System"
+      },
+      {
+        "command": "remoteUse.nvidia",
+        "title": "Remote Use: NVIDIA Compute Surface"
+      }
+    ],
+    "themes": [
+      {
+        "label": "æ:// Gold-on-Void",
+        "uiTheme": "vs-dark",
+        "path": "./themes/ae-gold-on-void-color-theme.json"
+      }
+    ],
+    "configuration": {
+      "title": "Remote Use",
+      "properties": {
+        "remoteUse.hermesRepoPath": {
+          "type": "string",
+          "default": "",
+          "description": "Absolute path to the Hermes repository root. Leave empty to disable Hermes-dependent commands."
+        },
+        "remoteUse.vlcPath": {
+          "type": "string",
+          "default": "",
+          "format": "file",
+          "description": "Absolute path to VLC. Leave empty for auto-detect."
+        },
+        "remoteUse.daoSurfacePath": {
+          "type": "string",
+          "default": "",
+          "format": "file",
+          "description": "Absolute path to DAO surface HTML. Leave empty for default."
+        },
+        "remoteUse.htmlSurfacePath": {
+          "type": "string",
+          "default": "",
+          "format": "file",
+          "description": "Preferred local HTML surface path for `remoteUse.htmlSurface`. Leave empty for built-in candidate resolution."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "compile": "tsc -p ./",
+    "package": "vsce package"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@vscode/vsce": "^3.9.2",
+    "typescript": "^5.6.0"
+  }
+}


### PR DESCRIPTION
## Summary

Hermes ships **no CUDA/NVIDIA skill**. This adds the first one, formalizing the `>_n:`
operator grammar (`>_n: → nvidia (NemoClaw) → compute`, per AGENTS.md) as a concrete,
agent-addressable GPU compute surface.

Scope:
- **SKILL.md** — the `>_n:` NemoClaw pattern, `nvidia-smi` host bridge for VS Code webviews,
  the VS Code webview `file://` pitfall, WebGPU fallback, the `[N/A]`→`n/a` NaN guard, a
  checkable verification checklist, **and the compiler layer** (nvcc kernels + NVIDIA CUDA
  Tile IR as the backend under the surface).
- **references/host-bridge.md** — the full `remoteUse.nvidia` extension handler plus the
  complete webview↔host message contract.
- **templates/nvidia-tiles.html** — the shipped green-NVIDIA 6-tile surface (GPU / Compute
  Path / Processes / Bench / Routes / Envelope).

## Why this belongs upstream

- `mlops/` has no CUDA skill today (only `evaluation`, `huggingface-hub`, `inference`,
  `models`). Every other major compute path has a skill; CUDA was the gap.
- It is scoped to the Hermes operator grammar (`>_n:`) and the `remoteUse.*` VS Code surface
  system, so it slots in beside `optimizing-attention-flash` and the surface-dev skills.

## Verification

- `npm run compile` (tsc) exits 0
- `pytest secret_source_bridge/tests.py tests/hermes_runtime/test_computer_use.py` → 28/28
- SKILL.md frontmatter validated (name + ≤1024-char description + version/author/license/metadata)
- No secrets hardcoded
- Surface render-verified (headless Edge)

## Related

- CUDA Tile IR (NVIDIA/cuda-tile): https://github.com/NVIDIA/cuda-tile — the MLIR kernel
  compiler infra that sits under this surface (linked in Resources).

## Test plan

- [ ] `skills_list` / skill loader picks up `mlops/cuda` after a fresh session
- [ ] `remoteUse.nvidia` opens the NVIDIA Tiles surface and telemetry populates via `nvidia-smi`
- [ ] `nvcc matmul.cu -o matmul` compiles on a node with the CUDA toolkit (per Workflow 4)
