### PR TITLE
feat(codex): bridge native computer-use approvals

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -811,6 +811,9 @@ class CodexAppServerSession:
                                                   (we decline; user controls
                                                   permission profile in
                                                   ~/.codex/config.toml).
+          mcpServer/elicitation/request          — structured MCP consent;
+                                                  Computer Use app grants are
+                                                  bridged to Hermes approvals.
         """
         if self._client is None:
             return
@@ -845,6 +848,11 @@ class CodexAppServerSession:
                     rid,
                     {"action": "accept", "content": None, "_meta": None},
                 )
+            elif _is_computer_use_elicitation(params):
+                self._client.respond(
+                    rid,
+                    self._decide_computer_use_elicitation(params),
+                )
             else:
                 self._client.respond(
                     rid,
@@ -857,6 +865,61 @@ class CodexAppServerSession:
             self._client.respond_error(
                 rid, code=-32601, message=f"Unsupported method: {method}"
             )
+
+    def _decide_computer_use_elicitation(self, params: dict) -> dict:
+        """Bridge Codex Computer Use's app grant into Hermes approvals.
+
+        The Computer Use client runs inside the trusted ``node_repl`` MCP and
+        asks through a normal MCP elicitation. Preserve its advertised
+        persistence scope so "always" really survives future app-server
+        sessions. Missing UI, exceptions, and unknown choices fail closed.
+        """
+        message = str(params.get("message") or "Allow Computer Use app access?")
+        meta = params.get("_meta") or {}
+        tool_params = meta.get("tool_params") or {}
+        app_id = str(tool_params.get("app") or "unknown app")
+        display_name = _computer_use_display_name(meta) or app_id
+        description = (
+            f"Codex Computer Use requests access to {display_name} ({app_id})"
+        )
+        supported_persistence = _computer_use_persistence(meta)
+        if supported_persistence is None:
+            return {"action": "decline", "content": None, "_meta": None}
+        allow_permanent = "always" in supported_persistence
+
+        try:
+            if self._approval_callback is not None:
+                choice = self._approval_callback(
+                    message,
+                    description,
+                    allow_permanent=allow_permanent,
+                )
+            else:
+                from tools.approval import request_elicitation_choice
+
+                choice = request_elicitation_choice(
+                    message,
+                    description,
+                    allow_permanent=allow_permanent,
+                    surface="codex-computer-use",
+                )
+        except Exception:
+            logger.exception("Computer Use elicitation approval failed")
+            choice = "deny"
+
+        response_meta = None
+        if choice == "always":
+            if "always" not in supported_persistence:
+                return {"action": "decline", "content": None, "_meta": None}
+            response_meta = {"persist": "always"}
+        elif choice == "session":
+            if "session" not in supported_persistence:
+                return {"action": "decline", "content": None, "_meta": None}
+            response_meta = {"persist": "session"}
+        elif choice != "once":
+            return {"action": "decline", "content": None, "_meta": None}
+
+        return {"action": "accept", "content": None, "_meta": response_meta}
 
     def _decide_exec_approval(self, params: dict) -> str:
         if self._routing.auto_approve_exec:
@@ -1026,6 +1089,54 @@ def _apply_compaction_notification(result: TurnResult, note: dict) -> None:
     result.compacted = True
     result.thread_id = params.get("threadId") or result.thread_id
     result.turn_id = params.get("turnId") or result.turn_id
+
+
+def _is_computer_use_elicitation(params: dict) -> bool:
+    """Recognize only the trusted node_repl Computer Use approval shape.
+
+    Checking both the MCP server and Codex-injected connector metadata keeps a
+    third-party MCP from opting into this privileged persistence bridge merely
+    by copying the user-visible message.
+    """
+    if params.get("serverName") != "node_repl" or params.get("mode") != "form":
+        return False
+    meta = params.get("_meta") or {}
+    return (
+        isinstance(meta, dict)
+        and meta.get("codex_approval_kind") == "mcp_tool_call"
+        and meta.get("connector_id") == "computer-use"
+        and isinstance(meta.get("tool_params"), dict)
+        and isinstance(meta["tool_params"].get("app"), str)
+        and bool(meta["tool_params"]["app"].strip())
+        and _computer_use_persistence(meta) is not None
+    )
+
+
+def _computer_use_persistence(meta: dict) -> Optional[frozenset[str]]:
+    """Validate and normalize Computer Use's advertised grant scopes."""
+    value = meta.get("persist")
+    if not isinstance(value, list):
+        return None
+    if any(not isinstance(item, str) for item in value):
+        return None
+    scopes = frozenset(value)
+    if not scopes.issubset({"session", "always"}):
+        return None
+    return scopes
+
+
+def _computer_use_display_name(meta: dict) -> Optional[str]:
+    """Extract the app label supplied for the approval UI, if present."""
+    displays = meta.get("tool_params_display") or []
+    if not isinstance(displays, list):
+        return None
+    for item in displays:
+        if not isinstance(item, dict) or item.get("name") != "app":
+            continue
+        value = item.get("value")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
 
 
 def _approval_choice_to_codex_decision(choice: str) -> str:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -65,6 +65,15 @@ from agent.redact import redact_sensitive_text
 logger = logging.getLogger(__name__)
 
 
+def _approval_event_choices(*, allow_permanent: bool = True) -> list[str]:
+    """Choices advertised to API/desktop approval clients."""
+    choices = ["once", "session"]
+    if allow_permanent:
+        choices.append("always")
+    choices.append("deny")
+    return choices
+
+
 def _hermes_version() -> str:
     """Return the hermes-agent version string, or "dev" if it can't be resolved.
 
@@ -4312,7 +4321,10 @@ class APIServerAdapter(BasePlatformAdapter):
                         "event": "approval.request",
                         "run_id": run_id,
                         "timestamp": time.time(),
-                        "choices": ["once", "session", "always", "deny"],
+                        "choices": _approval_event_choices(
+                            allow_permanent=event.get("allow_permanent", True)
+                            is not False
+                        ),
                     })
                     self._set_run_status(
                         run_id,

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -2635,7 +2635,7 @@ class QQAdapter(BasePlatformAdapter):
             req: ApprovalRequest,
             reply_to: Optional[str] = None,
     ) -> SendResult:
-        """Send a 3-button approval request (``allow-once / allow-always / deny``).
+        """Send an approval request with only the supported scope buttons.
 
         The rendered text comes from :func:`build_approval_text`; callers can
         override by passing a custom :class:`ApprovalRequest`.
@@ -2648,7 +2648,10 @@ class QQAdapter(BasePlatformAdapter):
         return await self.send_with_keyboard(
             chat_id,
             build_approval_text(req),
-            build_approval_keyboard(req.session_key),
+            build_approval_keyboard(
+                req.session_key,
+                allow_permanent=req.allow_permanent,
+            ),
             reply_to=reply_to,
         )
 
@@ -2676,7 +2679,7 @@ class QQAdapter(BasePlatformAdapter):
         :func:`tools.approval.resolve_gateway_approval` — dispatched by the
         adapter's interaction callback (:meth:`_default_interaction_dispatch`).
         """
-        del metadata  # QQ doesn't have thread_id / DM targeting overrides.
+        allow_permanent = (metadata or {}).get("allow_permanent", True) is not False
 
         # Use the reply-to message for passive-message context when we have one.
         # QQ requires a msg_id on outbound messages to a user we've never
@@ -2689,6 +2692,7 @@ class QQAdapter(BasePlatformAdapter):
             description=description,
             command_preview=command,
             timeout_sec=self._APPROVAL_TIMEOUT_SECONDS,
+            allow_permanent=allow_permanent,
         )
         return await self.send_approval_request(
             chat_id, req, reply_to=msg_id,

--- a/gateway/platforms/qqbot/keyboards.py
+++ b/gateway/platforms/qqbot/keyboards.py
@@ -10,7 +10,7 @@ This module provides:
 
 - :class:`InlineKeyboard` + button dataclasses — serialized into the
   ``keyboard`` field of the outbound message body.
-- :func:`build_approval_keyboard` — 3-button ✅ once / ⭐ always / ❌ deny
+- :func:`build_approval_keyboard` — ✅ once / optional ⭐ always / ❌ deny
   keyboard for tool-approval flows.
 - :func:`build_update_prompt_keyboard` — Yes/No keyboard for update confirms.
 - :func:`parse_approval_button_data` / :func:`parse_update_prompt_button_data`
@@ -201,46 +201,53 @@ def _make_callback_button(
     )
 
 
-def build_approval_keyboard(session_key: str) -> InlineKeyboard:
-    """Build the 3-button approval keyboard.
+def build_approval_keyboard(
+    session_key: str,
+    *,
+    allow_permanent: bool = True,
+) -> InlineKeyboard:
+    """Build the approval keyboard with only supported grant scopes.
 
-    Layout: ``[✅ 允许一次] [⭐ 始终允许] [❌ 拒绝]`` — all three share
-    ``group_id='approval'`` so clicking one greys out the rest.
+    Layout: ``[✅ 允许一次] [optional ⭐ 始终允许] [❌ 拒绝]``. All
+    rendered buttons share ``group_id='approval'`` so clicking one greys out
+    the rest.
 
     :param session_key: Embedded into ``button_data`` so the decision
         routes back to the right pending approval.
     """
-    return InlineKeyboard(
-        content=KeyboardContent(
-            rows=[
-                KeyboardRow(buttons=[
-                    _make_callback_button(
-                        btn_id="allow",
-                        label="✅ 允许一次",
-                        visited_label="已允许",
-                        data=f"{APPROVAL_BUTTON_PREFIX}{session_key}:allow-once",
-                        style=1,
-                        group_id="approval",
-                    ),
-                    _make_callback_button(
-                        btn_id="always",
-                        label="⭐ 始终允许",
-                        visited_label="已始终允许",
-                        data=f"{APPROVAL_BUTTON_PREFIX}{session_key}:allow-always",
-                        style=1,
-                        group_id="approval",
-                    ),
-                    _make_callback_button(
-                        btn_id="deny",
-                        label="❌ 拒绝",
-                        visited_label="已拒绝",
-                        data=f"{APPROVAL_BUTTON_PREFIX}{session_key}:deny",
-                        style=0,
-                        group_id="approval",
-                    ),
-                ]),
-            ]
+    buttons = [
+        _make_callback_button(
+            btn_id="allow",
+            label="✅ 允许一次",
+            visited_label="已允许",
+            data=f"{APPROVAL_BUTTON_PREFIX}{session_key}:allow-once",
+            style=1,
+            group_id="approval",
+        ),
+    ]
+    if allow_permanent:
+        buttons.append(
+            _make_callback_button(
+                btn_id="always",
+                label="⭐ 始终允许",
+                visited_label="已始终允许",
+                data=f"{APPROVAL_BUTTON_PREFIX}{session_key}:allow-always",
+                style=1,
+                group_id="approval",
+            )
         )
+    buttons.append(
+        _make_callback_button(
+            btn_id="deny",
+            label="❌ 拒绝",
+            visited_label="已拒绝",
+            data=f"{APPROVAL_BUTTON_PREFIX}{session_key}:deny",
+            style=0,
+            group_id="approval",
+        )
+    )
+    return InlineKeyboard(
+        content=KeyboardContent(rows=[KeyboardRow(buttons=buttons)])
     )
 
 
@@ -286,6 +293,7 @@ class ApprovalRequest:
     :param tool_name: Tool name (plugin approvals).
     :param severity: ``'critical' | 'info' | ''``.
     :param timeout_sec: Seconds until the approval expires.
+    :param allow_permanent: Whether the UI may offer a durable grant.
     """
     session_key: str
     title: str
@@ -295,6 +303,7 @@ class ApprovalRequest:
     tool_name: str = ""
     severity: str = ""
     timeout_sec: int = 120
+    allow_permanent: bool = True
 
 
 def build_approval_text(req: ApprovalRequest) -> str:
@@ -380,7 +389,10 @@ class ApprovalSender:
         :returns: ``True`` on success, ``False`` on failure.
         """
         text = build_approval_text(req)
-        keyboard = build_approval_keyboard(req.session_key)
+        keyboard = build_approval_keyboard(
+            req.session_key,
+            allow_permanent=req.allow_permanent,
+        )
 
         logger.info(
             "[%s] Sending approval request to %s:%s (session=%.20s…)",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18549,6 +18549,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
                 cmd = approval_data.get("command", "")
                 desc = approval_data.get("description", "dangerous command")
+                allow_permanent = approval_data.get("allow_permanent", True) is not False
 
                 # Redact credentials from the command before displaying it in
                 # the approval prompt — Tirith's findings are already redacted,
@@ -18563,13 +18564,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # false positives from MagicMock auto-attribute creation in tests.
                 if getattr(type(_status_adapter), "send_exec_approval", None) is not None:
                     try:
+                        approval_metadata = dict(_status_thread_metadata or {})
+                        approval_metadata["allow_permanent"] = allow_permanent
                         _approval_fut = safe_schedule_threadsafe(
                             _status_adapter.send_exec_approval(
                                 chat_id=_status_chat_id,
                                 command=cmd,
                                 session_key=_approval_session_key,
                                 description=desc,
-                                metadata=_status_thread_metadata,
+                                metadata=approval_metadata,
                             ),
                             _loop_for_step,
                             logger=logger,
@@ -18595,12 +18598,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # Slack threads and reserved by Matrix clients.
                 _p = getattr(_status_adapter, "typed_command_prefix", "/")
                 cmd_preview = cmd[:200] + "..." if len(cmd) > 200 else cmd
+                scope_instructions = (
+                    f"Reply `{_p}approve` to execute, `{_p}approve session` to approve this pattern "
+                    f"for the session, `{_p}approve always` to approve permanently, or `{_p}deny` to cancel."
+                    if allow_permanent
+                    else (
+                        f"Reply `{_p}approve` to execute, `{_p}approve session` to approve this pattern "
+                        f"for the session, or `{_p}deny` to cancel."
+                    )
+                )
                 msg = (
                     f"⚠️ **Dangerous command requires approval:**\n"
                     f"```\n{cmd_preview}\n```\n"
                     f"Reason: {desc}\n\n"
-                    f"Reply `{_p}approve` to execute, `{_p}approve session` to approve this pattern "
-                    f"for the session, `{_p}approve always` to approve permanently, or `{_p}deny` to cancel."
+                    f"{scope_instructions}"
                 )
                 try:
                     _approval_send_fut = safe_schedule_threadsafe(

--- a/hermes_cli/codex_runtime_switch.py
+++ b/hermes_cli/codex_runtime_switch.py
@@ -264,6 +264,10 @@ def apply(
             "Hermes tools available via MCP callback)."
         )
         msg_lines.append(
+            "Native Codex Computer Use app grants are routed through "
+            "Hermes approvals when the bundled plugin is installed."
+        )
+        msg_lines.append(
             "Effective on next session — current cached agent keeps "
             "the prior runtime to preserve prompt cache."
         )

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -643,6 +643,193 @@ class TestServerRequestRouting:
         s.run_turn("hi", turn_timeout=1.0)
         assert ("elic-1", {"action": "accept", "content": None, "_meta": None}) in client.responses
 
+    @pytest.mark.parametrize(
+        "choice,persist",
+        [("once", None), ("session", "session"), ("always", "always")],
+    )
+    def test_computer_use_elicitation_uses_interactive_approval_scope(
+        self, choice, persist
+    ):
+        """Codex Computer Use app approval reaches Hermes through node_repl.
+
+        Preserve the user's requested persistence scope on the MCP response so
+        an ``always`` approval survives future Codex app-server sessions.
+        """
+        client = FakeClient()
+        client.queue_server_request(
+            "mcpServer/elicitation/request", request_id="cua-1",
+            threadId="t", turnId="tu1", serverName="node_repl",
+            mode="form", message='Allow Computer Use to use "Hermes"?',
+            requestedSchema={"type": "object", "properties": {}},
+            _meta={
+                "codex_approval_kind": "mcp_tool_call",
+                "connector_id": "computer-use",
+                # Presentation labels may be localized; connector_id is the
+                # stable protocol identity.
+                "connector_name": "Uso del ordenador",
+                "persist": ["session", "always"],
+                "riskLevel": "low",
+                "tool_params": {"app": "com.nousresearch.hermes"},
+                "tool_params_display": [
+                    {"display_name": "App", "name": "app", "value": "Hermes"}
+                ],
+            },
+        )
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+        approvals = []
+
+        def approve(command, description, *, allow_permanent=True):
+            approvals.append((command, description, allow_permanent))
+            return choice
+
+        s = make_session(client, approval_callback=approve)
+        s.run_turn("hi", turn_timeout=1.0)
+
+        response_meta = {"persist": persist} if persist else None
+        assert (
+            "cua-1",
+            {"action": "accept", "content": None, "_meta": response_meta},
+        ) in client.responses
+        assert approvals == [
+            (
+                'Allow Computer Use to use "Hermes"?',
+                "Codex Computer Use requests access to Hermes "
+                "(com.nousresearch.hermes)",
+                True,
+            )
+        ]
+
+    def test_computer_use_elicitation_uses_gateway_approval_router(self):
+        client = FakeClient()
+        client.queue_server_request(
+            "mcpServer/elicitation/request", request_id="cua-2",
+            serverName="node_repl", mode="form",
+            message='Allow Computer Use to use "Finder"?',
+            requestedSchema={"type": "object", "properties": {}},
+            _meta={
+                "codex_approval_kind": "mcp_tool_call",
+                "connector_id": "computer-use",
+                "connector_name": "Computer Use",
+                "persist": ["session", "always"],
+                "tool_params": {"app": "com.apple.finder"},
+                "tool_params_display": [
+                    {"display_name": "App", "name": "app", "value": "Finder"}
+                ],
+            },
+        )
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+
+        s = make_session(client)
+        with patch(
+            "tools.approval.request_elicitation_choice",
+            return_value="always",
+        ) as request_consent:
+            s.run_turn("hi", turn_timeout=1.0)
+
+        assert (
+            "cua-2",
+            {
+                "action": "accept",
+                "content": None,
+                "_meta": {"persist": "always"},
+            },
+        ) in client.responses
+        request_consent.assert_called_once_with(
+            'Allow Computer Use to use "Finder"?',
+            "Codex Computer Use requests access to Finder (com.apple.finder)",
+            allow_permanent=True,
+            surface="codex-computer-use",
+        )
+
+    def test_computer_use_rejects_unsupported_persistence_choice(self):
+        client = FakeClient()
+        client.queue_server_request(
+            "mcpServer/elicitation/request", request_id="cua-scope",
+            serverName="node_repl", mode="form",
+            message='Allow Computer Use to use "Finder"?',
+            requestedSchema={"type": "object", "properties": {}},
+            _meta={
+                "codex_approval_kind": "mcp_tool_call",
+                "connector_id": "computer-use",
+                "connector_name": "Computer Use",
+                "persist": ["session"],
+                "tool_params": {"app": "com.apple.finder"},
+            },
+        )
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+
+        s = make_session(client, approval_callback=lambda *a, **k: "always")
+        s.run_turn("hi", turn_timeout=1.0)
+
+        assert (
+            "cua-scope",
+            {"action": "decline", "content": None, "_meta": None},
+        ) in client.responses
+
+    def test_malformed_computer_use_persistence_fails_closed(self):
+        client = FakeClient()
+        client.queue_server_request(
+            "mcpServer/elicitation/request", request_id="cua-malformed",
+            serverName="node_repl", mode="form",
+            message='Allow Computer Use to use "Finder"?',
+            requestedSchema={"type": "object", "properties": {}},
+            _meta={
+                "codex_approval_kind": "mcp_tool_call",
+                "connector_id": "computer-use",
+                "connector_name": "Computer Use",
+                "persist": 7,
+                "tool_params": {"app": "com.apple.finder"},
+            },
+        )
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+        approvals = []
+        s = make_session(
+            client,
+            approval_callback=lambda *a, **k: approvals.append(a) or "always",
+        )
+
+        s.run_turn("hi", turn_timeout=1.0)
+
+        assert approvals == []
+        assert (
+            "cua-malformed",
+            {"action": "decline", "content": None, "_meta": None},
+        ) in client.responses
+
+    def test_spoofed_computer_use_elicitation_stays_declined(self):
+        client = FakeClient()
+        client.queue_server_request(
+            "mcpServer/elicitation/request", request_id="cua-spoof",
+            serverName="some-third-party", mode="form",
+            message='Allow Computer Use to use "Finder"?',
+            requestedSchema={"type": "object", "properties": {}},
+            _meta={"connector_id": "computer-use"},
+        )
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+
+        s = make_session(client, approval_callback=lambda *a, **k: "always")
+        s.run_turn("hi", turn_timeout=1.0)
+
+        assert (
+            "cua-spoof",
+            {"action": "decline", "content": None, "_meta": None},
+        ) in client.responses
+
     def test_mcp_elicitation_for_other_servers_declines(self):
         """For third-party MCP servers we decline by default so users
         explicitly opt in through codex's own UI."""

--- a/tests/gateway/test_api_approval_choices.py
+++ b/tests/gateway/test_api_approval_choices.py
@@ -1,0 +1,15 @@
+"""Approval choice rendering for the desktop/API gateway."""
+
+from gateway.platforms.api_server import _approval_event_choices
+
+
+def test_api_approval_choices_include_always_when_supported():
+    assert _approval_event_choices(allow_permanent=True) == [
+        "once", "session", "always", "deny"
+    ]
+
+
+def test_api_approval_choices_hide_always_when_unsupported():
+    assert _approval_event_choices(allow_permanent=False) == [
+        "once", "session", "deny"
+    ]

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1069,6 +1069,15 @@ class TestBuildApprovalKeyboard:
         assert len(kb.content.rows) == 1
         assert len(kb.content.rows[0].buttons) == 3
 
+    def test_permanent_button_is_omitted_when_unsupported(self):
+        from gateway.platforms.qqbot.keyboards import build_approval_keyboard
+
+        kb = build_approval_keyboard("session-1", allow_permanent=False)
+        buttons = kb.content.rows[0].buttons
+
+        assert [button.id for button in buttons] == ["allow", "deny"]
+        assert all("allow-always" not in button.action.data for button in buttons)
+
     def test_button_data_embeds_session_key(self):
         from gateway.platforms.qqbot.keyboards import build_approval_keyboard
         kb = build_approval_keyboard("agent:main:qqbot:c2c:UID")
@@ -1819,6 +1828,25 @@ class TestSendExecApproval:
             chat_id="u", command="ls", session_key="s",
             metadata={"thread_id": "ignored", "anything": "else"},
         )
+
+    @pytest.mark.asyncio
+    async def test_metadata_disables_permanent_approval(self):
+        adapter = self._make_adapter()
+        captured = []
+
+        async def fake_send_approval(chat_id, req, reply_to=None):
+            from gateway.platforms.base import SendResult
+            captured.append(req)
+            return SendResult(success=True)
+
+        adapter.send_approval_request = fake_send_approval  # type: ignore[assignment]
+
+        await adapter.send_exec_approval(
+            chat_id="u", command="ls", session_key="s",
+            metadata={"allow_permanent": False},
+        )
+
+        assert captured[0].allow_permanent is False
 
 
 class TestSendUpdatePrompt:

--- a/tests/tools/test_approval_elicitation_choice.py
+++ b/tests/tools/test_approval_elicitation_choice.py
@@ -1,0 +1,103 @@
+"""Approval-scope contracts for MCP elicitations."""
+
+from unittest.mock import patch
+
+from tools.approval import request_elicitation_consent, request_elicitation_choice
+
+
+def test_elicitation_choice_preserves_cli_always_scope():
+    with (
+        patch("tools.approval.get_current_session_key", return_value="test"),
+        patch("tools.approval._is_gateway_approval_context", return_value=False),
+        patch("tools.approval.sys.stdin.isatty", return_value=True),
+        patch("tools.approval.prompt_dangerous_approval", return_value="always") as prompt,
+    ):
+        choice = request_elicitation_choice(
+            "Allow Computer Use to use Finder?",
+            "Computer Use app access",
+            allow_permanent=True,
+        )
+
+    assert choice == "always"
+    prompt.assert_called_once_with(
+        "Allow Computer Use to use Finder?",
+        "Computer Use app access",
+        timeout_seconds=None,
+        allow_permanent=True,
+    )
+
+
+def test_elicitation_choice_headless_cli_fails_closed_without_prompting():
+    with (
+        patch("tools.approval.get_current_session_key", return_value="headless"),
+        patch("tools.approval._is_gateway_approval_context", return_value=False),
+        patch("tools.approval.sys.stdin.isatty", return_value=False),
+        patch(
+            "tools.approval.prompt_dangerous_approval",
+            side_effect=AssertionError("headless context must not prompt"),
+        ),
+    ):
+        assert request_elicitation_choice("confirm", "description") == "deny"
+
+
+def test_elicitation_choice_propagates_permanent_flag_to_gateway_payload():
+    from tools import approval
+
+    captured = []
+    session_key = "gateway-approval-scope"
+    approval._gateway_notify_cbs[session_key] = lambda data: None
+    try:
+        with (
+            patch("tools.approval.get_current_session_key", return_value=session_key),
+            patch("tools.approval._is_gateway_approval_context", return_value=True),
+            patch(
+                "tools.approval._await_gateway_decision",
+                side_effect=lambda _key, _cb, data, **_kw: (
+                    captured.append(data)
+                    or {"resolved": True, "choice": "session"}
+                ),
+            ),
+        ):
+            choice = request_elicitation_choice(
+                "confirm",
+                "description",
+                allow_permanent=False,
+            )
+    finally:
+        approval._gateway_notify_cbs.pop(session_key, None)
+
+    assert choice == "session"
+    assert captured == [
+        {
+            "command": "confirm",
+            "description": "description",
+            "pattern_key": "mcp_elicitation",
+            "pattern_keys": ["mcp_elicitation"],
+            "allow_permanent": False,
+        }
+    ]
+
+
+def test_gateway_resolver_rejects_hidden_permanent_choice():
+    from tools import approval
+
+    session_key = "gateway-no-permanent"
+    entry = approval._ApprovalEntry({"allow_permanent": False})
+    approval._gateway_queues[session_key] = [entry]
+    try:
+        assert approval.resolve_gateway_approval(session_key, "always") == 0
+        assert approval.has_blocking_approval(session_key) is True
+        assert entry.event.is_set() is False
+
+        assert approval.resolve_gateway_approval(session_key, "session") == 1
+        assert entry.result == "session"
+        assert entry.event.is_set() is True
+    finally:
+        approval._gateway_queues.pop(session_key, None)
+
+
+def test_legacy_elicitation_api_normalizes_scoped_approval_to_accept():
+    with patch(
+        "tools.approval.request_elicitation_choice", return_value="session"
+    ):
+        assert request_elicitation_consent("confirm", "description") == "accept"

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1480,8 +1480,18 @@ def resolve_gateway_approval(session_key: str, choice: str,
         queue = _gateway_queues.get(session_key)
         if not queue:
             return 0
+        candidates = list(queue) if resolve_all else [queue[0]]
+        # Approval UIs can intentionally hide permanent approval for requests
+        # whose underlying protocol does not support it. Enforce that scope at
+        # the resolver too so a crafted API request or typed command cannot
+        # submit a choice the user was never offered.
+        if choice == "always" and any(
+            entry.data.get("allow_permanent") is False
+            for entry in candidates
+        ):
+            return 0
         if resolve_all:
-            targets = list(queue)
+            targets = candidates
             queue.clear()
         else:
             targets = [queue.pop(0)]
@@ -3155,15 +3165,15 @@ def check_execute_code_guard(code: str, env_type: str,
 # MCP elicitation entry point
 # =========================================================================
 
-def request_elicitation_consent(
+def request_elicitation_choice(
     message: str,
     description: str,
     *,
     timeout_seconds: int | None = None,
+    allow_permanent: bool = False,
     surface: str = "mcp-elicitation",
 ) -> str:
-    """Route an MCP elicitation request to whichever approval surface owns
-    the active session and return a normalized result.
+    """Route an MCP elicitation and preserve the user's approval scope.
 
     Gateway sessions (Telegram, Slack, Discord, etc.) go through
     ``_await_gateway_decision`` so the notify_cb posts a message and the
@@ -3171,16 +3181,18 @@ def request_elicitation_consent(
     CLI/TUI sessions go through ``prompt_dangerous_approval``.
 
     Always fails closed: missing notify_cb in a gateway session, timeouts,
-    and exceptions all map to ``"decline"`` so a server treats them as
+    and exceptions all map to ``"deny"`` so a server treats them as
     "user did not approve" rather than retrying or hanging.
 
-    Returns one of ``"accept" | "decline" | "cancel"``.
+    Returns one of ``"once" | "session" | "always" | "deny" | "cancel"``.
+    Keeping the scope is important for protocols such as Codex Computer Use,
+    whose elicitation response can persist an app grant across sessions.
     """
     try:
         session_key = get_current_session_key()
     except Exception as exc:  # pragma: no cover -- defensive
         logger.warning("Elicitation consent: session lookup failed: %s", exc)
-        return "decline"
+        return "deny"
 
     if _is_gateway_approval_context():
         with _lock:
@@ -3191,13 +3203,14 @@ def request_elicitation_consent(
                 "notify_cb is registered — failing closed",
                 session_key,
             )
-            return "decline"
+            return "deny"
 
         approval_data = {
             "command": message,
             "description": description,
             "pattern_key": "mcp_elicitation",
             "pattern_keys": ["mcp_elicitation"],
+            "allow_permanent": allow_permanent,
         }
         try:
             decision = _await_gateway_decision(
@@ -3207,34 +3220,76 @@ def request_elicitation_consent(
             logger.error(
                 "Elicitation gateway dispatch failed: %s", exc, exc_info=True,
             )
-            return "decline"
+            return "deny"
 
         if decision.get("notify_failed"):
-            return "decline"
+            return "deny"
         if not decision.get("resolved"):
             return "cancel"
         choice = decision.get("choice")
         if choice in ("once", "session", "always"):
-            return "accept"
-        return "decline"
+            return choice
+        return "deny"
 
-    # CLI / TUI path. allow_permanent=False because elicitation is a
-    # per-call confirmation — there is no pattern to remember.
+    # CLI / TUI path. A detached app-server/cron process has no visible stdin
+    # approval surface; fail closed immediately instead of waiting on an
+    # invisible input() prompt until timeout.
+    try:
+        if not sys.stdin.isatty():
+            logger.warning(
+                "Elicitation requested without an interactive approval "
+                "surface — failing closed"
+            )
+            return "deny"
+    except Exception:
+        return "deny"
+
+    # Most elicitations are per-call confirmations, but a
+    # protocol may explicitly advertise durable persistence (for example,
+    # Codex Computer Use app grants). Only those callers set
+    # allow_permanent=True.
     try:
         choice = prompt_dangerous_approval(
             message,
             description,
             timeout_seconds=timeout_seconds,
-            allow_permanent=False,
+            allow_permanent=allow_permanent,
         )
     except Exception as exc:
         logger.error(
             "Elicitation CLI prompt failed: %s", exc, exc_info=True,
         )
-        return "decline"
+        return "deny"
 
     if choice in ("once", "session", "always"):
+        return choice
+    return "deny"
+
+
+def request_elicitation_consent(
+    message: str,
+    description: str,
+    *,
+    timeout_seconds: int | None = None,
+    surface: str = "mcp-elicitation",
+) -> str:
+    """Backward-compatible normalized MCP elicitation result.
+
+    Existing MCP SDK callers only understand accept/decline/cancel. New
+    transports that can carry persistence metadata should call
+    :func:`request_elicitation_choice` instead.
+    """
+    choice = request_elicitation_choice(
+        message,
+        description,
+        timeout_seconds=timeout_seconds,
+        allow_permanent=False,
+        surface=surface,
+    )
+    if choice in ("once", "session", "always"):
         return "accept"
+    if choice == "cancel":
+        return "cancel"
     return "decline"
 
 

--- a/website/docs/user-guide/features/codex-app-server-runtime.md
+++ b/website/docs/user-guide/features/codex-app-server-runtime.md
@@ -18,6 +18,7 @@ Not using OpenAI Codex? `hermes setup --portal` configures a non-Codex backend w
 - Run OpenAI agent turns against your **ChatGPT subscription** (no API key required) using the same auth flow Codex CLI uses.
 - Use **Codex's own toolset and sandbox** — `shell` for terminal/read/write/search, `apply_patch` for structured edits, `update_plan` for planning, all running inside seatbelt/landlock sandboxing.
 - **Native Codex plugins** — Linear, GitHub, Gmail, Calendar, Canva, etc. — installed via `codex plugin` are auto-migrated and active in your Hermes session.
+- **Native Codex Computer Use on macOS** — when Codex's bundled Computer Use plugin is installed, GUI turns use Codex's persistent `node_repl` + accessibility-first runtime instead of Hermes' generic one-action screenshot loop.
 - **Hermes' richer tools come along** — web_search, web_extract, browser automation, vision, image generation, skills, and TTS work via an MCP callback. Codex calls back into Hermes for tools it doesn't have built in.
 - **Memory and skill nudges keep working** — Codex's events are projected into Hermes' message shape so the self-improvement loop sees a normal-looking transcript.
 
@@ -54,6 +55,44 @@ Examples (the ones the OpenClaw thread highlighted as "YouTube-video-worthy"):
 What's NOT migrated:
 - Plugins you haven't installed yet — install them in Codex first.
 - ChatGPT app marketplace entries (`app/list`) — these are already enabled inside codex by virtue of your account auth.
+
+#### Native Computer Use on macOS
+
+Codex Computer Use is also available through this runtime when the bundled
+`computer-use` and `node_repl` MCP servers are present in your Codex install.
+This is the same execution stack used by Codex desktop: a persistent JavaScript
+session, accessibility-tree reads and diffs, multiple UI actions per model
+turn, and a fresh app-state read after the actions. It avoids repeatedly
+sending full screenshots through Hermes' generic `computer_use` function.
+
+Check that Codex sees both components:
+
+```bash
+codex mcp get computer-use --json
+codex mcp get node_repl --json
+```
+
+The first time a Hermes task targets an app, Codex asks for app access through
+an MCP elicitation. Hermes routes that request through its normal approval UI:
+
+- **Allow once** grants only that call.
+- **Allow for this session** reuses the grant for the current Codex session.
+- **Always allow** persists the app grant so later Hermes/Codex sessions do not
+  prompt again.
+
+Hermes only enables this persistence bridge for the trusted `node_repl` server
+when Codex marks the request as the `computer-use` connector. Other MCP
+elicitations keep the existing fail-closed behavior. Headless contexts without
+an approval surface also decline new app grants; approve the app once from an
+interactive Hermes session first.
+
+:::note
+The ChatGPT subscription Responses endpoint used by Hermes' default
+`openai-codex` transport does not expose the Responses API `computer` tool.
+Selecting `codex_app_server` is therefore required for the native Codex GUI
+stack; merely selecting a Codex model on Hermes' default runtime still uses
+Hermes' generic `computer_use` tool.
+:::
 
 ### 3. Hermes tool callback (MCP server, registered in `~/.codex/config.toml`)
 
@@ -123,6 +162,7 @@ The kanban tools are gated by `HERMES_KANBAN_TASK` env var the dispatcher sets �
 | Codex sandbox (seatbelt/landlock, profiles) | — | yes (Codex built-in) |
 | ChatGPT subscription auth | — | yes (via `openai-codex` provider) |
 | Native Codex plugins (Linear, GitHub, etc.) | — | yes (auto-migrated) |
+| Native Codex Computer Use (macOS) | — | yes (when bundled Codex plugin is installed) |
 | User MCP servers | yes | yes (auto-migrated to codex) |
 | Memory + skill review (background) | yes | yes (via item projection) |
 | Multi-turn conversations | yes | yes |
@@ -166,6 +206,7 @@ That command:
 - Migrates user MCP servers from `~/.hermes/config.yaml` to `~/.codex/config.toml`.
 - **Discovers and migrates installed native Codex plugins** (Linear, GitHub, Gmail, Calendar, Canva, etc.) by querying Codex's `plugin/list` RPC.
 - **Registers Hermes' own tools as an MCP server** so the codex subprocess can call back for tools codex doesn't ship with.
+- **Routes native Computer Use app grants through Hermes approvals**, preserving once/session/always scope.
 - **Writes `default_permissions = ":workspace"`** so the sandbox allows writes within the workspace without prompting for every operation.
 - Tells you what was migrated. Takes effect on the **next** session — the current cached agent keeps the prior runtime so prompt caches stay valid.
 
@@ -228,6 +269,12 @@ Codex requests approval before executing commands or applying patches. These get
 - **Deny** → command is rejected; Codex continues in read-only mode.
 
 For `apply_patch` (file edit) approvals, Hermes shows a summary of what changed (`1 add, 1 update: /tmp/new.py, /tmp/old.py`) when codex provides the data via the corresponding `fileChange` item.
+
+Codex Computer Use app grants use the same approval surface. Unlike shell and
+patch approvals, Computer Use advertises whether a grant can persist. Hermes
+passes that scope back to Codex, so choosing **Always allow** is durable across
+new app-server sessions. A missing approval UI or malformed/spoofed elicitation
+is declined.
 
 ## Permission profiles
 


### PR DESCRIPTION
## Summary

- propagate structured approval choices through the Codex app-server bridge
- map trusted `node_repl` Computer Use app-access elicitations to once/session/always
- persist `always` through Codex's approval scope so it survives later app-server sessions
- keep malformed, spoofed, unsupported, unrelated third-party, and headless requests fail-closed
- preserve existing simple accept/decline behavior for surfaces that cannot persist choices

## Problem

Hermes could accept a Codex app-server approval prompt, but it discarded the selected approval scope. Native Computer Use app-access requests routed through persistent `node_repl` therefore could not reliably distinguish one-time, session, and durable approval.

## Security boundary

Choice bridging is limited to app-access elicitations carrying the expected trusted metadata for Codex's bundled `node_repl` and Computer Use connector. Unsupported or malformed requests are declined, and unrelated third-party MCP servers do not gain a durable approval path.

## Verification

- `244 passed` across:
  - `tests/agent/transports/test_codex_app_server_session.py`
  - `tests/tools/test_approval_elicitation_choice.py`
  - `tests/gateway/test_api_approval_choices.py`
  - `tests/gateway/test_qqbot.py`
- fresh Hermes task with `model.openai_runtime: codex_app_server` returned `node_repl=ready` and `computer_use=ready`
- Codex CLI `0.144.0` reports bundled `node_repl` and `computer-use` MCP services enabled

Four existing non-failing QQ async-mock `RuntimeWarning`s were emitted by the targeted test run.
