### PR TITLE
fix(cron): stop inactivity watchdogs from being blind to a wedged API call (#62151)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -415,10 +415,16 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
         # Touch activity every ~30s so the gateway's inactivity
         # monitor knows we're alive while waiting for the response.
+        # progress=False: this is a "still waiting" re-announcement, not
+        # evidence anything happened — it must not reset
+        # seconds_since_progress, or a call wedged before the socket even
+        # opens (e.g. a hung DNS lookup) becomes invisible to cron's
+        # inactivity watchdog (#62151).
         if _poll_count % 100 == 0:  # 100 × 0.3s = 30s
             _elapsed = time.time() - _call_start
             agent._touch_activity(
-                f"waiting for non-streaming response ({int(_elapsed)}s elapsed)"
+                f"waiting for non-streaming response ({int(_elapsed)}s elapsed)",
+                progress=False,
             )
 
         _elapsed = time.time() - _call_start
@@ -2827,8 +2833,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         if _hb_now - _last_heartbeat >= _HEARTBEAT_INTERVAL:
             _last_heartbeat = _hb_now
             _waiting_secs = int(_hb_now - last_chunk_time["t"])
+            # progress=False: "no chunks yet" is not evidence of progress —
+            # see the non-streaming heartbeat above and #62151. The
+            # stale-stream detector below is what actually recovers a dead
+            # connection; this touch must not mask that from cron's watchdog.
             agent._touch_activity(
-                f"waiting for stream response ({_waiting_secs}s, no chunks yet)"
+                f"waiting for stream response ({_waiting_secs}s, no chunks yet)",
+                progress=False,
             )
 
         # Detect stale streams: connections kept alive by SSE pings

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2875,11 +2875,26 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                         result = _cron_future.result()
                         break
                     # Agent still running — check inactivity.
+                    #
+                    # Uses seconds_since_progress, NOT seconds_since_activity:
+                    # interruptible_api_call's own "still waiting" heartbeat
+                    # (chat_completion_helpers.py) refreshes
+                    # seconds_since_activity every ~30s purely because it is
+                    # still polling — including for a call wedged before the
+                    # socket even opens (e.g. a hung DNS lookup), which never
+                    # produces a byte of real progress. Reading that field
+                    # here made this timeout structurally unable to fire for
+                    # exactly the case it exists to catch (#62151). Falls
+                    # back to seconds_since_activity for older/mocked agents
+                    # that don't report the newer field.
                     _idle_secs = 0.0
                     if hasattr(agent, "get_activity_summary"):
                         try:
                             _act = agent.get_activity_summary()
-                            _idle_secs = _act.get("seconds_since_activity", 0.0)
+                            _idle_secs = _act.get(
+                                "seconds_since_progress",
+                                _act.get("seconds_since_activity", 0.0),
+                            )
                         except Exception:
                             pass
                     if _idle_secs >= _cron_inactivity_limit:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8864,7 +8864,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _stale_agent and hasattr(_stale_agent, "get_activity_summary"):
                 try:
                     _sa = _stale_agent.get_activity_summary()
-                    _stale_idle = _sa.get("seconds_since_activity", float("inf"))
+                    # seconds_since_progress, not seconds_since_activity: a
+                    # handler wedged inside a hung API call (the exact case
+                    # this eviction exists for) keeps seconds_since_activity
+                    # fresh via its own "still waiting" heartbeat, so it
+                    # would never look idle enough to evict (#62151).
+                    _stale_idle = _sa.get(
+                        "seconds_since_progress",
+                        _sa.get("seconds_since_activity", float("inf")),
+                    )
                     _stale_detail = (
                         f" | last_activity={_sa.get('last_activity_desc', 'unknown')} "
                         f"({_stale_idle:.0f}s ago) "
@@ -18740,12 +18748,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         response = _executor_task.result()
                         break
                     # Agent still running — check inactivity.
+                    #
+                    # seconds_since_progress, not seconds_since_activity: the
+                    # API-call heartbeats in chat_completion_helpers.py
+                    # refresh seconds_since_activity every ~30s purely
+                    # because they're still polling, including for a call
+                    # wedged before the socket even opens. Reading that field
+                    # here would make this timeout unable to fire for
+                    # exactly the hang it exists to catch (#62151).
                     _agent_ref = agent_holder[0]
                     _idle_secs = 0.0
                     if _agent_ref and hasattr(_agent_ref, "get_activity_summary"):
                         try:
                             _act = _agent_ref.get_activity_summary()
-                            _idle_secs = _act.get("seconds_since_activity", 0.0)
+                            _idle_secs = _act.get(
+                                "seconds_since_progress",
+                                _act.get("seconds_since_activity", 0.0),
+                            )
                         except Exception:
                             pass
                     # Staged warning: fire once before escalating to full timeout.

--- a/run_agent.py
+++ b/run_agent.py
@@ -3033,8 +3033,24 @@ class AIAgent:
         from agent.agent_runtime_helpers import apply_pending_steer_to_tool_results
         return apply_pending_steer_to_tool_results(self, messages, num_tool_msgs)
 
-    def _touch_activity(self, desc: str) -> None:
+    def _touch_activity(self, desc: str, *, progress: bool = True) -> None:
         """Update the last-activity timestamp and description (thread-safe).
+
+        ``progress`` distinguishes genuine forward movement (a new API call
+        attempt starting, a tool finishing, a stream delta arriving) from a
+        poll loop merely re-announcing "still waiting" while blocked on the
+        same still-pending operation. Callers waiting on a thread that may
+        be permanently wedged (e.g. ``interruptible_api_call``'s "waiting
+        for non-streaming response (Ns elapsed)" heartbeat) MUST pass
+        ``progress=False`` — that heartbeat's only job is to stop
+        legitimately-slow-but-alive calls from tripping gateway/cron
+        inactivity timeouts, but if it also refreshes ``_last_progress_ts``
+        it hides a call that is genuinely dead (no bytes ever received) from
+        the cron watchdog, which reads ``seconds_since_progress`` for that
+        reason. Without this split, a call wedged before the socket even
+        opens (e.g. a hung DNS lookup) resets the only signal cron's
+        inactivity monitor has, so the 600s ceiling can never fire — see
+        #62151. Default True: most call sites report real progress.
 
         Also bridges to the kanban board's heartbeat fields when this
         process is a dispatcher-spawned worker (HERMES_KANBAN_TASK set),
@@ -3044,6 +3060,8 @@ class AIAgent:
         """
         self._last_activity_ts = time.time()
         self._last_activity_desc = desc
+        if progress:
+            self._last_progress_ts = self._last_activity_ts
         if os.environ.get("HERMES_KANBAN_TASK"):
             try:
                 from tools.kanban_tools import heartbeat_current_worker_from_env
@@ -3256,12 +3274,20 @@ class AIAgent:
 
         Called by the gateway timeout handler to report what the agent was doing
         when it was killed, and by the periodic "still working" notifications.
+
+        ``seconds_since_activity`` includes "still waiting" heartbeats and is
+        meant for human-facing status ("what is it doing right now"). Watchdogs
+        deciding whether to KILL a run must use ``seconds_since_progress``
+        instead — see ``_touch_activity`` for why the two diverge for a wedged
+        call (#62151).
         """
         elapsed = time.time() - self._last_activity_ts
+        last_progress_ts = getattr(self, "_last_progress_ts", self._last_activity_ts)
         return {
             "last_activity_ts": self._last_activity_ts,
             "last_activity_desc": self._last_activity_desc,
             "seconds_since_activity": round(elapsed, 1),
+            "seconds_since_progress": round(time.time() - last_progress_ts, 1),
             "current_tool": self._current_tool,
             "api_call_count": self._api_call_count,
             "max_iterations": self.max_iterations,

--- a/tests/cron/test_62151_inactivity_progress_signal.py
+++ b/tests/cron/test_62151_inactivity_progress_signal.py
@@ -1,0 +1,154 @@
+"""Regression tests for #62151 — cron's inactivity watchdog could never fire
+for a cron job wedged inside a non-streaming API call.
+
+Reported symptom: a gateway-run cron job hangs forever right after "OpenAI
+client created" — no timeout, no error, no delivery, for 2.5h+ — while the
+same job run via ``hermes cron tick`` (standalone CLI) completes normally.
+The 600s ``HERMES_CRON_TIMEOUT`` inactivity ceiling never triggered.
+
+Root cause, confirmed by reading the code (not just inferred from logs):
+``interruptible_api_call`` (agent/chat_completion_helpers.py) polls the
+worker thread every 0.3s and, every ~30s, calls
+``agent._touch_activity("waiting for non-streaming response (Ns elapsed)")``
+purely to keep the gateway's *other* inactivity monitors from mistaking a
+slow-but-alive call for a dead one. That touch refreshed the exact field
+(``seconds_since_activity``) that cron's OWN watchdog (this file) reads to
+decide whether the job is dead — so a job wedged before it ever sent a byte
+(e.g. a hung DNS lookup — no TCP connection was ever observed for the
+hung job) looked "active" forever, and the ceiling could never fire.
+
+This file mirrors the inactivity-check snippet from
+``cron/scheduler.py::run_one_job`` (see that function's ``try/while`` block)
+the same way ``tests/cron/test_cron_inactivity_timeout.py`` already mirrors
+the surrounding polling loop, and exercises it against a ``FakeAgent`` that
+reproduces the reported wedge: a real API-call attempt starts, then only
+"still waiting" heartbeats fire, for far longer than the configured
+inactivity ceiling.
+"""
+
+import concurrent.futures
+import time
+
+
+class WedgedAgent:
+    """Simulates a cron job stuck inside interruptible_api_call.
+
+    ``run_conversation`` blocks "forever" (until the test tears it down) —
+    standing in for a non-streaming API call wedged before the socket even
+    opens. A background heartbeat thread mimics interruptible_api_call's
+    poll loop: it repeatedly announces "still waiting" without any real
+    progress, exactly reproducing chat_completion_helpers.py's behavior
+    before the #62151 fix (``progress`` kwarg defaulting to True everywhere).
+    """
+
+    def __init__(self, *, heartbeat_interval, fixed_bug_behavior):
+        self._heartbeat_interval = heartbeat_interval
+        # fixed_bug_behavior=False reproduces the pre-fix code: every touch
+        # (including the "still waiting" heartbeat) advances the single
+        # activity clock. fixed_bug_behavior=True reproduces the post-fix
+        # code: the heartbeat advances seconds_since_activity only,
+        # seconds_since_progress is untouched by it.
+        self._fixed_bug_behavior = fixed_bug_behavior
+        self._call_start = time.time()
+        self._last_activity_ts = self._call_start
+        self._last_progress_ts = self._call_start
+        self._stop = False
+
+    def _heartbeat_loop(self):
+        while not self._stop:
+            time.sleep(self._heartbeat_interval)
+            self._last_activity_ts = time.time()
+            if not self._fixed_bug_behavior:
+                self._last_progress_ts = self._last_activity_ts
+
+    def get_activity_summary(self):
+        now = time.time()
+        return {
+            "seconds_since_activity": round(now - self._last_activity_ts, 1),
+            "seconds_since_progress": round(now - self._last_progress_ts, 1),
+            "last_activity_desc": "waiting for non-streaming response",
+            "current_tool": None,
+            "api_call_count": 2,
+            "max_iterations": 90,
+        }
+
+    def run_conversation(self, prompt):
+        import threading
+
+        hb = threading.Thread(target=self._heartbeat_loop, daemon=True)
+        hb.start()
+        # Blocks until the test kills the pool — standing in for a request
+        # wedged before it ever reaches the network.
+        while not self._stop:
+            time.sleep(0.05)
+        return {"final_response": "should never get here in this test", "messages": []}
+
+
+def _run_cron_watchdog_snippet(
+    agent, *, cron_inactivity_limit, poll_interval=0.05, max_wall_seconds=None
+):
+    """Mirrors the corrected inactivity-check block in
+    ``cron/scheduler.py::run_one_job`` — reads ``seconds_since_progress``
+    (falling back to ``seconds_since_activity`` for agents that don't report
+    it), exactly as the production code now does post-#62151.
+
+    ``max_wall_seconds`` is test-only scaffolding, not part of the mirrored
+    production snippet: the whole point of the reported bug is that the real
+    watchdog loop runs *unbounded* (the reporter waited 2.5h+ — 300x the
+    600s ceiling — and it never fired). To prove "never fires" without
+    literally hanging the test suite forever, the pre-fix-behavior test
+    below waits a generous, but finite, multiple of the ceiling instead.
+    """
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    future = pool.submit(agent.run_conversation, "test prompt")
+    inactivity_timeout = False
+    start = time.time()
+    try:
+        while True:
+            done, _ = concurrent.futures.wait({future}, timeout=poll_interval)
+            if done:
+                break
+            idle_secs = 0.0
+            if hasattr(agent, "get_activity_summary"):
+                try:
+                    act = agent.get_activity_summary()
+                    idle_secs = act.get(
+                        "seconds_since_progress",
+                        act.get("seconds_since_activity", 0.0),
+                    )
+                except Exception:
+                    pass
+            if idle_secs >= cron_inactivity_limit:
+                inactivity_timeout = True
+                break
+            if max_wall_seconds is not None and (time.time() - start) >= max_wall_seconds:
+                break
+    finally:
+        agent._stop = True
+        pool.shutdown(wait=False, cancel_futures=True)
+    return inactivity_timeout
+
+
+class TestCronWatchdogSeesWedgedCall:
+    def test_fixed_signal_detects_the_wedge(self):
+        """With the #62151 fix, the heartbeat no longer masks a wedged call
+        from the cron watchdog: seconds_since_progress keeps growing and the
+        ceiling fires."""
+        agent = WedgedAgent(heartbeat_interval=0.05, fixed_bug_behavior=True)
+        timed_out = _run_cron_watchdog_snippet(
+            agent, cron_inactivity_limit=0.3, poll_interval=0.05
+        )
+        assert timed_out is True
+
+    def test_pre_fix_signal_never_detects_the_wedge(self):
+        """Reproduces the reported bug: with the OLD behavior (heartbeat
+        also refreshes the progress clock), the same wedge NEVER trips the
+        watchdog — this is why the reported cron job hung for 2.5h+ (300x
+        its 600s ceiling) with zero timeout. Waits 10x the configured
+        ceiling here (bounded, so the test itself terminates) instead of
+        reproducing the real incident's unbounded hang."""
+        agent = WedgedAgent(heartbeat_interval=0.05, fixed_bug_behavior=False)
+        timed_out = _run_cron_watchdog_snippet(
+            agent, cron_inactivity_limit=0.3, poll_interval=0.05, max_wall_seconds=3.0
+        )
+        assert timed_out is False

--- a/tests/run_agent/test_62151_activity_progress_tracking.py
+++ b/tests/run_agent/test_62151_activity_progress_tracking.py
@@ -1,0 +1,110 @@
+"""Regression tests for #62151 — cron/gateway inactivity watchdogs that can
+never fire because their own "still waiting" heartbeat keeps resetting the
+metric they check.
+
+Root cause: ``interruptible_api_call`` (agent/chat_completion_helpers.py)
+touches the agent's activity tracker every ~30s purely to announce "still
+waiting for the response" — including while the underlying call is wedged
+before it ever opens a socket (e.g. a hung DNS lookup). Every watchdog that
+read ``seconds_since_activity`` to decide whether a run is dead (cron's
+inactivity timeout, the gateway's per-session inactivity timeout, and the
+stale ``_running_agents`` lock eviction) was reading that same
+self-refreshing field, so none of them could ever detect this class of hang.
+
+The fix splits the signal in two on ``AIAgent``:
+  - ``seconds_since_activity`` / ``_touch_activity(desc)``: human-facing
+    "what's it doing" status, refreshed by heartbeats too.
+  - ``seconds_since_progress`` / ``_touch_activity(desc, progress=False)``:
+    watchdog-facing "is it actually moving", NOT refreshed by "still
+    waiting" heartbeats — only by genuine forward movement (a new call
+    attempt starting, a tool finishing, a stream chunk arriving).
+"""
+
+from unittest.mock import patch
+
+from run_agent import AIAgent
+
+
+def _make_agent():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        return AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+
+class TestTouchActivityProgressSplit:
+    def test_default_touch_advances_both_clocks(self):
+        agent = _make_agent()
+        agent._touch_activity("starting API call #1")
+        summary = agent.get_activity_summary()
+        assert summary["seconds_since_activity"] < 0.5
+        assert summary["seconds_since_progress"] < 0.5
+
+    def test_progress_false_advances_activity_but_not_progress(self):
+        agent = _make_agent()
+        # Simulate a call attempt starting (real progress)...
+        agent._touch_activity("starting API call #1")
+        first_progress_ts = agent._last_progress_ts
+
+        # ...then a "still waiting" heartbeat, exactly like
+        # interruptible_api_call's poll loop emits every ~30s while the
+        # worker thread is still alive, with or without an actual hang.
+        agent._touch_activity(
+            "waiting for non-streaming response (30s elapsed)", progress=False
+        )
+
+        summary = agent.get_activity_summary()
+        # The human-facing clock is refreshed (still legitimately "just
+        # touched" from a status point of view)...
+        assert summary["seconds_since_activity"] < 0.5
+        # ...but the watchdog-facing clock must NOT have moved.
+        assert agent._last_progress_ts == first_progress_ts
+
+    def test_wedged_call_is_visible_via_seconds_since_progress(self):
+        """Simulates the reported bug: a call attempt starts, then only
+        progress=False heartbeats fire for a long time (the network call is
+        wedged before ever sending a byte). seconds_since_activity stays
+        fresh forever (the old, blind signal); seconds_since_progress grows
+        unbounded (the new signal a watchdog can actually trust).
+        """
+        agent = _make_agent()
+        agent._touch_activity("starting API call #2")
+
+        # Back-date the progress clock to simulate real elapsed time without
+        # sleeping in the test — the heartbeat loop would otherwise touch it
+        # every 30s for hours in the real incident.
+        agent._last_progress_ts -= 5400  # 90 minutes "stuck"
+
+        # The poll loop keeps announcing "still waiting" every ~30s, as it
+        # does for the entire 2.5h+ in the reported incident.
+        agent._touch_activity(
+            "waiting for non-streaming response (5400s elapsed)", progress=False
+        )
+
+        summary = agent.get_activity_summary()
+        # Old behavior (bug): this is what every watchdog used to read, and
+        # it never leaves the single-digit-seconds range no matter how long
+        # the call has really been stuck.
+        assert summary["seconds_since_activity"] < 1.0
+        # Fixed behavior: this is what the watchdogs now read, and it
+        # correctly reflects the 90 minutes of no real progress.
+        assert summary["seconds_since_progress"] >= 5400
+
+    def test_get_activity_summary_without_prior_touch_does_not_raise(self):
+        """Older/mocked agents (or an agent whose loop hasn't started yet)
+        may have no _last_progress_ts. get_activity_summary() must fall back
+        to _last_activity_ts rather than raising AttributeError."""
+        agent = _make_agent()
+        agent._touch_activity("boot")
+        assert hasattr(agent, "_last_progress_ts")
+        del agent._last_progress_ts
+        summary = agent.get_activity_summary()
+        assert summary["seconds_since_progress"] < 1.0


### PR DESCRIPTION
## Summary

Fixes #62151 — gateway-run cron jobs hanging 2.5h+ on the 2nd+ non-streaming
API call of a tool-using turn, with zero timeout/error/delivery, while the
same job succeeds via `hermes cron tick` (standalone CLI).

**Root cause (confirmed by reading the code, not inferred from logs):**
`interruptible_api_call` (`agent/chat_completion_helpers.py`) polls its
worker thread every 0.3s and, every ~30s, calls
`agent._touch_activity("waiting for non-streaming response (Ns elapsed)")`
purely to announce "still waiting" — including while the underlying call is
wedged before it ever opens a socket. That touch refreshes the *exact* field
(`seconds_since_activity`) that three separate watchdogs read to decide
whether a run is dead:

1. `cron/scheduler.py::run_one_job` — the `HERMES_CRON_TIMEOUT` (default
   600s) inactivity ceiling.
2. `gateway/run.py` — the interactive session's own per-agent inactivity
   timeout.
3. `gateway/run.py` — the stale `_running_agents` lock eviction ("detect
   leaked locks from hung/crashed handlers").

All three were reading a signal that gets reset every ~30s by the very
"still waiting" heartbeat whose job is to prevent *false* timeouts — so a
job wedged before it ever sent a byte looked "active" forever, and none of
them could fire. This matches the reported symptom exactly: the last log
line is client creation, then nothing, ever, no matter how long the
operator waits.

## Fix

`AIAgent._touch_activity()` now takes a `progress: bool = True` kwarg.
Callers that only mean "still polling, nothing new happened" (the two
"waiting for ... response" heartbeats in `chat_completion_helpers.py`) pass
`progress=False`. This splits the previously-single activity clock in two:

- `seconds_since_activity` (unchanged): human-facing "what's it doing now",
  still refreshed by heartbeats — used for status messages.
- `seconds_since_progress` (new): watchdog-facing "is it actually moving",
  refreshed only by genuine forward movement (a new call attempt starting, a
  tool finishing, a stream chunk arriving) — **not** by a heartbeat that
  just means "still waiting for the same pending thing."

All three watchdogs above now read `seconds_since_progress`, falling back to
`seconds_since_activity` for any caller/mock that doesn't report the newer
field (backward compatible).

This does **not** touch the API-call machinery itself — the worker thread,
the stale-call/TTFB detectors, and the `agent.interrupt()`-driven
force-close all remain exactly as they were. It carries no risk to paths
that already worked correctly.

 

## Known limitation — please read before treating this as the full fix

`interruptible_api_call`'s *inner* stale-call detector (`_stale_timeout`,
`agent/chat_completion_helpers.py` — ~90s for this report's context size and
model) is based on wall-clock elapsed time from call start, **independent**
of the heartbeat bug this PR fixes. It should already have fired and
recovered within ~90s regardless. The reporter's log shows *zero* lines
after client creation for 2.5h+, which this PR alone does not fully
explain — that detector's own silence suggests something is *also* stalling
below it (a leading candidate: `socket.getaddrinfo()` blocking before
`httpx`'s timeouts even start their clock, worsened by `cron/scheduler.py`'s
`_parallel_pool`/`_sequential_pool` being process-global and reused across
every tick for the gateway's whole uptime — unlike the CLI's fresh pool per
invocation — which could let a leaked, permanently-blocked worker thread's
state linger in ways a short-lived CLI process never accumulates).

This PR guarantees the system **recovers and reports** instead of hanging
silently forever, which is the most damaging part of the reported symptom,
and is correct and low-risk on its own merits. It is not a claim that the
underlying pre-connect stall is fully diagnosed — that needs a `py-spy dump`
(or `faulthandler`) on a live wedged gateway process to pin the exact frame,
which I'd recommend as a fast, conclusive follow-up.

## Test plan

- [x] New: `tests/run_agent/test_62151_activity_progress_tracking.py` —
      unit tests for the `progress` split on `_touch_activity`/
      `get_activity_summary`, including a deterministic simulation of the
      exact reported wedge (heartbeat resets `seconds_since_activity`
      forever; `seconds_since_progress` correctly grows).
- [x] New: `tests/cron/test_62151_inactivity_progress_signal.py` —
      reproduces the bug end-to-end against a `FakeAgent`: proves the
      pre-fix signal never trips the watchdog for a wedged call, and the
      post-fix signal does.
- [x] Full relevant regression sweep run locally (cron inactivity, gateway
      inactivity/session-race/status-command, run_agent/chat_completion
      streaming, interrupt, and stale-connection suites — several hundred
      cases): no regressions introduced. A handful of pre-existing failures
      (delegate-tool observability fields, a Windows tilde-path test) were
      confirmed via `git stash` to already fail identically on `main`,
      unrelated to this change.