### PR TITLE
fix(telemetry): persist first accounted fallback route

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2501,7 +2501,7 @@ class SessionDB:
         )
         def _do(conn):
             row = conn.execute(
-                "SELECT model, billing_provider, api_call_count FROM sessions WHERE id = ?",
+                "SELECT model, model_config, billing_provider, api_call_count FROM sessions WHERE id = ?",
                 (session_id,),
             ).fetchone()
             existing_model = row["model"] if row is not None else None
@@ -2510,8 +2510,11 @@ class SessionDB:
 
             # Session creation records the requested primary route before any API
             # call. If it fails and fallback succeeds, the first accounted usage
-            # event is the first authoritative route. After that, preserve the
-            # legacy row: one row cannot represent mixed-provider usage.
+            # event is the first authoritative billing route. Preserve the
+            # requested runtime model in model_config before replacing the legacy
+            # model column so resume still restores the turn-scoped primary route.
+            # After that, preserve the legacy row: one row cannot represent
+            # mixed-provider usage.
             first_accounted_route = (
                 existing_api_calls == 0
                 and bool(model)
@@ -2519,13 +2522,30 @@ class SessionDB:
                 and (existing_model != model or existing_provider != billing_provider)
             )
             if first_accounted_route:
+                try:
+                    raw_runtime_config = row["model_config"] if row is not None else None
+                    runtime_config = json.loads(raw_runtime_config or "{}")
+                    if not isinstance(runtime_config, dict):
+                        runtime_config = {}
+                except (TypeError, ValueError, json.JSONDecodeError):
+                    runtime_config = {}
+                if existing_model:
+                    runtime_config.setdefault("model", existing_model)
                 conn.execute(
                     """UPDATE sessions
                        SET model = ?, billing_provider = ?,
                            billing_base_url = COALESCE(?, billing_base_url),
-                           billing_mode = COALESCE(?, billing_mode)
+                           billing_mode = COALESCE(?, billing_mode),
+                           model_config = ?
                        WHERE id = ?""",
-                    (model, billing_provider, billing_base_url, billing_mode, session_id),
+                    (
+                        model,
+                        billing_provider,
+                        billing_base_url,
+                        billing_mode,
+                        json.dumps(runtime_config),
+                        session_id,
+                    ),
                 )
             conn.execute(sql, params)
         self._execute_write(_do)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2500,6 +2500,33 @@ class SessionDB:
             session_id,
         )
         def _do(conn):
+            row = conn.execute(
+                "SELECT model, billing_provider, api_call_count FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            existing_model = row["model"] if row is not None else None
+            existing_provider = row["billing_provider"] if row is not None else None
+            existing_api_calls = int((row["api_call_count"] if row is not None else 0) or 0)
+
+            # Session creation records the requested primary route before any API
+            # call. If it fails and fallback succeeds, the first accounted usage
+            # event is the first authoritative route. After that, preserve the
+            # legacy row: one row cannot represent mixed-provider usage.
+            first_accounted_route = (
+                existing_api_calls == 0
+                and bool(model)
+                and bool(billing_provider)
+                and (existing_model != model or existing_provider != billing_provider)
+            )
+            if first_accounted_route:
+                conn.execute(
+                    """UPDATE sessions
+                       SET model = ?, billing_provider = ?,
+                           billing_base_url = COALESCE(?, billing_base_url),
+                           billing_mode = COALESCE(?, billing_mode)
+                       WHERE id = ?""",
+                    (model, billing_provider, billing_base_url, billing_mode, session_id),
+                )
             conn.execute(sql, params)
         self._execute_write(_do)
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -291,6 +291,7 @@ class TestSessionLifecycle:
         assert session["billing_provider"] == "custom:zai"
         assert session["billing_base_url"] == "https://api.z.ai/api/coding/paas/v4/"
         assert session["api_call_count"] == 1
+        assert json.loads(session["model_config"])["model"] == "gpt-5.6-sol"
 
     def test_accounted_primary_route_is_not_rewritten_by_later_fallback(self, db):
         """A mixed-provider session keeps its first accounted route in the legacy row."""
@@ -308,6 +309,25 @@ class TestSessionLifecycle:
         assert session["model"] == "gpt-5.6-sol"
         assert session["billing_provider"] == "openai-codex"
         assert session["api_call_count"] == 2
+
+    def test_first_accounted_fallback_recovers_malformed_runtime_config(self, db):
+        """Malformed metadata preserves the primary model without inventing a provider."""
+        db.create_session(session_id="s1", source="cli", model="gpt-5.6-sol")
+        db._execute_write(
+            lambda conn: conn.execute(
+                "UPDATE sessions SET model_config = ? WHERE id = ?", ("{bad", "s1")
+            )
+        )
+
+        db.update_token_counts(
+            "s1", input_tokens=10, output_tokens=5, model="glm-5.2",
+            billing_provider="custom:zai", api_call_count=1,
+        )
+
+        session = db.get_session("s1")
+        assert session["model"] == "glm-5.2"
+        assert session["billing_provider"] == "custom:zai"
+        assert json.loads(session["model_config"]) == {"model": "gpt-5.6-sol"}
 
     def test_update_token_counts_preserves_existing_model(self, db):
         db.create_session(session_id="s1", source="cli", model="anthropic/claude-opus-4.6")

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -272,6 +272,43 @@ class TestSessionLifecycle:
         session = db.get_session("s1")
         assert session["model"] == "openai/gpt-5.4"
 
+    def test_first_accounted_fallback_replaces_requested_primary_route(self, db):
+        """First successful fallback usage must persist one coherent route pair."""
+        db.create_session(session_id="s1", source="cli", model="gpt-5.6-sol")
+
+        db.update_token_counts(
+            "s1",
+            input_tokens=10,
+            output_tokens=5,
+            model="glm-5.2",
+            billing_provider="custom:zai",
+            billing_base_url="https://api.z.ai/api/coding/paas/v4/",
+            api_call_count=1,
+        )
+
+        session = db.get_session("s1")
+        assert session["model"] == "glm-5.2"
+        assert session["billing_provider"] == "custom:zai"
+        assert session["billing_base_url"] == "https://api.z.ai/api/coding/paas/v4/"
+        assert session["api_call_count"] == 1
+
+    def test_accounted_primary_route_is_not_rewritten_by_later_fallback(self, db):
+        """A mixed-provider session keeps its first accounted route in the legacy row."""
+        db.create_session(session_id="s1", source="cli", model="gpt-5.6-sol")
+        db.update_token_counts(
+            "s1", input_tokens=10, output_tokens=5, model="gpt-5.6-sol",
+            billing_provider="openai-codex", api_call_count=1,
+        )
+        db.update_token_counts(
+            "s1", input_tokens=10, output_tokens=5, model="glm-5.2",
+            billing_provider="custom:zai", api_call_count=1,
+        )
+
+        session = db.get_session("s1")
+        assert session["model"] == "gpt-5.6-sol"
+        assert session["billing_provider"] == "openai-codex"
+        assert session["api_call_count"] == 2
+
     def test_update_token_counts_preserves_existing_model(self, db):
         db.create_session(session_id="s1", source="cli", model="anthropic/claude-opus-4.6")
         db.update_token_counts("s1", input_tokens=10, output_tokens=5, model="openai/gpt-5.4")

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1340,6 +1340,58 @@ def test_stored_session_runtime_overrides_skips_bare_billing_provider():
     assert ov["model_override"]["provider"] == "custom:myendpoint"
 
 
+def test_stored_session_runtime_overrides_prefers_primary_model_config_over_fallback_billing_model():
+    """First-turn fallback attribution must not make TUI resume the fallback route."""
+    ov = server._stored_session_runtime_overrides(
+        {
+            "model": "glm-5.2",
+            "billing_provider": "custom:zai",
+            "model_config": {
+                "model": "gpt-5.6-sol",
+                "provider": "openai-codex",
+            },
+        }
+    )
+
+    assert ov["model_override"] == {
+        "model": "gpt-5.6-sol",
+        "provider": "openai-codex",
+        "base_url": None,
+        "api_mode": None,
+    }
+    assert ov["provider_override"] == "openai-codex"
+
+
+def test_stored_session_runtime_overrides_does_not_pair_runtime_model_with_billing_provider():
+    """Recovered runtime model without provider must use configured resolution, not billing."""
+    ov = server._stored_session_runtime_overrides(
+        {
+            "model": "glm-5.2",
+            "billing_provider": "custom:zai",
+            "model_config": {"model": "gpt-5.6-sol"},
+        }
+    )
+
+    assert ov["model_override"]["model"] == "gpt-5.6-sol"
+    assert ov["model_override"]["provider"] is None
+    assert "provider_override" not in ov
+
+
+def test_stored_session_runtime_overrides_keeps_provider_for_coherent_legacy_model_config():
+    """A model-only legacy config still uses its routable billing provider when models agree."""
+    ov = server._stored_session_runtime_overrides(
+        {
+            "model": "claude-opus-4-6",
+            "billing_provider": "anthropic",
+            "model_config": {"model": "claude-opus-4-6"},
+        }
+    )
+
+    assert ov["model_override"]["model"] == "claude-opus-4-6"
+    assert ov["model_override"]["provider"] == "anthropic"
+    assert ov["provider_override"] == "anthropic"
+
+
 def test_persist_live_session_runtime_preserves_resume_metadata(monkeypatch):
     updates = {}
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2239,7 +2239,10 @@ def _stored_session_runtime_overrides(row: dict | None) -> dict:
             logger.debug("failed to parse stored session model_config", exc_info=True)
 
     overrides: dict = {}
-    model = str(row.get("model") or model_config.get("model") or "").strip()
+    # model_config is the durable runtime contract. The legacy model column is
+    # also used for first-accounted-route billing attribution, so a first-turn
+    # fallback may intentionally differ from the primary model restored here.
+    model = str(model_config.get("model") or row.get("model") or "").strip()
     # ``billing_provider`` is only the billing bucket — for a custom endpoint it is the
     # bare class ``"custom"``, which agent_init treats as non-routable, so restoring it as
     # the provider override makes ``session.resume`` fail with "No LLM provider configured".
@@ -2250,7 +2253,20 @@ def _stored_session_runtime_overrides(row: dict | None) -> dict:
         model_config.get("billing_provider") or row.get("billing_provider") or ""
     ).strip()
     provider = explicit_provider
-    if not provider and billing_provider.lower() not in _BARE_BILLING_PROVIDERS:
+    # A runtime model preserved in model_config is deliberately separate from
+    # first-accounted billing attribution when it differs from the legacy model
+    # column. Never pair that primary model with the fallback billing provider
+    # when its explicit provider metadata is absent (for example after recovering
+    # malformed legacy JSON); leaving the provider unset makes normal configured-
+    # provider resolution apply. Equal models retain legacy provider fallback.
+    runtime_model = str(model_config.get("model") or "").strip()
+    billing_model = str(row.get("model") or "").strip()
+    has_split_runtime_model = bool(runtime_model and runtime_model != billing_model)
+    if (
+        not provider
+        and not has_split_runtime_model
+        and billing_provider.lower() not in _BARE_BILLING_PROVIDERS
+    ):
         provider = billing_provider
     base_url = str(model_config.get("base_url") or "").strip()
     api_mode = str(model_config.get("api_mode") or "").strip()


### PR DESCRIPTION
## Problem

A session row is created with the requested primary model before the first API call. If that primary fails before producing any accounted usage and automatic fallback succeeds, `update_token_counts()` currently keeps the requested model via `COALESCE(model, ?)`, while other route fields may describe the fallback.

That can persist an incoherent pair such as a GPT model with `custom:zai`, even though every accounted API call used the fallback route.

## Fix

Treat the first accounted usage event as authoritative only while the existing session has `api_call_count == 0`:

- replace the pre-created requested `model` and `billing_provider` together;
- carry over fallback `billing_base_url` and `billing_mode` when supplied;
- preserve the existing first-accounted route after any API call has already been recorded.

This keeps the legacy aggregate row internally coherent without pretending it can represent mixed-provider usage.

## Scope and related work

This is intentionally narrower than the other open fallback/usage PRs:

- #60487 updates the session row immediately on fallback activation. That can relabel aggregate usage after the primary has already produced accounted calls.
- #51634 adds per-model usage attribution, which is the proper solution for sessions that genuinely contain calls from multiple routes.

This PR only fixes the zero-accounted-call case. It does not attempt to attribute mid-session mixed usage in the single legacy row.

## Tests

Added regression coverage proving that:

1. the first successful fallback replaces the unaccounted requested route with one coherent fallback route;
2. a later fallback does not rewrite a route after primary usage has already been accounted.

Validation on current `main`:

```text
python -m pytest tests/test_hermes_state.py -q
341 passed in 6.29s
```

`git diff --check` passes for both changed files.
