### PR TITLE
fix(dashboard): group analytics by configured timezone

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -13909,15 +13909,37 @@ async def update_config_raw(body: RawConfigUpdate, profile: Optional[str] = None
 # ---------------------------------------------------------------------------
 
 
+def _analytics_local_day(started_at: float, tz) -> Optional[str]:
+    """Return a session's local calendar day, or ``None`` for bad data."""
+    try:
+        if tz is None:
+            # ``fromtimestamp`` without an explicit zone uses the server's local
+            # timezone, including the historical offset for this timestamp.
+            return datetime.fromtimestamp(started_at).date().isoformat()
+        return datetime.fromtimestamp(started_at, tz).date().isoformat()
+    except (TypeError, ValueError, OverflowError, OSError):
+        return None
+
+
 @app.get("/api/analytics/usage")
 async def get_usage_analytics(days: int = 30, profile: Optional[str] = None):
+    import hermes_time
     from agent.insights import InsightsEngine
 
     db = _open_session_db_for_profile(profile)
     try:
         cutoff = time.time() - (days * 86400)
+        # Resolve without the process-global cache so profile-scoped requests
+        # and runtime timezone edits take effect immediately.
+        with _config_profile_scope(profile):
+            tz = hermes_time.resolve_timezone()
+        db._conn.create_function(
+            "hermes_local_day",
+            1,
+            lambda started_at: _analytics_local_day(started_at, tz),
+        )
         cur = db._conn.execute("""
-            SELECT date(started_at, 'unixepoch') as day,
+            SELECT hermes_local_day(started_at) as day,
                    SUM(input_tokens) as input_tokens,
                    SUM(output_tokens) as output_tokens,
                    SUM(cache_read_tokens) as cache_read_tokens,

--- a/hermes_time.py
+++ b/hermes_time.py
@@ -93,6 +93,16 @@ def _get_zoneinfo(name: str) -> Optional[ZoneInfo]:
         return None
 
 
+def resolve_timezone() -> Optional[ZoneInfo]:
+    """Resolve the current scoped timezone without consulting the cache.
+
+    Use this for request-scoped profile reads and other paths that must observe
+    runtime config changes immediately. Hot-path callers should use
+    :func:`get_timezone` instead.
+    """
+    return _get_zoneinfo(_resolve_timezone_name())
+
+
 def get_timezone() -> Optional[ZoneInfo]:
     """Return the user's configured ZoneInfo, or None (meaning server-local).
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4702,6 +4702,99 @@ class TestNewEndpoints:
             "top_skills": [],
         }
 
+    def test_analytics_usage_groups_days_in_configured_timezone(self, monkeypatch):
+        from datetime import datetime, timezone
+
+        import hermes_time
+        from hermes_cli import web_server
+        from hermes_state import SessionDB
+
+        monkeypatch.setenv("HERMES_TIMEZONE", "UTC")
+        hermes_time.reset_cache()
+        assert str(hermes_time.get_timezone()) == "UTC"
+        # Simulate a runtime config/env update after the process-global cache
+        # has already been populated. Analytics must use the current value.
+        monkeypatch.setenv("HERMES_TIMEZONE", "Asia/Bangkok")
+        monkeypatch.setattr(
+            web_server.time,
+            "time",
+            lambda: datetime(2026, 5, 13, 12, tzinfo=timezone.utc).timestamp(),
+        )
+
+        db = SessionDB()
+        try:
+            assert db._conn is not None
+            rows = [
+                ("bangkok-may-12", datetime(2026, 5, 11, 18, tzinfo=timezone.utc), 10),
+                ("bangkok-may-13", datetime(2026, 5, 12, 18, tzinfo=timezone.utc), 20),
+            ]
+            for session_id, started_at, input_tokens in rows:
+                db.create_session(session_id=session_id, source="cli", model="test/model")
+                db.update_token_counts(session_id, input_tokens=input_tokens)
+                db._conn.execute(
+                    "UPDATE sessions SET started_at = ? WHERE id = ?",
+                    (started_at.timestamp(), session_id),
+                )
+            db._conn.commit()
+        finally:
+            db.close()
+
+        try:
+            resp = self.client.get("/api/analytics/usage?days=7")
+        finally:
+            hermes_time.reset_cache()
+
+        assert resp.status_code == 200
+        daily = resp.json()["daily"]
+        assert [(row["day"], row["input_tokens"]) for row in daily] == [
+            ("2026-05-12", 10),
+            ("2026-05-13", 20),
+        ]
+
+    def test_analytics_usage_uses_requested_profile_timezone(self, monkeypatch):
+        from datetime import datetime, timezone
+
+        import hermes_time
+        from hermes_cli import profiles as profiles_mod
+        from hermes_cli import web_server
+        from hermes_state import SessionDB
+
+        monkeypatch.delenv("HERMES_TIMEZONE", raising=False)
+        hermes_time.reset_cache()
+        worker_home = profiles_mod.get_profile_dir("worker")
+        worker_home.mkdir(parents=True)
+        (worker_home / "config.yaml").write_text(
+            "timezone: Asia/Bangkok\n", encoding="utf-8"
+        )
+        monkeypatch.setattr(
+            web_server.time,
+            "time",
+            lambda: datetime(2026, 5, 13, 12, tzinfo=timezone.utc).timestamp(),
+        )
+
+        db = SessionDB(db_path=worker_home / "state.db")
+        try:
+            assert db._conn is not None
+            db.create_session(
+                session_id="worker-local-day", source="cli", model="test/model"
+            )
+            db.update_token_counts("worker-local-day", input_tokens=10)
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ? WHERE id = ?",
+                (
+                    datetime(2026, 5, 12, 18, tzinfo=timezone.utc).timestamp(),
+                    "worker-local-day",
+                ),
+            )
+            db._conn.commit()
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/analytics/usage?days=7&profile=worker")
+
+        assert resp.status_code == 200
+        assert [row["day"] for row in resp.json()["daily"]] == ["2026-05-13"]
+
     def test_models_analytics_merges_session_only_duplicate_into_accounted_provider(self):
         """Session-only model rows should not render as duplicate zero-token cards.
 


### PR DESCRIPTION
## Summary
- group dashboard daily token/cost analytics by the configured IANA timezone instead of UTC
- resolve timezone per requested profile without using stale process cache state
- preserve server-local fallback and return `NULL` for invalid stored timestamps

## Test Plan
- [x] TDD regression: configured timezone grouping failed before implementation and passes after
- [x] TDD regression: requested-profile timezone failed without profile scoping and passes after
- [x] stale timezone-cache regression
- [x] `python -m pytest tests/hermes_cli/test_web_server.py::TestNewEndpoints -q -o "addopts="` — 60 passed
- [x] `ruff check hermes_time.py hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`
- [x] `git diff --check`
- [x] two-pass independent review approved after profile/cache fixes

Closes #23982