### PR TITLE
fix(router): preserve durable state through one-turn routes

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12110,8 +12110,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             return None
 
         turn_route = self._resolve_turn_agent_config(message)
+        self._capture_ephemeral_router_state(
+            router_ephemeral=turn_route.get("router_ephemeral", False)
+        )
         if turn_route["signature"] != self._active_agent_route_signature:
+            discarded_agent = self.agent
             self.agent = None
+            if not turn_route.get("router_ephemeral", False):
+                self._release_agent_clients(discarded_agent)
 
         # Initialize agent if needed
         if self.agent is None:
@@ -12122,6 +12128,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             request_overrides=turn_route.get("request_overrides"),
             router_ephemeral=turn_route.get("router_ephemeral", False),
         ):
+            self._restore_ephemeral_router_session_model(
+                router_ephemeral=turn_route.get("router_ephemeral", False),
+                restore_model=turn_route.get("router_restore_model"),
+            )
             return None
         
         # Route image attachments based on the active model's vision capability.
@@ -12543,18 +12553,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             self.conversation_history = result.get("messages", self.conversation_history) if result else self.conversation_history
 
             # If auto-compression fired mid-turn, the agent created a new
-            # continuation session and mutated self.agent.session_id. Sync
-            # the CLI's session_id so /status, /resume, title generation,
-            # and the exit summary all target the live child session rather
-            # than the ended parent. Mirrors the gateway's post-run sync
-            # (gateway/run.py around line 9983).
-            if (
-                self.agent
-                and getattr(self.agent, "session_id", None)
-                and self.agent.session_id != self.session_id
-            ):
-                self._transfer_session_yolo(self.session_id, self.agent.session_id)
-                self.session_id = self.agent.session_id
+            # continuation session. An ephemeral directive restores the durable
+            # agent before this point, so prefer the temporary agent's recorded
+            # child session when available.
+            _completed_session_id = getattr(self, "_last_ephemeral_router_session_id", None) or getattr(
+                self.agent, "session_id", None
+            )
+            if _completed_session_id and _completed_session_id != self.session_id:
+                self._transfer_session_yolo(self.session_id, _completed_session_id)
+                self.session_id = _completed_session_id
                 self._pending_title = None
 
             # Get the final response
@@ -16163,12 +16170,19 @@ def main(
                                 announce=False,
                             )
                     turn_route = cli._resolve_turn_agent_config(effective_query)
+                    cli._capture_ephemeral_router_state(
+                        router_ephemeral=turn_route.get("router_ephemeral", False)
+                    )
                     if turn_route["signature"] != cli._active_agent_route_signature:
+                        discarded_agent = cli.agent
                         cli.agent = None
+                        if not turn_route.get("router_ephemeral", False):
+                            cli._release_agent_clients(discarded_agent)
                     if cli._init_agent(
                         model_override=turn_route["model"],
                         runtime_override=turn_route["runtime"],
                         request_overrides=turn_route.get("request_overrides"),
+                        router_ephemeral=turn_route.get("router_ephemeral", False),
                     ):
                         cli.agent.quiet_mode = True
                         cli.agent.suppress_status_output = True
@@ -16177,8 +16191,9 @@ def main(
                         # status lines).  The response is printed once below.
                         cli.agent.stream_delta_callback = None
                         cli.agent.tool_gen_callback = None
+                        run_agent = cli.agent
                         try:
-                            result = cli.agent.run_conversation(
+                            result = run_agent.run_conversation(
                                 user_message=effective_query,
                                 conversation_history=cli.conversation_history,
                             )
@@ -16186,15 +16201,27 @@ def main(
                             _emit_interrupted_session_end(cli, reason="keyboard_interrupt")
                             print(f"\nsession_id: {cli.session_id}", file=sys.stderr)
                             sys.exit(130)
+                        finally:
+                            _quiet_completed_session_id = getattr(run_agent, "session_id", None)
+                            cli._restore_ephemeral_router_session_model(
+                                router_ephemeral=turn_route.get("router_ephemeral", False),
+                                restore_model=turn_route.get("router_restore_model"),
+                            )
                         # Sync session_id if mid-run compression created a
-                        # continuation session. The exit line below reports
-                        # session_id to stderr for automation wrappers; without
-                        # this sync it would point at the ended parent.
+                        # continuation session. The temporary routed agent may
+                        # already have been released, so keep its recorded ID.
+                        _quiet_completed_session_id = (
+                            getattr(cli, "_last_ephemeral_router_session_id", None)
+                            or _quiet_completed_session_id
+                        )
                         if (
-                            getattr(cli.agent, "session_id", None)
-                            and cli.agent.session_id != cli.session_id
+                            _quiet_completed_session_id
+                            and _quiet_completed_session_id != cli.session_id
                         ):
-                            cli.session_id = cli.agent.session_id
+                            cli._transfer_session_yolo(
+                                cli.session_id, _quiet_completed_session_id
+                            )
+                            cli.session_id = _quiet_completed_session_id
                         response = result.get("final_response", "") if isinstance(result, dict) else str(result)
                         # Surface backend errors that produced no visible output
                         # (e.g. invalid model slug → provider 4xx). Mirrors the
@@ -16253,7 +16280,11 @@ def main(
                                     _exit_code = 1
                         sys.exit(_exit_code)
 
-                # Exit with error code if credentials or agent init fails
+                # Exit with error code if credentials or agent init fails.
+                cli._restore_ephemeral_router_session_model(
+                    router_ephemeral=turn_route.get("router_ephemeral", False),
+                    restore_model=turn_route.get("router_restore_model"),
+                )
                 sys.exit(1)
             else:
                 # Single-query mode (`hermes chat -q "…"`): skip the welcome

--- a/cli.py
+++ b/cli.py
@@ -7880,6 +7880,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         if result.api_mode:
             self.api_mode = result.api_mode
 
+        # `/model` is a deliberate session-level user action. Replace the
+        # router-derived pin before attempting an in-place agent swap, so a
+        # later one-turn route directive restores this model—not the route
+        # chosen before the explicit switch.
+        self._set_explicit_session_model_pin(
+            result.new_model,
+            {
+                "provider": self.provider,
+                "base_url": self.base_url,
+                "api_mode": self.api_mode,
+                "command": self.acp_command,
+                "args": list(self.acp_args or []),
+            },
+        )
+
         if self.agent is not None:
             try:
                 self.agent.switch_model(
@@ -7890,17 +7905,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     api_mode=result.api_mode,
                 )
             except Exception as exc:
-                # The agent rolled itself back to the old working model/client.
-                # Roll the CLI's own staged fields back too and abort the rest
-                # of the commit (note + success print) so a failed switch is a
-                # no-op rather than a dead session (#50163).
-                for _k, _v in _cli_snapshot.items():
-                    setattr(self, _k, _v)
-                _cprint(
-                    f"  ⚠ Model switch to {result.new_model} failed ({exc}); "
-                    f"staying on {old_model}."
-                )
-                return
+                # A failed in-place swap may have partially mutated the agent.
+                # Discard it so the next turn builds a clean agent from the
+                # explicit session pin and compatible runtime settings.
+                self.agent = None
+                _cprint(f"  ⚠ Agent swap failed ({exc}); change will apply on next turn.")
 
         self._pending_model_switch_note = (
             f"[Note: model was just switched from {old_model} to {result.new_model} "
@@ -12111,6 +12120,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             model_override=turn_route["model"],
             runtime_override=turn_route["runtime"],
             request_overrides=turn_route.get("request_overrides"),
+            router_ephemeral=turn_route.get("router_ephemeral", False),
         ):
             return None
         
@@ -12368,6 +12378,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         "error": _summary,
                     }
                 finally:
+                    # A route directive is intentionally one-turn only. Restore
+                    # the durable session model even if the temporary agent run
+                    # failed after creating its SessionDB row.
+                    self._restore_ephemeral_router_session_model(
+                        router_ephemeral=turn_route.get("router_ephemeral", False),
+                        restore_model=turn_route.get("router_restore_model"),
+                    )
                     # Surface any credit notices queued during the turn (cold-start
                     # seed / per-turn capture) now that the response is done — printing
                     # at this boundary paints cleanly above the prompt instead of being

--- a/cli.py
+++ b/cli.py
@@ -12209,6 +12209,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     for w in _ctx_result.warnings:
                         _cprint(f"  {_DIM}⚠ {w}{_RST}")
                     if _ctx_result.blocked:
+                        self._restore_ephemeral_router_session_model(
+                            router_ephemeral=turn_route.get("router_ephemeral", False),
+                            restore_model=turn_route.get("router_restore_model"),
+                        )
                         return "\n".join(_ctx_result.warnings) or "Context injection refused."
                     message = _ctx_result.message
             except Exception as e:
@@ -16113,6 +16117,7 @@ def main(
                 # Quiet mode: suppress banner, spinner, tool previews.
                 # Only print the final response and parseable session info.
                 cli.tool_progress_mode = "off"
+                turn_route = None
                 if cli._ensure_runtime_credentials():
                     effective_query: Any = query
                     if single_query_images or single_query_image_urls:
@@ -16281,10 +16286,11 @@ def main(
                         sys.exit(_exit_code)
 
                 # Exit with error code if credentials or agent init fails.
-                cli._restore_ephemeral_router_session_model(
-                    router_ephemeral=turn_route.get("router_ephemeral", False),
-                    restore_model=turn_route.get("router_restore_model"),
-                )
+                if turn_route is not None:
+                    cli._restore_ephemeral_router_session_model(
+                        router_ephemeral=turn_route.get("router_ephemeral", False),
+                        restore_model=turn_route.get("router_restore_model"),
+                    )
                 sys.exit(1)
             else:
                 # Single-query mode (`hermes chat -q "…"`): skip the welcome

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3897,7 +3897,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         accordingly.
         """
         from hermes_cli.models import resolve_fast_mode_overrides
+        from hermes_cli.model_router import select_model_for_turn
 
+        effective_model, router_tier = select_model_for_turn(user_message, model)
         runtime = {
             "api_key": runtime_kwargs.get("api_key"),
             "base_url": runtime_kwargs.get("base_url"),
@@ -3909,10 +3911,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "max_tokens": runtime_kwargs.get("max_tokens"),
         }
         route = {
-            "model": model,
+            "model": effective_model,
+            "router_tier": router_tier,
             "runtime": runtime,
             "signature": (
-                model,
+                effective_model,
                 runtime["provider"],
                 runtime["base_url"],
                 runtime["api_mode"],

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4007,6 +4007,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         model = override.get("model")
         return model.strip() if isinstance(model, str) and model.strip() else None
 
+    def _resolve_session_router_pin(
+        self, session_id: Optional[str], session_key: Optional[str]
+    ) -> Tuple[Optional[str], Optional[int]]:
+        """Return the session-stable model, preferring an explicit `/model`."""
+        pinned_model, message_count = self._get_pinned_session_router_model(session_id)
+        explicit_model = self._get_explicit_session_model_override(session_key)
+        # A direct /model command is deliberate user intent. It may
+        # intentionally replace the persisted router choice; route/cache
+        # rebuilding is appropriate for that explicit session action.
+        return explicit_model or pinned_model, message_count
+
     def _get_pinned_session_router_model(
         self, session_id: Optional[str]
     ) -> Tuple[Optional[str], Optional[int]]:
@@ -18138,13 +18149,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Session rows record the actual model selected for the first turn.
             # Reuse it on later turns (including cache eviction/restart) instead
             # of reclassifying follow-ups and rebuilding a new system prompt.
-            _pinned_router_model, _current_msg_count = (
-                self._get_pinned_session_router_model(session_id)
+            _pinned_router_model, _current_msg_count = self._resolve_session_router_pin(
+                session_id, session_key
             )
-            if _pinned_router_model is None:
-                _pinned_router_model = self._get_explicit_session_model_override(
-                    session_key
-                )
 
             turn_route = self._resolve_turn_agent_config(
                 message,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3903,8 +3903,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         accordingly.
         """
         from hermes_cli.models import resolve_fast_mode_overrides
-        from hermes_cli.model_router import select_model_for_session_turn
+        from hermes_cli.model_router import (
+            explicit_model_router_tier,
+            select_model_for_session_turn,
+        )
 
+        explicit_router_tier = explicit_model_router_tier(user_message)
         effective_model, router_tier = select_model_for_session_turn(
             user_message, model, pinned_model=pinned_model
         )
@@ -3921,6 +3925,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         route = {
             "model": effective_model,
             "router_tier": router_tier,
+            "router_ephemeral": explicit_router_tier is not None,
+            # A route directive may use a temporary model for this response;
+            # retain the prior durable pin (or primary base model for a new
+            # session) for the next ordinary turn.
+            "router_restore_model": pinned_model or model,
             "runtime": runtime,
             "signature": (
                 effective_model,
@@ -3991,6 +4000,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             db.update_session_meta(session_id, json.dumps(config), model=model)
         except Exception:
             logger.debug("Failed to sync gateway session model metadata", exc_info=True)
+    def _restore_ephemeral_router_session_model(
+        self, session_id: Optional[str], turn_route: dict
+    ) -> None:
+        """Restore durable session routing after a one-turn model directive."""
+        if not turn_route.get("router_ephemeral") or not session_id:
+            return
+        restore_model = turn_route.get("router_restore_model")
+        if not isinstance(restore_model, str) or not restore_model.strip():
+            return
+        session_db = getattr(self, "_session_db", None)
+        if session_db is None:
+            return
+        try:
+            session_db.update_session_model(session_id, restore_model.strip())
+        except Exception:
+            logger.debug(
+                "Could not restore router session model after ephemeral route",
+                exc_info=True,
+            )
 
     def _get_explicit_session_model_override(
         self, session_key: Optional[str]
@@ -18917,6 +18945,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _conversation_kwargs["persist_user_timestamp"] = _persist_user_timestamp_override
                 result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
             finally:
+                # A one-turn directive must not become a durable model pin even
+                # when the delegated conversation raises before normal result
+                # handling. Agent compression may already have rotated its
+                # session_id, so restore against the agent's current row.
+                try:
+                    _ephemeral_agent = agent_holder[0]
+                    _ephemeral_session_id = getattr(
+                        _ephemeral_agent, "session_id", session_id
+                    )
+                    self._restore_ephemeral_router_session_model(
+                        _ephemeral_session_id, turn_route
+                    )
+                except Exception:
+                    logger.debug(
+                        "Could not restore ephemeral router session after run failure",
+                        exc_info=True,
+                    )
                 unregister_gateway_notify(_approval_session_key)
                 # Cancel any pending clarify entries so blocked agent
                 # threads don't hang past the end of the run (interrupt,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3992,6 +3992,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             logger.debug("Failed to sync gateway session model metadata", exc_info=True)
 
+    def _get_explicit_session_model_override(
+        self, session_key: Optional[str]
+    ) -> Optional[str]:
+        """Return an explicit `/model` selection without reclassifying it."""
+        if not session_key:
+            return None
+        overrides = getattr(self, "_session_model_overrides", None)
+        if not isinstance(overrides, dict):
+            return None
+        override = overrides.get(session_key)
+        if not isinstance(override, dict):
+            return None
+        model = override.get("model")
+        return model.strip() if isinstance(model, str) and model.strip() else None
+
     def _get_pinned_session_router_model(
         self, session_id: Optional[str]
     ) -> Tuple[Optional[str], Optional[int]]:
@@ -13349,7 +13364,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             reasoning_config = self._resolve_session_reasoning_config(source=source)
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
-            turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+            session_key = self._session_key_for_source(source)
+            turn_route = self._resolve_turn_agent_config(
+                prompt,
+                model,
+                runtime_kwargs,
+                pinned_model=self._get_explicit_session_model_override(session_key),
+            )
 
             # Enrich the prompt with image descriptions so the background
             # agent can see user-attached images (same as the main flow).
@@ -18120,6 +18141,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _pinned_router_model, _current_msg_count = (
                 self._get_pinned_session_router_model(session_id)
             )
+            if _pinned_router_model is None:
+                _pinned_router_model = self._get_explicit_session_model_override(
+                    session_key
+                )
 
             turn_route = self._resolve_turn_agent_config(
                 message,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -44,7 +44,7 @@ from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
 from datetime import datetime
-from typing import Callable, Dict, Optional, Any, List, Union
+from typing import Callable, Dict, Optional, Any, List, Tuple, Union
 
 # account_usage imports the OpenAI SDK chain (~230 ms). Only needed by
 # /usage; we still import it at module top in the gateway because test
@@ -3888,7 +3888,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         return model, runtime_kwargs
 
-    def _resolve_turn_agent_config(self, user_message: str, model: str, runtime_kwargs: dict) -> dict:
+    def _resolve_turn_agent_config(
+        self,
+        user_message: str,
+        model: str,
+        runtime_kwargs: dict,
+        pinned_model: Optional[str] = None,
+    ) -> dict:
         """Build the effective model/runtime config for a single turn.
 
         Always uses the session's primary model/provider.  If `/fast` is
@@ -3897,9 +3903,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         accordingly.
         """
         from hermes_cli.models import resolve_fast_mode_overrides
-        from hermes_cli.model_router import select_model_for_turn
+        from hermes_cli.model_router import select_model_for_session_turn
 
-        effective_model, router_tier = select_model_for_turn(user_message, model)
+        effective_model, router_tier = select_model_for_session_turn(
+            user_message, model, pinned_model=pinned_model
+        )
         runtime = {
             "api_key": runtime_kwargs.get("api_key"),
             "base_url": runtime_kwargs.get("base_url"),
@@ -3983,6 +3991,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             db.update_session_meta(session_id, json.dumps(config), model=model)
         except Exception:
             logger.debug("Failed to sync gateway session model metadata", exc_info=True)
+
+    def _get_pinned_session_router_model(
+        self, session_id: Optional[str]
+    ) -> Tuple[Optional[str], Optional[int]]:
+        """Return a prior effective session model and its message count.
+
+        The first routed agent persists its effective model in SessionDB. Later
+        turns use that model as a pin, including after an agent-cache eviction
+        or gateway restart, so keyword classification cannot rebuild a live
+        conversation on a different model.
+        """
+        if self._session_db is None or not session_id:
+            return None, None
+        try:
+            session = self._session_db.get_session(session_id)
+            if not session:
+                return None, None
+            message_count = int(session.get("message_count") or 0)
+            model = session.get("model")
+            if message_count > 0 and isinstance(model, str) and model.strip():
+                return model.strip(), message_count
+            return None, message_count
+        except Exception:
+            return None, None
 
     async def _handle_adapter_fatal_error(self, adapter: BasePlatformAdapter) -> None:
         """React to an adapter failure after startup.
@@ -18082,7 +18114,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     log_message="interim_assistant_callback scheduling error",
                 )
 
-            turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
+            # Session rows record the actual model selected for the first turn.
+            # Reuse it on later turns (including cache eviction/restart) instead
+            # of reclassifying follow-ups and rebuilding a new system prompt.
+            _pinned_router_model, _current_msg_count = (
+                self._get_pinned_session_router_model(session_id)
+            )
+
+            turn_route = self._resolve_turn_agent_config(
+                message,
+                model,
+                runtime_kwargs,
+                pinned_model=_pinned_router_model,
+            )
 
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool
@@ -18103,7 +18147,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             # Detect cross-process writes: when another process (e.g. hermes
             # dashboard) appends to the same session in the shared SessionDB,
-            # the cached agent's in-memory transcript becomes stale.  Compare
+            # the cached agent's in-memory transcript becomes stale. Compare
             # the session's current message_count against the count recorded
             # when the agent was cached; on mismatch, invalidate the cache
             # so a fresh agent re-reads from disk. (#45966)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4000,6 +4000,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             db.update_session_meta(session_id, json.dumps(config), model=model)
         except Exception:
             logger.debug("Failed to sync gateway session model metadata", exc_info=True)
+
+    def _capture_ephemeral_router_system_prompt(
+        self, session_id: Optional[str], turn_route: dict
+    ) -> None:
+        """Preserve the durable prompt before a temporary model rebuild writes it."""
+        if not turn_route.get("router_ephemeral") or not session_id:
+            return
+        session_db = getattr(self, "_session_db", None)
+        if session_db is None:
+            return
+        try:
+            row = session_db.get_session(session_id)
+            prompt = row.get("system_prompt") if row else None
+            if isinstance(prompt, str) and prompt:
+                turn_route["router_restore_system_prompt"] = prompt
+        except Exception:
+            logger.debug(
+                "Could not snapshot router system prompt before ephemeral route",
+                exc_info=True,
+            )
+
     def _restore_ephemeral_router_session_model(
         self, session_id: Optional[str], turn_route: dict
     ) -> None:
@@ -4009,14 +4030,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         restore_model = turn_route.get("router_restore_model")
         if not isinstance(restore_model, str) or not restore_model.strip():
             return
+        restore_prompt = turn_route.pop("router_restore_system_prompt", None)
         session_db = getattr(self, "_session_db", None)
         if session_db is None:
             return
         try:
             session_db.update_session_model(session_id, restore_model.strip())
+            if isinstance(restore_prompt, str) and restore_prompt:
+                session_db.update_system_prompt(session_id, restore_prompt)
         except Exception:
             logger.debug(
-                "Could not restore router session model after ephemeral route",
+                "Could not restore router session state after ephemeral route",
                 exc_info=True,
             )
 
@@ -16368,6 +16392,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 agent._last_flushed_db_idx = 0
         agent._api_call_count = 0
 
+    def _cache_agent_for_turn(
+        self,
+        session_key: str,
+        agent: Any,
+        signature: tuple,
+        message_count: Optional[int],
+        *,
+        router_ephemeral: bool,
+    ) -> None:
+        """Cache reusable agents, never a one-turn routing override."""
+        if router_ephemeral:
+            return
+        lock = getattr(self, "_agent_cache_lock", None)
+        cache = getattr(self, "_agent_cache", None)
+        if lock is None or cache is None:
+            return
+        with lock:
+            cache[session_key] = (
+                agent,
+                signature,
+                message_count,
+                getattr(agent, "session_id", None),
+            )
+            self._enforce_agent_cache_cap()
+
     def _commit_memory_before_soft_evict(self, agent: Any, key: str) -> None:
         """Fire on_session_end extraction before soft-evicting a live agent.
 
@@ -18187,6 +18236,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 runtime_kwargs,
                 pinned_model=_pinned_router_model,
             )
+            self._capture_ephemeral_router_system_prompt(session_id, turn_route)
 
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool
@@ -18222,7 +18272,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     pass
 
             _xproc_evicted_agent = None
-            if _cache_lock and _cache is not None:
+            if not turn_route.get("router_ephemeral") and _cache_lock and _cache is not None:
                 with _cache_lock:
                     cached = _cache.get(session_key)
                     if cached and cached[1] == _sig:
@@ -18358,17 +18408,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # Reload from disk — do not reuse the startup snapshot (#60955).
                     fallback_model=self._refresh_fallback_model(),
                 )
-                if _cache_lock and _cache is not None:
-                    with _cache_lock:
-                        # Record the session_id the snapshot was taken for
-                        # alongside the message_count, so the cross-process
-                        # guard can skip the (meaningless) count comparison
-                        # when the active session_id later switches under
-                        # the same session_key (#54947).
-                        _cache[session_key] = (
-                            agent, _sig, _current_msg_count, session_id,
-                        )
-                        self._enforce_agent_cache_cap()
+                self._cache_agent_for_turn(
+                    session_key,
+                    agent,
+                    _sig,
+                    _current_msg_count,
+                    router_ephemeral=turn_route.get("router_ephemeral", False),
+                )
                 logger.debug("Created new agent for session %s (sig=%s)", session_key, _sig)
 
             # Per-message state — callbacks and reasoning config change every
@@ -18957,6 +19003,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     self._restore_ephemeral_router_session_model(
                         _ephemeral_session_id, turn_route
                     )
+                    if turn_route.get("router_ephemeral"):
+                        self._release_evicted_agent_soft(_ephemeral_agent)
                 except Exception:
                     logger.debug(
                         "Could not restore ephemeral router session after run failure",

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -180,7 +180,10 @@ class CLIAgentSetupMixin:
         API call is marked accordingly.
         """
         from hermes_cli.models import resolve_fast_mode_overrides
-        from hermes_cli.model_router import select_model_for_session_turn
+        from hermes_cli.model_router import (
+            explicit_model_router_tier,
+            select_model_for_session_turn,
+        )
 
         pinned_model = None
         active_signature = getattr(self, "_active_agent_route_signature", None)
@@ -194,6 +197,7 @@ class CLIAgentSetupMixin:
             except Exception:
                 pass
 
+        explicit_router_tier = explicit_model_router_tier(user_message)
         effective_model, router_tier = select_model_for_session_turn(
             user_message, self.model, pinned_model=pinned_model
         )
@@ -209,6 +213,8 @@ class CLIAgentSetupMixin:
         route = {
             "model": effective_model,
             "router_tier": router_tier,
+            "router_ephemeral": explicit_router_tier is not None,
+            "router_restore_model": pinned_model or self.model,
             "runtime": runtime,
             "signature": (
                 effective_model,
@@ -232,7 +238,75 @@ class CLIAgentSetupMixin:
         route["request_overrides"] = overrides
         return route
 
-    def _init_agent(self, *, model_override: str = None, runtime_override: dict = None, request_overrides: dict | None = None) -> bool:
+    def _set_active_agent_route_signature(
+        self,
+        effective_model: str,
+        runtime: dict,
+        *,
+        router_ephemeral: bool = False,
+    ) -> None:
+        """Persist the reusable route identity, excluding one-turn directives."""
+        if router_ephemeral:
+            self._active_agent_route_signature = None
+            return
+        self._active_agent_route_signature = (
+            effective_model,
+            runtime.get("provider"),
+            runtime.get("base_url"),
+            runtime.get("api_mode"),
+            runtime.get("command"),
+            tuple(runtime.get("args") or ()),
+        )
+
+    def _restore_ephemeral_router_session_model(
+        self, *, router_ephemeral: bool, restore_model: str | None
+    ) -> None:
+        """Keep a one-turn directive out of the durable CLI session pin."""
+        from cli import logger
+
+        if not router_ephemeral or not isinstance(restore_model, str) or not restore_model.strip():
+            return
+        session_db = getattr(self, "_session_db", None)
+        session_id = getattr(getattr(self, "agent", None), "session_id", None) or getattr(
+            self, "session_id", None
+        )
+        if session_db is None or not session_id:
+            return
+        try:
+            session_db.update_session_model(session_id, restore_model.strip())
+        except Exception:
+            logger.debug(
+                "Could not restore CLI router session model after ephemeral route",
+                exc_info=True,
+            )
+
+    def _set_explicit_session_model_pin(self, model: str, runtime: dict) -> None:
+        """Make a deliberate `/model` selection beat any router-derived pin."""
+        self._set_active_agent_route_signature(model, runtime)
+        session_db = getattr(self, "_session_db", None)
+        # Compression can rotate the active agent's backing SessionDB row. Use
+        # that current row when present so the next ordinary turn restores the
+        # deliberate CLI selection rather than an older router-derived pin.
+        session_id = getattr(getattr(self, "agent", None), "session_id", None) or getattr(
+            self, "session_id", None
+        )
+        if session_db is None or not session_id:
+            return
+        try:
+            session_db.update_session_model(session_id, model)
+        except Exception:
+            from cli import logger
+
+            logger.debug("Could not persist explicit CLI model selection", exc_info=True)
+
+    def _init_agent(
+        self,
+        *,
+        model_override: str = None,
+        runtime_override: dict = None,
+        request_overrides: dict | None = None,
+        router_ephemeral: bool = False,
+    ) -> bool:
         """
         Initialize the agent on first use.
         When resuming a session, restores conversation history from SQLite.
@@ -432,13 +506,14 @@ class CLIAgentSetupMixin:
                 seed_credits_at_session_start(self.agent)
             except Exception:
                 pass
-            self._active_agent_route_signature = (
+            # A copyable route directive is one-turn only. Keep the selected
+            # agent through this response, then force the next ordinary turn to
+            # rebuild from the durable session pin instead of inheriting this
+            # temporary model as its session route.
+            self._set_active_agent_route_signature(
                 effective_model,
-                runtime.get("provider"),
-                runtime.get("base_url"),
-                runtime.get("api_mode"),
-                runtime.get("command"),
-                tuple(runtime.get("args") or ()),
+                runtime,
+                router_ephemeral=router_ephemeral,
             )
 
             # Force-create DB row on /title intent, then apply title.

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -180,9 +180,23 @@ class CLIAgentSetupMixin:
         API call is marked accordingly.
         """
         from hermes_cli.models import resolve_fast_mode_overrides
-        from hermes_cli.model_router import select_model_for_turn
+        from hermes_cli.model_router import select_model_for_session_turn
 
-        effective_model, router_tier = select_model_for_turn(user_message, self.model)
+        pinned_model = None
+        active_signature = getattr(self, "_active_agent_route_signature", None)
+        if isinstance(active_signature, tuple) and active_signature:
+            pinned_model = active_signature[0]
+        elif getattr(self, "_session_db", None) is not None:
+            try:
+                session = self._session_db.get_session(self.session_id)
+                if session and int(session.get("message_count") or 0) > 0:
+                    pinned_model = session.get("model")
+            except Exception:
+                pass
+
+        effective_model, router_tier = select_model_for_session_turn(
+            user_message, self.model, pinned_model=pinned_model
+        )
         runtime = {
             "api_key": self.api_key,
             "base_url": self.base_url,

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -186,10 +186,13 @@ class CLIAgentSetupMixin:
         )
 
         pinned_model = None
+        explicit_pin = getattr(self, "_explicit_session_model_pin", None)
+        if isinstance(explicit_pin, str) and explicit_pin.strip():
+            pinned_model = explicit_pin.strip()
         active_signature = getattr(self, "_active_agent_route_signature", None)
-        if isinstance(active_signature, tuple) and active_signature:
+        if pinned_model is None and isinstance(active_signature, tuple) and active_signature:
             pinned_model = active_signature[0]
-        elif getattr(self, "_session_db", None) is not None:
+        elif pinned_model is None and getattr(self, "_session_db", None) is not None:
             try:
                 session = self._session_db.get_session(self.session_id)
                 if session and int(session.get("message_count") or 0) > 0:
@@ -258,30 +261,88 @@ class CLIAgentSetupMixin:
             tuple(runtime.get("args") or ()),
         )
 
+    def _release_agent_clients(self, agent: object) -> None:
+        """Release a discarded agent without ending its session tool state."""
+        if agent is None:
+            return
+        try:
+            release_clients = getattr(agent, "release_clients", None)
+            if callable(release_clients):
+                release_clients()
+        except Exception:
+            pass
+
+    def _capture_ephemeral_router_state(self, *, router_ephemeral: bool) -> None:
+        """Snapshot the durable CLI agent/prompt before a one-turn route override."""
+        self._ephemeral_router_state = None
+        self._last_ephemeral_router_session_id = None
+        if not router_ephemeral:
+            return
+
+        agent = getattr(self, "agent", None)
+        session_db = getattr(self, "_session_db", None)
+        session_id = getattr(agent, "session_id", None) or getattr(self, "session_id", None)
+        prompt = getattr(agent, "_cached_system_prompt", None)
+        if not prompt and session_db is not None and session_id:
+            try:
+                row = session_db.get_session(session_id)
+                candidate = row.get("system_prompt") if row else None
+                prompt = candidate if isinstance(candidate, str) and candidate else None
+            except Exception:
+                prompt = None
+
+        self._ephemeral_router_state = {
+            "agent": agent,
+            "signature": getattr(self, "_active_agent_route_signature", None),
+            "session_id": session_id,
+            "system_prompt": prompt,
+        }
+
     def _restore_ephemeral_router_session_model(
         self, *, router_ephemeral: bool, restore_model: str | None
     ) -> None:
-        """Keep a one-turn directive out of the durable CLI session pin."""
+        """Restore the durable CLI model, prompt, and reusable agent after a directive."""
         from cli import logger
 
         if not router_ephemeral or not isinstance(restore_model, str) or not restore_model.strip():
             return
+
+        state = getattr(self, "_ephemeral_router_state", None)
+        self._ephemeral_router_state = None
+        temporary_agent = getattr(self, "agent", None)
         session_db = getattr(self, "_session_db", None)
-        session_id = getattr(getattr(self, "agent", None), "session_id", None) or getattr(
-            self, "session_id", None
-        )
-        if session_db is None or not session_id:
-            return
-        try:
-            session_db.update_session_model(session_id, restore_model.strip())
-        except Exception:
-            logger.debug(
-                "Could not restore CLI router session model after ephemeral route",
-                exc_info=True,
-            )
+        session_id = getattr(temporary_agent, "session_id", None) or getattr(self, "session_id", None)
+        self._last_ephemeral_router_session_id = session_id
+        durable_prompt = state.get("system_prompt") if isinstance(state, dict) else None
+        if session_db is not None and session_id:
+            try:
+                session_db.update_session_model(session_id, restore_model.strip())
+                if isinstance(durable_prompt, str) and durable_prompt:
+                    session_db.update_system_prompt(session_id, durable_prompt)
+            except Exception:
+                logger.debug(
+                    "Could not restore CLI router session state after ephemeral route",
+                    exc_info=True,
+                )
+
+        durable_agent = state.get("agent") if isinstance(state, dict) else None
+        durable_session_id = state.get("session_id") if isinstance(state, dict) else None
+        durable_signature = state.get("signature") if isinstance(state, dict) else None
+        if durable_agent is not None and durable_session_id == session_id:
+            self.agent = durable_agent
+            self._active_agent_route_signature = durable_signature
+            if temporary_agent is not durable_agent:
+                CLIAgentSetupMixin._release_agent_clients(self, temporary_agent)
+        else:
+            # Compression or a cold-start directive requires a fresh durable
+            # agent next turn; the temporary agent must still release clients.
+            self.agent = None
+            self._active_agent_route_signature = durable_signature
+            CLIAgentSetupMixin._release_agent_clients(self, temporary_agent)
 
     def _set_explicit_session_model_pin(self, model: str, runtime: dict) -> None:
         """Make a deliberate `/model` selection beat any router-derived pin."""
+        self._explicit_session_model_pin = model
         self._set_active_agent_route_signature(model, runtime)
         session_db = getattr(self, "_session_db", None)
         # Compression can rotate the active agent's backing SessionDB row. Use

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -180,7 +180,9 @@ class CLIAgentSetupMixin:
         API call is marked accordingly.
         """
         from hermes_cli.models import resolve_fast_mode_overrides
+        from hermes_cli.model_router import select_model_for_turn
 
+        effective_model, router_tier = select_model_for_turn(user_message, self.model)
         runtime = {
             "api_key": self.api_key,
             "base_url": self.base_url,
@@ -191,10 +193,11 @@ class CLIAgentSetupMixin:
             "credential_pool": getattr(self, "_credential_pool", None),
         }
         route = {
-            "model": self.model,
+            "model": effective_model,
+            "router_tier": router_tier,
             "runtime": runtime,
             "signature": (
-                self.model,
+                effective_model,
                 runtime["provider"],
                 runtime["base_url"],
                 runtime["api_mode"],

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -975,6 +975,26 @@ def _ensure_hermes_home_managed(home: Path):
 
 DEFAULT_CONFIG = {
     "model": "",
+    "model_router": {
+        "enabled": False,
+        "default": "standard",
+        "routes": {
+            "quick": {
+                "model": "",
+                "description": "Quick questions, reconnaissance, and low-level changes.",
+            },
+            "standard": {
+                "model": "",
+                "description": "Standard implementation and synthesis.",
+            },
+            "complex": {
+                "model": "",
+                "description": "Complex architecture, synthesis, planning, and advisor work.",
+            },
+        },
+        "quick_keywords": [],
+        "complex_keywords": [],
+    },
     "providers": {},
     "fallback_providers": [],
     "credential_pool_strategies": {},
@@ -5203,7 +5223,7 @@ def check_config_version() -> Tuple[int, int]:
 
 # Fields that are valid at root level of config.yaml
 _KNOWN_ROOT_KEYS = {
-    "_config_version", "model", "providers", "fallback_model",
+    "_config_version", "model", "model_router", "providers", "fallback_model",
     "fallback_providers", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "moa", "custom_providers", "context", "memory", "gateway",

--- a/hermes_cli/model_router.py
+++ b/hermes_cli/model_router.py
@@ -133,8 +133,8 @@ def _as_keywords(router_cfg: Mapping[str, Any], key: str, default: tuple[str, ..
     return default
 
 
-def _explicit_tier(text: str) -> Optional[str]:
-    lowered = text.strip().lower()
+def _explicit_tier(value: Any) -> Optional[str]:
+    lowered = _extract_text(value).strip().lower()
     # Copyable overrides:
     #   /sol design this
     #   route:sol design this
@@ -225,6 +225,30 @@ def select_model_for_turn(
     return model, tier
 
 
+def explicit_model_router_tier(
+    user_message: Any, config: Optional[Mapping[str, Any]] = None
+) -> Optional[str]:
+    """Return a valid explicit routing tier, if this turn deliberately requests one.
+
+    Explicit directives are one-turn user actions. They are recognized only
+    while the router is enabled and only when the configured route supplies a
+    model, so callers can distinguish them from ordinary keyword selection.
+    """
+    if config is None:
+        try:
+            from hermes_cli.config import load_config
+
+            config = load_config()
+        except Exception:
+            config = {}
+
+    router_cfg = _router_config(config)
+    if not _truthy(router_cfg.get("enabled")):
+        return None
+    tier = _explicit_tier(user_message)
+    return tier if tier and _route_model(router_cfg, tier) else None
+
+
 def select_model_for_session_turn(
     user_message: Any,
     base_model: str,
@@ -233,8 +257,8 @@ def select_model_for_session_turn(
 ) -> Tuple[str, Optional[str]]:
     """Select a model once, then preserve it for a session's later turns.
 
-    A previous effective session model wins while routing is enabled. Keeping a
-    model stable avoids rebuilding an agent (and its frozen system prompt/tool
+    A prior session pin wins after an explicit one-turn directive and even if
+    routing is later disabled. Keeping a model stable avoids
     schemas) merely because a follow-up message contains a different keyword.
     ``pinned_model`` may be a configured route or an explicit session model;
     in the latter case the tier is intentionally unknown (``None``).
@@ -248,23 +272,31 @@ def select_model_for_session_turn(
             config = {}
 
     router_cfg = _router_config(config)
-    if not _truthy(router_cfg.get("enabled")):
-        return base_model, None
+
+    router_enabled = _truthy(router_cfg.get("enabled"))
 
     # Copyable in-message router directives are deliberate per-turn actions.
-    # They may intentionally rebuild the agent; ordinary keyword classification
-    # below must remain session-pinned for cache stability.
-    explicit_tier = _explicit_tier(user_message)
-    if explicit_tier:
-        explicit_model = _route_model(router_cfg, explicit_tier)
-        if explicit_model:
-            return explicit_model, explicit_tier
+    # When routing is enabled they may intentionally rebuild the agent and must
+    # beat an ordinary session pin. Disabling routing still disables directives
+    # for new turns, matching the existing feature-off contract.
+    if router_enabled:
+        explicit_tier = explicit_model_router_tier(user_message, config)
+        if explicit_tier:
+            return _route_model(router_cfg, explicit_tier), explicit_tier
 
+    # Once a session has an effective model, preserve it even if routing is
+    # later disabled or reconfigured. Existing session context/tool schemas are
+    # model-specific and switching on a follow-up destroys prompt-cache
+    # stability. Disabling the router affects only sessions that have not yet
+    # selected a model.
     if isinstance(pinned_model, str) and pinned_model.strip():
         pinned = pinned_model.strip()
         for tier in ("quick", "standard", "complex"):
             if _route_model(router_cfg, tier) == pinned:
                 return pinned, tier
         return pinned, None
+
+    if not router_enabled:
+        return base_model, None
 
     return select_model_for_turn(user_message, base_model, config)

--- a/hermes_cli/model_router.py
+++ b/hermes_cli/model_router.py
@@ -1,7 +1,8 @@
-"""Lightweight per-turn model routing for Hermes.
+"""Deterministic, session-stable model routing for Hermes.
 
 The router intentionally stays heuristic-only: it does not call an LLM to pick
-an LLM, so quick turns remain cheap and prompt-cache behaviour stays predictable.
+an LLM. It selects a model for a new session, then keeps that session pinned so
+prompt-cache and frozen-system-prompt invariants remain intact.
 """
 
 from __future__ import annotations
@@ -222,3 +223,39 @@ def select_model_for_turn(
     tier = classify_model_router_tier(user_message, router_cfg)
     model = _route_model(router_cfg, tier) or base_model
     return model, tier
+
+
+def select_model_for_session_turn(
+    user_message: Any,
+    base_model: str,
+    pinned_model: Optional[str] = None,
+    config: Optional[Mapping[str, Any]] = None,
+) -> Tuple[str, Optional[str]]:
+    """Select a model once, then preserve it for a session's later turns.
+
+    A previous effective session model wins while routing is enabled. Keeping a
+    model stable avoids rebuilding an agent (and its frozen system prompt/tool
+    schemas) merely because a follow-up message contains a different keyword.
+    ``pinned_model`` may be a configured route or an explicit session model;
+    in the latter case the tier is intentionally unknown (``None``).
+    """
+    if config is None:
+        try:
+            from hermes_cli.config import load_config
+
+            config = load_config()
+        except Exception:
+            config = {}
+
+    router_cfg = _router_config(config)
+    if not _truthy(router_cfg.get("enabled")):
+        return base_model, None
+
+    if isinstance(pinned_model, str) and pinned_model.strip():
+        pinned = pinned_model.strip()
+        for tier in ("quick", "standard", "complex"):
+            if _route_model(router_cfg, tier) == pinned:
+                return pinned, tier
+        return pinned, None
+
+    return select_model_for_turn(user_message, base_model, config)

--- a/hermes_cli/model_router.py
+++ b/hermes_cli/model_router.py
@@ -251,6 +251,15 @@ def select_model_for_session_turn(
     if not _truthy(router_cfg.get("enabled")):
         return base_model, None
 
+    # Copyable in-message router directives are deliberate per-turn actions.
+    # They may intentionally rebuild the agent; ordinary keyword classification
+    # below must remain session-pinned for cache stability.
+    explicit_tier = _explicit_tier(user_message)
+    if explicit_tier:
+        explicit_model = _route_model(router_cfg, explicit_tier)
+        if explicit_model:
+            return explicit_model, explicit_tier
+
     if isinstance(pinned_model, str) and pinned_model.strip():
         pinned = pinned_model.strip()
         for tier in ("quick", "standard", "complex"):

--- a/hermes_cli/model_router.py
+++ b/hermes_cli/model_router.py
@@ -1,0 +1,224 @@
+"""Lightweight per-turn model routing for Hermes.
+
+The router intentionally stays heuristic-only: it does not call an LLM to pick
+an LLM, so quick turns remain cheap and prompt-cache behaviour stays predictable.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping, Optional, Tuple
+
+
+DEFAULT_QUICK_KEYWORDS = (
+    "quick",
+    "quickly",
+    "fast answer",
+    "short answer",
+    "quick response",
+    "recon",
+    "reconnaissance",
+    "scan",
+    "inspect",
+    "look up",
+    "lookup",
+    "find",
+    "read",
+    "summarize",
+    "summarise",
+    "rename",
+    "format",
+    "small change",
+    "tiny change",
+    "low level",
+    "low-level",
+    "simple",
+)
+
+DEFAULT_COMPLEX_KEYWORDS = (
+    "architecture",
+    "architectural",
+    "system design",
+    "design doc",
+    "planning",
+    "plan",
+    "strategy",
+    "roadmap",
+    "advisor",
+    "advise",
+    "tradeoff",
+    "trade-off",
+    "deep dive",
+    "deep research",
+    "complex",
+    "high stakes",
+    "migration plan",
+    "security review",
+    "audit",
+    "final qc",
+    "synthesis",
+    "synthesize",
+)
+
+EXPLICIT_TIER_ALIASES = {
+    "luna": "quick",
+    "quick": "quick",
+    "fast": "quick",
+    "terra": "standard",
+    "standard": "standard",
+    "normal": "standard",
+    "sol": "complex",
+    "complex": "complex",
+    "architect": "complex",
+    "advisor": "complex",
+}
+
+_STANDARD_ACTION_WORDS = (
+    "implement",
+    "build",
+    "fix",
+    "debug",
+    "refactor",
+    "change",
+    "edit",
+    "update",
+    "write",
+    "create",
+    "test",
+    "verify",
+)
+
+
+def _extract_text(value: Any) -> str:
+    """Best-effort text extraction from chat strings or OpenAI content parts."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Mapping):
+        parts: list[str] = []
+        for key in ("text", "content", "message", "prompt"):
+            if key in value:
+                parts.append(_extract_text(value.get(key)))
+        return "\n".join(p for p in parts if p)
+    if isinstance(value, (list, tuple)):
+        return "\n".join(_extract_text(item) for item in value if item is not None)
+    return str(value)
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "on", "enabled"}
+
+
+def _router_config(config: Optional[Mapping[str, Any]]) -> Mapping[str, Any]:
+    if not isinstance(config, Mapping):
+        return {}
+    router = config.get("model_router") or {}
+    return router if isinstance(router, Mapping) else {}
+
+
+def _as_keywords(router_cfg: Mapping[str, Any], key: str, default: tuple[str, ...]) -> tuple[str, ...]:
+    raw = router_cfg.get(key)
+    if isinstance(raw, str):
+        value = raw.strip().lower()
+        return (value,) if value else default
+    if isinstance(raw, (list, tuple)):
+        values = tuple(str(item).lower() for item in raw if str(item).strip())
+        return values or default
+    return default
+
+
+def _explicit_tier(text: str) -> Optional[str]:
+    lowered = text.strip().lower()
+    # Copyable overrides:
+    #   /sol design this
+    #   route:sol design this
+    #   model:luna answer fast
+    match = re.search(r"(?:^|\s)(?:route|model)\s*:\s*(luna|terra|sol|quick|standard|complex|advisor)\b", lowered)
+    if not match:
+        match = re.search(r"^/(luna|terra|sol|quick|standard|complex)\b", lowered)
+    if match:
+        return EXPLICIT_TIER_ALIASES.get(match.group(1))
+    return None
+
+
+def classify_model_router_tier(user_message: Any, router_cfg: Optional[Mapping[str, Any]] = None) -> str:
+    """Classify a user turn into quick, standard, or complex."""
+    cfg = router_cfg if isinstance(router_cfg, Mapping) else {}
+    default_tier = str(cfg.get("default") or "standard").strip().lower()
+    default_tier = EXPLICIT_TIER_ALIASES.get(default_tier, default_tier)
+    if default_tier not in {"quick", "standard", "complex"}:
+        default_tier = "standard"
+
+    text = _extract_text(user_message)
+    lowered = text.lower()
+    stripped = lowered.strip()
+    if not stripped:
+        return default_tier
+
+    explicit = _explicit_tier(stripped)
+    if explicit:
+        return explicit
+
+    complex_keywords = _as_keywords(cfg, "complex_keywords", DEFAULT_COMPLEX_KEYWORDS)
+    quick_keywords = _as_keywords(cfg, "quick_keywords", DEFAULT_QUICK_KEYWORDS)
+
+    if any(keyword and keyword in lowered for keyword in complex_keywords):
+        return "complex"
+
+    has_code_block = "```" in text
+    has_standard_action = any(re.search(rf"\b{re.escape(word)}\b", lowered) for word in _STANDARD_ACTION_WORDS)
+
+    if any(keyword and keyword in lowered for keyword in quick_keywords):
+        # A quick keyword in a long coding task should not demote real work.
+        if len(stripped) < 800 and not has_code_block:
+            return "quick"
+
+    # Short factual questions and one-line lookups belong on the cheap/fast tier.
+    if len(stripped) <= 180 and "?" in stripped and not has_standard_action:
+        return "quick"
+
+    return default_tier
+
+
+def _route_model(router_cfg: Mapping[str, Any], tier: str) -> str:
+    routes = router_cfg.get("routes") or {}
+    if not isinstance(routes, Mapping):
+        return ""
+    entry = routes.get(tier) or routes.get(EXPLICIT_TIER_ALIASES.get(tier, tier))
+    if isinstance(entry, str):
+        return entry.strip()
+    if isinstance(entry, Mapping):
+        return str(entry.get("model") or "").strip()
+    return ""
+
+
+def select_model_for_turn(
+    user_message: Any,
+    base_model: str,
+    config: Optional[Mapping[str, Any]] = None,
+) -> Tuple[str, Optional[str]]:
+    """Return (effective_model, router_tier) for a turn.
+
+    If ``model_router.enabled`` is absent/false or the selected route has no
+    model, the base model is returned and tier is ``None``.
+    """
+    if config is None:
+        try:
+            from hermes_cli.config import load_config
+
+            config = load_config()
+        except Exception:
+            config = {}
+
+    router_cfg = _router_config(config)
+    if not _truthy(router_cfg.get("enabled")):
+        return base_model, None
+
+    tier = classify_model_router_tier(user_message, router_cfg)
+    model = _route_model(router_cfg, tier) or base_model
+    return model, tier

--- a/tests/gateway/test_compression_failure_session_sync.py
+++ b/tests/gateway/test_compression_failure_session_sync.py
@@ -115,7 +115,9 @@ def _runner(session_store):
         {"provider": "openai-codex", "api_mode": "codex_responses", "base_url": "https://chatgpt.com/backend-api/codex", "api_key": "token"},
     )
     runner._resolve_session_reasoning_config = lambda **_kwargs: None
-    runner._resolve_turn_agent_config = lambda message, model, runtime: {"model": model, "runtime": runtime}
+    runner._resolve_turn_agent_config = (
+        lambda message, model, runtime, pinned_model=None: {"model": model, "runtime": runtime}
+    )
     runner._load_service_tier = lambda: None
     runner._agent_config_signature = lambda *_args, **_kwargs: ("sig",)
     runner._extract_cache_busting_config = lambda _config: ()

--- a/tests/hermes_cli/test_apply_model_switch_result_context.py
+++ b/tests/hermes_cli/test_apply_model_switch_result_context.py
@@ -40,7 +40,14 @@ class _StubCLI:
     base_url = ""
     _explicit_base_url = ""
     api_mode = ""
+    acp_command = None
+    acp_args = []
     _pending_model_switch_note = ""
+
+    def _set_explicit_session_model_pin(self, model, runtime):
+        # Display-only tests do not have a SessionDB; retain enough state to
+        # model the session-level pin established by the real CLI mixin.
+        self._active_agent_route_signature = (model, runtime)
 
 
 def _run_display(monkeypatch, result):

--- a/tests/hermes_cli/test_model_router.py
+++ b/tests/hermes_cli/test_model_router.py
@@ -171,3 +171,24 @@ def test_gateway_router_preserves_explicit_model_override():
     assert gateway_run.GatewayRunner._get_explicit_session_model_override(
         runner, "session-1"
     ) == "custom-explicit-model"
+
+
+def test_gateway_router_explicit_override_beats_persisted_route():
+    import gateway.run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._session_db = SimpleNamespace(
+        get_session=lambda session_id: {
+            "id": session_id,
+            "model": "gpt-5.6-luna",
+            "message_count": 2,
+        }
+    )
+    runner._session_model_overrides = {
+        "session-1": {"model": "custom-explicit-model"}
+    }
+
+    assert runner._resolve_session_router_pin("db-session", "session-1") == (
+        "custom-explicit-model",
+        2,
+    )

--- a/tests/hermes_cli/test_model_router.py
+++ b/tests/hermes_cli/test_model_router.py
@@ -159,3 +159,15 @@ def test_gateway_router_does_not_pin_empty_session():
     assert gateway_run.GatewayRunner._get_pinned_session_router_model(
         runner, "session-1"
     ) == (None, 0)
+
+
+def test_gateway_router_preserves_explicit_model_override():
+    import gateway.run as gateway_run
+
+    runner = SimpleNamespace(
+        _session_model_overrides={"session-1": {"model": "custom-explicit-model"}}
+    )
+
+    assert gateway_run.GatewayRunner._get_explicit_session_model_override(
+        runner, "session-1"
+    ) == "custom-explicit-model"

--- a/tests/hermes_cli/test_model_router.py
+++ b/tests/hermes_cli/test_model_router.py
@@ -258,6 +258,74 @@ def test_cli_ephemeral_route_preserves_compressed_child_session_id():
     ]
 
 
+def test_cli_blocked_context_route_restores_durable_agent(monkeypatch):
+    import cli as cli_mod
+    import agent.context_references as context_refs
+    import agent.model_metadata as model_metadata
+
+    calls = []
+    durable = SimpleNamespace(
+        session_id="session-1", _cached_system_prompt="Model: gpt-5.6-terra"
+    )
+    route = {
+        "signature": ("gpt-5.6-sol",),
+        "model": "gpt-5.6-sol",
+        "runtime": {},
+        "router_ephemeral": True,
+        "router_restore_model": "gpt-5.6-terra",
+    }
+    stub = SimpleNamespace(
+        session_id="session-1",
+        agent=durable,
+        _session_db=SimpleNamespace(
+            update_session_model=lambda session_id, model: calls.append(("model", session_id, model)),
+            update_system_prompt=lambda session_id, prompt: calls.append(("prompt", session_id, prompt)),
+        ),
+        model="gpt-5.6-terra",
+        base_url="",
+        api_key="",
+        _active_agent_route_signature=("gpt-5.6-terra",),
+        _secret_capture_callback=lambda *_args: None,
+        _ensure_runtime_credentials=lambda: True,
+        _resolve_turn_agent_config=lambda _message: route,
+        _init_agent=lambda **_kwargs: True,
+    )
+    stub._capture_ephemeral_router_state = (
+        lambda *, router_ephemeral: cli_mod.HermesCLI._capture_ephemeral_router_state(
+            stub, router_ephemeral=router_ephemeral
+        )
+    )
+    stub._restore_ephemeral_router_session_model = (
+        lambda *, router_ephemeral, restore_model: cli_mod.HermesCLI._restore_ephemeral_router_session_model(
+            stub, router_ephemeral=router_ephemeral, restore_model=restore_model
+        )
+    )
+    stub._release_agent_clients = lambda agent: cli_mod.HermesCLI._release_agent_clients(stub, agent)
+
+    monkeypatch.setattr(cli_mod, "set_secret_capture_callback", lambda _callback: None)
+    monkeypatch.setattr(model_metadata, "get_model_context_length", lambda *_args, **_kwargs: 1000)
+    monkeypatch.setattr(
+        context_refs,
+        "preprocess_context_references",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            expanded=False,
+            blocked=True,
+            references=["@file:private"],
+            injected_tokens=0,
+            warnings=["Context injection refused."],
+        ),
+    )
+
+    response = cli_mod.HermesCLI.chat(stub, "route:sol @file:private")
+
+    assert response == "Context injection refused."
+    assert stub.agent is durable
+    assert calls == [
+        ("model", "session-1", "gpt-5.6-terra"),
+        ("prompt", "session-1", "Model: gpt-5.6-terra"),
+    ]
+
+
 def test_cli_explicit_model_switch_replaces_router_pin():
     import cli as cli_mod
 

--- a/tests/hermes_cli/test_model_router.py
+++ b/tests/hermes_cli/test_model_router.py
@@ -127,6 +127,17 @@ def test_session_turn_pins_the_first_effective_model():
     ) == ("gpt-5.6-luna", "quick")
 
 
+def test_session_turn_explicit_directive_overrides_pinned_model():
+    from hermes_cli.model_router import select_model_for_session_turn
+
+    assert select_model_for_session_turn(
+        "route:sol draft an architecture plan",
+        "gpt-5.6-terra",
+        pinned_model="gpt-5.6-luna",
+        config=ROUTER_CONFIG,
+    ) == ("gpt-5.6-sol", "complex")
+
+
 def test_gateway_router_pin_uses_persisted_session_model():
     import gateway.run as gateway_run
 

--- a/tests/hermes_cli/test_model_router.py
+++ b/tests/hermes_cli/test_model_router.py
@@ -1,0 +1,116 @@
+from types import SimpleNamespace
+
+
+ROUTER_CONFIG = {
+    "model_router": {
+        "enabled": True,
+        "default": "standard",
+        "routes": {
+            "quick": {"model": "gpt-5.6-luna"},
+            "standard": {"model": "gpt-5.6-terra"},
+            "complex": {"model": "gpt-5.6-sol"},
+        },
+    }
+}
+
+
+def test_select_model_routes_quick_standard_and_complex():
+    from hermes_cli.model_router import select_model_for_turn
+
+    assert select_model_for_turn("what time is it?", "gpt-5.5", ROUTER_CONFIG) == (
+        "gpt-5.6-luna",
+        "quick",
+    )
+    assert select_model_for_turn("implement the auth route", "gpt-5.5", ROUTER_CONFIG) == (
+        "gpt-5.6-terra",
+        "standard",
+    )
+    assert select_model_for_turn("draft an architectural migration plan", "gpt-5.5", ROUTER_CONFIG) == (
+        "gpt-5.6-sol",
+        "complex",
+    )
+
+
+def test_select_model_supports_explicit_route_overrides():
+    from hermes_cli.model_router import select_model_for_turn
+
+    assert select_model_for_turn("/sol advise on the data model", "gpt-5.5", ROUTER_CONFIG) == (
+        "gpt-5.6-sol",
+        "complex",
+    )
+    assert select_model_for_turn("route:luna summarize this", "gpt-5.5", ROUTER_CONFIG) == (
+        "gpt-5.6-luna",
+        "quick",
+    )
+
+
+def test_select_model_disabled_keeps_base_model():
+    from hermes_cli.model_router import select_model_for_turn
+
+    assert select_model_for_turn(
+        "architect the platform",
+        "gpt-5.5",
+        {"model_router": {"enabled": False}},
+    ) == ("gpt-5.5", None)
+
+
+def test_cli_turn_route_uses_model_router(monkeypatch):
+    import cli as cli_mod
+    import hermes_cli.model_router as model_router
+
+    monkeypatch.setattr(
+        model_router,
+        "select_model_for_turn",
+        lambda message, base_model: ("gpt-5.6-sol", "complex"),
+    )
+    stub = SimpleNamespace(
+        model="gpt-5.6-terra",
+        api_key="primary-key",
+        base_url="https://chatgpt.com/backend-api/codex",
+        provider="openai-codex",
+        api_mode="codex_responses",
+        acp_command=None,
+        acp_args=[],
+        _credential_pool=None,
+        service_tier="",
+    )
+
+    route = cli_mod.HermesCLI._resolve_turn_agent_config(stub, "architect this")
+
+    assert route["model"] == "gpt-5.6-sol"
+    assert route["router_tier"] == "complex"
+    assert route["signature"][0] == "gpt-5.6-sol"
+    assert route["runtime"]["provider"] == "openai-codex"
+
+
+def test_gateway_turn_route_uses_model_router(monkeypatch):
+    import gateway.run as gateway_run
+    import hermes_cli.model_router as model_router
+
+    monkeypatch.setattr(
+        model_router,
+        "select_model_for_turn",
+        lambda message, base_model: ("gpt-5.6-luna", "quick"),
+    )
+    runner = SimpleNamespace(_service_tier="")
+    runtime_kwargs = {
+        "api_key": "***",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "provider": "openai-codex",
+        "api_mode": "codex_responses",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+    }
+
+    route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+        runner,
+        "what is the status?",
+        "gpt-5.6-terra",
+        runtime_kwargs,
+    )
+
+    assert route["model"] == "gpt-5.6-luna"
+    assert route["router_tier"] == "quick"
+    assert route["signature"][0] == "gpt-5.6-luna"
+    assert route["runtime"]["provider"] == "openai-codex"

--- a/tests/hermes_cli/test_model_router.py
+++ b/tests/hermes_cli/test_model_router.py
@@ -167,6 +167,97 @@ def test_cli_restores_session_pin_after_ephemeral_route():
     assert calls == [("session-1", "gpt-5.6-terra")]
 
 
+def test_cli_ephemeral_route_restores_durable_agent_and_system_prompt():
+    import cli as cli_mod
+
+    calls = []
+
+    class SessionDB:
+        def get_session(self, session_id):
+            assert session_id == "session-1"
+            return {"system_prompt": "Model: gpt-5.6-terra"}
+
+        def update_session_model(self, session_id, model):
+            calls.append(("model", session_id, model))
+
+        def update_system_prompt(self, session_id, prompt):
+            calls.append(("prompt", session_id, prompt))
+
+    durable = SimpleNamespace(
+        session_id="session-1", _cached_system_prompt="Model: gpt-5.6-terra"
+    )
+    released = []
+    temporary = SimpleNamespace(
+        session_id="session-1", release_clients=lambda: released.append(True)
+    )
+    signature = ("gpt-5.6-terra", "openai-codex", "", "", None, ())
+    stub = SimpleNamespace(
+        session_id="session-1",
+        agent=durable,
+        _active_agent_route_signature=signature,
+        _session_db=SessionDB(),
+    )
+    stub._release_agent_clients = lambda candidate: cli_mod.HermesCLI._release_agent_clients(
+        stub, candidate
+    )
+
+    cli_mod.HermesCLI._capture_ephemeral_router_state(stub, router_ephemeral=True)
+    stub.agent = temporary
+    stub._active_agent_route_signature = None
+    cli_mod.HermesCLI._restore_ephemeral_router_session_model(
+        stub,
+        router_ephemeral=True,
+        restore_model="gpt-5.6-terra",
+    )
+
+    assert stub.agent is durable
+    assert stub._active_agent_route_signature == signature
+    assert released == [True]
+    assert calls == [
+        ("model", "session-1", "gpt-5.6-terra"),
+        ("prompt", "session-1", "Model: gpt-5.6-terra"),
+    ]
+
+
+def test_cli_ephemeral_route_preserves_compressed_child_session_id():
+    import cli as cli_mod
+
+    calls = []
+
+    class SessionDB:
+        def update_session_model(self, session_id, model):
+            calls.append(("model", session_id, model))
+
+        def update_system_prompt(self, session_id, prompt):
+            calls.append(("prompt", session_id, prompt))
+
+    durable = SimpleNamespace(
+        session_id="parent-session", _cached_system_prompt="Model: gpt-5.6-terra"
+    )
+    temporary = SimpleNamespace(session_id="child-session")
+    stub = SimpleNamespace(
+        session_id="parent-session",
+        agent=durable,
+        _active_agent_route_signature=("gpt-5.6-terra",),
+        _session_db=SessionDB(),
+    )
+
+    cli_mod.HermesCLI._capture_ephemeral_router_state(stub, router_ephemeral=True)
+    stub.agent = temporary
+    cli_mod.HermesCLI._restore_ephemeral_router_session_model(
+        stub,
+        router_ephemeral=True,
+        restore_model="gpt-5.6-terra",
+    )
+
+    assert stub.agent is None
+    assert stub._last_ephemeral_router_session_id == "child-session"
+    assert calls == [
+        ("model", "child-session", "gpt-5.6-terra"),
+        ("prompt", "child-session", "Model: gpt-5.6-terra"),
+    ]
+
+
 def test_cli_explicit_model_switch_replaces_router_pin():
     import cli as cli_mod
 
@@ -195,7 +286,55 @@ def test_cli_explicit_model_switch_replaces_router_pin():
     )
 
     assert stub._active_agent_route_signature[0] == "custom-explicit-model"
+    assert stub._explicit_session_model_pin == "custom-explicit-model"
     assert calls == [("session-1", "custom-explicit-model")]
+
+
+def test_cli_explicit_model_pin_beats_stale_session_route_after_restore_failure(monkeypatch):
+    import cli as cli_mod
+    import hermes_cli.model_router as model_router
+
+    captured = {}
+
+    def select_model(message, base_model, pinned_model=None):
+        captured["pinned_model"] = pinned_model
+        return pinned_model or base_model, "standard"
+
+    monkeypatch.setattr(model_router, "explicit_model_router_tier", lambda message, config=None: None)
+    monkeypatch.setattr(model_router, "select_model_for_session_turn", select_model)
+    stub = SimpleNamespace(
+        model="custom-explicit-model",
+        session_id="session-1",
+        agent=SimpleNamespace(session_id="session-1"),
+        _explicit_session_model_pin="custom-explicit-model",
+        _active_agent_route_signature=None,
+        _session_db=SimpleNamespace(
+            get_session=lambda session_id: {
+                "model": "temporary-route-model", "message_count": 2
+            },
+            update_session_model=lambda session_id, model: (_ for _ in ()).throw(
+                RuntimeError("database unavailable")
+            ),
+        ),
+        api_key="primary-key",
+        base_url="https://chatgpt.com/backend-api/codex",
+        provider="openai-codex",
+        api_mode="codex_responses",
+        acp_command=None,
+        acp_args=[],
+        _credential_pool=None,
+        service_tier="",
+    )
+
+    cli_mod.HermesCLI._restore_ephemeral_router_session_model(
+        stub,
+        router_ephemeral=True,
+        restore_model="custom-explicit-model",
+    )
+    route = cli_mod.HermesCLI._resolve_turn_agent_config(stub, "continue normally")
+
+    assert captured["pinned_model"] == "custom-explicit-model"
+    assert route["model"] == "custom-explicit-model"
 
 
 def test_cli_model_switch_pins_explicit_model_and_discards_failed_agent(monkeypatch):
@@ -374,6 +513,60 @@ def test_gateway_restores_session_pin_after_ephemeral_route():
     )
 
     assert calls == [("session-1", "gpt-5.6-luna")]
+
+
+def test_gateway_ephemeral_route_restores_durable_system_prompt():
+    import gateway.run as gateway_run
+
+    calls = []
+
+    class SessionDB:
+        def get_session(self, session_id):
+            assert session_id == "session-1"
+            return {"system_prompt": "Model: gpt-5.6-terra"}
+
+        def update_session_model(self, session_id, model):
+            calls.append(("model", session_id, model))
+
+        def update_system_prompt(self, session_id, prompt):
+            calls.append(("prompt", session_id, prompt))
+
+    turn_route = {
+        "router_ephemeral": True,
+        "router_restore_model": "gpt-5.6-terra",
+    }
+    runner = SimpleNamespace(_session_db=SessionDB())
+
+    gateway_run.GatewayRunner._capture_ephemeral_router_system_prompt(
+        runner, "session-1", turn_route
+    )
+    gateway_run.GatewayRunner._restore_ephemeral_router_session_model(
+        runner, "session-1", turn_route
+    )
+
+    assert calls == [
+        ("model", "session-1", "gpt-5.6-terra"),
+        ("prompt", "session-1", "Model: gpt-5.6-terra"),
+    ]
+
+
+def test_gateway_does_not_overwrite_durable_cache_for_ephemeral_route():
+    import gateway.run as gateway_run
+
+    durable = object()
+    cache = {"session-key": (durable, ("gpt-5.6-terra",), 2)}
+    runner = SimpleNamespace(_agent_cache=cache, _agent_cache_lock=None)
+
+    gateway_run.GatewayRunner._cache_agent_for_turn(
+        runner,
+        "session-key",
+        object(),
+        ("gpt-5.6-sol",),
+        2,
+        router_ephemeral=True,
+    )
+
+    assert cache["session-key"][0] is durable
 
 
 def test_session_turn_pins_the_first_effective_model():

--- a/tests/hermes_cli/test_model_router.py
+++ b/tests/hermes_cli/test_model_router.py
@@ -60,8 +60,8 @@ def test_cli_turn_route_uses_model_router(monkeypatch):
 
     monkeypatch.setattr(
         model_router,
-        "select_model_for_turn",
-        lambda message, base_model: ("gpt-5.6-sol", "complex"),
+        "select_model_for_session_turn",
+        lambda message, base_model, pinned_model=None: ("gpt-5.6-sol", "complex"),
     )
     stub = SimpleNamespace(
         model="gpt-5.6-terra",
@@ -89,8 +89,8 @@ def test_gateway_turn_route_uses_model_router(monkeypatch):
 
     monkeypatch.setattr(
         model_router,
-        "select_model_for_turn",
-        lambda message, base_model: ("gpt-5.6-luna", "quick"),
+        "select_model_for_session_turn",
+        lambda message, base_model, pinned_model=None: ("gpt-5.6-luna", "quick"),
     )
     runner = SimpleNamespace(_service_tier="")
     runtime_kwargs = {
@@ -114,3 +114,48 @@ def test_gateway_turn_route_uses_model_router(monkeypatch):
     assert route["router_tier"] == "quick"
     assert route["signature"][0] == "gpt-5.6-luna"
     assert route["runtime"]["provider"] == "openai-codex"
+
+
+def test_session_turn_pins_the_first_effective_model():
+    from hermes_cli.model_router import select_model_for_session_turn
+
+    assert select_model_for_session_turn(
+        "draft an architectural migration plan",
+        "gpt-5.6-terra",
+        pinned_model="gpt-5.6-luna",
+        config=ROUTER_CONFIG,
+    ) == ("gpt-5.6-luna", "quick")
+
+
+def test_gateway_router_pin_uses_persisted_session_model():
+    import gateway.run as gateway_run
+
+    runner = SimpleNamespace(
+        _session_db=SimpleNamespace(
+            get_session=lambda session_id: {
+                "id": session_id,
+                "model": "gpt-5.6-luna",
+                "message_count": 2,
+            }
+        )
+    )
+    assert gateway_run.GatewayRunner._get_pinned_session_router_model(
+        runner, "session-1"
+    ) == ("gpt-5.6-luna", 2)
+
+
+def test_gateway_router_does_not_pin_empty_session():
+    import gateway.run as gateway_run
+
+    runner = SimpleNamespace(
+        _session_db=SimpleNamespace(
+            get_session=lambda session_id: {
+                "id": session_id,
+                "model": "gpt-5.6-luna",
+                "message_count": 0,
+            }
+        )
+    )
+    assert gateway_run.GatewayRunner._get_pinned_session_router_model(
+        runner, "session-1"
+    ) == (None, 0)

--- a/tests/hermes_cli/test_model_router.py
+++ b/tests/hermes_cli/test_model_router.py
@@ -54,6 +54,17 @@ def test_select_model_disabled_keeps_base_model():
     ) == ("gpt-5.5", None)
 
 
+def test_session_router_preserves_existing_pin_when_disabled():
+    from hermes_cli.model_router import select_model_for_session_turn
+
+    assert select_model_for_session_turn(
+        "follow up on the implementation",
+        "gpt-5.6-terra",
+        pinned_model="gpt-5.6-luna",
+        config={"model_router": {"enabled": False}},
+    ) == ("gpt-5.6-luna", None)
+
+
 def test_cli_turn_route_uses_model_router(monkeypatch):
     import cli as cli_mod
     import hermes_cli.model_router as model_router
@@ -81,6 +92,204 @@ def test_cli_turn_route_uses_model_router(monkeypatch):
     assert route["router_tier"] == "complex"
     assert route["signature"][0] == "gpt-5.6-sol"
     assert route["runtime"]["provider"] == "openai-codex"
+
+
+def test_cli_marks_explicit_route_as_ephemeral(monkeypatch):
+    import cli as cli_mod
+    import hermes_cli.model_router as model_router
+
+    monkeypatch.setattr(
+        model_router,
+        "select_model_for_session_turn",
+        lambda message, base_model, pinned_model=None: ("gpt-5.6-sol", "complex"),
+    )
+    monkeypatch.setattr(
+        model_router,
+        "explicit_model_router_tier",
+        lambda message, config=None: "complex",
+    )
+    stub = SimpleNamespace(
+        model="gpt-5.6-terra",
+        api_key="primary-key",
+        base_url="https://chatgpt.com/backend-api/codex",
+        provider="openai-codex",
+        api_mode="codex_responses",
+        acp_command=None,
+        acp_args=[],
+        _credential_pool=None,
+        service_tier="",
+    )
+
+    route = cli_mod.HermesCLI._resolve_turn_agent_config(stub, "route:sol audit this")
+
+    assert route["model"] == "gpt-5.6-sol"
+    assert route["router_ephemeral"] is True
+    assert route["router_restore_model"] == "gpt-5.6-terra"
+
+
+def test_cli_ephemeral_route_clears_active_signature():
+    import cli as cli_mod
+
+    stub = SimpleNamespace()
+    cli_mod.HermesCLI._set_active_agent_route_signature(
+        stub,
+        "gpt-5.6-sol",
+        {
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_mode": "codex_responses",
+            "command": None,
+            "args": [],
+        },
+        router_ephemeral=True,
+    )
+
+    assert stub._active_agent_route_signature is None
+
+
+def test_cli_restores_session_pin_after_ephemeral_route():
+    import cli as cli_mod
+
+    calls = []
+    stub = SimpleNamespace(
+        session_id="session-1",
+        agent=SimpleNamespace(session_id="session-1"),
+        _session_db=SimpleNamespace(
+            update_session_model=lambda session_id, model: calls.append((session_id, model))
+        ),
+    )
+    cli_mod.HermesCLI._restore_ephemeral_router_session_model(
+        stub,
+        router_ephemeral=True,
+        restore_model="gpt-5.6-terra",
+    )
+
+    assert calls == [("session-1", "gpt-5.6-terra")]
+
+
+def test_cli_explicit_model_switch_replaces_router_pin():
+    import cli as cli_mod
+
+    calls = []
+    stub = SimpleNamespace(
+        session_id="session-1",
+        _session_db=SimpleNamespace(
+            update_session_model=lambda session_id, model: calls.append((session_id, model))
+        ),
+    )
+    stub._set_active_agent_route_signature = (
+        lambda model, runtime, router_ephemeral=False: cli_mod.HermesCLI._set_active_agent_route_signature(
+            stub, model, runtime, router_ephemeral=router_ephemeral
+        )
+    )
+    runtime = {
+        "provider": "openai-codex",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "api_mode": "codex_responses",
+        "command": None,
+        "args": [],
+    }
+
+    cli_mod.HermesCLI._set_explicit_session_model_pin(
+        stub, "custom-explicit-model", runtime
+    )
+
+    assert stub._active_agent_route_signature[0] == "custom-explicit-model"
+    assert calls == [("session-1", "custom-explicit-model")]
+
+
+def test_cli_model_switch_pins_explicit_model_and_discards_failed_agent(monkeypatch):
+    import cli as cli_mod
+    import hermes_cli.model_switch as model_switch
+
+    monkeypatch.setattr(cli_mod, "_cprint", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        model_switch, "resolve_display_context_length", lambda *args, **kwargs: None
+    )
+    switch_calls = []
+    pin_calls = []
+
+    class FailingAgent:
+        session_id = "agent-session"
+        _config_context_length = None
+
+        def switch_model(self, **kwargs):
+            switch_calls.append(kwargs)
+            raise RuntimeError("in-place swap failed")
+
+    stub = SimpleNamespace(
+        session_id="cli-session",
+        model="gpt-5.6-luna",
+        provider="openai-codex",
+        requested_provider="openai-codex",
+        api_key="existing-key",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_mode="codex_responses",
+        acp_command=None,
+        acp_args=[],
+        agent=FailingAgent(),
+        _session_db=SimpleNamespace(
+            update_session_model=lambda session_id, model: pin_calls.append(
+                (session_id, model)
+            )
+        ),
+    )
+    stub._set_active_agent_route_signature = (
+        lambda model, runtime, router_ephemeral=False: cli_mod.HermesCLI._set_active_agent_route_signature(
+            stub, model, runtime, router_ephemeral=router_ephemeral
+        )
+    )
+    stub._set_explicit_session_model_pin = lambda model, runtime: cli_mod.HermesCLI._set_explicit_session_model_pin(
+        stub, model, runtime
+    )
+    result = SimpleNamespace(
+        success=True,
+        new_model="custom-explicit-model",
+        target_provider="openai-codex",
+        api_key=None,
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_mode="codex_responses",
+        provider_label="OpenAI Codex",
+        model_info=None,
+        warning_message=None,
+        provider_changed=False,
+    )
+
+    cli_mod.HermesCLI._apply_model_switch_result(stub, result, persist_global=False)
+
+    assert switch_calls == [{
+        "new_model": "custom-explicit-model",
+        "new_provider": "openai-codex",
+        "api_key": None,
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "api_mode": "codex_responses",
+    }]
+    assert stub.agent is None
+    assert stub._active_agent_route_signature[0] == "custom-explicit-model"
+    assert pin_calls == [("agent-session", "custom-explicit-model")]
+
+    import hermes_cli.model_router as model_router
+
+    captured = {}
+    monkeypatch.setattr(
+        model_router,
+        "explicit_model_router_tier",
+        lambda message, config=None: "complex",
+    )
+    monkeypatch.setattr(
+        model_router,
+        "select_model_for_session_turn",
+        lambda message, base_model, pinned_model=None: (
+            captured.setdefault("pinned_model", pinned_model) and "gpt-5.6-sol",
+            "complex",
+        ),
+    )
+    next_route = cli_mod.HermesCLI._resolve_turn_agent_config(
+        stub, "route:sol review this"
+    )
+
+    assert captured["pinned_model"] == "custom-explicit-model"
+    assert next_route["router_restore_model"] == "custom-explicit-model"
 
 
 def test_gateway_turn_route_uses_model_router(monkeypatch):
@@ -116,6 +325,57 @@ def test_gateway_turn_route_uses_model_router(monkeypatch):
     assert route["runtime"]["provider"] == "openai-codex"
 
 
+def test_gateway_marks_explicit_route_as_ephemeral(monkeypatch):
+    import gateway.run as gateway_run
+    import hermes_cli.model_router as model_router
+
+    monkeypatch.setattr(
+        model_router,
+        "select_model_for_session_turn",
+        lambda message, base_model, pinned_model=None: ("gpt-5.6-sol", "complex"),
+    )
+    monkeypatch.setattr(
+        model_router,
+        "explicit_model_router_tier",
+        lambda message, config=None: "complex",
+    )
+    runner = SimpleNamespace(_service_tier="")
+    runtime_kwargs = {
+        "api_key": "***", "base_url": "https://chatgpt.com/backend-api/codex",
+        "provider": "openai-codex", "api_mode": "codex_responses",
+        "command": None, "args": [], "credential_pool": None,
+    }
+
+    route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+        runner, "route:sol audit", "gpt-5.6-terra", runtime_kwargs
+    )
+
+    assert route["model"] == "gpt-5.6-sol"
+    assert route["router_ephemeral"] is True
+
+
+def test_gateway_restores_session_pin_after_ephemeral_route():
+    import gateway.run as gateway_run
+
+    calls = []
+    runner = SimpleNamespace(
+        _session_db=SimpleNamespace(
+            update_session_model=lambda session_id, model: calls.append((session_id, model))
+        )
+    )
+
+    gateway_run.GatewayRunner._restore_ephemeral_router_session_model(
+        runner,
+        "session-1",
+        {
+            "router_ephemeral": True,
+            "router_restore_model": "gpt-5.6-luna",
+        },
+    )
+
+    assert calls == [("session-1", "gpt-5.6-luna")]
+
+
 def test_session_turn_pins_the_first_effective_model():
     from hermes_cli.model_router import select_model_for_session_turn
 
@@ -132,6 +392,18 @@ def test_session_turn_explicit_directive_overrides_pinned_model():
 
     assert select_model_for_session_turn(
         "route:sol draft an architecture plan",
+        "gpt-5.6-terra",
+        pinned_model="gpt-5.6-luna",
+        config=ROUTER_CONFIG,
+    ) == ("gpt-5.6-sol", "complex")
+
+
+def test_session_turn_multimodal_explicit_directive_overrides_pinned_model():
+    from hermes_cli.model_router import select_model_for_session_turn
+
+    message = [{"type": "text", "text": "route:sol draft an architecture plan"}]
+    assert select_model_for_session_turn(
+        message,
         "gpt-5.6-terra",
         pinned_model="gpt-5.6-luna",
         config=ROUTER_CONFIG,


### PR DESCRIPTION
## Summary
- preserve explicit CLI `/model` choices across one-turn `route:*` directives
- keep temporary router turns out of durable gateway prompt/agent caches
- restore the durable session prompt/model and release temporary clients on all paths, including early exits

## Validation
- `PYTHONDONTWRITEBYTECODE=1 /Users/madhulekh/.hermes/hermes-agent/venv/bin/python -m pytest -p no:cacheprovider -q tests/hermes_cli/test_model_router.py tests/hermes_cli/test_apply_model_switch_result_context.py tests/gateway/test_agent_cache.py tests/gateway/test_model_switch_persistence.py tests/gateway/test_session_model_reset.py tests/gateway/test_compression_failure_session_sync.py` (122 passed)
- `ruff check cli.py hermes_cli/cli_agent_setup_mixin.py gateway/run.py tests/hermes_cli/test_model_router.py tests/gateway/test_agent_cache.py tests/gateway/test_compression_failure_session_sync.py` (passed)