### PR TITLE
fix(codex): clamp prompt_cache_key to 64 chars for Codex/ChatGPT backend

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -257,6 +257,15 @@ class ResponsesApiTransport(ProviderTransport):
         # the cache-scope routing headers below. Falls back to session_id when
         # there is no static content to hash.
         cache_key = _content_cache_key(instructions, response_tools) or session_id
+        # prompt_cache_key is capped at 64 chars by the OpenAI Responses /
+        # ChatGPT-Codex backend (HTTP 400 "string too long" past that). The
+        # content-addressed hash from _content_cache_key() is always well
+        # under the limit, but the session_id fallback is caller-supplied and
+        # unbounded (e.g. control-plane session keys like
+        # ``agent:<uuid>:issue:<uuid>``), so clamp here. Routing hint only —
+        # never a correctness boundary — so truncation is safe. See #62063.
+        if cache_key and len(cache_key) > 64:
+            cache_key = cache_key[:64]
         # xAI Responses takes prompt_cache_key in extra_body (set further
         # down); GitHub Models opts out of cache-key routing entirely.
         if not is_github_responses and not is_xai_responses and cache_key:

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -112,6 +112,60 @@ class TestCodexBuildKwargs:
         )
         assert kw1["prompt_cache_key"] == kw2["prompt_cache_key"]
 
+    def test_cache_key_session_id_fallback_clamped_to_64_chars(self, transport, monkeypatch):
+        """Regression for #62063: the OpenAI Responses / ChatGPT-Codex backend
+        caps prompt_cache_key at 64 chars (HTTP 400 'string too long' past
+        that). When there's no static content to hash, the session_id
+        fallback must be clamped — caller-supplied session keys (e.g.
+        control-plane keys like ``agent:<uuid>:issue:<uuid>``) can exceed 64
+        chars."""
+        import agent.transports.codex as codex_module
+
+        monkeypatch.setattr(codex_module, "_content_cache_key", lambda *a, **k: None)
+        long_session_id = "agent:" + ("a" * 140)
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4", messages=messages, tools=[],
+            session_id=long_session_id,
+        )
+        assert kw["prompt_cache_key"] == long_session_id[:64]
+        assert len(kw["prompt_cache_key"]) == 64
+
+    def test_content_cache_key_is_none_only_when_both_empty(self):
+        """The session_id fallback in build_kwargs only fires when
+        _content_cache_key() returns None, which only happens when both
+        instructions and tools are empty. Pins down the actual trigger
+        condition for #62063's fallback path."""
+        from agent.transports.codex import _content_cache_key
+
+        assert _content_cache_key("", None) is None
+        assert _content_cache_key("", []) is None
+        assert _content_cache_key("some instructions", None) is not None
+        assert _content_cache_key("", [{"name": "terminal"}]) is not None
+
+    def test_realistic_call_never_leaks_raw_long_session_id_today(self, transport):
+        """End-to-end sanity check mirroring the production call site
+        (agent/chat_completion_helpers.py never passes an explicit
+        ``instructions`` kwarg — it relies on the messages[0] system-role
+        extraction or the DEFAULT_AGENT_IDENTITY fallback in build_kwargs).
+        Because that fallback always yields non-empty instructions,
+        ``_content_cache_key`` never returns None in real traffic, so
+        ``prompt_cache_key`` is always the bounded ``pck_`` hash — never the
+        raw (potentially >64-char) session_id. This is what makes the
+        session_id-fallback clamp defense-in-depth rather than the only
+        guard, and documents the current DEFAULT_AGENT_IDENTITY-dependent
+        behavior in case that fallback is ever removed."""
+        long_session_id = "agent:" + ("b" * 140)
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4", messages=messages, tools=[],
+            session_id=long_session_id,
+            is_codex_backend=True,
+        )
+        assert kw["prompt_cache_key"].startswith("pck_")
+        assert kw["prompt_cache_key"] != long_session_id
+        assert len(kw["prompt_cache_key"]) <= 64
+
     def test_github_responses_no_cache_key(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(


### PR DESCRIPTION
## Summary
- Fixes #62063: the OpenAI Responses / ChatGPT-Codex backend caps `prompt_cache_key` at 64 chars and returns HTTP 400 ("string too long") past that.
- `agent/transports/codex.py::build_kwargs` falls back to the raw `session_id` for the cache key when there's no static content to hash. `session_id` is caller-supplied and unbounded (e.g. control-plane session keys like `agent:<uuid>:issue:<uuid>` run ~140 chars), so any session_id over 64 chars broke every call on this backend.
- Clamp the resolved `cache_key` to 64 chars right after it's computed, before it's used as `kwargs["prompt_cache_key"]` (Codex path) or `extra_body["prompt_cache_key"]` (xAI path). Per the existing docstring, the key is a routing hint only — never a correctness boundary — so truncation is safe.

## Root cause detail
- `_content_cache_key()` returns a bounded `pck_<hash>` (28 chars) whenever `instructions` or `tools` is non-empty. In today's call path `instructions` always falls back to `DEFAULT_AGENT_IDENTITY` when unset, so in practice the raw-`session_id` fallback is rarely hit — but it's still reachable (e.g. if that fallback logic changes, or the caller passes tools=None/instructions="" through a path that skips the identity fallback), and when it is hit, the value is completely unbounded. The clamp closes this at the single point of consumption so it can never regress regardless of what feeds `cache_key`.

## Test plan
- [x] `tests/agent/transports/test_codex_transport.py::test_cache_key_session_id_fallback_clamped_to_64_chars` — forces the fallback (monkeypatches `_content_cache_key` to return `None`) with a 146-char session_id and asserts the resulting `prompt_cache_key` is exactly 64 chars.
- [x] `tests/agent/transports/test_codex_transport.py::test_content_cache_key_is_none_only_when_both_empty` — pins down the exact trigger condition for the fallback.
- [x] `tests/agent/transports/test_codex_transport.py::test_realistic_call_never_leaks_raw_long_session_id_today` — production-shaped call (no explicit `instructions`, matching `agent/chat_completion_helpers.py`) with a 146-char session_id; confirms the emitted key is always the bounded content hash.
- [x] Full existing suite for the transport, adapter, and auxiliary client passes unchanged (377 tests).
 