### PR TITLE
feat(config): add streaming override for providers and models

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2835,6 +2835,19 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             "stream" in _err_lower
                             and "not supported" in _err_lower
                         )
+                        # Some LiteLLM proxy/model combinations accept
+                        # stream=True, but route the request to a non-streaming
+                        # upstream and then crash while iterating the completed
+                        # ModelResponse: "'async for' requires an object with
+                        # __aiter__ method, got ModelResponse". Treat that as a
+                        # permanent streaming-unsupported signal for the current
+                        # session so the outer retry uses non-streaming instead
+                        # of replaying the same proxy 500.
+                        _is_litellm_modelresponse_stream_bug = (
+                            "async for" in _err_lower
+                            and "__aiter__" in _err_lower
+                            and "modelresponse" in _err_lower
+                        )
                         # AWS Bedrock (AnthropicBedrock SDK path): IAM policies
                         # with bedrock:InvokeModel but not
                         # InvokeModelWithResponseStream reject messages.stream()
@@ -2856,7 +2869,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             _is_bedrock_stream_denied = (
                                 is_streaming_access_denied_error(e)
                             )
-                        if _is_stream_unsupported or _is_bedrock_stream_denied:
+                        if (
+                            _is_stream_unsupported
+                            or _is_litellm_modelresponse_stream_bug
+                            or _is_bedrock_stream_denied
+                        ):
                             agent._disable_streaming = True
                             agent._safe_print(
                                 "\n⚠  AWS IAM denied bedrock:InvokeModelWithResponseStream. "

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -47,6 +47,7 @@ from agent.message_sanitization import (
     _strip_images_from_messages,
     _strip_non_ascii,
 )
+from hermes_cli.timeouts import get_provider_streaming_enabled
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
     estimate_messages_tokens_rough,
@@ -1282,7 +1283,14 @@ def run_conversation(
                 # Provider signaled "stream not supported" on a previous
                 # attempt — switch to non-streaming for the rest of this
                 # session instead of re-failing every retry.
+                _streaming_override = None
+                if not getattr(agent, "_disable_streaming", False):
+                    _streaming_override = get_provider_streaming_enabled(
+                        agent.provider, agent.model, agent.base_url
+                    )
                 if getattr(agent, "_disable_streaming", False):
+                    _use_streaming = False
+                elif _streaming_override is False:
                     _use_streaming = False
                 # CopilotACPClient communicates via subprocess stdio and
                 # returns a plain SimpleNamespace — not an iterable

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4701,7 +4701,7 @@ def _normalize_custom_provider_entry(
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models", "extra_body", "extra_headers",
-        "ssl_ca_cert", "ssl_verify",
+        "ssl_ca_cert", "ssl_verify", "streaming",
     }
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:
@@ -4843,6 +4843,12 @@ def _normalize_custom_provider_entry(
     elif isinstance(ssl_verify, str) and ssl_verify.strip():
         normalized["ssl_verify"] = ssl_verify.strip()
 
+    streaming = entry.get("streaming")
+    if isinstance(streaming, bool):
+        normalized["streaming"] = streaming
+    elif isinstance(streaming, str) and streaming.strip():
+        normalized["streaming"] = streaming.strip()
+
     return normalized
 
 
@@ -4873,6 +4879,7 @@ def _custom_provider_entry_to_provider_config(
         "extra_headers",
         "ssl_ca_cert",
         "ssl_verify",
+        "streaming",
     ):
         if field in normalized:
             provider_entry[field] = normalized[field]
@@ -5214,7 +5221,7 @@ _KNOWN_ROOT_KEYS = {
 _VALID_CUSTOM_PROVIDER_FIELDS = {
     "name", "base_url", "api_key", "api_mode", "model", "models",
     "context_length", "rate_limit_delay", "extra_body",
-    "ssl_ca_cert", "ssl_verify",
+    "ssl_ca_cert", "ssl_verify", "streaming",
     # key_env is read at runtime by runtime_provider.py and auxiliary_client.py
     # — include it here so the set accurately describes the supported schema.
     "key_env",

--- a/hermes_cli/timeouts.py
+++ b/hermes_cli/timeouts.py
@@ -1,6 +1,18 @@
 from __future__ import annotations
 
 
+def _coerce_optional_bool(raw: object) -> bool | None:
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, str):
+        lowered = raw.strip().lower()
+        if lowered in {"true", "1", "yes", "on"}:
+            return True
+        if lowered in {"false", "0", "no", "off"}:
+            return False
+    return None
+
+
 def _coerce_timeout(raw: object) -> float | None:
     try:
         timeout = float(raw)
@@ -67,6 +79,81 @@ def get_provider_stale_timeout(
             return timeout
 
     return _coerce_timeout(provider_config.get("stale_timeout_seconds"))
+
+
+def get_provider_streaming_enabled(
+    provider_id: str, model: str | None = None, base_url: str | None = None
+) -> bool | None:
+    """Return provider/model streaming override, if configured.
+
+    ``None`` means no explicit override; callers should use the default runtime
+    streaming policy. ``False`` disables stream=True for the matching provider or
+    model route, which is useful for proxies/models that expose non-streaming
+    Chat Completions only. ``base_url`` lets custom endpoints resolve settings
+    from their named ``providers`` / ``custom_providers`` entry even when the
+    runtime provider id is the generic ``custom``.
+    """
+    if not provider_id:
+        return None
+
+    try:
+        from hermes_cli.config import load_config_readonly
+        config = load_config_readonly()
+    except Exception:
+        return None
+
+    providers = config.get("providers", {}) if isinstance(config, dict) else {}
+    provider_config = (
+        providers.get(provider_id, {}) if isinstance(providers, dict) else {}
+    )
+    if not isinstance(provider_config, dict):
+        provider_config = {}
+
+    streaming = _get_streaming_from_provider_config(provider_config, model)
+    if streaming is not None:
+        return streaming
+
+    if base_url:
+        custom_config = _get_custom_provider_config_by_base_url(config, base_url)
+        if custom_config is not None:
+            streaming = _get_streaming_from_provider_config(custom_config, model)
+            if streaming is not None:
+                return streaming
+    return None
+
+
+def _get_streaming_from_provider_config(
+    provider_config: dict[str, object], model: str | None
+) -> bool | None:
+    model_config = _get_model_config(provider_config, model)
+    if model_config is not None:
+        streaming = _coerce_optional_bool(model_config.get("streaming"))
+        if streaming is not None:
+            return streaming
+    return _coerce_optional_bool(provider_config.get("streaming"))
+
+
+def _get_custom_provider_config_by_base_url(
+    config: dict[str, object], base_url: str
+) -> dict[str, object] | None:
+    target = str(base_url or "").rstrip("/").lower()
+    if not target:
+        return None
+
+    try:
+        from hermes_cli.config import get_compatible_custom_providers
+
+        entries = get_compatible_custom_providers(config)
+    except Exception:
+        entries = []
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        entry_url = str(entry.get("base_url") or "").rstrip("/").lower()
+        if entry_url == target:
+            return entry
+    return None
 
 
 def _get_model_config(

--- a/run_agent.py
+++ b/run_agent.py
@@ -119,6 +119,7 @@ from agent.iteration_budget import IterationBudget
 from hermes_cli.env_loader import load_hermes_dotenv
 from hermes_cli.timeouts import (
     get_provider_request_timeout,
+    get_provider_streaming_enabled,
     get_provider_stale_timeout,
 )
 
@@ -4560,11 +4561,19 @@ class AIAgent:
         # api_mode-flip race (the Anthropic SDK raises a non-retryable
         # TypeError on them). See #31673.
         from agent.anthropic_adapter import create_anthropic_message
+        _streaming_override = get_provider_streaming_enabled(
+            self.provider,
+            self.model,
+            getattr(self, "_anthropic_base_url", None) or self.base_url,
+        )
         return create_anthropic_message(
             self._anthropic_client,
             api_kwargs,
             log_prefix=getattr(self, "log_prefix", ""),
-            prefer_stream=not bool(getattr(self, "_disable_streaming", False)),
+            prefer_stream=(
+                not bool(getattr(self, "_disable_streaming", False))
+                and _streaming_override is not False
+            ),
         )
 
     def _rebuild_anthropic_client(self) -> None:

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -136,17 +136,19 @@ class TestNormalizeCustomProviderEntry:
         ]
         assert len(unknown_warnings) == 1
 
-    def test_timeout_keys_not_flagged_unknown(self, caplog):
-        """request_timeout_seconds and stale_timeout_seconds should not produce warnings."""
+    def test_runtime_keys_not_flagged_unknown(self, caplog):
+        """Runtime provider knobs should not produce warnings."""
         entry = {
             "base_url": "https://api.example.com/v1",
             "api_key": "***",
             "request_timeout_seconds": 300,
             "stale_timeout_seconds": 900,
+            "streaming": False,
         }
         with caplog.at_level(logging.WARNING):
             result = _normalize_custom_provider_entry(entry, provider_key="test")
         assert result is not None
+        assert result["streaming"] is False
         assert not any("unknown config keys" in r.message.lower() for r in caplog.records)
 
     def test_camel_case_warning_logged(self, caplog):

--- a/tests/hermes_cli/test_timeouts.py
+++ b/tests/hermes_cli/test_timeouts.py
@@ -4,6 +4,7 @@ import textwrap
 
 from hermes_cli.timeouts import (
     get_provider_request_timeout,
+    get_provider_streaming_enabled,
     get_provider_stale_timeout,
 )
 
@@ -128,6 +129,81 @@ def test_invalid_stale_timeout_values_return_none(monkeypatch, tmp_path):
 
     assert get_provider_stale_timeout("openai-codex", "gpt-5.4") is None
     assert get_provider_stale_timeout("openai-codex", "gpt-5.5") is None
+
+
+def test_provider_streaming_override_used_when_no_model_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(
+        tmp_path,
+        """\
+        providers:
+          litellm:
+            streaming: false
+        """,
+    )
+
+    assert get_provider_streaming_enabled("litellm", "gpt-5.5") is False
+
+
+def test_model_streaming_override_wins(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(
+        tmp_path,
+        """\
+        providers:
+          litellm:
+            streaming: true
+            models:
+              gpt-5.5:
+                streaming: false
+        """,
+    )
+
+    assert get_provider_streaming_enabled("litellm", "gpt-5.5") is False
+    assert get_provider_streaming_enabled("litellm", "gpt-4.1") is True
+
+
+def test_custom_provider_streaming_resolves_by_base_url(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(
+        tmp_path,
+        """\
+        providers:
+          corporate-litellm:
+            base_url: https://litellm.example.com/v1
+            streaming: true
+            models:
+              gpt-5.5:
+                streaming: false
+        """,
+    )
+
+    assert (
+        get_provider_streaming_enabled(
+            "custom", "gpt-5.5", "https://litellm.example.com/v1/"
+        )
+        is False
+    )
+    assert (
+        get_provider_streaming_enabled(
+            "custom", "gpt-4.1", "https://litellm.example.com/v1/"
+        )
+        is True
+    )
+
+
+def test_invalid_streaming_override_returns_none(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(
+        tmp_path,
+        """\
+        providers:
+          litellm:
+            streaming: sometimes
+        """,
+    )
+
+    assert get_provider_streaming_enabled("litellm", "gpt-5.5") is None
 
 
 def test_anthropic_adapter_honors_timeout_kwarg():

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6716,6 +6716,43 @@ class TestAnthropicCredentialRefresh:
         agent._anthropic_client.messages.create.assert_called_once_with(model="claude-sonnet-4-20250514")
         assert result is response
 
+    def test_anthropic_messages_create_honors_provider_streaming_false(self):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()),
+        ):
+            agent = AIAgent(
+                api_key="sk-ant-oat01-current-token",
+                base_url="https://openrouter.ai/api/v1",
+                api_mode="anthropic_messages",
+                provider="openrouter",
+                model="claude-sonnet-4-20250514",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        response = SimpleNamespace(content=[])
+        agent._anthropic_base_url = "https://openrouter.ai/api/v1"
+        agent._anthropic_client = MagicMock()
+        agent._anthropic_client.messages.create.return_value = response
+
+        with (
+            patch.object(agent, "_try_refresh_anthropic_client_credentials", return_value=False),
+            patch("run_agent.get_provider_streaming_enabled", return_value=False) as streaming_enabled,
+        ):
+            result = agent._anthropic_messages_create({"model": "claude-sonnet-4-20250514"})
+
+        streaming_enabled.assert_called_once_with(
+            "openrouter",
+            "claude-sonnet-4-20250514",
+            "https://openrouter.ai/api/v1",
+        )
+        agent._anthropic_client.messages.stream.assert_not_called()
+        agent._anthropic_client.messages.create.assert_called_once_with(model="claude-sonnet-4-20250514")
+        assert result is response
+
     def test_anthropic_messages_create_does_not_mask_bedrock_stream_validation_errors(self):
         with (
             patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -600,6 +600,38 @@ class TestStreamingFallback:
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_litellm_modelresponse_stream_500_sets_flag_and_raises(
+        self, mock_close, mock_create
+    ):
+        """LiteLLM's ModelResponse stream bug means the model route is non-streaming."""
+        from run_agent import AIAgent
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = Exception(
+            "HTTP 500: 'async for' requires an object with __aiter__ method, "
+            "got ModelResponse"
+        )
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://litellm.example.com/v1",
+            provider="custom",
+            model="gpt-5.5",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        with pytest.raises(Exception, match="ModelResponse"):
+            agent._interruptible_streaming_api_call({})
+
+        assert agent._disable_streaming is True
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
     def test_non_transport_error_propagates(self, mock_close, mock_create):
         """Non-transport streaming errors propagate to the main retry loop."""
         from run_agent import AIAgent
@@ -1641,6 +1673,66 @@ def _valid_acp_response():
         usage=SimpleNamespace(prompt_tokens=5, completion_tokens=3),
         model="claude-opus-4.7",
     )
+
+
+class TestProviderStreamingConfig:
+    """Provider config can force the conversation loop to use non-streaming."""
+
+    def test_model_streaming_false_routes_to_non_streaming(self):
+        from run_agent import AIAgent
+        from agent.conversation_loop import run_conversation
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://litellm.example.com/v1",
+            provider="custom",
+            model="gpt-5.5",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent.messages = []
+        agent.tools = []
+        agent.max_iterations = 1
+
+        final_response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content="non-streaming ok",
+                        tool_calls=None,
+                        role="assistant",
+                    ),
+                    finish_reason="stop",
+                )
+            ],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=2, total_tokens=3),
+            model="gpt-5.5",
+        )
+
+        with (
+            patch(
+                "agent.conversation_loop.get_provider_streaming_enabled",
+                return_value=False,
+            ) as mock_streaming_enabled,
+            patch.object(
+                agent,
+                "_interruptible_api_call",
+                return_value=final_response,
+            ) as mock_non_stream,
+            patch.object(agent, "_interruptible_streaming_api_call") as mock_stream,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = run_conversation(agent, "hello")
+
+        assert result["completed"] is True
+        assert result["final_response"] == "non-streaming ok"
+        mock_streaming_enabled.assert_called()
+        mock_non_stream.assert_called_once()
+        mock_stream.assert_not_called()
 
 
 def _make_acp_agent(provider="copilot-acp", base_url="acp://copilot"):

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1116,6 +1116,19 @@ model:
   api_key: your-together-key
 ```
 
+For named custom endpoints, provider-specific runtime knobs live under `providers.<id>`. Set `streaming: false` when a proxy or model route accepts normal Chat Completions but fails `stream=True`:
+
+```yaml
+providers:
+  corporate-litellm:
+    base_url: https://litellm.example.com/v1
+    api_key: ${LITELLM_API_KEY}
+    streaming: true
+    models:
+      gpt-5.5:
+        streaming: false
+```
+
 ---
 
 ### Context Length Detection

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -89,6 +89,8 @@ You can set `providers.<id>.request_timeout_seconds` for a provider-wide request
 
 You can also set `providers.<id>.stale_timeout_seconds` for the non-streaming stale-call detector, plus `providers.<id>.models.<model>.stale_timeout_seconds` for a model-specific override. This wins over the legacy `HERMES_API_CALL_STALE_TIMEOUT` env var.
 
+You can disable `stream=True` for a provider or a specific model route with `providers.<id>.streaming: false` or `providers.<id>.models.<model>.streaming: false`. Use this for OpenAI-compatible proxies where only some model routes fail streaming but work as normal non-streaming Chat Completions.
+
 Leaving these unset keeps the legacy defaults (`HERMES_API_TIMEOUT=1800`s, `HERMES_API_CALL_STALE_TIMEOUT=90`s, native Anthropic 900s). The non-streaming stale detector is auto-disabled for local endpoints when left implicit and can scale upward for very large contexts. Not currently wired for AWS Bedrock (both `bedrock_converse` and AnthropicBedrock SDK paths use boto3 with its own timeout configuration). See the commented example in [`cli-config.yaml.example`](https://github.com/NousResearch/hermes-agent/blob/main/cli-config.yaml.example).
 
 ## Update Behavior


### PR DESCRIPTION
## What does this PR do?

Add support for `streaming` configuration option to disable `stream=True` for specific providers or model routes. This is useful for OpenAI-compatible proxies where only some model routes fail streaming but work as normal non-streaming Chat Completions.

## Related Issue

Extends https://github.com/NousResearch/hermes-agent/pull/60894

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

Changes include:
- New `_coerce_optional_bool()` helper to parse boolean config values
- `get_provider_streaming_enabled()` function to resolve streaming config from provider/model hierarchy and custom provider base URLs
- Detection of LiteLLM's ModelResponse stream bug in `interruptible_streaming_api_call()` to treat it as permanent streaming-unsupported signal
- Conversation loop now checks provider streaming config before deciding to use streaming
- Config validation and normalization for the new `streaming` field
- Documentation updates with examples for provider-specific and model-specific streaming overrides

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Have a litellm proxy that doesn't support streaming on a model
2. prompt model
3. Hermes will auto switch to no streaming instead of producing an Error 500

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

Previous to fix:

<img width="1133" height="476" alt="image" src="https://github.com/user-attachments/assets/a7844dfc-3cbd-455a-a13e-655d9d5673d1" />

