### PR TITLE
Fix cleanup of disposable backend probe containers

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -941,6 +941,7 @@ def _probe_remote_backend(env_type: str) -> str | None:
     if cached is not None:
         return cached or None
 
+    env = None
     try:
         # Import locally: tools/ imports are heavy and only relevant when a
         # non-local backend is actually configured.
@@ -991,7 +992,10 @@ def _probe_remote_backend(env_type: str) -> str | None:
                 "docker_env": config.get("docker_env", {}),
                 "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
                 "docker_extra_args": config.get("docker_extra_args", []),
-                "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
+                # A prompt probe is disposable infrastructure, not a user
+                # terminal session. Never let it reuse or leave behind the
+                # profile's long-lived Docker container.
+                "docker_persist_across_processes": False,
                 "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
             }
 
@@ -1026,6 +1030,15 @@ def _probe_remote_backend(env_type: str) -> str | None:
         logger.debug("Backend probe failed: %s", e)
         _BACKEND_PROBE_CACHE[cache_key] = ""
         return None
+    finally:
+        if env is not None:
+            try:
+                env.cleanup()
+                wait_for_cleanup = getattr(env, "wait_for_cleanup", None)
+                if callable(wait_for_cleanup):
+                    wait_for_cleanup(timeout=30)
+            except Exception as e:
+                logger.debug("Backend probe cleanup failed: %s", e)
 
     # Parse key=value lines back into a tidy summary.
     parsed: dict[str, str] = {}

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1270,6 +1270,9 @@ class TestEnvironmentHints:
         _pb._clear_backend_probe_cache()
 
         class _FakeEnv:
+            cleaned = False
+            waited = False
+
             def execute(self, cmd, timeout=None):
                 return {
                     "returncode": 0,
@@ -1279,11 +1282,20 @@ class TestEnvironmentHints:
                     ),
                 }
 
+            def cleanup(self):
+                self.cleaned = True
+
+            def wait_for_cleanup(self, timeout):
+                self.waited = True
+                return True
+
         created = {}
 
         def _fake_create_environment(*, env_type, **kwargs):
             created["env_type"] = env_type
-            return _FakeEnv()
+            created["container_config"] = kwargs["container_config"]
+            created["env"] = _FakeEnv()
+            return created["env"]
 
         # Patch the REAL factory in tools.terminal_tool — the probe imports it
         # locally, so the import itself must succeed (the bug was here).
@@ -1295,6 +1307,9 @@ class TestEnvironmentHints:
         assert line is not None
         assert "Linux 6.8.0" in line
         assert "root" in line
+        assert created["container_config"]["docker_persist_across_processes"] is False
+        assert created["env"].cleaned is True
+        assert created["env"].waited is True
 
     def test_remote_backend_list_covers_known_sandboxes(self):
         """Regression guard: if someone adds a remote backend, they must list it here."""
@@ -1644,5 +1659,3 @@ class TestParallelToolCallGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
-


### PR DESCRIPTION
## Summary
- force prompt backend probes to opt out of cross-process Docker persistence
- clean up and wait for disposable probe environments before returning
- add regression coverage for lifecycle and configuration invariants

## Verification
- `scripts/run_tests.sh tests/agent/test_prompt_builder.py -q` (160 passed)
- `ruff check agent/prompt_builder.py tests/agent/test_prompt_builder.py`
- real Docker probe leaves the prompt-backend-probe container count unchanged