### PR TITLE
fix(desktop): chmod staged node-pty spawn-helper

### DIFF
--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -13,6 +13,7 @@ import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve, join } from 'node:path'
 import {
+  chmodSync,
   cpSync,
   existsSync,
   mkdirSync,
@@ -51,6 +52,13 @@ function copyGlobByExt(srcDir, destDir, extensions) {
   }
 }
 
+function copyNativeFile(src, dest, { executable = false } = {}) {
+  cpSync(src, dest)
+  if (executable) {
+    chmodSync(dest, 0o755)
+  }
+}
+
 /**
  * Copies the locally-compiled build/Release output (used when no prebuild
  * was available and node-pty was built from source for the host machine).
@@ -72,14 +80,20 @@ function copyBuildRelease(srcDir, destDir) {
       continue
     }
     if (entry.name === 'spawn-helper' || /\.(node|dll|exe)$/.test(entry.name)) {
-      cpSync(join(srcDir, entry.name), join(destDir, entry.name))
+      copyNativeFile(join(srcDir, entry.name), join(destDir, entry.name), {
+        executable: entry.name === 'spawn-helper'
+      })
     }
   }
 }
 
-export function stageNodePty({ platform = process.platform, arch = process.arch } = {}) {
-  const srcRoot = resolveNodePtyRoot()
-  const destRoot = resolve(projectRoot, 'dist/node_modules/node-pty')
+export function stageNodePty({
+  platform = process.platform,
+  arch = process.arch,
+  sourceRoot = resolveNodePtyRoot(),
+  destRoot = resolve(projectRoot, 'dist/node_modules/node-pty')
+} = {}) {
+  const srcRoot = sourceRoot
 
   rmSync(destRoot, { recursive: true, force: true })
   mkdirSync(destRoot, { recursive: true })
@@ -110,11 +124,13 @@ export function stageNodePty({ platform = process.platform, arch = process.arch 
         continue
       }
       if (entry.isFile() && /\.(node|dll|exe)$/.test(entry.name)) {
-        cpSync(join(prebuildDir, entry.name), join(destPrebuild, entry.name))
+        copyNativeFile(join(prebuildDir, entry.name), join(destPrebuild, entry.name))
         continue
       }
       if (entry.name === 'spawn-helper') {
-        cpSync(join(prebuildDir, entry.name), join(destPrebuild, entry.name))
+        copyNativeFile(join(prebuildDir, entry.name), join(destPrebuild, entry.name), {
+          executable: true
+        })
       }
     }
   } else {

--- a/apps/desktop/scripts/stage-native-deps.test.mjs
+++ b/apps/desktop/scripts/stage-native-deps.test.mjs
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import { stageNodePty } from './stage-native-deps.mjs'
+
+function makeNodePtyFixture() {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-stage-native-deps-'))
+  const sourceRoot = path.join(tempRoot, 'node-pty')
+  const destRoot = path.join(tempRoot, 'dist', 'node_modules', 'node-pty')
+
+  fs.mkdirSync(path.join(sourceRoot, 'lib'), { recursive: true })
+  fs.writeFileSync(path.join(sourceRoot, 'package.json'), '{"main":"lib/index.js"}\n')
+  fs.writeFileSync(path.join(sourceRoot, 'lib', 'index.js'), 'export {}\n')
+
+  return { tempRoot, sourceRoot, destRoot }
+}
+
+function writeFileWithMode(file, mode) {
+  fs.mkdirSync(path.dirname(file), { recursive: true })
+  fs.writeFileSync(file, 'binary')
+  fs.chmodSync(file, mode)
+}
+
+function modeBits(file) {
+  return fs.statSync(file).mode & 0o777
+}
+
+test('stageNodePty makes prebuilt darwin spawn-helper executable', () => {
+  const { tempRoot, sourceRoot, destRoot } = makeNodePtyFixture()
+  try {
+    writeFileWithMode(path.join(sourceRoot, 'prebuilds', 'darwin-arm64', 'pty.node'), 0o644)
+    writeFileWithMode(path.join(sourceRoot, 'prebuilds', 'darwin-arm64', 'spawn-helper'), 0o644)
+
+    stageNodePty({ platform: 'darwin', arch: 'arm64', sourceRoot, destRoot })
+
+    const helper = path.join(destRoot, 'prebuilds', 'darwin-arm64', 'spawn-helper')
+    const native = path.join(destRoot, 'prebuilds', 'darwin-arm64', 'pty.node')
+
+    assert.equal(modeBits(helper), 0o755)
+    assert.equal(modeBits(native), 0o644)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('stageNodePty makes build/Release spawn-helper executable', () => {
+  const { tempRoot, sourceRoot, destRoot } = makeNodePtyFixture()
+  try {
+    writeFileWithMode(path.join(sourceRoot, 'build', 'Release', 'pty.node'), 0o644)
+    writeFileWithMode(path.join(sourceRoot, 'build', 'Release', 'spawn-helper'), 0o644)
+    writeFileWithMode(path.join(sourceRoot, 'prebuilds', 'linux-x64', 'pty.node'), 0o644)
+
+    stageNodePty({ platform: 'linux', arch: 'x64', sourceRoot, destRoot })
+
+    const helper = path.join(destRoot, 'build', 'Release', 'spawn-helper')
+    const native = path.join(destRoot, 'build', 'Release', 'pty.node')
+
+    assert.equal(modeBits(helper), 0o755)
+    assert.equal(modeBits(native), 0o644)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary

Fixes #62324.

Hermes Desktop stages node-pty native files into `apps/desktop/dist/node_modules/node-pty` before packaging. The macOS `spawn-helper` file is executed directly by node-pty, so a staged copy without execute bits makes terminal startup fail with `posix_spawnp failed`.

This change routes native file copies through a small helper and explicitly sets `spawn-helper` to `0755` in both staging paths:

- `prebuilds/<platform>-<arch>/spawn-helper`
- `build/Release/spawn-helper`

Other native payloads such as `.node` files keep their copied mode; only the executable helper is chmodded.

## Tests

```text
node --test apps/desktop/scripts/stage-native-deps.test.mjs
git diff --check
```

I also attempted `node --test apps/desktop/scripts/before-pack.test.mjs apps/desktop/scripts/stage-native-deps.test.mjs`; `stage-native-deps.test.mjs` passed, but `before-pack.test.mjs` could not load because this fresh worktree has no installed `electron-builder` package.
