### PR TITLE
fix(gateway): mask PATH in systemd unit staleness check (WSL Windows-interop churn)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2854,6 +2854,31 @@ def _normalize_launchd_plist_for_comparison(text: str) -> str:
     )
 
 
+def _normalize_systemd_unit_for_comparison(text: str) -> str:
+    """Normalize a systemd unit for staleness checks.
+
+    Mirrors ``_normalize_launchd_plist_for_comparison`` for the same reason:
+    the generated unit's ``Environment="PATH=..."`` is assembled from the
+    invoking shell's PATH. Under WSL that PATH also carries the volatile
+    Windows-interop ``/mnt/*`` entries (e.g. ``.../WindowsApps``,
+    ``.../WindowsPowerShell/v1.0``) that ``_build_wsl_interop_paths`` harvests
+    from ``os.environ`` — those vary between the login shell that installed the
+    unit and the (often non-login) shell that later runs status/restart. Raw
+    text comparison then flags a unit that differs only by its PATH payload as
+    perpetually outdated, so every restart needlessly rewrites the unit and
+    daemon-reloads. Strip optional directives (older-systemd churn) and mask
+    the PATH value before comparing.
+    """
+    import re
+
+    normalized = _normalize_service_definition(_strip_optional_systemd_directives(text))
+    return re.sub(
+        r'(Environment="PATH=)[^"\n]*(")',
+        r"\1__HERMES_PATH__\2",
+        normalized,
+    )
+
+
 def systemd_unit_is_current(system: bool = False) -> bool:
     # ── HERMES_HOME sync chokepoint ──────────────────────────────────────
     # Every path that compares OR regenerates the unit funnels through here:
@@ -2881,14 +2906,12 @@ def systemd_unit_is_current(system: bool = False) -> bool:
     expected_user = _read_systemd_user_from_unit(unit_path) if system else None
     expected = generate_systemd_unit(system=system, run_as_user=expected_user)
     # Normalize out directives that older systemd versions silently drop
-    # (RestartMaxDelaySec, RestartSteps) so a unit that differs only by
-    # those directives is not perpetually flagged as outdated.
-    norm_installed = _normalize_service_definition(
-        _strip_optional_systemd_directives(installed)
-    )
-    norm_expected = _normalize_service_definition(
-        _strip_optional_systemd_directives(expected)
-    )
+    # (RestartMaxDelaySec, RestartSteps) and the shell-dependent PATH payload
+    # (unstable under WSL Windows-interop) so a unit that differs only by those
+    # is not perpetually flagged as outdated. See
+    # _normalize_systemd_unit_for_comparison.
+    norm_installed = _normalize_systemd_unit_for_comparison(installed)
+    norm_expected = _normalize_systemd_unit_for_comparison(expected)
     return norm_installed == norm_expected
 
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2854,27 +2854,46 @@ def _normalize_launchd_plist_for_comparison(text: str) -> str:
     )
 
 
+def _mask_volatile_wsl_interop_path(path_value: str) -> str:
+    """Drop volatile WSL Windows-interop (``/mnt/*``) entries from a PATH value.
+
+    Only the ``/mnt/*`` segments that ``_build_wsl_interop_paths`` harvests from
+    ``os.environ`` vary between the login shell that installs the unit and the
+    (often non-login) shell that later compares it. The deterministic service
+    entries in the same PATH — ``_build_service_path_dirs`` output, the resolved
+    Node directory, user-local bins — are preserved verbatim so a genuine change
+    to any of them still marks the unit stale.
+    """
+    kept = [seg for seg in path_value.split(":") if not seg.startswith("/mnt/")]
+    return ":".join(kept)
+
+
 def _normalize_systemd_unit_for_comparison(text: str) -> str:
     """Normalize a systemd unit for staleness checks.
 
-    Mirrors ``_normalize_launchd_plist_for_comparison`` for the same reason:
-    the generated unit's ``Environment="PATH=..."`` is assembled from the
+    The generated unit's ``Environment="PATH=..."`` is assembled from the
     invoking shell's PATH. Under WSL that PATH also carries the volatile
     Windows-interop ``/mnt/*`` entries (e.g. ``.../WindowsApps``,
     ``.../WindowsPowerShell/v1.0``) that ``_build_wsl_interop_paths`` harvests
     from ``os.environ`` — those vary between the login shell that installed the
     unit and the (often non-login) shell that later runs status/restart. Raw
-    text comparison then flags a unit that differs only by its PATH payload as
+    text comparison then flags a unit that differs only by those entries as
     perpetually outdated, so every restart needlessly rewrites the unit and
-    daemon-reloads. Strip optional directives (older-systemd churn) and mask
-    the PATH value before comparing.
+    daemon-reloads.
+
+    Strip optional directives (older-systemd churn) and drop *only* the volatile
+    ``/mnt/*`` PATH segments before comparing. Unlike
+    ``_normalize_launchd_plist_for_comparison`` (macOS, no interop churn) this
+    deliberately does NOT mask the whole PATH: the deterministic service entries
+    in that field are load-bearing, so a change to a non-``/mnt`` entry must keep
+    the unit stale and trigger the rewrite/daemon-reload path.
     """
     import re
 
     normalized = _normalize_service_definition(_strip_optional_systemd_directives(text))
     return re.sub(
-        r'(Environment="PATH=)[^"\n]*(")',
-        r"\1__HERMES_PATH__\2",
+        r'(Environment="PATH=)([^"\n]*)(")',
+        lambda m: m.group(1) + _mask_volatile_wsl_interop_path(m.group(2)) + m.group(3),
         normalized,
     )
 

--- a/tests/hermes_cli/test_systemd_optional_directives.py
+++ b/tests/hermes_cli/test_systemd_optional_directives.py
@@ -261,11 +261,26 @@ class TestSystemdUnitPathNormalization:
     treated as current — otherwise every restart rewrites it + daemon-reloads.
     """
 
-    def test_masks_path_value(self):
+    def test_masks_only_volatile_mnt_segments(self):
         from hermes_cli.gateway import _normalize_systemd_unit_for_comparison
+        # Same deterministic entry (/a/bin), differing volatile /mnt/* payloads.
         a = 'Environment="PATH=/a/bin:/mnt/c/WINDOWS/system32"'
         b = 'Environment="PATH=/a/bin:/mnt/c/Users/user/AppData/Local/Microsoft/WindowsApps"'
         assert _normalize_systemd_unit_for_comparison(a) == _normalize_systemd_unit_for_comparison(b)
+
+    def test_non_mnt_path_difference_survives_normalization(self):
+        """A change to a deterministic (non-/mnt) PATH entry must NOT be masked
+        away — otherwise real service-PATH updates (Node dir, service bins) would
+        be silently treated as current. This is the case the reviewer flagged."""
+        from hermes_cli.gateway import _normalize_systemd_unit_for_comparison
+        a = 'Environment="PATH=/opt/node-v20/bin:/mnt/c/WINDOWS/system32"'
+        b = 'Environment="PATH=/opt/node-v22/bin:/mnt/c/WINDOWS/system32"'
+        assert _normalize_systemd_unit_for_comparison(a) != _normalize_systemd_unit_for_comparison(b)
+
+    def test_mask_helper_drops_mnt_keeps_service_entries(self):
+        from hermes_cli.gateway import _mask_volatile_wsl_interop_path
+        value = "/home/a/venv/bin:/mnt/c/WINDOWS/system32:/usr/bin:/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/"
+        assert _mask_volatile_wsl_interop_path(value) == "/home/a/venv/bin:/usr/bin"
 
     def test_non_path_differences_still_visible(self):
         from hermes_cli.gateway import _normalize_systemd_unit_for_comparison
@@ -319,6 +334,48 @@ WantedBy=default.target
         )
 
         assert gw.systemd_unit_is_current(system=False) is True
+
+    def test_unit_differing_only_by_non_mnt_path_is_outdated(self, tmp_path, monkeypatch):
+        """Regression for the reviewer's concern: when the ONLY difference is a
+        deterministic (non-/mnt) PATH entry — everything else, including all
+        other directives, identical — the unit must still be flagged stale so
+        refresh_systemd_unit_if_needed() rewrites and daemon-reloads it."""
+        from hermes_cli import gateway as gw
+
+        base = """[Unit]
+Description=Hermes Gateway
+
+[Service]
+Type=simple
+ExecStart=/home/a/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main gateway run
+WorkingDirectory=/home/a/.hermes
+Environment="PATH={path}"
+Environment="VIRTUAL_ENV=/home/a/.hermes/hermes-agent/venv"
+Environment="HERMES_HOME=/home/a/.hermes"
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+"""
+        # Identical volatile /mnt/* payload; only the deterministic Node dir moved.
+        installed = base.format(
+            path="/opt/node-v20/bin:/mnt/c/WINDOWS/system32:/usr/bin:/bin"
+        )
+        regenerated = base.format(
+            path="/opt/node-v22/bin:/mnt/c/WINDOWS/system32:/usr/bin:/bin"
+        )
+        unit_file = tmp_path / "hermes-gateway.service"
+        unit_file.write_text(installed)
+
+        monkeypatch.setattr(gw, "get_systemd_unit_path", lambda system=False: unit_file)
+        monkeypatch.setattr(
+            gw,
+            "generate_systemd_unit",
+            lambda system=False, run_as_user=None: regenerated,
+        )
+
+        assert gw.systemd_unit_is_current(system=False) is False
 
     def test_unit_differing_by_hermes_home_still_outdated(self, tmp_path, monkeypatch):
         """PATH masking must not hide a genuinely changed non-PATH directive."""

--- a/tests/hermes_cli/test_systemd_optional_directives.py
+++ b/tests/hermes_cli/test_systemd_optional_directives.py
@@ -245,3 +245,110 @@ WantedBy=default.target
         unit_file = tmp_path / "nonexistent.service"
         monkeypatch.setattr(gw, "get_systemd_unit_path", lambda system=False: unit_file)
         assert gw.systemd_unit_is_current(system=False) is False
+
+
+# ---------------------------------------------------------------------------
+# PATH normalization (WSL Windows-interop staleness churn)
+# ---------------------------------------------------------------------------
+
+
+class TestSystemdUnitPathNormalization:
+    """The generated unit's Environment="PATH=..." is assembled from the
+    invoking shell. Under WSL it also carries volatile Windows-interop /mnt/*
+    entries harvested from os.environ, which differ between the login shell
+    that installed the unit and the non-login shell that later runs
+    status/restart. A unit that differs ONLY by its PATH payload must be
+    treated as current — otherwise every restart rewrites it + daemon-reloads.
+    """
+
+    def test_masks_path_value(self):
+        from hermes_cli.gateway import _normalize_systemd_unit_for_comparison
+        a = 'Environment="PATH=/a/bin:/mnt/c/WINDOWS/system32"'
+        b = 'Environment="PATH=/a/bin:/mnt/c/Users/user/AppData/Local/Microsoft/WindowsApps"'
+        assert _normalize_systemd_unit_for_comparison(a) == _normalize_systemd_unit_for_comparison(b)
+
+    def test_non_path_differences_still_visible(self):
+        from hermes_cli.gateway import _normalize_systemd_unit_for_comparison
+        a = 'Environment="PATH=/x"\nRestartSec=5'
+        b = 'Environment="PATH=/y"\nRestartSec=10'
+        assert _normalize_systemd_unit_for_comparison(a) != _normalize_systemd_unit_for_comparison(b)
+
+    def test_other_environment_lines_untouched(self):
+        from hermes_cli.gateway import _normalize_systemd_unit_for_comparison
+        a = 'Environment="PATH=/x"\nEnvironment="HERMES_HOME=/home/a/.hermes"'
+        b = 'Environment="PATH=/y"\nEnvironment="HERMES_HOME=/home/b/.hermes"'
+        # PATH is masked away, but the differing HERMES_HOME must remain visible
+        assert _normalize_systemd_unit_for_comparison(a) != _normalize_systemd_unit_for_comparison(b)
+
+    def test_unit_differing_only_by_wsl_interop_path_is_current(self, tmp_path, monkeypatch):
+        """Reproduces the live WSL churn: installed unit has extra Windows-interop
+        /mnt/* PATH entries that the regenerated unit lacks; still current."""
+        from hermes_cli import gateway as gw
+
+        base = """[Unit]
+Description=Hermes Gateway
+
+[Service]
+Type=simple
+ExecStart=/home/a/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main gateway run
+WorkingDirectory=/home/a/.hermes
+Environment="PATH={path}"
+Environment="VIRTUAL_ENV=/home/a/.hermes/hermes-agent/venv"
+Environment="HERMES_HOME=/home/a/.hermes"
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+"""
+        installed = base.format(
+            path="/home/a/.hermes/hermes-agent/venv/bin:/mnt/c/WINDOWS/system32:"
+            "/mnt/c/Users/user/AppData/Local/Microsoft/WindowsApps:/usr/bin:/bin"
+        )
+        regenerated = base.format(
+            path="/home/a/.hermes/hermes-agent/venv/bin:/mnt/c/WINDOWS/system32:/usr/bin:/bin"
+        )
+        unit_file = tmp_path / "hermes-gateway.service"
+        unit_file.write_text(installed)
+
+        monkeypatch.setattr(gw, "get_systemd_unit_path", lambda system=False: unit_file)
+        monkeypatch.setattr(
+            gw,
+            "generate_systemd_unit",
+            lambda system=False, run_as_user=None: regenerated,
+        )
+
+        assert gw.systemd_unit_is_current(system=False) is True
+
+    def test_unit_differing_by_hermes_home_still_outdated(self, tmp_path, monkeypatch):
+        """PATH masking must not hide a genuinely changed non-PATH directive."""
+        from hermes_cli import gateway as gw
+
+        installed = """[Unit]
+Description=Hermes Gateway
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python gateway run
+Environment="PATH=/a:/mnt/c/WINDOWS/system32"
+Environment="HERMES_HOME=/home/a/.hermes"
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+"""
+        regenerated = installed.replace(
+            'HERMES_HOME=/home/a/.hermes', 'HERMES_HOME=/home/a/.hermes/profiles/coder'
+        ).replace('PATH=/a:/mnt/c/WINDOWS/system32', 'PATH=/a:/usr/bin')
+        unit_file = tmp_path / "hermes-gateway.service"
+        unit_file.write_text(installed)
+
+        monkeypatch.setattr(gw, "get_systemd_unit_path", lambda system=False: unit_file)
+        monkeypatch.setattr(
+            gw,
+            "generate_systemd_unit",
+            lambda system=False, run_as_user=None: regenerated,
+        )
+
+        assert gw.systemd_unit_is_current(system=False) is False


### PR DESCRIPTION
## Problem

On WSL, `hermes gateway status` prints **"⚠ Installed gateway service definition is outdated"** on every invocation, and every `hermes gateway restart` needlessly rewrites the unit file + `daemon-reload`s — even when nothing has changed.

Root cause: `generate_systemd_unit()` bakes `Environment="PATH=..."` from the invoking shell's `os.environ["PATH"]`. Under WSL that PATH also carries the Windows-interop `/mnt/*` entries that `_build_wsl_interop_paths()` harvests (e.g. `.../Microsoft/WindowsApps`, `.../WindowsPowerShell/v1.0`). Those entries vary between the **login shell** that installed the unit and the **non-login shell** that later runs status/restart. The strict text comparison in `systemd_unit_is_current()` then flags a unit that differs *only* by its PATH payload as perpetually outdated.

Live diff on an affected machine — the sole difference between installed and freshly generated unit:

```diff
-Environment="PATH=...OpenSSH/:/mnt/c/Users/<user>/AppData/Local/Microsoft/WindowsApps:/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0:/usr/local/sbin:..."
+Environment="PATH=...OpenSSH/:/usr/local/sbin:..."
```

## Fix

The **launchd** path already solved the identical class of problem: `_normalize_launchd_plist_for_comparison()` masks the PATH payload before comparison because it is "assembled from the invoking shell … that makes raw text comparison unstable across shells." This PR mirrors that for systemd.

New `_normalize_systemd_unit_for_comparison()` strips the optional-directive churn (as before) **and** masks the `Environment="PATH=..."` value, and `systemd_unit_is_current()` now routes both sides through it. Non-PATH differences (`RestartSec`, `HERMES_HOME`, `ExecStart`, `VIRTUAL_ENV`, …) remain fully visible, so genuine drift is still detected and repaired.

## Verification

- New unit tests in `test_systemd_optional_directives.py` (PATH masking, non-PATH differences stay visible, a WSL-interop reproduction, and a guard that a changed `HERMES_HOME` alongside a changed PATH is still flagged outdated).
- Full file: `16 passed`.
- Against a live affected WSL install: `systemd_unit_is_current()` flips `False → True` (warning gone), while a forced `RestartSec` change still reports `False`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
