### PR TITLE
fix(agent): isolate output-cap recovery from compression

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3038,14 +3038,21 @@ def run_conversation(
                 # (``/new``), switch to a larger-context model, or reduce
                 # attachments.  Forced compaction via ``/compress``
                 # (``force=True``) is unaffected — it never reaches this loop.
+                # Parsed output-cap errors are exempt: the input already fits and
+                # recovery only lowers max_tokens — no compaction required.
                 _overflow_reasons = {
                     FailoverReason.long_context_tier,
                     FailoverReason.payload_too_large,
                     FailoverReason.context_overflow,
                 }
+                _is_recoverable_output_cap = (
+                    classified.reason == FailoverReason.context_overflow
+                    and parse_available_output_tokens_from_error(error_msg) is not None
+                )
                 if (
                     classified.reason in _overflow_reasons
                     and not getattr(agent, "compression_enabled", True)
+                    and not _is_recoverable_output_cap
                 ):
                     agent._flush_status_buffer()
                     agent._vprint(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -52,6 +52,7 @@ from agent.model_metadata import (
     estimate_messages_tokens_rough,
     estimate_request_tokens_rough,
     get_context_length_from_provider_error,
+    compute_safe_output_tokens,
     is_output_cap_error,
     parse_available_output_tokens_from_error,
     save_context_length,
@@ -1090,6 +1091,9 @@ def run_conversation(
         max_retries = agent._api_max_retries
         _retry = TurnRetryState()
         max_compression_attempts = 3
+        output_cap_attempts = 0
+        max_output_cap_attempts = 3
+        previous_available_out = None
 
         finish_reason = "stop"
         response = None  # Guard against UnboundLocalError if all retries fail
@@ -3446,25 +3450,43 @@ def run_conversation(
                     available_out = parse_available_output_tokens_from_error(error_msg)
                     if available_out is not None:
                         # Error is purely about the output cap being too large.
-                        # Cap output to the available space and retry without
-                        # touching context_length or triggering compression.
-                        safe_out = max(1, available_out - 64)  # small safety margin
+                        # Rebuild only the request kwargs in the inner retry loop:
+                        # the conversation itself already fits and must not be
+                        # compacted or reprocessed through the outer agent loop.
+                        safe_out = compute_safe_output_tokens(
+                            available_out,
+                            previous_available_out=previous_available_out,
+                        )
                         agent._ephemeral_max_output_tokens = safe_out
+                        previous_available_out = available_out
+                        output_cap_attempts += 1
                         agent._buffer_vprint(
                             f"⚠️  Output cap too large for current prompt — "
                             f"retrying with max_tokens={safe_out:,} "
                             f"(available_tokens={available_out:,}; context_length unchanged at {old_ctx:,})"
                         )
-                        # Still count against compression_attempts so we don't
-                        # loop forever if the error keeps recurring.
-                        compression_attempts += 1
-                        if compression_attempts > max_compression_attempts:
+                        if output_cap_attempts > max_output_cap_attempts:
                             agent._flush_status_buffer()
-                            agent._vprint(f"{agent.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached.", force=True)
-                            agent._vprint(f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
-                            logger.error(f"{agent.log_prefix}Context compression failed after {max_compression_attempts} attempts.")
+                            agent._vprint(
+                                f"{agent.log_prefix}❌ Output token budget recovery failed after "
+                                f"{max_output_cap_attempts} attempts.",
+                                force=True,
+                            )
+                            agent._vprint(
+                                f"{agent.log_prefix}   💡 Lower model.max_tokens or check whether "
+                                "the provider is changing the rendered prompt between retries.",
+                                force=True,
+                            )
+                            logger.error(
+                                "%sOutput token budget recovery failed after %s attempts.",
+                                agent.log_prefix,
+                                max_output_cap_attempts,
+                            )
                             agent._persist_session(messages, conversation_history)
-                            _final_response = f"Context length exceeded: max compression attempts ({max_compression_attempts}) reached."
+                            _final_response = (
+                                "Output token budget recovery failed: max attempts "
+                                f"({max_output_cap_attempts}) reached."
+                            )
                             return {
                                 "final_response": _final_response,
                                 "messages": messages,
@@ -3473,10 +3495,17 @@ def run_conversation(
                                 "error": _final_response,
                                 "partial": True,
                                 "failed": True,
-                                "compression_exhausted": True,
+                                "output_cap_exhausted": True,
                             }
-                        _retry.restart_with_compressed_messages = True
-                        break
+                        # This error class has its own bounded recovery policy.
+                        # It was counted by the generic exception handler before
+                        # classification, so refund that count and let
+                        # output_cap_attempts control the retry budget.
+                        retry_count -= 1
+                        # Keep the same api_messages snapshot. The next inner-loop
+                        # attempt consumes the one-shot cap while avoiding a full
+                        # outer-loop rebuild and its hooks/middleware.
+                        continue
 
                     # The error is output-cap-shaped (about max_tokens being
                     # too large) but the provider's wording didn't let us parse

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1115,6 +1115,32 @@ def get_context_length_from_provider_error(
     return None
 
 
+OUTPUT_CAP_BASE_MARGIN = 128
+
+
+def compute_safe_output_tokens(
+    available_out: int,
+    *,
+    previous_available_out: Optional[int] = None,
+) -> int:
+    """Reserve space for request growth when retrying an output-cap error.
+
+    Providers normally report ``available_out`` from the request they just
+    rejected.  Some OpenAI-compatible servers can report a slightly larger
+    input on the next request even when Hermes preserves the message payload.
+    Keep a base reserve, and grow it when the reported available output shrinks
+    between retries.
+    """
+    margin = OUTPUT_CAP_BASE_MARGIN
+    if (
+        previous_available_out is not None
+        and previous_available_out > available_out
+    ):
+        observed_input_growth = previous_available_out - available_out
+        margin = max(margin, observed_input_growth + OUTPUT_CAP_BASE_MARGIN)
+    return max(1, available_out - margin)
+
+
 def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
     """Detect an "output cap too large" error and return how many output tokens are available.
 

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -1048,3 +1048,92 @@ class TestOverflowWithCompactionDisabled:
         mock_compress.assert_called_once()
         assert result["completed"] is True
         assert result.get("compaction_disabled") is not True
+
+# ---------------------------------------------------------------------------
+# Output-cap recovery (input fits; requested output does not)
+# ---------------------------------------------------------------------------
+
+
+def _make_vllm_output_cap_error(*, context: int, input_tokens: int, max_tokens: int):
+    """Create the vLLM 400 whose available output Hermes can parse."""
+    total = input_tokens + max_tokens
+    err = Exception(
+        f"This model's maximum context length is {context} tokens. However, "
+        f"you requested {max_tokens} output tokens and your prompt contains at least "
+        f"{input_tokens} input tokens, for a total of at least {total} tokens. "
+        "Please reduce the length of the input prompt or the number of requested "
+        "output tokens."
+    )
+    err.status_code = 400
+    return err
+
+
+class TestOutputCapRecovery:
+    def test_retries_inside_inner_loop_without_compression_or_outer_rebuild(self, agent):
+        """A parsed output-cap error keeps messages stable and only lowers output."""
+        context = 131_072
+        initial_input = 65_537
+        agent.max_tokens = 65_536
+        agent.step_callback = MagicMock()
+        payloads = []
+
+        def _provider(**kwargs):
+            payloads.append(kwargs)
+            if len(payloads) == 1:
+                raise _make_vllm_output_cap_error(
+                    context=context,
+                    input_tokens=initial_input,
+                    max_tokens=kwargs["max_tokens"],
+                )
+            return _mock_response(content="Recovered with a smaller output cap")
+
+        agent.client.chat.completions.create.side_effect = _provider
+
+        with (
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert mock_compress.call_count == 0
+        assert len(payloads) == 2
+        assert payloads[0]["max_tokens"] == 65_536
+        # 65,535 available - 128 base reserve.
+        assert payloads[1]["max_tokens"] == 65_407
+        assert payloads[1]["messages"] == payloads[0]["messages"]
+        # An outer-loop restart would invoke the step callback a second time.
+        assert agent.step_callback.call_count == 1
+
+    def test_repeated_output_cap_error_has_its_own_terminal_result(self, agent):
+        """Output-cap exhaustion must not masquerade as failed compression."""
+        context = 131_072
+        agent.max_tokens = 65_536
+        payloads = []
+
+        def _provider(**kwargs):
+            payloads.append(kwargs)
+            input_tokens = 65_537 + (65 * (len(payloads) - 1))
+            raise _make_vllm_output_cap_error(
+                context=context,
+                input_tokens=input_tokens,
+                max_tokens=kwargs["max_tokens"],
+            )
+
+        agent.client.chat.completions.create.side_effect = _provider
+
+        with (
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert mock_compress.call_count == 0
+        assert len(payloads) == 4
+        assert result["output_cap_exhausted"] is True
+        assert "Output token budget recovery failed" in result["final_response"]
+        assert "compression" not in result["final_response"].lower()

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -1137,3 +1137,40 @@ class TestOutputCapRecovery:
         assert result["output_cap_exhausted"] is True
         assert "Output token budget recovery failed" in result["final_response"]
         assert "compression" not in result["final_response"].lower()
+
+    def test_output_cap_retries_when_compaction_disabled(self, agent):
+        """Parsed vLLM output-cap errors must retry even when auto-compaction is off."""
+        agent.compression_enabled = False
+        context = 131_072
+        initial_input = 65_537
+        agent.max_tokens = 65_536
+        payloads = []
+
+        def _provider(**kwargs):
+            payloads.append(kwargs)
+            if len(payloads) == 1:
+                raise _make_vllm_output_cap_error(
+                    context=context,
+                    input_tokens=initial_input,
+                    max_tokens=kwargs["max_tokens"],
+                )
+            return _mock_response(content="Recovered with compaction disabled")
+
+        agent.client.chat.completions.create.side_effect = _provider
+
+        with (
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert result.get("compaction_disabled") is not True
+        mock_compress.assert_not_called()
+        assert len(payloads) == 2
+        assert payloads[0]["max_tokens"] == 65_536
+        # 65,535 available - 128 base reserve.
+        assert payloads[1]["max_tokens"] == 65_407
+        assert payloads[1]["messages"] == payloads[0]["messages"]

--- a/tests/test_ctx_halving_fix.py
+++ b/tests/test_ctx_halving_fix.py
@@ -305,7 +305,10 @@ class TestContextNotHalvedOnOutputCapError:
     def test_output_cap_error_sets_ephemeral_not_context_length(self):
         """On 'max_tokens too large' error, _ephemeral_max_output_tokens is set
         and compressor.context_length is left unchanged."""
-        from agent.model_metadata import parse_available_output_tokens_from_error
+        from agent.model_metadata import (
+            compute_safe_output_tokens,
+            parse_available_output_tokens_from_error,
+        )
 
         error_msg = (
             "max_tokens: 128000 > context_window: 200000 "
@@ -320,11 +323,11 @@ class TestContextNotHalvedOnOutputCapError:
         assert available_out == 20_000, "parser must detect the error"
 
         # The fix: set ephemeral, skip context_length modification
-        agent._ephemeral_max_output_tokens = max(1, available_out - 64)
+        agent._ephemeral_max_output_tokens = compute_safe_output_tokens(available_out)
 
         # context_length must be untouched
         assert agent.context_compressor.context_length == old_ctx
-        assert agent._ephemeral_max_output_tokens == 19_936
+        assert agent._ephemeral_max_output_tokens == 19_872
 
     def test_prompt_too_long_with_explicit_limit_uses_provider_limit(self):
         """Prompt-too-long errors only change context_length when they report a concrete limit."""
@@ -338,25 +341,35 @@ class TestContextNotHalvedOnOutputCapError:
         assert get_context_length_from_provider_error(error_msg, 1_000_000) == 200_000
 
     def test_output_cap_error_safety_margin(self):
-        """The ephemeral value includes a 64-token safety margin below available_out."""
-        from agent.model_metadata import parse_available_output_tokens_from_error
+        """The retry leaves a 128-token reserve below provider-reported room."""
+        from agent.model_metadata import (
+            OUTPUT_CAP_BASE_MARGIN,
+            compute_safe_output_tokens,
+            parse_available_output_tokens_from_error,
+        )
 
         error_msg = (
             "max_tokens: 32768 > context_window: 200000 "
             "- input_tokens: 190000 = available_tokens: 10000"
         )
         available_out = parse_available_output_tokens_from_error(error_msg)
-        safe_out = max(1, available_out - 64)
-        assert safe_out == 9_936
+        safe_out = compute_safe_output_tokens(available_out)
+        assert OUTPUT_CAP_BASE_MARGIN == 128
+        assert safe_out == 9_872
+
+    def test_output_cap_margin_grows_with_observed_input_growth(self):
+        """A provider reporting 65 fewer available tokens reserves that growth."""
+        from agent.model_metadata import compute_safe_output_tokens
+
+        safe_out = compute_safe_output_tokens(
+            9_935,
+            previous_available_out=10_000,
+        )
+        # 65 observed input growth + 128 base reserve.
+        assert safe_out == 9_742
 
     def test_safety_margin_never_goes_below_one(self):
         """When available_out is very small, safe_out must be at least 1."""
-        from agent.model_metadata import parse_available_output_tokens_from_error
+        from agent.model_metadata import compute_safe_output_tokens
 
-        error_msg = (
-            "max_tokens: 10 > context_window: 200000 "
-            "- input_tokens: 199990 = available_tokens: 1"
-        )
-        available_out = parse_available_output_tokens_from_error(error_msg)
-        safe_out = max(1, available_out - 64)
-        assert safe_out == 1
+        assert compute_safe_output_tokens(1) == 1

--- a/tests/test_output_cap_parsing.py
+++ b/tests/test_output_cap_parsing.py
@@ -1,5 +1,6 @@
 import pytest
 from agent.model_metadata import (
+    compute_safe_output_tokens,
     is_output_cap_error,
     parse_available_output_tokens_from_error,
 )
@@ -166,3 +167,26 @@ class TestParseVllmTokenBasedOutputCap:
                "least 140000 input tokens, for a total of at least 141024 "
                "tokens.")
         assert parse_available_output_tokens_from_error(msg) is None
+
+class TestOutputCapRecoveryMargin:
+    """The retry reserve must survive vLLM reporting modest prompt growth."""
+
+    def test_base_margin_survives_65_token_growth(self):
+        context = 131_072
+        first_input = 65_537
+        available = context - first_input
+
+        retry_cap = compute_safe_output_tokens(available)
+
+        assert retry_cap + first_input + 65 < context
+
+    def test_observed_growth_increases_the_next_reserve(self):
+        previous_available = 65_535
+        current_available = previous_available - 65
+
+        retry_cap = compute_safe_output_tokens(
+            current_available,
+            previous_available_out=previous_available,
+        )
+
+        assert retry_cap == current_available - (65 + 128)


### PR DESCRIPTION
## What does this PR do?

Fixes a retry loop for output-cap errors on OpenAI-compatible providers such as local vLLM. This is not a conversation-too-large problem: the prompt fits, but the requested output plus the prompt exceeds the model context window. Previously Hermes used a fixed 64-token reserve, rebuilt the whole outer loop after each failure, and counted those retries as compression attempts. If the provider reported even 65 extra input tokens on the next request, every retry remained just over the limit and eventually reported a misleading compression failure.

The recovery now retries inside the existing API loop with the same message payload, uses an output-cap-specific retry budget and error message, and reserves 128 tokens plus any observed input growth from the prior output-cap error.

## Related Issue

Fixes #61761

Related: #61846 addresses the fixed margin only. This change also keeps output-cap recovery in the inner API retry loop and separates it from compression accounting.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

The output-cap recovery now calculates a safer one-shot output limit through `compute_safe_output_tokens()` rather than subtracting a fixed 64 tokens. It keeps the retry in the inner API loop, so Hermes rebuilds only request kwargs and does not rerun outer-loop hooks, middleware, or compression-related work. Output-cap retries have their own bounded counter and return an output-budget-specific error if they cannot recover, instead of claiming that context compression failed. Regression tests cover the vLLM error format, +65-token input growth, stable outbound messages, no compression, and the new terminal result.

## How to Test

1. Run the targeted regression suite:

   ```bash
   scripts/run_tests.sh tests/test_ctx_halving_fix.py tests/test_output_cap_parsing.py tests/run_agent/test_413_compression.py -q
   ```

   Result: `78 passed`.

   The full `scripts/run_tests.sh` suite was also run. It did not finish green because 7 tests outside this change failed and 3 unrelated test files hit the per-file timeout; this PR's targeted regression suite passes.

2. Reproduce the original failure using the local mock vLLM server and throwaway `repro-outcap` Hermes profile. The mock reports +65 input tokens on each retry.

   Before this change, the fixed 64-token reserve never converged:

   ```text
   Attempt 1: input 134,465, requested max_tokens 65,536, sum 200,001 (over by 1)
   Attempt 2: input 134,530, requested max_tokens 65,471, sum 200,001 (over by 1)
   Attempt 3: input 134,595, requested max_tokens 65,406, sum 200,001 (over by 1)
   Attempt 4: input 134,660, requested max_tokens 65,341, sum 200,001 (over by 1) -> fails
   Context length exceeded: max compression attempts (3) reached.
   ```

   After this change, the same smaller local repro succeeds on its second request:

   ```text
   $ HERMES_HOME="$HOME/.hermes/profiles/repro-outcap" hermes -z "Say hello in one word. Do not use tools." -t ""
   ok (mock accepted request)
   ```

   ```text
   attempt=1 input=32,832 max_tokens=32,768 sum=65,600 context=65,536 over_by=64
   POST /v1/chat/completions -> 400
   attempt=2 input=32,897 max_tokens=32,576 sum=65,473 context=65,536 over_by=-63
   POST /v1/chat/completions -> 200
   ```

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (related #61846 found and referenced above)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (full CI-parity suite was attempted; see test note above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu

### Documentation & Housekeeping

- [x] N/A — no user-facing documentation changes are needed for internal retry recovery.
- [x] N/A — no configuration keys were added or changed.
- [x] N/A — no contributor workflow or documented architecture contract changed.
- [x] N/A — provider-agnostic Python retry logic; no platform-specific behavior changed.
- [x] N/A — no model tool descriptions or schemas changed.

