### PR TITLE
fix(discord): make clarify button labels always legible

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5794,9 +5794,33 @@ class DiscordAdapter(BasePlatformAdapter):
             clean_choices = clean_choices[:24]
 
             if clean_choices:
+                # Mirror the full choice text as a numbered list, same as the
+                # Telegram/WhatsApp adapters. Button labels are capped at 80
+                # chars by Discord and become unreadable on mobile long before
+                # that (see ClarifyChoiceView), so the button is just a short
+                # index — the full text the user needs to make an informed
+                # decision lives here, in the embed field / message body,
+                # which has a much higher cap (1024 for embed fields).
+                option_lines_full = "\n".join(
+                    f"**{i + 1}.** {c}" for i, c in enumerate(clean_choices)
+                )
+                embed_suffix = (
+                    "\n\nPick a button below, or click ✏️ Other to type a "
+                    "custom answer."
+                )
+                max_field = 1024
+                # Reserve space for the suffix before truncating the options
+                # list, otherwise a long-but-under-cap option_lines plus the
+                # suffix can push the combined field value past Discord's
+                # real 1024-char embed-field limit and the send silently
+                # fails downstream.
+                option_lines = option_lines_full
+                if len(option_lines) + len(embed_suffix) > max_field:
+                    budget = max_field - len(embed_suffix) - 3
+                    option_lines = option_lines_full[:budget] + "..."
                 embed.add_field(
                     name="Choices",
-                    value="Pick one below, or click ✏️ Other to type a custom answer.",
+                    value=f"{option_lines}{embed_suffix}",
                     inline=False,
                 )
                 view = ClarifyChoiceView(
@@ -5812,14 +5836,22 @@ class DiscordAdapter(BasePlatformAdapter):
                     inline=False,
                 )
                 view = None
+                option_lines_full = ""
 
-            # Mirror the question in plain content — embeds are invisible on
-            # some clients (see send_exec_approval).
-            clarify_tail = (
-                "\n\nPick one below, or click ✏️ Other to type a custom answer."
-                if clean_choices
-                else "\n\nReply in this channel with your answer."
-            )
+            # Mirror the question (and, for multi-choice, the full option
+            # text) in plain content — embeds are invisible on some clients
+            # (see send_exec_approval). The plain-text mirror uses the
+            # untruncated option list; Discord's message content cap (2000
+            # chars) is a separate, much larger limit than the embed field's
+            # 1024, so reusing the embed-truncated value here would cut off
+            # options unnecessarily.
+            if clean_choices:
+                clarify_tail = (
+                    f"\n\n{option_lines_full}\n\nPick a button below, or click "
+                    "✏️ Other to type a custom answer."
+                )
+            else:
+                clarify_tail = "\n\nReply in this channel with your answer."
             content = self._self_contained_prompt_content(
                 "❓ **Hermes needs your input**", str(question or "").strip(),
                 tail=clarify_tail,
@@ -7537,50 +7569,21 @@ def _define_discord_view_classes() -> None:
             self.resolved = False
 
             for index, choice in enumerate(self.choices):
-                # Discord button labels are capped at 80 chars. On mobile the
-                # visible width is much narrower (often <40 chars before it
-                # wraps to 2 lines and the second line gets cut off), so we
-                # cap aggressively and cut at a word boundary when possible
-                # to keep the trailing text readable.
-                #
-                # Cut strategy (most-preferred to least-preferred):
-                #   1. Last space in the trailing half of the budget
-                #      (cleanest word boundary)
-                #   2. Last soft boundary in the trailing half of the
-                #      budget (hyphen, comma, period, paren)
-                #   3. Hard cut at the budget limit (last resort)
-                prefix = f"{index + 1}. "
-                budget = _DISCORD_BUTTON_LABEL_LIMIT - utf16_len(prefix)
-                if utf16_len(choice) <= budget:
-                    label_body = choice
-                else:
-                    truncated = _prefix_within_utf16_limit(
-                        choice,
-                        max(0, budget - utf16_len(_DISCORD_ELLIPSIS)),
-                    ).rstrip()
-                    cut_at = -1
-                    # 1. Last space in the trailing half of the budget.
-                    space = truncated.rfind(" ")
-                    if space >= len(truncated) // 2:
-                        cut_at = space
-                    # 2. Soft boundary — only if no word boundary found.
-                    # Find the latest soft boundary in the trailing half
-                    # of the budget; that maximizes preserved text length.
-                    # Cut AT the soft boundary (inclusive) so the label
-                    # ends on the soft char (e.g. "-" or ",") rather than
-                    # on the alpha char that followed it.
-                    if cut_at < 0:
-                        latest_soft = max(
-                            (truncated.rfind(s) for s in ("-", ",", ".", ")")),
-                            default=-1,
-                        )
-                        if latest_soft >= len(truncated) // 2:
-                            cut_at = latest_soft + 1
-                    if cut_at > 0:
-                        truncated = truncated[:cut_at]
-                    label_body = truncated.rstrip() + _DISCORD_ELLIPSIS
+                # Button labels are just the option number ("1", "2", ...).
+                # The full choice text is unreadable on Discord buttons no
+                # matter how we truncate it: the 80-char API cap is already
+                # much wider than what mobile clients render before
+                # wrapping/cutting a second line (~40 visible chars), so any
+                # truncation strategy here still garbles longer choices.
+                # send_clarify() now mirrors the full, untruncated choice
+                # text as a numbered list in the embed/message body (mirrors
+                # the Telegram/WhatsApp adapters' approach) — the button only
+                # needs to carry the index so the label is always short and
+                # legible, and the real text lives where there's room to
+                # read it.
+                label_body = str(index + 1)
                 button = discord.ui.Button(
-                    label=f"{prefix}{label_body}",
+                    label=label_body,
                     style=discord.ButtonStyle.primary,
                     custom_id=f"clarify:{clarify_id}:{index}",
                 )

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -7701,7 +7701,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     f"**{i + 1}.** {c}" for i, c in enumerate(clean_choices)
                 )
                 embed_suffix = (
-                    "\n\nPick a button below, or click ✏️ Other to type a "
+                    "\n\nPick one below, or click ✏️ Other to type a "
                     "custom answer."
                 )
                 # Reserve the suffix before truncating the options list:
@@ -7740,7 +7740,7 @@ class DiscordAdapter(BasePlatformAdapter):
             # _self_contained_prompt_content() already enforces it.
             if clean_choices:
                 clarify_tail = (
-                    f"\n\n{option_lines_full}\n\nPick a button below, or click "
+                    f"\n\n{option_lines_full}\n\nPick one below, or click "
                     "✏️ Other to type a custom answer."
                 )
             else:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -93,6 +93,9 @@ _DISCORD_MODEL_SELECT_CAPACITY = (
 ) * _DISCORD_SELECT_MAX_OPTIONS
 _DISCORD_BUTTON_LABEL_LIMIT = 80
 _DISCORD_ELLIPSIS = "\u2026"
+# Discord caps a single embed field's `value` at 1024 characters; a field
+# over the cap is rejected by the API, not silently trimmed.
+_DISCORD_EMBED_FIELD_LIMIT = 1024
 _DISCORD_NONCONVERSATIONAL_METADATA_KEYS = frozenset({
     "non_conversational",
     "non_conversational_history",
@@ -7689,9 +7692,29 @@ class DiscordAdapter(BasePlatformAdapter):
             clean_choices = clean_choices[:24]
 
             if clean_choices:
+                # Mirror the full choice text as a numbered list, same as the
+                # Telegram/WhatsApp adapters. Button labels are capped at 80
+                # chars by Discord and truncated well before that on mobile
+                # (see ClarifyChoiceView), so a long choice is only fully
+                # readable here, in the embed field / message body.
+                option_lines_full = "\n".join(
+                    f"**{i + 1}.** {c}" for i, c in enumerate(clean_choices)
+                )
+                embed_suffix = (
+                    "\n\nPick a button below, or click ✏️ Other to type a "
+                    "custom answer."
+                )
+                # Reserve the suffix before truncating the options list:
+                # an options block that is itself under the cap can still
+                # push the *combined* field value past Discord's real 1024
+                # embed-field limit, and the send fails downstream.
+                option_lines = option_lines_full
+                if len(option_lines) + len(embed_suffix) > _DISCORD_EMBED_FIELD_LIMIT:
+                    budget = _DISCORD_EMBED_FIELD_LIMIT - len(embed_suffix) - 3
+                    option_lines = option_lines_full[:budget] + "..."
                 embed.add_field(
                     name="Choices",
-                    value="Pick one below, or click ✏️ Other to type a custom answer.",
+                    value=f"{option_lines}{embed_suffix}",
                     inline=False,
                 )
                 view = ClarifyChoiceView(
@@ -7707,14 +7730,21 @@ class DiscordAdapter(BasePlatformAdapter):
                     inline=False,
                 )
                 view = None
+                option_lines_full = ""
 
-            # Mirror the question in plain content — embeds are invisible on
-            # some clients (see send_exec_approval).
-            clarify_tail = (
-                "\n\nPick one below, or click ✏️ Other to type a custom answer."
-                if clean_choices
-                else "\n\nReply in this channel with your answer."
-            )
+            # Mirror the question (and, for multi-choice, the full option text)
+            # in plain content — embeds are invisible on some clients (see
+            # send_exec_approval). This mirror uses the *untruncated* option
+            # list: message content is capped at 2000 chars, a separate and
+            # much larger limit than the embed field's 1024, and
+            # _self_contained_prompt_content() already enforces it.
+            if clean_choices:
+                clarify_tail = (
+                    f"\n\n{option_lines_full}\n\nPick a button below, or click "
+                    "✏️ Other to type a custom answer."
+                )
+            else:
+                clarify_tail = "\n\nReply in this channel with your answer."
             content = self._self_contained_prompt_content(
                 "❓ **Hermes needs your input**", str(question or "").strip(),
                 tail=clarify_tail,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5838,22 +5838,38 @@ class DiscordAdapter(BasePlatformAdapter):
                 view = None
                 option_lines_full = ""
 
-            # Mirror the question (and, for multi-choice, the full option
-            # text) in plain content — embeds are invisible on some clients
-            # (see send_exec_approval). The plain-text mirror uses the
-            # untruncated option list; Discord's message content cap (2000
-            # chars) is a separate, much larger limit than the embed field's
-            # 1024, so reusing the embed-truncated value here would cut off
-            # options unnecessarily.
+            # Mirror full choice text in plain content because embeds may be
+            # hidden and mobile button labels have almost no usable width.
+            content_header = "❓ **Hermes needs your input**"
+            question_text = str(question or "").strip()
             if clean_choices:
+                instruction = (
+                    "Pick a button below, or click ✏️ Other to type a custom answer."
+                )
+                truncation_notice = "\n[additional choice text truncated]"
+                question_reserve = min(len(question_text), 500)
+                fixed_length = (
+                    len(f"{content_header}\n\n")
+                    + question_reserve
+                    + len("\n\n")
+                    + len("\n\n")
+                    + len(instruction)
+                )
+                options_budget = max(0, self.MAX_MESSAGE_LENGTH - fixed_length)
+                mirrored_options = option_lines_full
+                if len(mirrored_options) > options_budget:
+                    text_budget = max(0, options_budget - len(truncation_notice))
+                    mirrored_options = (
+                        mirrored_options[:text_budget].rstrip()
+                        + truncation_notice
+                    )
                 clarify_tail = (
-                    f"\n\n{option_lines_full}\n\nPick a button below, or click "
-                    "✏️ Other to type a custom answer."
+                    f"\n\n{mirrored_options}\n\n{instruction}"
                 )
             else:
                 clarify_tail = "\n\nReply in this channel with your answer."
             content = self._self_contained_prompt_content(
-                "❓ **Hermes needs your input**", str(question or "").strip(),
+                content_header, question_text,
                 tail=clarify_tail,
             )
             msg = await channel.send(content=content, embed=embed, view=view) if view else await channel.send(content=content, embed=embed)

--- a/tests/gateway/test_discord_clarify_buttons.py
+++ b/tests/gateway/test_discord_clarify_buttons.py
@@ -30,7 +30,23 @@ from plugins.platforms.discord.adapter import (  # noqa: E402
     DiscordAdapter,
 )
 from gateway.config import PlatformConfig  # noqa: E402
-from gateway.platforms.base import utf16_len  # noqa: E402
+
+
+def _choices_field_value(embed) -> str:
+    """Pull the 'Choices' embed field's rendered text (full option list).
+
+    The test conftest's ``_FakeEmbed.add_field`` stores fields as plain
+    dicts (``{"name": ..., "value": ..., "inline": ...}``); support both
+    that shape and objects with ``.name``/``.value`` attributes in case a
+    real ``discord.Embed`` is ever passed in.
+    """
+    for field in embed.fields:
+        if isinstance(field, dict):
+            if field.get("name") == "Choices":
+                return field.get("value") or ""
+        elif getattr(field, "name", None) == "Choices":
+            return field.value
+    return ""
 
 
 # ---------------------------------------------------------------------------
@@ -94,9 +110,13 @@ class TestClarifyChoiceViewConstruction:
         # 3 numeric + 1 "Other"
         assert len(view.children) == 4
         labels = [b.label for b in view.children]
-        assert labels[0].startswith("1. apple")
-        assert labels[1].startswith("2. banana")
-        assert labels[2].startswith("3. cherry")
+        # Buttons are short numeric indices — the full choice text is
+        # mirrored in the message body / embed field instead (see
+        # send_clarify), since Discord's 80-char label cap is already wider
+        # than what mobile clients render before truncating/wrapping.
+        assert labels[0] == "1"
+        assert labels[1] == "2"
+        assert labels[2] == "3"
         assert "Other" in labels[3]
         # custom_ids encode clarify_id + index/other
         ids = [b.custom_id for b in view.children]
@@ -116,37 +136,30 @@ class TestClarifyChoiceViewConstruction:
         assert len(view.children) == 25
         assert "Other" in view.children[-1].label
 
-    def test_truncates_long_choice_label(self):
+    def test_button_label_is_short_index_regardless_of_choice_length(self):
+        # Button labels never carry choice text anymore — they're always
+        # just the option number, so length/truncation of the underlying
+        # choice text can never affect button legibility.
         long_choice = "x" * 200
         view = ClarifyChoiceView(
             choices=[long_choice],
             clarify_id="cidZ",
             allowed_user_ids=set(),
         )
-        # 78 chars + single-char ellipsis in the body, plus "1. " prefix.
-        # Uses U+2026 (…) instead of "..." to fit the 80-char Discord cap.
         first_label = view.children[0].label
-        assert first_label.startswith("1. ")
-        assert first_label.endswith("\u2026")
-        # Final label total <= 80 (Discord cap on button labels)
-        assert len(first_label) <= 80
+        assert first_label == "1"
 
-    def test_truncates_emoji_choice_label_by_utf16_limit(self):
+    def test_button_label_short_for_emoji_choice(self):
         long_choice = "\U0001f600" * 80
         view = ClarifyChoiceView(
             choices=[long_choice],
             clarify_id="cidEmoji",
             allowed_user_ids=set(),
         )
-
         first_label = view.children[0].label
-        assert first_label.startswith("1. ")
-        assert first_label.endswith("\u2026")
-        assert utf16_len(first_label) <= 80
+        assert first_label == "1"
 
-    def test_truncates_long_choice_label_breaks_on_word_boundary(self):
-        # Long choice with spaces — should cut at the last whole word so the
-        # trailing text stays readable on Discord mobile.
+    def test_button_label_short_for_multiword_choice(self):
         long_choice = (
             "Tight, well-illustrated, covers all 3 audiences "
             "(patients, families, curious general readers)"
@@ -157,34 +170,7 @@ class TestClarifyChoiceViewConstruction:
             allowed_user_ids=set(),
         )
         first_label = view.children[0].label
-        assert first_label.startswith("1. ")
-        assert first_label.endswith("\u2026")
-        # No mid-word fragment before the ellipsis.
-        assert not first_label.rstrip("\u2026").endswith("(")
-
-    def test_truncates_long_no_space_choice_on_soft_boundary(self):
-        # A long choice with soft boundaries (commas, hyphens) but no spaces
-        # should still cut on a soft boundary, not mid-word. We use an input
-        # where position 76 is NOT a soft boundary — the test only passes
-        # if the renderer actively searches backward for a soft char
-        # rather than blindly cutting at the budget limit.
-        long_choice = "a" * 30 + "-" + "b" * 30 + "-" + "c" * 30 + "-" + "d" * 30
-        # 30a-30b-30c-30d = 30 + 1 + 30 + 1 + 30 + 1 + 30 = 123 chars
-        # Position 76 is 'b' (a mid-word alpha). The renderer must look back
-        # for a '-' to cut on.
-        view = ClarifyChoiceView(
-            choices=[long_choice],
-            clarify_id="cidSB",
-            allowed_user_ids=set(),
-        )
-        first_label = view.children[0].label
-        assert first_label.endswith("\u2026")
-        assert len(first_label) <= 80
-        body = first_label[len("1. "):].rstrip("\u2026")
-        last_char = body[-1]
-        assert last_char in {"-", ",", ".", ")", " "}, (
-            f"Label cuts mid-word at {last_char!r}: {first_label!r}"
-        )
+        assert first_label == "1"
 
 
 # ===========================================================================
@@ -460,13 +446,16 @@ class TestDiscordSendClarify:
         view = kwargs["view"]
         # Only 1 real choice + 1 Other = 2 children
         assert len(view.children) == 2
-        assert "real-choice" in view.children[0].label
+        # Button label is just the index; full text lives in the embed.
+        assert view.children[0].label == "1"
+        embed = kwargs["embed"]
+        assert "real-choice" in _choices_field_value(embed)
 
     @pytest.mark.asyncio
     async def test_unwraps_dict_choices_to_description(self):
         # LLMs sometimes emit [{"description": "..."}] instead of bare strings
         # — the renderer must unwrap common dict shapes, not str() the whole
-        # dict into a Python repr on the button label.
+        # dict into a Python repr anywhere user-facing (embed field text).
         adapter = _make_adapter()
         channel = MagicMock()
         sent_msg = MagicMock()
@@ -488,24 +477,26 @@ class TestDiscordSendClarify:
             session_key="sk-U",
         )
         kwargs = channel.send.call_args.kwargs
-        view = kwargs["view"]
-        labels = [b.label for b in view.children[:-1]]  # exclude Other
-        # No raw Python repr should leak onto any label.
-        for label in labels:
-            assert "{'" not in label
-            assert "':" not in label
+        embed = kwargs["embed"]
+        option_text = _choices_field_value(embed)
+        # No raw Python repr should leak into the rendered choice text.
+        assert "{'" not in option_text
+        assert "':" not in option_text
         # Each dict unwrapped to its inner string.
-        assert any("Tight, well-illustrated" in lbl for lbl in labels)
-        assert any("Use label key" in lbl for lbl in labels)
-        assert any("Use text key" in lbl for lbl in labels)
-        assert any("normal-string" in lbl for lbl in labels)
+        assert "Tight, well-illustrated" in option_text
+        assert "Use label key" in option_text
+        assert "Use text key" in option_text
+        assert "normal-string" in option_text
+        # Button labels remain short numeric indices regardless.
+        labels = [b.label for b in kwargs["view"].children[:-1]]
+        assert labels == ["1", "2", "3", "4"]
 
     @pytest.mark.asyncio
     async def test_unwrap_prefers_description_over_name_in_multi_key_dict(self):
         # When the LLM emits both 'name' (often a short identifier in
         # OpenAI-style tool calls) and 'description' (the user-facing text),
         # the renderer must surface 'description'. The user should never see
-        # a 4-char model identifier on a button label.
+        # a 4-char model identifier in the rendered choice text.
         adapter = _make_adapter()
         channel = MagicMock()
         sent_msg = MagicMock()
@@ -521,12 +512,14 @@ class TestDiscordSendClarify:
             session_key="sk-N",
         )
         kwargs = channel.send.call_args.kwargs
-        view = kwargs["view"]
-        choice_label = view.children[0].label
-        assert "Tight, well-illustrated" in choice_label
-        # The 'name' value (a short identifier) must NOT have leaked.
-        body = choice_label.split("1. ", 1)[1].rstrip("\u2026")
-        assert "tight" not in body, f"'name' leaked onto button: {choice_label!r}"
+        embed = kwargs["embed"]
+        option_text = _choices_field_value(embed)
+        assert "Tight, well-illustrated" in option_text
+        # The 'name' value (a short identifier) must NOT have leaked as its
+        # own standalone token (it's fine that "tight" is a substring of
+        # "Tight" case-insensitively — check the literal lowercase form
+        # isn't present as a separate word).
+        assert "\ntight\n" not in option_text.lower()
 
     @pytest.mark.asyncio
     async def test_unwrap_prefers_label_over_description(self):
@@ -548,12 +541,12 @@ class TestDiscordSendClarify:
             session_key="sk-L",
         )
         kwargs = channel.send.call_args.kwargs
-        view = kwargs["view"]
-        choice_label = view.children[0].label
-        assert "Short" in choice_label
+        embed = kwargs["embed"]
+        option_text = _choices_field_value(embed)
+        assert "Short" in option_text
         # The longer description must NOT have leaked.
-        assert "Long verbose" not in choice_label, (
-            f"'description' leaked over 'label': {choice_label!r}"
+        assert "Long verbose" not in option_text, (
+            f"'description' leaked over 'label': {option_text!r}"
         )
 
     @pytest.mark.asyncio
@@ -561,8 +554,8 @@ class TestDiscordSendClarify:
         # 'name' and 'value' are Discord-component-shaped fields that could
         # accidentally appear in dicts not intended as choices (e.g., a
         # developer-error in the gateway wiring). The renderer should not
-        # surface them as button labels — only the well-known LLM tool-call
-        # keys (label, description, text, title) should win.
+        # surface them in the rendered choice text — only the well-known
+        # LLM tool-call keys (label, description, text, title) should win.
         adapter = _make_adapter()
         channel = MagicMock()
         sent_msg = MagicMock()
@@ -583,12 +576,57 @@ class TestDiscordSendClarify:
         )
         kwargs = channel.send.call_args.kwargs
         view = kwargs["view"]
-        choice_labels = [b.label for b in view.children[:-1]]  # exclude Other
-        # Only the well-formed dict survives.
-        assert len(choice_labels) == 1, (
-            f"Expected 1 choice, got {len(choice_labels)}: {choice_labels!r}"
+        # Only the well-formed dict survives as an actual button.
+        choice_buttons = view.children[:-1]  # exclude Other
+        assert len(choice_buttons) == 1, (
+            f"Expected 1 choice, got {len(choice_buttons)}"
         )
-        assert "real choice" in choice_labels[0]
-        for label in choice_labels:
-            assert "only_name_here" not in label, f"name leaked: {label!r}"
-            assert "only_value_here" not in label, f"value leaked: {label!r}"
+        embed = kwargs["embed"]
+        option_text = _choices_field_value(embed)
+        assert "real choice" in option_text
+        assert "only_name_here" not in option_text
+        assert "only_value_here" not in option_text
+
+    @pytest.mark.asyncio
+    async def test_choices_field_value_never_exceeds_discord_embed_field_cap(self):
+        # Regression test: the "Choices" embed field value is the numbered
+        # option list PLUS a fixed instruction suffix ("Pick a button
+        # below, or click..."). Truncating only the option list to 1024
+        # chars and then appending the suffix can push the *combined*
+        # value over Discord's real 1024-char embed-field cap, which
+        # causes channel.send() to raise and send_clarify() to report a
+        # failed send on exactly the long-choice-list case this feature
+        # exists to handle.
+        adapter = _make_adapter()
+        channel = MagicMock()
+        sent_msg = MagicMock()
+        sent_msg.id = 999
+        channel.send = AsyncMock(return_value=sent_msg)
+        adapter._client.get_channel = MagicMock(return_value=channel)
+
+        # 24 choices (the max allowed) of substantial length guarantees the
+        # raw numbered option list alone is well over 1024 chars, forcing
+        # the truncation path to run.
+        long_choices = [f"Option number {i} with some extra descriptive text" for i in range(24)]
+
+        result = await adapter.send_clarify(
+            chat_id="9001",
+            question="Pick one",
+            choices=long_choices,
+            clarify_id="cidCap",
+            session_key="sk-Cap",
+        )
+
+        assert result.success is True
+        kwargs = channel.send.call_args.kwargs
+        embed = kwargs["embed"]
+        option_text = _choices_field_value(embed)
+        assert len(option_text) <= 1024, (
+            f"Choices embed field value is {len(option_text)} chars, "
+            "exceeding Discord's 1024-char embed field cap"
+        )
+        # The instruction suffix must still be present and intact even when
+        # the option list had to be truncated to make room for it.
+        assert option_text.endswith(
+            "Pick a button below, or click ✏️ Other to type a custom answer."
+        )

--- a/tests/gateway/test_discord_clarify_buttons.py
+++ b/tests/gateway/test_discord_clarify_buttons.py
@@ -398,5 +398,5 @@ class TestClarifyChoicesFullTextMirror:
         # The instruction suffix must still be present and intact even when
         # the option list had to be truncated to make room for it.
         assert option_text.endswith(
-            "Pick a button below, or click ✏️ Other to type a custom answer."
+            "Pick one below, or click ✏️ Other to type a custom answer."
         )

--- a/tests/gateway/test_discord_clarify_buttons.py
+++ b/tests/gateway/test_discord_clarify_buttons.py
@@ -294,3 +294,109 @@ class TestDiscordSendClarify:
         for label in choice_labels:
             assert "only_name_here" not in label, f"name leaked: {label!r}"
             assert "only_value_here" not in label, f"value leaked: {label!r}"
+
+
+# ===========================================================================
+# Full choice text mirrored into the embed field / message body (#62291)
+# ===========================================================================
+
+
+def _choices_field_value(embed) -> str:
+    """Pull the 'Choices' embed field's rendered text (full option list).
+
+    The test conftest's ``_FakeEmbed.add_field`` stores fields as plain
+    dicts (``{"name": ..., "value": ..., "inline": ...}``); support both
+    that shape and objects with ``.name``/``.value`` attributes in case a
+    real ``discord.Embed`` is ever passed in.
+    """
+    for field in embed.fields:
+        if isinstance(field, dict):
+            if field.get("name") == "Choices":
+                return field.get("value") or ""
+        elif getattr(field, "name", None) == "Choices":
+            return field.value
+    return ""
+
+
+class TestClarifyChoicesFullTextMirror:
+    """Button labels are capped at 80 chars and truncated well before that
+    on mobile, so the full choice text has to be readable somewhere. It is
+    mirrored as a numbered list in the embed field and the plain content."""
+
+    @pytest.mark.asyncio
+    async def test_full_choice_text_is_mirrored_in_the_embed_and_content(self):
+        adapter = _make_adapter()
+        channel = MagicMock()
+        sent_msg = MagicMock()
+        sent_msg.id = 999
+        channel.send = AsyncMock(return_value=sent_msg)
+        adapter._client.get_channel = MagicMock(return_value=channel)
+
+        # Longer than the 80-char button-label cap: the button necessarily
+        # truncates it, so the untruncated text must survive elsewhere.
+        long_choice = "Deploy the staging stack and run the full smoke suite before promoting to production"
+        assert len(long_choice) > 80
+
+        result = await adapter.send_clarify(
+            chat_id="9001",
+            question="Pick one",
+            choices=[long_choice, "Cancel"],
+            clarify_id="cidMirror",
+            session_key="sk-Mirror",
+        )
+
+        assert result.success is True
+        kwargs = channel.send.call_args.kwargs
+        option_text = _choices_field_value(kwargs["embed"])
+        assert long_choice in option_text, (
+            "Full choice text must appear in the Choices embed field"
+        )
+        assert "**1.**" in option_text and "**2.**" in option_text
+        # Embeds are invisible on some clients, so the plain content mirror
+        # must carry the same untruncated text.
+        assert long_choice in kwargs["content"]
+
+    @pytest.mark.asyncio
+    async def test_choices_field_value_never_exceeds_discord_embed_field_cap(self):
+        # Regression test: the "Choices" embed field value is the numbered
+        # option list PLUS a fixed instruction suffix ("Pick a button
+        # below, or click..."). Truncating only the option list to 1024
+        # chars and then appending the suffix can push the *combined*
+        # value over Discord's real 1024-char embed-field cap, which
+        # causes channel.send() to raise and send_clarify() to report a
+        # failed send on exactly the long-choice-list case this feature
+        # exists to handle.
+        adapter = _make_adapter()
+        channel = MagicMock()
+        sent_msg = MagicMock()
+        sent_msg.id = 999
+        channel.send = AsyncMock(return_value=sent_msg)
+        adapter._client.get_channel = MagicMock(return_value=channel)
+
+        # 24 choices (the max allowed) of substantial length guarantees the
+        # raw numbered option list alone is well over 1024 chars, forcing
+        # the truncation path to run.
+        long_choices = [
+            f"Option number {i} with some extra descriptive text" for i in range(24)
+        ]
+
+        result = await adapter.send_clarify(
+            chat_id="9001",
+            question="Pick one",
+            choices=long_choices,
+            clarify_id="cidCap",
+            session_key="sk-Cap",
+        )
+
+        assert result.success is True
+        kwargs = channel.send.call_args.kwargs
+        option_text = _choices_field_value(kwargs["embed"])
+        assert len(option_text) <= 1024, (
+            f"Choices embed field value is {len(option_text)} chars, "
+            "exceeding Discord's 1024-char embed field cap"
+        )
+        # The instruction suffix must still be present and intact even when
+        # the option list had to be truncated to make room for it.
+        assert option_text.endswith(
+            "Pick a button below, or click ✏️ Other to type a custom answer."
+        )

--- a/tests/gateway/test_discord_clarify_buttons.py
+++ b/tests/gateway/test_discord_clarify_buttons.py
@@ -368,6 +368,29 @@ class TestDiscordSendClarify:
         assert len(kwargs["view"].children) == 4
 
     @pytest.mark.asyncio
+    async def test_plain_content_respects_discord_2000_character_cap(self):
+        adapter = _make_adapter()
+        channel = MagicMock()
+        sent_msg = MagicMock(id=1000)
+        channel.send = AsyncMock(return_value=sent_msg)
+        adapter._client.get_channel = MagicMock(return_value=channel)
+
+        await adapter.send_clarify(
+            chat_id="9001",
+            question="Pick one of these detailed choices",
+            choices=[f"choice-{index}-" + "x" * 200 for index in range(24)],
+            clarify_id="cid-content-cap",
+            session_key="sk-content-cap",
+        )
+
+        content = channel.send.call_args.kwargs["content"]
+        assert len(content) <= 2000
+        assert "[additional choice text truncated]" in content
+        assert content.endswith(
+            "Pick a button below, or click ✏️ Other to type a custom answer."
+        )
+
+    @pytest.mark.asyncio
     async def test_open_ended_omits_view(self):
         adapter = _make_adapter()
         channel = MagicMock()


### PR DESCRIPTION
## Summary

Discord clarify buttons previously embedded truncated choice text directly in button labels. Mobile clients cut or wrap those labels aggressively, so even valid 80-character labels remain difficult to read.

## Changes

- Button labels are short numeric indexes.
- Full numbered choice text appears in the embed field.
- The same choices are mirrored in plain message content because some clients hide embeds.
- The plain fallback now budgets the question, numbered choices, and instruction suffix against Discord's 2,000-character message-content limit.
- Oversized choice text is truncated explicitly with `[additional choice text truncated]` while preserving the prompt and response instructions.
- Existing dict-choice normalization remains intact.

## Tests

Coverage verifies short button labels, full choice visibility, dict unwrapping, embed limits, and the 2,000-character plain-content cap with oversized choices.

```text
pytest -q tests/gateway/test_discord_clarify_buttons.py
22 passed
```

`git diff --check` is clean.