### PR TITLE
feat(cli): show provider name in status bar for fallback visibility

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5144,9 +5144,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             yolo_active = self._is_session_yolo_active()
 
             if width < 52:
+                _f_p = snapshot.get("provider", "")
+                _f_ml = snapshot["model_short"] + (" (" + _f_p + ")" if _f_p else "")
                 frags = [
                     ("class:status-bar", " ⚕ "),
-                    ("class:status-bar-strong", snapshot["model_short"]),
+                    ("class:status-bar-strong", _f_ml),
                     ("class:status-bar-dim", " · "),
                     ("class:status-bar-dim", duration_label),
                 ]
@@ -5162,9 +5164,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     bg_count = snapshot.get("active_background_tasks", 0)
                     bg_proc_count = snapshot.get("active_background_processes", 0)
                     bg_subagent_count = snapshot.get("active_background_subagents", 0)
+                    _f_p2 = snapshot.get("provider", "")
+                    _f_ml2 = snapshot["model_short"] + (" (" + _f_p2 + ")" if _f_p2 else "")
                     frags = [
                         ("class:status-bar", " ⚕ "),
-                        ("class:status-bar-strong", snapshot["model_short"]),
+                        ("class:status-bar-strong", _f_ml2),
                         ("class:status-bar-dim", " · "),
                         (self._status_bar_context_style(percent), percent_label),
                     ]

--- a/cli.py
+++ b/cli.py
@@ -4563,6 +4563,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         snapshot = {
             "model_name": model_name,
             "model_short": model_short,
+            "provider": getattr(self, "provider", ""),
             "duration": format_duration_compact(elapsed_seconds),
             "prompt_elapsed": self._format_prompt_elapsed(
                 getattr(self, "_prompt_start_time", None),
@@ -5066,12 +5067,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
             yolo_active = self._is_session_yolo_active()
             if width < 52:
-                text = f"⚕ {snapshot['model_short']} · {duration_label}"
+                _sb_p = snapshot.get("provider", "")
+                _sb_ml = snapshot["model_short"] + (" (" + _sb_p + ")" if _sb_p else "")
+                text = "⚕ " + _sb_ml + " · " + duration_label
                 if yolo_active:
                     text += " · ⚠ YOLO"
                 return self._trim_status_bar_text(text, width)
             if width < 76:
-                parts = [f"⚕ {snapshot['model_short']}", percent_label]
+                _sb_p2 = snapshot.get("provider", "")
+                _sb_ml2 = snapshot["model_short"] + (" (" + _sb_p2 + ")" if _sb_p2 else "")
+                parts = ["⚕ " + _sb_ml2, percent_label]
                 compressions = snapshot.get("compressions", 0)
                 if compressions:
                     parts.append(f"🗜️ {compressions}")
@@ -5097,7 +5102,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 context_label = "ctx --"
 
             compressions = snapshot.get("compressions", 0)
-            parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            _sb_p3 = snapshot.get("provider", "")
+            _sb_ml3 = snapshot["model_short"] + (" (" + _sb_p3 + ")" if _sb_p3 else "")
+            parts = ["⚕ " + _sb_ml3, context_label, percent_label]
             if compressions:
                 parts.append(f"🗜️ {compressions}")
             bg_count = snapshot.get("active_background_tasks", 0)

--- a/cli.py
+++ b/cli.py
@@ -5205,9 +5205,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     bg_count = snapshot.get("active_background_tasks", 0)
                     bg_proc_count = snapshot.get("active_background_processes", 0)
                     bg_subagent_count = snapshot.get("active_background_subagents", 0)
+                    _f_p3 = snapshot.get("provider", "")
+                    _f_ml3 = snapshot["model_short"] + (" (" + _f_p3 + ")" if _f_p3 else "")
                     frags = [
                         ("class:status-bar", " ⚕ "),
-                        ("class:status-bar-strong", snapshot["model_short"]),
+                        ("class:status-bar-strong", _f_ml3),
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", context_label),
                         ("class:status-bar-dim", " │ "),

--- a/cli.py
+++ b/cli.py
@@ -4563,7 +4563,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         snapshot = {
             "model_name": model_name,
             "model_short": model_short,
-            "provider": getattr(self, "provider", ""),
+            # Prefer agent.provider — it updates on fallback.
+            # self.provider reflects the originally configured provider and never
+            # changes mid-session.
+            "provider": getattr(agent, "provider", None) or getattr(self, "provider", ""),
             "duration": format_duration_compact(elapsed_seconds),
             "prompt_elapsed": self._format_prompt_elapsed(
                 getattr(self, "_prompt_start_time", None),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11760,6 +11760,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
+                    provider=agent_result.get("provider"),
                 )
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -94,6 +94,7 @@ def format_runtime_footer(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    provider: Optional[str] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
@@ -107,6 +108,9 @@ def format_runtime_footer(
             m = _model_short(model)
             if m:
                 parts.append(m)
+        elif field == "provider":
+            if provider:
+                parts.append(f"({provider})")
         elif field == "context_pct":
             if context_length and context_length > 0 and context_tokens >= 0:
                 pct = max(0, min(100, round((context_tokens / context_length) * 100)))
@@ -130,6 +134,7 @@ def build_footer_line(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    provider: Optional[str] = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
@@ -145,5 +150,6 @@ def build_footer_line(
         context_tokens=context_tokens,
         context_length=context_length,
         cwd=cwd,
+        provider=provider,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
     )

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import os
 from typing import Any, Iterable, Optional
 
-_DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
+_DEFAULT_FIELDS: tuple[str, ...] = ("model", "provider", "context_pct", "cwd")
 _SEP = " · "
 
 


### PR DESCRIPTION
## Problem

When all fallback providers use the same model name, the CLI status bar showed only the model name — making it impossible to tell which provider is actually serving requests or when a fallback occurred.

## Solution

Add the active provider name in parentheses to the CLI status bar in all three width layouts:

**Before:** `⚕ ModelName · 71/131K · 54% · 0:15`
**After:** `⚕ ModelName (provider) · 71/131K · 54% · 0:15`

### Changes

- `cli.py` — Added `"provider"` key to the status bar snapshot dict and updated all rendering paths:
  - `_build_status_bar_text()` — 3 width branches (console fallback)
  - `_get_status_bar_fragments()` — 3 width branches (actual TUI path)
- `gateway/runtime_footer.py` — Added `"provider"` to the default fields tuple so the gateway footer (Telegram, Discord, etc.) also shows the provider

### Behavior

- Provider is shown as `(provider-name)` after the model
- If provider is empty/unknown, nothing extra is shown (backward compatible)
- Works across all terminal widths (< 52, < 76, full)