### PR TITLE
docs(gemini): clarify subscription versus API access

### DIFF
--- a/website/docs/guides/google-gemini.md
+++ b/website/docs/guides/google-gemini.md
@@ -18,6 +18,10 @@ Hermes Agent supports Google Gemini as a native provider using the **Google AI S
 Set `GOOGLE_API_KEY` or `GEMINI_API_KEY`. Hermes checks both names for the `gemini` provider.
 :::
 
+:::warning A Google AI subscription does not replace API setup
+Google AI Pro and Ultra benefits do **not** authorize Gemini use in Hermes. Hermes requires a [Gemini API key](https://ai.google.dev/gemini-api/docs/api-key), with [API quota and billing](https://ai.google.dev/gemini-api/docs/billing) managed separately. Do not purchase a consumer plan solely to unlock Hermes.
+:::
+
 ## Quick Start
 
 ```bash
@@ -205,6 +209,10 @@ GEMINI_API_KEY=...
 ```
 
 Then run `hermes model` again.
+
+### "Unknown provider 'gemini-oauth'" or "Unknown provider 'google-gemini-cli'"
+
+These provider IDs—and `google-antigravity`—are unsupported. Use `provider: gemini` with `GOOGLE_API_KEY` or `GEMINI_API_KEY`; subscription authentication cannot be reused by Hermes.
 
 ### "This Google API key is on the free tier"
 

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -54,6 +54,10 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 
 For the official API-key path, see the dedicated [Google Gemini guide](/guides/google-gemini).
 
+:::warning Google AI Pro and Ultra
+Consumer subscriptions do not authorize the Hermes `gemini` provider. Hermes requires a Google AI Studio API key with separate API quota and billing. See the [Google Gemini guide](/guides/google-gemini).
+:::
+
 :::tip Model key alias
 In the `model:` config section, you can use either `default:` or `model:` as the key name for your model ID. Both `model: { default: my-model }` and `model: { model: my-model }` work identically.
 :::

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/google-gemini.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/google-gemini.md
@@ -18,6 +18,10 @@ Hermes Agent 通过 **Google AI Studio / Gemini API** 原生支持 Google Gemini
 设置 `GOOGLE_API_KEY` 或 `GEMINI_API_KEY`。Hermes 对 `gemini` provider 会同时检查这两个名称。
 :::
 
+:::warning Google AI 订阅不能替代 API 配置
+Google AI Pro 和 Ultra 权益并不授权在 Hermes 中使用 Gemini。Hermes 需要 [Gemini API 密钥](https://ai.google.dev/gemini-api/docs/api-key)，[API 配额和计费](https://ai.google.dev/gemini-api/docs/billing)需另行管理。请勿仅为解锁 Hermes 而购买消费者订阅。
+:::
+
 ## 快速开始
 
 ```bash
@@ -205,6 +209,10 @@ GEMINI_API_KEY=...
 ```
 
 然后重新运行 `hermes model`。
+
+### "Unknown provider 'gemini-oauth'" 或 "Unknown provider 'google-gemini-cli'"
+
+这些 provider ID 以及 `google-antigravity` 均不受支持。请使用 `provider: gemini`，并设置 `GOOGLE_API_KEY` 或 `GEMINI_API_KEY`；Hermes 无法复用订阅身份验证。
 
 ### "This Google API key is on the free tier"
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/integrations/providers.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/integrations/providers.md
@@ -45,6 +45,10 @@ sidebar_position: 1
 
 官方 API key 路径请参见专属的 [Google Gemini 指南](/guides/google-gemini)。
 
+:::warning Google AI Pro 和 Ultra
+消费者订阅不授权 Hermes 的 `gemini` provider。Hermes 需要 Google AI Studio API 密钥，API 配额和计费需另行管理。详情请参见 [Google Gemini 指南](/guides/google-gemini)。
+:::
+
 :::tip 模型 key 别名
 在 `model:` 配置节中，可以使用 `default:` 或 `model:` 作为模型 ID 的键名。`model: { default: my-model }` 和 `model: { model: my-model }` 效果完全相同。
 :::


### PR DESCRIPTION
## What does this PR do?

Clarifies that Google AI Pro and Ultra consumer subscriptions do not authorize the Hermes `gemini` provider. The Gemini guide now points users to the supported API-key path, warns against purchasing a consumer plan solely for Hermes, and explains that stale `gemini-oauth`, `google-gemini-cli`, and `google-antigravity` provider instructions are unsupported.

The provider overview receives a shorter matching warning so users see the distinction before choosing or purchasing a provider plan.

## Related Issue

Fixes #60699

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- Added a concise subscription-versus-API warning to `website/docs/guides/google-gemini.md`.
- Added troubleshooting guidance for stale Google OAuth provider names.
- Added a matching warning to `website/docs/integrations/providers.md`.

## How to Test

1. `cd website && npm ci`
2. `npm run build`
3. Confirm the Gemini API-key and billing links return HTTP 200.

## Validation

- `git diff --check` — passed
- Docusaurus production build for `en` and `zh-Hans` — passed
- Google Gemini API-key documentation link — HTTP 200
- Google Gemini API billing documentation link — HTTP 200

The site build reports existing unrelated broken-link and broken-anchor warnings outside the two changed pages; it exits successfully, and this PR introduces no generated-file changes.

## Checklist

- [x] I read the contributing guide.
- [x] I searched open and closed PRs for issue #60699 and the proposed wording; no competing PR was found.
- [x] The PR contains only the two documentation files related to this issue.
- [x] Relevant documentation build completed successfully.
- [x] Cross-platform impact: N/A (documentation only).
