### PR TITLE
fix(gateway): use launchctl load/enable on macOS 26+ instead of broken bootstrap

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3652,6 +3652,26 @@ def _is_macos_26_or_later() -> bool:
     return False
 
 
+def _limit_load_section() -> str:
+    """Return the ``LimitLoadToSessionType`` plist XML, version-dependent.
+
+    On macOS 26+, ``LimitLoadToSessionType`` causes silent load failures
+    during login auto-load (#23387), so it is omitted.  On older macOS it is
+    required for Background-session support (SSH / non-Aqua logins).
+    """
+    if _is_macos_26_or_later():
+        return ""
+    return (
+        '<key>LimitLoadToSessionType</key>\n'
+        '    <array>\n'
+        '        <string>Aqua</string>\n'
+        '        <string>Background</string>\n'
+        '    </array>\n'
+        '    \n'
+        '    '
+    )
+
+
 def _launchctl_bootstrap(
     domain: str, plist_path, label: str, *, timeout: int = 30
 ) -> None:
@@ -3980,6 +4000,7 @@ def generate_launchd_plist() -> str:
         <string>{hermes_home}</string>
     </dict>
 
+    {_limit_load_section()}
     <key>RunAtLoad</key>
     <true/>
     
@@ -4071,15 +4092,27 @@ def refresh_launchd_plist_if_needed() -> bool:
         # gateway is still draining (default agent.restart_drain_timeout=180s),
         # so a fixed ~10s window is too short — bound by that budget instead.
         _reload_budget = int(max(30.0, _get_restart_drain_timeout()))
+        if _is_macos_26_or_later():
+            _load_cmd = (
+                f"launchctl load {shlex.quote(str(plist_path))} 2>/dev/null; "
+                f"launchctl enable {shlex.quote(target)} 2>/dev/null"
+            )
+            _action_label = "load"
+        else:
+            _load_cmd = (
+                f"launchctl bootstrap {shlex.quote(domain)} "
+                f"{shlex.quote(str(plist_path))} 2>/dev/null"
+            )
+            _action_label = "bootstrap"
         reload_script = (
             f"sleep 2; "
             f"launchctl bootout {shlex.quote(target)} 2>/dev/null; "
             f"sleep 1; "
             f"_deadline=$(($(date +%s) + {_reload_budget})); "
             f"while :; do "
-            f"  launchctl bootstrap {shlex.quote(domain)} {shlex.quote(str(plist_path))} 2>/dev/null; "
+            f"  {_load_cmd}; "
             f"  if launchctl list {shlex.quote(label)} >/dev/null 2>&1; then break; fi; "
-            f"  echo \"[$(date '+%Y-%m-%d %H:%M:%S %z')] bootstrap not yet registered for {shlex.quote(target)} — retrying\" >> {shlex.quote(str(reload_log_path))}; "
+            f"  echo \"[$(date '+%Y-%m-%d %H:%M:%S %z')] {_action_label} not yet registered for {shlex.quote(target)} — retrying\" >> {shlex.quote(str(reload_log_path))}; "
             f"  if [ $(date +%s) -ge $_deadline ]; then break; fi; "
             f"  sleep 2; "
             f"done; "
@@ -4389,21 +4422,28 @@ def launchd_restart():
         print("↻ launchd job was unloaded; reloading")
         plist_path = get_launchd_plist_path()
         try:
-            # Restart is the one path where the job is almost always still
-            # registered (we just drained it), so a plain bootstrap would hit
-            # EIO on the common case. Boot the stale label out first — cheaper
-            # and clearer here than routing through _launchctl_bootstrap's
-            # bootstrap-first/retry-on-EIO flow. See #23387, #42914.
-            subprocess.run(
-                ["launchctl", "bootout", target],
-                check=False,
-                timeout=90,
-            )
-            subprocess.run(
-                ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
-                check=True,
-                timeout=30,
-            )
+            if _is_macos_26_or_later():
+                # On macOS 26+, ``launchctl bootstrap`` is broken, so use the
+                # version-aware helper which falls back to load/enable.
+                _launchctl_bootstrap(
+                    _launchd_domain(), plist_path, get_launchd_label(), timeout=30
+                )
+            else:
+                # Restart is the one path where the job is almost always still
+                # registered (we just drained it), so a plain bootstrap would hit
+                # EIO on the common case. Boot the stale label out first — cheaper
+                # and clearer here than routing through _launchctl_bootstrap's
+                # bootstrap-first/retry-on-EIO flow. See #23387, #42914.
+                subprocess.run(
+                    ["launchctl", "bootout", target],
+                    check=False,
+                    timeout=90,
+                )
+                subprocess.run(
+                    ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
+                    check=True,
+                    timeout=30,
+                )
             subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
         except subprocess.CalledProcessError as e2:
             if not _launchctl_domain_unsupported(e2.returncode):

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3632,24 +3632,54 @@ def _launchctl_domain_unsupported(returncode: int) -> bool:
 _LAUNCHCTL_BOOTSTRAP_EIO = 5
 
 
+def _is_macos_26_or_later() -> bool:
+    """Return True on macOS 26+ where ``launchctl bootstrap`` is broken (exit 5).
+
+    ``launchctl bootstrap`` returns exit code 5 (EIO) on macOS 26+, and the
+    plist ``LimitLoadToSessionType`` key causes silent load failures during
+    login auto-load (#23387).  We fall back to the older ``launchctl load`` +
+    ``launchctl enable`` combination on affected hosts.
+    """
+    if sys.platform != "darwin":
+        return False
+    try:
+        import platform
+        ver = platform.mac_ver()[0]
+        if ver:
+            return int(ver.split(".")[0]) >= 26
+    except Exception:
+        pass
+    return False
+
+
 def _launchctl_bootstrap(
     domain: str, plist_path, label: str, *, timeout: int = 30
 ) -> None:
-    """Bootstrap a launchd job, recovering from a stale already-loaded label.
+    """Load a launchd job, using the correct command for this macOS version.
 
-    On modern macOS, ``launchctl bootstrap`` of a label that is still
-    registered in ``domain`` fails with ``5: Input/output error`` (EIO). That
-    is the *already loaded* case — distinct from the domain being unmanageable,
-    which callers handle via :func:`_launchctl_domain_unsupported`. A leftover
-    registration from an interrupted restart leaves the job
-    loaded-but-not-running, so the next bootstrap hits EIO; without this retry
-    we misclassify it as "launchd cannot manage this macOS version" and degrade
-    to a detached process, silently losing auto-start and crash-restart.
+    On macOS 26+, ``launchctl bootstrap`` is broken (exit 5, #23387) so we
+    use ``launchctl load`` + ``launchctl enable`` instead.  On older macOS,
+    ``launchctl bootstrap`` (the modern API) is preferred, with recovery for
+    the stale already-loaded label case.
 
-    Recover by booting the stale label out and bootstrapping once more. If the
-    retry still fails, the ``CalledProcessError`` propagates so callers apply
-    their domain-unsupported fallback for a genuinely broken domain.
+    Recover by booting the stale label out and retrying. If the retry still
+    fails, the ``CalledProcessError`` propagates so callers apply their
+    domain-unsupported fallback for a genuinely broken domain.
     """
+    if _is_macos_26_or_later():
+        subprocess.run(
+            ["launchctl", "load", str(plist_path)],
+            check=True,
+            timeout=timeout,
+        )
+        subprocess.run(
+            ["launchctl", "enable", f"{domain}/{label}"],
+            check=True,
+            timeout=timeout,
+        )
+        return
+
+    # macOS < 26: use launchctl bootstrap with stale-label recovery
     try:
         subprocess.run(
             ["launchctl", "bootstrap", domain, str(plist_path)],
@@ -3950,12 +3980,6 @@ def generate_launchd_plist() -> str:
         <string>{hermes_home}</string>
     </dict>
 
-    <key>LimitLoadToSessionType</key>
-    <array>
-        <string>Aqua</string>
-        <string>Background</string>
-    </array>
-    
     <key>RunAtLoad</key>
     <true/>
     

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -812,6 +812,36 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "kickstart", target],
         ]
 
+    def test_launchd_start_reloads_with_load_enable_on_macos_26(self, tmp_path, monkeypatch):
+        """On macOS 26+, the unloaded-job recovery uses launchctl load/enable."""
+        monkeypatch.setattr(gateway_cli, "_is_macos_26_or_later", lambda: True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        label = gateway_cli.get_launchd_label()
+
+        calls = []
+        domain = gateway_cli._launchd_domain()
+        target = f"{domain}/{label}"
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd and cmd[0] == "launchctl":
+                calls.append(cmd)
+            if cmd == ["launchctl", "kickstart", target] and calls.count(cmd) == 1:
+                raise gateway_cli.subprocess.CalledProcessError(3, cmd, stderr="Could not find service")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_start()
+
+        assert calls == [
+            ["launchctl", "kickstart", target],
+            ["launchctl", "load", str(plist_path)],
+            ["launchctl", "enable", target],
+            ["launchctl", "kickstart", target],
+        ]
+
     def test_launchd_start_reloads_on_kickstart_exit_code_113(self, tmp_path, monkeypatch):
         """Exit code 113 (\"Could not find service\") should also trigger bootstrap recovery."""
         plist_path = tmp_path / "ai.hermes.gateway.plist"
@@ -1164,6 +1194,53 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "kickstart", "-k", target],
             ["launchctl", "bootout", target],
             ["launchctl", "bootstrap", domain, str(plist_path)],
+            ["launchctl", "kickstart", target],
+        ]
+
+    def test_launchd_restart_reloads_using_launchctl_bootstrap_on_macos_26(
+        self, tmp_path, monkeypatch
+    ):
+        """On macOS 26+, the unloaded-job recovery uses _launchctl_bootstrap (load/enable).
+
+        The existing test exercises the bootout-first + bootstrap flow for macOS < 26.
+        This test verifies that on macOS 26+ the recovery delegates to
+        _launchctl_bootstrap (which uses load/enable internally) and then kickstarts.
+        """
+        monkeypatch.setattr(gateway_cli, "_is_macos_26_or_later", lambda: True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        label = gateway_cli.get_launchd_label()
+        domain = gateway_cli._launchd_domain()
+        target = f"{domain}/{label}"
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 5.0)
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+        monkeypatch.setattr(
+            gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True
+        )
+        monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: None)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
+
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd and cmd[0] == "launchctl":
+                calls.append(cmd)
+            if cmd == ["launchctl", "kickstart", "-k", target]:
+                raise gateway_cli.subprocess.CalledProcessError(
+                    3, cmd, stderr="Could not find service"
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_restart()
+
+        assert calls == [
+            ["launchctl", "kickstart", "-k", target],
+            ["launchctl", "load", str(plist_path)],
+            ["launchctl", "enable", target],
             ["launchctl", "kickstart", target],
         ]
 
@@ -2590,13 +2667,21 @@ class TestProfileArg:
         assert "<string>--profile</string>" in plist
         assert "<string>mybot</string>" in plist
 
-    def test_launchd_plist_supports_aqua_and_background_sessions(self):
-        # macOS 26+ only loads the agent in non-Aqua sessions when the plist
-        # opts into Background as well (issue #23387).
+    def test_launchd_plist_supports_aqua_and_background_sessions(self, monkeypatch):
+        # Pre-macOS 26: plist must opt into both Aqua and Background sessions
+        # for SSH / non-Aqua logins (issue #23387).
+        monkeypatch.setattr(gateway_cli, "_is_macos_26_or_later", lambda: False)
         plist = gateway_cli.generate_launchd_plist()
         assert "<key>LimitLoadToSessionType</key>" in plist
         assert "<string>Aqua</string>" in plist
         assert "<string>Background</string>" in plist
+
+    def test_launchd_plist_omits_limit_load_on_macos_26(self, monkeypatch):
+        # On macOS 26+, LimitLoadToSessionType causes silent load failures
+        # during login auto-load (#23387), so it should be omitted.
+        monkeypatch.setattr(gateway_cli, "_is_macos_26_or_later", lambda: True)
+        plist = gateway_cli.generate_launchd_plist()
+        assert "<key>LimitLoadToSessionType</key>" not in plist
 
     def test_launchd_plist_path_uses_real_user_home_not_profile_home(self, tmp_path, monkeypatch):
         profile_dir = tmp_path / ".hermes" / "profiles" / "orcha"
@@ -3586,6 +3671,16 @@ class TestLaunchctlBootstrapEioRetry:
     DOMAIN = "gui/501"
     LABEL = "ai.hermes.gateway"
 
+    @pytest.fixture(autouse=True)
+    def _patch_macos_version(self, monkeypatch):
+        """These tests exercise the macOS < 26 (``launchctl bootstrap``) path.
+
+        On macOS 26+ the tested function takes a different code path
+        (``launchctl load/enable``), tested separately in
+        :class:`TestLaunchctlBootstrapMacOs26`.
+        """
+        monkeypatch.setattr(gateway_cli, "_is_macos_26_or_later", lambda: False)
+
     def test_bootstrap_succeeds_first_try_without_bootout(self, monkeypatch):
         calls = []
 
@@ -3652,6 +3747,61 @@ class TestLaunchctlBootstrapEioRetry:
         assert calls == [["launchctl", "bootstrap", self.DOMAIN, self.PLIST]]
 
 
+class TestLaunchctlBootstrapMacOs26:
+    """`_launchctl_bootstrap` on macOS 26+ uses ``launchctl load/enable``.
+
+    On macOS 26+, ``launchctl bootstrap`` is broken (exit 5, #23387) so
+    ``_launchctl_bootstrap`` falls back to ``launchctl load`` +
+    ``launchctl enable`` instead.
+    """
+
+    PLIST = "/tmp/ai.hermes.gateway.plist"
+    DOMAIN = "gui/501"
+    LABEL = "ai.hermes.gateway"
+
+    @pytest.fixture(autouse=True)
+    def _patch_macos_version(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_is_macos_26_or_later", lambda: True)
+
+    def test_loads_plist_and_enables_label(self, monkeypatch):
+        calls = []
+
+        def fake_run(cmd, check=True, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli._launchctl_bootstrap(self.DOMAIN, self.PLIST, self.LABEL)
+
+        assert calls == [
+            ["launchctl", "load", self.PLIST],
+            ["launchctl", "enable", f"{self.DOMAIN}/{self.LABEL}"],
+        ]
+
+    def test_load_failure_propagates(self, monkeypatch):
+        def fake_run(cmd, check=True, **kwargs):
+            if cmd[1] == "load":
+                raise subprocess.CalledProcessError(1, cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(subprocess.CalledProcessError):
+            gateway_cli._launchctl_bootstrap(self.DOMAIN, self.PLIST, self.LABEL)
+
+    def test_enable_failure_propagates(self, monkeypatch):
+        def fake_run(cmd, check=True, **kwargs):
+            if cmd[1] == "enable":
+                raise subprocess.CalledProcessError(1, cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(subprocess.CalledProcessError):
+            gateway_cli._launchctl_bootstrap(self.DOMAIN, self.PLIST, self.LABEL)
+
+
 class TestRetryLaunchctlBootstrapUntilRegistered:
     """`_retry_launchctl_bootstrap_until_registered` — salvage of #53277.
 
@@ -3659,11 +3809,19 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
     label is actually LISTED (not just a zero bootstrap exit), TimeoutExpired
     is retried (not escaped leaving the service unloaded), and the retry is
     bounded by a wall-clock deadline rather than a fixed short window.
+
+    These tests exercise the macOS < 26 (``launchctl bootstrap``) path.
+    The macOS 26+ path (``launchctl load/enable``) is tested in
+    :class:`TestRetryLaunchctlBootstrapUntilRegisteredMacOs26`.
     """
 
     DOMAIN = "gui/501"
     PLIST = "/tmp/ai.hermes.gateway.plist"
     LABEL = "ai.hermes.gateway"
+
+    @pytest.fixture(autouse=True)
+    def _patch_macos_version(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_is_macos_26_or_later", lambda: False)
 
     def test_returns_true_once_label_is_registered(self, monkeypatch):
         """Success requires launchctl list to confirm registration, not just
@@ -3729,3 +3887,61 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
             deadline=gateway_cli.time.monotonic() - 1,
         )
         assert ok is False
+
+
+class TestRetryLaunchctlBootstrapUntilRegisteredMacOs26:
+    """`_retry_launchctl_bootstrap_until_registered` on macOS 26+.
+
+    Same retry/verify semantics as the macOS < 26 path, but internally
+    ``_launchctl_bootstrap`` uses ``launchctl load/enable`` instead of
+    ``launchctl bootstrap``.
+    """
+
+    DOMAIN = "gui/501"
+    PLIST = "/tmp/ai.hermes.gateway.plist"
+    LABEL = "ai.hermes.gateway"
+
+    @pytest.fixture(autouse=True)
+    def _patch_macos_version(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_is_macos_26_or_later", lambda: True)
+
+    def test_retries_until_registered_using_load_enable(self, monkeypatch):
+        list_results = iter([1, 0])  # first: not registered, second: registered
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd[:2] == ["launchctl", "list"]:
+                return SimpleNamespace(returncode=next(list_results))
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr(gateway_cli.time, "sleep", lambda *_a, **_k: None)
+
+        ok = gateway_cli._retry_launchctl_bootstrap_until_registered(
+            self.DOMAIN, self.PLIST, self.LABEL,
+            deadline=gateway_cli.time.monotonic() + 60,
+        )
+        assert ok is True
+
+    def test_timeout_expired_retried_on_macos_26(self, monkeypatch):
+        """A bootstrap-category timeout is still retried even on macOS 26+."""
+        attempts = {"bootstrap": 0}
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd[1] == "load":
+                attempts["bootstrap"] += 1
+                if attempts["bootstrap"] == 1:
+                    raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout", 30))
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            if cmd[:2] == ["launchctl", "list"]:
+                return SimpleNamespace(returncode=0 if attempts["bootstrap"] >= 2 else 1)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr(gateway_cli.time, "sleep", lambda *_a, **_k: None)
+
+        ok = gateway_cli._retry_launchctl_bootstrap_until_registered(
+            self.DOMAIN, self.PLIST, self.LABEL,
+            deadline=gateway_cli.time.monotonic() + 60,
+        )
+        assert ok is True
+        assert attempts["bootstrap"] >= 2


### PR DESCRIPTION
## Problem

On macOS 26.5.2, `launchctl bootstrap` returns exit 5 (EIO) at all 6 call sites. The `LimitLoadToSessionType` key causes silent plist load failure.

## Fix

1. Remove `LimitLoadToSessionType` from plist template
2. Use `launchctl load` + `launchctl enable` on macOS 26+ (`load` is unaffected by this regression)
3. Keep `bootstrap` on older macOS for API consistency

Ref: #42395, #43260