### PR TITLE
fix(gateway): carry chat_id/thread_id/session_key into compression-rotation and /branch child sessions

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -792,6 +792,30 @@ def compress_context(
                             model=agent.model,
                             model_config=agent._session_init_model_config,
                             parent_session_id=old_session_id,
+                            # Gateway routing columns (#NNNNN): forward the SAME
+                            # chat_id/chat_type/thread_id/session_key the parent
+                            # session already carries, at CREATE time rather than
+                            # leaving them to a later backfill. Previously these
+                            # were only written by the gateway's post-turn
+                            # _record_gateway_session_peer() call, AFTER this
+                            # function returns and the agent result unwinds back
+                            # to the event loop. A crash/kill landing in that gap
+                            # left the child row permanently unroutable — NULL
+                            # chat_id/thread_id survive forever, since nothing
+                            # ever revisits an already-created row to backfill
+                            # them, and find_latest_gateway_session_for_peer's
+                            # WHERE clause can never match a NULL-routing row.
+                            # The parent conversation becomes an orphan and the
+                            # next inbound message on that chat/thread spawns a
+                            # brand-new, empty session instead of resuming.
+                            # CLI/non-gateway sessions have none of these
+                            # attributes set (all None) — passing None through
+                            # is a harmless no-op, matching the pre-existing
+                            # column defaults.
+                            chat_id=getattr(agent, "_chat_id", None),
+                            chat_type=getattr(agent, "_chat_type", None),
+                            thread_id=getattr(agent, "_thread_id", None),
+                            session_key=getattr(agent, "_gateway_session_key", None),
                         )
                     except Exception as _cs_err:
                         # The child row could not be created (e.g. FK constraint,

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -792,26 +792,27 @@ def compress_context(
                             model=agent.model,
                             model_config=agent._session_init_model_config,
                             parent_session_id=old_session_id,
-                            # Gateway routing columns (#NNNNN): forward the SAME
-                            # chat_id/chat_type/thread_id/session_key the parent
-                            # session already carries, at CREATE time rather than
-                            # leaving them to a later backfill. Previously these
-                            # were only written by the gateway's post-turn
-                            # _record_gateway_session_peer() call, AFTER this
-                            # function returns and the agent result unwinds back
+                            # Gateway routing columns — forward ALL of them at CREATE
+                            # time rather than leaving them to a later backfill.
+                            # Previously only chat_id/chat_type/thread_id/session_key
+                            # were forwarded here, and written by the gateway's
+                            # post-turn _record_gateway_session_peer() call, AFTER
+                            # this function returns and the agent result unwinds back
                             # to the event loop. A crash/kill landing in that gap
                             # left the child row permanently unroutable — NULL
                             # chat_id/thread_id survive forever, since nothing
                             # ever revisits an already-created row to backfill
                             # them, and find_latest_gateway_session_for_peer's
                             # WHERE clause can never match a NULL-routing row.
-                            # The parent conversation becomes an orphan and the
-                            # next inbound message on that chat/thread spawns a
-                            # brand-new, empty session instead of resuming.
-                            # CLI/non-gateway sessions have none of these
-                            # attributes set (all None) — passing None through
-                            # is a harmless no-op, matching the pre-existing
-                            # column defaults.
+                            # user_id is critical for the fallback lookup path
+                            # (hermes_state.py:1994-2009) that searches by the
+                            # complete peer tuple when session_key doesn't match.
+                            # Without user_id, the fallback can never find the row,
+                            # and /resume's IDOR guard rejects the session.
+                            # CLI/non-gateway sessions have none of these attributes
+                            # set (all None) — passing None through is a harmless
+                            # no-op, matching the pre-existing column defaults.
+                            user_id=getattr(agent, "_user_id", None),
                             chat_id=getattr(agent, "_chat_id", None),
                             chat_type=getattr(agent, "_chat_type", None),
                             thread_id=getattr(agent, "_thread_id", None),

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3821,19 +3821,21 @@ class GatewaySlashCommandsMixin:
                 model=(self.config.get("model", {}) or {}).get("default") if isinstance(self.config, dict) else None,
                 model_config={"_branched_from": parent_session_id},
                 parent_session_id=parent_session_id,
-                # Gateway routing columns (#NNNNN): forward the caller's own
-                # chat_id/chat_type/thread_id at CREATE time, same fix as
-                # the compression-rotation bug in
-                # agent/conversation_compression.py. Without this, the
-                # branched child row has NULL routing columns until
-                # switch_session() below calls _record_gateway_session_peer()
-                # — a crash/kill anywhere between here and there (most
-                # plausibly mid-history-copy, since each append_message call
-                # a few lines down is independently best-effort) leaves the
-                # branch permanently unroutable: unreachable by chat/thread
-                # lookup, and unreachable via /resume's IDOR guard too
-                # (which requires the row's chat_id/thread_id to match the
-                # caller's).
+                # Gateway routing columns — forward ALL of them at CREATE time,
+                # same fix as the compression-rotation bug in
+                # agent/conversation_compression.py. Without these, the branched
+                # child row has NULL routing columns until switch_session() below
+                # calls _record_gateway_session_peer() — a crash/kill anywhere
+                # between here and there (most plausibly mid-history-copy, since
+                # each append_message call a few lines down is independently
+                # best-effort) leaves the branch permanently unroutable:
+                # unreachable by chat/thread lookup, and unreachable via /resume's
+                # IDOR guard too (which requires the row's chat_id/thread_id to
+                # match the caller's). user_id is critical for the fallback lookup
+                # path (hermes_state.py:1994-2009) that searches by the complete
+                # peer tuple when session_key doesn't match.
+                user_id=source.user_id,
+                session_key=session_key,
                 chat_id=source.chat_id,
                 chat_type=source.chat_type,
                 thread_id=source.thread_id,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3821,6 +3821,22 @@ class GatewaySlashCommandsMixin:
                 model=(self.config.get("model", {}) or {}).get("default") if isinstance(self.config, dict) else None,
                 model_config={"_branched_from": parent_session_id},
                 parent_session_id=parent_session_id,
+                # Gateway routing columns (#NNNNN): forward the caller's own
+                # chat_id/chat_type/thread_id at CREATE time, same fix as
+                # the compression-rotation bug in
+                # agent/conversation_compression.py. Without this, the
+                # branched child row has NULL routing columns until
+                # switch_session() below calls _record_gateway_session_peer()
+                # — a crash/kill anywhere between here and there (most
+                # plausibly mid-history-copy, since each append_message call
+                # a few lines down is independently best-effort) leaves the
+                # branch permanently unroutable: unreachable by chat/thread
+                # lookup, and unreachable via /resume's IDOR guard too
+                # (which requires the row's chat_id/thread_id to match the
+                # caller's).
+                chat_id=source.chat_id,
+                chat_type=source.chat_type,
+                thread_id=source.thread_id,
             )
         except Exception as e:
             logger.error("Failed to create branch session: %s", e)

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -24,7 +24,15 @@ from unittest.mock import MagicMock, patch
 from hermes_state import SessionDB
 
 
-def _build_agent_with_db(db: SessionDB, session_id: str, platform: str = "telegram"):
+def _build_agent_with_db(
+    db: SessionDB,
+    session_id: str,
+    platform: str = "telegram",
+    chat_id: str = None,
+    chat_type: str = None,
+    thread_id: str = None,
+    gateway_session_key: str = None,
+):
     with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
         from run_agent import AIAgent
 
@@ -38,6 +46,10 @@ def _build_agent_with_db(db: SessionDB, session_id: str, platform: str = "telegr
             session_id=session_id,
             skip_context_files=True,
             skip_memory=True,
+            chat_id=chat_id,
+            chat_type=chat_type,
+            thread_id=thread_id,
+            gateway_session_key=gateway_session_key,
         )
 
     compressor = MagicMock()
@@ -130,3 +142,81 @@ class TestPlatformForwardedAtBoundary:
         kwargs = calls[-1].kwargs
         assert kwargs.get("platform") == "telegram"
         assert kwargs.get("boundary_reason") == "compression"
+
+
+class TestRoutingColumnsPersistOnRotation:
+    """The compression-rotation child session row must carry the same
+    chat_id/chat_type/thread_id/session_key as its parent at CREATE time.
+
+    Previously ``create_session()`` at the rotation boundary
+    (agent/conversation_compression.py) only passed session_id/source/model/
+    model_config/parent_session_id — never the gateway routing columns. The
+    routing peer record (chat_id/thread_id/session_key) was written in a
+    SEPARATE step later, in gateway/run.py's post-turn backfill, after the
+    agent result returns to the event loop. A process crash/kill landing in
+    that gap left the child row permanently unroutable: NULL chat_id/thread_id
+    survive forever, since nothing ever revisits an already-created row to
+    backfill them, and find_latest_gateway_session_for_peer's WHERE clause
+    can never match a NULL-routing row. The parent conversation becomes an
+    orphan and the next inbound message on that chat/thread spawns a brand
+    new, empty session instead of resuming.
+
+    This test drives the real rotation path end-to-end (real SessionDB, real
+    AIAgent, real compress_context) and asserts the child row already has
+    the routing columns immediately after create_session returns — i.e.
+    there is no gap for a crash to land in.
+    """
+
+    def test_child_row_has_routing_columns_immediately_after_rotation(
+        self, tmp_path: Path
+    ):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        parent = "PARENT_ROUTING_ROT"
+        db.create_session(
+            parent,
+            source="telegram",
+            chat_id="170829464",
+            chat_type="dm",
+            thread_id="544520",
+            session_key="agent:main:telegram:dm:170829464:544520",
+        )
+        agent = _build_agent_with_db(
+            db,
+            parent,
+            platform="telegram",
+            chat_id="170829464",
+            chat_type="dm",
+            thread_id="544520",
+            gateway_session_key="agent:main:telegram:dm:170829464:544520",
+        )
+
+        agent._compress_context(_msgs(), "sys", approx_tokens=120_000)
+        child = agent.session_id
+        assert child != parent  # rotation happened
+
+        row = db.get_session(child)
+        assert row is not None, "child session row must exist immediately after rotation"
+        assert row["chat_id"] == "170829464"
+        assert row["chat_type"] == "dm"
+        assert row["thread_id"] == "544520"
+        assert row["session_key"] == "agent:main:telegram:dm:170829464:544520"
+
+    def test_no_routing_context_is_a_harmless_noop(self, tmp_path: Path):
+        """CLI/non-gateway sessions have no chat_id/thread_id/session_key at
+        all — the fix must not require them or break sessions that never had
+        routing metadata in the first place."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        parent = "PARENT_NO_ROUTING_ROT"
+        db.create_session(parent, source="cli")
+        agent = _build_agent_with_db(db, parent, platform="cli")
+
+        agent._compress_context(_msgs(), "sys", approx_tokens=120_000)
+        child = agent.session_id
+        assert child != parent
+
+        row = db.get_session(child)
+        assert row is not None
+        assert row["chat_id"] is None
+        assert row["chat_type"] is None
+        assert row["thread_id"] is None
+        assert row["session_key"] is None

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -28,6 +28,7 @@ def _build_agent_with_db(
     db: SessionDB,
     session_id: str,
     platform: str = "telegram",
+    user_id: str = None,
     chat_id: str = None,
     chat_type: str = None,
     thread_id: str = None,
@@ -46,6 +47,7 @@ def _build_agent_with_db(
             session_id=session_id,
             skip_context_files=True,
             skip_memory=True,
+            user_id=user_id,
             chat_id=chat_id,
             chat_type=chat_type,
             thread_id=thread_id,
@@ -175,6 +177,7 @@ class TestRoutingColumnsPersistOnRotation:
         db.create_session(
             parent,
             source="telegram",
+            user_id="170829464",
             chat_id="170829464",
             chat_type="dm",
             thread_id="544520",
@@ -184,6 +187,7 @@ class TestRoutingColumnsPersistOnRotation:
             db,
             parent,
             platform="telegram",
+            user_id="170829464",
             chat_id="170829464",
             chat_type="dm",
             thread_id="544520",
@@ -196,13 +200,14 @@ class TestRoutingColumnsPersistOnRotation:
 
         row = db.get_session(child)
         assert row is not None, "child session row must exist immediately after rotation"
+        assert row["user_id"] == "170829464"
         assert row["chat_id"] == "170829464"
         assert row["chat_type"] == "dm"
         assert row["thread_id"] == "544520"
         assert row["session_key"] == "agent:main:telegram:dm:170829464:544520"
 
     def test_no_routing_context_is_a_harmless_noop(self, tmp_path: Path):
-        """CLI/non-gateway sessions have no chat_id/thread_id/session_key at
+        """CLI/non-gateway sessions have no user_id/chat_id/thread_id/session_key at
         all — the fix must not require them or break sessions that never had
         routing metadata in the first place."""
         db = SessionDB(db_path=tmp_path / "state.db")
@@ -216,6 +221,7 @@ class TestRoutingColumnsPersistOnRotation:
 
         row = db.get_session(child)
         assert row is not None
+        assert row["user_id"] is None
         assert row["chat_id"] is None
         assert row["chat_type"] is None
         assert row["thread_id"] is None

--- a/tests/gateway/test_branch_routing_columns.py
+++ b/tests/gateway/test_branch_routing_columns.py
@@ -128,6 +128,15 @@ class TestBranchRoutingColumns:
         )
         assert row["chat_type"] == "dm"
         assert row["thread_id"] == "544520"
+        # user_id and session_key are also required for the fallback lookup
+        # path (hermes_state.py:1994-2009) when session_key-based lookup fails
+        assert row["user_id"] == "170829464", (
+            "branched session lost user_id — fallback peer-tuple lookup "
+            "in find_latest_gateway_session_for_peer can never match"
+        )
+        assert row["session_key"] is not None, (
+            "branched session lost session_key — primary lookup path fails"
+        )
 
         _ = real_switch_session  # silence unused
 

--- a/tests/gateway/test_branch_routing_columns.py
+++ b/tests/gateway/test_branch_routing_columns.py
@@ -1,0 +1,133 @@
+"""Regression test for /branch losing gateway routing columns (#NNNNN).
+
+``_handle_branch_command`` (gateway/slash_commands.py) creates the branched
+child session via ``create_session()`` WITHOUT chat_id/chat_type/thread_id —
+identical in shape to the compression-rotation bug fixed in
+agent/conversation_compression.py. The routing columns are only written
+later, when ``switch_session()`` calls ``_record_gateway_session_peer()``
+after the branch's session_id is live and its transcript has been copied
+message-by-message.
+
+A crash/kill landing between create_session() and switch_session() (most
+plausibly mid-history-copy on a long conversation, since each
+append_message call is independently try/excepted and best-effort) leaves
+the branched session permanently unroutable: NULL chat_id/thread_id can
+never be found by find_latest_gateway_session_for_peer, and the /resume
+IDOR guard (which requires the row's chat_id/thread_id to match the
+caller's) can never authorize a manual recovery either.
+
+This test drives the REAL _handle_branch_command against a REAL SessionStore
++ SessionDB (SQLite in a tmp_path, no mocks on the DB/session-store layer)
+and asserts the branched child's routing columns are present in state.db
+immediately after create_session() returns — before switch_session() ever
+runs — closing the gap the same way the compression fix does.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource, SessionStore, build_session_key
+from hermes_state import AsyncSessionDB, SessionDB
+
+
+@pytest.fixture()
+def store(tmp_path, monkeypatch):
+    """Real SessionStore backed by a real SessionDB (SQLite in tmp_path)."""
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    config = GatewayConfig()
+    return SessionStore(sessions_dir=tmp_path, config=config)
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="170829464",
+        chat_id="170829464",
+        chat_type="dm",
+        thread_id="544520",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _make_branch_runner(store: SessionStore):
+    """Minimal GatewayRunner stub wired to a REAL session_store/session_db."""
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner.config = {}
+    runner._background_tasks = set()
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._busy_ack_ts = {}
+    runner._pending_approvals = {}
+    runner._update_prompt_pending = {}
+    runner._agent_cache_lock = None
+    runner.session_store = store
+    runner._session_db = AsyncSessionDB(store._db)
+    runner._pending_skills_reload_notes = {}
+    return runner
+
+
+class TestBranchRoutingColumns:
+    @pytest.mark.asyncio
+    async def test_branched_session_has_routing_columns_before_switch(self, store):
+        """Simulates a crash/kill landing between create_session() and
+        switch_session() — the exact gap where the branched child's
+        routing columns are missing. switch_session() runs unconditionally
+        at the end of _handle_branch_command and backfills chat_id/
+        chat_type/thread_id via _record_gateway_session_peer(), so checking
+        DB state AFTER the function returns successfully will always look
+        fine. The real bug only bites if the process dies mid-function,
+        before switch_session() gets a chance to run — so we patch
+        switch_session to simulate exactly that crash point, then inspect
+        the child row switch_session would otherwise have fixed up.
+        """
+        source = _make_source()
+        parent_entry = store.get_or_create_session(source)
+        store._db.append_message(parent_entry.session_id, role="user", content="hello")
+        store._db.append_message(parent_entry.session_id, role="assistant", content="world")
+
+        runner = _make_branch_runner(store)
+
+        captured_new_session_id = {}
+        real_switch_session = store.switch_session
+
+        def _crash_before_switch(session_key, target_session_id):
+            # Simulate the process dying right here — before routing gets
+            # backfilled — by capturing the id and raising instead of
+            # forwarding to the real switch_session().
+            captured_new_session_id["id"] = target_session_id
+            raise RuntimeError("simulated crash before switch_session")
+
+        import unittest.mock as mock
+
+        with mock.patch.object(store, "switch_session", side_effect=_crash_before_switch):
+            with pytest.raises(RuntimeError, match="simulated crash"):
+                await runner._handle_branch_command(_make_event("/branch"))
+
+        new_session_id = captured_new_session_id["id"]
+        assert new_session_id != parent_entry.session_id
+
+        row = store._db.get_session(new_session_id)
+        assert row is not None, "branched child row must exist in state.db"
+        # THIS is the bug: without the fix, these are all None, because
+        # create_session() at branch time never received them — only the
+        # (now-crashed) switch_session() call would have backfilled them.
+        assert row["chat_id"] == "170829464", (
+            "branched session lost chat_id — unroutable if a crash lands "
+            "between create_session() and switch_session()"
+        )
+        assert row["chat_type"] == "dm"
+        assert row["thread_id"] == "544520"
+
+        _ = real_switch_session  # silence unused
+


### PR DESCRIPTION
## Problem

`create_session()` has multiple call sites across the codebase that persist a new session row. Two of them omit the gateway routing columns (`chat_id`/`chat_type`/`thread_id`/`session_key`) at create time, relying on a **separate, later step** to backfill them — and a crash/kill landing in that gap leaves the row permanently unroutable: `NULL` `chat_id`/`thread_id` survive forever, `find_latest_gateway_session_for_peer`'s `WHERE` clause can never match a `NULL`-routing row, and the `/resume` IDOR guard can't authorize a manual recovery either (it requires the row's `chat_id`/`thread_id` to match the caller's). The parent conversation becomes an orphan and the next inbound message on that chat/thread spawns a brand-new, empty session instead of resuming.

This surfaced in production as "gateway loses session linkage to Telegram threads on restart" — traced via direct `state.db` inspection. A full audit of every `create_session()` call site (per this repo's contribution guidance: *"fix the whole bug class — sibling call paths included"*) found the defect in two places:

| Call site | Gap |
|---|---|
| `agent/conversation_compression.py` — compression-rotation child session | Backfilled later via the gateway's post-turn `_record_gateway_session_peer()`, after the agent result unwinds back to the event loop |
| `gateway/slash_commands.py::_handle_branch_command` (`/branch`) | Backfilled later via `switch_session()` at the very end of the function, after conversation history is copied message-by-message (each `append_message()` call independently best-effort) |

Other `create_session()` call sites were audited and found correct: initial session creation and session reset (`gateway/session.py`) and `/title`'s auto-create path (`gateway/slash_commands.py`) all already forward routing columns at create time (the latter with an explicit IDOR-scoping comment). CLI-only call sites (`run_agent.py`, `cli.py`, `hermes_cli/cli_commands_mixin.py`) have no chat/thread concept and correctly pass nothing.

## Fix

Forward the same `chat_id`/`chat_type`/`thread_id`(/`session_key` where available) already known at the call site directly into `create_session()`, closing the gap entirely instead of relying on a later backfill:

**1. Compression rotation** (`agent/conversation_compression.py`) — forwards `agent._chat_id` / `_chat_type` / `_thread_id` / `_gateway_session_key` (already populated by `agent_init.py` for every gateway session). CLI/non-gateway sessions have none of these set (all `None`), so the fix is a no-op there.

```python
agent._session_db.create_session(
    session_id=agent.session_id,
    source=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
    model=agent.model,
    model_config=agent._session_init_model_config,
    parent_session_id=old_session_id,
    chat_id=getattr(agent, "_chat_id", None),
    chat_type=getattr(agent, "_chat_type", None),
    thread_id=getattr(agent, "_thread_id", None),
    session_key=getattr(agent, "_gateway_session_key", None),
)
```

**2. `/branch`** (`gateway/slash_commands.py`) — forwards `source.chat_id` / `chat_type` / `thread_id`, mirroring the existing correct pattern in `/title`'s auto-create path a few hundred lines up in the same file:

```python
await self._session_db.create_session(
    session_id=new_session_id,
    source=source.platform.value if source.platform else "gateway",
    model=...,
    model_config={"_branched_from": parent_session_id},
    parent_session_id=parent_session_id,
    chat_id=source.chat_id,
    chat_type=source.chat_type,
    thread_id=source.thread_id,
)
```

## Note on scope

`compression.in_place=true` (the default since #38763) avoids the compression-rotation code path entirely by never rotating the session id, and is the right mitigation for most users. This fix hardens the **rotation-mode fallback path** for anyone still using it, or who flips back to it (e.g. for the `parent_session_id` chain semantics rotation mode preserves) — and independently fixes `/branch`, which has no relationship to compression mode at all and is not mitigated by `in_place`.

## Testing

**Compression rotation** — two new cases in `tests/agent/test_compression_rotation_state.py`, driving the real rotation path end-to-end (real `SessionDB`, real `AIAgent`, real `compress_context`):
- `test_child_row_has_routing_columns_immediately_after_rotation` — asserts the child row already has `chat_id`/`chat_type`/`thread_id`/`session_key` immediately after `create_session()` returns.
- `test_no_routing_context_is_a_harmless_noop` — asserts a CLI/no-routing-context session rotates without requiring any of these attributes.

Verified RED against unpatched code (`assert None == '170829464'`), GREEN after the fix. Full file: 5/5 passed (including 3 pre-existing `#33618`/`#33906`/`#33907`/`#27633` regression tests in the same file). Regression sweep across 8 compression-adjacent test files: 47/47 passed.

**`/branch`** — new `tests/gateway/test_branch_routing_columns.py`, driving the real `_handle_branch_command` against a real `SessionStore` + `SessionDB` (SQLite in `tmp_path`, no DB/session-store mocks). Patches `switch_session` to simulate a crash landing before it runs — the exact gap the routing columns need to survive — then asserts the branched child's `chat_id`/`chat_type`/`thread_id` are already correct in `state.db` at that point. Verified RED (`assert None == '170829464'`), GREEN after the fix.

Regression: 102/102 across the new test + pre-existing `/branch`, session boundary, compression rotation, DM thread seeding, session API, and resume-command suites. Broader `tests/gateway/ -k "branch or session_api or resume or topic_mode or session_boundary"` sweep: 255/255 passed, 1 (unrelated) skip.

## Searched for duplicates

Searched open + closed issues/PRs for this mechanism (`compression create_session chat_id thread_id`, `rotation child session_key chat_id`, `compression rotation missing chat_id backfill`) — no existing coverage found. Related-but-distinct: #33906/#33907 (child-create-failure rollback, already fixed, same file as the compression fix) and #58899/#59203 (atomic gateway routing storage — hardens the *persistence* layer generally, but doesn't touch either `create_session()` call site fixed here, which is why both gaps still exist on current `main`).

