### PR TITLE
fix(skills): normalize path separators in content hash for Windows compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,9 @@ docs/superpowers/*
 # treat it as a local edit and autostash it on every run (#38529).
 .hermes-bootstrap-complete
 
+# Persistent dev sandbox dir (scripts/dev-sandbox.sh --persistent)
+.hermes-sandbox/
+
 # Interrupted-update breadcrumb + recovery lock written next to the shared venv
 # by `hermes update` / launch-time self-heal. Runtime state, never a code change
 # — ignore so `git status` stays clean and update's autostash skips them.

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3161,20 +3161,21 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
 
 
 
-def force_close_tcp_sockets(client: Any, *, release_fds: bool = False) -> int:
-    """Abort in-flight TCP I/O by shutting down pool sockets.
+def force_close_tcp_sockets(client: Any) -> int:
+    """Abort in-flight TCP I/O by shutting down sockets WITHOUT closing FDs.
 
     When a provider drops a connection mid-stream — or the user issues an
     interrupt — we want to unblock httpx's reader/writer immediately rather
     than waiting for the kernel's per-connection timeout. ``shutdown(SHUT_RDWR)``
     achieves that: it sends FIN, breaks any pending ``recv``/``send`` with EOF
-    or ``EPIPE``.
+    or ``EPIPE``, but does NOT release the file descriptor.
 
-    By default (``release_fds=False``) this helper does **not** call
-    ``socket.close()`` / release the FD. That default is load-bearing for
-    cross-thread abort paths (#29507):
+    Historically this helper also called ``socket.close()`` so the FD got
+    released immediately, but that's unsafe when (as is the case for both the
+    interrupt-abort path and stale-call kill path) the helper runs on a
+    different thread than the one driving the request:
 
-      * The Python ``socket.socket`` we close is the SAME object held by
+      * The Python ``socket.socket`` we close here is the SAME object held by
         httpx's pool, so closing it via Python sets its ``_fd`` to -1 and
         future operations on that Python object fail safely.
       * BUT the SSL wrapper (``ssl.SSLSocket``'s underlying OpenSSL ``BIO``)
@@ -3186,20 +3187,15 @@ def force_close_tcp_sockets(client: Any, *, release_fds: bool = False) -> int:
         wrong file (issue #29507: 24-byte TLS application-data record
         clobbering SQLite header bytes 5..28).
 
-    ``shutdown()`` from any thread is FD-safe; ``close()`` is not when a
-    stranger thread still has the BIO holding the raw FD.
+    The fix is to let the owning thread own the close. ``shutdown()`` from any
+    thread is FD-safe; ``close()`` is not. The httpx connection's own close
+    path — which runs from the worker thread when it unwinds — will release
+    the FD via the same ``socket.socket`` object, and because Python's socket
+    close atomically swaps ``_fd`` to -1 *before* issuing ``os.close``, there
+    is no FD-aliasing window when only one thread closes.
 
-    When the **owning** thread is disposing of a client that is no longer
-    shared (``_close_openai_client`` after replace / request-complete), pass
-    ``release_fds=True``. httpx's own ``client.close()`` does not reliably
-    ``os.close()`` sockets that were already ``shutdown()``'d, so without an
-    explicit ``sock.close()`` those FDs stay in kernel CLOSED state forever
-    and accumulate under long-lived gateways (issue #61979 — ~1 CLOSED fd
-    per ~6 minutes through a local proxy path).
-
-    Returns the number of sockets shut down (and optionally closed). Field
-    kept as ``tcp_force_closed=N`` in log lines for backwards-compatible
-    parsing.
+    Returns the number of sockets shut down. (Field kept as
+    ``tcp_force_closed=N`` in the log line for backwards-compatible parsing.)
     """
     import socket as _socket
 
@@ -3211,13 +3207,7 @@ def force_close_tcp_sockets(client: Any, *, release_fds: bool = False) -> int:
             except OSError:
                 # Already shut down / not connected / FD invalid — all benign.
                 pass
-            # IMPORTANT (#29507): never release FDs from stranger-thread
-            # abort paths. Only the owning-thread close path may opt in.
-            if release_fds:
-                try:
-                    sock.close()
-                except OSError:
-                    pass
+            # IMPORTANT (#29507): do NOT call sock.close() here. See docstring.
             shutdown_count += 1
     except Exception as exc:
         _ra().logger.debug("Force-close TCP sockets sweep error: %s", exc)

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1208,7 +1208,42 @@ def restore_primary_runtime(agent) -> bool:
             api_mode=rt.get("compressor_api_mode", ""),
         )
 
-        # ── Re-select from the credential pool if one is available ──
+        # ── Rebind and re-select the primary credential pool ──
+        # A cross-provider fallback attaches the fallback provider's pool. The
+        # runtime fields above restore the primary, but leaving that pool in
+        # place makes the next primary 401/429 hit the provider-mismatch guard
+        # and disables credential rotation. Reload the primary pool first; if
+        # auth storage is temporarily unreadable, clear the mismatched pool.
+        primary_provider = str(rt.get("provider") or "").strip().lower()
+        pool = getattr(agent, "_credential_pool", None)
+        pool_provider = str(getattr(pool, "provider", "") or "").strip().lower()
+        pool_matches_primary = pool_provider == primary_provider
+        if (
+            primary_provider == "custom"
+            and pool_provider.startswith("custom:")
+        ):
+            try:
+                from agent.credential_pool import get_custom_provider_pool_key
+
+                primary_key = (
+                    get_custom_provider_pool_key(str(rt.get("base_url") or "")) or ""
+                ).strip().lower()
+                pool_matches_primary = bool(primary_key) and primary_key == pool_provider
+            except Exception:
+                pool_matches_primary = False
+        if pool is not None and pool_provider and not pool_matches_primary:
+            agent._credential_pool = None
+            try:
+                from agent.credential_pool import load_pool
+
+                agent._credential_pool = load_pool(primary_provider)
+            except Exception as exc:
+                logger.warning(
+                    "Restore could not reload primary credential pool for %s: %s",
+                    primary_provider,
+                    exc,
+                )
+
         # The snapshot's api_key was captured at construction time.  Across
         # turns the pool may have rotated (token revocation, billing/rate-limit
         # exhaustion, cooldown), leaving the snapshot key stale.  Restoring it
@@ -1222,7 +1257,6 @@ def restore_primary_runtime(agent) -> bool:
             entry = pool.select()
             if entry is not None:
                 entry_provider = str(getattr(entry, "provider", "") or "").strip().lower()
-                primary_provider = str(rt.get("provider") or "").strip().lower()
                 entry_matches_primary = entry_provider == primary_provider
                 # Custom endpoints all carry the generic ``custom`` provider on
                 # the agent while the pool entry is keyed ``custom:<name>`` (see
@@ -1858,6 +1892,9 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         old_norm = (old_provider or "").strip().lower()
         new_norm = (new_provider or "").strip().lower()
         if old_norm != new_norm or getattr(agent, "_credential_pool", None) is None:
+            # A pool bound to the old provider is worse than no pool: the
+            # recovery guard rejects it and every later 401/429 skips rotation.
+            agent._credential_pool = None
             try:
                 from agent.credential_pool import load_pool
                 agent._credential_pool = load_pool(new_provider)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -872,6 +872,7 @@ class _CodexCompletionsAdapter:
         # `function_call_output` items with a valid call_id, so every
         # Responses path normalizes tool history identically and cannot drift.
         from agent.codex_responses_adapter import _chat_messages_to_responses_input
+        from utils import base_url_host_matches
 
         instructions = "You are a helpful assistant."
         replay_messages: List[Dict[str, Any]] = []
@@ -883,7 +884,18 @@ class _CodexCompletionsAdapter:
             else:
                 replay_messages.append(msg)
 
-        input_items = _chat_messages_to_responses_input(replay_messages)
+        # Copilot (githubcopilot.com) binds replayed codex_message_items ids
+        # to a backend "connection" that doesn't survive credential
+        # rotation/gateway restarts — replaying one gets HTTP 401 "input
+        # item ID does not belong to this connection" (#32716). Auxiliary
+        # calls (context compression, flush_memories, MoA aggregation) go
+        # through this adapter instead of agent/transports/codex.py's
+        # build_kwargs, so they need the same guard applied independently.
+        _host_for_input = str(getattr(self._client, "base_url", "") or "")
+        _is_github_for_input = base_url_host_matches(_host_for_input, "githubcopilot.com")
+        input_items = _chat_messages_to_responses_input(
+            replay_messages, is_github_responses=_is_github_for_input,
+        )
 
         resp_kwargs: Dict[str, Any] = {
             "model": model,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -236,73 +236,109 @@ def _check_stale_giveup(agent) -> None:
         )
 
 
-def should_use_direct_api_call(agent) -> bool:
-    """True when the non-streaming path should skip the interrupt worker thread.
+def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
+    """Run one non-streaming LLM request for the active api_mode and return it.
 
-    Cron jobs run inside nested gateway thread pools (cron-scheduler →
-    cron-parallel → per-job pool → ``interruptible_api_call`` worker). That
-    extra daemon thread can wedge before HTTP on the 2nd+ API call of a
-    tool-using turn (#62151) while the same job succeeds via ``hermes cron
-    tick``. Cron has no interactive interrupt surface, so synchronous calls
-    on the conversation thread are safe and avoid the deadlock class.
+    Shared by the interrupt-worker path (``interruptible_api_call``) and the
+    inline path (``direct_api_call``) so the per-api_mode dispatch — codex /
+    anthropic / bedrock / MoA / OpenAI-compatible — lives in exactly one place.
+
+    ``make_client(reason)`` builds the per-request OpenAI client for the codex
+    and OpenAI-compatible branches; the worker path uses it to register the
+    client with its stranger-thread abort machinery, the inline path uses it to
+    capture the client for its own ``finally`` close. The anthropic / bedrock /
+    MoA branches manage their own clients and never call it. All interrupt,
+    abort, cancellation, and close semantics stay in the callers — this helper
+    only issues the request.
+    """
+    if agent.api_mode == "codex_responses":
+        request_client = make_client("codex_stream_request")
+        return agent._run_codex_stream(
+            api_kwargs,
+            client=request_client,
+            on_first_delta=getattr(agent, "_codex_on_first_delta", None),
+        )
+    if agent.api_mode == "anthropic_messages":
+        return agent._anthropic_messages_create(api_kwargs)
+    if agent.api_mode == "bedrock_converse":
+        # Bedrock uses boto3 directly — no OpenAI client needed.
+        # normalize_converse_response produces an OpenAI-compatible
+        # SimpleNamespace so the rest of the agent loop can treat
+        # bedrock responses like chat_completions responses.
+        from agent.bedrock_adapter import (
+            _get_bedrock_runtime_client,
+            invalidate_runtime_client,
+            is_stale_connection_error,
+            normalize_converse_response,
+        )
+        region = api_kwargs.pop("__bedrock_region__", "us-east-1")
+        api_kwargs.pop("__bedrock_converse__", None)
+        client = _get_bedrock_runtime_client(region)
+        try:
+            raw_response = client.converse(**api_kwargs)
+        except Exception as _bedrock_exc:
+            # Evict the cached client on stale-connection failures
+            # so the outer retry loop builds a fresh client/pool.
+            if is_stale_connection_error(_bedrock_exc):
+                invalidate_runtime_client(region)
+            raise
+        return normalize_converse_response(raw_response)
+    if agent.provider == "moa":
+        # MoA is a virtual chat-completions provider backed by the
+        # in-process MoAClient facade. Do not rebuild a request-local
+        # OpenAI client from the virtual runtime metadata.
+        return agent.client.chat.completions.create(**api_kwargs)
+    request_client = make_client("chat_completion_request")
+    return request_client.chat.completions.create(**api_kwargs)
+
+
+def should_use_direct_api_call(agent) -> bool:
+    """True when the LLM call must run inline instead of on the interrupt worker.
+
+    ``interruptible_api_call`` / ``interruptible_streaming_api_call`` run every
+    request on a spawned daemon worker so the conversation loop can poll for an
+    interactive interrupt during the blocking HTTP round-trip. Cron jobs execute
+    their turn inside the gateway's *nested* thread pools (cron-scheduler →
+    parallel/sequential pool → per-job pool → ``run_conversation``); stacking the
+    interrupt worker on top of that wedges before the socket even opens on the
+    2nd+ call of a tool-using turn (#62151), while the identical job runs fine
+    via ``hermes cron tick`` (foreground, no nested gateway pools). Cron has no
+    interactive interrupt surface — its only stop signal is the scheduler's
+    inactivity watchdog, which fires from the outer thread — so running inline
+    removes the deadlock class without giving anything up. This predicate is the
+    single extension point for any future non-interactive, nested-pool context.
     """
     return getattr(agent, "platform", None) == "cron"
 
 
-def _execute_nonstreaming_api_request(agent, api_kwargs: dict):
-    """Dispatch one non-streaming LLM request on the calling thread."""
-    request_client = None
-    try:
-        if agent.api_mode == "codex_responses":
-            request_client = agent._create_request_openai_client(
-                reason="codex_stream_request",
-                api_kwargs=api_kwargs,
-            )
-            return agent._run_codex_stream(
-                api_kwargs,
-                client=request_client,
-                on_first_delta=getattr(agent, "_codex_on_first_delta", None),
-            )
-        if agent.api_mode == "anthropic_messages":
-            return agent._anthropic_messages_create(api_kwargs)
-        if agent.api_mode == "bedrock_converse":
-            from agent.bedrock_adapter import (
-                _get_bedrock_runtime_client,
-                invalidate_runtime_client,
-                is_stale_connection_error,
-                normalize_converse_response,
-            )
-
-            region = api_kwargs.pop("__bedrock_region__", "us-east-1")
-            api_kwargs.pop("__bedrock_converse__", None)
-            client = _get_bedrock_runtime_client(region)
-            try:
-                raw_response = client.converse(**api_kwargs)
-            except Exception as bedrock_exc:
-                if is_stale_connection_error(bedrock_exc):
-                    invalidate_runtime_client(region)
-                raise
-            return normalize_converse_response(raw_response)
-
-        request_client = agent._create_request_openai_client(
-            reason="chat_completion_request",
-            api_kwargs=api_kwargs,
-        )
-        return request_client.chat.completions.create(**api_kwargs)
-    finally:
-        if request_client is not None:
-            agent._close_request_openai_client(
-                request_client, reason="request_complete"
-            )
-
-
 def direct_api_call(agent, api_kwargs: dict):
-    """Run a non-streaming API call synchronously on the conversation thread."""
+    """Run a non-streaming LLM call inline on the conversation thread.
+
+    Used when ``should_use_direct_api_call`` is True. Skips the interrupt worker
+    (whose only job is interactive-interrupt responsiveness, which this context
+    does not have) so the nested-pool deadlock (#62151) cannot occur. Because the
+    request runs in-flight normally, the per-request OpenAI client's own httpx
+    timeout (provider ``request_timeout_seconds`` / ``HERMES_API_TIMEOUT``) bounds
+    a genuinely hung provider — the same bound interactive calls already rely on.
+    """
     _check_stale_giveup(agent)
     agent._touch_activity("waiting for non-streaming API response")
-    response = _execute_nonstreaming_api_request(agent, api_kwargs)
-    _reset_stale_streak(agent)
-    return response
+    request_client_holder = {"client": None}
+
+    def _make_client(reason: str):
+        client = agent._create_request_openai_client(reason=reason, api_kwargs=api_kwargs)
+        request_client_holder["client"] = client
+        return client
+
+    try:
+        return _dispatch_nonstreaming_api_request(
+            agent, api_kwargs, make_client=_make_client
+        )
+    finally:
+        if request_client_holder["client"] is not None:
+            agent._close_request_openai_client(
+                request_client_holder["client"], reason="request_complete"
+            )
 
 
 def interruptible_api_call(agent, api_kwargs: dict):
@@ -319,6 +355,12 @@ def interruptible_api_call(agent, api_kwargs: dict):
     the main retry loop can try again with backoff / credential rotation /
     provider fallback.
     """
+    # Cron and other non-interactive, nested-pool contexts must not spawn the
+    # interrupt worker — it wedges before the socket opens on the 2nd+ call
+    # (#62151). Run inline instead. See should_use_direct_api_call.
+    if should_use_direct_api_call(agent):
+        return direct_api_call(agent, api_kwargs)
+
     result = {"response": None, "error": None}
 
     # Cross-turn stale-call circuit breaker (#58962) — non-streaming sibling
@@ -382,56 +424,19 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
     def _call():
         try:
-            if agent.api_mode == "codex_responses":
-                request_client = _set_request_client(
+            # _set_request_client registers each per-request OpenAI client with
+            # the stranger-thread abort machinery above; the shared dispatch
+            # helper builds it via this callback so the interrupt / stale-call
+            # detectors can force-close the worker's connection.
+            result["response"] = _dispatch_nonstreaming_api_request(
+                agent,
+                api_kwargs,
+                make_client=lambda reason: _set_request_client(
                     agent._create_request_openai_client(
-                        reason="codex_stream_request",
-                        api_kwargs=api_kwargs,
+                        reason=reason, api_kwargs=api_kwargs
                     )
-                )
-                result["response"] = agent._run_codex_stream(
-                    api_kwargs,
-                    client=request_client,
-                    on_first_delta=getattr(agent, "_codex_on_first_delta", None),
-                )
-            elif agent.api_mode == "anthropic_messages":
-                result["response"] = agent._anthropic_messages_create(api_kwargs)
-            elif agent.api_mode == "bedrock_converse":
-                # Bedrock uses boto3 directly — no OpenAI client needed.
-                # normalize_converse_response produces an OpenAI-compatible
-                # SimpleNamespace so the rest of the agent loop can treat
-                # bedrock responses like chat_completions responses.
-                from agent.bedrock_adapter import (
-                    _get_bedrock_runtime_client,
-                    invalidate_runtime_client,
-                    is_stale_connection_error,
-                    normalize_converse_response,
-                )
-                region = api_kwargs.pop("__bedrock_region__", "us-east-1")
-                api_kwargs.pop("__bedrock_converse__", None)
-                client = _get_bedrock_runtime_client(region)
-                try:
-                    raw_response = client.converse(**api_kwargs)
-                except Exception as _bedrock_exc:
-                    # Evict the cached client on stale-connection failures
-                    # so the outer retry loop builds a fresh client/pool.
-                    if is_stale_connection_error(_bedrock_exc):
-                        invalidate_runtime_client(region)
-                    raise
-                result["response"] = normalize_converse_response(raw_response)
-            elif agent.provider == "moa":
-                # MoA is a virtual chat-completions provider backed by the
-                # in-process MoAClient facade. Do not rebuild a request-local
-                # OpenAI client from the virtual runtime metadata.
-                result["response"] = agent.client.chat.completions.create(**api_kwargs)
-            else:
-                request_client = _set_request_client(
-                    agent._create_request_openai_client(
-                        reason="chat_completion_request",
-                        api_kwargs=api_kwargs,
-                    )
-                )
-                result["response"] = request_client.chat.completions.create(**api_kwargs)
+                ),
+            )
         except Exception as e:
             # If the request was cancelled by the main thread's interrupt
             # handler, the transport error is the expected consequence of our
@@ -1941,6 +1946,15 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     """
     if agent._interrupt_requested:
         raise InterruptedError("Agent interrupted before streaming API call")
+
+    # Cron and other non-interactive, nested-pool contexts deadlock on the
+    # spawned worker thread (#62151). They also have no stream consumer, so the
+    # deltas this path produces go nowhere. Delegate to the non-streaming entry
+    # (which runs inline via should_use_direct_api_call) exactly like the codex
+    # branch below — routing through the _interruptible_api_call method keeps the
+    # outer loop's per-request retry/refresh seam intact.
+    if should_use_direct_api_call(agent):
+        return agent._interruptible_api_call(api_kwargs)
 
     if agent.api_mode == "codex_responses":
         # Codex streams internally via _run_codex_stream. The main dispatch

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -236,6 +236,75 @@ def _check_stale_giveup(agent) -> None:
         )
 
 
+def should_use_direct_api_call(agent) -> bool:
+    """True when the non-streaming path should skip the interrupt worker thread.
+
+    Cron jobs run inside nested gateway thread pools (cron-scheduler →
+    cron-parallel → per-job pool → ``interruptible_api_call`` worker). That
+    extra daemon thread can wedge before HTTP on the 2nd+ API call of a
+    tool-using turn (#62151) while the same job succeeds via ``hermes cron
+    tick``. Cron has no interactive interrupt surface, so synchronous calls
+    on the conversation thread are safe and avoid the deadlock class.
+    """
+    return getattr(agent, "platform", None) == "cron"
+
+
+def _execute_nonstreaming_api_request(agent, api_kwargs: dict):
+    """Dispatch one non-streaming LLM request on the calling thread."""
+    request_client = None
+    try:
+        if agent.api_mode == "codex_responses":
+            request_client = agent._create_request_openai_client(
+                reason="codex_stream_request",
+                api_kwargs=api_kwargs,
+            )
+            return agent._run_codex_stream(
+                api_kwargs,
+                client=request_client,
+                on_first_delta=getattr(agent, "_codex_on_first_delta", None),
+            )
+        if agent.api_mode == "anthropic_messages":
+            return agent._anthropic_messages_create(api_kwargs)
+        if agent.api_mode == "bedrock_converse":
+            from agent.bedrock_adapter import (
+                _get_bedrock_runtime_client,
+                invalidate_runtime_client,
+                is_stale_connection_error,
+                normalize_converse_response,
+            )
+
+            region = api_kwargs.pop("__bedrock_region__", "us-east-1")
+            api_kwargs.pop("__bedrock_converse__", None)
+            client = _get_bedrock_runtime_client(region)
+            try:
+                raw_response = client.converse(**api_kwargs)
+            except Exception as bedrock_exc:
+                if is_stale_connection_error(bedrock_exc):
+                    invalidate_runtime_client(region)
+                raise
+            return normalize_converse_response(raw_response)
+
+        request_client = agent._create_request_openai_client(
+            reason="chat_completion_request",
+            api_kwargs=api_kwargs,
+        )
+        return request_client.chat.completions.create(**api_kwargs)
+    finally:
+        if request_client is not None:
+            agent._close_request_openai_client(
+                request_client, reason="request_complete"
+            )
+
+
+def direct_api_call(agent, api_kwargs: dict):
+    """Run a non-streaming API call synchronously on the conversation thread."""
+    _check_stale_giveup(agent)
+    agent._touch_activity("waiting for non-streaming API response")
+    response = _execute_nonstreaming_api_request(agent, api_kwargs)
+    _reset_stale_streak(agent)
+    return response
+
+
 def interruptible_api_call(agent, api_kwargs: dict):
     """
     Run the API call in a background thread so the main conversation loop

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -324,21 +324,43 @@ def direct_api_call(agent, api_kwargs: dict):
     _check_stale_giveup(agent)
     agent._touch_activity("waiting for non-streaming API response")
     request_client_holder = {"client": None}
+    request_client_lock = threading.Lock()
+
+    def _abort_active_request(reason: str) -> None:
+        """Abort the inline request from cron's watchdog/interrupt thread."""
+        with request_client_lock:
+            request_client = request_client_holder["client"]
+        if request_client is not None:
+            agent._abort_request_openai_client(request_client, reason=reason)
 
     def _make_client(reason: str):
         client = agent._create_request_openai_client(reason=reason, api_kwargs=api_kwargs)
-        request_client_holder["client"] = client
+        with request_client_lock:
+            request_client_holder["client"] = client
+        agent._active_request_abort = _abort_active_request
         return client
 
     try:
-        return _dispatch_nonstreaming_api_request(
+        response = _dispatch_nonstreaming_api_request(
             agent, api_kwargs, make_client=_make_client
         )
+    except Exception:
+        if getattr(agent, "_interrupt_requested", False):
+            raise InterruptedError("Agent interrupted during API call") from None
+        raise
+    else:
+        if getattr(agent, "_interrupt_requested", False):
+            raise InterruptedError("Agent interrupted during API call")
+        _reset_stale_streak(agent)
+        return response
     finally:
-        if request_client_holder["client"] is not None:
-            agent._close_request_openai_client(
-                request_client_holder["client"], reason="request_complete"
-            )
+        if getattr(agent, "_active_request_abort", None) is _abort_active_request:
+            agent._active_request_abort = None
+        with request_client_lock:
+            request_client = request_client_holder["client"]
+            request_client_holder["client"] = None
+        if request_client is not None:
+            agent._close_request_openai_client(request_client, reason="request_complete")
 
 
 def interruptible_api_call(agent, api_kwargs: dict):

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -293,22 +293,18 @@ def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
 
 
 def should_use_direct_api_call(agent) -> bool:
-    """True when the LLM call must run inline instead of on the interrupt worker.
+    """Whether a cron OpenAI-wire request should skip the interrupt worker.
 
-    ``interruptible_api_call`` / ``interruptible_streaming_api_call`` run every
-    request on a spawned daemon worker so the conversation loop can poll for an
-    interactive interrupt during the blocking HTTP round-trip. Cron jobs execute
-    their turn inside the gateway's *nested* thread pools (cron-scheduler →
-    parallel/sequential pool → per-job pool → ``run_conversation``); stacking the
-    interrupt worker on top of that wedges before the socket even opens on the
-    2nd+ call of a tool-using turn (#62151), while the identical job runs fine
-    via ``hermes cron tick`` (foreground, no nested gateway pools). Cron has no
-    interactive interrupt surface — its only stop signal is the scheduler's
-    inactivity watchdog, which fires from the outer thread — so running inline
-    removes the deadlock class without giving anything up. This predicate is the
-    single extension point for any future non-interactive, nested-pool context.
+    Issue #62151 is specific to OpenRouter's chat-completions path inside the
+    gateway cron thread stack. Keep native/Codex/Bedrock/MoA transports on their
+    established workers: their cancellation and client ownership differ, and
+    the report provides no evidence that those paths share the pre-HTTP wedge.
     """
-    return getattr(agent, "platform", None) == "cron"
+    return (
+        getattr(agent, "platform", None) == "cron"
+        and getattr(agent, "api_mode", None) == "chat_completions"
+        and getattr(agent, "provider", None) != "moa"
+    )
 
 
 def direct_api_call(agent, api_kwargs: dict):

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -314,6 +314,7 @@ def _chat_messages_to_responses_input(
     messages: List[Dict[str, Any]],
     *,
     is_xai_responses: bool = False,
+    is_github_responses: bool = False,
     replay_encrypted_reasoning: bool = True,
     current_issuer_kind: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
@@ -337,6 +338,16 @@ def _chat_messages_to_responses_input(
     ``AIAgent._disable_codex_reasoning_replay`` which both strips cached
     items from the conversation history and threads ``replay_enabled=False``
     through this converter so subsequent turns send no reasoning items.
+
+    ``is_github_responses`` drops the ``id`` field from replayed
+    ``codex_message_items`` regardless of length. The Copilot backend
+    (api.githubcopilot.com/responses) binds these ids to a specific
+    backend "connection" — credential-pool rotation, a gateway restart,
+    or routine load-balancer churn between turns all invalidate it — and
+    rejects a stale id with HTTP 401 "input item ID does not belong to
+    this connection" even for short ids (see #32716). ``phase``/
+    ``status``/``content`` are still replayed; only ``id`` is unsafe to
+    reuse across a Copilot connection.
 
     ``current_issuer_kind`` enables a per-item cross-issuer guard. The
     Responses API's ``encrypted_content`` blob is decryptable only by the
@@ -470,7 +481,11 @@ def _chat_messages_to_responses_input(
                             "content": normalized_content_parts,
                         }
                         item_id = raw_item.get("id")
-                        if isinstance(item_id, str) and item_id.strip():
+                        if (
+                            not is_github_responses
+                            and isinstance(item_id, str)
+                            and item_id.strip()
+                        ):
                             stripped_id = item_id.strip()
                             if len(stripped_id) <= _MAX_RESPONSES_ITEM_ID_LENGTH:
                                 replay_item["id"] = stripped_id

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -288,6 +288,13 @@ _RESPONSES_BUILTIN_TOOL_TYPES = {
 
 _RESPONSE_MESSAGE_STATUSES = {"completed", "incomplete", "in_progress"}
 
+# The Responses API rejects input[].id longer than this with a non-retryable
+# HTTP 400 ("string too long"). Codex-issued assistant message ids are
+# server-assigned base64 blobs that can run 400+ chars, while Hermes-minted
+# ids (msg_...) stay well under this cap and are worth keeping for
+# prefix-cache hits. Drop only the oversized ones on replay.
+_MAX_RESPONSES_ITEM_ID_LENGTH = 64
+
 
 def _normalize_responses_message_status(value: Any, *, default: str = "completed") -> str:
     """Normalize a Responses assistant message status for replay.
@@ -464,7 +471,9 @@ def _chat_messages_to_responses_input(
                         }
                         item_id = raw_item.get("id")
                         if isinstance(item_id, str) and item_id.strip():
-                            replay_item["id"] = item_id.strip()
+                            stripped_id = item_id.strip()
+                            if len(stripped_id) <= _MAX_RESPONSES_ITEM_ID_LENGTH:
+                                replay_item["id"] = stripped_id
                         phase = raw_item.get("phase")
                         if isinstance(phase, str) and phase.strip():
                             replay_item["phase"] = phase.strip()
@@ -718,7 +727,9 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
             }
             item_id = item.get("id")
             if isinstance(item_id, str) and item_id.strip():
-                normalized_item["id"] = item_id.strip()
+                stripped_id = item_id.strip()
+                if len(stripped_id) <= _MAX_RESPONSES_ITEM_ID_LENGTH:
+                    normalized_item["id"] = stripped_id
             phase = item.get("phase")
             if isinstance(phase, str) and phase.strip():
                 normalized_item["phase"] = phase.strip()

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -600,7 +600,11 @@ def _chat_messages_to_responses_input(
 # Input preflight / validation
 # ---------------------------------------------------------------------------
 
-def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
+def _preflight_codex_input_items(
+    raw_items: Any,
+    *,
+    is_github_responses: bool = False,
+) -> List[Dict[str, Any]]:
     if not isinstance(raw_items, list):
         raise ValueError("Codex Responses input must be a list of input items.")
 
@@ -741,7 +745,11 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
                 "content": normalized_content,
             }
             item_id = item.get("id")
-            if isinstance(item_id, str) and item_id.strip():
+            if (
+                not is_github_responses
+                and isinstance(item_id, str)
+                and item_id.strip()
+            ):
                 stripped_id = item_id.strip()
                 if len(stripped_id) <= _MAX_RESPONSES_ITEM_ID_LENGTH:
                     normalized_item["id"] = stripped_id
@@ -816,6 +824,7 @@ def _preflight_codex_api_kwargs(
     api_kwargs: Any,
     *,
     allow_stream: bool = False,
+    is_github_responses: bool = False,
 ) -> Dict[str, Any]:
     if not isinstance(api_kwargs, dict):
         raise ValueError("Codex Responses request must be a dict.")
@@ -837,7 +846,10 @@ def _preflight_codex_api_kwargs(
         instructions = str(instructions)
     instructions = instructions.strip() or DEFAULT_AGENT_IDENTITY
 
-    normalized_input = _preflight_codex_input_items(api_kwargs.get("input"))
+    normalized_input = _preflight_codex_input_items(
+        api_kwargs.get("input"),
+        is_github_responses=is_github_responses,
+    )
 
     tools = api_kwargs.get("tools")
     normalized_tools = None

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1318,6 +1318,13 @@ def run_conversation(
                         return agent._interruptible_streaming_api_call(
                             next_api_kwargs, on_first_delta=_stop_spinner
                         )
+                    from agent.chat_completion_helpers import (
+                        direct_api_call,
+                        should_use_direct_api_call,
+                    )
+
+                    if should_use_direct_api_call(agent):
+                        return direct_api_call(agent, next_api_kwargs)
                     return agent._interruptible_api_call(next_api_kwargs)
 
                 from hermes_cli.middleware import run_llm_execution_middleware

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1167,7 +1167,11 @@ def run_conversation(
                 if agent._force_ascii_payload:
                     _sanitize_structure_non_ascii(api_kwargs)
                 if agent.api_mode == "codex_responses":
-                    api_kwargs = agent._get_transport().preflight_kwargs(api_kwargs, allow_stream=False)
+                    api_kwargs = agent._get_transport().preflight_kwargs(
+                        api_kwargs,
+                        allow_stream=False,
+                        is_github_responses=agent._is_copilot_url(),
+                    )
                 # Copilot x-initiator: the first API call of a user turn is
                 # marked "user" so Copilot bills a premium request; tool-loop
                 # follow-ups keep the default "agent" header (#3040).
@@ -1314,6 +1318,12 @@ def run_conversation(
                         _use_streaming = False
 
                 def _perform_api_call(next_api_kwargs):
+                    if agent.api_mode == "codex_responses":
+                        next_api_kwargs = agent._get_transport().preflight_kwargs(
+                            next_api_kwargs,
+                            allow_stream=False,
+                            is_github_responses=agent._is_copilot_url(),
+                        )
                     if _use_streaming:
                         return agent._interruptible_streaming_api_call(
                             next_api_kwargs, on_first_delta=_stop_spinner

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1318,13 +1318,6 @@ def run_conversation(
                         return agent._interruptible_streaming_api_call(
                             next_api_kwargs, on_first_delta=_stop_spinner
                         )
-                    from agent.chat_completion_helpers import (
-                        direct_api_call,
-                        should_use_direct_api_call,
-                    )
-
-                    if should_use_direct_api_call(agent):
-                        return direct_api_call(agent, next_api_kwargs)
                     return agent._interruptible_api_call(next_api_kwargs)
 
                 from hermes_cli.middleware import run_llm_execution_middleware

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1147,6 +1147,7 @@ def _classify_400(
             "encrypted content for item" in error_msg
             and "could not be verified" in error_msg
         )
+        or "could not decrypt the provided encrypted_content" in error_msg
     ):
         return result_fn(
             FailoverReason.invalid_encrypted_content,

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -440,13 +440,23 @@ class ResponsesApiTransport(ProviderTransport):
             return False
         return True
 
-    def preflight_kwargs(self, api_kwargs: Any, *, allow_stream: bool = False) -> dict:
+    def preflight_kwargs(
+        self,
+        api_kwargs: Any,
+        *,
+        allow_stream: bool = False,
+        is_github_responses: bool = False,
+    ) -> dict:
         """Validate and sanitize Codex API kwargs before the call.
 
         Normalizes input items, strips unsupported fields, validates structure.
         """
         from agent.codex_responses_adapter import _preflight_codex_api_kwargs
-        return _preflight_codex_api_kwargs(api_kwargs, allow_stream=allow_stream)
+        return _preflight_codex_api_kwargs(
+            api_kwargs,
+            allow_stream=allow_stream,
+            is_github_responses=is_github_responses,
+        )
 
     def map_finish_reason(self, raw_reason: str) -> str:
         """Map Codex response.status to OpenAI finish_reason.

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -81,6 +81,7 @@ class ResponsesApiTransport(ProviderTransport):
         return _chat_messages_to_responses_input(
             messages,
             is_xai_responses=bool(kwargs.get("is_xai_responses")),
+            is_github_responses=bool(kwargs.get("is_github_responses")),
             replay_encrypted_reasoning=bool(
                 kwargs.get("replay_encrypted_reasoning", True)
             ),
@@ -239,6 +240,7 @@ class ResponsesApiTransport(ProviderTransport):
             "input": _chat_messages_to_responses_input(
                 payload_messages,
                 is_xai_responses=is_xai_responses,
+                is_github_responses=is_github_responses,
                 replay_encrypted_reasoning=replay_encrypted_reasoning,
                 current_issuer_kind=issuer_kind,
             ),

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -67,9 +67,9 @@ class ResponsesApiTransport(ProviderTransport):
         """Classify the current Responses endpoint from transport params."""
         from agent.codex_responses_adapter import _classify_responses_issuer
         return _classify_responses_issuer(
-            is_xai_responses=bool(params.get("is_xai_responses")),
-            is_github_responses=bool(params.get("is_github_responses")),
-            is_codex_backend=bool(params.get("is_codex_backend")),
+            is_xai_responses=params.get("is_xai_responses") is True,
+            is_github_responses=params.get("is_github_responses") is True,
+            is_codex_backend=params.get("is_codex_backend") is True,
             base_url=params.get("base_url"),
         )
 
@@ -80,8 +80,8 @@ class ResponsesApiTransport(ProviderTransport):
         self._last_issuer_kind = issuer
         return _chat_messages_to_responses_input(
             messages,
-            is_xai_responses=bool(kwargs.get("is_xai_responses")),
-            is_github_responses=bool(kwargs.get("is_github_responses")),
+            is_xai_responses=kwargs.get("is_xai_responses") is True,
+            is_github_responses=kwargs.get("is_github_responses") is True,
             replay_encrypted_reasoning=bool(
                 kwargs.get("replay_encrypted_reasoning", True)
             ),
@@ -138,9 +138,9 @@ class ResponsesApiTransport(ProviderTransport):
         if not instructions:
             instructions = DEFAULT_AGENT_IDENTITY
 
-        is_github_responses = params.get("is_github_responses", False)
-        is_codex_backend = params.get("is_codex_backend", False)
-        is_xai_responses = params.get("is_xai_responses", False)
+        is_github_responses = params.get("is_github_responses") is True
+        is_codex_backend = params.get("is_codex_backend") is True
+        is_xai_responses = params.get("is_xai_responses") is True
         replay_encrypted_reasoning = bool(
             params.get("replay_encrypted_reasoning", True)
         )

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -67,6 +67,8 @@ npm run dev          # Vite renderer + Electron, which boots the Python backend
 Point the app at a specific source checkout, or sandbox it away from your real config:
 
 ```bash
+# throwaway HERMES_HOME, separate Electron userData, distinct app name to avoid the single-instance lock
+../scripts/dev-sandbox.sh npm run dev
 HERMES_DESKTOP_HERMES_ROOT=/path/to/clone npm run dev
 HERMES_HOME=/tmp/throwaway npm run dev
 npm run dev:fake-boot   # exercise the startup overlay with deterministic delays

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -424,7 +424,7 @@ const BOOT_FAKE_STEP_MS = (() => {
   return Math.max(120, raw)
 })()
 
-const APP_NAME = 'Hermes'
+const APP_NAME = process.env.HERMES_DESKTOP_APP_NAME || 'Hermes'
 const TITLEBAR_HEIGHT = 34
 const MACOS_TRAFFIC_LIGHTS_HEIGHT = 14
 

--- a/apps/desktop/electron/update-relaunch.test.ts
+++ b/apps/desktop/electron/update-relaunch.test.ts
@@ -162,6 +162,7 @@ test('collectRelaunchEnv preserves HERMES_HOME + HERMES_DESKTOP_* + sandbox opt-
     HERMES_DESKTOP_REMOTE_URL: 'http://box:9119',
     HERMES_DESKTOP_REMOTE_TOKEN: 'secret',
     HERMES_DESKTOP_HERMES_ROOT: '/home/u/dev/hermes',
+    HERMES_DESKTOP_APP_NAME: 'HermesSandbox',
     ELECTRON_DISABLE_SANDBOX: '1', // sandbox opt-out — preserved
     PATH: '/usr/bin', // not preserved
     HOME: '/home/u', // not preserved
@@ -173,6 +174,7 @@ test('collectRelaunchEnv preserves HERMES_HOME + HERMES_DESKTOP_* + sandbox opt-
     HERMES_DESKTOP_REMOTE_URL: 'http://box:9119',
     HERMES_DESKTOP_REMOTE_TOKEN: 'secret',
     HERMES_DESKTOP_HERMES_ROOT: '/home/u/dev/hermes',
+    HERMES_DESKTOP_APP_NAME: 'HermesSandbox',
     ELECTRON_DISABLE_SANDBOX: '1'
   })
   assert.deepEqual(collectRelaunchEnv(null), {})

--- a/apps/desktop/src/app/chat/composer/composer-utils.test.ts
+++ b/apps/desktop/src/app/chat/composer/composer-utils.test.ts
@@ -1,7 +1,14 @@
 import type { Unstable_TriggerItem } from '@assistant-ui/core'
 import { describe, expect, it } from 'vitest'
 
-import { pickPlaceholder, slashArgStage, slashChipKindForItem, slashCommandToken } from './composer-utils'
+import {
+  isPendingDraftPersistCurrent,
+  type PendingDraftPersist,
+  pickPlaceholder,
+  slashArgStage,
+  slashChipKindForItem,
+  slashCommandToken
+} from './composer-utils'
 
 const item = (group: string): Unstable_TriggerItem =>
   ({ id: 'x', type: 'slash', label: 'x', metadata: { group } }) as unknown as Unstable_TriggerItem
@@ -36,5 +43,38 @@ describe('pickPlaceholder', () => {
   it('returns a member of the pool', () => {
     const pool = ['a', 'b', 'c'] as const
     expect(pool).toContain(pickPlaceholder(pool))
+  })
+})
+
+describe('isPendingDraftPersistCurrent (#54527 integrity guard)', () => {
+  it('accepts a write when the pending entry still matches what was captured', () => {
+    const entry: PendingDraftPersist = { scope: 'session-a', text: 'hello' }
+
+    expect(isPendingDraftPersistCurrent(entry, entry)).toBe(true)
+    expect(isPendingDraftPersistCurrent({ scope: 'session-a', text: 'hello' }, entry)).toBe(true)
+  })
+
+  it('rejects when the pending slot was cleared (session swap / newer flush already committed)', () => {
+    const entry: PendingDraftPersist = { scope: 'session-a', text: 'hello' }
+
+    expect(isPendingDraftPersistCurrent(null, entry)).toBe(false)
+  })
+
+  it('rejects when the pending slot now belongs to a different session (the #54527 misroute shape)', () => {
+    const captured: PendingDraftPersist = { scope: 'session-a', text: 'carefully composed prompt' }
+    const supersededBy: PendingDraftPersist = { scope: 'session-b', text: 'different draft' }
+
+    expect(isPendingDraftPersistCurrent(supersededBy, captured)).toBe(false)
+  })
+
+  it('rejects when the pending slot was replaced by a newer keystroke in the same session', () => {
+    const captured: PendingDraftPersist = { scope: 'session-a', text: 'first draft' }
+    const supersededBy: PendingDraftPersist = { scope: 'session-a', text: 'first draft continued' }
+
+    expect(isPendingDraftPersistCurrent(supersededBy, captured)).toBe(false)
+  })
+
+  it('rejects when nothing was ever captured', () => {
+    expect(isPendingDraftPersistCurrent(null, null)).toBe(false)
   })
 })

--- a/apps/desktop/src/app/chat/composer/composer-utils.ts
+++ b/apps/desktop/src/app/chat/composer/composer-utils.ts
@@ -58,3 +58,28 @@ export interface QueueEditState {
 }
 
 export const cloneAttachments = (attachments: ComposerAttachment[]) => attachments.map(a => ({ ...a }))
+
+export interface PendingDraftPersist {
+  scope: string | null
+  text: string
+}
+
+/**
+ * Defense-in-depth for #54527: the debounce timer and the `pagehide` flush
+ * both write a captured `{ scope, text }` pair some time after it was
+ * scheduled. Before either commits the write, this checks the pair is still
+ * the one currently on file — i.e. nothing cleared or replaced it in the
+ * meantime (a session swap, a newer keystroke). The scope-capture fix
+ * upstream (`draftScopeRef`) already makes every captured pair correct by
+ * construction; this guard exists so that if a future change reintroduces a
+ * stale/live-ref read at one of these call sites, the write is dropped
+ * instead of silently filing one session's text under another session's key.
+ */
+export function isPendingDraftPersistCurrent(
+  pending: PendingDraftPersist | null,
+  expected: PendingDraftPersist | null
+): boolean {
+  return (
+    pending !== null && expected !== null && pending.scope === expected.scope && pending.text === expected.text
+  )
+}

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
@@ -5,7 +5,12 @@ import { SLASH_COMMAND_RE } from '@/lib/chat-runtime'
 import { $composerAttachments, type ComposerAttachment, stashSessionDraft, takeSessionDraft } from '@/store/composer'
 import { isBrowsingHistory } from '@/store/composer-input-history'
 
-import { cloneAttachments, DRAFT_PERSIST_DEBOUNCE_MS, type QueueEditState } from '../composer-utils'
+import {
+  cloneAttachments,
+  DRAFT_PERSIST_DEBOUNCE_MS,
+  isPendingDraftPersistCurrent,
+  type QueueEditState
+} from '../composer-utils'
 import {
   type ComposerInsertMode,
   focusComposerInput,
@@ -77,6 +82,13 @@ export function useComposerDraft({
   const draftPersistTimerRef = useRef<number | undefined>(undefined)
   const activeQueueSessionKeyRef = useRef(activeQueueSessionKey)
   activeQueueSessionKeyRef.current = activeQueueSessionKey
+  // Owned only by the swap effect below — unlike activeQueueSessionKeyRef this
+  // does NOT update on every render, so it always reflects the session whose
+  // text is actually loaded in the editor. Async work (debounce timers,
+  // pagehide flush) must persist against this, not the render-time ref, or a
+  // session switch mid-flight files one session's draft under another's key
+  // (#54527).
+  const draftScopeRef = useRef(activeQueueSessionKey)
   const sessionIdRef = useRef(sessionId)
   sessionIdRef.current = sessionId
   const queueEditStateRef = useRef<QueueEditState | null>(queueEditRef.current)
@@ -222,10 +234,20 @@ export function useComposerDraft({
         return
       }
 
-      const scope = activeQueueSessionKeyRef.current
-      pendingDraftPersistRef.current = { scope, text }
+      const scope = draftScopeRef.current
+      const entry = { scope, text }
+      pendingDraftPersistRef.current = entry
       window.clearTimeout(draftPersistTimerRef.current)
       draftPersistTimerRef.current = window.setTimeout(() => {
+        // Integrity guard (defense-in-depth, #54527): only commit if this is
+        // still the pending write on file. A session swap or a newer
+        // keystroke clears/replaces it before firing in the normal case; this
+        // catches any future call site that skips that bookkeeping instead of
+        // silently filing text under the wrong session.
+        if (!isPendingDraftPersistCurrent(pendingDraftPersistRef.current, entry)) {
+          return
+        }
+
         pendingDraftPersistRef.current = null
         stashAt(scope, text)
       }, DRAFT_PERSIST_DEBOUNCE_MS)
@@ -285,6 +307,14 @@ export function useComposerDraft({
   // never clears composer state; this effect alone stashes on leave, restores
   // on enter. Keyed writes are idempotent, so no skip-sentinel.
   useEffect(() => {
+    // A pending debounce timer from the outgoing session is now stale — its
+    // scope was correct when scheduled, but the authoritative stash below
+    // (and the cleanup on the way out) already covers that text. Letting it
+    // fire later would just clobber with an older snapshot.
+    window.clearTimeout(draftPersistTimerRef.current)
+    pendingDraftPersistRef.current = null
+    draftScopeRef.current = activeQueueSessionKey
+
     const { attachments, text } = takeSessionDraft(activeQueueSessionKey)
     loadIntoComposer(text, attachments)
 
@@ -304,7 +334,7 @@ export function useComposerDraft({
   // inside the debounce/rAF window would drop trailing keystrokes without this.
   useEffect(() => {
     const flushPendingDraftPersist = () => {
-      const scope = activeQueueSessionKeyRef.current
+      const scope = draftScopeRef.current
       const editing = queueEditStateRef.current
 
       if (editing?.sessionKey === scope || isBrowsingHistory(sessionIdRef.current)) {

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -79,7 +79,11 @@ export function useComposerSubmit({
 
     const restore = () => {
       loadIntoComposer(text, submittedAttachments)
-      stashAt(activeQueueSessionKeyRef.current, text, submittedAttachments)
+      // Use the scope captured at dispatch, not whatever session is focused
+      // now — the gateway can reject well after the user has switched away,
+      // and re-stashing into the currently-focused session would overwrite
+      // its draft with the rejected text from a different session (#54527).
+      stashAt(submittedScope, text, submittedAttachments)
     }
 
     void Promise.resolve(attachments ? onSubmit(text, { attachments }) : onSubmit(text))

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -812,6 +812,7 @@ export function DesktopController() {
     branchCurrentSession: branchInNewChat,
     busyRef,
     createBackendSessionForSend,
+    getRouteToken,
     handleSkinCommand,
     openMemoryGraph: openStarmap,
     refreshSessions,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -51,7 +51,9 @@ interface HarnessHandle {
 }
 
 function Harness({
+  activeSessionIdRef: activeSessionIdRefProp,
   busyRef,
+  getRouteToken,
   onReady,
   onSeedState,
   openMemoryGraph,
@@ -59,11 +61,14 @@ function Harness({
   requestGateway,
   resumeStoredSession,
   seedMessages,
+  selectedStoredSessionIdRef: selectedStoredSessionIdRefProp,
   storedSessionId,
   activeSessionId,
   createBackendSessionForSend
 }: {
+  activeSessionIdRef?: MutableRefObject<string | null>
   busyRef?: MutableRefObject<boolean>
+  getRouteToken?: () => string
   onReady: (handle: HarnessHandle) => void
   onSeedState?: (state: Record<string, unknown>) => void
   openMemoryGraph?: () => void
@@ -71,15 +76,16 @@ function Harness({
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
   resumeStoredSession?: (storedSessionId: string) => Promise<void> | void
   seedMessages?: unknown[]
+  selectedStoredSessionIdRef?: MutableRefObject<string | null>
   storedSessionId?: null | string
   activeSessionId?: null | string
   createBackendSessionForSend?: () => Promise<null | string>
 }) {
-  const activeSessionIdRef: MutableRefObject<string | null> = {
+  const activeSessionIdRef: MutableRefObject<string | null> = activeSessionIdRefProp ?? {
     current: activeSessionId === undefined ? RUNTIME_SESSION_ID : activeSessionId
   }
 
-  const selectedStoredSessionIdRef: MutableRefObject<string | null> = {
+  const selectedStoredSessionIdRef: MutableRefObject<string | null> = selectedStoredSessionIdRefProp ?? {
     current: storedSessionId === undefined ? RUNTIME_SESSION_ID : storedSessionId
   }
 
@@ -98,6 +104,7 @@ function Harness({
     branchCurrentSession: async () => true,
     busyRef: localBusyRef,
     createBackendSessionForSend: createBackendSessionForSend ?? (async () => RUNTIME_SESSION_ID),
+    getRouteToken: getRouteToken ?? (() => 'token'),
     handleSkinCommand: () => '',
     openMemoryGraph: openMemoryGraph ?? (() => undefined),
     refreshSessions,
@@ -1239,7 +1246,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
 
     expect(ok).toBe(true)
     expect(calls.map(c => c.method)).toEqual(['prompt.submit', 'session.resume', 'prompt.submit'])
-    expect(calls[1]?.params).toEqual({ session_id: STORED_SESSION_ID })
+    expect(calls[1]?.params).toEqual({ session_id: STORED_SESSION_ID, source: 'desktop' })
     expect(calls[2]?.params).toEqual({
       session_id: RECOVERED_SESSION_ID,
       text: 'message during starved loop'
@@ -1313,6 +1320,125 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(ok).toBe(true)
     expect(createBackendSessionForSend).toHaveBeenCalledTimes(1)
     expect(calls).not.toContain('session.resume')
+  })
+})
+
+describe('usePromptActions submit session-context isolation (#54527)', () => {
+  const STORED_SESSION_A = 'stored-project-a'
+  const STORED_SESSION_B = 'stored-project-b'
+  const RUNTIME_SESSION_B = 'rt-session-b-wrong'
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('aborts submit when the user switches sessions during session.resume (no misroute)', async () => {
+    // Exact #54527 failure: user submits in Session A while its runtime binding
+    // is gone; before resume returns they switch to Session B. Without a pinned
+    // context the resumed runtime id belongs to B and A's text lands in the
+    // wrong chat — permanently lost from A.
+    let releaseResume: () => void = () => {}
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: STORED_SESSION_A }
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'session.resume') {
+        await new Promise<void>(resolve => {
+          releaseResume = resolve
+        })
+
+        // Simulate the user switching to Session B while resume is in flight.
+        selectedStoredSessionIdRef.current = STORED_SESSION_B
+        activeSessionIdRef.current = RUNTIME_SESSION_B
+
+        return { session_id: RUNTIME_SESSION_B } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={STORED_SESSION_A}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    const submitting = handle!.submitText('carefully composed prompt for project A')
+    await waitFor(() => expect(calls.some(c => c.method === 'session.resume')).toBe(true))
+    releaseResume()
+
+    expect(await submitting).toBe(false)
+    expect(calls.some(c => c.method === 'prompt.submit')).toBe(false)
+    expect(calls.find(c => c.method === 'session.resume')?.params).toEqual({
+      session_id: STORED_SESSION_A
+    })
+  })
+
+  it('aborts recovery submit when the user switches sessions during timeout resume', async () => {
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    let submitAttempts = 0
+    let releaseResume: () => void = () => {}
+
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: STORED_SESSION_A }
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'prompt.submit') {
+        submitAttempts += 1
+
+        if (submitAttempts === 1) {
+          throw new Error('request timed out: prompt.submit')
+        }
+      }
+
+      if (method === 'session.resume') {
+        await new Promise<void>(resolve => {
+          releaseResume = resolve
+        })
+        selectedStoredSessionIdRef.current = STORED_SESSION_B
+
+        return { session_id: RUNTIME_SESSION_B } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={STORED_SESSION_A}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    const submitting = handle!.submitText('message that must not land in session B')
+    await waitFor(() => expect(calls.some(c => c.method === 'session.resume')).toBe(true))
+    releaseResume()
+
+    expect(await submitting).toBe(false)
+    expect(submitAttempts).toBe(1)
+    expect(calls.filter(c => c.method === 'prompt.submit')).toHaveLength(1)
+    expect(calls.find(c => c.method === 'session.resume')?.params).toMatchObject({
+      session_id: STORED_SESSION_A
+    })
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -158,6 +158,7 @@ interface PromptActionsOptions {
   busyRef: MutableRefObject<boolean>
   branchCurrentSession: () => Promise<boolean>
   createBackendSessionForSend: (preview?: string | null) => Promise<string | null>
+  getRouteToken: () => string
   handleSkinCommand: (arg: string) => string
   openMemoryGraph: () => void
   refreshSessions: () => Promise<void>
@@ -186,6 +187,7 @@ export function usePromptActions({
   busyRef,
   branchCurrentSession,
   createBackendSessionForSend,
+  getRouteToken,
   handleSkinCommand,
   openMemoryGraph,
   refreshSessions,
@@ -354,6 +356,7 @@ export function usePromptActions({
     busyRef,
     copy,
     createBackendSessionForSend,
+    getRouteToken,
     requestGateway,
     selectedStoredSessionIdRef,
     syncAttachmentsForSubmit,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -35,6 +35,7 @@ interface SubmitPromptDeps {
   busyRef: MutableRefObject<boolean>
   copy: Translations['desktop']
   createBackendSessionForSend: (preview?: string | null) => Promise<string | null>
+  getRouteToken: () => string
   requestGateway: GatewayRequest
   selectedStoredSessionIdRef: MutableRefObject<string | null>
   syncAttachmentsForSubmit: (
@@ -57,6 +58,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
     busyRef,
     copy,
     createBackendSessionForSend,
+    getRouteToken,
     requestGateway,
     selectedStoredSessionIdRef,
     syncAttachmentsForSubmit,
@@ -113,9 +115,20 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         return false
       }
 
+      // Pin the session context for the whole async submit pipeline. Without
+      // this, a fast session switch during session.resume / file.attach can
+      // redirect the user's text into a different chat (#54527).
+      const startingActiveSessionId = activeSessionIdRef.current
+      const startingStoredSessionId = selectedStoredSessionIdRef.current
+      const startingRouteToken = getRouteToken()
+
+      const sessionContextDrifted = (): boolean =>
+        selectedStoredSessionIdRef.current !== startingStoredSessionId ||
+        getRouteToken() !== startingRouteToken
+
       // One submit in flight per session — drop any concurrent re-fire so a
       // stalled turn can't stack the same prompt into multiple real turns.
-      const submitLockKey = selectedStoredSessionIdRef.current || activeSessionId || '__pending_new__'
+      const submitLockKey = startingStoredSessionId || startingActiveSessionId || '__pending_new__'
 
       if (_submitInFlight.has(submitLockKey)) {
         return false
@@ -166,7 +179,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             // (what made drained-after-interrupt sends go silent).
             interrupted: false
           }),
-          selectedStoredSessionIdRef.current
+          startingStoredSessionId
         )
 
       // After sync rewrites refs, refresh the optimistic message in place so the
@@ -178,7 +191,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             ...state,
             messages: state.messages.map(message => (message.id === optimisticId ? buildUserMessage() : message))
           }),
-          selectedStoredSessionIdRef.current
+          startingStoredSessionId
         )
 
       const dropOptimistic = (sid: null | string) => {
@@ -197,8 +210,15 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             awaitingResponse: false,
             pendingBranchGroup: null
           }),
-          selectedStoredSessionIdRef.current
+          startingStoredSessionId
         )
+      }
+
+      const abortForSessionSwitch = (optimisticSessionId: null | string): false => {
+        dropOptimistic(optimisticSessionId)
+        releaseBusy()
+
+        return false
       }
 
       setMutableRef(busyRef, true)
@@ -214,7 +234,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         setMessages(current => [...current, buildUserMessage()])
       }
 
-      if (!sessionId && selectedStoredSessionIdRef.current) {
+      if (!sessionId && startingStoredSessionId) {
         // A stored session is SELECTED but its runtime binding is gone (the
         // live session was orphan-reaped, or a timeout/reconnect cleared
         // activeSessionId). Continuing the selected conversation must mean
@@ -224,8 +244,12 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         // new-chat draft).
         try {
           const resumed = await requestGateway<{ session_id: string }>('session.resume', {
-            session_id: selectedStoredSessionIdRef.current
+            session_id: startingStoredSessionId
           })
+
+          if (sessionContextDrifted()) {
+            return abortForSessionSwitch(sessionId)
+          }
 
           if (resumed?.session_id) {
             sessionId = resumed.session_id
@@ -235,6 +259,10 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           // Resume failed (session gone from state.db, gateway hiccup) —
           // fall through to creating a fresh session rather than dead-ending
           // the user's message.
+        }
+
+        if (sessionContextDrifted()) {
+          return abortForSessionSwitch(sessionId)
         }
 
         if (sessionId) {
@@ -253,6 +281,10 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           return false
         }
 
+        if (sessionContextDrifted()) {
+          return abortForSessionSwitch(sessionId)
+        }
+
         if (!sessionId) {
           dropOptimistic(null)
           releaseBusy()
@@ -268,6 +300,10 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         const syncedAttachments = await syncAttachmentsForSubmit(sessionId, attachments, {
           updateComposerAttachments: usingComposerAttachments
         })
+
+        if (sessionContextDrifted()) {
+          return abortForSessionSwitch(sessionId)
+        }
 
         // Rewrite the optimistic message + prompt text with the synced refs so
         // the gateway receives @file: paths that resolve in its workspace.
@@ -288,7 +324,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         } catch (firstErr) {
           if (
             (isSessionNotFoundError(firstErr) || isGatewayTimeoutError(firstErr)) &&
-            selectedStoredSessionIdRef.current
+            startingStoredSessionId
           ) {
             // Re-register the session in the gateway and get a fresh live ID.
             // Timeouts recover the same way as "session not found": a starved
@@ -296,9 +332,13 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             // the stored session is fine — resume + retry instead of erroring
             // out and losing the session binding.
             const resumed = await requestGateway<{ session_id: string }>('session.resume', {
-              session_id: selectedStoredSessionIdRef.current,
+              session_id: startingStoredSessionId,
               source: 'desktop'
             })
+
+            if (sessionContextDrifted()) {
+              return abortForSessionSwitch(sessionId)
+            }
 
             const recoveredId = resumed?.session_id
 
@@ -375,6 +415,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       busyRef,
       copy,
       createBackendSessionForSend,
+      getRouteToken,
       requestGateway,
       selectedStoredSessionIdRef,
       syncAttachmentsForSubmit,

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1623,7 +1623,7 @@ def claim_dispatch(job_id: str) -> bool:
         return True
 
 
-def heartbeat_run_claim(job_id: str) -> bool:
+def heartbeat_run_claim(job_id: str, *, expected_owner: str) -> bool:
     """Refresh a one-shot's ``run_claim`` timestamp while its run is alive.
 
     Called periodically from the scheduler's run monitor (#62002) so a
@@ -1632,16 +1632,22 @@ def heartbeat_run_claim(job_id: str) -> bool:
     nor this process's own next tick will re-dispatch or stale-remove the job
     while the run is in flight. mark_job_run() clears the claim on completion.
 
-    Returns True if a claim was refreshed; False when the job or its claim is
-    gone (nothing to refresh — e.g. a manual run that never stamped one).
+    ``expected_owner`` is the stable owner copied from the dispatched job. The
+    compare-and-refresh prevents a stale runner that resumes after a long sleep
+    from extending a claim another scheduler process has since taken over.
+
+    Returns True if this owner's one-shot claim was refreshed; False when the
+    job, claim, or ownership no longer matches.
     """
     with _jobs_lock():
         jobs = load_jobs()
         for job in jobs:
             if job.get("id") != job_id:
                 continue
+            if job.get("schedule", {}).get("kind") != "once":
+                return False
             claim = job.get("run_claim")
-            if not isinstance(claim, dict):
+            if not isinstance(claim, dict) or claim.get("by") != expected_owner:
                 return False
             claim["at"] = _hermes_now().isoformat()
             save_jobs(jobs)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3109,19 +3109,23 @@ def run_job(
         _is_oneshot = (
             isinstance(_job_schedule, dict) and _job_schedule.get("kind") == "once"
         )
+        _run_claim = job.get("run_claim")
+        _run_claim_owner = (
+            str(_run_claim.get("by") or "") if isinstance(_run_claim, dict) else ""
+        )
         _CLAIM_HEARTBEAT_SECONDS = 60.0
         _last_claim_heartbeat = time.monotonic()
 
         def _heartbeat_run_claim_if_due():
             nonlocal _last_claim_heartbeat
-            if not _is_oneshot:
+            if not _is_oneshot or not _run_claim_owner:
                 return
             _mono = time.monotonic()
             if _mono - _last_claim_heartbeat < _CLAIM_HEARTBEAT_SECONDS:
                 return
             _last_claim_heartbeat = _mono
             try:
-                heartbeat_run_claim(job_id)
+                heartbeat_run_claim(job_id, expected_owner=_run_claim_owner)
             except Exception:
                 logger.debug(
                     "Job '%s': run_claim heartbeat failed", job_name, exc_info=True

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -160,6 +160,10 @@ class GatewayStreamConsumer:
         # reply that was split across the platform's edit limit while streaming
         # doesn't leave stale fragments above the final message.
         self._preview_message_ids: "set[str]" = set()
+        # IDs from only the active text segment.  A tool boundary preserves
+        # the run-wide set for fresh-final bookkeeping, but a failure recovery
+        # must never delete an earlier finalized preamble/commentary message.
+        self._segment_preview_message_ids: "set[str]" = set()
         self._already_sent = False
         self._edit_supported = True  # Disabled when progressive edits are no longer usable
         self._last_edit_time = 0.0
@@ -173,6 +177,10 @@ class GatewayStreamConsumer:
         # Telegram overflow delivery.  In that case the already-visible prefix
         # is intentional content, not a stale preview to delete.
         self._fallback_preserve_partial_messages = False
+        # Keep fallback recovery responsive. Telegram's adapter already bounds
+        # edit retries at five seconds; a final-delivery fallback must not hold
+        # the stream task through a longer flood cooldown before retrying.
+        self._max_fallback_flood_retry_seconds = 5.0
         self._flood_strikes = 0         # Consecutive flood-control edit failures
         self._current_edit_interval = self.cfg.edit_interval  # Adaptive backoff
         self._final_response_sent = False
@@ -341,6 +349,7 @@ class GatewayStreamConsumer:
         self._fallback_final_send = False
         self._fallback_prefix = ""
         self._fallback_preserve_partial_messages = False
+        self._segment_preview_message_ids = set()
         # #29346: a tool/segment boundary means what we delivered was an interim
         # preamble, not the final answer — clear the flags so a premature setter
         # can't fool the gateway. Safe: got_done returns before any reset, and
@@ -1073,15 +1082,15 @@ class GatewayStreamConsumer:
                 )
                 if result.success:
                     break
-                if attempt == 0 and self._is_flood_error(result):
-                    delay = float(getattr(result, "retry_after", None) or 3.0)
+                retry_delay = self._fallback_flood_retry_delay(result)
+                if attempt == 0 and retry_delay is not None:
                     logger.debug(
                         "Flood control on fallback send, retrying in %.1fs",
-                        delay,
+                        retry_delay,
                     )
-                    await asyncio.sleep(delay)
+                    await asyncio.sleep(retry_delay)
                 else:
-                    break  # non-flood error or second attempt failed
+                    break  # non-flood error, long flood wait, or second failure
 
             if not result or not result.success:
                 if sent_any_chunk:
@@ -1151,7 +1160,10 @@ class GatewayStreamConsumer:
         gateway can safely retry, and ``ambiguous`` when a timeout may have
         reached the platform already.
         """
-        stale_ids = set(self._preview_message_ids)
+        # Tool/segment boundaries intentionally preserve the run-wide preview
+        # IDs for normal fresh-final cleanup.  This recovery replaces only the
+        # active final segment, so never delete an earlier finalized preamble.
+        stale_ids = set(self._segment_preview_message_ids)
         if self._message_id and self._message_id != "__no_edit__":
             stale_ids.add(str(self._message_id))
 
@@ -1173,13 +1185,13 @@ class GatewayStreamConsumer:
 
             if getattr(result, "success", False):
                 break
-            if attempt == 0 and self._is_flood_error(result):
-                delay = float(getattr(result, "retry_after", None) or 3.0)
+            retry_delay = self._fallback_flood_retry_delay(result)
+            if attempt == 0 and retry_delay is not None:
                 logger.debug(
                     "Flood control on empty fallback final send; retrying in %.1fs",
-                    delay,
+                    retry_delay,
                 )
-                await asyncio.sleep(delay)
+                await asyncio.sleep(retry_delay)
                 continue
             return (
                 "ambiguous"
@@ -1202,7 +1214,7 @@ class GatewayStreamConsumer:
                         exc,
                     )
 
-        self._preview_message_ids = set()
+        self._segment_preview_message_ids = set()
         self._message_id = new_message_id or "__no_edit__"
         self._already_sent = True
         self._final_response_sent = True
@@ -1221,6 +1233,22 @@ class GatewayStreamConsumer:
         error = str(getattr(result_or_exc, "error", None) or result_or_exc).lower()
         name = result_or_exc.__class__.__name__.lower()
         return "timeout" in error or "timed out" in error or "timeout" in name
+
+    def _fallback_flood_retry_delay(self, result: Any) -> float | None:
+        """Return a bounded retry delay for a fallback send, if safe to retry."""
+        if not self._is_flood_error(result):
+            return None
+        try:
+            delay = float(getattr(result, "retry_after", None) or 3.0)
+        except (TypeError, ValueError):
+            delay = 3.0
+        if delay > self._max_fallback_flood_retry_seconds:
+            logger.debug(
+                "Flood control requests %.1fs; leaving final delivery to the gateway",
+                delay,
+            )
+            return None
+        return max(0.0, delay)
 
     def _is_flood_error(self, result) -> bool:
         """Check if a SendResult failure is due to flood control / rate limiting."""
@@ -1441,9 +1469,11 @@ class GatewayStreamConsumer:
         return base
 
     def _track_preview_id(self, message_id: Optional[str]) -> None:
-        """Record a real preview message id for fresh-final cleanup."""
+        """Record a real preview message id for finalization cleanup."""
         if message_id and message_id != "__no_edit__":
-            self._preview_message_ids.add(str(message_id))
+            message_id = str(message_id)
+            self._preview_message_ids.add(message_id)
+            self._segment_preview_message_ids.add(message_id)
 
     def _track_preview_ids_from_result(self, result: Any) -> None:
         """Record every message id a send/edit result exposes: the primary id

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -982,6 +982,36 @@ class GatewayStreamConsumer:
         continuation = self._continuation_text(final_text)
         self._fallback_final_send = False
         if not continuation.strip():
+            # Some platforms treat a successful streaming preview as durable
+            # delivery. Telegram clients can instead lose or retain only part
+            # of that preview after a failed final edit, so opt-in adapters
+            # commit the completed answer with a fresh final send.
+            if (
+                final_text.strip()
+                and final_text == self._visible_prefix()
+                and getattr(
+                    self.adapter,
+                    "RESEND_FINAL_ON_EMPTY_STREAM_FALLBACK",
+                    False,
+                ) is True
+            ):
+                delivery = await self._send_empty_fallback_final(final_text)
+                if delivery == "delivered":
+                    return
+                self._already_sent = True
+                self._fallback_prefix = ""
+                self._fallback_preserve_partial_messages = False
+                if delivery == "ambiguous":
+                    # A timeout may mean Telegram accepted the send but the
+                    # client never received the response. Preserve duplicate
+                    # suppression for that one uncertain outcome.
+                    self._final_content_delivered = True
+                else:
+                    # A confirmed failure leaves the gateway free to perform
+                    # its normal final send.
+                    self._final_response_sent = False
+                    self._final_content_delivered = False
+                return
             # Nothing new to send — the visible partial already matches final text.
             # BUT: if final_text itself has meaningful content (e.g. a timeout
             # message after a long tool call), the prefix-based continuation
@@ -1044,10 +1074,12 @@ class GatewayStreamConsumer:
                 if result.success:
                     break
                 if attempt == 0 and self._is_flood_error(result):
+                    delay = float(getattr(result, "retry_after", None) or 3.0)
                     logger.debug(
-                        "Flood control on fallback send, retrying in 3s"
+                        "Flood control on fallback send, retrying in %.1fs",
+                        delay,
                     )
-                    await asyncio.sleep(3.0)
+                    await asyncio.sleep(delay)
                 else:
                     break  # non-flood error or second attempt failed
 
@@ -1111,6 +1143,84 @@ class GatewayStreamConsumer:
         self._last_sent_text = chunks[-1]
         self._fallback_prefix = ""
         self._fallback_preserve_partial_messages = False
+
+    async def _send_empty_fallback_final(self, final_text: str) -> str:
+        """Commit a completed answer after Telegram finalization fails.
+
+        Returns ``delivered`` on confirmed success, ``failed`` when the
+        gateway can safely retry, and ``ambiguous`` when a timeout may have
+        reached the platform already.
+        """
+        stale_ids = set(self._preview_message_ids)
+        if self._message_id and self._message_id != "__no_edit__":
+            stale_ids.add(str(self._message_id))
+
+        result = None
+        for attempt in range(2):
+            try:
+                result = await self.adapter.send(
+                    chat_id=self.chat_id,
+                    content=final_text,
+                    metadata=self._metadata_for_send(final=True),
+                )
+            except Exception as exc:
+                logger.debug("Empty fallback final send failed: %s", exc)
+                return (
+                    "ambiguous"
+                    if self._send_failure_may_have_delivered(exc)
+                    else "failed"
+                )
+
+            if getattr(result, "success", False):
+                break
+            if attempt == 0 and self._is_flood_error(result):
+                delay = float(getattr(result, "retry_after", None) or 3.0)
+                logger.debug(
+                    "Flood control on empty fallback final send; retrying in %.1fs",
+                    delay,
+                )
+                await asyncio.sleep(delay)
+                continue
+            return (
+                "ambiguous"
+                if self._send_failure_may_have_delivered(result)
+                else "failed"
+            )
+
+        new_message_id = getattr(result, "message_id", None)
+        delete_fn = getattr(self.adapter, "delete_message", None)
+        if delete_fn is not None:
+            for stale_id in stale_ids:
+                if not stale_id or stale_id == new_message_id:
+                    continue
+                try:
+                    await delete_fn(self.chat_id, stale_id)
+                except Exception as exc:
+                    logger.debug(
+                        "Empty fallback preview cleanup failed (%s): %s",
+                        stale_id,
+                        exc,
+                    )
+
+        self._preview_message_ids = set()
+        self._message_id = new_message_id or "__no_edit__"
+        self._already_sent = True
+        self._final_response_sent = True
+        self._final_content_delivered = True
+        self._last_sent_text = final_text
+        self._fallback_prefix = ""
+        self._fallback_preserve_partial_messages = False
+        self._notify_new_message()
+        return "delivered"
+
+    @staticmethod
+    def _send_failure_may_have_delivered(result_or_exc: Any) -> bool:
+        """Return True for timeout failures where retrying may duplicate."""
+        if getattr(result_or_exc, "retryable", None) is True:
+            return False
+        error = str(getattr(result_or_exc, "error", None) or result_or_exc).lower()
+        name = result_or_exc.__class__.__name__.lower()
+        return "timeout" in error or "timed out" in error or "timeout" in name
 
     def _is_flood_error(self, result) -> bool:
         """Check if a SendResult failure is due to flood control / rate limiting."""
@@ -1246,11 +1356,12 @@ class GatewayStreamConsumer:
         if not prefix or not prefix.strip():
             return
         try:
-            await self._edit_message(
+            result = await self._edit_message(
                 message_id=self._message_id,
                 content=prefix,
             )
-            self._last_sent_text = prefix
+            if getattr(result, "success", False):
+                self._last_sent_text = prefix
         except Exception:
             pass  # best-effort — don't let this block the fallback path
 
@@ -1665,6 +1776,7 @@ class GatewayStreamConsumer:
                         self._flood_strikes = 0
                         return True
                     else:
+                        immediate_final_fallback = False
                         if (
                             finalize
                             and is_turn_final
@@ -1726,12 +1838,30 @@ class GatewayStreamConsumer:
                                 self._MAX_FLOOD_STRIKES,
                                 self._current_edit_interval,
                             )
-                            if self._flood_strikes < self._MAX_FLOOD_STRIKES:
+                            immediate_final_fallback = (
+                                finalize
+                                and is_turn_final
+                                and getattr(
+                                    self.adapter,
+                                    "FALLBACK_ON_FINAL_EDIT_FLOOD",
+                                    False,
+                                ) is True
+                            )
+                            if (
+                                self._flood_strikes < self._MAX_FLOOD_STRIKES
+                                and not immediate_final_fallback
+                            ):
                                 # Don't disable edits yet — just slow down.
                                 # Update _last_edit_time so the next edit
                                 # respects the new interval.
                                 self._last_edit_time = time.monotonic()
                                 return False
+
+                            if immediate_final_fallback:
+                                logger.debug(
+                                    "Turn-final edit hit flood control; "
+                                    "entering fallback immediately"
+                                )
 
                         # Non-flood error OR flood strikes exhausted: enter
                         # fallback mode — send only the missing tail once the
@@ -1745,8 +1875,12 @@ class GatewayStreamConsumer:
                         self._edit_supported = False
                         self._already_sent = True
                         # Best-effort: strip the cursor from the last visible
-                        # message so the user doesn't see a stuck ▉.
-                        await self._try_strip_cursor()
+                        # message so the user doesn't see a stuck ▉. A
+                        # turn-final Telegram flood skips this cosmetic edit:
+                        # another edit would consume the same flood budget and
+                        # delay the fallback send that carries the answer.
+                        if not immediate_final_fallback:
+                            await self._try_strip_cursor()
                         return False
                 else:
                     # Editing not supported — skip intermediate updates.

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -271,12 +271,27 @@ def build_top_level_parser():
     chat_parser.add_argument(
         "--image", help="Optional local image path to attach to a single query"
     )
+    # `default=argparse.SUPPRESS` on flags that are ALSO declared on the
+    # top-level parser: when the user writes `hermes -m foo chat`, argparse
+    # first sets `args.model = "foo"` from the top-level parser, then
+    # dispatches to the chat subparser. Without SUPPRESS the chat subparser's
+    # own default (`None`) would silently clobber the top-level value because
+    # the subparser shares the same namespace and `dest`. SUPPRESS keeps the
+    # subparser action a no-op unless the user actually passes the flag after
+    # the subcommand. Matches the pattern already used for `-s/--skills` and
+    # the relaunch-inherited flags `-r/--resume`, `-c/--continue`,
+    # `-w/--worktree`, `--yolo`, etc. (see tests/hermes_cli/
+    # test_argparse_flag_propagation.py).
     _inherited_flag(
         chat_parser,
-        "-m", "--model", help="Model to use (e.g., anthropic/claude-sonnet-4)",
+        "-m", "--model",
+        default=argparse.SUPPRESS,
+        help="Model to use (e.g., anthropic/claude-sonnet-4)",
     )
     chat_parser.add_argument(
-        "-t", "--toolsets", help="Comma-separated toolsets to enable"
+        "-t", "--toolsets",
+        default=argparse.SUPPRESS,
+        help="Comma-separated toolsets to enable",
     )
     _inherited_flag(
         chat_parser,
@@ -293,7 +308,7 @@ def build_top_level_parser():
         # are also valid values, and runtime resolution (resolve_runtime_provider)
         # handles validation/error reporting consistently with the top-level
         # `--provider` flag.
-        default=None,
+        default=argparse.SUPPRESS,
         help="Inference provider (default: auto). Built-in or a user-defined name from `providers:` in config.yaml.",
     )
     chat_parser.add_argument(
@@ -401,14 +416,14 @@ def build_top_level_parser():
         chat_parser,
         "--tui",
         action="store_true",
-        default=False,
+        default=argparse.SUPPRESS,
         help="Launch the modern TUI instead of the classic REPL",
     )
     _inherited_flag(
         chat_parser,
         "--cli",
         action="store_true",
-        default=False,
+        default=argparse.SUPPRESS,
         help="Force the classic prompt_toolkit REPL (overrides display.interface=tui)",
     )
     _inherited_flag(
@@ -416,7 +431,7 @@ def build_top_level_parser():
         "--dev",
         dest="tui_dev",
         action="store_true",
-        default=False,
+        default=argparse.SUPPRESS,
         help="With --tui: run TypeScript sources via tsx (skip dist build)",
     )
 

--- a/hermes_cli/azure_detect.py
+++ b/hermes_cli/azure_detect.py
@@ -46,6 +46,8 @@ from urllib import request as urllib_request
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
 
+from hermes_cli.urllib_security import open_credentialed_url
+
 logger = logging.getLogger(__name__)
 
 
@@ -158,7 +160,7 @@ def _http_get_json(url: str,
     _apply_auth_headers(req, token, mode)
     req.add_header("User-Agent", "hermes-agent/azure-detect")
     try:
-        with urllib_request.urlopen(req, timeout=timeout) as resp:
+        with open_credentialed_url(req, timeout=timeout) as resp:
             body = resp.read()
             try:
                 return resp.status, json.loads(body.decode("utf-8", errors="replace"))
@@ -269,7 +271,7 @@ def _probe_anthropic_messages(base_url: str,
     req.add_header("content-type", "application/json")
     req.add_header("User-Agent", "hermes-agent/azure-detect")
     try:
-        with urllib_request.urlopen(req, timeout=6.0) as resp:
+        with open_credentialed_url(req, timeout=6.0) as resp:
             # Should never 200 — "probe" isn't a real deployment.  But
             # if it does, the endpoint definitely speaks Anthropic.
             return resp.status < 500

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -29,6 +29,40 @@ COPILOT_EDITOR_VERSION = "vscode/1.104.1"
 COPILOT_REASONING_EFFORTS_GPT5 = ["minimal", "low", "medium", "high"]
 COPILOT_REASONING_EFFORTS_O_SERIES = ["low", "medium", "high"]
 
+_CREDENTIAL_REDIRECT_HEADERS = {
+    "authorization",
+    "x-api-key",
+    "api-key",
+    "x-goog-api-key",
+    "cookie",
+}
+
+
+class _StripCredentialRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Drop credential headers when urllib follows redirects to another host."""
+
+    def __init__(self, original_host: str):
+        self._original_host = original_host
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        new_host = (urllib.parse.urlparse(newurl).hostname or "").lower()
+        if new_host and new_host != self._original_host:
+            clean_headers = {
+                name: value
+                for name, value in req.header_items()
+                if name.lower() not in _CREDENTIAL_REDIRECT_HEADERS
+            }
+            return urllib.request.Request(newurl, headers=clean_headers, method="GET")
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def _urlopen_model_catalog_request(req: urllib.request.Request, *, timeout: float):
+    if not any(name.lower() in _CREDENTIAL_REDIRECT_HEADERS for name, _ in req.header_items()):
+        return urllib.request.urlopen(req, timeout=timeout)
+    original_host = (urllib.parse.urlparse(req.full_url).hostname or "").lower()
+    opener = urllib.request.build_opener(_StripCredentialRedirectHandler(original_host))
+    return opener.open(req, timeout=timeout)
+
 
 # Fallback OpenRouter snapshot used when the live catalog is unavailable.
 # (model_id, display description shown in menus)
@@ -921,7 +955,7 @@ def fetch_nous_recommended_models(
             url,
             headers={"Accept": "application/json"},
         )
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
             data = json.loads(resp.read().decode())
         if not isinstance(data, dict):
             data = {}
@@ -1398,7 +1432,7 @@ def fetch_openrouter_models(
             "https://openrouter.ai/api/v1/models",
             headers={"Accept": "application/json"},
         )
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
             payload = json.loads(resp.read().decode())
     except Exception:
         return list(_openrouter_catalog_cache or fallback)
@@ -1519,7 +1553,7 @@ def fetch_models_with_pricing(
 
     try:
         req = urllib.request.Request(url, headers=headers)
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
             payload = json.loads(resp.read().decode())
     except Exception:
         _pricing_cache[cache_key] = {}
@@ -1633,7 +1667,7 @@ def _fetch_novita_pricing(
 
     try:
         req = urllib.request.Request(url, headers=headers)
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
             payload = json.loads(resp.read().decode())
     except Exception:
         _pricing_cache[cache_key] = {}
@@ -2747,7 +2781,7 @@ def _fetch_anthropic_models(
             _anthropic_models_url(base_url),
             headers=h,
         )
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
             return json.loads(resp.read().decode())
 
     try:
@@ -2862,7 +2896,7 @@ def fetch_github_model_catalog(
     for headers in attempts:
         req = urllib.request.Request(COPILOT_MODELS_URL, headers=headers)
         try:
-            with urllib.request.urlopen(req, timeout=timeout) as resp:
+            with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
                 data = json.loads(resp.read().decode())
                 items = _payload_items(data)
                 models: list[dict[str, Any]] = []
@@ -2979,7 +3013,7 @@ def _lmstudio_fetch_raw_models(
     headers = _lmstudio_request_headers(api_key)
     request = urllib.request.Request(server_root + "/api/v1/models", headers=headers)
     try:
-        with urllib.request.urlopen(request, timeout=timeout) as resp:
+        with _urlopen_model_catalog_request(request, timeout=timeout) as resp:
             payload = json.loads(resp.read().decode())
     except urllib.error.HTTPError as exc:
         if exc.code in {401, 403}:
@@ -3591,7 +3625,7 @@ def probe_api_models(
         tried.append(url)
         req = urllib.request.Request(url, headers=headers)
         try:
-            with urllib.request.urlopen(req, timeout=timeout) as resp:
+            with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
                 data = json.loads(resp.read().decode())
                 return {
                     "models": [m.get("id", "") for m in data.get("data", [])],

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, NamedTuple, Optional
 
 from hermes_cli import __version__ as _HERMES_VERSION
+from hermes_cli.urllib_security import open_credentialed_url
 
 # Identify ourselves so endpoints fronted by Cloudflare's Browser Integrity
 # Check (error 1010) don't reject the default ``Python-urllib/*`` signature.
@@ -29,43 +30,9 @@ COPILOT_EDITOR_VERSION = "vscode/1.104.1"
 COPILOT_REASONING_EFFORTS_GPT5 = ["minimal", "low", "medium", "high"]
 COPILOT_REASONING_EFFORTS_O_SERIES = ["low", "medium", "high"]
 
-_CREDENTIAL_REDIRECT_HEADERS = {
-    "authorization",
-    "x-api-key",
-    "api-key",
-    "x-goog-api-key",
-    "cookie",
-}
-
-_ORIGINAL_URLOPEN = urllib.request.urlopen
-
-
-class _StripCredentialRedirectHandler(urllib.request.HTTPRedirectHandler):
-    """Drop credential headers when urllib follows redirects to another host."""
-
-    def __init__(self, original_host: str):
-        self._original_host = original_host
-
-    def redirect_request(self, req, fp, code, msg, headers, newurl):
-        new_host = (urllib.parse.urlparse(newurl).hostname or "").lower()
-        if new_host and new_host != self._original_host:
-            clean_headers = {
-                name: value
-                for name, value in req.header_items()
-                if name.lower() not in _CREDENTIAL_REDIRECT_HEADERS
-            }
-            return urllib.request.Request(newurl, headers=clean_headers, method="GET")
-        return super().redirect_request(req, fp, code, msg, headers, newurl)
-
-
 def _urlopen_model_catalog_request(req: urllib.request.Request, *, timeout: float):
-    if urllib.request.urlopen is not _ORIGINAL_URLOPEN:
-        return urllib.request.urlopen(req, timeout=timeout)
-    if not any(name.lower() in _CREDENTIAL_REDIRECT_HEADERS for name, _ in req.header_items()):
-        return urllib.request.urlopen(req, timeout=timeout)
-    original_host = (urllib.parse.urlparse(req.full_url).hostname or "").lower()
-    opener = urllib.request.build_opener(_StripCredentialRedirectHandler(original_host))
-    return opener.open(req, timeout=timeout)
+    """Open catalog requests without forwarding headers across origins."""
+    return open_credentialed_url(req, timeout=timeout)
 
 
 # Fallback OpenRouter snapshot used when the live catalog is unavailable.
@@ -3154,15 +3121,13 @@ def ensure_lmstudio_model_loaded(
     load_headers = dict(headers)
     load_headers["Content-Type"] = "application/json"
     try:
-        with urllib.request.urlopen(
-            urllib.request.Request(
-                server_root + "/api/v1/models/load",
-                data=body,
-                headers=load_headers,
-                method="POST",
-            ),
-            timeout=timeout,
-        ) as resp:
+        load_request = urllib.request.Request(
+            server_root + "/api/v1/models/load",
+            data=body,
+            headers=load_headers,
+            method="POST",
+        )
+        with _urlopen_model_catalog_request(load_request, timeout=timeout) as resp:
             resp.read()
     except Exception:
         return None

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -37,6 +37,8 @@ _CREDENTIAL_REDIRECT_HEADERS = {
     "cookie",
 }
 
+_ORIGINAL_URLOPEN = urllib.request.urlopen
+
 
 class _StripCredentialRedirectHandler(urllib.request.HTTPRedirectHandler):
     """Drop credential headers when urllib follows redirects to another host."""
@@ -57,6 +59,8 @@ class _StripCredentialRedirectHandler(urllib.request.HTTPRedirectHandler):
 
 
 def _urlopen_model_catalog_request(req: urllib.request.Request, *, timeout: float):
+    if urllib.request.urlopen is not _ORIGINAL_URLOPEN:
+        return urllib.request.urlopen(req, timeout=timeout)
     if not any(name.lower() in _CREDENTIAL_REDIRECT_HEADERS for name, _ in req.header_items()):
         return urllib.request.urlopen(req, timeout=timeout)
     original_host = (urllib.parse.urlparse(req.full_url).hostname or "").lower()

--- a/hermes_cli/urllib_security.py
+++ b/hermes_cli/urllib_security.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import urllib.parse
 import urllib.request
 from collections.abc import Callable, Iterable
@@ -58,18 +59,38 @@ class SafeCredentialRedirectHandler(urllib.request.HTTPRedirectHandler):
         return redirected
 
 
+def _secure_opener_from_installed_policy(original_url: str):
+    """Clone the installed opener's handlers, replacing redirect policy only."""
+    installed = getattr(urllib.request, "_opener", None)
+    if installed is None:
+        installed = urllib.request.build_opener()
+
+    handlers = [
+        copy.copy(handler)
+        for handler in getattr(installed, "handlers", ())
+        if not isinstance(handler, urllib.request.HTTPRedirectHandler)
+    ]
+    handlers.append(SafeCredentialRedirectHandler(original_url))
+    return urllib.request.build_opener(*handlers)
+
+
 def open_credentialed_url(
     request: urllib.request.Request,
     *,
     timeout: float,
-    opener_factory: Callable[..., Any] = urllib.request.build_opener,
+    opener_factory: Callable[..., Any] | None = None,
 ):
     """Open a request without forwarding credentials across origins.
 
-    ``opener_factory`` is an explicit instrumentation/test seam. Security is
+    The default preserves an application-installed opener's proxy, TLS,
+    cookies, custom protocol handlers, and instrumentation while replacing its
+    redirect handler. ``opener_factory`` is an explicit test seam; security is
     never disabled based on global ``urlopen`` identity.
     """
-    opener = opener_factory(SafeCredentialRedirectHandler(request.full_url))
+    if opener_factory is None:
+        opener = _secure_opener_from_installed_policy(request.full_url)
+    else:
+        opener = opener_factory(SafeCredentialRedirectHandler(request.full_url))
     return opener.open(request, timeout=timeout)
 
 

--- a/hermes_cli/urllib_security.py
+++ b/hermes_cli/urllib_security.py
@@ -58,6 +58,28 @@ class SafeCredentialRedirectHandler(urllib.request.HTTPRedirectHandler):
         return redirected
 
 
+class _CrossOriginRequestSanitizer(urllib.request.BaseHandler):
+    """Strip headers after installed request processors have run."""
+
+    # Request processors run in ascending order. Keep this last so an installed
+    # cookie/auth/instrumentation processor cannot re-add a secret after the
+    # redirect handler sanitizes the new Request.
+    handler_order = 1_000_000_000
+
+    def __init__(self, original_url: str) -> None:
+        self._original_origin = url_origin(original_url)
+
+    def _sanitize(self, request: urllib.request.Request):
+        if url_origin(request.full_url) != self._original_origin:
+            for name, _value in list(request.header_items()):
+                if name.lower() not in _CROSS_ORIGIN_SAFE_HEADERS:
+                    request.remove_header(name)
+        return request
+
+    http_request = _sanitize
+    https_request = _sanitize
+
+
 def _secure_opener_from_installed_policy(original_url: str):
     """Clone the installed opener's handlers, replacing redirect policy only."""
     installed = getattr(urllib.request, "_opener", None)
@@ -70,8 +92,17 @@ def _secure_opener_from_installed_policy(original_url: str):
         if not isinstance(handler, urllib.request.HTTPRedirectHandler)
     ]
     handlers.append(SafeCredentialRedirectHandler(original_url))
+    handlers.append(_CrossOriginRequestSanitizer(original_url))
     secured = urllib.request.build_opener(*handlers)
-    secured.addheaders = list(getattr(installed, "addheaders", ()))
+    # OpenerDirector injects addheaders after request processors, which would
+    # bypass the sanitizer on redirects. Carry them on the initial request
+    # instead, then leave the rebuilt opener's late-injection list empty.
+    setattr(
+        secured,
+        "_hermes_initial_addheaders",
+        list(getattr(installed, "addheaders", ())),
+    )
+    secured.addheaders = []
     return secured
 
 
@@ -90,6 +121,9 @@ def open_credentialed_url(
     """
     if opener_factory is None:
         opener = _secure_opener_from_installed_policy(request.full_url)
+        for name, value in getattr(opener, "_hermes_initial_addheaders", ()):
+            if not request.has_header(name):
+                request.add_header(name, value)
     else:
         opener = opener_factory(SafeCredentialRedirectHandler(request.full_url))
     return opener.open(request, timeout=timeout)

--- a/hermes_cli/urllib_security.py
+++ b/hermes_cli/urllib_security.py
@@ -64,7 +64,10 @@ class _CrossOriginRequestSanitizer(urllib.request.BaseHandler):
     # Request processors run in ascending order. Keep this last so an installed
     # cookie/auth/instrumentation processor cannot re-add a secret after the
     # redirect handler sanitizes the new Request.
-    handler_order = 1_000_000_000
+    # Infinity is greater than every finite handler order. If an installed
+    # processor also uses infinity, stable sorting keeps this appended handler
+    # after it, so sanitization still owns the final request boundary.
+    handler_order = float("inf")  # type: ignore[assignment]
 
     def __init__(self, original_url: str) -> None:
         self._original_origin = url_origin(original_url)

--- a/hermes_cli/urllib_security.py
+++ b/hermes_cli/urllib_security.py
@@ -18,14 +18,13 @@ def url_origin(url: str) -> tuple[str, str, int | None]:
     """Return a normalized (scheme, hostname, effective port) origin."""
     parsed = urllib.parse.urlparse(url)
     scheme = (parsed.scheme or "").lower()
-    try:
-        port = parsed.port
-    except ValueError:
-        port = None
+    # Accessing ``parsed.port`` validates malformed/non-numeric ports. Let the
+    # ValueError fail the request closed instead of collapsing it to a default.
+    port = parsed.port
     return (
         scheme,
         (parsed.hostname or "").lower().rstrip("."),
-        port or _DEFAULT_PORTS.get(scheme),
+        port if port is not None else _DEFAULT_PORTS.get(scheme),
     )
 
 

--- a/hermes_cli/urllib_security.py
+++ b/hermes_cli/urllib_security.py
@@ -1,0 +1,80 @@
+"""Security policy for credential-bearing stdlib urllib requests."""
+
+from __future__ import annotations
+
+import urllib.parse
+import urllib.request
+from collections.abc import Callable, Iterable
+from typing import Any
+
+# Headers safe to forward to a different origin. Everything else is dropped:
+# custom provider headers routinely carry credentials under arbitrary names.
+_CROSS_ORIGIN_SAFE_HEADERS = frozenset({"accept", "user-agent"})
+_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+
+def url_origin(url: str) -> tuple[str, str, int | None]:
+    """Return a normalized (scheme, hostname, effective port) origin."""
+    parsed = urllib.parse.urlparse(url)
+    scheme = (parsed.scheme or "").lower()
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
+    return (
+        scheme,
+        (parsed.hostname or "").lower().rstrip("."),
+        port or _DEFAULT_PORTS.get(scheme),
+    )
+
+
+class SafeCredentialRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Preserve request headers only while redirects stay on one origin."""
+
+    def __init__(
+        self,
+        original_url: str,
+        *,
+        cross_origin_safe_headers: Iterable[str] = _CROSS_ORIGIN_SAFE_HEADERS,
+    ) -> None:
+        self._original_origin = url_origin(original_url)
+        self._cross_origin_safe_headers = frozenset(
+            str(name).lower() for name in cross_origin_safe_headers
+        )
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        # Let urllib enforce status/method semantics first (notably 307/308).
+        redirected = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if redirected is None:
+            return None
+
+        resolved_url = urllib.parse.urljoin(req.full_url, newurl)
+        if url_origin(resolved_url) != self._original_origin:
+            # Use an allowlist rather than guessing credential header names.
+            # normalize_extra_headers permits arbitrary secret-bearing names.
+            for name, _value in list(redirected.header_items()):
+                if name.lower() not in self._cross_origin_safe_headers:
+                    redirected.remove_header(name)
+        return redirected
+
+
+def open_credentialed_url(
+    request: urllib.request.Request,
+    *,
+    timeout: float,
+    opener_factory: Callable[..., Any] = urllib.request.build_opener,
+):
+    """Open a request without forwarding credentials across origins.
+
+    ``opener_factory`` is an explicit instrumentation/test seam. Security is
+    never disabled based on global ``urlopen`` identity.
+    """
+    opener = opener_factory(SafeCredentialRedirectHandler(request.full_url))
+    return opener.open(request, timeout=timeout)
+
+
+__all__ = [
+    "SafeCredentialRedirectHandler",
+    "open_credentialed_url",
+    "url_origin",
+]

--- a/hermes_cli/urllib_security.py
+++ b/hermes_cli/urllib_security.py
@@ -70,7 +70,9 @@ def _secure_opener_from_installed_policy(original_url: str):
         if not isinstance(handler, urllib.request.HTTPRedirectHandler)
     ]
     handlers.append(SafeCredentialRedirectHandler(original_url))
-    return urllib.request.build_opener(*handlers)
+    secured = urllib.request.build_opener(*handlers)
+    secured.addheaders = list(getattr(installed, "addheaders", ()))
+    return secured
 
 
 def open_credentialed_url(

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -32,6 +32,10 @@
               mkdir -p $out/bin
               install -Dm755 ${../hermes} $out/bin/hermes
             '')
+            (pkgs.runCommand "dev-sandbox" { } ''
+              mkdir -p $out/bin
+              install -Dm755 ${../scripts/dev-sandbox.sh} $out/bin/sandbox
+            '')
             uv
           ]
           ++ self'.packages.default.passthru.devDeps;
@@ -42,7 +46,7 @@
           # for the devshell to pick up the src
           export HERMES_PYTHON_SRC_ROOT=$(git rev-parse --show-toplevel)
           echo "Hermes Agent dev shell in $HERMES_PYTHON_SRC_ROOT"
-          echo "Ready. Run 'hermes' to start."
+          echo "Ready. Run 'hermes' or 'sandbox hermes' to start."
         '';
       };
     };

--- a/plugins/model-providers/anthropic/__init__.py
+++ b/plugins/model-providers/anthropic/__init__.py
@@ -4,6 +4,7 @@ import json
 import logging
 import urllib.request
 
+from hermes_cli.urllib_security import open_credentialed_url
 from providers import register_provider
 from providers.base import ProviderProfile
 
@@ -28,7 +29,7 @@ class AnthropicProfile(ProviderProfile):
             req.add_header("x-api-key", api_key)
             req.add_header("anthropic-version", "2023-06-01")
             req.add_header("Accept", "application/json")
-            with urllib.request.urlopen(req, timeout=timeout) as resp:
+            with open_credentialed_url(req, timeout=timeout) as resp:
                 data = json.loads(resp.read().decode())
             return [
                 m["id"]

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4075,7 +4075,11 @@ class TelegramAdapter(BasePlatformAdapter):
                     self.name, wait,
                 )
                 if wait > 5.0:
-                    return SendResult(success=False, error=f"flood_control:{wait}")
+                    return SendResult(
+                        success=False,
+                        error=f"flood_control:{wait}",
+                        retry_after=float(wait),
+                    )
                 await asyncio.sleep(wait)
                 try:
                     await self._bot.edit_message_text(

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -457,6 +457,14 @@ class TelegramAdapter(BasePlatformAdapter):
     # edit and the final edit, skipping the plain-text → MarkdownV2 conversion.
     # Fixes #25710.
     REQUIRES_EDIT_FINALIZE: bool = True
+    # Retrying a turn-final edit consumes more of the same Telegram flood
+    # budget while the completed answer remains undelivered. Move directly to
+    # the final fallback path instead.
+    FALLBACK_ON_FINAL_EDIT_FLOOD: bool = True
+    # A failed final edit can leave Telegram clients with only a partial or
+    # non-durable preview. Commit empty-tail fallbacks as a fresh final message
+    # instead of trusting the preview as completed delivery.
+    RESEND_FINAL_ON_EMPTY_STREAM_FALLBACK: bool = True
 
     # Adaptive text-batch ingress: short messages need a tighter delay so the
     # first token reaches the agent fast.  Numbers tuned for "feels instant":

--- a/providers/base.py
+++ b/providers/base.py
@@ -210,25 +210,32 @@ class ProviderProfile:
 
         # urllib keeps every header — including Authorization — when it
         # follows a redirect, so a catalog endpoint answering 3xx to a
-        # different host would receive the provider API key.  Drop
-        # credential headers on cross-host redirects.
+        # different origin would receive the provider API key.  Drop
+        # credential headers on cross-origin redirects.  Origin = scheme +
+        # hostname + effective port: a different port on the same host can
+        # be a different service, so it must not inherit credentials either.
         sensitive = {"authorization", "x-api-key", "api-key", "x-goog-api-key", "cookie"}
-        original_host = (urllib.parse.urlparse(url).hostname or "").lower()
 
-        class _StripAuthOnCrossHostRedirect(urllib.request.HTTPRedirectHandler):
+        def _origin(target_url: str) -> tuple:
+            parsed = urllib.parse.urlparse(target_url)
+            scheme = (parsed.scheme or "").lower()
+            port = parsed.port or {"http": 80, "https": 443}.get(scheme)
+            return scheme, (parsed.hostname or "").lower(), port
+
+        original_origin = _origin(url)
+
+        class _StripAuthOnCrossOriginRedirect(urllib.request.HTTPRedirectHandler):
             def redirect_request(self, redirected, fp, code, msg, hdrs, newurl):
                 new_req = super().redirect_request(
                     redirected, fp, code, msg, hdrs, newurl
                 )
-                if new_req is not None:
-                    new_host = (urllib.parse.urlparse(newurl).hostname or "").lower()
-                    if new_host != original_host:
-                        for header in list(new_req.headers):
-                            if header.lower() in sensitive:
-                                new_req.remove_header(header)
+                if new_req is not None and _origin(newurl) != original_origin:
+                    for header in list(new_req.headers):
+                        if header.lower() in sensitive:
+                            new_req.remove_header(header)
                 return new_req
 
-        opener = urllib.request.build_opener(_StripAuthOnCrossHostRedirect())
+        opener = urllib.request.build_opener(_StripAuthOnCrossOriginRedirect())
 
         try:
             with opener.open(req, timeout=timeout) as resp:

--- a/providers/base.py
+++ b/providers/base.py
@@ -194,6 +194,7 @@ class ProviderProfile:
             url = effective_base.rstrip("/") + "/models"
 
         import json
+        import urllib.parse
         import urllib.request
 
         req = urllib.request.Request(url)
@@ -207,8 +208,30 @@ class ProviderProfile:
         for k, v in self.default_headers.items():
             req.add_header(k, v)
 
+        # urllib keeps every header — including Authorization — when it
+        # follows a redirect, so a catalog endpoint answering 3xx to a
+        # different host would receive the provider API key.  Drop
+        # credential headers on cross-host redirects.
+        sensitive = {"authorization", "x-api-key", "api-key", "x-goog-api-key", "cookie"}
+        original_host = (urllib.parse.urlparse(url).hostname or "").lower()
+
+        class _StripAuthOnCrossHostRedirect(urllib.request.HTTPRedirectHandler):
+            def redirect_request(self, redirected, fp, code, msg, hdrs, newurl):
+                new_req = super().redirect_request(
+                    redirected, fp, code, msg, hdrs, newurl
+                )
+                if new_req is not None:
+                    new_host = (urllib.parse.urlparse(newurl).hostname or "").lower()
+                    if new_host != original_host:
+                        for header in list(new_req.headers):
+                            if header.lower() in sensitive:
+                                new_req.remove_header(header)
+                return new_req
+
+        opener = urllib.request.build_opener(_StripAuthOnCrossHostRedirect())
+
         try:
-            with urllib.request.urlopen(req, timeout=timeout) as resp:
+            with opener.open(req, timeout=timeout) as resp:
                 data = json.loads(resp.read().decode())
             items = data if isinstance(data, list) else data.get("data", [])
             return [m["id"] for m in items if isinstance(m, dict) and "id" in m]

--- a/providers/base.py
+++ b/providers/base.py
@@ -194,8 +194,9 @@ class ProviderProfile:
             url = effective_base.rstrip("/") + "/models"
 
         import json
-        import urllib.parse
         import urllib.request
+
+        from hermes_cli.urllib_security import open_credentialed_url
 
         req = urllib.request.Request(url)
         if api_key:
@@ -208,37 +209,8 @@ class ProviderProfile:
         for k, v in self.default_headers.items():
             req.add_header(k, v)
 
-        # urllib keeps every header — including Authorization — when it
-        # follows a redirect, so a catalog endpoint answering 3xx to a
-        # different origin would receive the provider API key.  Drop
-        # credential headers on cross-origin redirects.  Origin = scheme +
-        # hostname + effective port: a different port on the same host can
-        # be a different service, so it must not inherit credentials either.
-        sensitive = {"authorization", "x-api-key", "api-key", "x-goog-api-key", "cookie"}
-
-        def _origin(target_url: str) -> tuple:
-            parsed = urllib.parse.urlparse(target_url)
-            scheme = (parsed.scheme or "").lower()
-            port = parsed.port or {"http": 80, "https": 443}.get(scheme)
-            return scheme, (parsed.hostname or "").lower(), port
-
-        original_origin = _origin(url)
-
-        class _StripAuthOnCrossOriginRedirect(urllib.request.HTTPRedirectHandler):
-            def redirect_request(self, redirected, fp, code, msg, hdrs, newurl):
-                new_req = super().redirect_request(
-                    redirected, fp, code, msg, hdrs, newurl
-                )
-                if new_req is not None and _origin(newurl) != original_origin:
-                    for header in list(new_req.headers):
-                        if header.lower() in sensitive:
-                            new_req.remove_header(header)
-                return new_req
-
-        opener = urllib.request.build_opener(_StripAuthOnCrossOriginRedirect())
-
         try:
-            with opener.open(req, timeout=timeout) as resp:
+            with open_credentialed_url(req, timeout=timeout) as resp:
                 data = json.loads(resp.read().decode())
             items = data if isinstance(data, list) else data.get("data", [])
             return [m["id"] for m in items if isinstance(m, dict) and "id" in m]

--- a/run_agent.py
+++ b/run_agent.py
@@ -2674,6 +2674,16 @@ class AIAgent:
         """
         self._interrupt_requested = True
         self._interrupt_message = message
+        # A cron turn performs its API request on the conversation thread to
+        # avoid the nested interrupt-worker deadlock.  Unlike the normal worker
+        # path, its client is registered here so this cross-thread interrupt can
+        # still shut down the active sockets promptly.
+        _abort_active_request = getattr(self, "_active_request_abort", None)
+        if callable(_abort_active_request):
+            try:
+                _abort_active_request("interrupt_abort")
+            except Exception:
+                logger.debug("Failed to abort active inline request", exc_info=True)
         # Signal all tools to abort any in-flight operations immediately.
         # Scope the interrupt to this agent's execution thread so other
         # agents running in the same process (gateway) are not affected.

--- a/run_agent.py
+++ b/run_agent.py
@@ -3992,18 +3992,17 @@ class AIAgent:
         return create_openai_client(self, client_kwargs, reason=reason, shared=shared)
 
     @staticmethod
-    def _force_close_tcp_sockets(client: Any, *, release_fds: bool = False) -> int:
+    def _force_close_tcp_sockets(client: Any) -> int:
         """Forwarder — see ``agent.agent_runtime_helpers.force_close_tcp_sockets``."""
         from agent.agent_runtime_helpers import force_close_tcp_sockets
-        return force_close_tcp_sockets(client, release_fds=release_fds)
+        return force_close_tcp_sockets(client)
 
     def _close_openai_client(self, client: Any, *, reason: str, shared: bool) -> None:
         if client is None:
             return
-        # Owning-thread dispose: shutdown + release FDs so already-shutdown
-        # sockets don't linger in kernel CLOSED state (#61979). Cross-thread
-        # abort uses _abort_request_openai_client (release_fds=False) instead.
-        force_closed = self._force_close_tcp_sockets(client, release_fds=True)
+        # Force-close TCP sockets first to prevent CLOSE-WAIT accumulation,
+        # then do the graceful SDK-level close.
+        force_closed = self._force_close_tcp_sockets(client)
         try:
             client.close()
             logger.info(

--- a/scripts/dev-sandbox.sh
+++ b/scripts/dev-sandbox.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Run a Hermes instance in an isolated sandbox — separate HERMES_HOME,
+# separate Electron userData, and a distinct Desktop app name so it doesn't compete
+# with your main desktop instance's single-instance lock.
+#
+# By default the sandbox is throwaway: a temp dir is created and removed on
+# exit. Use --persistent to keep the sandbox across restarts (stored under
+# .hermes-sandbox/ in the worktree git root).
+#
+# Usage:
+#   scripts/dev-sandbox.sh python -m hermes_cli.main
+#   scripts/dev-sandbox.sh hermes desktop
+#   scripts/dev-sandbox.sh electron .
+#   scripts/dev-sandbox.sh -- npm run dev   # from apps/desktop/
+#   scripts/dev-sandbox.sh --persistent hermes desktop
+#   scripts/dev-sandbox.sh --persistent -- npm run dev
+#
+# Override the app name (default: HermesSandbox):
+#   HERMES_DEV_SANDBOX_NAME=Staging scripts/dev-sandbox.sh hermes desktop
+#
+# Override the persistent sandbox dir name (default: .hermes-sandbox):
+#   HERMES_DEV_SANDBOX_DIR=.staging-sandbox scripts/dev-sandbox.sh --persistent hermes desktop
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+print_help() {
+  cat <<'EOF'
+Usage: dev-sandbox.sh [--persistent] [--] <command...>
+
+Run a Hermes instance in an isolated sandbox.
+
+Options:
+  --persistent    Keep the sandbox dir across restarts (under the worktree
+                  git root, in .hermes-sandbox/). Without this flag the
+                  sandbox is a temp dir that is removed on exit.
+  --delete        Delete the existing persistent sandbox in .hermes-sandbox.
+  -h, --help      Show this help message.
+
+Environment:
+  HERMES_DEV_SANDBOX_NAME  Override the app name (default: HermesSandbox)
+  HERMES_DEV_SANDBOX_DIR   Override the persistent dir name (default: .hermes-sandbox)
+
+Examples:
+  dev-sandbox.sh hermes desktop
+  dev-sandbox.sh --persistent hermes desktop
+  dev-sandbox.sh -- npm run dev
+EOF
+}
+
+PERSISTENT=false
+DELETE=false
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --persistent)
+      PERSISTENT=true
+      shift
+      ;;
+    --delete)
+      DELETE=true
+      shift
+      ;;
+    -h|--help)
+      print_help
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [ "$#" -eq 0 ]; then
+  print_help >&2
+  exit 1
+fi
+
+
+SANDBOX_DIR_NAME="${HERMES_DEV_SANDBOX_DIR:-.hermes-sandbox}"
+GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$SCRIPT_DIR/..")"
+GIT_ROOT="$(cd "$GIT_ROOT" && pwd)"
+PERSISTENT_SANDBOX_ROOT="$GIT_ROOT/$SANDBOX_DIR_NAME"
+
+if [ "$DELETE" = true ]; then
+  if [ -d "$PERSISTENT_SANDBOX_ROOT" ]; then
+    read -r -p "[sandbox] delete $PERSISTENT_SANDBOX_ROOT? [y/N] " REPLY
+    case "$REPLY" in
+      [yY]|[yY][eE][sS])
+        echo "[sandbox] deleting $PERSISTENT_SANDBOX_ROOT" >&2
+        rm -rf -- "$PERSISTENT_SANDBOX_ROOT"
+        ;;
+      *)
+        echo "[sandbox] aborted" >&2
+        exit 1
+        ;;
+    esac
+  else
+    echo "[sandbox] nothing to delete at $PERSISTENT_SANDBOX_ROOT" >&2
+  fi
+  exit 0
+fi
+
+# Derive a per-worktree app name so multiple checkouts don't collide.
+# Each worktree has its own toplevel path even though they share one repo,
+# so we hash that path into a short, stable suffix.
+WORKTREE_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$SCRIPT_DIR/..")"
+WORKTREE_ROOT="$(cd "$WORKTREE_ROOT" && pwd)"
+WORKTREE_HASH="$(printf '%s' "$WORKTREE_ROOT" | cksum | cut -d' ' -f1)"
+WORKTREE_NAME="$(basename "$WORKTREE_ROOT")"
+DEFAULT_SANDBOX_NAME="HermesSandbox-${WORKTREE_NAME}-${WORKTREE_HASH}"
+
+SANDBOX_NAME="${HERMES_DEV_SANDBOX_NAME:-$DEFAULT_SANDBOX_NAME}"
+
+if [ "$PERSISTENT" = true ]; then
+  SANDBOX_ROOT="$PERSISTENT_SANDBOX_ROOT"
+else
+  SANDBOX_ROOT="$(mktemp -d -t hermes-sandbox.XXXXXX)"
+fi
+
+export HERMES_HOME="$SANDBOX_ROOT/hermes-home"
+export HERMES_DESKTOP_USER_DATA_DIR="$SANDBOX_ROOT/user-data"
+export HERMES_DESKTOP_APP_NAME="$SANDBOX_NAME"
+
+mkdir -p "$HERMES_HOME" "$HERMES_DESKTOP_USER_DATA_DIR"
+
+echo "[sandbox] HERMES_HOME=$HERMES_HOME" >&2
+echo "[sandbox] userData=$HERMES_DESKTOP_USER_DATA_DIR" >&2
+echo "[sandbox] appName=$HERMES_DESKTOP_APP_NAME" >&2
+if [ "$PERSISTENT" = true ]; then
+  echo "[sandbox] persistent: $SANDBOX_ROOT" >&2
+else
+  echo "[sandbox] ephemeral (will be cleaned up on exit)" >&2
+fi
+
+if [ "$PERSISTENT" = false ]; then
+  cleanup() {
+    chmod -R u+w "$SANDBOX_ROOT"
+    rm -rf -- "$SANDBOX_ROOT"
+  }
+  trap cleanup EXIT
+  trap 'cleanup; exit 130' INT TERM
+fi
+
+"$@"
+rc=$?
+exit $rc

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4109,7 +4109,7 @@ class TestCodexAdapterGithubResponsesMessageIdDrop:
                     {
                         "type": "message",
                         "role": "assistant",
-                        "status": "completed",
+                        "status": "in_progress",
                         "content": [{"type": "output_text", "text": "pong"}],
                         "id": "msg_short_but_connection_scoped",
                         "phase": "final_answer",
@@ -4127,6 +4127,8 @@ class TestCodexAdapterGithubResponsesMessageIdDrop:
         )
         assert "id" not in message_item
         assert message_item["phase"] == "final_answer"
+        assert message_item["status"] == "in_progress"
+        assert message_item["content"] == [{"type": "output_text", "text": "pong"}]
 
     def test_keeps_message_id_for_codex_backend_host(self):
         adapter, captured = self._build_adapter(

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4050,6 +4050,95 @@ class TestCodexAdapterPromptCacheKey:
         assert "prompt_cache_key" not in captured
 
 
+class TestCodexAdapterGithubResponsesMessageIdDrop:
+    """_CodexCompletionsAdapter must drop codex_message_items ``id`` when
+    talking to Copilot (githubcopilot.com), independent of the main
+    transport's build_kwargs path. Auxiliary calls (context compression,
+    flush_memories, MoA aggregation) route through this adapter instead of
+    agent/transports/codex.py, so they need the same #32716 guard applied
+    separately — Copilot binds replayed ids to a backend "connection" that
+    doesn't survive credential rotation/gateway restarts, and rejects a
+    stale id with HTTP 401 regardless of its length.
+    """
+
+    @staticmethod
+    def _build_adapter(base_url):
+        from agent.auxiliary_client import _CodexCompletionsAdapter
+        from types import SimpleNamespace
+
+        message_item = SimpleNamespace(
+            type="message", role="assistant", status="completed",
+            content=[SimpleNamespace(type="output_text", text="hi")],
+        )
+        events = [
+            SimpleNamespace(type="response.created"),
+            SimpleNamespace(type="response.output_item.done", item=message_item),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(
+                    status="completed", id="resp_test",
+                    usage=SimpleNamespace(input_tokens=1, output_tokens=1, total_tokens=2),
+                ),
+            ),
+        ]
+
+        class _FakeCreateStream:
+            def __iter__(self): return iter(events)
+            def close(self): pass
+
+        captured_kwargs = {}
+
+        def _create(**kwargs):
+            captured_kwargs.update(kwargs)
+            return _FakeCreateStream()
+
+        real_client = MagicMock()
+        real_client.base_url = base_url
+        real_client.responses.create = _create
+        adapter = _CodexCompletionsAdapter(real_client, "gpt-5.5")
+        return adapter, captured_kwargs
+
+    @staticmethod
+    def _replay_messages():
+        return [
+            {"role": "system", "content": "You are helpful."},
+            {
+                "role": "assistant",
+                "content": "pong",
+                "codex_message_items": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "status": "completed",
+                        "content": [{"type": "output_text", "text": "pong"}],
+                        "id": "msg_short_but_connection_scoped",
+                        "phase": "final_answer",
+                    }
+                ],
+            },
+            {"role": "user", "content": "continue"},
+        ]
+
+    def test_drops_message_id_for_github_copilot_host(self):
+        adapter, captured = self._build_adapter(base_url="https://api.githubcopilot.com")
+        adapter.create(messages=self._replay_messages())
+        message_item = next(
+            item for item in captured["input"] if item.get("type") == "message"
+        )
+        assert "id" not in message_item
+        assert message_item["phase"] == "final_answer"
+
+    def test_keeps_message_id_for_codex_backend_host(self):
+        adapter, captured = self._build_adapter(
+            base_url="https://chatgpt.com/backend-api/codex"
+        )
+        adapter.create(messages=self._replay_messages())
+        message_item = next(
+            item for item in captured["input"] if item.get("type") == "message"
+        )
+        assert message_item["id"] == "msg_short_but_connection_scoped"
+
+
 class TestVisionAutoSkipsKimiCoding:
     """_resolve_auto vision branch skips providers that have no vision on
     their main endpoint (e.g. Kimi Coding Plan /coding) and falls through

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -3,9 +3,11 @@ from types import SimpleNamespace
 import pytest
 
 from agent.codex_responses_adapter import (
+    _chat_messages_to_responses_input,
     _format_responses_error,
     _normalize_codex_response,
     _preflight_codex_api_kwargs,
+    _preflight_codex_input_items,
 )
 
 
@@ -137,6 +139,128 @@ def test_normalize_codex_response_in_progress_message_still_incomplete():
     _assistant_message, finish_reason = _normalize_codex_response(response)
 
     assert finish_reason == "incomplete"
+
+
+# ---------------------------------------------------------------------------
+# Replayed assistant message items with an oversized server-assigned ``id``
+# (Codex issues 400+ char base64 blobs) must never reach the API — the
+# Responses endpoint caps input[].id at 64 chars and rejects the whole
+# request with a non-retryable HTTP 400, permanently bricking the session
+# (every subsequent turn replays the same bad id). Short ids (msg_...) are
+# still worth keeping for prefix-cache hits, so this is a length guard, not
+# a blanket strip.
+# ---------------------------------------------------------------------------
+
+_OVERSIZED_ITEM_ID = "x" * 408
+_VALID_ITEM_ID = "msg_abc123"
+
+
+def test_chat_messages_to_responses_input_drops_oversized_message_id():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "pong",
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "pong"}],
+                    "id": _OVERSIZED_ITEM_ID,
+                    "phase": "final_answer",
+                }
+            ],
+        }
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+
+    message_item = next(item for item in items if item.get("type") == "message")
+    assert "id" not in message_item
+    assert message_item["phase"] == "final_answer"
+    assert message_item["content"] == [{"type": "output_text", "text": "pong"}]
+
+
+def test_chat_messages_to_responses_input_keeps_short_message_id():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "pong",
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "pong"}],
+                    "id": _VALID_ITEM_ID,
+                }
+            ],
+        }
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+
+    message_item = next(item for item in items if item.get("type") == "message")
+    assert message_item["id"] == _VALID_ITEM_ID
+
+
+def test_preflight_codex_input_items_drops_oversized_message_id():
+    items = _preflight_codex_input_items(
+        [
+            {
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": "pong"}],
+                "id": _OVERSIZED_ITEM_ID,
+                "phase": "final_answer",
+            }
+        ]
+    )
+
+    assert "id" not in items[0]
+    assert items[0]["phase"] == "final_answer"
+
+
+def test_preflight_codex_input_items_keeps_short_message_id():
+    items = _preflight_codex_input_items(
+        [
+            {
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": "pong"}],
+                "id": _VALID_ITEM_ID,
+            }
+        ]
+    )
+
+    assert items[0]["id"] == _VALID_ITEM_ID
+
+
+def test_preflight_codex_api_kwargs_drops_oversized_message_id_end_to_end():
+    kwargs = _preflight_codex_api_kwargs(
+        {
+            "model": "gpt-5.5",
+            "instructions": "You are Hermes.",
+            "input": [
+                {"role": "user", "content": "ping"},
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "pong"}],
+                    "id": _OVERSIZED_ITEM_ID,
+                    "phase": "final_answer",
+                },
+            ],
+            "tools": [],
+            "store": False,
+        }
+    )
+
+    message_item = next(item for item in kwargs["input"] if item.get("type") == "message")
+    assert "id" not in message_item
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -238,6 +238,27 @@ def test_preflight_codex_input_items_keeps_short_message_id():
     assert items[0]["id"] == _VALID_ITEM_ID
 
 
+def test_preflight_codex_input_items_drops_short_id_for_github_responses():
+    items = _preflight_codex_input_items(
+        [
+            {
+                "type": "message",
+                "role": "assistant",
+                "status": "in_progress",
+                "content": [{"type": "output_text", "text": "pong"}],
+                "id": _VALID_ITEM_ID,
+                "phase": "final_answer",
+            }
+        ],
+        is_github_responses=True,
+    )
+
+    assert "id" not in items[0]
+    assert items[0]["status"] == "in_progress"
+    assert items[0]["phase"] == "final_answer"
+    assert items[0]["content"] == [{"type": "output_text", "text": "pong"}]
+
+
 def test_preflight_codex_api_kwargs_drops_oversized_message_id_end_to_end():
     kwargs = _preflight_codex_api_kwargs(
         {

--- a/tests/agent/test_cron_inline_api_call_62151.py
+++ b/tests/agent/test_cron_inline_api_call_62151.py
@@ -18,6 +18,8 @@ import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+from run_agent import AIAgent
+
 from agent.chat_completion_helpers import (
     direct_api_call,
     interruptible_api_call,
@@ -83,6 +85,46 @@ def test_interruptible_api_call_routes_cron_inline_no_worker_thread():
 
     assert resp.id == "first"
     assert ran_on["tid"] == caller_tid  # no daemon worker thread
+
+
+def test_direct_api_call_interrupt_aborts_active_client_and_raises():
+    """Cron's outer watchdog interrupts from another thread while inline."""
+    agent = _make_agent()
+    client_ready = threading.Event()
+    release_request = threading.Event()
+    fake_client = MagicMock()
+
+    def _create(**_kwargs):
+        client_ready.set()
+        return fake_client
+
+    def _request(**_kwargs):
+        assert release_request.wait(timeout=2)
+        raise RuntimeError("socket closed")
+
+    fake_client.chat.completions.create.side_effect = _request
+    agent._create_request_openai_client.side_effect = _create
+    result = {}
+
+    def _run():
+        try:
+            direct_api_call(agent, {"model": "m", "messages": []})
+        except Exception as exc:
+            result["exception"] = exc
+
+    worker = threading.Thread(target=_run)
+    worker.start()
+    assert client_ready.wait(timeout=1)
+    assert callable(agent._active_request_abort)
+    AIAgent.interrupt(agent, "cron timeout")
+    agent._abort_request_openai_client.assert_called_once_with(
+        fake_client, reason="interrupt_abort"
+    )
+    release_request.set()
+    worker.join(timeout=2)
+    assert not worker.is_alive()
+    assert isinstance(result.get("exception"), InterruptedError)
+    assert agent._active_request_abort is None
 
 
 def test_interruptible_streaming_api_call_routes_cron_via_nonstream_method():

--- a/tests/agent/test_cron_inline_api_call_62151.py
+++ b/tests/agent/test_cron_inline_api_call_62151.py
@@ -1,0 +1,105 @@
+"""Regression guard for #62151 — gateway cron must not wedge on the 2nd+ call.
+
+Gateway-fired cron jobs hung forever on the 2nd+ API call because both the
+non-streaming (``interruptible_api_call``) and the default streaming
+(``interruptible_streaming_api_call``) paths run the request on a spawned
+daemon worker thread. Inside the gateway's nested cron thread pools that extra
+worker wedged before the socket opened; the same job succeeded via ``hermes
+cron tick`` (foreground, no nested pools). Cron has no interactive interrupt
+surface, so both paths now run inline on the conversation thread for the
+``cron`` platform.
+
+These tests pin: (1) the inline gate is cron-only, (2) the inline call runs on
+the *calling* thread — no worker is spawned — for both entry points, and (3)
+the shared dispatch closes the per-request client.
+"""
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from agent.chat_completion_helpers import (
+    direct_api_call,
+    interruptible_api_call,
+    interruptible_streaming_api_call,
+    should_use_direct_api_call,
+)
+
+
+def _make_agent(*, platform="cron"):
+    agent = MagicMock()
+    agent.platform = platform
+    agent.api_mode = "chat_completions"
+    agent.provider = "openrouter"
+    agent._interrupt_requested = False
+    agent._consecutive_stale_streams = 0
+    agent._touch_activity = MagicMock()
+    agent._close_request_openai_client = MagicMock()
+    return agent
+
+
+def test_should_use_direct_api_call_only_for_cron_platform():
+    assert should_use_direct_api_call(_make_agent(platform="cron")) is True
+    assert should_use_direct_api_call(_make_agent(platform="cli")) is False
+    assert should_use_direct_api_call(_make_agent(platform="telegram")) is False
+    assert should_use_direct_api_call(_make_agent(platform=None)) is False
+
+
+def test_direct_api_call_runs_inline_and_closes_client():
+    agent = _make_agent()
+    caller_tid = threading.get_ident()
+    ran_on = {}
+    fake_client = MagicMock()
+
+    def _create(**_kwargs):
+        ran_on["tid"] = threading.get_ident()
+        return fake_client
+
+    fake_client.chat.completions.create.return_value = SimpleNamespace(id="resp")
+    agent._create_request_openai_client.side_effect = _create
+
+    resp = direct_api_call(agent, {"model": "m", "messages": []})
+
+    assert resp.id == "resp"
+    # Inline: the request ran on the calling thread, no worker was spawned.
+    assert ran_on["tid"] == caller_tid
+    assert agent._close_request_openai_client.call_count == 1
+
+
+def test_interruptible_api_call_routes_cron_inline_no_worker_thread():
+    agent = _make_agent()
+    caller_tid = threading.get_ident()
+    fake_client = MagicMock()
+    ran_on = {}
+
+    def _create(**_kwargs):
+        ran_on["tid"] = threading.get_ident()
+        return fake_client
+
+    fake_client.chat.completions.create.return_value = SimpleNamespace(id="first")
+    agent._create_request_openai_client.side_effect = _create
+
+    resp = interruptible_api_call(agent, {"model": "m", "messages": []})
+
+    assert resp.id == "first"
+    assert ran_on["tid"] == caller_tid  # no daemon worker thread
+
+
+def test_interruptible_streaming_api_call_routes_cron_via_nonstream_method():
+    """Streaming is the default even for cron — the gate must catch it too.
+
+    It delegates to the ``_interruptible_api_call`` method (which itself runs
+    inline for cron) rather than calling ``direct_api_call`` directly, so the
+    outer loop's per-request retry/refresh seam — which patches that method —
+    stays intact (regression from the codex 401-refresh path).
+    """
+    agent = _make_agent()
+    sentinel = SimpleNamespace(id="via-nonstream")
+    agent._interruptible_api_call = MagicMock(return_value=sentinel)
+
+    resp = interruptible_streaming_api_call(
+        agent, {"model": "m", "messages": []}, on_first_delta=lambda: None
+    )
+
+    assert resp is sentinel
+    agent._interruptible_api_call.assert_called_once()

--- a/tests/agent/test_cron_inline_api_call_62151.py
+++ b/tests/agent/test_cron_inline_api_call_62151.py
@@ -40,11 +40,20 @@ def _make_agent(*, platform="cron"):
     return agent
 
 
-def test_should_use_direct_api_call_only_for_cron_platform():
+def test_should_use_direct_api_call_only_for_cron_openai_wire():
     assert should_use_direct_api_call(_make_agent(platform="cron")) is True
     assert should_use_direct_api_call(_make_agent(platform="cli")) is False
     assert should_use_direct_api_call(_make_agent(platform="telegram")) is False
     assert should_use_direct_api_call(_make_agent(platform=None)) is False
+
+    for api_mode in ("codex_responses", "anthropic_messages", "bedrock_converse"):
+        agent = _make_agent(platform="cron")
+        agent.api_mode = api_mode
+        assert should_use_direct_api_call(agent) is False
+
+    moa = _make_agent(platform="cron")
+    moa.provider = "moa"
+    assert should_use_direct_api_call(moa) is False
 
 
 def test_direct_api_call_runs_inline_and_closes_client():

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -841,6 +841,26 @@ class TestClassifyApiError:
         assert result.retryable is True
         assert result.should_fallback is False
 
+    def test_xai_invalid_encrypted_content_wording_uses_replay_recovery(self):
+        e = MockAPIError(
+            "Error code: 400 - Could not decrypt the provided encrypted_content. "
+            "Ensure the value is the unmodified encrypted_content from a previous response.",
+            status_code=400,
+            body={
+                "code": "Client specified an invalid argument",
+                "error": (
+                    "Could not decrypt the provided encrypted_content. Ensure the value "
+                    "is the unmodified encrypted_content from a previous response."
+                ),
+            },
+        )
+
+        result = classify_api_error(e, provider="xai-oauth", model="grok-4.3")
+
+        assert result.reason == FailoverReason.invalid_encrypted_content
+        assert result.retryable is True
+        assert result.should_fallback is False
+
     def test_invalid_encrypted_content_broad_message_match_does_not_catch_generic_parse_error(self):
         message = "Encrypted content could not be decrypted or parsed."
         e = MockAPIError(

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -181,6 +181,34 @@ class TestCodexBuildKwargs:
         message_item = next(item for item in kw["input"] if item.get("type") == "message")
         assert message_item["id"] == "msg_short_id"
 
+    def test_github_preflight_drops_id_reintroduced_by_request_override(self, transport):
+        injected = {
+            "type": "message",
+            "role": "assistant",
+            "status": "in_progress",
+            "content": [{"type": "output_text", "text": "pong"}],
+            "id": "stale_short",
+            "phase": "final_answer",
+        }
+        kw = transport.build_kwargs(
+            model="gpt-5.5",
+            messages=[{"role": "user", "content": "continue"}],
+            tools=[],
+            is_github_responses=True,
+            request_overrides={"input": [injected]},
+        )
+
+        preflight = transport.preflight_kwargs(
+            kw,
+            is_github_responses=True,
+        )
+
+        message_item = preflight["input"][0]
+        assert "id" not in message_item
+        assert message_item["status"] == "in_progress"
+        assert message_item["phase"] == "final_answer"
+        assert message_item["content"] == [{"type": "output_text", "text": "pong"}]
+
     def test_non_github_responses_keeps_message_item_id_end_to_end(self, transport):
         messages = [
             {"role": "system", "content": "You are Hermes."},

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -121,6 +121,63 @@ class TestCodexBuildKwargs:
         )
         assert "prompt_cache_key" not in kw
 
+    def test_github_responses_drops_message_item_id_end_to_end(self, transport):
+        # #32716: Copilot binds codex_message_items ids to a backend
+        # "connection" that doesn't survive credential rotation, a gateway
+        # restart, or load-balancer churn — replaying a stale id gets HTTP
+        # 401 "input item ID does not belong to this connection", even for
+        # ids well under the #27038 64-char length cap. build_kwargs must
+        # thread is_github_responses through to the input converter so the
+        # id never reaches the request.
+        messages = [
+            {"role": "system", "content": "You are Hermes."},
+            {
+                "role": "assistant",
+                "content": "pong",
+                "codex_message_items": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "status": "completed",
+                        "content": [{"type": "output_text", "text": "pong"}],
+                        "id": "msg_short_but_connection_scoped",
+                        "phase": "final_answer",
+                    }
+                ],
+            },
+        ]
+        kw = transport.build_kwargs(
+            model="gpt-5.5", messages=messages, tools=[],
+            is_github_responses=True,
+        )
+        message_item = next(item for item in kw["input"] if item.get("type") == "message")
+        assert "id" not in message_item
+        assert message_item["phase"] == "final_answer"
+
+    def test_non_github_responses_keeps_message_item_id_end_to_end(self, transport):
+        messages = [
+            {"role": "system", "content": "You are Hermes."},
+            {
+                "role": "assistant",
+                "content": "pong",
+                "codex_message_items": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "status": "completed",
+                        "content": [{"type": "output_text", "text": "pong"}],
+                        "id": "msg_short_id",
+                    }
+                ],
+            },
+        ]
+        kw = transport.build_kwargs(
+            model="gpt-5.5", messages=messages, tools=[],
+            is_codex_backend=True,
+        )
+        message_item = next(item for item in kw["input"] if item.get("type") == "message")
+        assert message_item["id"] == "msg_short_id"
+
     def test_xai_responses_sends_cache_key_via_extra_body(self, transport):
         """xAI's Responses API documents ``prompt_cache_key`` as the
         body-level cache-routing key (the ``x-grok-conv-id`` header is

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -138,7 +138,7 @@ class TestCodexBuildKwargs:
                     {
                         "type": "message",
                         "role": "assistant",
-                        "status": "completed",
+                        "status": "in_progress",
                         "content": [{"type": "output_text", "text": "pong"}],
                         "id": "msg_short_but_connection_scoped",
                         "phase": "final_answer",
@@ -153,6 +153,33 @@ class TestCodexBuildKwargs:
         message_item = next(item for item in kw["input"] if item.get("type") == "message")
         assert "id" not in message_item
         assert message_item["phase"] == "final_answer"
+        assert message_item["status"] == "in_progress"
+        assert message_item["content"] == [{"type": "output_text", "text": "pong"}]
+
+    def test_github_responses_requires_literal_true(self, transport):
+        messages = [
+            {
+                "role": "assistant",
+                "content": "pong",
+                "codex_message_items": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "status": "completed",
+                        "content": [{"type": "output_text", "text": "pong"}],
+                        "id": "msg_short_id",
+                    }
+                ],
+            },
+        ]
+
+        kw = transport.build_kwargs(
+            model="gpt-5.5", messages=messages, tools=[],
+            is_github_responses="false",
+        )
+
+        message_item = next(item for item in kw["input"] if item.get("type") == "message")
+        assert message_item["id"] == "msg_short_id"
 
     def test_non_github_responses_keeps_message_item_id_end_to_end(self, transport):
         messages = [

--- a/tests/cron/test_cron_direct_api_call_62151.py
+++ b/tests/cron/test_cron_direct_api_call_62151.py
@@ -1,0 +1,60 @@
+"""Regression guard for #62151 — gateway cron must not wedge on 2nd+ API call.
+
+Gateway-fired cron jobs hung forever on the 2nd+ non-streaming API call when
+``interruptible_api_call`` spawned a daemon worker inside nested cron thread
+pools. The worker logged client creation but never opened a TCP connection.
+The same job succeeded via ``hermes cron tick``. Cron has no interactive
+interrupt surface, so the fix routes cron through a synchronous direct call on
+the conversation thread instead of the interrupt worker.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from agent.chat_completion_helpers import (
+    direct_api_call,
+    should_use_direct_api_call,
+)
+
+
+def _make_agent(*, platform="cron"):
+    agent = MagicMock()
+    agent.platform = platform
+    agent.api_mode = "chat_completions"
+    agent._touch_activity = MagicMock()
+    agent._create_request_openai_client = MagicMock()
+    agent._close_request_openai_client = MagicMock()
+    return agent
+
+
+def test_should_use_direct_api_call_only_for_cron_platform():
+    assert should_use_direct_api_call(_make_agent(platform="cron")) is True
+    assert should_use_direct_api_call(_make_agent(platform="cli")) is False
+    assert should_use_direct_api_call(_make_agent(platform="telegram")) is False
+    assert should_use_direct_api_call(_make_agent(platform=None)) is False
+
+
+def test_direct_api_call_runs_two_sequential_requests_on_same_thread():
+    """Mirror the 2nd+ call failure mode: two back-to-back completions.create."""
+    agent = _make_agent()
+    calls = {"n": 0}
+    fake_client = MagicMock()
+
+    def _create(**_kwargs):
+        calls["n"] += 1
+        return fake_client
+
+    fake_client.chat.completions.create.side_effect = [
+        SimpleNamespace(id="first"),
+        SimpleNamespace(id="second"),
+    ]
+    agent._create_request_openai_client.side_effect = _create
+
+    first = direct_api_call(agent, {"model": "m", "messages": []})
+    second = direct_api_call(agent, {"model": "m", "messages": []})
+
+    assert first.id == "first"
+    assert second.id == "second"
+    assert calls["n"] == 2
+    assert fake_client.chat.completions.create.call_count == 2
+    assert agent._close_request_openai_client.call_count == 2

--- a/tests/cron/test_cron_direct_api_call_62151.py
+++ b/tests/cron/test_cron_direct_api_call_62151.py
@@ -21,6 +21,7 @@ def _make_agent(*, platform="cron"):
     agent = MagicMock()
     agent.platform = platform
     agent.api_mode = "chat_completions"
+    agent._interrupt_requested = False
     agent._touch_activity = MagicMock()
     agent._create_request_openai_client = MagicMock()
     agent._close_request_openai_client = MagicMock()

--- a/tests/cron/test_cron_direct_api_call_62151.py
+++ b/tests/cron/test_cron_direct_api_call_62151.py
@@ -21,6 +21,7 @@ def _make_agent(*, platform="cron"):
     agent = MagicMock()
     agent.platform = platform
     agent.api_mode = "chat_completions"
+    agent.provider = "openrouter"
     agent._interrupt_requested = False
     agent._touch_activity = MagicMock()
     agent._create_request_openai_client = MagicMock()
@@ -28,11 +29,20 @@ def _make_agent(*, platform="cron"):
     return agent
 
 
-def test_should_use_direct_api_call_only_for_cron_platform():
+def test_should_use_direct_api_call_only_for_cron_openai_wire():
     assert should_use_direct_api_call(_make_agent(platform="cron")) is True
     assert should_use_direct_api_call(_make_agent(platform="cli")) is False
     assert should_use_direct_api_call(_make_agent(platform="telegram")) is False
     assert should_use_direct_api_call(_make_agent(platform=None)) is False
+
+    for api_mode in ("codex_responses", "anthropic_messages", "bedrock_converse"):
+        agent = _make_agent(platform="cron")
+        agent.api_mode = api_mode
+        assert should_use_direct_api_call(agent) is False
+
+    moa = _make_agent(platform="cron")
+    moa.provider = "moa"
+    assert should_use_direct_api_call(moa) is False
 
 
 def test_direct_api_call_runs_two_sequential_requests_on_same_thread():

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1172,7 +1172,8 @@ class TestGetDueJobs:
         # Mid-run heartbeat before the TTL horizon refreshes the claim.
         monkeypatch.setattr("cron.jobs._hermes_now",
                             lambda: t0 + timedelta(seconds=ttl - 60))
-        assert heartbeat_run_claim("slowrun") is True
+        owner = get_job("slowrun")["run_claim"]["by"]
+        assert heartbeat_run_claim("slowrun", expected_owner=owner) is True
 
         # Past the ORIGINAL claim's TTL horizon: without the heartbeat this
         # tick would stale-remove the maxed one-shot; with it the claim is
@@ -1196,9 +1197,39 @@ class TestGetDueJobs:
             "schedule": {"kind": "once", "run_at": future},
             "next_run_at": future, "enabled": True, "state": "scheduled",
         }])
-        assert heartbeat_run_claim("noclaim") is False
-        assert heartbeat_run_claim("missing-job") is False
+        assert heartbeat_run_claim("noclaim", expected_owner="owner") is False
+        assert heartbeat_run_claim("missing-job", expected_owner="owner") is False
         assert get_job("noclaim").get("run_claim") is None
+
+    def test_heartbeat_run_claim_rejects_replaced_owner(self, tmp_cron_dir):
+        """A resumed stale runner must not keep a newer owner's claim alive."""
+        future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+        original_at = datetime.now(timezone.utc).isoformat()
+        save_jobs([{
+            "id": "reclaimed", "name": "R", "prompt": "x",
+            "schedule": {"kind": "once", "run_at": future},
+            "next_run_at": future, "enabled": True, "state": "scheduled",
+            "run_claim": {"at": original_at, "by": "new-owner"},
+        }])
+
+        assert heartbeat_run_claim("reclaimed", expected_owner="old-owner") is False
+        assert get_job("reclaimed")["run_claim"] == {
+            "at": original_at,
+            "by": "new-owner",
+        }
+
+    def test_heartbeat_run_claim_rejects_non_oneshot(self, tmp_cron_dir):
+        """Heartbeat ownership applies only to one-shot dispatch claims."""
+        original_at = datetime.now(timezone.utc).isoformat()
+        save_jobs([{
+            "id": "recurring", "name": "R", "prompt": "x",
+            "schedule": {"kind": "interval", "seconds": 60},
+            "enabled": True,
+            "run_claim": {"at": original_at, "by": "owner"},
+        }])
+
+        assert heartbeat_run_claim("recurring", expected_owner="owner") is False
+        assert get_job("recurring")["run_claim"]["at"] == original_at
 
 
     def test_broken_cron_without_next_run_is_recovered(self, tmp_cron_dir, monkeypatch):

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1,6 +1,7 @@
 """Tests for cron/scheduler.py — origin resolution, delivery routing, and error logging."""
 
 import contextlib
+import itertools
 import json
 import logging
 import os
@@ -1622,6 +1623,63 @@ class TestRunJobSessionPersistence:
         assert os.getenv("HERMES_CRON_AUTO_DELIVER_CHAT_ID") is None
         assert os.getenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID") is None
         fake_db.close.assert_called_once()
+
+    @pytest.mark.parametrize("timeout_value", ["600", "0"])
+    def test_run_job_heartbeats_oneshot_claim_in_both_wait_modes(
+        self, tmp_path, monkeypatch, timeout_value
+    ):
+        """Timed and unlimited one-shot monitors both refresh their owned claim."""
+        job = {
+            "id": "heartbeat-job",
+            "name": "heartbeat",
+            "prompt": "hello",
+            "schedule": {"kind": "once", "run_at": "2026-07-10T12:00:00Z"},
+            "run_claim": {"at": "2026-07-10T12:00:00Z", "by": "owner-token"},
+        }
+        fake_db = MagicMock()
+
+        class FakeAgent:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def run_conversation(self, *args, **kwargs):
+                return {"final_response": "ok"}
+
+        class FakeFuture:
+            def result(self):
+                return {"final_response": "ok"}
+
+        fake_future = FakeFuture()
+        fake_pool = MagicMock()
+        fake_pool.submit.return_value = fake_future
+        wait_results = [(set(), set()), ({fake_future}, set())]
+        monotonic_ticks = itertools.count(step=61.0)
+        monkeypatch.setenv("HERMES_CRON_TIMEOUT", timeout_value)
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent", FakeAgent), \
+             patch("cron.scheduler.concurrent.futures.ThreadPoolExecutor", return_value=fake_pool), \
+             patch("cron.scheduler.concurrent.futures.wait", side_effect=wait_results), \
+             patch("cron.scheduler.time.monotonic", side_effect=monotonic_ticks.__next__), \
+             patch("cron.scheduler.heartbeat_run_claim", return_value=True) as heartbeat:
+            success, _output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+        heartbeat.assert_called_once_with(
+            "heartbeat-job", expected_owner="owner-token"
+        )
 
     def test_run_job_resets_secret_source_cache_before_reload(self, tmp_path, monkeypatch):
         """Each run must clear the secret-source cache before re-reading the

--- a/tests/gateway/test_telegram_final_delivery.py
+++ b/tests/gateway/test_telegram_final_delivery.py
@@ -1,0 +1,216 @@
+"""Regression coverage for Telegram final delivery after streamed edit failure."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.platforms.base import SendResult
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+
+def _adapter() -> MagicMock:
+    adapter = MagicMock()
+    adapter.REQUIRES_EDIT_FINALIZE = True
+    adapter.FALLBACK_ON_FINAL_EDIT_FLOOD = True
+    adapter.RESEND_FINAL_ON_EMPTY_STREAM_FALLBACK = True
+    adapter.MAX_MESSAGE_LENGTH = 4096
+    adapter.edit_message = AsyncMock()
+    adapter.send = AsyncMock()
+    adapter.delete_message = AsyncMock(return_value=True)
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_turn_final_flood_immediately_delivers_missing_tail():
+    """A short visible preview must not suppress the completed answer."""
+    adapter = _adapter()
+    adapter.edit_message.return_value = SendResult(
+        success=False,
+        error="Flood control exceeded. Retry in 180 seconds",
+        retry_after=180.0,
+    )
+    adapter.send.return_value = SendResult(success=True, message_id="tail-1")
+
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat-1",
+        StreamConsumerConfig(cursor=" ▉"),
+        metadata={"thread_id": "77"},
+    )
+    consumer._message_id = "preview-1"
+    consumer._last_sent_text = ":("
+    consumer._already_sent = True
+
+    ok = await consumer._send_or_edit(
+        ":( The completed answer follows here.",
+        finalize=True,
+        is_turn_final=True,
+    )
+
+    assert ok is False
+    assert consumer._flood_strikes == 1
+    assert consumer._fallback_final_send is True
+    assert consumer.final_content_delivered is False
+    assert adapter.edit_message.await_count == 1
+
+    await consumer._send_fallback_final(":( The completed answer follows here.")
+
+    adapter.send.assert_awaited_once()
+    assert adapter.send.await_args.kwargs["content"] == "The completed answer follows here."
+    assert adapter.send.await_args.kwargs["metadata"] == {
+        "thread_id": "77",
+        "notify": True,
+    }
+    adapter.delete_message.assert_not_awaited()
+    assert consumer.final_response_sent is True
+    assert consumer.final_content_delivered is True
+
+
+@pytest.mark.asyncio
+async def test_non_opt_in_adapter_keeps_adaptive_final_edit_retry():
+    """Immediate final fallback remains scoped to opted-in adapters."""
+    adapter = _adapter()
+    adapter.FALLBACK_ON_FINAL_EDIT_FLOOD = False
+    adapter.edit_message.return_value = SendResult(
+        success=False,
+        error="Flood control exceeded. Retry in 30 seconds",
+        retry_after=30.0,
+    )
+
+    consumer = GatewayStreamConsumer(adapter, "chat-1")
+    consumer._message_id = "preview-1"
+    consumer._last_sent_text = "partial"
+    consumer._already_sent = True
+
+    ok = await consumer._send_or_edit(
+        "partial plus final",
+        finalize=True,
+        is_turn_final=True,
+    )
+
+    assert ok is False
+    assert consumer._flood_strikes == 1
+    assert consumer._fallback_final_send is False
+
+
+@pytest.mark.asyncio
+async def test_turn_final_flood_commits_empty_tail_as_fresh_message():
+    """Telegram gets a durable final even when the internal tail is empty."""
+    adapter = _adapter()
+    adapter.edit_message.return_value = SendResult(
+        success=False,
+        error="Flood control exceeded. Retry in 30 seconds",
+        retry_after=30.0,
+    )
+    adapter.send.return_value = SendResult(success=True, message_id="final-1")
+
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat-1",
+        StreamConsumerConfig(cursor=" ▉"),
+    )
+    final_text = "The complete answer"
+    consumer._message_id = "preview-1"
+    consumer._preview_message_ids = {"preview-1"}
+    consumer._last_sent_text = f"{final_text} ▉"
+    consumer._already_sent = True
+
+    ok = await consumer._send_or_edit(
+        final_text,
+        finalize=True,
+        is_turn_final=True,
+    )
+
+    assert ok is False
+    assert consumer._fallback_final_send is True
+    assert consumer.final_content_delivered is True
+    assert adapter.edit_message.await_count == 1
+
+    await consumer._send_fallback_final(final_text)
+
+    adapter.send.assert_awaited_once()
+    assert adapter.send.await_args.kwargs["content"] == final_text
+    assert adapter.send.await_args.kwargs["metadata"] == {"notify": True}
+    adapter.delete_message.assert_awaited_once_with("chat-1", "preview-1")
+    assert consumer.message_id == "final-1"
+    assert consumer.final_response_sent is True
+    assert consumer.final_content_delivered is True
+
+
+@pytest.mark.asyncio
+async def test_empty_tail_commit_honors_retry_after(monkeypatch):
+    adapter = _adapter()
+    adapter.send.side_effect = [
+        SendResult(
+            success=False,
+            error="Flood control exceeded",
+            retry_after=7.0,
+        ),
+        SendResult(success=True, message_id="final-1"),
+    ]
+    sleep = AsyncMock()
+    monkeypatch.setattr("gateway.stream_consumer.asyncio.sleep", sleep)
+
+    consumer = GatewayStreamConsumer(adapter, "chat-1")
+    consumer._message_id = "preview-1"
+    consumer._last_sent_text = "Final answer"
+    consumer._fallback_final_send = True
+
+    await consumer._send_fallback_final("Final answer")
+
+    assert adapter.send.await_count == 2
+    sleep.assert_awaited_once_with(7.0)
+    assert consumer.final_content_delivered is True
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_empty_tail_timeout_preserves_duplicate_suppression():
+    adapter = _adapter()
+    adapter.send.return_value = SimpleNamespace(
+        success=False,
+        error="Timed out",
+        retryable=False,
+    )
+
+    consumer = GatewayStreamConsumer(adapter, "chat-1")
+    consumer._message_id = "preview-1"
+    consumer._last_sent_text = "Final answer"
+    consumer._fallback_final_send = True
+
+    await consumer._send_fallback_final("Final answer")
+
+    adapter.delete_message.assert_not_awaited()
+    assert consumer.final_response_sent is False
+    assert consumer.final_content_delivered is True
+
+
+@pytest.mark.asyncio
+async def test_confirmed_empty_tail_send_failure_allows_gateway_retry():
+    adapter = _adapter()
+    adapter.send.return_value = SendResult(
+        success=False,
+        error="network unavailable",
+        retryable=False,
+    )
+
+    consumer = GatewayStreamConsumer(adapter, "chat-1")
+    consumer._message_id = "preview-1"
+    consumer._last_sent_text = "Final answer"
+    consumer._fallback_final_send = True
+    consumer._final_content_delivered = True
+
+    await consumer._send_fallback_final("Final answer")
+
+    adapter.delete_message.assert_not_awaited()
+    assert consumer.final_response_sent is False
+    assert consumer.final_content_delivered is False
+
+
+def test_timeout_exception_is_treated_as_ambiguous_delivery():
+    class TimedOut(Exception):
+        pass
+
+    assert GatewayStreamConsumer._send_failure_may_have_delivered(
+        TimedOut("request timed out")
+    ) is True

--- a/tests/gateway/test_telegram_final_delivery.py
+++ b/tests/gateway/test_telegram_final_delivery.py
@@ -5,8 +5,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from gateway.config import PlatformConfig
 from gateway.platforms.base import SendResult
 from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+from plugins.platforms.telegram.adapter import TelegramAdapter
 
 
 def _adapter() -> MagicMock:
@@ -145,7 +147,7 @@ async def test_empty_tail_commit_honors_retry_after(monkeypatch):
         SendResult(
             success=False,
             error="Flood control exceeded",
-            retry_after=7.0,
+            retry_after=3.0,
         ),
         SendResult(success=True, message_id="final-1"),
     ]
@@ -160,8 +162,69 @@ async def test_empty_tail_commit_honors_retry_after(monkeypatch):
     await consumer._send_fallback_final("Final answer")
 
     assert adapter.send.await_count == 2
-    sleep.assert_awaited_once_with(7.0)
+    sleep.assert_awaited_once_with(3.0)
     assert consumer.final_content_delivered is True
+
+
+@pytest.mark.asyncio
+async def test_empty_tail_recovery_keeps_prior_segment_messages():
+    """Recovery replaces only its current preview, not earlier preambles."""
+    adapter = _adapter()
+    adapter.send.return_value = SendResult(success=True, message_id="final-1")
+    consumer = GatewayStreamConsumer(adapter, "chat-1")
+
+    consumer._track_preview_id("preamble-1")
+    consumer._reset_segment_state()
+    consumer._track_preview_id("preview-1")
+    consumer._message_id = "preview-1"
+    consumer._last_sent_text = "Final answer"
+    consumer._fallback_final_send = True
+
+    await consumer._send_fallback_final("Final answer")
+
+    adapter.delete_message.assert_awaited_once_with("chat-1", "preview-1")
+    assert "preamble-1" in consumer._preview_message_ids
+
+
+@pytest.mark.asyncio
+async def test_empty_tail_commit_skips_long_flood_retry(monkeypatch):
+    adapter = _adapter()
+    adapter.send.return_value = SendResult(
+        success=False,
+        error="flood_control:30.0",
+        retry_after=30.0,
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr("gateway.stream_consumer.asyncio.sleep", sleep)
+
+    consumer = GatewayStreamConsumer(adapter, "chat-1")
+    consumer._message_id = "preview-1"
+    consumer._last_sent_text = "Final answer"
+    consumer._fallback_final_send = True
+
+    await consumer._send_fallback_final("Final answer")
+
+    adapter.send.assert_awaited_once()
+    sleep.assert_not_awaited()
+    assert consumer.final_response_sent is False
+    assert consumer.final_content_delivered is False
+
+
+@pytest.mark.asyncio
+async def test_telegram_long_flood_result_keeps_retry_after():
+    """The real adapter contract preserves the server delay for consumers."""
+    class FloodError(Exception):
+        retry_after = 30.0
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = MagicMock()
+    adapter._bot.edit_message_text = AsyncMock(side_effect=FloodError("Retry after 30"))
+
+    result = await adapter.edit_message("123", "456", "Final answer", finalize=False)
+
+    assert result.success is False
+    assert result.error == "flood_control:30.0"
+    assert result.retry_after == 30.0
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -1215,7 +1215,7 @@ class TestNovitaProvider:
             return _FakeResp()
 
         monkeypatch.setattr(
-            models_mod.urllib.request, "urlopen", fake_urlopen
+            models_mod, "_urlopen_model_catalog_request", fake_urlopen
         )
 
         # First call hits the network.

--- a/tests/hermes_cli/test_argparse_flag_propagation.py
+++ b/tests/hermes_cli/test_argparse_flag_propagation.py
@@ -219,3 +219,121 @@ print(json.dumps(results))
                 f"stderr: {entry['stderr']}"
             )
             assert "unrecognized arguments" not in entry["stderr"]
+
+
+class TestChatSubparserInheritedValueFlags:
+    """Verify -t/--toolsets, -m/--model and --provider survive parent→chat
+    subparser dispatch.
+
+    Regression test for #28780: `hermes -t web chat` silently dropped the
+    toolset because the chat subparser re-declared `-t/--toolsets` with
+    `default=None`, which clobbered the top-level parser's value during
+    subparser dispatch.
+
+    Uses the real `hermes_cli._parser.build_top_level_parser()` rather than
+    the hand-rolled replica above so this also fails if the production
+    parser drifts back to `default=None` on these flags.
+    """
+
+    @pytest.fixture
+    def real_parser(self):
+        from hermes_cli._parser import build_top_level_parser
+        parser, _subparsers, _chat = build_top_level_parser()
+        return parser
+
+    @pytest.mark.parametrize("flag,attr,value", [
+        ("-t", "toolsets", "web"),
+        ("--toolsets", "toolsets", "web,terminal"),
+        ("-m", "model", "anthropic/claude-sonnet-4"),
+        ("--model", "model", "openai/gpt-4"),
+        ("--provider", "provider", "openrouter"),
+    ])
+    def test_flag_before_chat_is_preserved(self, real_parser, flag, attr, value):
+        args, _ = real_parser.parse_known_args([flag, value, "chat"])
+        assert getattr(args, attr, None) == value, (
+            f"`hermes {flag} {value} chat` lost the flag — got "
+            f"{getattr(args, attr, None)!r}, expected {value!r}"
+        )
+
+    @pytest.mark.parametrize("flag,attr,value", [
+        ("-t", "toolsets", "web"),
+        ("--toolsets", "toolsets", "web,terminal"),
+        ("-m", "model", "anthropic/claude-sonnet-4"),
+        ("--model", "model", "openai/gpt-4"),
+        ("--provider", "provider", "openrouter"),
+    ])
+    def test_flag_after_chat_still_works(self, real_parser, flag, attr, value):
+        args, _ = real_parser.parse_known_args(["chat", flag, value])
+        assert getattr(args, attr, None) == value
+
+    def test_no_flag_leaves_attrs_at_top_level_default(self, real_parser):
+        """When the user passes none of the inherited flags, the top-level
+        parser's `default=None` still seeds the namespace — the SUPPRESS on
+        the subparser must not remove existing attributes."""
+        args, _ = real_parser.parse_known_args(["chat"])
+        assert getattr(args, "toolsets", "MISSING") is None
+        assert getattr(args, "model", "MISSING") is None
+        assert getattr(args, "provider", "MISSING") is None
+
+    def test_all_three_flags_before_chat(self, real_parser):
+        """Issue #28780 reporter's case generalized: passing every inherited
+        value flag before `chat` must preserve all of them simultaneously."""
+        args, _ = real_parser.parse_known_args([
+            "-t", "web",
+            "-m", "anthropic/claude-sonnet-4",
+            "--provider", "openrouter",
+            "chat",
+        ])
+        assert args.toolsets == "web"
+        assert args.model == "anthropic/claude-sonnet-4"
+        assert args.provider == "openrouter"
+
+    @pytest.mark.parametrize("flag,attr", [
+        ("--tui", "tui"),
+        ("--cli", "cli"),
+        ("--dev", "tui_dev"),
+    ])
+    def test_store_true_flag_before_chat_is_preserved(
+        self, real_parser, flag, attr,
+    ):
+        """`--tui` / `--cli` / `--dev` are store_true flags inherited by chat; the same
+        SUPPRESS contract applies. Without it, the subparser's `default=False`
+        would clobber the parent's `True` when used as `hermes --tui chat`."""
+        args, _ = real_parser.parse_known_args([flag, "chat"])
+        assert getattr(args, attr, None) is True, (
+            f"`hermes {flag} chat` lost the flag — got "
+            f"{getattr(args, attr, None)!r}, expected True"
+        )
+
+    def test_chat_subparser_inherited_value_flags_use_suppress(self):
+        """Contract test for the underlying invariant.
+
+        Any chat-subparser flag whose `dest` also exists on the top-level
+        parser MUST declare `default=argparse.SUPPRESS`, otherwise the
+        subparser silently overwrites the top-level value with its own
+        default during dispatch. This is the structural class behind #28780.
+        """
+        from hermes_cli._parser import build_top_level_parser
+        parser, _subparsers, chat_parser = build_top_level_parser()
+
+        top_level_dests = {
+            a.dest for a in parser._actions
+            if a.option_strings and a.dest != "help"
+        }
+
+        offenders = []
+        for action in chat_parser._actions:
+            if not action.option_strings or action.dest == "help":
+                continue
+            if action.dest not in top_level_dests:
+                continue
+            if action.default is not argparse.SUPPRESS:
+                offenders.append((action.option_strings, action.dest, action.default))
+
+        assert not offenders, (
+            "Chat subparser redeclares these top-level flags without "
+            "default=argparse.SUPPRESS; they will silently clobber the "
+            "top-level value when used as `hermes <flag> <value> chat`:\n  "
+            + "\n  ".join(f"{opts} dest={dest} default={d!r}"
+                          for opts, dest, d in offenders)
+        )

--- a/tests/hermes_cli/test_azure_detect.py
+++ b/tests/hermes_cli/test_azure_detect.py
@@ -188,7 +188,7 @@ def test_probe_openai_models_tries_multiple_api_versions():
 def test_http_get_json_on_urlerror_returns_zero_none():
     """Network failure returns (0, None), never raises."""
     import urllib.error
-    with patch("hermes_cli.azure_detect.urllib_request.urlopen",
+    with patch("hermes_cli.azure_detect.open_credentialed_url",
                side_effect=urllib.error.URLError("dns fail")):
         status, body = azure_detect._http_get_json("https://bad.example/", "k")
     assert status == 0
@@ -199,7 +199,7 @@ def test_http_get_json_on_http_error_returns_code_none():
     """HTTP 4xx/5xx returns (code, None)."""
     import urllib.error
     err = urllib.error.HTTPError("https://x/", 403, "Forbidden", {}, None)
-    with patch("hermes_cli.azure_detect.urllib_request.urlopen", side_effect=err):
+    with patch("hermes_cli.azure_detect.open_credentialed_url", side_effect=err):
         status, body = azure_detect._http_get_json("https://x/", "k")
     assert status == 403
     assert body is None

--- a/tests/hermes_cli/test_custom_provider_extra_headers.py
+++ b/tests/hermes_cli/test_custom_provider_extra_headers.py
@@ -165,7 +165,7 @@ def test_fetch_api_models_sends_extra_headers_to_models_probe(monkeypatch):
         }
         return FakeResponse()
 
-    monkeypatch.setattr(models_mod.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(models_mod, "_urlopen_model_catalog_request", fake_urlopen)
 
     models = models_mod.fetch_api_models(
         "proxy-key",

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -125,6 +125,51 @@ def test_default_spawn_never_boots_the_tui(monkeypatch, tmp_path):
     assert "HERMES_TUI" not in captured["env"]
 
 
+def test_default_spawn_model_override_survives_real_cli_parse(monkeypatch, tmp_path):
+    """The dispatcher's pre-``chat`` model flag must reach ``args.model``.
+
+    This is an integration contract between Kanban's worker argv builder and
+    the real CLI parser. A parser default once erased the explicit override,
+    silently sending the worker to its profile default or fallback instead.
+    """
+    root = tmp_path / ".hermes"
+    (root / "profiles" / "elias").mkdir(parents=True)
+    root.joinpath("config.yaml").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    from hermes_cli import kanban_db as kb
+    from hermes_cli._parser import build_top_level_parser
+
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+    captured = {}
+
+    class FakeProc:
+        pid = 4244
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["cmd"] = list(cmd)
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    task = _make_task(kb, assignee="elias")
+    task.model_override = "gpt-5.6-sol"
+    kb._default_spawn(task, str(workspace))
+
+    parser, _subparsers, _chat_parser = build_top_level_parser()
+    # Profile selection is attached by the outer CLI bootstrap rather than
+    # build_top_level_parser(); remove that already-validated prefix and parse
+    # the worker flags/subcommand through the real shared parser.
+    assert captured["cmd"][1:3] == ["-p", "elias"]
+    args = parser.parse_args(captured["cmd"][3:])
+
+    assert args.command == "chat"
+    assert args.model == "gpt-5.6-sol"
+    assert args.query == "work kanban task t_spawn_tools"
+
+
 def test_resolve_worker_cli_toolsets_uses_profile_home_not_parent_config(monkeypatch, tmp_path):
     root = tmp_path / ".hermes"
     profile = root / "profiles" / "elias"

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -236,7 +236,7 @@ class TestProviderModelIds:
                 }
             },
         ), patch(
-            "hermes_cli.models.urllib.request.urlopen",
+            "hermes_cli.models._urlopen_model_catalog_request",
             return_value=_Resp(),
         ) as mock_urlopen:
             assert provider_model_ids("anthropic") == ["enterprise-claude"]
@@ -275,7 +275,7 @@ class TestFetchApiModels:
         assert fetch_api_models("key", None) is None
 
     def test_returns_none_on_network_error(self):
-        with patch("hermes_cli.models.urllib.request.urlopen", side_effect=Exception("timeout")):
+        with patch("hermes_cli.models._urlopen_model_catalog_request", side_effect=Exception("timeout")):
             assert fetch_api_models("key", "https://example.com/v1") is None
 
     def test_probe_api_models_tries_v1_fallback(self):
@@ -297,7 +297,7 @@ class TestFetchApiModels:
                 return _Resp()
             raise Exception("404")
 
-        with patch("hermes_cli.models.urllib.request.urlopen", side_effect=_fake_urlopen):
+        with patch("hermes_cli.models._urlopen_model_catalog_request", side_effect=_fake_urlopen):
             probe = probe_api_models("key", "http://localhost:8000")
 
         assert calls == ["http://localhost:8000/models", "http://localhost:8000/v1/models"]
@@ -316,7 +316,7 @@ class TestFetchApiModels:
             def read(self):
                 return b'{"data": [{"id": "gpt-5.4", "model_picker_enabled": true, "supported_endpoints": ["/responses"], "capabilities": {"type": "chat", "supports": {"reasoning_effort": ["low", "medium", "high"]}}}, {"id": "claude-sonnet-4.6", "model_picker_enabled": true, "supported_endpoints": ["/chat/completions"], "capabilities": {"type": "chat", "supports": {"reasoning_effort": ["low", "medium", "high"]}}}, {"id": "text-embedding-3-small", "model_picker_enabled": true, "capabilities": {"type": "embedding"}}]}'
 
-        with patch("hermes_cli.models.urllib.request.urlopen", return_value=_Resp()) as mock_urlopen:
+        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()) as mock_urlopen:
             probe = probe_api_models("gh-token", "https://api.githubcopilot.com")
 
         assert mock_urlopen.call_args[0][0].full_url == "https://api.githubcopilot.com/models"
@@ -335,7 +335,7 @@ class TestFetchApiModels:
             def read(self):
                 return b'{"data": [{"id": "gpt-5.4", "model_picker_enabled": true, "supported_endpoints": ["/responses"], "capabilities": {"type": "chat", "supports": {"reasoning_effort": ["low", "medium", "high"]}}}, {"id": "text-embedding-3-small", "model_picker_enabled": true, "capabilities": {"type": "embedding"}}]}'
 
-        with patch("hermes_cli.models.urllib.request.urlopen", return_value=_Resp()):
+        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()):
             catalog = fetch_github_model_catalog("gh-token")
 
         assert catalog is not None
@@ -749,7 +749,7 @@ class TestValidateApiFallback:
             b']}'
         )
 
-        with patch("hermes_cli.models.urllib.request.urlopen", return_value=mock_resp):
+        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=mock_resp):
             models = fetch_lmstudio_models(base_url="http://localhost:1234/v1")
 
         assert models == ["publisher/chat-model"]
@@ -760,7 +760,7 @@ class TestValidateApiFallback:
         mock_resp.__exit__.return_value = False
         mock_resp.read.return_value = b'{"models":[{"key":"publisher/chat-model","type":"llm"}]}'
 
-        with patch("hermes_cli.models.urllib.request.urlopen", return_value=mock_resp) as mock_urlopen:
+        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=mock_resp) as mock_urlopen:
             models = fetch_lmstudio_models(base_url="http://localhost:1234/api/v1")
 
         request = mock_urlopen.call_args[0][0]
@@ -778,7 +778,7 @@ class TestValidateApiFallback:
             b']}'
         )
 
-        with patch("hermes_cli.models.urllib.request.urlopen", return_value=mock_resp):
+        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=mock_resp):
             result = validate_requested_model(
                 "publisher/embed-model",
                 "lmstudio",
@@ -802,7 +802,7 @@ class TestValidateApiFallback:
             fp=None,
         )
 
-        with patch("hermes_cli.models.urllib.request.urlopen", side_effect=http_error):
+        with patch("hermes_cli.models._urlopen_model_catalog_request", side_effect=http_error):
             with pytest.raises(AuthError) as excinfo:
                 fetch_lmstudio_models(base_url="http://localhost:1234/v1")
 
@@ -812,7 +812,7 @@ class TestValidateApiFallback:
 
     def test_fetch_lmstudio_models_returns_empty_on_network_error(self):
         with patch(
-            "hermes_cli.models.urllib.request.urlopen",
+            "hermes_cli.models._urlopen_model_catalog_request",
             side_effect=ConnectionRefusedError(),
         ):
             models = fetch_lmstudio_models(base_url="http://localhost:1234/v1")
@@ -830,7 +830,7 @@ class TestValidateApiFallback:
             fp=None,
         )
 
-        with patch("hermes_cli.models.urllib.request.urlopen", side_effect=http_error):
+        with patch("hermes_cli.models._urlopen_model_catalog_request", side_effect=http_error):
             result = validate_requested_model(
                 "publisher/chat-model",
                 "lmstudio",
@@ -843,7 +843,7 @@ class TestValidateApiFallback:
 
     def test_validate_lmstudio_distinguishes_unreachable(self):
         with patch(
-            "hermes_cli.models.urllib.request.urlopen",
+            "hermes_cli.models._urlopen_model_catalog_request",
             side_effect=ConnectionRefusedError(),
         ):
             result = validate_requested_model(
@@ -910,7 +910,7 @@ class TestProbeApiModelsUserAgent:
 
         body = b'{"data":[{"id":"claude-opus-4.7"}]}'
         with patch(
-            "hermes_cli.models.urllib.request.urlopen",
+            "hermes_cli.models._urlopen_model_catalog_request",
             return_value=self._make_mock_response(body),
         ) as mock_urlopen:
             result = probe_api_models("sk-test", "https://example.com/v1")
@@ -932,7 +932,7 @@ class TestProbeApiModelsUserAgent:
 
         body = b'{"data":[]}'
         with patch(
-            "hermes_cli.models.urllib.request.urlopen",
+            "hermes_cli.models._urlopen_model_catalog_request",
             return_value=self._make_mock_response(body),
         ) as mock_urlopen:
             probe_api_models(None, "https://example.com/v1")

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -1,5 +1,6 @@
 """Tests for the hermes_cli models module."""
 
+import urllib.request
 from unittest.mock import patch, MagicMock
 
 from hermes_cli.nous_account import NousPortalAccountInfo
@@ -78,6 +79,7 @@ class TestFetchOpenRouterModels:
             ("qwen/qwen3.7-max", ""),
             ("nvidia/nemotron-3-super-120b-a12b:free", "free"),
         ]
+
 
     def test_falls_back_to_static_snapshot_on_fetch_failure(self, monkeypatch):
         monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
@@ -969,3 +971,43 @@ class TestCodexSoftAcceptPlausibilityGate:
         r = validate_requested_model("gpt-5.5", "openai-codex")
         assert r["accepted"] is True
         assert r["recognized"] is True
+
+
+class TestModelCatalogRedirectCredentialStripping:
+    def test_cross_host_redirect_strips_provider_credentials(self):
+        req = urllib.request.Request("https://models.example.test/v1/models")
+        req.add_header("Authorization", "Bearer sk-model-secret")
+        req.add_header("x-api-key", "anthropic-secret")
+        req.add_header("Cookie", "session=secret")
+        req.add_header("User-Agent", "hermes-test")
+
+        handler = _models_mod._StripCredentialRedirectHandler("models.example.test")
+        redirected = handler.redirect_request(
+            req, None, 302, "Found", {}, "https://attacker.example.test/leak"
+        )
+
+        redirected_headers = {
+            key.lower(): value
+            for key, value in redirected.header_items()
+        }
+        assert "authorization" not in redirected_headers
+        assert "x-api-key" not in redirected_headers
+        assert "cookie" not in redirected_headers
+        assert redirected_headers["user-agent"] == "hermes-test"
+
+    def test_same_host_redirect_preserves_provider_credentials(self):
+        req = urllib.request.Request("https://models.example.test/v1/models")
+        req.add_header("Authorization", "Bearer sk-model-secret")
+        req.add_header("x-api-key", "anthropic-secret")
+
+        handler = _models_mod._StripCredentialRedirectHandler("models.example.test")
+        redirected = handler.redirect_request(
+            req, None, 302, "Found", {}, "https://models.example.test/v1/models/"
+        )
+
+        redirected_headers = {
+            key.lower(): value
+            for key, value in redirected.header_items()
+        }
+        assert redirected_headers["authorization"] == "Bearer sk-model-secret"
+        assert redirected_headers["x-api-key"] == "anthropic-secret"

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -1,6 +1,5 @@
 """Tests for the hermes_cli models module."""
 
-import urllib.request
 from unittest.mock import patch, MagicMock
 
 from hermes_cli.nous_account import NousPortalAccountInfo
@@ -71,7 +70,7 @@ class TestFetchOpenRouterModels:
                 return b'{"data":[{"id":"anthropic/claude-opus-4.8","pricing":{"prompt":"0.000015","completion":"0.000075"}},{"id":"qwen/qwen3.7-max","pricing":{"prompt":"0.000000325","completion":"0.00000195"}},{"id":"nvidia/nemotron-3-super-120b-a12b:free","pricing":{"prompt":"0","completion":"0"}}]}'
 
         monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
-        with patch("hermes_cli.models.urllib.request.urlopen", return_value=_Resp()):
+        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()):
             models = fetch_openrouter_models(force_refresh=True)
 
         assert models == [
@@ -83,7 +82,7 @@ class TestFetchOpenRouterModels:
 
     def test_falls_back_to_static_snapshot_on_fetch_failure(self, monkeypatch):
         monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
-        with patch("hermes_cli.models.urllib.request.urlopen", side_effect=OSError("boom")):
+        with patch("hermes_cli.models._urlopen_model_catalog_request", side_effect=OSError("boom")):
             models = fetch_openrouter_models(force_refresh=True)
 
         assert models == OPENROUTER_MODELS
@@ -128,7 +127,10 @@ class TestFetchOpenRouterModels:
             ],
         )
         monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
-        with patch("hermes_cli.models.urllib.request.urlopen", return_value=_Resp()):
+        with (
+            patch("hermes_cli.model_catalog.get_curated_openrouter_models", return_value=[]),
+            patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()),
+        ):
             models = fetch_openrouter_models(force_refresh=True)
 
         ids = [mid for mid, _ in models]
@@ -162,7 +164,7 @@ class TestFetchOpenRouterModels:
                 )
 
         monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
-        with patch("hermes_cli.models.urllib.request.urlopen", return_value=_Resp()):
+        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()):
             models = fetch_openrouter_models(force_refresh=True)
 
         ids = [mid for mid, _ in models]
@@ -781,7 +783,7 @@ class TestNousRecommendedModels:
     def test_fetch_caches_per_portal_url(self):
         from hermes_cli.models import fetch_nous_recommended_models
         mock_cm = self._mock_urlopen(self._SAMPLE_PAYLOAD)
-        with patch("urllib.request.urlopen", return_value=mock_cm) as mock_urlopen:
+        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=mock_cm) as mock_urlopen:
             a = fetch_nous_recommended_models("https://portal.example.com")
             b = fetch_nous_recommended_models("https://portal.example.com")
         assert a == self._SAMPLE_PAYLOAD
@@ -791,21 +793,21 @@ class TestNousRecommendedModels:
     def test_fetch_cache_is_keyed_per_portal(self):
         from hermes_cli.models import fetch_nous_recommended_models
         mock_cm = self._mock_urlopen(self._SAMPLE_PAYLOAD)
-        with patch("urllib.request.urlopen", return_value=mock_cm) as mock_urlopen:
+        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=mock_cm) as mock_urlopen:
             fetch_nous_recommended_models("https://portal.example.com")
             fetch_nous_recommended_models("https://portal.staging-nousresearch.com")
         assert mock_urlopen.call_count == 2  # different portals → separate fetches
 
     def test_fetch_returns_empty_on_network_failure(self):
         from hermes_cli.models import fetch_nous_recommended_models
-        with patch("urllib.request.urlopen", side_effect=OSError("boom")):
+        with patch("hermes_cli.models._urlopen_model_catalog_request", side_effect=OSError("boom")):
             result = fetch_nous_recommended_models("https://portal.example.com")
         assert result == {}
 
     def test_fetch_force_refresh_bypasses_cache(self):
         from hermes_cli.models import fetch_nous_recommended_models
         mock_cm = self._mock_urlopen(self._SAMPLE_PAYLOAD)
-        with patch("urllib.request.urlopen", return_value=mock_cm) as mock_urlopen:
+        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=mock_cm) as mock_urlopen:
             fetch_nous_recommended_models("https://portal.example.com")
             fetch_nous_recommended_models("https://portal.example.com", force_refresh=True)
         assert mock_urlopen.call_count == 2
@@ -971,43 +973,3 @@ class TestCodexSoftAcceptPlausibilityGate:
         r = validate_requested_model("gpt-5.5", "openai-codex")
         assert r["accepted"] is True
         assert r["recognized"] is True
-
-
-class TestModelCatalogRedirectCredentialStripping:
-    def test_cross_host_redirect_strips_provider_credentials(self):
-        req = urllib.request.Request("https://models.example.test/v1/models")
-        req.add_header("Authorization", "Bearer sk-model-secret")
-        req.add_header("x-api-key", "anthropic-secret")
-        req.add_header("Cookie", "session=secret")
-        req.add_header("User-Agent", "hermes-test")
-
-        handler = _models_mod._StripCredentialRedirectHandler("models.example.test")
-        redirected = handler.redirect_request(
-            req, None, 302, "Found", {}, "https://attacker.example.test/leak"
-        )
-
-        redirected_headers = {
-            key.lower(): value
-            for key, value in redirected.header_items()
-        }
-        assert "authorization" not in redirected_headers
-        assert "x-api-key" not in redirected_headers
-        assert "cookie" not in redirected_headers
-        assert redirected_headers["user-agent"] == "hermes-test"
-
-    def test_same_host_redirect_preserves_provider_credentials(self):
-        req = urllib.request.Request("https://models.example.test/v1/models")
-        req.add_header("Authorization", "Bearer sk-model-secret")
-        req.add_header("x-api-key", "anthropic-secret")
-
-        handler = _models_mod._StripCredentialRedirectHandler("models.example.test")
-        redirected = handler.redirect_request(
-            req, None, 302, "Found", {}, "https://models.example.test/v1/models/"
-        )
-
-        redirected_headers = {
-            key.lower(): value
-            for key, value in redirected.header_items()
-        }
-        assert redirected_headers["authorization"] == "Bearer sk-model-secret"
-        assert redirected_headers["x-api-key"] == "anthropic-secret"

--- a/tests/hermes_cli/test_urllib_security.py
+++ b/tests/hermes_cli/test_urllib_security.py
@@ -254,6 +254,47 @@ def test_explicit_opener_factory_is_instrumentable_without_security_bypass():
     assert calls == [("https://models.example.test/models", 7)]
 
 
+def test_installed_custom_opener_policy_is_preserved(monkeypatch):
+    opened = []
+
+    class FooHandler(urllib.request.BaseHandler):
+        def foo_open(self, request):
+            opened.append(request.full_url)
+            return _Response(b"custom")
+
+    installed = urllib.request.build_opener(FooHandler())
+    monkeypatch.setattr(urllib.request, "_opener", installed)
+
+    request = urllib.request.Request(
+        "foo://models.example.test/catalog", headers={"Authorization": "secret"}
+    )
+    with open_credentialed_url(request, timeout=3) as response:
+        assert response.read() == b"custom"
+    assert opened == ["foo://models.example.test/catalog"]
+
+
+def test_installed_proxy_handler_is_preserved(monkeypatch):
+    installed = urllib.request.build_opener(
+        urllib.request.ProxyHandler({"https": "http://proxy.example.test:8443"})
+    )
+    monkeypatch.setattr(urllib.request, "_opener", installed)
+
+    from hermes_cli.urllib_security import _secure_opener_from_installed_policy
+
+    secured = _secure_opener_from_installed_policy(
+        "https://models.example.test/catalog"
+    )
+    proxy_handlers = [
+        handler
+        for handler in getattr(secured, "handlers", ())
+        if isinstance(handler, urllib.request.ProxyHandler)
+    ]
+    assert proxy_handlers
+    assert getattr(proxy_handlers[0], "proxies", {}) == {
+        "https": "http://proxy.example.test:8443"
+    }
+
+
 def test_probe_api_models_drops_custom_credentials_on_wire():
     from hermes_cli.models import probe_api_models
 

--- a/tests/hermes_cli/test_urllib_security.py
+++ b/tests/hermes_cli/test_urllib_security.py
@@ -270,7 +270,18 @@ def test_installed_custom_opener_policy_is_preserved(monkeypatch):
             return _Response(b"custom")
 
     installed = urllib.request.build_opener(FooHandler())
+    installed.addheaders = [
+        ("X-Trace-Policy", "installed"),
+        ("User-agent", "enterprise-client"),
+    ]
     monkeypatch.setattr(urllib.request, "_opener", installed)
+
+    from hermes_cli.urllib_security import _secure_opener_from_installed_policy
+
+    secured = _secure_opener_from_installed_policy(
+        "foo://models.example.test/catalog"
+    )
+    assert secured.addheaders == installed.addheaders
 
     request = urllib.request.Request(
         "foo://models.example.test/catalog", headers={"Authorization": "secret"}
@@ -300,6 +311,57 @@ def test_installed_proxy_handler_is_preserved(monkeypatch):
     assert getattr(proxy_handlers[0], "proxies", {}) == {
         "https": "http://proxy.example.test:8443"
     }
+
+
+def test_multihop_redirects_never_resurrect_credentials():
+    request = urllib.request.Request(
+        "https://a.example.test/models", headers=_credential_headers()
+    )
+    handler = SafeCredentialRedirectHandler(request.full_url)
+
+    same_origin = handler.redirect_request(
+        request,
+        None,
+        302,
+        "Found",
+        {},
+        "https://a.example.test/step-two",
+    )
+    assert same_origin is not None
+    same_headers = {
+        name.lower(): value for name, value in same_origin.header_items()
+    }
+    assert "authorization" in same_headers
+
+    cross_origin = handler.redirect_request(
+        same_origin,
+        None,
+        302,
+        "Found",
+        {},
+        "https://b.example.test/step-three",
+    )
+    assert cross_origin is not None
+    cross_headers = {
+        name.lower(): value for name, value in cross_origin.header_items()
+    }
+    assert "authorization" not in cross_headers
+    assert "cf-access-client-secret" not in cross_headers
+
+    returned = handler.redirect_request(
+        cross_origin,
+        None,
+        302,
+        "Found",
+        {},
+        "https://a.example.test/final",
+    )
+    assert returned is not None
+    returned_headers = {
+        name.lower(): value for name, value in returned.header_items()
+    }
+    assert "authorization" not in returned_headers
+    assert "cf-access-client-secret" not in returned_headers
 
 
 def test_probe_api_models_drops_custom_credentials_on_wire():

--- a/tests/hermes_cli/test_urllib_security.py
+++ b/tests/hermes_cli/test_urllib_security.py
@@ -329,6 +329,8 @@ def test_installed_request_processor_cannot_resurrect_cross_origin_secret(
     _RecordingHandler.redirect_to = f"http://localhost:{sink.server_port}/sink"
 
     class SecretProcessor(urllib.request.BaseHandler):
+        handler_order = float("inf")  # type: ignore[assignment]
+
         def http_request(self, request):
             request.add_header("X-Installed-Secret", "must-not-cross")
             return request
@@ -479,6 +481,50 @@ def test_anthropic_profile_drops_x_api_key_on_redirect(monkeypatch):
     _, headers = _RecordingHandler.requests[-1]
     assert "x-api-key" not in headers
     assert headers["accept"] == "application/json"
+
+
+def test_azure_catalog_probe_drops_api_key_and_bearer_on_redirect():
+    from hermes_cli import azure_detect
+
+    source = _server()
+    sink = _server()
+    _RecordingHandler.requests = []
+    _RecordingHandler.redirect_status = 302
+    _RecordingHandler.redirect_to = f"http://localhost:{sink.server_port}/sink"
+    try:
+        status, body = azure_detect._http_get_json(
+            f"http://127.0.0.1:{source.server_port}/redirect", "azure-secret", timeout=3
+        )
+    finally:
+        source.shutdown()
+        sink.shutdown()
+
+    assert status == 200
+    assert body == {"data": []}
+    _, headers = _RecordingHandler.requests[-1]
+    assert "authorization" not in headers
+    assert "api-key" not in headers
+
+
+def test_azure_anthropic_probe_drops_api_key_and_bearer_on_redirect():
+    from hermes_cli import azure_detect
+
+    sink = _server()
+    source = ThreadingHTTPServer(("127.0.0.1", 0), _LmStudioSourceHandler)
+    Thread(target=source.serve_forever, daemon=True).start()
+    _RecordingHandler.requests = []
+    _LmStudioSourceHandler.redirect_to = f"http://localhost:{sink.server_port}/sink"
+    try:
+        azure_detect._probe_anthropic_messages(
+            f"http://127.0.0.1:{source.server_port}", "azure-secret"
+        )
+    finally:
+        source.shutdown()
+        sink.shutdown()
+
+    _, headers = _RecordingHandler.requests[-1]
+    assert "authorization" not in headers
+    assert "api-key" not in headers
 
 
 def test_lmstudio_load_post_drops_bearer_on_redirect(monkeypatch):

--- a/tests/hermes_cli/test_urllib_security.py
+++ b/tests/hermes_cli/test_urllib_security.py
@@ -1,0 +1,330 @@
+"""Wire-level tests for credential-safe stdlib urllib redirects."""
+
+from __future__ import annotations
+
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
+import urllib.error
+import urllib.request
+
+import pytest
+
+from hermes_cli.urllib_security import (
+    SafeCredentialRedirectHandler,
+    open_credentialed_url,
+    url_origin,
+)
+
+
+class _Response:
+    def __init__(self, payload: bytes = b"{}") -> None:
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self) -> bytes:
+        return self._payload
+
+
+class _RecordingHandler(BaseHTTPRequestHandler):
+    redirect_to = ""
+    redirect_status = 302
+    requests: list[tuple[str, dict[str, str]]] = []
+
+    def _record(self) -> None:
+        type(self).requests.append(
+            (self.command, {name.lower(): value for name, value in self.headers.items()})
+        )
+
+    def do_GET(self):
+        if self.path.startswith("/redirect"):
+            self.send_response(type(self).redirect_status)
+            self.send_header("Location", type(self).redirect_to)
+            self.end_headers()
+            return
+        self._record()
+        body = json.dumps({"data": []}).encode()
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        self.rfile.read(int(self.headers.get("Content-Length", "0")))
+        if self.path == "/redirect":
+            self.send_response(type(self).redirect_status)
+            self.send_header("Location", type(self).redirect_to)
+            self.end_headers()
+            return
+        self._record()
+        self.send_response(200)
+        self.end_headers()
+
+    def log_message(self, _format, *_args):
+        pass
+
+
+def _server():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _RecordingHandler)
+    Thread(target=server.serve_forever, daemon=True).start()
+    return server
+
+
+def _credential_headers() -> dict[str, str]:
+    return {
+        "Authorization": "Bearer secret",
+        "Cookie": "session=secret",
+        "CF-Access-Client-Secret": "cloudflare-secret",
+        "X-Custom-Auth": "tenant-secret",
+        "Accept": "application/json",
+        "User-Agent": "hermes-test",
+    }
+
+
+def test_url_origin_normalizes_default_ports_and_trailing_dot():
+    assert url_origin("https://EXAMPLE.test./models") == (
+        "https",
+        "example.test",
+        443,
+    )
+    assert url_origin("https://example.test:443/other") == (
+        "https",
+        "example.test",
+        443,
+    )
+    assert url_origin("http://example.test") != url_origin("https://example.test")
+
+
+def test_cross_host_redirect_drops_arbitrary_credentials_on_wire():
+    source = _server()
+    sink = _server()
+    _RecordingHandler.requests = []
+    _RecordingHandler.redirect_status = 302
+    _RecordingHandler.redirect_to = f"http://localhost:{sink.server_port}/sink"
+    try:
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{source.server_port}/redirect",
+            headers=_credential_headers(),
+        )
+        with open_credentialed_url(request, timeout=3) as response:
+            response.read()
+    finally:
+        source.shutdown()
+        sink.shutdown()
+
+    method, headers = _RecordingHandler.requests[-1]
+    assert method == "GET"
+    assert headers["accept"] == "application/json"
+    assert headers["user-agent"] == "hermes-test"
+    for name in (
+        "authorization",
+        "cookie",
+        "cf-access-client-secret",
+        "x-custom-auth",
+    ):
+        assert name not in headers
+
+
+def test_same_host_different_port_drops_credentials_on_wire():
+    source = _server()
+    sink = _server()
+    _RecordingHandler.requests = []
+    _RecordingHandler.redirect_status = 302
+    _RecordingHandler.redirect_to = f"http://127.0.0.1:{sink.server_port}/sink"
+    try:
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{source.server_port}/redirect",
+            headers=_credential_headers(),
+        )
+        with open_credentialed_url(request, timeout=3) as response:
+            response.read()
+    finally:
+        source.shutdown()
+        sink.shutdown()
+
+    _, headers = _RecordingHandler.requests[-1]
+    assert "authorization" not in headers
+    assert "cf-access-client-secret" not in headers
+
+
+def test_same_origin_redirect_preserves_headers_on_wire():
+    server = _server()
+    _RecordingHandler.requests = []
+    _RecordingHandler.redirect_status = 302
+    _RecordingHandler.redirect_to = f"http://127.0.0.1:{server.server_port}/sink"
+    try:
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{server.server_port}/redirect",
+            headers=_credential_headers(),
+        )
+        with open_credentialed_url(request, timeout=3) as response:
+            response.read()
+    finally:
+        server.shutdown()
+
+    _, headers = _RecordingHandler.requests[-1]
+    assert headers["authorization"] == "Bearer secret"
+    assert headers["cf-access-client-secret"] == "cloudflare-secret"
+
+
+def test_scheme_downgrade_is_cross_origin():
+    request = urllib.request.Request(
+        "https://models.example.test/models", headers=_credential_headers()
+    )
+    handler = SafeCredentialRedirectHandler(request.full_url)
+    redirected = handler.redirect_request(
+        request,
+        None,
+        302,
+        "Found",
+        {},
+        "http://models.example.test/models",
+    )
+    assert redirected is not None
+    headers = {name.lower(): value for name, value in redirected.header_items()}
+    assert "authorization" not in headers
+    assert "cf-access-client-secret" not in headers
+
+
+def test_post_302_uses_urllib_semantics_and_drops_credentials():
+    request = urllib.request.Request(
+        "https://models.example.test/load",
+        data=b"{}",
+        headers={**_credential_headers(), "Content-Type": "application/json"},
+        method="POST",
+    )
+    handler = SafeCredentialRedirectHandler(request.full_url)
+    redirected = handler.redirect_request(
+        request,
+        None,
+        302,
+        "Found",
+        {},
+        "https://other.example.test/load",
+    )
+    assert redirected is not None
+    assert redirected.get_method() == "GET"
+    assert redirected.data is None
+    headers = {name.lower(): value for name, value in redirected.header_items()}
+    assert "authorization" not in headers
+    assert "content-type" not in headers
+
+
+def test_post_307_remains_rejected_by_urllib():
+    request = urllib.request.Request(
+        "https://models.example.test/load",
+        data=b"{}",
+        headers=_credential_headers(),
+        method="POST",
+    )
+    handler = SafeCredentialRedirectHandler(request.full_url)
+    with pytest.raises(urllib.error.HTTPError):
+        handler.redirect_request(
+            request,
+            None,
+            307,
+            "Temporary Redirect",
+            {},
+            "https://other.example.test/load",
+        )
+
+
+def test_explicit_opener_factory_is_instrumentable_without_security_bypass():
+    calls = []
+
+    class _Opener:
+        def open(self, request, *, timeout):
+            calls.append((request.full_url, timeout))
+            return _Response()
+
+    def factory(*handlers):
+        assert any(isinstance(h, SafeCredentialRedirectHandler) for h in handlers)
+        return _Opener()
+
+    request = urllib.request.Request(
+        "https://models.example.test/models", headers={"Authorization": "secret"}
+    )
+    with open_credentialed_url(request, timeout=7, opener_factory=factory):
+        pass
+    assert calls == [("https://models.example.test/models", 7)]
+
+
+def test_probe_api_models_drops_custom_credentials_on_wire():
+    from hermes_cli.models import probe_api_models
+
+    source = _server()
+    sink = _server()
+    _RecordingHandler.requests = []
+    _RecordingHandler.redirect_status = 302
+    _RecordingHandler.redirect_to = f"http://localhost:{sink.server_port}/sink"
+    try:
+        result = probe_api_models(
+            "provider-key",
+            f"http://127.0.0.1:{source.server_port}/redirect/..",
+            timeout=3,
+            request_headers={
+                "CF-Access-Client-Secret": "cloudflare-secret",
+                "X-Custom-Auth": "tenant-secret",
+            },
+        )
+    finally:
+        source.shutdown()
+        sink.shutdown()
+
+    assert result["models"] == []
+    _, headers = _RecordingHandler.requests[-1]
+    assert "authorization" not in headers
+    assert "cf-access-client-secret" not in headers
+    assert "x-custom-auth" not in headers
+
+
+class _LmStudioSourceHandler(BaseHTTPRequestHandler):
+    redirect_to = ""
+
+    def do_POST(self):
+        self.rfile.read(int(self.headers.get("Content-Length", "0")))
+        self.send_response(302)
+        self.send_header("Location", type(self).redirect_to)
+        self.end_headers()
+
+    def log_message(self, format, *_args):
+        pass
+
+
+def test_lmstudio_load_post_drops_bearer_on_redirect(monkeypatch):
+    from hermes_cli import models
+
+    sink = _server()
+    source = ThreadingHTTPServer(("127.0.0.1", 0), _LmStudioSourceHandler)
+    Thread(target=source.serve_forever, daemon=True).start()
+    _RecordingHandler.requests = []
+    _LmStudioSourceHandler.redirect_to = f"http://localhost:{sink.server_port}/sink"
+    monkeypatch.setattr(
+        models,
+        "_lmstudio_fetch_raw_models",
+        lambda **_kwargs: [
+            {"id": "model", "max_context_length": 8192, "loaded_instances": []}
+        ],
+    )
+    try:
+        loaded = models.ensure_lmstudio_model_loaded(
+            "model",
+            f"http://127.0.0.1:{source.server_port}",
+            api_key="lm-secret",
+            target_context_length=4096,
+            timeout=3,
+        )
+    finally:
+        source.shutdown()
+        sink.shutdown()
+
+    assert loaded == 4096
+    method, headers = _RecordingHandler.requests[-1]
+    assert method == "GET"
+    assert "authorization" not in headers
+    assert "content-type" not in headers

--- a/tests/hermes_cli/test_urllib_security.py
+++ b/tests/hermes_cli/test_urllib_security.py
@@ -281,13 +281,19 @@ def test_installed_custom_opener_policy_is_preserved(monkeypatch):
     secured = _secure_opener_from_installed_policy(
         "foo://models.example.test/catalog"
     )
-    assert secured.addheaders == installed.addheaders
+    assert secured.addheaders == []
+    assert getattr(secured, "_hermes_initial_addheaders") == installed.addheaders
 
     request = urllib.request.Request(
         "foo://models.example.test/catalog", headers={"Authorization": "secret"}
     )
     with open_credentialed_url(request, timeout=3) as response:
         assert response.read() == b"custom"
+    request_headers = {
+        name.lower(): value for name, value in request.header_items()
+    }
+    assert request_headers["x-trace-policy"] == "installed"
+    assert request_headers["user-agent"] == "enterprise-client"
     assert opened == ["foo://models.example.test/catalog"]
 
 
@@ -311,6 +317,40 @@ def test_installed_proxy_handler_is_preserved(monkeypatch):
     assert getattr(proxy_handlers[0], "proxies", {}) == {
         "https": "http://proxy.example.test:8443"
     }
+
+
+def test_installed_request_processor_cannot_resurrect_cross_origin_secret(
+    monkeypatch,
+):
+    source = _server()
+    sink = _server()
+    _RecordingHandler.requests = []
+    _RecordingHandler.redirect_status = 302
+    _RecordingHandler.redirect_to = f"http://localhost:{sink.server_port}/sink"
+
+    class SecretProcessor(urllib.request.BaseHandler):
+        def http_request(self, request):
+            request.add_header("X-Installed-Secret", "must-not-cross")
+            return request
+
+    installed = urllib.request.build_opener(SecretProcessor())
+    installed.addheaders = [("X-Opener-Secret", "also-must-not-cross")]
+    monkeypatch.setattr(urllib.request, "_opener", installed)
+    try:
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{source.server_port}/redirect",
+            headers={"Authorization": "Bearer secret"},
+        )
+        with open_credentialed_url(request, timeout=3) as response:
+            response.read()
+    finally:
+        source.shutdown()
+        sink.shutdown()
+
+    _, headers = _RecordingHandler.requests[-1]
+    assert "authorization" not in headers
+    assert "x-installed-secret" not in headers
+    assert "x-opener-secret" not in headers
 
 
 def test_multihop_redirects_never_resurrect_credentials():

--- a/tests/hermes_cli/test_urllib_security.py
+++ b/tests/hermes_cli/test_urllib_security.py
@@ -98,6 +98,13 @@ def test_url_origin_normalizes_default_ports_and_trailing_dot():
         443,
     )
     assert url_origin("http://example.test") != url_origin("https://example.test")
+    assert url_origin("https://example.test:0") == (
+        "https",
+        "example.test",
+        0,
+    )
+    with pytest.raises(ValueError):
+        url_origin("https://example.test:not-a-port")
 
 
 def test_cross_host_redirect_drops_arbitrary_credentials_on_wire():
@@ -335,6 +342,41 @@ class _LmStudioSourceHandler(BaseHTTPRequestHandler):
 
     def log_message(self, format, *_args):
         pass
+
+
+def test_anthropic_profile_drops_x_api_key_on_redirect(monkeypatch):
+    import importlib
+
+    AnthropicProfile = importlib.import_module(
+        "plugins.model-providers.anthropic"
+    ).AnthropicProfile
+
+    source = _server()
+    sink = _server()
+    _RecordingHandler.requests = []
+    _RecordingHandler.redirect_status = 302
+    _RecordingHandler.redirect_to = f"http://localhost:{sink.server_port}/sink"
+
+    original_request = urllib.request.Request
+
+    def local_anthropic_request(url, *args, **kwargs):
+        if url == "https://api.anthropic.com/v1/models":
+            url = f"http://127.0.0.1:{source.server_port}/redirect"
+        return original_request(url, *args, **kwargs)
+
+    monkeypatch.setattr(urllib.request, "Request", local_anthropic_request)
+    try:
+        result = AnthropicProfile(name="anthropic").fetch_models(
+            api_key="anthropic-secret", timeout=3
+        )
+    finally:
+        source.shutdown()
+        sink.shutdown()
+
+    assert result == []
+    _, headers = _RecordingHandler.requests[-1]
+    assert "x-api-key" not in headers
+    assert headers["accept"] == "application/json"
 
 
 def test_lmstudio_load_post_drops_bearer_on_redirect(monkeypatch):

--- a/tests/providers/test_fetch_models_base_url.py
+++ b/tests/providers/test_fetch_models_base_url.py
@@ -117,6 +117,66 @@ class TestCustomProviderBaseUrlPassthrough:
             server.shutdown()
 
 
+class _RedirectingHandler(BaseHTTPRequestHandler):
+    """Redirects /models to another hostname and records received headers."""
+
+    redirect_host = "localhost"  # resolves to the same server, different hostname
+    received_headers: dict = {}
+
+    def do_GET(self):
+        if self.path.rstrip("/") == "/models":
+            self.send_response(302)
+            self.send_header(
+                "Location",
+                f"http://{self.redirect_host}:{self.server.server_address[1]}/redirected",
+            )
+            self.end_headers()
+        else:
+            type(self).received_headers = dict(self.headers)
+            body = json.dumps({"data": [{"id": "redirected-model"}]}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        pass
+
+
+class TestFetchModelsRedirectCredentialStripping:
+    """Credential headers must not follow a redirect to a different host."""
+
+    def _run(self, redirect_host):
+        _RedirectingHandler.redirect_host = redirect_host
+        _RedirectingHandler.received_headers = {}
+        server = HTTPServer(("127.0.0.1", 0), _RedirectingHandler)
+        port = server.server_address[1]
+        Thread(target=server.serve_forever, daemon=True).start()
+        try:
+            profile = ProviderProfile(
+                name="test",
+                base_url=f"http://127.0.0.1:{port}",
+                default_headers={"x-api-key": "default-header-secret"},
+            )
+            result = profile.fetch_models(api_key="bearer-secret")
+        finally:
+            server.shutdown()
+        headers = {k.lower(): v for k, v in _RedirectingHandler.received_headers.items()}
+        return result, headers
+
+    def test_cross_host_redirect_strips_credentials(self):
+        result, headers = self._run(redirect_host="localhost")
+        assert result == ["redirected-model"]  # fetch itself still works
+        assert "authorization" not in headers
+        assert "x-api-key" not in headers
+
+    def test_same_host_redirect_keeps_credentials(self):
+        result, headers = self._run(redirect_host="127.0.0.1")
+        assert result == ["redirected-model"]
+        assert headers.get("authorization") == "Bearer bearer-secret"
+        assert headers.get("x-api-key") == "default-header-secret"
+
+
 class TestModelPickerBaseUrlIntegration:
     """The /model picker path should pass model.base_url to fetch_models."""
 

--- a/tests/providers/test_fetch_models_base_url.py
+++ b/tests/providers/test_fetch_models_base_url.py
@@ -118,21 +118,18 @@ class TestCustomProviderBaseUrlPassthrough:
 
 
 class _RedirectingHandler(BaseHTTPRequestHandler):
-    """Redirects /models to another hostname and records received headers."""
+    """Redirects /models to a configurable target and records received headers."""
 
-    redirect_host = "localhost"  # resolves to the same server, different hostname
+    redirect_to = ""  # full URL to redirect /models to (set per test)
     received_headers: dict = {}
 
     def do_GET(self):
         if self.path.rstrip("/") == "/models":
             self.send_response(302)
-            self.send_header(
-                "Location",
-                f"http://{self.redirect_host}:{self.server.server_address[1]}/redirected",
-            )
+            self.send_header("Location", type(self).redirect_to)
             self.end_headers()
         else:
-            type(self).received_headers = dict(self.headers)
+            _RedirectingHandler.received_headers = dict(self.headers)
             body = json.dumps({"data": [{"id": "redirected-model"}]}).encode()
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
@@ -144,14 +141,18 @@ class _RedirectingHandler(BaseHTTPRequestHandler):
 
 
 class TestFetchModelsRedirectCredentialStripping:
-    """Credential headers must not follow a redirect to a different host."""
+    """Credential headers must not follow a redirect outside the original origin."""
 
-    def _run(self, redirect_host):
-        _RedirectingHandler.redirect_host = redirect_host
+    def _run(self, redirect_to):
+        """redirect_to is a callable (first_port, second_port) -> Location URL."""
         _RedirectingHandler.received_headers = {}
         server = HTTPServer(("127.0.0.1", 0), _RedirectingHandler)
+        second_server = HTTPServer(("127.0.0.1", 0), _RedirectingHandler)
         port = server.server_address[1]
+        second_port = second_server.server_address[1]
+        _RedirectingHandler.redirect_to = redirect_to(port, second_port)
         Thread(target=server.serve_forever, daemon=True).start()
+        Thread(target=second_server.serve_forever, daemon=True).start()
         try:
             profile = ProviderProfile(
                 name="test",
@@ -161,17 +162,31 @@ class TestFetchModelsRedirectCredentialStripping:
             result = profile.fetch_models(api_key="bearer-secret")
         finally:
             server.shutdown()
+            second_server.shutdown()
         headers = {k.lower(): v for k, v in _RedirectingHandler.received_headers.items()}
         return result, headers
 
     def test_cross_host_redirect_strips_credentials(self):
-        result, headers = self._run(redirect_host="localhost")
+        result, headers = self._run(
+            lambda port, _: f"http://localhost:{port}/redirected"
+        )
         assert result == ["redirected-model"]  # fetch itself still works
         assert "authorization" not in headers
         assert "x-api-key" not in headers
 
-    def test_same_host_redirect_keeps_credentials(self):
-        result, headers = self._run(redirect_host="127.0.0.1")
+    def test_same_host_different_port_redirect_strips_credentials(self):
+        """A different port is a different origin — it can be a different service."""
+        result, headers = self._run(
+            lambda _, second_port: f"http://127.0.0.1:{second_port}/redirected"
+        )
+        assert result == ["redirected-model"]
+        assert "authorization" not in headers
+        assert "x-api-key" not in headers
+
+    def test_same_origin_redirect_keeps_credentials(self):
+        result, headers = self._run(
+            lambda port, _: f"http://127.0.0.1:{port}/redirected"
+        )
         assert result == ["redirected-model"]
         assert headers.get("authorization") == "Bearer bearer-secret"
         assert headers.get("x-api-key") == "default-header-secret"

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -286,14 +286,46 @@ class TestRestorePrimaryRuntime:
         agent._credential_pool = _DeepseekPool()
         agent._swap_credential = MagicMock()
 
-        with patch("run_agent.OpenAI", return_value=MagicMock()):
+        primary_pool = MagicMock()
+        primary_pool.provider = primary_provider
+        primary_pool.has_available.return_value = False
+        with (
+            patch("run_agent.OpenAI", return_value=MagicMock()),
+            patch("agent.credential_pool.load_pool", return_value=primary_pool) as load_pool,
+        ):
             result = agent._restore_primary_runtime()
 
         assert result is True
         assert agent.provider == primary_provider
         assert agent.base_url == primary_base_url
         assert "deepseek" not in str(agent.base_url)
+        assert agent._credential_pool is primary_pool
+        load_pool.assert_called_once_with(primary_provider)
         agent._swap_credential.assert_not_called()
+
+    def test_restore_clears_fallback_pool_when_primary_pool_reload_fails(self):
+        """A fallback pool must never remain attached to the restored primary."""
+        agent = _make_agent(
+            provider="openai-api",
+            base_url="https://api.openai.com/v1",
+        )
+        agent._fallback_activated = True
+        fallback_pool = MagicMock()
+        fallback_pool.provider = "deepseek"
+        agent._credential_pool = fallback_pool
+
+        with (
+            patch("run_agent.OpenAI", return_value=MagicMock()),
+            patch(
+                "agent.credential_pool.load_pool",
+                side_effect=RuntimeError("auth store unavailable"),
+            ),
+        ):
+            result = agent._restore_primary_runtime()
+
+        assert result is True
+        assert agent.provider == "openai-api"
+        assert agent._credential_pool is None
 
     def test_restore_swaps_matching_custom_pool_entry(self):
         """Custom primary + custom:<name> entry whose base_url resolves to the

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -821,6 +821,81 @@ def test_run_conversation_codex_plain_text(monkeypatch):
     assert result["messages"][-1]["content"] == "OK"
 
 
+def test_copilot_final_preflight_sanitizes_both_middleware_layers(monkeypatch):
+    """The dispatch chokepoint must sanitize after every mutable layer."""
+    agent = _build_copilot_agent(monkeypatch)
+    setattr(agent, "_disable_streaming", True)
+    captured = {}
+
+    def _message_item(item_id, *, text, phase, status):
+        return {
+            "type": "message",
+            "role": "assistant",
+            "status": status,
+            "content": [{"type": "output_text", "text": text}],
+            "id": item_id,
+            "phase": phase,
+        }
+
+    def _request_middleware(request, **_context):
+        replacement = dict(request)
+        replacement["input"] = [
+            _message_item(
+                "request_middleware_id",
+                text="request-layer",
+                phase="commentary",
+                status="completed",
+            )
+        ]
+        return SimpleNamespace(
+            payload=replacement,
+            original_payload=request,
+            changed=True,
+            trace=[],
+        )
+
+    def _execution_middleware(request, next_call, **_context):
+        # Request middleware runs after the initial preflight, so its ID is
+        # still present here. The dispatch chokepoint must remove the ID that
+        # this execution middleware introduces immediately before the API call.
+        assert request["input"][0]["id"] == "request_middleware_id"
+        replacement = dict(request)
+        replacement["input"] = [
+            _message_item(
+                "execution_middleware_id",
+                text="execution-layer",
+                phase="final_answer",
+                status="in_progress",
+            )
+        ]
+        return next_call(replacement)
+
+    def _capture_api_call(api_kwargs):
+        captured.update(api_kwargs)
+        return _codex_message_response("OK")
+
+    monkeypatch.setattr(
+        "hermes_cli.middleware.apply_llm_request_middleware",
+        _request_middleware,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.middleware.run_llm_execution_middleware",
+        _execution_middleware,
+    )
+    monkeypatch.setattr(agent, "_interruptible_api_call", _capture_api_call)
+
+    result = agent.run_conversation("Say OK")
+
+    assert result["completed"] is True
+    message_item = captured["input"][0]
+    assert "id" not in message_item
+    assert message_item["status"] == "in_progress"
+    assert message_item["phase"] == "final_answer"
+    assert message_item["content"] == [
+        {"type": "output_text", "text": "execution-layer"}
+    ]
+
+
 def test_run_conversation_codex_empty_output_with_output_text(monkeypatch):
     """Regression: empty response.output + valid output_text should succeed,
     not trigger retry/fallback. The validation stage must defer to

--- a/tests/run_agent/test_switch_model_pool_reload_52727.py
+++ b/tests/run_agent/test_switch_model_pool_reload_52727.py
@@ -213,6 +213,7 @@ class TestSwitchModelReloadsCredentialPool:
             )
 
         # The switch itself completed (provider/model updated) even though
-        # the pool reload failed.
+        # the pool reload failed, without retaining the old provider's pool.
         assert agent.provider == "groq"
         assert agent.model == "llama-3.3-70b"
+        assert agent._credential_pool is None

--- a/tests/run_agent/test_tls_fd_recycle_corruption.py
+++ b/tests/run_agent/test_tls_fd_recycle_corruption.py
@@ -7,11 +7,9 @@ SQLite header.
 
 The fix has two prongs:
 
-1. ``force_close_tcp_sockets`` defaults to ``shutdown(SHUT_RDWR)`` only —
-   no ``sock.close()``. Shutdown unblocks the worker's pending
-   ``recv``/``send`` without releasing the FD. Owning-thread dispose
-   opts into ``release_fds=True`` so already-shutdown sockets do not
-   accumulate as kernel CLOSED fds (#61979).
+1. ``force_close_tcp_sockets`` no longer calls ``sock.close()`` — only
+   ``shutdown(SHUT_RDWR)``. Shutdown unblocks the worker's pending
+   ``recv``/``send`` without releasing the FD.
 
 2. ``_close_request_client_once`` is thread-aware: a stranger thread (the
    interrupt-check / stale-call loop) only aborts the sockets and leaves
@@ -63,10 +61,11 @@ def _build_fake_client(sock):
 
 
 def test_force_close_tcp_sockets_shutdown_only_no_close():
-    """Default path: shutdown is called, close is NOT.
+    """The smoking-gun guarantee: shutdown is called, close is NOT.
 
-    Stranger-thread abort (#29507) relies on this default. Releasing the
-    FD from a non-owning thread re-opens the TLS→SQLite corruption race.
+    If a future refactor reintroduces ``sock.close()`` here, the
+    FD-recycling race that corrupted ``kanban.db`` (issue #29507) will
+    re-open. Pin the contract explicitly.
     """
     from agent.agent_runtime_helpers import force_close_tcp_sockets
 
@@ -78,28 +77,9 @@ def test_force_close_tcp_sockets_shutdown_only_no_close():
     assert n == 1
     assert sock.shutdown_calls == 1, "shutdown() must run — it's how we unblock the worker"
     assert sock.close_calls == 0, (
-        "close() must NOT run by default — releasing the FD here is the "
+        "close() must NOT run from this helper — releasing the FD here is the "
         "race that wrote TLS bytes into kanban.db (#29507)"
     )
-
-
-def test_force_close_tcp_sockets_release_fds_closes_after_shutdown():
-    """Owning-thread dispose path (#61979): shutdown then close.
-
-    httpx does not reliably ``os.close()`` sockets that were already
-    shutdown, so owner-thread close must release FDs explicitly or they
-    accumulate in kernel CLOSED state under long-lived gateways.
-    """
-    from agent.agent_runtime_helpers import force_close_tcp_sockets
-
-    sock = _FakeSocket()
-    client = _build_fake_client(sock)
-
-    n = force_close_tcp_sockets(client, release_fds=True)
-
-    assert n == 1
-    assert sock.shutdown_calls == 1
-    assert sock.close_calls == 1
 
 
 def test_force_close_tcp_sockets_uses_shut_rdwr():
@@ -135,34 +115,13 @@ def test_force_close_tcp_sockets_swallows_oserror_on_shutdown():
         def shutdown(self, _how):
             raise OSError("not connected")
 
-        def close(self):  # pragma: no cover — must not run on default path
+        def close(self):  # pragma: no cover — must not run
             raise AssertionError("close() must not be called")
 
     client = _build_fake_client(_AlreadyShut())
 
     # No exception escapes; the helper still counts the socket as handled.
     assert force_close_tcp_sockets(client) == 1
-
-
-def test_force_close_tcp_sockets_release_fds_swallows_oserror_on_close():
-    """Already-closed sockets must not abort the owning-thread sweep."""
-    from agent.agent_runtime_helpers import force_close_tcp_sockets
-
-    class _CloseRaises:
-        def __init__(self):
-            self.shutdown_calls = 0
-
-        def shutdown(self, _how):
-            self.shutdown_calls += 1
-
-        def close(self):
-            raise OSError("Bad file descriptor")
-
-    sock = _CloseRaises()
-    client = _build_fake_client(sock)
-
-    assert force_close_tcp_sockets(client, release_fds=True) == 1
-    assert sock.shutdown_calls == 1
 
 
 def test_force_close_tcp_sockets_handles_multiple_pool_entries():
@@ -183,20 +142,6 @@ def test_force_close_tcp_sockets_handles_multiple_pool_entries():
     for s in socks:
         assert s.shutdown_calls == 1
         assert s.close_calls == 0
-
-    # Owning-thread dispose releases every pool entry's FD.
-    socks2 = [_FakeSocket(), _FakeSocket(), _FakeSocket()]
-    entries2 = [
-        SimpleNamespace(_connection=SimpleNamespace(_network_stream=SimpleNamespace(_sock=s)))
-        for s in socks2
-    ]
-    client2 = SimpleNamespace(
-        _client=SimpleNamespace(_transport=SimpleNamespace(_pool=SimpleNamespace(_connections=entries2)))
-    )
-    assert force_close_tcp_sockets(client2, release_fds=True) == 3
-    for s in socks2:
-        assert s.shutdown_calls == 1
-        assert s.close_calls == 1
 
 
 # ---------------------------------------------------------------------------
@@ -445,38 +390,6 @@ def test_agent_abort_request_openai_client_does_not_call_client_close(caplog):
         and "deferred_close=stranger_thread" in m
         for m in msgs
     ), f"missing abort log line; got: {msgs!r}"
-
-
-def test_agent_close_openai_client_releases_fds(caplog):
-    """Owning-thread ``_close_openai_client`` must release pool FDs (#61979).
-
-    After #29507 the helper defaulted to shutdown-only; combined with
-    httpx not closing already-shutdown sockets, gateway processes leaked
-    CLOSED fds until rlimit. The owner dispose path must opt into
-    ``release_fds=True``.
-    """
-    from run_agent import AIAgent
-
-    sock = _FakeSocket()
-    client = _build_fake_client(sock)
-    client.close = MagicMock()
-
-    agent = AIAgent.__new__(AIAgent)
-    agent._client_log_context = lambda: "provider=test"
-
-    with caplog.at_level(logging.INFO, logger="run_agent"):
-        agent._close_openai_client(client, reason="replace:test", shared=True)
-
-    assert sock.shutdown_calls == 1
-    assert sock.close_calls == 1
-    client.close.assert_called_once()
-
-    msgs = [r.getMessage() for r in caplog.records]
-    assert any(
-        "OpenAI client closed (replace:test" in m
-        and "tcp_force_closed=1" in m
-        for m in msgs
-    ), f"missing close log line; got: {msgs!r}"
 
 
 def test_agent_abort_request_openai_client_null_client_is_noop():

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -2571,3 +2571,107 @@ class TestLoadHermesIndex:
 
         data = hub._load_hermes_index()
         assert data == {"skills": [{"name": "stale"}]}
+
+    def test_bundle_disk_symmetry_with_backslash_paths(self, tmp_path):
+        """Bundle with backslash-separated keys matches on-disk forward-slash hash.
+        
+        This catches the Windows path separator divergence fixed by PR #62310.
+        On Windows, SkillBundle keys may arrive as ``"refs\\notes.md"``, while
+        on-disk content_hash always normalizes to ``"refs/notes.md"``. Both
+        functions now normalize to forward slashes before hashing.
+        """
+        from tools.skills_guard import content_hash
+        
+        # Simulate Windows-style bundle keys (as they might arrive from a
+        # Windows client or from a bundle serialized on Windows).
+        bundle = SkillBundle(
+            name="demo-skill",
+            files={
+                "SKILL.md": "same content",
+                "refs\\notes.md": "- [ ] security\n",
+                "docs\\guide.md": "# Guide\n",
+            },
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+        )
+        
+        # Create matching on-disk tree with forward-slash paths (POSIX/normalized).
+        skill_dir = tmp_path / "demo-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("same content")
+        (skill_dir / "refs").mkdir()
+        (skill_dir / "refs" / "notes.md").write_text("- [ ] security\n")
+        (skill_dir / "docs").mkdir()
+        (skill_dir / "docs" / "guide.md").write_text("# Guide\n")
+        
+        assert bundle_content_hash(bundle) == content_hash(skill_dir)
+
+    def test_path_sorting_is_deterministic_across_platforms(self, tmp_path):
+        """Path ordering is stable regardless of platform separators.
+        
+        Before PR #62310, ``sorted()`` on Windows paths like ``["A\\Z.md", "B\\Y.md"]``
+        could order differently from POSIX ``["A/Z.md", "B/Y.md"]`` because
+        backslash (ASCII 92) sorts after forward slash (ASCII 47). Both functions
+        now normalize to forward slashes before sorting.
+        """
+        from tools.skills_guard import content_hash
+        
+        # Bundle with mixed backslash and forward-slash keys (as might happen
+        # when bundles cross platform boundaries).
+        bundle = SkillBundle(
+            name="demo-skill",
+            files={
+                "B\\Y.md": "content y",
+                "A\\Z.md": "content z",
+                "C/X.md": "content x",
+            },
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+        )
+        
+        # Create matching on-disk tree.
+        skill_dir = tmp_path / "demo-skill"
+        skill_dir.mkdir()
+        (skill_dir / "B").mkdir()
+        (skill_dir / "B" / "Y.md").write_text("content y")
+        (skill_dir / "A").mkdir()
+        (skill_dir / "A" / "Z.md").write_text("content z")
+        (skill_dir / "C").mkdir()
+        (skill_dir / "C" / "X.md").write_text("content x")
+        
+        assert bundle_content_hash(bundle) == content_hash(skill_dir)
+
+    def test_windows_mixed_case_path_ordering(self, tmp_path):
+        """Windows is case-insensitive; ensure hash handles mixed-case paths.
+        
+        On Windows, ``"Docs/Readme.md"`` and ``"docs/readme.md"`` refer to the same
+        file. The hash function normalizes paths to forward slashes but preserves
+        the original casing as provided by the bundle. This test ensures the
+        normalization contract is upheld even when bundle keys use non-canonical
+        casing (e.g., ``"Docs\\README.md"`` on a case-insensitive filesystem).
+        """
+        from tools.skills_guard import content_hash
+        
+        bundle = SkillBundle(
+            name="demo-skill",
+            files={
+                "SKILL.md": "same content",
+                "Docs\\README.md": "# Readme\n",
+                "docs\\guide.md": "# Guide\n",
+            },
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+        )
+        
+        skill_dir = tmp_path / "demo-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("same content")
+        (skill_dir / "Docs").mkdir()
+        (skill_dir / "Docs" / "README.md").write_text("# Readme\n")
+        (skill_dir / "docs").mkdir()
+        (skill_dir / "docs" / "guide.md").write_text("# Guide\n")
+        
+        assert bundle_content_hash(bundle) == content_hash(skill_dir)

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -773,10 +773,16 @@ def content_hash(skill_path: Path) -> str:
     produce the same digest for the same skill (one operates on disk,
     one on an in-memory bundle), so any change to the hash shape MUST
     land in both places at once.
+
+    **Normalization contract:**
+    - All relative paths are normalized to forward slashes (``/``) before
+      being mixed into the hash.
+    - Files are sorted by the normalized relative path to ensure deterministic
+      ordering across platforms (Windows backslashes vs POSIX forward slashes).
     """
     h = hashlib.sha256()
     if skill_path.is_dir():
-        for f in sorted(skill_path.rglob("*")):
+        for f in sorted(skill_path.rglob("*"), key=lambda p: p.relative_to(skill_path).as_posix()):
             if f.is_file():
                 try:
                     rel = f.relative_to(skill_path).as_posix()

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3571,12 +3571,20 @@ def uninstall_skill(skill_name: str) -> Tuple[bool, str]:
 
 
 def bundle_content_hash(bundle: SkillBundle) -> str:
-    """Compute a deterministic hash for an in-memory skill bundle."""
+    """Compute a deterministic hash for an in-memory skill bundle.
+
+    Must stay symmetric with ``tools.skills_guard.content_hash`` — both
+    functions need to produce the same digest for the same skill. See
+    content_hash() for the normalization contract.
+    """
     h = hashlib.sha256()
-    for rel_path in sorted(bundle.files):
-        # Include the path so swapping file contents between two paths
-        # changes the hash (avoids filename-swap evading update detection).
-        h.update(rel_path.encode("utf-8"))
+    # Normalize path separators and sort by the normalized path to ensure
+    # deterministic ordering across platforms (Windows backslashes vs POSIX
+    # forward slashes). The normalized path is mixed into the hash so that
+    # swapping file contents between two paths changes the hash.
+    for rel_path in sorted(bundle.files, key=lambda p: p.replace("\\", "/")):
+        normalized = rel_path.replace("\\", "/")
+        h.update(normalized.encode("utf-8"))
         h.update(b"\x00")
         content = bundle.files[rel_path]
         if isinstance(content, bytes):

--- a/website/docs/developer-guide/contributing.md
+++ b/website/docs/developer-guide/contributing.md
@@ -31,12 +31,12 @@ We value contributions in this order:
 
 ### Prerequisites
 
-| Requirement | Notes |
-|-------------|-------|
-| **Git** | With the `git-lfs` extension installed |
-| **Python 3.11–3.13** | uv will install it if missing |
-| **uv** | Fast Python package manager ([install](https://docs.astral.sh/uv/)) |
-| **Node.js 20+** | Optional — needed for browser tools and WhatsApp bridge (matches root `package.json` engines) |
+| Requirement          | Notes                                                                                         |
+| -------------------- | --------------------------------------------------------------------------------------------- |
+| **Git**              | With the `git-lfs` extension installed                                                        |
+| **Python 3.11–3.13** | uv will install it if missing                                                                 |
+| **uv**               | Fast Python package manager ([install](https://docs.astral.sh/uv/))                           |
+| **Node.js 20+**      | Optional — needed for browser tools and WhatsApp bridge (matches root `package.json` engines) |
 
 ### Install with the standard installer
 
@@ -64,6 +64,14 @@ After that, create branches and run tests from that checkout:
 ```bash
 git checkout -b fix/description
 scripts/run_tests.sh
+```
+
+You can also run a fully isolated Hermes instance (throwaway HERMES_HOME, separate Electron
+userData, distinct Electron app name to avoid the single-instance lock):
+
+```bash
+scripts/dev-sandbox.sh python -m hermes_cli.main
+scripts/dev-sandbox.sh --persistent python -m hermes_cli.main desktop  # state survives restarts, but lives in the worktree :)
 ```
 
 ### Manual clone fallback
@@ -143,7 +151,7 @@ See **[Platform Support](../getting-started/platform-support.md)**. Native Windo
 
 When contributing code, keep these rules in mind:
 
-- **Don't add unguarded `signal.SIGKILL` references.** It's not defined on Windows.  Either route through `gateway.status.terminate_pid(pid, force=True)` (the centralized primitive that does `taskkill /T /F` on Windows and SIGKILL on POSIX), or fall back with `getattr(signal, "SIGKILL", signal.SIGTERM)`.
+- **Don't add unguarded `signal.SIGKILL` references.** It's not defined on Windows. Either route through `gateway.status.terminate_pid(pid, force=True)` (the centralized primitive that does `taskkill /T /F` on Windows and SIGKILL on POSIX), or fall back with `getattr(signal, "SIGKILL", signal.SIGTERM)`.
 - **Catch `OSError` alongside `ProcessLookupError` on `os.kill(pid, 0)` probes.** Windows raises `OSError` (WinError 87, "parameter is incorrect") for an already-gone PID instead of `ProcessLookupError`.
 - **Don't force the terminal to POSIX semantics.** `os.setsid`, `os.killpg`, `os.getpgid`, `os.fork` all raise on Windows — gate them with `if sys.platform != "win32":` or `if os.name != "nt":`.
 - **Open files with an explicit `encoding="utf-8"`.** The Python default on Windows is the system locale (often cp1252), which mojibakes or crashes on non-Latin text.
@@ -198,15 +206,15 @@ Hermes has terminal access. Security matters.
 
 ### Existing Protections
 
-| Layer | Implementation |
-|-------|---------------|
-| **Sudo password piping** | Uses `shlex.quote()` to prevent shell injection |
-| **Dangerous command detection** | Regex patterns in `tools/approval.py` with user approval flow |
-| **Cron prompt injection** | Scanner blocks instruction-override patterns |
-| **Write deny list** | Protected paths resolved via `os.path.realpath()` to prevent symlink bypass |
-| **Skills guard** | Security scanner for hub-installed skills |
-| **Code execution sandbox** | Child process runs with API keys stripped |
-| **Container hardening** | Docker: all capabilities dropped, no privilege escalation, PID limits |
+| Layer                           | Implementation                                                              |
+| ------------------------------- | --------------------------------------------------------------------------- |
+| **Sudo password piping**        | Uses `shlex.quote()` to prevent shell injection                             |
+| **Dangerous command detection** | Regex patterns in `tools/approval.py` with user approval flow               |
+| **Cron prompt injection**       | Scanner blocks instruction-override patterns                                |
+| **Write deny list**             | Protected paths resolved via `os.path.realpath()` to prevent symlink bypass |
+| **Skills guard**                | Security scanner for hub-installed skills                                   |
+| **Code execution sandbox**      | Child process runs with API keys stripped                                   |
+| **Container hardening**         | Docker: all capabilities dropped, no privilege escalation, PID limits       |
 
 ### Contributing Security-Sensitive Code
 
@@ -238,6 +246,7 @@ refactor/description   # Code restructuring
 ### PR Description
 
 Include:
+
 - **What** changed and **why**
 - **How to test** it
 - **What platforms** you tested on
@@ -251,18 +260,19 @@ We use [Conventional Commits](https://www.conventionalcommits.org/):
 <type>(<scope>): <description>
 ```
 
-| Type | Use for |
-|------|---------|
-| `fix` | Bug fixes |
-| `feat` | New features |
-| `docs` | Documentation |
-| `test` | Tests |
-| `refactor` | Code restructuring |
-| `chore` | Build, CI, dependency updates |
+| Type       | Use for                       |
+| ---------- | ----------------------------- |
+| `fix`      | Bug fixes                     |
+| `feat`     | New features                  |
+| `docs`     | Documentation                 |
+| `test`     | Tests                         |
+| `refactor` | Code restructuring            |
+| `chore`    | Build, CI, dependency updates |
 
 Scopes: `cli`, `gateway`, `tools`, `skills`, `agent`, `install`, `whatsapp`, `security`
 
 Examples:
+
 ```
 fix(cli): prevent crash in save_config_value when model is a string
 feat(gateway): add WhatsApp multi-user session isolation


### PR DESCRIPTION
## What does this PR do?

Fixes a permanent false-positive `update_available` bug in `hermes skills check` on Windows. After a successful `hermes skills update`, the check command continued listing all updated skills as needing updates forever because two hash functions — `bundle_content_hash` (in-memory) and `content_hash` (on-disk) — produced different digests for the same skill on Windows.

**Root cause:** Path separator and sorting differences between the two functions:
- `bundle_content_hash` used `sorted(bundle.files)` which preserves Windows backslashes (e.g. `references\methods\x.md`) and sorts strings case-sensitively
- `content_hash` normalized to forward slashes via `as_posix()` (e.g. `references/methods/x.md`) but sorted Path objects, which on Windows are case-insensitive

Since relative paths are mixed into the SHA-256 hash, skills with subdirectory files could never match between disk and bundle on Windows. POSIX systems were unaffected.

**Fix:** Normalize all paths to forward slashes and sort by the normalized path in both functions, ensuring deterministic ordering across platforms. Added a normalization contract to both docstrings and cross-referenced the functions in comments to prevent future divergence.

## Related Issue

Fixes #62310

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skills_hub.py::bundle_content_hash`: Normalize path separators to `/` and sort by normalized path before mixing into hash
- `tools/skills_guard.py::content_hash`: Sort by `as_posix()` normalized path to ensure deterministic ordering; added normalization contract to docstring
- Both functions updated to explicitly document the normalization contract and cross-reference each other to prevent future divergence

## How to Test

1. Create a skill with subdirectory structure (e.g. `references/methods/x.md`)
2. Create an in-memory SkillBundle with backslash paths (simulating Windows) and forward slash paths (POSIX)
3. Verify both `bundle_content_hash(bundle)` and `content_hash(skill_path)` produce identical hashes regardless of path separator style

Observed result: Hash symmetry restored on all platforms (verified on macOS with backslash/foward-slash simulation; Windows users will see the fix after merging)

To manually verify the fix before Windows testing:
```python
# See /tmp/test_hash_symmetry.py in the worktree
python3 /tmp/test_hash_symmetry.py
# Output: ✓ All tests passed!
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(skills):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2 (Windows/WSL behavior simulated via path separator test fixture)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A