### PR TITLE
fix(cron): respect per-job messaging opt-in

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -114,20 +114,26 @@ class CronPromptInjectionBlocked(Exception):
     """
 
 
-def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
+def _resolve_cron_disabled_toolsets(cfg: dict, job: dict | None = None) -> list[str]:
     """Toolsets a cron-spawned agent must never receive.
 
-    Three protected toolsets are always disabled in cron context:
-      - ``cronjob`` — would let a cron-spawned agent schedule more cron jobs
-      - ``messaging`` — interactive, needs a live gateway session
-      - ``clarify`` — interactive, blocks waiting for user input
+    ``cronjob`` and ``clarify`` are always disabled in cron context.
+    ``messaging`` is disabled by default too, but router/fan-out jobs can
+    explicitly opt in with job-scoped ``enabled_toolsets: ["messaging"]``.
 
     User-level ``agent.disabled_toolsets`` from config.yaml is layered on top
     so per-job ``enabled_toolsets`` cannot bypass policy that applies to
     ordinary agent runs (#25752 — LLM-supplied enabled_toolsets was widening
     past config.yaml's denylist).
     """
-    disabled = ["cronjob", "messaging", "clarify"]
+    disabled = ["cronjob", "clarify"]
+    job_cfg = job if job is not None else cfg
+    job_enabled = {
+        str(name).strip()
+        for name in (job_cfg or {}).get("enabled_toolsets") or []
+    }
+    if "messaging" not in job_enabled:
+        disabled.append("messaging")
     agent_cfg = (cfg or {}).get("agent") or {}
     user_disabled = agent_cfg.get("disabled_toolsets") or []
     for name in user_disabled:
@@ -2261,13 +2267,24 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                 # silent skip — do not pollute the prompt with error messages
 
     # Always prepend cron execution guidance so the agent knows how
-    # delivery works and can suppress delivery when appropriate.
+    # delivery works and can suppress delivery when appropriate. Messaging is
+    # exceptional and only available when this job explicitly opted in.
+    messaging_enabled = "messaging" in {
+        str(name).strip() for name in job.get("enabled_toolsets") or []
+    }
+    delivery_guidance = (
+        "You may use send_message only when this job's prompt explicitly asks "
+        "for an additional or differently targeted message. Your final response "
+        "is still automatically delivered by the scheduler. "
+        if messaging_enabled
+        else "Your final response will be automatically delivered to the user — "
+        "do NOT use send_message or try to deliver the output yourself. Just "
+        "produce your report/output as your final response and the system "
+        "handles the rest. "
+    )
     cron_hint = (
-        "[IMPORTANT: You are running as a scheduled cron job. "
-        "DELIVERY: Your final response will be automatically delivered "
-        "to the user — do NOT use send_message or try to deliver "
-        "the output yourself. Just produce your report/output as your "
-        "final response and the system handles the rest. "
+        "[IMPORTANT: You are running as a scheduled cron job. DELIVERY: "
+        f"{delivery_guidance}"
         "SILENT: If there is genuinely nothing new to report, respond "
         "with exactly \"[SILENT]\" (nothing else) to suppress delivery. "
         "Never combine [SILENT] with content — either report your "
@@ -3062,7 +3079,7 @@ def run_job(
             provider_sort=pr.get("sort"),
             openrouter_min_coding_score=(_cfg.get("openrouter") or {}).get("min_coding_score"),
             enabled_toolsets=_resolve_cron_enabled_toolsets(job, _cfg),
-            disabled_toolsets=_resolve_cron_disabled_toolsets(_cfg),
+            disabled_toolsets=_resolve_cron_disabled_toolsets(_cfg, job),
             quiet_mode=True,
             # Cron jobs should always inherit the user's SOUL.md identity from
             # HERMES_HOME. When a workdir is configured, also inject project

--- a/tests/cron/test_cron_messaging_toolset.py
+++ b/tests/cron/test_cron_messaging_toolset.py
@@ -1,0 +1,54 @@
+"""Tests for cron jobs that intentionally need the messaging toolset."""
+
+from __future__ import annotations
+
+
+def test_cron_disables_messaging_by_default():
+    from cron.scheduler import _resolve_cron_disabled_toolsets
+
+    disabled = _resolve_cron_disabled_toolsets({})
+
+    assert "cronjob" in disabled
+    assert "clarify" in disabled
+    assert "messaging" in disabled
+
+
+def test_cron_allows_messaging_when_job_explicitly_requests_it():
+    from cron.scheduler import _resolve_cron_disabled_toolsets
+
+    disabled = _resolve_cron_disabled_toolsets({}, {"enabled_toolsets": ["web", "messaging"]})
+
+    assert "cronjob" in disabled
+    assert "clarify" in disabled
+    assert "messaging" not in disabled
+
+
+def test_cron_allows_messaging_when_legacy_single_arg_contains_enabled_toolsets():
+    from cron.scheduler import _resolve_cron_disabled_toolsets
+
+    disabled = _resolve_cron_disabled_toolsets({"enabled_toolsets": ["web", "messaging"]})
+
+    assert "messaging" not in disabled
+
+
+def test_cron_global_config_enabled_toolsets_does_not_grant_messaging_to_all_jobs():
+    from cron.scheduler import _resolve_cron_disabled_toolsets
+
+    disabled = _resolve_cron_disabled_toolsets(
+        {"enabled_toolsets": ["web", "messaging"]},
+        {"enabled_toolsets": ["web"]},
+    )
+
+    assert "messaging" in disabled
+
+
+def test_cron_prompt_allows_explicit_router_jobs_to_use_send_message():
+    from cron.scheduler import _build_job_prompt
+
+    prompt = _build_job_prompt({
+        "prompt": "Route Ziv items with send_message, then return [SILENT].",
+        "enabled_toolsets": ["web", "messaging"],
+    })
+
+    assert "You may use send_message only when this job's prompt explicitly asks" in prompt
+    assert "do NOT use send_message" not in prompt


### PR DESCRIPTION
## Summary

- Makes cron's `messaging` exception job-scoped instead of global-config scoped.
- Keeps `messaging` disabled by default for ordinary cron jobs.
- Allows `send_message` only for jobs whose own `enabled_toolsets` includes `messaging`.
- Preserves the global `agent.disabled_toolsets` denylist.
- Adjusts cron guidance so opted-in router/fan-out jobs may send explicitly requested secondary messages while final-response delivery remains automatic.
- Adds regression coverage for default-disabled behavior, explicit per-job opt-in, global-config isolation, and prompt guidance.

## Motivation

A cron job can request `enabled_toolsets: [..., "messaging"]`, but the cron runner still adds `messaging` to `disabled_toolsets`. The agent therefore does not receive `send_message` even though the job configuration asks for it.

This affects router/fan-out jobs that auto-deliver a final response but need a distinct secondary notification. The messaging toolset remains present in current main's runtime/toolset model; this change only permits an explicit per-job opt-in.

Fixes #20140.
Supersedes closed #42863 with a current-main port.

## Test Plan

- `python -m pytest tests/cron/test_cron_messaging_toolset.py tests/cron/test_scheduler.py -q -o 'addopts='` → `218 passed`
- `python -m ruff check cron/scheduler.py tests/cron/test_cron_messaging_toolset.py` → passed
- `git diff origin/main...HEAD --check` → passed

Ported onto current `main` on 2026-07-10 while preserving newer cron denylist, MCP-toolset, prompt-scanning, and failure-delivery behavior.