### PR TITLE
fix(update): resolve venv dir for both venv/ and .venv/ layouts

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6354,7 +6354,7 @@ def _update_via_zip(args):
     if not uv_bin:
         uv_bin = _ensure_uv_for_termux(pip_cmd)
     if uv_bin:
-        uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+        uv_env = {**os.environ, "VIRTUAL_ENV": str((_resolve_project_venv_dir() or PROJECT_ROOT / "venv"))}
         if _is_termux_env(uv_env):
             uv_env.pop("PYTHONPATH", None)
             uv_env.pop("PYTHONHOME", None)
@@ -7132,7 +7132,7 @@ def _recover_from_interrupted_install() -> None:
 
             uv_bin = ensure_uv()
             if uv_bin:
-                uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+                uv_env = {**os.environ, "VIRTUAL_ENV": str((_resolve_project_venv_dir() or PROJECT_ROOT / "venv"))}
                 if _is_termux_env(uv_env):
                     uv_env.pop("PYTHONPATH", None)
                     uv_env.pop("PYTHONHOME", None)
@@ -7215,10 +7215,27 @@ def _is_windows() -> bool:
     return sys.platform == "win32"
 
 
+def _resolve_project_venv_dir() -> Path | None:
+    """Return the project venv directory, checking both ``venv/`` and ``.venv/``.
+
+    ``hermes setup`` and ``hermes update`` historically create ``venv/``, but
+    users who bootstrap with ``uv venv`` or ``python -m venv .venv`` end up with
+    a ``.venv/`` directory. The codebase already recognises both names in some
+    places (e.g. ``_dirs_to_preserve`` lists both), but several hot paths
+    hardcode ``"venv"`` — causing them to silently miss the venv on ``.venv``
+    installs and skip quarantine/concurrent-instance safety checks on Windows.
+    """
+    for name in ("venv", ".venv"):
+        candidate = PROJECT_ROOT / name
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
 def _venv_scripts_dir() -> Path | None:
     """Return the venv Scripts directory if we're running inside the project venv."""
-    venv_dir = PROJECT_ROOT / "venv"
-    if not venv_dir.is_dir():
+    venv_dir = _resolve_project_venv_dir()
+    if not venv_dir:
         return None
     scripts = venv_dir / ("Scripts" if _is_windows() else "bin")
     return scripts if scripts.is_dir() else None
@@ -9911,7 +9928,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         install_group = "all"
 
         if uv_bin:
-            uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+            uv_env = {**os.environ, "VIRTUAL_ENV": str((_resolve_project_venv_dir() or PROJECT_ROOT / "venv"))}
             if _is_termux_env(uv_env):
                 uv_env.pop("PYTHONPATH", None)
                 uv_env.pop("PYTHONHOME", None)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7941,7 +7941,10 @@ def _recover_core_update_marker_locked() -> None:
 
         uv_bin = ensure_uv()
         if uv_bin:
-            uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+            uv_env = {
+                **os.environ,
+                "VIRTUAL_ENV": str(_resolve_project_venv_dir()),
+            }
             if _is_termux_env(uv_env):
                 uv_env.pop("PYTHONPATH", None)
                 uv_env.pop("PYTHONHOME", None)
@@ -8015,6 +8018,21 @@ def _windows_running_hermes_launcher_locked() -> bool:
     return False
 
 
+def _resolve_project_venv_dir() -> Path:
+    """Resolve the venv used by this checkout, with a legacy fallback.
+
+    Prefer ``.venv`` (the development and official Docker layout), then
+    ``venv`` (the standard installer layout). If neither exists, retain the
+    installer's historical ``venv`` creation target.
+    """
+    for name in (".venv", "venv"):
+        candidate = PROJECT_ROOT / name
+        if candidate.is_dir():
+            return candidate
+
+    return PROJECT_ROOT / "venv"
+
+
 def _default_venv_install_target() -> tuple[list[str], dict[str, str] | None]:
     """Return ``(install_cmd_prefix, env)`` for the project venv when possible."""
     try:
@@ -8024,7 +8042,7 @@ def _default_venv_install_target() -> tuple[list[str], dict[str, str] | None]:
     except Exception:
         uv_bin = None
     if uv_bin:
-        env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+        env = {**os.environ, "VIRTUAL_ENV": str(_resolve_project_venv_dir())}
         if _is_termux_env(env):
             env.pop("PYTHONPATH", None)
             env.pop("PYTHONHOME", None)
@@ -8077,7 +8095,7 @@ def _is_windows() -> bool:
 
 def _venv_scripts_dir() -> Path | None:
     """Return the venv Scripts directory if we're running inside the project venv."""
-    venv_dir = PROJECT_ROOT / "venv"
+    venv_dir = _resolve_project_venv_dir()
     if not venv_dir.is_dir():
         return None
     from hermes_constants import venv_bin_dir

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -958,7 +958,10 @@ def _update_via_zip(args):
     if not uv_bin:
         uv_bin = _ensure_uv_for_termux(pip_cmd)
     if uv_bin:
-        uv_env = {**os.environ, "VIRTUAL_ENV": str(_m().PROJECT_ROOT / "venv")}
+        uv_env = {
+            **os.environ,
+            "VIRTUAL_ENV": str(_m()._resolve_project_venv_dir()),
+        }
         if _m()._is_termux_env(uv_env):
             uv_env.pop("PYTHONPATH", None)
             uv_env.pop("PYTHONHOME", None)
@@ -2844,7 +2847,7 @@ def _venv_core_imports_healthy() -> tuple[bool, str]:
     Returns ``(healthy, detail)``. Never raises; unknown states report
     healthy so a probe failure can't force needless reinstalls.
     """
-    venv_dir = _m().PROJECT_ROOT / "venv"
+    venv_dir = _m()._resolve_project_venv_dir()
     venv_python = venv_python_path(venv_dir, windows=_m()._is_windows())
     if not venv_python.exists():
         # No venv interpreter at all. In a dev checkout that's normal (the
@@ -2922,7 +2925,7 @@ def _detect_venv_python_processes(
     except Exception:
         return []
 
-    venv_dir = _m().PROJECT_ROOT / "venv"
+    venv_dir = _m()._resolve_project_venv_dir()
     try:
         venv_prefix = str(venv_dir.resolve()).lower().rstrip(os.sep) + os.sep
     except OSError:
@@ -4187,20 +4190,24 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 # A managed install whose venv is gone entirely (interrupted
                 # repair after the old venv was moved aside) needs the venv
                 # recreated before dependencies can be installed into it.
+                repair_venv = _m()._resolve_project_venv_dir()
                 venv_python_missing = not (
                     venv_python_path(
-                        _m().PROJECT_ROOT / "venv", windows=_m()._is_windows()
+                        repair_venv, windows=_m()._is_windows()
                     )
                 ).exists()
                 if venv_python_missing and repair_uv:
                     print("→ Recreating virtual environment...")
                     subprocess.run(
-                        [repair_uv, "venv", "venv"],
+                        [repair_uv, "venv", str(repair_venv)],
                         cwd=_m().PROJECT_ROOT,
                         check=False,
                     )
                 if repair_uv:
-                    repair_env = {**os.environ, "VIRTUAL_ENV": str(_m().PROJECT_ROOT / "venv")}
+                    repair_env = {
+                        **os.environ,
+                        "VIRTUAL_ENV": str(repair_venv),
+                    }
                     _m()._install_python_dependencies_with_optional_fallback(
                         [repair_uv, "pip"], env=repair_env, group="all"
                     )
@@ -4386,7 +4393,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
         install_group = "all"
 
         if uv_bin:
-            uv_env = {**os.environ, "VIRTUAL_ENV": str(_m().PROJECT_ROOT / "venv")}
+            uv_env = {
+                **os.environ,
+                "VIRTUAL_ENV": str(_m()._resolve_project_venv_dir()),
+            }
             if _m()._is_termux_env(uv_env):
                 uv_env.pop("PYTHONPATH", None)
                 uv_env.pop("PYTHONHOME", None)

--- a/tests/hermes_cli/test_project_venv_resolution.py
+++ b/tests/hermes_cli/test_project_venv_resolution.py
@@ -1,0 +1,63 @@
+"""Behavior tests for update/recovery venv layout resolution."""
+
+from __future__ import annotations
+
+import subprocess
+
+from hermes_cli import main as cli_main
+from hermes_cli import update_cmd
+
+
+def test_resolve_project_venv_probes_dotvenv_then_venv(tmp_path, monkeypatch):
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", tmp_path)
+    dotvenv = tmp_path / ".venv"
+    legacy = tmp_path / "venv"
+    dotvenv.mkdir()
+    legacy.mkdir()
+
+    assert cli_main._resolve_project_venv_dir() == dotvenv
+
+    dotvenv.rmdir()
+    assert cli_main._resolve_project_venv_dir() == legacy
+
+
+def test_resolve_project_venv_keeps_legacy_creation_target(tmp_path, monkeypatch):
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", tmp_path)
+
+    assert cli_main._resolve_project_venv_dir() == tmp_path / "venv"
+
+
+def test_default_uv_install_targets_dotvenv(tmp_path, monkeypatch):
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", tmp_path)
+    dotvenv = tmp_path / ".venv"
+    dotvenv.mkdir()
+    monkeypatch.setattr("hermes_cli.managed_uv.ensure_uv", lambda: "uv")
+    monkeypatch.setattr(cli_main, "_is_termux_env", lambda *args: False)
+
+    prefix, env = cli_main._default_venv_install_target()
+
+    assert prefix == ["uv", "pip"]
+    assert env is not None
+    assert env["VIRTUAL_ENV"] == str(dotvenv)
+
+
+def test_update_health_probe_uses_dotvenv_python(tmp_path, monkeypatch):
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", tmp_path)
+    bin_dir = "Scripts" if cli_main._is_windows() else "bin"
+    python_name = "python.exe" if cli_main._is_windows() else "python"
+    python = tmp_path / ".venv" / bin_dir / python_name
+    python.parent.mkdir(parents=True)
+    python.write_bytes(b"")
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    # _venv_core_imports_healthy is defined in update_cmd and calls
+    # subprocess.run via update_cmd's module global, so patch it there —
+    # patching cli_main.subprocess has no effect on Linux CI.
+    monkeypatch.setattr(update_cmd.subprocess, "run", fake_run)
+
+    assert cli_main._venv_core_imports_healthy() == (True, "")
+    assert calls[0][0] == str(python)


### PR DESCRIPTION
## Problem

`_venv_scripts_dir()` hardcodes `PROJECT_ROOT / "venv"`, returning `None` for `.venv` installs. This silently disables the Windows quarantine/concurrent-instance safety checks that depend on finding the venv scripts directory.

The codebase already recognises both venv layouts elsewhere (e.g. `_dirs_to_preserve` at line 4775 iterates `("venv", ".venv")`), but 4 hot paths hardcode `"venv"`:
- `_venv_scripts_dir()` at line 7220
- VIRTUAL_ENV env-var at line 6357 (termux pip install)
- VIRTUAL_ENV env-var at line 7135 (ensurepip)
- VIRTUAL_ENV env-var at line 9928 (postinstall)

## Fix

Add `_resolve_project_venv_dir()` helper that checks both `venv/` and `.venv/`. Route `_venv_scripts_dir()` through it. For VIRTUAL_ENV assignments, use `_resolve_project_venv_dir() or PROJECT_ROOT / "venv"` to preserve the fallback behaviour for non-venv installs.

Fixes #49665

## Note

This is a re-submission of #49842 which was closed without merge. Issue #49665 is still open and the bug is still live on `main`.

## Testing

Verified on a production Hermes install at `/home/hani/.hermes/hermes-agent/venv/` (uses `venv/` layout) — existing behaviour preserved. The `.venv/` path is exercised by users who bootstrap with `uv venv` or `python -m venv .venv`.
