### PR TITLE
fix(desktop): allow cold audio transcription requests

### DIFF
--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -10,7 +10,8 @@ import {
   getSessionMessages,
   getStatus,
   listAllProfileSessions,
-  listSessions
+  listSessions,
+  transcribeAudio
 } from './hermes'
 import { refreshActiveProfile } from './store/profile'
 
@@ -122,6 +123,20 @@ describe('Hermes REST session helpers', () => {
     const call = api.mock.calls[0]?.[0] as { path: string; timeoutMs?: number }
     expect(call.path).toBe('/api/status')
     expect(call.timeoutMs).toBeUndefined()
+  })
+
+  it('uses a dedicated timeout for audio transcription cold starts', async () => {
+    await transcribeAudio('data:audio/webm;base64,AA==', 'audio/webm')
+
+    expect(api).toHaveBeenCalledWith({
+      path: '/api/audio/transcribe',
+      method: 'POST',
+      timeoutMs: 180_000,
+      body: {
+        data_url: 'data:audio/webm;base64,AA==',
+        mime_type: 'audio/webm'
+      }
+    })
   })
 
   it('tags cross-profile message reads for Electron routing and backend lookup', async () => {

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -71,6 +71,7 @@ import type {
 export const STARTUP_REQUEST_TIMEOUT_MS = 60_000
 const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 30_000
 const SESSION_LIST_REQUEST_TIMEOUT_MS = 60_000
+const AUDIO_TRANSCRIPTION_REQUEST_TIMEOUT_MS = 180_000
 // prompt.submit is effectively fire-and-forget: turn completion is signaled by
 // stream / message.complete events, NOT by the RPC return. A long turn (MoA
 // presets running references + aggregator in series, deep reasoning, large tool
@@ -997,6 +998,7 @@ export function transcribeAudio(dataUrl: string, mimeType?: string): Promise<Aud
   return window.hermesDesktop.api<AudioTranscriptionResponse>({
     path: '/api/audio/transcribe',
     method: 'POST',
+    timeoutMs: AUDIO_TRANSCRIPTION_REQUEST_TIMEOUT_MS,
     body: {
       data_url: dataUrl,
       mime_type: mimeType


### PR DESCRIPTION
## Symptom

The first microphone transcription after the backend starts can silently fail in Hermes Desktop: the recording uploads, the backend transcribes successfully, but no text ever reaches the composer.

## Cause

Desktop REST IPC requests default to a 15-second timeout. A cold `/api/audio/transcribe` request has to initialize the local STT runtime (e.g. `faster-whisper medium` load) before transcribing, which can take ~25 s on a modest CPU — the renderer stops waiting while the backend later completes the request. Warm requests fit the default, which makes the failure look intermittent.

## Fix

Give `transcribeAudio()` a dedicated `AUDIO_TRANSCRIPTION_REQUEST_TIMEOUT_MS = 180_000` passed as the per-request `timeoutMs`. No other call path, global default, TTS, backend behavior, response shape, or error string changes.

## Tests

- New focused Vitest: `uses a dedicated timeout for audio transcription cold starts` (asserts the exact IPC request carries `timeoutMs: 180000` for `POST /api/audio/transcribe`) — RED before the fix, GREEN after.
- `npm run test:ui --workspace apps/desktop -- src/hermes.test.ts` — 10 passed
- `npm run typecheck --workspace apps/desktop` — passed
- `npm run lint --workspace apps/desktop -- --quiet` — passed

Reproduced and verified end-to-end against a remote agent over an SSH tunnel: cold request previously timed out client-side at 15 s while the backend finished at ~25 s; with this change the transcript arrives.