### PR TITLE
fix(desktop): don't emit js files when we build desktop

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -38,7 +38,7 @@
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
     "test:desktop:platforms": "node --test electron/bootstrap-platform.test.ts electron/hardening.test.ts electron/backend-env.test.ts electron/backend-probes.test.ts electron/backend-ready.test.ts electron/bootstrap-runner.test.ts electron/connection-config.test.ts electron/dashboard-token.test.ts electron/gateway-ws-probe.test.ts electron/oauth-net-request.test.ts electron/desktop-uninstall.test.ts electron/session-windows.test.ts electron/link-title-window.test.ts electron/workspace-cwd.test.ts electron/fs-read-dir.test.ts electron/git-root.test.ts electron/git-worktree-ops.test.ts electron/windows-child-process.test.ts electron/update-remote.test.ts electron/update-count.test.ts electron/update-rebuild.test.ts electron/update-marker.test.ts electron/update-relaunch.test.ts electron/windows-user-env.test.ts electron/wsl-clipboard-image.test.ts electron/titlebar-overlay-width.test.ts electron/window-state.test.ts electron/zoom.test.ts electron/windows-hermes-resolution.test.ts electron/oauth-session-request.test.ts",
-    "typecheck": "tsc -p . --noEmit",
+    "typecheck": "tsc -p . --noEmit && tsc -p tsconfig.electron.json --noEmit",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",
     "fmt": "prettier --write 'src/**/*.{ts,tsx}' 'electron/**/*.ts' 'vite.config.ts'",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,7 +18,7 @@
     "profile:main": "wait-on http://127.0.0.1:5174 && node scripts/bundle-electron-main.mjs --dev && cross-env XCURSOR_SIZE=24 HERMES_DESKTOP_DEV_SERVER=http://127.0.0.1:5174 electron --inspect=9229 .",
     "profile:main:cpu": "wait-on http://127.0.0.1:5174 && node scripts/bundle-electron-main.mjs --dev && cross-env XCURSOR_SIZE=24 NODE_OPTIONS=--cpu-prof HERMES_DESKTOP_DEV_SERVER=http://127.0.0.1:5174 electron .",
     "start": "npm run build && electron .",
-    "build": "node scripts/assert-root-install.mjs && node scripts/write-build-stamp.mjs && tsc -b && vite build && node scripts/bundle-electron-main.mjs && node scripts/stage-native-deps.mjs",
+    "build": "node scripts/assert-root-install.mjs && node scripts/write-build-stamp.mjs && vite build && node scripts/bundle-electron-main.mjs && node scripts/stage-native-deps.mjs",
     "postbuild": "node scripts/assert-dist-built.mjs",
     "prebuilder": "node scripts/patch-electron-builder-mac-binary.mjs",
     "builder": "cross-env NODE_OPTIONS=--max-old-space-size=16384 node scripts/run-electron-builder.mjs",


### PR DESCRIPTION
## What does this PR do?

Stops the desktop build from emitting `.js` files next to `.tsx` sources (and into `build/electron-types/`), and ensures `electron/` stays type-checked in CI.

## Changes Made

- **`apps/desktop/package.json` — `build` script:** removed `tsc -b` from the build pipeline. `tsc -b` (build mode) was emitting `.js`/`.d.ts` files alongside sources because the root `tsconfig.json` has no `outDir` and no `noEmit`. The emitted artifacts are not consumed by anything downstream — esbuild bundles electron code directly from `.ts` sources — so the emit is pure spam. The build still succeeds without it.
- **`apps/desktop/package.json` — `typecheck` script:** extended to `tsc -p . --noEmit && tsc -p tsconfig.electron.json --noEmit`. Removing `tsc -b` from `build` also removed the only step that type-checked the `electron/` directory. The CI `typecheck` job runs `tsc -p . --noEmit`, which uses `tsconfig.json` whose `include` is only `["src", "../shared/src"]` — so `electron/` was silently uncovered. The second `tsc` call closes that gap. (`tsc -b --noEmit` cannot be used because `composite: true` conflicts with `noEmit` — TS6310.)

## How to Test

1. `cd apps/desktop && npm run build` — succeeds, no `.js` files emitted into `src/` or `build/electron-types/`
2. `cd apps/desktop && npm run typecheck` — succeeds, now covers both `src/` and `electron/`
3. CI `typecheck` job (`.github/workflows/typecheck.yml`) runs `npm run --prefix apps/desktop typecheck` — covers both projects.

## Checklist

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] My PR contains only changes related to this fix
- [x] I've run `npm run build` and `npm run typecheck` and both pass
