### PR TITLE
fix(providers): use native query-param auth for Gemini model discovery (#62259)

### DIFF
--- a/plugins/model-providers/gemini/__init__.py
+++ b/plugins/model-providers/gemini/__init__.py
@@ -9,14 +9,64 @@ carries the thinking_config translation hook so the transport's profile
 path produces the same extra_body shape the legacy flag path did.
 """
 
+import logging
 from typing import Any
 
 from providers import register_provider
-from providers.base import ProviderProfile
+from providers.base import ProviderProfile, _profile_user_agent
+
+logger = logging.getLogger(__name__)
 
 
 class GeminiProfile(ProviderProfile):
     """Gemini — translate reasoning_config to thinking_config in extra_body."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Fetch the live catalog from the native Gemini endpoint.
+
+        The base implementation sends ``Authorization: Bearer <key>`` to
+        ``{base_url}/models``. That works for OpenAI-compatible providers, but
+        the native ``/v1beta`` endpoint rejects Bearer auth with HTTP 401 — it
+        requires the key as a ``?key=`` query param. Left to the base path, the
+        probe 401s and the picker silently falls back to the static list
+        (#62259). Hit the native endpoint with query-param auth (the same auth
+        the native inference client already uses) and strip the ``models/``
+        prefix each entry's ``name`` carries so IDs match what inference expects.
+        """
+        effective_base = (base_url or self.base_url or "").rstrip("/")
+        if not (effective_base and api_key):
+            return None
+
+        import json
+        import urllib.parse
+        import urllib.request
+
+        url = f"{effective_base}/models?key={urllib.parse.quote(api_key)}"
+        req = urllib.request.Request(url)
+        req.add_header("Accept", "application/json")
+        req.add_header("User-Agent", _profile_user_agent())
+        for k, v in self.default_headers.items():
+            req.add_header(k, v)
+
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                data = json.loads(resp.read().decode())
+            items = data.get("models", []) if isinstance(data, dict) else []
+            ids = [
+                str(m["name"]).removeprefix("models/")
+                for m in items
+                if isinstance(m, dict) and m.get("name")
+            ]
+            return ids or None
+        except Exception as exc:
+            logger.debug("fetch_models(gemini): %s", exc)
+            return None
 
     def build_extra_body(
         self, *, session_id: str | None = None, **context: Any

--- a/plugins/model-providers/gemini/__init__.py
+++ b/plugins/model-providers/gemini/__init__.py
@@ -38,10 +38,26 @@ class GeminiProfile(ProviderProfile):
         (#62259). Hit the native endpoint with query-param auth (the same auth
         the native inference client already uses) and strip the ``models/``
         prefix each entry's ``name`` carries so IDs match what inference expects.
+
+        Gemini's OpenAI-compatibility base URL (``.../openai``) *does* speak
+        Bearer + OpenAI-style ``data[].id``, so this native override is gated to
+        native endpoints only; the compat base URL delegates to the base
+        implementation.
         """
         effective_base = (base_url or self.base_url or "").rstrip("/")
         if not (effective_base and api_key):
             return None
+
+        # The OpenAI-compat endpoint speaks Bearer + data[].id — let the base
+        # ProviderProfile handle it rather than forcing native query-param auth.
+        from agent.transports.chat_completions import (
+            _is_gemini_openai_compat_base_url,
+        )
+
+        if _is_gemini_openai_compat_base_url(effective_base):
+            return super().fetch_models(
+                api_key=api_key, base_url=base_url, timeout=timeout
+            )
 
         import json
         import urllib.parse
@@ -65,7 +81,10 @@ class GeminiProfile(ProviderProfile):
             ]
             return ids or None
         except Exception as exc:
-            logger.debug("fetch_models(gemini): %s", exc)
+            # Never log the exception value: urllib errors embed the request
+            # URL, which carries the api_key in the ``?key=`` query param. Log
+            # the exception type only.
+            logger.debug("fetch_models(gemini) failed: %s", type(exc).__name__)
             return None
 
     def build_extra_body(

--- a/plugins/model-providers/gemini/__init__.py
+++ b/plugins/model-providers/gemini/__init__.py
@@ -4,14 +4,64 @@ Reports api_mode="chat_completions" but runs on GeminiNativeClient; this
 profile carries auth/endpoint metadata and the thinking_config translation hook.
 """
 
+import logging
 from typing import Any
 
 from providers import register_provider
-from providers.base import ProviderProfile
+from providers.base import ProviderProfile, _profile_user_agent
+
+logger = logging.getLogger(__name__)
 
 
 class GeminiProfile(ProviderProfile):
     """Gemini — translate reasoning_config to thinking_config in extra_body."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Fetch the live catalog from the native Gemini endpoint.
+
+        The base implementation sends ``Authorization: Bearer <key>`` to
+        ``{base_url}/models``. That works for OpenAI-compatible providers, but
+        the native ``/v1beta`` endpoint rejects Bearer auth with HTTP 401 — it
+        requires the key as a ``?key=`` query param. Left to the base path, the
+        probe 401s and the picker silently falls back to the static list
+        (#62259). Hit the native endpoint with query-param auth (the same auth
+        the native inference client already uses) and strip the ``models/``
+        prefix each entry's ``name`` carries so IDs match what inference expects.
+        """
+        effective_base = (base_url or self.base_url or "").rstrip("/")
+        if not (effective_base and api_key):
+            return None
+
+        import json
+        import urllib.parse
+        import urllib.request
+
+        url = f"{effective_base}/models?key={urllib.parse.quote(api_key)}"
+        req = urllib.request.Request(url)
+        req.add_header("Accept", "application/json")
+        req.add_header("User-Agent", _profile_user_agent())
+        for k, v in self.default_headers.items():
+            req.add_header(k, v)
+
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                data = json.loads(resp.read().decode())
+            items = data.get("models", []) if isinstance(data, dict) else []
+            ids = [
+                str(m["name"]).removeprefix("models/")
+                for m in items
+                if isinstance(m, dict) and m.get("name")
+            ]
+            return ids or None
+        except Exception as exc:
+            logger.debug("fetch_models(gemini): %s", exc)
+            return None
 
     def build_extra_body(self, *, session_id: str | None = None, **context: Any) -> dict[str, Any]:
         """Native: ``thinking_config``; OpenAI-compat /openai subpath:

--- a/plugins/model-providers/gemini/__init__.py
+++ b/plugins/model-providers/gemini/__init__.py
@@ -33,10 +33,26 @@ class GeminiProfile(ProviderProfile):
         (#62259). Hit the native endpoint with query-param auth (the same auth
         the native inference client already uses) and strip the ``models/``
         prefix each entry's ``name`` carries so IDs match what inference expects.
+
+        Gemini's OpenAI-compatibility base URL (``.../openai``) *does* speak
+        Bearer + OpenAI-style ``data[].id``, so this native override is gated to
+        native endpoints only; the compat base URL delegates to the base
+        implementation.
         """
         effective_base = (base_url or self.base_url or "").rstrip("/")
         if not (effective_base and api_key):
             return None
+
+        # The OpenAI-compat endpoint speaks Bearer + data[].id — let the base
+        # ProviderProfile handle it rather than forcing native query-param auth.
+        from agent.transports.chat_completions import (
+            _is_gemini_openai_compat_base_url,
+        )
+
+        if _is_gemini_openai_compat_base_url(effective_base):
+            return super().fetch_models(
+                api_key=api_key, base_url=base_url, timeout=timeout
+            )
 
         import json
         import urllib.parse
@@ -60,7 +76,10 @@ class GeminiProfile(ProviderProfile):
             ]
             return ids or None
         except Exception as exc:
-            logger.debug("fetch_models(gemini): %s", exc)
+            # Never log the exception value: urllib errors embed the request
+            # URL, which carries the api_key in the ``?key=`` query param. Log
+            # the exception type only.
+            logger.debug("fetch_models(gemini) failed: %s", type(exc).__name__)
             return None
 
     def build_extra_body(self, *, session_id: str | None = None, **context: Any) -> dict[str, Any]:

--- a/tests/providers/test_fetch_models_base_url.py
+++ b/tests/providers/test_fetch_models_base_url.py
@@ -140,6 +140,36 @@ class _RedirectingHandler(BaseHTTPRequestHandler):
         pass
 
 
+class _NativeGeminiHandler(BaseHTTPRequestHandler):
+    """Mimics the native /v1beta endpoint: rejects Bearer, honours ?key=."""
+
+    def do_GET(self):
+        # Native Gemini API rejects Bearer auth (this is the #62259 bug).
+        if self.headers.get("Authorization"):
+            self.send_response(401)
+            self.end_headers()
+            return
+        from urllib.parse import urlparse, parse_qs
+        parsed = urlparse(self.path)
+        if parsed.path.rstrip("/") == "/models" and parse_qs(parsed.query).get("key"):
+            body = json.dumps({
+                "models": [
+                    {"name": "models/gemini-2.5-pro"},
+                    {"name": "models/gemini-3.5-flash"},
+                ]
+            }).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_response(401)
+            self.end_headers()
+
+    def log_message(self, format, *args):
+        pass
+
+
 class TestFetchModelsRedirectCredentialStripping:
     """Credential headers must not follow a redirect outside the original origin."""
 
@@ -190,6 +220,31 @@ class TestFetchModelsRedirectCredentialStripping:
         assert result == ["redirected-model"]
         assert headers.get("authorization") == "Bearer bearer-secret"
         assert headers.get("x-api-key") == "default-header-secret"
+
+
+class TestGeminiNativeFetchModels:
+    """GeminiProfile.fetch_models uses query-param auth against the native API (#62259)."""
+
+    def test_native_query_param_auth_strips_prefix(self):
+        server = HTTPServer(("127.0.0.1", 0), _NativeGeminiHandler)
+        port = server.server_address[1]
+        Thread(target=server.serve_forever, daemon=True).start()
+        try:
+            from plugins.model_providers.gemini import GeminiProfile
+            profile = GeminiProfile(name="gemini", base_url=f"http://127.0.0.1:{port}")
+            result = profile.fetch_models(api_key="test-key")
+            # models/ prefix stripped; Bearer path would have 401'd → None
+            assert result == ["gemini-2.5-pro", "gemini-3.5-flash"]
+        finally:
+            server.shutdown()
+
+    def test_no_api_key_returns_none(self):
+        from plugins.model_providers.gemini import GeminiProfile
+        profile = GeminiProfile(
+            name="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta",
+        )
+        assert profile.fetch_models(api_key="") is None
 
 
 class TestModelPickerBaseUrlIntegration:

--- a/tests/providers/test_fetch_models_base_url.py
+++ b/tests/providers/test_fetch_models_base_url.py
@@ -246,6 +246,39 @@ class TestGeminiNativeFetchModels:
         )
         assert profile.fetch_models(api_key="") is None
 
+    def test_openai_compat_base_url_delegates_to_base(self):
+        """The OpenAI-compat ``/openai`` base URL speaks Bearer + data[].id, so
+        the native override must delegate to ProviderProfile.fetch_models rather
+        than force native ``?key=`` auth (which the compat endpoint rejects)."""
+        from plugins.model_providers.gemini import GeminiProfile
+        profile = GeminiProfile(
+            name="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+        )
+        with patch(
+            "providers.base.ProviderProfile.fetch_models",
+            return_value=["gemini-compat-model"],
+        ) as base_fetch:
+            result = profile.fetch_models(api_key="test-key")
+        assert result == ["gemini-compat-model"]
+        base_fetch.assert_called_once()
+
+    def test_native_fetch_exception_does_not_log_key_bearing_url(self, caplog):
+        """urllib errors embed the request URL (which carries the ?key= api
+        key); the failure path must not log the exception value."""
+        import logging
+        from plugins.model_providers.gemini import GeminiProfile
+
+        profile = GeminiProfile(
+            name="gemini",
+            # Unroutable port → connection error carrying the URL in the exc.
+            base_url="http://127.0.0.1:1/v1beta",
+        )
+        with caplog.at_level(logging.DEBUG):
+            result = profile.fetch_models(api_key="super-secret-key")
+        assert result is None
+        assert "super-secret-key" not in caplog.text
+
 
 class TestModelPickerBaseUrlIntegration:
     """The /model picker path should pass model.base_url to fetch_models."""

--- a/tests/providers/test_fetch_models_base_url.py
+++ b/tests/providers/test_fetch_models_base_url.py
@@ -145,6 +145,36 @@ class _RedirectingHandler(BaseHTTPRequestHandler):
         pass
 
 
+class _NativeGeminiHandler(BaseHTTPRequestHandler):
+    """Mimics the native /v1beta endpoint: rejects Bearer, honours ?key=."""
+
+    def do_GET(self):
+        # Native Gemini API rejects Bearer auth (this is the #62259 bug).
+        if self.headers.get("Authorization"):
+            self.send_response(401)
+            self.end_headers()
+            return
+        from urllib.parse import urlparse, parse_qs
+        parsed = urlparse(self.path)
+        if parsed.path.rstrip("/") == "/models" and parse_qs(parsed.query).get("key"):
+            body = json.dumps({
+                "models": [
+                    {"name": "models/gemini-2.5-pro"},
+                    {"name": "models/gemini-3.5-flash"},
+                ]
+            }).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_response(401)
+            self.end_headers()
+
+    def log_message(self, format, *args):
+        pass
+
+
 class TestFetchModelsRedirectCredentialStripping:
     """Credential headers must not follow a redirect outside the original origin."""
 
@@ -187,6 +217,31 @@ class TestFetchModelsRedirectCredentialStripping:
         assert result == ["redirected-model"]
         assert headers.get("authorization") == "Bearer bearer-secret"
         assert headers.get("x-api-key") == "default-header-secret"
+
+
+class TestGeminiNativeFetchModels:
+    """GeminiProfile.fetch_models uses query-param auth against the native API (#62259)."""
+
+    def test_native_query_param_auth_strips_prefix(self):
+        server = HTTPServer(("127.0.0.1", 0), _NativeGeminiHandler)
+        port = server.server_address[1]
+        Thread(target=server.serve_forever, daemon=True).start()
+        try:
+            from plugins.model_providers.gemini import GeminiProfile
+            profile = GeminiProfile(name="gemini", base_url=f"http://127.0.0.1:{port}")
+            result = profile.fetch_models(api_key="test-key")
+            # models/ prefix stripped; Bearer path would have 401'd → None
+            assert result == ["gemini-2.5-pro", "gemini-3.5-flash"]
+        finally:
+            server.shutdown()
+
+    def test_no_api_key_returns_none(self):
+        from plugins.model_providers.gemini import GeminiProfile
+        profile = GeminiProfile(
+            name="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta",
+        )
+        assert profile.fetch_models(api_key="") is None
 
 
 class TestModelPickerBaseUrlIntegration:

--- a/tests/providers/test_fetch_models_base_url.py
+++ b/tests/providers/test_fetch_models_base_url.py
@@ -243,6 +243,39 @@ class TestGeminiNativeFetchModels:
         )
         assert profile.fetch_models(api_key="") is None
 
+    def test_openai_compat_base_url_delegates_to_base(self):
+        """The OpenAI-compat ``/openai`` base URL speaks Bearer + data[].id, so
+        the native override must delegate to ProviderProfile.fetch_models rather
+        than force native ``?key=`` auth (which the compat endpoint rejects)."""
+        from plugins.model_providers.gemini import GeminiProfile
+        profile = GeminiProfile(
+            name="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+        )
+        with patch(
+            "providers.base.ProviderProfile.fetch_models",
+            return_value=["gemini-compat-model"],
+        ) as base_fetch:
+            result = profile.fetch_models(api_key="test-key")
+        assert result == ["gemini-compat-model"]
+        base_fetch.assert_called_once()
+
+    def test_native_fetch_exception_does_not_log_key_bearing_url(self, caplog):
+        """urllib errors embed the request URL (which carries the ?key= api
+        key); the failure path must not log the exception value."""
+        import logging
+        from plugins.model_providers.gemini import GeminiProfile
+
+        profile = GeminiProfile(
+            name="gemini",
+            # Unroutable port → connection error carrying the URL in the exc.
+            base_url="http://127.0.0.1:1/v1beta",
+        )
+        with caplog.at_level(logging.DEBUG):
+            result = profile.fetch_models(api_key="super-secret-key")
+        assert result is None
+        assert "super-secret-key" not in caplog.text
+
 
 class TestModelPickerBaseUrlIntegration:
     """The /model picker path should pass model.base_url to fetch_models."""


### PR DESCRIPTION
## What does this PR do?

Fixes live model discovery for the **Gemini** provider. `hermes model` / the `/model` picker showed only the 4 hard-coded fallback models instead of the 50+ the Google API actually exposes.

`ProviderProfile.fetch_models()` hard-codes OpenAI-style auth: `Authorization: Bearer <key>` against `{base_url}/models`. Gemini's `base_url` is the **native** endpoint `https://generativelanguage.googleapis.com/v1beta`, which **rejects Bearer auth with HTTP 401** — it requires the key as a `?key=` query param. So the probe 401'd, `fetch_models()` returned `None`, and the picker silently fell back to the static list.

`GeminiProfile` now overrides `fetch_models()` to hit `{base_url}/models?key=<key>` — the same query-param auth the native inference client already uses — and strips the `models/` prefix each returned `name` carries, so live discovery matches what inference expects. This is Approach A from the issue (native endpoint), chosen because it reuses the native auth model already in place rather than adding a second endpoint path.

## Related Issue

Fixes #62259

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/model-providers/gemini/__init__.py` — add `GeminiProfile.fetch_models()` override: native `{base_url}/models?key=<key>` query-param auth, parse the `{"models": [{"name": "models/..."}]}` shape, strip the `models/` prefix. Returns `None` on no key / no base_url / any error so callers keep the static fallback.
- `tests/providers/test_fetch_models_base_url.py` — regression tests: a fake native handler that 401s on Bearer and honours `?key=`, asserting the prefix is stripped and IDs returned; plus a no-api-key → `None` case.

## How to Test

```
scripts/run_tests.sh tests/providers/test_fetch_models_base_url.py
```

Result: `8 tests passed, 0 failed` (2 new + 6 existing). The new `test_native_query_param_auth_strips_prefix` fails against the old code path (Bearer → 401 → `None`) and passes with the fix.

Real-endpoint proof from the issue:

```bash
# Old path — native endpoint + Bearer:
curl -s -o /dev/null -w "%{http_code}\n" \
  "https://generativelanguage.googleapis.com/v1beta/models" \
  -H "Authorization: Bearer $GOOGLE_API_KEY"     # -> 401

# New path — native endpoint + query-param auth:
curl -s "https://generativelanguage.googleapis.com/v1beta/models?key=$GOOGLE_API_KEY" | grep -c '"name"'   # -> 50
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (ran the affected suite via `scripts/run_tests.sh`)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behavior fix; docstring added on the override)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure stdlib `urllib`, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Credits

Root-cause analysis and the chosen Approach A (native `/v1beta` endpoint with `?key=` query-param auth) come from @Olegever's report in #62259.
