### PR TITLE
fix(deepseek): extract prompt_cache_hit_tokens + update Jul 2026 pricing

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -759,10 +759,17 @@ class ChatCompletionsTransport(ProviderTransport):
         return True
 
     def extract_cache_stats(self, response: Any) -> dict[str, int] | None:
-        """Extract OpenRouter/OpenAI cache stats from prompt_tokens_details."""
+        """Extract cache stats from OpenAI/OpenRouter prompt_tokens_details, or
+        DeepSeek's own top-level prompt_cache_hit_tokens (the two shapes are
+        mutually exclusive, so checking DeepSeek's fields first is safe for
+        any provider). See NousResearch/hermes-agent#61871.
+        """
         usage = getattr(response, "usage", None)
         if usage is None:
             return None
+        ds_hit = getattr(usage, "prompt_cache_hit_tokens", 0) or 0
+        if ds_hit:
+            return {"cached_tokens": ds_hit, "creation_tokens": 0}
         details = getattr(usage, "prompt_tokens_details", None)
         if details is None:
             return None

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -452,9 +452,21 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
     ): PricingEntry(
         input_cost_per_million=Decimal("0.14"),
         output_cost_per_million=Decimal("0.28"),
+        cache_read_cost_per_million=Decimal("0.0028"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-03-16",
+        pricing_version="deepseek-pricing-2026-07-10",
+    ),
+    (
+        "deepseek",
+        "deepseek-v4-flash",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.14"),
+        output_cost_per_million=Decimal("0.28"),
+        cache_read_cost_per_million=Decimal("0.0028"),
+        source="official_docs_snapshot",
+        source_url="https://api-docs.deepseek.com/quick_start/pricing",
+        pricing_version="deepseek-pricing-2026-07-10",
     ),
     (
         "deepseek",
@@ -470,12 +482,12 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         "deepseek",
         "deepseek-v4-pro",
     ): PricingEntry(
-        input_cost_per_million=Decimal("1.74"),
-        output_cost_per_million=Decimal("3.48"),
-        cache_read_cost_per_million=Decimal("0.0145"),
+        input_cost_per_million=Decimal("0.435"),
+        output_cost_per_million=Decimal("0.87"),
+        cache_read_cost_per_million=Decimal("0.003625"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-05-12",
+        pricing_version="deepseek-pricing-2026-07-10",
     ),
     # Google Gemini
     (


### PR DESCRIPTION
## Summary

Fixes two gaps in direct-DeepSeek-API support (i.e. `provider: deepseek` / `base_url: api.deepseek.com`, **not** via OpenRouter):

**1. Cache stat extraction always returned 0 (closes #61871)**

`extract_cache_stats` only read the OpenAI/OpenRouter nested shape:
```
usage.prompt_tokens_details.cached_tokens
```
DeepSeek's own API returns cache stats as top-level fields:
```
usage.prompt_cache_hit_tokens
usage.prompt_cache_miss_tokens
```
Neither field had any reader anywhere in the codebase (`grep` returns zero hits on `prompt_cache_hit_tokens` before this PR).

Fix: check `prompt_cache_hit_tokens` on `usage` first; fall back to `prompt_tokens_details` for OpenAI/OpenRouter. The two shapes are mutually exclusive, so the order is safe for any provider.

**2. Pricing table gaps / stale entries**

- `deepseek-chat`: `cache_read_cost_per_million` was missing → cache-read cost was always billed at input rate
- `deepseek-v4-flash`: entry was missing entirely
- `deepseek-v4-pro`: price cut not yet reflected (~75% reduction, effective Jul 2026)

All three updated to DeepSeek's [current pricing page](https://api-docs.deepseek.com/quick_start/pricing) as of 2026-07-10.

## Test plan

- [ ] Run a direct-DeepSeek session and confirm `cache_read_tokens` is non-zero on repeated prompts
- [ ] Confirm cost estimates for `deepseek-chat`, `deepseek-v4-flash`, `deepseek-v4-pro` match current published rates
- [ ] Confirm OpenAI/OpenRouter cache stat path still works (no regression — the fallback is unchanged)