### PR TITLE
fix(docker): gate recursive chown behind stat-uid check to skip expensive walk on warm boots (#62208)

### DIFF
--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -216,6 +216,13 @@ chown_hermes_tree() {
     if refuse_symlinked_path "recursive chown" "$target"; then
         return 0
     fi
+    # Short-circuit: skip the recursive chown when the target is already owned
+    # by hermes:hermes.  Warm boots on profiles with tens of thousands of paths
+    # otherwise pay a full tree walk (via `chown -R`) just to confirm ownership
+    # that's already correct — adding minutes to container startup (#62208).
+    if [ "$(stat -c '%u:%g' "$target" 2>/dev/null)" = "$(id -u hermes 2>/dev/null):$(id -g hermes 2>/dev/null)" ]; then
+        return 0
+    fi
     chown -R hermes:hermes "$target" 2>/dev/null || \
         echo "[stage2] Warning: chown $target failed (rootless container?) — continuing"
 }


### PR DESCRIPTION
## Summary
On warm boots, `chown_hermes_tree()` ran unconditional recursive `chown -R hermes:hermes` on profiles, cron, logs, and other directories even when ownership was already correct. On large profiles with tens of thousands of paths, this added minutes to startup.

## Change
Added a `stat`-vs-`id` ownership guard at the top of `chown_hermes_tree()` in `docker/stage2-hook.sh`. If the target directory is already owned by `hermes:hermes`, the function returns immediately. When ownership needs repair (first boot, UID remap), it runs as before.

## Verification
6 existing tests pass. Manual check confirms both paths: chown runs on mismatch, skips on match.