### PR TITLE
feat(skills): add x-pulse — sourced X discussion digest via x_search

### DIFF
--- a/optional-skills/social-media/x-pulse/SKILL.md
+++ b/optional-skills/social-media/x-pulse/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: x-pulse
+description: "Summarize the most-discussed X posts on chosen topics."
+version: 1.0.0
+author: HumphreySun98
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Social-Media, X, Twitter, Trends, Digest, Grok]
+    related_skills: [xurl]
+    requires_tools: [x_search]
+---
+
+# X Pulse Skill
+
+Build a sourced digest of what's being discussed on X (Twitter) about a set of
+topics, using the native `x_search` tool (xAI Grok's X index). It is for
+*reading* the current conversation — trending discussion, reactions, claims —
+not for posting; use the `xurl` skill to post or DM. xAI has **no** trending or
+engagement-sort parameter, so "hottest" is expressed as a well-formed query and
+the value here is the multi-topic sweep, dedup, and scheduled delivery.
+
+## When to Use
+
+- User asks "what's happening / trending on X about <topic>?"
+- User wants a recurring digest of X discussion (a "daily X pulse")
+- User wants sourced reactions to a launch, event, or claim from X
+
+Do NOT use for general web search (use `web_search`) or to publish to X (use
+the `xurl` skill).
+
+## Prerequisites
+
+- xAI credentials so the `x_search` tool is registered — either a SuperGrok
+  OAuth login (`hermes auth add xai-oauth`) or `XAI_API_KEY` in `~/.hermes/.env`.
+  This skill only appears when `x_search` is available (`requires_tools`).
+- No extra packages; the digest script is pure Python stdlib.
+
+## How to Run
+
+1. Call the native `x_search` tool once per topic (it answers a single query at
+   a time) and collect each JSON result.
+2. Write the collected results to a JSON file with `write_file`.
+3. Run the digest builder through the `terminal` tool:
+   ```
+   python scripts/build_digest.py --input results.json --title "X Pulse" --date 2026-07-10
+   ```
+4. Deliver the markdown it prints with `send_message`, or schedule the whole
+   flow with `cronjob`.
+
+## Quick Reference
+
+| Need | How |
+|---|---|
+| Hottest discussion on a topic | `x_search(query="most-discussed posts about <topic> in the last 24h, cite the posts")` |
+| Restrict to accounts | `x_search(query=..., allowed_x_handles=[...])` — max 20, mutually exclusive with `excluded_x_handles` |
+| Recent window | `x_search(query=..., from_date="YYYY-MM-DD", to_date="YYYY-MM-DD")` |
+| Merge topics into one digest | `python scripts/build_digest.py --input results.json` |
+| Daily delivery | `cronjob(action="create", schedule="0 9 * * *", prompt="Run the x-pulse skill for <topics> and send the digest")` |
+
+`build_digest.py` input is a JSON list of `{"topic": "<label>", "result": <x_search JSON>}`.
+
+## Procedure
+
+1. Resolve the topic list from the user (2–6 topics works well).
+2. For each topic, call `x_search` with a query that asks for the **most
+   discussed / highest-engagement** posts in the desired window and requests
+   citations, e.g. `"the most-discussed posts about AI safety in the last 24
+   hours — summarize the main threads and cite the posts"`.
+3. Assemble a JSON list of `{"topic", "result"}` (parse each `x_search` return)
+   and save it with `write_file` to e.g. `results.json`.
+4. Run `python scripts/build_digest.py --input results.json --title "X Pulse"
+   --date <today>` through the `terminal` tool.
+5. Send the resulting markdown with `send_message` to the requested chat, or
+   register a `cronjob` that repeats steps 1–5 on a schedule.
+
+## Pitfalls
+
+- **No trending API.** xAI's X Search has no popularity/sort parameter — the six
+  supported knobs are `allowed_x_handles`, `excluded_x_handles`, `from_date`,
+  `to_date`, `enable_image_understanding`, `enable_video_understanding`. "Hot"
+  lives entirely in the query wording.
+- **Unsourced answers.** When a result has `degraded: true`, the answer came
+  from the model's own knowledge, not the live X index. The digest flags these
+  with a ⚠️ line — treat them as unverified.
+- **Handle limits.** Up to 20 handles per filter; `allowed_x_handles` and
+  `excluded_x_handles` cannot be combined in one call.
+- **Date ranges.** Dates are `YYYY-MM-DD`; a `from_date` later than today
+  returns nothing. Keep windows recent for "what's hot right now".
+
+## Verification
+
+```
+echo '[{"topic":"AI","result":{"success":true,"answer":"Big week for open models.","citations":[{"url":"https://x.com/a/status/1","title":"post"}],"degraded":false}}]' | python scripts/build_digest.py --title "X Pulse"
+```
+
+Prints a markdown digest with the topic section and a deduped Sources list.

--- a/optional-skills/social-media/x-pulse/scripts/build_digest.py
+++ b/optional-skills/social-media/x-pulse/scripts/build_digest.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Assemble an X pulse digest from one or more ``x_search`` results.
+
+The native ``x_search`` tool answers ONE query at a time and returns JSON with
+an ``answer`` string, a ``citations`` list (``[{"url", "title"}]``), and a
+``degraded`` flag that is ``True`` when the answer came from the model's own
+knowledge rather than the live X index. This helper merges several per-topic
+results into a single deduplicated markdown digest suitable for delivery via
+``send_message`` or a scheduled ``cronjob``.
+
+Input (``--input FILE`` or stdin): a JSON list of entries, one per topic::
+
+    [{"topic": "AI research", "result": {<x_search JSON>}}, ...]
+
+Output (stdout): a markdown digest. Pure stdlib; no network.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any, Dict, List, Tuple
+
+
+def _norm_url(url: str) -> str:
+    """Normalize a URL for dedup: drop fragment, trailing slash, lowercase."""
+    u = (url or "").strip()
+    u = u.split("#", 1)[0]
+    if u.endswith("/"):
+        u = u[:-1]
+    return u.lower()
+
+
+def dedupe_citations(citations: Any) -> List[Dict[str, str]]:
+    """Deduplicate citations by normalized URL, preserving first-seen order."""
+    seen: set = set()
+    out: List[Dict[str, str]] = []
+    for c in citations or []:
+        if not isinstance(c, dict):
+            continue
+        url = str(c.get("url") or "").strip()
+        if not url:
+            continue
+        key = _norm_url(url)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append({"url": url, "title": str(c.get("title") or "").strip()})
+    return out
+
+
+def _citation_lines(citations: List[Dict[str, str]]) -> List[str]:
+    lines = []
+    for c in citations:
+        label = c["title"] or c["url"]
+        lines.append(f"- [{label}]({c['url']})")
+    return lines
+
+
+def _topic_section(topic: str, result: Any) -> Tuple[str, List[Dict[str, str]]]:
+    """Render one topic's section and return (markdown, its deduped citations)."""
+    if not isinstance(result, dict) or not result.get("success"):
+        err = result.get("error") if isinstance(result, dict) else None
+        note = f": {err}" if err else ""
+        return f"### {topic}\n\n_(no result{note})_\n", []
+
+    answer = str(result.get("answer") or "").strip()
+    citations = dedupe_citations(result.get("citations"))
+    lines = [f"### {topic}", ""]
+    if result.get("degraded"):
+        lines.append(
+            "> ⚠️ Unsourced — the answer came from the model's own knowledge, "
+            "not the live X index. Treat with caution."
+        )
+        lines.append("")
+    lines.append(answer or "_(empty answer)_")
+    if citations:
+        lines.append("")
+        lines.extend(_citation_lines(citations))
+    lines.append("")
+    return "\n".join(lines), citations
+
+
+def build_digest(entries: Any, title: str = "X Pulse", date_str: str = "") -> str:
+    """Build a markdown digest from a list of ``{topic, result}`` entries."""
+    header = f"# {title}"
+    if date_str:
+        header += f" — {date_str}"
+    parts: List[str] = [header, ""]
+
+    if not entries:
+        parts.append("_No topics provided._")
+        return "\n".join(parts) + "\n"
+
+    all_citations: List[Dict[str, str]] = []
+    for entry in entries:
+        entry = entry or {}
+        topic = str(entry.get("topic") or "").strip() or "(untitled)"
+        section, cites = _topic_section(topic, entry.get("result"))
+        parts.append(section)
+        all_citations.extend(cites)
+
+    merged = dedupe_citations(all_citations)
+    if merged:
+        parts.extend(["---", "", f"**Sources ({len(merged)})**", ""])
+        parts.extend(_citation_lines(merged))
+
+    return "\n".join(parts).rstrip() + "\n"
+
+
+def main(argv: List[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Build an X pulse digest from x_search results."
+    )
+    ap.add_argument("--input", help="JSON file with per-topic results (default: stdin).")
+    ap.add_argument("--title", default="X Pulse")
+    ap.add_argument("--date", default="", dest="date_str")
+    args = ap.parse_args(argv)
+
+    raw = (
+        open(args.input, encoding="utf-8").read()
+        if args.input
+        else sys.stdin.read()
+    )
+    try:
+        entries = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"error: invalid JSON input: {exc}", file=sys.stderr)
+        return 2
+    if not isinstance(entries, list):
+        print(
+            "error: input must be a JSON list of {topic, result} entries",
+            file=sys.stderr,
+        )
+        return 2
+
+    sys.stdout.write(build_digest(entries, title=args.title, date_str=args.date_str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/skills/test_x_pulse_skill.py
+++ b/tests/skills/test_x_pulse_skill.py
@@ -1,0 +1,130 @@
+"""Tests for optional-skills/social-media/x-pulse/scripts/build_digest.py."""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "social-media"
+    / "x-pulse"
+)
+sys.path.insert(0, str(SKILL_DIR / "scripts"))
+
+import build_digest as bd  # noqa: E402
+
+
+# ── dedupe_citations ────────────────────────────────────────────────────────
+
+class TestDedupeCitations:
+    def test_dedupes_by_normalized_url(self):
+        cites = [
+            {"url": "https://x.com/a/status/1", "title": "one"},
+            {"url": "https://x.com/a/status/1/", "title": "dup trailing slash"},
+            {"url": "HTTPS://X.com/a/status/1#frag", "title": "dup case+frag"},
+            {"url": "https://x.com/b/status/2", "title": "two"},
+        ]
+        out = bd.dedupe_citations(cites)
+        assert [c["url"] for c in out] == [
+            "https://x.com/a/status/1",
+            "https://x.com/b/status/2",
+        ]
+        # First-seen title/order preserved.
+        assert out[0]["title"] == "one"
+
+    def test_skips_empty_and_non_dict(self):
+        cites = [{"url": ""}, "not-a-dict", None, {"title": "no url"}]
+        assert bd.dedupe_citations(cites) == []
+
+    def test_none_input(self):
+        assert bd.dedupe_citations(None) == []
+
+
+# ── build_digest ────────────────────────────────────────────────────────────
+
+class TestBuildDigest:
+    def _ok(self, answer, citations, degraded=False):
+        return {"success": True, "answer": answer, "citations": citations,
+                "degraded": degraded}
+
+    def test_multi_topic_digest_and_global_sources_dedup(self):
+        entries = [
+            {"topic": "AI", "result": self._ok(
+                "Open models are hot.",
+                [{"url": "https://x.com/a/status/1", "title": "post A"}])},
+            {"topic": "Space", "result": self._ok(
+                "Launch reactions.",
+                [{"url": "https://x.com/a/status/1", "title": "same post"},
+                 {"url": "https://x.com/b/status/2", "title": "post B"}])},
+        ]
+        out = bd.build_digest(entries, title="X Pulse", date_str="2026-07-10")
+        assert out.startswith("# X Pulse — 2026-07-10")
+        assert "### AI" in out and "### Space" in out
+        assert "Open models are hot." in out
+        # Global Sources dedups the shared post → 2 unique sources, not 3.
+        assert "**Sources (2)**" in out
+
+    def test_degraded_result_is_flagged(self):
+        entries = [{"topic": "Rumor", "result": self._ok(
+            "Might be true.", [], degraded=True)}]
+        out = bd.build_digest(entries)
+        assert "⚠️ Unsourced" in out
+
+    def test_failed_result_renders_no_result(self):
+        entries = [{"topic": "Broken", "result": {"success": False, "error": "boom"}}]
+        out = bd.build_digest(entries)
+        assert "### Broken" in out
+        assert "_(no result: boom)_" in out
+        # No Sources section when there are no citations anywhere.
+        assert "**Sources" not in out
+
+    def test_empty_entries(self):
+        out = bd.build_digest([])
+        assert "_No topics provided._" in out
+
+    def test_untitled_topic_fallback(self):
+        entries = [{"result": self._ok("x", [])}]
+        assert "### (untitled)" in bd.build_digest(entries)
+
+
+# ── main() CLI ──────────────────────────────────────────────────────────────
+
+class TestMain:
+    def test_stdin_json_to_stdout(self, monkeypatch, capsys):
+        import io
+        payload = '[{"topic":"AI","result":{"success":true,"answer":"hi","citations":[],"degraded":false}}]'
+        monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+        rc = bd.main(["--title", "X Pulse"])
+        assert rc == 0
+        assert "### AI" in capsys.readouterr().out
+
+    def test_invalid_json_returns_2(self, monkeypatch):
+        import io
+        monkeypatch.setattr("sys.stdin", io.StringIO("{not json"))
+        assert bd.main([]) == 2
+
+    def test_non_list_returns_2(self, monkeypatch):
+        import io
+        monkeypatch.setattr("sys.stdin", io.StringIO('{"topic":"x"}'))
+        assert bd.main([]) == 2
+
+
+# ── SKILL.md frontmatter standards ──────────────────────────────────────────
+
+def test_description_meets_hardline_standard():
+    text = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+    m = re.search(r'^description:\s*"?(.*?)"?\s*$', text, re.MULTILINE)
+    assert m, "SKILL.md must declare a description"
+    desc = m.group(1)
+    assert len(desc) <= 60, f"description is {len(desc)} chars (max 60): {desc!r}"
+    assert desc.endswith("."), "description must end with a period"
+
+
+def test_referenced_sections_present():
+    text = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+    for section in ("## When to Use", "## Prerequisites", "## How to Run",
+                    "## Procedure", "## Pitfalls", "## Verification"):
+        assert section in text, f"missing section: {section}"


### PR DESCRIPTION
## What does this PR do?

Adds an **optional** skill, `x-pulse`, that turns the native `x_search` tool
(xAI Grok's X index) into a multi-topic "X pulse": it sweeps several topics,
merges the per-topic results into one **deduplicated, source-cited** markdown
digest, and delivers it via `send_message` or a scheduled `cronjob`.

Why a skill (not a tool): the X-data capability already exists as the native
`x_search` tool. xAI's X Search has **no** trending / engagement-sort
parameter (only handles + date + media-understanding knobs), so "hottest" is
expressed as a well-formed query. The value this skill adds is the workflow
around the existing tool — multi-topic sweep, citation dedup, degraded /
unsourced flagging, and scheduled delivery — which is exactly the
"instructions + existing tools" case the contributor guide says should be a
skill.

## Related Issue

No existing issue — there is no X-trends/x_search skill in-tree (the existing
`skills/social-media/xurl` skill is the X **posting** CLI, a different path).

## Type of Change

- [x] 🎯 New skill (bundled or hub)

## Changes Made

- `optional-skills/social-media/x-pulse/SKILL.md` — modern section order,
  `description` ≤ 60 chars, gated by `requires_tools: [x_search]` so it only
  surfaces when xAI is configured; cross-platform.
- `optional-skills/social-media/x-pulse/scripts/build_digest.py` — pure-stdlib
  digest builder: dedup citations by normalized URL, flag `degraded` topics,
  render markdown with a global Sources list.
- `tests/skills/test_x_pulse_skill.py` — 13 tests (dedup, digest assembly,
  degraded flag, failed-result, CLI, and SKILL.md description/section
  standards). Stdlib + pytest only, no network.

Placed under `optional-skills/` per the guide (depends on a paid xAI /
SuperGrok credential).

## How to Test

1. `scripts/run_tests.sh tests/skills/test_x_pulse_skill.py -q` → all pass (13).
2. Verification command from SKILL.md:
   ```
   echo '[{"topic":"AI","result":{"success":true,"answer":"Big week for open models.","citations":[{"url":"https://x.com/a/status/1","title":"post"}],"degraded":false}}]' | python optional-skills/social-media/x-pulse/scripts/build_digest.py --title "X Pulse"
   ```
   Prints a markdown digest with the topic section and a deduped Sources list.

## For New Skills

- [x] This skill is **not** universally needed (paid xAI credential) → placed in
  `optional-skills/`, gated by `requires_tools: [x_search]`.
- [x] SKILL.md follows the standard format (frontmatter, trigger conditions,
  steps, pitfalls, verification) with `description` ≤ 60 chars.
- [x] No external dependencies — pure Python stdlib helper script.
- [x] Ships a helper script (`build_digest.py`) rather than expecting inline
  parsing; tested at `tests/skills/test_x_pulse_skill.py`.

## Checklist

- [x] I've read the Contributing Guide
- [x] Conventional Commits (`feat(skills):`)
- [x] I searched for existing PRs / skills (no x_search/X-trends skill exists)
- [x] Only changes related to this skill
- [x] Affected test module passes — `tests/skills/test_x_pulse_skill.py` (13)
- [x] Tested on: Ubuntu (WSL2), against current `main`
