### PR TITLE
feat(mcp-catalog): add Unstructured Transform MCP server

### DIFF
--- a/optional-mcps/unstructured/manifest.yaml
+++ b/optional-mcps/unstructured/manifest.yaml
@@ -1,0 +1,70 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: unstructured
+description: Turn any document (PDF, email, image, scanned file — 60+ formats) into structured, AI-ready data with Unstructured Transform — partition, enrich, chunk, and embed on demand.
+source: https://docs.unstructured.io/transform/overview
+
+# Unstructured Transform is a hosted service that converts documents into
+# structured, AI-ready data on demand: it partitions, enriches, chunks, and
+# embeds files across 60+ formats (PDFs, emails, images, scanned docs, …).
+# Nothing runs locally — Hermes's MCP client connects straight to the remote
+# Streamable HTTP endpoint, and the mcp_oauth_manager handles OAuth 2.1
+# discovery, dynamic client registration (RFC 7591), PKCE, token exchange, and
+# refresh. Same shape as the `linear` entry (case 1: native MCP OAuth, no
+# third-party provider).
+#
+# Note: Unstructured's docs show `npx -y mcp-remote https://mcp.transform...`
+# for clients that DON'T speak remote MCP + OAuth natively. Hermes does (this
+# is the same path the `linear` entry uses), so we connect to the URL directly
+# and skip the mcp-remote stdio bridge entirely.
+#
+# Why this belongs in the catalog: it drops document parsing/extraction into
+# any Hermes workflow without a bespoke ETL pipeline — read a spec PDF while
+# coding, extract structure from scanned contracts, chunk + embed a policy doc
+# for grounding, turn an email thread into structured records. You describe the
+# processing in plain language; Transform handles extraction and parsing.
+transport:
+  type: http
+  url: https://mcp.transform.unstructured.io
+
+auth:
+  type: oauth
+  # No `provider:` — this is native MCP OAuth (case 1), not a third-party
+  # provider like Google. The MCP client triggers the browser flow on the
+  # first probe / first connect. Transform's server returns 401 on an
+  # unauthenticated request (it does NOT serve tools without auth), so the
+  # SDK's reactive OAuth trigger fires correctly here — unlike the
+  # DCR-less / auth-optional servers called out in the MCP docs.
+
+# Tool selection at install time:
+# The exact tool names aren't pinned in a stable public doc, so we leave
+# `default_enabled` unset: the install-time checklist starts from whatever the
+# live server probes (all pre-checked) and users prune from there. Same choice
+# the `linear` entry made. Once the tool surface is documented, a follow-up PR
+# can encode a curated `tools.default_enabled` subset.
+
+post_install: |
+  On first connection, Hermes opens a browser to authenticate with Unstructured
+  (OAuth 2.1) — sign in with your Unstructured account. Transform includes a
+  free tier (15,000 pages/month), so no special approval is needed to start.
+  Tokens are cached under ~/.hermes/mcp-tokens/ and refreshed automatically.
+
+  Two things to know because auth happens on first connect:
+    - The install-time tool probe often runs BEFORE you've completed OAuth, so
+      it may not list tools yet — that's expected. Complete the browser sign-in,
+      then run:  hermes mcp configure unstructured  to load and prune the tool
+      list.
+    - If you add/enable this from inside a running Hermes session, finish auth
+      from a fresh terminal with:  hermes mcp login unstructured
+      (the in-session config reload only waits ~30s — not long enough for an
+      interactive OAuth flow).
+
+  Headless / remote host? Complete the browser flow with paste-back or an SSH
+  port-forward — see the "OAuth over SSH / Remote Hosts" guide.
+
+  Restart your Hermes session after authenticating so the Transform tools load.
+
+  Re-run the tool checklist any time with:
+    hermes mcp configure unstructured

--- a/optional-mcps/unstructured/manifest.yaml
+++ b/optional-mcps/unstructured/manifest.yaml
@@ -49,7 +49,9 @@ post_install: |
   On first connection, Hermes opens a browser to authenticate with Unstructured
   (OAuth 2.1) — sign in with your Unstructured account. Transform includes a
   free tier (15,000 pages/month), so no special approval is needed to start.
-  Tokens are cached under ~/.hermes/mcp-tokens/ and refreshed automatically.
+  Tokens are cached under your active Hermes home (HERMES_HOME/mcp-tokens/,
+  which is ~/.hermes/mcp-tokens/ on the default profile) and refreshed
+  automatically.
 
   Two things to know because auth happens on first connect:
     - The install-time tool probe often runs BEFORE you've completed OAuth, so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -334,6 +334,7 @@ locales = ["locales/*.yaml"]
 # entry; tests/test_packaging_metadata.py enforces an entry per optional-mcps/<name>.
 "optional-mcps/linear" = ["optional-mcps/linear/manifest.yaml"]
 "optional-mcps/n8n" = ["optional-mcps/n8n/manifest.yaml"]
+"optional-mcps/unstructured" = ["optional-mcps/unstructured/manifest.yaml"]
 
 [tool.setuptools.package-data]
 hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]


### PR DESCRIPTION
## What does this PR do?

Adds the Unstructured Transform hosted MCP server to the curated catalog as the
`unstructured` entry. Transform converts documents into structured, AI-ready
data on demand — partitioning, enriching, chunking, and embedding across 60+
formats (PDFs, emails, images, scanned files) — making document parsing
available to any Hermes workflow.

It follows the existing `linear` archetype: a remote Streamable HTTP endpoint
with native MCP OAuth 2.1 (case 1, no third-party provider), so
`mcp_oauth_manager` handles DCR, PKCE, and token refresh and nothing installs
locally. Unstructured's docs show an `npx mcp-remote` bridge for clients that
lack native remote-MCP + OAuth support; Hermes has it, so the entry connects to
the URL directly.

## Related Issue

N/A — no existing issue.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `optional-mcps/unstructured/manifest.yaml` — new `http` + `oauth` entry
  (`https://mcp.transform.unstructured.io`). `tools.default_enabled` left unset
  so the install-time probe lists the live tool surface (matches `linear`).
  `post_install` notes the free tier and the OAuth-on-first-connect behavior
  (probe-before-auth, in-session reload race, headless/SSH).
- `pyproject.toml` — per-entry `[tool.setuptools.data-files]` target so the
  manifest ships in the wheel (matches `linear`/`n8n`; `graft optional-mcps` in
  `MANIFEST.in` already covers the sdist).

## How to Test

1. `hermes mcp catalog` — `unstructured` appears in the list.
2. `hermes mcp install unstructured` — writes an `mcp_servers.unstructured`
   block (`url` + `auth: oauth`) to `~/.hermes/config.yaml`.
3. `hermes mcp login unstructured`, then `hermes mcp test unstructured` —
   completes browser OAuth and lists the server's tools.
4. `pytest tests/hermes_cli/test_mcp_catalog.py tests/test_packaging_metadata.py -q`
   — 46 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass <!-- ran the catalog + packaging suites: 46 passed -->
- [x] I've added tests for my changes — covered by the existing `test_all_shipped_manifests_parse` contract test, which parses this manifest
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (catalog entries are self-describing via the manifest)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — remote HTTP + OAuth, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
