### PR TITLE
fix(cli): don't reroute /model onto an unconfigured provider (#62240)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1147,11 +1147,14 @@ def switch_model(
                 detected_provider = detected[0]
                 # detect_provider_for_model() matches Hermes' built-in static
                 # catalogs (CURATED_MODELS), so a bare name that also lives
-                # there — e.g. ``gpt-5.5`` under ``openai-api`` — would silently
-                # reroute the session onto that vendor even when the user never
-                # configured it.  The credential resolver then finds no key for
-                # it and leaves the *previous* provider's base_url in place, so
-                # the request is sent to the wrong endpoint and 401s (#62240).
+                # there — e.g. ``gpt-5.5`` under ``openai-api`` — would select
+                # that vendor as the switch target even when the user never
+                # configured it (#62240). The remaining concern this guard
+                # addresses is exactly that: don't pick an unconfigured provider
+                # off a static-catalog match. (The live-agent switch is now
+                # separately rejected and rolled back when the target can't be
+                # resolved — see agent/agent_runtime_helpers.py — so this is
+                # about not offering the wrong target in the first place.)
                 # Only accept a cross-provider static reroute when the detected
                 # provider actually has credentials; a configured custom/user
                 # provider that declares the model already wins earlier via

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1144,7 +1144,35 @@ def switch_model(
         ):
             detected = detect_provider_for_model(new_model, current_provider)
             if detected:
-                target_provider, new_model = detected
+                detected_provider = detected[0]
+                # detect_provider_for_model() matches Hermes' built-in static
+                # catalogs (CURATED_MODELS), so a bare name that also lives
+                # there — e.g. ``gpt-5.5`` under ``openai-api`` — would silently
+                # reroute the session onto that vendor even when the user never
+                # configured it.  The credential resolver then finds no key for
+                # it and leaves the *previous* provider's base_url in place, so
+                # the request is sent to the wrong endpoint and 401s (#62240).
+                # Only accept a cross-provider static reroute when the detected
+                # provider actually has credentials; a configured custom/user
+                # provider that declares the model already wins earlier via
+                # step d.5.  When the authed set is unknown (empty), fall back
+                # to the historical behaviour so we never over-block.
+                if detected_provider == current_provider:
+                    target_provider, new_model = detected
+                else:
+                    _authed = get_authenticated_provider_slugs(
+                        current_provider=current_provider,
+                        user_providers=user_providers,
+                        custom_providers=custom_providers,
+                    )
+                    if not _authed or detected_provider in _authed:
+                        target_provider, new_model = detected
+                    else:
+                        logger.debug(
+                            "Not rerouting '%s' to unconfigured provider %s "
+                            "(no credentials); keeping current provider %s",
+                            new_model, detected_provider, current_provider,
+                        )
 
     # =================================================================
     # COMMON PATH: Resolve credentials, normalize, get metadata

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1229,7 +1229,37 @@ def _route_from_model_input(st: _Switch) -> Optional[ModelSwitchResult]:
     if not config_routed and not is_custom:  # e
         detected = detect_provider_for_model(st.new_model, current_provider)
         if detected:
-            st.target_provider, st.new_model = detected
+            detected_provider = detected[0]
+            # detect_provider_for_model() matches Hermes' built-in static
+            # catalogs (CURATED_MODELS), so a bare name that also lives there —
+            # e.g. ``gpt-5.5`` under ``openai-api`` — would select that vendor as
+            # the switch target even when the user never configured it (#62240).
+            # The remaining concern this guard addresses is exactly that: don't
+            # pick an unconfigured provider off a static-catalog match. (The
+            # live-agent switch is now separately rejected and rolled back when
+            # the target can't be resolved — see agent/agent_runtime_helpers.py —
+            # so this is about not offering the wrong target in the first place.)
+            # Only accept a cross-provider static reroute when the detected
+            # provider actually has credentials; a configured custom/user
+            # provider that declares the model already wins earlier via step d.5.
+            # When the authed set is unknown (empty), fall back to the historical
+            # behaviour so we never over-block.
+            if detected_provider == current_provider:
+                st.target_provider, st.new_model = detected
+            else:
+                _authed = get_authenticated_provider_slugs(
+                    current_provider=current_provider,
+                    user_providers=st.user_providers,
+                    custom_providers=st.custom_providers,
+                )
+                if not _authed or detected_provider in _authed:
+                    st.target_provider, st.new_model = detected
+                else:
+                    logger.debug(
+                        "Not rerouting '%s' to unconfigured provider %s (no credentials); "
+                        "keeping current provider %s",
+                        st.new_model, detected_provider, current_provider,
+                    )
     return None
 
 

--- a/tests/hermes_cli/test_model_switch_configured_provider_routing.py
+++ b/tests/hermes_cli/test_model_switch_configured_provider_routing.py
@@ -308,3 +308,100 @@ def test_xai_oauth_soft_accept_preserved_when_no_match():
     )
     assert result.success is True, result.error_message
     assert result.target_provider == "xai-oauth"
+
+
+# ---------------------------------------------------------------------------
+# #62240: step-e static-catalog reroute must not switch onto an unconfigured
+# provider.  ``detect_provider_for_model`` matches Hermes' built-in
+# CURATED_MODELS, so a bare name that also lives there (e.g. ``gpt-5.5`` under
+# ``openai-api``) would silently reroute the session to that vendor even when
+# the user only configured a different endpoint for it — leaving the previous
+# provider's base_url in place and 401ing.  The reroute is now gated on the
+# detected provider actually having credentials.
+# ---------------------------------------------------------------------------
+
+def _run_switch_detect(
+    *,
+    raw_input,
+    current_provider,
+    detected,
+    authed,
+    custom_providers=None,
+    current_model="old-model",
+    current_base_url="https://api.deepseek.com/v1",
+):
+    """Drive ``switch_model`` with a live step-e ``detect_provider_for_model``
+    return and a controlled authenticated-provider set.
+
+    Only step e is exercised here: alias/aggregator/config paths are neutralised
+    so ``detect_provider_for_model`` decides the reroute, and
+    ``get_authenticated_provider_slugs`` is pinned to ``authed`` to prove the
+    credential gate.
+    """
+    with patch("hermes_cli.model_switch.resolve_alias", return_value=None), \
+         patch("hermes_cli.model_switch.list_provider_models", return_value=[]), \
+         patch("hermes_cli.model_switch.normalize_model_for_provider", side_effect=lambda model, provider: model), \
+         patch("hermes_cli.models.validate_requested_model", return_value=_ACCEPTED), \
+         patch("hermes_cli.models.detect_provider_for_model", return_value=detected), \
+         patch("hermes_cli.model_switch.get_authenticated_provider_slugs", return_value=authed), \
+         patch("hermes_cli.model_switch.get_model_info", return_value=None), \
+         patch("hermes_cli.model_switch.get_model_capabilities", return_value=None), \
+         patch(
+             "hermes_cli.runtime_provider.resolve_runtime_provider",
+             return_value={
+                 "api_key": "***",
+                 "base_url": current_base_url or "http://resolved/v1",
+                 "api_mode": "",
+             },
+         ):
+        return switch_model(
+            raw_input=raw_input,
+            current_provider=current_provider,
+            current_model=current_model,
+            current_base_url=current_base_url,
+            custom_providers=custom_providers or [],
+        )
+
+
+def test_static_reroute_skipped_when_detected_provider_unauthenticated():
+    """The core #62240 repro: ``/model gpt-5.5`` while on deepseek must NOT
+    reroute to the built-in ``openai-api`` catalog when the user has no
+    openai-api credentials — stay on the current provider instead of inheriting
+    a stale base_url."""
+    result = _run_switch_detect(
+        raw_input="gpt-5.5",
+        current_provider="deepseek",
+        detected=("openai-api", "gpt-5.5"),
+        authed=["deepseek", "custom:lmuai"],
+        custom_providers=[{"name": "lmuai", "base_url": "https://api.lmuai.com/v1"}],
+    )
+    assert result.success is True, result.error_message
+    assert result.target_provider == "deepseek"
+    assert result.new_model == "gpt-5.5"
+
+
+def test_static_reroute_allowed_when_detected_provider_authenticated():
+    """No regression: when the user IS authenticated for the detected provider,
+    the static reroute still happens."""
+    result = _run_switch_detect(
+        raw_input="gpt-5.5",
+        current_provider="deepseek",
+        detected=("openai-api", "gpt-5.5"),
+        authed=["deepseek", "openai-api"],
+    )
+    assert result.success is True, result.error_message
+    assert result.target_provider == "openai-api"
+    assert result.new_model == "gpt-5.5"
+
+
+def test_static_reroute_allowed_when_authed_set_unknown():
+    """When the authenticated set can't be determined (empty), fall back to the
+    historical reroute behaviour so the gate never over-blocks."""
+    result = _run_switch_detect(
+        raw_input="gpt-5.5",
+        current_provider="deepseek",
+        detected=("openai-api", "gpt-5.5"),
+        authed=[],
+    )
+    assert result.success is True, result.error_message
+    assert result.target_provider == "openai-api"

--- a/tests/hermes_cli/test_model_switch_configured_provider_routing.py
+++ b/tests/hermes_cli/test_model_switch_configured_provider_routing.py
@@ -311,13 +311,13 @@ def test_xai_oauth_soft_accept_preserved_when_no_match():
 
 
 # ---------------------------------------------------------------------------
-# #62240: step-e static-catalog reroute must not switch onto an unconfigured
+# #62240: step-e static-catalog reroute must not select an unconfigured
 # provider.  ``detect_provider_for_model`` matches Hermes' built-in
 # CURATED_MODELS, so a bare name that also lives there (e.g. ``gpt-5.5`` under
-# ``openai-api``) would silently reroute the session to that vendor even when
-# the user only configured a different endpoint for it — leaving the previous
-# provider's base_url in place and 401ing.  The reroute is now gated on the
-# detected provider actually having credentials.
+# ``openai-api``) would pick that vendor as the switch target even when the
+# user never configured it.  The reroute is now gated on the detected provider
+# actually having credentials, so an unconfigured static-catalog match no
+# longer wins the target selection.
 # ---------------------------------------------------------------------------
 
 def _run_switch_detect(
@@ -366,8 +366,8 @@ def _run_switch_detect(
 def test_static_reroute_skipped_when_detected_provider_unauthenticated():
     """The core #62240 repro: ``/model gpt-5.5`` while on deepseek must NOT
     reroute to the built-in ``openai-api`` catalog when the user has no
-    openai-api credentials — stay on the current provider instead of inheriting
-    a stale base_url."""
+    openai-api credentials — stay on the current provider instead of selecting
+    an unconfigured provider off the static-catalog match."""
     result = _run_switch_detect(
         raw_input="gpt-5.5",
         current_provider="deepseek",

--- a/tests/hermes_cli/test_model_switch_configured_provider_routing.py
+++ b/tests/hermes_cli/test_model_switch_configured_provider_routing.py
@@ -122,3 +122,100 @@ def test_xai_oauth_soft_accept_preserved_when_no_match():
     )
     assert result.success is True, result.error_message
     assert result.target_provider == "xai-oauth"
+
+
+# ---------------------------------------------------------------------------
+# #62240: step-e static-catalog reroute must not select an unconfigured
+# provider.  ``detect_provider_for_model`` matches Hermes' built-in
+# CURATED_MODELS, so a bare name that also lives there (e.g. ``gpt-5.5`` under
+# ``openai-api``) would pick that vendor as the switch target even when the
+# user never configured it.  The reroute is now gated on the detected provider
+# actually having credentials, so an unconfigured static-catalog match no
+# longer wins the target selection.
+# ---------------------------------------------------------------------------
+
+def _run_switch_detect(
+    *,
+    raw_input,
+    current_provider,
+    detected,
+    authed,
+    custom_providers=None,
+    current_model="old-model",
+    current_base_url="https://api.deepseek.com/v1",
+):
+    """Drive ``switch_model`` with a live step-e ``detect_provider_for_model``
+    return and a controlled authenticated-provider set.
+
+    Only step e is exercised here: alias/aggregator/config paths are neutralised
+    so ``detect_provider_for_model`` decides the reroute, and
+    ``get_authenticated_provider_slugs`` is pinned to ``authed`` to prove the
+    credential gate.
+    """
+    with patch("hermes_cli.model_switch.resolve_alias", return_value=None), \
+         patch("hermes_cli.model_switch.list_provider_models", return_value=[]), \
+         patch("hermes_cli.model_switch.normalize_model_for_provider", side_effect=lambda model, provider: model), \
+         patch("hermes_cli.models_validate.validate_requested_model", return_value=_ACCEPTED), \
+         patch("hermes_cli.models.detect_provider_for_model", return_value=detected), \
+         patch("hermes_cli.model_switch.get_authenticated_provider_slugs", return_value=authed), \
+         patch("hermes_cli.model_switch.get_model_info", return_value=None), \
+         patch("hermes_cli.model_switch.get_model_capabilities", return_value=None), \
+         patch(
+             "hermes_cli.runtime_provider.resolve_runtime_provider",
+             return_value={
+                 "api_key": "***",
+                 "base_url": current_base_url or "http://resolved/v1",
+                 "api_mode": "",
+             },
+         ):
+        return switch_model(
+            raw_input=raw_input,
+            current_provider=current_provider,
+            current_model=current_model,
+            current_base_url=current_base_url,
+            custom_providers=custom_providers or [],
+        )
+
+
+def test_static_reroute_skipped_when_detected_provider_unauthenticated():
+    """The core #62240 repro: ``/model gpt-5.5`` while on deepseek must NOT
+    reroute to the built-in ``openai-api`` catalog when the user has no
+    openai-api credentials — stay on the current provider instead of inheriting
+    a stale base_url."""
+    result = _run_switch_detect(
+        raw_input="gpt-5.5",
+        current_provider="deepseek",
+        detected=("openai-api", "gpt-5.5"),
+        authed=["deepseek", "custom:lmuai"],
+        custom_providers=[{"name": "lmuai", "base_url": "https://api.lmuai.com/v1"}],
+    )
+    assert result.success is True, result.error_message
+    assert result.target_provider == "deepseek"
+    assert result.new_model == "gpt-5.5"
+
+
+def test_static_reroute_allowed_when_detected_provider_authenticated():
+    """No regression: when the user IS authenticated for the detected provider,
+    the static reroute still happens."""
+    result = _run_switch_detect(
+        raw_input="gpt-5.5",
+        current_provider="deepseek",
+        detected=("openai-api", "gpt-5.5"),
+        authed=["deepseek", "openai-api"],
+    )
+    assert result.success is True, result.error_message
+    assert result.target_provider == "openai-api"
+    assert result.new_model == "gpt-5.5"
+
+
+def test_static_reroute_allowed_when_authed_set_unknown():
+    """When the authenticated set can't be determined (empty), fall back to the
+    historical reroute behaviour so the gate never over-blocks."""
+    result = _run_switch_detect(
+        raw_input="gpt-5.5",
+        current_provider="deepseek",
+        detected=("openai-api", "gpt-5.5"),
+        authed=[],
+    )
+    assert result.success is True, result.error_message
+    assert result.target_provider == "openai-api"


### PR DESCRIPTION
## What does this PR do?

Fixes a silent mis-route in `/model`: when a bare model name that also lives in
Hermes' built-in `CURATED_MODELS` is typed while on a different provider, the
session was switched onto that built-in vendor **even when the user never
configured credentials for it**.

`switch_model`'s step-e `detect_provider_for_model()` matches only Hermes'
static catalogs. So `/model gpt-5.5` while on `deepseek` matched `openai-api`
and set `provider = openai-api`. But the user had no `openai-api` credentials,
so the credential resolver produced no `base_url`/key and the **previous**
provider's `base_url` was left in place — the request went to
`api.deepseek.com/v1` as `openai-api`/`gpt-5.5` and 401'd, then fell back to an
unintended model.

The fix gates the cross-provider static reroute on the detected provider
actually having credentials. A configured `custom_providers` / `providers.<slug>`
entry that **declares** the model already wins earlier via the existing
configured-provider detection (step d.5, #45006), so declared custom models
route correctly; this change stops the *undeclared* built-in-catalog name from
hijacking the switch onto an unconfigured endpoint.

## Related Issue

Fixes #62240

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/model_switch.py` — in `switch_model` step e, only accept a
  cross-provider `detect_provider_for_model()` reroute when the detected
  provider is in `get_authenticated_provider_slugs(...)`. If the detected
  provider is the current one, or the authed set is empty/unknown, fall back to
  the historical behaviour so the gate never over-blocks.
- `tests/hermes_cli/test_model_switch_configured_provider_routing.py` — 3
  regression tests: reroute skipped when the detected provider is
  unauthenticated (#62240 repro); reroute preserved when it *is* authenticated
  (no regression); reroute preserved when the authed set is unknown.

## How to Test

```
scripts/run_tests.sh tests/hermes_cli/test_model_switch_configured_provider_routing.py -q
```

Result: `13 passed` (10 existing + 3 new). Also ran the broader switch_model
suite (`test_model_switch_custom_providers.py`, `test_user_providers_model_switch.py`,
`test_model_switch_opencode_anthropic.py`, `test_opencode_go_flat_namespace.py`,
`test_model_switch_variant_tags.py`, `test_openai_codex_model_validation_fallback.py`,
`test_switch_model_context.py`): `112 passed`.

Manual repro (before → after): with `custom_providers: [{name: lmuai, base_url:
https://api.lmuai.com/v1}]` and no `openai-api` credentials, `/model gpt-5.5`
while on `deepseek` previously switched to `provider=openai-api` with a stale
`base_url=api.deepseek.com/v1`; now it stays on the configured provider instead
of the unconfigured built-in vendor.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected tests and all pass (see How to Test)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — code comments explain the gate; N/A for README/docs
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A (no architecture/workflow change)
- [x] I've considered cross-platform impact — N/A (pure Python control-flow, no platform-specific code)
- [x] I've updated tool descriptions/schemas — N/A
