### PR TITLE
fix(xai): pin OAuth TTS/STT requests to resolved xAI base UR

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -1269,6 +1269,38 @@ class TestTranscribeXAI:
         url = call_args[0][0] if call_args[0] else call_args.kwargs.get("url", "")
         assert "custom.x.ai" in url
 
+    def test_oauth_credentials_ignore_stt_base_url_override(
+        self,
+        monkeypatch,
+        sample_ogg,
+        mock_xai_http_module,
+    ):
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        monkeypatch.setenv("XAI_STT_BASE_URL", "https://attacker.example/v1")
+        mock_xai_http_module.resolve_xai_http_credentials.return_value = {
+            "provider": "xai-oauth",
+            "api_key": "oauth-bearer-token",
+            "base_url": "https://api.x.ai/v1",
+        }
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"text": "test", "language": "en", "duration": 1.0}
+
+        with patch(
+            "tools.transcription_tools._load_stt_config",
+            return_value={"xai": {"base_url": "https://attacker.example/config"}},
+        ), patch("requests.post", return_value=mock_response) as mock_post:
+            from tools.transcription_tools import _transcribe_xai
+
+            result = _transcribe_xai(sample_ogg, "grok-stt")
+
+        assert result["success"] is True
+        call_args = mock_post.call_args
+        url = call_args[0][0] if call_args[0] else call_args.kwargs.get("url", "")
+        assert url == "https://api.x.ai/v1/stt"
+        assert call_args.kwargs["headers"]["Authorization"] == "Bearer oauth-bearer-token"
+
     def test_diarize_sent_when_configured(self, monkeypatch, sample_ogg, mock_xai_http_module):
         monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
 

--- a/tests/tools/test_tts_xai_speech_tags.py
+++ b/tests/tools/test_tts_xai_speech_tags.py
@@ -132,6 +132,48 @@ def test_generate_xai_tts_sends_auxiliary_rewriter_output_to_api(
     assert captured["json"]["text"] == rewriter_output
 
 
+def test_generate_xai_tts_uses_oauth_pinned_base_url(tmp_path, monkeypatch):
+    """OAuth bearer tokens must not follow user/env base URL overrides."""
+    captured = {}
+
+    class FakeResponse:
+        content = b"mp3"
+
+        def raise_for_status(self):
+            pass
+
+    def fake_post(url, headers, json, timeout):
+        captured["url"] = url
+        captured["headers"] = headers
+        return FakeResponse()
+
+    monkeypatch.setenv("XAI_BASE_URL", "https://attacker.example/v1")
+    monkeypatch.setattr(
+        "tools.xai_http.resolve_xai_http_credentials",
+        lambda: {
+            "provider": "xai-oauth",
+            "api_key": "oauth-bearer-token",
+            "base_url": "https://api.x.ai/v1",
+        },
+    )
+    monkeypatch.setattr("requests.post", fake_post)
+
+    out = tmp_path / "out.mp3"
+    _generate_xai_tts(
+        "Bonjour.",
+        str(out),
+        {
+            "xai": {
+                "base_url": "https://attacker.example/config",
+                "auto_speech_tags": False,
+            }
+        },
+    )
+
+    assert captured["url"] == "https://api.x.ai/v1/tts"
+    assert captured["headers"]["Authorization"] == "Bearer oauth-bearer-token"
+
+
 def test_auto_speech_tags_calls_auxiliary_rewriter_with_tts_audio_tags_task():
     """When input has no explicit speech tags, the function must call the
     auxiliary rewriter with task='tts_audio_tags' and a system prompt

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1448,12 +1448,15 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
 
     stt_config = _load_stt_config()
     xai_config = stt_config.get("xai") or {}
-    base_url = str(
-        xai_config.get("base_url")
-        or get_env_value("XAI_STT_BASE_URL")
-        or creds.get("base_url")
-        or XAI_STT_BASE_URL
-    ).strip().rstrip("/")
+    if creds.get("provider") == "xai-oauth":
+        base_url = str(creds.get("base_url") or XAI_STT_BASE_URL).strip().rstrip("/")
+    else:
+        base_url = str(
+            xai_config.get("base_url")
+            or get_env_value("XAI_STT_BASE_URL")
+            or creds.get("base_url")
+            or XAI_STT_BASE_URL
+        ).strip().rstrip("/")
     language = str(
         xai_config.get("language")
         or os.getenv("HERMES_LOCAL_STT_LANGUAGE")

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1240,12 +1240,15 @@ def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -
         optimize_streaming_latency = max(0, min(2, optimize_streaming_latency))
     if auto_speech_tags:
         text = _apply_xai_auto_speech_tags(text)
-    base_url = str(
-        xai_config.get("base_url")
-        or creds.get("base_url")
-        or get_env_value("XAI_BASE_URL")
-        or DEFAULT_XAI_BASE_URL
-    ).strip().rstrip("/")
+    if creds.get("provider") == "xai-oauth":
+        base_url = str(creds.get("base_url") or DEFAULT_XAI_BASE_URL).strip().rstrip("/")
+    else:
+        base_url = str(
+            xai_config.get("base_url")
+            or creds.get("base_url")
+            or get_env_value("XAI_BASE_URL")
+            or DEFAULT_XAI_BASE_URL
+        ).strip().rstrip("/")
 
     # Match the documented minimal POST /v1/tts shape by default. Only send
     # output_format when Hermes actually needs a non-default format/override.


### PR DESCRIPTION
## Summary

xAI OAuth credentials are intentionally pinned to an xAI-owned inference origin by the auth layer, because an override such as `XAI_BASE_URL=https://attacker.example/v1` would otherwise send the user's SuperGrok OAuth bearer token to a third party.

The xAI TTS and STT side-tool paths resolved OAuth credentials through `resolve_xai_http_credentials()`, but then allowed tool config or env base URL overrides to replace the resolver's pinned `base_url` before sending `Authorization: Bearer ...`.

This PR makes OAuth-authenticated TTS/STT calls use the resolved xAI base URL only. API-key based xAI usage keeps the existing custom base URL behavior.

## Changes

- In `tools/tts_tool.py`, when `resolve_xai_http_credentials()` returns `provider == "xai-oauth"`, use only the resolver-provided `base_url`.
- In `tools/transcription_tools.py`, apply the same OAuth-only base URL pinning for xAI STT.
- Preserve custom `XAI_BASE_URL`, `XAI_STT_BASE_URL`, and config `base_url` behavior for non-OAuth/API-key credentials.
- Add regressions proving OAuth TTS/STT requests ignore attacker-controlled base URL overrides and send the bearer only to the pinned xAI endpoint.

## Why

The auth layer already treats xAI OAuth base URL overrides as a credential-leak vector and validates them before returning runtime credentials. Side tools should not bypass that boundary after credentials have been resolved.

## Tests

```text
python -m pytest -p no:timeout -p no:cacheprovider tests/tools/test_tts_xai_speech_tags.py tests/tools/test_transcription_tools.py -k "xai" -q --tb=short
48 passed, 87 deselected

python -m ruff check --no-cache tools/tts_tool.py tools/transcription_tools.py tests/tools/test_tts_xai_speech_tags.py tests/tools/test_transcription_tools.py