### PR TITLE
fix(web): filter plugin-registry fallback by capability in _get_backend()

### DIFF
--- a/tests/tools/test_web_providers.py
+++ b/tests/tools/test_web_providers.py
@@ -201,6 +201,100 @@ class TestPerCapabilityBackendSelection:
         assert web_tools._get_extract_backend() == "tavily"
 
 
+class TestBackendFallbackRespectsCapability:
+    """Regression test: the final plugin-registry walk in ``_get_backend()``
+    must filter candidates by the requested capability.
+
+    Before this fix, an always-available, capability-restricted provider
+    (e.g. an extract-only local provider needing no API key/credentials)
+    could be handed back for a search request with no other configured
+    backend or credentials — ``_get_search_backend()`` would return a
+    provider whose ``supports_search()`` is False, and ``web_search_tool``
+    would then report a misleading "No web search provider configured"
+    error instead of actually trying an available search-capable provider
+    (or giving a correct error when none exists). Caught when re-adding
+    trafilatura (extract-only, always available) surfaced the gap in CI.
+    """
+
+    def _make_fake_provider(self):
+        """Build a fresh extract-only, always-available fake provider instance."""
+        from agent.web_search_provider import WebSearchProvider
+
+        class _AlwaysAvailableExtractOnly(WebSearchProvider):
+            """Fake provider: extract-only, no credentials ever required."""
+
+            @property
+            def name(self) -> str:
+                return "always-on-extract-only"
+
+            @property
+            def display_name(self) -> str:
+                return "Always-On Extract Only"
+
+            def is_available(self) -> bool:
+                return True
+
+            def supports_search(self) -> bool:
+                return False
+
+            def supports_extract(self) -> bool:
+                return True
+
+            def extract(self, urls, **kwargs):
+                return [{"url": u, "title": "", "content": "stub"} for u in urls]
+
+        return _AlwaysAvailableExtractOnly()
+
+    @pytest.fixture(autouse=True)
+    def _register_fake_provider(self):
+        from agent.web_search_registry import register_provider, _reset_for_tests
+
+        _reset_for_tests()
+        register_provider(self._make_fake_provider())
+        yield
+        _reset_for_tests()
+
+    def test_search_backend_never_returns_extract_only_provider(self, monkeypatch):
+        """``_get_search_backend()`` must skip an extract-only provider even
+        when it's the only always-available candidate in the registry."""
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
+        for k in (
+            "TAVILY_API_KEY", "EXA_API_KEY", "PARALLEL_API_KEY",
+            "FIRECRAWL_API_KEY", "FIRECRAWL_API_URL", "SEARXNG_URL",
+            "BRAVE_SEARCH_API_KEY",
+        ):
+            monkeypatch.delenv(k, raising=False)
+        monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: False)
+        monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
+
+        backend = web_tools._get_search_backend()
+        assert backend != "always-on-extract-only", (
+            "search backend resolution returned a provider that cannot "
+            "search — supports_search() was never checked in the "
+            "plugin-registry fallback walk"
+        )
+
+    def test_extract_backend_can_still_return_extract_only_provider(self, monkeypatch):
+        """Sanity check: the capability filter isn't overly strict — an
+        extract-only provider IS a valid extract backend."""
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
+        for k in (
+            "TAVILY_API_KEY", "EXA_API_KEY", "PARALLEL_API_KEY",
+            "FIRECRAWL_API_KEY", "FIRECRAWL_API_URL", "SEARXNG_URL",
+            "BRAVE_SEARCH_API_KEY",
+        ):
+            monkeypatch.delenv(k, raising=False)
+        monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: False)
+        monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
+
+        backend = web_tools._get_extract_backend()
+        assert backend == "always-on-extract-only"
+
+
 # ---------------------------------------------------------------------------
 # Config key presence in DEFAULT_CONFIG
 # ---------------------------------------------------------------------------

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -220,12 +220,22 @@ def _list_registered_web_providers():
         return []
 
 
-def _get_backend() -> str:
+def _get_backend(capability: Optional[str] = None) -> str:
     """Determine which web backend to use (shared fallback).
 
     Reads ``web.backend`` from config.yaml (set by ``hermes tools``).
     Falls back to whichever API key is present for users who configured
     keys manually without running setup.
+
+    ``capability`` (``"search"`` / ``"extract"`` / ``None``) restricts the
+    final plugin-registry walk below to providers that actually support the
+    requested capability. Without this, an always-available capability-
+    restricted provider (e.g. trafilatura, extract-only) could be handed
+    back for a search request that has no other configured backend —
+    reachable in prod whenever no search credentials are set and no
+    ``web.backend``/``web.search_backend`` override is given. ``None``
+    preserves the old promiscuous behavior for the ``__main__`` demo block,
+    which doesn't have (or need) a specific capability in mind.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
     if configured in _LEGACY_WEB_BACKENDS or _registered_web_provider(configured) is not None:
@@ -260,6 +270,10 @@ def _get_backend() -> str:
     # _is_backend_available() (which would re-do the registry lookup).
     for provider in _list_registered_web_providers():
         if provider.name in _LEGACY_WEB_BACKENDS:
+            continue
+        if capability == "search" and not provider.supports_search():
+            continue
+        if capability == "extract" and not provider.supports_extract():
             continue
         try:
             if provider.is_available():
@@ -305,7 +319,7 @@ def _get_capability_backend(capability: str) -> str:
     specific = (cfg.get(f"{capability}_backend") or "").lower().strip()
     if specific and _is_backend_available(specific):
         return specific
-    return _get_backend()
+    return _get_backend(capability)
 
 
 def _is_backend_available(backend: str) -> bool:


### PR DESCRIPTION
## Problem

`_get_backend()`'s final fallback step â€” the plugin-registry walk used when no built-in backend has credentials configured â€” picks the first registered, non-legacy provider whose `is_available()` returns `True`, with **no check that the provider actually supports the requested capability**:

```python
for provider in _list_registered_web_providers():
    if provider.name in _LEGACY_WEB_BACKENDS:
        continue
    if provider.is_available():
        return provider.name   # capability never checked
```

Any plugin-registered provider that is (a) extract-only (`supports_search() == False`) and (b) always available (no credentials required â€” e.g. a local, no-API-key extract backend) will be handed back by `_get_search_backend()` whenever no other search backend is configured/credentialed. `web_search_tool` then dispatches to a provider that can't search at all, producing a misleading "no provider configured"-shaped failure instead of either trying a real search-capable provider or giving an accurate error.

This is a real, currently-reachable gap for **any** always-on, capability-restricted provider registered via `ctx.register_web_search_provider()` â€” not tied to a specific plugin. I found it while testing a local extract-only plugin against current `main`.

## Fix

Thread the capability through `_get_backend(capability: Optional[str] = None)` and filter the plugin-registry walk by it:

```python
def _get_backend(capability: Optional[str] = None) -> str:
    ...
    for provider in _list_registered_web_providers():
        if provider.name in _LEGACY_WEB_BACKENDS:
            continue
        if capability == "search" and not provider.supports_search():
            continue
        if capability == "extract" and not provider.supports_extract():
            continue
        if provider.is_available():
            return provider.name
    return "firecrawl"
```

`_get_capability_backend()` now passes its own capability through instead of calling the old bare `_get_backend()`. The `__main__` demo block's call is unaffected (`capability=None` preserves the old promiscuous behavior there, which is fine for a diagnostic print, not real dispatch).

## Testing

New `tests/tools/test_web_providers.py::TestBackendFallbackRespectsCapability`: registers a fake always-available, extract-only provider and asserts `_get_search_backend()` never returns it (RED verified against the pre-fix code â€” `assert 'always-on-extract-only' != 'always-on-extract-only'` failed) while `_get_extract_backend()` correctly still can (sanity check that the filter isn't overly strict). GREEN after the fix.

Full `tests/tools/test_web_providers.py`: 22/22 passed. Broader web sweep (`test_web_providers`, `test_web_tools_config`, `test_web_tools_dict_urls`, `test_browser_secret_exfil`): 107/107 passed.

## Searched for duplicates

Searched open + closed issues/PRs (`get_backend capability search extract provider`, `search backend extract-only provider`, `supports_search fallback registry`, `web_search_tool no provider configured but credentials`) â€” no existing coverage found.