### PR TITLE
fix(ui-tui): redraw after session resume

### DIFF
--- a/ui-tui/src/app/sessionResumeView.test.ts
+++ b/ui-tui/src/app/sessionResumeView.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { evictInkCachesMock, forceRedrawMock } = vi.hoisted(() => ({
+  evictInkCachesMock: vi.fn(),
+  forceRedrawMock: vi.fn()
+}))
+
+vi.mock('@hermes/ink', () => ({
+  evictInkCaches: evictInkCachesMock,
+  forceRedraw: forceRedrawMock
+}))
+
+import { refreshSessionView, scheduleResumeScrollToBottom } from './sessionResumeView.js'
+
+describe('refreshSessionView', () => {
+  afterEach(() => {
+    evictInkCachesMock.mockReset()
+    forceRedrawMock.mockReset()
+  })
+
+  it('evicts Ink caches and forces a full repaint', () => {
+    const stdout = {} as NodeJS.WriteStream
+
+    refreshSessionView(stdout)
+
+    expect(evictInkCachesMock).toHaveBeenCalledWith('all')
+    expect(forceRedrawMock).toHaveBeenCalledWith(stdout)
+  })
+})
+
+describe('scheduleResumeScrollToBottom', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    evictInkCachesMock.mockReset()
+    forceRedrawMock.mockReset()
+  })
+
+  it('re-snaps while sticky and stops when the user scrolls away', () => {
+    vi.useFakeTimers()
+    let sticky = true
+    let lastManualScrollAt = 0
+    const scrollToBottom = vi.fn()
+
+    const cancel = scheduleResumeScrollToBottom(
+      {
+        current: {
+          getLastManualScrollAt: () => lastManualScrollAt,
+          isSticky: () => sticky,
+          scrollToBottom
+        }
+      } as any,
+      [0, 80, 240]
+    )
+
+    vi.advanceTimersByTime(0)
+    expect(scrollToBottom).toHaveBeenCalledTimes(1)
+    expect(evictInkCachesMock).toHaveBeenCalledWith('all')
+    expect(forceRedrawMock).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(80)
+    expect(scrollToBottom).toHaveBeenCalledTimes(2)
+    expect(forceRedrawMock).toHaveBeenCalledTimes(1)
+
+    sticky = false
+    lastManualScrollAt = Date.now() + 1
+    vi.advanceTimersByTime(160)
+    expect(scrollToBottom).toHaveBeenCalledTimes(2)
+
+    cancel()
+  })
+
+  it('cancels pending resume snaps', () => {
+    vi.useFakeTimers()
+    const scrollToBottom = vi.fn()
+
+    const cancel = scheduleResumeScrollToBottom(
+      {
+        current: {
+          getLastManualScrollAt: () => 0,
+          isSticky: () => true,
+          scrollToBottom
+        }
+      } as any,
+      [20]
+    )
+
+    cancel()
+    vi.advanceTimersByTime(20)
+
+    expect(scrollToBottom).not.toHaveBeenCalled()
+    expect(forceRedrawMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps the immediate resume snap even before sticky state settles', () => {
+    vi.useFakeTimers()
+    let sticky = false
+    const scrollToBottom = vi.fn()
+
+    const cancel = scheduleResumeScrollToBottom(
+      {
+        current: {
+          getLastManualScrollAt: () => 0,
+          isSticky: () => sticky,
+          scrollToBottom
+        }
+      } as any,
+      [0, 80]
+    )
+
+    vi.advanceTimersByTime(0)
+    expect(scrollToBottom).toHaveBeenCalledTimes(1)
+    expect(forceRedrawMock).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(80)
+    expect(scrollToBottom).toHaveBeenCalledTimes(1)
+    expect(forceRedrawMock).toHaveBeenCalledTimes(1)
+
+    sticky = true
+    cancel()
+  })
+})

--- a/ui-tui/src/app/sessionResumeView.ts
+++ b/ui-tui/src/app/sessionResumeView.ts
@@ -1,0 +1,41 @@
+import type { ScrollBoxHandle } from '@hermes/ink'
+import { evictInkCaches, forceRedraw } from '@hermes/ink'
+import type { RefObject } from 'react'
+
+export const refreshSessionView = (stdout: NodeJS.WriteStream = process.stdout) => {
+  evictInkCaches('all')
+  forceRedraw(stdout)
+}
+
+export const scheduleResumeScrollToBottom = (
+  scrollRef: RefObject<null | ScrollBoxHandle>,
+  delays: readonly number[] = [0, 80, 240]
+) => {
+  const startedAt = Date.now()
+
+  const timers = delays.map((delay, index) =>
+    setTimeout(() => {
+      const scroll = scrollRef.current
+
+      if (!scroll) {
+        return
+      }
+
+      const manuallyScrolledAfterResume = scroll.getLastManualScrollAt() > startedAt
+
+      if (!manuallyScrolledAfterResume && (index === 0 || scroll.isSticky())) {
+        scroll.scrollToBottom()
+
+        if (index === 0) {
+          refreshSessionView()
+        }
+      }
+    }, delay)
+  )
+
+  return () => {
+    for (const timer of timers) {
+      clearTimeout(timer)
+    }
+  }
+}

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -22,9 +22,12 @@ import type { Msg, PanelSection, SessionInfo, Usage } from '../types.js'
 
 import type { ComposerActions, GatewayRpc, StateSetter } from './interfaces.js'
 import { patchOverlayState } from './overlayStore.js'
+import { scheduleResumeScrollToBottom } from './sessionResumeView.js'
 import { turnController } from './turnController.js'
 import { patchTurnState } from './turnStore.js'
 import { getUiState, patchUiState } from './uiStore.js'
+
+export { refreshSessionView, scheduleResumeScrollToBottom } from './sessionResumeView.js'
 
 const usageFrom = (info: null | SessionInfo): Usage => (info?.usage ? { ...ZERO, ...info.usage } : ZERO)
 
@@ -66,34 +69,6 @@ export const hydrateLiveSessionInflight = (inflight?: null | SessionInflightTurn
   }
 
   turnController.hydrateStreamingText(assistant)
-}
-
-export const scheduleResumeScrollToBottom = (
-  scrollRef: RefObject<null | ScrollBoxHandle>,
-  delays: readonly number[] = [0, 80, 240]
-) => {
-  const startedAt = Date.now()
-  const timers = delays.map((delay, index) =>
-    setTimeout(() => {
-      const scroll = scrollRef.current
-
-      if (!scroll) {
-        return
-      }
-
-      const manuallyScrolledAfterResume = scroll.getLastManualScrollAt() > startedAt
-
-      if (!manuallyScrolledAfterResume && (index === 0 || scroll.isSticky())) {
-        scroll.scrollToBottom()
-      }
-    }, delay)
-  )
-
-  return () => {
-    for (const timer of timers) {
-      clearTimeout(timer)
-    }
-  }
 }
 
 const trimTail = (items: Msg[]) => {
@@ -148,6 +123,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
       targetSid ? rpc<SessionCloseResponse>('session.close', { session_id: targetSid }) : Promise.resolve(null),
     [rpc]
   )
+
   const cancelResumeScrollRef = useRef<null | (() => void)>(null)
 
   const resetSession = useCallback(() => {


### PR DESCRIPTION
## Summary
- force a full Ink redraw on the immediate resume snap after switching TUI sessions
- keep the resume scroll helper isolated in a small module with focused coverage
- preserve the existing sticky follow-up snaps while fixing the stale first paint

## Testing
- ./node_modules/.bin/vitest run src/app/sessionResumeView.test.ts
- ./node_modules/.bin/eslint src/app/useSessionLifecycle.ts src/app/sessionResumeView.ts src/app/sessionResumeView.test.ts
- ./node_modules/.bin/esbuild src/app/sessionResumeView.ts --bundle --platform=node --format=esm --external:@hermes/ink --external:react >/dev/null
- ./node_modules/.bin/esbuild src/app/sessionResumeView.test.ts --bundle --platform=node --format=esm --external:vitest --external:@hermes/ink >/dev/null
- git diff --check

Closes #62170