### PR TITLE
fix(profiles): preserve safe symlinks on archive import

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1963,23 +1963,74 @@ def _normalize_profile_archive_parts(member_name: str) -> List[str]:
     return parts
 
 
+def _normalize_profile_archive_link(
+    member_parts: List[str], link_name: str
+) -> Tuple[str, List[str]]:
+    normalized_name = link_name.replace("\\", "/")
+    posix_path = PurePosixPath(normalized_name)
+    windows_path = PureWindowsPath(link_name)
+
+    if (
+        not normalized_name
+        or posix_path.is_absolute()
+        or windows_path.is_absolute()
+        or windows_path.drive
+        or len(member_parts) < 2
+    ):
+        raise ValueError(f"Unsafe archive link target: {link_name}")
+
+    resolved_parts = list(member_parts[:-1])
+    for part in posix_path.parts:
+        if part in {"", "."}:
+            continue
+        if part == "..":
+            if len(resolved_parts) <= 1:
+                raise ValueError(f"Unsafe archive link target: {link_name}")
+            resolved_parts.pop()
+        else:
+            resolved_parts.append(part)
+
+    if not resolved_parts or resolved_parts[0] != member_parts[0]:
+        raise ValueError(f"Unsafe archive link target: {link_name}")
+    return normalized_name, resolved_parts
+
+
 def _safe_extract_profile_archive(archive: Path, destination: Path) -> None:
-    """Extract a profile archive without allowing path escapes or links."""
+    """Extract regular members and profile-confined relative symlinks."""
     import tarfile
 
     with tarfile.open(archive, "r:gz") as tf:
+        regular_members = []
+        symlink_members = []
+        seen_paths: set[Tuple[str, ...]] = set()
+
         for member in tf.getmembers():
             parts = _normalize_profile_archive_parts(member.name)
+            member_path = tuple(part.casefold() for part in parts)
+            if member_path in seen_paths:
+                raise ValueError(f"Duplicate archive member path: {member.name}")
+            seen_paths.add(member_path)
+
+            if member.issym():
+                link_name, resolved_parts = _normalize_profile_archive_link(
+                    parts, member.linkname
+                )
+                symlink_members.append(
+                    (member, parts, link_name, resolved_parts)
+                )
+                continue
+            if not (member.isdir() or member.isfile()):
+                raise ValueError(
+                    f"Unsupported archive member type: {member.name}"
+                )
+            regular_members.append((member, parts))
+
+        for member, parts in regular_members:
             target = destination.joinpath(*parts)
 
             if member.isdir():
                 target.mkdir(parents=True, exist_ok=True)
                 continue
-
-            if not member.isfile():
-                raise ValueError(
-                    f"Unsupported archive member type: {member.name}"
-                )
 
             target.parent.mkdir(parents=True, exist_ok=True)
             extracted = tf.extractfile(member)
@@ -1993,6 +2044,23 @@ def _safe_extract_profile_archive(archive: Path, destination: Path) -> None:
                 os.chmod(target, member.mode & 0o777)
             except OSError:
                 pass
+
+        for member, parts, link_name, resolved_parts in symlink_members:
+            target = destination.joinpath(*parts)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if os.path.lexists(target):
+                raise ValueError(f"Duplicate archive member path: {member.name}")
+
+            link_target = destination.joinpath(*resolved_parts)
+            try:
+                target.symlink_to(
+                    link_name,
+                    target_is_directory=link_target.is_dir(),
+                )
+            except OSError as exc:
+                raise ValueError(
+                    f"Cannot create archive symlink: {member.name}"
+                ) from exc
 
 
 def _inspect_profile_archive_roots(archive: Path) -> set[str]:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -2220,23 +2220,74 @@ def _normalize_profile_archive_parts(member_name: str) -> List[str]:
     return parts
 
 
+def _normalize_profile_archive_link(
+    member_parts: List[str], link_name: str
+) -> Tuple[str, List[str]]:
+    normalized_name = link_name.replace("\\", "/")
+    posix_path = PurePosixPath(normalized_name)
+    windows_path = PureWindowsPath(link_name)
+
+    if (
+        not normalized_name
+        or posix_path.is_absolute()
+        or windows_path.is_absolute()
+        or windows_path.drive
+        or len(member_parts) < 2
+    ):
+        raise ValueError(f"Unsafe archive link target: {link_name}")
+
+    resolved_parts = list(member_parts[:-1])
+    for part in posix_path.parts:
+        if part in {"", "."}:
+            continue
+        if part == "..":
+            if len(resolved_parts) <= 1:
+                raise ValueError(f"Unsafe archive link target: {link_name}")
+            resolved_parts.pop()
+        else:
+            resolved_parts.append(part)
+
+    if not resolved_parts or resolved_parts[0] != member_parts[0]:
+        raise ValueError(f"Unsafe archive link target: {link_name}")
+    return normalized_name, resolved_parts
+
+
 def _safe_extract_profile_archive(archive: Path, destination: Path) -> None:
-    """Extract a profile archive without allowing path escapes or links."""
+    """Extract regular members and profile-confined relative symlinks."""
     import tarfile
 
     with tarfile.open(archive, "r:gz") as tf:
+        regular_members = []
+        symlink_members = []
+        seen_paths: set[Tuple[str, ...]] = set()
+
         for member in tf.getmembers():
             parts = _normalize_profile_archive_parts(member.name)
+            member_path = tuple(part.casefold() for part in parts)
+            if member_path in seen_paths:
+                raise ValueError(f"Duplicate archive member path: {member.name}")
+            seen_paths.add(member_path)
+
+            if member.issym():
+                link_name, resolved_parts = _normalize_profile_archive_link(
+                    parts, member.linkname
+                )
+                symlink_members.append(
+                    (member, parts, link_name, resolved_parts)
+                )
+                continue
+            if not (member.isdir() or member.isfile()):
+                raise ValueError(
+                    f"Unsupported archive member type: {member.name}"
+                )
+            regular_members.append((member, parts))
+
+        for member, parts in regular_members:
             target = destination.joinpath(*parts)
 
             if member.isdir():
                 target.mkdir(parents=True, exist_ok=True)
                 continue
-
-            if not member.isfile():
-                raise ValueError(
-                    f"Unsupported archive member type: {member.name}"
-                )
 
             target.parent.mkdir(parents=True, exist_ok=True)
             extracted = tf.extractfile(member)
@@ -2250,6 +2301,23 @@ def _safe_extract_profile_archive(archive: Path, destination: Path) -> None:
                 os.chmod(target, member.mode & 0o777)
             except OSError:
                 pass
+
+        for member, parts, link_name, resolved_parts in symlink_members:
+            target = destination.joinpath(*parts)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if os.path.lexists(target):
+                raise ValueError(f"Duplicate archive member path: {member.name}")
+
+            link_target = destination.joinpath(*resolved_parts)
+            try:
+                target.symlink_to(
+                    link_name,
+                    target_is_directory=link_target.is_dir(),
+                )
+            except OSError as exc:
+                raise ValueError(
+                    f"Cannot create archive symlink: {member.name}"
+                ) from exc
 
 
 def _inspect_profile_archive_roots(archive: Path) -> set[str]:

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -1279,6 +1279,128 @@ class TestExportImport:
         assert not absolute_target.exists()
         assert not get_profile_dir("coder").exists()
 
+    def test_import_preserves_safe_relative_symlinks(self, profile_env, tmp_path):
+        if os.name == "nt":
+            probe = tmp_path / "symlink-probe"
+            try:
+                probe.symlink_to("symlink-target")
+            except OSError:
+                pytest.skip("Windows symlink creation requires optional privileges")
+            else:
+                probe.unlink()
+
+        archive_path = tmp_path / "export" / "symlinks.tar.gz"
+        archive_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with tarfile.open(archive_path, "w:gz") as tf:
+            link = tarfile.TarInfo("coder/data/link.txt")
+            link.type = tarfile.SYMTYPE
+            link.linkname = "target.txt"
+            tf.addfile(link)
+
+            dangling = tarfile.TarInfo("coder/data/dangling.txt")
+            dangling.type = tarfile.SYMTYPE
+            dangling.linkname = "missing.txt"
+            tf.addfile(dangling)
+
+            data = b"profile data"
+            target = tarfile.TarInfo("coder/data/target.txt")
+            target.size = len(data)
+            tf.addfile(target, io.BytesIO(data))
+
+        imported = import_profile(str(archive_path), name="coder")
+
+        link_path = imported / "data" / "link.txt"
+        dangling_path = imported / "data" / "dangling.txt"
+        assert link_path.is_symlink()
+        assert link_path.read_bytes() == b"profile data"
+        assert os.readlink(link_path) == "target.txt"
+        assert dangling_path.is_symlink()
+        assert not dangling_path.exists()
+        assert os.readlink(dangling_path) == "missing.txt"
+
+    @pytest.mark.parametrize(
+        "linkname",
+        ["/outside", "C:\\outside", "C:outside", "\\outside"],
+    )
+    def test_import_rejects_unsafe_symlink_target(
+        self, profile_env, tmp_path, linkname
+    ):
+        archive_path = tmp_path / "export" / "unsafe-link.tar.gz"
+        archive_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with tarfile.open(archive_path, "w:gz") as tf:
+            link = tarfile.TarInfo("coder/link")
+            link.type = tarfile.SYMTYPE
+            link.linkname = linkname
+            tf.addfile(link)
+
+        with pytest.raises(ValueError, match="Unsafe archive link target"):
+            import_profile(str(archive_path), name="coder")
+
+        assert not get_profile_dir("coder").exists()
+
+    def test_import_rejects_hardlink_member(self, profile_env, tmp_path):
+        archive_path = tmp_path / "export" / "hardlink.tar.gz"
+        archive_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with tarfile.open(archive_path, "w:gz") as tf:
+            data = b"profile data"
+            target = tarfile.TarInfo("coder/target.txt")
+            target.size = len(data)
+            tf.addfile(target, io.BytesIO(data))
+
+            link = tarfile.TarInfo("coder/link.txt")
+            link.type = tarfile.LNKTYPE
+            link.linkname = "coder/target.txt"
+            tf.addfile(link)
+
+        with pytest.raises(ValueError, match="Unsupported archive member type"):
+            import_profile(str(archive_path), name="coder")
+
+        assert not get_profile_dir("coder").exists()
+
+    @pytest.mark.parametrize(
+        "duplicate_name",
+        ["coder/config.yaml", "coder/Config.yaml"],
+    )
+    def test_import_rejects_duplicate_member_path(
+        self, profile_env, tmp_path, duplicate_name
+    ):
+        archive_path = tmp_path / "export" / "duplicate.tar.gz"
+        archive_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with tarfile.open(archive_path, "w:gz") as tf:
+            for member_name, data in (
+                ("coder/config.yaml", b"first"),
+                (duplicate_name, b"second"),
+            ):
+                member = tarfile.TarInfo(member_name)
+                member.size = len(data)
+                tf.addfile(member, io.BytesIO(data))
+
+        with pytest.raises(ValueError, match="Duplicate archive member path"):
+            import_profile(str(archive_path), name="coder")
+
+        assert not get_profile_dir("coder").exists()
+
+    def test_import_rejects_symlink_target_outside_profile_root(
+        self, profile_env, tmp_path
+    ):
+        archive_path = tmp_path / "export" / "escaping-link.tar.gz"
+        archive_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with tarfile.open(archive_path, "w:gz") as tf:
+            link = tarfile.TarInfo("coder/nested/link")
+            link.type = tarfile.SYMTYPE
+            link.linkname = "../../outside"
+            tf.addfile(link)
+
+        with pytest.raises(ValueError, match="Unsafe archive link target"):
+            import_profile(str(archive_path), name="coder")
+
+        assert not get_profile_dir("coder").exists()
+
     def test_export_nonexistent_raises(self, profile_env, tmp_path):
         with pytest.raises(FileNotFoundError):
             export_profile("nonexistent", str(tmp_path / "out.tar.gz"))

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -1192,6 +1192,39 @@ class TestExportImport:
         assert imported.is_dir()
         assert (imported / "marker.txt").read_text() == "hello"
 
+    def test_export_import_round_trip_preserves_safe_relative_symlink(
+        self, profile_env, tmp_path
+    ):
+        if os.name == "nt":
+            probe = tmp_path / "symlink-probe"
+            try:
+                probe.symlink_to("symlink-target")
+            except OSError:
+                pytest.skip("Windows symlink creation requires optional privileges")
+            else:
+                probe.unlink()
+
+        create_profile("coder", no_alias=True)
+        profile_dir = get_profile_dir("coder")
+        data_dir = profile_dir / "data"
+        data_dir.mkdir()
+        (data_dir / "target.txt").write_text("profile data")
+        (data_dir / "link.txt").symlink_to("target.txt")
+
+        archive_path = tmp_path / "export" / "coder.tar.gz"
+        archive_path.parent.mkdir(parents=True, exist_ok=True)
+        export_profile("coder", str(archive_path))
+
+        import shutil
+
+        shutil.rmtree(profile_dir)
+        imported = import_profile(str(archive_path), name="coder")
+
+        link_path = imported / "data" / "link.txt"
+        assert link_path.is_symlink()
+        assert link_path.read_text() == "profile data"
+        assert os.readlink(link_path) == "target.txt"
+
     def test_import_to_existing_name_raises(self, profile_env, tmp_path):
         create_profile("coder", no_alias=True)
         profile_dir = get_profile_dir("coder")

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -791,6 +791,67 @@ class TestExportImport:
         assert any("valid_link" in n for n in names)
         assert any("valid_target.txt" in n for n in names)
 
+    def test_export_import_round_trip_preserves_safe_relative_symlink(
+        self, profile_env, tmp_path
+    ):
+        create_profile("coder", no_alias=True)
+        profile_dir = get_profile_dir("coder")
+        data_dir = profile_dir / "data"
+        data_dir.mkdir()
+        (data_dir / "target.txt").write_text("profile data")
+        try:
+            (data_dir / "link.txt").symlink_to("target.txt")
+        except OSError:
+            pytest.skip("symlink creation requires optional privileges")
+
+        archive_path = tmp_path / "export" / "coder.tar.gz"
+        archive_path.parent.mkdir(parents=True, exist_ok=True)
+        export_profile("coder", str(archive_path))
+
+        shutil.rmtree(profile_dir)
+        imported = import_profile(str(archive_path), name="coder")
+
+        link_path = imported / "data" / "link.txt"
+        assert link_path.is_symlink()
+        assert link_path.read_text() == "profile data"
+        assert os.readlink(link_path) == "target.txt"
+
+    @pytest.mark.parametrize(
+        "linkname",
+        ["/outside", "C:\\outside", "C:outside", "\\outside", "../../outside"],
+    )
+    def test_import_rejects_unsafe_symlink_target(
+        self, profile_env, tmp_path, linkname
+    ):
+        archive_path = tmp_path / "unsafe-link.tar.gz"
+        with tarfile.open(archive_path, "w:gz") as tf:
+            link = tarfile.TarInfo("coder/nested/link")
+            link.type = tarfile.SYMTYPE
+            link.linkname = linkname
+            tf.addfile(link)
+
+        with pytest.raises(ValueError, match="Unsafe archive link target"):
+            import_profile(str(archive_path), name="coder")
+
+        assert not get_profile_dir("coder").exists()
+
+    def test_import_rejects_hardlink_member(self, profile_env, tmp_path):
+        archive_path = tmp_path / "hardlink.tar.gz"
+        with tarfile.open(archive_path, "w:gz") as tf:
+            target = tarfile.TarInfo("coder/target.txt")
+            target.size = 4
+            tf.addfile(target, io.BytesIO(b"data"))
+
+            link = tarfile.TarInfo("coder/link.txt")
+            link.type = tarfile.LNKTYPE
+            link.linkname = "coder/target.txt"
+            tf.addfile(link)
+
+        with pytest.raises(ValueError, match="Unsupported archive member type"):
+            import_profile(str(archive_path), name="coder")
+
+        assert not get_profile_dir("coder").exists()
+
 
 
 
@@ -1123,5 +1184,4 @@ class TestResolveProfileEnvSpelling:
         # No HERMES_HOME: the platform default root applies (existing contract).
         monkeypatch.delenv("HERMES_HOME", raising=False)
         assert Path(resolve_profile_env("default")) == _get_default_hermes_home()
-
 


### PR DESCRIPTION
## Summary

- preserve profile-confined relative symlinks when importing profile archives
- validate every member and link target before writing, then create symlinks after regular members
- continue rejecting hardlinks, absolute/drive-qualified targets, root escapes, and duplicate or case-colliding member paths

## Problem

`export_profile()` intentionally stages profiles with `symlinks=True`, but `_safe_extract_profile_archive()` rejected every symlink member. A profile archive produced by Hermes could therefore fail to import when it contained a valid relative symlink.

## Security model

Symlink targets are normalized lexically relative to the link parent and must remain under the archive's single profile root. Regular files and directories are extracted first, so archive order cannot turn a later file write into symlink traversal. Hardlinks and other special member types remain unsupported. Duplicate normalized paths, including case-only collisions that alias on Windows, are rejected before extraction.

## Verification

- WSL Ubuntu: `163 passed` for `tests/hermes_cli/test_profiles.py`
- Windows targeted import cases: `8 passed, 1 skipped` (normal symlink creation skipped only when the host lacks the optional privilege)
- `ruff check hermes_cli/profiles.py tests/hermes_cli/test_profiles.py`
- `git diff --check`

Duplicate searches for `profile import symlink`, `profile archive symlink`, and `Unsupported archive member type` found no other open fix PR.

Related context: #58394 established that profile export must preserve symlinks.