### PR TITLE
fix(gateway): refresh forum command scope on reconnect

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2948,8 +2948,16 @@ class TelegramAdapter(BasePlatformAdapter):
                         logger.warning("[%s] set_my_commands FAILED for scope %s: %s", self.name, scope_name, scope_err)
                 # Forum topics don't inherit AllGroupChats — Telegram resolves
                 # commands via BotCommandScopeChat(chat_id) for forum groups.
-                # Lazy registration happens in _ensure_forum_commands on first
-                # message from a forum topic (see _handle_text_message).
+                # Proactively (re)register the per-chat scope for forum groups
+                # declared in config so their menus refresh on every reconnect,
+                # at parity with the global scopes above. Without this a forum
+                # group's menu drifts out of sync whenever the command set
+                # changes (e.g. a plugin or skill is added) until the lazy,
+                # message-gated _ensure_forum_commands happens to re-fire — which
+                # in a mention-gated group may not happen for a long time. Forum
+                # groups not present in config are still covered lazily on first
+                # message (see _handle_text_message).
+                await self._register_configured_forum_command_scopes(bot_commands)
                 if hidden_count:
                     logger.info(
                         "[%s] Telegram menu: %d commands registered, %d hidden (over %d limit). Use /commands for full list.",
@@ -7453,12 +7461,75 @@ class TelegramAdapter(BasePlatformAdapter):
             return True
         return self._message_matches_mention_patterns(message)
 
+    def _configured_forum_chat_ids(self) -> set[int]:
+        """Return forum-supergroup chat IDs declared under
+        ``platforms.telegram.extra.group_topics``.
+
+        Accepts both supported shapes — the list form
+        ``[{"chat_id": "-100...", "topics": [...]}]`` and the legacy mapping
+        ``{"-100...": [...]}`` — mirroring the ``group_topics`` parsing used
+        elsewhere in this adapter. These are known forum groups whose per-chat
+        command scope can be registered proactively at connect time instead of
+        waiting for the lazy first-message path.
+        """
+        raw = self.config.extra.get("group_topics", [])
+        if isinstance(raw, dict):
+            candidates = list(raw.keys())
+        elif isinstance(raw, list):
+            candidates = [e.get("chat_id") for e in raw if isinstance(e, dict)]
+        else:
+            candidates = []
+        chat_ids: set[int] = set()
+        for cid in candidates:
+            if cid is None:
+                continue
+            try:
+                chat_ids.add(int(cid))
+            except (TypeError, ValueError):
+                continue
+        return chat_ids
+
+    async def _register_configured_forum_command_scopes(self, bot_commands) -> None:
+        """Proactively (re)register the per-chat command scope for every forum
+        group declared in config.
+
+        Forum topics resolve their command menu only via
+        ``BotCommandScopeChat(chat_id)`` and do NOT inherit AllGroupChats, so
+        the global-scope refresh in :meth:`_run_post_connect_housekeeping` never
+        reaches them. Pushing the same command list here on every reconnect
+        keeps forum menus in sync with the rest of the bot; the lazy
+        :meth:`_ensure_forum_commands` remains the fallback for forum groups not
+        present in config. Non-fatal per chat.
+        """
+        if not self._bot:
+            return
+        from telegram import BotCommandScopeChat
+        for chat_id in self._configured_forum_chat_ids():
+            try:
+                await self._bot.set_my_commands(
+                    bot_commands, scope=BotCommandScopeChat(chat_id=chat_id)
+                )
+                self._forum_command_registered.add(chat_id)
+                logger.info(
+                    "[%s] set_my_commands OK for forum chat %s (%d cmds)",
+                    self.name, chat_id, len(bot_commands),
+                )
+            except Exception as scope_err:
+                logger.warning(
+                    "[%s] set_my_commands FAILED for forum chat %s: %s",
+                    self.name, chat_id, scope_err,
+                )
+
     async def _ensure_forum_commands(self, message) -> None:
         """Lazy-register bot commands for forum supergroups.
 
         Forum topics don't inherit AllGroupChats scope — Telegram resolves
         via BotCommandScopeChat(chat_id).  Register on first message so the
         command menu works in topic views.
+
+        This is the fallback for forum groups not declared in config;
+        configured forum groups are refreshed proactively on every reconnect
+        by :meth:`_register_configured_forum_command_scopes`.
         """
         async with self._forum_lock:
             try:

--- a/tests/gateway/test_telegram_forum_commands.py
+++ b/tests/gateway/test_telegram_forum_commands.py
@@ -116,3 +116,76 @@ async def test_ensure_forum_commands_race_safety():
 
     # The lock should make this exactly 1 call, not 2.
     assert adapter._bot.set_my_commands.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Proactive per-chat scope refresh for configured forum groups (#<issue>)
+# ---------------------------------------------------------------------------
+
+
+def test_configured_forum_chat_ids_list_shape():
+    adapter = _make_test_adapter()
+    adapter.config.extra["group_topics"] = [
+        {"chat_id": "-1001", "topics": [{"thread_id": 3, "name": "A"}]},
+        {"chat_id": -1002, "topics": []},
+        {"no_chat_id": True},  # ignored
+    ]
+    assert adapter._configured_forum_chat_ids() == {-1001, -1002}
+
+
+def test_configured_forum_chat_ids_dict_shape():
+    adapter = _make_test_adapter()
+    adapter.config.extra["group_topics"] = {
+        "-1001": [{"thread_id": 3}],
+        "-1002": [],
+        "not-an-int": [],  # ignored (unparseable)
+    }
+    assert adapter._configured_forum_chat_ids() == {-1001, -1002}
+
+
+def test_configured_forum_chat_ids_absent():
+    adapter = _make_test_adapter()
+    assert adapter._configured_forum_chat_ids() == set()
+
+
+@pytest.mark.asyncio
+async def test_register_configured_forum_scopes_pushes_per_chat():
+    """Configured forum groups get their per-chat command scope set at connect
+    time — without waiting for a message — so their menus stay in sync with the
+    global scopes when the command set changes."""
+    adapter = _make_test_adapter()
+    adapter.config.extra["group_topics"] = [
+        {"chat_id": "-1001", "topics": []},
+        {"chat_id": "-1002", "topics": []},
+    ]
+    # Opaque sentinel list; the adapter must pass it through to set_my_commands
+    # verbatim (the exact command objects are built by the caller).
+    bot_commands = [object(), object()]
+
+    # ``telegram`` is a sys.modules mock here (see conftest); track the chat_id
+    # passed to BotCommandScopeChat so assertions see an int, not a bare mock.
+    with patch("telegram.BotCommandScopeChat") as MockScope:
+        def _make_scope(chat_id):
+            s = MagicMock()
+            s.chat_id = chat_id
+            return s
+        MockScope.side_effect = _make_scope
+        await adapter._register_configured_forum_command_scopes(bot_commands)
+
+    # One set_my_commands per configured forum chat, each carrying the full
+    # command list under a chat-scoped BotCommandScopeChat.
+    assert adapter._bot.set_my_commands.await_count == 2
+    scoped_chat_ids = set()
+    for call in adapter._bot.set_my_commands.await_args_list:
+        assert call.args[0] is bot_commands
+        scoped_chat_ids.add(call.kwargs["scope"].chat_id)
+    assert scoped_chat_ids == {-1001, -1002}
+    # Registering here suppresses redundant lazy registration later.
+    assert adapter._forum_command_registered == {-1001, -1002}
+
+
+@pytest.mark.asyncio
+async def test_register_configured_forum_scopes_noop_without_config():
+    adapter = _make_test_adapter()
+    await adapter._register_configured_forum_command_scopes([])
+    adapter._bot.set_my_commands.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

Forum supergroups resolve their slash-command menu only via
`BotCommandScopeChat(chat_id)` and do **not** inherit the `AllGroupChats` scope.
`_run_post_connect_housekeeping` re-pushes the `Default` / `AllPrivateChats` /
`AllGroupChats` scopes on every reconnect, but forum per-chat scopes were only
ever set lazily by `_ensure_forum_commands` — on the first message that passes
`_should_process_message` (a mention or a command), guarded once-per-process.

As a result, when the command set changes (e.g. a plugin or skill that registers
a slash command is added), a forum group's command menu silently drifts out of
sync with every other chat type — indefinitely in a mention-gated group where
the lazy trigger rarely fires. DMs and non-forum groups stay correct because
their scopes are refreshed on every reconnect; forum groups are the only scope
left behind.

This registers per-chat command scopes for forum groups declared in config
(`platforms.telegram.extra.group_topics`) during post-connect housekeeping,
reusing the same command list already pushed to the global scopes — so forum
menus refresh on every reconnect, at parity with the global scopes. Forum groups
not present in config remain covered by the existing lazy `_ensure_forum_commands`
path.

## Related Issue

No existing issue — happy to file one if you'd prefer it tracked separately.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/telegram/adapter.py`
  - `_run_post_connect_housekeeping`: after the global scopes, call the new
    proactive forum-scope refresh with the same `bot_commands` list.
  - `_configured_forum_chat_ids()`: extract forum chat IDs from `group_topics`
    (both the list-of-dicts and the legacy `{chat_id: [...]}` mapping shapes).
  - `_register_configured_forum_command_scopes(bot_commands)`: push a per-chat
    `BotCommandScopeChat` for each configured forum group; non-fatal per chat.
  - `_ensure_forum_commands`: docstring notes it is now the fallback for forum
    groups not present in config.
- `tests/gateway/test_telegram_forum_commands.py`: cover chat-id parsing (both
  shapes) and proactive per-chat registration.

## How to Test

1. Declare a forum supergroup under `platforms.telegram.extra.group_topics`.
2. With the gateway running, add a slash command (enable a plugin/skill that
   registers one).
3. Restart/reconnect the gateway.
   - **Before:** the new command shows in DMs and non-forum groups, but not in
     the forum group's `/` menu until a mention/command message happens to
     trigger lazy registration.
   - **After:** it appears in the forum group's `/` menu immediately on reconnect.

Unit tests: `scripts/run_tests.sh tests/gateway/test_telegram_forum_commands.py`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] `pytest tests/ -q` full suite — ran the affected gateway files instead:
  `test_telegram_forum_commands.py` (10 passed) and `test_telegram_group_gating.py`
  (51 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian (Linux)

### Documentation & Housekeeping

- [x] Docstrings added on the new methods — README/docs N/A
- [x] `cli-config.yaml.example` — N/A (no new config keys; reuses existing
  `group_topics`)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact — N/A (no platform-specific code)
- [x] Tool descriptions/schemas — N/A
