### PR TITLE
fix(cli): canonical final display, truthful route facts, and upgrade-safe updates

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -704,11 +704,14 @@ def init_agent(
     # erased delta1, so downstream state machines never learned a
     # block was open and leaked delta2 as content).
     agent._stream_think_scrubber = StreamingThinkScrubber()
-    # Visible assistant text already delivered through live token callbacks
-    # during the current model response. Used to avoid re-sending the same
-    # commentary when the provider later returns it as a completed interim
-    # assistant message.
+    # Assistant text received through live token callbacks during the current
+    # model response. This remains available for partial-stream recovery even
+    # when a UI chooses not to render draft answer-body tokens.
     agent._current_streamed_assistant_text = ""
+    # Assistant text actually rendered to the user. Used to avoid re-sending
+    # the same commentary when the provider later returns it as a completed
+    # interim assistant message.
+    agent._current_visible_streamed_assistant_text = ""
 
     # Optional current-turn user-message override used when the API-facing
     # user message intentionally differs from the persisted transcript

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2282,9 +2282,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     _fire_first_delta()
                     agent._fire_reasoning_delta(reasoning_text)
                 content = getattr(message, "content", None)
-                if isinstance(content, str) and content:
+                aux_stream_cb = getattr(agent, "_stream_callback", None)
+                if isinstance(content, str) and content and aux_stream_cb is not None:
                     _fire_first_delta()
-                    agent._fire_stream_delta(content)
+                    try:
+                        aux_stream_cb(content)
+                    except Exception:
+                        pass
             return stream
 
         # Capture rate limit headers from the initial HTTP response.

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -738,20 +738,24 @@ class MoAChatCompletions:
     ) -> dict[str, Any]:
         """Build private MoA completion facts from actual reference outcomes."""
 
-        reference_labels = [
-            label
-            for label, _text, accounting in reference_outputs
-            if isinstance(label, str)
-            and isinstance(accounting, _RefAccounting)
-            and accounting.succeeded is True
-        ]
+        reference_labels: list[str] = []
+        failed_count = 0
+        for label, _text, accounting in reference_outputs:
+            if isinstance(accounting, _RefAccounting) and accounting.succeeded is True:
+                if isinstance(label, str):
+                    reference_labels.append(label)
+            else:
+                failed_count += 1
+        reference_total = len(reference_outputs)
         aggregator_model = str((aggregator or {}).get("model") or "").strip()
         aggregator_count = 1 if aggregator_model else 0
         return {
             "moa": {
-                "observed": bool(reference_labels or aggregator_count),
+                "observed": bool(reference_labels or failed_count or aggregator_count),
                 "reference_models": reference_labels,
                 "reference_count": len(reference_labels),
+                "reference_total": reference_total,
+                "failed_count": failed_count,
                 "aggregator_model": aggregator_model,
                 "aggregator_count": aggregator_count,
             }
@@ -788,11 +792,32 @@ class MoAChatCompletions:
                 aggregator_count = 1 if aggregator_model.strip() else 0
         else:
             aggregator_count = 1 if aggregator_model.strip() else 0
+        if "failed_count" in moa:
+            try:
+                failed_count = int(moa.get("failed_count") or 0)
+            except Exception:
+                failed_count = 0
+        else:
+            failed_count = 0
+        if "reference_total" in moa:
+            try:
+                reference_total = int(moa.get("reference_total") or 0)
+            except Exception:
+                reference_total = reference_count + failed_count
+        else:
+            reference_total = reference_count + failed_count
         return {
             "moa": {
-                "observed": bool(moa.get("observed")) or reference_count > 0 or aggregator_count > 0,
+                "observed": (
+                    bool(moa.get("observed"))
+                    or reference_count > 0
+                    or failed_count > 0
+                    or aggregator_count > 0
+                ),
                 "reference_models": reference_models,
                 "reference_count": reference_count,
+                "reference_total": reference_total,
+                "failed_count": failed_count,
                 "aggregator_model": aggregator_model,
                 "aggregator_count": aggregator_count,
             }

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -55,6 +55,7 @@ class _RefAccounting:
         "model",
         "provider",
         "temperature",
+        "succeeded",
     )
 
     def __init__(
@@ -69,6 +70,7 @@ class _RefAccounting:
         model: str | None = None,
         provider: str | None = None,
         temperature: Any = None,
+        succeeded: bool = False,
     ):
         self.usage = usage
         self.cost_usd = cost_usd
@@ -79,6 +81,7 @@ class _RefAccounting:
         self.model = model
         self.provider = provider
         self.temperature = temperature
+        self.succeeded = bool(succeeded)
 
 # Per-tool-result character budget for the advisory reference view. Tool
 # results can be huge (a full diff, a 5000-line file dump); replaying them
@@ -319,6 +322,7 @@ def _run_reference(
             model=slot.get("model"),
             provider=runtime.get("provider") or slot.get("provider"),
             temperature=temperature,
+            succeeded=True,
         )
         return label, _output_text, acct
     except Exception as exc:
@@ -330,6 +334,7 @@ def _run_reference(
             model=slot.get("model"),
             provider=runtime.get("provider") or slot.get("provider"),
             temperature=temperature,
+            succeeded=False,
         )
 
 
@@ -365,7 +370,7 @@ def _run_references_parallel(
                 results[idx] = (
                     _slot_label(slot),
                     "[skipped: MoA presets cannot recursively reference MoA]",
-                    _RefAccounting(CanonicalUsage()),
+                    _RefAccounting(CanonicalUsage(), succeeded=False),
                 )
                 continue
             futures[
@@ -723,6 +728,75 @@ class MoAChatCompletions:
         # caller to stitch in the live session_id + resolved aggregator output
         # and flush to the trace file (only when moa.save_traces is on).
         self._pending_trace: Any = None
+        self._last_coordination_turn_facts: dict[str, Any] | None = None
+        self._pending_coordination_turn_facts: dict[str, Any] | None = None
+
+    def _coordination_facts_from_outputs(
+        self,
+        reference_outputs: list[tuple[str, str, Any]],
+        aggregator: dict[str, str],
+    ) -> dict[str, Any]:
+        """Build private MoA completion facts from actual reference outcomes."""
+
+        reference_labels = [
+            label
+            for label, _text, accounting in reference_outputs
+            if isinstance(label, str)
+            and isinstance(accounting, _RefAccounting)
+            and accounting.succeeded is True
+        ]
+        aggregator_model = str((aggregator or {}).get("model") or "").strip()
+        aggregator_count = 1 if aggregator_model else 0
+        return {
+            "moa": {
+                "observed": bool(reference_labels or aggregator_count),
+                "reference_models": reference_labels,
+                "reference_count": len(reference_labels),
+                "aggregator_model": aggregator_model,
+                "aggregator_count": aggregator_count,
+            }
+        }
+
+    def _publish_pending_coordination_turn_facts(self) -> None:
+        pending = getattr(self, "_pending_coordination_turn_facts", None)
+        self._pending_coordination_turn_facts = None
+        if isinstance(pending, dict):
+            self._last_coordination_turn_facts = pending
+
+    def coordination_turn_facts(self) -> dict[str, Any]:
+        """Return runtime facts for the most recently completed MoA create()."""
+
+        facts = getattr(self, "_last_coordination_turn_facts", None)
+        if not isinstance(facts, dict):
+            return {}
+        moa = facts.get("moa")
+        if not isinstance(moa, dict):
+            return {}
+        reference_models = [str(label) for label in moa.get("reference_models") or [] if str(label)]
+        aggregator_model = str(moa.get("aggregator_model") or "")
+        if "reference_count" in moa:
+            try:
+                reference_count = int(moa.get("reference_count") or 0)
+            except Exception:
+                reference_count = len(reference_models)
+        else:
+            reference_count = len(reference_models)
+        if "aggregator_count" in moa:
+            try:
+                aggregator_count = int(moa.get("aggregator_count") or 0)
+            except Exception:
+                aggregator_count = 1 if aggregator_model.strip() else 0
+        else:
+            aggregator_count = 1 if aggregator_model.strip() else 0
+        return {
+            "moa": {
+                "observed": bool(moa.get("observed")) or reference_count > 0 or aggregator_count > 0,
+                "reference_models": reference_models,
+                "reference_count": reference_count,
+                "aggregator_model": aggregator_model,
+                "aggregator_count": aggregator_count,
+            }
+        }
 
     def consume_reference_usage(self) -> tuple[Any, Any]:
         """Pop pending reference-fan-out usage + cost, resetting both to empty.
@@ -760,6 +834,7 @@ class MoAChatCompletions:
         streaming and non-streaming modes. Non-streaming already has the inline
         output and ignores the fallback.
         """
+        self._publish_pending_coordination_turn_facts()
         pending = self._pending_trace
         self._pending_trace = None
         if not pending or "aggregator_input_messages" not in pending:
@@ -798,6 +873,9 @@ class MoAChatCompletions:
             logger.debug("MoA reference_callback failed for %s: %s", event, exc)
 
     def create(self, **api_kwargs: Any) -> Any:
+        self._last_coordination_turn_facts = None
+        self._pending_coordination_turn_facts = None
+
         from hermes_cli.config import load_config
         from hermes_cli.moa_config import resolve_moa_preset
 
@@ -957,6 +1035,11 @@ class MoAChatCompletions:
                     ref_count=_ref_count,
                 )
 
+        self._pending_coordination_turn_facts = self._coordination_facts_from_outputs(
+            reference_outputs,
+            aggregator,
+        )
+
         agg_messages = [dict(m) for m in messages]
         if reference_outputs:
             joined = "\n\n".join(
@@ -1010,16 +1093,20 @@ class MoAChatCompletions:
             # actually governs the aggregator stream, not just call_llm's default.
             if api_kwargs.get("timeout") is not None:
                 stream_kwargs["timeout"] = api_kwargs["timeout"]
-        _agg_response = call_llm(
-            task="moa_aggregator",
-            messages=agg_messages,
-            temperature=aggregator_temperature,
-            max_tokens=agg_kwargs.get("max_tokens"),
-            tools=agg_kwargs.get("tools"),
-            extra_body=agg_kwargs.get("extra_body"),
-            **stream_kwargs,
-            **_slot_runtime(aggregator),
-        )
+        try:
+            _agg_response = call_llm(
+                task="moa_aggregator",
+                messages=agg_messages,
+                temperature=aggregator_temperature,
+                max_tokens=agg_kwargs.get("max_tokens"),
+                tools=agg_kwargs.get("tools"),
+                extra_body=agg_kwargs.get("extra_body"),
+                **stream_kwargs,
+                **_slot_runtime(aggregator),
+            )
+        except Exception:
+            self._pending_coordination_turn_facts = None
+            raise
         # Non-streaming path (quiet mode / eval / subagents): the aggregator
         # output is available inline, so capture it into the pending trace now.
         # Streaming path: the aggregator's raw token stream is returned to the
@@ -1035,6 +1122,8 @@ class MoAChatCompletions:
                     self._pending_trace["aggregator_output"] = _extract_text(_agg_response)
                 except Exception:  # pragma: no cover - defensive
                     self._pending_trace["aggregator_output"] = None
+        if not stream:
+            self._publish_pending_coordination_turn_facts()
         return _agg_response
 
 
@@ -1050,6 +1139,11 @@ class MoAClient:
         usage without reaching into ``.chat.completions`` internals.
         """
         return self.chat.completions.consume_reference_usage()
+
+    def coordination_turn_facts(self) -> dict[str, Any]:
+        """Return runtime facts for the most recently completed MoA create()."""
+
+        return self.chat.completions.coordination_turn_facts()
 
     @property
     def last_aggregator_slot(self) -> Any:

--- a/agent/route_depth_bar.py
+++ b/agent/route_depth_bar.py
@@ -37,8 +37,15 @@ def _mechanism_fields(receipt: TurnReceipt) -> list[str]:
     return [str(segment).strip() for segment in receipt.mechanism_segments if str(segment).strip()]
 
 
-def _count_field(label: str, value: int | None) -> str:
-    return f"{label} unknown" if value is None else f"{label} {value}"
+def _coordination_field(receipt: TurnReceipt) -> str:
+    value = getattr(receipt, "coordination_count", 0)
+    if value is None:
+        return "协同 Agent unknown"
+    try:
+        count = max(0, int(value))
+    except Exception:
+        return "协同 Agent unknown"
+    return f"协同 Agent {count}"
 
 
 def _opencode_field(state: str) -> str:
@@ -86,8 +93,7 @@ def format_route_depth_bar(receipt: TurnReceipt) -> str:
         *_mechanism_fields(receipt),
         _opencode_field(receipt.opencode_state),
         _tool_field(receipt),
-        _count_field("agents", receipt.agents_count),
-        _count_field("subagents", receipt.subagents_count),
+        _coordination_field(receipt),
         _human_field(receipt.human_language_state),
         _elapsed_field(receipt),
         _evidence_field(receipt.evidence_status),

--- a/agent/route_depth_bar.py
+++ b/agent/route_depth_bar.py
@@ -1,0 +1,107 @@
+"""Format and apply the runtime-owned route/depth status bar."""
+
+from __future__ import annotations
+
+import re
+from typing import Tuple
+
+from agent.turn_receipt import TurnReceipt
+
+_ROUTE_BAR_RE = re.compile(r"^\s*路径：[^\n\r]*(?:\r?\n)?", re.UNICODE)
+
+
+def _tool_field(receipt: TurnReceipt) -> str:
+    if receipt.tool_total <= 0 and not receipt.tool_names:
+        return "工具 none"
+    names = receipt.tool_names[:3]
+    if names:
+        joined = "+".join(names)
+        if receipt.tool_total > len(names):
+            joined += f"+{receipt.tool_total - len(names)}"
+    else:
+        joined = str(receipt.tool_total)
+    if receipt.tool_failed:
+        joined += f"({receipt.tool_failed} failed)"
+    return f"工具 {joined}"
+
+
+def _count_field(label: str, value: int | None) -> str:
+    return f"{label} unknown" if value is None else f"{label} {value}"
+
+
+def _opencode_field(state: str) -> str:
+    normalized = (state or "unknown").strip().lower()
+    if normalized in {"called", "yes", "true", "1", "已调用"}:
+        return "OpenCode 已调用"
+    if normalized in {"not_called", "none", "false", "0", "未调用"}:
+        return "OpenCode 未调用"
+    return "OpenCode unknown"
+
+
+def _human_field(state: str) -> str:
+    normalized = (state or "unknown").strip().lower()
+    if normalized in {"seen", "yes", "true", "1", "ok", "✓"}:
+        return "人话 ✓"
+    if normalized in {"not_seen", "none", "false", "0"}:
+        return "人话 none"
+    return "人话 unknown"
+
+
+def _elapsed_field(receipt: TurnReceipt) -> str:
+    if receipt.elapsed_seconds is None:
+        return "用时 N/A"
+    seconds = max(0, int(round(receipt.elapsed_seconds)))
+    return f"用时 {seconds}s"
+
+
+def _evidence_field(status: str) -> str:
+    normalized = (status or "unknown").strip().lower()
+    if normalized in {"ok", "true", "yes", "pass", "passed", "✓"}:
+        return "证据 ✓"
+    if normalized in {"failed", "fail", "error", "errored"}:
+        return "证据 failed"
+    if normalized in {"partial", "incomplete"}:
+        return "证据 partial"
+    return "证据 unknown"
+
+
+def format_route_depth_bar(receipt: TurnReceipt) -> str:
+    """Return the one-line runtime-owned status bar for ``receipt``."""
+
+    fields = [
+        f"路径：{receipt.route or 'native'}",
+        f"原因：{receipt.reason or 'runtime_default'}",
+        _opencode_field(receipt.opencode_state),
+        _tool_field(receipt),
+        _count_field("agents", receipt.agents_count),
+        _count_field("subagents", receipt.subagents_count),
+        _human_field(receipt.human_language_state),
+        _elapsed_field(receipt),
+        _evidence_field(receipt.evidence_status),
+    ]
+    return "｜".join(fields)
+
+
+def strip_route_depth_bar(text: str) -> str:
+    """Remove a leading model-authored/runtime route bar if present."""
+
+    if not isinstance(text, str) or not text:
+        return text or ""
+    return _ROUTE_BAR_RE.sub("", text, count=1).lstrip("\n")
+
+
+def apply_route_depth_bar(text: str, receipt: TurnReceipt) -> Tuple[str, bool]:
+    """Prepend exactly one runtime route/depth bar to ``text``.
+
+    Any leading model-authored ``路径：`` line is stripped/replaced.  Returns
+    ``(new_text, changed)``.
+    """
+
+    original = text or ""
+    body = strip_route_depth_bar(original)
+    bar = format_route_depth_bar(receipt)
+    if body:
+        updated = f"{bar}\n{body}"
+    else:
+        updated = bar
+    return updated, updated != original

--- a/agent/route_depth_bar.py
+++ b/agent/route_depth_bar.py
@@ -11,18 +11,30 @@ _ROUTE_BAR_RE = re.compile(r"^\s*路径：[^\n\r]*(?:\r?\n)?", re.UNICODE)
 
 
 def _tool_field(receipt: TurnReceipt) -> str:
-    if receipt.tool_total <= 0 and not receipt.tool_names:
+    total = receipt.tool_total if receipt.tool_total > 0 else len(receipt.tool_names)
+    if total <= 0 and not receipt.tool_names:
         return "工具 none"
-    names = receipt.tool_names[:3]
-    if names:
-        joined = "+".join(names)
-        if receipt.tool_total > len(names):
-            joined += f"+{receipt.tool_total - len(names)}"
+
+    unique_names: list[str] = []
+    for name in receipt.tool_names:
+        cleaned = str(name or "").strip()
+        if cleaned and cleaned not in unique_names:
+            unique_names.append(cleaned)
+
+    visible_names = unique_names[:3]
+    if visible_names:
+        joined = "+".join(visible_names)
+        if len(unique_names) > len(visible_names):
+            joined += "+…"
     else:
-        joined = str(receipt.tool_total)
-    if receipt.tool_failed:
-        joined += f"({receipt.tool_failed} failed)"
-    return f"工具 {joined}"
+        joined = "unknown"
+
+    call_word = "call" if total == 1 else "calls"
+    return f"工具 {joined} ({total} {call_word}, {receipt.tool_failed} failed)"
+
+
+def _mechanism_fields(receipt: TurnReceipt) -> list[str]:
+    return [str(segment).strip() for segment in receipt.mechanism_segments if str(segment).strip()]
 
 
 def _count_field(label: str, value: int | None) -> str:
@@ -71,6 +83,7 @@ def format_route_depth_bar(receipt: TurnReceipt) -> str:
     fields = [
         f"路径：{receipt.route or 'native'}",
         f"原因：{receipt.reason or 'runtime_default'}",
+        *_mechanism_fields(receipt),
         _opencode_field(receipt.opencode_state),
         _tool_field(receipt),
         _count_field("agents", receipt.agents_count),

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -24,12 +24,14 @@ from __future__ import annotations
 
 import logging
 import threading
+import time
 import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 from agent.conversation_compression import conversation_history_after_compression
 from agent.iteration_budget import IterationBudget
+from agent.turn_receipt import TurnReceipt
 from agent.model_metadata import (
     estimate_messages_tokens_rough,
     estimate_request_tokens_rough,
@@ -218,6 +220,14 @@ def build_turn_context(
     turn_id = f"{agent.session_id or 'session'}:{effective_task_id}:{uuid.uuid4().hex[:8]}"
     agent._current_turn_id = turn_id
     agent._current_api_request_id = ""
+    agent._current_turn_receipt = TurnReceipt.start(
+        session_id=agent.session_id or "",
+        turn_id=turn_id,
+        provider=getattr(agent, "provider", "") or "",
+        model=getattr(agent, "model", "") or "",
+        platform=getattr(agent, "platform", "") or "",
+        start_monotonic=time.monotonic(),
+    )
 
     # Reset retry counters and iteration budget at the start of each turn.
     agent._invalid_tool_retries = 0

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -23,6 +23,7 @@ keep the exact logger name (``"agent.conversation_loop"``).
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.route_depth_bar import apply_route_depth_bar
@@ -65,6 +66,27 @@ def _runtime_turn_fact_dicts(agent):
             yield value
 
 
+def _client_coordination_turn_fact_dicts(agent):
+    client = getattr(agent, "client", None)
+    method = getattr(client, "coordination_turn_facts", None)
+    if not callable(method):
+        return
+    try:
+        facts = method()
+    except Exception:
+        return
+    if isinstance(facts, Mapping):
+        yield facts
+
+
+def _apply_turn_fact_dicts(receipt: TurnReceipt, fact_dicts) -> None:
+    for facts in fact_dicts or []:
+        try:
+            apply_turn_facts(receipt, facts)
+        except Exception:
+            continue
+
+
 def _apply_runtime_route_depth_bar(
     agent,
     *,
@@ -103,8 +125,8 @@ def _apply_runtime_route_depth_bar(
         messages=current_turn_messages,
         agent=agent,
     )
-    for facts in _runtime_turn_fact_dicts(agent):
-        apply_turn_facts(receipt, facts)
+    _apply_turn_fact_dicts(receipt, _runtime_turn_fact_dicts(agent))
+    _apply_turn_fact_dicts(receipt, _client_coordination_turn_fact_dicts(agent))
     if isinstance(user_message, str) and user_message.startswith(("说人话", "用人话")):
         receipt.human_language_state = "seen"
     agent._current_turn_receipt = receipt

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -25,6 +25,108 @@ from __future__ import annotations
 import os
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
+from agent.route_depth_bar import apply_route_depth_bar
+from agent.turn_receipt import TurnReceipt, apply_turn_facts, update_turn_receipt_from_result
+
+
+def _ensure_canonical_final_message(messages, final_response: str) -> None:
+    """Persist ``final_response`` as the durable final assistant message."""
+
+    if not final_response:
+        return
+    try:
+        tail = messages[-1] if messages else None
+        tail_role = tail.get("role") if isinstance(tail, dict) else None
+        tail_tool_calls = tail.get("tool_calls") if isinstance(tail, dict) else None
+    except Exception:
+        tail = None
+        tail_role = None
+        tail_tool_calls = None
+
+    if tail_role == "assistant" and not tail_tool_calls and isinstance(tail, dict):
+        tail["content"] = final_response
+    else:
+        messages.append({"role": "assistant", "content": final_response})
+
+
+def _runtime_turn_fact_dicts(agent):
+    """Yield optional generic runtime fact dicts without importing WIP systems."""
+
+    for attr in (
+        "_turn_facts",
+        "turn_facts",
+        "_coordination_turn_facts",
+        "coordination_turn_facts",
+        "_moa_turn_facts",
+        "moa_turn_facts",
+    ):
+        value = getattr(agent, attr, None)
+        if isinstance(value, dict):
+            yield value
+
+
+def _apply_runtime_route_depth_bar(
+    agent,
+    *,
+    final_response: str,
+    completed: bool,
+    failed: bool,
+    interrupted: bool,
+    api_call_count: int,
+    _turn_exit_reason: str,
+    messages,
+    turn_id: str,
+    user_message: str,
+) -> tuple[str, bool]:
+    """Apply the runtime-owned route/depth bar to ``final_response``."""
+
+    receipt = getattr(agent, "_current_turn_receipt", None)
+    if not isinstance(receipt, TurnReceipt):
+        receipt = TurnReceipt.start(
+            session_id=getattr(agent, "session_id", "") or "",
+            turn_id=turn_id or getattr(agent, "_current_turn_id", "") or "",
+            provider=getattr(agent, "provider", "") or "",
+            model=getattr(agent, "model", "") or "",
+            platform=getattr(agent, "platform", "") or "",
+        )
+    current_turn_messages = messages
+    current_turn_idx = getattr(agent, "_persist_user_message_idx", None)
+    if isinstance(current_turn_idx, int) and 0 <= current_turn_idx < len(messages):
+        current_turn_messages = messages[current_turn_idx:]
+    update_turn_receipt_from_result(
+        receipt,
+        completed=completed,
+        failed=failed,
+        interrupted=interrupted,
+        api_calls=api_call_count,
+        exit_reason=_turn_exit_reason,
+        messages=current_turn_messages,
+        agent=agent,
+    )
+    for facts in _runtime_turn_fact_dicts(agent):
+        apply_turn_facts(receipt, facts)
+    if isinstance(user_message, str) and user_message.startswith(("说人话", "用人话")):
+        receipt.human_language_state = "seen"
+    agent._current_turn_receipt = receipt
+    return apply_route_depth_bar(final_response, receipt)
+
+
+def _route_depth_bar_enabled(agent, _final_response: str) -> bool:
+    """Return whether this runtime owns an assistant-body route bar.
+
+    The bar is a classic CLI contract. Core ``run_conversation`` is also used
+    by gateways, tests, API servers, and workers whose payloads must not be
+    silently prefixed. An explicit runtime opt-in is supported for sibling
+    surfaces. Model-authored leading bars are replaced only on opted-in
+    surfaces; ordinary non-CLI text beginning with ``路径：`` is preserved.
+    """
+
+    explicit = getattr(agent, "_route_depth_bar_enabled", None)
+    if explicit is not None:
+        return bool(explicit)
+    if bool(getattr(agent, "_roadmap_mode", False)):
+        return False
+    return str(getattr(agent, "platform", "") or "").strip().lower() == "cli"
 
 
 def finalize_turn(
@@ -184,10 +286,10 @@ def finalize_turn(
         _cleanup_errors.append(f"cleanup_task_resources: {_cleanup_err}")
         logger.error("finalize_turn: _cleanup_task_resources failed: %s", _cleanup_err, exc_info=True)
 
-    # Persist session to both JSON log and SQLite only after private retry
-    # scaffolding has been removed. Otherwise a later user "continue" turn
-    # can replay assistant("(empty)") / recovery nudges and fall into the
-    # same empty-response loop again.
+    # Remove private retry scaffolding before the final canonical assistant
+    # message is written back and persisted below. Otherwise a later user
+    # "continue" turn can replay assistant("(empty)") / recovery nudges and
+    # fall into the same empty-response loop again.
     try:
         agent._drop_trailing_empty_response_scaffolding(messages)
 
@@ -208,30 +310,9 @@ def finalize_turn(
         if interrupted:
             from agent.message_sanitization import close_interrupted_tool_sequence
             close_interrupted_tool_sequence(messages, final_response)
-
-        # Some recovery/fallback paths return a real final_response without
-        # adding a closing assistant message to the transcript (e.g. the
-        # partial-stream and prior-turn-content recovery ``break`` sites in
-        # ``conversation_loop``). If persisted as-is, the durable session can
-        # end at a tool/user message even though the caller — and the gateway
-        # platform — already saw a completed assistant response. The next turn
-        # then replays a user-only backlog and the model re-answers every
-        # "unanswered" message. Close the durable turn at the source, at the
-        # single chokepoint every recovery ``break`` flows through, so the
-        # invariant "delivered final_response ⇒ assistant row in transcript"
-        # holds regardless of which path produced it. (#43849 / #44100)
-        if final_response and not interrupted:
-            try:
-                _tail_role = messages[-1].get("role") if messages else None
-            except Exception:
-                _tail_role = None
-            if _tail_role != "assistant":
-                messages.append({"role": "assistant", "content": final_response})
-
-        agent._persist_session(messages, conversation_history)
-    except Exception as _persist_err:
-        _cleanup_errors.append(f"persist_session: {_persist_err}")
-        logger.error("finalize_turn: _persist_session failed: %s", _persist_err, exc_info=True)
+    except Exception as _sanitize_err:
+        _cleanup_errors.append(f"sanitize_transcript: {_sanitize_err}")
+        logger.error("finalize_turn: transcript sanitization failed: %s", _sanitize_err, exc_info=True)
 
     # ── Turn-exit diagnostic log ─────────────────────────────────────
     # Always logged at INFO so agent.log captures WHY every turn ended.
@@ -383,6 +464,43 @@ def finalize_turn(
         except Exception as exc:
             logger.warning("transform_llm_output hook failed: %s", exc)
 
+    # Runtime-owned route/depth status bar.  This deliberately happens after
+    # model/plugin/finalizer text transforms and before post_llm_call,
+    # persistence, memory sync, and visible delivery so every downstream surface
+    # agrees on the same canonical final_response.  A model-authored leading
+    # ``路径：`` line is stripped/replaced inside apply_route_depth_bar().
+    if (
+        final_response
+        and not interrupted
+        and _route_depth_bar_enabled(agent, final_response)
+    ):
+        try:
+            final_response, _route_bar_changed = _apply_runtime_route_depth_bar(
+                agent,
+                final_response=final_response,
+                completed=completed,
+                failed=failed,
+                interrupted=interrupted,
+                api_call_count=api_call_count,
+                _turn_exit_reason=_turn_exit_reason,
+                messages=messages,
+                turn_id=turn_id,
+                user_message=user_message,
+            )
+            if _route_bar_changed:
+                _response_transformed = True
+        except Exception as exc:
+            logger.warning("route/depth status bar finalization failed: %s", exc)
+
+    # Some recovery/fallback paths return a real final_response without adding
+    # a closing assistant message to the transcript (e.g. partial-stream and
+    # prior-turn-content recovery break sites in conversation_loop). Write the
+    # final transformed body back to the last assistant message (or append one)
+    # before post hooks and persistence so visible final, DB/history, and hooks
+    # all share the same canonical content. (#43849 / #44100 + route-bar fix)
+    if final_response and not interrupted:
+        _ensure_canonical_final_message(messages, final_response)
+
     # Plugin hook: post_llm_call
     # Fired once per turn after the tool-calling loop completes.
     # Plugins can use this to persist conversation data (e.g. sync
@@ -403,6 +521,16 @@ def finalize_turn(
             )
         except Exception as exc:
             logger.warning("post_llm_call hook failed: %s", exc)
+
+    # Persist session to both JSON log and SQLite after every final-response
+    # transform has run and the canonical assistant message has been written
+    # back into ``messages``. This is the upgrade-regression seam for keeping
+    # DB/history and visible final output byte-aligned.
+    try:
+        agent._persist_session(messages, conversation_history)
+    except Exception as _persist_err:
+        _cleanup_errors.append(f"persist_session: {_persist_err}")
+        logger.error("finalize_turn: _persist_session failed: %s", _persist_err, exc_info=True)
 
     # Extract reasoning from the CURRENT turn only.  Walk backwards
     # but stop at the user message that started this turn — anything
@@ -434,6 +562,8 @@ def finalize_turn(
         "interrupted": interrupted,
         "response_transformed": _response_transformed,
         "response_previewed": getattr(agent, "_response_was_previewed", False),
+        "stream_text_received": bool(getattr(agent, "_current_streamed_assistant_text", "") or ""),
+        "stream_text_visible": bool(getattr(agent, "_current_visible_streamed_assistant_text", "") or ""),
         "model": agent.model,
         "provider": agent.provider,
         "base_url": agent.base_url,

--- a/agent/turn_receipt.py
+++ b/agent/turn_receipt.py
@@ -29,6 +29,8 @@ class TurnReceipt:
     mechanism_segments: list[str] = field(default_factory=list)
     agents_count: Optional[int] = 0
     subagents_count: Optional[int] = 0
+    coordination_count: Optional[int] = 0
+    coordination_breakdown: dict[str, Optional[int]] = field(default_factory=dict)
     delegation_observed: bool = False
     human_language_state: str = "unknown"  # unknown | seen | not_seen
     evidence_status: str = "unknown"  # ok | partial | failed | unknown
@@ -89,6 +91,12 @@ def _tool_call_name(tool_call: Any) -> str:
     return str(getattr(function, "name", "") or getattr(tool_call, "name", "") or "").strip()
 
 
+def _tool_call_id(tool_call: Any) -> str:
+    if isinstance(tool_call, Mapping):
+        return str(tool_call.get("id") or tool_call.get("call_id") or "").strip()
+    return str(getattr(tool_call, "id", "") or getattr(tool_call, "call_id", "") or "").strip()
+
+
 def _message_role(message: Any) -> str:
     if isinstance(message, Mapping):
         return str(message.get("role") or "")
@@ -101,6 +109,26 @@ def _message_tool_calls(message: Any) -> list[Any]:
     else:
         calls = getattr(message, "tool_calls", None) or []
     return list(calls) if isinstance(calls, (list, tuple)) else []
+
+
+def _message_tool_call_id(message: Any) -> str:
+    if isinstance(message, Mapping):
+        return str(message.get("tool_call_id") or message.get("call_id") or "").strip()
+    return str(getattr(message, "tool_call_id", "") or getattr(message, "call_id", "") or "").strip()
+
+
+def _message_explicit_tool_names(message: Any) -> set[str]:
+    if isinstance(message, Mapping):
+        raw_names = (message.get("name"), message.get("tool_name"))
+    else:
+        raw_names = (getattr(message, "name", ""), getattr(message, "tool_name", ""))
+    return {str(name).strip() for name in raw_names if str(name or "").strip()}
+
+
+def _message_content(message: Any) -> Any:
+    if isinstance(message, Mapping):
+        return message.get("content")
+    return getattr(message, "content", None)
 
 
 def _failure_from_mapping(payload: Mapping[str, Any]) -> bool:
@@ -164,6 +192,103 @@ def _int_or_zero(value: Any) -> int:
         return 0
 
 
+def _normalize_coordination_count(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return max(0, int(value))
+    except Exception:
+        return None
+
+
+def _recompute_coordination_count(receipt: TurnReceipt) -> None:
+    if "explicit" in receipt.coordination_breakdown:
+        receipt.coordination_count = _normalize_coordination_count(
+            receipt.coordination_breakdown.get("explicit")
+        )
+        return
+    total = 0
+    for count in receipt.coordination_breakdown.values():
+        normalized = _normalize_coordination_count(count)
+        if normalized is None:
+            receipt.coordination_count = None
+            return
+        total += normalized
+    receipt.coordination_count = total
+
+
+_AUTHORITATIVE_COORDINATION_COMPONENTS = {"explicit", "moa", "omo", "delegate_task"}
+
+
+def _has_explicit_coordination_total(receipt: TurnReceipt) -> bool:
+    return "explicit" in receipt.coordination_breakdown
+
+
+def _has_authoritative_coordination_component(receipt: TurnReceipt) -> bool:
+    return any(component in receipt.coordination_breakdown for component in _AUTHORITATIVE_COORDINATION_COMPONENTS)
+
+
+def _set_coordination_component(receipt: TurnReceipt, key: str, count: Any) -> None:
+    component = str(key or "").strip().lower()
+    if not component:
+        return
+    if component == "explicit":
+        receipt.coordination_breakdown.clear()
+        receipt.coordination_breakdown[component] = _normalize_coordination_count(count)
+        _recompute_coordination_count(receipt)
+        return
+    if _has_explicit_coordination_total(receipt):
+        _recompute_coordination_count(receipt)
+        return
+    if component == "delegation" and _has_authoritative_coordination_component(receipt):
+        receipt.coordination_breakdown.pop("delegation", None)
+        _recompute_coordination_count(receipt)
+        return
+    if component in _AUTHORITATIVE_COORDINATION_COMPONENTS:
+        receipt.coordination_breakdown.pop("delegation", None)
+    receipt.coordination_breakdown[component] = _normalize_coordination_count(count)
+    _recompute_coordination_count(receipt)
+
+
+def _clear_coordination_component(receipt: TurnReceipt, key: str) -> None:
+    component = str(key or "").strip().lower()
+    if component in receipt.coordination_breakdown:
+        del receipt.coordination_breakdown[component]
+        _recompute_coordination_count(receipt)
+
+
+def _decode_tool_result_payload(content: Any) -> Mapping[str, Any] | None:
+    if isinstance(content, Mapping):
+        return content
+    if not isinstance(content, str):
+        return None
+    stripped = content.strip()
+    if not stripped:
+        return None
+    try:
+        decoded = json.loads(stripped)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+    return decoded if isinstance(decoded, Mapping) else None
+
+
+def _delegate_task_result_count(message: Any) -> Optional[int]:
+    payload = _decode_tool_result_payload(_message_content(message))
+    if not isinstance(payload, Mapping):
+        return None
+    results = payload.get("results")
+    if isinstance(results, list):
+        return len(results)
+    status = str(payload.get("status") or "").strip().lower()
+    mode = str(payload.get("mode") or "").strip().lower()
+    if status == "dispatched" and mode == "background":
+        count = payload.get("count")
+        if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+            return None
+        return count
+    return None
+
+
 def update_turn_receipt_from_result(
     receipt: TurnReceipt,
     *,
@@ -196,12 +321,28 @@ def update_turn_receipt_from_result(
 
     names: list[str] = []
     failures = 0
+    assistant_tool_names_by_call_id: dict[str, set[str]] = {}
+    delegate_call_ids: list[str] = []
+    seen_delegate_call_ids: set[str] = set()
+    duplicate_delegate_call_id = False
+    delegate_calls_without_id = 0
     for message in messages or []:
         if _message_role(message) == "assistant":
             for call in _message_tool_calls(message):
                 name = _tool_call_name(call)
+                call_id = _tool_call_id(call)
                 if name:
                     names.append(name)
+                if call_id and name:
+                    assistant_tool_names_by_call_id.setdefault(call_id, set()).add(name)
+                if name == "delegate_task":
+                    if call_id:
+                        if call_id in seen_delegate_call_ids:
+                            duplicate_delegate_call_id = True
+                        seen_delegate_call_ids.add(call_id)
+                        delegate_call_ids.append(call_id)
+                    else:
+                        delegate_calls_without_id += 1
         elif _message_role(message) == "tool":
             if _tool_result_failed(message):
                 failures += 1
@@ -209,12 +350,67 @@ def update_turn_receipt_from_result(
     receipt.tool_names = names
     receipt.tool_total = len(names)
     receipt.tool_failed = failures
-    if any(name == "delegate_task" for name in names):
+
+    delegate_call_count = len(delegate_call_ids) + delegate_calls_without_id
+    if delegate_call_count:
         receipt.delegation_observed = True
         if receipt.agents_count == 0:
             receipt.agents_count = None
         if receipt.subagents_count == 0:
             receipt.subagents_count = None
+
+        delegate_result_total = 0
+        delegate_result_unknown = False
+        delegate_results_by_call_id: dict[str, list[Optional[int]]] = {
+            call_id: [] for call_id in seen_delegate_call_ids
+        }
+        anonymous_delegate_results: list[Optional[int]] = []
+        for message in messages or []:
+            if _message_role(message) != "tool":
+                continue
+            call_id = _message_tool_call_id(message)
+            explicit_tool_names = _message_explicit_tool_names(message)
+            explicit_non_delegate = any(name != "delegate_task" for name in explicit_tool_names)
+            explicit_delegate = "delegate_task" in explicit_tool_names
+            if call_id and call_id in delegate_results_by_call_id:
+                if explicit_non_delegate:
+                    delegate_results_by_call_id[call_id].append(None)
+                else:
+                    delegate_results_by_call_id[call_id].append(_delegate_task_result_count(message))
+            elif explicit_delegate and not explicit_non_delegate:
+                anonymous_delegate_results.append(_delegate_task_result_count(message))
+
+        delegate_call_id_name_conflict = any(
+            "delegate_task" in call_names and len(call_names) > 1
+            for call_names in assistant_tool_names_by_call_id.values()
+        )
+        if duplicate_delegate_call_id or delegate_call_id_name_conflict:
+            delegate_result_unknown = True
+
+        for result_counts in delegate_results_by_call_id.values():
+            if len(result_counts) != 1 or result_counts[0] is None:
+                delegate_result_unknown = True
+            else:
+                delegate_result_total += result_counts[0]
+
+        if delegate_calls_without_id:
+            if delegate_calls_without_id != 1 or len(anonymous_delegate_results) != 1:
+                delegate_result_unknown = True
+            else:
+                for result_count in anonymous_delegate_results:
+                    if result_count is None:
+                        delegate_result_unknown = True
+                    else:
+                        delegate_result_total += result_count
+        elif anonymous_delegate_results:
+            delegate_result_unknown = True
+
+        if delegate_result_unknown:
+            _set_coordination_component(receipt, "delegate_task", None)
+        else:
+            _set_coordination_component(receipt, "delegate_task", delegate_result_total)
+    else:
+        _clear_coordination_component(receipt, "delegate_task")
 
     if failed or interrupted:
         receipt.evidence_status = "failed" if failed else "partial"
@@ -274,6 +470,7 @@ def apply_turn_facts(receipt: TurnReceipt, facts: Mapping[str, Any] | None) -> T
             _add_mechanism_segment(receipt, str(segment))
 
     moa_failed_refs_observed = False
+    explicit_coordination_summary = False
     moa = _as_mapping(facts.get("moa"))
     if moa:
         reference_count = _count_strings(moa.get("reference_models"))
@@ -296,6 +493,7 @@ def apply_turn_facts(receipt: TurnReceipt, facts: Mapping[str, Any] | None) -> T
             else:
                 segment = f"MoA {reference_count}+{aggregator_count}"
             _add_mechanism_segment(receipt, segment)
+            _set_coordination_component(receipt, "moa", reference_count + aggregator_count)
             if receipt.route == "native":
                 receipt.route = "moa"
                 receipt.reason = "provider_moa"
@@ -311,33 +509,74 @@ def apply_turn_facts(receipt: TurnReceipt, facts: Mapping[str, Any] | None) -> T
         observed = bool(omo.get("observed")) or parent_count > 0 or descendant_count > 0
         if observed:
             _add_mechanism_segment(receipt, f"OMO {parent_count}+{descendant_count}")
+            _set_coordination_component(receipt, "omo", parent_count + descendant_count)
 
     coordination = _as_mapping(facts.get("coordination"))
     if coordination:
-        modes = coordination.get("modes") or []
+        raw_modes = coordination.get("modes") or []
+        if isinstance(raw_modes, str):
+            modes = {raw_modes.strip().lower()} if raw_modes.strip() else set()
+        elif isinstance(raw_modes, (list, tuple, set)):
+            modes = {str(mode).strip().lower() for mode in raw_modes if str(mode).strip()}
+        else:
+            modes = set()
         breakdown = _as_mapping(coordination.get("breakdown"))
-        if isinstance(modes, (list, tuple)) and "omo" in {str(mode) for mode in modes}:
+        if "omo" in modes:
             parent_count = _int_or_zero(breakdown.get("omo_parent"))
             descendant_count = _int_or_zero(breakdown.get("omo_descendants"))
             if parent_count or descendant_count:
                 _add_mechanism_segment(receipt, f"OMO {parent_count}+{descendant_count}")
+                _set_coordination_component(receipt, "omo", parent_count + descendant_count)
+        if "moa" in modes:
+            reference_count = _int_or_zero(
+                breakdown.get("moa_references", breakdown.get("reference_count"))
+            )
+            raw_aggregator_count = breakdown.get("moa_aggregators")
+            if raw_aggregator_count is None:
+                raw_aggregator_count = breakdown.get("moa_aggregator")
+            if raw_aggregator_count is None:
+                raw_aggregator_count = breakdown.get("aggregator_count")
+            aggregator_count = _int_or_zero(raw_aggregator_count)
+            if reference_count or aggregator_count:
+                _set_coordination_component(receipt, "moa", reference_count + aggregator_count)
+        if "agents" in coordination:
+            explicit_coordination_summary = True
+            _set_coordination_component(receipt, "explicit", coordination.get("agents"))
+            _clear_coordination_component(receipt, "delegation")
 
     delegation = _as_mapping(facts.get("delegation")) or _as_mapping(facts.get("agents"))
     if delegation:
         if "observed" in delegation:
             receipt.delegation_observed = bool(delegation.get("observed"))
+        raw_agents = delegation.get("agents") if "agents" in delegation else None
+        raw_subagents = delegation.get("subagents") if "subagents" in delegation else None
         if "agents" in delegation:
             try:
-                _raw_agents = delegation.get("agents")
-                receipt.agents_count = int(_raw_agents) if _raw_agents is not None else None
+                receipt.agents_count = int(raw_agents) if raw_agents is not None else None
             except Exception:
                 receipt.agents_count = None
         if "subagents" in delegation:
             try:
-                _raw_subagents = delegation.get("subagents")
-                receipt.subagents_count = int(_raw_subagents) if _raw_subagents is not None else None
+                receipt.subagents_count = int(raw_subagents) if raw_subagents is not None else None
             except Exception:
                 receipt.subagents_count = None
+        if explicit_coordination_summary:
+            _clear_coordination_component(receipt, "delegation")
+        else:
+            agents_count = _normalize_coordination_count(raw_agents)
+            subagents_count = _normalize_coordination_count(raw_subagents)
+            has_agent_count = raw_agents is not None and agents_count is not None
+            has_subagent_count = raw_subagents is not None and subagents_count is not None
+            observed = bool(delegation.get("observed")) or has_agent_count or has_subagent_count
+            if observed:
+                if has_subagent_count:
+                    _set_coordination_component(receipt, "delegation", subagents_count)
+                elif has_agent_count:
+                    _set_coordination_component(receipt, "delegation", agents_count)
+                else:
+                    _set_coordination_component(receipt, "delegation", None)
+            else:
+                _clear_coordination_component(receipt, "delegation")
 
     human = _as_mapping(facts.get("human_language")) or _as_mapping(facts.get("human"))
     if human:

--- a/agent/turn_receipt.py
+++ b/agent/turn_receipt.py
@@ -1,0 +1,279 @@
+"""Runtime-owned per-turn receipt facts.
+
+The receipt is deliberately small: it captures facts the runtime can know
+without importing heavier coordination systems.  Final response formatters can
+use it to add durable status metadata without asking the model to author it.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Optional
+
+
+@dataclass
+class TurnReceipt:
+    session_id: str
+    turn_id: str
+    provider: str = ""
+    model: str = ""
+    platform: str = ""
+    route: str = "native"
+    reason: str = "runtime_default"
+    opencode_state: str = "unknown"  # unknown | called | not_called
+    tool_names: list[str] = field(default_factory=list)
+    tool_total: int = 0
+    tool_failed: int = 0
+    agents_count: Optional[int] = 0
+    subagents_count: Optional[int] = 0
+    delegation_observed: bool = False
+    human_language_state: str = "unknown"  # unknown | seen | not_seen
+    evidence_status: str = "unknown"  # ok | partial | failed | unknown
+    api_calls: int = 0
+    completed: bool = False
+    failed: bool = False
+    interrupted: bool = False
+    exit_reason: str = "unknown"
+    start_monotonic: Optional[float] = None
+    elapsed_seconds: Optional[float] = None
+
+    @classmethod
+    def start(
+        cls,
+        *,
+        session_id: str,
+        turn_id: str,
+        provider: str = "",
+        model: str = "",
+        platform: str = "",
+        start_monotonic: Optional[float] = None,
+    ) -> "TurnReceipt":
+        receipt = cls(
+            session_id=session_id or "",
+            turn_id=turn_id or "",
+            provider=provider or "",
+            model=model or "",
+            platform=platform or "",
+            start_monotonic=start_monotonic,
+        )
+        _infer_route_from_runtime(receipt)
+        return receipt
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _infer_route_from_runtime(receipt: TurnReceipt) -> None:
+    provider = (receipt.provider or "").strip().lower()
+    model = (receipt.model or "").strip().lower()
+    if provider == "moa":
+        receipt.route = "moa"
+        receipt.reason = "provider_moa"
+    elif provider.startswith("opencode") or model.startswith("opencode"):
+        receipt.route = "opencode"
+        receipt.reason = "provider_opencode"
+        receipt.opencode_state = "called"
+
+
+def _tool_call_name(tool_call: Any) -> str:
+    if isinstance(tool_call, Mapping):
+        function = tool_call.get("function")
+        if isinstance(function, Mapping):
+            return str(function.get("name") or "").strip()
+        return str(tool_call.get("name") or "").strip()
+    function = getattr(tool_call, "function", None)
+    return str(getattr(function, "name", "") or getattr(tool_call, "name", "") or "").strip()
+
+
+def _message_role(message: Any) -> str:
+    if isinstance(message, Mapping):
+        return str(message.get("role") or "")
+    return str(getattr(message, "role", "") or "")
+
+
+def _message_tool_calls(message: Any) -> list[Any]:
+    if isinstance(message, Mapping):
+        calls = message.get("tool_calls") or []
+    else:
+        calls = getattr(message, "tool_calls", None) or []
+    return list(calls) if isinstance(calls, (list, tuple)) else []
+
+
+def _failure_from_mapping(payload: Mapping[str, Any]) -> bool:
+    """Return failure only from explicit, structured execution metadata."""
+
+    if payload.get("is_error") is True or payload.get("success") is False:
+        return True
+    status = str(payload.get("status") or "").strip().lower()
+    if status in {"error", "failed", "failure"}:
+        return True
+    exit_code = payload.get("exit_code")
+    if exit_code is not None:
+        try:
+            if int(exit_code) != 0:
+                return True
+        except (TypeError, ValueError):
+            pass
+    error = payload.get("error")
+    return error not in (None, "", False, 0, [], {})
+
+
+def _tool_result_failed(message: Any) -> bool:
+    """Classify a tool result without scanning successful prose for keywords."""
+
+    if isinstance(message, Mapping) and _failure_from_mapping(message):
+        return True
+    if isinstance(message, Mapping):
+        content = message.get("content")
+    else:
+        content = getattr(message, "content", None)
+    if isinstance(content, Mapping):
+        return _failure_from_mapping(content)
+    if not isinstance(content, str):
+        return False
+    stripped = content.strip()
+    if not (stripped.startswith("{") and stripped.endswith("}")):
+        return False
+    try:
+        decoded = json.loads(stripped)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return False
+    return isinstance(decoded, Mapping) and _failure_from_mapping(decoded)
+
+
+def update_turn_receipt_from_result(
+    receipt: TurnReceipt,
+    *,
+    completed: bool,
+    failed: bool,
+    interrupted: bool,
+    api_calls: int,
+    exit_reason: str,
+    messages: list[Mapping[str, Any]] | list[Any],
+    agent: Any = None,
+) -> TurnReceipt:
+    """Update ``receipt`` from finalizer/runtime facts."""
+
+    if agent is not None:
+        receipt.provider = str(getattr(agent, "provider", receipt.provider) or receipt.provider)
+        receipt.model = str(getattr(agent, "model", receipt.model) or receipt.model)
+        receipt.platform = str(getattr(agent, "platform", receipt.platform) or receipt.platform)
+        _infer_route_from_runtime(receipt)
+
+    receipt.completed = bool(completed)
+    receipt.failed = bool(failed)
+    receipt.interrupted = bool(interrupted)
+    try:
+        receipt.api_calls = int(api_calls or 0)
+    except Exception:
+        receipt.api_calls = 0
+    receipt.exit_reason = str(exit_reason or "unknown")
+    if receipt.start_monotonic is not None and receipt.elapsed_seconds is None:
+        receipt.elapsed_seconds = max(0.0, time.monotonic() - receipt.start_monotonic)
+
+    names: list[str] = []
+    failures = 0
+    for message in messages or []:
+        if _message_role(message) == "assistant":
+            for call in _message_tool_calls(message):
+                name = _tool_call_name(call)
+                if name:
+                    names.append(name)
+        elif _message_role(message) == "tool":
+            if _tool_result_failed(message):
+                failures += 1
+
+    receipt.tool_names = names
+    receipt.tool_total = len(names)
+    receipt.tool_failed = failures
+    if any(name == "delegate_task" for name in names):
+        receipt.delegation_observed = True
+        if receipt.agents_count == 0:
+            receipt.agents_count = None
+        if receipt.subagents_count == 0:
+            receipt.subagents_count = None
+
+    if failed or interrupted:
+        receipt.evidence_status = "failed" if failed else "partial"
+    elif completed:
+        receipt.evidence_status = "ok"
+    elif receipt.evidence_status == "unknown":
+        receipt.evidence_status = "partial"
+
+    return receipt
+
+
+def apply_turn_facts(receipt: TurnReceipt, facts: Mapping[str, Any] | None) -> TurnReceipt:
+    """Merge optional runtime fact dictionaries into ``receipt``.
+
+    This accepts a narrow, generic shape so future MoA/coordination layers can
+    pass facts without this module depending on those systems.
+    """
+
+    if not isinstance(facts, Mapping):
+        return receipt
+
+    route = _as_mapping(facts.get("route"))
+    if route.get("actual"):
+        receipt.route = str(route["actual"])
+    if route.get("reason"):
+        receipt.reason = str(route["reason"])
+
+    opencode = _as_mapping(facts.get("opencode"))
+    if "state" in opencode:
+        receipt.opencode_state = str(opencode.get("state") or "unknown")
+    elif "observed" in opencode:
+        receipt.opencode_state = "called" if bool(opencode.get("observed")) else "not_called"
+
+    tools = _as_mapping(facts.get("tools"))
+    if tools:
+        names = tools.get("names")
+        if isinstance(names, (list, tuple)):
+            receipt.tool_names = [str(name) for name in names if str(name)]
+        if "total" in tools:
+            try:
+                receipt.tool_total = int(tools.get("total") or 0)
+            except Exception:
+                pass
+        elif receipt.tool_names:
+            receipt.tool_total = len(receipt.tool_names)
+        if "failed" in tools:
+            try:
+                receipt.tool_failed = int(tools.get("failed") or 0)
+            except Exception:
+                pass
+
+    delegation = _as_mapping(facts.get("delegation")) or _as_mapping(facts.get("agents"))
+    if delegation:
+        if "observed" in delegation:
+            receipt.delegation_observed = bool(delegation.get("observed"))
+        if "agents" in delegation:
+            try:
+                _raw_agents = delegation.get("agents")
+                receipt.agents_count = int(_raw_agents) if _raw_agents is not None else None
+            except Exception:
+                receipt.agents_count = None
+        if "subagents" in delegation:
+            try:
+                _raw_subagents = delegation.get("subagents")
+                receipt.subagents_count = int(_raw_subagents) if _raw_subagents is not None else None
+            except Exception:
+                receipt.subagents_count = None
+
+    human = _as_mapping(facts.get("human_language")) or _as_mapping(facts.get("human"))
+    if human:
+        if "state" in human:
+            receipt.human_language_state = str(human.get("state") or "unknown")
+        elif "observed" in human:
+            receipt.human_language_state = "seen" if bool(human.get("observed")) else "not_seen"
+
+    evidence = _as_mapping(facts.get("evidence"))
+    if evidence.get("level"):
+        receipt.evidence_status = str(evidence.get("level") or "unknown")
+    elif evidence.get("status"):
+        receipt.evidence_status = str(evidence.get("status") or "unknown")
+
+    return receipt

--- a/agent/turn_receipt.py
+++ b/agent/turn_receipt.py
@@ -26,6 +26,7 @@ class TurnReceipt:
     tool_names: list[str] = field(default_factory=list)
     tool_total: int = 0
     tool_failed: int = 0
+    mechanism_segments: list[str] = field(default_factory=list)
     agents_count: Optional[int] = 0
     subagents_count: Optional[int] = 0
     delegation_observed: bool = False
@@ -144,6 +145,25 @@ def _tool_result_failed(message: Any) -> bool:
     return isinstance(decoded, Mapping) and _failure_from_mapping(decoded)
 
 
+def _add_mechanism_segment(receipt: TurnReceipt, segment: str) -> None:
+    text = str(segment or "").strip()
+    if text and text not in receipt.mechanism_segments:
+        receipt.mechanism_segments.append(text)
+
+
+def _count_strings(value: Any) -> int:
+    if isinstance(value, (list, tuple)):
+        return len([item for item in value if str(item)])
+    return 0
+
+
+def _int_or_zero(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except Exception:
+        return 0
+
+
 def update_turn_receipt_from_result(
     receipt: TurnReceipt,
     *,
@@ -245,6 +265,50 @@ def apply_turn_facts(receipt: TurnReceipt, facts: Mapping[str, Any] | None) -> T
                 receipt.tool_failed = int(tools.get("failed") or 0)
             except Exception:
                 pass
+
+    mechanisms = facts.get("mechanisms") or facts.get("mechanism_segments")
+    if isinstance(mechanisms, str):
+        _add_mechanism_segment(receipt, mechanisms)
+    elif isinstance(mechanisms, (list, tuple)):
+        for segment in mechanisms:
+            _add_mechanism_segment(receipt, str(segment))
+
+    moa = _as_mapping(facts.get("moa"))
+    if moa:
+        reference_count = _count_strings(moa.get("reference_models"))
+        aggregator_count = 1 if str(moa.get("aggregator_model") or "").strip() else 0
+        if "reference_count" in moa:
+            reference_count = _int_or_zero(moa.get("reference_count"))
+        if "aggregator_count" in moa:
+            aggregator_count = _int_or_zero(moa.get("aggregator_count"))
+        observed = bool(moa.get("observed")) or reference_count > 0 or aggregator_count > 0
+        if observed:
+            _add_mechanism_segment(receipt, f"MoA {reference_count}+{aggregator_count}")
+            if receipt.route == "native":
+                receipt.route = "moa"
+                receipt.reason = "provider_moa"
+
+    omo = _as_mapping(facts.get("omo"))
+    if omo:
+        parent_count = 1 if str(omo.get("parent_session_id") or "").strip() else 0
+        descendant_count = _count_strings(omo.get("descendant_session_ids") or [])
+        if "parent_count" in omo:
+            parent_count = _int_or_zero(omo.get("parent_count"))
+        if "descendant_count" in omo:
+            descendant_count = _int_or_zero(omo.get("descendant_count"))
+        observed = bool(omo.get("observed")) or parent_count > 0 or descendant_count > 0
+        if observed:
+            _add_mechanism_segment(receipt, f"OMO {parent_count}+{descendant_count}")
+
+    coordination = _as_mapping(facts.get("coordination"))
+    if coordination:
+        modes = coordination.get("modes") or []
+        breakdown = _as_mapping(coordination.get("breakdown"))
+        if isinstance(modes, (list, tuple)) and "omo" in {str(mode) for mode in modes}:
+            parent_count = _int_or_zero(breakdown.get("omo_parent"))
+            descendant_count = _int_or_zero(breakdown.get("omo_descendants"))
+            if parent_count or descendant_count:
+                _add_mechanism_segment(receipt, f"OMO {parent_count}+{descendant_count}")
 
     delegation = _as_mapping(facts.get("delegation")) or _as_mapping(facts.get("agents"))
     if delegation:

--- a/agent/turn_receipt.py
+++ b/agent/turn_receipt.py
@@ -273,6 +273,7 @@ def apply_turn_facts(receipt: TurnReceipt, facts: Mapping[str, Any] | None) -> T
         for segment in mechanisms:
             _add_mechanism_segment(receipt, str(segment))
 
+    moa_failed_refs_observed = False
     moa = _as_mapping(facts.get("moa"))
     if moa:
         reference_count = _count_strings(moa.get("reference_models"))
@@ -281,9 +282,20 @@ def apply_turn_facts(receipt: TurnReceipt, facts: Mapping[str, Any] | None) -> T
             reference_count = _int_or_zero(moa.get("reference_count"))
         if "aggregator_count" in moa:
             aggregator_count = _int_or_zero(moa.get("aggregator_count"))
-        observed = bool(moa.get("observed")) or reference_count > 0 or aggregator_count > 0
+        failed_count = max(0, _int_or_zero(moa.get("failed_count"))) if "failed_count" in moa else 0
+        if "reference_total" in moa:
+            reference_total = max(0, _int_or_zero(moa.get("reference_total")))
+        else:
+            reference_total = reference_count + failed_count
+        reference_total = max(reference_total, reference_count + failed_count)
+        observed = bool(moa.get("observed")) or reference_count > 0 or failed_count > 0 or aggregator_count > 0
         if observed:
-            _add_mechanism_segment(receipt, f"MoA {reference_count}+{aggregator_count}")
+            if failed_count > 0:
+                segment = f"MoA {reference_count}/{reference_total}+{aggregator_count}"
+                moa_failed_refs_observed = True
+            else:
+                segment = f"MoA {reference_count}+{aggregator_count}"
+            _add_mechanism_segment(receipt, segment)
             if receipt.route == "native":
                 receipt.route = "moa"
                 receipt.reason = "provider_moa"
@@ -339,5 +351,10 @@ def apply_turn_facts(receipt: TurnReceipt, facts: Mapping[str, Any] | None) -> T
         receipt.evidence_status = str(evidence.get("level") or "unknown")
     elif evidence.get("status"):
         receipt.evidence_status = str(evidence.get("status") or "unknown")
+
+    if moa_failed_refs_observed and not receipt.failed and not receipt.interrupted:
+        current_evidence = (receipt.evidence_status or "unknown").strip().lower()
+        if current_evidence not in {"failed", "fail", "error", "errored"}:
+            receipt.evidence_status = "partial"
 
     return receipt

--- a/cli.py
+++ b/cli.py
@@ -52,6 +52,10 @@ os.environ["HERMES_QUIET"] = "1"  # Our own modules
 import yaml
 
 from hermes_cli.fallback_config import get_fallback_chain
+from hermes_cli.final_response_display_policy import (
+    assistant_body_for_tts,
+    decide_final_response_display,
+)
 from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
 from hermes_cli.cli_commands_mixin import CLICommandsMixin
 
@@ -460,6 +464,7 @@ def load_cli_config() -> Dict[str, Any]:
             "show_reasoning": True,
             "reasoning_full": False,
             "streaming": True,
+            "assistant_body_streaming": False,
             "busy_input_mode": "interrupt",
             "persistent_output": True,
             "persistent_output_max_lines": 200,
@@ -3753,6 +3758,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         
         # streaming: stream tokens to the terminal as they arrive (display.streaming in config.yaml)
         self.streaming_enabled = CLI_CONFIG["display"].get("streaming", False)
+        # Assistant answer-body deltas are draft/provisional until the agent
+        # finalizer returns canonical final_response. Keep tool/status/reasoning
+        # streams live, but render answer body from final_response by default so
+        # one user turn cannot show raw stream + transformed final as two full
+        # answers.
+        self.assistant_body_streaming = bool(
+            CLI_CONFIG["display"].get("assistant_body_streaming", False)
+        )
         # show_timestamps: prefix user and assistant labels with timestamps
         self.show_timestamps = CLI_CONFIG["display"].get("timestamps", False)
         self.timestamp_format = CLI_CONFIG["display"].get("timestamp_format", "%H:%M")
@@ -5619,7 +5632,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 self._deferred_content = ""
                 self._emit_stream_text(deferred)
 
-    def _stream_delta(self, text) -> None:
+    def _stream_delta(self, text) -> bool:
         """Line-buffered streaming callback for real-time token rendering.
 
         Receives text deltas from the agent as tokens arrive. Buffers
@@ -5634,12 +5647,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         about to execute).  Flushes any open boxes and resets state so
         tool feed lines render cleanly between turns.
         """
+        _visible_generation_before = getattr(self, "_stream_body_visible_generation", 0)
+
         if text is None:
             self._flush_stream()
             self._reset_stream_state()
-            return
+            return False
         if not text:
-            return
+            return False
 
         self._stream_started = True
 
@@ -5729,7 +5744,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     self._emit_stream_text(safe)
                     self._stream_last_was_newline = safe.endswith("\n")
                     self._stream_prefilt = self._stream_prefilt[len(safe):]
-                return
+                return (
+                    getattr(self, "_stream_body_visible_generation", 0)
+                    != _visible_generation_before
+                )
 
         # Inside a reasoning block — look for close tag.
         # Keep accumulating _stream_prefilt because close tags can arrive
@@ -5751,8 +5769,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     # Process remaining text after close tag through full
                     # filtering (it could contain another open tag)
                     if after:
-                        self._stream_delta(after)
-                    return
+                        return self._stream_delta(after) or (
+                            getattr(self, "_stream_body_visible_generation", 0)
+                            != _visible_generation_before
+                        )
+                    return (
+                        getattr(self, "_stream_body_visible_generation", 0)
+                        != _visible_generation_before
+                    )
             # When show_reasoning is on, stream reasoning content live
             # instead of silently accumulating. Keep only the tail that
             # could be a partial close tag prefix.
@@ -5763,19 +5787,28 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     safe_reasoning = self._stream_prefilt[:-max_tag_len]
                     self._stream_reasoning_delta(safe_reasoning)
                 self._stream_prefilt = self._stream_prefilt[-max_tag_len:]
-            return
+            return (
+                getattr(self, "_stream_body_visible_generation", 0)
+                != _visible_generation_before
+            )
 
-    def _emit_stream_text(self, text: str) -> None:
+    def _emit_stream_text(self, text: str) -> bool:
         """Emit filtered text to the streaming display."""
         if not text:
-            return
+            return False
+
+        if not getattr(self, "assistant_body_streaming", True):
+            # Final-only answer-body mode: keep reasoning/status/tool progress
+            # live, but do not render draft assistant body deltas. The agent
+            # still records received text separately for partial-stream recovery.
+            return False
 
         # When show_reasoning is on and reasoning is still rendering,
         # defer content until the reasoning box closes.  This ensures the
         # reasoning block always appears BEFORE the response in the terminal.
         if self.show_reasoning and getattr(self, "_reasoning_box_opened", False):
             self._deferred_content = getattr(self, "_deferred_content", "") + text
-            return
+            return False
 
         # Close the live reasoning box before opening the response box
         self._close_reasoning_box()
@@ -5785,7 +5818,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # Strip leading whitespace/newlines before first visible content
             text = text.lstrip("\n")
             if not text:
-                return
+                return False
             self._stream_box_opened = True
             try:
                 from hermes_cli.skin_engine import get_active_skin
@@ -5810,6 +5843,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             fill = w - 2 - HermesCLI._status_bar_display_width(label)
             _cprint(f"\n{_ACCENT}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}")
 
+        self._stream_body_visible_generation = getattr(
+            self, "_stream_body_visible_generation", 0
+        ) + 1
         self._stream_buf += text
 
         # Emit complete lines, keep partial remainder in buffer
@@ -5886,6 +5922,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 if self.final_response_markdown == "strip":
                     chunk = _strip_markdown_syntax(chunk)
                 _emit_one(chunk)
+        return True
 
     def _flush_stream(self) -> None:
         """Emit any remaining partial line from the stream buffer and close the box."""
@@ -5899,6 +5936,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         # Close reasoning box if still open (in case no content tokens arrived)
         self._close_reasoning_box()
+
+        if not getattr(self, "assistant_body_streaming", True):
+            self._stream_buf = ""
+            self._stream_table_buf = []
+            self._in_stream_table = False
+            return
 
         _tc = getattr(self, "_stream_text_ansi", "")
 
@@ -5952,6 +5995,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self._deferred_content = ""
         self._stream_table_buf = []
         self._in_stream_table = False
+        self._stream_body_visible_generation = 0
 
     def _slow_command_status(self, command: str) -> str:
         """Return a user-facing status message for slower slash commands."""
@@ -12656,7 +12700,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         display_reasoning = reasoning.strip()
                     _cprint(f"\n{r_top}\n{_DIM}{display_reasoning}{_RST}\n{r_bot}")
 
-            if response and not response_previewed:
+            if response:
                 # Use skin engine for label/color with fallback
                 try:
                     from hermes_cli.skin_engine import get_active_skin
@@ -12670,16 +12714,32 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     _resp_text = _maybe_remap_for_light_mode("#FFF8DC")
 
                 is_error_response = result and (result.get("failed") or result.get("partial"))
-                already_streamed = self._stream_started and self._stream_box_opened and not is_error_response
-                if use_streaming_tts and _streaming_box_opened and not is_error_response:
-                    # Text was already printed sentence-by-sentence; just close the box
+                stream_text_received = bool(
+                    result.get("stream_text_received")
+                    if result and "stream_text_received" in result
+                    else self._stream_started
+                )
+                stream_text_visible = bool(
+                    result.get("stream_text_visible")
+                    if result and "stream_text_visible" in result
+                    else (self._stream_started and self._stream_box_opened)
+                )
+                decision = decide_final_response_display(
+                    response=response,
+                    response_previewed=response_previewed,
+                    response_transformed=bool(result and result.get("response_transformed")),
+                    stream_text_received=stream_text_received,
+                    stream_text_visible=stream_text_visible,
+                    is_error_response=bool(is_error_response),
+                    use_streaming_tts=bool(use_streaming_tts),
+                    streaming_tts_box_opened=bool(_streaming_box_opened),
+                )
+                if decision.close_streaming_tts_box:
+                    # Text was already printed sentence-by-sentence; close that
+                    # frame before a transformed canonical panel is rendered.
                     w = self._scrollback_box_width()
                     _cprint(f"\n{_ACCENT}╰{'─' * (w - 2)}╯{_RST}")
-                elif already_streamed:
-                    # Response was already streamed token-by-token with box framing;
-                    # _flush_stream() already closed the box. Skip Rich Panel.
-                    pass
-                else:
+                if decision.render_panel:
                     _chat_console = ChatConsole()
                     _chat_console.print(Panel(
                         _render_final_assistant_content(response, mode=self.final_response_markdown),
@@ -12713,7 +12773,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # Speak response aloud if voice TTS is enabled
             # Skip batch TTS when streaming TTS already handled it
             if self._voice_tts and response and not use_streaming_tts:
-                self._voice_speak_response_async(response)
+                self._voice_speak_response_async(assistant_body_for_tts(response))
 
 
             # Re-queue the interrupt message (and any that arrived while we were

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1801,6 +1801,11 @@ DEFAULT_CONFIG = {
         # Per-platform overrides via display.platforms.<platform>.memory_notifications.
         "memory_notifications": "on",
         "streaming": False,
+        # Classic CLI receives assistant answer-body stream deltas for recovery
+        # accounting, but renders the official answer from canonical
+        # final_response by default. Reasoning/tool/status progress streams are
+        # unaffected. Set true to opt back into legacy live answer-body output.
+        "assistant_body_streaming": False,
         "timestamps": False,      # Show timestamp on user and assistant labels
         "timestamp_format": "%H:%M",  # strftime format for timestamps (e.g. "%b-%d %H:%M")
         "final_response_markdown": "strip",  # render | strip | raw

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6605,6 +6605,26 @@ def _normalize_max_turns_config(config: Dict[str, Any]) -> Dict[str, Any]:
     return config
 
 
+def _apply_legacy_display_streaming_compat(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Map legacy display.answer_body_streaming when the new key is absent."""
+
+    display = config.get("display")
+    if not isinstance(display, dict):
+        return config
+    if "assistant_body_streaming" in display:
+        return config
+
+    legacy = str(display.get("answer_body_streaming") or "").strip().lower()
+    if legacy not in {"live", "final_only"}:
+        return config
+
+    normalized = dict(config)
+    normalized_display = dict(display)
+    normalized_display["assistant_body_streaming"] = legacy == "live"
+    normalized["display"] = normalized_display
+    return normalized
+
+
 def cfg_get(cfg: Optional[Dict[str, Any]], *keys: str, default: Any = None) -> Any:
     """Traverse nested dict keys safely, returning ``default`` on any miss.
 
@@ -6961,6 +6981,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                     user_config["agent"] = agent_user_config
                     user_config.pop("max_turns", None)
 
+                user_config = _apply_legacy_display_streaming_compat(user_config)
                 config = _deep_merge(config, user_config)
             except Exception as e:
                 # Last-known-good fallback (port of openai/codex#31188's

--- a/hermes_cli/final_response_display_policy.py
+++ b/hermes_cli/final_response_display_policy.py
@@ -1,0 +1,92 @@
+"""Classic-CLI final response display decisions.
+
+The classic CLI has two independent answer surfaces during a turn:
+
+* live token callbacks (draft/provisional text), and
+* the canonical ``final_response`` returned by the agent finalizer.
+
+This module keeps the policy small and testable so future rebases do not
+accidentally show both as full assistant answers for one user turn.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from agent.route_depth_bar import strip_route_depth_bar
+
+
+@dataclass(frozen=True)
+class FinalResponseDisplayDecision:
+    """How the CLI should surface the canonical final response."""
+
+    render_panel: bool
+    close_streaming_tts_box: bool = False
+    reason: str = "render_final_response"
+
+
+def assistant_body_for_tts(response: str) -> str:
+    """Return answer body text without the runtime-only route/status bar."""
+
+    return strip_route_depth_bar(response or "")
+
+
+def decide_final_response_display(
+    *,
+    response: str,
+    response_previewed: bool,
+    response_transformed: bool,
+    stream_text_received: bool,
+    stream_text_visible: bool,
+    is_error_response: bool,
+    use_streaming_tts: bool,
+    streaming_tts_box_opened: bool,
+) -> FinalResponseDisplayDecision:
+    """Return the display action for one completed classic-CLI turn.
+
+    ``stream_text_received`` is intentionally separate from
+    ``stream_text_visible``: final-only UIs may receive draft assistant body
+    deltas for partial-stream recovery while choosing not to render them.
+    Only actually visible untransformed answer-body text can suppress the
+    canonical final panel.
+    """
+
+    if not response:
+        return FinalResponseDisplayDecision(False, reason="empty_response")
+
+    # Runtime/plugin/finalizer transforms (including the route/depth bar)
+    # make the returned final_response canonical. It must be rendered even if
+    # raw text was previewed or spoken while streaming; otherwise terminal and
+    # persisted final content diverge. The caller closes any open streaming-TTS
+    # frame before rendering the canonical panel.
+    if response_transformed:
+        return FinalResponseDisplayDecision(
+            True,
+            close_streaming_tts_box=(
+                use_streaming_tts
+                and streaming_tts_box_opened
+                and not is_error_response
+            ),
+            reason="transformed_final_response",
+        )
+
+    if response_previewed and stream_text_visible:
+        return FinalResponseDisplayDecision(False, reason="previewed")
+
+    if use_streaming_tts and streaming_tts_box_opened and not is_error_response:
+        return FinalResponseDisplayDecision(
+            False,
+            close_streaming_tts_box=True,
+            reason="streaming_tts_visible",
+        )
+
+    if is_error_response:
+        return FinalResponseDisplayDecision(True, reason="error_response")
+
+    if stream_text_visible:
+        return FinalResponseDisplayDecision(False, reason="already_visible_stream")
+
+    if stream_text_received:
+        return FinalResponseDisplayDecision(True, reason="not_visible")
+
+    return FinalResponseDisplayDecision(True, reason="render_final_response")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9782,26 +9782,126 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 text=True,
             )
             if pull_result.returncode != 0:
-                # ff-only failed — local and remote have diverged (e.g. upstream
-                # force-pushed or rebase).  Since local changes are already
-                # stashed, reset to match the remote exactly.
-                print(
-                    "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
-                )
-                reset_result = subprocess.run(
-                    git_cmd + ["reset", "--hard", f"origin/{branch}"],
+                # ``ff-only`` can fail either because the remote rewrote history
+                # or because this checkout carries committed local patches.  The
+                # autostash above protects only uncommitted files; a blind hard
+                # reset would orphan local commits and silently remove their
+                # runtime behaviour.  Replay committed patches when present and
+                # fail closed on conflicts.  Only reset when we have proved that
+                # the branch has no local-only commits.
+                ahead_result = subprocess.run(
+                    git_cmd + ["rev-list", "--count", f"origin/{branch}..HEAD"],
                     cwd=PROJECT_ROOT,
                     capture_output=True,
                     text=True,
                 )
-                if reset_result.returncode != 0:
-                    print(f"✗ Failed to reset to origin/{branch}.")
-                    if reset_result.stderr.strip():
-                        print(f"  {reset_result.stderr.strip()}")
+                try:
+                    ahead_count = (
+                        int(ahead_result.stdout.strip())
+                        if ahead_result.returncode == 0
+                        else None
+                    )
+                except (TypeError, ValueError):
+                    ahead_count = None
+
+                if ahead_count is None:
                     print(
-                        f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
+                        "  ✗ Fast-forward failed and local commit safety "
+                        "could not be verified."
+                    )
+                    print(
+                        "    No reset was performed; committed work was not discarded."
+                    )
+                    print(
+                        f"    Inspect manually: git log --oneline "
+                        f"origin/{branch}..HEAD"
                     )
                     sys.exit(1)
+
+                if ahead_count > 0:
+                    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
+                    sha_suffix = (pre_pull_sha or "unknown")[:8]
+                    backup_branch = f"hermes-local-commits-{timestamp}-{sha_suffix}"
+                    backup_result = subprocess.run(
+                        git_cmd + ["branch", backup_branch, "HEAD"],
+                        cwd=PROJECT_ROOT,
+                        capture_output=True,
+                        text=True,
+                    )
+                    if backup_result.returncode != 0:
+                        print(
+                            f"  ✗ Could not preserve {ahead_count} local commit(s) "
+                            "on a backup branch."
+                        )
+                        print(
+                            "    Update stopped; no reset was performed and "
+                            "committed work was not discarded."
+                        )
+                        if backup_result.stderr.strip():
+                            print(f"    {backup_result.stderr.strip()}")
+                        sys.exit(1)
+
+                    print(
+                        f"  ✓ {ahead_count} local commit(s) preserved on "
+                        f"backup branch '{backup_branch}'"
+                    )
+                    print(f"→ Rebasing local commits onto origin/{branch}...")
+                    rebase_result = subprocess.run(
+                        git_cmd + ["rebase", f"origin/{branch}"],
+                        cwd=PROJECT_ROOT,
+                        capture_output=True,
+                        text=True,
+                    )
+                    if rebase_result.returncode != 0:
+                        abort_result = subprocess.run(
+                            git_cmd + ["rebase", "--abort"],
+                            cwd=PROJECT_ROOT,
+                            capture_output=True,
+                            text=True,
+                        )
+                        print("  ✗ Local commits could not be rebased automatically.")
+                        print(
+                            f"    They are kept on backup branch '{backup_branch}' "
+                            "and were not discarded."
+                        )
+                        if abort_result.returncode != 0:
+                            print("  ✗ Rebase abort also failed; the checkout may still be in progress.")
+                            abort_detail = (
+                                abort_result.stderr.strip()
+                                or abort_result.stdout.strip()
+                                or "git rebase --abort returned a non-zero status"
+                            )
+                            print(f"    {abort_detail}")
+                            print("    Inspect with: git status")
+                            print("    Recover with: git rebase --abort")
+                        else:
+                            print(
+                                f"    Resolve manually, then retry: git rebase origin/{branch}"
+                            )
+                        sys.exit(1)
+                    print(
+                        f"  ✓ Local commits rebased onto origin/{branch}; "
+                        "committed patches remain active."
+                    )
+                else:
+                    print(
+                        "  ⚠ Fast-forward not possible, but no local-only commits "
+                        "were found; resetting to match remote..."
+                    )
+                    reset_result = subprocess.run(
+                        git_cmd + ["reset", "--hard", f"origin/{branch}"],
+                        cwd=PROJECT_ROOT,
+                        capture_output=True,
+                        text=True,
+                    )
+                    if reset_result.returncode != 0:
+                        print(f"✗ Failed to reset to origin/{branch}.")
+                        if reset_result.stderr.strip():
+                            print(f"  {reset_result.stderr.strip()}")
+                        print(
+                            f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
+                        )
+                        sys.exit(1)
 
             # Post-pull syntax guard: validate critical-path files actually
             # parse before declaring the update successful. If a bad commit

--- a/run_agent.py
+++ b/run_agent.py
@@ -4627,13 +4627,9 @@ class AIAgent:
                 if ctx_scrubber is not None:
                     think_tail = ctx_scrubber.feed(think_tail)
                 if think_tail:
-                    callbacks = [cb for cb in (self.stream_delta_callback, self._stream_callback) if cb is not None]
-                    for cb in callbacks:
-                        try:
-                            cb(think_tail)
-                        except Exception:
-                            pass
                     self._record_streamed_assistant_text(think_tail)
+                    if self._deliver_stream_text_to_callbacks(think_tail):
+                        self._record_visible_streamed_assistant_text(think_tail)
         # Flush any benign partial-tag tail held by the context scrubber so it
         # reaches the UI before we clear state for the next model call.  If
         # the scrubber is mid-span, flush() drops the orphaned content.
@@ -4641,21 +4637,50 @@ class AIAgent:
         if scrubber is not None:
             tail = scrubber.flush()
             if tail:
-                callbacks = [cb for cb in (self.stream_delta_callback, self._stream_callback) if cb is not None]
-                for cb in callbacks:
-                    try:
-                        cb(tail)
-                    except Exception:
-                        pass
                 self._record_streamed_assistant_text(tail)
+                if self._deliver_stream_text_to_callbacks(tail):
+                    self._record_visible_streamed_assistant_text(tail)
         self._current_streamed_assistant_text = ""
+        self._current_visible_streamed_assistant_text = ""
 
     def _record_streamed_assistant_text(self, text: str) -> None:
-        """Accumulate visible assistant text emitted through stream callbacks."""
+        """Accumulate assistant text received through stream callbacks."""
         if isinstance(text, str) and text:
             self._current_streamed_assistant_text = (
                 getattr(self, "_current_streamed_assistant_text", "") + text
             )
+
+    def _record_visible_streamed_assistant_text(self, text: str) -> None:
+        """Accumulate assistant text actually rendered to the user."""
+        if isinstance(text, str) and text:
+            self._current_visible_streamed_assistant_text = (
+                getattr(self, "_current_visible_streamed_assistant_text", "") + text
+            )
+
+    def _deliver_stream_text_to_callbacks(self, text: str) -> bool:
+        """Deliver stream text and report whether answer-body text was visible.
+
+        ``stream_delta_callback`` is the visual/UI callback and may return
+        ``False`` to indicate final-only buffering. ``_stream_callback`` is an
+        auxiliary stream consumer (for example streaming TTS) and does not make
+        text visible in the assistant transcript by itself.
+        """
+        visible_delivered = False
+        display_cb = getattr(self, "stream_delta_callback", None)
+        if display_cb is not None:
+            try:
+                rendered = display_cb(text)
+                if rendered is not False:
+                    visible_delivered = True
+            except Exception:
+                pass
+        aux_cb = getattr(self, "_stream_callback", None)
+        if aux_cb is not None and aux_cb is not display_cb:
+            try:
+                aux_cb(text)
+            except Exception:
+                pass
+        return visible_delivered
 
     @staticmethod
     def _normalize_interim_visible_text(text: str) -> str:
@@ -4670,7 +4695,9 @@ class AIAgent:
         if not visible_content:
             return False
         streamed = self._normalize_interim_visible_text(
-            self._strip_think_blocks(getattr(self, "_current_streamed_assistant_text", "") or "")
+            self._strip_think_blocks(
+                getattr(self, "_current_visible_streamed_assistant_text", "") or ""
+            )
         )
         return bool(streamed) and streamed == visible_content
 
@@ -4731,16 +4758,14 @@ class AIAgent:
                 text = text.lstrip("\n")
         if not text:
             return
-        callbacks = [cb for cb in (self.stream_delta_callback, self._stream_callback) if cb is not None]
-        delivered = False
-        for cb in callbacks:
-            try:
-                cb(text)
-                delivered = True
-            except Exception:
-                pass
-        if delivered:
+        has_stream_consumers = bool(
+            getattr(self, "stream_delta_callback", None) is not None
+            or getattr(self, "_stream_callback", None) is not None
+        )
+        if has_stream_consumers or not getattr(self, "_current_streamed_assistant_text", ""):
             self._record_streamed_assistant_text(text)
+        if self._deliver_stream_text_to_callbacks(text):
+            self._record_visible_streamed_assistant_text(text)
 
     def _fire_reasoning_delta(self, text: str) -> None:
         """Fire reasoning callback if registered."""

--- a/scripts/verify_final_response_contract.py
+++ b/scripts/verify_final_response_contract.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Verify upgrade-critical final-response contracts.
+
+This deterministic script complements focused pytest coverage by checking the
+source-level wiring that has regressed during upstream rebases: final-only
+classic CLI config, the display-policy import/use, and route-bar finalizer
+persistence ownership.  It exits non-zero if those seams disappear.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+
+CHECKS = [
+    (
+        "hermes_cli/config.py",
+        '"assistant_body_streaming": False',
+        "DEFAULT_CONFIG must keep classic assistant answer-body streaming final-only by default",
+    ),
+    (
+        "cli.py",
+        "decide_final_response_display",
+        "classic CLI must route final panel decisions through the durable policy helper",
+    ),
+    (
+        "agent/turn_finalizer.py",
+        "apply_route_depth_bar",
+        "turn finalizer must apply the runtime-owned route/depth bar",
+    ),
+    (
+        "agent/turn_finalizer.py",
+        "_ensure_canonical_final_message",
+        "turn finalizer must persist the transformed canonical assistant message",
+    ),
+    (
+        "run_agent.py",
+        "_current_visible_streamed_assistant_text",
+        "agent must track received stream text separately from visibly rendered stream text",
+    ),
+]
+
+
+def main() -> int:
+    failures: list[str] = []
+    for rel, needle, message in CHECKS:
+        text = (ROOT / rel).read_text(encoding="utf-8")
+        if needle not in text:
+            failures.append(f"{rel}: missing {needle!r} — {message}")
+    if failures:
+        for failure in failures:
+            print(f"FAIL: {failure}")
+        return 1
+    print("OK: final-response display and route-bar persistence contracts are wired")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/agent/test_moa_turn_facts.py
+++ b/tests/agent/test_moa_turn_facts.py
@@ -109,6 +109,13 @@ def _bar_for(facts):
     return format_route_depth_bar(receipt)
 
 
+def _assert_coordination(bar: str, expected: str) -> None:
+    fields = bar.split("｜")
+    assert [field for field in fields if field.startswith("协同 Agent ")] == [expected]
+    assert not any(field.startswith("agents ") for field in fields)
+    assert not any(field.startswith("subagents ") for field in fields)
+
+
 def test_moa_client_reports_all_successful_references_compact_and_evidence_ok(monkeypatch, tmp_path) -> None:
     client, _calls = _install_fake_moa(
         monkeypatch,
@@ -134,6 +141,7 @@ def test_moa_client_reports_all_successful_references_compact_and_evidence_ok(mo
     bar = _bar_for(facts)
     assert "MoA 4+1" in bar
     assert "MoA 4/4+1" not in bar
+    _assert_coordination(bar, "协同 Agent 5")
     assert receipt.evidence_status == "ok"
     assert "证据 ✓" in bar
 
@@ -157,6 +165,7 @@ def test_moa_client_reports_success_total_and_failed_references_as_partial(monke
     receipt = _receipt_for(facts)
     bar = _bar_for(facts)
     assert "MoA 2/3+1" in bar
+    _assert_coordination(bar, "协同 Agent 3")
     assert receipt.evidence_status == "partial"
     assert "证据 partial" in bar
 
@@ -180,6 +189,7 @@ def test_moa_client_reports_zero_references_when_all_refs_fail_but_aggregator_su
     receipt = _receipt_for(facts)
     bar = _bar_for(facts)
     assert "MoA 0/2+1" in bar
+    _assert_coordination(bar, "协同 Agent 1")
     assert receipt.evidence_status == "partial"
     assert "证据 partial" in bar
 
@@ -212,6 +222,7 @@ def test_moa_runtime_facts_builder_counts_explicit_skipped_reference_output_as_f
     receipt = _receipt_for(facts)
     bar = _bar_for(facts)
     assert "MoA 1/2+1" in bar
+    _assert_coordination(bar, "协同 Agent 2")
     assert receipt.evidence_status == "partial"
     assert "证据 partial" in bar
 
@@ -236,6 +247,7 @@ def test_moa_client_no_configured_references_keeps_aggregator_only_not_partial(m
     bar = _bar_for(facts)
     assert "MoA 0+1" in bar
     assert "MoA 0/0+1" not in bar
+    _assert_coordination(bar, "协同 Agent 1")
     assert receipt.evidence_status == "ok"
     assert "证据 ✓" in bar
 

--- a/tests/agent/test_moa_turn_facts.py
+++ b/tests/agent/test_moa_turn_facts.py
@@ -11,20 +11,33 @@ def _response(content="done", *, model="fake-model"):
     return SimpleNamespace(choices=[choice], usage=None, model=model)
 
 
-def _write_moa_config(home, *, refs, aggregator_model="agg-model", fanout=None):
+def _write_moa_config(home, *, refs, aggregator_model="agg-model", fanout=None, enabled=True):
     home.mkdir()
-    ref_yaml = "\n".join(
-        f"        - provider: openrouter\n          model: {model}" for model in refs
+    ref_lines = []
+    for ref in refs:
+        if isinstance(ref, dict):
+            provider = ref.get("provider") or "openrouter"
+            model = ref.get("model") or ""
+        else:
+            provider = "openrouter"
+            model = str(ref)
+        ref_lines.append(f"        - provider: {provider}\n          model: {model}")
+    ref_yaml = "\n".join(ref_lines)
+    reference_section = (
+        f"      reference_models:\n{ref_yaml}"
+        if ref_yaml
+        else "      reference_models: []"
     )
     fanout_yaml = f"\n      fanout: {fanout}" if fanout else ""
+    enabled_yaml = "true" if enabled else "false"
     (home / "config.yaml").write_text(
         f"""
 moa:
   default_preset: review
   presets:
     review:{fanout_yaml}
-      reference_models:
-{ref_yaml if ref_yaml else '        []'}
+      enabled: {enabled_yaml}
+{reference_section}
       aggregator:
         provider: openrouter
         model: {aggregator_model}
@@ -33,9 +46,9 @@ moa:
     )
 
 
-def _install_fake_moa(monkeypatch, tmp_path, *, refs, fail_refs=(), aggregator_raises_for=(), stream=False):
+def _install_fake_moa(monkeypatch, tmp_path, *, refs, fail_refs=(), aggregator_raises_for=(), stream=False, enabled=True):
     home = tmp_path / ".hermes"
-    _write_moa_config(home, refs=refs)
+    _write_moa_config(home, refs=refs, enabled=enabled)
     monkeypatch.setenv("HERMES_HOME", str(home))
     calls = []
     fail_refs = set(fail_refs)
@@ -65,7 +78,7 @@ def _install_fake_moa(monkeypatch, tmp_path, *, refs, fail_refs=(), aggregator_r
     return MoAClient("review"), calls
 
 
-def _bar_for(facts):
+def _receipt_for(facts, *, failed=False, interrupted=False):
     from agent.route_depth_bar import format_route_depth_bar
     from agent.turn_receipt import TurnReceipt, apply_turn_facts, update_turn_receipt_from_result
 
@@ -78,18 +91,54 @@ def _bar_for(facts):
     )
     update_turn_receipt_from_result(
         receipt,
-        completed=True,
-        failed=False,
-        interrupted=False,
+        completed=not failed and not interrupted,
+        failed=failed,
+        interrupted=interrupted,
         api_calls=1,
         exit_reason="stop",
         messages=[],
     )
     apply_turn_facts(receipt, facts)
+    return receipt
+
+
+def _bar_for(facts):
+    from agent.route_depth_bar import format_route_depth_bar
+
+    receipt = _receipt_for(facts)
     return format_route_depth_bar(receipt)
 
 
-def test_moa_client_reports_only_successful_references_and_completed_aggregator(monkeypatch, tmp_path) -> None:
+def test_moa_client_reports_all_successful_references_compact_and_evidence_ok(monkeypatch, tmp_path) -> None:
+    client, _calls = _install_fake_moa(
+        monkeypatch,
+        tmp_path,
+        refs=["ref-a", "ref-b", "ref-c", "ref-d"],
+    )
+
+    client.chat.completions.create(messages=[{"role": "user", "content": "q"}], tools=[])
+
+    facts = client.coordination_turn_facts()
+    assert facts["moa"]["reference_models"] == [
+        "openrouter:ref-a",
+        "openrouter:ref-b",
+        "openrouter:ref-c",
+        "openrouter:ref-d",
+    ]
+    assert facts["moa"]["reference_count"] == 4
+    assert facts["moa"]["reference_total"] == 4
+    assert facts["moa"]["failed_count"] == 0
+    assert facts["moa"]["aggregator_count"] == 1
+
+    receipt = _receipt_for(facts)
+    bar = _bar_for(facts)
+    assert "MoA 4+1" in bar
+    assert "MoA 4/4+1" not in bar
+    assert receipt.evidence_status == "ok"
+    assert "证据 ✓" in bar
+
+
+def test_moa_client_reports_success_total_and_failed_references_as_partial(monkeypatch, tmp_path) -> None:
     client, _calls = _install_fake_moa(
         monkeypatch,
         tmp_path,
@@ -102,8 +151,14 @@ def test_moa_client_reports_only_successful_references_and_completed_aggregator(
     facts = client.coordination_turn_facts()
     assert facts["moa"]["reference_models"] == ["openrouter:ref-a", "openrouter:ref-b"]
     assert facts["moa"]["reference_count"] == 2
+    assert facts["moa"]["reference_total"] == 3
+    assert facts["moa"]["failed_count"] == 1
     assert facts["moa"]["aggregator_count"] == 1
-    assert "MoA 2+1" in _bar_for(facts)
+    receipt = _receipt_for(facts)
+    bar = _bar_for(facts)
+    assert "MoA 2/3+1" in bar
+    assert receipt.evidence_status == "partial"
+    assert "证据 partial" in bar
 
 
 def test_moa_client_reports_zero_references_when_all_refs_fail_but_aggregator_succeeds(monkeypatch, tmp_path) -> None:
@@ -119,8 +174,84 @@ def test_moa_client_reports_zero_references_when_all_refs_fail_but_aggregator_su
     facts = client.coordination_turn_facts()
     assert facts["moa"]["reference_models"] == []
     assert facts["moa"]["reference_count"] == 0
+    assert facts["moa"]["reference_total"] == 2
+    assert facts["moa"]["failed_count"] == 2
     assert facts["moa"]["aggregator_count"] == 1
-    assert "MoA 0+1" in _bar_for(facts)
+    receipt = _receipt_for(facts)
+    bar = _bar_for(facts)
+    assert "MoA 0/2+1" in bar
+    assert receipt.evidence_status == "partial"
+    assert "证据 partial" in bar
+
+
+def test_moa_runtime_facts_builder_counts_explicit_skipped_reference_output_as_failed_slot() -> None:
+    from agent.moa_loop import MoAChatCompletions, _RefAccounting
+    from agent.usage_pricing import CanonicalUsage
+
+    facts = MoAChatCompletions("review")._coordination_facts_from_outputs(
+        [
+            (
+                "openrouter:ref-a",
+                "advice from ref-a",
+                _RefAccounting(CanonicalUsage(), succeeded=True),
+            ),
+            (
+                "moa:nested",
+                "[skipped: MoA presets cannot recursively reference MoA]",
+                _RefAccounting(CanonicalUsage(), succeeded=False),
+            ),
+        ],
+        {"provider": "openrouter", "model": "agg-model"},
+    )
+
+    assert facts["moa"]["reference_models"] == ["openrouter:ref-a"]
+    assert facts["moa"]["reference_count"] == 1
+    assert facts["moa"]["reference_total"] == 2
+    assert facts["moa"]["failed_count"] == 1
+    assert facts["moa"]["aggregator_count"] == 1
+    receipt = _receipt_for(facts)
+    bar = _bar_for(facts)
+    assert "MoA 1/2+1" in bar
+    assert receipt.evidence_status == "partial"
+    assert "证据 partial" in bar
+
+
+def test_moa_client_no_configured_references_keeps_aggregator_only_not_partial(monkeypatch, tmp_path) -> None:
+    client, _calls = _install_fake_moa(
+        monkeypatch,
+        tmp_path,
+        refs=[],
+        enabled=False,
+    )
+
+    client.chat.completions.create(messages=[{"role": "user", "content": "q"}], tools=[])
+
+    facts = client.coordination_turn_facts()
+    assert facts["moa"]["reference_models"] == []
+    assert facts["moa"]["reference_count"] == 0
+    assert facts["moa"]["reference_total"] == 0
+    assert facts["moa"]["failed_count"] == 0
+    assert facts["moa"]["aggregator_count"] == 1
+    receipt = _receipt_for(facts)
+    bar = _bar_for(facts)
+    assert "MoA 0+1" in bar
+    assert "MoA 0/0+1" not in bar
+    assert receipt.evidence_status == "ok"
+    assert "证据 ✓" in bar
+
+
+def test_moa_failed_reference_facts_do_not_downgrade_failed_receipt_to_partial(monkeypatch, tmp_path) -> None:
+    client, _calls = _install_fake_moa(
+        monkeypatch,
+        tmp_path,
+        refs=["ref-a"],
+        fail_refs={"ref-a"},
+    )
+
+    client.chat.completions.create(messages=[{"role": "user", "content": "q"}], tools=[])
+
+    receipt = _receipt_for(client.coordination_turn_facts(), failed=True)
+    assert receipt.evidence_status == "failed"
 
 
 def test_moa_client_clears_stale_facts_when_aggregator_raises(monkeypatch, tmp_path) -> None:
@@ -208,13 +339,13 @@ def test_moa_cache_hit_reuses_successful_labels_without_fabricating_failed_refs_
     client.chat.completions.create(messages=messages, tools=[])
     first = client.coordination_turn_facts()
     assert first["moa"]["reference_models"] == ["openrouter:ref-a"]
-    assert "MoA 1+1" in _bar_for(first)
+    assert "MoA 1/2+1" in _bar_for(first)
 
     client.chat.completions.create(messages=messages, tools=[])
     cached = client.coordination_turn_facts()
     assert cached["moa"]["reference_models"] == ["openrouter:ref-a"]
     assert "openrouter:ref-b" not in cached["moa"]["reference_models"]
-    assert "MoA 1+1" in _bar_for(cached)
+    assert "MoA 1/2+1" in _bar_for(cached)
 
     with pytest.raises(RuntimeError, match="aggregator failed"):
         client.chat.completions.create(

--- a/tests/agent/test_moa_turn_facts.py
+++ b/tests/agent/test_moa_turn_facts.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+def _response(content="done", *, model="fake-model"):
+    message = SimpleNamespace(content=content, tool_calls=[])
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], usage=None, model=model)
+
+
+def _write_moa_config(home, *, refs, aggregator_model="agg-model", fanout=None):
+    home.mkdir()
+    ref_yaml = "\n".join(
+        f"        - provider: openrouter\n          model: {model}" for model in refs
+    )
+    fanout_yaml = f"\n      fanout: {fanout}" if fanout else ""
+    (home / "config.yaml").write_text(
+        f"""
+moa:
+  default_preset: review
+  presets:
+    review:{fanout_yaml}
+      reference_models:
+{ref_yaml if ref_yaml else '        []'}
+      aggregator:
+        provider: openrouter
+        model: {aggregator_model}
+""".strip(),
+        encoding="utf-8",
+    )
+
+
+def _install_fake_moa(monkeypatch, tmp_path, *, refs, fail_refs=(), aggregator_raises_for=(), stream=False):
+    home = tmp_path / ".hermes"
+    _write_moa_config(home, refs=refs)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    calls = []
+    fail_refs = set(fail_refs)
+    aggregator_raises_for = set(aggregator_raises_for)
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        if kwargs["task"] == "moa_reference":
+            model = kwargs["model"]
+            if model in fail_refs:
+                raise RuntimeError(f"ref failed: {model}")
+            return _response(f"advice from {model}", model=model)
+
+        joined_messages = "\n".join(
+            str(message.get("content") or "") for message in kwargs.get("messages") or []
+        )
+        for marker in aggregator_raises_for:
+            if marker in joined_messages:
+                raise RuntimeError(f"aggregator failed for {marker}")
+        if stream:
+            return iter(["chunk-1", "chunk-2"])
+        return _response("aggregator answer", model="agg-model")
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+    from agent.moa_loop import MoAClient
+
+    return MoAClient("review"), calls
+
+
+def _bar_for(facts):
+    from agent.route_depth_bar import format_route_depth_bar
+    from agent.turn_receipt import TurnReceipt, apply_turn_facts, update_turn_receipt_from_result
+
+    receipt = TurnReceipt.start(
+        session_id="s",
+        turn_id="t",
+        provider="openrouter",
+        model="agg-model",
+        platform="cli",
+    )
+    update_turn_receipt_from_result(
+        receipt,
+        completed=True,
+        failed=False,
+        interrupted=False,
+        api_calls=1,
+        exit_reason="stop",
+        messages=[],
+    )
+    apply_turn_facts(receipt, facts)
+    return format_route_depth_bar(receipt)
+
+
+def test_moa_client_reports_only_successful_references_and_completed_aggregator(monkeypatch, tmp_path) -> None:
+    client, _calls = _install_fake_moa(
+        monkeypatch,
+        tmp_path,
+        refs=["ref-a", "ref-b", "ref-c"],
+        fail_refs={"ref-c"},
+    )
+
+    client.chat.completions.create(messages=[{"role": "user", "content": "q"}], tools=[])
+
+    facts = client.coordination_turn_facts()
+    assert facts["moa"]["reference_models"] == ["openrouter:ref-a", "openrouter:ref-b"]
+    assert facts["moa"]["reference_count"] == 2
+    assert facts["moa"]["aggregator_count"] == 1
+    assert "MoA 2+1" in _bar_for(facts)
+
+
+def test_moa_client_reports_zero_references_when_all_refs_fail_but_aggregator_succeeds(monkeypatch, tmp_path) -> None:
+    client, _calls = _install_fake_moa(
+        monkeypatch,
+        tmp_path,
+        refs=["ref-a", "ref-b"],
+        fail_refs={"ref-a", "ref-b"},
+    )
+
+    client.chat.completions.create(messages=[{"role": "user", "content": "q"}], tools=[])
+
+    facts = client.coordination_turn_facts()
+    assert facts["moa"]["reference_models"] == []
+    assert facts["moa"]["reference_count"] == 0
+    assert facts["moa"]["aggregator_count"] == 1
+    assert "MoA 0+1" in _bar_for(facts)
+
+
+def test_moa_client_clears_stale_facts_when_aggregator_raises(monkeypatch, tmp_path) -> None:
+    client, _calls = _install_fake_moa(
+        monkeypatch,
+        tmp_path,
+        refs=["ref-a", "ref-b"],
+        aggregator_raises_for={"fail-turn"},
+    )
+    client.chat.completions.create(messages=[{"role": "user", "content": "ok-turn"}], tools=[])
+    assert "MoA 2+1" in _bar_for(client.coordination_turn_facts())
+
+    with pytest.raises(RuntimeError, match="aggregator failed"):
+        client.chat.completions.create(messages=[{"role": "user", "content": "fail-turn"}], tools=[])
+
+    assert client.coordination_turn_facts() == {}
+    assert "MoA" not in _bar_for(client.coordination_turn_facts())
+
+
+def test_moa_streaming_facts_publish_only_after_successful_post_consume(monkeypatch, tmp_path) -> None:
+    client, _calls = _install_fake_moa(
+        monkeypatch,
+        tmp_path,
+        refs=["ref-a", "ref-b"],
+        stream=True,
+    )
+
+    stream = client.chat.completions.create(
+        messages=[{"role": "user", "content": "q"}],
+        tools=[],
+        stream=True,
+    )
+
+    assert list(stream) == ["chunk-1", "chunk-2"]
+    assert client.coordination_turn_facts() == {}
+
+    client.consume_and_save_trace("sess", aggregator_output_fallback="streamed answer")
+
+    facts = client.coordination_turn_facts()
+    assert facts["moa"]["reference_models"] == ["openrouter:ref-a", "openrouter:ref-b"]
+    assert facts["moa"]["aggregator_count"] == 1
+    assert "MoA 2+1" in _bar_for(facts)
+
+
+class _FailingStream:
+    def __iter__(self):
+        raise RuntimeError("stream exploded")
+
+
+def test_moa_failing_stream_without_post_consume_leaves_facts_empty(monkeypatch, tmp_path) -> None:
+    home = tmp_path / ".hermes"
+    _write_moa_config(home, refs=["ref-a"])
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    def fake_call_llm(**kwargs):
+        if kwargs["task"] == "moa_reference":
+            return _response("advice", model=kwargs["model"])
+        return _FailingStream()
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+    from agent.moa_loop import MoAClient
+
+    client = MoAClient("review")
+    stream = client.chat.completions.create(
+        messages=[{"role": "user", "content": "q"}],
+        tools=[],
+        stream=True,
+    )
+
+    with pytest.raises(RuntimeError, match="stream exploded"):
+        list(stream)
+    assert client.coordination_turn_facts() == {}
+
+
+def test_moa_cache_hit_reuses_successful_labels_without_fabricating_failed_refs_or_leaking_failed_turn(monkeypatch, tmp_path) -> None:
+    client, _calls = _install_fake_moa(
+        monkeypatch,
+        tmp_path,
+        refs=["ref-a", "ref-b"],
+        fail_refs={"ref-b"},
+        aggregator_raises_for={"new-fail-turn"},
+    )
+
+    messages = [{"role": "user", "content": "same-turn"}]
+    client.chat.completions.create(messages=messages, tools=[])
+    first = client.coordination_turn_facts()
+    assert first["moa"]["reference_models"] == ["openrouter:ref-a"]
+    assert "MoA 1+1" in _bar_for(first)
+
+    client.chat.completions.create(messages=messages, tools=[])
+    cached = client.coordination_turn_facts()
+    assert cached["moa"]["reference_models"] == ["openrouter:ref-a"]
+    assert "openrouter:ref-b" not in cached["moa"]["reference_models"]
+    assert "MoA 1+1" in _bar_for(cached)
+
+    with pytest.raises(RuntimeError, match="aggregator failed"):
+        client.chat.completions.create(
+            messages=[{"role": "user", "content": "new-fail-turn"}],
+            tools=[],
+        )
+    assert client.coordination_turn_facts() == {}

--- a/tests/agent/test_route_depth_bar.py
+++ b/tests/agent/test_route_depth_bar.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from agent.route_depth_bar import apply_route_depth_bar, format_route_depth_bar
+from agent.turn_receipt import TurnReceipt, apply_turn_facts, update_turn_receipt_from_result
+
+
+def _completed_receipt() -> TurnReceipt:
+    receipt = TurnReceipt.start(
+        session_id="session-1",
+        turn_id="turn-1",
+        provider="openrouter",
+        model="openai/gpt-5.5",
+        platform="cli",
+    )
+    update_turn_receipt_from_result(
+        receipt,
+        completed=True,
+        failed=False,
+        interrupted=False,
+        api_calls=1,
+        exit_reason="text_response(finish_reason=stop)",
+        messages=[],
+    )
+    return receipt
+
+
+def test_format_native_no_tool_bar_uses_runtime_unknowns_conservatively() -> None:
+    receipt = _completed_receipt()
+
+    assert format_route_depth_bar(receipt) == (
+        "路径：native｜原因：runtime_default｜OpenCode unknown｜工具 none｜"
+        "agents 0｜subagents 0｜人话 unknown｜用时 N/A｜证据 ✓"
+    )
+
+
+def test_apply_prepends_one_runtime_bar() -> None:
+    receipt = _completed_receipt()
+
+    text, changed = apply_route_depth_bar("Body", receipt)
+
+    assert changed is True
+    assert text.count("路径：") == 1
+    assert text.splitlines()[0].startswith("路径：native｜原因：runtime_default")
+    assert text.splitlines()[1] == "Body"
+
+
+def test_existing_model_authored_bar_is_replaced() -> None:
+    receipt = _completed_receipt()
+    original = "路径：模型声称｜原因：模型记忆｜OpenCode 已调用\nBody"
+
+    text, changed = apply_route_depth_bar(original, receipt)
+
+    assert changed is True
+    assert text.count("路径：") == 1
+    assert "模型声称" not in text
+    assert text.splitlines()[1] == "Body"
+
+
+def test_runtime_facts_surface_tools_subagents_and_human_language() -> None:
+    receipt = _completed_receipt()
+    apply_turn_facts(
+        receipt,
+        {
+            "route": {"actual": "moa", "reason": "provider_moa"},
+            "opencode": {"observed": False},
+            "tools": {"called": True, "names": ["terminal", "read_file"], "total": 2, "succeeded": 2, "failed": 0},
+            "delegation": {"observed": True, "agents": 1, "subagents": 3},
+            "human_language": {"observed": True, "source": "unit"},
+            "evidence": {"level": "ok", "sources": ["unit"]},
+        },
+    )
+
+    bar = format_route_depth_bar(receipt)
+
+    assert "路径：moa" in bar
+    assert "原因：provider_moa" in bar
+    assert "OpenCode 未调用" in bar
+    assert "工具 terminal+read_file" in bar
+    assert "agents 1" in bar
+    assert "subagents 3" in bar
+    assert "人话 ✓" in bar
+    assert "证据 ✓" in bar
+
+
+def test_success_tool_payloads_do_not_false_positive_as_failures() -> None:
+    receipt = _completed_receipt()
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "t1", "function": {"name": "terminal", "arguments": "{}"}},
+                {"id": "t2", "function": {"name": "read_file", "arguments": "{}"}},
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "t1",
+            "content": '{"output":"ok", "exit_code":0, "error":null}',
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "t2",
+            "content": "No errors found in the file; 0 failed checks.",
+        },
+    ]
+
+    update_turn_receipt_from_result(
+        receipt,
+        completed=True,
+        failed=False,
+        interrupted=False,
+        api_calls=1,
+        exit_reason="text_response(finish_reason=stop)",
+        messages=messages,
+    )
+
+    assert receipt.tool_failed == 0
+    assert "failed)" not in format_route_depth_bar(receipt)
+
+
+def test_structured_failed_tool_payload_is_counted() -> None:
+    receipt = _completed_receipt()
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "t1", "function": {"name": "terminal", "arguments": "{}"}}
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "t1",
+            "content": '{"output":"", "exit_code":1, "error":"permission denied"}',
+        },
+    ]
+
+    update_turn_receipt_from_result(
+        receipt,
+        completed=False,
+        failed=True,
+        interrupted=False,
+        api_calls=1,
+        exit_reason="tool_error",
+        messages=messages,
+    )
+
+    assert receipt.tool_failed == 1
+    assert "terminal(1 failed)" in format_route_depth_bar(receipt)
+
+
+def test_total_only_tool_fact_does_not_double_count() -> None:
+    receipt = _completed_receipt()
+    apply_turn_facts(receipt, {"tools": {"total": 5}})
+
+    bar = format_route_depth_bar(receipt)
+
+    assert "工具 5" in bar
+    assert "工具 5+5" not in bar

--- a/tests/agent/test_route_depth_bar.py
+++ b/tests/agent/test_route_depth_bar.py
@@ -75,7 +75,7 @@ def test_runtime_facts_surface_tools_subagents_and_human_language() -> None:
     assert "路径：moa" in bar
     assert "原因：provider_moa" in bar
     assert "OpenCode 未调用" in bar
-    assert "工具 terminal+read_file" in bar
+    assert "工具 terminal+read_file (2 calls, 0 failed)" in bar
     assert "agents 1" in bar
     assert "subagents 3" in bar
     assert "人话 ✓" in bar
@@ -116,7 +116,7 @@ def test_success_tool_payloads_do_not_false_positive_as_failures() -> None:
     )
 
     assert receipt.tool_failed == 0
-    assert "failed)" not in format_route_depth_bar(receipt)
+    assert "工具 terminal+read_file (2 calls, 0 failed)" in format_route_depth_bar(receipt)
 
 
 def test_structured_failed_tool_payload_is_counted() -> None:
@@ -147,7 +147,7 @@ def test_structured_failed_tool_payload_is_counted() -> None:
     )
 
     assert receipt.tool_failed == 1
-    assert "terminal(1 failed)" in format_route_depth_bar(receipt)
+    assert "工具 terminal (1 call, 1 failed)" in format_route_depth_bar(receipt)
 
 
 def test_total_only_tool_fact_does_not_double_count() -> None:
@@ -156,5 +156,115 @@ def test_total_only_tool_fact_does_not_double_count() -> None:
 
     bar = format_route_depth_bar(receipt)
 
-    assert "工具 5" in bar
+    assert "工具 unknown (5 calls, 0 failed)" in bar
     assert "工具 5+5" not in bar
+
+
+def test_all_four_same_tool_keeps_name_and_explicit_counts() -> None:
+    receipt = _completed_receipt()
+    receipt.tool_names = ["terminal", "terminal", "terminal", "terminal"]
+    receipt.tool_total = 4
+    receipt.tool_failed = 0
+
+    bar = format_route_depth_bar(receipt)
+
+    assert "工具 terminal (4 calls, 0 failed)" in bar
+    assert "+3" not in bar
+
+
+def test_duplicate_tool_names_are_deduped_with_explicit_total_and_failures() -> None:
+    receipt = _completed_receipt()
+    receipt.tool_names = ["skill_view", "read_file", "read_file", "read_file"]
+    receipt.tool_total = 4
+    receipt.tool_failed = 1
+
+    bar = format_route_depth_bar(receipt)
+
+    assert "工具 skill_view+read_file (4 calls, 1 failed)" in bar
+    assert "read_file+read_file" not in bar
+    assert "read_file+2" not in bar
+
+
+def test_more_than_three_unique_tools_uses_ellipsis_and_keeps_counts() -> None:
+    receipt = _completed_receipt()
+    receipt.tool_names = ["skill_view", "read_file", "terminal", "patch", "python"]
+    receipt.tool_total = 5
+    receipt.tool_failed = 0
+
+    bar = format_route_depth_bar(receipt)
+
+    assert "工具 skill_view+read_file+terminal+… (5 calls, 0 failed)" in bar
+    tool_field = next(field for field in bar.split("｜") if field.startswith("工具 "))
+    assert "patch" not in tool_field
+
+
+def test_failed_duplicate_tool_keeps_explicit_failure_count() -> None:
+    receipt = _completed_receipt()
+    receipt.tool_names = ["terminal", "terminal", "read_file"]
+    receipt.tool_total = 3
+    receipt.tool_failed = 2
+
+    bar = format_route_depth_bar(receipt)
+
+    assert "工具 terminal+read_file (3 calls, 2 failed)" in bar
+    assert "terminal+terminal" not in bar
+
+
+def test_moa_facts_render_mechanism_without_counting_references_as_subagents() -> None:
+    receipt = _completed_receipt()
+    apply_turn_facts(
+        receipt,
+        {
+            "route": {"actual": "moa", "reason": "provider_moa"},
+            "moa": {
+                "observed": True,
+                "reference_models": ["ref-a", "ref-b", "ref-c", "ref-d"],
+                "aggregator_model": "agg-model",
+            },
+        },
+    )
+
+    bar = format_route_depth_bar(receipt)
+
+    assert "路径：moa" in bar
+    assert "MoA 4+1" in bar
+    assert "agents 0" in bar
+    assert "subagents 0" in bar
+
+
+def test_omo_facts_render_compact_mechanism_without_subagent_claims() -> None:
+    receipt = _completed_receipt()
+    apply_turn_facts(
+        receipt,
+        {
+            "omo": {
+                "parent_session_id": "parent-1",
+                "descendant_session_ids": ["child-1", "child-2"],
+                "session_created_events": 2,
+            },
+        },
+    )
+
+    bar = format_route_depth_bar(receipt)
+
+    assert "OMO 1+2" in bar
+    assert "subagents 0" in bar
+
+
+def test_deep_fact_dict_is_ignored() -> None:
+    receipt = _completed_receipt()
+    apply_turn_facts(
+        receipt,
+        {
+            "deep": {
+                "observed": True,
+                "protocol_key": "review",
+                "child_session_ids": ["deep-a", "deep-b"],
+            },
+        },
+    )
+
+    bar = format_route_depth_bar(receipt)
+
+    assert bar.startswith("路径：native｜原因：runtime_default")
+    assert "Deep" not in bar

--- a/tests/agent/test_route_depth_bar.py
+++ b/tests/agent/test_route_depth_bar.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import json
+
+import pytest
+
 from agent.route_depth_bar import apply_route_depth_bar, format_route_depth_bar
 from agent.turn_receipt import TurnReceipt, apply_turn_facts, update_turn_receipt_from_result
 
@@ -24,12 +28,61 @@ def _completed_receipt() -> TurnReceipt:
     return receipt
 
 
+def _assert_single_coordination_field(bar: str, expected: str) -> None:
+    fields = bar.split("｜")
+    coordination_fields = [field for field in fields if field.startswith("协同 Agent ")]
+    assert coordination_fields == [expected]
+    assert not any(field.startswith("agents ") for field in fields)
+    assert not any(field.startswith("subagents ") for field in fields)
+
+
+def _apply_messages(messages: list[dict]) -> TurnReceipt:
+    receipt = _completed_receipt()
+    update_turn_receipt_from_result(
+        receipt,
+        completed=True,
+        failed=False,
+        interrupted=False,
+        api_calls=1,
+        exit_reason="text_response(finish_reason=stop)",
+        messages=messages,
+    )
+    return receipt
+
+
+def _assistant_delegate_calls(*call_ids: str | None) -> dict:
+    calls = []
+    for call_id in call_ids:
+        call = {"function": {"name": "delegate_task", "arguments": "{}"}}
+        if call_id is not None:
+            call["id"] = call_id
+        calls.append(call)
+    return {"role": "assistant", "content": "", "tool_calls": calls}
+
+
+def _tool_result(
+    content: dict | str,
+    *,
+    call_id: str | None = None,
+    name: str | None = None,
+    tool_name: str | None = None,
+) -> dict:
+    message: dict = {"role": "tool", "content": json.dumps(content) if isinstance(content, dict) else content}
+    if call_id is not None:
+        message["tool_call_id"] = call_id
+    if name is not None:
+        message["name"] = name
+    if tool_name is not None:
+        message["tool_name"] = tool_name
+    return message
+
+
 def test_format_native_no_tool_bar_uses_runtime_unknowns_conservatively() -> None:
     receipt = _completed_receipt()
 
     assert format_route_depth_bar(receipt) == (
         "路径：native｜原因：runtime_default｜OpenCode unknown｜工具 none｜"
-        "agents 0｜subagents 0｜人话 unknown｜用时 N/A｜证据 ✓"
+        "协同 Agent 0｜人话 unknown｜用时 N/A｜证据 ✓"
     )
 
 
@@ -56,7 +109,7 @@ def test_existing_model_authored_bar_is_replaced() -> None:
     assert text.splitlines()[1] == "Body"
 
 
-def test_runtime_facts_surface_tools_subagents_and_human_language() -> None:
+def test_runtime_facts_surface_tools_coordination_and_human_language() -> None:
     receipt = _completed_receipt()
     apply_turn_facts(
         receipt,
@@ -76,8 +129,7 @@ def test_runtime_facts_surface_tools_subagents_and_human_language() -> None:
     assert "原因：provider_moa" in bar
     assert "OpenCode 未调用" in bar
     assert "工具 terminal+read_file (2 calls, 0 failed)" in bar
-    assert "agents 1" in bar
-    assert "subagents 3" in bar
+    _assert_single_coordination_field(bar, "协同 Agent 3")
     assert "人话 ✓" in bar
     assert "证据 ✓" in bar
 
@@ -228,8 +280,55 @@ def test_moa_facts_render_mechanism_without_counting_references_as_subagents() -
 
     assert "路径：moa" in bar
     assert "MoA 4+1" in bar
-    assert "agents 0" in bar
-    assert "subagents 0" in bar
+    _assert_single_coordination_field(bar, "协同 Agent 5")
+
+
+def test_moa_degraded_counts_successful_refs_plus_aggregator_and_marks_partial() -> None:
+    receipt = _completed_receipt()
+    apply_turn_facts(
+        receipt,
+        {
+            "moa": {
+                "observed": True,
+                "reference_models": ["ref-a", "ref-b"],
+                "reference_count": 2,
+                "reference_total": 3,
+                "failed_count": 1,
+                "aggregator_model": "agg-model",
+                "aggregator_count": 1,
+            },
+        },
+    )
+
+    bar = format_route_depth_bar(receipt)
+
+    assert "MoA 2/3+1" in bar
+    _assert_single_coordination_field(bar, "协同 Agent 3")
+    assert "证据 partial" in bar
+
+
+def test_moa_all_refs_fail_counts_successful_aggregator_only() -> None:
+    receipt = _completed_receipt()
+    apply_turn_facts(
+        receipt,
+        {
+            "moa": {
+                "observed": True,
+                "reference_models": [],
+                "reference_count": 0,
+                "reference_total": 2,
+                "failed_count": 2,
+                "aggregator_model": "agg-model",
+                "aggregator_count": 1,
+            },
+        },
+    )
+
+    bar = format_route_depth_bar(receipt)
+
+    assert "MoA 0/2+1" in bar
+    _assert_single_coordination_field(bar, "协同 Agent 1")
+    assert "证据 partial" in bar
 
 
 def test_omo_facts_render_compact_mechanism_without_subagent_claims() -> None:
@@ -248,7 +347,582 @@ def test_omo_facts_render_compact_mechanism_without_subagent_claims() -> None:
     bar = format_route_depth_bar(receipt)
 
     assert "OMO 1+2" in bar
-    assert "subagents 0" in bar
+    _assert_single_coordination_field(bar, "协同 Agent 3")
+
+
+def test_explicit_trusted_coordination_agent_count_wins_over_delegation_counts() -> None:
+    receipt = _completed_receipt()
+    apply_turn_facts(
+        receipt,
+        {
+            "coordination": {"observed": True, "agents": 6, "modes": ["deep"]},
+            "delegation": {"observed": True, "agents": 2, "subagents": 5},
+        },
+    )
+
+    bar = format_route_depth_bar(receipt)
+
+    _assert_single_coordination_field(bar, "协同 Agent 6")
+
+
+def test_split_call_explicit_coordination_remains_authoritative_over_generic_delegation() -> None:
+    receipt = _completed_receipt()
+    apply_turn_facts(receipt, {"coordination": {"observed": True, "agents": 6, "modes": ["deep"]}})
+    apply_turn_facts(receipt, {"delegation": {"observed": True, "agents": 2, "subagents": 5}})
+
+    _assert_single_coordination_field(format_route_depth_bar(receipt), "协同 Agent 6")
+    assert receipt.coordination_breakdown == {"explicit": 6}
+
+
+def test_omo_coordination_and_derived_omo_are_idempotent_per_mechanism() -> None:
+    receipt = _completed_receipt()
+    facts = {
+        "omo": {
+            "parent_session_id": "parent-1",
+            "descendant_session_ids": ["child-1", "child-2"],
+        },
+        "coordination": {
+            "observed": True,
+            "modes": ["omo"],
+            "breakdown": {"omo_parent": 1, "omo_descendants": 2},
+        },
+    }
+
+    apply_turn_facts(receipt, facts)
+    apply_turn_facts(receipt, facts)
+
+    bar = format_route_depth_bar(receipt)
+
+    assert bar.count("OMO 1+2") == 1
+    _assert_single_coordination_field(bar, "协同 Agent 3")
+
+
+def test_generic_delegation_does_not_double_count_after_omo_component() -> None:
+    receipt = _completed_receipt()
+    apply_turn_facts(receipt, {"omo": {"observed": True, "parent_count": 1, "descendant_count": 2}})
+    apply_turn_facts(receipt, {"delegation": {"observed": True, "agents": 1, "subagents": 2}})
+
+    bar = format_route_depth_bar(receipt)
+
+    assert "OMO 1+2" in bar
+    _assert_single_coordination_field(bar, "协同 Agent 3")
+    assert receipt.coordination_breakdown == {"omo": 3}
+
+
+def test_generic_delegation_prefers_concrete_subagent_count_then_agents_count() -> None:
+    receipt = _completed_receipt()
+    apply_turn_facts(receipt, {"delegation": {"observed": True, "agents": 4}})
+    assert "协同 Agent 4" in format_route_depth_bar(receipt)
+
+    receipt = _completed_receipt()
+    apply_turn_facts(receipt, {"delegation": {"observed": True, "agents": 4, "subagents": 2}})
+    assert "协同 Agent 2" in format_route_depth_bar(receipt)
+
+
+def test_explicit_trusted_total_overrides_unknown_delegate_task_component() -> None:
+    receipt = _completed_receipt()
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "delegation-1", "function": {"name": "delegate_task", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "delegation-1", "content": "not json"},
+    ]
+    update_turn_receipt_from_result(
+        receipt,
+        completed=True,
+        failed=False,
+        interrupted=False,
+        api_calls=1,
+        exit_reason="text_response(finish_reason=stop)",
+        messages=messages,
+    )
+    apply_turn_facts(
+        receipt,
+        {"coordination": {"observed": True, "agents": 6, "modes": ["deep"]}},
+    )
+
+    _assert_single_coordination_field(format_route_depth_bar(receipt), "协同 Agent 6")
+
+
+def test_delegate_task_tool_result_counts_results_only_from_actual_delegate_call() -> None:
+    receipt = _completed_receipt()
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "delegation-1", "function": {"name": "delegate_task", "arguments": "{}"}}
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "delegation-1",
+            "content": json.dumps({"results": [{"summary": "a"}, {"summary": "b"}]}),
+        },
+    ]
+
+    update_turn_receipt_from_result(
+        receipt,
+        completed=True,
+        failed=False,
+        interrupted=False,
+        api_calls=1,
+        exit_reason="text_response(finish_reason=stop)",
+        messages=messages,
+    )
+
+    _assert_single_coordination_field(format_route_depth_bar(receipt), "协同 Agent 2")
+
+
+def test_delegate_task_background_dispatched_payload_counts_actual_top_level_delegate_result() -> None:
+    receipt = _apply_messages(
+        [
+            _assistant_delegate_calls("delegation-1"),
+            _tool_result(
+                {"status": "dispatched", "mode": "background", "count": 3},
+                call_id="delegation-1",
+            ),
+        ]
+    )
+
+    _assert_single_coordination_field(format_route_depth_bar(receipt), "协同 Agent 3")
+    assert receipt.coordination_breakdown == {"delegate_task": 3}
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"status": "dispatched", "mode": "background"},
+        {"status": "dispatched", "mode": "background", "count": None},
+        {"status": "dispatched", "mode": "background", "count": "3"},
+        {"status": "dispatched", "mode": "background", "count": 1.5},
+        {"status": "dispatched", "mode": "background", "count": -1},
+        {"status": "done", "mode": "background", "count": 3},
+        {"status": "dispatched", "mode": "foreground", "count": 3},
+        {"count": 3},
+    ],
+)
+def test_delegate_task_background_dispatched_payload_invalid_count_or_shape_fails_closed_unknown(
+    payload: dict,
+) -> None:
+    receipt = _apply_messages(
+        [
+            _assistant_delegate_calls("delegation-1"),
+            _tool_result(payload, call_id="delegation-1"),
+        ]
+    )
+
+    _assert_single_coordination_field(format_route_depth_bar(receipt), "协同 Agent unknown")
+    assert receipt.coordination_breakdown == {"delegate_task": None}
+
+
+def test_delegate_task_pool_fallback_synchronous_results_shape_remains_accepted() -> None:
+    receipt = _apply_messages(
+        [
+            _assistant_delegate_calls("delegation-1"),
+            _tool_result(
+                {"results": [{"summary": "a"}, {"summary": "b"}, {"summary": "c"}]},
+                call_id="delegation-1",
+            ),
+        ]
+    )
+
+    _assert_single_coordination_field(format_route_depth_bar(receipt), "协同 Agent 3")
+    assert receipt.coordination_breakdown == {"delegate_task": 3}
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"status": "dispatched", "mode": "background", "count": 3},
+        {"results": [{"summary": "a"}, {"summary": "b"}, {"summary": "c"}]},
+    ],
+)
+def test_delegate_task_result_with_matching_call_id_but_explicit_terminal_name_fails_closed_unknown(
+    payload: dict,
+) -> None:
+    receipt = _apply_messages(
+        [
+            _assistant_delegate_calls("d1"),
+            _tool_result(payload, call_id="d1", name="terminal"),
+        ]
+    )
+
+    _assert_single_coordination_field(format_route_depth_bar(receipt), "协同 Agent unknown")
+    assert receipt.coordination_breakdown == {"delegate_task": None}
+
+
+def test_delegate_task_result_with_matching_call_id_but_explicit_read_file_tool_name_fails_closed_unknown() -> None:
+    receipt = _apply_messages(
+        [
+            _assistant_delegate_calls("d1"),
+            _tool_result(
+                {"results": [{"summary": "a"}]},
+                call_id="d1",
+                tool_name="read_file",
+            ),
+        ]
+    )
+
+    _assert_single_coordination_field(format_route_depth_bar(receipt), "协同 Agent unknown")
+    assert receipt.coordination_breakdown == {"delegate_task": None}
+
+
+@pytest.mark.parametrize(
+    "tool_result",
+    [
+        _tool_result({"status": "dispatched", "mode": "background", "count": 1}, call_id="d1"),
+        _tool_result({"results": [{"summary": "a"}]}, call_id="d1", name="delegate_task"),
+        _tool_result({"results": [{"summary": "a"}]}, call_id="d1", name="terminal"),
+    ],
+)
+def test_reused_assistant_call_id_between_delegate_task_and_terminal_fails_closed_unknown(
+    tool_result: dict,
+) -> None:
+    receipt = _apply_messages(
+        [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "d1", "function": {"name": "delegate_task", "arguments": "{}"}},
+                    {"id": "d1", "function": {"name": "terminal", "arguments": "{}"}},
+                ],
+            },
+            tool_result,
+        ]
+    )
+
+    _assert_single_coordination_field(format_route_depth_bar(receipt), "协同 Agent unknown")
+    assert receipt.coordination_breakdown == {"delegate_task": None}
+
+
+@pytest.mark.parametrize("result_message_count", [1, 2])
+def test_duplicate_delegate_task_expected_call_id_fails_closed_unknown(
+    result_message_count: int,
+) -> None:
+    messages = [_assistant_delegate_calls("d1", "d1")]
+    messages.extend(
+        _tool_result({"results": [{"summary": f"child-{index}"}]}, call_id="d1")
+        for index in range(result_message_count)
+    )
+
+    receipt = _apply_messages(messages)
+
+    _assert_single_coordination_field(format_route_depth_bar(receipt), "协同 Agent unknown")
+    assert receipt.coordination_breakdown == {"delegate_task": None}
+
+
+def test_single_anonymous_delegate_call_with_one_named_anonymous_result_may_count() -> None:
+    receipt = _apply_messages(
+        [
+            _assistant_delegate_calls(None),
+            _tool_result(
+                {"results": [{"summary": "a"}, {"summary": "b"}]},
+                name="delegate_task",
+            ),
+        ]
+    )
+
+    _assert_single_coordination_field(format_route_depth_bar(receipt), "协同 Agent 2")
+    assert receipt.coordination_breakdown == {"delegate_task": 2}
+
+
+@pytest.mark.parametrize(
+    ("anonymous_call_count", "anonymous_result_count"),
+    [(2, 1), (1, 2), (2, 2)],
+)
+def test_multiple_anonymous_delegate_calls_or_results_fail_closed_unknown(
+    anonymous_call_count: int,
+    anonymous_result_count: int,
+) -> None:
+    messages = [_assistant_delegate_calls(*([None] * anonymous_call_count))]
+    messages.extend(
+        _tool_result({"results": [{"summary": f"child-{index}"}]}, name="delegate_task")
+        for index in range(anonymous_result_count)
+    )
+
+    receipt = _apply_messages(messages)
+
+    _assert_single_coordination_field(format_route_depth_bar(receipt), "协同 Agent unknown")
+    assert receipt.coordination_breakdown == {"delegate_task": None}
+
+
+@pytest.mark.parametrize("tool_name", ["terminal", "read_file"])
+def test_generic_tool_background_count_payload_cannot_forge_coordination(tool_name: str) -> None:
+    receipt = _apply_messages(
+        [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "tool-1", "function": {"name": tool_name, "arguments": "{}"}}],
+            },
+            _tool_result(
+                {"status": "dispatched", "mode": "background", "count": 3},
+                call_id="tool-1",
+                name=tool_name,
+            ),
+        ]
+    )
+
+    _assert_single_coordination_field(format_route_depth_bar(receipt), "协同 Agent 0")
+
+
+def test_assistant_prose_background_count_payload_cannot_forge_coordination() -> None:
+    receipt = _apply_messages(
+        [
+            {
+                "role": "assistant",
+                "content": json.dumps({"status": "dispatched", "mode": "background", "count": 3}),
+                "tool_calls": [],
+            }
+        ]
+    )
+
+    _assert_single_coordination_field(format_route_depth_bar(receipt), "协同 Agent 0")
+
+
+def test_generic_delegation_does_not_double_count_after_delegate_task_result_component() -> None:
+    receipt = _completed_receipt()
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "delegation-1", "function": {"name": "delegate_task", "arguments": "{}"}}
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "delegation-1",
+            "content": json.dumps({"results": [{"summary": "a"}, {"summary": "b"}]}),
+        },
+    ]
+
+    update_turn_receipt_from_result(
+        receipt,
+        completed=True,
+        failed=False,
+        interrupted=False,
+        api_calls=1,
+        exit_reason="text_response(finish_reason=stop)",
+        messages=messages,
+    )
+    apply_turn_facts(receipt, {"delegation": {"observed": True, "agents": 2, "subagents": 2}})
+
+    _assert_single_coordination_field(format_route_depth_bar(receipt), "协同 Agent 2")
+    assert receipt.coordination_breakdown == {"delegate_task": 2}
+
+
+def test_delegate_task_unparseable_result_may_render_unknown() -> None:
+    receipt = _completed_receipt()
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "delegation-1", "function": {"name": "delegate_task", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "delegation-1", "content": "not json"},
+    ]
+
+    update_turn_receipt_from_result(
+        receipt,
+        completed=True,
+        failed=False,
+        interrupted=False,
+        api_calls=1,
+        exit_reason="text_response(finish_reason=stop)",
+        messages=messages,
+    )
+
+    _assert_single_coordination_field(format_route_depth_bar(receipt), "协同 Agent unknown")
+
+
+def test_generic_tool_output_with_results_does_not_change_coordination_facts() -> None:
+    receipt = _completed_receipt()
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "tool-1", "function": {"name": "terminal", "arguments": "{}"}}
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "tool-1",
+            "name": "terminal",
+            "content": json.dumps({"results": [{"summary": "fake"}, {"summary": "fake"}]}),
+        },
+    ]
+
+    update_turn_receipt_from_result(
+        receipt,
+        completed=True,
+        failed=False,
+        interrupted=False,
+        api_calls=1,
+        exit_reason="text_response(finish_reason=stop)",
+        messages=messages,
+    )
+
+    _assert_single_coordination_field(format_route_depth_bar(receipt), "协同 Agent 0")
+
+
+def test_duplicate_delegate_task_results_for_one_call_fail_closed_unknown() -> None:
+    receipt = _completed_receipt()
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "d1", "function": {"name": "delegate_task", "arguments": "{}"}}
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "d1",
+            "content": json.dumps({"results": [{"summary": "a"}, {"summary": "b"}]}),
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "d1",
+            "content": json.dumps({"results": [{"summary": "c"}, {"summary": "d"}]}),
+        },
+    ]
+
+    update_turn_receipt_from_result(
+        receipt,
+        completed=True,
+        failed=False,
+        interrupted=False,
+        api_calls=1,
+        exit_reason="text_response(finish_reason=stop)",
+        messages=messages,
+    )
+    bar = format_route_depth_bar(receipt)
+
+    _assert_single_coordination_field(bar, "协同 Agent unknown")
+    assert "协同 Agent 4" not in bar
+    assert receipt.coordination_breakdown == {"delegate_task": None}
+
+
+def test_trusted_explicit_moa_total_is_whole_turn_and_order_independent_with_delegate_task() -> None:
+    coordination_facts = {"coordination": {"observed": True, "agents": 6, "modes": ["moa"]}}
+    delegate_messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "d1", "function": {"name": "delegate_task", "arguments": "{}"}}
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "d1",
+            "content": json.dumps({"results": [{"summary": "a"}, {"summary": "b"}]}),
+        },
+    ]
+
+    delegate_first = _completed_receipt()
+    update_turn_receipt_from_result(
+        delegate_first,
+        completed=True,
+        failed=False,
+        interrupted=False,
+        api_calls=1,
+        exit_reason="text_response(finish_reason=stop)",
+        messages=delegate_messages,
+    )
+    apply_turn_facts(delegate_first, coordination_facts)
+
+    explicit_first = _completed_receipt()
+    apply_turn_facts(explicit_first, coordination_facts)
+    update_turn_receipt_from_result(
+        explicit_first,
+        completed=True,
+        failed=False,
+        interrupted=False,
+        api_calls=1,
+        exit_reason="text_response(finish_reason=stop)",
+        messages=delegate_messages,
+    )
+
+    for receipt in (delegate_first, explicit_first):
+        bar = format_route_depth_bar(receipt)
+        _assert_single_coordination_field(bar, "协同 Agent 6")
+        assert "协同 Agent 8" not in bar
+        assert receipt.coordination_breakdown == {"explicit": 6}
+
+
+def test_trusted_explicit_omo_total_is_whole_turn_and_order_independent_with_delegate_task() -> None:
+    coordination_facts = {"coordination": {"observed": True, "agents": 6, "modes": ["omo"]}}
+    delegate_messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "d1", "function": {"name": "delegate_task", "arguments": "{}"}}
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "d1",
+            "content": json.dumps({"results": [{"summary": "a"}, {"summary": "b"}]}),
+        },
+    ]
+
+    delegate_first = _completed_receipt()
+    update_turn_receipt_from_result(
+        delegate_first,
+        completed=True,
+        failed=False,
+        interrupted=False,
+        api_calls=1,
+        exit_reason="text_response(finish_reason=stop)",
+        messages=delegate_messages,
+    )
+    apply_turn_facts(delegate_first, coordination_facts)
+
+    explicit_first = _completed_receipt()
+    apply_turn_facts(explicit_first, coordination_facts)
+    update_turn_receipt_from_result(
+        explicit_first,
+        completed=True,
+        failed=False,
+        interrupted=False,
+        api_calls=1,
+        exit_reason="text_response(finish_reason=stop)",
+        messages=delegate_messages,
+    )
+
+    for receipt in (delegate_first, explicit_first):
+        bar = format_route_depth_bar(receipt)
+        _assert_single_coordination_field(bar, "协同 Agent 6")
+        assert "协同 Agent 8" not in bar
+        assert receipt.coordination_breakdown == {"explicit": 6}
+
+
+def test_coordination_moa_breakdown_accepts_singular_aggregator_without_explicit_total() -> None:
+    receipt = _completed_receipt()
+
+    apply_turn_facts(
+        receipt,
+        {
+            "coordination": {
+                "modes": ["moa"],
+                "breakdown": {"moa_references": 4, "moa_aggregator": 1},
+            }
+        },
+    )
+
+    _assert_single_coordination_field(format_route_depth_bar(receipt), "协同 Agent 5")
 
 
 def test_deep_fact_dict_is_ignored() -> None:

--- a/tests/agent/test_route_depth_bar_finalizer.py
+++ b/tests/agent/test_route_depth_bar_finalizer.py
@@ -222,7 +222,9 @@ def test_finalizer_applies_moa_client_mechanism_facts(monkeypatch) -> None:
     first = result["final_response"].splitlines()[0]
     assert "路径：moa" in first
     assert "MoA 4+1" in first
-    assert "subagents 0" in first
+    assert "协同 Agent 5" in first
+    assert "agents " not in first
+    assert "subagents " not in first
 
 
 def test_finalizer_does_not_trust_omo_schema_markers_in_tool_output_or_assistant_prose(monkeypatch) -> None:
@@ -304,4 +306,6 @@ def test_finalizer_applies_runtime_owned_omo_turn_facts(monkeypatch) -> None:
     first = result["final_response"].splitlines()[0]
     assert "路径：omo" in first
     assert "OMO 1+2" in first
-    assert "subagents 0" in first
+    assert "协同 Agent 3" in first
+    assert "agents " not in first
+    assert "subagents " not in first

--- a/tests/agent/test_route_depth_bar_finalizer.py
+++ b/tests/agent/test_route_depth_bar_finalizer.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from agent.turn_finalizer import finalize_turn
+from agent.turn_receipt import TurnReceipt
+
+
+class FakeAgent:
+    def __init__(self) -> None:
+        self.max_iterations = 90
+        self.iteration_budget = SimpleNamespace(remaining=10, used=1, max_total=90)
+        self.quiet_mode = True
+        self.model = "test-model"
+        self.provider = "test-provider"
+        self.base_url = ""
+        self.session_id = "sess-test"
+        self.platform = "cli"
+        self.context_compressor = SimpleNamespace(last_prompt_tokens=0)
+        self.session_input_tokens = 0
+        self.session_output_tokens = 0
+        self.session_cache_read_tokens = 0
+        self.session_cache_write_tokens = 0
+        self.session_reasoning_tokens = 0
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.session_total_tokens = 0
+        self.session_estimated_cost_usd = 0
+        self.session_cost_status = "unknown"
+        self.session_cost_source = "test"
+        self._tool_guardrail_halt_decision = None
+        self._interrupt_message = None
+        self._response_was_previewed = False
+        self._skill_nudge_interval = 0
+        self._iters_since_skill = 0
+        self.valid_tool_names = []
+        self._roadmap_mode = False
+        self._persist_user_message_idx = 0
+        self._current_turn_receipt = TurnReceipt.start(
+            session_id="sess-test",
+            turn_id="turn-test",
+            provider="test-provider",
+            model="test-model",
+            platform="cli",
+        )
+        self.persisted: list[dict[str, Any]] = []
+
+    def _handle_max_iterations(self, messages, api_call_count):
+        raise AssertionError("not expected")
+
+    def _emit_status(self, *_args, **_kwargs):
+        pass
+
+    def _safe_print(self, *_args, **_kwargs):
+        pass
+
+    def _save_trajectory(self, *_args, **_kwargs):
+        pass
+
+    def _cleanup_task_resources(self, *_args, **_kwargs):
+        pass
+
+    def _drop_trailing_empty_response_scaffolding(self, messages):
+        pass
+
+    def _persist_session(self, messages, conversation_history):
+        self.persisted = [dict(message) for message in messages]
+
+    def _file_mutation_verifier_enabled(self):
+        return False
+
+    def _turn_completion_explainer_enabled(self):
+        return False
+
+    def _drain_pending_steer(self):
+        return None
+
+    def clear_interrupt(self):
+        pass
+
+    def _sync_external_memory_for_turn(self, **_kwargs):
+        pass
+
+
+def test_finalizer_replaces_model_bar_and_persists_canonical_final(monkeypatch) -> None:
+    agent = FakeAgent()
+    post_seen: dict[str, str] = {}
+
+    def invoke_hook(name: str, **kwargs):
+        if name == "post_llm_call":
+            post_seen["assistant_response"] = kwargs["assistant_response"]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", invoke_hook)
+    raw = "路径：模型声称｜原因：模型记忆｜OpenCode 已调用\nBody"
+    messages = [
+        {"role": "user", "content": "do it"},
+        {"role": "assistant", "content": raw, "finish_reason": "stop"},
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response=raw,
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn-test",
+        user_message="do it",
+        original_user_message="do it",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(finish_reason=stop)",
+    )
+
+    first = result["final_response"].splitlines()[0]
+    assert result["response_transformed"] is True
+    assert first.startswith("路径：native｜原因：runtime_default")
+    assert result["final_response"].count("路径：") == 1
+    assert "模型声称" not in first
+    assert agent.persisted[-1]["content"] == result["final_response"]
+    assert post_seen["assistant_response"] == result["final_response"]
+
+
+def test_finalizer_counts_only_tools_from_current_turn(monkeypatch) -> None:
+    agent = FakeAgent()
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    messages = [
+        {"role": "user", "content": "old turn"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "old-1", "function": {"name": "read_file", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "old-1", "content": "old result"},
+        {"role": "user", "content": "current turn"},
+        {"role": "assistant", "content": "Current answer", "finish_reason": "stop"},
+    ]
+    agent._persist_user_message_idx = 3
+
+    result = finalize_turn(
+        agent,
+        final_response="Current answer",
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn-test",
+        user_message="current turn",
+        original_user_message="current turn",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(finish_reason=stop)",
+    )
+
+    first = result["final_response"].splitlines()[0]
+    assert "工具 none" in first
+    assert "read_file" not in first
+
+
+def test_literal_human_language_prefix_is_runtime_fact(monkeypatch) -> None:
+    agent = FakeAgent()
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    messages = [
+        {"role": "user", "content": "用人话解释这个结果"},
+        {"role": "assistant", "content": "Plain answer", "finish_reason": "stop"},
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response="Plain answer",
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn-test",
+        user_message="用人话解释这个结果",
+        original_user_message="用人话解释这个结果",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(finish_reason=stop)",
+    )
+
+    assert "人话 ✓" in result["final_response"].splitlines()[0]
+
+
+def test_non_cli_leading_path_text_is_not_rewritten(monkeypatch) -> None:
+    agent = FakeAgent()
+    agent.platform = "telegram"
+    agent._current_turn_receipt.platform = "telegram"
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    original = "路径：用户要说明路线\nBody"
+    messages = [
+        {"role": "user", "content": "explain"},
+        {"role": "assistant", "content": original, "finish_reason": "stop"},
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response=original,
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn-test",
+        user_message="explain",
+        original_user_message="explain",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(finish_reason=stop)",
+    )
+
+    assert result["final_response"] == original
+    assert result["response_transformed"] is False
+    assert agent.persisted[-1]["content"] == original

--- a/tests/agent/test_route_depth_bar_finalizer.py
+++ b/tests/agent/test_route_depth_bar_finalizer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 from typing import Any
 
@@ -44,6 +45,7 @@ class FakeAgent:
             model="test-model",
             platform="cli",
         )
+        self.client: Any = None
         self.persisted: list[dict[str, Any]] = []
 
     def _handle_max_iterations(self, messages, api_call_count):
@@ -83,6 +85,24 @@ class FakeAgent:
         pass
 
 
+def _finalize(agent: FakeAgent, *, final_response: str, messages: list[dict[str, Any]], user_message: str = "do it"):
+    return finalize_turn(
+        agent,
+        final_response=final_response,
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn-test",
+        user_message=user_message,
+        original_user_message=user_message,
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(finish_reason=stop)",
+    )
+
+
 def test_finalizer_replaces_model_bar_and_persists_canonical_final(monkeypatch) -> None:
     agent = FakeAgent()
     post_seen: dict[str, str] = {}
@@ -99,21 +119,7 @@ def test_finalizer_replaces_model_bar_and_persists_canonical_final(monkeypatch) 
         {"role": "assistant", "content": raw, "finish_reason": "stop"},
     ]
 
-    result = finalize_turn(
-        agent,
-        final_response=raw,
-        api_call_count=1,
-        interrupted=False,
-        failed=False,
-        messages=messages,
-        conversation_history=[],
-        effective_task_id="task",
-        turn_id="turn-test",
-        user_message="do it",
-        original_user_message="do it",
-        _should_review_memory=False,
-        _turn_exit_reason="text_response(finish_reason=stop)",
-    )
+    result = _finalize(agent, final_response=raw, messages=messages)
 
     first = result["final_response"].splitlines()[0]
     assert result["response_transformed"] is True
@@ -142,20 +148,11 @@ def test_finalizer_counts_only_tools_from_current_turn(monkeypatch) -> None:
     ]
     agent._persist_user_message_idx = 3
 
-    result = finalize_turn(
+    result = _finalize(
         agent,
         final_response="Current answer",
-        api_call_count=1,
-        interrupted=False,
-        failed=False,
         messages=messages,
-        conversation_history=[],
-        effective_task_id="task",
-        turn_id="turn-test",
         user_message="current turn",
-        original_user_message="current turn",
-        _should_review_memory=False,
-        _turn_exit_reason="text_response(finish_reason=stop)",
     )
 
     first = result["final_response"].splitlines()[0]
@@ -171,20 +168,11 @@ def test_literal_human_language_prefix_is_runtime_fact(monkeypatch) -> None:
         {"role": "assistant", "content": "Plain answer", "finish_reason": "stop"},
     ]
 
-    result = finalize_turn(
+    result = _finalize(
         agent,
         final_response="Plain answer",
-        api_call_count=1,
-        interrupted=False,
-        failed=False,
         messages=messages,
-        conversation_history=[],
-        effective_task_id="task",
-        turn_id="turn-test",
         user_message="用人话解释这个结果",
-        original_user_message="用人话解释这个结果",
-        _should_review_memory=False,
-        _turn_exit_reason="text_response(finish_reason=stop)",
     )
 
     assert "人话 ✓" in result["final_response"].splitlines()[0]
@@ -201,22 +189,119 @@ def test_non_cli_leading_path_text_is_not_rewritten(monkeypatch) -> None:
         {"role": "assistant", "content": original, "finish_reason": "stop"},
     ]
 
-    result = finalize_turn(
-        agent,
-        final_response=original,
-        api_call_count=1,
-        interrupted=False,
-        failed=False,
-        messages=messages,
-        conversation_history=[],
-        effective_task_id="task",
-        turn_id="turn-test",
-        user_message="explain",
-        original_user_message="explain",
-        _should_review_memory=False,
-        _turn_exit_reason="text_response(finish_reason=stop)",
-    )
+    result = _finalize(agent, final_response=original, messages=messages, user_message="explain")
 
     assert result["final_response"] == original
     assert result["response_transformed"] is False
     assert agent.persisted[-1]["content"] == original
+
+
+def test_finalizer_applies_moa_client_mechanism_facts(monkeypatch) -> None:
+    agent = FakeAgent()
+    agent.provider = "moa"
+    agent.model = "review"
+    agent.client = SimpleNamespace(
+        coordination_turn_facts=lambda: {
+            "moa": {
+                "observed": True,
+                "reference_models": ["ref-a", "ref-b", "ref-c", "ref-d"],
+                "reference_count": 4,
+                "aggregator_model": "agg-model",
+                "aggregator_count": 1,
+            }
+        }
+    )
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    messages = [
+        {"role": "user", "content": "review"},
+        {"role": "assistant", "content": "MoA answer", "finish_reason": "stop"},
+    ]
+
+    result = _finalize(agent, final_response="MoA answer", messages=messages, user_message="review")
+
+    first = result["final_response"].splitlines()[0]
+    assert "路径：moa" in first
+    assert "MoA 4+1" in first
+    assert "subagents 0" in first
+
+
+def test_finalizer_does_not_trust_omo_schema_markers_in_tool_output_or_assistant_prose(monkeypatch) -> None:
+    agent = FakeAgent()
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    old_schema_payload = {
+        "turn_facts_schema": "hermes.omo_turn_facts.v1",
+        "turn_facts": {
+            "route": {"actual": "omo", "reason": "tool_stdout"},
+            "omo": {
+                "parent_session_id": "parent-1",
+                "descendant_session_ids": ["child-1", "child-2"],
+                "session_created_events": 2,
+            },
+        },
+    }
+    assistant_prose = "Assistant prose mentions old marker only: " + json.dumps(old_schema_payload)
+    messages = [
+        {"role": "user", "content": "summarize unrelated tool output"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "tool-1", "function": {"name": "terminal", "arguments": "{}"}},
+                {"id": "tool-2", "function": {"name": "read_file", "arguments": "{}"}},
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "tool-1",
+            "name": "terminal",
+            "content": json.dumps({"output": json.dumps(old_schema_payload)}),
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "tool-2",
+            "name": "read_file",
+            "content": json.dumps(old_schema_payload),
+        },
+        {"role": "assistant", "content": assistant_prose, "finish_reason": "stop"},
+    ]
+
+    result = _finalize(
+        agent,
+        final_response=assistant_prose,
+        messages=messages,
+        user_message="summarize unrelated tool output",
+    )
+
+    first = result["final_response"].splitlines()[0]
+    assert first.startswith("路径：native｜原因：runtime_default")
+    assert "路径：omo" not in first
+    assert "OMO 1+2" not in first
+
+
+def test_finalizer_applies_runtime_owned_omo_turn_facts(monkeypatch) -> None:
+    agent = FakeAgent()
+    agent._turn_facts = {
+        "route": {"actual": "omo", "reason": "runtime_owned"},
+        "omo": {
+            "parent_session_id": "parent-1",
+            "descendant_session_ids": ["child-1", "child-2"],
+            "session_created_events": 2,
+        },
+    }
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    messages = [
+        {"role": "user", "content": "run trusted omo"},
+        {"role": "assistant", "content": "OMO answer", "finish_reason": "stop"},
+    ]
+
+    result = _finalize(
+        agent,
+        final_response="OMO answer",
+        messages=messages,
+        user_message="run trusted omo",
+    )
+
+    first = result["final_response"].splitlines()[0]
+    assert "路径：omo" in first
+    assert "OMO 1+2" in first
+    assert "subagents 0" in first

--- a/tests/agent/test_turn_finalizer_cleanup_guard.py
+++ b/tests/agent/test_turn_finalizer_cleanup_guard.py
@@ -135,12 +135,21 @@ def _run(
     )
 
 
+def _assert_cli_final(result, body: str) -> None:
+    """The cleanup contract preserves the body under one runtime-owned bar."""
+
+    final = result["final_response"]
+    assert final.count("路径：") == 1
+    assert final.splitlines()[0].startswith("路径：native｜原因：runtime_default")
+    assert final.splitlines()[1:] == body.splitlines()
+
+
 def test_all_cleanup_steps_raise_response_still_returned():
     agent = _StubAgent(
         raise_in=("save_trajectory", "cleanup_task_resources", "persist_session")
     )
     result = _run(agent)
-    assert result["final_response"] == "PARTIAL SUMMARY FROM MODEL"
+    _assert_cli_final(result, "PARTIAL SUMMARY FROM MODEL")
     labels = [e.split(":")[0] for e in result["cleanup_errors"]]
     assert labels == ["save_trajectory", "cleanup_task_resources", "persist_session"]
 
@@ -152,7 +161,7 @@ def test_single_cleanup_step_raises_does_not_skip_others(step):
     agent = _StubAgent(raise_in=(step,))
     result = _run(agent)
     # Response survives.
-    assert result["final_response"] == "PARTIAL SUMMARY FROM MODEL"
+    _assert_cli_final(result, "PARTIAL SUMMARY FROM MODEL")
     # Exactly the failing step is recorded; the others ran without error.
     assert result["cleanup_errors"] == [
         next(
@@ -167,7 +176,7 @@ def test_single_cleanup_step_raises_does_not_skip_others(step):
 def test_clean_turn_has_no_cleanup_errors_key():
     agent = _StubAgent(raise_in=())
     result = _run(agent)
-    assert result["final_response"] == "PARTIAL SUMMARY FROM MODEL"
+    _assert_cli_final(result, "PARTIAL SUMMARY FROM MODEL")
     assert result["completed"] is False
     assert "cleanup_errors" not in result
 
@@ -180,5 +189,5 @@ def test_text_response_on_last_allowed_call_is_completed():
         api_call_count=agent.max_iterations,
         turn_exit_reason="text_response(finish_reason=stop)",
     )
-    assert result["final_response"] == "final report"
+    _assert_cli_final(result, "final report")
     assert result["completed"] is True

--- a/tests/cli/test_answer_body_streaming_final_only.py
+++ b/tests/cli/test_answer_body_streaming_final_only.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+def _strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+@pytest.fixture
+def cli_stub(monkeypatch):
+    from cli import HermesCLI
+    import cli as cli_mod
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.show_reasoning = False
+    cli.final_response_markdown = "raw"
+    cli.show_timestamps = False
+    cli.assistant_body_streaming = False
+    cli._reset_stream_state()
+
+    emitted: list[str] = []
+    monkeypatch.setattr(cli_mod, "_cprint", lambda text: emitted.append(text))
+    monkeypatch.setattr(cli_mod, "_terminal_width_for_streaming", lambda: 74)
+    return cli, emitted
+
+
+def test_answer_body_stream_deltas_are_buffered_not_rendered_by_default(cli_stub) -> None:
+    cli, emitted = cli_stub
+
+    visible = cli._stream_delta("draft body that must wait for canonical final\n")
+    cli._flush_stream()
+
+    plain = _strip_ansi("\n".join(emitted))
+    assert visible is False
+    assert "draft body that must wait" not in plain
+    assert cli._stream_box_opened is False
+
+
+def test_final_only_streaming_still_surfaces_reasoning_when_enabled(monkeypatch) -> None:
+    from cli import HermesCLI
+    import cli as cli_mod
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.show_reasoning = True
+    cli.final_response_markdown = "raw"
+    cli.show_timestamps = False
+    cli.assistant_body_streaming = False
+    cli._reset_stream_state()
+
+    emitted: list[str] = []
+    monkeypatch.setattr(cli_mod, "_cprint", lambda text: emitted.append(text))
+    monkeypatch.setattr(cli_mod, "_terminal_width_for_streaming", lambda: 74)
+
+    visible = cli._stream_delta("<think>reasoning stays live</think>\nfinal body waits\n")
+    cli._flush_stream()
+
+    plain = _strip_ansi("\n".join(emitted))
+    assert visible is False
+    assert "reasoning stays live" in plain
+    assert "final body waits" not in plain
+
+
+def test_legacy_visible_stream_reports_every_visible_delta(cli_stub) -> None:
+    cli, _emitted = cli_stub
+    cli.assistant_body_streaming = True
+
+    first_visible = cli._stream_delta("first ")
+    second_visible = cli._stream_delta("second\n")
+
+    assert first_visible is True
+    assert second_visible is True

--- a/tests/cli/test_final_response_display_policy.py
+++ b/tests/cli/test_final_response_display_policy.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from hermes_cli.config import DEFAULT_CONFIG
+from hermes_cli.final_response_display_policy import (
+    assistant_body_for_tts,
+    decide_final_response_display,
+)
+
+
+def test_default_config_keeps_assistant_answer_body_final_only() -> None:
+    assert DEFAULT_CONFIG["display"]["assistant_body_streaming"] is False
+
+
+def test_transformed_final_renders_even_if_raw_stream_was_received() -> None:
+    decision = decide_final_response_display(
+        response="路径：native｜原因：runtime_default\nBody",
+        response_previewed=False,
+        response_transformed=True,
+        stream_text_received=True,
+        stream_text_visible=False,
+        is_error_response=False,
+        use_streaming_tts=False,
+        streaming_tts_box_opened=False,
+    )
+
+    assert decision.render_panel is True
+    assert decision.close_streaming_tts_box is False
+    assert decision.reason == "transformed_final_response"
+
+
+def test_visible_untransformed_stream_can_skip_legacy_final_panel() -> None:
+    decision = decide_final_response_display(
+        response="Body",
+        response_previewed=False,
+        response_transformed=False,
+        stream_text_received=True,
+        stream_text_visible=True,
+        is_error_response=False,
+        use_streaming_tts=False,
+        streaming_tts_box_opened=False,
+    )
+
+    assert decision.render_panel is False
+    assert decision.reason == "already_visible_stream"
+
+
+def test_received_but_not_visible_stream_renders_canonical_final() -> None:
+    decision = decide_final_response_display(
+        response="Body",
+        response_previewed=False,
+        response_transformed=False,
+        stream_text_received=True,
+        stream_text_visible=False,
+        is_error_response=False,
+        use_streaming_tts=False,
+        streaming_tts_box_opened=False,
+    )
+
+    assert decision.render_panel is True
+    assert decision.reason == "not_visible"
+
+
+def test_preview_flag_does_not_hide_final_when_draft_body_was_not_visible() -> None:
+    decision = decide_final_response_display(
+        response="路径：native｜原因：runtime_default\nBody",
+        response_previewed=True,
+        response_transformed=True,
+        stream_text_received=True,
+        stream_text_visible=False,
+        is_error_response=False,
+        use_streaming_tts=False,
+        streaming_tts_box_opened=False,
+    )
+
+    assert decision.render_panel is True
+    assert decision.reason == "transformed_final_response"
+
+
+def test_transformed_final_overrides_visible_preview_suppression() -> None:
+    decision = decide_final_response_display(
+        response="路径：native｜原因：runtime_default\nBody",
+        response_previewed=True,
+        response_transformed=True,
+        stream_text_received=True,
+        stream_text_visible=True,
+        is_error_response=False,
+        use_streaming_tts=False,
+        streaming_tts_box_opened=False,
+    )
+
+    assert decision.render_panel is True
+    assert decision.reason == "transformed_final_response"
+
+
+def test_transformed_final_renders_and_closes_streaming_tts_box() -> None:
+    decision = decide_final_response_display(
+        response="路径：native｜原因：runtime_default\nBody",
+        response_previewed=False,
+        response_transformed=True,
+        stream_text_received=True,
+        stream_text_visible=False,
+        is_error_response=False,
+        use_streaming_tts=True,
+        streaming_tts_box_opened=True,
+    )
+
+    assert decision.render_panel is True
+    assert decision.close_streaming_tts_box is True
+    assert decision.reason == "transformed_final_response"
+
+
+def test_tts_receives_body_without_runtime_route_bar() -> None:
+    response = "路径：native｜原因：runtime_default｜工具 none\nBody to speak"
+
+    assert assistant_body_for_tts(response) == "Body to speak"

--- a/tests/cli/test_stream_partial_line_flush.py
+++ b/tests/cli/test_stream_partial_line_flush.py
@@ -28,6 +28,7 @@ def cli_stub(monkeypatch):
     cli.show_reasoning = False
     cli.final_response_markdown = "raw"
     cli.show_timestamps = False
+    cli.assistant_body_streaming = True
     cli._reset_stream_state()
 
     emitted = []

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -127,6 +127,59 @@ class TestLoadConfigDefaults:
             assert config["agent"]["max_turns"] == 42
             assert "max_turns" not in config
 
+    def test_legacy_answer_body_streaming_live_maps_to_assistant_body_streaming(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config_path = tmp_path / "config.yaml"
+            config_path.write_text("display:\n  answer_body_streaming: live\n")
+
+            config = load_config()
+
+            assert config["display"]["assistant_body_streaming"] is True
+
+    def test_legacy_answer_body_streaming_final_only_maps_to_false(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config_path = tmp_path / "config.yaml"
+            config_path.write_text("display:\n  answer_body_streaming: final_only\n")
+
+            config = load_config()
+
+            assert config["display"]["assistant_body_streaming"] is False
+
+    def test_invalid_legacy_answer_body_streaming_keeps_default_false(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config_path = tmp_path / "config.yaml"
+            config_path.write_text("display:\n  answer_body_streaming: sometimes\n")
+
+            config = load_config()
+
+            assert config["display"]["assistant_body_streaming"] is False
+
+    def test_new_false_wins_over_legacy_live_answer_body_streaming(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config_path = tmp_path / "config.yaml"
+            config_path.write_text(
+                "display:\n"
+                "  answer_body_streaming: live\n"
+                "  assistant_body_streaming: false\n"
+            )
+
+            config = load_config()
+
+            assert config["display"]["assistant_body_streaming"] is False
+
+    def test_new_assistant_body_streaming_key_wins_over_legacy_answer_key(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config_path = tmp_path / "config.yaml"
+            config_path.write_text(
+                "display:\n"
+                "  answer_body_streaming: final_only\n"
+                "  assistant_body_streaming: true\n"
+            )
+
+            config = load_config()
+
+            assert config["display"]["assistant_body_streaming"] is True
+
 
 class TestLoadConfigParseFailure:
     """A YAML parse failure must NOT silently fall back to defaults.

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -524,16 +524,154 @@ def test_install_heartbeat_prints_when_dependency_install_is_silent(monkeypatch,
 
 
 # ---------------------------------------------------------------------------
-# ff-only fallback to reset --hard on diverged history
+# Diverged history: preserve committed local patches across updates
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_update_rebases_local_commits_instead_of_reset(
+    monkeypatch, tmp_path, capsys
+):
+    """A diverged checkout with local-only commits must replay them, never drop them."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    recorded = []
+
+    def fake_run(cmd, **kwargs):
+        recorded.append(cmd)
+        joined = " ".join(str(c) for c in cmd)
+        if "fetch origin main" in joined:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if "rev-parse --abbrev-ref HEAD" in joined:
+            return SimpleNamespace(stdout="main\n", stderr="", returncode=0)
+        if "rev-list HEAD..origin/main --count" in joined:
+            return SimpleNamespace(stdout="3\n", stderr="", returncode=0)
+        if "pull --ff-only origin main" in joined:
+            return SimpleNamespace(
+                stdout="",
+                stderr="fatal: Not possible to fast-forward, aborting.\n",
+                returncode=128,
+            )
+        if "rev-list --count origin/main..HEAD" in joined:
+            return SimpleNamespace(stdout="2\n", stderr="", returncode=0)
+        if "branch hermes-local-commits-" in joined:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if "rebase origin/main" in joined:
+            return SimpleNamespace(stdout="Successfully rebased\n", stderr="", returncode=0)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    hermes_main.cmd_update(SimpleNamespace())
+
+    assert any(
+        c[:2] == ["git", "branch"] and "hermes-local-commits-" in c[2]
+        for c in recorded
+    )
+    assert ["git", "rebase", "origin/main"] in recorded
+    assert ["git", "reset", "--hard", "origin/main"] not in recorded
+    out = capsys.readouterr().out
+    assert "2 local commit(s)" in out
+    assert "rebased" in out.lower()
+
+
+def test_cmd_update_aborts_conflicted_rebase_without_hard_reset(
+    monkeypatch, tmp_path, capsys
+):
+    """A rebase conflict must fail loud and restore the pre-update branch state."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    recorded = []
+
+    def fake_run(cmd, **kwargs):
+        recorded.append(cmd)
+        joined = " ".join(str(c) for c in cmd)
+        if "fetch origin main" in joined:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if "rev-parse --abbrev-ref HEAD" in joined:
+            return SimpleNamespace(stdout="main\n", stderr="", returncode=0)
+        if "rev-list HEAD..origin/main --count" in joined:
+            return SimpleNamespace(stdout="3\n", stderr="", returncode=0)
+        if "pull --ff-only origin main" in joined:
+            return SimpleNamespace(stdout="", stderr="diverged\n", returncode=128)
+        if "rev-list --count origin/main..HEAD" in joined:
+            return SimpleNamespace(stdout="1\n", stderr="", returncode=0)
+        if "branch hermes-local-commits-" in joined:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if "rebase origin/main" in joined:
+            return SimpleNamespace(stdout="", stderr="CONFLICT\n", returncode=1)
+        if "rebase --abort" in joined:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit, match="1"):
+        hermes_main.cmd_update(SimpleNamespace())
+
+    assert ["git", "rebase", "--abort"] in recorded
+    assert ["git", "reset", "--hard", "origin/main"] not in recorded
+    out = capsys.readouterr().out
+    assert "kept on backup branch" in out
+    assert "not discarded" in out
+
+
+def test_cmd_update_surfaces_rebase_abort_failure(monkeypatch, tmp_path, capsys):
+    """A failed abort must report that the checkout may still be mid-rebase."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    recorded = []
+
+    def fake_run(cmd, **kwargs):
+        recorded.append(cmd)
+        joined = " ".join(str(c) for c in cmd)
+        if "fetch origin main" in joined:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if "rev-parse --abbrev-ref HEAD" in joined:
+            return SimpleNamespace(stdout="main\n", stderr="", returncode=0)
+        if "rev-list HEAD..origin/main --count" in joined:
+            return SimpleNamespace(stdout="3\n", stderr="", returncode=0)
+        if "pull --ff-only origin main" in joined:
+            return SimpleNamespace(stdout="", stderr="diverged\n", returncode=128)
+        if "rev-list --count origin/main..HEAD" in joined:
+            return SimpleNamespace(stdout="1\n", stderr="", returncode=0)
+        if "branch hermes-local-commits-" in joined:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if "rebase origin/main" in joined:
+            return SimpleNamespace(stdout="", stderr="CONFLICT\n", returncode=1)
+        if "rebase --abort" in joined:
+            return SimpleNamespace(
+                stdout="",
+                stderr="abort failed: permission denied\n",
+                returncode=1,
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit, match="1"):
+        hermes_main.cmd_update(SimpleNamespace())
+
+    assert ["git", "rebase", "--abort"] in recorded
+    assert ["git", "reset", "--hard", "origin/main"] not in recorded
+    out = capsys.readouterr().out
+    assert "abort failed: permission denied" in out
+    assert "may still be in progress" in out
+    assert "kept on backup branch" in out
+
+
+# ---------------------------------------------------------------------------
+# ff-only fallback to reset --hard on diverged history without local commits
 # ---------------------------------------------------------------------------
 
 def _make_update_side_effect(
     current_branch="main",
     commit_count="3",
+    ahead_count="0",
     ff_only_fails=False,
     reset_fails=False,
     fetch_fails=False,
     fetch_stderr="",
+    backup_fails=False,
 ):
     """Build a subprocess.run side_effect for cmd_update tests."""
     recorded = []
@@ -548,6 +686,16 @@ def _make_update_side_effect(
         if "rev-parse" in joined and "--abbrev-ref" in joined:
             return SimpleNamespace(stdout=f"{current_branch}\n", stderr="", returncode=0)
         if "checkout" in joined and "main" in joined:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if "rev-list --count origin/" in joined and "..HEAD" in joined:
+            return SimpleNamespace(stdout=f"{ahead_count}\n", stderr="", returncode=0)
+        if "branch hermes-local-commits-" in joined:
+            if backup_fails:
+                return SimpleNamespace(
+                    stdout="",
+                    stderr="fatal: cannot lock ref\n",
+                    returncode=1,
+                )
             return SimpleNamespace(stdout="", stderr="", returncode=0)
         if "rev-list" in joined:
             return SimpleNamespace(stdout=f"{commit_count}\n", stderr="", returncode=0)
@@ -584,6 +732,45 @@ def test_cmd_update_falls_back_to_reset_when_ff_only_fails(monkeypatch, tmp_path
 
     out = capsys.readouterr().out
     assert "Fast-forward not possible" in out
+
+
+def test_cmd_update_fails_closed_when_local_commit_count_is_unknown(
+    monkeypatch, tmp_path, capsys
+):
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    side_effect, recorded = _make_update_side_effect(
+        ff_only_fails=True,
+        ahead_count="not-a-number",
+    )
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    with pytest.raises(SystemExit, match="1"):
+        hermes_main.cmd_update(SimpleNamespace())
+
+    assert ["git", "reset", "--hard", "origin/main"] not in recorded
+    assert "could not be verified" in capsys.readouterr().out
+
+
+def test_cmd_update_fails_closed_when_backup_branch_cannot_be_created(
+    monkeypatch, tmp_path, capsys
+):
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    side_effect, recorded = _make_update_side_effect(
+        ff_only_fails=True,
+        ahead_count="1",
+        backup_fails=True,
+    )
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    with pytest.raises(SystemExit, match="1"):
+        hermes_main.cmd_update(SimpleNamespace())
+
+    assert ["git", "reset", "--hard", "origin/main"] not in recorded
+    out = capsys.readouterr().out
+    assert "Could not preserve 1 local commit" in out
+    assert "fatal: cannot lock ref" in out
 
 
 def test_cmd_update_no_reset_when_ff_only_succeeds(monkeypatch, tmp_path):

--- a/tests/run_agent/test_final_object_streaming_no_body.py
+++ b/tests/run_agent/test_final_object_streaming_no_body.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from agent.chat_completion_helpers import interruptible_streaming_api_call
+
+
+class _CompletedObjectClient:
+    def __init__(self, response):
+        self._response = response
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
+
+    def create(self, **_kwargs):
+        return self._response
+
+
+def test_completed_response_object_does_not_stream_answer_body(monkeypatch) -> None:
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="canonical answer", reasoning_content=None))]
+    )
+    agent = SimpleNamespace(
+        provider="moa",
+        model="default",
+        api_mode="chat_completions",
+        base_url="https://example.invalid/v1",
+        _disable_streaming=False,
+        _create_request_openai_client=lambda **_kwargs: _CompletedObjectClient(response),
+        _close_request_openai_client=lambda *_args, **_kwargs: None,
+        _capture_rate_limits=lambda _response: None,
+        _capture_credits=lambda _response: None,
+        _check_openrouter_cache_status=lambda _response: None,
+        _stream_diag_init=lambda: {},
+        _stream_diag_capture_response=lambda *_args, **_kwargs: None,
+        _stream_diag_finalize=lambda *_args, **_kwargs: None,
+        _fire_reasoning_delta=lambda text: None,
+        _fire_stream_delta=lambda text: streamed.append(text),
+        _is_provider_stream_parse_error=lambda _exc: False,
+        _interrupt_requested=False,
+        _touch_activity=lambda _message: None,
+    )
+    streamed: list[str] = []
+    monkeypatch.setattr("agent.chat_completion_helpers.get_provider_stale_timeout", lambda *_args, **_kwargs: 1)
+
+    result = interruptible_streaming_api_call(agent, {"stream": True})
+
+    assert result is response
+    assert agent._disable_streaming is True
+    assert streamed == []

--- a/tests/run_agent/test_stream_visibility_accounting.py
+++ b/tests/run_agent/test_stream_visibility_accounting.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from run_agent import AIAgent
+
+
+def _agent_without_init():
+    agent = AIAgent.__new__(AIAgent)
+    agent._stream_needs_break = False
+    agent._stream_think_scrubber = None
+    agent._stream_context_scrubber = None
+    agent.stream_delta_callback = lambda text: False
+    agent._stream_callback = None
+    agent._current_streamed_assistant_text = ""
+    agent._current_visible_streamed_assistant_text = ""
+    agent._strip_think_blocks = lambda content: content
+    return agent
+
+
+def test_stream_delta_records_received_text_without_marking_visible() -> None:
+    agent = _agent_without_init()
+
+    AIAgent._fire_stream_delta(agent, "draft body")
+
+    assert agent._current_streamed_assistant_text == "draft body"
+    assert agent._current_visible_streamed_assistant_text == ""
+
+
+def test_stream_delta_none_return_remains_visible_for_legacy_callbacks() -> None:
+    agent = _agent_without_init()
+    agent.stream_delta_callback = lambda text: None
+
+    AIAgent._fire_stream_delta(agent, "visible body")
+
+    assert agent._current_streamed_assistant_text == "visible body"
+    assert agent._current_visible_streamed_assistant_text == "visible body"
+
+
+def test_interim_content_was_streamed_uses_visible_text_only() -> None:
+    agent = _agent_without_init()
+    agent._current_streamed_assistant_text = "hidden draft"
+    agent._current_visible_streamed_assistant_text = ""
+
+    assert AIAgent._interim_content_was_streamed(agent, "hidden draft") is False


### PR DESCRIPTION
## Summary

Fix three related durability/truthfulness problems in the classic CLI:

1. Render the assistant answer body exactly once from the canonical finalized response while keeping reasoning, tool, and progress streams live.
2. Generate and persist one runtime-owned route/depth bar from observed execution facts, including truthful MoA success/degradation facts.
3. Preserve committed local patches when `hermes update` encounters diverged history instead of silently discarding them with `reset --hard`.

## Runtime display changes

- Default classic CLI answer-body streaming to final-only.
- Track stream text received separately from text actually rendered.
- Keep auxiliary streaming consumers such as TTS without feeding completed-response bodies into the visual draft callback.
- Add a runtime-owned route/depth bar and persist the same canonical transformed response that is displayed.
- Restrict route-bar injection to CLI or explicit opt-in surfaces.
- Restore MoA runtime facts from actual completed calls:
  - successful references are counted from explicit runtime outcomes, not configured slots;
  - failed/skipped references are excluded from the success numerator;
  - full success stays compact (`MoA 4+1`);
  - degraded participation is explicit (`MoA 3/4+1`) and downgrades evidence to `partial`;
  - failed aggregator/stream paths do not publish stale facts.
- Keep MoA references distinct from Hermes `subagents`.
- Accept OMO/coordination facts only from runtime-owned agent/client facts; assistant prose and generic tool stdout cannot forge route facts.
- Make tool summaries unambiguous and compact: deduplicated names plus explicit total calls/failures.
- Map legacy `display.answer_body_streaming` (`live` / `final_only`) to the new boolean key when the new key is absent; the new key wins.
- Strip runtime status metadata from batch TTS.

## Update safety changes

When `git pull --ff-only` fails:

- Verify the local commit count relative to `origin/<branch>`.
- Fail closed if that count cannot be established.
- If local commits exist, create a unique backup branch and rebase them onto the updated remote.
- Abort and report conflicts without hard-resetting local commits.
- Surface a failed `git rebase --abort` as a potentially stuck checkout with recovery guidance.
- Permit the existing hard-reset fallback only after proving there are no local-only commits.

## Verification

Latest base: `origin/main` at `9eaf3abf6`.

Automated:

- Post-rebase focused + adjacent status/config/streaming/MoA suite: **247 passed**.
- Additional MoA adjacent suite during implementation: **84 passed**.
- Final-response contract verifier: **PASS**.
- Changed-file `py_compile`: **PASS**.
- `git diff --check`: **PASS**.
- Added-line security scan: no hardcoded secret, shell injection, eval/exec, pickle, or SQL-format findings.
- Independent reviewer round 1: requested trust-boundary and MoA lifecycle fixes.
- Independent reviewer round 2: **APPROVED**.
- Final degraded-MoA delta reviewer: **APPROVED**.

Live worktree smokes + SQLite readback:

- Native CLI session `20260711_142511_1c50e2`:
  - one exact final marker line;
  - one route bar;
  - one canonical assistant DB row;
  - marker once and route bar once in the persisted assistant body.
- Real MoA session `20260711_144934_6e7bde`:
  - 4 configured references; 3 succeeded; Claude bridge reference failed authentication; aggregator succeeded;
  - final bar: `路径：moa｜原因：provider_moa｜MoA 3/4+1｜...｜证据 partial`;
  - one exact final marker line, one route bar, one canonical assistant DB row;
  - persisted DB first line matches visible stdout exactly.

## Notes

The runtime bar is generated from runtime facts rather than model-authored prose. Non-CLI surfaces are not prefixed unless they explicitly opt in. Generic terminal/read-file output and assistant prose cannot inject OMO/MoA/Deep status facts.
