### PR TITLE
ci: add concurrency group and job timeouts to typecheck workflow

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -4,10 +4,15 @@ name: Typecheck
 on:
   workflow_call:
 
+concurrency:
+  group: typecheck-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   typecheck:
     name: Check TypeScript
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         package:
@@ -37,6 +42,7 @@ jobs:
   desktop-build:
     name: Build desktop app
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -6,7 +6,9 @@ on:
 
 concurrency:
   group: typecheck-${{ github.ref }}
-  cancel-in-progress: true
+  # Match the caller's (ci.yml) PR-only cancellation policy so post-merge
+  # Typecheck runs on successive pushes to main are not cancelled.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   typecheck:


### PR DESCRIPTION
## What does this PR do?

`typecheck.yml` is the only reusable (`workflow_call`) workflow in the repo with neither a `concurrency:` group nor a `timeout-minutes` on its jobs. Every other reusable workflow (`contributor-check.yml`, `docker-lint.yml`, `docs-site-checks.yml`, `history-check.yml`, `lint.yml`, `osv-scanner.yml`, `supply-chain-audit.yml`, `tests.yml`, `uv-lockfile-check.yml`) already sets both.

This brings it in line:

- Adds a workflow-level `concurrency:` group so superseded typecheck runs on the same ref are cancelled instead of piling up.
- Adds `timeout-minutes` to both jobs so a hung step fails fast rather than inheriting the GitHub Actions 6 hour default and holding a runner for hours.

The `concurrency:` block uses the same `<name>-${{ github.ref }}` / `cancel-in-progress: true` shape as `lint.yml`.

## Related Issue

Fixes #62256

This is separate from #45722 / #45731, which cover only the read-only `permissions:` block on the same file. This PR does not touch `permissions:`.

## Type of Change

- [x] ♻️ Refactor (no behavior change) — CI configuration only, no product code touched

## Changes Made

- `.github/workflows/typecheck.yml`:
  - Added a `concurrency:` block (`group: typecheck-${{ github.ref }}`, `cancel-in-progress: true`).
  - Added `timeout-minutes: 10` to the `typecheck` job.
  - Added `timeout-minutes: 15` to the `desktop-build` job.

## How to Test

1. `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/typecheck.yml'))"` parses cleanly.
2. Push two commits in quick succession to a branch that triggers this workflow; the earlier typecheck run is cancelled once the newer one starts.
3. On any run, both `Check TypeScript` and `Build desktop app` now show their configured timeout in the job settings.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: CI workflow YAML only, no Python code paths touched. Validated with `yaml.safe_load` and cross-checked against the sibling workflows.
- [ ] I've added tests for my changes — N/A: CI configuration change.
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A, runners are `ubuntu-latest`
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
