### PR TITLE
feat(kanban): add distributed worker routing

### DIFF
--- a/docs/kanban/distributed-coordinator-design.md
+++ b/docs/kanban/distributed-coordinator-design.md
@@ -1,0 +1,316 @@
+# Distributed Kanban: coordinator / supervisor split
+
+Status: implemented baseline; this document records the design constraints and
+remaining follow-up work.
+Scope: run Hermes agents across private-network machines (for example, Linux
+and macOS workers over Tailscale).
+sharing one Kanban board, with tasks, comments, and artifacts crossing machines.
+
+---
+
+## 1. The finding that drives the design
+
+`release_stale_claims()` (`hermes_cli/kanban_db.py:3600`) reclaims any task where
+`claim_expires < now`. The **only** escape is this predicate:
+
+```python
+if (
+    host_local                      # claim_lock.startswith(f"{socket.gethostname()}:")
+    and row["worker_pid"]
+    and _pid_alive(row["worker_pid"])
+    and not heartbeat_stale
+):
+    # extend the lease instead of reclaiming
+```
+
+A remote worker is never `host_local`, so it can **never be rescued**. It is
+reclaimed at `DEFAULT_CLAIM_TTL_SECONDS` (900s) even when perfectly healthy.
+The task returns to `ready`, the dispatcher spawns it again — while the original
+worker is still running. **Duplicate execution.**
+
+This is not a theoretical race. Lease renewal today is *model-driven*:
+`heartbeat_claim()` (the only writer of `claim_expires`) is reached solely via the
+`kanban_heartbeat` tool, which the LLM chooses to call. `_touch_activity` bridges
+API traffic into `last_heartbeat_at` but **not** into `claim_expires`. So healthy
+workers routinely blow past the 15-minute lease and survive *only* because of the
+PID rescue above. Single-host that is a sound design. Cross-host the safety net
+is simply absent.
+
+Note what this means: `last_heartbeat_at` being fresh cannot save a remote claim.
+`heartbeat_stale` only *removes* the rescue; it never grants one.
+
+### Corollary
+
+You cannot fix this by teaching `release_stale_claims` to check a remote PID.
+"Is the owning process alive?" is a question **only the owning machine can answer**.
+
+---
+
+## 2. The seam already exists inside `dispatch_once`
+
+Draw the line at *"does this operation need a local process table?"*
+
+Grep for `os.kill`, `/proc`, `Popen`, `_pid_alive`, `reap`. Everything that hits
+them belongs on the machine that owns the process. Everything else is pure state
+transition and belongs in one central place.
+
+| `dispatch_once` step | Today | Belongs to |
+|---|---|---|
+| promote `todo`→`ready` when parents done | SQL | **Coordinator** |
+| expire leases (`claim_expires < now`) | `release_stale_claims` | **Coordinator** (time only) |
+| PID-alive lease extension | `release_stale_claims` | **Supervisor** (becomes renewal) |
+| crashed-worker detection | `detect_crashed_workers` | **Supervisor** |
+| stale-heartbeat detection | `detect_stale_running` | **Coordinator** (decide) |
+| kill the stale worker | `detect_stale_running` → `os.kill` | **Supervisor** (execute) |
+| `enforce_max_runtime` | mixed | Coordinator decides, Supervisor kills |
+| zombie reaping | `reap_worker_zombies` | **Supervisor** |
+| circuit breaker / `consecutive_failures` | `_record_task_failure` | **Coordinator** |
+| spawn the worker | `_default_spawn` → `Popen` | **Supervisor** |
+| dispatch tick lock | `_dispatch_tick_lock(db_path)` — a *local file lock* | **Coordinator** (becomes real, single-process) |
+
+**The rule: the coordinator decides, the supervisor executes.**
+
+Any reclaim with a kill side-effect becomes two-phase. The coordinator cannot
+`os.kill` across a network, so it sets `cancel_requested` on the task; the owning
+supervisor observes it and terminates its child. This state does not exist today.
+
+### The interface is already half-parameterized
+
+`dispatch_once` already accepts `spawn_fn=` and `signal_fn=` as injection points
+(used by tests). `_pid_alive` and `reap_worker_zombies` are the two remaining
+local-only calls. That is the entire supervisor interface:
+
+```python
+class Supervisor(Protocol):
+    def spawn(self, task, workspace_path, board) -> int | None: ...   # -> worker_pid
+    def signal(self, pid: int, sig: int) -> None: ...
+    def is_alive(self, pid: int) -> bool: ...
+    def reap(self) -> None: ...
+```
+
+Three of four already exist as parameters. Build 0 is mostly *naming* this.
+
+---
+
+## 3. Lease redesign
+
+Replace the model-driven heartbeat + PID rescue with a **machine-driven lease**.
+
+- Each machine runs one **agent supervisor** process.
+- The supervisor claims a task, spawns the child, and then renews the lease on a
+  timer for as long as its child is alive (this is where `_pid_alive` legitimately
+  lives — it is probing *its own* child).
+- `release_stale_claims` becomes purely time-based: no PID, no host prefix. An
+  expired lease now genuinely means *"the owning machine stopped vouching for
+  this task."*
+
+Consequences:
+
+- **The lease gets much shorter.** 900s was chosen because renewal was unreliable
+  and PID-rescue was the real mechanism. With automatic renewal, a 60–90s lease is
+  fine. Renew at `TTL/3`. Shorter lease ⇒ faster recovery when the MacBook dies.
+- **`kanban_heartbeat` stops being load-bearing** for ownership. It stays as a
+  progress signal (feeding `last_heartbeat_at`, the wedged-in-a-logic-loop
+  backstop), which is what it should always have been.
+- **The coordinator must stamp `claim_expires` itself.** Never accept a
+  client-supplied expiry. Two machines, two clocks — a skewed MacBook clock would
+  otherwise grant itself an arbitrary lease. The API verb is `renew`, not
+  `set_expiry(T)`.
+
+### Fencing (the partition case)
+
+MacBook alive, tailnet drops. The supervisor cannot renew; the coordinator expires
+the lease. Nobody else can claim it (capability filter — there is no second macOS
+machine), so it sits `ready`. Then the tailnet comes back and the MacBook's child
+is *still running*.
+
+The fence token already exists: `heartbeat_claim()` returns `bool` — "True if we
+still own it" — because its `UPDATE` is guarded by `AND claim_lock = ?`. Today
+nothing acts on that return value. Cross-machine it becomes load-bearing:
+
+> **A failed renewal is not a retry. It is a kill signal.**
+> The supervisor must immediately terminate the orphaned child.
+
+Otherwise a reconnecting machine resumes a task the coordinator already gave away.
+
+---
+
+## 4. Routing
+
+Confirmed absent from the schema: there is no `target_machine`, no `machine_id`,
+no capability column. `tasks` has `assignee` (a profile name) and nothing else,
+and `dispatch_once` claims any `ready` task that has one. Point two machines at
+one board today and the Linux box will happily claim the Xcode task.
+
+Capability filtering is therefore a **precondition for a shared board existing**,
+not a later refinement.
+
+### Two routing keys, not one
+
+- **`assignee` → profile.** The supervisor can *enumerate profiles from disk*.
+  This is a **fact**. If the Mac has no `ios-specialist` profile, `_default_spawn`
+  fails, `consecutive_failures` climbs, and the breaker trips after 2.
+- **`required_capabilities` → declared.** `macos`, `xcode`, `bluetooth`. This is a
+  **promise**. Unverifiable, but expresses intent.
+
+Use both:
+
+```
+claimable ⟺ task.assignee ∈ machine.profiles
+          ∧ task.required_capabilities ⊆ machine.capabilities
+          ∧ (task.target_machine IS NULL ∨ task.target_machine = machine.id)
+```
+
+Schema:
+
+```sql
+CREATE TABLE machines (
+  id            TEXT PRIMARY KEY,   -- stable UUID, NOT hostname
+  hostname      TEXT,
+  last_seen_at  INTEGER
+);
+CREATE TABLE machine_profiles     (machine_id TEXT, profile    TEXT);
+CREATE TABLE machine_capabilities (machine_id TEXT, capability TEXT);
+CREATE TABLE task_capabilities    (task_id    TEXT, capability TEXT);
+
+ALTER TABLE tasks ADD COLUMN target_machine TEXT;   -- optional hard pin
+ALTER TABLE tasks ADD COLUMN machine_id     TEXT;   -- owner of worker_pid
+ALTER TABLE tasks ADD COLUMN cancel_requested INTEGER NOT NULL DEFAULT 0;
+```
+
+Subset check as clean SQL, inside the existing `write_txn` before the CAS:
+
+```sql
+NOT EXISTS (
+  SELECT 1 FROM task_capabilities tc
+   WHERE tc.task_id = t.id
+     AND tc.capability NOT IN (SELECT capability
+                                 FROM machine_capabilities
+                                WHERE machine_id = :me)
+)
+```
+
+**Use a stable machine UUID, not `socket.gethostname()`.** `claim_lock` already
+encodes host (`host:pid` from `_claimer_id()`), which gives a migration path — but
+hostnames collide (`MacBook-Pro.local`), change, and are trivially spoofed.
+
+### Empty-capabilities default
+
+A task with no required capabilities is claimable anywhere — which is exactly the
+Xcode-task-on-Linux failure. Do not fix this at the call site. Let **profiles
+declare their own requirements** (`requires: [macos, xcode]` in the profile's
+`config.yaml`) and have `create_task` copy them onto the task. `kanban_create`'s
+signature never changes, and the existing single-machine board keeps working
+because its profiles declare nothing.
+
+---
+
+## 5. Transport and deployment
+
+A Tailscale address in `100.64.0.0/10` is already a flat, authenticated,
+encrypted network with no inbound ports exposed, which is most of what a TLS +
+public-coordinator design buys.
+
+- Coordinator binds to the tailnet interface. No certs, no public URL.
+- Per-machine bearer token anyway, as defense-in-depth against a compromised
+  tailnet node.
+- **Store: keep SQLite**, held by the coordinator process. One writer, one
+  machine, no network filesystem. This is the store you already have and it is
+  correct for two machines. Postgres when you add a third or actually contend.
+- Artifacts: coordinator local disk. S3 later, behind the same API.
+
+Every function in `kanban_db.py` is already `(conn, ...) -> result`. That is a
+service layer in a trenchcoat. The coordinator holds the `conn`; `RemoteBackend`
+mirrors the existing signatures minus that first argument. No Protocol needs to be
+invented from scratch.
+
+### Forbidden
+
+`HERMES_KANBAN_DB` already exists as a path override. Pointing it at NFS,
+Syncthing, or Dropbox will appear to work and will corrupt the board. Say so
+explicitly in the config docs — it is the path of least resistance.
+
+---
+
+## 6. Consumers beyond the nine tools
+
+A `KanbanBackend` covering the agent tools leaves these behind — they open their
+own connections:
+
+- `gateway/kanban_watchers.py` — tails `task_events` to push completions to chat
+- `hermes_cli/kanban_swarm.py`, `kanban_decompose.py`, `kanban_specify.py`,
+  `kanban_diagnostics.py`
+- `plugins/kanban/dashboard/plugin_api.py` — the only writer of attachments
+
+Also: there are **no agent-facing attachment tools today**. Attachments exist only
+through the dashboard's HTTP API, which stores a resolved absolute local path
+(`stored_path=str(dest_path.resolve())`). `kanban_artifact_*` is net-new surface,
+not an adaptation.
+
+The nine registered tools are: `kanban_show`, `kanban_list`, `kanban_complete`,
+`kanban_block`, `kanban_heartbeat`, `kanban_comment`, `kanban_create`,
+`kanban_unblock`, `kanban_link`. There is no `kanban_claim` — claiming is the
+dispatcher's job, and workers never claim. Any design where the worker claims is
+reinventing `dispatch_once`.
+
+---
+
+## 7. Workspaces
+
+`_default_spawn` passes `HERMES_KANBAN_WORKSPACE`, `HERMES_KANBAN_BRANCH`, and
+`TERMINAL_CWD`; `tasks` carries `workspace_path`. All local paths.
+
+The baseline remote worker runs scratch tasks in a machine-local workspace.
+Cross-machine project and worktree tasks still need a portable workspace
+specification that the worker's own machine resolves — clone, fetch, checkout —
+never a path handed over the wire. That remains a follow-up before routing a
+shared repository task to another machine.
+
+---
+
+## 8. Increments
+
+**Build 0 — no network at all.**
+Split `dispatch_once` into `decide()` and `execute()` along the process-table line.
+Name the `Supervisor` protocol; `spawn_fn`/`signal_fn` already exist as parameters.
+Add the routing schema and the claim filter. Replace PID-rescue with
+supervisor-driven lease renewal. Make failed renewal kill the child.
+Existing tests (`tests/hermes_cli/test_kanban_db.py`,
+`tests/plugins/test_kanban_worker_runs.py`) are the guard.
+*Exit criterion: on this one box, a task tagged `macos` is never claimed locally,
+and a healthy long-running worker is never reclaimed.*
+
+**Build 0.5 — coordinator as a thin wrapper.**
+HTTP server over the existing `kanban_db` functions, holding the `conn`, bound to
+the tailnet. `RemoteBackend` mirrors the same signatures. Point the *MacBook's
+supervisor* at it — not its tools yet.
+*Skip a `remote_task_create` tool. It would be deleted in Build 1.*
+
+**Build 1 — the tools.** Route the nine tools through the backend, plus the
+watchers, swarm, decompose, diagnostics.
+
+**Build 2 — workspace specs, then artifacts.**
+
+**Build 3 — live events, inbox, mentions.** Deferring this is correct.
+
+---
+
+## 9. Corrections to the original sketch
+
+- `delegate_task` does **not** block the parent. `run_agent.py:5705` reads
+  `background=(not _is_subagent)`; top-level delegations return a handle
+  immediately. Background children are also **detached** from the parent's
+  `_active_children` and are *not* cancelled on parent interrupt
+  (`delegate_tool.py:2831-2857`). Two of the three stated reasons for rejecting
+  `delegate_task` are false. The third — children are `AIAgent` objects on a
+  `DaemonThreadPoolExecutor`, in-process threads — is true, sufficient, and the
+  only one that matters: **a thread cannot run on a MacBook.**
+- `resolve_secret()` does not exist. The helper is `get_secret(name, default=None)`
+  in `agent/secret_scope.py:123`. `cfg_get` does exist as written.
+- `hermes worker start` does not exist. A worker is
+  `hermes -p <profile> --cli chat -q "work kanban task <id>"` with
+  `HERMES_KANBAN_TASK` in env. The sketch's `worker_loop()` — which claims — is
+  the wrong shape; see §6.
+- **`detect_crashed_workers` is already host-safe.** It filters on the `claim_lock`
+  host prefix and its docstring states PIDs from other hosts are meaningless. The
+  cross-host PID hazard is in `release_stale_claims`' *rescue* path (§1), not here.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2703,6 +2703,16 @@ DEFAULT_CONFIG = {
     # each claimable ready task. One dispatcher per profile is sufficient;
     # running more than one on the same kanban.db will race for claims.
     "kanban": {
+        # Optional private coordinator endpoint for a shared Kanban board.
+        # Keep this in config.yaml because it is deployment behaviour, not a
+        # secret. The matching bearer token stays in the environment.
+        "coordinator_url": "",
+        # Extra capabilities advertised by this physical machine for Kanban
+        # routing (for example: ["xcode", "bluetooth"]). The platform
+        # capability (macos/linux/windows) is added automatically. Because
+        # this is machine-level state, only the default Hermes root's
+        # config.yaml value is consulted; named profile overrides are ignored.
+        "machine_capabilities": [],
         # Run the dispatcher inside the gateway process. On by default —
         # the cost is ~300µs every `dispatch_interval_seconds` when idle,
         # and gateway is the supervisor users already have. Set to false

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -66,6 +66,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "status": t.status,
         "priority": t.priority,
         "tenant": t.tenant,
+        "target_machine": t.target_machine,
         "workspace_kind": t.workspace_kind,
         "workspace_path": t.workspace_path,
         "branch_name": t.branch_name,
@@ -308,6 +309,18 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_create.add_argument("title", help="Task title")
     p_create.add_argument("--body", default=None, help="Optional opening post")
     p_create.add_argument("--assignee", default=None, help="Profile name to assign")
+    p_create.add_argument(
+        "--target-machine",
+        default=None,
+        help="Optional machine UUID pin (otherwise any eligible machine)",
+    )
+    p_create.add_argument(
+        "--require",
+        action="append",
+        default=[],
+        dest="required_capabilities",
+        help="Required machine capability (repeatable, e.g. --require macos --require xcode)",
+    )
     p_create.add_argument("--parent", action="append", default=[],
                           help="Parent task id (repeatable)")
     p_create.add_argument("--workspace", default="scratch",
@@ -669,6 +682,39 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_daemon.add_argument("--force", action="store_true",
                           help=argparse.SUPPRESS)
 
+    # --- distributed coordinator / remote worker ---
+    p_coordinator = sub.add_parser(
+        "coordinator",
+        help="Run the authenticated coordinator for a shared Kanban board",
+    )
+    p_coordinator.add_argument(
+        "--db",
+        type=Path,
+        default=None,
+        help="Board SQLite path (defaults to the current board)",
+    )
+    p_coordinator.add_argument("--host", default="127.0.0.1")
+    p_coordinator.add_argument("--port", default=8788, type=int)
+    p_coordinator.add_argument(
+        "--token-env", default="HERMES_KANBAN_COORDINATOR_TOKEN",
+        help="Environment variable containing the coordinator bearer token",
+    )
+
+    p_remote_worker = sub.add_parser(
+        "remote-worker",
+        help="Run a worker that polls a private Kanban coordinator",
+    )
+    p_remote_worker.add_argument(
+        "--url",
+        default=None,
+        help="Coordinator URL (defaults to kanban.coordinator_url)",
+    )
+    p_remote_worker.add_argument("--token-env", default="HERMES_KANBAN_COORDINATOR_TOKEN")
+    p_remote_worker.add_argument("--profile", required=True)
+    p_remote_worker.add_argument("--capability", action="append", default=[])
+    p_remote_worker.add_argument("--poll-seconds", type=float, default=10.0)
+    p_remote_worker.add_argument("--max-retry-seconds", type=float, default=60.0)
+
     # --- watch ---
     p_watch = sub.add_parser(
         "watch",
@@ -894,6 +940,14 @@ def kanban_command(args: argparse.Namespace) -> int:
     if action == "boards":
         return _dispatch_boards(args)
 
+    # These commands own their runtime loop and do not need a local board
+    # connection before starting. In particular, a remote worker may run on a
+    # machine that has never hosted a local board database.
+    if action == "coordinator":
+        return _cmd_coordinator(args)
+    if action == "remote-worker":
+        return _cmd_remote_worker(args)
+
     # `--board <slug>` applies to every subcommand below by way of an
     # env-var pin for the duration of this call. Using HERMES_KANBAN_BOARD
     # (rather than threading `board=` through 50+ kb.connect() sites)
@@ -961,6 +1015,8 @@ def kanban_command(args: argparse.Namespace) -> int:
             "tail":     _cmd_tail,
             "dispatch": _cmd_dispatch,
             "daemon":   _cmd_daemon,
+            "coordinator": _cmd_coordinator,
+            "remote-worker": _cmd_remote_worker,
             "watch":    _cmd_watch,
             "stats":    _cmd_stats,
             "log":      _cmd_log,
@@ -1001,6 +1057,38 @@ def _profile_author() -> str:
         return get_active_profile_name() or "user"
     except Exception:
         return "user"
+
+
+def _cmd_coordinator(args: argparse.Namespace) -> int:
+    """Start the shared-board coordinator from the supported CLI surface."""
+    from hermes_cli.kanban_coordinator import run
+
+    return run(
+        db_path=getattr(args, "db", None) or kb.kanban_db_path(),
+        host=args.host,
+        port=args.port,
+        token_env=args.token_env,
+    )
+
+
+def _cmd_remote_worker(args: argparse.Namespace) -> int:
+    """Start a remote worker, defaulting its endpoint to config.yaml."""
+    from hermes_cli.kanban_remote import configured_coordinator_url
+    from hermes_cli.kanban_remote_worker import run
+
+    url = (args.url or configured_coordinator_url()).strip()
+    if not url:
+        raise RuntimeError(
+            "set kanban.coordinator_url or pass remote-worker --url"
+        )
+    return run(
+        url=url,
+        token_env=args.token_env,
+        profile=args.profile,
+        capabilities=args.capability,
+        poll_seconds=args.poll_seconds,
+        max_retry_seconds=args.max_retry_seconds,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1347,6 +1435,10 @@ def _cmd_create(args: argparse.Namespace) -> int:
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),
             initial_status=getattr(args, "initial_status", "running"),
+            target_machine=getattr(args, "target_machine", None),
+            required_capabilities=(
+                getattr(args, "required_capabilities", None) or None
+            ),
         )
         task = kb.get_task(conn, task_id)
     if getattr(args, "json", False):

--- a/hermes_cli/kanban_coordinator.py
+++ b/hermes_cli/kanban_coordinator.py
@@ -1,0 +1,328 @@
+"""Private HTTP coordinator for a distributed Hermes Kanban board.
+
+The coordinator is deliberately small: it owns the SQLite connection and the
+claim CAS, while workers on other machines poll it and run normal Hermes task
+processes locally. It is meant to bind only on a private network such as a
+Tailscale interface; bearer authentication remains mandatory.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hmac
+import os
+import threading
+import time
+import uuid
+from dataclasses import asdict
+from pathlib import Path
+from typing import Optional
+
+from fastapi import FastAPI, Header, HTTPException
+from pydantic import BaseModel, Field
+
+from hermes_cli import kanban_db as kb
+
+
+class MachineRegistration(BaseModel):
+    machine_id: str
+    hostname: Optional[str] = None
+    profiles: list[str] = Field(default_factory=list)
+    capabilities: list[str] = Field(default_factory=list)
+
+
+class ClaimRequest(BaseModel):
+    machine_id: str
+
+
+class RenewRequest(BaseModel):
+    claim_lock: str
+
+
+class WorkerStartedRequest(BaseModel):
+    claim_lock: str
+    worker_pid: int = Field(gt=0)
+
+
+class CompletionRequest(BaseModel):
+    result: Optional[str] = None
+    claim_lock: str
+
+
+class BlockRequest(BaseModel):
+    reason: Optional[str] = None
+    kind: Optional[str] = None
+    claim_lock: str
+
+
+class CommentRequest(BaseModel):
+    author: str
+    body: str
+
+
+def _task_payload(conn, task: kb.Task) -> dict:
+    payload = asdict(task)
+    payload["required_capabilities"] = list(kb.task_capabilities(conn, task.id))
+    return payload
+
+
+def _machine_uuid(value: str) -> str:
+    """Normalize an external machine identity without leaking a 500 to clients."""
+    try:
+        return str(uuid.UUID(value))
+    except (TypeError, ValueError, AttributeError) as exc:
+        raise HTTPException(status_code=422, detail="machine_id must be a UUID") from exc
+
+
+def create_app(*, db_path: Path, token: str) -> FastAPI:
+    """Create an authenticated coordinator app for one explicit board DB."""
+    if not token:
+        raise ValueError("coordinator token is required")
+    db_path = Path(db_path).expanduser()
+    app = FastAPI(title="Hermes Kanban Coordinator", version="0.1")
+
+    def require_token(authorization: Optional[str] = Header(default=None)) -> None:
+        expected = f"Bearer {token}"
+        if authorization is None or not hmac.compare_digest(authorization, expected):
+            raise HTTPException(status_code=401, detail="invalid coordinator token")
+
+    @app.get("/v1/health")
+    def health(authorization: Optional[str] = Header(default=None)) -> dict:
+        require_token(authorization)
+        return {"ok": True}
+
+    @app.post("/v1/machines/register")
+    def register(
+        request: MachineRegistration,
+        authorization: Optional[str] = Header(default=None),
+    ) -> dict:
+        require_token(authorization)
+        with contextlib.closing(kb.connect(db_path)) as conn:
+            machine_id = kb.register_machine(
+                conn,
+                _machine_uuid(request.machine_id),
+                hostname=request.hostname,
+                profiles=request.profiles,
+                capabilities=request.capabilities,
+            )
+        return {"machine_id": machine_id}
+
+    @app.get("/v1/machines")
+    def machines(authorization: Optional[str] = Header(default=None)) -> dict:
+        require_token(authorization)
+        with contextlib.closing(kb.connect(db_path)) as conn:
+            now = int(time.time())
+            rows = conn.execute(
+                "SELECT id, hostname, last_seen_at FROM machines ORDER BY hostname, id"
+            ).fetchall()
+            profiles: dict[str, list[str]] = {}
+            for row in conn.execute(
+                "SELECT machine_id, profile FROM machine_profiles ORDER BY machine_id, profile"
+            ).fetchall():
+                profiles.setdefault(row["machine_id"], []).append(row["profile"])
+            capabilities: dict[str, list[str]] = {}
+            for row in conn.execute(
+                "SELECT machine_id, capability FROM machine_capabilities ORDER BY machine_id, capability"
+            ).fetchall():
+                capabilities.setdefault(row["machine_id"], []).append(row["capability"])
+            active = {
+                row["machine_id"]: row["count"]
+                for row in conn.execute(
+                    "SELECT machine_id, COUNT(*) AS count FROM tasks "
+                    "WHERE status = 'running' AND machine_id IS NOT NULL GROUP BY machine_id"
+                ).fetchall()
+            }
+        payload = [{
+            "machine_id": row["id"],
+            "hostname": row["hostname"],
+            "last_seen_at": row["last_seen_at"],
+            "online": now - int(row["last_seen_at"]) <= 90,
+            "profiles": profiles.get(row["id"], []),
+            "capabilities": capabilities.get(row["id"], []),
+            "active_workers": active.get(row["id"], 0),
+        } for row in rows]
+        return {"machines": payload, "count": len(payload), "checked_at": now}
+
+    @app.post("/v1/tasks/claim-next")
+    def claim_next(
+        request: ClaimRequest,
+        authorization: Optional[str] = Header(default=None),
+    ) -> dict:
+        require_token(authorization)
+        with contextlib.closing(kb.connect(db_path)) as conn:
+            machine_id = _machine_uuid(request.machine_id)
+            rows = conn.execute(
+                "SELECT id FROM tasks WHERE status = 'ready' AND claim_lock IS NULL "
+                "ORDER BY priority DESC, created_at ASC"
+            ).fetchall()
+            for row in rows:
+                claimed = kb.claim_task(
+                    conn,
+                    row["id"],
+                    machine_id=machine_id,
+                    enforce_machine_routing=True,
+                    require_registered_profile=True,
+                )
+                if claimed is not None:
+                    return {"task": _task_payload(conn, claimed)}
+        return {"task": None}
+
+    @app.post("/v1/tasks/{task_id}/renew")
+    def renew(
+        task_id: str,
+        request: RenewRequest,
+        authorization: Optional[str] = Header(default=None),
+    ) -> dict:
+        require_token(authorization)
+        with contextlib.closing(kb.connect(db_path)) as conn:
+            renewed = kb.heartbeat_claim(conn, task_id, claimer=request.claim_lock)
+            if renewed:
+                # Lease renewal says the process still owns the claim; the
+                # worker heartbeat also records that its process remains
+                # alive, preventing stale-worker recovery from reclaiming a
+                # healthy long-running remote task.
+                kb.heartbeat_worker(conn, task_id)
+                task = kb.get_task(conn, task_id)
+                if task is not None and task.machine_id:
+                    conn.execute(
+                        "UPDATE machines SET last_seen_at = ? WHERE id = ?",
+                        (int(time.time()), task.machine_id),
+                    )
+        return {"renewed": renewed}
+
+    @app.post("/v1/tasks/{task_id}/worker-started")
+    def worker_started(
+        task_id: str,
+        request: WorkerStartedRequest,
+        authorization: Optional[str] = Header(default=None),
+    ) -> dict:
+        require_token(authorization)
+        with contextlib.closing(kb.connect(db_path)) as conn:
+            recorded = kb.record_worker_started(
+                conn,
+                task_id,
+                claim_lock=request.claim_lock,
+                worker_pid=request.worker_pid,
+            )
+        return {"recorded": recorded}
+
+    @app.get("/v1/tasks/{task_id}")
+    def show(task_id: str, authorization: Optional[str] = Header(default=None)) -> dict:
+        require_token(authorization)
+        with contextlib.closing(kb.connect(db_path)) as conn:
+            task = kb.get_task(conn, task_id)
+            if task is None:
+                raise HTTPException(status_code=404, detail="task not found")
+            return {
+                "task": _task_payload(conn, task),
+                "comments": [asdict(item) for item in kb.list_comments(conn, task_id)],
+                "events": [asdict(item) for item in kb.list_events(conn, task_id)],
+                "runs": [asdict(item) for item in kb.list_runs(conn, task_id)],
+                "parents": kb.parent_ids(conn, task_id),
+                "children": kb.child_ids(conn, task_id),
+                "worker_context": kb.build_worker_context(conn, task_id),
+            }
+
+    @app.post("/v1/tasks/{task_id}/complete")
+    def complete(
+        task_id: str,
+        request: CompletionRequest,
+        authorization: Optional[str] = Header(default=None),
+    ) -> dict:
+        require_token(authorization)
+        with contextlib.closing(kb.connect(db_path)) as conn:
+            task = kb.get_task(conn, task_id)
+            if task is None or task.status != "running" or task.claim_lock != request.claim_lock:
+                return {"completed": False}
+            completed = kb.complete_task(conn, task_id, result=request.result)
+        return {"completed": completed}
+
+    @app.post("/v1/tasks/{task_id}/block")
+    def block(
+        task_id: str,
+        request: BlockRequest,
+        authorization: Optional[str] = Header(default=None),
+    ) -> dict:
+        require_token(authorization)
+        with contextlib.closing(kb.connect(db_path)) as conn:
+            task = kb.get_task(conn, task_id)
+            if task is None or task.status != "running" or task.claim_lock != request.claim_lock:
+                return {"blocked": False}
+            blocked = kb.block_task(
+                conn, task_id, reason=request.reason, kind=request.kind,
+            )
+        return {"blocked": blocked}
+
+    @app.post("/v1/tasks/{task_id}/comments")
+    def comment(
+        task_id: str,
+        request: CommentRequest,
+        authorization: Optional[str] = Header(default=None),
+    ) -> dict:
+        require_token(authorization)
+        with contextlib.closing(kb.connect(db_path)) as conn:
+            comment_id = kb.add_comment(
+                conn, task_id, author=request.author, body=request.body,
+            )
+        return {"comment_id": comment_id}
+
+    return app
+
+
+def run(*, db_path: Path, host: str, port: int, token_env: str) -> int:
+    """Run one coordinator process with an explicit deployment configuration."""
+    import uvicorn
+
+    token = os.environ.get(token_env, "").strip()
+    if not token:
+        raise RuntimeError(f"set {token_env} to a coordinator bearer token")
+    stop = threading.Event()
+
+    def register_local_loop() -> None:
+        while not stop.is_set():
+            try:
+                with contextlib.closing(kb.connect(db_path)) as conn:
+                    kb.register_local_machine(conn)
+            except Exception:
+                # The HTTP service remains authoritative; a transient local
+                # registration failure retries without taking it down.
+                pass
+            stop.wait(15)
+
+    heartbeat = threading.Thread(
+        target=register_local_loop,
+        name="kanban-local-machine-heartbeat",
+        daemon=True,
+    )
+    heartbeat.start()
+    try:
+        uvicorn.run(create_app(db_path=db_path, token=token), host=host, port=port)
+    finally:
+        stop.set()
+        heartbeat.join(timeout=2)
+    return 0
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run a Hermes Kanban coordinator")
+    parser.add_argument("--db", required=True, type=Path, help="Board SQLite path")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", default=8788, type=int)
+    parser.add_argument("--token-env", default="HERMES_KANBAN_COORDINATOR_TOKEN")
+    args = parser.parse_args(argv)
+    try:
+        return run(
+            db_path=args.db,
+            host=args.host,
+            port=args.port,
+            token_env=args.token_env,
+        )
+    except RuntimeError as exc:
+        parser.error(str(exc))
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hermes_cli/kanban_coordinator.py
+++ b/hermes_cli/kanban_coordinator.py
@@ -46,18 +46,61 @@ class WorkerStartedRequest(BaseModel):
 
 class CompletionRequest(BaseModel):
     result: Optional[str] = None
-    claim_lock: str
+    summary: Optional[str] = None
+    metadata: Optional[dict] = None
+    created_cards: list[str] = Field(default_factory=list)
+    expected_run_id: Optional[int] = None
+    claim_lock: str = ""
 
 
 class BlockRequest(BaseModel):
     reason: Optional[str] = None
     kind: Optional[str] = None
-    claim_lock: str
+    expected_run_id: Optional[int] = None
+    claim_lock: str = ""
 
 
 class CommentRequest(BaseModel):
     author: str
     body: str
+
+
+class TaskCreateRequest(BaseModel):
+    title: str
+    body: Optional[str] = None
+    assignee: Optional[str] = None
+    created_by: Optional[str] = None
+    workspace_kind: str = "scratch"
+    workspace_path: Optional[str] = None
+    branch_name: Optional[str] = None
+    tenant: Optional[str] = None
+    priority: int = 0
+    parents: list[str] = Field(default_factory=list)
+    triage: bool = False
+    idempotency_key: Optional[str] = None
+    max_runtime_seconds: Optional[int] = None
+    skills: Optional[list[str]] = None
+    max_retries: Optional[int] = None
+    goal_mode: bool = False
+    goal_max_turns: Optional[int] = None
+    initial_status: str = "running"
+    session_id: Optional[str] = None
+    project_id: Optional[str] = None
+    target_machine: Optional[str] = None
+    required_capabilities: list[str] = Field(default_factory=list)
+
+
+class TaskListRequest(BaseModel):
+    assignee: Optional[str] = None
+    status: Optional[str] = None
+    tenant: Optional[str] = None
+    include_archived: bool = False
+    limit: Optional[int] = None
+
+
+class LinkRequest(BaseModel):
+    parent_id: str
+    child_id: str
 
 
 def _task_payload(conn, task: kb.Task) -> dict:
@@ -71,7 +114,25 @@ def _machine_uuid(value: str) -> str:
     try:
         return str(uuid.UUID(value))
     except (TypeError, ValueError, AttributeError) as exc:
-        raise HTTPException(status_code=422, detail="machine_id must be a UUID") from exc
+        raise HTTPException(
+            status_code=422, detail="machine_id must be a UUID"
+        ) from exc
+
+
+def _claim_authorizes(task: kb.Task, claim_lock: str) -> bool:
+    """Fence running mutations while permitting orchestrator edits off-lease."""
+    if task.status != "running":
+        return not claim_lock
+    return bool(claim_lock) and task.claim_lock == claim_lock
+
+
+def _maintenance_once(db_path: Path) -> dict[str, int]:
+    """Refresh coordinator presence and recover expired remote leases once."""
+    with contextlib.closing(kb.connect(db_path)) as conn:
+        kb.register_local_machine(conn)
+        reclaimed = kb.release_stale_claims(conn)
+        promoted = kb.recompute_ready(conn)
+    return {"reclaimed": reclaimed, "promoted": promoted}
 
 
 def create_app(*, db_path: Path, token: str) -> FastAPI:
@@ -132,15 +193,18 @@ def create_app(*, db_path: Path, token: str) -> FastAPI:
                     "WHERE status = 'running' AND machine_id IS NOT NULL GROUP BY machine_id"
                 ).fetchall()
             }
-        payload = [{
-            "machine_id": row["id"],
-            "hostname": row["hostname"],
-            "last_seen_at": row["last_seen_at"],
-            "online": now - int(row["last_seen_at"]) <= 90,
-            "profiles": profiles.get(row["id"], []),
-            "capabilities": capabilities.get(row["id"], []),
-            "active_workers": active.get(row["id"], 0),
-        } for row in rows]
+        payload = [
+            {
+                "machine_id": row["id"],
+                "hostname": row["hostname"],
+                "last_seen_at": row["last_seen_at"],
+                "online": now - int(row["last_seen_at"]) <= 90,
+                "profiles": profiles.get(row["id"], []),
+                "capabilities": capabilities.get(row["id"], []),
+                "active_workers": active.get(row["id"], 0),
+            }
+            for row in rows
+        ]
         return {"machines": payload, "count": len(payload), "checked_at": now}
 
     @app.post("/v1/tasks/claim-next")
@@ -206,6 +270,86 @@ def create_app(*, db_path: Path, token: str) -> FastAPI:
             )
         return {"recorded": recorded}
 
+    @app.post("/v1/tasks")
+    def create_task(
+        request: TaskCreateRequest,
+        authorization: Optional[str] = Header(default=None),
+    ) -> dict:
+        require_token(authorization)
+        try:
+            with contextlib.closing(kb.connect(db_path)) as conn:
+                task_id = kb.create_task(
+                    conn,
+                    title=request.title,
+                    body=request.body,
+                    assignee=request.assignee,
+                    created_by=request.created_by,
+                    workspace_kind=request.workspace_kind,
+                    workspace_path=request.workspace_path,
+                    branch_name=request.branch_name,
+                    tenant=request.tenant,
+                    priority=request.priority,
+                    parents=request.parents,
+                    triage=request.triage,
+                    idempotency_key=request.idempotency_key,
+                    max_runtime_seconds=request.max_runtime_seconds,
+                    skills=request.skills,
+                    max_retries=request.max_retries,
+                    goal_mode=request.goal_mode,
+                    goal_max_turns=request.goal_max_turns,
+                    initial_status=request.initial_status,
+                    session_id=request.session_id,
+                    project_id=request.project_id,
+                    target_machine=request.target_machine,
+                    required_capabilities=request.required_capabilities,
+                )
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        return {"task_id": task_id}
+
+    @app.post("/v1/tasks/query")
+    def list_tasks(
+        request: TaskListRequest,
+        authorization: Optional[str] = Header(default=None),
+    ) -> dict:
+        require_token(authorization)
+        try:
+            with contextlib.closing(kb.connect(db_path)) as conn:
+                tasks = kb.list_tasks(
+                    conn,
+                    assignee=request.assignee,
+                    status=request.status,
+                    tenant=request.tenant,
+                    include_archived=request.include_archived,
+                    limit=request.limit,
+                )
+                payload = [_task_payload(conn, task) for task in tasks]
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        return {"tasks": payload}
+
+    @app.post("/v1/tasks/recompute-ready")
+    def recompute_ready(
+        authorization: Optional[str] = Header(default=None),
+    ) -> dict:
+        require_token(authorization)
+        with contextlib.closing(kb.connect(db_path)) as conn:
+            promoted = kb.recompute_ready(conn)
+        return {"promoted": promoted}
+
+    @app.post("/v1/tasks/link")
+    def link_tasks(
+        request: LinkRequest,
+        authorization: Optional[str] = Header(default=None),
+    ) -> dict:
+        require_token(authorization)
+        try:
+            with contextlib.closing(kb.connect(db_path)) as conn:
+                kb.link_tasks(conn, request.parent_id, request.child_id)
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        return {"linked": True}
+
     @app.get("/v1/tasks/{task_id}")
     def show(task_id: str, authorization: Optional[str] = Header(default=None)) -> dict:
         require_token(authorization)
@@ -232,9 +376,24 @@ def create_app(*, db_path: Path, token: str) -> FastAPI:
         require_token(authorization)
         with contextlib.closing(kb.connect(db_path)) as conn:
             task = kb.get_task(conn, task_id)
-            if task is None or task.status != "running" or task.claim_lock != request.claim_lock:
+            if task is None or not _claim_authorizes(task, request.claim_lock):
                 return {"completed": False}
-            completed = kb.complete_task(conn, task_id, result=request.result)
+            try:
+                completed = kb.complete_task(
+                    conn,
+                    task_id,
+                    result=request.result,
+                    summary=request.summary,
+                    metadata=request.metadata,
+                    created_cards=request.created_cards,
+                    expected_run_id=request.expected_run_id,
+                )
+            except kb.HallucinatedCardsError as exc:
+                return {
+                    "completed": False,
+                    "error": "hallucinated_cards",
+                    "phantom_cards": list(exc.phantom),
+                }
         return {"completed": completed}
 
     @app.post("/v1/tasks/{task_id}/block")
@@ -246,12 +405,26 @@ def create_app(*, db_path: Path, token: str) -> FastAPI:
         require_token(authorization)
         with contextlib.closing(kb.connect(db_path)) as conn:
             task = kb.get_task(conn, task_id)
-            if task is None or task.status != "running" or task.claim_lock != request.claim_lock:
+            if task is None or not _claim_authorizes(task, request.claim_lock):
                 return {"blocked": False}
             blocked = kb.block_task(
-                conn, task_id, reason=request.reason, kind=request.kind,
+                conn,
+                task_id,
+                reason=request.reason,
+                kind=request.kind,
+                expected_run_id=request.expected_run_id,
             )
         return {"blocked": blocked}
+
+    @app.post("/v1/tasks/{task_id}/unblock")
+    def unblock(
+        task_id: str,
+        authorization: Optional[str] = Header(default=None),
+    ) -> dict:
+        require_token(authorization)
+        with contextlib.closing(kb.connect(db_path)) as conn:
+            unblocked = kb.unblock_task(conn, task_id)
+        return {"unblocked": unblocked}
 
     @app.post("/v1/tasks/{task_id}/comments")
     def comment(
@@ -262,7 +435,10 @@ def create_app(*, db_path: Path, token: str) -> FastAPI:
         require_token(authorization)
         with contextlib.closing(kb.connect(db_path)) as conn:
             comment_id = kb.add_comment(
-                conn, task_id, author=request.author, body=request.body,
+                conn,
+                task_id,
+                author=request.author,
+                body=request.body,
             )
         return {"comment_id": comment_id}
 
@@ -278,20 +454,19 @@ def run(*, db_path: Path, host: str, port: int, token_env: str) -> int:
         raise RuntimeError(f"set {token_env} to a coordinator bearer token")
     stop = threading.Event()
 
-    def register_local_loop() -> None:
+    def maintenance_loop() -> None:
         while not stop.is_set():
             try:
-                with contextlib.closing(kb.connect(db_path)) as conn:
-                    kb.register_local_machine(conn)
+                _maintenance_once(db_path)
             except Exception:
-                # The HTTP service remains authoritative; a transient local
-                # registration failure retries without taking it down.
+                # The HTTP service remains authoritative; transient database
+                # maintenance failures retry without taking it down.
                 pass
             stop.wait(15)
 
     heartbeat = threading.Thread(
-        target=register_local_loop,
-        name="kanban-local-machine-heartbeat",
+        target=maintenance_loop,
+        name="kanban-coordinator-maintenance",
         daemon=True,
     )
     heartbeat.start()

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -84,6 +84,7 @@ import sys
 import threading
 import logging
 import time
+import uuid
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -181,7 +182,7 @@ DEFAULT_CLAIM_TTL_SECONDS = 15 * 60
 DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS = 60 * 60
 
 # Grace added to a claim when a reclaim is deferred because the previous
-# host-local worker is still alive after a termination attempt. Releasing the
+# machine-local worker is still alive after a termination attempt. Releasing the
 # claim in that state would spawn a duplicate alongside the surviving worker —
 # the runaway seen when a cgroup memory.high throttle parks a worker in
 # uninterruptible (D) state, where a pending SIGKILL cannot be delivered until
@@ -388,6 +389,113 @@ def kanban_home() -> Path:
         return Path(override).expanduser()
     from hermes_constants import get_default_hermes_root
     return get_default_hermes_root()
+
+
+_MACHINE_ID_LOCK = threading.RLock()
+_MACHINE_ID_CACHE: dict[str, str] = {}
+
+
+def machine_id_path() -> Path:
+    """Return the machine-global identity file shared by every profile/board."""
+    return kanban_home() / "kanban" / "machine-id"
+
+
+def _parse_machine_id(raw: str, path: Path) -> str:
+    value = raw.strip()
+    try:
+        return str(uuid.UUID(value))
+    except (ValueError, AttributeError) as exc:
+        raise RuntimeError(
+            f"invalid Hermes Kanban machine identity at {path}: expected UUID"
+        ) from exc
+
+
+def get_machine_id() -> str:
+    """Return this machine's durable UUID, creating it atomically if absent.
+
+    The file lives under the machine-global Kanban root rather than an active
+    profile or board, so every local dispatcher, dashboard, and worker agrees
+    on one identity. Creation uses ``O_EXCL`` to prevent concurrent profile
+    startups from choosing different IDs. A malformed existing file fails
+    closed instead of silently rotating identity while workers may be alive.
+    """
+    path = machine_id_path()
+    cache_key = str(path.expanduser().absolute())
+    with _MACHINE_ID_LOCK:
+        cached = _MACHINE_ID_CACHE.get(cache_key)
+        if cached:
+            return cached
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            candidate = str(uuid.uuid4())
+            try:
+                fd = os.open(
+                    path,
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                    0o600,
+                )
+            except FileExistsError:
+                # Another process won creation. The retry loop below handles
+                # the tiny window before its UUID write becomes visible.
+                try:
+                    raw = path.read_text(encoding="utf-8")
+                except FileNotFoundError:
+                    raw = ""
+            else:
+                with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                    handle.write(candidate + "\n")
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                raw = candidate
+
+        # A racing process can observe the O_EXCL-created inode just before
+        # the winner flushes its UUID. Retry briefly for empty/partial data;
+        # a persistently malformed identity still fails closed.
+        for attempt in range(100):
+            try:
+                machine_id = _parse_machine_id(raw, path)
+                break
+            except RuntimeError:
+                if attempt == 99:
+                    raise
+                time.sleep(0.01)
+                try:
+                    raw = path.read_text(encoding="utf-8")
+                except FileNotFoundError:
+                    raw = ""
+        _MACHINE_ID_CACHE[cache_key] = machine_id
+        return machine_id
+
+
+def _legacy_hostname() -> str:
+    """Return the pre-machine-ID claim owner used only for DB migration."""
+    import socket
+    try:
+        return socket.gethostname() or "unknown"
+    except Exception:
+        return "unknown"
+
+
+def _claim_is_owned_by_this_machine(
+    owner_machine_id: Optional[str],
+    claim_lock: Optional[str],
+) -> bool:
+    """Return whether a task's PID belongs to this machine.
+
+    New rows use the explicit ``machine_id`` column. The claim-token prefixes
+    are consulted only for pre-migration running rows: first the durable UUID
+    form, then the legacy hostname form.
+    """
+    local_id = get_machine_id()
+    if owner_machine_id:
+        return str(owner_machine_id) == local_id
+    lock = str(claim_lock or "")
+    return lock.startswith(f"{local_id}:") or lock.startswith(
+        f"{_legacy_hostname()}:"
+    )
 
 
 def boards_root() -> Path:
@@ -854,6 +962,7 @@ class Task:
     claim_lock: Optional[str]
     claim_expires: Optional[int]
     tenant: Optional[str]
+    target_machine: Optional[str] = None
     branch_name: Optional[str] = None
     project_id: Optional[str] = None
     result: Optional[str] = None
@@ -867,6 +976,10 @@ class Task:
     # (Pre-rename column: ``spawn_failures``.)
     consecutive_failures: int = 0
     worker_pid: Optional[int] = None
+    # Durable identity of the machine that owns ``worker_pid`` for the active
+    # claim. Cleared when the task leaves ``running``; historical ownership is
+    # retained on the corresponding ``task_runs`` row.
+    machine_id: Optional[str] = None
     # Short excerpt of the last failure's error text (any outcome, not
     # just spawn). Pre-rename column: ``last_spawn_error``.
     last_failure_error: Optional[str] = None
@@ -945,6 +1058,9 @@ class Task:
             claim_lock=row["claim_lock"],
             claim_expires=row["claim_expires"],
             tenant=row["tenant"] if "tenant" in keys else None,
+            target_machine=(
+                row["target_machine"] if "target_machine" in keys else None
+            ),
             result=row["result"] if "result" in keys else None,
             idempotency_key=row["idempotency_key"] if "idempotency_key" in keys else None,
             consecutive_failures=(
@@ -956,6 +1072,7 @@ class Task:
                 else (row["spawn_failures"] if "spawn_failures" in keys else 0)
             ),
             worker_pid=row["worker_pid"] if "worker_pid" in keys else None,
+            machine_id=row["machine_id"] if "machine_id" in keys else None,
             last_failure_error=(
                 row["last_failure_error"] if "last_failure_error" in keys
                 # Same belt-and-suspenders fallback as consecutive_failures above.
@@ -1020,6 +1137,7 @@ class Run:
     claim_lock: Optional[str]
     claim_expires: Optional[int]
     worker_pid: Optional[int]
+    machine_id: Optional[str]
     max_runtime_seconds: Optional[int]
     last_heartbeat_at: Optional[int]
     started_at: int
@@ -1044,6 +1162,7 @@ class Run:
             claim_lock=row["claim_lock"],
             claim_expires=row["claim_expires"],
             worker_pid=row["worker_pid"],
+            machine_id=(row["machine_id"] if "machine_id" in row.keys() else None),
             max_runtime_seconds=row["max_runtime_seconds"],
             last_heartbeat_at=row["last_heartbeat_at"],
             started_at=int(row["started_at"]),
@@ -1113,6 +1232,7 @@ CREATE TABLE IF NOT EXISTS tasks (
     project_id           TEXT,
     claim_lock           TEXT,
     claim_expires        INTEGER,
+    target_machine       TEXT,
     tenant               TEXT,
     result               TEXT,
     idempotency_key      TEXT,
@@ -1122,6 +1242,9 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- exceeds DEFAULT_FAILURE_LIMIT consecutive non-successes.
     consecutive_failures INTEGER NOT NULL DEFAULT 0,
     worker_pid           INTEGER,
+    -- Durable owner of worker_pid. Unlike the legacy claim_lock prefix this
+    -- survives hostname changes and cannot collide across machines.
+    machine_id           TEXT,
     -- Short excerpt of the most recent failure's error text.
     last_failure_error   TEXT,
     max_runtime_seconds  INTEGER,
@@ -1184,6 +1307,30 @@ CREATE TABLE IF NOT EXISTS task_links (
     PRIMARY KEY (parent_id, child_id)
 );
 
+CREATE TABLE IF NOT EXISTS machines (
+    id           TEXT PRIMARY KEY,
+    hostname     TEXT,
+    last_seen_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS machine_profiles (
+    machine_id TEXT NOT NULL,
+    profile    TEXT NOT NULL,
+    PRIMARY KEY (machine_id, profile)
+);
+
+CREATE TABLE IF NOT EXISTS machine_capabilities (
+    machine_id TEXT NOT NULL,
+    capability TEXT NOT NULL,
+    PRIMARY KEY (machine_id, capability)
+);
+
+CREATE TABLE IF NOT EXISTS task_capabilities (
+    task_id    TEXT NOT NULL,
+    capability TEXT NOT NULL,
+    PRIMARY KEY (task_id, capability)
+);
+
 CREATE TABLE IF NOT EXISTS task_comments (
     id         INTEGER PRIMARY KEY AUTOINCREMENT,
     task_id    TEXT NOT NULL,
@@ -1218,6 +1365,7 @@ CREATE TABLE IF NOT EXISTS task_runs (
     claim_lock          TEXT,
     claim_expires       INTEGER,
     worker_pid          INTEGER,
+    machine_id          TEXT,
     max_runtime_seconds INTEGER,
     last_heartbeat_at   INTEGER,
     started_at          INTEGER NOT NULL,
@@ -1267,6 +1415,8 @@ CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status ON tasks(assignee, status);
 CREATE INDEX IF NOT EXISTS idx_tasks_status          ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_links_child           ON task_links(child_id);
 CREATE INDEX IF NOT EXISTS idx_links_parent          ON task_links(parent_id);
+CREATE INDEX IF NOT EXISTS idx_machine_profiles_name ON machine_profiles(profile);
+CREATE INDEX IF NOT EXISTS idx_task_capabilities     ON task_capabilities(task_id);
 CREATE INDEX IF NOT EXISTS idx_comments_task         ON task_comments(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_events_task           ON task_events(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_runs_task             ON task_runs(task_id, started_at);
@@ -1863,6 +2013,10 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         _add_column_if_missing(conn, "tasks", "branch_name", "branch_name TEXT")
     if "project_id" not in cols:
         _add_column_if_missing(conn, "tasks", "project_id", "project_id TEXT")
+    if "target_machine" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "target_machine", "target_machine TEXT"
+        )
     if "idempotency_key" not in cols:
         _add_column_if_missing(
             conn, "tasks", "idempotency_key", "idempotency_key TEXT"
@@ -1903,6 +2057,8 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             )
     if "worker_pid" not in cols:
         _add_column_if_missing(conn, "tasks", "worker_pid", "worker_pid INTEGER")
+    if "machine_id" not in cols:
+        _add_column_if_missing(conn, "tasks", "machine_id", "machine_id TEXT")
     if "last_failure_error" not in cols:
         added = _add_column_if_missing(
             conn, "tasks", "last_failure_error", "last_failure_error TEXT"
@@ -2015,6 +2171,17 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         "ON task_events(run_id, id)"
     )
 
+    # Attempt history keeps the machine owner even after active task claim
+    # fields are cleared. Fresh DBs get this from SCHEMA_SQL; legacy DBs need
+    # the same additive migration as ``tasks.machine_id``.
+    run_cols = {
+        row["name"] for row in conn.execute("PRAGMA table_info(task_runs)")
+    }
+    if run_cols and "machine_id" not in run_cols:
+        _add_column_if_missing(
+            conn, "task_runs", "machine_id", "machine_id TEXT"
+        )
+
     notify_table_exists = conn.execute(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='kanban_notify_subs'"
     ).fetchone() is not None
@@ -2039,8 +2206,32 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     ).fetchone() is not None
     if runs_exist:
         with write_txn(conn):
+            # Backfill only legacy claims that this machine can prove it owns.
+            # Foreign hostname claims remain NULL and therefore can never
+            # authorize a local PID operation during a rolling migration.
+            legacy_running = conn.execute(
+                "SELECT id, claim_lock, current_run_id FROM tasks "
+                "WHERE status = 'running' AND machine_id IS NULL"
+            ).fetchall()
+            local_machine_id = get_machine_id()
+            for legacy in legacy_running:
+                if not _claim_is_owned_by_this_machine(None, legacy["claim_lock"]):
+                    continue
+                conn.execute(
+                    "UPDATE tasks SET machine_id = ? "
+                    "WHERE id = ? AND status = 'running' AND machine_id IS NULL",
+                    (local_machine_id, legacy["id"]),
+                )
+                if legacy["current_run_id"] is not None:
+                    conn.execute(
+                        "UPDATE task_runs SET machine_id = ? "
+                        "WHERE id = ? AND machine_id IS NULL",
+                        (local_machine_id, int(legacy["current_run_id"])),
+                    )
+
             inflight = conn.execute(
                 "SELECT id, assignee, claim_lock, claim_expires, worker_pid, "
+                "       machine_id, "
                 "       max_runtime_seconds, last_heartbeat_at, started_at "
                 "FROM tasks "
                 "WHERE status = 'running' AND current_run_id IS NULL"
@@ -2051,14 +2242,14 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
                     """
                     INSERT INTO task_runs (
                         task_id, profile, status,
-                        claim_lock, claim_expires, worker_pid,
+                        claim_lock, claim_expires, worker_pid, machine_id,
                         max_runtime_seconds, last_heartbeat_at,
                         started_at
-                    ) VALUES (?, ?, 'running', ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, 'running', ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         row["id"], row["assignee"], row["claim_lock"],
-                        row["claim_expires"], row["worker_pid"],
+                        row["claim_expires"], row["worker_pid"], row["machine_id"],
                         row["max_runtime_seconds"], row["last_heartbeat_at"],
                         started,
                     ),
@@ -2136,7 +2327,7 @@ _REBUILD_SPECS = {
         " id INTEGER PRIMARY KEY AUTOINCREMENT,"
         " task_id TEXT NOT NULL, profile TEXT, step_key TEXT,"
         " status TEXT NOT NULL, claim_lock TEXT, claim_expires INTEGER,"
-        " worker_pid INTEGER, max_runtime_seconds INTEGER,"
+        " worker_pid INTEGER, machine_id TEXT, max_runtime_seconds INTEGER,"
         " last_heartbeat_at INTEGER, started_at INTEGER NOT NULL,"
         " ended_at INTEGER, outcome TEXT, summary TEXT, metadata TEXT,"
         " error TEXT)",
@@ -2361,13 +2552,190 @@ def _new_task_id() -> str:
 
 
 def _claimer_id() -> str:
-    """Return a ``host:pid`` string that identifies this claimer."""
-    import socket
+    """Return a ``machine-uuid:pid`` token that identifies this claimer."""
+    return f"{get_machine_id()}:{os.getpid()}"
+
+
+_CAPABILITY_RE = re.compile(r"^[a-z0-9][a-z0-9_.-]{0,63}$")
+
+
+def _normalize_capabilities(values: Optional[Iterable[str]]) -> tuple[str, ...]:
+    capabilities: set[str] = set()
+    for raw in values or ():
+        value = str(raw).strip().lower()
+        if not value:
+            continue
+        if not _CAPABILITY_RE.fullmatch(value):
+            raise ValueError(f"invalid machine capability: {raw!r}")
+        capabilities.add(value)
+    return tuple(sorted(capabilities))
+
+
+def local_machine_capabilities() -> tuple[str, ...]:
+    """Return platform + operator-declared capabilities for this machine.
+
+    Machine routing is deliberately anchored to the default Hermes root's
+    ``config.yaml`` rather than the active profile config: whichever profile's
+    gateway wins the singleton dispatcher lock must advertise the same host.
+    """
+    platform_capability = (
+        "macos" if sys.platform == "darwin"
+        else "windows" if _IS_WINDOWS
+        else "linux"
+    )
+    configured: list[str] = []
+    config_path = kanban_home() / "config.yaml"
     try:
-        host = socket.gethostname() or "unknown"
-    except Exception:
-        host = "unknown"
-    return f"{host}:{os.getpid()}"
+        import yaml
+        raw = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        kanban_cfg = raw.get("kanban", {}) if isinstance(raw, dict) else {}
+        values = kanban_cfg.get("machine_capabilities", [])
+        if isinstance(values, (list, tuple, set)):
+            configured = [str(v) for v in values]
+    except FileNotFoundError:
+        pass
+    except Exception as exc:
+        _log.warning("kanban: could not read machine capabilities: %s", exc)
+    return _normalize_capabilities([platform_capability, *configured])
+
+
+def local_machine_profiles() -> tuple[str, ...]:
+    """Return spawnable profile names without loading full profile metadata."""
+    profiles = {"default"}
+    root = kanban_home() / "profiles"
+    try:
+        for entry in root.iterdir():
+            if (
+                entry.is_dir()
+                and re.fullmatch(r"[a-z0-9][a-z0-9_-]{0,63}", entry.name)
+                and entry.name != "default"
+            ):
+                profiles.add(entry.name)
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        _log.warning("kanban: could not enumerate local profiles: %s", exc)
+    return tuple(sorted(profiles))
+
+
+def register_machine(
+    conn: sqlite3.Connection,
+    machine_id: str,
+    *,
+    profiles: Iterable[str],
+    capabilities: Iterable[str],
+    hostname: Optional[str] = None,
+) -> str:
+    """Upsert a machine's advertised profiles and capabilities."""
+    machine_id = str(uuid.UUID(str(machine_id)))
+    normalized_profiles = tuple(sorted({_canonical_assignee(p) for p in profiles if p}))
+    normalized_capabilities = _normalize_capabilities(capabilities)
+    with write_txn(conn):
+        conn.execute(
+            "INSERT INTO machines (id, hostname, last_seen_at) VALUES (?, ?, ?) "
+            "ON CONFLICT(id) DO UPDATE SET hostname=excluded.hostname, "
+            "last_seen_at=excluded.last_seen_at",
+            (machine_id, hostname or _legacy_hostname(), int(time.time())),
+        )
+        conn.execute(
+            "DELETE FROM machine_profiles WHERE machine_id = ?", (machine_id,)
+        )
+        conn.executemany(
+            "INSERT INTO machine_profiles (machine_id, profile) VALUES (?, ?)",
+            [(machine_id, profile) for profile in normalized_profiles],
+        )
+        conn.execute(
+            "DELETE FROM machine_capabilities WHERE machine_id = ?", (machine_id,)
+        )
+        conn.executemany(
+            "INSERT INTO machine_capabilities (machine_id, capability) "
+            "VALUES (?, ?)",
+            [(machine_id, capability) for capability in normalized_capabilities],
+        )
+    return machine_id
+
+
+def register_local_machine(conn: sqlite3.Connection) -> str:
+    """Upsert this machine's presence, profiles, and capabilities."""
+    return register_machine(
+        conn,
+        get_machine_id(),
+        profiles=local_machine_profiles(),
+        capabilities=local_machine_capabilities(),
+        hostname=_legacy_hostname(),
+    )
+
+
+def record_worker_started(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    claim_lock: str,
+    worker_pid: int,
+) -> bool:
+    """Record a claimed worker process without trusting a foreign PID for control.
+
+    The PID is operational metadata: its owning machine reports it so the
+    coordinator/dashboard can display the live remote worker.  Process
+    inspection and termination remain machine-local, guarded by ``machine_id``.
+    """
+    if int(worker_pid) <= 0:
+        raise ValueError("worker_pid must be positive")
+    with write_txn(conn):
+        task = conn.execute(
+            "SELECT status, claim_lock, current_run_id FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if task is None or task["status"] != "running" or task["claim_lock"] != claim_lock:
+            return False
+        conn.execute("UPDATE tasks SET worker_pid = ? WHERE id = ?", (int(worker_pid), task_id))
+        run_id = task["current_run_id"]
+        if run_id is not None:
+            conn.execute("UPDATE task_runs SET worker_pid = ? WHERE id = ?", (int(worker_pid), run_id))
+            _append_event(conn, task_id, "worker_started", {"worker_pid": int(worker_pid)}, run_id=run_id)
+    return True
+
+
+def task_capabilities(conn: sqlite3.Connection, task_id: str) -> tuple[str, ...]:
+    return tuple(
+        row["capability"] for row in conn.execute(
+            "SELECT capability FROM task_capabilities WHERE task_id = ? "
+            "ORDER BY capability",
+            (task_id,),
+        ).fetchall()
+    )
+
+
+def _routing_mismatch(
+    conn: sqlite3.Connection,
+    task_id: str,
+    machine_id: str,
+    *,
+    require_registered_profile: bool = False,
+) -> Optional[str]:
+    row = conn.execute(
+        "SELECT assignee, target_machine FROM tasks WHERE id = ?", (task_id,)
+    ).fetchone()
+    if row is None:
+        return "missing"
+    if row["target_machine"] and row["target_machine"] != machine_id:
+        return "target_machine"
+    if require_registered_profile and row["assignee"]:
+        has_profile = conn.execute(
+            "SELECT 1 FROM machine_profiles WHERE machine_id = ? AND profile = ?",
+            (machine_id, row["assignee"]),
+        ).fetchone()
+        if has_profile is None:
+            return "profile"
+    missing_capability = conn.execute(
+        "SELECT 1 FROM task_capabilities tc "
+        "WHERE tc.task_id = ? AND NOT EXISTS ("
+        "  SELECT 1 FROM machine_capabilities mc "
+        "  WHERE mc.machine_id = ? AND mc.capability = tc.capability"
+        ") LIMIT 1",
+        (task_id, machine_id),
+    ).fetchone()
+    return "capabilities" if missing_capability is not None else None
 
 
 # ---------------------------------------------------------------------------
@@ -2407,6 +2775,8 @@ def create_task(
     session_id: Optional[str] = None,
     board: Optional[str] = None,
     project_id: Optional[str] = None,
+    target_machine: Optional[str] = None,
+    required_capabilities: Optional[Iterable[str]] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -2432,6 +2802,9 @@ def create_task(
     translation skill regardless of the profile's default config).
     """
     assignee = _canonical_assignee(assignee)
+    if target_machine is not None:
+        target_machine = str(uuid.UUID(str(target_machine)))
+    required_capabilities_list = _normalize_capabilities(required_capabilities)
     if not title or not title.strip():
         raise ValueError("title is required")
     if initial_status not in VALID_INITIAL_STATUSES:
@@ -2635,8 +3008,9 @@ def create_task(
                         created_by, created_at, workspace_kind, workspace_path,
                         branch_name, project_id, tenant, idempotency_key,
                         max_runtime_seconds,
-                        skills, max_retries, goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        skills, max_retries, goal_mode, goal_max_turns, session_id,
+                        target_machine
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -2659,7 +3033,13 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        target_machine,
                     ),
+                )
+                conn.executemany(
+                    "INSERT INTO task_capabilities (task_id, capability) "
+                    "VALUES (?, ?)",
+                    [(task_id, cap) for cap in required_capabilities_list],
                 )
                 for pid in parents:
                     conn.execute(
@@ -2678,6 +3058,8 @@ def create_task(
                         "branch_name": branch_name,
                         "skills": list(skills_list) if skills_list else None,
                         "goal_mode": bool(goal_mode) or None,
+                        "target_machine": target_machine,
+                        "required_capabilities": list(required_capabilities_list),
                     },
                 )
             return task_id
@@ -3375,6 +3757,9 @@ def claim_task(
     *,
     ttl_seconds: Optional[int] = None,
     claimer: Optional[str] = None,
+    machine_id: Optional[str] = None,
+    enforce_machine_routing: bool = False,
+    require_registered_profile: bool = False,
 ) -> Optional[Task]:
     """Atomically transition ``ready -> running``.
 
@@ -3382,9 +3767,28 @@ def claim_task(
     already claimed (or is not in ``ready`` status).
     """
     now = int(time.time())
-    lock = claimer or _claimer_id()
+    owner_machine_id = (
+        str(uuid.UUID(str(machine_id))) if machine_id is not None
+        else get_machine_id()
+    )
+    lock = claimer or f"{owner_machine_id}:{os.getpid()}"
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
+        if enforce_machine_routing:
+            mismatch = _routing_mismatch(
+                conn,
+                task_id,
+                owner_machine_id,
+                require_registered_profile=require_registered_profile,
+            )
+            if mismatch is not None:
+                _append_event(
+                    conn,
+                    task_id,
+                    "claim_rejected",
+                    {"reason": mismatch, "machine_id": owner_machine_id},
+                )
+                return None
         # Structural invariant: never transition ready -> running while any
         # parent is not yet 'done'. This is the single enforcement point
         # regardless of which writer (create_task, link_tasks, unblock_task,
@@ -3436,12 +3840,13 @@ def claim_task(
                SET status        = 'running',
                    claim_lock    = ?,
                    claim_expires = ?,
+                   machine_id    = ?,
                    started_at    = COALESCE(started_at, ?)
              WHERE id = ?
                AND status = 'ready'
                AND claim_lock IS NULL
             """,
-            (lock, expires, now, task_id),
+            (lock, expires, owner_machine_id, now, task_id),
         )
         if cur.rowcount != 1:
             return None
@@ -3456,9 +3861,9 @@ def claim_task(
             """
             INSERT INTO task_runs (
                 task_id, profile, step_key, status,
-                claim_lock, claim_expires, max_runtime_seconds,
+                claim_lock, claim_expires, machine_id, max_runtime_seconds,
                 started_at
-            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?, ?)
             """,
             (
                 task_id,
@@ -3466,6 +3871,7 @@ def claim_task(
                 trow["current_step_key"] if trow else None,
                 lock,
                 expires,
+                owner_machine_id,
                 trow["max_runtime_seconds"] if trow else None,
                 now,
             ),
@@ -3477,7 +3883,12 @@ def claim_task(
         )
         _append_event(
             conn, task_id, "claimed",
-            {"lock": lock, "expires": expires, "run_id": run_id},
+            {
+                "lock": lock,
+                "expires": expires,
+                "run_id": run_id,
+                "machine_id": owner_machine_id,
+            },
             run_id=run_id,
         )
         claimed = get_task(conn, task_id)
@@ -3497,6 +3908,7 @@ def claim_review_task(
     *,
     ttl_seconds: Optional[int] = None,
     claimer: Optional[str] = None,
+    machine_id: Optional[str] = None,
 ) -> Optional[Task]:
     """Atomically transition ``review -> running``.
 
@@ -3511,7 +3923,11 @@ def claim_review_task(
     independently from the original worker run.
     """
     now = int(time.time())
-    lock = claimer or _claimer_id()
+    owner_machine_id = (
+        str(uuid.UUID(str(machine_id))) if machine_id is not None
+        else get_machine_id()
+    )
+    lock = claimer or f"{owner_machine_id}:{os.getpid()}"
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
         cur = conn.execute(
@@ -3520,12 +3936,13 @@ def claim_review_task(
                SET status        = 'running',
                    claim_lock    = ?,
                    claim_expires = ?,
+                   machine_id    = ?,
                    started_at    = COALESCE(started_at, ?)
              WHERE id = ?
                AND status = 'review'
                AND claim_lock IS NULL
             """,
-            (lock, expires, now, task_id),
+            (lock, expires, owner_machine_id, now, task_id),
         )
         if cur.rowcount != 1:
             return None
@@ -3538,9 +3955,9 @@ def claim_review_task(
             """
             INSERT INTO task_runs (
                 task_id, profile, step_key, status,
-                claim_lock, claim_expires, max_runtime_seconds,
+                claim_lock, claim_expires, machine_id, max_runtime_seconds,
                 started_at
-            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?, ?)
             """,
             (
                 task_id,
@@ -3548,6 +3965,7 @@ def claim_review_task(
                 trow["current_step_key"] if trow else None,
                 lock,
                 expires,
+                owner_machine_id,
                 trow["max_runtime_seconds"] if trow else None,
                 now,
             ),
@@ -3559,8 +3977,13 @@ def claim_review_task(
         )
         _append_event(
             conn, task_id, "claimed",
-            {"lock": lock, "expires": expires, "run_id": run_id,
-             "source_status": "review"},
+            {
+                "lock": lock,
+                "expires": expires,
+                "run_id": run_id,
+                "source_status": "review",
+                "machine_id": owner_machine_id,
+            },
             run_id=run_id,
         )
         return get_task(conn, task_id)
@@ -3597,6 +4020,109 @@ def heartbeat_claim(
         return False
 
 
+def renew_owned_leases(
+    conn: sqlite3.Connection,
+    *,
+    now: Optional[int] = None,
+) -> int:
+    """Proactively extend the claim leases of *this machine's* live workers.
+
+    This is the machine-driven counterpart to the reactive PID rescue inside
+    :func:`release_stale_claims`. That rescue only fires *after* a lease has
+    already expired, and — critically — only for a machine-local claim, so a
+    worker running on another machine can never be rescued: its healthy lease
+    expires on the TTL and the reclaim path spawns a duplicate beside it. The
+    fix is to stop letting healthy leases expire at all: each machine renews
+    the leases of the workers *it* owns, on a timer, before expiry. An expired
+    lease then means what a lease is supposed to mean — *the owning machine
+    stopped vouching for this task* — and reclaim becomes unambiguously safe.
+
+    Ownership is explicit (``tasks.machine_id`` == ours) and liveness is
+    ``_pid_alive(worker_pid)`` — exactly the signals the rescue branch uses,
+    because "is my worker alive?" is a question only the worker's own machine
+    can answer. A worker whose heartbeat is stale by more than
+    ``DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS`` is deliberately *not* renewed:
+    it is wedged (running but making no observable progress), and letting its
+    lease lapse hands it to ``release_stale_claims`` / ``detect_stale_running``
+    for reclaim — preserving the #29747 backstop.
+
+    To bound event churn a lease is only renewed after its first third has
+    elapsed (at most 2/3 of the TTL remains); a freshly claimed task is left
+    alone until then. Renewal cadence is therefore ~TTL/3, which is why the TTL
+    can safely drop far below the legacy 15 minutes once every machine renews.
+
+    Note the deliberately-omitted piece: *fencing*. When a coordinator can
+    reassign a running task to another machine, a failed renewal must become a
+    kill signal for the orphaned local worker. That requires a stable machine
+    identity (host prefixes collide and mutate) and a real reassignment path,
+    neither of which exists on a single local DB — a claim only ever fires from
+    ``ready`` here, so ownership never changes under a live worker. Fencing
+    therefore lands with the coordinator (Build 0.5), not with this change.
+
+    Returns the number of leases renewed this pass. Safe to call every tick.
+    """
+    now = int(time.time()) if now is None else int(now)
+    ttl = _resolve_claim_ttl_seconds()
+    # Renew after the first third has elapsed: remaining <= 2/3 TTL.
+    renew_below = (ttl * 2) // 3
+    candidates = conn.execute(
+        "SELECT id, claim_lock, worker_pid, machine_id, claim_expires, "
+        "       last_heartbeat_at "
+        "FROM tasks "
+        "WHERE status = 'running' AND claim_lock IS NOT NULL "
+        "  AND worker_pid IS NOT NULL",
+    ).fetchall()
+
+    renewed = 0
+    for row in candidates:
+        lock = row["claim_lock"] or ""
+        if not _claim_is_owned_by_this_machine(row["machine_id"], lock):
+            continue  # not ours — another machine renews its own
+        if not _pid_alive(row["worker_pid"]):
+            continue  # dead worker — leave it for the crash/reclaim paths
+        hb = row["last_heartbeat_at"]
+        heartbeat_stale = (
+            hb is not None
+            and (now - int(hb)) > DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS
+        )
+        if heartbeat_stale:
+            continue  # wedged — let the lease lapse so reclaim can act
+        # Only renew after the first third of the lease has elapsed.
+        cur_expires = row["claim_expires"]
+        if cur_expires is not None and (int(cur_expires) - now) > renew_below:
+            continue
+        new_expires = now + ttl
+        with write_txn(conn):
+            cur = conn.execute(
+                "UPDATE tasks SET claim_expires = ? "
+                "WHERE id = ? AND status = 'running' AND claim_lock = ?",
+                (new_expires, row["id"], lock),
+            )
+            if cur.rowcount != 1:
+                continue  # row changed under us; nothing renewed
+            run_id = _current_run_id(conn, row["id"])
+            if run_id is not None:
+                conn.execute(
+                    "UPDATE task_runs SET claim_expires = ? WHERE id = ?",
+                    (new_expires, run_id),
+                )
+            _append_event(
+                conn, row["id"], "claim_renewed",
+                {
+                    "reason": "owner_alive",
+                    "claim_lock": lock,
+                    "worker_pid": int(row["worker_pid"]),
+                    "claim_expires_was": (
+                        int(cur_expires) if cur_expires is not None else None
+                    ),
+                    "claim_expires_now": new_expires,
+                },
+                run_id=run_id,
+            )
+            renewed += 1
+    return renewed
+
+
 def release_stale_claims(
     conn: sqlite3.Connection,
     *,
@@ -3604,7 +4130,7 @@ def release_stale_claims(
 ) -> int:
     """Reset any ``running`` task whose claim has expired.
 
-    A stale-by-TTL claim whose host-local worker PID is still alive is
+    A stale-by-TTL claim whose machine-local worker PID is still alive is
     *extended* (with a ``claim_extended`` event) instead of being
     reclaimed. Reclaiming a live worker mid-flight produces the spawn-
     then-immediately-reclaim loop seen on slow models that spend longer
@@ -3629,9 +4155,9 @@ def release_stale_claims(
     """
     now = int(time.time())
     reclaimed = 0
-    host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
     stale = conn.execute(
-        "SELECT id, claim_lock, worker_pid, claim_expires, last_heartbeat_at "
+        "SELECT id, claim_lock, worker_pid, machine_id, claim_expires, "
+        "       last_heartbeat_at "
         "FROM tasks "
         "WHERE status = 'running' AND claim_expires IS NOT NULL "
         "  AND claim_expires < ?",
@@ -3639,7 +4165,9 @@ def release_stale_claims(
     ).fetchall()
     for row in stale:
         lock = row["claim_lock"] or ""
-        host_local = lock.startswith(host_prefix)
+        machine_local = _claim_is_owned_by_this_machine(
+            row["machine_id"], lock,
+        )
         hb = row["last_heartbeat_at"]
         # Heartbeat staleness backstop: if we have a heartbeat at all
         # and it's older than the max-stale threshold, the worker is
@@ -3650,7 +4178,7 @@ def release_stale_claims(
             and (now - int(hb)) > DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS
         )
         if (
-            host_local
+            machine_local
             and row["worker_pid"]
             and _pid_alive(row["worker_pid"])
             and not heartbeat_stale
@@ -3692,7 +4220,8 @@ def release_stale_claims(
             continue
 
         termination = _terminate_reclaimed_worker(
-            row["worker_pid"], row["claim_lock"], signal_fn=signal_fn,
+            row["worker_pid"], row["claim_lock"],
+            machine_id=row["machine_id"], signal_fn=signal_fn,
         )
         # Never release a claim while our own worker is still alive: that would
         # spawn a duplicate beside it. Hold the claim and retry next tick.
@@ -3705,7 +4234,7 @@ def release_stale_claims(
         with write_txn(conn):
             cur = conn.execute(
                 "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
-                "claim_expires = NULL, worker_pid = NULL "
+                "claim_expires = NULL, worker_pid = NULL, machine_id = NULL "
                 "WHERE id = ? AND status = 'running' AND claim_lock IS ? "
                 "AND claim_expires IS NOT NULL AND claim_expires < ?",
                 (row["id"], row["claim_lock"], now),
@@ -3730,7 +4259,10 @@ def release_stale_claims(
                     if row["last_heartbeat_at"] is not None else None
                 ),
                 "now": now,
-                "host_local": host_local,
+                # Keep the existing payload key for API compatibility; its
+                # value is now derived from the stable machine UUID.
+                "host_local": machine_local,
+                "machine_id": row["machine_id"],
                 "heartbeat_stale": bool(heartbeat_stale),
             }
             payload.update(termination)
@@ -3762,7 +4294,8 @@ def reclaim_task(
     reclaimable state (not running, or doesn't exist).
     """
     row = conn.execute(
-        "SELECT status, claim_lock, worker_pid FROM tasks WHERE id = ?",
+        "SELECT status, claim_lock, worker_pid, machine_id "
+        "FROM tasks WHERE id = ?",
         (task_id,),
     ).fetchone()
     if not row:
@@ -3772,12 +4305,13 @@ def reclaim_task(
         return False
     prev_lock = row["claim_lock"]
     termination = _terminate_reclaimed_worker(
-        row["worker_pid"], prev_lock, signal_fn=signal_fn,
+        row["worker_pid"], prev_lock,
+        machine_id=row["machine_id"], signal_fn=signal_fn,
     )
     with write_txn(conn):
         cur = conn.execute(
             "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
-            "claim_expires = NULL, worker_pid = NULL "
+            "claim_expires = NULL, worker_pid = NULL, machine_id = NULL "
             "WHERE id = ? AND status IN ('running', 'ready', 'blocked') "
             "AND claim_lock IS ?",
             (task_id, prev_lock),
@@ -4053,6 +4587,7 @@ def complete_task(
                        claim_lock   = NULL,
                        claim_expires= NULL,
                        worker_pid   = NULL,
+                       machine_id   = NULL,
                        block_kind   = NULL,
                        block_recurrences = 0
                  WHERE id = ?
@@ -4070,6 +4605,7 @@ def complete_task(
                        claim_lock   = NULL,
                        claim_expires= NULL,
                        worker_pid   = NULL,
+                       machine_id   = NULL,
                        block_kind   = NULL,
                        block_recurrences = 0
                  WHERE id = ?
@@ -4606,6 +5142,7 @@ def block_task(
                        claim_lock    = NULL,
                        claim_expires = NULL,
                        worker_pid    = NULL,
+                       machine_id    = NULL,
                        block_kind    = ?
                  WHERE id = ?
                    AND status IN ('running', 'ready')
@@ -4659,6 +5196,7 @@ def block_task(
                        claim_lock    = NULL,
                        claim_expires = NULL,
                        worker_pid    = NULL,
+                       machine_id    = NULL,
                        block_kind    = ?,
                        block_recurrences = ?
                  WHERE id = ?
@@ -4698,6 +5236,7 @@ def block_task(
                            claim_lock    = NULL,
                            claim_expires = NULL,
                            worker_pid    = NULL,
+                           machine_id    = NULL,
                            block_kind    = ?,
                            block_recurrences = ?
                      WHERE id = ?
@@ -4713,6 +5252,7 @@ def block_task(
                            claim_lock    = NULL,
                            claim_expires = NULL,
                            worker_pid    = NULL,
+                           machine_id    = NULL,
                            block_kind    = ?,
                            block_recurrences = ?
                      WHERE id = ?
@@ -5208,7 +5748,8 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
     with write_txn(conn):
         cur = conn.execute(
             "UPDATE tasks SET status = 'archived', "
-            "    claim_lock = NULL, claim_expires = NULL, worker_pid = NULL "
+            "    claim_lock = NULL, claim_expires = NULL, worker_pid = NULL, "
+            "    machine_id = NULL "
             "WHERE id = ? AND status != 'archived'",
             (task_id,),
         )
@@ -5251,6 +5792,7 @@ def delete_archived_task(conn: sqlite3.Connection, task_id: str) -> bool:
         conn.execute("DELETE FROM task_comments WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM task_events WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM task_runs WHERE task_id = ?", (task_id,))
+        conn.execute("DELETE FROM task_capabilities WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM kanban_notify_subs WHERE task_id = ?", (task_id,))
         cur = conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
         return cur.rowcount == 1
@@ -5274,6 +5816,7 @@ def delete_task(conn: sqlite3.Connection, task_id: str) -> bool:
         conn.execute("DELETE FROM task_comments WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM task_events WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM task_runs WHERE task_id = ?", (task_id,))
+        conn.execute("DELETE FROM task_capabilities WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM kanban_notify_subs WHERE task_id = ?", (task_id,))
     recompute_ready(conn)
     return True
@@ -5605,7 +6148,8 @@ def schedule_task(
                SET status       = 'scheduled',
                    claim_lock   = NULL,
                    claim_expires= NULL,
-                   worker_pid   = NULL
+                   worker_pid   = NULL,
+                   machine_id   = NULL
              WHERE id = ?
                AND status IN ('todo', 'ready', 'running', 'blocked')
         """
@@ -5692,6 +6236,11 @@ class DispatchResult:
 
     reclaimed: int = 0
     promoted: int = 0
+    renewed: int = 0
+    """Count of this machine's own live leases proactively extended this tick
+    by ``renew_owned_leases`` — before expiry, so a busy worker is never
+    mistaken for a dead one. The machine-driven replacement for the reactive
+    post-expiry PID rescue in ``release_stale_claims``."""
     spawned: list[tuple[str, str, str]] = field(default_factory=list)
     """List of ``(task_id, assignee, workspace_path)`` triples."""
     skipped_unassigned: list[str] = field(default_factory=list)
@@ -5710,6 +6259,9 @@ class DispatchResult:
     operator-actionable failure. Tracked separately so health telemetry
     can distinguish "real stuck" (nothing spawned but spawnable work
     available) from "correctly idle" (nothing spawnable in the queue)."""
+    skipped_routing: list[tuple[str, str]] = field(default_factory=list)
+    """Tasks ineligible for this machine as ``(task_id, reason)`` pairs.
+    They remain ready for another registered machine and are not failures."""
     skipped_per_profile_capped: list[tuple[str, str, int]] = field(default_factory=list)
     """Tasks deferred this tick because their assignee is already at
     ``kanban.max_in_progress_per_profile`` (#21582). Each entry is
@@ -5916,9 +6468,10 @@ def _terminate_reclaimed_worker(
     pid: Optional[int],
     claim_lock: Optional[str],
     *,
+    machine_id: Optional[str] = None,
     signal_fn=None,
 ) -> dict[str, Any]:
-    """Best-effort host-local worker termination for reclaim paths."""
+    """Best-effort machine-local worker termination for reclaim paths."""
     import signal
 
     info: dict[str, Any] = {
@@ -5931,8 +6484,7 @@ def _terminate_reclaimed_worker(
     if not pid or pid <= 0 or not claim_lock:
         return info
 
-    host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
-    if not str(claim_lock).startswith(host_prefix):
+    if not _claim_is_owned_by_this_machine(machine_id, claim_lock):
         return info
     info["host_local"] = True
 
@@ -5975,11 +6527,11 @@ def _terminate_reclaimed_worker(
 
 
 def _worker_survived_termination(termination: dict) -> bool:
-    """True when we tried to kill our own host-local worker and it is still alive.
+    """True when our own machine-local worker survived termination.
 
     Reclaiming in this state would release the claim and let the dispatcher
     spawn a second worker while the first is still running — the duplication
-    loop. Only host-local workers we actually signalled count: a non-local
+    loop. Only machine-local workers we actually signalled count: a non-local
     claim lock or a no-op attempt (no ``os.kill`` available) must fall through
     to the normal release path, since we cannot manage that worker anyway.
     """
@@ -6095,19 +6647,17 @@ def enforce_max_runtime(
     breaker has already given up, in which case the task stays blocked
     where ``_record_spawn_failure`` parked it.
 
-    Runs host-local: only tasks claimed by this host are candidates
+    Runs machine-local: only tasks owned by this machine are candidates
     (same reasoning as ``detect_crashed_workers``). ``signal_fn`` is a
     test hook; defaults to ``os.kill`` on POSIX.
     """
     import signal
     timed_out: list[str] = []
     now = int(time.time())
-    host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
-
     rows = conn.execute(
         "SELECT t.id, t.worker_pid, "
         "       COALESCE(r.started_at, t.started_at) AS active_started_at, "
-        "       t.max_runtime_seconds, t.claim_lock "
+        "       t.max_runtime_seconds, t.claim_lock, t.machine_id "
         "FROM tasks t "
         "LEFT JOIN task_runs r ON r.id = t.current_run_id "
         "WHERE t.status = 'running' AND t.max_runtime_seconds IS NOT NULL "
@@ -6116,7 +6666,7 @@ def enforce_max_runtime(
     ).fetchall()
     for row in rows:
         lock = row["claim_lock"] or ""
-        if not lock.startswith(host_prefix):
+        if not _claim_is_owned_by_this_machine(row["machine_id"], lock):
             continue
         # Runtime is per attempt, not lifetime-of-task. ``tasks.started_at``
         # intentionally records the first time a task ever started, so retries
@@ -6156,7 +6706,7 @@ def enforce_max_runtime(
         with write_txn(conn):
             cur = conn.execute(
                 "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
-                "claim_expires = NULL, worker_pid = NULL, "
+                "claim_expires = NULL, worker_pid = NULL, machine_id = NULL, "
                 "last_heartbeat_at = NULL "
                 "WHERE id = ? AND status = 'running' "
                 "  AND worker_pid = ? AND claim_lock IS ?",
@@ -6221,7 +6771,7 @@ def detect_stale_running(
        ``_STALE_HEARTBEAT_GAP_SECONDS`` (or NULL — never sent a heartbeat).
 
     On reclaim the task is reset to ``ready``, the run is closed with
-    ``outcome='stale'``, and the host-local worker (if still running) is
+    ``outcome='stale'``, and the machine-local worker (if still running) is
     terminated.
 
     Only considers ``status='running'`` tasks. Blocked tasks are never
@@ -6236,11 +6786,11 @@ def detect_stale_running(
 
 
     now = int(time.time())
-    host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
     reclaimed: list[str] = []
 
     rows = conn.execute(
-        "SELECT t.id, t.worker_pid, t.last_heartbeat_at, t.claim_lock, "
+        "SELECT t.id, t.worker_pid, t.machine_id, t.last_heartbeat_at, "
+        "       t.claim_lock, "
         "       COALESCE(r.started_at, t.started_at) AS active_started_at "
         "FROM tasks t "
         "LEFT JOIN task_runs r ON r.id = t.current_run_id "
@@ -6265,9 +6815,9 @@ def detect_stale_running(
         tid = row["id"]
         lock = row["claim_lock"] or ""
 
-        # Terminate the worker if it's still host-local.
+        # Terminate the worker if it belongs to this machine.
         termination = _terminate_reclaimed_worker(
-            pid, lock, signal_fn=signal_fn,
+            pid, lock, machine_id=row["machine_id"], signal_fn=signal_fn,
         )
 
         # Never release a claim while our own worker is still alive: that would
@@ -6282,7 +6832,7 @@ def detect_stale_running(
         with write_txn(conn):
             cur = conn.execute(
                 "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
-                "claim_expires = NULL, worker_pid = NULL, "
+                "claim_expires = NULL, worker_pid = NULL, machine_id = NULL, "
                 "last_heartbeat_at = NULL "
                 "WHERE id = ? AND status = 'running' "
                 "  AND claim_lock IS ?",
@@ -6350,8 +6900,8 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     Different from ``release_stale_claims``: this checks liveness
     immediately rather than waiting for the claim TTL.
 
-    Only considers tasks claimed by *this host* — PIDs from other hosts
-    are meaningless here. The host-local check is enough because
+    Only considers tasks owned by *this machine* — PIDs from other machines
+    are meaningless here. The machine-ID check is enough because
     ``_default_spawn`` always runs the worker on the same host as the
     dispatcher (the whole design is single-host).
 
@@ -6382,14 +6932,14 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # (task_id, pid, claimer, protocol_violation, error_text)
     with write_txn(conn):
         rows = conn.execute(
-            "SELECT id, worker_pid, claim_lock, started_at FROM tasks "
+            "SELECT id, worker_pid, machine_id, claim_lock, started_at "
+            "FROM tasks "
             "WHERE status = 'running' AND worker_pid IS NOT NULL"
         ).fetchall()
-        host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
         for row in rows:
-            # Only check liveness for claims owned by this host.
+            # Only check liveness for claims owned by this machine.
             lock = row["claim_lock"] or ""
-            if not lock.startswith(host_prefix):
+            if not _claim_is_owned_by_this_machine(row["machine_id"], lock):
                 continue
             # Skip liveness check inside the launch-window grace period
             # so a freshly-spawned worker isn't reclaimed before its PID
@@ -6457,7 +7007,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
 
             cur = conn.execute(
                 "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
-                "claim_expires = NULL, worker_pid = NULL "
+                "claim_expires = NULL, worker_pid = NULL, machine_id = NULL "
                 "WHERE id = ? AND status = 'running' "
                 "  AND worker_pid = ? AND claim_lock IS ?",
                 (row["id"], pid, row["claim_lock"]),
@@ -6616,7 +7166,7 @@ def _record_task_failure(
                 # Spawn path: still running, also clear claim state.
                 conn.execute(
                     "UPDATE tasks SET status = 'blocked', claim_lock = NULL, "
-                    "claim_expires = NULL, worker_pid = NULL, "
+                    "claim_expires = NULL, worker_pid = NULL, machine_id = NULL, "
                     "consecutive_failures = ?, last_failure_error = ? "
                     "WHERE id = ? AND status IN ('running', 'ready')",
                     (failures, error[:500], task_id),
@@ -6664,7 +7214,7 @@ def _record_task_failure(
                 # Spawn path: transition running → ready + clear claim.
                 conn.execute(
                     "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
-                    "claim_expires = NULL, worker_pid = NULL, "
+                    "claim_expires = NULL, worker_pid = NULL, machine_id = NULL, "
                     "consecutive_failures = ?, last_failure_error = ? "
                     "WHERE id = ? AND status = 'running'",
                     (failures, error[:500], task_id),
@@ -7032,7 +7582,7 @@ def _dispatch_once_locked(
     Steps:
       1. Reclaim stale running tasks (TTL expired).
       2. Reclaim stale running tasks (no recent heartbeat).
-      3. Reclaim crashed running tasks (host-local PID no longer alive).
+      3. Reclaim crashed running tasks (machine-local PID no longer alive).
       3. Promote todo -> ready where all parents are done.
       4. For each ready task with an assignee, atomically claim and call
          ``spawn_fn(task, workspace_path, board) -> Optional[int]``. The
@@ -7060,6 +7610,12 @@ def _dispatch_once_locked(
     reap_worker_zombies()
 
     result = DispatchResult()
+    # Renew this machine's own live leases BEFORE the reclaim scan, so a
+    # healthy worker's lease never appears expired to release_stale_claims
+    # (or, cross-machine, to another machine's dispatcher). This is what makes
+    # an expired lease mean "the owner stopped vouching" rather than merely
+    # "the TTL elapsed while the worker was busy".
+    result.renewed = renew_owned_leases(conn)
     result.reclaimed = release_stale_claims(conn)
     result.stale = detect_stale_running(
         conn, stale_timeout_seconds=stale_timeout_seconds,
@@ -7083,6 +7639,7 @@ def _dispatch_once_locked(
         result.rate_limited.extend(_crash_rate_limited)
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
+    local_machine_id = register_local_machine(conn)
 
     # Count tasks already running so max_spawn enforces concurrency rather
     # than a per-tick spawn budget. See the docstring above for the full
@@ -7158,6 +7715,12 @@ def _dispatch_once_locked(
     for row in ready_rows:
         if max_spawn is not None and running_count + spawned >= max_spawn:
             break
+        routing_mismatch = _routing_mismatch(
+            conn, row["id"], local_machine_id,
+        )
+        if routing_mismatch is not None:
+            result.skipped_routing.append((row["id"], routing_mismatch))
+            continue
         row_assignee = row["assignee"]
         if not row_assignee:
             # Honour kanban.default_assignee: when the dispatcher hits an
@@ -7270,7 +7833,13 @@ def _dispatch_once_locked(
                     _per_profile_running.get(row_assignee, 0) + 1
                 )
             continue
-        claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
+        claimed = claim_task(
+            conn,
+            row["id"],
+            ttl_seconds=ttl_seconds,
+            machine_id=local_machine_id,
+            enforce_machine_routing=True,
+        )
         if claimed is None:
             continue
         try:

--- a/hermes_cli/kanban_remote.py
+++ b/hermes_cli/kanban_remote.py
@@ -1,0 +1,180 @@
+"""Small client adapter that lets Kanban worker tools use a coordinator."""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Any, Optional
+
+from hermes_cli import kanban_db as local
+
+
+class RemoteConnection:
+    def close(self) -> None:
+        return None
+
+
+class RemoteKanban:
+    def __init__(self, base_url: str, token: str):
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+
+    def _request(self, method: str, path: str, body: Optional[dict] = None) -> dict:
+        data = json.dumps(body).encode("utf-8") if body is not None else None
+        request = urllib.request.Request(
+            self.base_url + path,
+            data=data,
+            method=method,
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": "application/json",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=15) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"coordinator {exc.code}: {detail}") from exc
+
+    def _detail(self, task_id: str) -> dict:
+        return self._request("GET", f"/v1/tasks/{task_id}")
+
+    def get_task(self, _conn: RemoteConnection, task_id: str) -> Optional[local.Task]:
+        try:
+            payload = dict(self._detail(task_id)["task"])
+            payload.pop("required_capabilities", None)
+            return local.Task(**payload)
+        except RuntimeError as exc:
+            if "coordinator 404:" in str(exc):
+                return None
+            raise
+
+    def list_comments(self, _conn: RemoteConnection, task_id: str) -> list[local.Comment]:
+        return [local.Comment(**item) for item in self._detail(task_id)["comments"]]
+
+    def list_events(self, _conn: RemoteConnection, task_id: str) -> list[local.Event]:
+        return [local.Event(**item) for item in self._detail(task_id)["events"]]
+
+    def list_runs(self, _conn: RemoteConnection, task_id: str) -> list[local.Run]:
+        return [local.Run(**item) for item in self._detail(task_id)["runs"]]
+
+    def latest_run(self, conn: RemoteConnection, task_id: str) -> Optional[local.Run]:
+        runs = self.list_runs(conn, task_id)
+        return runs[-1] if runs else None
+
+    def parent_ids(self, _conn: RemoteConnection, task_id: str) -> list[str]:
+        return self._detail(task_id)["parents"]
+
+    def child_ids(self, _conn: RemoteConnection, task_id: str) -> list[str]:
+        return self._detail(task_id)["children"]
+
+    def build_worker_context(self, _conn: RemoteConnection, task_id: str) -> str:
+        return self._detail(task_id)["worker_context"]
+
+    def register_machine(
+        self,
+        machine_id: str,
+        *,
+        hostname: str,
+        profiles: list[str],
+        capabilities: list[str],
+    ) -> str:
+        return str(self._request("POST", "/v1/machines/register", {
+            "machine_id": machine_id,
+            "hostname": hostname,
+            "profiles": profiles,
+            "capabilities": capabilities,
+        })["machine_id"])
+
+    def claim_next(self, machine_id: str) -> Optional[local.Task]:
+        payload = self._request("POST", "/v1/tasks/claim-next", {"machine_id": machine_id})
+        raw = payload.get("task")
+        if raw is None:
+            return None
+        raw = dict(raw)
+        raw.pop("required_capabilities", None)
+        return local.Task(**raw)
+
+    def list_machines(self) -> dict:
+        return self._request("GET", "/v1/machines")
+
+    def heartbeat_claim(
+        self, _conn: RemoteConnection, task_id: str, *, claimer: Optional[str] = None,
+    ) -> bool:
+        lock = claimer or os.environ.get("HERMES_KANBAN_CLAIM_LOCK", "")
+        return bool(self._request("POST", f"/v1/tasks/{task_id}/renew", {"claim_lock": lock})["renewed"])
+
+    def heartbeat_worker(self, conn: RemoteConnection, task_id: str, **_kwargs: Any) -> bool:
+        return self.heartbeat_claim(conn, task_id)
+
+    def record_worker_started(self, task_id: str, *, claim_lock: str, worker_pid: int) -> bool:
+        return bool(self._request("POST", f"/v1/tasks/{task_id}/worker-started", {
+            "claim_lock": claim_lock,
+            "worker_pid": worker_pid,
+        })["recorded"])
+
+    def complete_task(self, _conn: RemoteConnection, task_id: str, *, result: Optional[str] = None, **kwargs: Any) -> bool:
+        return bool(self._request("POST", f"/v1/tasks/{task_id}/complete", {
+            "result": result,
+            "claim_lock": str(
+                kwargs.get("claim_lock")
+                or kwargs.get("claimer")
+                or os.environ.get("HERMES_KANBAN_CLAIM_LOCK", "")
+            ),
+        })["completed"])
+
+    def block_task(self, _conn: RemoteConnection, task_id: str, *, reason: Optional[str] = None, kind: Optional[str] = None, **kwargs: Any) -> bool:
+        return bool(self._request("POST", f"/v1/tasks/{task_id}/block", {
+            "reason": reason,
+            "kind": kind,
+            "claim_lock": str(
+                kwargs.get("claim_lock")
+                or kwargs.get("claimer")
+                or os.environ.get("HERMES_KANBAN_CLAIM_LOCK", "")
+            ),
+        })["blocked"])
+
+    def add_comment(self, _conn: RemoteConnection, task_id: str, *, author: str, body: str) -> int:
+        return int(self._request("POST", f"/v1/tasks/{task_id}/comments", {"author": author, "body": body})["comment_id"])
+
+
+def configured_coordinator_url() -> str:
+    """Return the configured coordinator endpoint, if this machine uses one.
+
+    The endpoint is ordinary deployment configuration, so ``config.yaml`` is
+    authoritative. The environment fallback is retained only so existing
+    installations can upgrade without an outage; it is intentionally not
+    documented as the preferred setup.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        kanban = (load_config() or {}).get("kanban") or {}
+        if isinstance(kanban, dict):
+            url = str(kanban.get("coordinator_url") or "").strip()
+            if url:
+                return url.rstrip("/")
+    except Exception:
+        # A coordinator must not make a malformed optional config prevent
+        # local Kanban from starting. The caller will either use the legacy
+        # value below or report that no coordinator is configured.
+        pass
+    return os.environ.get("HERMES_KANBAN_COORDINATOR_URL", "").strip().rstrip("/")
+
+
+def connect_from_config() -> tuple[RemoteKanban, RemoteConnection]:
+    url = configured_coordinator_url()
+    token = os.environ.get("HERMES_KANBAN_COORDINATOR_TOKEN", "").strip()
+    if not url or not token:
+        raise RuntimeError(
+            "kanban.coordinator_url and HERMES_KANBAN_COORDINATOR_TOKEN are required"
+        )
+    return RemoteKanban(url, token), RemoteConnection()
+
+
+# Compatibility for private deployments that set the endpoint in an
+# EnvironmentFile before coordinator_url was added to config.yaml.
+connect_from_env = connect_from_config

--- a/hermes_cli/kanban_remote.py
+++ b/hermes_cli/kanban_remote.py
@@ -16,7 +16,17 @@ class RemoteConnection:
         return None
 
 
+class RemoteKanbanError(RuntimeError):
+    def __init__(self, status: int, payload: Any):
+        self.status = status
+        self.payload = payload
+        super().__init__(f"coordinator {status}: {payload}")
+
+
 class RemoteKanban:
+    VALID_BLOCK_KINDS = local.VALID_BLOCK_KINDS
+    HallucinatedCardsError = local.HallucinatedCardsError
+
     def __init__(self, base_url: str, token: str):
         self.base_url = base_url.rstrip("/")
         self.token = token
@@ -37,22 +47,39 @@ class RemoteKanban:
                 return json.loads(response.read().decode("utf-8"))
         except urllib.error.HTTPError as exc:
             detail = exc.read().decode("utf-8", errors="replace")
-            raise RuntimeError(f"coordinator {exc.code}: {detail}") from exc
+            try:
+                payload = json.loads(detail)
+            except json.JSONDecodeError:
+                payload = detail
+            raise RemoteKanbanError(exc.code, payload) from exc
+
+    @staticmethod
+    def _task(raw: dict) -> local.Task:
+        payload = dict(raw)
+        payload.pop("required_capabilities", None)
+        return local.Task(**payload)
+
+    @staticmethod
+    def _raise_value_error(exc: RemoteKanbanError) -> None:
+        detail = exc.payload
+        if isinstance(detail, dict):
+            detail = detail.get("detail", detail)
+        raise ValueError(str(detail)) from exc
 
     def _detail(self, task_id: str) -> dict:
         return self._request("GET", f"/v1/tasks/{task_id}")
 
     def get_task(self, _conn: RemoteConnection, task_id: str) -> Optional[local.Task]:
         try:
-            payload = dict(self._detail(task_id)["task"])
-            payload.pop("required_capabilities", None)
-            return local.Task(**payload)
-        except RuntimeError as exc:
-            if "coordinator 404:" in str(exc):
+            return self._task(self._detail(task_id)["task"])
+        except RemoteKanbanError as exc:
+            if exc.status == 404:
                 return None
             raise
 
-    def list_comments(self, _conn: RemoteConnection, task_id: str) -> list[local.Comment]:
+    def list_comments(
+        self, _conn: RemoteConnection, task_id: str
+    ) -> list[local.Comment]:
         return [local.Comment(**item) for item in self._detail(task_id)["comments"]]
 
     def list_events(self, _conn: RemoteConnection, task_id: str) -> list[local.Event]:
@@ -82,63 +109,198 @@ class RemoteKanban:
         profiles: list[str],
         capabilities: list[str],
     ) -> str:
-        return str(self._request("POST", "/v1/machines/register", {
-            "machine_id": machine_id,
-            "hostname": hostname,
-            "profiles": profiles,
-            "capabilities": capabilities,
-        })["machine_id"])
+        return str(
+            self._request(
+                "POST",
+                "/v1/machines/register",
+                {
+                    "machine_id": machine_id,
+                    "hostname": hostname,
+                    "profiles": profiles,
+                    "capabilities": capabilities,
+                },
+            )["machine_id"]
+        )
 
     def claim_next(self, machine_id: str) -> Optional[local.Task]:
-        payload = self._request("POST", "/v1/tasks/claim-next", {"machine_id": machine_id})
+        payload = self._request(
+            "POST", "/v1/tasks/claim-next", {"machine_id": machine_id}
+        )
         raw = payload.get("task")
         if raw is None:
             return None
-        raw = dict(raw)
-        raw.pop("required_capabilities", None)
-        return local.Task(**raw)
+        return self._task(raw)
+
+    def create_task(self, _conn: RemoteConnection, **kwargs: Any) -> str:
+        body = dict(kwargs)
+        for key in ("parents", "skills", "required_capabilities"):
+            if body.get(key) is not None:
+                body[key] = list(body[key])
+        try:
+            return str(self._request("POST", "/v1/tasks", body)["task_id"])
+        except RemoteKanbanError as exc:
+            if exc.status == 422:
+                self._raise_value_error(exc)
+            raise
+
+    def list_tasks(
+        self,
+        _conn: RemoteConnection,
+        *,
+        assignee: Optional[str] = None,
+        status: Optional[str] = None,
+        tenant: Optional[str] = None,
+        include_archived: bool = False,
+        limit: Optional[int] = None,
+        **_kwargs: Any,
+    ) -> list[local.Task]:
+        try:
+            payload = self._request(
+                "POST",
+                "/v1/tasks/query",
+                {
+                    "assignee": assignee,
+                    "status": status,
+                    "tenant": tenant,
+                    "include_archived": include_archived,
+                    "limit": limit,
+                },
+            )
+        except RemoteKanbanError as exc:
+            if exc.status == 422:
+                self._raise_value_error(exc)
+            raise
+        return [self._task(raw) for raw in payload["tasks"]]
+
+    def recompute_ready(self, _conn: RemoteConnection, **_kwargs: Any) -> int:
+        return int(self._request("POST", "/v1/tasks/recompute-ready")["promoted"])
+
+    def link_tasks(
+        self,
+        _conn: RemoteConnection,
+        parent_id: str,
+        child_id: str,
+    ) -> None:
+        try:
+            self._request(
+                "POST",
+                "/v1/tasks/link",
+                {
+                    "parent_id": parent_id,
+                    "child_id": child_id,
+                },
+            )
+        except RemoteKanbanError as exc:
+            if exc.status == 422:
+                self._raise_value_error(exc)
+            raise
+
+    def unblock_task(self, _conn: RemoteConnection, task_id: str) -> bool:
+        return bool(self._request("POST", f"/v1/tasks/{task_id}/unblock")["unblocked"])
 
     def list_machines(self) -> dict:
         return self._request("GET", "/v1/machines")
 
     def heartbeat_claim(
-        self, _conn: RemoteConnection, task_id: str, *, claimer: Optional[str] = None,
+        self,
+        _conn: RemoteConnection,
+        task_id: str,
+        *,
+        claimer: Optional[str] = None,
     ) -> bool:
         lock = claimer or os.environ.get("HERMES_KANBAN_CLAIM_LOCK", "")
-        return bool(self._request("POST", f"/v1/tasks/{task_id}/renew", {"claim_lock": lock})["renewed"])
+        return bool(
+            self._request("POST", f"/v1/tasks/{task_id}/renew", {"claim_lock": lock})[
+                "renewed"
+            ]
+        )
 
-    def heartbeat_worker(self, conn: RemoteConnection, task_id: str, **_kwargs: Any) -> bool:
+    def heartbeat_worker(
+        self, conn: RemoteConnection, task_id: str, **_kwargs: Any
+    ) -> bool:
         return self.heartbeat_claim(conn, task_id)
 
-    def record_worker_started(self, task_id: str, *, claim_lock: str, worker_pid: int) -> bool:
-        return bool(self._request("POST", f"/v1/tasks/{task_id}/worker-started", {
-            "claim_lock": claim_lock,
-            "worker_pid": worker_pid,
-        })["recorded"])
+    def record_worker_started(
+        self, task_id: str, *, claim_lock: str, worker_pid: int
+    ) -> bool:
+        return bool(
+            self._request(
+                "POST",
+                f"/v1/tasks/{task_id}/worker-started",
+                {
+                    "claim_lock": claim_lock,
+                    "worker_pid": worker_pid,
+                },
+            )["recorded"]
+        )
 
-    def complete_task(self, _conn: RemoteConnection, task_id: str, *, result: Optional[str] = None, **kwargs: Any) -> bool:
-        return bool(self._request("POST", f"/v1/tasks/{task_id}/complete", {
-            "result": result,
-            "claim_lock": str(
-                kwargs.get("claim_lock")
-                or kwargs.get("claimer")
-                or os.environ.get("HERMES_KANBAN_CLAIM_LOCK", "")
-            ),
-        })["completed"])
+    def complete_task(
+        self,
+        _conn: RemoteConnection,
+        task_id: str,
+        *,
+        result: Optional[str] = None,
+        **kwargs: Any,
+    ) -> bool:
+        payload = self._request(
+            "POST",
+            f"/v1/tasks/{task_id}/complete",
+            {
+                "result": result,
+                "summary": kwargs.get("summary"),
+                "metadata": kwargs.get("metadata"),
+                "created_cards": list(kwargs.get("created_cards") or []),
+                "expected_run_id": kwargs.get("expected_run_id"),
+                "claim_lock": str(
+                    kwargs.get("claim_lock")
+                    or kwargs.get("claimer")
+                    or os.environ.get("HERMES_KANBAN_CLAIM_LOCK", "")
+                ),
+            },
+        )
+        if payload.get("error") == "hallucinated_cards":
+            raise local.HallucinatedCardsError(
+                list(payload.get("phantom_cards") or []),
+                task_id,
+            )
+        return bool(payload["completed"])
 
-    def block_task(self, _conn: RemoteConnection, task_id: str, *, reason: Optional[str] = None, kind: Optional[str] = None, **kwargs: Any) -> bool:
-        return bool(self._request("POST", f"/v1/tasks/{task_id}/block", {
-            "reason": reason,
-            "kind": kind,
-            "claim_lock": str(
-                kwargs.get("claim_lock")
-                or kwargs.get("claimer")
-                or os.environ.get("HERMES_KANBAN_CLAIM_LOCK", "")
-            ),
-        })["blocked"])
+    def block_task(
+        self,
+        _conn: RemoteConnection,
+        task_id: str,
+        *,
+        reason: Optional[str] = None,
+        kind: Optional[str] = None,
+        **kwargs: Any,
+    ) -> bool:
+        return bool(
+            self._request(
+                "POST",
+                f"/v1/tasks/{task_id}/block",
+                {
+                    "reason": reason,
+                    "kind": kind,
+                    "expected_run_id": kwargs.get("expected_run_id"),
+                    "claim_lock": str(
+                        kwargs.get("claim_lock")
+                        or kwargs.get("claimer")
+                        or os.environ.get("HERMES_KANBAN_CLAIM_LOCK", "")
+                    ),
+                },
+            )["blocked"]
+        )
 
-    def add_comment(self, _conn: RemoteConnection, task_id: str, *, author: str, body: str) -> int:
-        return int(self._request("POST", f"/v1/tasks/{task_id}/comments", {"author": author, "body": body})["comment_id"])
+    def add_comment(
+        self, _conn: RemoteConnection, task_id: str, *, author: str, body: str
+    ) -> int:
+        return int(
+            self._request(
+                "POST",
+                f"/v1/tasks/{task_id}/comments",
+                {"author": author, "body": body},
+            )["comment_id"]
+        )
 
 
 def configured_coordinator_url() -> str:

--- a/hermes_cli/kanban_remote_worker.py
+++ b/hermes_cli/kanban_remote_worker.py
@@ -17,6 +17,20 @@ from hermes_cli.kanban_remote import RemoteKanban
 
 log = logging.getLogger(__name__)
 
+
+def _terminate_and_reap(proc: subprocess.Popen) -> None:
+    """Fence a child that no longer owns its coordinator claim."""
+    if proc.poll() is not None:
+        proc.wait()
+        return
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
 def _worker_workspace(task_id: str) -> Path:
     path = kb.kanban_home() / "remote-workspaces" / task_id
     path.mkdir(parents=True, exist_ok=True)
@@ -45,11 +59,13 @@ def _run_task(client: RemoteKanban, task, *, profile: str, machine_id: str) -> N
     proc = subprocess.Popen(
         [
             *kb._resolve_hermes_argv(),
-            "-p", profile,
+            "-p",
+            profile,
             "--cli",
             "--accept-hooks",
             "chat",
-            "-q", prompt,
+            "-q",
+            prompt,
         ],
         cwd=str(workspace),
         env=env,
@@ -57,6 +73,7 @@ def _run_task(client: RemoteKanban, task, *, profile: str, machine_id: str) -> N
     )
     reported_started = False
     while proc.poll() is None:
+        rejected_reason: Optional[str] = None
         try:
             if not reported_started:
                 reported_started = client.record_worker_started(
@@ -64,10 +81,27 @@ def _run_task(client: RemoteKanban, task, *, profile: str, machine_id: str) -> N
                     claim_lock=task.claim_lock or "",
                     worker_pid=proc.pid,
                 )
-            client.heartbeat_claim(None, task.id, claimer=task.claim_lock)
+                if not reported_started:
+                    rejected_reason = "worker start"
+            if rejected_reason is None:
+                renewed = client.heartbeat_claim(
+                    None,
+                    task.id,
+                    claimer=task.claim_lock,
+                )
+                if not renewed:
+                    rejected_reason = "lease renewal"
         except Exception:
             # The coordinator lease remains the authority; retry next poll.
             pass
+        if rejected_reason is not None:
+            log.error(
+                "coordinator rejected %s for %s; fencing child",
+                rejected_reason,
+                task.id,
+            )
+            _terminate_and_reap(proc)
+            return
         time.sleep(20)
     # A normal worker closes its task through kanban_complete or kanban_block.
     # Do not leave a terminated remote process holding a lease until its TTL.
@@ -140,7 +174,9 @@ def run(
     if not token:
         raise RuntimeError(f"set {token_env} before starting the worker")
 
-    merged_capabilities = sorted(set(kb.local_machine_capabilities()) | set(capabilities))
+    merged_capabilities = sorted(
+        set(kb.local_machine_capabilities()) | set(capabilities)
+    )
     client = RemoteKanban(url, token)
     try:
         run_worker_loop(

--- a/hermes_cli/kanban_remote_worker.py
+++ b/hermes_cli/kanban_remote_worker.py
@@ -1,0 +1,187 @@
+"""Polling supervisor for a Hermes worker attached to a remote coordinator."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import socket
+import subprocess
+import time
+from pathlib import Path
+from typing import Optional
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.kanban_remote import RemoteKanban
+
+
+log = logging.getLogger(__name__)
+
+def _worker_workspace(task_id: str) -> Path:
+    path = kb.kanban_home() / "remote-workspaces" / task_id
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _run_task(client: RemoteKanban, task, *, profile: str, machine_id: str) -> None:
+    workspace = _worker_workspace(task.id)
+    context = client.build_worker_context(None, task.id)
+    prompt = (
+        f"Work the assigned remote Kanban task. Your local workspace is {workspace}.\n\n"
+        f"{context}"
+    )
+    env = os.environ.copy()
+    env.update({
+        "HERMES_KANBAN_TASK": task.id,
+        "HERMES_KANBAN_RUN_ID": str(task.current_run_id or ""),
+        "HERMES_KANBAN_CLAIM_LOCK": task.claim_lock or "",
+        "HERMES_KANBAN_COORDINATOR_URL": client.base_url,
+        "HERMES_KANBAN_COORDINATOR_TOKEN": client.token,
+        "HERMES_MACHINE_ID": machine_id,
+        "TERMINAL_CWD": str(workspace),
+        "HERMES_PROFILE": profile,
+    })
+    env.pop("HERMES_TUI", None)
+    proc = subprocess.Popen(
+        [
+            *kb._resolve_hermes_argv(),
+            "-p", profile,
+            "--cli",
+            "--accept-hooks",
+            "chat",
+            "-q", prompt,
+        ],
+        cwd=str(workspace),
+        env=env,
+        stdin=subprocess.DEVNULL,
+    )
+    reported_started = False
+    while proc.poll() is None:
+        try:
+            if not reported_started:
+                reported_started = client.record_worker_started(
+                    task.id,
+                    claim_lock=task.claim_lock or "",
+                    worker_pid=proc.pid,
+                )
+            client.heartbeat_claim(None, task.id, claimer=task.claim_lock)
+        except Exception:
+            # The coordinator lease remains the authority; retry next poll.
+            pass
+        time.sleep(20)
+    # A normal worker closes its task through kanban_complete or kanban_block.
+    # Do not leave a terminated remote process holding a lease until its TTL.
+    try:
+        current = client.get_task(None, task.id)
+        if current is not None and current.status == "running":
+            client.block_task(
+                None,
+                task.id,
+                reason=f"remote worker exited with status {proc.returncode}",
+                kind="transient",
+                claim_lock=task.claim_lock,
+            )
+    except Exception as exc:
+        # The coordinator may be briefly unreachable exactly as the child
+        # exits. Do not crash the supervisor: the lease/dispatcher recovery
+        # path will make the unfinished task visible again.
+        log.warning("could not finalize remote task %s: %s", task.id, exc)
+
+
+def run_worker_loop(
+    client: RemoteKanban,
+    *,
+    profile: str,
+    capabilities: list[str],
+    poll_seconds: float,
+    max_retry_seconds: float,
+    sleep_fn=time.sleep,
+) -> None:
+    """Register, claim and run work forever with bounded outage backoff."""
+    machine_id = kb.get_machine_id()
+    delay = max(1.0, poll_seconds)
+    maximum_delay = max(delay, max_retry_seconds)
+    while True:
+        try:
+            client.register_machine(
+                machine_id,
+                hostname=socket.gethostname(),
+                profiles=[profile],
+                capabilities=capabilities,
+            )
+            task = client.claim_next(machine_id)
+            delay = max(1.0, poll_seconds)
+        except (OSError, RuntimeError) as exc:
+            log.warning(
+                "Kanban coordinator unavailable; retrying in %.1fs: %s",
+                delay,
+                exc,
+            )
+            sleep_fn(delay)
+            delay = min(maximum_delay, delay * 2)
+            continue
+        if task is None:
+            sleep_fn(max(1.0, poll_seconds))
+            continue
+        _run_task(client, task, profile=profile, machine_id=machine_id)
+
+
+def run(
+    *,
+    url: str,
+    token_env: str,
+    profile: str,
+    capabilities: list[str],
+    poll_seconds: float,
+    max_retry_seconds: float,
+) -> int:
+    """Run a remote worker using the same configuration surface as the CLI."""
+    token = os.environ.get(token_env, "").strip()
+    if not token:
+        raise RuntimeError(f"set {token_env} before starting the worker")
+
+    merged_capabilities = sorted(set(kb.local_machine_capabilities()) | set(capabilities))
+    client = RemoteKanban(url, token)
+    try:
+        run_worker_loop(
+            client,
+            profile=profile,
+            capabilities=merged_capabilities,
+            poll_seconds=poll_seconds,
+            max_retry_seconds=max_retry_seconds,
+        )
+    except KeyboardInterrupt:
+        log.info("remote Kanban worker stopped")
+    return 0
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Run a remote Hermes Kanban worker")
+    parser.add_argument("--url", required=True, help="Coordinator base URL")
+    parser.add_argument("--token-env", default="HERMES_KANBAN_COORDINATOR_TOKEN")
+    parser.add_argument("--profile", required=True)
+    parser.add_argument("--capability", action="append", default=[])
+    parser.add_argument("--poll-seconds", type=float, default=10.0)
+    parser.add_argument(
+        "--max-retry-seconds",
+        type=float,
+        default=60.0,
+        help="Maximum coordinator reconnect delay after an outage (default: 60)",
+    )
+    args = parser.parse_args(argv)
+    try:
+        return run(
+            url=args.url,
+            token_env=args.token_env,
+            profile=args.profile,
+            capabilities=args.capability,
+            poll_seconds=args.poll_seconds,
+            max_retry_seconds=args.max_retry_seconds,
+        )
+    except RuntimeError as exc:
+        parser.error(str(exc))
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1043,6 +1043,7 @@
           },
         }) : null,
         h(OrchestrationPanel, null),
+        h(WorkerMachines, { board: board }),
         h(AttentionStrip, {
           boardData,
           onOpen: setSelectedTaskId,
@@ -1502,6 +1503,66 @@
             }),
           )
         : null,
+    );
+  }
+
+  // Registered machines are scheduling capacity, not merely active task
+  // processes. Keep them visible even while idle so an operator can confirm a
+  // remote worker is enrolled before routing work to it.
+  function WorkerMachines(props) {
+    const [data, setData] = useState(null);
+    const [expanded, setExpanded] = useState(false);
+    const load = useCallback(function () {
+      return SDK.fetchJSON(withBoard(`${API}/workers/machines`, props.board))
+        .then(function (result) { setData(result); })
+        .catch(function () { /* board remains usable if roster is unavailable */ });
+    }, [props.board]);
+
+    useEffect(function () {
+      load();
+      const timer = setInterval(load, 15000);
+      return function () { clearInterval(timer); };
+    }, [load]);
+
+    const machines = (data && data.machines) || [];
+    const online = machines.filter(function (machine) { return machine.online; }).length;
+    return h(Card, { className: "hermes-kanban-workers" },
+      h(CardContent, { className: "py-3" },
+        h("div", { className: "flex items-center justify-between gap-3" },
+          h("div", { className: "flex items-center gap-2" },
+            h("strong", { className: "text-sm" }, "Workers"),
+            h(Badge, { variant: online > 0 ? "secondary" : "outline" },
+              `${online}/${machines.length} online`),
+          ),
+          h(Button, {
+            size: "sm",
+            variant: "ghost",
+            onClick: function () { setExpanded(function (value) { return !value; }); },
+          }, expanded ? "Hide" : "Show"),
+        ),
+        expanded ? h("div", { className: "mt-3 grid gap-2" },
+          machines.length === 0
+            ? h("div", { className: "text-xs text-muted-foreground" },
+                "No registered worker machines yet.")
+            : machines.map(function (machine) {
+                return h("div", {
+                  key: machine.machine_id,
+                  className: "flex flex-wrap items-center gap-x-3 gap-y-1 rounded border px-3 py-2 text-xs",
+                },
+                  h("span", { className: "font-medium" }, machine.hostname || machine.machine_id),
+                  h(Badge, { variant: machine.online ? "secondary" : "outline" },
+                    machine.online ? "online" : "offline"),
+                  h("span", { className: "text-muted-foreground" },
+                    `${machine.active_workers || 0} active`),
+                  h("span", { className: "text-muted-foreground" },
+                    (machine.profiles || []).join(", ") || "no profiles"),
+                  h("span", { className: "text-muted-foreground" },
+                    (machine.capabilities || []).join(", ") || "no capabilities"),
+                  h("code", { className: "text-[10px] text-muted-foreground" }, machine.machine_id),
+                );
+              }),
+        ) : null,
+      ),
     );
   }
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import sqlite3
 import time
 from dataclasses import asdict
@@ -223,6 +224,7 @@ def _run_dict(r: kanban_db.Run) -> dict[str, Any]:
         "claim_lock": r.claim_lock,
         "claim_expires": r.claim_expires,
         "worker_pid": r.worker_pid,
+        "machine_id": r.machine_id,
         "max_runtime_seconds": r.max_runtime_seconds,
         "last_heartbeat_at": r.last_heartbeat_at,
         "started_at": r.started_at,
@@ -592,6 +594,8 @@ class CreateTaskBody(BaseModel):
     skills: Optional[list[str]] = None
     goal_mode: bool = False
     goal_max_turns: Optional[int] = None
+    target_machine: Optional[str] = None
+    required_capabilities: list[str] = Field(default_factory=list)
 
 
 @router.post("/tasks")
@@ -616,6 +620,8 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             skills=payload.skills,
             goal_mode=payload.goal_mode,
             goal_max_turns=payload.goal_max_turns,
+            target_machine=payload.target_machine,
+            required_capabilities=payload.required_capabilities,
         )
         task = kanban_db.get_task(conn, task_id)
         body: dict[str, Any] = {"task": _task_dict(task) if task else None}
@@ -1349,14 +1355,89 @@ except ImportError:
     _psutil = None  # type: ignore[assignment]
 
 
+MACHINE_ONLINE_SECONDS = 90
+
+
+@router.get("/workers/machines")
+def list_worker_machines(
+    board: Optional[str] = Query(None, description="Kanban board slug (omit for current)"),
+):
+    """Return every registered dispatch machine, including idle remote workers.
+
+    This is intentionally separate from ``/workers/active``: an idle machine
+    is useful scheduling capacity and should remain visible even when it has
+    no in-flight task.
+    """
+    from hermes_cli.kanban_remote import configured_coordinator_url
+    if configured_coordinator_url():
+        from hermes_cli.kanban_remote import connect_from_config
+        try:
+            remote, remote_conn = connect_from_config()
+        except (OSError, RuntimeError) as exc:
+            raise HTTPException(
+                status_code=503,
+                detail=f"Kanban coordinator is unavailable: {exc}",
+            ) from exc
+        try:
+            return remote.list_machines()
+        except (OSError, RuntimeError) as exc:
+            raise HTTPException(
+                status_code=503,
+                detail=f"Kanban coordinator is unavailable: {exc}",
+            ) from exc
+        finally:
+            remote_conn.close()
+
+    board = _resolve_board(board)
+    conn = _conn(board=board)
+    try:
+        now = int(time.time())
+        rows = conn.execute(
+            "SELECT id, hostname, last_seen_at FROM machines ORDER BY hostname, id"
+        ).fetchall()
+        capabilities: dict[str, list[str]] = {}
+        for row in conn.execute(
+            "SELECT machine_id, capability FROM machine_capabilities ORDER BY machine_id, capability"
+        ).fetchall():
+            capabilities.setdefault(row["machine_id"], []).append(row["capability"])
+        profiles_by_machine: dict[str, list[str]] = {}
+        for row in conn.execute(
+            "SELECT machine_id, profile FROM machine_profiles ORDER BY machine_id, profile"
+        ).fetchall():
+            profiles_by_machine.setdefault(row["machine_id"], []).append(row["profile"])
+        active_counts = {
+            row["machine_id"]: row["count"]
+            for row in conn.execute(
+                "SELECT machine_id, COUNT(*) AS count FROM tasks "
+                "WHERE status = 'running' AND machine_id IS NOT NULL GROUP BY machine_id"
+            ).fetchall()
+        }
+        machines = [
+            {
+                "machine_id": row["id"],
+                "hostname": row["hostname"],
+                "last_seen_at": row["last_seen_at"],
+                "online": now - int(row["last_seen_at"]) <= MACHINE_ONLINE_SECONDS,
+                "profiles": profiles_by_machine.get(row["id"], []),
+                "capabilities": capabilities.get(row["id"], []),
+                "active_workers": active_counts.get(row["id"], 0),
+            }
+            for row in rows
+        ]
+        return {"machines": machines, "count": len(machines), "checked_at": now}
+    finally:
+        conn.close()
+
+
 @router.get("/workers/active")
 def list_active_workers(
     board: Optional[str] = Query(None, description="Kanban board slug (omit for current)"),
 ):
     """Return every currently-running worker on the board.
 
-    A worker is a ``task_runs`` row whose ``ended_at`` is NULL and whose
-    ``worker_pid`` is non-NULL, belonging to a task with ``status='running'``.
+    A worker is a ``task_runs`` row whose ``ended_at`` is NULL, has a reported
+    ``worker_pid``, and whose task is ``running``. Remote workers report their
+    own PID through the coordinator; this host must not attempt to inspect it.
 
     Returns ``{workers: [...], count: N, checked_at: <epoch>}``.  Each
     worker entry carries enough context for the dashboard to link back to
@@ -1375,6 +1456,8 @@ def list_active_workers(
                 t.assignee    AS task_assignee,
                 r.profile,
                 r.worker_pid,
+                r.machine_id,
+                m.hostname AS machine_hostname,
                 r.started_at,
                 r.claim_lock,
                 r.claim_expires,
@@ -1382,6 +1465,7 @@ def list_active_workers(
                 r.max_runtime_seconds
             FROM task_runs r
             JOIN tasks t ON t.id = r.task_id
+            LEFT JOIN machines m ON m.id = r.machine_id
             WHERE r.ended_at IS NULL
               AND r.worker_pid IS NOT NULL
               AND t.status = 'running'
@@ -1397,6 +1481,8 @@ def list_active_workers(
                 "task_assignee": row["task_assignee"],
                 "profile": row["profile"],
                 "worker_pid": row["worker_pid"],
+                "machine_id": row["machine_id"],
+                "machine_hostname": row["machine_hostname"],
                 "started_at": row["started_at"],
                 "claim_lock": row["claim_lock"],
                 "claim_expires": row["claim_expires"],

--- a/tests/hermes_cli/test_kanban_coordinator.py
+++ b/tests/hermes_cli/test_kanban_coordinator.py
@@ -1,11 +1,27 @@
 from __future__ import annotations
 
+import time
 import uuid
 
 from fastapi.testclient import TestClient
 
 from hermes_cli import kanban_db as kb
-from hermes_cli.kanban_coordinator import create_app
+from hermes_cli.kanban_coordinator import _maintenance_once, create_app
+from hermes_cli.kanban_remote import RemoteConnection, RemoteKanban, RemoteKanbanError
+
+
+def _remote_client(client: TestClient, headers: dict[str, str]) -> RemoteKanban:
+    remote = RemoteKanban("http://coordinator", "secret")
+
+    def request(method: str, path: str, body=None) -> dict:
+        response = client.request(method, path, headers=headers, json=body)
+        payload = response.json()
+        if response.status_code >= 400:
+            raise RemoteKanbanError(response.status_code, payload)
+        return payload
+
+    remote._request = request
+    return remote
 
 
 def test_coordinator_registers_and_claims_only_eligible_machine(tmp_path):
@@ -27,27 +43,33 @@ def test_coordinator_registers_and_claims_only_eligible_machine(tmp_path):
     mac_id = str(uuid.uuid4())
 
     assert client.get("/v1/health").status_code == 401
-    assert client.post(
-        "/v1/machines/register",
-        headers=headers,
-        json={
-            "machine_id": linux_id,
-            "hostname": "linux",
-            "profiles": ["ops"],
-            "capabilities": ["linux"],
-        },
-    ).status_code == 200
+    assert (
+        client.post(
+            "/v1/machines/register",
+            headers=headers,
+            json={
+                "machine_id": linux_id,
+                "hostname": "linux",
+                "profiles": ["ops"],
+                "capabilities": ["linux"],
+            },
+        ).status_code
+        == 200
+    )
 
-    assert client.post(
-        "/v1/machines/register",
-        headers=headers,
-        json={
-            "machine_id": mac_id,
-            "hostname": "mac",
-            "profiles": ["ios"],
-            "capabilities": ["macos", "xcode"],
-        },
-    ).status_code == 200
+    assert (
+        client.post(
+            "/v1/machines/register",
+            headers=headers,
+            json={
+                "machine_id": mac_id,
+                "hostname": "mac",
+                "profiles": ["ios"],
+                "capabilities": ["macos", "xcode"],
+            },
+        ).status_code
+        == 200
+    )
 
     machines = client.get("/v1/machines", headers=headers).json()
     assert machines["count"] == 2
@@ -58,13 +80,17 @@ def test_coordinator_registers_and_claims_only_eligible_machine(tmp_path):
     assert mac["capabilities"] == ["macos", "xcode"]
 
     first = client.post(
-        "/v1/tasks/claim-next", headers=headers, json={"machine_id": linux_id},
+        "/v1/tasks/claim-next",
+        headers=headers,
+        json={"machine_id": linux_id},
     ).json()["task"]
     assert first["id"] == linux_task
     assert first["machine_id"] == linux_id
 
     second = client.post(
-        "/v1/tasks/claim-next", headers=headers, json={"machine_id": mac_id},
+        "/v1/tasks/claim-next",
+        headers=headers,
+        json={"machine_id": mac_id},
     ).json()["task"]
     assert second["id"] == mac_task
     assert second["required_capabilities"] == ["macos", "xcode"]
@@ -114,3 +140,133 @@ def test_coordinator_rejects_invalid_machine_identity_without_500(tmp_path):
         json={"machine_id": "not-a-uuid"},
     )
     assert response.status_code == 422
+
+
+def test_coordinator_maintenance_recovers_remote_lease_without_pid_control(
+    tmp_path,
+    monkeypatch,
+):
+    db_path = tmp_path / "kanban.db"
+    kb.init_db(db_path)
+    machine_id = str(uuid.uuid4())
+    with kb.connect(db_path) as conn:
+        kb.register_machine(
+            conn,
+            machine_id,
+            hostname="remote",
+            profiles=["ios"],
+            capabilities=["macos"],
+        )
+        task_id = kb.create_task(conn, title="Remote work", assignee="ios")
+        claimed = kb.claim_task(
+            conn,
+            task_id,
+            machine_id=machine_id,
+            enforce_machine_routing=True,
+            require_registered_profile=True,
+        )
+        assert claimed is not None
+        expired = int(time.time()) - 1
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ?, worker_pid = ? WHERE id = ?",
+            (expired, 4242, task_id),
+        )
+        conn.execute(
+            "UPDATE task_runs SET claim_expires = ?, worker_pid = ? WHERE id = ?",
+            (expired, 4242, claimed.current_run_id),
+        )
+        parent = kb.create_task(conn, title="Finished parent", assignee="ios")
+        child = kb.create_task(
+            conn,
+            title="Waiting child",
+            assignee="ios",
+            parents=[parent],
+        )
+        conn.execute("UPDATE tasks SET status = 'done' WHERE id = ?", (parent,))
+
+    def forbidden_kill(*_args):
+        raise AssertionError("coordinator attempted remote PID control")
+
+    monkeypatch.setattr(kb.os, "kill", forbidden_kill)
+
+    assert _maintenance_once(db_path) == {"reclaimed": 1, "promoted": 1}
+
+    with kb.connect(db_path) as conn:
+        recovered = kb.get_task(conn, task_id)
+        assert recovered.status == "ready"
+        assert recovered.claim_lock is None
+        assert kb.latest_run(conn, task_id).outcome == "reclaimed"
+        assert kb.get_task(conn, child).status == "ready"
+        claimed_again = kb.claim_task(
+            conn,
+            task_id,
+            machine_id=machine_id,
+            enforce_machine_routing=True,
+            require_registered_profile=True,
+        )
+        assert claimed_again is not None
+
+
+def test_remote_backend_supports_orchestrator_contract_and_structured_handoff(
+    tmp_path,
+):
+    db_path = tmp_path / "kanban.db"
+    kb.init_db(db_path)
+    client = TestClient(create_app(db_path=db_path, token="secret"))
+    headers = {"Authorization": "Bearer secret"}
+    remote = _remote_client(client, headers)
+    conn = RemoteConnection()
+
+    root = remote.create_task(
+        conn,
+        title="Root",
+        assignee="ios",
+        created_by="orchestrator",
+    )
+    created_card = remote.create_task(
+        conn,
+        title="Follow-up",
+        assignee="ios",
+        created_by="ios",
+    )
+    listed = remote.list_tasks(conn, assignee="ios", limit=10)
+    assert {task.id for task in listed} == {root, created_card}
+
+    assert remote.complete_task(
+        conn,
+        root,
+        result="full result",
+        summary="handoff summary",
+        metadata={"tests": ["contract"]},
+        created_cards=[created_card],
+    )
+    with kb.connect(db_path) as local_conn:
+        run = kb.latest_run(local_conn, root)
+        assert run.summary == "handoff summary"
+        assert run.metadata == {"tests": ["contract"]}
+        completed = [
+            event
+            for event in kb.list_events(local_conn, root)
+            if event.kind == "completed"
+        ][-1]
+        assert completed.payload["verified_cards"] == [created_card]
+
+    parent = remote.create_task(
+        conn,
+        title="Parent",
+        assignee="ios",
+    )
+    child = remote.create_task(
+        conn,
+        title="Child",
+        assignee="ios",
+    )
+    remote.link_tasks(conn, parent, child)
+    assert remote.get_task(conn, child).status == "todo"
+    assert remote.complete_task(conn, parent, result="done")
+    assert remote.recompute_ready(conn) == 0
+    assert remote.get_task(conn, child).status == "ready"
+
+    assert remote.block_task(conn, child, reason="needs input", kind="needs_input")
+    assert remote.unblock_task(conn, child)
+    assert remote.get_task(conn, child).status == "ready"

--- a/tests/hermes_cli/test_kanban_coordinator.py
+++ b/tests/hermes_cli/test_kanban_coordinator.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import uuid
+
+from fastapi.testclient import TestClient
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.kanban_coordinator import create_app
+
+
+def test_coordinator_registers_and_claims_only_eligible_machine(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    kb.init_db(db_path)
+    with kb.connect(db_path) as conn:
+        mac_task = kb.create_task(
+            conn,
+            title="Xcode work",
+            assignee="ios",
+            required_capabilities=["macos", "xcode"],
+        )
+        linux_task = kb.create_task(conn, title="Linux work", assignee="ops")
+
+    app = create_app(db_path=db_path, token="secret")
+    client = TestClient(app)
+    headers = {"Authorization": "Bearer secret"}
+    linux_id = str(uuid.uuid4())
+    mac_id = str(uuid.uuid4())
+
+    assert client.get("/v1/health").status_code == 401
+    assert client.post(
+        "/v1/machines/register",
+        headers=headers,
+        json={
+            "machine_id": linux_id,
+            "hostname": "linux",
+            "profiles": ["ops"],
+            "capabilities": ["linux"],
+        },
+    ).status_code == 200
+
+    assert client.post(
+        "/v1/machines/register",
+        headers=headers,
+        json={
+            "machine_id": mac_id,
+            "hostname": "mac",
+            "profiles": ["ios"],
+            "capabilities": ["macos", "xcode"],
+        },
+    ).status_code == 200
+
+    machines = client.get("/v1/machines", headers=headers).json()
+    assert machines["count"] == 2
+    assert {item["hostname"] for item in machines["machines"]} == {"linux", "mac"}
+    mac = next(item for item in machines["machines"] if item["hostname"] == "mac")
+    assert mac["online"] is True
+    assert mac["profiles"] == ["ios"]
+    assert mac["capabilities"] == ["macos", "xcode"]
+
+    first = client.post(
+        "/v1/tasks/claim-next", headers=headers, json={"machine_id": linux_id},
+    ).json()["task"]
+    assert first["id"] == linux_task
+    assert first["machine_id"] == linux_id
+
+    second = client.post(
+        "/v1/tasks/claim-next", headers=headers, json={"machine_id": mac_id},
+    ).json()["task"]
+    assert second["id"] == mac_task
+    assert second["required_capabilities"] == ["macos", "xcode"]
+
+    assert client.post(
+        f"/v1/tasks/{mac_task}/renew",
+        headers=headers,
+        json={"claim_lock": second["claim_lock"]},
+    ).json() == {"renewed": True}
+    assert client.post(
+        f"/v1/tasks/{mac_task}/worker-started",
+        headers=headers,
+        json={"claim_lock": second["claim_lock"], "worker_pid": 4242},
+    ).json() == {"recorded": True}
+    with kb.connect(db_path) as conn:
+        assert kb.get_task(conn, mac_task).worker_pid == 4242
+        assert kb.latest_run(conn, mac_task).worker_pid == 4242
+    assert client.post(
+        f"/v1/tasks/{mac_task}/complete",
+        headers=headers,
+        json={"result": "wrong lock", "claim_lock": "not-the-owner"},
+    ).json() == {"completed": False}
+    assert client.post(
+        f"/v1/tasks/{mac_task}/complete",
+        headers=headers,
+        json={"result": "finished", "claim_lock": second["claim_lock"]},
+    ).json() == {"completed": True}
+
+
+def test_coordinator_rejects_invalid_machine_identity_without_500(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    kb.init_db(db_path)
+    client = TestClient(create_app(db_path=db_path, token="secret"))
+    headers = {"Authorization": "Bearer secret"}
+
+    response = client.post(
+        "/v1/machines/register",
+        headers=headers,
+        json={"machine_id": "not-a-uuid"},
+    )
+    assert response.status_code == 422
+    assert response.json()["detail"] == "machine_id must be a UUID"
+
+    response = client.post(
+        "/v1/tasks/claim-next",
+        headers=headers,
+        json={"machine_id": "not-a-uuid"},
+    )
+    assert response.status_code == 422

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -644,6 +644,160 @@ def test_stale_claim_released_when_worker_not_host_local(
         assert kb.get_task(conn, t).status == "ready"
 
 
+# ---------------------------------------------------------------------------
+# Machine-driven lease renewal (renew_owned_leases)
+# ---------------------------------------------------------------------------
+
+def test_renew_extends_live_lease_before_expiry(kanban_home, monkeypatch):
+    """A live host-local worker deep into its lease is renewed proactively,
+    so the lease never expires and release_stale_claims never sees it."""
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="a")
+        host = _kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, t, claimer=f"{host}:worker")
+        kb._set_worker_pid(conn, t, 12345)
+
+        ttl = _kb._resolve_claim_ttl_seconds()
+        now = int(time.time())
+        # Lease is into its final third (only 10s of headroom left) but not
+        # yet expired: the reactive rescue would not fire, renewal should.
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ? WHERE id = ?", (now + 10, t),
+        )
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+
+        res = kb.renew_owned_leases(conn, now=now)
+        assert res == 1
+
+        task = kb.get_task(conn, t)
+        assert task.status == "running"
+        assert task.claim_expires >= now + ttl - 1
+        kinds = [
+            r["kind"] for r in conn.execute(
+                "SELECT kind FROM task_events WHERE task_id = ?", (t,),
+            ).fetchall()
+        ]
+        assert "claim_renewed" in kinds
+
+
+def test_renew_skips_fresh_lease_to_bound_event_churn(kanban_home, monkeypatch):
+    """A freshly claimed lease (>2/3 TTL remaining) is left alone: renewing
+    every tick would spam claim_renewed events."""
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="a")
+        host = _kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, t, claimer=f"{host}:worker")
+        kb._set_worker_pid(conn, t, 12345)
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+
+        # claim_task just set expires ~ now + TTL, so plenty of headroom.
+        res = kb.renew_owned_leases(conn)
+        assert res == 0
+
+
+def test_renew_skips_remote_lease(kanban_home, monkeypatch):
+    """Another machine's claim is never renewed here — that machine renews
+    its own. This is the whole point: we only vouch for our own workers."""
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="a")
+        # Claim owned by a *different* host.
+        kb.claim_task(
+            conn,
+            t,
+            claimer="other-host:worker",
+            machine_id="00000000-0000-4000-8000-000000000001",
+        )
+        kb._set_worker_pid(conn, t, 12345)
+        now = int(time.time())
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ? WHERE id = ?", (now + 10, t),
+        )
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+
+        res = kb.renew_owned_leases(conn, now=now)
+        assert res == 0
+        # Lease left untouched -> release_stale_claims will reclaim it once it
+        # expires, which is the correct cross-machine behavior.
+        assert kb.get_task(conn, t).claim_expires == now + 10
+
+
+def test_renew_skips_dead_worker(kanban_home, monkeypatch):
+    """A host-local claim whose worker PID is gone is not renewed — the crash
+    and reclaim paths must be allowed to release it."""
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="a")
+        host = _kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, t, claimer=f"{host}:worker")
+        kb._set_worker_pid(conn, t, 12345)
+        now = int(time.time())
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ? WHERE id = ?", (now + 10, t),
+        )
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+
+        res = kb.renew_owned_leases(conn, now=now)
+        assert res == 0
+
+
+def test_renew_skips_wedged_worker(kanban_home, monkeypatch):
+    """A live but wedged worker (heartbeat stale > max) is NOT renewed, so its
+    lease lapses and the stale/reclaim backstop (#29747) can act."""
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="a")
+        host = _kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, t, claimer=f"{host}:worker")
+        kb._set_worker_pid(conn, t, 12345)
+        now = int(time.time())
+        stale_hb = now - _kb.DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS - 60
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ?, last_heartbeat_at = ? "
+            "WHERE id = ?",
+            (now + 10, stale_hb, t),
+        )
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+
+        res = kb.renew_owned_leases(conn, now=now)
+        assert res == 0
+
+
+def test_dispatch_renews_owned_lease_before_reclaim(kanban_home, monkeypatch):
+    """The dispatch tick must renew before scanning expired claims.
+
+    A live local worker whose lease has just crossed expiry stays running
+    instead of being released and made eligible for a duplicate spawn.
+    """
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="a")
+        host = _kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, t, claimer=f"{host}:worker")
+        kb._set_worker_pid(conn, t, 12345)
+        now = int(time.time())
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ? WHERE id = ?", (now - 1, t),
+        )
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+
+        result = kb.dispatch_once(conn)
+
+        assert result.renewed == 1
+        assert result.reclaimed == 0
+        task = kb.get_task(conn, t)
+        assert task.status == "running"
+        assert task.claim_expires > now
+
+
 def test_detect_stale_defers_when_live_worker_survives(kanban_home, monkeypatch):
     """detect_stale_running must also hold the claim when the worker survives."""
     import hermes_cli.kanban_db as _kb

--- a/tests/hermes_cli/test_kanban_machine_identity.py
+++ b/tests/hermes_cli/test_kanban_machine_identity.py
@@ -1,0 +1,215 @@
+"""Stable machine ownership tests for distributed Kanban preparation."""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def machine_home(tmp_path, monkeypatch):
+    root = tmp_path / ".hermes"
+    root.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    kb._MACHINE_ID_CACHE.clear()
+    yield root
+    kb._MACHINE_ID_CACHE.clear()
+
+
+def test_machine_id_is_uuid_and_shared_across_profiles(machine_home, monkeypatch):
+    first = kb.get_machine_id()
+    assert str(uuid.UUID(first)) == first
+    assert kb.machine_id_path() == machine_home / "kanban" / "machine-id"
+    assert kb.machine_id_path().read_text(encoding="utf-8").strip() == first
+
+    profile_home = machine_home / "profiles" / "ios-specialist"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    assert kb.get_machine_id() == first
+    assert kb.machine_id_path() == machine_home / "kanban" / "machine-id"
+
+
+def test_machine_id_file_is_created_once_across_threads(machine_home):
+    import concurrent.futures
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=12) as pool:
+        values = list(pool.map(lambda _n: kb.get_machine_id(), range(48)))
+
+    assert len(set(values)) == 1
+    assert kb.machine_id_path().read_text(encoding="utf-8").strip() == values[0]
+
+
+def test_invalid_machine_id_fails_closed(machine_home):
+    path = kb.machine_id_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("not-a-uuid\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="invalid Hermes Kanban machine identity"):
+        kb.get_machine_id()
+
+
+def test_claim_stamps_task_and_run_then_clears_active_owner(machine_home):
+    kb.init_db()
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="owned", assignee="worker")
+        claimed = kb.claim_task(conn, task_id, claimer="opaque-claim-token")
+        assert claimed is not None
+        local_machine_id = kb.get_machine_id()
+        assert claimed.machine_id == local_machine_id
+
+        run = kb.latest_run(conn, task_id)
+        assert run is not None
+        assert run.machine_id == local_machine_id
+
+        assert kb.complete_task(conn, task_id, result="done") is True
+        assert kb.get_task(conn, task_id).machine_id is None
+        assert kb.latest_run(conn, task_id).machine_id == local_machine_id
+
+
+def test_machine_column_not_claim_token_controls_pid_ownership(
+    machine_home, monkeypatch,
+):
+    kb.init_db()
+    with kb.connect() as conn:
+        local_task = kb.create_task(conn, title="local", assignee="worker")
+        # Deliberately misleading token: explicit task.machine_id still makes
+        # this local and therefore renewable.
+        kb.claim_task(conn, local_task, claimer="foreign-looking:token")
+        kb._set_worker_pid(conn, local_task, 12345)
+        now = int(time.time())
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ? WHERE id = ?",
+            (now + 1, local_task),
+        )
+        monkeypatch.setattr(kb, "_pid_alive", lambda _pid: True)
+        assert kb.renew_owned_leases(conn, now=now) == 1
+
+        remote_task = kb.create_task(conn, title="remote", assignee="worker")
+        remote_id = str(uuid.uuid4())
+        # Deliberately spoof the local token prefix: explicit remote ownership
+        # must win, preventing this process from probing a foreign PID.
+        kb.claim_task(
+            conn,
+            remote_task,
+            claimer=f"{kb.get_machine_id()}:spoofed",
+            machine_id=remote_id,
+        )
+        kb._set_worker_pid(conn, remote_task, 54321)
+        conn.execute(
+            "UPDATE tasks SET started_at = ?, claim_expires = ? WHERE id = ?",
+            (now - 300, now + 1, remote_task),
+        )
+        monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+
+        assert kb.renew_owned_leases(conn, now=now) == 0
+        assert kb.detect_crashed_workers(conn) == []
+        assert kb.get_task(conn, remote_task).status == "running"
+
+
+def test_migration_backfills_provably_local_legacy_claim(machine_home):
+    path = kb.init_db()
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="legacy", assignee="worker")
+        kb.claim_task(conn, task_id)
+        kb._set_worker_pid(conn, task_id, os.getpid())
+        legacy_lock = f"{kb._legacy_hostname()}:legacy-worker"
+        conn.execute(
+            "UPDATE tasks SET machine_id = NULL, claim_lock = ? WHERE id = ?",
+            (legacy_lock, task_id),
+        )
+        conn.execute(
+            "UPDATE task_runs SET machine_id = NULL, claim_lock = ? "
+            "WHERE id = (SELECT current_run_id FROM tasks WHERE id = ?)",
+            (legacy_lock, task_id),
+        )
+
+    kb.init_db(path)
+
+    with kb.connect(path) as conn:
+        task = kb.get_task(conn, task_id)
+        run = kb.latest_run(conn, task_id)
+        assert task.machine_id == kb.get_machine_id()
+        assert run is not None
+        assert run.machine_id == kb.get_machine_id()
+
+
+def test_dispatch_leaves_missing_capability_for_another_machine(
+    machine_home, monkeypatch,
+):
+    kb.init_db()
+    monkeypatch.setattr(kb, "local_machine_capabilities", lambda: ("linux",))
+    monkeypatch.setattr(kb, "local_machine_profiles", lambda: ("default",))
+    spawned: list[str] = []
+
+    with kb.connect() as conn:
+        restricted = kb.create_task(
+            conn,
+            title="Needs Xcode",
+            assignee="default",
+            required_capabilities=["macos", "xcode"],
+        )
+        ordinary = kb.create_task(
+            conn, title="Runs here", assignee="default",
+        )
+
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda task, _workspace: spawned.append(task.id),
+        )
+
+        assert spawned == [ordinary]
+        assert (restricted, "capabilities") in result.skipped_routing
+        assert kb.get_task(conn, restricted).status == "ready"
+        assert kb.task_capabilities(conn, restricted) == ("macos", "xcode")
+
+
+def test_dispatch_honors_target_machine_pin(machine_home, monkeypatch):
+    kb.init_db()
+    monkeypatch.setattr(kb, "local_machine_capabilities", lambda: ("linux",))
+    monkeypatch.setattr(kb, "local_machine_profiles", lambda: ("default",))
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Pinned elsewhere",
+            assignee="default",
+            target_machine=str(uuid.uuid4()),
+        )
+        result = kb.dispatch_once(
+            conn, spawn_fn=lambda *_args, **_kwargs: pytest.fail("must not spawn"),
+        )
+
+        assert result.skipped_routing == [(task_id, "target_machine")]
+        assert kb.get_task(conn, task_id).status == "ready"
+
+
+def test_claim_routing_check_is_inside_claim_transaction(machine_home, monkeypatch):
+    kb.init_db()
+    monkeypatch.setattr(kb, "local_machine_capabilities", lambda: ("linux",))
+    monkeypatch.setattr(kb, "local_machine_profiles", lambda: ("default",))
+
+    with kb.connect() as conn:
+        local_id = kb.register_local_machine(conn)
+        task_id = kb.create_task(
+            conn,
+            title="Foreign capability",
+            assignee="default",
+            required_capabilities=["macos"],
+        )
+
+        assert kb.claim_task(
+            conn,
+            task_id,
+            machine_id=local_id,
+            enforce_machine_routing=True,
+        ) is None
+        assert kb.get_task(conn, task_id).status == "ready"

--- a/tests/hermes_cli/test_kanban_remote.py
+++ b/tests/hermes_cli/test_kanban_remote.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+from types import SimpleNamespace
 
 import pytest
 
@@ -57,6 +58,60 @@ def test_remote_worker_retries_coordinator_with_bounded_backoff(monkeypatch):
         )
 
     assert sleeps == [2]
+
+
+def test_remote_worker_fences_child_when_renewal_is_rejected(monkeypatch):
+    class Process:
+        pid = 1234
+        returncode = None
+        terminated = False
+        waited = False
+
+        def poll(self):
+            return 1 if self.terminated else None
+
+        def terminate(self):
+            self.terminated = True
+            self.returncode = -15
+
+        def wait(self, timeout=None):
+            self.waited = True
+            return self.returncode
+
+        def kill(self):
+            raise AssertionError("graceful termination should have reaped child")
+
+    process = Process()
+
+    class Client:
+        base_url = "http://coordinator"
+        token = "secret"
+
+        def build_worker_context(self, _conn, _task_id):
+            return "context"
+
+        def record_worker_started(self, *_args, **_kwargs):
+            return True
+
+        def heartbeat_claim(self, *_args, **_kwargs):
+            return False
+
+    monkeypatch.setattr(
+        kanban_remote_worker.subprocess, "Popen", lambda *_a, **_kw: process
+    )
+    monkeypatch.setattr(
+        kanban_remote_worker.kb, "_resolve_hermes_argv", lambda: ["hermes"]
+    )
+
+    kanban_remote_worker._run_task(
+        Client(),
+        SimpleNamespace(id="t_remote", current_run_id=1, claim_lock="lock"),
+        profile="ios",
+        machine_id="machine-id",
+    )
+
+    assert process.terminated is True
+    assert process.waited is True
 
 
 def _parse_kanban(argv: list[str]):

--- a/tests/hermes_cli/test_kanban_remote.py
+++ b/tests/hermes_cli/test_kanban_remote.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from hermes_cli import kanban
+from hermes_cli import kanban_remote
+from hermes_cli import kanban_remote_worker
+
+
+def test_configured_coordinator_url_prefers_config_over_legacy_environment(
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_KANBAN_COORDINATOR_URL", "http://legacy:8788")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": {"coordinator_url": "http://configured:8788/"}},
+    )
+
+    assert kanban_remote.configured_coordinator_url() == "http://configured:8788"
+
+
+def test_configured_coordinator_url_keeps_legacy_fallback(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_COORDINATOR_URL", "http://legacy:8788/")
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"kanban": {}})
+
+    assert kanban_remote.configured_coordinator_url() == "http://legacy:8788"
+
+
+def test_remote_worker_retries_coordinator_with_bounded_backoff(monkeypatch):
+    class StopLoop(Exception):
+        pass
+
+    class Client:
+        attempts = 0
+
+        def register_machine(self, *_args, **_kwargs):
+            self.attempts += 1
+            if self.attempts == 1:
+                raise RuntimeError("temporary outage")
+
+        def claim_next(self, _machine_id):
+            raise StopLoop()
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(kanban_remote_worker.kb, "get_machine_id", lambda: "machine-id")
+
+    with pytest.raises(StopLoop):
+        kanban_remote_worker.run_worker_loop(
+            Client(),
+            profile="default",
+            capabilities=["linux"],
+            poll_seconds=2,
+            max_retry_seconds=5,
+            sleep_fn=sleeps.append,
+        )
+
+    assert sleeps == [2]
+
+
+def _parse_kanban(argv: list[str]):
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    kanban.build_parser(subparsers)
+    return parser.parse_args(["kanban", *argv])
+
+
+def test_remote_worker_cli_uses_configured_endpoint(monkeypatch):
+    called = {}
+    monkeypatch.setattr(
+        kanban_remote,
+        "configured_coordinator_url",
+        lambda: "http://coordinator:8788",
+    )
+    monkeypatch.setattr(
+        kanban_remote_worker,
+        "run",
+        lambda **kwargs: called.update(kwargs) or 7,
+    )
+
+    result = kanban.kanban_command(
+        _parse_kanban(["remote-worker", "--profile", "ios", "--capability", "xcode"]),
+    )
+
+    assert result == 7
+    assert called == {
+        "url": "http://coordinator:8788",
+        "token_env": "HERMES_KANBAN_COORDINATOR_TOKEN",
+        "profile": "ios",
+        "capabilities": ["xcode"],
+        "poll_seconds": 10.0,
+        "max_retry_seconds": 60.0,
+    }
+
+
+def test_coordinator_cli_defaults_to_current_board_database(monkeypatch, tmp_path):
+    called = {}
+    monkeypatch.setattr(kanban.kb, "kanban_db_path", lambda: tmp_path / "board.db")
+    monkeypatch.setattr(
+        "hermes_cli.kanban_coordinator.run",
+        lambda **kwargs: called.update(kwargs) or 3,
+    )
+
+    result = kanban.kanban_command(_parse_kanban(["coordinator", "--port", "9999"]))
+
+    assert result == 3
+    assert called == {
+        "db_path": tmp_path / "board.db",
+        "host": "127.0.0.1",
+        "port": 9999,
+        "token_env": "HERMES_KANBAN_COORDINATOR_TOKEN",
+    }

--- a/tests/plugins/test_kanban_worker_runs.py
+++ b/tests/plugins/test_kanban_worker_runs.py
@@ -147,6 +147,40 @@ def test_workers_active_excludes_runs_without_pid(client):
 
 
 # ---------------------------------------------------------------------------
+# GET /workers/machines
+# ---------------------------------------------------------------------------
+
+def test_worker_machines_lists_idle_registered_remote_capacity(client):
+    """Registered machines remain visible even with no active task."""
+    machine_id = "a0aa0000-0000-4000-8000-000000000001"
+    conn = kb.connect()
+    try:
+        kb.register_machine(
+            conn,
+            machine_id,
+            hostname="mac-worker",
+            profiles=["ios"],
+            capabilities=["macos", "xcode"],
+        )
+    finally:
+        conn.close()
+
+    r = client.get("/api/plugins/kanban/workers/machines")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["count"] == 1
+    assert body["machines"] == [{
+        "machine_id": machine_id,
+        "hostname": "mac-worker",
+        "last_seen_at": body["machines"][0]["last_seen_at"],
+        "online": True,
+        "profiles": ["ios"],
+        "capabilities": ["macos", "xcode"],
+        "active_workers": 0,
+    }]
+
+
+# ---------------------------------------------------------------------------
 # GET /runs/{run_id}
 # ---------------------------------------------------------------------------
 
@@ -373,7 +407,7 @@ def test_terminate_run_ok(client, monkeypatch):
     # Capture signal calls so we don't actually SIGTERM a random PID.
     sent = []
 
-    def _fake_terminate(pid, prev_lock, *, signal_fn=None):
+    def _fake_terminate(pid, prev_lock, *, machine_id=None, signal_fn=None):
         sent.append((pid, prev_lock))
         return {"signal": "SIGTERM", "delivered": True}
 

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -979,6 +979,28 @@ def test_create_happy_path(worker_env):
         conn.close()
 
 
+def test_create_routes_task_to_machine_capabilities(worker_env):
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    machine_id = "a0aa0000-0000-4000-8000-000000000001"
+    out = json.loads(kt._handle_create({
+        "title": "Mac-only child",
+        "assignee": "peer",
+        "target_machine": machine_id,
+        "required_capabilities": ["macos", "xcode"],
+    }))
+    assert out["ok"] is True
+
+    conn = kb.connect()
+    try:
+        child = kb.get_task(conn, out["task_id"])
+        assert child.target_machine == machine_id
+        assert kb.task_capabilities(conn, child.id) == ("macos", "xcode")
+    finally:
+        conn.close()
+
+
 def test_create_inherits_worker_dir_workspace(monkeypatch, worker_env):
     """A worker scoped to a dir: task that spawns a child without a
     workspace arg inherits the dir, not scratch (so follow-up code-gen

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -858,6 +858,16 @@ def _handle_create(args: dict, **kw) -> str:
     # CLI / dashboard paths and on legacy hosts that don't set the env.
     session_id = args.get("session_id") or os.environ.get("HERMES_SESSION_ID")
     priority = args.get("priority")
+    target_machine = args.get("target_machine")
+    required_capabilities = args.get("required_capabilities")
+    if isinstance(required_capabilities, str):
+        required_capabilities = [required_capabilities]
+    if required_capabilities is not None and not isinstance(
+        required_capabilities, (list, tuple),
+    ):
+        return tool_error(
+            "required_capabilities must be a list of capability names"
+        )
     # Resolve workspace. If the caller passed one explicitly, honor it.
     # Otherwise, a dispatcher-spawned worker (HERMES_KANBAN_TASK set)
     # inherits its own running task's workspace, so a worker editing a
@@ -920,6 +930,10 @@ def _handle_create(args: dict, **kw) -> str:
                 parents=tuple(parents),
                 tenant=tenant,
                 priority=int(priority) if priority is not None else 0,
+                target_machine=(
+                    str(target_machine).strip() if target_machine else None
+                ),
+                required_capabilities=required_capabilities,
                 workspace_kind=str(workspace_kind),
                 workspace_path=workspace_path,
                 project_id=project_id,
@@ -1448,6 +1462,23 @@ KANBAN_CREATE_SCHEMA = {
                 "description": (
                     "Dispatcher tiebreaker. Higher = picked sooner "
                     "when multiple ready tasks share an assignee."
+                ),
+            },
+            "target_machine": {
+                "type": "string",
+                "description": (
+                    "Optional stable machine UUID pin. Use only when the "
+                    "caller already knows the exact registered worker."
+                ),
+            },
+            "required_capabilities": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Machine capabilities required to claim this task. "
+                    "Use ['macos'] to route work to a Mac worker and add "
+                    "'xcode' for Xcode work; use ['linux'] for a Linux "
+                    "worker. Leave empty when any eligible machine may run it."
                 ),
             },
             "workspace_kind": {

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -175,6 +175,10 @@ def _connect(board: Optional[str] = None):
     → ``default``). Per-tool ``board`` lets a Telegram-side agent override
     the env-pinned active board without restarting Hermes.
     """
+    from hermes_cli.kanban_remote import configured_coordinator_url
+    if configured_coordinator_url():
+        from hermes_cli.kanban_remote import connect_from_config
+        return connect_from_config()
     from hermes_cli import kanban_db as kb
     return kb, kb.connect(board=board)
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -931,9 +931,22 @@ Every transition appends a row to `task_events`. Each row carries an optional `r
 
 `hermes kanban tail <id>` shows these for a single task. `hermes kanban watch` streams them board-wide.
 
-## Out of scope
+## Multi-host boards
 
-Kanban is deliberately single-host. `~/.hermes/kanban.db` is a local SQLite file and the dispatcher spawns workers on the same machine. Running a shared board across two hosts is not supported — there's no coordination primitive for "worker X on host A, worker Y on host B," and the crash-detection path assumes PIDs are host-local. If you need multi-host, run an independent board per host and use `delegate_task` / a message queue to bridge them.
+Kanban remains single-host by default: the local dispatcher owns `kanban.db`
+and spawns workers on that machine. For a shared private board, run
+`hermes kanban coordinator` on the machine that owns the database and
+`hermes kanban remote-worker` on each additional machine. Remote workers
+register their profiles and capabilities, claim only eligible tasks, and renew
+coordinator-issued leases while their local child is alive.
+
+The coordinator is the only database owner and recovers expired leases. Worker
+PIDs remain host-local: the coordinator never attempts to signal a PID reported
+by another machine, and a remote supervisor terminates its own child as soon as
+the coordinator rejects lease renewal. Bind the coordinator only to a trusted
+private network such as Tailscale and configure a bearer token through
+`HERMES_KANBAN_COORDINATOR_TOKEN`; this API is not intended for the public
+internet.
 
 ## Design spec
 


### PR DESCRIPTION
## Summary

- add stable machine identities, capability-aware routing, and machine-owned lease renewal for Kanban tasks
- add an authenticated private coordinator plus a reconnecting remote worker, exposed through `hermes kanban coordinator` and `hermes kanban remote-worker`
- expose registered worker capacity in the Kanban dashboard and let agents route created tasks by machine UUID or capability (for example `macos` and `xcode`)

## Why

Hermes could only dispatch work from one local board process. There was no safe way to distinguish machines, route macOS/Xcode work to a Mac worker, or keep a healthy remote worker's claim alive. Agent-created tasks also could not express a target machine or required capabilities.

## Validation

- End-to-end LXC-to-Mac direct agent chat verified over authenticated Tailscale API transport.
- End-to-end Mac-targeted Kanban card was claimed by the Mac machine UUID and completed.
- `scripts/run_tests.sh $(rg --files tests | rg "kanban" | sort)`
  - 42 files, 1,001 tests passed.

## Deployment notes

The coordinator endpoint belongs in `kanban.coordinator_url`; the bearer token remains in `HERMES_KANBAN_COORDINATOR_TOKEN`. The coordinator is designed for a private network such as Tailscale and is not a public dashboard endpoint.
