### PR TITLE
fix(codex): drop oversized message ids on Responses input replay

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -288,6 +288,13 @@ _RESPONSES_BUILTIN_TOOL_TYPES = {
 
 _RESPONSE_MESSAGE_STATUSES = {"completed", "incomplete", "in_progress"}
 
+# The Responses API rejects input[].id longer than this with a non-retryable
+# HTTP 400 ("string too long"). Codex-issued assistant message ids are
+# server-assigned base64 blobs that can run 400+ chars, while Hermes-minted
+# ids (msg_...) stay well under this cap and are worth keeping for
+# prefix-cache hits. Drop only the oversized ones on replay.
+_MAX_RESPONSES_ITEM_ID_LENGTH = 64
+
 
 def _normalize_responses_message_status(value: Any, *, default: str = "completed") -> str:
     """Normalize a Responses assistant message status for replay.
@@ -464,7 +471,9 @@ def _chat_messages_to_responses_input(
                         }
                         item_id = raw_item.get("id")
                         if isinstance(item_id, str) and item_id.strip():
-                            replay_item["id"] = item_id.strip()
+                            stripped_id = item_id.strip()
+                            if len(stripped_id) <= _MAX_RESPONSES_ITEM_ID_LENGTH:
+                                replay_item["id"] = stripped_id
                         phase = raw_item.get("phase")
                         if isinstance(phase, str) and phase.strip():
                             replay_item["phase"] = phase.strip()
@@ -718,7 +727,9 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
             }
             item_id = item.get("id")
             if isinstance(item_id, str) and item_id.strip():
-                normalized_item["id"] = item_id.strip()
+                stripped_id = item_id.strip()
+                if len(stripped_id) <= _MAX_RESPONSES_ITEM_ID_LENGTH:
+                    normalized_item["id"] = stripped_id
             phase = item.get("phase")
             if isinstance(phase, str) and phase.strip():
                 normalized_item["phase"] = phase.strip()

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -3,9 +3,11 @@ from types import SimpleNamespace
 import pytest
 
 from agent.codex_responses_adapter import (
+    _chat_messages_to_responses_input,
     _format_responses_error,
     _normalize_codex_response,
     _preflight_codex_api_kwargs,
+    _preflight_codex_input_items,
 )
 
 
@@ -137,6 +139,128 @@ def test_normalize_codex_response_in_progress_message_still_incomplete():
     _assistant_message, finish_reason = _normalize_codex_response(response)
 
     assert finish_reason == "incomplete"
+
+
+# ---------------------------------------------------------------------------
+# Replayed assistant message items with an oversized server-assigned ``id``
+# (Codex issues 400+ char base64 blobs) must never reach the API — the
+# Responses endpoint caps input[].id at 64 chars and rejects the whole
+# request with a non-retryable HTTP 400, permanently bricking the session
+# (every subsequent turn replays the same bad id). Short ids (msg_...) are
+# still worth keeping for prefix-cache hits, so this is a length guard, not
+# a blanket strip.
+# ---------------------------------------------------------------------------
+
+_OVERSIZED_ITEM_ID = "x" * 408
+_VALID_ITEM_ID = "msg_abc123"
+
+
+def test_chat_messages_to_responses_input_drops_oversized_message_id():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "pong",
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "pong"}],
+                    "id": _OVERSIZED_ITEM_ID,
+                    "phase": "final_answer",
+                }
+            ],
+        }
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+
+    message_item = next(item for item in items if item.get("type") == "message")
+    assert "id" not in message_item
+    assert message_item["phase"] == "final_answer"
+    assert message_item["content"] == [{"type": "output_text", "text": "pong"}]
+
+
+def test_chat_messages_to_responses_input_keeps_short_message_id():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "pong",
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "pong"}],
+                    "id": _VALID_ITEM_ID,
+                }
+            ],
+        }
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+
+    message_item = next(item for item in items if item.get("type") == "message")
+    assert message_item["id"] == _VALID_ITEM_ID
+
+
+def test_preflight_codex_input_items_drops_oversized_message_id():
+    items = _preflight_codex_input_items(
+        [
+            {
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": "pong"}],
+                "id": _OVERSIZED_ITEM_ID,
+                "phase": "final_answer",
+            }
+        ]
+    )
+
+    assert "id" not in items[0]
+    assert items[0]["phase"] == "final_answer"
+
+
+def test_preflight_codex_input_items_keeps_short_message_id():
+    items = _preflight_codex_input_items(
+        [
+            {
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": "pong"}],
+                "id": _VALID_ITEM_ID,
+            }
+        ]
+    )
+
+    assert items[0]["id"] == _VALID_ITEM_ID
+
+
+def test_preflight_codex_api_kwargs_drops_oversized_message_id_end_to_end():
+    kwargs = _preflight_codex_api_kwargs(
+        {
+            "model": "gpt-5.5",
+            "instructions": "You are Hermes.",
+            "input": [
+                {"role": "user", "content": "ping"},
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "pong"}],
+                    "id": _OVERSIZED_ITEM_ID,
+                    "phase": "final_answer",
+                },
+            ],
+            "tools": [],
+            "store": False,
+        }
+    )
+
+    message_item = next(item for item in kwargs["input"] if item.get("type") == "message")
+    assert "id" not in message_item
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #27038 — root cause, not a workaround.

Codex assigns assistant `message` items a server-side `id` that can run 400+ chars (base64 encrypted blob). The Responses API caps `input[N].id` at 64 chars and rejects the whole request with a **non-retryable HTTP 400**:

```
Invalid 'input[1].id': string too long. Expected a string with maximum length 64,
but got a string with length 408 instead.
```

Once a session captures one of these long ids into `codex_message_items`, it is persisted to the session history and replayed on every subsequent turn — permanently bricking the session for the `openai-codex` provider. No amount of model fallback helps, since the bad payload is rebuilt from history on every retry.

## Root cause

Two call sites in `agent/codex_responses_adapter.py` copied the replayed message `id` through without a length check:

- `_chat_messages_to_responses_input` — history → Responses input converter (used on every turn, all Responses-based transports)
- `_preflight_codex_input_items` — the final validation gate inside `_preflight_codex_api_kwargs`, called unconditionally in `agent/conversation_loop.py` before every `codex_responses` API call

This preflight gate is why the fix there alone is sufficient defense-in-depth: it runs regardless of how the `input` array was built. The history-converter fix additionally stops the oversized id from ever reaching preflight in the normal path.

This mirrors the existing pattern for `reasoning` items, which already strip their `id` before replay (with a comment explaining that `store=False` makes server-side id lookup impossible anyway — the comment doesn't currently apply to message items, but the same constraint holds).

## Fix

Add a 64-char length guard (`_MAX_RESPONSES_ITEM_ID_LENGTH`) at both replay sites. Oversized ids are dropped; short Hermes-minted ids (`msg_...`) are kept so prefix-cache hits aren't lost. This is the guard confirmed working by multiple reporters on the issue thread (darconadalabarga, MrSimonC) rather than the blanket-strip alternative, which would also throw away valid short ids.

```python
item_id = raw_item.get("id")
if isinstance(item_id, str) and item_id.strip():
    stripped_id = item_id.strip()
    if len(stripped_id) <= _MAX_RESPONSES_ITEM_ID_LENGTH:
        replay_item["id"] = stripped_id
```

Applied identically in `_chat_messages_to_responses_input` and `_preflight_codex_input_items`.

## Verification

Confirmed the bug is real before fixing:
- Added tests asserting oversized (408-char) ids are dropped and short ids are kept, at both call sites plus an end-to-end `_preflight_codex_api_kwargs` test.
- **3 of 5 new tests failed against unmodified `main`**, reproducing the exact `input[1].id` leak described in the issue.
- After the fix: all 5 pass.

Confirmed no other code path builds Responses `message` input items with an `id` (grepped `agent/**/*.py` for the pattern) — this is the only place the bug could originate.

Full regression run, all green:

```
tests/agent/test_codex_responses_adapter.py .................... (21 passed, 5 new)
tests/run_agent/test_run_agent_codex_responses.py .... (79 passed)
tests/agent/transports/test_codex_transport.py ... (passed)
tests/agent/test_replay_cleanup.py ... (passed)
tests/gateway/test_replay_entry_fields.py ... (passed)
tests/test_hermes_state.py ... (passed)
tests/run_agent/test_codex_xai_oauth_recovery.py .... (46 passed)
```

## Test plan

- [x] New unit tests reproduce the 400 before the fix, pass after
- [x] Existing adapter/transport/replay/session-state suites unaffected
- [x] Manually confirmed no other adapter builds Responses `message` items with `id` (only `codex_responses_adapter.py` owns this shape)

Not in scope: #32716 (Copilot 401 "input item id does not belong to this connection") is a different root cause — connection-scoped id rejection, not length — and needs a separate fix.

## Parallel contributions

This is the selected implementation for #27038. Earlier/parallel fixes #17318 (@gary1003), #43820 (@adambiggs), and #35488 (@santosderek) identified the same replay boundary and are credited in the closeout.

## Infographic

![Safe Responses replay](https://v3b.fal.media/files/b/0aa1c424/Psz7xB2f6OMDiSfer6wtv_vG5I1m3h.png)
