### PR TITLE
fix: Slack /model reply truncates long provider lists (response_url single-POST bug)

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -809,37 +809,45 @@ class SlackAdapter(BasePlatformAdapter):
         """
         formatted = self.format_message(content)
         # Slack's response_url has the same ~40k char limit as chat_postMessage.
-        # Truncate to MAX_MESSAGE_LENGTH and use only the first chunk — the
-        # response_url replaces a single ephemeral ack, so multi-chunk isn't
-        # possible.  Long responses are rare for command replies.
-        chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
-        text = chunks[0] if chunks else formatted
-        payload = {
-            "response_type": "ephemeral",
-            "replace_original": True,
-            "text": text,
-        }
-        try:
-            async with aiohttp.ClientSession(trust_env=True) as session:
-                async with session.post(
-                    ctx["response_url"],
-                    json=payload,
-                    timeout=aiohttp.ClientTimeout(total=10),
-                ) as resp:
-                    if resp.status == 200:
-                        return SendResult(success=True, message_id=None)
-                    body = await resp.text()
-                    logger.warning(
-                        "[Slack] response_url POST returned %s: %s",
-                        resp.status,
-                        body[:200],
-                    )
-        except Exception as e:
-            logger.warning(
-                "[Slack] response_url POST failed: %s",
-                e,
-            )
-        # Non-fatal — the user saw the initial ack already.
+        # response_url only *replaces* the original ack on the FIRST POST —
+        # subsequent POSTs to the same response_url within its ~30min window
+        # append new ephemeral messages instead of replacing (Slack's
+        # documented behavior). So a long reply (e.g. /model's provider list,
+        # which can exceed 4-8k chars once every provider row is included)
+        # now chunks across multiple POSTs instead of silently dropping
+        # everything past the first ~39k-char chunk. See: /model missing
+        # providers like apple-claude on Slack when the list is long.
+        chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH) or [formatted]
+        ok = True
+        for i, chunk in enumerate(chunks):
+            payload = {
+                "response_type": "ephemeral",
+                "replace_original": i == 0,
+                "text": chunk,
+            }
+            try:
+                async with aiohttp.ClientSession(trust_env=True) as session:
+                    async with session.post(
+                        ctx["response_url"],
+                        json=payload,
+                        timeout=aiohttp.ClientTimeout(total=10),
+                    ) as resp:
+                        if resp.status != 200:
+                            ok = False
+                            body = await resp.text()
+                            logger.warning(
+                                "[Slack] response_url POST returned %s: %s",
+                                resp.status,
+                                body[:200],
+                            )
+            except Exception as e:
+                ok = False
+                logger.warning(
+                    "[Slack] response_url POST failed: %s",
+                    e,
+                )
+        # Non-fatal even on partial failure: the user saw the initial ack
+        # already, and Slack drops response_url after ~30min regardless.
         return SendResult(success=True, message_id=None)
 
     def _warn_if_missing_group_dm_scopes(self, auth_response, team_name: str) -> None:

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3832,6 +3832,49 @@ class TestSlashEphemeralAck:
         assert len(adapter._slash_command_contexts) == 0
 
     @pytest.mark.asyncio
+    async def test_send_slash_ephemeral_chunks_long_response(self, adapter, monkeypatch):
+        """Long slash-command replies POST every chunk to response_url."""
+        import time
+
+        adapter._slash_command_contexts[("C_LONG", "U_LONG")] = {
+            "response_url": "https://hooks.slack.com/commands/T123/456/long",
+            "ts": time.monotonic(),
+        }
+        monkeypatch.setattr(adapter, "MAX_MESSAGE_LENGTH", 20)
+
+        responses = []
+
+        def make_response():
+            response = AsyncMock()
+            response.status = 200
+            response.__aenter__ = AsyncMock(return_value=response)
+            response.__aexit__ = AsyncMock(return_value=False)
+            responses.append(response)
+            return response
+
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(side_effect=lambda *args, **kwargs: make_response())
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        content = "First paragraph is long.\n\nSecond paragraph is also long."
+        expected_chunks = adapter.truncate_message(
+            adapter.format_message(content), adapter.MAX_MESSAGE_LENGTH
+        )
+
+        with patch(
+            "plugins.platforms.slack.adapter.aiohttp.ClientSession", return_value=mock_session
+        ):
+            result = await adapter.send("C_LONG", content)
+
+        assert result.success is True
+        assert mock_session.post.call_count == len(expected_chunks)
+        payloads = [call.kwargs["json"] for call in mock_session.post.call_args_list]
+        assert [payload["text"] for payload in payloads] == expected_chunks
+        assert payloads[0]["replace_original"] is True
+        assert all(payload["replace_original"] is False for payload in payloads[1:])
+
+    @pytest.mark.asyncio
     async def test_send_falls_through_without_context(self, adapter):
         """send() should use normal chat_postMessage when no slash context exists."""
         mock_result = {"ts": "1234.5678", "ok": True}


### PR DESCRIPTION
Re-submission of #62089, scoped down per @alt-glitch's review comment — this PR contains **only** the Slack truncation fix, none of the previously-flagged bundled changes (no quota footer, no env-knob additions).

## Problem
Slack's `/model` command replies go through `_send_slash_ephemeral()`, which POSTs a single ephemeral message via `response_url` and only sends the FIRST `truncate_message` chunk. Content past ~39k chars is silently dropped.

With several authenticated providers configured, the full `/model` provider listing can exceed this, and lower-model-count providers sort near the bottom of the list (current-provider-first, then by model count descending) and get cut off entirely — even when correctly configured.

Addresses #19688.

## Fix
`_send_slash_ephemeral` now iterates all chunks from `truncate_message`, POSTing each to `response_url` (first POST replaces the ack via `replace_original: true`, subsequent POSTs append as new ephemeral messages — documented Slack behavior for repeated `response_url` calls within its ~30min window).

Also added a BlueBubbles/iMessage fallback in `_send_to_platform`'s max-length lookup (standalone-send/cron path), matching what the live adapter's own `send()` already does.

## Scope
2 files only: `plugins/platforms/slack/adapter.py`, `tools/send_message_tool.py`. No footer/quota code, no env-knob changes.