### PR TITLE
fix(gateway): bound final shutdown cleanup

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -952,6 +952,10 @@ class GatewayConfig:
     # tooling and downgrade safety; set gateway.write_sessions_json: false in
     # config.yaml to stop producing the file.
     write_sessions_json: bool = True
+
+    # Bound best-effort synchronous cleanup after messaging adapters are down.
+    # Zero preserves the legacy inline, unbounded behavior.
+    shutdown_cleanup_timeout: float = 5.0
     
     # Delivery settings
     always_log_local: bool = True  # Always save cron outputs to local files
@@ -1139,6 +1143,7 @@ class GatewayConfig:
             "quick_commands": self.quick_commands,
             "sessions_dir": str(self.sessions_dir),
             "write_sessions_json": self.write_sessions_json,
+            "shutdown_cleanup_timeout": self.shutdown_cleanup_timeout,
             "always_log_local": self.always_log_local,
             "filter_silence_narration": self.filter_silence_narration,
             "stt_enabled": self.stt_enabled,
@@ -1294,6 +1299,16 @@ class GatewayConfig:
             max_concurrent_raw,
             max_concurrent_key,
         )
+        if "shutdown_cleanup_timeout" in data:
+            shutdown_cleanup_timeout_raw = data.get("shutdown_cleanup_timeout")
+        else:
+            shutdown_cleanup_timeout_raw = nested_gateway.get(
+                "shutdown_cleanup_timeout"
+            )
+        shutdown_cleanup_timeout = max(
+            0.0,
+            _coerce_float(shutdown_cleanup_timeout_raw, 5.0),
+        )
         unauthorized_dm_behavior = _normalize_unauthorized_dm_behavior(
             data.get("unauthorized_dm_behavior"),
             "pair",
@@ -1318,6 +1333,7 @@ class GatewayConfig:
             quick_commands=quick_commands,
             sessions_dir=sessions_dir,
             write_sessions_json=_coerce_bool(data.get("write_sessions_json"), True),
+            shutdown_cleanup_timeout=shutdown_cleanup_timeout,
             always_log_local=_coerce_bool(data.get("always_log_local"), True),
             filter_silence_narration=_coerce_bool(
                 data.get("filter_silence_narration"), True
@@ -1504,6 +1520,10 @@ def load_gateway_config() -> GatewayConfig:
                 if "systemd_watchdog_seconds" in gateway_section:
                     gw_data["systemd_watchdog_seconds"] = gateway_section[
                         "systemd_watchdog_seconds"
+                    ]
+                if "shutdown_cleanup_timeout" in gateway_section:
+                    gw_data["shutdown_cleanup_timeout"] = gateway_section[
+                        "shutdown_cleanup_timeout"
                     ]
 
             if "max_concurrent_sessions" in yaml_cfg:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -94,6 +94,7 @@ _TELEGRAM_CONNECT_TIMEOUT_SECS_DEFAULT = 180.0
 # 180s budget (is_reconnect=True preserves the offline update queue, #46621).
 _TELEGRAM_INITIAL_CONNECT_TIMEOUT_SECS_DEFAULT = 45.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
+_SHUTDOWN_CLEANUP_TIMEOUT_SECS_DEFAULT = 5.0
 # End reasons that mean the USER deliberately closed this thread of work
 # (/new -> session_reset / new_session, an explicit exit, or a /switch).
 # Shared by _classify_completion_target (pre-flight verdict) and
@@ -7666,6 +7667,79 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return max(0.0, timeout)
         return _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT
 
+    def _shutdown_cleanup_timeout_secs(self) -> float:
+        """Return the per-step timeout for late shutdown cleanup hooks."""
+        raw = getattr(
+            getattr(self, "config", None),
+            "shutdown_cleanup_timeout",
+            _SHUTDOWN_CLEANUP_TIMEOUT_SECS_DEFAULT,
+        )
+        try:
+            return max(0.0, float(raw))
+        except (TypeError, ValueError):
+            return _SHUTDOWN_CLEANUP_TIMEOUT_SECS_DEFAULT
+
+    async def _run_bounded_shutdown_step(
+        self,
+        label: str,
+        func: Callable[[], Any],
+        *,
+        timeout: Optional[float] = None,
+    ) -> str:
+        """Run a synchronous late-shutdown step without letting it wedge exit.
+
+        This is for best-effort cleanup after adapters are already down. The
+        worker is daemonized so a timed-out cleanup cannot keep the Python
+        process alive after the gateway has decided to exit.
+        """
+        timeout = self._shutdown_cleanup_timeout_secs() if timeout is None else timeout
+        if timeout <= 0:
+            try:
+                func()
+            except BaseException as exc:  # noqa: BLE001 - shutdown cleanup is best-effort
+                logger.debug("Shutdown phase %s failed: %s", label, exc)
+                return "failed"
+            return "done"
+
+        loop = asyncio.get_running_loop()
+        fut: concurrent.futures.Future = concurrent.futures.Future()
+
+        def _runner() -> None:
+            try:
+                result = func()
+            except BaseException as exc:  # noqa: BLE001 - report best-effort failures
+                fut.set_exception(exc)
+            else:
+                fut.set_result(result)
+
+        thread = threading.Thread(
+            target=_runner,
+            name=f"hermes-shutdown-{label}",
+            daemon=True,
+        )
+        thread.start()
+
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(asyncio.wrap_future(fut, loop=loop)),
+                timeout,
+            )
+            return "done"
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Shutdown phase %s exceeded %.2fs; continuing shutdown so the "
+                "gateway process can exit. The daemon cleanup thread may still "
+                "finish in the background. (#58666)",
+                label,
+                timeout,
+            )
+            return "timed out"
+        except asyncio.CancelledError:
+            raise
+        except BaseException as exc:  # noqa: BLE001 - contain worker failures during shutdown
+            logger.debug("Shutdown phase %s failed: %s", label, exc)
+            return "failed"
+
     def _platform_connect_timeout_secs(self, platform=None, *, initial: bool = False) -> float:
         """Return the per-platform connect timeout used during startup/retry.
 
@@ -15183,9 +15257,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # where drain succeeded without interrupt, and (b) anything
             # that got respawned between the earlier call and adapter
             # disconnect (defense in depth; safe to call repeatedly).
-            _kill_tool_subprocesses("final-cleanup")
+            final_cleanup_status = await GatewayRunner._run_bounded_shutdown_step(
+                self,
+                "final-cleanup",
+                lambda: _kill_tool_subprocesses("final-cleanup"),
+                timeout=GatewayRunner._shutdown_cleanup_timeout_secs(self),
+            )
             logger.info(
-                "Shutdown phase: final-cleanup tool kill done at +%.2fs",
+                "Shutdown phase: final-cleanup tool kill %s at +%.2fs",
+                final_cleanup_status,
                 _phase_elapsed(),
             )
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2929,6 +2929,11 @@ DEFAULT_CONFIG = {
         "loop_watchdog_probe_timeout_s": 10.0,
         "loop_watchdog_max_strikes": 3,
 
+        # Seconds allowed for each best-effort synchronous cleanup step after
+        # messaging adapters are down. ``0`` runs cleanup inline without a
+        # deadline; positive values continue shutdown when the deadline expires.
+        "shutdown_cleanup_timeout": 5,
+
         # Whether the gateway keeps writing the legacy sessions.json mirror of
         # its routing index. The primary copy lives in state.db (the
         # gateway_routing table). Default True for backward compatibility with

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -240,6 +240,24 @@ class TestGatewayConfigRoundtrip:
             for record in caplog.records
         )
 
+    def test_shutdown_cleanup_timeout_roundtrips_and_accepts_nested_config(self):
+        config = GatewayConfig.from_dict(
+            {"gateway": {"shutdown_cleanup_timeout": "0.25"}}
+        )
+
+        assert config.shutdown_cleanup_timeout == 0.25
+        assert (
+            GatewayConfig.from_dict(config.to_dict()).shutdown_cleanup_timeout == 0.25
+        )
+
+    def test_shutdown_cleanup_timeout_defaults_and_clamps_negative_values(self):
+        assert GatewayConfig.from_dict({}).shutdown_cleanup_timeout == 5.0
+        assert (
+            GatewayConfig.from_dict({"shutdown_cleanup_timeout": -1})
+            .shutdown_cleanup_timeout
+            == 0.0
+        )
+
 
     def test_roundtrip_preserves_unauthorized_dm_behavior(self):
         config = GatewayConfig(
@@ -409,12 +427,30 @@ class TestLoadGatewayConfig:
             "    - guest\n",
             encoding="utf-8",
         )
+
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
         config = load_gateway_config()
 
         assert config.multiplex_profiles is True
         assert config.multiplex_profile_allowlist == ["worker", "guest"]
+
+    def test_loads_nested_shutdown_cleanup_timeout_from_config_yaml(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n"
+            "  shutdown_cleanup_timeout: 0.25\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.shutdown_cleanup_timeout == 0.25
 
     def test_discord_websocket_health_settings_seed_platform_extra(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -1,5 +1,6 @@
 import asyncio
 import subprocess
+import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -166,6 +167,65 @@ async def test_planned_service_exit_issues_no_restart_of_its_own(monkeypatch):
         await runner.stop()
 
     assert runner._exit_code == GATEWAY_SERVICE_RESTART_EXIT_CODE
+
+
+@pytest.mark.asyncio
+async def test_gateway_stop_bounds_wedged_final_cleanup(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    """A wedged late cleanup must not keep launchd/service restarts alive."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    runner, adapter = make_restart_runner()
+    runner.config.shutdown_cleanup_timeout = 0.01
+    adapter.disconnect = AsyncMock()
+    entered_cleanup = threading.Event()
+    release_cleanup = threading.Event()
+
+    def _wedged_kill_all(task_id=None):
+        entered_cleanup.set()
+        release_cleanup.wait(timeout=5)
+        return 0
+
+    import tools.process_registry as _pr
+
+    monkeypatch.setattr(_pr.process_registry, "kill_all", _wedged_kill_all)
+
+    try:
+        with (
+            caplog.at_level("WARNING", logger="gateway.run"),
+            patch("gateway.status.remove_pid_file"),
+            patch("gateway.status.write_runtime_status"),
+        ):
+            await asyncio.wait_for(
+                runner.stop(restart=True, service_restart=True),
+                timeout=1,
+            )
+    finally:
+        release_cleanup.set()
+
+    assert entered_cleanup.is_set()
+    adapter.disconnect.assert_awaited_once()
+    assert runner._shutdown_event.is_set() is True
+    assert runner._exit_code == GATEWAY_SERVICE_RESTART_EXIT_CODE
+    assert "Shutdown phase final-cleanup exceeded 0.01s" in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("timeout", "failure"),
+    [(0.0, RuntimeError("inline failure")), (1.0, SystemExit("worker failure"))],
+)
+async def test_bounded_shutdown_step_reports_cleanup_failure(timeout, failure):
+    runner, _adapter = make_restart_runner()
+
+    def _fail():
+        raise failure
+
+    status = await runner._run_bounded_shutdown_step("failing-cleanup", _fail, timeout=timeout)
+
+    assert status == "failed"
 
 
 @pytest.mark.asyncio
@@ -343,5 +403,3 @@ def test_pid_exists_zombie_via_psutil_returns_false(monkeypatch):
     monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
 
     assert status._pid_exists(4242) is False
-
-


### PR DESCRIPTION
## Summary

Fixes #58666.

When `/restart` is requested under a service manager, the gateway sets `_shutdown_event` after adapter teardown but then runs final tool/environment cleanup inline on the event loop. If that best-effort cleanup wedges, the loop never returns to the main gateway task, so housekeeping never stops and launchd/systemd never observes process exit.

This adds a bounded late-shutdown helper for the post-adapter `final-cleanup` phase:

- runs synchronous cleanup in a daemon worker so a wedged hook cannot keep the process alive
- reads the deadline from `gateway.shutdown_cleanup_timeout` in `config.yaml` (default 5s)
- reports `done`, `timed out`, and `failed` distinctly instead of logging exceptions as successful cleanup
- contains `SystemExit`/`KeyboardInterrupt` raised by the cleanup worker while preserving cancellation of the shutdown task itself
- logs and continues shutdown when cleanup exceeds the deadline
- preserves legacy inline behavior when the setting is `0`

The regression injects a generic post-disconnect final-cleanup wedge. It proves `stop(restart=True, service_restart=True)` still completes and preserves the service-restart exit code without claiming an unproven `channel_overrides` trigger. Additional coverage proves inline exceptions and worker `SystemExit` are reported as failed cleanup.

This supersedes closed #61011. That version used a new non-secret `HERMES_*` environment variable; this rescope follows the maintainer review by making the timeout a typed `gateway.*` configuration value with YAML loading and serialization coverage.

## Duplicate / overlap check

- inspected the current issue timeline and all publish-gate matches
- `channel_overrides` matches concern model/routing behavior, launchd matches concern service management, and MCP shutdown matches bound an earlier subsystem
- none bounds this generic post-adapter final-cleanup phase

## Verification

- rebased onto exact current `main` `8b09a9df8476010a78e86d6c32254b4ac14a8c4f`
- 77 focused gateway shutdown and config tests passed
- Ruff, lock validation, `git diff --check`, public identity/privacy checks, gitleaks, and the existing-PR review-follow-up gate passed

Current head: `5fb82eb188439957f7e04842c45a6424ad5c8046`
