### PR TITLE
fix(x_search): raise handle-filter cap from 10 to 20 to match xAI

### DIFF
--- a/tests/tools/test_x_search_tool.py
+++ b/tests/tools/test_x_search_tool.py
@@ -97,6 +97,38 @@ def test_x_search_rejects_conflicting_handle_filters(monkeypatch):
     assert result["error"] == "allowed_x_handles and excluded_x_handles cannot be used together"
 
 
+def test_x_search_accepts_up_to_20_handles(monkeypatch):
+    """xAI allows up to 20 handles per filter; the tool must not reject 20."""
+    from tools.x_search_tool import x_search_tool, MAX_HANDLES
+
+    assert MAX_HANDLES == 20
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["json"] = json
+        return _FakeResponse({"output_text": "ok", "citations": []})
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    handles = [f"handle{i}" for i in range(20)]
+    result = json.loads(x_search_tool(query="what's trending", allowed_x_handles=handles))
+    assert result["success"] is True
+    assert captured["json"]["tools"][0]["allowed_x_handles"] == handles
+
+
+def test_x_search_rejects_more_than_20_handles(monkeypatch):
+    from tools.x_search_tool import x_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+
+    result = json.loads(
+        x_search_tool(query="hi", allowed_x_handles=[f"h{i}" for i in range(21)])
+    )
+    assert result["error"] == "allowed_x_handles supports at most 20 handles"
+
+
 def test_x_search_extracts_inline_url_citations(monkeypatch):
     from tools.x_search_tool import x_search_tool
 

--- a/tools/x_search_tool.py
+++ b/tools/x_search_tool.py
@@ -59,7 +59,10 @@ DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
 DEFAULT_X_SEARCH_MODEL = "grok-4.20-reasoning"
 DEFAULT_X_SEARCH_TIMEOUT_SECONDS = 180
 DEFAULT_X_SEARCH_RETRIES = 2
-MAX_HANDLES = 10
+# xAI's X Search accepts up to 20 handles for each of allowed_x_handles /
+# excluded_x_handles (they remain mutually exclusive per request).
+# https://docs.x.ai/developers/tools/x-search
+MAX_HANDLES = 20
 
 
 # ---------------------------------------------------------------------------
@@ -470,12 +473,12 @@ X_SEARCH_SCHEMA = {
             "allowed_x_handles": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": "Optional list of X handles to include exclusively (max 10).",
+                "description": "Optional list of X handles to include exclusively (max 20).",
             },
             "excluded_x_handles": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": "Optional list of X handles to exclude (max 10).",
+                "description": "Optional list of X handles to exclude (max 20).",
             },
             "from_date": {
                 "type": "string",


### PR DESCRIPTION
## What does this PR do?

xAI's X Search tool accepts **up to 20 handles** for each of
`allowed_x_handles` and `excluded_x_handles` (they remain mutually exclusive
per request). The Hermes `x_search` tool hard-capped `MAX_HANDLES` at **10**,
so a valid 11–20-handle filter was rejected client-side with
`"... supports at most 10 handles"` before any request was made.

Raise the cap to 20 to match the current xAI limit, and update the schema
parameter descriptions (`max 10` → `max 20`). Fail-fast validation above 20
and the allowed/excluded mutual-exclusivity guard are unchanged.

Ref: <https://docs.x.ai/developers/tools/x-search> ("The maximum number of
handles you can include/exclude is 20.")

## Related Issue

No existing issue — found while auditing the `x_search` tool against xAI's
current API docs.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/x_search_tool.py` — `MAX_HANDLES` 10 → 20 (with a doc-linked comment);
  schema descriptions updated to `max 20`.
- `tests/tools/test_x_search_tool.py` — regression tests: 20 handles accepted
  (and forwarded to the request), 21 handles rejected with the updated message.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_x_search_tool.py -q` → all pass (27).
2. `x_search(query=..., allowed_x_handles=[20 handles])` now succeeds instead of
   erroring; 21 handles still fails fast.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits (`fix(x_search):`)
- [x] I searched for existing PRs (none touch the handle cap)
- [x] Only changes related to this fix
- [x] Affected test module passes — `tests/tools/test_x_search_tool.py` (27). Full suite not run locally.
- [x] Added regression tests
- [x] Tested on: Ubuntu (WSL2), against current `main`

### Documentation & Housekeeping

- [x] Tool schema descriptions updated (`max 10` → `max 20`)
- [x] No config keys changed — N/A
- [x] No architecture/workflow change — N/A
