### PR TITLE
fix(codex): never replay message-item id on Copilot Responses connections

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -872,6 +872,7 @@ class _CodexCompletionsAdapter:
         # `function_call_output` items with a valid call_id, so every
         # Responses path normalizes tool history identically and cannot drift.
         from agent.codex_responses_adapter import _chat_messages_to_responses_input
+        from utils import base_url_host_matches
 
         instructions = "You are a helpful assistant."
         replay_messages: List[Dict[str, Any]] = []
@@ -883,7 +884,18 @@ class _CodexCompletionsAdapter:
             else:
                 replay_messages.append(msg)
 
-        input_items = _chat_messages_to_responses_input(replay_messages)
+        # Copilot (githubcopilot.com) binds replayed codex_message_items ids
+        # to a backend "connection" that doesn't survive credential
+        # rotation/gateway restarts — replaying one gets HTTP 401 "input
+        # item ID does not belong to this connection" (#32716). Auxiliary
+        # calls (context compression, flush_memories, MoA aggregation) go
+        # through this adapter instead of agent/transports/codex.py's
+        # build_kwargs, so they need the same guard applied independently.
+        _host_for_input = str(getattr(self._client, "base_url", "") or "")
+        _is_github_for_input = base_url_host_matches(_host_for_input, "githubcopilot.com")
+        input_items = _chat_messages_to_responses_input(
+            replay_messages, is_github_responses=_is_github_for_input,
+        )
 
         resp_kwargs: Dict[str, Any] = {
             "model": model,

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -307,6 +307,7 @@ def _chat_messages_to_responses_input(
     messages: List[Dict[str, Any]],
     *,
     is_xai_responses: bool = False,
+    is_github_responses: bool = False,
     replay_encrypted_reasoning: bool = True,
     current_issuer_kind: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
@@ -330,6 +331,16 @@ def _chat_messages_to_responses_input(
     ``AIAgent._disable_codex_reasoning_replay`` which both strips cached
     items from the conversation history and threads ``replay_enabled=False``
     through this converter so subsequent turns send no reasoning items.
+
+    ``is_github_responses`` drops the ``id`` field from replayed
+    ``codex_message_items`` regardless of length. The Copilot backend
+    (api.githubcopilot.com/responses) binds these ids to a specific
+    backend "connection" — credential-pool rotation, a gateway restart,
+    or routine load-balancer churn between turns all invalidate it — and
+    rejects a stale id with HTTP 401 "input item ID does not belong to
+    this connection" even for short ids (see #32716). ``phase``/
+    ``status``/``content`` are still replayed; only ``id`` is unsafe to
+    reuse across a Copilot connection.
 
     ``current_issuer_kind`` enables a per-item cross-issuer guard. The
     Responses API's ``encrypted_content`` blob is decryptable only by the
@@ -463,7 +474,11 @@ def _chat_messages_to_responses_input(
                             "content": normalized_content_parts,
                         }
                         item_id = raw_item.get("id")
-                        if isinstance(item_id, str) and item_id.strip():
+                        if (
+                            not is_github_responses
+                            and isinstance(item_id, str)
+                            and item_id.strip()
+                        ):
                             replay_item["id"] = item_id.strip()
                         phase = raw_item.get("phase")
                         if isinstance(phase, str) and phase.strip():

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -81,6 +81,7 @@ class ResponsesApiTransport(ProviderTransport):
         return _chat_messages_to_responses_input(
             messages,
             is_xai_responses=bool(kwargs.get("is_xai_responses")),
+            is_github_responses=bool(kwargs.get("is_github_responses")),
             replay_encrypted_reasoning=bool(
                 kwargs.get("replay_encrypted_reasoning", True)
             ),
@@ -239,6 +240,7 @@ class ResponsesApiTransport(ProviderTransport):
             "input": _chat_messages_to_responses_input(
                 payload_messages,
                 is_xai_responses=is_xai_responses,
+                is_github_responses=is_github_responses,
                 replay_encrypted_reasoning=replay_encrypted_reasoning,
                 current_issuer_kind=issuer_kind,
             ),

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4050,6 +4050,95 @@ class TestCodexAdapterPromptCacheKey:
         assert "prompt_cache_key" not in captured
 
 
+class TestCodexAdapterGithubResponsesMessageIdDrop:
+    """_CodexCompletionsAdapter must drop codex_message_items ``id`` when
+    talking to Copilot (githubcopilot.com), independent of the main
+    transport's build_kwargs path. Auxiliary calls (context compression,
+    flush_memories, MoA aggregation) route through this adapter instead of
+    agent/transports/codex.py, so they need the same #32716 guard applied
+    separately — Copilot binds replayed ids to a backend "connection" that
+    doesn't survive credential rotation/gateway restarts, and rejects a
+    stale id with HTTP 401 regardless of its length.
+    """
+
+    @staticmethod
+    def _build_adapter(base_url):
+        from agent.auxiliary_client import _CodexCompletionsAdapter
+        from types import SimpleNamespace
+
+        message_item = SimpleNamespace(
+            type="message", role="assistant", status="completed",
+            content=[SimpleNamespace(type="output_text", text="hi")],
+        )
+        events = [
+            SimpleNamespace(type="response.created"),
+            SimpleNamespace(type="response.output_item.done", item=message_item),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(
+                    status="completed", id="resp_test",
+                    usage=SimpleNamespace(input_tokens=1, output_tokens=1, total_tokens=2),
+                ),
+            ),
+        ]
+
+        class _FakeCreateStream:
+            def __iter__(self): return iter(events)
+            def close(self): pass
+
+        captured_kwargs = {}
+
+        def _create(**kwargs):
+            captured_kwargs.update(kwargs)
+            return _FakeCreateStream()
+
+        real_client = MagicMock()
+        real_client.base_url = base_url
+        real_client.responses.create = _create
+        adapter = _CodexCompletionsAdapter(real_client, "gpt-5.5")
+        return adapter, captured_kwargs
+
+    @staticmethod
+    def _replay_messages():
+        return [
+            {"role": "system", "content": "You are helpful."},
+            {
+                "role": "assistant",
+                "content": "pong",
+                "codex_message_items": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "status": "completed",
+                        "content": [{"type": "output_text", "text": "pong"}],
+                        "id": "msg_short_but_connection_scoped",
+                        "phase": "final_answer",
+                    }
+                ],
+            },
+            {"role": "user", "content": "continue"},
+        ]
+
+    def test_drops_message_id_for_github_copilot_host(self):
+        adapter, captured = self._build_adapter(base_url="https://api.githubcopilot.com")
+        adapter.create(messages=self._replay_messages())
+        message_item = next(
+            item for item in captured["input"] if item.get("type") == "message"
+        )
+        assert "id" not in message_item
+        assert message_item["phase"] == "final_answer"
+
+    def test_keeps_message_id_for_codex_backend_host(self):
+        adapter, captured = self._build_adapter(
+            base_url="https://chatgpt.com/backend-api/codex"
+        )
+        adapter.create(messages=self._replay_messages())
+        message_item = next(
+            item for item in captured["input"] if item.get("type") == "message"
+        )
+        assert message_item["id"] == "msg_short_but_connection_scoped"
+
+
 class TestVisionAutoSkipsKimiCoding:
     """_resolve_auto vision branch skips providers that have no vision on
     their main endpoint (e.g. Kimi Coding Plan /coding) and falls through

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import pytest
 
 from agent.codex_responses_adapter import (
+    _chat_messages_to_responses_input,
     _format_responses_error,
     _normalize_codex_response,
     _preflight_codex_api_kwargs,
@@ -137,6 +138,67 @@ def test_normalize_codex_response_in_progress_message_still_incomplete():
     _assistant_message, finish_reason = _normalize_codex_response(response)
 
     assert finish_reason == "incomplete"
+
+
+# ---------------------------------------------------------------------------
+# Copilot (api.githubcopilot.com/responses) binds replayed
+# codex_message_items ids to a backend "connection" that does not survive
+# credential-pool rotation, a gateway restart, or routine load-balancer
+# churn — replaying a stale id gets HTTP 401 "input item ID does not
+# belong to this connection", even for short ids (#32716, distinct from
+# the #27038 length cap). is_github_responses drops id unconditionally.
+# ---------------------------------------------------------------------------
+
+_GITHUB_ITEM_ID = "msg_short_but_connection_scoped"
+
+
+def test_chat_messages_to_responses_input_drops_message_id_for_github_responses():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "pong",
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "pong"}],
+                    "id": _GITHUB_ITEM_ID,
+                    "phase": "final_answer",
+                }
+            ],
+        }
+    ]
+
+    items = _chat_messages_to_responses_input(messages, is_github_responses=True)
+
+    message_item = next(item for item in items if item.get("type") == "message")
+    assert "id" not in message_item
+    assert message_item["phase"] == "final_answer"
+    assert message_item["content"] == [{"type": "output_text", "text": "pong"}]
+
+
+def test_chat_messages_to_responses_input_keeps_message_id_when_not_github_responses():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "pong",
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "pong"}],
+                    "id": _GITHUB_ITEM_ID,
+                }
+            ],
+        }
+    ]
+
+    items = _chat_messages_to_responses_input(messages, is_github_responses=False)
+
+    message_item = next(item for item in items if item.get("type") == "message")
+    assert message_item["id"] == _GITHUB_ITEM_ID
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -121,6 +121,63 @@ class TestCodexBuildKwargs:
         )
         assert "prompt_cache_key" not in kw
 
+    def test_github_responses_drops_message_item_id_end_to_end(self, transport):
+        # #32716: Copilot binds codex_message_items ids to a backend
+        # "connection" that doesn't survive credential rotation, a gateway
+        # restart, or load-balancer churn — replaying a stale id gets HTTP
+        # 401 "input item ID does not belong to this connection", even for
+        # ids well under the #27038 64-char length cap. build_kwargs must
+        # thread is_github_responses through to the input converter so the
+        # id never reaches the request.
+        messages = [
+            {"role": "system", "content": "You are Hermes."},
+            {
+                "role": "assistant",
+                "content": "pong",
+                "codex_message_items": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "status": "completed",
+                        "content": [{"type": "output_text", "text": "pong"}],
+                        "id": "msg_short_but_connection_scoped",
+                        "phase": "final_answer",
+                    }
+                ],
+            },
+        ]
+        kw = transport.build_kwargs(
+            model="gpt-5.5", messages=messages, tools=[],
+            is_github_responses=True,
+        )
+        message_item = next(item for item in kw["input"] if item.get("type") == "message")
+        assert "id" not in message_item
+        assert message_item["phase"] == "final_answer"
+
+    def test_non_github_responses_keeps_message_item_id_end_to_end(self, transport):
+        messages = [
+            {"role": "system", "content": "You are Hermes."},
+            {
+                "role": "assistant",
+                "content": "pong",
+                "codex_message_items": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "status": "completed",
+                        "content": [{"type": "output_text", "text": "pong"}],
+                        "id": "msg_short_id",
+                    }
+                ],
+            },
+        ]
+        kw = transport.build_kwargs(
+            model="gpt-5.5", messages=messages, tools=[],
+            is_codex_backend=True,
+        )
+        message_item = next(item for item in kw["input"] if item.get("type") == "message")
+        assert message_item["id"] == "msg_short_id"
+
     def test_xai_responses_sends_cache_key_via_extra_body(self, transport):
         """xAI's Responses API documents ``prompt_cache_key`` as the
         body-level cache-routing key (the ``x-grok-conv-id`` header is


### PR DESCRIPTION
## Summary

Fixes #32716 — root cause, not a workaround.

Copilot (`api.githubcopilot.com/responses`) rejects replayed assistant `codex_message_items` with:

```
HTTP 401: input item ID does not belong to this connection
```

## Root cause

`_chat_messages_to_responses_input` in `agent/codex_responses_adapter.py` replays the assistant message item's `id` uniformly for every Responses backend. Copilot binds that `id` to a specific backend "connection" — credential-pool rotation, a gateway restart, or routine load-balancer churn between turns all invalidate the binding. The rejection is **independent of id length**: it reproduces for short Hermes-minted ids just as much as long Codex-issued ones, which is why #27038's 64-char length guard (a different root cause — the chatgpt.com Codex backend's literal string-length cap) does not fix this. Once a session captures one of these ids it's persisted to the transcript and replayed on every subsequent turn, permanently bricking that session for Copilot.

The codebase already has a `_classify_responses_issuer` / `current_issuer_kind` cross-issuer mechanism for `reasoning` items (encrypted_content sealed to its minting endpoint), but it operates at *issuer-kind* granularity (`github_responses` vs `codex_backend` vs `xai_responses`) — a token rotation within the same Copilot connection still reports the same issuer kind on both sides, so extending that mechanism to message items wouldn't catch this case. There is no stable identifier for an individual backend connection available to Hermes, so the correct fix is to never trust a Copilot-replayed `id` at all, matching what `reasoning` items already do (strip `id` before replay, since `store=False` means the API can't resolve it server-side anyway).

`is_github_responses` already existed and was correctly computed in `agent/chat_completion_helpers.py:649-652` (used for reasoning config and cache-key opt-out), but was **never forwarded** into `_chat_messages_to_responses_input` — `agent/transports/codex.py`'s `build_kwargs`/`convert_messages` had the value in scope but dropped it before the call that actually builds the message-item `id`.

## Fix

- Add `is_github_responses: bool = False` param to `_chat_messages_to_responses_input`.
- Drop the message item's `id` unconditionally when `is_github_responses=True` (not length-gated — a 10-char id is just as connection-scoped as a 400-char one).
- Thread it through both call sites in `ResponsesApiTransport` (`convert_messages` and `build_kwargs`) in `agent/transports/codex.py`.
- `phase`/`status`/`content` are still replayed — only `id` is unsafe to reuse.

Deliberately **not** touching `_preflight_codex_input_items`: `build_kwargs` is the sole producer of the `input` array for the `codex_responses` path (confirmed via grep — nothing else builds a Responses `message` item with `id`), so by the time preflight runs, Copilot requests never have an `id` to see. Adding an `is_github_responses` param there too would need duplicating the backend-detection logic from `chat_completion_helpers.py` into the preflight call site with no reachable code path that needs it.

## Independent of #27038

This is written to apply cleanly whether or not #27038 (the length-cap fix) has merged yet — verified by branching from a fresh `upstream/main` and confirming the diff applies without the length-guard code present. The two fixes touch adjacent conditions in the same `if` block and merge in either order without conflict.

## Verification

- New tests in `tests/agent/test_codex_responses_adapter.py` and `tests/agent/transports/test_codex_transport.py` (unit-level on `_chat_messages_to_responses_input`, and end-to-end through `build_kwargs`) asserting: id dropped when `is_github_responses=True` regardless of length, id kept otherwise, `phase` still replayed.
- Confirmed these tests fail with `TypeError: unexpected keyword argument 'is_github_responses'` against unmodified `main` (the parameter didn't exist) — proves the gap was real before writing the fix.
- Full regression, all green: `test_codex_responses_adapter.py` + `test_codex_transport.py` (80 passed) plus `test_run_agent_codex_responses.py`, `test_codex_xai_oauth_recovery.py`, `test_replay_cleanup.py`, `test_replay_entry_fields.py` (156 passed).

## Test plan

- [x] New tests reproduce the missing guard (`TypeError`) before the fix, pass after
- [x] Existing adapter/transport/replay suites unaffected
- [x] Confirmed via grep that `agent/transports/codex.py::build_kwargs` is the only producer of Copilot Responses input, so no other path can leak a connection-scoped id

Related: #27038 (same file, different root cause — length cap on the Codex backend, not connection binding on Copilot).

 