### PR TITLE
fix(slack): refresh thread context for investigations

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -63,6 +63,11 @@ except ImportError:  # pragma: no cover - plugin loaded outside package context
 
 logger = logging.getLogger(__name__)
 
+_THREAD_CONTEXT_MARKER = (
+    "[Thread context — prior messages in this thread "
+    "(not yet in conversation history)"
+)
+
 # ContextVar carrying the user_id of the slash-command invoker.
 # Set in _handle_slash_command, read in send() to match the correct
 # stashed response_url when multiple users issue commands on the same
@@ -2581,6 +2586,14 @@ class SlackAdapter(BasePlatformAdapter):
 
     # ----- Internal handlers -----
 
+    def _message_has_thread_context_marker(self, text: str) -> bool:
+        """Return whether a message already contains injected thread context."""
+        return _THREAD_CONTEXT_MARKER in (text or "")
+
+    def _is_investigate_thread_trigger(self, text: str) -> bool:
+        """Return whether a thread message should force thread-context fetch."""
+        return bool(re.match(r"^\s*investigate(?:\s|:|$)", text or "", re.IGNORECASE))
+
     @staticmethod
     def _workspace_thread_key(
         team_id: str, channel_id: str, thread_ts: str
@@ -3408,14 +3421,21 @@ class SlackAdapter(BasePlatformAdapter):
                     for t in to_remove:
                         self._mentioned_threads.discard(t)
 
-        # When entering a thread for the first time (no existing session),
-        # fetch thread context so the agent understands the conversation.
-        if is_thread_reply and not self._has_active_session_for_thread(
+        has_active_session = is_thread_reply and self._has_active_session_for_thread(
             channel_id=channel_id,
             thread_ts=event_thread_ts,
             user_id=user_id,
             team_id=team_id,
-        ):
+        )
+        # Normally context is prepended only on the first turn. Investigation
+        # prompts force a refresh because an interrupted earlier turn may have
+        # created the session without ever hydrating its Slack parent/thread.
+        force_thread_context = (
+            is_thread_reply
+            and self._is_investigate_thread_trigger(text)
+            and not self._message_has_thread_context_marker(text)
+        )
+        if is_thread_reply and (not has_active_session or force_thread_context):
             thread_context = await self._fetch_thread_context(
                 channel_id=channel_id,
                 thread_ts=event_thread_ts,
@@ -4297,11 +4317,12 @@ class SlackAdapter(BasePlatformAdapter):
         """Fetch recent thread messages to provide context when the bot is
         mentioned mid-thread for the first time.
 
-        This method is only called when there is NO active session for the
-        thread (guarded at the call site by _has_active_session_for_thread).
-        That guard ensures thread messages are prepended only on the very
-        first turn — after that the session history already holds them, so
-        there is no duplication across subsequent turns.
+        This method is normally called only when there is NO active session
+        for the thread. Explicit investigation requests may also call it for
+        an existing session so an interrupted first turn cannot leave the
+        agent without the Slack parent/thread context. The call site rejects
+        messages that already contain the context marker to avoid duplicate
+        hydration.
 
         Results are cached for _THREAD_CACHE_TTL seconds per thread to avoid
         hammering conversations.replies (Tier 3, ~50 req/min).

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3312,6 +3312,80 @@ class TestThreadReplyHandling:
         assert msg_event.text == "Follow-up question"
 
     @pytest.mark.asyncio
+    async def test_investigate_thread_reply_with_session_prepends_context(
+        self, adapter_with_session_store, mock_session_store
+    ):
+        session_key = "agent:main:slack:group:C123:123.000:U_USER"
+        mock_session_store._entries = {session_key: MagicMock()}
+        event = {
+            "text": "investigate why this failed",
+            "user": "U_USER",
+            "channel": "C123",
+            "ts": "123.456",
+            "thread_ts": "123.000",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+        }
+
+        with patch.object(
+            adapter_with_session_store,
+            "_fetch_thread_context",
+            new=AsyncMock(return_value="[Thread context]\n"),
+        ) as fetch_mock:
+            await adapter_with_session_store._handle_slack_message(event)
+
+        fetch_mock.assert_awaited_once_with(
+            channel_id="C123",
+            thread_ts="123.000",
+            current_ts="123.456",
+            team_id="T_TEAM",
+        )
+        msg_event = adapter_with_session_store.handle_message.call_args[0][0]
+        assert msg_event.text.startswith("[Thread context]\n")
+        assert msg_event.text.endswith("investigate why this failed")
+
+    @pytest.mark.asyncio
+    async def test_investigate_thread_reply_with_existing_marker_skips_refetch(
+        self, adapter_with_session_store, mock_session_store
+    ):
+        session_key = "agent:main:slack:group:C123:123.000:U_USER"
+        mock_session_store._entries = {session_key: MagicMock()}
+        event = {
+            "text": (
+                "[Thread context — prior messages in this thread "
+                "(not yet in conversation history):]\n"
+                "Alice: original issue\n"
+                "[End of thread context]\n\n"
+                "investigate: why this failed"
+            ),
+            "user": "U_USER",
+            "channel": "C123",
+            "ts": "123.456",
+            "thread_ts": "123.000",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+        }
+
+        with (
+            patch.object(
+                adapter_with_session_store,
+                "_is_investigate_thread_trigger",
+                return_value=True,
+            ) as trigger_mock,
+            patch.object(
+                adapter_with_session_store,
+                "_fetch_thread_context",
+                new=AsyncMock(),
+            ) as fetch_mock,
+        ):
+            await adapter_with_session_store._handle_slack_message(event)
+
+        trigger_mock.assert_called_once_with(event["text"])
+        fetch_mock.assert_not_awaited()
+        msg_event = adapter_with_session_store.handle_message.call_args[0][0]
+        assert msg_event.text == event["text"]
+
+    @pytest.mark.asyncio
     async def test_thread_reply_with_mention_strips_bot_id(
         self, adapter_with_session_store, mock_session_store
     ):


### PR DESCRIPTION
## Summary

- Re-fetches and prepends Slack thread context for explicit `investigate`, `investigate ...`, and `investigate: ...` thread replies even when a Hermes session already exists.
- Avoids duplicate hydration when the incoming message already contains the thread-context marker.
- Preserves current workspace-scoped Slack thread/session keys and the current plugin architecture.
- Adds focused regression coverage for forced hydration and duplicate suppression.

## Root cause

Slack thread context is normally fetched only when entering a thread with no active Hermes session. If an earlier empty or interrupted turn created the session without useful context, a later `investigate` request skipped `_fetch_thread_context()` and the agent missed the parent alert/request.

This keeps normal thread messages unchanged and refreshes context only for explicit investigation triggers.

Supersedes closed #23141 with a current-main port to `plugins/platforms/slack/adapter.py`.

## Validation

- `scripts/run_tests.sh tests/gateway/test_slack.py tests/gateway/test_slack_channel_session_scope.py tests/gateway/test_slack_mention.py -q` → `329 passed`
- `.venv/bin/ruff check plugins/platforms/slack/adapter.py tests/gateway/test_slack.py` → passed
- `git diff --check origin/main...HEAD` → passed

## Current status

Rebased onto current `main` (`d7b36070ef807841699ad32c5b6af547fee3ff64`) on 2026-07-20 while preserving newer workspace-scoped Slack thread state. No unresolved review threads at refresh time.
