### PR TITLE
fix(moa): propagate aggregator reasoning config

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -856,6 +856,7 @@ def init_agent(
         agent.client = MoAClient(
             agent.model or "default",
             reference_callback=_moa_reference_relay,
+            reasoning_config=agent.reasoning_config,
         )
         agent._client_kwargs = {}
         agent.api_key = api_key or "moa-virtual-provider"

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1887,7 +1887,10 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             agent.api_key = api_key or "moa-virtual-provider"
             agent.base_url = "moa://local"
             agent._client_kwargs = {}
-            agent.client = MoAClient(agent.model or "default")
+            agent.client = MoAClient(
+                agent.model or "default",
+                reasoning_config=getattr(agent, "reasoning_config", None),
+            )
         elif api_mode == "anthropic_messages":
             from agent.anthropic_adapter import (
                 build_anthropic_client,

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6388,6 +6388,7 @@ def call_llm(
     messages: list,
     temperature: Optional[float] = None,
     max_tokens: int = None,
+    reasoning_config: Optional[Dict[str, Any]] = None,
     tools: list = None,
     timeout: float = None,
     extra_body: dict = None,
@@ -6411,6 +6412,7 @@ def call_llm(
         messages: Chat messages list.
         temperature: Sampling temperature (None = provider default).
         max_tokens: Max output tokens (handles max_tokens vs max_completion_tokens).
+        reasoning_config: Reasoning configuration to apply to this call.
         tools: Tool definitions (for function calling).
         timeout: Request timeout in seconds (None = read from auxiliary.{task}.timeout config).
         extra_body: Additional request body fields.
@@ -6434,6 +6436,8 @@ def call_llm(
         resolved_api_mode = api_mode
     effective_extra_body = _get_task_extra_body(task)
     effective_extra_body.update(extra_body or {})
+    if reasoning_config is not None:
+        effective_extra_body["reasoning"] = dict(reasoning_config)
 
     if task == "vision":
         effective_provider, client, final_model = resolve_vision_provider_client(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -867,6 +867,7 @@ def run_conversation(
                     temperature=_preset_temperature(moa_config, "reference_temperature"),
                     aggregator_temperature=_preset_temperature(moa_config, "aggregator_temperature"),
                     max_tokens=moa_config.get("reference_max_tokens"),
+                    reasoning_config=agent.reasoning_config,
                 )
                 if _moa_context:
                     for _msg in reversed(api_messages):

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -577,6 +577,7 @@ def aggregate_moa_context(
     temperature: float | None = None,
     aggregator_temperature: float | None = None,
     max_tokens: int | None = None,
+    reasoning_config: dict[str, Any] | None = None,
 ) -> str:
     """Run configured reference models and synthesize their advice.
 
@@ -593,6 +594,10 @@ def aggregate_moa_context(
     like max_tokens, ``call_llm`` omits temperature when None so the
     provider default applies — matching single-model agent behavior. Presets
     may still pin explicit values.
+
+    ``reasoning_config`` applies only to the aggregator. Reference models keep
+    their provider defaults because they are advisory slots, not the acting
+    parent agent.
     """
     reference_outputs: list[tuple[str, str, Any]] = []
     ref_messages = _reference_messages(api_messages)
@@ -638,6 +643,7 @@ def aggregate_moa_context(
             messages=agg_messages,
             temperature=aggregator_temperature,
             max_tokens=max_tokens,
+            reasoning_config=reasoning_config,
             **agg_runtime,
         )
         synthesis = _extract_text(response)
@@ -1015,6 +1021,7 @@ class MoAChatCompletions:
             messages=agg_messages,
             temperature=aggregator_temperature,
             max_tokens=agg_kwargs.get("max_tokens"),
+            reasoning_config=agg_kwargs.get("reasoning_config"),
             tools=agg_kwargs.get("tools"),
             extra_body=agg_kwargs.get("extra_body"),
             **stream_kwargs,

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -689,8 +689,14 @@ def _attach_reference_guidance(agg_messages: list[dict[str, Any]], guidance: str
 class MoAChatCompletions:
     """OpenAI-chat-compatible facade where the aggregator is the acting model."""
 
-    def __init__(self, preset_name: str, reference_callback: Any = None):
+    def __init__(
+        self,
+        preset_name: str,
+        reference_callback: Any = None,
+        reasoning_config: dict[str, Any] | None = None,
+    ):
         self.preset_name = preset_name or "default"
+        self.reasoning_config = reasoning_config
         # Optional display hook. Called as reference outputs become available so
         # frontends can show each reference model's answer as a labelled block
         # before the aggregator acts. Signature:
@@ -1016,12 +1022,15 @@ class MoAChatCompletions:
             # actually governs the aggregator stream, not just call_llm's default.
             if api_kwargs.get("timeout") is not None:
                 stream_kwargs["timeout"] = api_kwargs["timeout"]
+        reasoning_config = agg_kwargs.get("reasoning_config")
+        if reasoning_config is None:
+            reasoning_config = self.reasoning_config
         _agg_response = call_llm(
             task="moa_aggregator",
             messages=agg_messages,
             temperature=aggregator_temperature,
             max_tokens=agg_kwargs.get("max_tokens"),
-            reasoning_config=agg_kwargs.get("reasoning_config"),
+            reasoning_config=reasoning_config,
             tools=agg_kwargs.get("tools"),
             extra_body=agg_kwargs.get("extra_body"),
             **stream_kwargs,
@@ -1046,9 +1055,18 @@ class MoAChatCompletions:
 
 
 class MoAClient:
-    def __init__(self, preset_name: str, reference_callback: Any = None):
+    def __init__(
+        self,
+        preset_name: str,
+        reference_callback: Any = None,
+        reasoning_config: dict[str, Any] | None = None,
+    ):
         self.chat = type("_MoAChat", (), {})()
-        self.chat.completions = MoAChatCompletions(preset_name, reference_callback=reference_callback)
+        self.chat.completions = MoAChatCompletions(
+            preset_name,
+            reference_callback=reference_callback,
+            reasoning_config=reasoning_config,
+        )
 
     def consume_reference_usage(self) -> Any:
         """Pop the pending reference-fan-out usage from the completions facade.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "calvinwberndtjr@gmail.com": "calvinberndt",  # PR #62180 (MoA aggregator reasoning propagation)
     "wilsonkinyuam@gmail.com": "WilsonKinyua",  # PR #62052 (tui: persist unflushed conversations on disconnect/restart)
     "humphreysun98@gmail.com": "HumphreySun98",  # PR #61142 salvage (web: null web/backend config value guards)
     "sonxi@nous.local": "17324393074",  # PR #53196 salvage (tools_config: known_plugin_toolsets null guard; commit under unlinked local identity)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3180,6 +3180,31 @@ class TestStaleBaseUrlWarning:
 
 
 class TestAuxiliaryTaskExtraBody:
+    def test_sync_call_maps_reasoning_config_to_request_body(self):
+        client = MagicMock()
+        client.base_url = "https://chatgpt.com/backend-api/codex"
+        response = MagicMock()
+        client.chat.completions.create.return_value = response
+
+        with patch("hermes_cli.config.load_config", return_value={}), patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(client, "gpt-5.6-sol"),
+        ):
+            result = call_llm(
+                task="moa_aggregator",
+                provider="openai-codex",
+                model="gpt-5.6-sol",
+                messages=[{"role": "user", "content": "review this"}],
+                reasoning_config={"enabled": True, "effort": "max"},
+            )
+
+        assert result is response
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["extra_body"]["reasoning"] == {
+            "enabled": True,
+            "effort": "max",
+        }
+
     def test_sync_call_merges_task_extra_body_from_config(self):
         client = MagicMock()
         client.base_url = "https://api.example.com/v1"
@@ -3869,6 +3894,14 @@ class TestCodexAdapterReasoningTranslation:
             extra_body={"reasoning": {"effort": "high"}},
         )
         assert captured.get("reasoning") == {"effort": "high", "summary": "auto"}
+
+    def test_reasoning_effort_max_passed_through(self):
+        adapter, captured = self._build_adapter()
+        adapter.create(
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={"reasoning": {"effort": "max"}},
+        )
+        assert captured.get("reasoning") == {"effort": "max", "summary": "auto"}
 
     def test_reasoning_disabled_omits_reasoning_and_include(self):
         adapter, captured = self._build_adapter()

--- a/tests/agent/test_moa_aggregator_reasoning.py
+++ b/tests/agent/test_moa_aggregator_reasoning.py
@@ -49,7 +49,7 @@ def _aggregator_call(calls):
 def test_acting_aggregator_receives_parent_reasoning_config(
     captured_calls, monkeypatch
 ):
-    from agent.moa_loop import MoAChatCompletions
+    from run_agent import AIAgent
 
     monkeypatch.setattr(
         "hermes_cli.moa_config.resolve_moa_preset",
@@ -65,10 +65,19 @@ def test_acting_aggregator_receives_parent_reasoning_config(
         },
     )
 
-    MoAChatCompletions("software-dev").create(
-        messages=[{"role": "user", "content": "review this change"}],
+    agent = AIAgent(
+        api_key="moa-virtual-provider",
+        base_url="moa://local",
+        model="software-dev",
+        provider="moa",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        enabled_toolsets=["file"],
+        max_iterations=1,
         reasoning_config=MAX_REASONING,
     )
+    agent.run_conversation("review this change")
 
     assert _aggregator_call(captured_calls)["reasoning_config"] == MAX_REASONING
 

--- a/tests/agent/test_moa_aggregator_reasoning.py
+++ b/tests/agent/test_moa_aggregator_reasoning.py
@@ -1,0 +1,87 @@
+"""Regression tests for reasoning configuration on MoA aggregators."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+MAX_REASONING = {"enabled": True, "effort": "max"}
+
+
+def _response(content: str = "aggregated") -> SimpleNamespace:
+    message = SimpleNamespace(content=content, tool_calls=[])
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], usage=None, model="gpt-5.6-sol")
+
+
+@pytest.fixture
+def captured_calls(monkeypatch):
+    calls = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        return _response()
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+    monkeypatch.setattr(
+        "agent.moa_loop._run_references_parallel",
+        lambda *args, **kwargs: [("advisor", "reference advice", None)],
+    )
+    monkeypatch.setattr(
+        "agent.moa_loop._slot_runtime",
+        lambda slot: {
+            "provider": slot["provider"],
+            "model": slot["model"],
+            "base_url": "https://example.invalid",
+            "api_key": "test-key",
+            "api_mode": "codex_responses",
+        },
+    )
+    return calls
+
+
+def _aggregator_call(calls):
+    return next(call for call in calls if call["task"] == "moa_aggregator")
+
+
+def test_acting_aggregator_receives_parent_reasoning_config(
+    captured_calls, monkeypatch
+):
+    from agent.moa_loop import MoAChatCompletions
+
+    monkeypatch.setattr(
+        "hermes_cli.moa_config.resolve_moa_preset",
+        lambda config, name: {
+            "enabled": True,
+            "reference_models": [
+                {"provider": "zai", "model": "glm-5"},
+            ],
+            "aggregator": {
+                "provider": "openai-codex",
+                "model": "gpt-5.6-sol",
+            },
+        },
+    )
+
+    MoAChatCompletions("software-dev").create(
+        messages=[{"role": "user", "content": "review this change"}],
+        reasoning_config=MAX_REASONING,
+    )
+
+    assert _aggregator_call(captured_calls)["reasoning_config"] == MAX_REASONING
+
+
+def test_one_shot_aggregator_receives_parent_reasoning_config(captured_calls):
+    from agent.moa_loop import aggregate_moa_context
+
+    aggregate_moa_context(
+        user_prompt="review this change",
+        api_messages=[{"role": "user", "content": "review this change"}],
+        reference_models=[{"provider": "zai", "model": "glm-5"}],
+        aggregator={"provider": "openai-codex", "model": "gpt-5.6-sol"},
+        reasoning_config=MAX_REASONING,
+    )
+
+    assert _aggregator_call(captured_calls)["reasoning_config"] == MAX_REASONING

--- a/website/docs/user-guide/features/mixture-of-agents.md
+++ b/website/docs/user-guide/features/mixture-of-agents.md
@@ -61,6 +61,11 @@ For each main model call when provider `moa` is selected, Hermes:
 
 Because MoA is selected through the normal model system, it composes automatically with `/goal`, gateway sessions, TUI sessions, and Desktop chat.
 
+The aggregator inherits the active session's reasoning setting, including
+`max`, just like the same model would outside MoA. Reference models keep their
+provider-default reasoning settings because they are advisory calls rather
+than the acting model.
+
 ## Configure presets
 
 You can configure named MoA presets from:

--- a/website/docs/user-guide/features/mixture-of-agents.md
+++ b/website/docs/user-guide/features/mixture-of-agents.md
@@ -61,10 +61,11 @@ For each main model call when provider `moa` is selected, Hermes:
 
 Because MoA is selected through the normal model system, it composes automatically with `/goal`, gateway sessions, TUI sessions, and Desktop chat.
 
-The aggregator inherits the active session's reasoning setting, including
-`max`, just like the same model would outside MoA. Reference models keep their
-provider-default reasoning settings because they are advisory calls rather
-than the acting model.
+When its provider supports configurable reasoning effort, the aggregator
+inherits the active session's setting, including `max`, just like the same
+model would outside MoA. Reference models keep their provider-default
+reasoning settings because they are advisory calls rather than the acting
+model.
 
 ## Configure presets
 


### PR DESCRIPTION
## Summary

- propagate the active agent `reasoning_config` to both persistent and one-shot MoA aggregator calls
- bind the parent reasoning setting to the virtual `MoAClient`, including model-switch reconstruction
- translate auxiliary reasoning configuration into the existing provider request body so Codex Responses receives `effort: max`
- keep reference-model reasoning on provider defaults and document that split

## Verification

- `uv run pytest tests/agent/test_auxiliary_client.py -q` (300 passed)
- affected MoA test matrix (49 passed)
- `uv run pytest tests/agent/test_moa_switch_api_mode.py -q` (4 passed)
- focused post-review matrix (40 passed)
- `uv run ruff check .`
- `uv run python -m compileall -q ...` for changed Python files
- `ascii-guard lint --exclude-code-blocks docs` (362 files, 0 errors)
- `uv run --with pyyaml==6.0.3 npm run build` in `website/` (English and zh-Hans builds succeeded; existing unrelated broken-link warnings remain)

## Known limitations

- The repository-wide `ty check` is advisory and currently reports thousands of pre-existing diagnostics; local `ty 0.0.21` also panics on `tools/checkpoint_manager.py`. The changed-file scan confirmed the new `call_llm(reasoning_config=...)` signature after the patch.
- The full suite was not run monolithically because upstream CI intentionally isolates each test file in a fresh process. A local monolithic `tests/agent` attempt reproduced known keychain/module-state leakage, so the affected files were rerun in CI-equivalent isolation.

## Deployment considerations

- No ports, environment variables, dependencies, schemas, or deployment workflow change.
- VM415 should deploy only after this PR is approved and merged; do not patch the live checkout directly.
