### PR TITLE
fix(gateway): notify home channels after supervisor restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6765,14 +6765,36 @@ class GatewayRunner:
             if active_agents:
                 self._increment_restart_failure_counts(set(active_agents.keys()))
 
-            if self._restart_requested and self._restart_command_source is None:
+            should_notify_home_on_next_boot = (
+                # Normal Hermes-managed restarts with no specific originating
+                # chat should announce the comeback to configured home channels.
+                (self._restart_requested and self._restart_command_source is None)
+                # External SIGTERM under supervisors such as systemd also comes
+                # back automatically, but it bypasses request_restart() and used
+                # to send only the shutdown half of the lifecycle. Persist the
+                # same marker so the next process can say it is back online.
+                or (
+                    getattr(self, "_signal_initiated_shutdown", False)
+                    and not self._restart_requested
+                )
+            )
+            if should_notify_home_on_next_boot:
                 try:
                     atomic_json_write(
                         _planned_restart_notification_path(),
                         {
                             "requested_at": time.time(),
-                            "via_service": bool(self._restart_via_service),
+                            "via_service": bool(
+                                self._restart_via_service
+                                or getattr(self, "_signal_initiated_shutdown", False)
+                            ),
                             "detached": bool(self._restart_detached),
+                            "reason": (
+                                "external_signal"
+                                if getattr(self, "_signal_initiated_shutdown", False)
+                                and not self._restart_requested
+                                else "planned_restart"
+                            ),
                         },
                         indent=None,
                     )

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -161,6 +162,24 @@ async def test_gateway_stop_launchd_service_restart_keeps_nonzero_exit(tmp_path,
         await runner.stop(restart=True, service_restart=True)
 
     assert runner._exit_code == GATEWAY_SERVICE_RESTART_EXIT_CODE
+
+
+@pytest.mark.asyncio
+async def test_unexpected_signal_writes_home_startup_marker(tmp_path, monkeypatch):
+    """External supervisor restarts should send the missing 'back online' half."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+    runner._signal_initiated_shutdown = True
+
+    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
+        await runner.stop()
+
+    marker = tmp_path / ".restart_pending.json"
+    assert marker.exists()
+    payload = json.loads(marker.read_text())
+    assert payload["reason"] == "external_signal"
+    assert payload["via_service"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

When the gateway is restarted by a supervisor, for example `systemctl --user restart hermes-gateway`, users get the shutdown notification but no matching "back online" message.

That makes the gateway look dead even after Telegram has reconnected.

This reuses the existing home-channel startup notification path for external SIGTERM restarts. If the gateway was killed by a supervisor and is going to be revived, it writes the same `.restart_pending.json` marker that planned service restarts already use.

## Why this shape

- Keeps the change narrow.
- Reuses the existing notification sender.
- Respects the existing `gateway_restart_notification` platform flag.
- Does not add a new config option or a new notification path.

Related to #27870 and overlaps with the broader config proposal in #55008. This PR is the smaller default-behavior fix for the asymmetric shutdown/startup lifecycle.

## Test plan

```bash
/home/cmcejas/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_gateway_shutdown.py tests/gateway/test_restart_notification.py -q -o 'addopts='
```

Result:

```text
42 passed in 26.04s
```

I also verified the same test set on current upstream main before making the pushable fork branch:

```text
48 passed in 21.83s
```
