### PR TITLE
feat(proxy): add OpenAI Codex OAuth pool upstream

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -591,7 +591,9 @@ class CredentialPool:
             last_status_at=time.time(),
             last_error_code=status_code,
             last_error_reason=normalized_error.get("reason"),
-            last_error_message=normalized_error.get("message"),
+            # Upstream messages may echo request content or identifiers. Persist
+            # only structured status/reason/reset metadata.
+            last_error_message=None,
             last_error_reset_at=normalized_error.get("reset_at"),
         )
         self._replace_entry(entry, updated)
@@ -1610,6 +1612,21 @@ class CredentialPool:
     def try_refresh_current(self) -> Optional[PooledCredential]:
         with self._lock:
             return self._try_refresh_current_unlocked()
+
+    def try_refresh_credential(self, *, api_key_hint: str) -> Optional[PooledCredential]:
+        """Force-refresh the stable pool entry that supplied ``api_key_hint``."""
+        with self._lock:
+            entry = next(
+                (candidate for candidate in self._entries
+                 if candidate.runtime_api_key == api_key_hint),
+                None,
+            )
+            if entry is None:
+                return None
+            refreshed = self._refresh_entry(entry, force=True)
+            if refreshed is not None:
+                self._current_id = refreshed.id
+            return refreshed
 
     def _try_refresh_current_unlocked(self) -> Optional[PooledCredential]:
         entry = self.current()

--- a/hermes_cli/proxy/adapters/__init__.py
+++ b/hermes_cli/proxy/adapters/__init__.py
@@ -9,12 +9,14 @@ from typing import Dict, Type
 
 from hermes_cli.proxy.adapters.base import UpstreamAdapter
 from hermes_cli.proxy.adapters.nous_portal import NousPortalAdapter
+from hermes_cli.proxy.adapters.openai_codex import OpenAICodexAdapter
 from hermes_cli.proxy.adapters.xai import XAIGrokAdapter
 
 # Registry of available adapter classes keyed by provider name as used on
 # the ``hermes proxy start --provider <name>`` CLI flag.
 ADAPTERS: Dict[str, Type[UpstreamAdapter]] = {
     "nous": NousPortalAdapter,
+    "openai-codex": OpenAICodexAdapter,
     "xai": XAIGrokAdapter,
 }
 

--- a/hermes_cli/proxy/adapters/base.py
+++ b/hermes_cli/proxy/adapters/base.py
@@ -14,8 +14,8 @@ The proxy server is otherwise provider-agnostic.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import FrozenSet, Optional
+from dataclasses import dataclass, field
+from typing import Dict, FrozenSet, Optional
 
 
 @dataclass(frozen=True)
@@ -34,9 +34,14 @@ class UpstreamCredential:
     expires_at: Optional[str] = None
     """ISO-8601 expiry timestamp for the bearer, when known. Informational."""
 
+    headers: Dict[str, str] = field(default_factory=dict)
+    """Provider-required HTTP headers, replacing same-named client headers."""
+
 
 class UpstreamAdapter(ABC):
     """Contract for an upstream provider the proxy can forward to."""
+
+    fail_closed_on_exhaustion = False
 
     @property
     @abstractmethod
@@ -86,13 +91,14 @@ class UpstreamAdapter(ABC):
         *,
         failed_credential: UpstreamCredential,
         status_code: int,
+        error_context: Optional[Dict[str, object]] = None,
     ) -> Optional[UpstreamCredential]:
         """Return an alternate credential after an upstream auth failure.
 
         The default is no retry. Providers can override this for one-shot
         fallback paths after the upstream rejects the first request.
         """
-        _ = failed_credential, status_code
+        _ = failed_credential, status_code, error_context
         return None
 
     def describe(self) -> str:

--- a/hermes_cli/proxy/adapters/nous_portal.py
+++ b/hermes_cli/proxy/adapters/nous_portal.py
@@ -81,6 +81,7 @@ class NousPortalAdapter(UpstreamAdapter):
         *,
         failed_credential: UpstreamCredential,
         status_code: int,
+        error_context=None,
     ) -> Optional[UpstreamCredential]:
         _ = failed_credential
         if status_code != 401:

--- a/hermes_cli/proxy/adapters/openai_codex.py
+++ b/hermes_cli/proxy/adapters/openai_codex.py
@@ -1,0 +1,113 @@
+"""OpenAI Codex subscription upstream backed by Hermes' OAuth pool."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Dict, FrozenSet, Optional
+
+from agent.auxiliary_client import _CODEX_AUX_BASE_URL, _codex_cloudflare_headers
+from agent.credential_pool import CredentialPool, PooledCredential, load_pool
+from hermes_cli.proxy.adapters.base import UpstreamAdapter, UpstreamCredential
+
+logger = logging.getLogger(__name__)
+_POOL_PROVIDER = "openai-codex"
+_ALLOWED_PATHS: FrozenSet[str] = frozenset({"/responses", "/models"})
+
+
+class OpenAICodexAdapter(UpstreamAdapter):
+    """Attach centrally-managed ChatGPT Codex OAuth credentials to Responses calls."""
+
+    auth_hint = "hermes auth add openai-codex"
+    fail_closed_on_exhaustion = True
+    upstream_base_url = _CODEX_AUX_BASE_URL
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._pool: Optional[CredentialPool] = None
+
+    @property
+    def name(self) -> str:
+        return _POOL_PROVIDER
+
+    @property
+    def display_name(self) -> str:
+        return "OpenAI Codex OAuth"
+
+    @property
+    def allowed_paths(self) -> FrozenSet[str]:
+        return _ALLOWED_PATHS
+
+    def _load_pool(self) -> Optional[CredentialPool]:
+        try:
+            return load_pool(_POOL_PROVIDER)
+        except Exception as exc:
+            logger.warning("proxy: failed to load OpenAI Codex credential pool: %s", exc)
+            return None
+
+    def is_authenticated(self) -> bool:
+        pool = self._load_pool()
+        return bool(pool and pool.has_available())
+
+    def get_credential(self) -> UpstreamCredential:
+        with self._lock:
+            # Keep one authoritative in-process pool so least_used counters and
+            # exhaustion state coordinate every isolated downstream client.
+            pool = self._pool or self._load_pool()
+            if pool is None or not pool.has_credentials():
+                raise RuntimeError(
+                    "No OpenAI Codex OAuth credentials found. Run "
+                    "`hermes auth add openai-codex` first."
+                )
+            entry = pool.select()
+            if entry is None:
+                raise RuntimeError(
+                    "All OpenAI Codex credentials are exhausted. Run "
+                    "`hermes auth reset openai-codex` after their usage window resets."
+                )
+            self._pool = pool
+            return self._credential_from_entry(entry)
+
+    def get_retry_credential(
+        self,
+        *,
+        failed_credential: UpstreamCredential,
+        status_code: int,
+        error_context: Optional[Dict[str, object]] = None,
+    ) -> Optional[UpstreamCredential]:
+        if status_code not in {401, 429}:
+            return None
+        with self._lock:
+            pool = self._pool or self._load_pool()
+            if pool is None:
+                return None
+            if status_code == 401:
+                # Reuse the pool's serialized, single-use-token-safe refresh path.
+                refreshed_entry = pool.try_refresh_current()
+                if refreshed_entry is not None:
+                    refreshed = self._credential_from_entry(refreshed_entry)
+                    if refreshed.bearer != failed_credential.bearer:
+                        return refreshed
+            next_entry = pool.mark_exhausted_and_rotate(
+                status_code=status_code,
+                error_context=error_context,
+                api_key_hint=failed_credential.bearer,
+            )
+            if next_entry is None:
+                return None
+            rotated = self._credential_from_entry(next_entry)
+            return rotated if rotated.bearer != failed_credential.bearer else None
+
+    def _credential_from_entry(self, entry: PooledCredential) -> UpstreamCredential:
+        bearer = str(entry.runtime_api_key or "").strip()
+        if not bearer:
+            raise RuntimeError("OpenAI Codex pool entry has no access token; re-authenticate it.")
+        return UpstreamCredential(
+            bearer=bearer,
+            base_url=str(self.upstream_base_url).rstrip("/"),
+            expires_at=entry.expires_at,
+            headers=_codex_cloudflare_headers(bearer),
+        )
+
+
+__all__ = ["OpenAICodexAdapter"]

--- a/hermes_cli/proxy/adapters/openai_codex.py
+++ b/hermes_cli/proxy/adapters/openai_codex.py
@@ -81,9 +81,14 @@ class OpenAICodexAdapter(UpstreamAdapter):
             pool = self._pool or self._load_pool()
             if pool is None:
                 return None
-            if status_code == 401:
-                # Reuse the pool's serialized, single-use-token-safe refresh path.
-                refreshed_entry = pool.try_refresh_current()
+            if status_code == 401 and (
+                error_context is None or error_context.get("allow_refresh", True)
+            ):
+                # Refresh the exact entry that failed; pool.current is mutable
+                # across concurrent requests and may identify another account.
+                refreshed_entry = pool.try_refresh_credential(
+                    api_key_hint=failed_credential.bearer
+                )
                 if refreshed_entry is not None:
                     refreshed = self._credential_from_entry(refreshed_entry)
                     if refreshed.bearer != failed_credential.bearer:

--- a/hermes_cli/proxy/adapters/xai.py
+++ b/hermes_cli/proxy/adapters/xai.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import threading
-from typing import FrozenSet, Optional
+from typing import Dict, FrozenSet, Optional
 
 from agent.credential_pool import CredentialPool, PooledCredential, load_pool
 from hermes_cli.auth import DEFAULT_XAI_OAUTH_BASE_URL
@@ -78,6 +78,7 @@ class XAIGrokAdapter(UpstreamAdapter):
         *,
         failed_credential: UpstreamCredential,
         status_code: int,
+        error_context: Optional[Dict[str, object]] = None,
     ) -> Optional[UpstreamCredential]:
         if status_code not in {401, 429}:
             return None
@@ -91,11 +92,19 @@ class XAIGrokAdapter(UpstreamAdapter):
                 # Mark the rate-limited key with its 1-hour cooldown and rotate
                 # to the next available credential. Returns None when the pool
                 # has no other key to offer — the 429 will flow back to the client.
-                refreshed = pool.mark_exhausted_and_rotate(status_code=status_code)
+                refreshed = pool.mark_exhausted_and_rotate(
+                    status_code=status_code,
+                    error_context=error_context,
+                    api_key_hint=failed_credential.bearer,
+                )
             else:
                 refreshed = pool.try_refresh_current()
                 if refreshed is None:
-                    refreshed = pool.mark_exhausted_and_rotate(status_code=status_code)
+                    refreshed = pool.mark_exhausted_and_rotate(
+                        status_code=status_code,
+                        error_context=error_context,
+                        api_key_hint=failed_credential.bearer,
+                    )
             if refreshed is None:
                 return None
 

--- a/hermes_cli/proxy/cli.py
+++ b/hermes_cli/proxy/cli.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import sys
+from pathlib import Path
 from typing import Any
 
 from hermes_cli.proxy.adapters import ADAPTERS, get_adapter
@@ -12,6 +14,7 @@ from hermes_cli.proxy.server import (
     AIOHTTP_AVAILABLE,
     DEFAULT_HOST,
     DEFAULT_PORT,
+    load_client_keys,
     run_server,
 )
 
@@ -46,27 +49,42 @@ def cmd_proxy_start(args: Any) -> int:
     if not adapter.is_authenticated():
         auth_hint = getattr(adapter, "auth_hint", f"hermes auth add {adapter.name}")
         print(
-            f"Not logged into {adapter.display_name}. "
-            f"Run `{auth_hint}` first.",
+            f"Not logged into {adapter.display_name}. Run `{auth_hint}` first.",
             file=sys.stderr,
         )
         return 2
 
     host = getattr(args, "host", None) or DEFAULT_HOST
     port = getattr(args, "port", None) or DEFAULT_PORT
+    client_keys = None
+    key_file = getattr(args, "client_keys_file", None)
+    if key_file:
+        try:
+            client_keys = load_client_keys(Path(key_file))
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            print(f"proxy: invalid client key file: {exc}", file=sys.stderr)
+            return 2
+    if adapter.name == "openai-codex" and not client_keys:
+        print("proxy: --client-keys-file is required for openai-codex", file=sys.stderr)
+        return 2
 
+    client_instruction = (
+        "Use a bearer token from the client key file."
+        if client_keys
+        else "Use any bearer token in the client — the proxy attaches your real credential."
+    )
     print(
         f"Starting Hermes proxy for {adapter.display_name}\n"
         f"  Listening on:  http://{host}:{port}/v1\n"
         f"  Forwarding to: (resolved per-request from your subscription)\n"
-        f"  Use any bearer token in the client — the proxy attaches your real credential.\n"
+        f"  {client_instruction}\n"
         f"\n"
         f"Press Ctrl+C to stop.",
         file=sys.stderr,
     )
 
     try:
-        asyncio.run(run_server(adapter, host=host, port=port))
+        asyncio.run(run_server(adapter, host=host, port=port, client_keys=client_keys))
     except KeyboardInterrupt:
         print("\nproxy: stopped", file=sys.stderr)
     except OSError as exc:
@@ -93,9 +111,7 @@ def cmd_proxy_status(args: Any) -> int:
             continue
         expires = f" (bearer expires {cred.expires_at})" if cred.expires_at else ""
         print(f"  [{name:8s}] {adapter.display_name} — ready{expires}")
-    print(
-        "\nStart the proxy with: hermes proxy start [--provider <name>]"
-    )
+    print("\nStart the proxy with: hermes proxy start [--provider <name>]")
     return 0
 
 

--- a/hermes_cli/proxy/cli.py
+++ b/hermes_cli/proxy/cli.py
@@ -123,7 +123,7 @@ def cmd_proxy(args: Any) -> int:
         "OAuth-authenticated provider credentials to outbound requests.\n"
         "\n"
         "Subcommands:\n"
-        "  hermes proxy start [--provider nous|xai] [--host 127.0.0.1] [--port 8645]\n"
+        "  hermes proxy start [--provider nous|openai-codex|xai] [--host 127.0.0.1] [--port 8645]\n"
         "      Run the proxy in the foreground.\n"
         "  hermes proxy status\n"
         "      Show which upstream adapters are ready.\n"

--- a/hermes_cli/proxy/server.py
+++ b/hermes_cli/proxy/server.py
@@ -12,14 +12,18 @@ or rewrite request/response bodies. It's a credential-attaching forwarder.
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import hmac
 import json
 import logging
 import signal
-from typing import Optional
+from pathlib import Path
+from typing import Mapping, Optional
 
 try:
     import aiohttp
     from aiohttp import web
+
     AIOHTTP_AVAILABLE = True
 except ImportError:
     aiohttp = None  # type: ignore[assignment]
@@ -33,21 +37,19 @@ logger = logging.getLogger(__name__)
 # Headers we strip when forwarding to the upstream. ``host``/``content-length``
 # are recomputed by aiohttp; ``authorization`` is replaced with our bearer.
 # Everything else (content-type, accept, user-agent, x-* headers) passes through.
-_HOP_BY_HOP_HEADERS = frozenset(
-    {
-        "host",
-        "content-length",
-        "connection",
-        "keep-alive",
-        "proxy-authenticate",
-        "proxy-authorization",
-        "te",
-        "trailers",
-        "transfer-encoding",
-        "upgrade",
-        "authorization",  # we replace this one
-    }
-)
+_HOP_BY_HOP_HEADERS = frozenset({
+    "host",
+    "content-length",
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+    "authorization",  # we replace this one
+})
 
 DEFAULT_PORT = 8645
 DEFAULT_HOST = "127.0.0.1"
@@ -97,13 +99,49 @@ def _error_context(body: bytes) -> dict:
         return {}
     context = {
         "reason": error.get("code") or error.get("type"),
-        "message": error.get("message"),
         "reset_at": error.get("reset_at") or error.get("resets_at"),
     }
     return {key: value for key, value in context.items() if value is not None}
 
 
-def create_app(adapter: UpstreamAdapter) -> "web.Application":
+def load_client_keys(path: Path) -> dict[str, str]:
+    """Load a label-to-token JSON map from an owner-only file."""
+    if path.stat().st_mode & 0o077:
+        raise ValueError(f"client key file must be mode 0600: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or not payload:
+        raise ValueError("client key file must contain a non-empty JSON object")
+    keys = {}
+    for label, token in payload.items():
+        if (
+            not isinstance(label, str)
+            or not label.strip()
+            or not isinstance(token, str)
+            or not token
+        ):
+            raise ValueError("client key labels and tokens must be non-empty strings")
+        keys[label.strip()] = token
+    return keys
+
+
+def _authenticate_client(
+    header: Optional[str], client_keys: Mapping[str, str]
+) -> Optional[str]:
+    supplied = ""
+    if header and header.lower().startswith("bearer "):
+        supplied = header[7:].strip()
+    matched = None
+    for label, token in client_keys.items():
+        if hmac.compare_digest(supplied.encode(), token.encode()):
+            matched = label
+    return matched
+
+
+def create_app(
+    adapter: UpstreamAdapter,
+    *,
+    client_keys: Optional[Mapping[str, str]] = None,
+) -> "web.Application":
     """Build the aiohttp application bound to a specific upstream adapter."""
     if not AIOHTTP_AVAILABLE:
         raise RuntimeError(
@@ -111,6 +149,8 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
             "pip install 'hermes-agent[messaging]' or `pip install aiohttp`."
         )
 
+    if adapter.name == "openai-codex" and not client_keys:
+        raise ValueError("OpenAI Codex proxy requires --client-keys-file")
     app = web.Application(client_max_size=MAX_REQUEST_BYTES)
     # AppKey ensures forward-compat with future aiohttp versions that strip
     # bare-string keys.
@@ -118,15 +158,25 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
     app[_adapter_key] = adapter
 
     async def handle_health(request: "web.Request") -> "web.Response":
-        return web.json_response(
-            {
-                "status": "ok",
-                "upstream": adapter.display_name,
-                "authenticated": adapter.is_authenticated(),
-            }
-        )
+        return web.json_response({
+            "status": "ok",
+            "upstream": adapter.display_name,
+            "authenticated": adapter.is_authenticated(),
+        })
 
     async def handle_proxy(request: "web.Request") -> "web.StreamResponse":
+        client_label = "anonymous"
+        if client_keys:
+            client_label = (
+                _authenticate_client(request.headers.get("Authorization"), client_keys)
+                or ""
+            )
+            if not client_label:
+                logger.warning("proxy: rejected unauthenticated client")
+                return _json_error(
+                    401, "Invalid proxy client key.", code="invalid_client_key"
+                )
+
         # Extract the path *after* /v1
         rel_path = request.match_info.get("tail", "")
         rel_path = "/" + rel_path.lstrip("/")
@@ -151,6 +201,13 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
         # need to forward large multipart uploads we'll switch to streaming
         # the request body too.
         body = await request.read()
+        model = "unknown"
+        try:
+            parsed = json.loads(body)
+            if isinstance(parsed, dict) and isinstance(parsed.get("model"), str):
+                model = parsed["model"][:128]
+        except (TypeError, ValueError):
+            pass
 
         timeout = aiohttp.ClientTimeout(total=None, sock_connect=15, sock_read=300)
 
@@ -161,12 +218,17 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
                 upstream_url = f"{upstream_url}?{request.query_string}"
 
             fwd_headers = _filter_request_headers(request.headers)
-            fwd_headers["Authorization"] = f"{active_cred.token_type} {active_cred.bearer}"
+            fwd_headers["Authorization"] = (
+                f"{active_cred.token_type} {active_cred.bearer}"
+            )
             fwd_headers.update(active_cred.headers)
 
             logger.debug(
                 "proxy: forwarding %s %s -> %s (body=%d bytes)",
-                request.method, rel_path, upstream_url, len(body),
+                request.method,
+                rel_path,
+                upstream_url,
+                len(body),
             )
 
             try:
@@ -218,6 +280,8 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
         session = session_or_response
 
         buffered_response_body = None
+        refresh_allowed = True
+        attempted_bearers = {cred.bearer}
         while upstream_resp.status in {401, 429}:
             failure_status = upstream_resp.status
             failure_body = await upstream_resp.read()
@@ -225,7 +289,10 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
                 retry_cred = adapter.get_retry_credential(
                     failed_credential=cred,
                     status_code=failure_status,
-                    error_context=_error_context(failure_body),
+                    error_context={
+                        **_error_context(failure_body),
+                        "allow_refresh": refresh_allowed,
+                    },
                 )
             except Exception as exc:
                 logger.warning("proxy: retry credential resolution failed: %s", exc)
@@ -242,6 +309,20 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
                     )
                 buffered_response_body = failure_body
                 break
+            if retry_cred.bearer in attempted_bearers:
+                if adapter.fail_closed_on_exhaustion:
+                    upstream_resp.release()
+                    await session.close()
+                    return _json_error(
+                        503,
+                        "All upstream credentials are exhausted or rejected.",
+                        code="credential_pool_exhausted",
+                    )
+                buffered_response_body = failure_body
+                break
+            if failure_status == 401:
+                refresh_allowed = False
+            attempted_bearers.add(retry_cred.bearer)
             upstream_resp.release()
             await session.close()
             cred = retry_cred
@@ -270,6 +351,14 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
             await session.close()
 
         await resp.write_eof()
+        fingerprint = hashlib.sha256(client_label.encode()).hexdigest()[:12]
+        logger.info(
+            "proxy: client=%s fingerprint=%s model=%s status=%s",
+            client_label,
+            fingerprint,
+            model,
+            upstream_resp.status,
+        )
         return resp
 
     # /health doesn't go through the upstream
@@ -285,6 +374,7 @@ async def run_server(
     host: str = DEFAULT_HOST,
     port: int = DEFAULT_PORT,
     shutdown_event: Optional[asyncio.Event] = None,
+    client_keys: Optional[Mapping[str, str]] = None,
 ) -> None:
     """Run the proxy in the current event loop until shutdown_event is set.
 
@@ -296,7 +386,7 @@ async def run_server(
             "pip install 'hermes-agent[messaging]' or `pip install aiohttp`."
         )
 
-    app = create_app(adapter)
+    app = create_app(adapter, client_keys=client_keys)
     runner = web.AppRunner(app, access_log=None)
     await runner.setup()
     site = web.TCPSite(runner, host=host, port=port)
@@ -304,7 +394,9 @@ async def run_server(
 
     logger.info(
         "proxy: listening on http://%s:%d/v1 -> %s",
-        host, port, adapter.display_name,
+        host,
+        port,
+        adapter.display_name,
     )
 
     stop_event = shutdown_event or asyncio.Event()
@@ -333,4 +425,5 @@ __all__ = [
     "DEFAULT_HOST",
     "DEFAULT_PORT",
     "AIOHTTP_AVAILABLE",
+    "load_client_keys",
 ]

--- a/hermes_cli/proxy/server.py
+++ b/hermes_cli/proxy/server.py
@@ -12,6 +12,7 @@ or rewrite request/response bodies. It's a credential-attaching forwarder.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import signal
 from typing import Optional
@@ -85,6 +86,23 @@ def _filter_response_headers(headers) -> dict:
     return out
 
 
+def _error_context(body: bytes) -> dict:
+    """Extract pool-relevant error metadata without logging request content."""
+    try:
+        payload = json.loads(body)
+    except (TypeError, ValueError):
+        return {}
+    error = payload.get("error") if isinstance(payload, dict) else None
+    if not isinstance(error, dict):
+        return {}
+    context = {
+        "reason": error.get("code") or error.get("type"),
+        "message": error.get("message"),
+        "reset_at": error.get("reset_at") or error.get("resets_at"),
+    }
+    return {key: value for key, value in context.items() if value is not None}
+
+
 def create_app(adapter: UpstreamAdapter) -> "web.Application":
     """Build the aiohttp application bound to a specific upstream adapter."""
     if not AIOHTTP_AVAILABLE:
@@ -144,6 +162,7 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
 
             fwd_headers = _filter_request_headers(request.headers)
             fwd_headers["Authorization"] = f"{active_cred.token_type} {active_cred.bearer}"
+            fwd_headers.update(active_cred.headers)
 
             logger.debug(
                 "proxy: forwarding %s %s -> %s (body=%d bytes)",
@@ -198,23 +217,38 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
             return session_or_response
         session = session_or_response
 
-        if upstream_resp.status in {401, 429}:
+        buffered_response_body = None
+        while upstream_resp.status in {401, 429}:
+            failure_status = upstream_resp.status
+            failure_body = await upstream_resp.read()
             try:
                 retry_cred = adapter.get_retry_credential(
                     failed_credential=cred,
-                    status_code=upstream_resp.status,
+                    status_code=failure_status,
+                    error_context=_error_context(failure_body),
                 )
             except Exception as exc:
                 logger.warning("proxy: retry credential resolution failed: %s", exc)
                 retry_cred = None
 
-            if retry_cred is not None:
-                upstream_resp.release()
-                await session.close()
-                session_or_response, upstream_resp = await _open_upstream(retry_cred)
-                if upstream_resp is None:
-                    return session_or_response
-                session = session_or_response
+            if retry_cred is None:
+                if adapter.fail_closed_on_exhaustion:
+                    upstream_resp.release()
+                    await session.close()
+                    return _json_error(
+                        503,
+                        "All upstream credentials are exhausted or rejected.",
+                        code="credential_pool_exhausted",
+                    )
+                buffered_response_body = failure_body
+                break
+            upstream_resp.release()
+            await session.close()
+            cred = retry_cred
+            session_or_response, upstream_resp = await _open_upstream(retry_cred)
+            if upstream_resp is None:
+                return session_or_response
+            session = session_or_response
 
         # Stream response back. Headers first, then chunked body.
         resp = web.StreamResponse(
@@ -224,6 +258,8 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
         await resp.prepare(request)
 
         try:
+            if buffered_response_body:
+                await resp.write(buffered_response_body)
             async for chunk in upstream_resp.content.iter_any():
                 if chunk:
                     await resp.write(chunk)

--- a/hermes_cli/proxy/server.py
+++ b/hermes_cli/proxy/server.py
@@ -12,7 +12,6 @@ or rewrite request/response bodies. It's a credential-attaching forwarder.
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import hmac
 import json
 import logging
@@ -165,13 +164,12 @@ def create_app(
         })
 
     async def handle_proxy(request: "web.Request") -> "web.StreamResponse":
-        client_label = "anonymous"
         if client_keys:
-            client_label = (
+            authenticated_client = (
                 _authenticate_client(request.headers.get("Authorization"), client_keys)
                 or ""
             )
-            if not client_label:
+            if not authenticated_client:
                 logger.warning("proxy: rejected unauthenticated client")
                 return _json_error(
                     401, "Invalid proxy client key.", code="invalid_client_key"
@@ -201,13 +199,6 @@ def create_app(
         # need to forward large multipart uploads we'll switch to streaming
         # the request body too.
         body = await request.read()
-        model = "unknown"
-        try:
-            parsed = json.loads(body)
-            if isinstance(parsed, dict) and isinstance(parsed.get("model"), str):
-                model = parsed["model"][:128]
-        except (TypeError, ValueError):
-            pass
 
         timeout = aiohttp.ClientTimeout(total=None, sock_connect=15, sock_read=300)
 
@@ -351,14 +342,6 @@ def create_app(
             await session.close()
 
         await resp.write_eof()
-        fingerprint = hashlib.sha256(client_label.encode()).hexdigest()[:12]
-        logger.info(
-            "proxy: client=%s fingerprint=%s model=%s status=%s",
-            client_label,
-            fingerprint,
-            model,
-            upstream_resp.status,
-        )
         return resp
 
     # /health doesn't go through the upstream

--- a/hermes_cli/subcommands/gateway.py
+++ b/hermes_cli/subcommands/gateway.py
@@ -337,6 +337,11 @@ def build_gateway_parser(
         default=None,
         help="Bind port (default: 8645)",
     )
+    proxy_start.add_argument(
+        "--client-keys-file",
+        default=None,
+        help="Path to a mode-0600 JSON object mapping client labels to bearer tokens",
+    )
 
     proxy_subparsers.add_parser(
         "status", help="Show which proxy upstreams are ready"

--- a/hermes_cli/subcommands/gateway.py
+++ b/hermes_cli/subcommands/gateway.py
@@ -321,7 +321,10 @@ def build_gateway_parser(
     proxy_start.add_argument(
         "--provider",
         default="nous",
-        help="Upstream provider: nous or xai (default: nous). See `hermes proxy providers`.",
+        help=(
+            "Upstream provider: nous, openai-codex, or xai (default: nous). "
+            "See `hermes proxy providers`."
+        ),
     )
     proxy_start.add_argument(
         "--host",

--- a/tests/hermes_cli/test_proxy.py
+++ b/tests/hermes_cli/test_proxy.py
@@ -611,7 +611,7 @@ class FakeAdapter(UpstreamAdapter):
             expires_at="2099-01-01T00:00:00Z",
         )
 
-    def get_retry_credential(self, *, failed_credential, status_code):
+    def get_retry_credential(self, *, failed_credential, status_code, error_context=None):
         _ = failed_credential
         self.retry_calls += 1
         if status_code != 401 or not self._retry_bearer:

--- a/tests/hermes_cli/test_proxy_openai_codex.py
+++ b/tests/hermes_cli/test_proxy_openai_codex.py
@@ -254,7 +254,7 @@ def test_error_message_content_is_never_persisted(tmp_path, monkeypatch):
     assert "customer@example.com" not in stored
 
 
-def test_proxy_codex_rejects_unknown_client_key_and_attributes_label(
+def test_proxy_codex_rejects_unknown_client_key_without_attribution_logging(
     tmp_path, monkeypatch, caplog
 ):
     aiohttp = pytest.importorskip("aiohttp")
@@ -307,7 +307,10 @@ def test_proxy_codex_rejects_unknown_client_key_and_attributes_label(
     with caplog.at_level(logging.INFO, logger="hermes_cli.proxy.server"):
         asyncio.run(run())
     assert calls == 1
-    assert "agent-a" in caplog.text
+    assert "rejected unauthenticated client" in caplog.text
+    assert "agent-a" not in caplog.text
+    assert "fingerprint=" not in caplog.text
+    assert "model=" not in caplog.text
     assert "client-secret-a" not in caplog.text
     assert "do not log me" not in caplog.text
 

--- a/tests/hermes_cli/test_proxy_openai_codex.py
+++ b/tests/hermes_cli/test_proxy_openai_codex.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import logging
 from pathlib import Path
 from typing import Any, Dict
 
@@ -19,7 +20,9 @@ def _jwt(account_id: str, *, exp: int = 4_102_444_800) -> str:
         "exp": exp,
         "https://api.openai.com/auth": {"chatgpt_account_id": account_id},
     }
-    encoded = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+    encoded = (
+        base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+    )
     return f"header.{encoded}.signature"
 
 
@@ -36,14 +39,25 @@ def _write_pool(home: Path, tokens: list[str]) -> None:
             "refresh_token": f"refresh-{index}",
             "request_count": 0,
         })
-    (home / "auth.json").write_text(json.dumps({
-        "version": 1,
-        "providers": {},
-        "credential_pool": {"openai-codex": entries},
-    }))
+    (home / "auth.json").write_text(
+        json.dumps({
+            "version": 1,
+            "providers": {},
+            "credential_pool": {"openai-codex": entries},
+        })
+    )
     (home / "config.yaml").write_text(
         "credential_pool_strategies:\n  openai-codex: least_used\n"
     )
+
+
+def _write_client_keys(home: Path) -> Path:
+    path = home / "proxy-clients.json"
+    path.write_text(
+        json.dumps({"agent-a": "client-secret-a", "agent-b": "client-secret-b"})
+    )
+    path.chmod(0o600)
+    return path
 
 
 def test_registry_discovers_openai_codex():
@@ -54,7 +68,9 @@ def test_registry_discovers_openai_codex():
     assert "/responses" in adapter.allowed_paths
 
 
-def test_codex_adapter_selects_pool_and_attaches_first_party_headers(tmp_path, monkeypatch):
+def test_codex_adapter_selects_pool_and_attaches_first_party_headers(
+    tmp_path, monkeypatch
+):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     token = _jwt("acct-company-a")
     _write_pool(tmp_path, [token])
@@ -78,7 +94,9 @@ def test_codex_adapter_centralizes_least_used_selection(tmp_path, monkeypatch):
     assert adapter.get_credential().bearer == second
 
 
-def test_codex_adapter_rotates_on_429_and_fails_closed_when_exhausted(tmp_path, monkeypatch):
+def test_codex_adapter_rotates_on_429_and_fails_closed_when_exhausted(
+    tmp_path, monkeypatch
+):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     first, second = _jwt("acct-a"), _jwt("acct-b")
     _write_pool(tmp_path, [first, second])
@@ -139,9 +157,15 @@ def test_proxy_codex_rewrites_client_headers_and_fails_closed(tmp_path, monkeypa
 
     async def upstream(request):
         captured["requests"].append(dict(request.headers))
-        return web.json_response({
-            "error": {"message": "usage limit reached", "type": "usage_limit_reached"}
-        }, status=429)
+        return web.json_response(
+            {
+                "error": {
+                    "message": "usage limit reached",
+                    "type": "usage_limit_reached",
+                }
+            },
+            status=429,
+        )
 
     async def start(app):
         runner = web.AppRunner(app, access_log=None)
@@ -158,7 +182,9 @@ def test_proxy_codex_rewrites_client_headers_and_fails_closed(tmp_path, monkeypa
         adapter = get_adapter("openai-codex")
         # Keep the test offline while exercising the real proxy and adapter.
         monkeypatch.setattr(adapter, "upstream_base_url", upstream_base)
-        proxy_runner, proxy_base = await start(create_app(adapter))
+        proxy_runner, proxy_base = await start(
+            create_app(adapter, client_keys={"agent-a": "isolated-client-dummy"})
+        )
         try:
             async with aiohttp.ClientSession() as session:
                 async with session.post(
@@ -176,9 +202,173 @@ def test_proxy_codex_rewrites_client_headers_and_fails_closed(tmp_path, monkeypa
             assert len(captured["requests"]) == 2
             assert captured["requests"][0]["ChatGPT-Account-ID"] == "acct-a"
             assert captured["requests"][1]["ChatGPT-Account-ID"] == "acct-b"
-            assert all("isolated-client-dummy" not in h.get("Authorization", "") for h in captured["requests"])
+            assert all(
+                "isolated-client-dummy" not in h.get("Authorization", "")
+                for h in captured["requests"]
+            )
         finally:
             await proxy_runner.cleanup()
             await upstream_runner.cleanup()
 
     asyncio.run(run())
+
+
+def test_codex_401_refresh_targets_failed_credential_during_interleaving(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    first, second = _jwt("acct-a"), _jwt("acct-b")
+    _write_pool(tmp_path, [first, second])
+    adapter = get_adapter("openai-codex")
+    failed_a = adapter.get_credential()
+    assert adapter.get_credential().bearer == second
+
+    def refresh(*_args, **_kwargs):
+        return {"access_token": _jwt("acct-a-refreshed"), "refresh_token": "next-a"}
+
+    monkeypatch.setattr("hermes_cli.auth.refresh_codex_oauth_pure", refresh)
+    retry = adapter.get_retry_credential(
+        failed_credential=failed_a,
+        status_code=401,
+        error_context={"reason": "invalid_token"},
+    )
+    assert retry is not None
+    assert retry.headers["ChatGPT-Account-ID"] == "acct-a-refreshed"
+
+
+def test_error_message_content_is_never_persisted(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_pool(tmp_path, [_jwt("acct-a")])
+    adapter = get_adapter("openai-codex")
+    adapter.get_retry_credential(
+        failed_credential=adapter.get_credential(),
+        status_code=429,
+        error_context={
+            "reason": "usage_limit_reached",
+            "message": "SECRET customer@example.com",
+            "reset_at": 4_102_444_800,
+        },
+    )
+    stored = (tmp_path / "auth.json").read_text()
+    assert "SECRET" not in stored
+    assert "customer@example.com" not in stored
+
+
+def test_proxy_codex_rejects_unknown_client_key_and_attributes_label(
+    tmp_path, monkeypatch, caplog
+):
+    aiohttp = pytest.importorskip("aiohttp")
+    from aiohttp import web
+    from hermes_cli.proxy.server import create_app, load_client_keys
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_pool(tmp_path, [_jwt("acct-a")])
+    keys = load_client_keys(_write_client_keys(tmp_path))
+    calls = 0
+
+    async def upstream(_request):
+        nonlocal calls
+        calls += 1
+        return web.json_response({"id": "ok", "output": []})
+
+    async def start(app):
+        runner = web.AppRunner(app, access_log=None)
+        await runner.setup()
+        site = web.TCPSite(runner, "127.0.0.1", 0)
+        await site.start()
+        port = list(site._server.sockets)[0].getsockname()[1]
+        return runner, f"http://127.0.0.1:{port}"
+
+    async def run():
+        upstream_app = web.Application()
+        upstream_app.router.add_post("/responses", upstream)
+        upstream_runner, upstream_base = await start(upstream_app)
+        adapter = get_adapter("openai-codex")
+        monkeypatch.setattr(adapter, "upstream_base_url", upstream_base)
+        proxy_runner, proxy_base = await start(create_app(adapter, client_keys=keys))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/responses",
+                    json={"model": "gpt-5.6", "input": "do not log me"},
+                    headers={"Authorization": "Bearer wrong"},
+                ) as response:
+                    assert response.status == 401
+                async with session.post(
+                    f"{proxy_base}/v1/responses",
+                    json={"model": "gpt-5.6", "input": "do not log me"},
+                    headers={"Authorization": "Bearer client-secret-a"},
+                ) as response:
+                    assert response.status == 200
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    with caplog.at_level(logging.INFO, logger="hermes_cli.proxy.server"):
+        asyncio.run(run())
+    assert calls == 1
+    assert "agent-a" in caplog.text
+    assert "client-secret-a" not in caplog.text
+    assert "do not log me" not in caplog.text
+
+
+def test_proxy_repeated_401_terminates_after_refresh_and_finite_rotation(
+    tmp_path, monkeypatch
+):
+    aiohttp = pytest.importorskip("aiohttp")
+    from aiohttp import web
+    from hermes_cli.proxy.server import create_app
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_pool(tmp_path, [_jwt("acct-a"), _jwt("acct-b")])
+    calls = refreshes = 0
+
+    def refresh(*_args, **_kwargs):
+        nonlocal refreshes
+        refreshes += 1
+        return {
+            "access_token": _jwt(f"refreshed-{refreshes}"),
+            "refresh_token": f"next-{refreshes}",
+        }
+
+    monkeypatch.setattr("hermes_cli.auth.refresh_codex_oauth_pure", refresh)
+
+    async def upstream(_request):
+        nonlocal calls
+        calls += 1
+        return web.json_response(
+            {"error": {"type": "invalid_token", "message": "still no"}}, status=401
+        )
+
+    async def start(app):
+        runner = web.AppRunner(app, access_log=None)
+        await runner.setup()
+        site = web.TCPSite(runner, "127.0.0.1", 0)
+        await site.start()
+        port = list(site._server.sockets)[0].getsockname()[1]
+        return runner, f"http://127.0.0.1:{port}"
+
+    async def run():
+        upstream_app = web.Application()
+        upstream_app.router.add_post("/responses", upstream)
+        upstream_runner, upstream_base = await start(upstream_app)
+        adapter = get_adapter("openai-codex")
+        monkeypatch.setattr(adapter, "upstream_base_url", upstream_base)
+        proxy_runner, proxy_base = await start(
+            create_app(adapter, client_keys={"test": "client-key"})
+        )
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/responses",
+                    json={"model": "gpt-5.6", "input": "hello"},
+                    headers={"Authorization": "Bearer client-key"},
+                ) as response:
+                    assert response.status == 503
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(asyncio.wait_for(run(), timeout=3))
+    assert refreshes == 1
+    assert calls == 3

--- a/tests/hermes_cli/test_proxy_openai_codex.py
+++ b/tests/hermes_cli/test_proxy_openai_codex.py
@@ -1,0 +1,184 @@
+"""Behavior tests for the OpenAI Codex subscription proxy upstream."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from hermes_cli.proxy.adapters import ADAPTERS, get_adapter
+from hermes_cli.proxy.adapters.base import UpstreamAdapter
+
+
+def _jwt(account_id: str, *, exp: int = 4_102_444_800) -> str:
+    payload = {
+        "exp": exp,
+        "https://api.openai.com/auth": {"chatgpt_account_id": account_id},
+    }
+    encoded = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+    return f"header.{encoded}.signature"
+
+
+def _write_pool(home: Path, tokens: list[str]) -> None:
+    entries = []
+    for index, token in enumerate(tokens):
+        entries.append({
+            "id": f"codex-{index}",
+            "label": f"account-{index}",
+            "auth_type": "oauth",
+            "priority": index,
+            "source": f"manual:device-{index}",
+            "access_token": token,
+            "refresh_token": f"refresh-{index}",
+            "request_count": 0,
+        })
+    (home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {},
+        "credential_pool": {"openai-codex": entries},
+    }))
+    (home / "config.yaml").write_text(
+        "credential_pool_strategies:\n  openai-codex: least_used\n"
+    )
+
+
+def test_registry_discovers_openai_codex():
+    assert "openai-codex" in ADAPTERS
+    adapter = get_adapter("OPENAI-CODEX")
+    assert isinstance(adapter, UpstreamAdapter)
+    assert adapter.name == "openai-codex"
+    assert "/responses" in adapter.allowed_paths
+
+
+def test_codex_adapter_selects_pool_and_attaches_first_party_headers(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    token = _jwt("acct-company-a")
+    _write_pool(tmp_path, [token])
+
+    cred = get_adapter("openai-codex").get_credential()
+
+    assert cred.bearer == token
+    assert cred.base_url == "https://chatgpt.com/backend-api/codex"
+    assert cred.headers["ChatGPT-Account-ID"] == "acct-company-a"
+    assert cred.headers["originator"] == "codex_cli_rs"
+    assert cred.headers["User-Agent"].startswith("codex_cli_rs/")
+
+
+def test_codex_adapter_centralizes_least_used_selection(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    first, second = _jwt("acct-a"), _jwt("acct-b")
+    _write_pool(tmp_path, [first, second])
+    adapter = get_adapter("openai-codex")
+
+    assert adapter.get_credential().bearer == first
+    assert adapter.get_credential().bearer == second
+
+
+def test_codex_adapter_rotates_on_429_and_fails_closed_when_exhausted(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    first, second = _jwt("acct-a"), _jwt("acct-b")
+    _write_pool(tmp_path, [first, second])
+    adapter = get_adapter("openai-codex")
+
+    failed = adapter.get_credential()
+    retry = adapter.get_retry_credential(
+        failed_credential=failed,
+        status_code=429,
+        error_context={"message": "usage limit reached", "reset_at": 4_102_444_800},
+    )
+    assert retry is not None
+    assert retry.bearer == second
+
+    final = adapter.get_retry_credential(
+        failed_credential=retry,
+        status_code=429,
+        error_context={"message": "usage limit reached"},
+    )
+    assert final is None
+    assert not adapter.is_authenticated()
+
+    stored = json.loads((tmp_path / "auth.json").read_text())
+    entries = stored["credential_pool"]["openai-codex"]
+    assert [entry["last_status"] for entry in entries] == ["exhausted", "exhausted"]
+
+
+def test_codex_adapter_refreshes_then_rotates_on_401(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    first, second = _jwt("acct-a"), _jwt("acct-b")
+    _write_pool(tmp_path, [first, second])
+    adapter = get_adapter("openai-codex")
+    failed = adapter.get_credential()
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.refresh_codex_oauth_pure",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("invalid grant")),
+    )
+    retry = adapter.get_retry_credential(
+        failed_credential=failed,
+        status_code=401,
+        error_context={"reason": "invalid_token", "message": "token rejected"},
+    )
+
+    assert retry is not None
+    assert retry.bearer == second
+
+
+def test_proxy_codex_rewrites_client_headers_and_fails_closed(tmp_path, monkeypatch):
+    aiohttp = pytest.importorskip("aiohttp")
+    from aiohttp import web
+    from hermes_cli.proxy.server import create_app
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    first, second = _jwt("acct-a"), _jwt("acct-b")
+    _write_pool(tmp_path, [first, second])
+    captured: Dict[str, Any] = {"requests": []}
+
+    async def upstream(request):
+        captured["requests"].append(dict(request.headers))
+        return web.json_response({
+            "error": {"message": "usage limit reached", "type": "usage_limit_reached"}
+        }, status=429)
+
+    async def start(app):
+        runner = web.AppRunner(app, access_log=None)
+        await runner.setup()
+        site = web.TCPSite(runner, "127.0.0.1", 0)
+        await site.start()
+        port = list(site._server.sockets)[0].getsockname()[1]
+        return runner, f"http://127.0.0.1:{port}"
+
+    async def run():
+        upstream_app = web.Application()
+        upstream_app.router.add_post("/responses", upstream)
+        upstream_runner, upstream_base = await start(upstream_app)
+        adapter = get_adapter("openai-codex")
+        # Keep the test offline while exercising the real proxy and adapter.
+        monkeypatch.setattr(adapter, "upstream_base_url", upstream_base)
+        proxy_runner, proxy_base = await start(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/responses",
+                    json={"model": "gpt-5.6", "input": "hello", "store": False},
+                    headers={
+                        "Authorization": "Bearer isolated-client-dummy",
+                        "ChatGPT-Account-ID": "must-not-leak",
+                        "originator": "must-not-leak",
+                    },
+                ) as response:
+                    body = await response.json()
+                    assert response.status == 503
+                    assert body["error"]["type"] == "credential_pool_exhausted"
+            assert len(captured["requests"]) == 2
+            assert captured["requests"][0]["ChatGPT-Account-ID"] == "acct-a"
+            assert captured["requests"][1]["ChatGPT-Account-ID"] == "acct-b"
+            assert all("isolated-client-dummy" not in h.get("Authorization", "") for h in captured["requests"])
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())

--- a/website/docs/user-guide/features/subscription-proxy.md
+++ b/website/docs/user-guide/features/subscription-proxy.md
@@ -72,8 +72,13 @@ automatically when the bearer approaches expiry.
 hermes proxy providers
 ```
 
-Currently shipped: `nous` (Nous Portal) and `xai` (xAI / Grok). More
-OAuth providers can be added by implementing the `UpstreamAdapter`
+Currently shipped:
+
+- `nous` — Nous Portal
+- `openai-codex` — ChatGPT Codex OAuth
+- `xai` — xAI / Grok
+
+More OAuth providers can be added by implementing the `UpstreamAdapter`
 interface in `hermes_cli/proxy/adapters/`.
 
 ## Check status
@@ -93,6 +98,34 @@ If you see `not logged in`, run `hermes portal`. If you see
 happens if you signed out from the Portal web UI) — just re-run
 `hermes portal`.
 
+## OpenAI Codex
+
+Authenticate the Codex subscription, then create a dedicated client-key file:
+
+```bash
+hermes auth add openai-codex
+printf '{"my-app":"replace-with-a-long-random-token"}\n' > ~/.hermes/proxy-clients.json
+chmod 0600 ~/.hermes/proxy-clients.json
+hermes proxy start --provider openai-codex \
+  --client-keys-file ~/.hermes/proxy-clients.json
+```
+
+The key file must be a non-empty JSON object mapping client labels to bearer
+tokens and must have mode `0600` (owner read/write only). The proxy refuses to
+start if the file is missing, malformed, or accessible by other users. Configure
+each client with its assigned token; unlike the Nous and xAI proxies, arbitrary
+bearer values are rejected for `openai-codex`.
+
+Codex supports only the Responses and model-list endpoints:
+
+| Path | Purpose |
+|------|---------|
+| `/v1/responses` | OpenAI Responses API (streaming + non-streaming) |
+| `/v1/models` | Model list |
+
+Clients that require `/v1/chat/completions` are not compatible with the Codex
+proxy unless they can use the Responses API instead.
+
 ## Allowed paths
 
 The proxy only forwards paths the upstream actually serves. For Nous
@@ -105,7 +138,8 @@ Portal:
 | `/v1/embeddings` | Embeddings |
 | `/v1/models` | Model list |
 
-Other paths (`/v1/images/generations`, `/v1/audio/speech`, etc.) return
+Each provider exposes only its listed paths. Other paths
+(`/v1/images/generations`, `/v1/audio/speech`, etc.) return
 404 with a clear error pointing at the allowed paths. This keeps stray
 clients from leaking weird requests to the upstream.
 
@@ -168,10 +202,10 @@ machines on your network use it:
 hermes proxy start --host 0.0.0.0 --port 8645
 ```
 
-⚠ **Be aware:** anyone on your network can now use your Portal
-subscription. The proxy has no auth of its own — it accepts any bearer.
-Use a firewall, VPN, or reverse proxy with proper auth if you expose
-this beyond your trusted network.
+⚠ **Be aware:** anyone on your network can now reach the proxy. The Nous and
+xAI providers accept any bearer; `openai-codex` requires a configured client
+key. Use a firewall, VPN, or reverse proxy with proper auth if you expose this
+beyond your trusted network.
 
 ## Rate limits
 
@@ -184,7 +218,7 @@ subscription quota. Monitor usage at
 
 The proxy is intentionally minimal. Per request:
 
-1. Receive `POST /v1/chat/completions` from your app
+1. Receive a request on a path allowed by the selected provider
 2. Look up the adapter's current credential (refresh if expiring)
 3. Forward the request body verbatim, with `Authorization: Bearer <minted-key>`
 4. Stream the response back unchanged (SSE preserved)


### PR DESCRIPTION
## Summary

- add an `openai-codex` upstream to `hermes proxy`
- centralize Codex OAuth refresh and credential-pool selection for isolated local clients
- rotate safely on 401/429 and fail closed when all credentials are exhausted
- require owner-only per-client key configuration for the Codex proxy
- preserve native Responses API/SSE semantics without logging request content

## Why

Multi-user Hermes hosts need Linux-user isolation for mail, memory, 1Password, and other per-person secrets. Copying rotating Codex OAuth tokens into every user home is unsafe and operationally fragile. A single ops-owned proxy lets isolated Hermes clients share company-owned subscription accounts while keeping refresh tokens centralized.

## Safety

- client key file must be mode 0600
- constant-time client token comparison
- finite retries, exact failed-credential refresh under concurrency
- arbitrary upstream error messages are not persisted
- no metered fallback
- existing Nous/xAI proxy behavior remains backward-compatible

## Verification

- 150 proxy + credential-pool tests passed locally
- independent review found no remaining blockers
- real local systemd proxy E2E returned `response.completed` and exact expected output through OpenAI Codex OAuth
- two isolated temporary Hermes homes completed named-custom-provider `codex_responses` calls through the same proxy
