### PR TITLE
fix(cli): replace {args} placeholder in exec-type quick commands

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8922,6 +8922,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     import subprocess
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
+                        user_args = cmd_original[len(base_cmd):].strip()
+                        if "{args}" in exec_cmd:
+                            exec_cmd = exec_cmd.replace("{args}", user_args)
                         try:
                             # shell=True is intentional: quick_commands are user-defined
                             # shell snippets from config.yaml — not agent/LLM controlled.

--- a/cli.py
+++ b/cli.py
@@ -26,6 +26,7 @@ except ModuleNotFoundError:
 import logging
 import os
 import shutil
+import shlex
 import sys
 import json
 import re
@@ -8924,7 +8925,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     if exec_cmd:
                         user_args = cmd_original[len(base_cmd):].strip()
                         if "{args}" in exec_cmd:
-                            exec_cmd = exec_cmd.replace("{args}", user_args)
+                            exec_cmd = exec_cmd.replace("{args}", shlex.quote(user_args))
                         try:
                             # shell=True is intentional: quick_commands are user-defined
                             # shell snippets from config.yaml — not agent/LLM controlled.


### PR DESCRIPTION
## Summary

Fixes #44718 — exec-type quick commands (`type: exec`) never replaced the `{args}` placeholder with the user's actual arguments.

## Root Cause

The exec-type handler in `cli.py` was missing the user-argument extraction step that the alias-type handler already has. When a user typed e.g. `/og 1`, the `{args}` placeholder remained literal and the script received `{args}` instead of `1`.

## Fix

Added two lines after `exec_cmd = qcmd.get("command", "")`:
- `user_args = cmd_original[len(base_cmd):].strip()` — extracts user arguments
- `exec_cmd = exec_cmd.replace("{args}", user_args)` — substitutes the placeholder

This matches the existing pattern from the alias-type handler at line 8954.

## Testing

- Manual test: define an exec-type quick command with `{args}`, run `/cmd hello`, verify script receives `hello` instead of `{args}`
- Backward compatible: if no `{args}` in command string, no substitution occurs

## Checklist
- [x] Conventional commit format
- [x] One logical change
- [x] Matches existing code patterns (alias handler)