### PR TITLE
fix: support multiple API server keys

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -850,7 +850,9 @@ class APIServerAdapter(BasePlatformAdapter):
         if raw_port is None:
             raw_port = os.getenv("API_SERVER_PORT", str(DEFAULT_PORT))
         self._port: int = _coerce_port(raw_port, DEFAULT_PORT)
-        self._api_key: str = extra.get("key", os.getenv("API_SERVER_KEY", ""))
+        self._api_keys: tuple[str, ...] = self._parse_api_keys(
+            extra.get("key", os.getenv("API_SERVER_KEY", "")),
+        )
         self._cors_origins: tuple[str, ...] = self._parse_cors_origins(
             extra.get("cors_origins", os.getenv("API_SERVER_CORS_ORIGINS", "")),
         )
@@ -900,6 +902,39 @@ class APIServerAdapter(BasePlatformAdapter):
         # Number of in-flight runs on the non-streaming chat/responses paths
         # (the /v1/runs path tracks its own in-flight set via _run_streams).
         self._inflight_agent_runs: int = 0
+
+    @staticmethod
+    def _parse_api_keys(value: Any) -> tuple[str, ...]:
+        """Normalize one or more configured API keys into a stable tuple.
+
+        Accepts a comma-separated string (``key1,key2``) or a list/tuple of
+        keys. Blank segments are dropped and duplicates removed while
+        preserving order. A single key with no comma yields a 1-tuple, so
+        existing single-key deployments are unchanged.
+        """
+        if not value:
+            return ()
+
+        if isinstance(value, str):
+            items = value.split(",")
+        elif isinstance(value, (list, tuple, set)):
+            items = value
+        else:
+            items = [str(value)]
+
+        seen: set[str] = set()
+        keys: list[str] = []
+        for item in items:
+            cleaned = str(item).strip()
+            if cleaned and cleaned not in seen:
+                seen.add(cleaned)
+                keys.append(cleaned)
+        return tuple(keys)
+
+    @property
+    def _auth_enabled(self) -> bool:
+        """True when at least one API key is configured."""
+        return bool(self._api_keys)
 
     @staticmethod
     def _parse_cors_origins(value: Any) -> tuple[str, ...]:
@@ -1054,14 +1089,20 @@ class APIServerAdapter(BasePlatformAdapter):
         connect() refuses to start the API server without API_SERVER_KEY, so
         the no-key branch only exists for tests or unsupported manual wiring.
         """
-        if not self._api_key:
+        if not self._api_keys:
             return None
 
         auth_header = request.headers.get("Authorization", "")
+        matched = False
         if auth_header.startswith("Bearer "):
             token = auth_header[7:].strip()
-            if hmac.compare_digest(token, self._api_key):
-                return None  # Auth OK
+            # Compare against every key (no early break) to avoid leaking,
+            # via response timing, which/how many keys are configured.
+            for key in self._api_keys:
+                if hmac.compare_digest(token, key):
+                    matched = True
+        if matched:
+            return None  # Auth OK
 
         logger.warning(
             "API server rejected invalid API key: %s",
@@ -1108,7 +1149,7 @@ class APIServerAdapter(BasePlatformAdapter):
         if not raw:
             return None, None
 
-        if not self._api_key:
+        if not self._auth_enabled:
             logger.warning(
                 "X-Hermes-Session-Key rejected: no API key configured. "
                 "Set API_SERVER_KEY to enable long-term memory scoping."
@@ -1471,7 +1512,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "model": self._model_name,
             "auth": {
                 "type": "bearer",
-                "required": bool(self._api_key),
+                "required": bool(self._api_keys),
             },
             "runtime": {
                 "mode": "server_agent",
@@ -2137,7 +2178,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # read arbitrary session history by guessing/enumerating session IDs.
         provided_session_id = request.headers.get("X-Hermes-Session-Id", "").strip()
         if provided_session_id:
-            if not self._api_key:
+            if not self._auth_enabled:
                 logger.warning(
                     "Session continuation via X-Hermes-Session-Id rejected: "
                     "no API key configured.  Set API_SERVER_KEY to enable "
@@ -4710,7 +4751,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     def _api_key_passes_startup_guard(self) -> bool:
         """Return True when API_SERVER_KEY is present and strong enough to start."""
-        if not self._api_key:
+        if not self._auth_enabled:
             logger.error(
                 "[%s] Refusing to start: API_SERVER_KEY is required for the API server, "
                 "including loopback-only binds on %s.",
@@ -4720,12 +4761,12 @@ class APIServerAdapter(BasePlatformAdapter):
 
         try:
             from hermes_cli.auth import has_usable_secret
-            if not has_usable_secret(self._api_key, min_length=16):
+            if any(not has_usable_secret(k, min_length=16) for k in self._api_keys):
                 logger.error(
-                    "[%s] Refusing to start: API_SERVER_KEY is a "
-                    "placeholder or too short (<16 chars). This endpoint "
+                    "[%s] Refusing to start: one or more API_SERVER_KEY values are "
+                    "placeholders or too short (<16 chars). This endpoint "
                     "dispatches terminal-capable agent work — a guessable "
-                    "key is remote code execution. Generate a strong secret "
+                    "key is remote code execution. Generate strong secrets "
                     "(e.g. `openssl rand -hex 32`) and set API_SERVER_KEY "
                     "before starting the API server on %s.",
                     self.name, self._host,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4364,7 +4364,7 @@ OPTIONAL_ENV_VARS = {
         "advanced": True,
     },
     "API_SERVER_KEY": {
-        "description": "Bearer token for API server authentication. Required whenever the API server is enabled; server refuses to start without it.",
+        "description": "Bearer token(s) for API server authentication. Required whenever the API server is enabled; server refuses to start without it. Supply multiple comma-separated keys to allow several clients to authenticate with their own secret.",
         "prompt": "API server auth key",
         "url": None,
         "password": True,

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -23,6 +23,8 @@ Add to `~/.hermes/.env`:
 ```bash
 API_SERVER_ENABLED=true
 API_SERVER_KEY=change-me-local-dev
+# Supply multiple comma-separated keys to give each client its own secret:
+# API_SERVER_KEY=client-a-secret,client-b-secret
 # Optional: only if a browser must call Hermes directly
 # API_SERVER_CORS_ORIGINS=http://localhost:3000
 ```

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/api-server.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/api-server.md
@@ -23,6 +23,8 @@ Hermes 本身需要配置好 provider（提供商）和工具后端，API 服务
 ```bash
 API_SERVER_ENABLED=true
 API_SERVER_KEY=change-me-local-dev
+# 用逗号分隔多个密钥，可让每个客户端使用各自的密钥：
+# API_SERVER_KEY=client-a-secret,client-b-secret
 # 可选：仅当浏览器需要直接调用 Hermes 时
 # API_SERVER_CORS_ORIGINS=http://localhost:3000
 ```


### PR DESCRIPTION
## Summary
- `API_SERVER_KEY` now accepts multiple comma-separated bearer tokens, letting several clients authenticate with their own secret against a single API server.
- Auth checks compare an incoming token against every configured key using `hmac.compare_digest` with no early break, so response timing does not leak which/how many keys are configured.
- Startup guard (`_api_key_passes_startup_guard`) validates the strength of every configured key, not just a single one.
- Updated `API_SERVER_KEY` env-var docs (EN + zh-Hans) to describe the multi-key format.

## Test plan
- [ ] Start API server with a single key — existing single-key deployments unchanged.
- [ ] Start with comma-separated keys — each key authenticates independently.
- [ ] Start with a blank/short key mixed in — server refuses to start.
- [ ] `python -m py_compile gateway/platforms/api_server.py` passes.