### PR TITLE
fix(gateway): invalidate cached agent on session changes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15678,6 +15678,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ("compression", "codex_app_server_auto"),
         ("compression", "target_ratio"),
         ("compression", "protect_last_n"),
+        ("context", "engine"),
         ("agent", "disabled_toolsets"),
         ("memory", "provider"),
     )
@@ -15773,6 +15774,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         cache_keys: dict | None = None,
         user_id: str | None = None,
         user_id_alt: str | None = None,
+        session_id: str | None = None,
+        context_engine: str | None = None,
     ) -> str:
         """Compute a stable string key from agent config values.
 
@@ -15800,6 +15803,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         broke #27371's per-user-peer contract in multi-user gateways.
         Per-user agent rebuilds in shared threads trade prompt-cache
         warmth for correct memory attribution.
+
+        ``session_id`` and ``context_engine`` are included because gateway
+        ``session_key`` values are stable across compression rollovers while
+        context engines bind durable state to the concrete Hermes session id.
+        Reusing a cached AIAgent after either identity changes can leave the
+        context engine pointed at stale session data.
         """
         import hashlib, json as _j
 
@@ -15826,6 +15835,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _cache_keys_sorted,
                 str(user_id or ""),
                 str(user_id_alt or ""),
+                str(session_id or ""),
+                str(context_engine or ""),
             ],
             sort_keys=True,
             default=str,
@@ -18092,6 +18103,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 cache_keys=self._extract_cache_busting_config(user_config),
                 user_id=getattr(source, "user_id", None),
                 user_id_alt=getattr(source, "user_id_alt", None),
+                session_id=session_id,
+                context_engine=cfg_get(user_config, "context", "engine"),
             )
             agent = None
             reused_cached_agent = False

--- a/tests/gateway/test_agent_cache_session_identity.py
+++ b/tests/gateway/test_agent_cache_session_identity.py
@@ -1,0 +1,40 @@
+"""Regression tests for gateway cached-agent session identity.
+
+A platform session_key can stay stable while compression rotates the underlying
+Hermes session_id. Reusing the old cached AIAgent across that boundary keeps the
+context engine bound to stale session state.
+"""
+
+from gateway.run import GatewayRunner
+
+
+def _signature(*, session_id: str, context_engine: str = "lcm") -> str:
+    return GatewayRunner._agent_config_signature(
+        "test-model",
+        {"provider": "test", "api_mode": "chat", "base_url": "https://example.invalid"},
+        ["terminal"],
+        "system prompt",
+        cache_keys={"context.engine": context_engine},
+        user_id="telegram-user",
+        user_id_alt=None,
+        session_id=session_id,
+        context_engine=context_engine,
+    )
+
+
+def test_agent_cache_signature_changes_when_session_id_rotates_under_same_session_key():
+    """A compressed child session must not reuse the parent session's cached AIAgent."""
+
+    parent_sig = _signature(session_id="session-parent")
+    child_sig = _signature(session_id="session-child")
+
+    assert parent_sig != child_sig
+
+
+def test_agent_cache_signature_changes_when_context_engine_identity_changes():
+    """Switching context engines must invalidate cached AIAgent/context bindings."""
+
+    lcm_sig = _signature(session_id="same-session", context_engine="lcm")
+    compressor_sig = _signature(session_id="same-session", context_engine="compressor")
+
+    assert lcm_sig != compressor_sig


### PR DESCRIPTION
## Summary
- include the concrete Hermes session ID in the gateway agent-cache signature
- include the selected context engine in cache invalidation
- add regression coverage for session rollover and context-engine changes

## Why
Platform session keys can remain stable while compression rotates the underlying Hermes session. Reusing the cached `AIAgent` across that boundary can leave its context engine bound to stale session state.

## Test plan
- [x] Regression test demonstrated RED before the production patch: 2 expected failures
- [x] Focused regression tests: 2 passed
- [x] Adjacent gateway cache/session tests: 27 passed
- [x] `py_compile` passed
- [x] `git diff --check` passed

No runtime restart or live-system mutation was performed.
