### PR TITLE
fix(gateway): call post-turn goal continuation on streaming path to prevent dead /goal loop (#62202)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12122,6 +12122,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             )
                     except Exception as _e:
                         logger.debug("trailing footer send failed: %s", _e)
+                # Goal continuation: streaming path skipped the outer
+                # _post_turn_goal_continuation call (the non-streaming
+                # path at _handle_message level).  Fire it here so the
+                # goal judge evaluates every turn, not just non-streaming ones.
+                if response and response.strip():
+                    try:
+                        _g_session_entry = self.session_store.get_or_create_session(source)
+                    except Exception:
+                        _g_session_entry = None
+                    if _g_session_entry is not None:
+                        await self._post_turn_goal_continuation(
+                            session_entry=_g_session_entry,
+                            source=source,
+                            final_response=response,
+                        )
                 return None
 
             return response


### PR DESCRIPTION
## Summary
The gateway's `/goal` loop was effectively dead because `_post_turn_goal_continuation()` was never called after streaming responses. The goal judge never fired, `turns_used` stayed at 0, and users reported the goal system did nothing despite correct configuration.

## Root Cause
`_handle_message_with_agent()` returns `None` when streaming already delivered the response (`already_sent=True`). The caller at `_handle_message` level only calls `_post_turn_goal_continuation()` after a non-None response, so the streaming path entirely skipped goal evaluation.

## Change
Added a goal continuation call inside `_handle_message_with_agent()` before the streaming `return None` path, mirroring the non-streaming path's logic. The streaming path now evaluates the goal judge after every turn.

## Verification
9 goal-related tests pass, 1 skipped.