### PR TITLE
fix(desktop): only show slash popover when / is first char

### DIFF
--- a/apps/desktop/src/app/chat/composer/text-utils.test.ts
+++ b/apps/desktop/src/app/chat/composer/text-utils.test.ts
@@ -46,6 +46,14 @@ describe('detectTrigger', () => {
     expect(detectTrigger('/path/to/file')).toBeNull()
   })
 
+  it('does not trigger slash popover mid-message', () => {
+    expect(detectTrigger('hello /')).toBeNull()
+    expect(detectTrigger('hello /skill')).toBeNull()
+    expect(detectTrigger('hello there /personality alic')).toBeNull()
+    expect(detectTrigger('text\n/skill')).toBeNull()
+    expect(detectTrigger('multi word message /')).toBeNull()
+  })
+
   it('still anchors at-mention triggers strictly at the token edge', () => {
     expect(detectTrigger('@file:path with space')).toBeNull()
   })

--- a/apps/desktop/src/app/chat/composer/text-utils.ts
+++ b/apps/desktop/src/app/chat/composer/text-utils.ts
@@ -11,8 +11,12 @@ export interface TriggerState {
 // user types args (`/personality alic` → arg completer suggests `alice`).
 // Restricting the slash command name to `[a-zA-Z][\w-]*` avoids matching file
 // paths like `src/foo/bar`.
+//
+// Slash commands only execute at the beginning of a message, so the `/`
+// trigger is anchored strictly at position 0 — not after whitespace — to
+// avoid opening the popover mid-message (e.g. `hello /`).
 const AT_TRIGGER_RE = /(?:^|[\s])(@)([^\s@/]*)$/
-const SLASH_TRIGGER_RE = /(?:^|[\s])(\/)((?:[a-zA-Z][\w-]*(?:\s+\S*)*)?)$/
+const SLASH_TRIGGER_RE = /^(\/)((?:[a-zA-Z][\w-]*(?:\s+\S*)*)?)$/
 
 /** Stable key for paste dedupe — `items` and `files` often mirror the same image as different objects. */
 export function blobDedupeKey(blob: Blob): string {


### PR DESCRIPTION
## What does this PR do?

The desktop composer's slash command popover opened on any `/` in the message, not just at the beginning. Since slash commands only execute at the start of a message, the popover was showing up in places where it could never work — e.g. typing `hello /` would pop the command list even though the slash isn't a command invocation there.

This anchors the slash trigger detection strictly at position 0, so the popover only appears when `/` is the first character of the message.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/composer/text-utils.ts` — changed `SLASH_TRIGGER_RE` left anchor from `(?:^|[\s])` to `^` so `/` only triggers at the start of the message. The `@`-mention trigger is left unchanged since those work anywhere.
- `apps/desktop/src/app/chat/composer/text-utils.test.ts` — added 5 test cases covering mid-message `/` (plain text before, word before, newline before, multi-word before) all returning `null`.

## How to Test

1. Open the desktop app, focus the composer
2. Type `hello /` — the slash popover should NOT appear
3. Clear the composer, type `/` — the slash popover SHOULD appear
4. Type `/skill` — popover shows matching commands
5. `cd apps/desktop && npx vitest run --environment jsdom src/app/chat/composer/text-utils.test.ts` — all 12 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS (Linux 7.1.0)

### Documentation & Housekeeping

- [x] N/A — I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] N/A — I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] N/A — I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] N/A — I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] N/A — I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Verification output:

```
tsc --noEmit: clean (0 errors)
eslint: clean (0 issues)
vitest: 12/12 tests passed (text-utils.test.ts)
```
