### PR TITLE
fix(gateway): /profile reports the profile serving the source on multiplexed gateways

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -330,12 +330,33 @@ class GatewaySlashCommandsMixin:
         return EphemeralReply(f"{header}{_tip_line}")
 
     async def _handle_profile_command(self, event: MessageEvent) -> str:
-        """Handle /profile — show active profile name and home directory."""
+        """Handle /profile — show the profile serving this source and its home.
+
+        On a multiplexed gateway the process-level active profile is always
+        the multiplexer's own (usually ``default``), so reporting it would
+        answer "default" in every chat regardless of which profile actually
+        serves the room/channel (``source.profile`` — stamped by the
+        ``/p/<profile>/`` URL prefix, a per-credential adapter, or a room→
+        profile map). Report the stamped profile and, like the scoped /reset
+        banner (#59003), resolve the displayed home under that profile's
+        runtime scope. Single-profile gateways are unchanged: an unstamped
+        source falls back to the active profile and the default home.
+        """
         from hermes_constants import display_hermes_home
         from hermes_cli.profiles import get_active_profile_name
 
-        display = display_hermes_home()
-        profile_name = get_active_profile_name()
+        source = getattr(event, "source", None)
+        profile_name = (
+            getattr(source, "profile", "") or ""
+        ).strip() or get_active_profile_name()
+        try:
+            from gateway.run import _profile_runtime_scope
+
+            profile_home = self._resolve_profile_home_for_source(source)
+            with _profile_runtime_scope(profile_home):
+                display = display_hermes_home()
+        except Exception:
+            display = display_hermes_home()
 
         lines = [
             t("gateway.profile.header", profile=profile_name),

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -337,25 +337,36 @@ class GatewaySlashCommandsMixin:
         answer "default" in every chat regardless of which profile actually
         serves the room/channel (``source.profile`` — stamped by the
         ``/p/<profile>/`` URL prefix, a per-credential adapter, or a room→
-        profile map). Report the stamped profile and, like the scoped /reset
-        banner (#59003), resolve the displayed home under that profile's
-        runtime scope. Single-profile gateways are unchanged: an unstamped
-        source falls back to the active profile and the default home.
+        profile map). When ``multiplex_profiles`` is on, report the stamped
+        profile and, like the scoped /reset banner (#59003), resolve the
+        displayed home under that profile's runtime scope. When multiplexing
+        is off (the default) the stamp is ignored — mirroring the gating in
+        ``_run_agent`` and ``_reset_notice_session_info`` — and the command
+        reports the active profile and default home, byte-identical to before.
         """
         from hermes_constants import display_hermes_home
         from hermes_cli.profiles import get_active_profile_name
 
+        multiplexed = getattr(
+            getattr(self, "config", None), "multiplex_profiles", False
+        )
         source = getattr(event, "source", None)
-        profile_name = (
-            getattr(source, "profile", "") or ""
-        ).strip() or get_active_profile_name()
-        try:
-            from gateway.run import _profile_runtime_scope
 
-            profile_home = self._resolve_profile_home_for_source(source)
-            with _profile_runtime_scope(profile_home):
+        profile_name = ""
+        if multiplexed:
+            profile_name = (getattr(source, "profile", "") or "").strip()
+        profile_name = profile_name or get_active_profile_name()
+
+        if multiplexed:
+            try:
+                from gateway.run import _profile_runtime_scope
+
+                profile_home = self._resolve_profile_home_for_source(source)
+                with _profile_runtime_scope(profile_home):
+                    display = display_hermes_home()
+            except Exception:
                 display = display_hermes_home()
-        except Exception:
+        else:
             display = display_hermes_home()
 
         lines = [

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -673,6 +673,60 @@ async def test_profile_command_reports_custom_root_profile(monkeypatch, tmp_path
 
 
 @pytest.mark.asyncio
+async def test_profile_command_reports_source_stamped_profile(monkeypatch, tmp_path):
+    """On a multiplexed gateway, /profile reports the profile SERVING the
+    source (source.profile — URL prefix / per-credential adapter / room map),
+    not the multiplexer's active profile, which is always the default and
+    made /profile answer "default" in every persona chat."""
+    hermes_home = tmp_path / ".hermes"
+    profile_home = hermes_home / "profiles" / "milo"
+    profile_home.mkdir(parents=True)
+
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    event = _make_event("/profile")
+    event.source.profile = "milo"
+
+    result = await runner._handle_profile_command(event)
+
+    assert "**Profile:** `milo`" in result
+    assert f"**Home:** `{profile_home}`" in result
+
+
+@pytest.mark.asyncio
+async def test_profile_command_unstamped_source_unchanged(monkeypatch, tmp_path):
+    """Single-profile behavior is untouched: an unstamped source reports the
+    active profile and the default home."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    result = await runner._handle_profile_command(_make_event("/profile"))
+
+    assert "**Profile:** `default`" in result
+    assert f"**Home:** `{hermes_home}`" in result
+
+
+@pytest.mark.asyncio
 async def test_post_delivery_callback_generation_snapshot_happens_after_bind():
     """Regression: the callback_generation snapshot in _process_message_background
     must happen AFTER the handler runs, not before.

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -691,6 +691,7 @@ async def test_profile_command_reports_source_stamped_profile(monkeypatch, tmp_p
         chat_type="dm",
     )
     runner = _make_runner(session_entry)
+    runner.config.multiplex_profiles = True
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
     event = _make_event("/profile")
@@ -700,6 +701,37 @@ async def test_profile_command_reports_source_stamped_profile(monkeypatch, tmp_p
 
     assert "**Profile:** `milo`" in result
     assert f"**Home:** `{profile_home}`" in result
+
+
+@pytest.mark.asyncio
+async def test_profile_command_ignores_stamp_when_multiplexing_off(monkeypatch, tmp_path):
+    """Without ``gateway.multiplex_profiles`` a stamped source is ignored:
+    /profile keeps reporting the active profile and the default home,
+    mirroring the multiplex gating in ``_run_agent`` and
+    ``_reset_notice_session_info``."""
+    hermes_home = tmp_path / ".hermes"
+    profile_home = hermes_home / "profiles" / "milo"
+    profile_home.mkdir(parents=True)
+
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    assert runner.config.multiplex_profiles is False
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    event = _make_event("/profile")
+    event.source.profile = "milo"
+
+    result = await runner._handle_profile_command(event)
+
+    assert "**Profile:** `default`" in result
+    assert f"**Home:** `{hermes_home}`" in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
On a multiplexed gateway the process-level active profile is always the multiplexer's own (usually `default`), so `/profile` answers "default" in every chat regardless of which profile actually serves it. When personas are routed per-chat (`/p/<profile>/` URL prefix, per-credential adapters, or per-chat mapping as in #61689), this makes working routing look broken — `/profile` is the first thing an operator reaches for to check it.

When `gateway.multiplex_profiles` is on, this reports `source.profile` when stamped and resolves the displayed home under that profile's runtime scope, mirroring the scoped `/reset`/`/new` banner from #59003. The source-profile lookup and scope entry are gated on `multiplex_profiles` — the same gating as `_run_agent` and `_reset_notice_session_info` — so with multiplexing off (the default) a stamped source is ignored and single-profile gateways are byte-for-byte unchanged.

Tests: stamped source on a multiplexed gateway reports the profile's name and `profiles/<name>` home; stamped source with multiplexing off is ignored (regression); unstamped source unchanged; the existing custom-root `/profile` test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)