### PR TITLE
fix(dashboard): scope PTY keep-alive tokens by resume session

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15457,7 +15457,8 @@ async def pty_ws(ws: WebSocket) -> None:
         return
 
     # --- spawn PTY ------------------------------------------------------
-    resume = ws.query_params.get("resume") or None
+    raw_resume = ws.query_params.get("resume") or None
+    resume = raw_resume
     profile = ws.query_params.get("profile") or None
     channel = _channel_or_close_code(ws)
     sidecar_url = _build_sidecar_url(channel) if channel else None
@@ -15500,6 +15501,9 @@ async def pty_ws(ws: WebSocket) -> None:
 
 
     attach_token = ws.query_params.get("attach") or None
+    if attach_token is not None and (raw_resume or profile):
+        # Key on query resume, not the active-session-file fallback used for argv.
+        attach_token = f"{attach_token}\0{profile or ''}\0{raw_resume or ''}"
 
     def _spawn():
         return PtyBridge.spawn(argv, cwd=cwd, env=env)

--- a/tests/test_pty_keepalive_ws.py
+++ b/tests/test_pty_keepalive_ws.py
@@ -1,53 +1,122 @@
+import json
+
 import pytest
 
 from hermes_cli import web_server
 
 
-@pytest.mark.asyncio
-async def test_attach_token_reuses_same_session(monkeypatch):
-    """Two connects with the same ?attach= token hit one spawned bridge."""
+class FakeBridge:
+    def __init__(self):
+        self.alive = True
+
+    def read(self, timeout):
+        return b""        # idle forever
+
+    def write(self, data):
+        pass
+
+    def resize(self, cols, rows):
+        pass
+
+    def close(self):
+        self.alive = False
+
+
+@pytest.fixture
+def pty_keepalive_harness(monkeypatch):
     spawned = []
-
-    class FakeBridge:
-        def __init__(self):
-            self.alive = True
-
-        def read(self, timeout):
-            return b""        # idle forever
-
-        def write(self, data):
-            pass
-
-        def resize(self, cols, rows):
-            pass
-
-        def close(self):
-            self.alive = False
 
     def fake_spawn(argv, cwd=None, env=None):
         b = FakeBridge()
-        spawned.append(b)
+        spawned.append(argv)
         return b
 
     monkeypatch.setattr(web_server.PtyBridge, "spawn", staticmethod(fake_spawn))
-    # bypass auth + argv resolution for the test
     monkeypatch.setattr(web_server, "_ws_auth_reason", lambda ws: (None, "test"))
     monkeypatch.setattr(web_server, "_ws_host_origin_reason", lambda ws: None)
     monkeypatch.setattr(web_server, "_ws_client_reason", lambda ws: None)
 
     async def fake_argv(**kw):
-        return (["x"], "/tmp", {})
+        return (["x", kw.get("resume") or "fresh"], "/tmp", {})
 
     monkeypatch.setattr(web_server, "_resolve_chat_argv_async", fake_argv)
 
-    from starlette.testclient import TestClient
-
     try:
-        client = TestClient(web_server.app)
-        with client.websocket_connect("/api/pty?attach=TOK1") as ws1:
-            ws1.send_bytes(b"hi")
-        with client.websocket_connect("/api/pty?attach=TOK1") as ws2:
-            ws2.send_bytes(b"again")
-        assert len(spawned) == 1                # reattached, did not respawn
+        yield spawned
     finally:
         web_server.PTY_REGISTRY._sessions.clear()
+
+
+@pytest.mark.asyncio
+async def test_attach_token_reuses_same_session(pty_keepalive_harness):
+    """Two connects with the same ?attach= token hit one spawned bridge."""
+    from starlette.testclient import TestClient
+
+    client = TestClient(web_server.app)
+    with client.websocket_connect("/api/pty?attach=TOK1") as ws1:
+        ws1.send_bytes(b"hi")
+    with client.websocket_connect("/api/pty?attach=TOK1") as ws2:
+        ws2.send_bytes(b"again")
+    assert len(pty_keepalive_harness) == 1                # reattached, did not respawn
+
+
+@pytest.mark.asyncio
+async def test_attach_token_reuses_same_resume(pty_keepalive_harness):
+    from starlette.testclient import TestClient
+
+    client = TestClient(web_server.app)
+    with client.websocket_connect("/api/pty?attach=TOK1&resume=same") as ws1:
+        ws1.send_bytes(b"hi")
+    with client.websocket_connect("/api/pty?attach=TOK1&resume=same") as ws2:
+        ws2.send_bytes(b"again")
+    assert pty_keepalive_harness == [["x", "same"]]
+
+
+@pytest.mark.asyncio
+async def test_attach_token_does_not_reuse_different_resume(pty_keepalive_harness):
+    """A keep-alive token must not pin /chat to an old selected session."""
+    from starlette.testclient import TestClient
+
+    client = TestClient(web_server.app)
+    with client.websocket_connect("/api/pty?attach=TOK1&resume=old") as ws1:
+        ws1.send_bytes(b"hi")
+    with client.websocket_connect("/api/pty?attach=TOK1&resume=new") as ws2:
+        ws2.send_bytes(b"again")
+    assert pty_keepalive_harness == [["x", "old"], ["x", "new"]]
+
+
+@pytest.mark.asyncio
+async def test_attach_token_does_not_reuse_different_profile(pty_keepalive_harness):
+    from starlette.testclient import TestClient
+
+    client = TestClient(web_server.app)
+    with client.websocket_connect("/api/pty?attach=TOK1&profile=alpha") as ws1:
+        ws1.send_bytes(b"hi")
+    with client.websocket_connect("/api/pty?attach=TOK1&profile=beta") as ws2:
+        ws2.send_bytes(b"again")
+    assert len(pty_keepalive_harness) == 2
+
+
+@pytest.mark.asyncio
+async def test_attach_token_reuses_default_chat_after_active_session_fallback(
+    pty_keepalive_harness, tmp_path, monkeypatch
+):
+    from starlette.testclient import TestClient
+
+    active_session_file = tmp_path / "active-session.json"
+    monkeypatch.setattr(
+        web_server,
+        "_active_session_file_for_channel",
+        lambda app, channel: active_session_file,
+    )
+
+    client = TestClient(web_server.app)
+    with client.websocket_connect("/api/pty?attach=TOK1&channel=CHAT") as ws1:
+        ws1.send_bytes(b"hi")
+
+    active_session_file.write_text(json.dumps({"session_id": "existing"}))
+
+    with client.websocket_connect("/api/pty?attach=TOK1&channel=CHAT") as ws2:
+        ws2.send_bytes(b"again")
+
+    assert pty_keepalive_harness == [["x", "fresh"]]


### PR DESCRIPTION
## Summary

- Scope dashboard `/api/pty` keep-alive registry keys by the selected `resume` session and `profile`, not just the browser attach token.
- Fixes dashboard chat getting stuck on the first selected session after the PTY keep-alive feature (#60515).

## Root cause

The dashboard stores one attach token per browser tab. When the user picks a different session in the sidebar, `?resume=` changes but the same attach token is reused. `PTY_REGISTRY.attach_or_spawn()` keyed only on that token, so the server reattached to the old PTY and ignored the new resume target.

## Changes

- `hermes_cli/web_server.py`: include raw query `resume` and `profile` in the internal keep-alive key before registry lookup.
- `tests/test_pty_keepalive_ws.py`: cover same-session reattach, different-resume/profile spawns, and default-chat reattach after active-session-file fallback.

## Test plan

- [x] `scripts/run_tests.sh tests/test_pty_keepalive_ws.py -q` (5 passed)
- [ ] Manual: open dashboard Chat, pick session A, then session B — terminal should show B's conversation without Reconnect