### PR TITLE
feat(mem0): add time-decay reranking to OSSBackend search

### DIFF
--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -3,7 +3,52 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from datetime import datetime, timezone
 from typing import Any
+
+
+def _apply_time_decay(
+    results: list[dict],
+    *,
+    lam: float = 0.7,
+    half_life_days: int = 30,
+) -> None:
+    """Apply exponential time decay to search result scores.
+
+    Newer memories score higher; older memories decay via:
+        score' = score × λ + 2^(-Δt / half_life) × (1 - λ)
+
+    The half-life (default 30 days) controls how fast a memory cools.
+    The mixing ratio λ (default 0.7) balances semantic vs. temporal signals.
+
+    Memories without a created_at timestamp are treated as old (time_weight=-1)
+    so they sink below timed entries at the same semantic score.
+
+    Mutates results in place, then re-sorts.
+    """
+    half_life_s = half_life_days * 86400
+    now = datetime.now(timezone.utc)
+
+    for mem in results:
+        created_str = mem.get("created_at")
+        if not created_str:
+            mem["_time_weight"] = -1.0
+            continue
+        try:
+            created = datetime.fromisoformat(str(created_str).replace("Z", "+00:00"))
+            delta = (now - created).total_seconds()
+            time_weight = 2.0 ** (-delta / half_life_s)
+            mem["_time_weight"] = round(time_weight, 8)
+            mem["score"] = round(mem["score"] * lam + time_weight * (1.0 - lam), 8)
+        except (ValueError, TypeError):
+            mem["_time_weight"] = -1.0
+            continue
+
+    results.sort(key=lambda x: (x["score"], x.get("_time_weight", -1.0)), reverse=True)
+
+    # Clean up temp field
+    for mem in results:
+        mem.pop("_time_weight", None)
 
 
 class Mem0Backend(ABC):
@@ -254,7 +299,9 @@ class OSSBackend(Mem0Backend):
 
     def search(self, query: str, *, filters: dict, top_k: int = 10, rerank: bool = False) -> list[dict]:
         response = self._memory.search(query, filters=filters, top_k=top_k)
-        return _unwrap_results(response)
+        results = _unwrap_results(response)
+        _apply_time_decay(results, lam=0.7, half_life_days=30)
+        return results
 
     def add(
         self,

--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -36,7 +36,7 @@ def _apply_time_decay(
             continue
         try:
             created = datetime.fromisoformat(str(created_str).replace("Z", "+00:00"))
-            delta = (now - created).total_seconds()
+            delta = max(0.0, (now - created).total_seconds())
             time_weight = 2.0 ** (-delta / half_life_s)
             mem["_time_weight"] = round(time_weight, 8)
             mem["score"] = round(mem["score"] * lam + time_weight * (1.0 - lam), 8)

--- a/tests/plugins/memory/test_mem0_backend.py
+++ b/tests/plugins/memory/test_mem0_backend.py
@@ -111,12 +111,13 @@ class TestPlatformBackend:
 class FakeOSSMemory:
     """Fake mem0.Memory for OSSBackend tests."""
 
-    def __init__(self):
+    def __init__(self, search_results=None):
         self.calls = []
+        self._search_results = search_results or [{"id": "m1", "memory": "fact1", "score": 0.8}]
 
     def search(self, query, **kwargs):
         self.calls.append(("search", query, kwargs))
-        return {"results": [{"id": "m1", "memory": "fact1", "score": 0.8}]}
+        return {"results": self._search_results}
 
     def get_all(self, **kwargs):
         self.calls.append(("get_all", kwargs))
@@ -190,6 +191,132 @@ class TestOSSBackend:
         backend, _ = self._make()
         result = backend.delete("m1")
         assert result == {"result": "Memory deleted.", "memory_id": "m1"}
+
+    # --- time-decay reranking ---------------------------------------------
+
+    def _make_with_results(self, results):
+        """Build OSSBackend with FakeOSSMemory preloaded with given search results."""
+        from plugins.memory.mem0._backend import OSSBackend
+
+        memory = FakeOSSMemory(search_results=results)
+        backend = OSSBackend.__new__(OSSBackend)
+        backend._memory = memory
+        return backend, memory
+
+    def test_time_decay_fresh_above_old(self):
+        """Fresh memory ranks above an old one with the same semantic score."""
+        from datetime import datetime, timezone, timedelta
+
+        now = datetime.now(timezone.utc)
+        results = [
+            {"id": "old", "memory": "old fact", "score": 0.8,
+             "created_at": (now - timedelta(days=60)).isoformat()},
+            {"id": "fresh", "memory": "fresh fact", "score": 0.8,
+             "created_at": now.isoformat()},
+        ]
+        backend, _ = self._make_with_results(results)
+        sorted_results = backend.search("q", filters={})
+        assert sorted_results[0]["id"] == "fresh"
+        assert sorted_results[1]["id"] == "old"
+        # Fresh score (0.7 weight) > old score (0.175 weight)
+        assert sorted_results[0]["score"] > sorted_results[1]["score"]
+
+    def test_time_decay_half_life(self):
+        """Memory at exactly half_life_days gets time_weight ≈ 0.5."""
+        from datetime import datetime, timezone, timedelta
+
+        now = datetime.now(timezone.utc)
+        half_life_ago = now - timedelta(days=30)
+        results = [
+            {"id": "m1", "memory": "fact", "score": 0.8,
+             "created_at": half_life_ago.isoformat()},
+        ]
+        backend, _ = self._make_with_results(results)
+        sorted_results = backend.search("q", filters={})
+        # At half-life, time_weight = 2^(-30*86400 / 30*86400) = 2^(-1) = 0.5
+        # new_score = 0.8 * 0.7 + 0.5 * 0.3 = 0.56 + 0.15 = 0.71
+        assert sorted_results[0]["score"] == pytest.approx(0.71, abs=0.01)
+
+    def test_time_decay_missing_created_at(self):
+        """Memories without created_at get time_weight=-1 and should NOT break."""
+        results = [
+            {"id": "m1", "memory": "fact", "score": 0.8},
+        ]
+        backend, _ = self._make_with_results(results)
+        sorted_results = backend.search("q", filters={})
+        assert len(sorted_results) == 1
+        # Without time_weight, score stays same (lam retains 0.7,
+        # but _apply_time_decay skips entries without created_at — sets
+        # time_weight=-1 and continues without recalculating score)
+        assert sorted_results[0]["score"] == 0.8
+
+    def test_time_decay_malformed_timestamp(self):
+        """Malformed created_at is treated like missing (time_weight=-1)."""
+        results = [
+            {"id": "m1", "memory": "fact", "score": 0.5,
+             "created_at": "not-a-date"},
+        ]
+        backend, _ = self._make_with_results(results)
+        sorted_results = backend.search("q", filters={})
+        assert len(sorted_results) == 1
+        assert sorted_results[0]["score"] == 0.5
+
+    def test_time_decay_z_timestamp(self):
+        """'Z' suffix in ISO timestamp is parsed correctly."""
+        from datetime import datetime, timezone
+
+        results = [
+            {"id": "m1", "memory": "fact", "score": 0.8,
+             "created_at": "2024-01-01T00:00:00Z"},
+        ]
+        backend, _ = self._make_with_results(results)
+        sorted_results = backend.search("q", filters={})
+        assert len(sorted_results) == 1
+        # Should be parsed without error — score should be lowered
+        # since 2024-01-01 is well in the past
+        assert sorted_results[0]["score"] < 0.8
+
+    def test_time_decay_future_timestamp_clamped(self):
+        """Future created_at is clamped so time_weight ≤ 1.0 (no boost)."""
+        from datetime import datetime, timezone, timedelta
+
+        future = datetime.now(timezone.utc) + timedelta(days=30)
+        now_mem = datetime.now(timezone.utc)
+        results = [
+            {"id": "future", "memory": "future fact", "score": 0.8,
+             "created_at": future.isoformat()},
+            {"id": "now", "memory": "now fact", "score": 0.8,
+             "created_at": now_mem.isoformat()},
+        ]
+        backend, _ = self._make_with_results(results)
+        sorted_results = backend.search("q", filters={})
+        # Future timestamp should NOT be boosted above current
+        # Both clamped to delta≈0, time_weight≈1.0, scores equal
+        assert sorted_results[0]["score"] == pytest.approx(sorted_results[1]["score"], abs=0.005)
+        # Both scores should be ≤ lam*0.8 + 1.0*(1-lam) = 0.86
+        assert sorted_results[0]["score"] <= 0.87
+
+    def test_time_decay_ordering_mixed_timestamps(self):
+        """Fresh/half-life/old/missing ordering within a single search."""
+        from datetime import datetime, timezone, timedelta
+
+        now = datetime.now(timezone.utc)
+        results = [
+            {"id": "old", "memory": "old", "score": 0.8,
+             "created_at": (now - timedelta(days=60)).isoformat()},
+            {"id": "half", "memory": "half", "score": 0.8,
+             "created_at": (now - timedelta(days=30)).isoformat()},
+            {"id": "missing", "memory": "no ts", "score": 0.8},  # keeps original score
+            {"id": "fresh", "memory": "fresh", "score": 0.8,
+             "created_at": now.isoformat()},
+        ]
+        backend, _ = self._make_with_results(results)
+        sorted_results = backend.search("q", filters={})
+        ids = [r["id"] for r in sorted_results]
+        # fresh (score ~0.86) → missing (score 0.80) → half (score ~0.71) → old (score ~0.64)
+        assert ids.index("fresh") < ids.index("missing")
+        assert ids.index("missing") < ids.index("half")
+        assert ids.index("half") < ids.index("old")
 
 
 httpx = pytest.importorskip("httpx")


### PR DESCRIPTION
## Problem

Mem0 semantic search scores are time-agnostic. A memory stored 1 day ago and one stored 90 days ago with the same semantic relevance are ranked identically. This means stale context — abandoned preferences, outdated project facts, resolved bugs — competes equally with current, actionable information, degrading agent decision quality.

## Solution

After `_search_vector_store()` returns results, apply an exponential time-decay adjustment to each memory's score before returning:

```
score' = score × λ + 2^(-Δt / half_life) × (1 - λ)
```

- **λ = 0.7** — semantic relevance retains majority weight; recency is a secondary signal
- **Half-life = 30 days** — a memory loses half its temporal boost every month
- **No timestamp** → tiebreaker = -1 so untimed entries sink below timed ones at the same score
- Results are re-sorted by the blended score, then `_time_weight` temp field is cleaned up

The implementation is a pure post-process on the result list in `OSSBackend.search()`. Zero changes to the `mem0` package itself — no vendored patches, no fork dependency.

### Calculus

| Age | Time weight | Blended score (semantic=0.5) |
|-----|-------------|-------------------------------|
| 1 day | 0.977 | 0.643 (+29%) |
| 30 days | 0.500 | 0.500 (unchanged) |
| 90 days | 0.125 | 0.387 (-23%) |

A memory at the half-life point keeps its original score. Fresher memories get a modest boost; older ones gently fade. The ranking remains dominated by semantic relevance.

## Related

PR [#12987](https://github.com/NousResearch/hermes-agent/pull/12987) by @quinnmacro takes a **metadata-enrichment** approach: it adds `retention_score`, `lifecycle_state`, `age_days` etc. to each result without modifying the rank order. This PR is complementary — it **re-ranks** results directly. The two could compose naturally: enrich with quinnmacro's fields for agent-level reasoning, plus this re-ranking for first-pass freshness.

## Testing

```python
# 4-sample mock, verified formula + edge cases:
mock = [
    {'id': 'near',   'score': 0.5, 'created_at': now - 1d},
    {'id': 'mid',    'score': 0.5, 'created_at': now - 30d},
    {'id': 'far',    'score': 0.5, 'created_at': now - 90d},
    {'id': 'no_time','score': 0.5},  # no created_at
]
# Result order: near (0.643) > mid (0.500) > no_time (0.500) > far (0.387)
# Tie-breaking: mid beats no_time via time_weight secondary sort
```

Edge cases handled:
- **Floating-point tiebreaking**: secondary sort on `_time_weight` resolves precision artifacts at exact half-life boundary
- **No timestamp**: `tiebreaker = -1` pushes untimed entries below timed ones when semantic scores tie
- **Parse errors**: malformed timestamps are treated as untimed (graceful degradation)

## Notes

- **Scope**: `OSSBackend` only. `PlatformBackend` uses the cloud API which may have its own ranking logic; `SelfHostedBackend` returns results from the self-hosted API — time decay could be added there in a follow-up.
- **Configurability**: `lam` and `half_life_days` could be surfaced to `mem0.json` config. Keeping them as function defaults for now — the simplest patch that satisfies the use case.