### PR TITLE
fix(dashboard): use cached PID probe in messaging platform payload to prevent fd leak

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6823,7 +6823,7 @@ def _messaging_platform_payload(
         else {}
     )
     gateway_running = (
-        get_running_pid() is not None
+        get_running_pid_cached() is not None
         or get_runtime_status_running_pid(runtime) is not None
     )
     env_vars = []

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2508,6 +2508,34 @@ class TestWebServerEndpoints:
             "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/google_chat"
         )
 
+    def test_messaging_platform_payload_uses_cached_pid_probe(self, monkeypatch):
+        """_messaging_platform_payload must use the cached PID probe, not the
+        raw one, to avoid fd leaks on high-frequency dashboard polling (#53484).
+        """
+        from hermes_cli import web_server as ws
+
+        raw_calls = {"count": 0}
+        cached_calls = {"count": 0}
+
+        def _fake_raw(*a, **kw):
+            raw_calls["count"] += 1
+            return None
+
+        def _fake_cached(*a, **kw):
+            cached_calls["count"] += 1
+            return None
+
+        monkeypatch.setattr(ws, "get_running_pid", _fake_raw)
+        monkeypatch.setattr(ws, "get_running_pid_cached", _fake_cached)
+
+        entry = next(
+            e for e in ws._messaging_platform_catalog() if e["id"] == "telegram"
+        )
+        ws._messaging_platform_payload(entry, {}, runtime=None)
+
+        assert raw_calls["count"] == 0
+        assert cached_calls["count"] == 1
+
     def test_messaging_catalog_covers_gateway_platforms(self):
         """Catalog is derived from the Platform enum, so every built-in shows up."""
         from gateway.config import Platform


### PR DESCRIPTION
Fixes #53484

## Description

`_messaging_platform_payload()` in `hermes_cli/web_server.py` called the uncached `get_running_pid()` on every invocation. This function opens and flocks `gateway.lock` via `is_gateway_runtime_lock_active()` each call. Under high-frequency dashboard polling (e.g. repeated `/api/messaging/platforms` requests), this accumulates open file descriptors, eventually hitting `OSError: [Errno 24] Too many open files`.

The `/api/status` endpoint was already fixed by commit 7d0ddbb2f which switched to `get_running_pid_cached()` — a 1-second TTL cached wrapper. However, `_messaging_platform_payload()` (called by `/api/messaging/platforms` and `/api/messaging/platforms/{id}/test`) was missed and still used the raw uncached `get_running_pid()`.

This PR switches the remaining call site to `get_running_pid_cached()`, completing the fd-leak fix across all dashboard HTTP polling endpoints.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py -k 'test_messaging_platform_payload_uses_cached_pid_probe' -q` — new test passes
- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py -k 'test_get_messaging_platforms or test_messaging_platform_test or test_slack_messaging or test_weixin_messaging or test_teams_messaging' -q` — existing messaging platform tests pass (5/5)
- `scripts/run_tests.sh tests/hermes_cli/test_whatsapp_onboarding.py -q` — whatsapp onboarding tests pass (8/8)
- `scripts/run_tests.sh tests/gateway/test_status.py -q` — gateway status tests pass (94/94)
- `python -c "compile(open('hermes_cli/web_server.py').read(), ..., 'exec')"` — compiles clean
- Conventional commit format, no secrets, no personal refs, focused diff (2 files)