### PR TITLE
feat(webhook): optional per-route model/provider override

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -764,6 +764,15 @@ class WebhookAdapter(BasePlatformAdapter):
         )
         if profile and isinstance(profile, str):
             source.profile = profile
+        # bvh_route_model_pin: optional per-route model/provider pin rides the
+        # source into the gateway's per-turn model resolution (run.py); the
+        # session /model override still wins. Inert when the route sets none.
+        _route_model = route_config.get("model")
+        if _route_model and isinstance(_route_model, str):
+            source.route_model = _route_model
+        _route_provider = route_config.get("provider")
+        if _route_provider and isinstance(_route_provider, str):
+            source.route_provider = _route_provider
         event = MessageEvent(
             text=prompt,
             message_type=MessageType.TEXT,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3839,6 +3839,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if ch_runtime_model and not ch.model:
                         model = ch_runtime_model
 
+        # bvh_route_model_pin: per-route pin set by the webhook platform on the
+        # source. Applied after channel_overrides; the session /model override
+        # below still wins (documented priority preserved).
+        _route_model = getattr(source, "route_model", None) if source is not None else None
+        _route_provider = getattr(source, "route_provider", None) if source is not None else None
+        if _route_provider:
+            runtime_kwargs = _resolve_runtime_agent_kwargs_for_provider(_route_provider)
+            _rt_model = runtime_kwargs.pop("model", None)
+            if _rt_model and not _route_model:
+                model = _rt_model
+        if _route_model:
+            model = _route_model
+
         if override and resolved_session_key:
             model, runtime_kwargs = self._apply_session_model_override(
                 resolved_session_key, model, runtime_kwargs


### PR DESCRIPTION
## What

A webhook route can now pin the model its agent turns run on, via optional `model:` / `provider:` keys in the route config:

```yaml
webhook:
  extra:
    routes:
      board-wake:
        events: ["board-wake"]
        secret: "..."
        prompt: "..."
        model: gpt-5.3-codex-spark      # optional — pin this route's turns
        provider: openai-codex          # optional — resolve runtime for this provider
```

## How

- `gateway/platforms/webhook.py`: the route's `model`/`provider` are stashed on the event **source** (`source.route_model` / `source.route_provider`) right where `source.profile` already gets set — no MessageEvent schema change.
- `gateway/run.py`: the per-turn model resolution consumes them **after** `channel_overrides` and **before** the session `/model` override apply, so the documented priority ("session /model → channel_overrides → global") is preserved with the route pin slotting between channel and global.
- Routes that set neither key behave exactly as before (the attributes are simply absent).

## Why

High-volume machine-to-machine webhook lanes — in our deployment, inter-agent "board wake" pings that fire dozens of times an hour — don't need the gateway's default (expensive) brain model, but changing the gateway default or fallback chain would degrade human-facing turns too. A per-route pin lets each webhook lane choose its thinking tier independently. We're running this in production across a 3-gateway fleet; happy to adjust naming/placement to maintainer preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)