### PR TITLE
feat(kanban): add fail-closed worker workspace guard

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1022,6 +1022,7 @@ class GatewayKanbanWatchersMixin:
                     stale_timeout_seconds=stale_timeout_seconds,
                     default_assignee=default_assignee,
                     max_in_progress_per_profile=max_in_progress_per_profile,
+                    workspace_guard=kanban_cfg.get("dispatcher"),
                 )
             except sqlite3.DatabaseError as exc:
                 if _is_corrupt_board_db_error(exc):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2716,6 +2716,14 @@ DEFAULT_CONFIG = {
         # same task/profile (spawn_failed, timed_out, or crashed). Reassignment
         # resets the streak for the new profile.
         "failure_limit": 2,
+        # Optional fail-closed worker startup guard. When canonical_roots is
+        # empty, dispatch behavior is unchanged. Once configured, workers may
+        # never run in/under those primary checkouts; worktree tasks must be
+        # registered linked worktrees on the task-scoped branch prefix.
+        "dispatcher": {
+            "canonical_roots": [],
+            "required_worktree_branch_prefix": "card/{task_id}/",
+        },
         # Worker stdout/stderr logs rotate at spawn time. Defaults preserve
         # the historical 2 MiB + one-backup behavior; long-running workers can
         # raise these to keep more early failure evidence.

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2122,11 +2122,20 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
     # (#28805). Same semantics as the gateway dispatch path so behavior
     # matches whether the user runs the CLI directly or relies on the
     # gateway-embedded dispatcher.
+    workspace_guard = None
     try:
         from hermes_cli.config import load_config
         _cfg = load_config()
         _kanban_cfg = _cfg.get("kanban", {}) if isinstance(_cfg, dict) else {}
-        default_assignee = (_kanban_cfg.get("default_assignee") or "").strip() or None
+        if not isinstance(_kanban_cfg, dict):
+            _kanban_cfg = {}
+        workspace_guard = _kanban_cfg.get("dispatcher")
+        default_assignee_raw = _kanban_cfg.get("default_assignee")
+        default_assignee = (
+            default_assignee_raw.strip() or None
+            if isinstance(default_assignee_raw, str)
+            else None
+        )
 
         def _coerce_positive_int(value):
             if value is None:
@@ -2161,6 +2170,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             failure_limit=getattr(args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT),
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
+            workspace_guard=workspace_guard,
         )
     if getattr(args, "json", False):
         print(json.dumps({
@@ -2169,6 +2179,10 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             "timed_out": res.timed_out,
             "stale": res.stale,
             "auto_blocked": res.auto_blocked,
+            "workspace_blocked": [
+                {"task_id": tid, "reason": reason}
+                for (tid, reason) in res.workspace_blocked
+            ],
             "promoted": res.promoted,
             "spawned": [
                 {"task_id": tid, "assignee": who, "workspace": ws}
@@ -2196,6 +2210,9 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
     print(f"Auto-blocked: {len(res.auto_blocked)}")
     if res.auto_blocked:
         print(f"  {', '.join(res.auto_blocked)}")
+    print(f"Workspace-blocked: {len(res.workspace_blocked)}")
+    for tid, reason in res.workspace_blocked:
+        print(f"  {tid}: {reason}")
     print(f"Promoted:     {res.promoted}")
     print(f"Spawned:      {len(res.spawned)}")
     for tid, who, ws in res.spawned:
@@ -2345,11 +2362,25 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
         except Exception:
             return False
 
+    workspace_guard = None
+    try:
+        from hermes_cli.config import load_config
+        _cfg = load_config()
+        _kanban_cfg = _cfg.get("kanban", {}) if isinstance(_cfg, dict) else {}
+        if isinstance(_kanban_cfg, dict):
+            workspace_guard = _kanban_cfg.get("dispatcher")
+    except Exception:
+        # Config loading failure preserves historical behavior. If a dispatcher
+        # guard was successfully extracted, unrelated config errors must never
+        # clear it; this block runs before extraction in that failure mode.
+        pass
+
     try:
         kb.run_daemon(
             interval=args.interval,
             max_spawn=args.max,
             failure_limit=getattr(args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT),
+            workspace_guard=workspace_guard,
             on_tick=_on_tick,
         )
     finally:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5375,6 +5375,213 @@ def _git_current_branch(path: Path) -> Optional[str]:
     return branch or None
 
 
+@dataclass(frozen=True)
+class _CanonicalWorkspaceRoot:
+    path: Path
+    common_dir: Path
+    registered_worktrees: frozenset[Path]
+
+
+@dataclass(frozen=True)
+class _WorkspaceGuardState:
+    roots: tuple[_CanonicalWorkspaceRoot, ...] = ()
+    required_branch_prefix: str = "card/{task_id}/"
+    config_error: Optional[str] = None
+
+
+def _git_registered_worktrees(repo_root: Path) -> Optional[frozenset[Path]]:
+    """Read Git's registered worktree paths without changing repository state."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "worktree", "list", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    paths: set[Path] = set()
+    for line in (result.stdout or "").splitlines():
+        if line.startswith("worktree "):
+            try:
+                paths.add(Path(line[len("worktree "):]).expanduser().resolve(strict=False))
+            except (OSError, RuntimeError):
+                return None
+    return frozenset(paths) if paths else None
+
+
+def _prepare_workspace_guard(config: Optional[dict]) -> Optional[_WorkspaceGuardState]:
+    """Validate configured canonical roots once per dispatcher tick.
+
+    An absent/empty root list preserves historical dispatch behavior. Once a
+    root is configured, malformed or unreadable guard state fails closed.
+    """
+    if config is None:
+        return None
+    if not isinstance(config, dict):
+        return _WorkspaceGuardState(config_error="kanban.dispatcher must be a mapping")
+    if not config:
+        return None
+    raw_roots = config.get("canonical_roots")
+    if raw_roots in (None, []):
+        return None
+    prefix = config.get("required_worktree_branch_prefix", "card/{task_id}/")
+    if not isinstance(raw_roots, (list, tuple)) or not raw_roots:
+        return _WorkspaceGuardState(config_error="canonical_roots must be a non-empty list")
+    if not isinstance(prefix, str) or not prefix:
+        return _WorkspaceGuardState(
+            config_error="required_worktree_branch_prefix must be a non-empty string"
+        )
+
+    roots: list[_CanonicalWorkspaceRoot] = []
+    seen_paths: set[Path] = set()
+    seen_common_dirs: set[Path] = set()
+    for raw_root in raw_roots:
+        if not isinstance(raw_root, str) or not raw_root.strip():
+            return _WorkspaceGuardState(config_error="canonical root entries must be paths")
+        root = Path(raw_root).expanduser()
+        if not root.is_absolute():
+            return _WorkspaceGuardState(
+                config_error=f"canonical root is not absolute: {raw_root!r}"
+            )
+        try:
+            root = root.resolve(strict=False)
+        except (OSError, RuntimeError) as exc:
+            return _WorkspaceGuardState(
+                config_error=f"cannot resolve canonical root {raw_root!r}: {exc}"
+            )
+        if not root.exists():
+            return _WorkspaceGuardState(config_error=f"missing canonical root: {root}")
+        if not root.is_dir() or not os.access(root, os.R_OK | os.X_OK):
+            return _WorkspaceGuardState(config_error=f"unreadable canonical root: {root}")
+        toplevel = _git_toplevel(root)
+        common_dir = _git_common_dir(root)
+        registered = _git_registered_worktrees(root)
+        if toplevel is None or common_dir is None or registered is None or toplevel != root:
+            return _WorkspaceGuardState(config_error=f"non-git canonical root: {root}")
+        if root in seen_paths or common_dir in seen_common_dirs:
+            return _WorkspaceGuardState(
+                config_error=f"ambiguous canonical roots resolve to the same repository: {root}"
+            )
+        seen_paths.add(root)
+        seen_common_dirs.add(common_dir)
+        roots.append(_CanonicalWorkspaceRoot(root, common_dir, registered))
+    return _WorkspaceGuardState(tuple(roots), prefix)
+
+
+def _path_is_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _workspace_guard_preflight_reason(
+    task: Task,
+    guard: _WorkspaceGuardState | None,
+) -> str | None:
+    """Validate worktree metadata before ensure_task_worktree mutates Git state."""
+    if guard is None:
+        return None
+    if guard.config_error:
+        return f"workspace startup guard: BLOCKED: {guard.config_error}"
+    if task.workspace_kind != "worktree":
+        return None
+    branch = (task.branch_name or "").strip()
+    try:
+        required_prefix = guard.required_branch_prefix.format(task_id=task.id)
+    except (KeyError, ValueError, IndexError, AttributeError) as exc:
+        return (
+            "workspace startup guard: BLOCKED: invalid "
+            f"required_worktree_branch_prefix template: {exc}"
+        )
+    if not branch:
+        return (
+            "workspace startup guard: BLOCKED: guarded worktree tasks must "
+            f"declare branch_name with prefix {required_prefix!r}"
+        )
+    if not branch.startswith(required_prefix):
+        return (
+            "workspace startup guard: BLOCKED: declared branch "
+            f"{branch!r} does not start with {required_prefix!r}"
+        )
+    return None
+
+
+def _workspace_guard_reason(task: Task, guard: _WorkspaceGuardState | None) -> str | None:
+    """Return a fail-closed block reason, or ``None`` when startup is safe."""
+    preflight_reason = _workspace_guard_preflight_reason(task, guard)
+    if preflight_reason:
+        return preflight_reason
+    if guard is None:
+        return None
+
+    raw_workspace = (task.workspace_path or "").strip()
+    if task.workspace_kind == "scratch" and not raw_workspace:
+        try:
+            workspace = (workspaces_root() / task.id).resolve(strict=False)
+        except (OSError, RuntimeError) as exc:
+            return f"workspace startup guard: BLOCKED: cannot resolve scratch workspace: {exc}"
+    elif not raw_workspace:
+        return (
+            "workspace startup guard: BLOCKED: worktree task has no existing "
+            "registered workspace_path"
+        )
+    else:
+        workspace = Path(raw_workspace).expanduser()
+        if not workspace.is_absolute():
+            return "workspace startup guard: BLOCKED: workspace path is not absolute"
+        try:
+            workspace = workspace.resolve(strict=False)
+        except (OSError, RuntimeError) as exc:
+            return f"workspace startup guard: BLOCKED: cannot resolve workspace path: {exc}"
+
+    for canonical in guard.roots:
+        if _path_is_within(workspace, canonical.path):
+            return (
+                "workspace startup guard: BLOCKED: workspace is equal to or inside "
+                f"configured canonical root {canonical.path}"
+            )
+
+    if task.workspace_kind != "worktree":
+        return None
+    if not workspace.is_dir() or not os.access(workspace, os.R_OK | os.X_OK):
+        return (
+            "workspace startup guard: BLOCKED: worktree workspace is missing or unreadable: "
+            f"{workspace}"
+        )
+    common_dir = _git_common_dir(workspace)
+    linked = [root for root in guard.roots if root.common_dir == common_dir]
+    if len(linked) != 1:
+        return (
+            "workspace startup guard: BLOCKED: worktree is not linked unambiguously "
+            "to exactly one configured canonical root"
+        )
+    if workspace not in linked[0].registered_worktrees or not _is_linked_worktree_checkout(workspace):
+        return (
+            "workspace startup guard: BLOCKED: workspace is not a registered linked "
+            f"Git worktree of {linked[0].path}"
+        )
+    try:
+        required_prefix = guard.required_branch_prefix.format(task_id=task.id)
+    except (KeyError, ValueError, IndexError, AttributeError) as exc:
+        return (
+            "workspace startup guard: BLOCKED: invalid "
+            f"required_worktree_branch_prefix template: {exc}"
+        )
+    branch = _git_current_branch(workspace)
+    if not branch or not branch.startswith(required_prefix):
+        return (
+            "workspace startup guard: BLOCKED: worktree branch "
+            f"{branch or '(detached)'} must start with {required_prefix}"
+        )
+    return None
+
+
 def _is_linked_worktree_checkout(path: Path) -> bool:
     git_dir = _git_dir(path)
     common_dir = _git_common_dir(path)
@@ -5722,6 +5929,10 @@ class DispatchResult:
     """Task ids reclaimed because their worker PID disappeared."""
     auto_blocked: list[str] = field(default_factory=list)
     """Task ids auto-blocked by the spawn-failure circuit breaker."""
+    workspace_blocked: list[tuple[str, str]] = field(default_factory=list)
+    """Tasks blocked before worker startup by the canonical workspace guard,
+    as ``(task_id, explicit_reason)`` pairs. These are safety blocks, not
+    spawn failures, and therefore do not increment retry counts."""
     timed_out: list[str] = field(default_factory=list)
     """Task ids whose workers exceeded ``max_runtime_seconds``."""
     stale: list[str] = field(default_factory=list)
@@ -6947,6 +7158,58 @@ def has_spawnable_review(conn: sqlite3.Connection) -> bool:
     return False
 
 
+def _guard_dispatch_task(
+    conn: sqlite3.Connection,
+    task: Task,
+    guard: _WorkspaceGuardState | None,
+    result: DispatchResult,
+    *,
+    dry_run: bool,
+    preflight_only: bool = False,
+) -> bool:
+    """Apply the startup guard; return True when dispatch must stop for task."""
+    reason = (
+        _workspace_guard_preflight_reason(task, guard)
+        if preflight_only
+        else _workspace_guard_reason(task, guard)
+    )
+    # Dry-run must not create worktrees. A not-yet-materialized worktree
+    # cannot be fully validated until real dispatch, but metadata preflight
+    # above still rejects missing or wrong branch declarations.
+    if (
+        not preflight_only
+        and dry_run
+        and task.workspace_kind == "worktree"
+        and not (task.workspace_path or "").strip()
+        and reason
+        and "no existing registered workspace_path" in reason
+    ):
+        return False
+    if reason is None:
+        return False
+    result.workspace_blocked.append((task.id, reason))
+    if dry_run:
+        return True
+
+    blocked = block_task(
+        conn,
+        task.id,
+        reason=reason,
+        kind="capability",
+        expected_run_id=task.current_run_id,
+    )
+    if blocked:
+        with write_txn(conn):
+            _append_event(
+                conn,
+                task.id,
+                "workspace_guard_blocked",
+                {"reason": reason},
+                run_id=task.current_run_id,
+            )
+    return True
+
+
 def dispatch_once(
     conn: sqlite3.Connection,
     *,
@@ -6960,6 +7223,7 @@ def dispatch_once(
     board: Optional[str] = None,
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
+    workspace_guard: Optional[dict] = None,
 ) -> DispatchResult:
     """Run one dispatcher tick under the board's single-writer lock.
 
@@ -6994,6 +7258,7 @@ def dispatch_once(
             board=board,
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
+            workspace_guard=workspace_guard,
         )
     with _dispatch_tick_lock(db_path) as held:
         if not held:
@@ -7010,6 +7275,7 @@ def dispatch_once(
             board=board,
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
+            workspace_guard=workspace_guard,
         )
 
 
@@ -7026,6 +7292,7 @@ def _dispatch_once_locked(
     board: Optional[str] = None,
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
+    workspace_guard: Optional[dict] = None,
 ) -> DispatchResult:
     """Run one dispatcher tick.
 
@@ -7060,6 +7327,7 @@ def _dispatch_once_locked(
     reap_worker_zombies()
 
     result = DispatchResult()
+    guard_state = _prepare_workspace_guard(workspace_guard)
     result.reclaimed = release_stale_claims(conn)
     result.stale = detect_stale_running(
         conn, stale_timeout_seconds=stale_timeout_seconds,
@@ -7260,6 +7528,11 @@ def _dispatch_once_locked(
                     )
             continue
         if dry_run:
+            task = get_task(conn, row["id"])
+            if task is not None and _guard_dispatch_task(
+                conn, task, guard_state, result, dry_run=True
+            ):
+                continue
             result.spawned.append((row["id"], row_assignee, ""))
             # Increment per-profile counter even in dry_run so the cap
             # check sees the would-be spawn on subsequent iterations.
@@ -7272,6 +7545,15 @@ def _dispatch_once_locked(
             continue
         claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
+            continue
+        if _guard_dispatch_task(
+            conn,
+            claimed,
+            guard_state,
+            result,
+            dry_run=False,
+            preflight_only=True,
+        ):
             continue
         try:
             resolved_branch_name = None
@@ -7291,6 +7573,16 @@ def _dispatch_once_locked(
         set_workspace_path(conn, claimed.id, str(workspace))
         if claimed.workspace_kind == "worktree":
             set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
+        guarded_task = get_task(conn, claimed.id) or claimed
+        current_guard_state = (
+            _prepare_workspace_guard(workspace_guard)
+            if claimed.workspace_kind == "worktree"
+            else guard_state
+        )
+        if _guard_dispatch_task(
+            conn, guarded_task, current_guard_state, result, dry_run=False
+        ):
+            continue
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
@@ -7360,10 +7652,24 @@ def _dispatch_once_locked(
             result.skipped_nonspawnable.append(row["id"])
             continue
         if dry_run:
+            task = get_task(conn, row["id"])
+            if task is not None and _guard_dispatch_task(
+                conn, task, guard_state, result, dry_run=True
+            ):
+                continue
             result.spawned.append((row["id"], row["assignee"], ""))
             continue
         claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
+            continue
+        if _guard_dispatch_task(
+            conn,
+            claimed,
+            guard_state,
+            result,
+            dry_run=False,
+            preflight_only=True,
+        ):
             continue
         try:
             resolved_branch_name = None
@@ -7383,6 +7689,16 @@ def _dispatch_once_locked(
         set_workspace_path(conn, claimed.id, str(workspace))
         if claimed.workspace_kind == "worktree":
             set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
+        guarded_task = get_task(conn, claimed.id) or claimed
+        current_guard_state = (
+            _prepare_workspace_guard(workspace_guard)
+            if claimed.workspace_kind == "worktree"
+            else guard_state
+        )
+        if _guard_dispatch_task(
+            conn, guarded_task, current_guard_state, result, dry_run=False
+        ):
+            continue
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
         # Force-load the sdlc-review skill for review agents — it carries
         # the review logic (AC verification, merge, etc.). The mandatory
@@ -7868,6 +8184,7 @@ def run_daemon(
     interval: float = 60.0,
     max_spawn: Optional[int] = None,
     failure_limit: int = DEFAULT_SPAWN_FAILURE_LIMIT,
+    workspace_guard: Optional[dict] = None,
     stop_event=None,
     on_tick=None,
 ) -> None:
@@ -7905,6 +8222,7 @@ def run_daemon(
                     conn,
                     max_spawn=max_spawn,
                     failure_limit=failure_limit,
+                    workspace_guard=workspace_guard,
                 )
             if on_tick is not None:
                 try:

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1958,10 +1958,20 @@ def dispatch(
     board: Optional[str] = Query(None),
 ):
     board = _resolve_board(board)
+    workspace_guard = None
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
+        if isinstance(kanban_cfg, dict):
+            workspace_guard = kanban_cfg.get("dispatcher")
+    except Exception:
+        pass
     conn = _conn(board=board)
     try:
         result = kanban_db.dispatch_once(
             conn, dry_run=dry_run, max_spawn=max_n, board=board,
+            workspace_guard=workspace_guard,
         )
         # DispatchResult is a dataclass.
         try:

--- a/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
+++ b/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
@@ -71,6 +71,45 @@ def test_cli_dispatch_passes_max_in_progress_from_config(isolated_kanban_home, m
     assert captured.get("max_in_progress_per_profile") == 2
 
 
+def test_cli_dispatch_preserves_guard_with_unrelated_malformed_config(
+    isolated_kanban_home, monkeypatch,
+):
+    from hermes_cli import kanban as kb_cli
+    from hermes_cli import kanban_db
+
+    guard = {"canonical_roots": ["/tmp/repo"]}
+    fake_config = {"kanban": {"dispatcher": guard, "default_assignee": ["bad"]}}
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: fake_config)
+    captured = {}
+    monkeypatch.setattr(
+        kanban_db, "dispatch_once",
+        lambda conn, **kw: (captured.update(kw), kanban_db.DispatchResult())[1],
+    )
+    args = argparse.Namespace(dry_run=True, max=None, failure_limit=2, json=False)
+    kb_cli._cmd_dispatch(args)
+    assert captured.get("workspace_guard") == guard
+    assert captured.get("default_assignee") is None
+
+
+def test_forced_daemon_passes_workspace_guard(isolated_kanban_home, monkeypatch):
+    from hermes_cli import kanban as kb_cli
+    from hermes_cli import kanban_db
+
+    guard = {"canonical_roots": ["/tmp/repo"]}
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config", lambda: {"kanban": {"dispatcher": guard}}
+    )
+    captured = {}
+    monkeypatch.setattr(kanban_db, "init_db", lambda: None)
+    monkeypatch.setattr(kanban_db, "run_daemon", lambda **kw: captured.update(kw))
+    args = argparse.Namespace(
+        force=True, interval=1.0, max=1, failure_limit=2,
+        pidfile=None, verbose=False,
+    )
+    assert kb_cli._cmd_daemon(args) == 0
+    assert captured.get("workspace_guard") == guard
+
+
 def test_cli_max_flag_overrides_config_max_spawn(isolated_kanban_home, monkeypatch):
     """--max on the CLI takes precedence over kanban.max_spawn in config.
     The CLI flag is the explicit operator signal; config is the default."""

--- a/tests/hermes_cli/test_kanban_workspace_guard.py
+++ b/tests/hermes_cli/test_kanban_workspace_guard.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+from hermes_cli import kanban_db as kb
+
+
+def git(cwd: Path, *args: str) -> str:
+    cp = subprocess.run(["git", "-C", str(cwd), *args], check=True, capture_output=True, text=True)
+    return cp.stdout.strip()
+
+
+def make_repo(tmp_path: Path) -> tuple[Path, Path]:
+    repo = tmp_path / "repo"; repo.mkdir()
+    git(repo, "init", "-b", "main")
+    git(repo, "config", "user.email", "guard@example.invalid")
+    git(repo, "config", "user.name", "Workspace Guard Test")
+    (repo / "README.md").write_text("base\n")
+    git(repo, "add", "README.md"); git(repo, "commit", "-m", "base")
+    worktree = tmp_path / "wt"
+    git(repo, "worktree", "add", "-b", "card/t_12345678/change", str(worktree), "HEAD")
+    return repo, worktree
+
+
+def task(kind: str, path: Path | None, branch: str | None = None):
+    if kind == "worktree" and branch is None:
+        branch = "card/t_12345678/change"
+    return SimpleNamespace(id="t_12345678", workspace_kind=kind,
+                           workspace_path=str(path) if path is not None else None,
+                           branch_name=branch)
+
+
+def config(repo: Path) -> dict:
+    return {"canonical_roots": [str(repo)],
+            "required_worktree_branch_prefix": "card/{task_id}/"}
+
+
+def test_workspace_guard_absent_config_preserves_legacy_behavior():
+    assert kb._prepare_workspace_guard(None) is None
+    assert kb._prepare_workspace_guard({}) is None
+
+
+def test_workspace_guard_falsey_non_mapping_config_fails_closed():
+    for malformed in ([], "", 0):
+        state = kb._prepare_workspace_guard(malformed)
+        reason = kb._workspace_guard_reason(task("scratch", None), state)
+        assert reason and "kanban.dispatcher must be a mapping" in reason
+
+
+def test_workspace_guard_canonical_checkout_blocks_even_when_clean(tmp_path: Path):
+    repo, _ = make_repo(tmp_path)
+    reason = kb._workspace_guard_reason(task("dir", repo), kb._prepare_workspace_guard(config(repo)))
+    assert reason and "configured canonical root" in reason
+
+
+def test_workspace_guard_dirty_canonical_checkout_blocks(tmp_path: Path):
+    repo, _ = make_repo(tmp_path); (repo / "README.md").write_text("dirty\n")
+    reason = kb._workspace_guard_reason(task("dir", repo), kb._prepare_workspace_guard(config(repo)))
+    assert reason and "BLOCKED" in reason
+
+
+def test_workspace_guard_registered_card_worktree_is_allowed(tmp_path: Path):
+    repo, worktree = make_repo(tmp_path)
+    state = kb._prepare_workspace_guard(config(repo))
+    assert kb._workspace_guard_reason(task("worktree", worktree), state) is None
+
+
+def test_workspace_guard_wrong_branch_blocks(tmp_path: Path):
+    repo, worktree = make_repo(tmp_path); git(worktree, "switch", "-c", "wrong/branch")
+    reason = kb._workspace_guard_reason(task("worktree", worktree), kb._prepare_workspace_guard(config(repo)))
+    assert reason and "must start with card/t_12345678/" in reason
+
+
+def test_workspace_guard_missing_root_fails_closed(tmp_path: Path):
+    state = kb._prepare_workspace_guard(config(tmp_path / "missing"))
+    reason = kb._workspace_guard_reason(task("scratch", None), state)
+    assert reason and "missing canonical root" in reason
+
+
+def test_workspace_guard_non_git_root_fails_closed(tmp_path: Path):
+    root = tmp_path / "plain"; root.mkdir()
+    state = kb._prepare_workspace_guard(config(root))
+    reason = kb._workspace_guard_reason(task("scratch", None), state)
+    assert reason and "non-git canonical root" in reason
+
+
+def test_workspace_guard_canonical_root_symlink_loop_fails_closed(tmp_path: Path):
+    loop = tmp_path / "loop"
+    loop.symlink_to(loop)
+    state = kb._prepare_workspace_guard(config(loop))
+    reason = kb._workspace_guard_reason(task("scratch", None), state)
+    assert reason and "cannot resolve canonical root" in reason
+
+
+def test_workspace_guard_explicit_workspace_symlink_loop_fails_closed(tmp_path: Path):
+    repo, _ = make_repo(tmp_path)
+    loop = tmp_path / "workspace-loop"
+    loop.symlink_to(loop)
+    reason = kb._workspace_guard_reason(
+        task("dir", loop), kb._prepare_workspace_guard(config(repo))
+    )
+    assert reason and "cannot resolve workspace path" in reason
+
+
+def test_workspace_guard_unmaterialized_worktree_blocks_real_start(tmp_path: Path):
+    repo, _ = make_repo(tmp_path)
+    reason = kb._workspace_guard_reason(task("worktree", None), kb._prepare_workspace_guard(config(repo)))
+    assert reason and "no existing registered workspace_path" in reason
+
+
+def test_workspace_guard_preflight_blocks_missing_or_wrong_declared_branch(tmp_path: Path):
+    repo, _ = make_repo(tmp_path)
+    state = kb._prepare_workspace_guard(config(repo))
+    missing = task("worktree", None, branch="")
+    wrong = task("worktree", None, branch="wt/t_12345678")
+    assert "must declare branch_name" in (kb._workspace_guard_preflight_reason(missing, state) or "")
+    assert "does not start with" in (kb._workspace_guard_preflight_reason(wrong, state) or "")
+
+
+def test_workspace_guard_malformed_branch_prefix_fails_closed(tmp_path: Path):
+    repo, _ = make_repo(tmp_path)
+    for malformed_prefix in ("{bogus}/", "{}", "{task_id.foo}"):
+        malformed = config(repo)
+        malformed["required_worktree_branch_prefix"] = malformed_prefix
+        state = kb._prepare_workspace_guard(malformed)
+        reason = kb._workspace_guard_preflight_reason(task("worktree", None), state)
+        assert reason and "invalid required_worktree_branch_prefix template" in reason
+
+
+def test_workspace_guard_resolves_default_scratch_path_before_root_check(
+    tmp_path: Path, monkeypatch,
+):
+    repo, _ = make_repo(tmp_path)
+    scratch_link = tmp_path / "scratch-link"
+    scratch_link.symlink_to(repo, target_is_directory=True)
+    monkeypatch.setattr(kb, "workspaces_root", lambda: scratch_link)
+    reason = kb._workspace_guard_reason(
+        task("scratch", None), kb._prepare_workspace_guard(config(repo))
+    )
+    assert reason and "configured canonical root" in reason
+
+
+def test_workspace_guard_refresh_observes_newly_created_worktree(tmp_path: Path):
+    repo = tmp_path / "repo"; repo.mkdir()
+    git(repo, "init", "-b", "main")
+    git(repo, "config", "user.email", "guard@example.invalid")
+    git(repo, "config", "user.name", "Workspace Guard Test")
+    (repo / "README.md").write_text("base\n")
+    git(repo, "add", "README.md"); git(repo, "commit", "-m", "base")
+    stale = kb._prepare_workspace_guard(config(repo))
+    worktree = tmp_path / "new-wt"
+    git(repo, "worktree", "add", "-b", "card/t_12345678/change", str(worktree), "HEAD")
+    assert "not a registered linked Git worktree" in (
+        kb._workspace_guard_reason(task("worktree", worktree), stale) or ""
+    )
+    refreshed = kb._prepare_workspace_guard(config(repo))
+    assert kb._workspace_guard_reason(task("worktree", worktree), refreshed) is None

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -2265,3 +2265,21 @@ def test_dashboard_failed_card_highlight_class_exists():
     assert "hermes-kanban-card--failed" in js
     assert "hermes-kanban-card--failed" in css
     assert "failedIds" in js
+
+
+def test_dashboard_dispatch_passes_workspace_guard(client, monkeypatch):
+    guard = {"canonical_roots": ["/tmp/repo"]}
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config", lambda: {"kanban": {"dispatcher": guard}}
+    )
+    captured = {}
+
+    def fake_dispatch_once(conn, **kwargs):
+        captured.update(kwargs)
+        return kb.DispatchResult()
+
+    plugin_module = sys.modules["hermes_dashboard_plugin_kanban_test"]
+    monkeypatch.setattr(plugin_module.kanban_db, "dispatch_once", fake_dispatch_once)
+    response = client.post("/api/plugins/kanban/dispatch?dry_run=true")
+    assert response.status_code == 200
+    assert captured.get("workspace_guard") == guard


### PR DESCRIPTION
## Summary
- add optional dispatcher canonical-root inventory with fail-closed validation
- block primary/review workers from canonical checkouts
- require registered linked worktrees on `card/<task-id>/...` branches
- refresh the read-only worktree inventory after `ensure_task_worktree` so newly-created valid worktrees are recognized
- record auditable `workspace_guard_blocked` events and expose counts in CLI/gateway telemetry
- preserve legacy behavior when no roots are configured

## Safety and scope
- ScoracleAI Kanban card: `t_0e1a837d`
- Curt approved this structural safety change in the P0 activation decision packet on 2026-07-10.
- No deployment, production data, credential, billing, or active-model changes are included.
- Runtime activation remains separate and occurs only after current-head Firewallius approval and green local tests.

## Verification
- `uv run ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_workspace_guard.py` → passed
- `uv run pytest -q tests/hermes_cli/test_kanban_workspace_guard.py tests/hermes_cli/test_kanban_dispatch_lock.py tests/gateway/test_kanban_watchers_mixin.py` → 19 passed
- broad Kanban suite: 732 passed; 17 order-dependent failures; immediate `pytest --lf` rerun → 17 passed
- `git diff --check` → passed

## Rollback
Revert this commit or remove `kanban.dispatcher.canonical_roots`; absent configuration preserves legacy behavior.
