### PR TITLE
chore(gitignore): ignore Playwright MCP artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ models-dev-upstream/
 .codex/
 .cursor/
 .gemini/
+.playwright-mcp/
 .zed/
 .mcp.json
 opencode.json


### PR DESCRIPTION
## Summary

- ignore the machine-local `.playwright-mcp/` output directory
- prevent generated browser snapshots and console logs from appearing as repository changes

## Verification

- `git diff --check`
- `git check-ignore -v --no-index .playwright-mcp/example.log`