### PR TITLE
fix(pricing): strip Bedrock version/date suffix before cost lookup

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -687,6 +687,15 @@ def _normalize_bedrock_model_name(model: str) -> str:
     lookup or every cross-region session prices as unknown.  Mirrors the
     prefix list in ``bedrock_adapter.is_anthropic_bedrock_model``.  Also
     normalizes dot-notation version numbers (``4.7`` → ``4-7``).
+
+    Bedrock foundation-model IDs also carry a trailing revision suffix that
+    the bare pricing keys don't have — a release date (``-20250514``), a
+    Bedrock model version (``-v1``), and/or a minor revision (``:0``), e.g.
+    ``anthropic.claude-opus-4-6-20250514-v1:0`` or ``anthropic.claude-opus-4-6-v1``.
+    These are stripped from the end so the id collapses to its bare
+    ``anthropic.claude-opus-4-6`` form.  The suffix pattern is anchored to the
+    end and only matches an 8-digit date, ``-vN``, and ``:N`` — it never eats
+    the model version itself (``-4-6`` / ``-4-8`` are preserved).
     """
     name = model.lower().strip()
     for prefix in ("us.", "global.", "eu.", "ap.", "jp."):
@@ -694,6 +703,10 @@ def _normalize_bedrock_model_name(model: str) -> str:
             name = name[len(prefix):]
             break
     name = re.sub(r"(\d+)\.(\d+)", r"\1-\2", name)
+    # Strip trailing Bedrock revision suffix: optional release date, optional
+    # -vN model version, optional :N minor revision. Anchored to end so the
+    # model version (e.g. -4-6) is never touched.
+    name = re.sub(r"(-\d{8})?(-v\d+)?(:\d+)?$", "", name)
     return name
 
 

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -299,6 +299,60 @@ def test_bedrock_cross_region_profile_prefix_resolves_to_pricing():
         assert scoped.cache_read_cost_per_million == bare.cache_read_cost_per_million
 
 
+def test_bedrock_version_suffix_resolves_to_pricing():
+    """Bedrock foundation-model IDs carry a trailing revision suffix — a
+    release date (``-20250514``), a model version (``-v1``), and/or a minor
+    revision (``:0``) — that the bare pricing keys don't have.  The pricing
+    lookup does an exact dict-key match, so without stripping these suffixes
+    an id like ``anthropic.claude-sonnet-4-5-20250929-v1:0`` (the shape AWS
+    actually returns from ListFoundationModels / inference profiles) prices
+    as unknown even though its bare row exists.  Assert every suffixed shape,
+    with and without a cross-region prefix, resolves to the same entry as the
+    bare id.
+    """
+    bedrock_url = "https://bedrock-runtime.us-east-1.amazonaws.com"
+    bare = get_pricing_entry(
+        "anthropic.claude-sonnet-4-5", provider="bedrock", base_url=bedrock_url
+    )
+    assert bare is not None
+    suffixed_ids = [
+        "anthropic.claude-sonnet-4-5-v1",
+        "anthropic.claude-sonnet-4-5-v1:0",
+        "anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "global.anthropic.claude-sonnet-4-5-v1",
+    ]
+    for mid in suffixed_ids:
+        entry = get_pricing_entry(mid, provider="bedrock", base_url=bedrock_url)
+        assert entry is not None, mid
+        assert entry.input_cost_per_million == bare.input_cost_per_million, mid
+        assert entry.output_cost_per_million == bare.output_cost_per_million, mid
+
+
+def test_bedrock_version_suffix_normalizer_preserves_model_version():
+    """The suffix stripper must not eat the model version itself.  Anchored to
+    the end, it only matches an 8-digit date, ``-vN``, and ``:N`` — so
+    ``-4-6`` / ``-4-8`` and bare provider IDs survive unchanged.
+    """
+    from agent.usage_pricing import _normalize_bedrock_model_name
+
+    assert (
+        _normalize_bedrock_model_name("anthropic.claude-opus-4-6-v1")
+        == "anthropic.claude-opus-4-6"
+    )
+    assert (
+        _normalize_bedrock_model_name("anthropic.claude-opus-4-6-20250514-v1:0")
+        == "anthropic.claude-opus-4-6"
+    )
+    # No suffix: unchanged.
+    assert (
+        _normalize_bedrock_model_name("anthropic.claude-opus-4-8")
+        == "anthropic.claude-opus-4-8"
+    )
+    # Non-Claude provider id with a version suffix collapses to its bare form.
+    assert _normalize_bedrock_model_name("amazon.nova-pro-v1:0") == "amazon.nova-pro"
+
+
 def test_bedrock_claude_cached_session_estimates_cost_not_unknown():
     """A Bedrock Claude session with cache hits must produce a dollar estimate,
     not ``unknown`` — the user-visible symptom in #50295.


### PR DESCRIPTION
## Problem

Bedrock foundation-model IDs returned by `ListFoundationModels` and inference profiles carry a trailing **revision suffix** that the bare `_OFFICIAL_DOCS_PRICING` keys don't have:

- a release date — `-20250514`
- a Bedrock model version — `-v1`
- and/or a minor revision — `:0`

e.g. `anthropic.claude-sonnet-4-5-20250929-v1:0` or `anthropic.claude-opus-4-6-v1`.

`_lookup_official_docs_pricing` does an **exact dict-key match** on the normalized name. `_normalize_bedrock_model_name` strips the region prefix (`us.`/`global.`/…) and normalizes dot-notation versions, but does **not** strip that trailing suffix — so any id carrying it misses its bare pricing row and the session reports `Total cost: unknown` even though the row exists.

### Reproduce on `main`

```python
from agent.usage_pricing import get_pricing_entry
url = "https://bedrock-runtime.us-east-1.amazonaws.com"
# bare id — resolves
get_pricing_entry("anthropic.claude-sonnet-4-5", provider="bedrock", base_url=url)  # -> PricingEntry
# real id AWS actually returns — misses, prices as unknown
get_pricing_entry("anthropic.claude-sonnet-4-5-20250929-v1:0", provider="bedrock", base_url=url)  # -> None
get_pricing_entry("anthropic.claude-opus-4-6-v1", provider="bedrock", base_url=url)  # -> None
```

## Fix

Add a trailing-suffix strip to `_normalize_bedrock_model_name`, anchored to the end of the string. It only matches an 8-digit date, `-vN`, and `:N` — so the model version itself (`-4-6` / `-4-8`) is never eaten, and non-Claude provider IDs (`amazon.nova-pro-v1:0` → `amazon.nova-pro`) collapse correctly too.

```python
name = re.sub(r"(-\d{8})?(-v\d+)?(:\d+)?$", "", name)
```

## Scope / relation to other work

This is the **`-v1`/date-suffix facet** of #50295. It is distinct from and non-overlapping with:
- **#46299** (open) — adds `cache_read`/`cache_write` cost *fields* to existing Bedrock Claude rows. That edits existing rows; this fixes key *matching*. No conflict.
- The cross-region-prefix facet (`us.`/`global.`/`eu.`) — already handled in `_normalize_bedrock_model_name` and covered by `test_bedrock_cross_region_profile_prefix_resolves_to_pricing`.

It does **not** add the missing current-gen rows (opus-4-8/4-7, sonnet-5) — that needs authoritative commercial (non-GovCloud) pricing numbers and is left for a separate change / maintainer with those figures.

## Tests

Two regression tests in `tests/agent/test_usage_pricing.py`:
- `test_bedrock_version_suffix_resolves_to_pricing` — asserts every suffixed shape (with/without cross-region prefix) resolves to the **same entry as the bare id** (an invariant, not a frozen dollar value, per the repo's "behavior contracts over snapshots" guidance).
- `test_bedrock_version_suffix_normalizer_preserves_model_version` — asserts the stripper preserves the model version and bare provider IDs.

`tests/agent/test_usage_pricing.py`: 17 passed. Ruff clean on both files.