### PR TITLE
fix(config): `save_config` lost-update — three-way merge-preserve + loud CAS conflict refusal at the `atomic_config_write` seam

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -12,6 +12,7 @@ This module provides:
 - hermes config wizard   - Re-run setup wizard
 """
 
+import collections
 import copy
 import json
 import logging
@@ -247,6 +248,27 @@ _LOAD_CONFIG_CACHE: Dict[str, Tuple[int, int, int, int, Dict[str, Any], Dict[str
 # _LOAD_CONFIG_CACHE but for read_raw_config() — used when callers want
 # the user's on-disk values without defaults merged in.
 _RAW_CONFIG_CACHE: Dict[str, Tuple[int, int, Dict[str, Any]]] = {}
+# path -> deque[(stat_signature, normalized_raw_state, self_written,
+# foreign_paths)]: the last N DISTINCT on-disk config states this process
+# has OBSERVED (via read_raw_config / load_config parses, or its own
+# save_config writes — the latter flagged self_written, with the key paths
+# that were merge-preserved from foreign edits in foreign_paths). save_config's
+# lost-update protection uses this as its three-way merge base: a caller
+# value that matches ANY previously observed disk state is a stale-snapshot
+# copy, not a deliberate edit, so a newer disk-side value must survive the
+# save. A deque of distinct states (dedup on stat signature), not just the
+# latest observation, because long-running processes (gateways) reload
+# config constantly — a reload AFTER a foreign disk edit would otherwise
+# absorb that edit into the base and mask the caller's staleness.
+# States are stored post _normalize_root_model_keys/_normalize_max_turns so
+# comparisons against save_config's write pipeline are domain-consistent.
+_DISK_STATE_OBSERVATIONS: Dict[str, Any] = {}
+_DISK_STATE_HISTORY_LIMIT = 8
+# (path, dotted_key) pairs already warned about by the unknown-key check —
+# warn once per process, never block.
+_UNKNOWN_KEY_WARNED: Set[Tuple[str, str]] = set()
+# Sentinel for "key absent at this path" in the three-way merge.
+_MERGE_MISSING = object()
 # Serializes all config read/write paths. libyaml's C extension is not
 # thread-safe for concurrent safe_load() on the same file, and multiple
 # tool threads (approval.py, browser_tool.py, setup flows) hit
@@ -6670,6 +6692,7 @@ def read_raw_config() -> Dict[str, Any]:
         path_key = str(config_path)
         cached = _RAW_CONFIG_CACHE.get(path_key)
         if cached is not None and cached[:2] == cache_key:
+            _note_disk_state(path_key, cache_key, cached[2])
             return copy.deepcopy(cached[2])
 
         try:
@@ -6682,7 +6705,354 @@ def read_raw_config() -> Dict[str, Any]:
         if not isinstance(data, dict):
             data = {}
         _RAW_CONFIG_CACHE[path_key] = (cache_key[0], cache_key[1], copy.deepcopy(data))
+        _note_disk_state(path_key, cache_key, data)
         return data
+
+
+class ConfigWriteConflictError(RuntimeError):
+    """save_config refused to write: the same key changed both on disk and
+    in the caller's snapshot since the caller loaded it.
+
+    Raised instead of silently letting one side's edit clobber the other's
+    (the config lost-update defect). Fail-closed: nothing is written. The
+    caller should re-load config.yaml, re-apply its change, and save again.
+    The message names the conflicting key path(s) only — config values can
+    be secrets and are never included.
+    """
+
+
+class ConfigDuplicateKeyError(RuntimeError):
+    """save_config refused to write: the on-disk config.yaml contains a
+    duplicate mapping key.
+
+    PyYAML parses duplicate keys last-one-wins, so the file's effective
+    semantics are ambiguous (usually a human mid-edit). A whole-file rewrite
+    would silently collapse the duplicates and destroy one of the stanzas —
+    fail closed and make the user fix the YAML instead.
+    """
+
+
+def _make_duplicate_key_rejecting_loader():
+    """A SafeLoader (C-accelerated when available) that raises
+    :class:`ConfigDuplicateKeyError` on duplicate mapping keys at any depth.
+
+    Only the construction step is overridden, so this composes with
+    ``CSafeLoader`` — the C extension accelerates parsing/composing while
+    ``construct_mapping`` remains the Python method we hook.
+    """
+    base_loader = getattr(yaml, "CSafeLoader", None) or yaml.SafeLoader
+
+    class _DupKeyRejectingLoader(base_loader):  # type: ignore[misc, valid-type]
+        def construct_mapping(self, node, deep=False):
+            seen = set()
+            for key_node, _value_node in node.value:
+                key = self.construct_object(key_node, deep=True)
+                try:
+                    if key in seen:
+                        raise ConfigDuplicateKeyError(
+                            f"duplicate mapping key {key!r} at line "
+                            f"{key_node.start_mark.line + 1}"
+                        )
+                    seen.add(key)
+                except TypeError:
+                    # Unhashable key (e.g. a list) — leave it to the normal
+                    # constructor's own error handling.
+                    continue
+            return super().construct_mapping(node, deep=deep)
+
+    return _DupKeyRejectingLoader
+
+
+_DUP_KEY_REJECTING_LOADER = None
+
+
+def _load_yaml_reject_duplicate_keys(text: str) -> Any:
+    global _DUP_KEY_REJECTING_LOADER
+    if _DUP_KEY_REJECTING_LOADER is None:
+        _DUP_KEY_REJECTING_LOADER = _make_duplicate_key_rejecting_loader()
+    return yaml.load(text, Loader=_DUP_KEY_REJECTING_LOADER)
+
+
+def _note_disk_state(
+    path_key: str,
+    sig: Tuple[int, int],
+    raw_data: Any,
+    *,
+    self_written: bool = False,
+    authored_paths: frozenset = frozenset(),
+) -> None:
+    """Record an observed on-disk config state for ``path_key``.
+
+    Called (under ``_CONFIG_LOCK``) wherever this process actually parses
+    config.yaml content — read_raw_config, _load_config_impl — and after
+    save_config's own writes. Dedups on the file's (mtime_ns, size)
+    signature so cache-hit hot paths cost one tuple compare.
+
+    ``self_written=True`` marks a state this process's own save_config
+    produced; ``authored_paths`` names the key paths that write actually
+    CHANGED relative to the disk state it replaced (values it merely
+    carried over or merge-preserved are not authored). The distinction
+    keeps in-process sequential saves last-write-wins on process-authored
+    values (a process may freely overwrite its own writes, even with older
+    values) while foreign edits — including ones a self-write carried
+    through unchanged — stay protected.
+    """
+    if not isinstance(raw_data, dict):
+        return
+    history = _DISK_STATE_OBSERVATIONS.get(path_key)
+    if history is None:
+        history = collections.deque(maxlen=_DISK_STATE_HISTORY_LIMIT)
+        _DISK_STATE_OBSERVATIONS[path_key] = history
+    if history and history[-1][0] == sig:
+        if self_written and not history[-1][2]:
+            history[-1] = (sig, history[-1][1], True, authored_paths)
+        return
+    normalized = _normalize_root_model_keys(
+        _normalize_max_turns_config(copy.deepcopy(raw_data))
+    )
+    if history and history[-1][1] == normalized:
+        if self_written and not history[-1][2]:
+            history[-1] = (history[-1][0], history[-1][1], True, authored_paths)
+        return
+    history.append((sig, normalized, self_written, authored_paths))
+
+
+def _read_disk_config_for_merge(config_path: Path) -> Optional[Dict[str, Any]]:
+    """Fresh disk read for save_config's lost-update merge.
+
+    Returns the parsed dict (``{}`` for an existing-but-empty file), or
+    ``None`` when there is nothing to merge against: file absent (plain
+    create), unreadable, unparseable, or a non-dict root. ``None`` makes
+    save_config fall back to its legacy overwrite behavior — for a corrupt
+    file that is deliberate: the content was already .bak-snapshotted by
+    ``_warn_config_parse_failure`` when the pipeline's raw read failed, and
+    the last-known-good retention in ``_load_config_impl`` keeps serving
+    the previous config until the YAML is fixed.
+
+    Raises :class:`ConfigDuplicateKeyError` when the file parses but has
+    duplicate mapping keys — see that class's docstring.
+    """
+    try:
+        text = config_path.read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError):
+        return None
+    try:
+        data = _load_yaml_reject_duplicate_keys(text)
+    except ConfigDuplicateKeyError as exc:
+        raise ConfigDuplicateKeyError(
+            f"Refusing to overwrite {config_path}: {exc}. The file's "
+            f"effective values are ambiguous (YAML is last-key-wins) and a "
+            f"rewrite would silently collapse the duplicates. Fix the "
+            f"duplicate key first."
+        ) from exc
+    except Exception:
+        return None
+    if data is None:
+        return {}
+    return data if isinstance(data, dict) else None
+
+
+def _config_path_value(state: Any, path: Tuple[str, ...]) -> Any:
+    """Value at a nested key path in ``state``, or ``_MERGE_MISSING``."""
+    node = state
+    for part in path:
+        if not isinstance(node, dict) or part not in node:
+            return _MERGE_MISSING
+        node = node[part]
+    return node
+
+
+def _merge_values_equal(a: Any, b: Any) -> bool:
+    if a is b:
+        return True
+    if a is _MERGE_MISSING or b is _MERGE_MISSING:
+        return False
+    return a == b
+
+
+def _path_has_prefix_in(key_path: Tuple[str, ...], paths: frozenset) -> bool:
+    """True when ``key_path`` or any of its ancestors is in ``paths``."""
+    return any(key_path[: len(p)] == p for p in paths)
+
+
+def _dict_diff_paths(
+    a: Dict[str, Any], b: Dict[str, Any], _path: Tuple[str, ...] = ()
+) -> set:
+    """Leaf-level key paths where two config dicts differ (either side may
+    be missing the path)."""
+    paths: set = set()
+    for key in set(a) | set(b):
+        va = a.get(key, _MERGE_MISSING)
+        vb = b.get(key, _MERGE_MISSING)
+        if isinstance(va, dict) and isinstance(vb, dict):
+            paths |= _dict_diff_paths(va, vb, _path + (key,))
+        elif not _merge_values_equal(va, vb):
+            paths.add(_path + (key,))
+    return paths
+
+
+def _three_way_config_merge(
+    ours: Dict[str, Any],
+    theirs: Dict[str, Any],
+    prior_states: List[Dict[str, Any]],
+    latest_self_state: Optional[Dict[str, Any]] = None,
+    latest_self_authored: frozenset = frozenset(),
+    _path: Tuple[str, ...] = (),
+    _preserved: Optional[List[Tuple[str, ...]]] = None,
+    _conflicts: Optional[List[Tuple[str, ...]]] = None,
+):
+    """Merge the caller's about-to-be-written config with the current disk.
+
+    ``ours``   — save_config's pipeline output (normalized, env templates
+                 restored, defaults stripped): what the caller wants disk to
+                 say.
+    ``theirs`` — the current on-disk config (normalized the same way).
+    ``prior_states`` — disk states this process previously observed (the
+                 merge base; see ``_DISK_STATE_OBSERVATIONS``).
+    ``latest_self_state`` / ``latest_self_authored`` — the last state this
+                 process's own save_config wrote, and the key paths that
+                 write actually CHANGED relative to the disk it replaced
+                 (carried-over and merge-preserved values are not
+                 authored).
+
+    Per key path:
+
+    * equal on both sides → keep;
+    * the current disk value is one THIS process authored in its own last
+      write → sequential in-process saves stay last-write-wins: the caller
+      may overwrite its own process's writes, even with older values;
+    * caller's value (or its absence) matches a previously observed disk
+      state while disk now differs → the caller is carrying a stale
+      snapshot: the disk-side (foreign) edit wins (recorded in
+      ``preserved``);
+    * caller introduced a new value and disk is unchanged since the last
+      observation → the caller's edit wins (including deletions);
+    * caller introduced a new value AND disk changed since the last
+      observation → conflict (recorded; the caller raises).
+
+    The deliberate bias: when staleness is ambiguous, prefer keeping what is
+    on disk — visibly (WARNING log), never silently. Silent loss of a
+    disk-side edit is the defect this exists to fix; a suppressed deletion
+    is visible in the log and recoverable, a clobbered hand-edit is neither.
+    """
+    if _preserved is None:
+        _preserved = []
+    if _conflicts is None:
+        _conflicts = []
+    latest_state = prior_states[-1] if prior_states else theirs
+    merged: Dict[str, Any] = {}
+    keys = list(ours.keys()) + [k for k in theirs.keys() if k not in ours]
+    for key in keys:
+        key_path = _path + (key,)
+        o = ours.get(key, _MERGE_MISSING)
+        t = theirs.get(key, _MERGE_MISSING)
+        if isinstance(o, dict) and isinstance(t, dict):
+            sub, _, _ = _three_way_config_merge(
+                o,
+                t,
+                prior_states,
+                latest_self_state,
+                latest_self_authored,
+                key_path,
+                _preserved,
+                _conflicts,
+            )
+            if sub:
+                merged[key] = sub
+            elif not o:
+                # caller explicitly kept an empty mapping
+                merged[key] = {}
+            # both sides had content but every child resolved to omission →
+            # drop the empty subtree (mirrors _strip_default_values)
+            continue
+        if o is not _MERGE_MISSING and t is not _MERGE_MISSING and o == t:
+            merged[key] = o
+            continue
+        if o is _MERGE_MISSING and t is _MERGE_MISSING:
+            continue
+        if (
+            latest_self_state is not None
+            and _path_has_prefix_in(key_path, latest_self_authored)
+            and _merge_values_equal(
+                t, _config_path_value(latest_self_state, key_path)
+            )
+        ):
+            # The disk value here is one this process AUTHORED in its own
+            # last write — no foreign edit to protect. In-process sequential
+            # saves keep last-write-wins semantics.
+            if o is not _MERGE_MISSING:
+                merged[key] = o
+            continue
+        o_seen_on_disk_before = any(
+            _merge_values_equal(o, _config_path_value(state, key_path))
+            for state in prior_states
+        )
+        if o_seen_on_disk_before:
+            # Stale snapshot: disk moved past the caller's copy of this key.
+            if t is not _MERGE_MISSING:
+                merged[key] = copy.deepcopy(t)
+            _preserved.append(key_path)
+        elif _merge_values_equal(t, _config_path_value(latest_state, key_path)):
+            # Disk unchanged since our last observation → caller's edit wins
+            # (an absent ``o`` here is a deliberate deletion).
+            if o is not _MERGE_MISSING:
+                merged[key] = o
+        else:
+            _conflicts.append(key_path)
+    return merged, _preserved, _conflicts
+
+
+def _warn_unknown_config_keys(config: Dict[str, Any], path_key: str) -> None:
+    """WARN (never block) on suspicious unknown second-level keys inside
+    top-level subtrees that ``DEFAULT_CONFIG`` actually defines as
+    non-empty dicts.
+
+    Deliberately narrow on two axes, because DEFAULT_CONFIG is NOT a
+    complete schema:
+
+    * unknown TOP-LEVEL keys stay silent — legit keys (``session_reset``,
+      ``plugins``, ``mcp_servers``, ...) live only at the top level of
+      user configs;
+    * within a defined subtree, an unknown child only warns when it is a
+      NEAR-MATCH of a known key or of a sibling key — the garbled/typo'd
+      key class (e.g. ``display.tool_progress_gr―ouping`` next to the real
+      ``tool_progress_grouping``). Live profile configs legitimately carry
+      15-25 second-level keys per file that DEFAULT_CONFIG doesn't
+      enumerate (``agent.verbose``, ``cron.script_timeout_seconds``, ...);
+      warning on every one would bury the signal.
+
+    Warns once per (config path, dotted key) per process.
+    """
+    import difflib
+
+    for top_key, value in config.items():
+        default_subtree = DEFAULT_CONFIG.get(top_key)
+        if not isinstance(default_subtree, dict) or not default_subtree:
+            continue
+        if not isinstance(value, dict):
+            continue
+        for child_key in value:
+            if child_key in default_subtree:
+                continue
+            candidates = [k for k in default_subtree if k != child_key]
+            candidates += [k for k in value if k != child_key]
+            close = difflib.get_close_matches(
+                str(child_key), [str(c) for c in candidates], n=1, cutoff=0.8
+            )
+            if not close:
+                continue
+            dotted = f"{top_key}.{child_key}"
+            warn_key = (path_key, dotted)
+            if warn_key in _UNKNOWN_KEY_WARNED:
+                continue
+            _UNKNOWN_KEY_WARNED.add(warn_key)
+            logger.warning(
+                "save_config: unknown config key %s looks like a garbled or "
+                "misspelled %s.%s — writing it anyway; check for a typo.",
+                dotted,
+                top_key,
+                close[0],
+            )
 
 
 def require_readable_config_before_write(config_path: Optional[Path] = None) -> None:
@@ -6949,6 +7319,9 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                 with open(config_path, encoding="utf-8") as f:
                     user_config = fast_safe_load(f) or {}
 
+                if isinstance(user_config, dict):
+                    _note_disk_state(path_key, user_sig, user_config)
+
                 if "max_turns" in user_config:
                     agent_user_config = dict(user_config.get("agent") or {})
                     if agent_user_config.get("max_turns") is None:
@@ -7127,6 +7500,18 @@ def save_config(
     before any normalisation).  This prevents config.yaml from being
     contaminated with schema defaults on every save, which makes future
     default changes invisible to users.
+
+    Lost-update protection: callers pass a dict mutated from a
+    ``load_config()`` snapshot, and this used to be a blind whole-file
+    reserialization — any disk-side edit made after that snapshot (a hand
+    edit, another process's ``hermes config set``, a second gateway) was
+    silently reverted. Now the current disk state is re-read and three-way
+    merge-preserved against the process's observed disk-state history
+    (``_DISK_STATE_OBSERVATIONS``): disk-side edits the caller never saw
+    survive the save. Raises :class:`ConfigWriteConflictError` (fail-closed,
+    nothing written) when the same key changed on both sides, and
+    :class:`ConfigDuplicateKeyError` when the on-disk YAML contains
+    duplicate mapping keys.
     """
     with _CONFIG_LOCK:
         if is_managed():
@@ -7148,11 +7533,22 @@ def save_config(
                     f"(managed by your administrator): {', '.join(sorted(_stripped))}",
                     file=sys.stderr,
                 )
-        from utils import atomic_yaml_write
-
         ensure_hermes_home()
         config_path = get_config_path()
+        path_key = str(config_path)
         require_readable_config_before_write(config_path)
+        # Lost-update merge base: the disk states this process observed
+        # BEFORE this save. Captured first — the reads below observe the
+        # CURRENT disk, which is the merge's "theirs", not the base.
+        prior_entries = list(_DISK_STATE_OBSERVATIONS.get(path_key, ()))
+        prior_disk_states = [entry[1] for entry in prior_entries]
+        latest_self_state: Optional[Dict[str, Any]] = None
+        latest_self_authored: frozenset = frozenset()
+        for entry in reversed(prior_entries):
+            if entry[2]:
+                latest_self_state = entry[1]
+                latest_self_authored = entry[3]
+                break
         # Compute explicit user paths BEFORE any normalisation --------
         # _normalize_max_turns_config may inject agent.max_turns from
         # DEFAULT_CONFIG; using the raw dict preserves which paths the
@@ -7192,13 +7588,59 @@ def save_config(
                 preserve_keys=effective_preserve_keys,
             )
 
+        # ── Lost-update protection ────────────────────────────────────
+        # Every caller of save_config mutated a snapshot from load_config();
+        # blindly reserializing that snapshot reverts any disk-side edit made
+        # after it was taken (hand-edits, `hermes config set` from another
+        # process, a second gateway). Re-read the disk and three-way
+        # merge-preserve: keys the caller didn't change keep the disk's
+        # current value; the same key changed on both sides is a loud,
+        # fail-closed refusal — silent loss is the defect, never the outcome.
+        final: Dict[str, Any] = normalized
+        # Paths this write AUTHORS (changes relative to the disk state it
+        # replaces). () = "the whole file" for the no-merge create/overwrite
+        # paths; recomputed as a real diff after a merge.
+        authored_paths: frozenset = frozenset({()})
+        disk_now_raw = _read_disk_config_for_merge(config_path)
+        if disk_now_raw is not None:
+            theirs = _normalize_root_model_keys(
+                _normalize_max_turns_config(copy.deepcopy(disk_now_raw))
+            )
+            merged, preserved_paths, conflict_paths = _three_way_config_merge(
+                final, theirs, prior_disk_states,
+                latest_self_state, latest_self_authored,
+            )
+            if conflict_paths:
+                dotted = ", ".join(".".join(p) for p in conflict_paths)
+                msg = (
+                    f"Refusing to save {config_path}: concurrent modification "
+                    f"of {dotted} — the key(s) changed on disk after this "
+                    f"process loaded its config snapshot, and the caller is "
+                    f"writing a different value. Re-load the config, re-apply "
+                    f"the change, and save again. (Values not shown: config "
+                    f"entries can contain secrets.)"
+                )
+                logger.error(msg)
+                raise ConfigWriteConflictError(msg)
+            if preserved_paths:
+                logger.warning(
+                    "save_config: preserved %d disk-side edit(s) the caller's "
+                    "config snapshot predates: %s",
+                    len(preserved_paths),
+                    ", ".join(".".join(p) for p in preserved_paths),
+                )
+            final = merged
+            authored_paths = frozenset(_dict_diff_paths(final, theirs))
+
+        _warn_unknown_config_keys(final, path_key)
+
         # Build optional commented-out sections for features that are off by
         # default or only relevant when explicitly configured.
         parts = []
-        sec = normalized.get("security", {})
+        sec = final.get("security", {})
         if not sec or sec.get("redact_secrets") is None:
             parts.append(_SECURITY_COMMENT)
-        fb = normalized.get("fallback_model", {})
+        fb = final.get("fallback_model", {})
         fb_is_valid = False
         if isinstance(fb, list):
             fb_is_valid = any(isinstance(e, dict) and e.get("provider") and e.get("model") for e in fb)
@@ -7207,13 +7649,29 @@ def save_config(
         if not fb_is_valid:
             parts.append(_FALLBACK_COMMENT)
 
-        atomic_yaml_write(
+        atomic_config_write(
             config_path,
-            normalized,
+            final,
             extra_content="".join(parts) if parts else None,
         )
         _secure_file(config_path)
-        _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(current_normalized)
+        # The last-expanded snapshot feeds env-template preservation and the
+        # last-known-good parse-failure fallback: overlay the merge result so
+        # disk-side values we just preserved aren't served stale from it.
+        _LAST_EXPANDED_CONFIG_BY_PATH[path_key] = copy.deepcopy(
+            _deep_merge(current_normalized, final)
+        )
+        try:
+            st = config_path.stat()
+            _note_disk_state(
+                path_key,
+                (st.st_mtime_ns, st.st_size),
+                final,
+                self_written=True,
+                authored_paths=authored_paths,
+            )
+        except OSError:
+            pass
 
 
 def _parse_env_value(raw_value: str) -> str:

--- a/tests/hermes_cli/test_config_save_lost_update.py
+++ b/tests/hermes_cli/test_config_save_lost_update.py
@@ -1,0 +1,447 @@
+"""save_config lost-update protection: three-way merge-preserve + CAS refusal.
+
+``save_config`` historically reserialized the caller's whole config dict over
+``config.yaml``. Every caller mutates a snapshot from ``load_config()``; any
+disk-side edit made after that snapshot (a human hand-edit, another process,
+``hermes config set`` from a second terminal) was silently reverted on the
+next save — the classic lost update.
+
+These tests pin the fix:
+
+* disk-side edits the caller never saw survive a save (two-writer race),
+* the same key changed on both sides is a LOUD refusal
+  (``ConfigWriteConflictError``), never silent loss,
+* duplicate mapping keys in the on-disk YAML reject the write
+  (``ConfigDuplicateKeyError``) instead of silently collapsing the dup,
+* unknown keys inside DEFAULT_CONFIG-defined subtrees warn (never block),
+  while top-level keys absent from DEFAULT_CONFIG stay silent —
+  DEFAULT_CONFIG is not a complete schema,
+* the pre-existing behaviors at the same seam are unchanged:
+  ``${ENV}`` template preservation, schema-default stripping, and the
+  legacy overwrite path when the on-disk YAML is unparseable (the
+  last-known-good retention seam).
+"""
+
+import logging
+import os
+import time
+
+import pytest
+import yaml
+
+from hermes_cli import config as cfg_mod
+from hermes_cli.config import (
+    DEFAULT_CONFIG,
+    load_config,
+    save_config,
+)
+from unittest.mock import patch
+
+ConfigWriteConflictError = getattr(cfg_mod, "ConfigWriteConflictError", None)
+ConfigDuplicateKeyError = getattr(cfg_mod, "ConfigDuplicateKeyError", None)
+
+
+@pytest.fixture(autouse=True)
+def _reset_config_module_state():
+    """Clear config.py module-level caches between tests in this file.
+
+    Each test file runs in its own process, but tests within this file share
+    module state; every test here uses a distinct tmp_path so path-keyed
+    caches cannot collide — this clear is belt-and-braces plus the
+    non-path-keyed warn sets.
+    """
+    for name in (
+        "_RAW_CONFIG_CACHE",
+        "_LOAD_CONFIG_CACHE",
+        "_LAST_EXPANDED_CONFIG_BY_PATH",
+        "_CONFIG_PARSE_WARNED",
+        "_DISK_STATE_OBSERVATIONS",
+        "_UNKNOWN_KEY_WARNED",
+    ):
+        state = getattr(cfg_mod, name, None)
+        if state is not None:
+            state.clear()
+    yield
+
+
+def _write_config(tmp_path, data):
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(data, sort_keys=False), encoding="utf-8"
+    )
+    # (mtime_ns, size)-keyed caches need the mtime to move between writes.
+    time.sleep(0.05)
+
+
+def _read_disk(tmp_path):
+    return yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+
+
+def _v0(**extra):
+    base = {
+        "_config_version": DEFAULT_CONFIG["_config_version"],
+        "model": {"default": "test/model-a"},
+    }
+    base.update(extra)
+    return base
+
+
+class TestLostUpdateMergePreserve:
+    def test_hand_edit_survives_two_writer_race(self, tmp_path):
+        """THE c002 repro: a disk-side key added after the caller's load must
+        survive the caller's save. Unpatched save_config clobbers it."""
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            _write_config(tmp_path, _v0())
+            caller_cfg = load_config()  # caller's (soon stale) snapshot
+
+            # External writer: a human hand-edit adds a top-level key the
+            # caller has never seen (the pins/session_reset/plugins shape).
+            _write_config(tmp_path, _v0(custom_pins={"x": 1}))
+
+            caller_cfg["memory"] = {"user_char_limit": 2200}
+            save_config(caller_cfg)
+
+            raw = _read_disk(tmp_path)
+            assert raw.get("custom_pins") == {"x": 1}, (
+                "lost update: the hand-edited key was clobbered by a stale "
+                "whole-file reserialization"
+            )
+            assert raw["memory"]["user_char_limit"] == 2200
+            assert raw["model"]["default"] == "test/model-a"
+
+    def test_foreign_value_change_survives_when_caller_did_not_touch_it(
+        self, tmp_path
+    ):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            _write_config(tmp_path, _v0(memory={"user_char_limit": 1111}))
+            caller_cfg = load_config()
+
+            _write_config(tmp_path, _v0(memory={"user_char_limit": 2222}))
+
+            caller_cfg["model"]["default"] = "test/model-b"
+            save_config(caller_cfg)
+
+            raw = _read_disk(tmp_path)
+            assert raw["memory"]["user_char_limit"] == 2222, (
+                "lost update: disk-side value change reverted by stale save"
+            )
+            assert raw["model"]["default"] == "test/model-b"
+
+    def test_foreign_edit_survives_even_after_intervening_load(self, tmp_path):
+        """A long-running process (gateway) reloads config constantly. A
+        reload AFTER the foreign edit must not launder the stale snapshot's
+        clobber — the disk-state history, not just the latest observation,
+        is the merge base."""
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            _write_config(tmp_path, _v0())
+            caller_cfg = load_config()
+
+            _write_config(tmp_path, _v0(custom_pins={"x": 1}))
+            load_config()  # unrelated in-process reload absorbs the edit
+
+            caller_cfg["memory"] = {"user_char_limit": 2200}
+            save_config(caller_cfg)
+
+            raw = _read_disk(tmp_path)
+            assert raw.get("custom_pins") == {"x": 1}
+            assert raw["memory"]["user_char_limit"] == 2200
+
+    def test_foreign_deletion_is_not_resurrected(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            _write_config(tmp_path, _v0(legacy_block={"a": 1}))
+            caller_cfg = load_config()
+
+            _write_config(tmp_path, _v0())  # external writer deleted the key
+
+            caller_cfg["memory"] = {"user_char_limit": 2200}
+            save_config(caller_cfg)
+
+            raw = _read_disk(tmp_path)
+            assert "legacy_block" not in raw, (
+                "stale save resurrected a key deleted on disk"
+            )
+            assert raw["memory"]["user_char_limit"] == 2200
+
+    def test_in_process_sequential_saves_stay_last_write_wins(self, tmp_path):
+        """A process may overwrite its OWN earlier save with older values —
+        the fallback_add pattern: the model picker saves a new primary, then
+        the command restores the pre-picker primary from an older snapshot.
+        Only FOREIGN disk transitions get lost-update protection."""
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            _write_config(tmp_path, _v0())
+            snapshot_before = load_config()
+
+            picker_cfg = load_config()
+            picker_cfg["model"] = {"default": "test/model-b"}
+            save_config(picker_cfg)  # this process's own intermediate write
+            time.sleep(0.05)
+
+            snapshot_before["fallback_providers"] = [
+                {"provider": "test", "model": "test/model-b"}
+            ]
+            save_config(snapshot_before)  # deliberately restores model-a
+
+            raw = _read_disk(tmp_path)
+            assert raw["model"]["default"] == "test/model-a", (
+                "in-process restore of the process's own write was wrongly "
+                "suppressed as a stale snapshot"
+            )
+            assert raw["fallback_providers"][0]["provider"] == "test"
+
+    def test_own_merge_preserved_foreign_value_stays_protected(self, tmp_path):
+        """A save that merge-PRESERVED a foreign edit must not launder that
+        value into 'our own write': a later stale snapshot still cannot
+        clobber it."""
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            _write_config(tmp_path, _v0())
+            stale_cfg = load_config()
+
+            # Foreign hand-edit lands on disk.
+            _write_config(tmp_path, _v0(custom_pins={"x": 1}))
+
+            # Our process saves an unrelated change; the merge preserves the
+            # foreign key — the write is self-authored but custom_pins is not.
+            mid_cfg = load_config()
+            mid_cfg["memory"] = {"user_char_limit": 2200}
+            save_config(mid_cfg)
+            assert _read_disk(tmp_path).get("custom_pins") == {"x": 1}
+            time.sleep(0.05)
+
+            # A stale snapshot from before the foreign edit saves again.
+            stale_cfg["display"] = {"show_thinking": True}
+            save_config(stale_cfg)
+
+            raw = _read_disk(tmp_path)
+            assert raw.get("custom_pins") == {"x": 1}, (
+                "merge-preserved foreign value was laundered into a "
+                "self-written state and clobbered by a stale snapshot"
+            )
+
+    def test_caller_deletion_on_quiet_disk_still_deletes(self, tmp_path):
+        """Fresh-snapshot deletions keep working: load, delete, save."""
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            _write_config(tmp_path, _v0(legacy_block={"a": 1}))
+            caller_cfg = load_config()
+            del caller_cfg["legacy_block"]
+            save_config(caller_cfg)
+
+            raw = _read_disk(tmp_path)
+            assert "legacy_block" not in raw
+
+
+class TestCasConflictRefusal:
+    def test_same_key_changed_both_sides_refuses_loudly(self, tmp_path):
+        assert ConfigWriteConflictError is not None, (
+            "patch not applied: hermes_cli.config.ConfigWriteConflictError "
+            "does not exist"
+        )
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            _write_config(tmp_path, _v0())
+            caller_cfg = load_config()
+
+            _write_config(tmp_path, _v0() | {"model": {"default": "test/model-b"}})
+
+            caller_cfg["model"]["default"] = "test/model-c"
+            with pytest.raises(ConfigWriteConflictError) as exc_info:
+                save_config(caller_cfg)
+
+            # Loud, names the conflicted path, and fail-closed: disk keeps
+            # the concurrent writer's value, nothing was written.
+            assert "model.default" in str(exc_info.value)
+            assert _read_disk(tmp_path)["model"]["default"] == "test/model-b"
+
+    def test_conflict_message_names_paths_not_values(self, tmp_path):
+        """Config values can be secrets — the refusal names key paths only."""
+        assert ConfigWriteConflictError is not None
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            _write_config(tmp_path, _v0(mcp_servers={"srv": {"api_key": "old-secret"}}))
+            caller_cfg = load_config()
+
+            _write_config(
+                tmp_path, _v0(mcp_servers={"srv": {"api_key": "disk-secret"}})
+            )
+
+            caller_cfg["mcp_servers"]["srv"]["api_key"] = "caller-secret"
+            with pytest.raises(ConfigWriteConflictError) as exc_info:
+                save_config(caller_cfg)
+
+            msg = str(exc_info.value)
+            assert "mcp_servers.srv.api_key" in msg
+            for leaked in ("old-secret", "disk-secret", "caller-secret"):
+                assert leaked not in msg
+
+
+class TestDuplicateKeyRejection:
+    def test_duplicate_key_on_disk_rejects_write(self, tmp_path):
+        assert ConfigDuplicateKeyError is not None, (
+            "patch not applied: hermes_cli.config.ConfigDuplicateKeyError "
+            "does not exist"
+        )
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            _write_config(tmp_path, _v0())
+            caller_cfg = load_config()
+
+            dup_text = (
+                "_config_version: {v}\n"
+                "model:\n  default: test/model-a\n"
+                "memory:\n  user_char_limit: 1111\n"
+                "memory:\n  user_char_limit: 2222\n"
+            ).format(v=DEFAULT_CONFIG["_config_version"])
+            (tmp_path / "config.yaml").write_text(dup_text, encoding="utf-8")
+            time.sleep(0.05)
+
+            caller_cfg["model"]["default"] = "test/model-b"
+            with pytest.raises(ConfigDuplicateKeyError, match="memory"):
+                save_config(caller_cfg)
+
+            # Fail-closed: the ambiguous file was not touched.
+            assert (tmp_path / "config.yaml").read_text(encoding="utf-8") == dup_text
+
+
+class TestUnknownKeyWarn:
+    def test_unknown_key_in_defined_subtree_warns_not_blocks(
+        self, tmp_path, caplog
+    ):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            _write_config(tmp_path, _v0())
+            caller_cfg = load_config()
+            caller_cfg.setdefault("display", {})["tool_progress_grouXping"] = True
+
+            with caplog.at_level(logging.WARNING, logger="hermes_cli.config"):
+                save_config(caller_cfg)
+
+            assert any(
+                "display.tool_progress_grouXping" in rec.message
+                for rec in caplog.records
+            ), "unknown key inside a DEFAULT_CONFIG subtree should WARN"
+            # warn-only: the write went through with the key intact
+            assert _read_disk(tmp_path)["display"]["tool_progress_grouXping"] is True
+
+    def test_real_estate_garble_shape_warns(self, tmp_path, caplog):
+        """The live defect this catches: an em-dash garble of a real key
+        (display.tool_progress_gr―ouping) sitting next to nothing — it
+        near-matches the known key and warns."""
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            _write_config(tmp_path, _v0())
+            caller_cfg = load_config()
+            caller_cfg.setdefault("display", {})["tool_progress_gr———ouping"] = True
+
+            with caplog.at_level(logging.WARNING, logger="hermes_cli.config"):
+                save_config(caller_cfg)
+
+            assert any(
+                "tool_progress_gr———ouping" in rec.message for rec in caplog.records
+            )
+
+    def test_benign_novel_key_in_defined_subtree_is_silent(
+        self, tmp_path, caplog
+    ):
+        """DEFAULT_CONFIG under-enumerates even second-level keys (live
+        profiles carry ~20 legit ones like agent.verbose). A novel key that
+        does NOT resemble any known/sibling key must stay silent —
+        otherwise the warning is noise nobody reads."""
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            _write_config(tmp_path, _v0())
+            caller_cfg = load_config()
+            caller_cfg.setdefault("agent", {})["verbose"] = True
+
+            with caplog.at_level(logging.WARNING, logger="hermes_cli.config"):
+                save_config(caller_cfg)
+
+            assert not any("agent.verbose" in rec.message for rec in caplog.records)
+            assert _read_disk(tmp_path)["agent"]["verbose"] is True
+
+    def test_unknown_top_level_key_is_silent(self, tmp_path, caplog):
+        """DEFAULT_CONFIG is NOT a complete schema — legit estate keys like
+        session_reset/plugins/mcp_servers are absent from it. Top-level
+        unknowns must stay silent."""
+        assert "session_reset" not in DEFAULT_CONFIG
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            _write_config(tmp_path, _v0())
+            caller_cfg = load_config()
+            caller_cfg["session_reset"] = {"mode": "both"}
+
+            with caplog.at_level(logging.WARNING, logger="hermes_cli.config"):
+                save_config(caller_cfg)
+
+            assert not any(
+                "session_reset" in rec.message for rec in caplog.records
+            )
+            assert _read_disk(tmp_path)["session_reset"] == {"mode": "both"}
+
+
+class TestExistingSeamBehaviorsUnchanged:
+    def test_env_template_preserved_through_two_writer_merge(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_TEST_LOST_UPDATE_KEY", "expanded-secret-value")
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            _write_config(
+                tmp_path,
+                _v0(mcp_servers={"srv": {"api_key": "${HERMES_TEST_LOST_UPDATE_KEY}"}}),
+            )
+            caller_cfg = load_config()
+            assert (
+                caller_cfg["mcp_servers"]["srv"]["api_key"]
+                == "expanded-secret-value"
+            )
+
+            # concurrent disk-side hand-edit, unrelated to the template
+            _write_config(
+                tmp_path,
+                _v0(
+                    mcp_servers={"srv": {"api_key": "${HERMES_TEST_LOST_UPDATE_KEY}"}},
+                    custom_pins={"x": 1},
+                ),
+            )
+
+            caller_cfg["memory"] = {"user_char_limit": 2200}
+            save_config(caller_cfg)
+
+            text = (tmp_path / "config.yaml").read_text(encoding="utf-8")
+            assert "${HERMES_TEST_LOST_UPDATE_KEY}" in text
+            assert "expanded-secret-value" not in text
+            raw = _read_disk(tmp_path)
+            assert raw.get("custom_pins") == {"x": 1}
+
+    def test_default_strip_unchanged(self, tmp_path):
+        """save(load()) still writes only user-authored keys — schema
+        defaults are not materialized by the merge."""
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            _write_config(
+                tmp_path,
+                {
+                    "_config_version": DEFAULT_CONFIG["_config_version"],
+                    "memory": {"user_char_limit": 2200},
+                },
+            )
+            save_config(load_config())
+            raw = _read_disk(tmp_path)
+
+            assert raw["memory"]["user_char_limit"] == 2200
+            assert "agent" not in raw
+            assert "gateway" not in raw
+
+    def test_corrupt_disk_yaml_keeps_legacy_overwrite_path(self, tmp_path):
+        """When the on-disk YAML is unparseable the disk state is UNKNOWN:
+        no merge, no conflict — save falls back to the legacy overwrite
+        (the corrupt content is .bak-snapshotted by the parse-failure
+        warner at the last-known-good seam)."""
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            _write_config(tmp_path, _v0())
+            caller_cfg = load_config()
+
+            (tmp_path / "config.yaml").write_text("\tbroken:\n", encoding="utf-8")
+            time.sleep(0.05)
+
+            caller_cfg["memory"] = {"user_char_limit": 2200}
+            save_config(caller_cfg)  # must not raise
+
+            raw = _read_disk(tmp_path)
+            assert raw["memory"]["user_char_limit"] == 2200
+            assert raw["model"]["default"] == "test/model-a"
+
+    def test_absent_file_still_created(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            save_config({"model": {"default": "test/model-a"}})
+            raw = _read_disk(tmp_path)
+            assert raw["model"]["default"] == "test/model-a"


### PR DESCRIPTION
## The defect

Any code path that loads config into memory, holds it, and later calls
`hermes_cli.config.save_config(cfg)` silently reverts every `config.yaml` edit made
in between by anyone else — another process, a human hand-edit, a second gateway.
`save_config` reserializes the caller's whole dict; its preservation logic
(`explicit_raw_paths` → `_strip_default_values(..., preserve_keys=...)`) can only KEEP
paths already present in that dict, never resurrect a path that exists on current disk
but not in the caller's stale copy. `_CONFIG_LOCK` is thread-level only, so
cross-process writers race freely.

`123c6f3a2` added `atomic_config_write` as the fail-closed single chokepoint for
config writes (unreadable-file guard), and `fe25806a6` (#60591) added last-known-good
retention when the file fails to parse — both harden this exact seam against
*corruption*-shaped loss. This PR extends the same seam against *concurrency*-shaped
loss, and routes `save_config` through `atomic_config_write` instead of its direct
`atomic_yaml_write` call while at it.

## Real-world impact (how we hit it, repeatedly)

Multi-writer setup: several agent sessions + four long-running gateways sharing
profile configs.

- **2026-07-05:** a session held a config dict ~1.5h; its final save reverted a
  privacy-relevant `agentmail.suppress_outbound_email` key added on disk (and
  committed to git) in the interim. The platform fails closed on the missing key —
  outbound email silently disabled until the next restart. Only keys added AFTER the
  stale reader's load are lost, which makes the failure look selective and mysterious.
- **2026-07-09/10 (live audit):** all four profile `config.yaml` files carried
  uncommitted gateway-reserialization churn: comments stripped (including a
  4-line reviewed rationale block), a deliberately pinned
  `auxiliary_models.compression` slot wiped back to auto, and a `session_reset`
  mode flip riding a save of unrelated keys. Cleaning it up cost a multi-slice
  remediation batch.
- **Operational side effects of the blind rewrite:** the gateway's whole-file
  reserialization emitted 78 trailing-whitespace lines in one profile config (0 at
  git HEAD) — our commit gate (`git diff --check`) then hard-blocked the snapshot
  commit until the file was whitespace-normalized with parse-equality proof. And
  because gateways run under launchd `KeepAlive` (one respawned mid-procedure during
  this very remediation), ANY manual config edit currently requires a full
  bootout/edit/bootstrap cycle to be safe from a concurrent rewrite. The write path
  itself has to stop reverting what it didn't change; procedures can't.

This class of blind whole-state overwrite is also what keeps un-fixing our other
fixes (e.g. a dependency-pin repair orphaned by an unrelated reset on 2026-07-09 took
every profile's memory daemon down for hours) — hence the insistence on fixing the
writer, not adding another healer.

## The fix

Inside `save_config`'s existing lock, after the normal pipeline (normalize →
`${ENV}`-template restore → default-strip):

1. **Re-read the disk** (fresh, dup-key-rejecting parse) — the merge's "theirs".
2. **Three-way merge-preserve** against the process's observed disk-state history
   (`_DISK_STATE_OBSERVATIONS`: the last 8 DISTINCT on-disk states this process
   parsed via `read_raw_config`/`load_config`, or wrote itself). Per key path:
   - equal both sides → keep;
   - the disk value is one this process **authored in its own last write** →
     in-process sequential saves stay last-write-wins (a process may overwrite its
     own writes, even with older values — e.g. `fallback_add`'s restore-the-primary
     flow). "Authored" = changed relative to the disk state that write replaced;
     values a save merely carried through or merge-preserved don't count, so a
     foreign edit can't be laundered into "ours" by an intermediate save;
   - the caller's value (or absence) matches a **previously observed** disk state
     while disk now differs → stale snapshot: the disk-side edit wins — foreign
     additions, value changes, and deletions the caller never saw all survive.
     Logged at WARNING with the preserved key paths;
   - caller introduces a new value on a quiet disk → caller wins (incl. deletions);
   - **same key changed on both sides → `ConfigWriteConflictError`**: loud, logged,
     fail-closed, nothing written. Message names key paths only — config values can
     be secrets.
3. **Duplicate mapping keys on disk → `ConfigDuplicateKeyError`** (write refused).
   YAML is last-key-wins, so a file with duplicates is semantically ambiguous —
   usually a human mid-edit; rewriting it would silently collapse a stanza.
4. **Garbled-key WARN (never blocks):** an unknown second-level key inside a
   `DEFAULT_CONFIG`-defined subtree warns only when it near-matches a known or
   sibling key (`difflib`, cutoff 0.8) — the shape of a real incident key
   `display.tool_progress_gr―ouping`. Everything else stays silent: DEFAULT_CONFIG
   is NOT a complete schema (live configs legitimately carry `session_reset`,
   `plugins`, `mcp_servers` at top level and 15–25 un-enumerated second-level keys
   like `agent.verbose`). Calibration receipt: against our five live estate configs
   this warns on exactly 0 keys, while the historical garble would have matched.
5. The write goes through **`atomic_config_write`** (the blessed chokepoint), and the
   post-write state is recorded as a self-written observation.

The history-based base matters: a naive "merge against the last observation" is
defeated by any unrelated in-process `load_config()` that runs after the foreign edit
(long-running gateways reload constantly) — it absorbs the edit into the base and
launders the stale clobber. Test
`test_foreign_edit_survives_even_after_intervening_load` pins this.

Relation to the two options floated in the original issue draft: this is (a)+(b)
hybridized without signature churn — merge-preserve generalized to ALL keys (not just
ex-schema ones) plus CAS-style refusal for true conflicts. The draft's `removals:`
escape-hatch turned out unnecessary: delete-by-omission callers (migration pops,
`_remove_mcp_server`) act on a fresh snapshot over a quiet disk, which the merge
resolves as caller-wins; the MCP and migration suites pass unchanged.

## Preserved behaviors (tested)

- `${ENV}` template preservation (`_preserve_env_ref_templates`) — templates still
  land on disk, expanded secrets still don't, including through a two-writer merge.
- Schema-default stripping — `save(load())` round-trip writes only user-authored keys.
- `require_readable_config_before_write` fail-closed guard (now double-covered via
  `atomic_config_write`).
- **`fe25806a6` adjacency:** when the on-disk YAML is unparseable the disk state is
  UNKNOWN — no merge, no spurious conflict; save keeps its legacy overwrite (the
  corrupt content was already `.bak`-snapshotted by `_warn_config_parse_failure`,
  and load-side last-known-good retention is untouched). The corrupt-file test pins
  this. `_LAST_EXPANDED_CONFIG_BY_PATH` (the LKG source) now also folds in
  merge-preserved disk values so a later parse-failure fallback doesn't serve them
  stale.

## Known limitations (deliberate)

- A fresh process that writes without ever reading has no observation history —
  behavior is unchanged from today (caller wins). Every real caller loads first.
- The window between save's re-read and the atomic rename is not cross-process
  locked (no flock); it shrinks from "caller's entire hold time" (minutes–hours in a
  gateway) to milliseconds.
- Bias under ambiguity is preservation: a long-running process deleting a key whose
  foreign addition it once observed gets the deletion suppressed WITH a WARNING
  naming the path. We chose visible suppression over silent loss — silent loss is
  the defect.

## Tests

`tests/hermes_cli/test_config_save_lost_update.py` — 18 tests: two-writer hand-edit
survival (the repro — fails on unpatched main), foreign value-change survival,
intervening-load survival, foreign-deletion non-resurrection, in-process
last-write-wins, anti-laundering, caller deletion on quiet disk, CAS refusal (+
paths-not-values message), dup-key rejection, garble WARN + benign-key silence +
top-level silence, env-template round-trip, default-strip round-trip, corrupt-disk
legacy path, absent-file create.

Full sweep of every `save_config`-touching test file (56 files, 2190 tests): 0
failures. Verified on `main` (`a9f3f0870`) and cherry-pick-clean onto our production
checkout.

## Environment

hermes-agent main @ `a9f3f0870` (2026-07-10), macOS, Python 3.11 venv.
