### PR TITLE
fix(tools): inject items into array schemas that lack it

### DIFF
--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -260,6 +260,35 @@ def test_items_sanitized_in_array_schema():
     assert items == {"type": "object", "properties": {}}
 
 
+def test_array_without_items_gets_string_items():
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "layover_at": {
+                "type": "array",  # no items — rejected by OpenAI strict validation
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    prop = out[0]["function"]["parameters"]["properties"]["layover_at"]
+    assert prop["items"] == {"type": "string"}
+
+
+def test_array_with_items_keeps_existing_items():
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "codes": {
+                "type": "array",
+                "items": {"type": "integer"},
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    prop = out[0]["function"]["parameters"]["properties"]["codes"]
+    assert prop["items"] == {"type": "integer"}
+
+
 def test_ref_with_default_sibling_stripped():
     """Strict backends reject ``default`` alongside ``$ref``."""
     tools = [_tool("t", {

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -234,6 +234,8 @@ def _sanitize_node(node: Any, path: str) -> Any:
     - Replaces bare-string schema values ("object", "string", ...) with
       ``{"type": <value>}`` so downstream consumers see a dict.
     - Injects ``properties: {}`` into object-typed nodes missing it.
+    - Injects ``items: {type: string}`` into array-typed nodes missing it
+      (required by OpenAI strict schema validation).
     - Normalizes ``type: [X, "null"]`` arrays to single ``type: X`` (keeping
       ``nullable: true`` as a hint), and multi-type arrays like
       ``["number", "string"]`` to an ``anyOf`` of single-type schemas so no
@@ -339,6 +341,12 @@ def _sanitize_node(node: Any, path: str) -> Any:
     # llama.cpp's grammar generator can't constrain a free-form object.
     if out.get("type") == "object" and not isinstance(out.get("properties"), dict):
         out["properties"] = {}
+
+    # Array nodes without items: inject a permissive string items schema.
+    # OpenAI strict schema validation (and some other backends) reject arrays
+    # that have no ``items`` definition (e.g. layover_at in trvl tools).
+    if out.get("type") == "array" and "items" not in out:
+        out["items"] = {"type": "string"}
 
     # Prune ``required`` entries that don't exist in properties (defense
     # against malformed MCP schemas; also caught upstream for MCP tools, but


### PR DESCRIPTION
## Problem

OpenAI strict schema validation (and some other backends) reject tool schemas where an array-typed node has no `items` definition. MCP tools that declare a bare `{"type": "array"}` parameter (e.g. `layover_at` in a travel MCP server) become unusable on those backends — every call fails schema validation.

## Fix

In `_sanitize_node`, inject a permissive `items: {type: string}` into array-typed nodes missing it, mirroring the existing treatment of `object` nodes without `properties`. Existing `items` definitions are untouched.

## Testing

- Added `test_array_without_items_gets_string_items` and `test_array_with_items_keeps_existing_items`
- Full suite: `pytest tests/tools/test_schema_sanitizer.py` — 49 passed
- Field-tested: running this patch locally against an MCP server with bare array params on the openai-codex provider; tools work where they previously 400'd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NnK5SU2SvDoic1h7NWSDL