### PR TITLE
fix(desktop): chmod spawn-helper executable after staging

### DIFF
--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -13,6 +13,7 @@ import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve, join } from 'node:path'
 import {
+  chmodSync,
   cpSync,
   existsSync,
   mkdirSync,
@@ -114,7 +115,16 @@ export function stageNodePty({ platform = process.platform, arch = process.arch 
         continue
       }
       if (entry.name === 'spawn-helper') {
-        cpSync(join(prebuildDir, entry.name), join(destPrebuild, entry.name))
+        // fs.cpSync does not preserve the source file's permission bits — the
+        // destination is created with the default mode from the process
+        // umask, not the source's mode. spawn-helper must be executable
+        // (node-pty's unixTerminal.js posix_spawns it directly), so restore
+        // the bit explicitly or every staged build silently ships a
+        // non-executable spawn-helper and the in-app terminal fails with
+        // "posix_spawnp failed".
+        const dest = join(destPrebuild, entry.name)
+        cpSync(join(prebuildDir, entry.name), dest)
+        chmodSync(dest, 0o755)
       }
     }
   } else {


### PR DESCRIPTION
Fixes #62324

## Summary

`stage-native-deps.mjs` copies node-pty's `spawn-helper` binary via `fs.cpSync` with no follow-up permission check. If the source binary (under `node_modules/node-pty/prebuilds/<platform>-<arch>/`) is ever non-executable at the point this script runs — e.g. from an `--ignore-scripts` install skipping node-pty's own postinstall chmod fixup, or a tar-extraction quirk in `prebuild-install` — that state silently propagates into every staged copy: `dist/`, the packed `.app`'s `asar.unpacked`, and the release build all ship a non-executable `spawn-helper`.

`node-pty`'s `unixTerminal.js` posix_spawns this binary directly, so a non-executable copy makes the in-app terminal fail outright:

```
Terminal failed to start: Error invoking remote method 'hermes:terminal:start': Error: posix_spawnp failed.
```

Reproduced this on a real build — found the identical broken permissions (`-rw-r--r--`, same timestamp) across every location this script populates, including the true source under `node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper`. Manually `chmod +x`-ing any one of the staged copies fixes the terminal immediately (no relaunch needed, since exec permission is checked fresh on every spawn attempt).

## Fix

Explicitly `chmodSync(dest, 0o755)` after staging `spawn-helper`, so this step is self-healing regardless of the source's permission state — cheap insurance for a binary that must be executable to be useful at all.

## Testing

- `node --check` passes on the modified file.
- Verified in isolation that `fs.cpSync` does preserve source permission bits correctly on this Node version (so the bug isn't in the copy call itself, it's the lack of any defensive check) — see the correction comment on the linked issue.
- Could not run the full `stageNodePty()` end-to-end in a fresh checkout without a full `npm install` of the workspace; happy to add a targeted unit test around this function if maintainers want one, just let me know the preferred test harness for this script.