### PR TITLE
fix(skills): resolve LobeHub identifiers reliably

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1458,6 +1458,65 @@ class TestTapsManager:
 
 
 # ---------------------------------------------------------------------------
+# LobeHubSource identifier resolution
+# ---------------------------------------------------------------------------
+
+
+class TestLobeHubIdentifierResolution:
+    @pytest.fixture
+    def source(self, monkeypatch):
+        source = LobeHubSource()
+        monkeypatch.setattr(
+            source,
+            "_fetch_index",
+            lambda: {
+                "agents": [
+                    {
+                        "identifier": "api-docs-writer",
+                        "meta": {
+                            "title": "API Documentation Optimization Expert",
+                            "description": "Improves API documentation.",
+                            "tags": ["documentation"],
+                        },
+                    }
+                ]
+            },
+        )
+        return source
+
+    def test_search_matches_agent_identifier(self, source):
+        results = source.search("api-docs-writer")
+
+        assert [result.identifier for result in results] == [
+            "lobehub/api-docs-writer"
+        ]
+
+    def test_fetch_accepts_case_insensitive_source_prefix(self, source, monkeypatch):
+        fetched = []
+
+        def fetch_agent(agent_id):
+            fetched.append(agent_id)
+            return {
+                "identifier": agent_id,
+                "meta": {"title": "Code Companion", "description": "Helps with code."},
+            }
+
+        monkeypatch.setattr(source, "_fetch_agent", fetch_agent)
+
+        bundle = source.fetch("LobeHub/code-companion")
+
+        assert bundle is not None
+        assert bundle.identifier == "lobehub/code-companion"
+        assert fetched == ["code-companion"]
+
+    def test_inspect_accepts_case_insensitive_source_prefix(self, source):
+        result = source.inspect("LobeHub/api-docs-writer")
+
+        assert result is not None
+        assert result.identifier == "lobehub/api-docs-writer"
+
+
+# ---------------------------------------------------------------------------
 # LobeHubSource._convert_to_skill_md
 # ---------------------------------------------------------------------------
 

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2724,6 +2724,14 @@ class LobeHubSource(SkillSource):
     def trust_level_for(self, identifier: str) -> str:
         return "community"
 
+    @staticmethod
+    def _agent_id(identifier: str) -> str:
+        """Strip a LobeHub source prefix without making it case-sensitive."""
+        prefix, separator, agent_id = identifier.partition("/")
+        if separator and prefix.lower() == "lobehub":
+            return agent_id
+        return identifier
+
     def search(self, query: str, limit: int = 10) -> List[SkillMeta]:
         index = self._fetch_index()
         if not index:
@@ -2738,13 +2746,14 @@ class LobeHubSource(SkillSource):
 
         for agent in agents:
             meta = agent.get("meta", agent)
-            title = meta.get("title", agent.get("identifier", ""))
+            identifier = agent.get("identifier", "")
+            title = meta.get("title", identifier)
             desc = meta.get("description", "")
             tags = meta.get("tags", [])
 
-            searchable = f"{title} {desc} {' '.join(tags) if isinstance(tags, list) else ''}".lower()
+            searchable = f"{identifier} {title} {desc} {' '.join(tags) if isinstance(tags, list) else ''}".lower()
             if query_lower in searchable:
-                identifier = agent.get("identifier", title.lower().replace(" ", "-"))
+                identifier = identifier or title.lower().replace(" ", "-")
                 results.append(SkillMeta(
                     name=identifier,
                     description=desc[:200],
@@ -2760,8 +2769,8 @@ class LobeHubSource(SkillSource):
         return results
 
     def fetch(self, identifier: str) -> Optional[SkillBundle]:
-        # Strip "lobehub/" prefix if present
-        agent_id = identifier.split("/", 1)[-1] if identifier.startswith("lobehub/") else identifier
+        # Strip the optional "lobehub/" prefix case-insensitively.
+        agent_id = self._agent_id(identifier)
 
         agent_data = self._fetch_agent(agent_id)
         if not agent_data:
@@ -2777,7 +2786,7 @@ class LobeHubSource(SkillSource):
         )
 
     def inspect(self, identifier: str) -> Optional[SkillMeta]:
-        agent_id = identifier.split("/", 1)[-1] if identifier.startswith("lobehub/") else identifier
+        agent_id = self._agent_id(identifier)
         index = self._fetch_index()
         if not index:
             return None

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -651,6 +651,20 @@ Hermes can search and convert agent entries from LobeHub's public catalog into i
 - Backing repo: [lobehub/lobe-chat-agents](https://github.com/lobehub/lobe-chat-agents)
 - Hermes source id: `lobehub`
 
+Use the full `lobehub/<agent-id>` identifier shown by search results when you
+install or inspect an entry:
+
+```bash
+hermes skills search "api documentation" --source lobehub
+hermes skills inspect lobehub/api-docs-writer
+hermes skills install lobehub/api-docs-writer
+```
+
+Source prefixes are case-insensitive. A bare agent id such as
+`api-docs-writer` also resolves when it matches exactly one skill across the
+configured sources, but the full identifier is unambiguous and recommended in
+scripts and documentation.
+
 #### 8. browse.sh (`browse-sh`)
 
 Hermes integrates with [browse.sh](https://browse.sh), Browserbase's catalog of 200+ site-specific browser-automation SKILL.md files (Airbnb, Amazon, arXiv, 12306.cn, Etsy, Xero, and many more). Each skill describes how to drive one website end-to-end and is suitable for use with Hermes' browser tools and any browser-automation skills you already have installed.


### PR DESCRIPTION
## Summary
- match LobeHub agent identifiers during search so unique bare names resolve
- accept case-insensitive `lobehub/` prefixes for install and inspect
- document canonical full identifiers and bare-name behavior

## Test Plan
- [x] TDD: 3 new LobeHub identifier-resolution tests failed before the fix and pass after it
- [x] `python -m pytest tests/tools/test_skills_hub.py -q -o "addopts="` — 161 passed
- [x] `ruff check tools/skills_hub.py tests/tools/test_skills_hub.py`
- [x] `git diff --check`
- [x] independent pre-commit review approved with no blocking issues

Closes #6866