### PR TITLE
fix(cli): coalesce None title/model in single-session HTML export

### DIFF
--- a/hermes_cli/session_export_html.py
+++ b/hermes_cli/session_export_html.py
@@ -811,7 +811,7 @@ def generate_multi_session_html_export(sessions: List[Dict[str, Any]]) -> str:
         sid = str(s.get("id", "N/A"))
         escaped_sid = _escape_html(sid)
         title = s.get("title") or "Hermes Session"
-        model = s.get("model", "Unknown")
+        model = s.get("model") or "Unknown"
         started_at = _format_timestamp(s.get("started_at", 0))
         messages = s.get("messages", [])
         
@@ -857,7 +857,7 @@ def generate_multi_session_html_export(sessions: List[Dict[str, Any]]) -> str:
 
     script_nonce = secrets.token_urlsafe(16)
     return HTML_TEMPLATE.format(
-        page_title="Hermes Session Export" if is_multi else _escape_html(sessions[0].get("title", "Hermes Session")),
+        page_title="Hermes Session Export" if is_multi else _escape_html(sessions[0].get("title") or "Hermes Session"),
         sidebar_html=sidebar_html,
         sessions_html="\n".join(sessions_html_list),
         main_margin="var(--sidebar-width)" if is_multi else "0",

--- a/tests/hermes_cli/test_session_export_html.py
+++ b/tests/hermes_cli/test_session_export_html.py
@@ -2,6 +2,7 @@
 
 from hermes_cli.session_export_html import (
     _generate_messages_html,
+    generate_html_export,
     generate_multi_session_html_export,
 )
 
@@ -58,3 +59,20 @@ def test_multi_session_export_keeps_switcher_script():
     assert "function showSession" in html
     assert 'data-id="aaaa1111"' in html
     assert 'id="view-bbbb2222"' in html
+
+
+def test_single_session_untitled_coalesces_none_title_and_model():
+    """An un-named session (title/model still ``None`` until async title
+    generation completes) is the default state, so the single-session export
+    must fall back to human-readable defaults for the browser-tab ``<title>``
+    and the ``Model:`` meta line — matching the on-page ``<h1>`` — instead of
+    leaking the literal string ``None``."""
+    session = {"id": "abc", "title": None, "model": None, "messages": []}
+    html = generate_html_export(session)
+
+    # Browser-tab title falls back to the same default as the <h1> header.
+    assert "<title>Hermes Session</title>" in html
+    assert "<title>None</title>" not in html
+    # Model meta falls back instead of rendering the literal "None".
+    assert "<strong>Model:</strong> Unknown" in html
+    assert "<strong>Model:</strong> None" not in html


### PR DESCRIPTION
## What does this PR do?

Single-session HTML exports of an un-named session render `<title>None</title>` in the browser tab and `Model: None` in the header meta.

An untitled session (`title` is `None`) is the **default state until async title generation completes**, so this is the common case for a freshly-exported session, not a rare edge case. The tab title and the on-page `<h1>` disagree for the very same session: the `<h1>` shows "Hermes Session" while the tab shows "None".

Root cause: in `generate_multi_session_html_export`, the browser-tab `page_title` and the `Model:` meta line use `dict.get(key, default)`, whose default only fires when the key is **absent** — not when it is present with value `None`. `_escape_html(None)` then stringifies to the literal `"None"`. The `<h1>` in the same function already uses the None-safe `... or "Hermes Session"` idiom, so the two were inconsistent.

The fix uses `... or "<default>"` at both sites so the tab title and model meta fall back consistently with the header.

## Related Issue

<!-- No filed issue; author-found inconsistency in the HTML export renderer. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/session_export_html.py`:
  - `model = s.get("model", "Unknown")` → `model = s.get("model") or "Unknown"` (Model meta no longer leaks "None").
  - single-session `page_title` `sessions[0].get("title", "Hermes Session")` → `sessions[0].get("title") or "Hermes Session"` (tab title no longer leaks "None").
- `tests/hermes_cli/test_session_export_html.py`: regression test for an untitled single session.

## How to Test

1. Export a single session whose title/model have not yet been populated (i.e. `{"id": "abc", "title": None, "model": None, "messages": []}`).
2. Before this change the rendered HTML contains `<title>None</title>` and `<strong>Model:</strong> None`.
3. After this change it contains `<title>Hermes Session</title>` and `<strong>Model:</strong> Unknown`, matching the on-page `<h1>`.

Automated: `pytest tests/hermes_cli/test_session_export_html.py -q` — the new `test_single_session_untitled_coalesces_none_title_and_model` fails before the fix and passes after.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A