### PR TITLE
docs(mcp): show provider-specific request headers

### DIFF
--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -201,8 +201,15 @@ mcp_servers:
   remote_api:
     url: "https://mcp.example.com/mcp"
     headers:
-      Authorization: "Bearer ***"
+      Authorization: "Bearer ${MCP_API_KEY}"
+      X-Workspace-slug: "${MCP_WORKSPACE_SLUG}"
 ```
+
+`headers` is a free-form map, so include every header required by the MCP
+provider—not only `Authorization`. For example, Plane Cloud's hosted MCP server
+requires both a bearer token and `X-Workspace-slug`; omitting the workspace
+header returns HTTP 400. Check the provider's MCP documentation for its exact
+header names and values.
 
 Use HTTP servers when:
 - the MCP server is hosted elsewhere


### PR DESCRIPTION
## Summary
- show that remote MCP `headers` accepts multiple provider-specific entries
- document Plane Cloud’s required `X-Workspace-slug` header and HTTP 400 failure mode
- use environment-variable placeholders for both header values

## Test Plan
- [x] `git diff --check`
- [ ] Docusaurus build (website dependencies are not installed in the isolated worktree)

Closes #25478