### PR TITLE
fix(slack): harden Assistant status lifecycle

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9101,6 +9101,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "Gateway intercepted clarify text response (session=%s, id=%s)",
                         _quick_key, _pending_clarify.clarify_id,
                     )
+                    # The clarify callback pauses the platform typing/status
+                    # indicator while waiting so Slack users can type their
+                    # answer. The active agent resumes as soon as this reply
+                    # resolves the wait, so re-enable its indicator here too.
+                    # Without this, Slack stays silent until the independent
+                    # long-running heartbeat fires (three minutes by default).
+                    _clarify_adapter = self._adapter_for_source(source)
+                    if _clarify_adapter:
+                        try:
+                            _clarify_adapter.resume_typing_for_chat(source.chat_id)
+                        except Exception:
+                            logger.debug(
+                                "Failed to resume typing after clarify response",
+                                exc_info=True,
+                            )
                     # Acknowledge with empty string so adapters that emit
                     # the agent's response don't double-post.  The agent
                     # itself will produce the next user-facing message.

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -477,6 +477,9 @@ class SlackAdapter(BasePlatformAdapter):
         # thread overwrite an older thread, leaving the older assistant status
         # stuck as "is thinking..." after final delivery.
         self._active_status_threads: Dict[str, set[str]] = {}
+        # Defensive bound for permanent Slack API failures or lost lifecycle
+        # metadata. Normal concurrency is far below this threshold.
+        self._ACTIVE_STATUS_THREADS_PER_CHAT_MAX = 128
         # Slash-command contexts: stash response_url + user_id so send()
         # can route the first reply ephemerally.  Keyed by
         # (channel_id, user_id) to avoid cross-user collisions.
@@ -1363,7 +1366,11 @@ class SlackAdapter(BasePlatformAdapter):
         if not self._app:
             return SendResult(success=False, error="Not connected")
 
+        thread_ts = None
         try:
+            # Resolve once so success and exception cleanup always target the
+            # same exact thread, including callers that provide reply_to only.
+            thread_ts = self._resolve_thread_ts(reply_to, metadata)
             # Check for a pending slash-command context.  When the user ran a
             # native slash command (e.g. /q, /stop, /model), the initial ack
             # already showed an ephemeral "Running /cmd…" message.  If we have
@@ -1382,7 +1389,6 @@ class SlackAdapter(BasePlatformAdapter):
             # Split long messages, preserving code block boundaries
             chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
 
-            thread_ts = self._resolve_thread_ts(reply_to, metadata)
             last_result = None
 
             # reply_broadcast: also post thread replies to the main channel.
@@ -1442,13 +1448,17 @@ class SlackAdapter(BasePlatformAdapter):
             # A failed final post must not leave Slack's persistent Assistant
             # status behind. Clear only this turn's thread; other concurrent
             # threads in the same DM/channel must keep their own status.
-            try:
-                await self.stop_typing(chat_id, metadata=metadata)
-            except Exception:
-                logger.debug(
-                    "[Slack] Failed to clear Assistant status after send error",
-                    exc_info=True,
-                )
+            if thread_ts:
+                try:
+                    await self.stop_typing(
+                        chat_id,
+                        metadata={"thread_id": thread_ts},
+                    )
+                except Exception:
+                    logger.debug(
+                        "[Slack] Failed to clear Assistant status after send error",
+                        exc_info=True,
+                    )
             return SendResult(success=False, error=str(e))
 
     async def send_private_notice(
@@ -1545,7 +1555,17 @@ class SlackAdapter(BasePlatformAdapter):
         if not thread_ts:
             return  # Can only set status in a thread context
 
-        self._active_status_threads.setdefault(chat_id, set()).add(str(thread_ts))
+        tracked = self._active_status_threads.setdefault(chat_id, set())
+        thread_ts = str(thread_ts)
+        tracked.add(thread_ts)
+        while len(tracked) > self._ACTIVE_STATUS_THREADS_PER_CHAT_MAX:
+            # Keep the status being refreshed. Slack statuses also expire
+            # server-side, so dropping an older orphan is safer than allowing
+            # an unbounded local leak after permanent API/scope failures.
+            stale_thread_ts = next((ts for ts in tracked if ts != thread_ts), None)
+            if stale_thread_ts is None:
+                break
+            tracked.discard(stale_thread_ts)
         try:
             await self._get_client(chat_id).assistant_threads_setStatus(
                 channel_id=chat_id,

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -472,8 +472,11 @@ class SlackAdapter(BasePlatformAdapter):
         # Track message IDs that should get reaction lifecycle (DMs / @mentions).
         self._reacting_message_ids: set = set()
         # Track active assistant thread status indicators so stop_typing can
-        # clear them (chat_id → thread_ts).
-        self._active_status_threads: Dict[str, str] = {}
+        # clear them. A single Slack channel can have several concurrent
+        # thread-bound Hermes turns; keying this by chat_id alone lets a newer
+        # thread overwrite an older thread, leaving the older assistant status
+        # stuck as "is thinking..." after final delivery.
+        self._active_status_threads: Dict[str, set[str]] = {}
         # Slash-command contexts: stash response_url + user_id so send()
         # can route the first reply ephemerally.  Keyed by
         # (channel_id, user_id) to avoid cross-user collisions.
@@ -1409,9 +1412,11 @@ class SlackAdapter(BasePlatformAdapter):
 
                 last_result = await self._get_client(chat_id).chat_postMessage(**kwargs)
 
-            # Clear Slack Assistant status as soon as the final message is posted.
+            # Clear Slack Assistant status for this thread as soon as the final
+            # message is posted. Preserve any other concurrently-active thread
+            # statuses in the same channel.
             if thread_ts:
-                await self.stop_typing(chat_id)
+                await self.stop_typing(chat_id, metadata={"thread_id": thread_ts})
 
             # Track the sent message ts so we can auto-respond to thread
             # replies without requiring @mention.
@@ -1434,6 +1439,16 @@ class SlackAdapter(BasePlatformAdapter):
 
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error("[Slack] Send error: %s", e, exc_info=True)
+            # A failed final post must not leave Slack's persistent Assistant
+            # status behind. Clear only this turn's thread; other concurrent
+            # threads in the same DM/channel must keep their own status.
+            try:
+                await self.stop_typing(chat_id, metadata=metadata)
+            except Exception:
+                logger.debug(
+                    "[Slack] Failed to clear Assistant status after send error",
+                    exc_info=True,
+                )
             return SendResult(success=False, error=str(e))
 
     async def send_private_notice(
@@ -1479,6 +1494,7 @@ class SlackAdapter(BasePlatformAdapter):
         content: str,
         *,
         finalize: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Edit a previously sent Slack message."""
         if not self._app:
@@ -1500,7 +1516,7 @@ class SlackAdapter(BasePlatformAdapter):
                     update_kwargs["blocks"] = blocks
             await self._get_client(chat_id).chat_update(**update_kwargs)
             if finalize:
-                await self.stop_typing(chat_id)
+                await self.stop_typing(chat_id, metadata=metadata)
             return SendResult(success=True, message_id=message_id)
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error(
@@ -1529,7 +1545,7 @@ class SlackAdapter(BasePlatformAdapter):
         if not thread_ts:
             return  # Can only set status in a thread context
 
-        self._active_status_threads[chat_id] = thread_ts
+        self._active_status_threads.setdefault(chat_id, set()).add(str(thread_ts))
         try:
             await self._get_client(chat_id).assistant_threads_setStatus(
                 channel_id=chat_id,
@@ -1545,17 +1561,44 @@ class SlackAdapter(BasePlatformAdapter):
         """Clear the assistant thread status indicator."""
         if not self._app:
             return
-        thread_ts = self._active_status_threads.pop(chat_id, None)
-        if not thread_ts:
+
+        requested_thread_ts = None
+        if metadata:
+            requested_thread_ts = metadata.get("thread_id") or metadata.get("thread_ts")
+
+        active = self._active_status_threads.get(chat_id)
+        if not active:
             return
-        try:
-            await self._get_client(chat_id).assistant_threads_setStatus(
-                channel_id=chat_id,
-                thread_ts=thread_ts,
-                status="",
-            )
-        except Exception as e:
-            logger.debug("[Slack] assistant.threads.setStatus clear failed: %s", e)
+
+        if isinstance(active, str):
+            # Backward compatibility for tests or long-lived adapters created
+            # before the per-thread tracking map shape existed.
+            legacy_thread_ts = str(active)
+            active = {legacy_thread_ts}
+            self._active_status_threads[chat_id] = active
+
+        if requested_thread_ts:
+            thread_ts_values = [str(requested_thread_ts)]
+        else:
+            thread_ts_values = list(active)
+
+        for thread_ts in thread_ts_values:
+            try:
+                await self._get_client(chat_id).assistant_threads_setStatus(
+                    channel_id=chat_id,
+                    thread_ts=thread_ts,
+                    status="",
+                )
+            except Exception as e:
+                # Slack still owns a visible status when this call fails. Keep
+                # the thread tracked so later cleanup attempts can retry rather
+                # than forgetting a server-side status that remains visible.
+                logger.debug("[Slack] assistant.threads.setStatus clear failed: %s", e)
+                continue
+            active.discard(thread_ts)
+
+        if not active:
+            self._active_status_threads.pop(chat_id, None)
 
     def _dm_top_level_threads_as_sessions(self) -> bool:
         """Whether top-level Slack DMs get per-message session threads.

--- a/tests/gateway/test_clarify_active_session_bypass.py
+++ b/tests/gateway/test_clarify_active_session_bypass.py
@@ -1,7 +1,7 @@
 """Regression tests for clarify replies while a gateway session is busy."""
 
 import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -85,3 +85,37 @@ async def test_active_session_routes_typed_choice_clarify_reply_to_runner_not_bu
     adapter._message_handler.assert_awaited_once_with(event)
     adapter._busy_session_handler.assert_not_awaited()
     assert adapter._pending_messages == {}
+
+
+@pytest.mark.asyncio
+async def test_gateway_clarify_reply_resumes_typing_before_returning_empty_ack():
+    """A clarify answer must re-enable the active run's typing indicator.
+
+    Clarify pauses typing while waiting so Slack's Assistant API does not
+    disable the compose box. The typed answer is intercepted by the gateway
+    and returns an empty acknowledgment instead of starting a second run; that
+    interception path must therefore resume the original run's indicator.
+    """
+    _clear_clarify_state()
+    from gateway.run import GatewayRunner
+    from tools import clarify_gateway as cm
+
+    adapter = _ClarifyBypassAdapter()
+    adapter.pause_typing_for_chat("12345")
+    event = _event("the missing details")
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._startup_restore_in_progress = False
+    runner._scale_to_zero_note_real_inbound = lambda: None
+    runner._is_user_authorized = lambda source: True
+    runner._session_key_for_source = lambda source: "clarify-session"
+    runner._adapter_for_source = lambda source: adapter
+    runner._update_prompt_pending = {}
+
+    cm.register("clarify-2", "clarify-session", "What is missing?", None)
+
+    with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+        result = await runner._handle_message(event)
+
+    assert result == ""
+    assert "12345" not in adapter._typing_paused

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2028,11 +2028,47 @@ class TestSendTyping:
     async def test_sets_status_in_thread(self, adapter):
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
         await adapter.send_typing("C123", metadata={"thread_id": "parent_ts"})
+        assert adapter._active_status_threads == {"C123": {"parent_ts"}}
         adapter._app.client.assistant_threads_setStatus.assert_called_once_with(
             channel_id="C123",
             thread_ts="parent_ts",
             status="is thinking...",
         )
+
+    @pytest.mark.asyncio
+    async def test_status_tracking_is_per_thread_not_per_channel(self, adapter):
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+
+        await adapter.send_typing("C123", metadata={"thread_id": "111.000"})
+        await adapter.send_typing("C123", metadata={"thread_id": "222.000"})
+
+        assert adapter._active_status_threads == {"C123": {"111.000", "222.000"}}
+
+        await adapter.stop_typing("C123", metadata={"thread_id": "111.000"})
+
+        assert adapter._active_status_threads == {"C123": {"222.000"}}
+        adapter._app.client.assistant_threads_setStatus.assert_any_await(
+            channel_id="C123",
+            thread_ts="111.000",
+            status="",
+        )
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_without_metadata_clears_all_channel_threads(self, adapter):
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        await adapter.send_typing("C123", metadata={"thread_id": "111.000"})
+        await adapter.send_typing("C123", metadata={"thread_id": "222.000"})
+        adapter._app.client.assistant_threads_setStatus.reset_mock()
+
+        await adapter.stop_typing("C123")
+
+        assert "C123" not in adapter._active_status_threads
+        cleared = {
+            call.kwargs["thread_ts"]
+            for call in adapter._app.client.assistant_threads_setStatus.await_args_list
+            if call.kwargs.get("status") == ""
+        }
+        assert cleared == {"111.000", "222.000"}
 
     @pytest.mark.asyncio
     async def test_noop_without_thread(self, adapter):
@@ -2096,7 +2132,50 @@ class TestSendTyping:
             thread_ts="parent_ts",
             status="",
         )
-        assert "C123" not in adapter._active_status_threads
+        assert adapter._active_status_threads["C123"] == {"parent_ts"}
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_partial_failure_keeps_only_failed_thread_tracked(self, adapter):
+        adapter._active_status_threads["C123"] = {"thread_ok", "thread_fail"}
+
+        async def set_status(*, channel_id, thread_ts, status):
+            if thread_ts == "thread_fail":
+                raise Exception("temporary Slack failure")
+
+        adapter._app.client.assistant_threads_setStatus = AsyncMock(
+            side_effect=set_status
+        )
+
+        await adapter.stop_typing("C123")
+
+        assert adapter._active_status_threads["C123"] == {"thread_fail"}
+        cleared = {
+            call.kwargs["thread_ts"]
+            for call in adapter._app.client.assistant_threads_setStatus.await_args_list
+        }
+        assert cleared == {"thread_ok", "thread_fail"}
+
+    @pytest.mark.asyncio
+    async def test_send_failure_attempts_exact_thread_status_clear(self, adapter):
+        adapter._app.client.chat_postMessage = AsyncMock(
+            side_effect=Exception("Slack post failed")
+        )
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        adapter._active_status_threads["C123"] = {"111.000", "222.000"}
+
+        result = await adapter.send(
+            "C123",
+            "done",
+            metadata={"thread_id": "111.000"},
+        )
+
+        assert not result.success
+        adapter._app.client.assistant_threads_setStatus.assert_called_once_with(
+            channel_id="C123",
+            thread_ts="111.000",
+            status="",
+        )
+        assert adapter._active_status_threads == {"C123": {"222.000"}}
 
     @pytest.mark.asyncio
     async def test_send_clears_status_after_final_post(self, adapter):
@@ -2104,7 +2183,7 @@ class TestSendTyping:
             return_value={"ts": "reply_ts"}
         )
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
-        adapter._active_status_threads["C123"] = "parent_ts"
+        adapter._active_status_threads["C123"] = {"parent_ts"}
 
         result = await adapter.send("C123", "done", metadata={"thread_id": "parent_ts"})
 
@@ -2121,7 +2200,7 @@ class TestSendTyping:
     async def test_streaming_final_edit_clears_status(self, adapter):
         adapter._app.client.chat_update = AsyncMock()
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
-        adapter._active_status_threads["C123"] = "parent_ts"
+        adapter._active_status_threads["C123"] = {"parent_ts"}
 
         result = await adapter.edit_message(
             "C123",
@@ -2147,7 +2226,7 @@ class TestSendTyping:
     async def test_streaming_intermediate_edit_keeps_status(self, adapter):
         adapter._app.client.chat_update = AsyncMock()
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
-        adapter._active_status_threads["C123"] = "parent_ts"
+        adapter._active_status_threads["C123"] = {"parent_ts"}
 
         result = await adapter.edit_message(
             "C123",
@@ -2158,7 +2237,29 @@ class TestSendTyping:
 
         assert result.success
         adapter._app.client.assistant_threads_setStatus.assert_not_called()
-        assert adapter._active_status_threads["C123"] == "parent_ts"
+        assert adapter._active_status_threads["C123"] == {"parent_ts"}
+
+    @pytest.mark.asyncio
+    async def test_streaming_final_edit_with_metadata_preserves_other_threads(self, adapter):
+        adapter._app.client.chat_update = AsyncMock()
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        adapter._active_status_threads["C123"] = {"111.000", "222.000"}
+
+        result = await adapter.edit_message(
+            "C123",
+            "reply_ts",
+            "done",
+            finalize=True,
+            metadata={"thread_id": "111.000"},
+        )
+
+        assert result.success
+        adapter._app.client.assistant_threads_setStatus.assert_called_once_with(
+            channel_id="C123",
+            thread_ts="111.000",
+            status="",
+        )
+        assert adapter._active_status_threads == {"C123": {"222.000"}}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2054,6 +2054,20 @@ class TestSendTyping:
         )
 
     @pytest.mark.asyncio
+    async def test_active_status_threads_bounded_per_chat(self, adapter):
+        adapter._app.client.assistant_threads_setStatus = AsyncMock(
+            side_effect=Exception("missing_scope")
+        )
+        adapter._ACTIVE_STATUS_THREADS_PER_CHAT_MAX = 4
+
+        for i in range(20):
+            await adapter.send_typing("C123", metadata={"thread_id": f"ts_{i}"})
+
+        tracked = adapter._active_status_threads["C123"]
+        assert len(tracked) <= 4
+        assert "ts_19" in tracked
+
+    @pytest.mark.asyncio
     async def test_stop_typing_without_metadata_clears_all_channel_threads(self, adapter):
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
         await adapter.send_typing("C123", metadata={"thread_id": "111.000"})
@@ -2167,6 +2181,28 @@ class TestSendTyping:
             "C123",
             "done",
             metadata={"thread_id": "111.000"},
+        )
+
+        assert not result.success
+        adapter._app.client.assistant_threads_setStatus.assert_called_once_with(
+            channel_id="C123",
+            thread_ts="111.000",
+            status="",
+        )
+        assert adapter._active_status_threads == {"C123": {"222.000"}}
+
+    @pytest.mark.asyncio
+    async def test_send_failure_with_reply_to_clears_only_that_thread(self, adapter):
+        adapter._app.client.chat_postMessage = AsyncMock(
+            side_effect=Exception("Slack post failed")
+        )
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        adapter._active_status_threads["C123"] = {"111.000", "222.000"}
+
+        result = await adapter.send(
+            "C123",
+            "done",
+            reply_to="111.000",
         )
 
         assert not result.success


### PR DESCRIPTION
## Summary

Harden the Slack Assistant status lifecycle in both directions:

- Resume the existing run's typing/status indicator after a `clarify` reply resolves.
- Clear the exact Slack thread's status when a turn finishes, including concurrent-thread, transient-clear-failure, streaming-finalize, and send-error paths.

Together these changes prevent both kinds of misleading Slack UI state: an active run that looks silent after clarification, and a completed run that remains stuck on `is thinking...` / `Evaluating...`.

## Problems

### Clarification replies do not resume status

The clarify callback deliberately pauses typing while it waits so Slack's Assistant API does not disable the compose box. When the user answers, the gateway intercepts the reply and resumes the existing agent run, but the interception path returned an empty acknowledgment without re-enabling typing. The run continued silently until the independent long-running heartbeat fired.

### Completed turns can leave stale status

Slack Assistant status is server-side state keyed by channel and thread. The adapter previously tracked only one `thread_ts` per `chat_id`, so overlapping threads could overwrite each other. Cleanup also removed tracking before Slack confirmed `assistant.threads.setStatus(status="")`; a transient failure therefore left a visible status with no local record available for retry. Failed final sends could leave the same stale state.

## Fix

- Resume the active adapter's typing state after a pending clarification resolves.
- Track active Slack Assistant statuses per channel and thread.
- Clear only the completed turn's exact thread after final post/edit delivery.
- Preserve other concurrent threads in the same DM/channel.
- Remove a tracked thread only after Slack confirms the empty-status clear.
- Keep failed clears tracked so later cleanup attempts can retry.
- Bound per-conversation status tracking at 128 entries so permanent
  API/scope failures cannot create an unbounded local leak.
- Resolve `reply_to`/metadata once and attempt exact-thread cleanup when a
  final Slack send fails.
- Keep all status operations best-effort so platform failures do not break the agent turn.

## Reproduction

### Clarify resume

1. Have an agent invoke the `clarify` tool in Slack.
2. Answer the clarification prompt.
3. Before this fix, the agent continues processing but Slack does not restore `is thinking...`.

### Stale status after completion

1. Start one or more agent turns in Slack Assistant threads in the same DM/channel.
2. Let a turn send its final response, or let its final send fail.
3. Before this fix, Slack can continue showing `is thinking...` / `Evaluating...` even though the turn has finished.
4. If the empty-status API call fails once, later cleanup cannot retry because the thread was already removed from local tracking.

## Verification

- `pytest -q -o 'addopts=' tests/gateway/test_clarify_active_session_bypass.py tests/gateway/test_typing_indicator_toggle.py tests/gateway/test_keep_typing_timeout.py tests/gateway/test_slack.py`
  - 232 passed
- `ruff check gateway/run.py plugins/platforms/slack/adapter.py tests/gateway/test_clarify_active_session_bypass.py tests/gateway/test_slack.py`
  - passed
- `git diff --check`
  - passed

Regression coverage includes:

- clarification reply resumes paused typing;
- concurrent Slack threads remain independently tracked;
- exact-thread final post/edit cleanup;
- failed clear remains tracked for retry;
- mixed clear success/failure retains only failed threads;
- permanent status-set failures remain bounded;
- failed final sends target the exact thread for both metadata and
  `reply_to`-only callers.

## Live verification

- Linux
- Slack Socket Mode / Assistant thread status
- Two gateway profiles sharing the same runtime source
- Reproduced a stale post-response status, applied the patch, restarted both profiles, and confirmed in Slack that the indicator now appears during work and clears after the final response.

Related: #24117, #32295, #8387
