### PR TITLE
fix(delegate): persist subagent cost deltas to session state DB

### DIFF
--- a/contributors/emails/seraphine@Seraphines-Mac-Studio.local
+++ b/contributors/emails/seraphine@Seraphines-Mac-Studio.local
@@ -1,0 +1,2 @@
+Bartok9
+# Seraphine Mac Studio local email on Bartok9 PR tips (per-PR attribution; Teknium/Daniel 2026-08-01)

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -11,10 +11,12 @@ Run with:  python -m pytest tests/test_delegate.py -v
 
 import json
 import os
+import tempfile
 import threading
 import time
 import types
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from tools.delegate_tool import (


### PR DESCRIPTION
## Summary

`delegate_task` already rolls subagent spend into the parent's in-memory `session_estimated_cost_usd`, but that delta was never written to the state DB. The live cost footer looked correct while `hermes insights` / `sessions.estimated_cost_usd permanently undercounted any session that used subagents (observed ~$12 gap on a heavy day).

## Motivation

Fixes #32220. Salvages the approach from stale/conflicting #32225 onto current main, adds session_id guard + regression tests.

## Critical change

After the in-memory rollup, call `parent_agent._session_db.update_token_counts(session_id, estimated_cost_usd=children_total, cost_status=\"estimated\", cost_source=\"subagent\")` when a session DB is present. Additive semantics keep nested orchestrator→worker trees correct.

## Verification

```bash
python3 -m pytest tests/tools/test_delegate.py::TestSubagentCostRollup::test_subagent_cost_persisted_to_session_db \
  tests/tools/test_delegate.py::TestSubagentCostRollup::test_subagent_cost_db_skipped_when_no_session_db \
  tests/tools/test_delegate.py::TestSubagentCostRollup::test_zero_cost_children_do_not_call_session_db \
  tests/tools/test_delegate.py::TestSubagentCostRollup::test_zero_cost_children_leave_parent_source_untouched \
  tests/tools/test_delegate.py::TestSubagentCostRollup::test_parent_with_real_source_not_overwritten -q
# 5 passed
```

Note: two unrelated pre-existing Suite tests (`test_single_child_cost_folded_into_parent`, `test_batch_children_costs_sum_into_parent`) fail on this machine under Python 3.14 due to `DaemonThreadPoolExecutor` lacking `_initializer` — not introduced by this change and not exercised by the DB persistence path (which patches `_run_single_child`).

## Differential vs #32225

- Rebased onto current main (original was CONFLICTING)
- Guard on `session_id` as well as `_session_db`
- Three focused regression tests for DB flush / skip paths

Closes #32220