### PR TITLE
Fix custom provider picker and auth edge cases

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -200,6 +200,30 @@ def _custom_provider_extra_body_for_agent(
     base_url: str,
     custom_providers: List[Dict[str, Any]],
 ) -> Optional[Dict[str, Any]]:
+    entry = _matching_custom_provider_for_agent(
+        provider=provider,
+        model=model,
+        base_url=base_url,
+        custom_providers=custom_providers,
+        require_model_match=True,
+        required_dict_field="extra_body",
+    )
+
+    if isinstance(entry, dict) and isinstance(entry.get("extra_body"), dict) and entry["extra_body"]:
+        return dict(entry["extra_body"])
+
+    return None
+
+
+def _matching_custom_provider_for_agent(
+    *,
+    provider: str,
+    model: str,
+    base_url: str,
+    custom_providers: List[Dict[str, Any]],
+    require_model_match: bool = False,
+    required_dict_field: str | None = None,
+) -> Optional[Dict[str, Any]]:
     provider_norm = (provider or "").strip().lower()
     if provider_norm == "custom":
         provider_key_filter = ""
@@ -225,17 +249,34 @@ def _custom_provider_extra_body_for_agent(
                 continue
         if _normalized_custom_base_url(entry.get("base_url")) != target_url:
             continue
-        extra_body = entry.get("extra_body")
-        if not isinstance(extra_body, dict) or not extra_body:
-            continue
+        if required_dict_field:
+            value = entry.get(required_dict_field)
+            if not isinstance(value, dict) or not value:
+                continue
         provider_model = str(entry.get("model", "") or "").strip()
         if provider_model:
             if _custom_provider_model_matches(model, entry):
-                return dict(extra_body)
+                return entry
+            if require_model_match:
+                continue
         elif fallback is None:
-            fallback = dict(extra_body)
+            fallback = entry
 
     return fallback
+
+
+def _apply_custom_provider_flags(agent, custom_providers: List[Dict[str, Any]]) -> None:
+    entry = _matching_custom_provider_for_agent(
+        provider=agent.provider,
+        model=agent.model,
+        base_url=agent.base_url,
+        custom_providers=custom_providers,
+    )
+    if not isinstance(entry, dict):
+        return
+
+    if is_truthy_value(entry.get("preserve_model_dots")):
+        agent._preserve_model_dots = True
 
 
 def _merge_custom_provider_extra_body(agent, custom_providers: List[Dict[str, Any]]) -> None:
@@ -1663,6 +1704,7 @@ def init_agent(
     # Store for reuse by _check_compression_model_feasibility (auxiliary
     # compression model context-length detection needs the same list).
     agent._custom_providers = _custom_providers
+    _apply_custom_provider_flags(agent, _custom_providers)
     _merge_custom_provider_extra_body(agent, _custom_providers)
 
     # Check custom_providers per-model context_length

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -1,13 +1,18 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { ComposerAttachment } from '@/store/composer'
+
+vi.mock('@/components/assistant-ui/directive-text', () => ({
+  formatRefValue: (value: string) => value
+}))
 
 import {
   attachmentDisplayText,
   coerceThinkingText,
   optimisticAttachmentRef,
   parseCommandDispatch,
-  parseSlashCommand
+  parseSlashCommand,
+  quickModelOptions
 } from './chat-runtime'
 
 const DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANS'
@@ -148,5 +153,48 @@ describe('parseSlashCommand', () => {
 
   it('does not treat text after horizontal whitespace as a command name (CLI parity)', () => {
     expect(parseSlashCommand('/ some words')).toEqual({ arg: '', name: '' })
+  })
+})
+
+describe('quickModelOptions', () => {
+  it('uses the catalog owner when stale sticky state pairs a model with the wrong provider', () => {
+    const options = quickModelOptions(
+      {
+        model: 'gpt-5.5',
+        provider: 'custom:provider-a',
+        providers: [
+          { slug: 'custom:provider-a', name: 'Provider A', models: ['gpt-5.5'] },
+          { slug: 'custom:provider-b', name: 'Provider B', models: ['grok-4.5'] }
+        ]
+      },
+      'custom:provider-a',
+      'grok-4.5'
+    )
+
+    expect(options[0]).toEqual({
+      model: 'grok-4.5',
+      provider: 'custom:provider-b',
+      providerName: 'custom:provider-b'
+    })
+  })
+
+  it('keeps other provider groups reachable when the current provider has many models', () => {
+    const grokModels = Array.from({ length: 9 }, (_, index) => `grok-${index}`)
+
+    const options = quickModelOptions(
+      {
+        model: 'grok-0',
+        provider: 'custom:provider-b',
+        providers: [
+          { slug: 'custom:provider-b', name: 'Provider B', models: grokModels },
+          { slug: 'custom:provider-a', name: 'Provider A', models: ['gpt-5.5', 'gpt-5.5-mini'] }
+        ]
+      },
+      'custom:provider-b',
+      'grok-0'
+    )
+
+    expect(options).toContainEqual({ model: 'gpt-5.5', provider: 'custom:provider-a', providerName: 'Provider A' })
+    expect(options).toHaveLength(8)
   })
 })

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -4,6 +4,7 @@ import type { QuickModelOption } from '@/app/chat/composer/types'
 import type { ClientSessionState, CommandDispatchResponse } from '@/app/types'
 import { formatRefValue } from '@/components/assistant-ui/directive-text'
 import { type ChatMessage, type ChatMessagePart, chatMessageText, textPart } from '@/lib/chat-messages'
+import { reconcilePickerSelection } from '@/lib/model-status-label'
 import { normalize } from '@/lib/text'
 import type { ComposerAttachment } from '@/store/composer'
 import type { ModelOptionsResponse, SessionInfo } from '@/types/hermes'
@@ -270,15 +271,17 @@ export function quickModelOptions(
   currentProvider: string,
   currentModel: string
 ): QuickModelOption[] {
+  const limit = 8
   const seen = new Set<string>()
   const options: QuickModelOption[] = []
+  const current = reconcilePickerSelection({ model: currentModel, provider: currentProvider }, data)
 
   const providers = [...(data?.providers ?? [])].sort((a, b) => {
-    if (a.slug === currentProvider) {
+    if (a.slug === current.provider) {
       return -1
     }
 
-    if (b.slug === currentProvider) {
+    if (b.slug === current.provider) {
       return 1
     }
 
@@ -304,17 +307,34 @@ export function quickModelOptions(
     options.push({ provider, providerName, model })
   }
 
-  if (currentProvider && currentModel) {
-    add(currentProvider, currentProvider, currentModel)
+  if (current.provider && current.model) {
+    add(current.provider, current.provider, current.model)
+  }
+
+  for (const provider of providers) {
+    const models = provider.models ?? []
+
+    if (models.length === 0) {
+      continue
+    }
+
+    const representative =
+      provider.slug === current.provider && models.includes(current.model) ? current.model : models[0]
+
+    add(provider.slug, provider.name, representative)
+
+    if (options.length >= limit) {
+      return options.slice(0, limit)
+    }
   }
 
   for (const provider of providers) {
     const models = [...(provider.models ?? [])].sort((a, b) => {
-      if (provider.slug === currentProvider && a === currentModel) {
+      if (provider.slug === current.provider && a === current.model) {
         return -1
       }
 
-      if (provider.slug === currentProvider && b === currentModel) {
+      if (provider.slug === current.provider && b === current.model) {
         return 1
       }
 
@@ -325,12 +345,12 @@ export function quickModelOptions(
       add(provider.slug, provider.name, model)
     }
 
-    if (options.length >= 8) {
+    if (options.length >= limit) {
       break
     }
   }
 
-  return options.slice(0, 8)
+  return options.slice(0, limit)
 }
 
 export function toRuntimeMessage(message: ChatMessage): ThreadMessage {

--- a/apps/desktop/src/lib/model-status-label.test.ts
+++ b/apps/desktop/src/lib/model-status-label.test.ts
@@ -4,6 +4,7 @@ import {
   currentPickerSelection,
   displayModelName,
   formatModelStatusLabel,
+  reconcilePickerSelection,
   reasoningEffortLabel
 } from './model-status-label'
 
@@ -59,6 +60,33 @@ describe('model-status-label', () => {
 
     it('falls back to the store while options are still loading', () => {
       expect(currentPickerSelection(true, store, undefined)).toEqual(store)
+    })
+
+    it('moves a stale sticky selection to the catalog provider that owns the model', () => {
+      const catalog = {
+        model: 'gpt-5.5',
+        provider: 'custom:provider-a',
+        providers: [
+          { slug: 'custom:provider-a', name: 'Provider A', models: ['gpt-5.5'] },
+          { slug: 'custom:provider-b', name: 'Provider B', models: ['grok-4.5'] }
+        ]
+      }
+
+      expect(currentPickerSelection(false, { model: 'grok-4.5', provider: 'custom:provider-a' }, catalog)).toEqual({
+        model: 'grok-4.5',
+        provider: 'custom:provider-b'
+      })
+    })
+  })
+
+  describe('reconcilePickerSelection', () => {
+    it('keeps unknown sticky selections while the catalog is incomplete', () => {
+      const selection = { model: 'grok-4.5', provider: 'custom:provider-a' }
+
+      expect(reconcilePickerSelection(selection, { providers: [] })).toEqual(selection)
+      expect(reconcilePickerSelection(selection, { providers: [{ slug: 'custom:provider-a', models: [] }] })).toEqual(
+        selection
+      )
     })
   })
 })

--- a/apps/desktop/src/lib/model-status-label.ts
+++ b/apps/desktop/src/lib/model-status-label.ts
@@ -9,6 +9,18 @@ const REASONING_LABELS: Record<string, string> = {
   xhigh: 'Max'
 }
 
+interface PickerModelProvider {
+  models?: string[]
+  name?: string
+  slug: string
+}
+
+interface PickerModelOptions {
+  model?: string
+  provider?: string
+  providers?: PickerModelProvider[]
+}
+
 export function reasoningEffortLabel(effort: string): string {
   const key = normalize(effort)
 
@@ -19,6 +31,36 @@ export function reasoningEffortLabel(effort: string): string {
   return REASONING_LABELS[key] ?? effort
 }
 
+function providerHasModel(options: PickerModelOptions | undefined, provider: string, model: string): boolean {
+  const row = options?.providers?.find(candidate => candidate.slug === provider)
+
+  return Boolean(row?.models?.includes(model))
+}
+
+function providerOwningModel(options: PickerModelOptions | undefined, model: string): string {
+  if (!model) {
+    return ''
+  }
+
+  return options?.providers?.find(provider => provider.models?.includes(model))?.slug ?? ''
+}
+
+export function reconcilePickerSelection(
+  selection: { model: string; provider: string },
+  options?: PickerModelOptions
+): { model: string; provider: string } {
+  const model = String(selection.model || '')
+  const provider = String(selection.provider || '')
+
+  if (!model || !provider || !options?.providers?.length || providerHasModel(options, provider, model)) {
+    return { model, provider }
+  }
+
+  const owner = providerOwningModel(options, model)
+
+  return owner ? { model, provider: owner } : { model, provider }
+}
+
 /** Which model/provider a picker should mark "current". With a live session the
  *  gateway's `model.options` is authoritative; pre-session there is no server
  *  "current", so the sticky composer pick wins over the profile default the
@@ -27,12 +69,15 @@ export function reasoningEffortLabel(effort: string): string {
 export function currentPickerSelection(
   hasSession: boolean,
   store: { model: string; provider: string },
-  options?: { model?: string; provider?: string }
+  options?: PickerModelOptions
 ): { model: string; provider: string } {
-  return {
-    model: String((hasSession && options?.model) || store.model || options?.model || ''),
-    provider: String((hasSession && options?.provider) || store.provider || options?.provider || '')
-  }
+  return reconcilePickerSelection(
+    {
+      model: String((hasSession && options?.model) || store.model || options?.model || ''),
+      provider: String((hasSession && options?.provider) || store.provider || options?.provider || '')
+    },
+    options
+  )
 }
 
 /** Strip provider prefix and normalize for display. */

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -222,7 +222,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         name="GitHub Copilot",
         auth_type="api_key",
         inference_base_url=DEFAULT_GITHUB_MODELS_BASE_URL,
-        api_key_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"),
+        api_key_env_vars=("COPILOT_GITHUB_TOKEN",),
         base_url_env_var="COPILOT_API_BASE_URL",
     ),
     "copilot-acp": ProviderConfig(

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4684,6 +4684,7 @@ def _normalize_custom_provider_entry(
         "defaultModel": "default_model",
         "contextLength": "context_length",
         "rateLimitDelay": "rate_limit_delay",
+        "preserveModelDots": "preserve_model_dots",
     }
     # api_key_env is a documented snake_case alias for key_env (see
     # website/docs/guides/azure-foundry.md).  Normalize it up front so the
@@ -4701,6 +4702,7 @@ def _normalize_custom_provider_entry(
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models", "extra_body", "extra_headers",
+        "preserve_model_dots",
         "ssl_ca_cert", "ssl_verify",
     }
     for camel, snake in _CAMEL_ALIASES.items():
@@ -4822,6 +4824,10 @@ def _normalize_custom_provider_entry(
     if isinstance(discover_models, bool):
         normalized["discover_models"] = discover_models
 
+    preserve_model_dots = entry.get("preserve_model_dots")
+    if isinstance(preserve_model_dots, bool):
+        normalized["preserve_model_dots"] = preserve_model_dots
+
     extra_body = entry.get("extra_body")
     if isinstance(extra_body, dict):
         normalized["extra_body"] = dict(extra_body)
@@ -4869,6 +4875,7 @@ def _custom_provider_entry_to_provider_config(
         "context_length",
         "rate_limit_delay",
         "discover_models",
+        "preserve_model_dots",
         "extra_body",
         "extra_headers",
         "ssl_ca_cert",

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -9,11 +9,8 @@ Token type support (per GitHub docs):
   ghu_          GitHub App token      ✓  (via environment variable)
   ghp_          Classic PAT           ✗  NOT SUPPORTED
 
-Credential search order (matching Copilot CLI behaviour):
+Credential search order for automatic provider discovery:
   1. COPILOT_GITHUB_TOKEN env var
-  2. GH_TOKEN env var
-  3. GITHUB_TOKEN env var
-  4. gh auth token  CLI fallback
 """
 
 from __future__ import annotations
@@ -43,8 +40,9 @@ COPILOT_OAUTH_CLIENT_ID = "Iv1.b507a08c87ecfe98"
 _CLASSIC_PAT_PREFIX = "ghp_"
 _SUPPORTED_PREFIXES = ("gho_", "github_pat_", "ghu_")
 
-# Env var search order (matches Copilot CLI)
-COPILOT_ENV_VARS = ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
+# Env var search order. Keep generic GitHub credentials out of implicit
+# provider discovery; only Copilot-specific credentials should enable Copilot.
+COPILOT_ENV_VARS = ("COPILOT_GITHUB_TOKEN",)
 
 # Polling constants
 _DEVICE_CODE_POLL_INTERVAL = 5  # seconds
@@ -66,7 +64,7 @@ def validate_copilot_token(token: str) -> tuple[bool, str]:
             "Copilot API. Use one of:\n"
             "  → `copilot login` or `hermes model` to authenticate via OAuth\n"
             "  → A fine-grained PAT (github_pat_*) with Copilot Requests permission\n"
-            "  → `gh auth login` with the default device code flow (produces gho_* tokens)"
+            "  → `COPILOT_GITHUB_TOKEN` with a supported Copilot token"
         )
 
     return True, "OK"
@@ -76,7 +74,8 @@ def resolve_copilot_token() -> tuple[str, str]:
     """Resolve a GitHub token suitable for Copilot API use.
 
     Returns (token, source) where source describes where the token came from.
-    Raises ValueError if only a classic PAT is available.
+    Ambient GitHub CLI credentials are deliberately ignored so a normal GitHub
+    login does not make Copilot appear as an authenticated model provider.
     """
     # 1. Check env vars in priority order
     for env_var in COPILOT_ENV_VARS:
@@ -89,16 +88,6 @@ def resolve_copilot_token() -> tuple[str, str]:
                 )
                 continue
             return val, env_var
-
-    # 2. Fall back to gh auth token
-    token = _try_gh_cli_token()
-    if token:
-        valid, msg = validate_copilot_token(token)
-        if not valid:
-            raise ValueError(
-                f"Token from `gh auth token` is a classic PAT (ghp_*). {msg}"
-            )
-        return token, "gh auth token"
 
     return "", ""
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2365,14 +2365,18 @@ def list_authenticated_providers(
     # post-pass so it covers every provider section uniformly, regardless of
     # which branch emitted the row.
     if current_model:
-        for _row in results:
-            if not _row.get("is_current"):
-                continue
-            _models = _row.get("models") or []
+        _current_row = next((_row for _row in results if _row.get("is_current")), None)
+        _model_belongs_elsewhere = any(
+            _row is not _current_row and current_model in (_row.get("models") or [])
+            for _row in results
+        )
+        if _current_row is not None and not _model_belongs_elsewhere:
+            _models = _current_row.get("models") or []
             if current_model not in _models:
-                _row["models"] = [current_model, *_models]
-                _row["total_models"] = _row.get("total_models", len(_models)) + 1
-            break
+                _current_row["models"] = [current_model, *_models]
+                _current_row["total_models"] = (
+                    _current_row.get("total_models", len(_models)) + 1
+                )
 
     # Sort: current provider first, then by model count descending
     results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -96,7 +96,7 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
     ),
     "github-copilot": HermesOverlay(
         transport="openai_chat",
-        extra_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN"),
+        extra_env_vars=("COPILOT_GITHUB_TOKEN",),
     ),
     "anthropic": HermesOverlay(
         transport="anthropic_messages",

--- a/run_agent.py
+++ b/run_agent.py
@@ -5226,6 +5226,8 @@ class AIAgent:
 
     def _anthropic_preserve_dots(self) -> bool:
         """True when using an anthropic-compatible endpoint that preserves dots in model names.
+        ``custom_providers[].preserve_model_dots`` lets third-party gateways opt
+        in without hard-coding private hostnames.
         Alibaba/DashScope keeps dots (e.g. qwen3.5-plus).
         MiniMax keeps dots (e.g. MiniMax-M2.7).
         Xiaomi MiMo keeps dots (e.g. mimo-v2.5, mimo-v2.5-pro).
@@ -5238,6 +5240,8 @@ class AIAgent:
         ``HTTP 400 The provided model identifier is invalid``.
         Regression for #11976; mirrors the opencode-go fix for #5211
         (commit f77be22c), which extended this same allowlist."""
+        if bool(getattr(self, "_preserve_model_dots", False)):
+            return True
         if (getattr(self, "provider", "") or "").lower() in {
             "alibaba", "minimax", "minimax-cn",
             "opencode-go", "opencode-zen",

--- a/tests/agent/test_custom_provider_extra_body.py
+++ b/tests/agent/test_custom_provider_extra_body.py
@@ -1,6 +1,6 @@
 from types import SimpleNamespace
 
-from agent.agent_init import _merge_custom_provider_extra_body
+from agent.agent_init import _apply_custom_provider_flags, _merge_custom_provider_extra_body
 
 
 def test_custom_provider_extra_body_merges_into_request_overrides():
@@ -122,3 +122,54 @@ def test_named_custom_provider_extra_body_matches_provider_key():
     )
 
     assert agent.request_overrides == {"extra_body": {"enable_thinking": False}}
+
+
+def test_custom_provider_preserve_model_dots_flag_matches_provider_key():
+    agent = SimpleNamespace(
+        provider="custom:anthropic-proxy",
+        model="vendor/model-4.5",
+        base_url="https://gateway.example.com/anthropic",
+        _preserve_model_dots=False,
+    )
+
+    _apply_custom_provider_flags(
+        agent,
+        [
+            {
+                "provider_key": "other-proxy",
+                "base_url": "https://gateway.example.com/anthropic",
+                "preserve_model_dots": True,
+            },
+            {
+                "provider_key": "anthropic-proxy",
+                "base_url": "https://gateway.example.com/anthropic/",
+                "model": "vendor/model-4.5",
+                "preserve_model_dots": True,
+            },
+        ],
+    )
+
+    assert agent._preserve_model_dots is True
+
+
+def test_custom_provider_preserve_model_dots_ignores_other_models():
+    agent = SimpleNamespace(
+        provider="custom:anthropic-proxy",
+        model="vendor/model-4.5",
+        base_url="https://gateway.example.com/anthropic",
+        _preserve_model_dots=False,
+    )
+
+    _apply_custom_provider_flags(
+        agent,
+        [
+            {
+                "provider_key": "anthropic-proxy",
+                "base_url": "https://gateway.example.com/anthropic",
+                "model": "vendor/other-4.5",
+                "preserve_model_dots": True,
+            }
+        ],
+    )
+
+    assert agent._preserve_model_dots is False

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -37,7 +37,7 @@ class TestTokenValidation:
 
 
 class TestResolveToken:
-    """Token resolution with env var priority."""
+    """Token resolution only uses explicit Copilot credentials."""
 
     def test_copilot_github_token_first_priority(self, monkeypatch):
         from hermes_cli.copilot_auth import resolve_copilot_token
@@ -48,53 +48,53 @@ class TestResolveToken:
         assert token == "gho_copilot_first"
         assert source == "COPILOT_GITHUB_TOKEN"
 
-    def test_gh_token_second_priority(self, monkeypatch):
+    def test_gh_token_is_ignored_for_implicit_copilot_auth(self, monkeypatch):
         from hermes_cli.copilot_auth import resolve_copilot_token
         monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
         monkeypatch.setenv("GH_TOKEN", "gho_gh_second")
         monkeypatch.setenv("GITHUB_TOKEN", "gho_github_third")
         token, source = resolve_copilot_token()
-        assert token == "gho_gh_second"
-        assert source == "GH_TOKEN"
+        assert token == ""
+        assert source == ""
 
-    def test_github_token_third_priority(self, monkeypatch):
+    def test_github_token_is_ignored_for_implicit_copilot_auth(self, monkeypatch):
         from hermes_cli.copilot_auth import resolve_copilot_token
         monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
         monkeypatch.delenv("GH_TOKEN", raising=False)
         monkeypatch.setenv("GITHUB_TOKEN", "gho_github_third")
         token, source = resolve_copilot_token()
-        assert token == "gho_github_third"
-        assert source == "GITHUB_TOKEN"
+        assert token == ""
+        assert source == ""
 
-    def test_classic_pat_in_env_skipped(self, monkeypatch):
-        """Classic PATs in env vars should be skipped, not returned."""
+    def test_classic_pat_in_copilot_env_returns_empty(self, monkeypatch):
+        """Classic PATs in the explicit Copilot env var should be skipped."""
         from hermes_cli.copilot_auth import resolve_copilot_token
         monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "ghp_classic_pat_nope")
         monkeypatch.delenv("GH_TOKEN", raising=False)
         monkeypatch.setenv("GITHUB_TOKEN", "gho_valid_oauth")
         token, source = resolve_copilot_token()
-        # Should skip the ghp_ token and find the gho_ one
-        assert token == "gho_valid_oauth"
-        assert source == "GITHUB_TOKEN"
+        assert token == ""
+        assert source == ""
 
-    def test_gh_cli_fallback(self, monkeypatch):
+    def test_gh_cli_fallback_is_ignored_for_implicit_copilot_auth(self, monkeypatch):
         from hermes_cli.copilot_auth import resolve_copilot_token
         monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
         monkeypatch.delenv("GH_TOKEN", raising=False)
         monkeypatch.delenv("GITHUB_TOKEN", raising=False)
         with patch("hermes_cli.copilot_auth._try_gh_cli_token", return_value="gho_from_cli"):
             token, source = resolve_copilot_token()
-        assert token == "gho_from_cli"
-        assert source == "gh auth token"
+        assert token == ""
+        assert source == ""
 
-    def test_gh_cli_classic_pat_raises(self, monkeypatch):
+    def test_gh_cli_classic_pat_is_ignored_for_implicit_copilot_auth(self, monkeypatch):
         from hermes_cli.copilot_auth import resolve_copilot_token
         monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
         monkeypatch.delenv("GH_TOKEN", raising=False)
         monkeypatch.delenv("GITHUB_TOKEN", raising=False)
         with patch("hermes_cli.copilot_auth._try_gh_cli_token", return_value="ghp_classic"):
-            with pytest.raises(ValueError, match="classic PAT"):
-                resolve_copilot_token()
+            token, source = resolve_copilot_token()
+        assert token == ""
+        assert source == ""
 
     def test_no_token_returns_empty(self, monkeypatch):
         from hermes_cli.copilot_auth import resolve_copilot_token
@@ -224,6 +224,4 @@ class TestEnvVarOrder:
     def test_copilot_env_vars_order_matches_docs(self):
         from hermes_cli.auth import PROVIDER_REGISTRY
         copilot = PROVIDER_REGISTRY["copilot"]
-        assert copilot.api_key_env_vars == (
-            "COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"
-        )
+        assert copilot.api_key_env_vars == ("COPILOT_GITHUB_TOKEN",)

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -70,6 +70,41 @@ def test_list_authenticated_providers_can_skip_custom_provider_live_probe(monkey
     assert row["total_models"] == 1
 
 
+def test_current_model_not_injected_into_wrong_custom_provider(monkeypatch):
+    """A stale UI/session provider must not make another provider's model appear under it."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="custom:provider-a",
+        current_model="grok-4.5",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "provider-a",
+                "base_url": "https://gateway.example.com",
+                "key_env": "GPT_KEY",
+                "api_mode": "codex_responses",
+                "model": "gpt-5.5",
+            },
+            {
+                "name": "provider-b",
+                "base_url": "https://gateway.example.com",
+                "key_env": "GROK_KEY",
+                "api_mode": "chat_completions",
+                "model": "grok-4.5",
+            },
+        ],
+        max_models=50,
+    )
+
+    by_slug = {p["slug"]: p for p in providers if p.get("is_user_defined")}
+
+    assert by_slug["custom:provider-a"]["is_current"] is True
+    assert by_slug["custom:provider-a"]["models"] == ["gpt-5.5"]
+    assert by_slug["custom:provider-b"]["models"] == ["grok-4.5"]
+
+
 def test_list_authenticated_providers_can_probe_only_current_custom_provider(monkeypatch):
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -8,11 +8,37 @@ are exposed in the model picker.
 import pytest
 from hermes_cli.model_switch import list_authenticated_providers, switch_model
 from hermes_cli import runtime_provider as rp
+from hermes_cli.config import get_compatible_custom_providers
 
 
 # =============================================================================
 # Tests for list_authenticated_providers including full models list
 # =============================================================================
+
+def test_providers_dict_preserve_model_dots_reaches_custom_provider_view():
+    providers = get_compatible_custom_providers(
+        {
+            "providers": {
+                "anthropic-proxy": {
+                    "api": "https://gateway.example.com/anthropic",
+                    "transport": "anthropic_messages",
+                    "default_model": "vendor/model-4.5",
+                    "preserve_model_dots": True,
+                }
+            }
+        }
+    )
+
+    assert providers == [
+        {
+            "name": "anthropic-proxy",
+            "base_url": "https://gateway.example.com/anthropic",
+            "provider_key": "anthropic-proxy",
+            "api_mode": "anthropic_messages",
+            "model": "vendor/model-4.5",
+            "preserve_model_dots": True,
+        }
+    ]
 
 def test_list_authenticated_providers_includes_full_models_list_from_user_providers(monkeypatch):
     """User-defined providers should expose both default_model and full models list.


### PR DESCRIPTION
## Summary

This PR fixes a few related custom-provider and provider-discovery edge cases:

- do not treat ambient GitHub credentials (`GH_TOKEN`, `GITHUB_TOKEN`, or `gh auth token`) as implicit Copilot credentials
- avoid injecting the current model into the wrong custom-provider row when stale session/UI state pairs a model with a provider that does not own it
- reconcile Desktop picker state against the fresh provider catalog and keep compact quick-model options provider-diverse
- add a `preserve_model_dots` custom-provider flag so Anthropic-compatible gateways can opt into exact dotted model ids without hard-coded host allowlists

## Why

These changes address cases already discussed in issues such as #25246, #49002, and #59063, and also add a generic solution for custom gateways whose model ids contain dots.

## Tests

- `venv/bin/pytest tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_copilot_auth.py tests/hermes_cli/test_user_providers_model_switch.py::test_providers_dict_preserve_model_dots_reaches_custom_provider_view tests/agent/test_custom_provider_extra_body.py tests/agent/test_minimax_provider.py::TestMinimaxPreserveDots -q`
- `cd apps/desktop && npm run test:ui -- src/lib/chat-runtime.test.ts src/lib/model-status-label.test.ts`
EOF
