### PR TITLE
fix(slack): quiesce socket tasks before close

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -88,8 +88,53 @@ jobs:
           cache-from: ${{ matrix.cache-from }}
           cache-to: ${{ matrix.cache-to }}
 
-      # Write the digest to a file and upload it as an artifact so the
-      # merge job can stitch both per-arch digests into a manifest list.
+      # Install the host-side pytest harness once, then exercise both the local
+      # PR image and (for publish events) the exact pushed platform digest.
+      - name: Install uv (for docker tests)
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
+
+      - name: Set up Python 3.11 (for docker tests)
+        run: uv python install 3.11
+
+      - name: Install Python dependencies (for docker tests)
+        run: |
+          # ``dev`` extra pulls in pytest, pytest-asyncio —
+          # everything tests/docker/ needs.  We deliberately avoid ``all``
+          # here because the docker tests only drive the container via
+          # subprocess and don't import hermes_agent's optional deps.
+          uv sync --locked --python 3.11 --extra dev
+
+      # Run the docker-integration test suite against the freshly-built
+      # image already loaded into the local daemon (`:test`). This is the PR
+      # candidate proof and reuses the one per-architecture build above.
+      - name: Run docker integration tests
+        env:
+          HERMES_TEST_IMAGE: ${{ env.IMAGE_NAME }}:test
+          OPENROUTER_API_KEY: ""
+          OPENAI_API_KEY: ""
+          NOUS_API_KEY: ""
+        run: |
+          scripts/run_tests.sh tests/docker/ --file-timeout 600
+
+      # A successful local tag is not publication evidence. Pull and test the
+      # exact canonical digest emitted by build-push-action before exporting its
+      # digest artifact; the manifest fan-in is therefore impossible unless each
+      # architecture's immutable pushed image passed the real Slack lifecycle.
+      - name: Test exact pushed platform digest
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'release'
+        env:
+          HERMES_TEST_IMAGE: ${{ env.IMAGE_NAME }}@${{ steps.push.outputs.digest }}
+          OPENROUTER_API_KEY: ""
+          OPENAI_API_KEY: ""
+          NOUS_API_KEY: ""
+        run: |
+          set -euo pipefail
+          docker pull "${HERMES_TEST_IMAGE}"
+          scripts/run_tests.sh tests/docker/test_slack_socket_mode_lifecycle.py \
+            --file-timeout 600
+
+      # Export only a platform digest that passed the exact-image lifecycle
+      # test. The merge job consumes these artifacts to assemble the manifest.
       - name: Export digest
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'release'
         run: |
@@ -105,46 +150,6 @@ jobs:
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
-
-      # Run the docker-integration test suite against the freshly-built
-      # image already loaded into the local daemon (`:test`).
-      #
-      # Piggybacking here avoids a second image build: the build step
-      # already loaded the image into the daemon under
-      # `${IMAGE_NAME}:test`, so we just point ``HERMES_TEST_IMAGE`` at
-      # that.  The fixture's ``HERMES_TEST_IMAGE`` branch (see
-      # tests/docker/conftest.py:62-63) short-circuits the rebuild.
-      #
-      # Why this job and not a standalone one: the image is 5GB+; passing
-      # it between jobs via ``docker save``/``upload-artifact`` is slower
-      # than the build itself.  Reusing the existing daemon state is the
-      # cheapest path to coverage on every PR that touches docker code.
-      # ---------------------------------------------------------------------
-      - name: Install uv (for docker tests)
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
-
-      - name: Set up Python 3.11 (for docker tests)
-        run: uv python install 3.11
-
-      - name: Install Python dependencies (for docker tests)
-        run: |
-          # ``dev`` extra pulls in pytest, pytest-asyncio —
-          # everything tests/docker/ needs.  We deliberately avoid ``all``
-          # here because the docker tests only drive the container via
-          # subprocess and don't import hermes_agent's optional deps.
-          uv sync --locked --python 3.11 --extra dev
-
-      - name: Run docker integration tests
-        env:
-          # Skip rebuild; use the image already loaded by the build step.
-          HERMES_TEST_IMAGE: ${{ env.IMAGE_NAME }}:test
-          # Match the policy in tests.yml :: test job — no accidental
-          # real-API calls from inside the harness.
-          OPENROUTER_API_KEY: ""
-          OPENAI_API_KEY: ""
-          NOUS_API_KEY: ""
-        run: |
-          scripts/run_tests.sh tests/docker/ --file-timeout 600
 
   # ---------------------------------------------------------------------------
   # Stitch both per-arch digests into a single tagged multi-arch manifest.

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -62,6 +62,13 @@ except ImportError:  # pragma: no cover - plugin loaded outside package context
 
 logger = logging.getLogger(__name__)
 
+_SOCKET_MODE_TASK_SETTLE_TIMEOUT_S = 5.0
+_SOCKET_MODE_CLIENT_TASK_ATTRS = (
+    "message_processor",
+    "current_session_monitor",
+    "message_receiver",
+)
+
 # ContextVar carrying the user_id of the slash-command invoker.
 # Set in _handle_slash_command, read in send() to match the correct
 # stashed response_url when multiple users issue commands on the same
@@ -501,12 +508,100 @@ class SlackAdapter(BasePlatformAdapter):
         self._socket_mode_task = task
         task.add_done_callback(self._on_socket_mode_task_done)
 
+    async def _quiesce_socket_mode_tasks(
+        self,
+        handler: Any,
+        outer_task: Optional[asyncio.Task],
+    ) -> None:
+        """Cancel and settle Socket Mode task owners before transport close.
+
+        slack-sdk 3.40.1 cancels its aiohttp task slots in ``close()`` but does
+        not await them before closing the shared ``ClientSession``. A reconnect
+        coroutine can therefore resume against that closed session and keep
+        retrying. Quiesce both Bolt's outer ``start_async()`` owner and the
+        feature-detected SDK task slots first. Clearing captured slots also
+        prevents the pinned SDK from cancelling the task currently performing
+        shutdown when lifecycle ownership overlaps during a reconnect race.
+        """
+        current_task = asyncio.current_task()
+        client = getattr(handler, "client", None)
+        seen: set[asyncio.Future[Any]] = set()
+        deadline = (
+            asyncio.get_running_loop().time() + _SOCKET_MODE_TASK_SETTLE_TIMEOUT_S
+        )
+
+        def collect_owned_tasks() -> None:
+            candidates = [outer_task]
+            if client is not None:
+                for attr in _SOCKET_MODE_CLIENT_TASK_ATTRS:
+                    candidate = getattr(client, attr, None)
+                    candidates.append(candidate)
+                    if isinstance(candidate, asyncio.Future):
+                        # Do not let the pinned SDK cancel the current shutdown
+                        # owner when close_async() runs after quiescence.
+                        if getattr(client, attr, None) is candidate:
+                            setattr(client, attr, None)
+
+            for candidate in candidates:
+                if (
+                    isinstance(candidate, asyncio.Future)
+                    and candidate is not current_task
+                ):
+                    seen.add(candidate)
+
+        collect_owned_tasks()
+        for task in seen:
+            if not task.done():
+                task.cancel()
+
+        while True:
+            pending = {task for task in seen if not task.done()}
+            if not pending:
+                if seen:
+                    await asyncio.gather(*seen, return_exceptions=True)
+                return
+
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                logger.warning(
+                    "[Slack] Socket Mode tasks did not settle before transport "
+                    "close (pending=%d)",
+                    len(pending),
+                )
+                return
+
+            done, pending = await asyncio.wait(pending, timeout=remaining)
+            if done:
+                await asyncio.gather(*done, return_exceptions=True)
+
+            # A reconnect coroutine can replace an SDK slot while cancellation
+            # is propagating. Capture and cancel that replacement under the
+            # same bounded deadline rather than allowing a new orphan owner.
+            previous_count = len(seen)
+            collect_owned_tasks()
+            for task in seen:
+                if not task.done():
+                    task.cancel()
+            if pending and len(seen) == previous_count:
+                logger.warning(
+                    "[Slack] Socket Mode tasks did not settle before transport "
+                    "close (pending=%d)",
+                    len(pending),
+                )
+                return
+
     async def _stop_socket_mode_handler(self) -> None:
         """Stop Socket Mode handler and task."""
         handler = self._handler
         task = self._socket_mode_task
         self._handler = None
         self._socket_mode_task = None
+
+        if handler is not None:
+            await self._quiesce_socket_mode_tasks(handler, task)
+        elif task is not None and task is not asyncio.current_task() and not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
 
         if handler is not None:
             try:
@@ -516,17 +611,6 @@ class SlackAdapter(BasePlatformAdapter):
                     "[Slack] Error while closing Socket Mode handler: %s",
                     e,
                     exc_info=True,
-                )
-
-        if task is not None and not task.done():
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
-            except Exception:  # pragma: no cover - defensive logging
-                logger.debug(
-                    "[Slack] Socket Mode task failed while stopping", exc_info=True
                 )
 
     async def _socket_transport_connected(self) -> Optional[bool]:

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -62,6 +62,20 @@ if [ -f "$HOME/.hermes/pytest_live_guard.py" ]; then
   EXTRA_PYTEST_PLUGINS="pytest_live_guard"
 fi
 
+# Docker image tests may target a daemon reached through a TLS context (for
+# example a task-local DinD service) rather than the default Unix socket.
+# Preserve only the connection selectors, and only when the caller explicitly
+# selected a pre-built test image. Certificate contents are never copied into
+# the test environment; DOCKER_CERT_PATH is a path to Docker-managed files.
+DOCKER_ENV=()
+if [ -n "${HERMES_TEST_IMAGE:-}" ]; then
+  for name in DOCKER_HOST DOCKER_TLS_VERIFY DOCKER_CERT_PATH; do
+    if [ -n "${!name:-}" ]; then
+      DOCKER_ENV+=("$name=${!name}")
+    fi
+  done
+fi
+
 
 # ── Run in hermetic env ──────────────────────────────────────────────────────
 # env -i: start with empty environment, opt-in only what we need.
@@ -80,6 +94,8 @@ exec env -i \
   PYTHONHASHSEED=0 \
   PYTHONDONTWRITEBYTECODE=1 \
   ${HERMES_RUN_SLOW_PET_TESTS:+HERMES_RUN_SLOW_PET_TESTS="$HERMES_RUN_SLOW_PET_TESTS"} \
+  ${HERMES_TEST_IMAGE:+HERMES_TEST_IMAGE="$HERMES_TEST_IMAGE"} \
+  "${DOCKER_ENV[@]}" \
   ${EXTRA_PYTHONPATH:+PYTHONPATH="$EXTRA_PYTHONPATH"} \
   ${EXTRA_PYTEST_PLUGINS:+PYTEST_PLUGINS="$EXTRA_PYTEST_PLUGINS"} \
   "$PYTHON" "$SCRIPT_DIR/run_tests_parallel.py" "$@"

--- a/tests/docker/conftest.py
+++ b/tests/docker/conftest.py
@@ -6,7 +6,7 @@ and exercise it via ``docker run``. They skip when Docker is unavailable
 
 Override the image with ``HERMES_TEST_IMAGE`` env var to point at a pre-built
 image (faster local iteration); otherwise the ``built_image`` fixture builds
-the repo's Dockerfile once per session.
+the repo's Dockerfile once per session with the exact checkout SHA baked in.
 
 """
 from __future__ import annotations
@@ -60,8 +60,24 @@ def built_image() -> str:
     repo_root = os.path.abspath(
         os.path.join(os.path.dirname(__file__), "..", ".."),
     )
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert head.returncode == 0, f"git rev-parse HEAD failed: {head.stderr}"
     result = subprocess.run(
-        ["docker", "build", "-t", IMAGE_TAG, repo_root],
+        [
+            "docker",
+            "build",
+            "--build-arg",
+            f"HERMES_GIT_SHA={head.stdout.strip()}",
+            "-t",
+            IMAGE_TAG,
+            repo_root,
+        ],
         capture_output=True, text=True, timeout=1200,
     )
     assert result.returncode == 0, (

--- a/tests/docker/test_dump_build_sha.py
+++ b/tests/docker/test_dump_build_sha.py
@@ -6,12 +6,11 @@ fails inside the published image and ``hermes dump`` used to report
 ``$HERMES_GIT_SHA`` build-arg to ``/opt/hermes/.hermes_build_sha`` and
 ``hermes_cli/build_info.py`` reads it as a fallback.
 
-CI (``.github/workflows/docker.yml``) always sets the build-arg
-to ``${{ github.sha }}``.  Local ``docker build`` (the ``built_image``
-fixture in ``tests/docker/conftest.py``) does NOT — so locally the file
-is absent and ``hermes dump`` correctly falls back to ``(unknown)``.
-
-This test handles both cases:
+CI (``.github/workflows/docker.yml``) sets the build-arg to
+``${{ github.sha }}``. The local ``built_image`` fixture in
+``tests/docker/conftest.py`` likewise bakes the checkout's exact ``HEAD`` so
+all lifecycle and build-identity assertions run against same-head source.
+Images supplied through ``HERMES_TEST_IMAGE`` retain their own baked identity.
 
 * If ``/opt/hermes/.hermes_build_sha`` exists in the image, assert that
   ``hermes dump`` surfaces its content as the version SHA (not

--- a/tests/docker/test_slack_socket_mode_lifecycle.py
+++ b/tests/docker/test_slack_socket_mode_lifecycle.py
@@ -1,0 +1,190 @@
+"""Exact-image Slack Socket Mode lifecycle regression.
+
+The harness executes with the image's own Python, Slack dependencies, and
+``SlackAdapter`` as the non-root ``hermes`` user. No Slack network call occurs.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import textwrap
+
+
+_LIFECYCLE_HARNESS = textwrap.dedent(
+    r"""
+    import asyncio
+    import json
+    import os
+    from importlib.metadata import version
+    from pathlib import Path
+
+    from slack_bolt.app.async_app import AsyncApp
+    from slack_sdk.socket_mode.aiohttp import SocketModeClient
+
+    from gateway.config import PlatformConfig
+    from plugins.platforms.slack import adapter as slack_adapter_module
+    from plugins.platforms.slack.adapter import SlackAdapter
+
+
+    class ControlledSession:
+        def __init__(self, order):
+            self.closed = False
+            self.order = order
+
+        async def close(self):
+            self.closed = True
+            self.order.append("session:closed")
+
+
+    async def owned_task(name, started, cancelling, release, order):
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelling.set()
+            await release.wait()
+            order.append(f"{name}:settled")
+            raise
+
+
+    async def run():
+        assert os.geteuid() != 0
+        assert Path("/opt/hermes/.install_method").read_text(encoding="utf-8").strip() == "docker"
+        assert not os.environ.get("PYTHONPATH")
+        expected_sha = os.environ["HERMES_EXPECTED_BUILD_SHA"]
+        assert Path("/opt/hermes/.hermes_build_sha").read_text(encoding="utf-8").strip() == expected_sha
+        assert version("slack-sdk") == "3.40.1"
+        assert version("slack-bolt") == "1.27.0"
+        assert version("aiohttp") == "3.14.1"
+
+        baseline = {
+            task
+            for task in asyncio.all_tasks()
+            if task is not asyncio.current_task() and not task.done()
+        }
+        order = []
+        handler = slack_adapter_module.AsyncSocketModeHandler(
+            AsyncApp(token="xoxb-image-test-token"),
+            "xapp-image-test-token",
+        )
+        client = handler.client
+        assert isinstance(client, SocketModeClient)
+        client.message_processor.cancel()
+        await asyncio.gather(client.message_processor, return_exceptions=True)
+        await client.aiohttp_client_session.close()
+        session = ControlledSession(order)
+        client.aiohttp_client_session = session
+
+        release = asyncio.Event()
+        started = [asyncio.Event() for _ in range(4)]
+        cancelling = [asyncio.Event() for _ in range(4)]
+        names = (
+            "outer",
+            "message_processor",
+            "current_session_monitor",
+            "message_receiver",
+        )
+        tasks = [
+            asyncio.create_task(
+                owned_task(name, started[index], cancelling[index], release, order)
+            )
+            for index, name in enumerate(names)
+        ]
+        outer, client.message_processor, client.current_session_monitor, client.message_receiver = tasks
+        for event in started:
+            await event.wait()
+
+        adapter = SlackAdapter(
+            PlatformConfig(enabled=True, token="xoxb-image-test-token")
+        )
+        adapter._handler = handler
+        adapter._socket_mode_task = outer
+        stop_task = asyncio.create_task(adapter._stop_socket_mode_handler())
+        for event in cancelling:
+            await asyncio.wait_for(event.wait(), timeout=0.5)
+
+        assert not stop_task.done()
+        assert not session.closed
+        release.set()
+        await asyncio.wait_for(stop_task, timeout=0.5)
+        assert session.closed
+        assert all(task.done() for task in tasks)
+        assert order[-1] == "session:closed"
+        assert adapter._handler is None
+        assert adapter._socket_mode_task is None
+
+        await asyncio.sleep(0)
+        leaked = {
+            task
+            for task in asyncio.all_tasks()
+            if task is not asyncio.current_task()
+            and not task.done()
+            and task not in baseline
+        }
+        assert leaked == set()
+        print(json.dumps({"lifecycle": "pass", "sha": expected_sha}))
+
+
+    asyncio.run(run())
+    """
+)
+
+
+def _repo_head() -> str:
+    root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def test_slack_socket_mode_lifecycle_uses_exact_immutable_image(
+    built_image: str,
+) -> None:
+    expected_sha = _repo_head()
+    inspect = subprocess.run(
+        ["docker", "image", "inspect", built_image],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert inspect.returncode == 0, inspect.stderr
+    image_config = json.loads(inspect.stdout)[0]["Config"]
+    assert image_config["Entrypoint"] == [
+        "/init",
+        "/opt/hermes/docker/main-wrapper.sh",
+    ]
+    env_keys = {entry.split("=", 1)[0] for entry in image_config.get("Env") or []}
+    assert "PYTHONPATH" not in env_keys
+
+    result = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--user",
+            "hermes",
+            "--env",
+            f"HERMES_EXPECTED_BUILD_SHA={expected_sha}",
+            "--entrypoint",
+            "/opt/hermes/.venv/bin/python",
+            built_image,
+            "-c",
+            _LIFECYCLE_HARNESS,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, (
+        f"image lifecycle harness failed ({result.returncode}):\n"
+        f"stdout={result.stdout[-2000:]}\nstderr={result.stderr[-2000:]}"
+    )
+    result_payload = json.loads(result.stdout.strip().splitlines()[-1])
+    assert result_payload == {"lifecycle": "pass", "sha": expected_sha}

--- a/tests/gateway/test_slack_socket_mode_reconnect.py
+++ b/tests/gateway/test_slack_socket_mode_reconnect.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from importlib.metadata import version
+import logging
+import time
+from typing import Any
+
+import pytest
+from slack_bolt.app.async_app import AsyncApp
+from slack_sdk.socket_mode.aiohttp import SocketModeClient
+
+from gateway.config import PlatformConfig
+from plugins.platforms.slack import adapter as slack_adapter_module
+from plugins.platforms.slack.adapter import SlackAdapter
+
+
+class ControlledClientSession:
+    """No-network aiohttp boundary that records transport-close ordering."""
+
+    def __init__(self, order: list[str]) -> None:
+        self.closed = False
+        self.order = order
+
+    async def close(self) -> None:
+        self.closed = True
+        self.order.append("session:closed")
+
+
+class ControlledWebSocket:
+    def __init__(self) -> None:
+        self.closed = False
+        self._receive_forever = asyncio.Event()
+
+    async def close(self) -> None:
+        self.closed = True
+
+    async def ping(self, _payload: bytes) -> None:
+        return None
+
+    async def receive(self) -> None:
+        await self._receive_forever.wait()
+
+
+class RetryingClientSession(ControlledClientSession):
+    """Fail once, then connect without network and record retry timing."""
+
+    def __init__(self, order: list[str]) -> None:
+        super().__init__(order)
+        self.attempt_times: list[float] = []
+        self.websocket = ControlledWebSocket()
+
+    async def ws_connect(self, _wss_uri: str, **_kwargs: Any) -> ControlledWebSocket:
+        self.attempt_times.append(time.monotonic())
+        if len(self.attempt_times) == 1:
+            raise ConnectionError("controlled transient failure")
+        return self.websocket
+
+    async def close(self) -> None:
+        await self.websocket.close()
+        await super().close()
+
+
+async def _cancellation_delayed_task(
+    name: str,
+    started: asyncio.Event,
+    cancelling: asyncio.Event,
+    release_cleanup: asyncio.Event,
+    order: list[str],
+) -> None:
+    started.set()
+    try:
+        await asyncio.Event().wait()
+    except asyncio.CancelledError:
+        cancelling.set()
+        await release_cleanup.wait()
+        order.append(f"{name}:settled")
+        raise
+
+
+async def _cancellation_resistant_task(
+    started: asyncio.Event,
+    cancelling: asyncio.Event,
+    release_cleanup: asyncio.Event,
+) -> None:
+    started.set()
+    while not release_cleanup.is_set():
+        try:
+            await release_cleanup.wait()
+        except asyncio.CancelledError:
+            cancelling.set()
+            continue
+
+
+async def _real_handler_with_controlled_session(
+    order: list[str],
+) -> tuple[Any, SocketModeClient, ControlledClientSession]:
+    handler = slack_adapter_module.AsyncSocketModeHandler(
+        AsyncApp(token="xoxb-test-token"),
+        "xapp-test-token",
+    )
+    client = handler.client
+    assert isinstance(client, SocketModeClient)
+    assert version("slack-sdk") == "3.40.1"
+    assert version("slack-bolt") == "1.27.0"
+
+    client.message_processor.cancel()
+    await asyncio.gather(client.message_processor, return_exceptions=True)
+    await client.aiohttp_client_session.close()
+    session = ControlledClientSession(order)
+    setattr(client, "aiohttp_client_session", session)
+    return handler, client, session
+
+
+async def _wait_for_attempt_count(
+    session: RetryingClientSession,
+    *,
+    expected: int,
+) -> None:
+    while len(session.attempt_times) < expected:
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_adapter_settles_real_sdk_tasks_before_closing_client_session() -> None:
+    """The adapter must quiesce old Socket Mode owners before transport close."""
+
+    order: list[str] = []
+    handler, client, session = await _real_handler_with_controlled_session(order)
+    release_cleanup = asyncio.Event()
+    started = [asyncio.Event() for _ in range(4)]
+    cancelling = [asyncio.Event() for _ in range(4)]
+    tasks = [
+        asyncio.create_task(
+            _cancellation_delayed_task(
+                name,
+                started[index],
+                cancelling[index],
+                release_cleanup,
+                order,
+            )
+        )
+        for index, name in enumerate(
+            ("outer", "message_processor", "current_session_monitor", "message_receiver")
+        )
+    ]
+    outer, client.message_processor, client.current_session_monitor, client.message_receiver = tasks
+    for event in started:
+        await event.wait()
+
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-test-token"))
+    adapter._handler = handler
+    adapter._socket_mode_task = outer
+    stop_task = asyncio.create_task(adapter._stop_socket_mode_handler())
+
+    try:
+        for event in cancelling:
+            await asyncio.wait_for(event.wait(), timeout=0.2)
+
+        assert not stop_task.done()
+        assert session.closed is False
+
+        release_cleanup.set()
+        await asyncio.wait_for(stop_task, timeout=0.2)
+
+        assert session.closed is True
+        assert all(task.done() for task in tasks)
+        assert order[-1] == "session:closed"
+        assert set(order[:-1]) == {
+            "outer:settled",
+            "message_processor:settled",
+            "current_session_monitor:settled",
+            "message_receiver:settled",
+        }
+        assert adapter._handler is None
+        assert adapter._socket_mode_task is None
+    finally:
+        release_cleanup.set()
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        if not session.closed:
+            with contextlib.suppress(Exception):
+                await handler.close_async()
+
+
+@pytest.mark.asyncio
+async def test_adapter_does_not_cancel_or_await_current_shutdown_owner() -> None:
+    order: list[str] = []
+    handler, client, session = await _real_handler_with_controlled_session(order)
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-test-token"))
+    adapter._handler = handler
+    adapter._socket_mode_task = asyncio.current_task()
+    client.current_session_monitor = asyncio.current_task()
+
+    await adapter._stop_socket_mode_handler()
+
+    current = asyncio.current_task()
+    assert current is not None
+    assert not current.cancelled()
+    assert client.current_session_monitor is None
+    assert session.closed is True
+    assert adapter._handler is None
+    assert adapter._socket_mode_task is None
+
+
+@pytest.mark.asyncio
+async def test_adapter_bounds_stubborn_task_cleanup_and_redacts_state_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    order: list[str] = []
+    handler, client, session = await _real_handler_with_controlled_session(order)
+    started = asyncio.Event()
+    cancelling = asyncio.Event()
+    release_cleanup = asyncio.Event()
+    stubborn_task = asyncio.create_task(
+        _cancellation_resistant_task(started, cancelling, release_cleanup)
+    )
+    await started.wait()
+    client.message_receiver = stubborn_task
+
+    adapter = SlackAdapter(
+        PlatformConfig(enabled=True, token="xoxb-secret-must-not-appear")
+    )
+    adapter._handler = handler
+    adapter._socket_mode_task = stubborn_task
+    adapter._proxy_url = "http://proxy-user:proxy-secret@proxy.invalid:8080"
+    handler.client.wss_uri = "wss://socket-mode.invalid/secret-path"
+    monkeypatch.setattr(
+        slack_adapter_module,
+        "_SOCKET_MODE_TASK_SETTLE_TIMEOUT_S",
+        0.01,
+    )
+    caplog.set_level(logging.WARNING, logger=slack_adapter_module.logger.name)
+
+    try:
+        await asyncio.wait_for(adapter._stop_socket_mode_handler(), timeout=0.2)
+        await asyncio.wait_for(cancelling.wait(), timeout=0.2)
+
+        assert session.closed is True
+        warning_text = "\n".join(record.getMessage() for record in caplog.records)
+        assert "did not settle before transport close" in warning_text
+        for secret in (
+            "xoxb-secret-must-not-appear",
+            "secret-path",
+            "proxy-user",
+            "proxy-secret",
+        ):
+            assert secret not in warning_text
+    finally:
+        release_cleanup.set()
+        await asyncio.gather(stubborn_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_live_real_client_retry_keeps_ping_interval_and_stop_is_terminal() -> None:
+    baseline = {
+        task
+        for task in asyncio.all_tasks()
+        if task is not asyncio.current_task() and not task.done()
+    }
+    order: list[str] = []
+    handler, client, replaced_session = await _real_handler_with_controlled_session(order)
+    await replaced_session.close()
+    retrying_session = RetryingClientSession(order)
+    setattr(client, "aiohttp_client_session", retrying_session)
+    client.wss_uri = "wss://socket-mode.invalid/no-network"
+    client.ping_interval = 0.02
+    connect_task = asyncio.create_task(client.connect())
+
+    try:
+        await asyncio.wait_for(
+            _wait_for_attempt_count(retrying_session, expected=2),
+            timeout=0.2,
+        )
+        assert (
+            retrying_session.attempt_times[1] - retrying_session.attempt_times[0]
+            >= client.ping_interval
+        )
+
+        adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-test-token"))
+        adapter._handler = handler
+        adapter._socket_mode_task = connect_task
+        await adapter._stop_socket_mode_handler()
+        await asyncio.sleep(client.ping_interval * 2)
+
+        assert connect_task.done()
+        assert len(retrying_session.attempt_times) == 2
+        assert retrying_session.closed is True
+        assert retrying_session.websocket.closed is True
+        assert replaced_session.closed is True
+    finally:
+        if not connect_task.done():
+            connect_task.cancel()
+        await asyncio.gather(connect_task, return_exceptions=True)
+        if not retrying_session.closed:
+            await retrying_session.close()
+
+    leaked = {
+        task
+        for task in asyncio.all_tasks()
+        if task is not asyncio.current_task()
+        and not task.done()
+        and task not in baseline
+    }
+    assert leaked == set()


### PR DESCRIPTION
## Summary
- cancel and settle Bolt/Slack SDK Socket Mode task owners before closing the shared aiohttp session
- feature-detect the pinned SDK task slots, deduplicate owners, skip the current shutdown task, and bound stubborn cleanup with state-only logging
- add real `SlackAdapter` + `SocketModeClient` lifecycle regressions in source and the official Docker image
- gate each pushed platform digest on the exact-image lifecycle test before manifest fan-in
- preserve `HERMES_TEST_IMAGE` and task-local Docker TLS selectors through the hermetic test wrapper

## Root cause
`SlackAdapter._stop_socket_mode_handler()` closed the handler/client session before cancelling the outer task, while slack-sdk 3.40.1 cancels but does not await its own task slots before closing aiohttp. A reconnect owner could resume against the closed session and retry forever.

## Test plan
- RED on main: real SDK tasks were still cleaning up after the session had closed
- GREEN: focused reconnect suite (4), existing Slack socket/reconnect suite (6)
- Ruff clean; ty introduces no diagnostics (18 existing adapter diagnostics remain)
- exact-SHA official Docker candidate lifecycle (1), build-SHA/immutable install (5), no `PYTHONPATH`, expected entrypoint and pinned versions
- targeted Semgrep: no new findings (2 existing adapter logging-rule findings)
- full suite executed; one unrelated pre-existing Copilot HOME assertion is reproducible on main and this head

No dependency, lockfile, backend, config knob, or runtime activation change.