### PR TITLE
fix(hindsight): pass configured max_tokens to reflect requests

### DIFF
--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -70,7 +70,7 @@ Config file: `~/.hermes/hindsight/config.json`
 |-----|---------|-------------|
 | `recall_budget` | `mid` | Recall thoroughness: `low` / `mid` / `high` |
 | `recall_prefetch_method` | `recall` | Auto-recall method: `recall` (raw facts) or `reflect` (LLM synthesis) |
-| `recall_max_tokens` | `4096` | Maximum tokens for recall results |
+| `recall_max_tokens` | `4096` | Maximum tokens for recall and reflect results |
 | `recall_max_input_chars` | `800` | Maximum input query length for auto-recall |
 | `recall_prompt_preamble` | — | Custom preamble for recalled memories in context |
 | `recall_tags` | — | Tags to filter when searching memories |

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1001,7 +1001,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "retain_every_n_turns", "description": "Retain every N turns (1 = every turn)", "default": 1},
             {"key": "retain_async","description": "Process retain asynchronously on the Hindsight server", "default": True},
             {"key": "retain_context", "description": "Context label for retained memories", "default": "conversation between Hermes Agent and the User"},
-            {"key": "recall_max_tokens", "description": "Maximum tokens for recall results", "default": 4096},
+            {"key": "recall_max_tokens", "description": "Maximum tokens for recall and reflect results", "default": 4096},
             {"key": "recall_max_input_chars", "description": "Maximum input query length for auto-recall", "default": 800},
             {"key": "recall_prompt_preamble", "description": "Custom preamble for recalled memories in context"},
             {"key": "timeout", "description": "API request timeout in seconds", "default": _DEFAULT_TIMEOUT},
@@ -1499,7 +1499,14 @@ class HindsightMemoryProvider(MemoryProvider):
             try:
                 if self._prefetch_method == "reflect":
                     logger.debug("Prefetch: calling reflect (bank=%s, query_len=%d)", self._bank_id, len(query))
-                    resp = self._run_hindsight_operation(lambda client: client.areflect(bank_id=self._bank_id, query=query, budget=self._budget))
+                    resp = self._run_hindsight_operation(
+                        lambda client: client.areflect(
+                            bank_id=self._bank_id,
+                            query=query,
+                            budget=self._budget,
+                            max_tokens=self._recall_max_tokens,
+                        )
+                    )
                     text = resp.text or ""
                 else:
                     recall_kwargs: dict = {
@@ -1762,7 +1769,10 @@ class HindsightMemoryProvider(MemoryProvider):
                              self._bank_id, len(query), self._budget)
                 resp = self._run_hindsight_operation(
                     lambda client: client.areflect(
-                        bank_id=self._bank_id, query=query, budget=self._budget
+                        bank_id=self._bank_id,
+                        query=query,
+                        budget=self._budget,
+                        max_tokens=self._recall_max_tokens,
                     )
                 )
                 logger.debug("Tool hindsight_reflect: response_len=%d", len(resp.text or ""))

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -734,6 +734,12 @@ class TestToolHandlers:
         ))
         assert result["result"] == "Synthesized answer"
 
+    def test_reflect_passes_configured_max_tokens(self, provider_with_config):
+        p = provider_with_config(recall_max_tokens=2048)
+        p.handle_tool_call("hindsight_reflect", {"query": "summarize"})
+        call_kwargs = p._client.areflect.call_args.kwargs
+        assert call_kwargs["max_tokens"] == 2048
+
     def test_reflect_missing_query(self, provider):
         result = json.loads(provider.handle_tool_call(
             "hindsight_reflect", {}
@@ -854,6 +860,18 @@ class TestPrefetch:
         assert call_kwargs["tags"] == ["t1"]
         assert call_kwargs["tags_match"] == "all"
         assert call_kwargs["types"] == ["world"]
+
+    def test_queue_prefetch_reflect_passes_configured_max_tokens(self, provider_with_config):
+        p = provider_with_config(
+            recall_prefetch_method="reflect",
+            recall_max_tokens=1024,
+        )
+        p.queue_prefetch("test query")
+        if p._prefetch_thread:
+            p._prefetch_thread.join(timeout=5.0)
+
+        call_kwargs = p._client.areflect.call_args.kwargs
+        assert call_kwargs["max_tokens"] == 1024
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- pass the configured `recall_max_tokens` value to Hindsight `areflect()` calls made by automatic reflect prefetch
- pass the same limit to the `hindsight_reflect` tool path
- clarify that `recall_max_tokens` limits both recall and reflect responses

## Root cause

Recall requests already forwarded `recall_max_tokens`, but both reflect call sites omitted the Hindsight client's supported `max_tokens` argument. Reflect requests therefore fell back to the server/client default instead of honoring the configured response limit.

## Tests

- `python -m pytest -q tests/plugins/memory/test_hindsight_provider.py` — 118 passed
- `ruff check plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py` — passed
- `python -m py_compile plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py` — passed
- `git diff --check` — passed
