### PR TITLE
fix(send_message): route bare sends to the session owner, not the global home channel

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -597,6 +597,133 @@ class TestSendMessageTool:
         assert "access_token=***" in result["error"]
 
 
+class TestSendMessageSessionOwnerRouting:
+    """C1 (2026-07-10) — a bare (no explicit chat_id) send from inside a gateway
+    session routes to the SESSION OWNER, never the global /sethome home channel.
+
+    In a multi-operator deployment, defaulting an operator session's output to
+    the single home channel delivers one operator's messages/files to whoever
+    ran /sethome (a cross-operator confidentiality leak). Fail-closed when the
+    owner is unknown; the home channel remains the default only for genuine
+    CLI/ad-hoc/cron sends with no session context, and for deliberate
+    cross-platform sends.
+    """
+
+    @staticmethod
+    def _config_with_home(home_chat_id):
+        config, _ = _make_config()
+        config.get_home_channel = lambda _platform: SimpleNamespace(chat_id=home_chat_id, name="Home")
+        return config
+
+    @staticmethod
+    def _send(target, message, *, config, session_env):
+        def _get_session_env(name, default=""):
+            return session_env.get(name, default)
+
+        send_mock = AsyncMock(return_value={"success": True})
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("gateway.session_context.get_session_env", side_effect=_get_session_env), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            result = json.loads(
+                send_message_tool({"action": "send", "target": target, "message": message})
+            )
+        return result, send_mock
+
+    def test_bare_send_routes_to_session_owner_not_home(self):
+        """In a telegram operator session, target='telegram' goes to the operator's
+        chat, NOT the founder /sethome home channel (the exact 2026-07-09 leak)."""
+        config = self._config_with_home("322794917")  # founder home
+        result, send_mock = self._send(
+            "telegram",
+            "here are your charts",
+            config=config,
+            session_env={"HERMES_SESSION_PLATFORM": "telegram", "HERMES_SESSION_CHAT_ID": "443861071"},
+        )
+        assert result["success"] is True
+        send_mock.assert_awaited_once()
+        assert send_mock.await_args.args[2] == "443861071"  # session owner, not 322794917
+        assert "322794917" not in json.dumps(result)
+        assert "session owner" in result.get("note", "")
+
+    def test_bare_send_carries_session_thread_id(self):
+        config = self._config_with_home("322794917")
+        result, send_mock = self._send(
+            "telegram",
+            "hi",
+            config=config,
+            session_env={
+                "HERMES_SESSION_PLATFORM": "telegram",
+                "HERMES_SESSION_CHAT_ID": "443861071",
+                "HERMES_SESSION_THREAD_ID": "17585",
+            },
+        )
+        assert result["success"] is True
+        assert send_mock.await_args.kwargs["thread_id"] == "17585"
+
+    def test_unknown_owner_fails_closed_no_home_fallback(self):
+        """In a session on this platform but the owner chat is unknown → do NOT
+        fall back to home; return an error and send nothing (leak invariant)."""
+        config = self._config_with_home("322794917")
+        result, send_mock = self._send(
+            "telegram",
+            "leak test",
+            config=config,
+            session_env={"HERMES_SESSION_PLATFORM": "telegram", "HERMES_SESSION_CHAT_ID": ""},
+        )
+        assert "error" in result
+        assert "322794917" not in json.dumps(result)  # never routed to home
+        send_mock.assert_not_awaited()
+
+    def test_cli_ad_hoc_still_uses_home(self):
+        """No gateway session (CLI/cron) → the home channel is the intended default."""
+        config = self._config_with_home("home-chat")
+        result, send_mock = self._send(
+            "telegram",
+            "cron report",
+            config=config,
+            session_env={},  # no HERMES_SESSION_PLATFORM → not a gateway session
+        )
+        assert result["success"] is True
+        send_mock.assert_awaited_once()
+        assert send_mock.await_args.args[2] == "home-chat"
+        assert "home channel" in result.get("note", "")
+
+    def test_cross_platform_send_in_session_uses_target_home(self):
+        """A telegram-session agent addressing a DIFFERENT platform (bare 'slack')
+        is a deliberate cross-platform send → target's home, not fail-closed."""
+        slack_cfg = SimpleNamespace(enabled=True, token="xoxb", extra={})
+        config = SimpleNamespace(
+            platforms={Platform.SLACK: slack_cfg},
+            get_home_channel=lambda _platform: SimpleNamespace(chat_id="C-slack-home", name="Home"),
+        )
+        result, send_mock = self._send(
+            "slack",
+            "cross-post",
+            config=config,
+            session_env={"HERMES_SESSION_PLATFORM": "telegram", "HERMES_SESSION_CHAT_ID": "443861071"},
+        )
+        assert result["success"] is True
+        assert send_mock.await_args.args[2] == "C-slack-home"
+        # cross-platform send is NOT session-owner routing: no "session owner" note
+        assert "session owner" not in result.get("note", "")
+
+    def test_explicit_target_bypasses_session_owner_logic(self):
+        """An explicit chat_id is used verbatim — session-owner routing only
+        applies when no chat_id was given."""
+        config = self._config_with_home("322794917")
+        result, send_mock = self._send(
+            "telegram:12345",
+            "hi",
+            config=config,
+            session_env={"HERMES_SESSION_PLATFORM": "telegram", "HERMES_SESSION_CHAT_ID": "443861071"},
+        )
+        assert result["success"] is True
+        assert send_mock.await_args.args[2] == "12345"
+
+
 class TestSendTelegramMediaDelivery:
     def test_sends_photo_with_caption_for_media_tag(self, tmp_path, monkeypatch):
         # A single captionable image + short text now rides as the photo's

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -440,6 +440,48 @@ def _handle_send(args):
     mirror_text = cleaned_message.strip() or _describe_media_for_mirror(media_files)
 
     used_home_channel = False
+    routed_to_session_owner = False
+    if not chat_id:
+        # Agent-initiated send with no explicit chat_id. BEFORE falling back to
+        # the configured home channel, prefer the OWNER of the current gateway
+        # session when we're operating inside one on THIS platform.
+        #
+        # Rationale: the home channel is a single global /sethome target. In a
+        # multi-operator deployment, defaulting a bare send from an operator's
+        # session to that home delivers one operator's messages/files to another
+        # (typically whoever ran /sethome) — a cross-operator confidentiality
+        # leak. The session owner's chat_id is the operator we are actually
+        # talking to. Mirrors the cron origin-routing in tools/cronjob_tools.py
+        # (HERMES_SESSION_PLATFORM / HERMES_SESSION_CHAT_ID). These contextvars
+        # are set per gateway message (gateway/run.py) and are task-local, so
+        # they survive context-compression rollovers within the same turn.
+        from gateway.session_context import get_session_env
+        session_platform = get_session_env("HERMES_SESSION_PLATFORM", "").strip().lower()
+        if session_platform == platform_name:
+            session_chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "").strip()
+            if session_chat_id:
+                chat_id = session_chat_id
+                routed_to_session_owner = True
+                # Defensive: an explicit caller thread wins. Today _parse_target_ref
+                # only yields a thread_id alongside a chat_id (never a bare thread),
+                # so thread_id is None here; the guard documents the intent and stays
+                # correct if that ever changes.
+                if thread_id is None:
+                    session_thread_id = get_session_env("HERMES_SESSION_THREAD_ID", "").strip()
+                    thread_id = session_thread_id or None
+            else:
+                # In a gateway session on this platform but the owner chat is
+                # unknown (e.g. a context-compression continuation that lost its
+                # chat context). FAIL CLOSED — do NOT fall back to the home
+                # channel: that is exactly the cross-operator leak vector. The
+                # agent must address an explicit target or say nothing.
+                return json.dumps({
+                    "error": f"Cannot resolve a delivery target on {platform_name}: this is an "
+                    f"operator session but its owner chat is unknown, and defaulting to the global "
+                    f"home channel could deliver to the wrong operator. Specify an explicit target "
+                    f"with '{platform_name}:CHAT_ID'."
+                })
+
     if not chat_id:
         home = config.get_home_channel(platform)
         if not home and platform_name == "weixin":
@@ -501,6 +543,12 @@ def _handle_send(args):
         )
         if used_home_channel and isinstance(result, dict) and result.get("success"):
             result["note"] = f"Sent to {platform_name} home channel (chat_id: {chat_id})"
+        elif routed_to_session_owner and isinstance(result, dict) and result.get("success"):
+            result["note"] = (
+                f"Sent to the current {platform_name} session owner (chat_id: {chat_id}); "
+                "no explicit target was given, so it was routed to the operator you are talking to "
+                "rather than the global home channel."
+            )
 
         # Mirror the sent message into the target's gateway session
         if isinstance(result, dict) and result.get("success") and mirror_text:


### PR DESCRIPTION
**Problem** — A `send_message` with no explicit `chat_id` falls straight back to the single global `/sethome` home channel (`config.get_home_channel`). In a multi-operator gateway that delivers one operator's messages/files to whoever ran `/sethome` — a cross-operator confidentiality leak (an agent in operator A's session doing a bare `send_message("telegram", …)` reaches operator B).

**Fix** — Before the home fallback, prefer the OWNER of the current gateway session when operating inside one on the same platform: route to `HERMES_SESSION_CHAT_ID` (carrying `HERMES_SESSION_THREAD_ID`). This **mirrors the existing cron origin-routing in `tools/cronjob_tools.py`** — no new mechanism. These contextvars are task-local, so they survive context-compression rollovers within the turn.

**Fail-closed** — In a same-platform session but the owner chat is unknown, return an actionable error (`platform:CHAT_ID`) and send nothing, rather than leaking to home. Only this already-ambiguous path changes; no-session (CLI/cron), cross-platform, and explicit-target paths are byte-identical to today.

**Test** — `TestSendMessageSessionOwnerRouting`, 6 cases across the routing matrix (owner-routing / thread-carry / fail-closed / CLI→home / cross-platform→home / explicit-target-verbatim). Green locally.

**Scope** — send only. The sibling `_handle_react` shares the same no-chat_id→home fallback but leaks only an emoji (no content) — a deliberate lower-severity follow-up.
