### PR TITLE
fix(dashboard): add secure=True to clear_session_cookies for __Host- cookie deletion

### DIFF
--- a/hermes_cli/dashboard_auth/cookies.py
+++ b/hermes_cli/dashboard_auth/cookies.py
@@ -196,11 +196,11 @@ def clear_session_cookies(response: Response, *, prefix: str = "") -> None:
     for variant in _NAME_VARIANTS:
         response.set_cookie(
             f"{variant}{SESSION_AT_COOKIE}", "", max_age=0,
-            path=path, httponly=True, samesite="lax",
+            path=path, httponly=True, samesite="lax", secure=True,
         )
         response.set_cookie(
             f"{variant}{SESSION_RT_COOKIE}", "", max_age=0,
-            path=path, httponly=True, samesite="lax",
+            path=path, httponly=True, samesite="lax", secure=True,
         )
 
 


### PR DESCRIPTION
## What

Add `secure=True` to both `response.set_cookie()` calls in
`clear_session_cookies()` (`hermes_cli/dashboard_auth/cookies.py`,
lines 199 and 204).

## Why

The `__Host-` cookie prefix (RFC 6265bis §8.5) requires browsers to
match ALL attributes exactly for deletion. `clear_session_cookies()`
sets cookie attributes manually — it does NOT use `_common_attrs()`
(which already sets `secure=True` at line 140). Without
`secure=True`, browsers silently ignore the deletion `Set-Cookie`:
the session cookie survives logout.

This is a sibling-call-path bug: the setter (`_common_attrs`) and
deleter (`clear_session_cookies`) are asymmetric. The fix makes
both sides emit `secure=True`.

## How to reproduce (on current main)

`hermes serve` with HTTPS behind a reverse proxy:
1. Open dashboard → login (basic auth)
2. Logout → login form appears
3. Close browser tab → reopen → dashboard loads WITHOUT login form
   (session cookie not deleted — `__Host-` attribute mismatch)

After fix: step 3 shows login form — cookie properly deleted.

## How to test

```bash
python -m py_compile hermes_cli/dashboard_auth/cookies.py
```

Manual E2E: login → logout → close tab → reopen → login form
(not auto-authenticated).

## Platforms tested

- Linux, Python 3.11, Firefox + Chromium
- Reverse proxy: Angie (TLS termination) → hermes serve :9119