### PR TITLE
fix(models): surface Opus 4.8 fast variant so the desktop picker shows its Fast toggle (#62236)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -457,6 +457,12 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "claude-fable-5",
         "claude-sonnet-5",
         "claude-opus-4-8",
+        # Opus 4.8's fast offering is a SEPARATE model id (not the speed=fast
+        # param), so it must be enumerated for the picker to collapse it into
+        # the opus-4.8 family and expose the Fast toggle — mirroring the
+        # OpenRouter fallback (anthropic/claude-opus-4.8-fast). Without this,
+        # the desktop model picker shows no fast control for Opus 4.8.
+        "claude-opus-4-8-fast",
         "claude-opus-4-7",
         "claude-opus-4-6",
         "claude-sonnet-4-6",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -402,6 +402,12 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "claude-fable-5",
         "claude-sonnet-5",
         "claude-opus-4-8",
+        # Opus 4.8's fast offering is a SEPARATE model id (not the speed=fast
+        # param), so it must be enumerated for the picker to collapse it into
+        # the opus-4.8 family and expose the Fast toggle — mirroring the
+        # OpenRouter fallback (anthropic/claude-opus-4.8-fast). Without this,
+        # the desktop model picker shows no fast control for Opus 4.8.
+        "claude-opus-4-8-fast",
         "claude-opus-4-7",
         "claude-opus-4-6",
         "claude-sonnet-4-6",

--- a/tests/hermes_cli/test_anthropic_picker_curated.py
+++ b/tests/hermes_cli/test_anthropic_picker_curated.py
@@ -16,6 +16,25 @@ from unittest.mock import patch
 from hermes_cli import models as M
 
 
+def _curated_fast_pairs(provider: str):
+    """Return ``(base, fast)`` id pairs where both the base model and its
+    ``<base>-fast`` variant are curated for ``provider``.
+
+    Derived from the live curated list rather than hard-coded ids, so the
+    contract survives catalog churn: whatever the current ``-fast`` variants
+    are, each must ship alongside its base so the desktop picker's
+    ``collapseModelFamilies`` can group them and ``resolveFastControl`` can
+    light the variant toggle.
+    """
+    curated = list(M._PROVIDER_MODELS[provider])
+    curated_set = set(curated)
+    return [
+        (m[: -len("-fast")], m)
+        for m in curated
+        if m.endswith("-fast") and m[: -len("-fast")] in curated_set
+    ]
+
+
 def test_anthropic_curated_alias_survives_when_live_omits_it():
     """A curated alias missing from /v1/models still surfaces (first)."""
     curated = M._PROVIDER_MODELS["anthropic"]
@@ -60,20 +79,69 @@ def test_anthropic_falls_back_to_curated_when_live_unavailable():
     assert "claude-fable-5" in result
 
 
-def test_anthropic_curated_lists_opus_48_fast_sibling():
-    """Opus 4.8's fast variant is a SEPARATE model id, so the desktop picker
-    only exposes its Fast toggle when the ``-fast`` sibling is enumerated next
-    to its base (collapseModelFamilies groups them, resolveFastControl lights
-    the variant toggle). Regression for the missing desktop fast control.
-    """
-    curated = M._PROVIDER_MODELS["anthropic"]
-    assert "claude-opus-4-8" in curated
-    assert "claude-opus-4-8-fast" in curated
+def test_anthropic_curated_fast_variants_ship_with_their_base():
+    """Every curated ``-fast`` Anthropic variant ships alongside its base id.
 
-    # Fast is offered as a variant model, NOT the speed=fast request param —
-    # so the base must not claim param-fast support (that path is Opus 4.6).
-    assert M.model_supports_fast_mode("claude-opus-4-8") is False
-    assert M.model_supports_fast_mode("claude-opus-4-6") is True
+    A fast variant is a SEPARATE model id, so the desktop picker only exposes
+    its Fast toggle when the ``-fast`` sibling is enumerated next to its base
+    (collapseModelFamilies groups them, resolveFastControl lights the variant
+    toggle). This is the picker-control contract, expressed generically over
+    whatever fast variants the catalog currently carries — not pinned to a
+    single catalog snapshot.
+    """
+    pairs = _curated_fast_pairs("anthropic")
+    # Regression guard: the Anthropic catalog must carry at least one variant
+    # fast pair (the desktop Fast toggle vanished when it carried none).
+    assert pairs, "no curated <base>/<base>-fast pair in the Anthropic catalog"
+
+    for base, fast in pairs:
+        # Both ids present (grouping precondition).
+        assert base in M._PROVIDER_MODELS["anthropic"]
+        assert fast in M._PROVIDER_MODELS["anthropic"]
+        # Fast is offered as a variant model, NOT the speed=fast request param,
+        # so the base must not also claim param-fast support (that would double
+        # up the control). The param-fast path is a separate mechanism.
+        assert M.model_supports_fast_mode(base) is False
+
+
+def test_desktop_model_options_exposes_curated_fast_sibling():
+    """The desktop ``model.options`` payload surfaces the curated fast sibling.
+
+    The desktop picker builds its rows via ``build_models_payload`` (the same
+    substrate the ``model.options`` gateway method calls), which populates a
+    provider row's ``models`` from the curated catalog — NOT from
+    ``provider_model_ids()``. This drives that path offline and asserts the
+    Anthropic row exposes each curated base/-fast pair with capabilities the
+    picker can gate the Fast control on.
+    """
+    from hermes_cli.inventory import build_models_payload, load_picker_context
+
+    ctx = load_picker_context()
+    payload = build_models_payload(
+        ctx,
+        include_unconfigured=True,  # surface Anthropic even without creds
+        picker_hints=True,
+        canonical_order=True,
+        pricing=False,              # no network
+        capabilities=True,
+        probe_custom_providers=False,
+        probe_current_custom_provider=False,
+    )
+    anthropic_rows = [
+        r for r in payload.get("providers", [])
+        if str(r.get("slug", "")).lower() == "anthropic"
+    ]
+    assert anthropic_rows, "Anthropic row absent from model.options payload"
+    row = anthropic_rows[0]
+    row_models = set(row.get("models", []))
+    caps = row.get("capabilities", {})
+
+    for base, fast in _curated_fast_pairs("anthropic"):
+        assert base in row_models, f"{base} missing from desktop Anthropic row"
+        assert fast in row_models, f"{fast} missing from desktop Anthropic row"
+        # The picker gates the variant toggle on the base NOT advertising
+        # param-fast, so the sibling is the only way to reach fast.
+        assert caps.get(base, {}).get("fast") is False
 
 
 def test_anthropic_fast_sibling_survives_live_merge():

--- a/tests/hermes_cli/test_anthropic_picker_curated.py
+++ b/tests/hermes_cli/test_anthropic_picker_curated.py
@@ -58,3 +58,28 @@ def test_anthropic_falls_back_to_curated_when_live_unavailable():
 
     assert result == list(M._PROVIDER_MODELS["anthropic"])
     assert "claude-fable-5" in result
+
+
+def test_anthropic_curated_lists_opus_48_fast_sibling():
+    """Opus 4.8's fast variant is a SEPARATE model id, so the desktop picker
+    only exposes its Fast toggle when the ``-fast`` sibling is enumerated next
+    to its base (collapseModelFamilies groups them, resolveFastControl lights
+    the variant toggle). Regression for the missing desktop fast control.
+    """
+    curated = M._PROVIDER_MODELS["anthropic"]
+    assert "claude-opus-4-8" in curated
+    assert "claude-opus-4-8-fast" in curated
+
+    # Fast is offered as a variant model, NOT the speed=fast request param —
+    # so the base must not claim param-fast support (that path is Opus 4.6).
+    assert M.model_supports_fast_mode("claude-opus-4-8") is False
+    assert M.model_supports_fast_mode("claude-opus-4-6") is True
+
+
+def test_anthropic_fast_sibling_survives_live_merge():
+    """The curated fast variant surfaces even when /v1/models omits it."""
+    live = ["claude-opus-4-8", "claude-sonnet-4-6"]
+    with patch.object(M, "_fetch_anthropic_models", return_value=live):
+        result = M.provider_model_ids("anthropic")
+
+    assert "claude-opus-4-8-fast" in result


### PR DESCRIPTION
## What does this PR do?

The desktop model picker never showed a **Fast mode** control for Claude Opus 4.8, contradicting the docs ("switch the model, reasoning effort, and fast mode from one dropdown"). The picker already has the machinery — it just wasn't being fed the data it needs.

Opus 4.8's fast offering is a **separate model id** (`claude-opus-4-8-fast`), *not* the `speed=fast` request parameter (that path is Opus 4.6 only). The desktop picker exposes fast for such models via its *variant* mechanism: `collapseModelFamilies` groups a `…-fast` id under its base, and `resolveFastControl` lights the Fast toggle — **but only when the `-fast` sibling is present in the provider's catalog**.

The direct Anthropic curated list (`_PROVIDER_MODELS["anthropic"]`) listed `claude-opus-4-8` but omitted `claude-opus-4-8-fast`, so the picker had no sibling to collapse and rendered no fast control. The OpenRouter fallback already lists both ids (`anthropic/claude-opus-4.8` + `…-fast`), confirming the intended behavior. This adds the missing sibling to the Anthropic list so the existing variant-fast path lights up. Because `provider_model_ids("anthropic")` merges curated-first then appends the live `/v1/models` catalog, the entry surfaces even when Anthropic's API hasn't enumerated the alias yet.

The `-fast` id is a real, first-class routed model (priced in `agent/usage_pricing.py`, covered by the Anthropic adapter tests), so selecting it works end-to-end.

## Related Issue

Fixes #62236

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/models.py` — add `claude-opus-4-8-fast` to `_PROVIDER_MODELS["anthropic"]`, immediately after its base `claude-opus-4-8`, with a comment explaining why the sibling must be enumerated for the picker.
- `tests/hermes_cli/test_anthropic_picker_curated.py` — regression tests: the fast sibling is curated, the base is variant-fast (not param-fast), and the sibling survives the live `/v1/models` merge.

## How to Test

```
scripts/run_tests.sh tests/hermes_cli/test_anthropic_picker_curated.py
```
Result: `5 passed` (3 existing + 2 new).

Manual (desktop): open the composer model picker on a direct-Anthropic setup, hover the **Opus 4.8** row → the edit submenu now shows the **Fast** toggle (previously absent).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected tests and they pass (`scripts/run_tests.sh tests/hermes_cli/test_anthropic_picker_curated.py`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings/comment) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (shared catalog data)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Notes / Scope

- Scoped to the **direct Anthropic** provider, where the curated-first merge guarantees the entry surfaces. The `nous` provider's catalog is served live from the Nous Portal / docs manifest (not `_PROVIDER_MODELS["nous"]`), and third-party aggregators (`opencode-zen`) may not serve the `-fast` variant, so those are intentionally left to their own catalogs.
- `/fast` remaining absent from the desktop slash palette is **intended** — it's classified `advanced` and redirects to "the relevant desktop control", which is exactly the picker's Fast toggle this PR restores.
