### PR TITLE
feat(kanban): add dashboard.use_system_fonts toggle for readability

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -558,6 +558,9 @@
             if (c.default_tenant) setTenantFilter(c.default_tenant);
             if (typeof c.lane_by_profile === "boolean") setLaneByProfile(c.lane_by_profile);
             if (typeof c.include_archived_by_default === "boolean") setIncludeArchived(c.include_archived_by_default);
+            if (c.use_system_fonts && typeof document !== "undefined") {
+              document.body.classList.add("use-system-fonts");
+            }
             setConfigApplied(true);
           }
         })

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -1590,3 +1590,21 @@
 .hermes-kanban-trash-label {
   font-weight: 500;
 }
+
+/* ------------------------------------------------------------------
+ * System-font override (dashboard.use_system_fonts: true)
+ * Replaces stylised/compressed display fonts with clean system fonts
+ * for readability on dashboard surfaces. Applied via body class toggle.
+ * ------------------------------------------------------------------ */
+.use-system-fonts,
+.use-system-fonts .hermes-kanban,
+.use-system-fonts .hermes-kanban * {
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif !important;
+}
+
+.use-system-fonts code,
+.use-system-fonts pre,
+.use-system-fonts .hermes-kanban code,
+.use-system-fonts .hermes-kanban pre {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace !important;
+}

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1708,6 +1708,7 @@ def get_config():
         "lane_by_profile": bool(k_cfg.get("lane_by_profile", True)),
         "include_archived_by_default": bool(k_cfg.get("include_archived_by_default", False)),
         "render_markdown": bool(k_cfg.get("render_markdown", True)),
+        "use_system_fonts": bool(dash_cfg.get("use_system_fonts", False)),
     }
 
 

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1179,6 +1179,7 @@ def test_config_returns_defaults_when_section_missing(client):
     assert data["lane_by_profile"] is True
     assert data["include_archived_by_default"] is False
     assert data["render_markdown"] is True
+    assert data["use_system_fonts"] is False
 
 
 def test_config_reads_dashboard_kanban_section(tmp_path, monkeypatch, client):
@@ -1198,6 +1199,22 @@ def test_config_reads_dashboard_kanban_section(tmp_path, monkeypatch, client):
     assert data["lane_by_profile"] is False
     assert data["include_archived_by_default"] is True
     assert data["render_markdown"] is False
+
+
+def test_config_use_system_fonts_from_dashboard_section(tmp_path, monkeypatch, client):
+    """use_system_fonts lives under dashboard (not dashboard.kanban)."""
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "config.yaml").write_text(
+        "dashboard:\n"
+        "  use_system_fonts: true\n"
+    )
+    r = client.get("/api/plugins/kanban/config")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["use_system_fonts"] is True
+    # Other defaults unchanged
+    assert data["default_tenant"] == ""
+    assert data["render_markdown"] is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary

The dashboard forced highly stylised/compressed display fonts (Mondwest, Collapse, Rules Compressed) throughout, making long reading sessions in the browser hard on the eyes. This adds a single opt-in switch so users can serve clean system fonts on dashboard surfaces while keeping the retro typography available for TUI/shell use.

Changes

- plugins/kanban/dashboard/plugin_api.py: /config now returns `use_system_fonts` (read from config.yaml → dashboard.use_system_fonts, default False).
- plugins/kanban/dashboard/dist/index.js: on config load, toggle `document.body.classList.add("use-system-fonts")` when the flag is set.
- plugins/kanban/dashboard/dist/style.css: .use-system-fonts override that swaps display fonts for system-ui / -apple-system stack, with ui-monospace fallback for code/pre.
- tests/plugins/test_kanban_dashboard_plugin.py: three targeted config tests covering default, dashboard.kanban section, and top-level dashboard.use_system_fonts.

How to Test

pytest tests/plugins/test_kanban_dashboard_plugin.py -q

Manual: add to ~/.hermes/config.yaml

  dashboard:
    use_system_fonts: true

then reload the dashboard and verify headings / UI text use a clean system font.

Checklist

- [x] Tests pass (3/3 targeted)
- [x] Conventional Commits
- [x] Scope locked (kanban dashboard plugin only)
- [x] Cross-platform: none (server-rendered dashboard + browser CSS)
- [x] Profile-safe paths: no hardcoded paths
- [x] .env not used for non-credential settings

Risk & Impact

Low. Feature flag is off by default, the override is injected via a single body class, and existing installations are unaffected.

Type: feature

Closes: #62179
