### PR TITLE
fix: guard Gemini fallback and gate Honcho context injection

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1193,6 +1193,7 @@ def init_agent(
         agent._fallback_chain = []
     agent._fallback_index = 0
     agent._fallback_activated = getattr(agent, "_fallback_activated", False)
+    agent._last_api_messages_for_fallback = []
     # Legacy attribute kept for backward compat (tests, external callers)
     agent._fallback_model = agent._fallback_chain[0] if agent._fallback_chain else None
     if agent._fallback_chain and not agent.quiet_mode:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -31,7 +31,11 @@ from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
 from agent.error_classifier import FailoverReason
 from agent.errors import EmptyStreamError
 from agent.turn_context import substitute_api_content
-from agent.gemini_native_adapter import is_native_gemini_base_url
+from agent.gemini_native_adapter import (
+    GeminiNativeClient,
+    is_native_gemini_base_url,
+    transcript_has_unsigned_gemini_tool_calls,
+)
 from agent.model_metadata import is_local_endpoint
 from agent.message_content import flatten_message_text
 from agent.message_sanitization import (
@@ -1531,39 +1535,35 @@ def _fallback_entry_unavailable_without_network(agent, fb: dict) -> Optional[str
 
 
 
-def _fallback_entry_incompatible_with_current_tool_history(agent, fb: dict) -> Optional[str]:
-    """Return a skip reason when a fallback cannot replay current tool history.
+def _native_gemini_fallback_transcript_skip_reason(agent, fb_client) -> Optional[str]:
+    """Return a skip reason when a resolved fallback cannot replay tool history.
 
     Native Gemini endpoints require Gemini-issued ``thought_signature`` metadata
-    (stored on tool calls as ``extra_content``) when replaying assistant
-    function-call parts. If the primary provider was not Gemini, existing tool
-    calls do not have those signatures, so switching into Gemini mid-transcript
-    produces a deterministic HTTP 400. Skip that fallback and try the next one.
+    (carried on tool calls via ``extra_content``) when replaying assistant
+    function-call parts. Tool calls produced elsewhere lack those signatures,
+    so switching into a native Gemini transport mid-transcript produces a
+    deterministic HTTP 400. Skip that fallback and try the next one.
+
+    Compatibility is decided from the *resolved* transport, never from
+    provider/model labels: ``resolve_provider_client()`` returns a
+    ``GeminiNativeClient`` only when the target endpoint speaks Gemini's
+    native REST API, so a ``gemini`` entry routed through Google's
+    OpenAI-compat ``/openai`` endpoint — or a Gemini-named model on an
+    aggregator — is never screened here.
+
+    Known conservative bias: ``_last_api_messages_for_fallback`` holds the
+    strict-sanitized outgoing copy, and strict-API sanitization strips
+    ``extra_content`` when the current model is not Gemini-family. Genuinely
+    signed history can therefore look unsigned after failing on a strict
+    non-Gemini provider; the guard then skips a fallback that might have
+    worked — the safe direction (never send a known-bad request).
     """
-    fb_provider = (fb.get("provider") or "").strip().lower()
-    fb_model = (fb.get("model") or "").strip().lower()
-    fb_base_url = (fb.get("base_url") or fb.get("baseUrl") or "").strip()
-    is_gemini_target = (
-        fb_provider == "gemini"
-        or fb_provider == "google"
-        or "gemini" in fb_model
-        or is_native_gemini_base_url(fb_base_url)
-    )
-    if not is_gemini_target:
+    if not isinstance(fb_client, GeminiNativeClient):
         return None
 
     messages = getattr(agent, "_last_api_messages_for_fallback", None) or []
-    for msg in messages:
-        if not isinstance(msg, dict) or msg.get("role") != "assistant":
-            continue
-        tool_calls = msg.get("tool_calls") or []
-        if not isinstance(tool_calls, list):
-            continue
-        for tool_call in tool_calls:
-            if not isinstance(tool_call, dict):
-                continue
-            if tool_call.get("extra_content") is None:
-                return "gemini_thought_signature_missing_after_non_gemini_tool_calls"
+    if transcript_has_unsigned_gemini_tool_calls(messages):
+        return "gemini_thought_signature_missing_after_non_gemini_tool_calls"
     return None
 
 
@@ -1620,16 +1620,6 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     fb_model = (fb.get("model") or "").strip()
     if not fb_provider or not fb_model:
         return agent._try_activate_fallback(reason)  # skip invalid, try next
-
-    transcript_skip_reason = _fallback_entry_incompatible_with_current_tool_history(agent, fb)
-    if transcript_skip_reason:
-        logger.warning(
-            "Fallback skip: %s/%s is incompatible with current tool-call history (%s)",
-            fb_provider,
-            fb_model,
-            transcript_skip_reason,
-        )
-        return agent._try_activate_fallback(reason)
 
     local_skip_reason = _fallback_entry_unavailable_without_network(agent, fb)
     if local_skip_reason:
@@ -1699,6 +1689,26 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 fb_provider)
             unavailable.add(fb_key)
             return agent._try_activate_fallback(reason)  # try next in chain
+
+        # Screen the *resolved* transport against the current tool-call
+        # history. Transcript-dependent, so the entry is NOT added to
+        # ``unavailable`` — a later turn without unsigned tool calls may
+        # use it.
+        transcript_skip_reason = _native_gemini_fallback_transcript_skip_reason(agent, fb_client)
+        if transcript_skip_reason:
+            logger.warning(
+                "Fallback skip: %s/%s resolved to a native Gemini endpoint "
+                "that cannot replay current tool-call history (%s)",
+                fb_provider,
+                fb_model,
+                transcript_skip_reason,
+            )
+            try:
+                fb_client.close()
+            except Exception:
+                pass
+            return agent._try_activate_fallback(reason)
+
         try:
             from hermes_cli.model_normalize import normalize_model_for_provider
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1531,6 +1531,43 @@ def _fallback_entry_unavailable_without_network(agent, fb: dict) -> Optional[str
 
 
 
+def _fallback_entry_incompatible_with_current_tool_history(agent, fb: dict) -> Optional[str]:
+    """Return a skip reason when a fallback cannot replay current tool history.
+
+    Native Gemini endpoints require Gemini-issued ``thought_signature`` metadata
+    (stored on tool calls as ``extra_content``) when replaying assistant
+    function-call parts. If the primary provider was not Gemini, existing tool
+    calls do not have those signatures, so switching into Gemini mid-transcript
+    produces a deterministic HTTP 400. Skip that fallback and try the next one.
+    """
+    fb_provider = (fb.get("provider") or "").strip().lower()
+    fb_model = (fb.get("model") or "").strip().lower()
+    fb_base_url = (fb.get("base_url") or fb.get("baseUrl") or "").strip()
+    is_gemini_target = (
+        fb_provider == "gemini"
+        or fb_provider == "google"
+        or "gemini" in fb_model
+        or is_native_gemini_base_url(fb_base_url)
+    )
+    if not is_gemini_target:
+        return None
+
+    messages = getattr(agent, "_last_api_messages_for_fallback", None) or []
+    for msg in messages:
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            continue
+        tool_calls = msg.get("tool_calls") or []
+        if not isinstance(tool_calls, list):
+            continue
+        for tool_call in tool_calls:
+            if not isinstance(tool_call, dict):
+                continue
+            if tool_call.get("extra_content") is None:
+                return "gemini_thought_signature_missing_after_non_gemini_tool_calls"
+    return None
+
+
+
 def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool:
     """Switch to the next fallback model/provider in the chain.
 
@@ -1583,6 +1620,16 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     fb_model = (fb.get("model") or "").strip()
     if not fb_provider or not fb_model:
         return agent._try_activate_fallback(reason)  # skip invalid, try next
+
+    transcript_skip_reason = _fallback_entry_incompatible_with_current_tool_history(agent, fb)
+    if transcript_skip_reason:
+        logger.warning(
+            "Fallback skip: %s/%s is incompatible with current tool-call history (%s)",
+            fb_provider,
+            fb_model,
+            transcript_skip_reason,
+        )
+        return agent._try_activate_fallback(reason)
 
     local_skip_reason = _fallback_entry_unavailable_without_network(agent, fb)
     if local_skip_reason:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1072,6 +1072,13 @@ def run_conversation(
         # the OpenAI SDK. Sanitizing here prevents the 3-retry cycle.
         _sanitize_messages_surrogates(api_messages)
 
+        # Keep the exact outbound replay history available to fallback
+        # activation. Native Gemini fallback targets require provider-issued
+        # thought signatures on replayed assistant function-call parts, so the
+        # fallback selector must be able to see whether current tool calls are
+        # Gemini-compatible before switching providers.
+        agent._last_api_messages_for_fallback = api_messages
+
         # Calculate approximate request size for logging and pressure checks.
         # estimate_messages_tokens_rough(api_messages) includes the system
         # prompt copy but not the tool schema payload, which is sent as a

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -253,6 +253,47 @@ def _tool_call_extra_signature(tool_call: Dict[str, Any]) -> Optional[str]:
     return None
 
 
+def tool_call_has_gemini_thought_signature(tool_call: Any) -> bool:
+    """Return True when a tool call carries a non-empty Gemini thought
+    signature that this adapter would replay as ``thoughtSignature``.
+
+    Kept next to ``_tool_call_extra_signature`` so callers screening
+    transcripts for native-Gemini compatibility (e.g. fallback selection)
+    share the exact extraction contract the request translator uses.
+    """
+    if not isinstance(tool_call, dict):
+        return False
+    return _tool_call_extra_signature(tool_call) is not None
+
+
+def transcript_has_unsigned_gemini_tool_calls(messages: Any) -> bool:
+    """Return True when replaying ``messages`` on the native Gemini API would
+    emit a ``functionCall`` part without a ``thoughtSignature`` — the request
+    shape Gemini rejects with a deterministic HTTP 400.
+
+    Mirrors ``_build_gemini_contents`` exactly: ``system`` and ``tool`` /
+    ``function`` roles never emit functionCall parts, non-dict messages and
+    tool calls are dropped by translation, and any other role's ``tool_calls``
+    are replayed. Kept in this module so the screen and the translator cannot
+    drift apart.
+    """
+    for msg in messages or []:
+        if not isinstance(msg, dict):
+            continue
+        role = str(msg.get("role") or "user").lower()
+        if role in ("system", "tool", "function"):
+            continue
+        tool_calls = msg.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            continue
+        for tool_call in tool_calls:
+            if not isinstance(tool_call, dict):
+                continue
+            if not tool_call_has_gemini_thought_signature(tool_call):
+                return True
+    return False
+
+
 def _translate_tool_call_to_gemini(tool_call: Dict[str, Any]) -> Dict[str, Any]:
     fn = tool_call.get("function") or {}
     args_raw = fn.get("arguments", "")
@@ -309,7 +350,10 @@ def _build_gemini_contents(messages: List[Dict[str, Any]]) -> tuple[List[Dict[st
     for msg in messages:
         if not isinstance(msg, dict):
             continue
-        role = str(msg.get("role") or "user")
+        # OpenAI-compatible roles are lowercase by convention, but normalize
+        # here so this translator and the fallback replay screen apply the
+        # same semantics to malformed/mixed-case transcript history.
+        role = str(msg.get("role") or "user").lower()
 
         if role == "system":
             system_text_parts.append(_coerce_content_to_text(msg.get("content")))

--- a/optional-skills/autonomous-ai-agents/honcho/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/honcho/SKILL.md
@@ -55,7 +55,7 @@ hermes honcho status    # shows resolved config, connection test, peer info
 
 ### Base Context Injection
 
-When Honcho injects context into the system prompt (in `hybrid` or `context` recall modes), it assembles the base context block in this order:
+In `hybrid` or `context` recall modes, Honcho injects live context into the user message at API-call time to preserve prompt caching. Only a static mode header belongs in the system prompt. The base context block is assembled in this order:
 
 1. **Session summary** -- a short digest of the current session so far (placed first so the model has immediate conversational continuity)
 2. **User representation** -- Honcho's accumulated model of the user (preferences, facts, patterns)
@@ -70,7 +70,7 @@ Honcho automatically selects between two prompt strategies:
 | Condition | Strategy | What happens |
 |-----------|----------|--------------|
 | No prior session or empty representation | **Cold start** | Lightweight intro prompt; skips summary injection; encourages the model to learn about the user |
-| Existing representation and/or session history | **Warm start** | Full base context injection (summary → representation → card); richer system prompt |
+| Existing representation and/or session history | **Warm start** | Full base context injection (summary → representation → card) in the API-call-time user-message context |
 
 You do not need to configure this -- it is automatic based on session state.
 
@@ -372,8 +372,15 @@ Config file: `$HERMES_HOME/honcho.json` (profile-local) or `~/.honcho/config.jso
 | `injectionFrequency` | `every-turn` | `every-turn` or `first-turn` |
 | `contextCadence` | `1` | Min turns between context API calls |
 | `dialecticCadence` | `2` | Min turns between dialectic LLM calls (recommended 1–5) |
+| `inject.sessionSummary` | `true` | Auto-inject the session summary layer |
+| `inject.userRepresentation` | `true` | Auto-inject the generated user representation |
+| `inject.userCard` | `true` | Auto-inject the curated user peer card |
+| `inject.aiRepresentation` | `true` | Auto-inject the generated AI self-representation |
+| `inject.aiCard` | `true` | Auto-inject the curated AI identity card |
 
 The `contextTokens` budget is enforced at injection time. If the session summary + representation + card exceed the budget, Honcho trims the summary first, then the representation, preserving the card. This prevents context blowup in long sessions.
+
+The `inject` object gates which prefetched layers are auto-injected into the prompt; the underlying data stays available through the Honcho tools and CLI. It resolves by whole-object presence (host block wins over root when present; missing sub-keys default to `true`), so suppressing a single noisy layer — e.g. `"inject": {"aiRepresentation": false}` — keeps every other layer injected. `hermes honcho setup` offers an `all` / `cards-only` preset, and `hermes honcho status` shows the resolved per-layer state.
 
 ### Memory-context sanitization
 
@@ -382,7 +389,7 @@ Honcho sanitizes the `memory-context` block before injection to prevent prompt i
 - Strips XML/HTML tags from user-authored conclusions
 - Normalizes whitespace and control characters
 - Truncates individual conclusions that exceed `messageMaxChars`
-- Escapes delimiter sequences that could break the system prompt structure
+- Escapes delimiter sequences that could break the memory-context block structure
 
 This fix addresses edge cases where raw user conclusions containing markup or special characters could corrupt the injected context block.
 

--- a/plugins/memory/honcho/README.md
+++ b/plugins/memory/honcho/README.md
@@ -307,6 +307,42 @@ Host key is derived from the active Hermes profile: `hermes` (default) or `herme
 | `firstTurnBaseWait` | float | `3.0` | Max seconds turn 1 waits for base context / session init. `0` disables the wait (fully async; context surfaces on later turns). Turns 2+ never wait on a stalled init |
 | `firstTurnDialecticWait` | float | `2.0` | Max seconds turn 1 waits for a dialectic result. `0` disables |
 
+### Context Injection (Per-Layer)
+
+Gates which prefetched context layers are auto-injected into the prompt.
+Only affects automatic injection — the underlying data stays available
+through the Honcho tools and CLI. Useful for keeping curated peer cards
+injected while suppressing noisier generated layers (e.g. a stale AI
+self-representation).
+
+```json
+"inject": {
+  "sessionSummary": true,
+  "userRepresentation": true,
+  "userCard": true,
+  "aiRepresentation": false,
+  "aiCard": true
+}
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `inject.sessionSummary` | bool | `true` | Inject the session summary layer |
+| `inject.userRepresentation` | bool | `true` | Inject the generated user representation |
+| `inject.userCard` | bool | `true` | Inject the curated user peer card |
+| `inject.aiRepresentation` | bool | `true` | Inject the generated AI self-representation |
+| `inject.aiCard` | bool | `true` | Inject the curated AI identity card |
+
+Unlike other keys, `inject` resolves by **whole-object presence**, not
+per-key merge: if the host block contains an `inject` object at all, that
+object wins and its missing sub-keys fall back to `true` (so a host-level
+`"inject": {}` means "this host explicitly uses defaults", not "merge with
+the root object"). Without a host-level object, a root-level `inject`
+applies; without either, every layer is injected (legacy behavior).
+
+`hermes honcho setup` offers an `all` / `cards-only` preset for these keys,
+and `hermes honcho status` shows the resolved per-layer state.
+
 ### Observation (Granular)
 
 Maps 1:1 to Honcho's per-peer `SessionPeerConfig`. When present, overrides `observationMode` preset.
@@ -384,6 +420,13 @@ Presets:
       "observation": {
         "user": { "observeMe": true, "observeOthers": true },
         "ai": { "observeMe": true, "observeOthers": true }
+      },
+      "inject": {
+        "sessionSummary": true,
+        "userRepresentation": true,
+        "userCard": true,
+        "aiRepresentation": false,
+        "aiCard": true
       },
       "writeFrequency": "async",
       "sessionStrategy": "per-directory",

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -594,29 +594,41 @@ class HonchoMemoryProvider(MemoryProvider):
             return True
         return not (self._init_thread and self._init_thread.is_alive())
 
+    def _inject_enabled(self, flag: str) -> bool:
+        """Per-layer injection gate from config; no config means inject (legacy)."""
+        if self._config is None:
+            return True
+        return getattr(self._config, flag, True)
+
     def _format_first_turn_context(self, ctx: dict) -> str:
-        """Format the prefetch context dict into a readable system prompt block."""
+        """Format the prefetch context dict into a readable system prompt block.
+
+        Each layer is gated by the ``inject`` config object (cards-first
+        hygiene): curated peer cards stay authoritative while noisy raw
+        representations can be suppressed from automatic injection without
+        touching the underlying Honcho data.
+        """
         parts = []
 
         # Session summary — session-scoped context, placed first for relevance
         summary = ctx.get("summary", "")
-        if summary:
+        if summary and self._inject_enabled("inject_session_summary"):
             parts.append(f"## Session Summary\n{summary}")
 
         rep = ctx.get("representation", "")
-        if rep:
+        if rep and self._inject_enabled("inject_user_representation"):
             parts.append(f"## User Representation\n{rep}")
 
         card = ctx.get("card", "")
-        if card:
+        if card and self._inject_enabled("inject_user_card"):
             parts.append(f"## User Peer Card\n{card}")
 
         ai_rep = ctx.get("ai_representation", "")
-        if ai_rep:
+        if ai_rep and self._inject_enabled("inject_ai_representation"):
             parts.append(f"## AI Self-Representation\n{ai_rep}")
 
         ai_card = ctx.get("ai_card", "")
-        if ai_card:
+        if ai_card and self._inject_enabled("inject_ai_card"):
             parts.append(f"## AI Identity Card\n{ai_card}")
 
         if not parts:

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -14,6 +14,17 @@ from hermes_constants import get_hermes_home
 from plugins.memory.honcho.client import _host_block, profile_host_key, resolve_active_host, resolve_config_path, HOST
 from hermes_cli.config import cfg_get
 
+# Setup-wizard preset for the ``inject`` context-layer gates: keep the
+# curated peer cards, suppress the generated/stale layers. Key names must
+# match client.py ``_resolve_injection``.
+CARDS_ONLY_INJECT = {
+    "sessionSummary": False,
+    "userRepresentation": False,
+    "userCard": True,
+    "aiRepresentation": False,
+    "aiCard": True,
+}
+
 
 def clone_honcho_for_profile(profile_name: str) -> bool:
     """Auto-clone Honcho config for a new profile from the default host block.
@@ -48,7 +59,7 @@ def clone_honcho_for_profile(profile_name: str) -> bool:
                 "sessionPeerPrefix", "contextTokens", "dialecticReasoningLevel",
                 "dialecticDynamic", "dialecticMaxChars", "messageMaxChars",
                 "dialecticMaxInputChars", "saveMessages", "observation",
-                "pinUserPeer", "userPeerAliases", "runtimePeerPrefix"):
+                "inject", "pinUserPeer", "userPeerAliases", "runtimePeerPrefix"):
         val = default_block.get(key)
         if val is not None:
             new_block[key] = val
@@ -117,7 +128,7 @@ def cmd_enable(args) -> None:
         for key in ("recallMode", "writeFrequency", "sessionStrategy",
                     "contextTokens", "dialecticReasoningLevel", "dialecticDynamic",
                     "dialecticMaxChars", "messageMaxChars", "dialecticMaxInputChars",
-                    "saveMessages", "observation"):
+                    "saveMessages", "observation", "inject"):
             val = default_block.get(key)
             if val is not None and key not in block:
                 block[key] = val
@@ -878,6 +889,40 @@ def cmd_setup(args) -> None:
         except (ValueError, TypeError):
             pass  # keep current
 
+    # --- 7a. Context injection layers ---
+    # Same host-over-root read the resolver uses (whole-object presence,
+    # see client.py _resolve_injection): a root-level object is the
+    # effective config when the host block has no ``inject`` key.
+    _existing_inject = (
+        hermes_host["inject"] if "inject" in hermes_host else cfg.get("inject")
+    )
+    if not isinstance(_existing_inject, dict):
+        _existing_inject = None
+    if _existing_inject is None or _existing_inject == {}:
+        current_layers = "all"
+    elif _existing_inject == CARDS_ONLY_INJECT:
+        current_layers = "cards-only"
+    else:
+        current_layers = "custom"
+    print("\n  Context injection layers (hybrid/context recall modes only):")
+    print("    all        -- inject every prefetched layer (default)")
+    print("    cards-only -- inject curated peer cards only; suppress the generated")
+    print("                  session summary and user/AI representations")
+    print("    Fine-tune per layer via the 'inject' object in honcho.json:")
+    print("    sessionSummary, userRepresentation, userCard, aiRepresentation, aiCard")
+    new_layers = _prompt("Inject layers", default=current_layers).strip().lower()
+    if new_layers in {"cards-only", "cardsonly", "cards"}:
+        hermes_host["inject"] = dict(CARDS_ONLY_INJECT)
+    elif new_layers == "all":
+        if isinstance(cfg.get("inject"), dict) and cfg.get("inject"):
+            # A root-level object would keep gating after a host-key pop
+            # (host presence wins wholesale), so restoring all-layers needs
+            # an explicit empty host object: "host chooses defaults".
+            hermes_host["inject"] = {}
+        else:
+            hermes_host.pop("inject", None)
+    # anything else (including "custom") keeps the current setting
+
     # --- 7b. Dialectic cadence ---
     current_dialectic = str(hermes_host.get("dialecticCadence") or cfg.get("dialecticCadence") or "2")
     print("\n  Dialectic cadence:")
@@ -1105,6 +1150,17 @@ def cmd_status(args) -> None:
     heuristic_on = "on" if hcfg.reasoning_heuristic else "off"
     print(f"  Reasoning:      base={hcfg.dialectic_reasoning_level}, cap={reasoning_cap}, heuristic={heuristic_on}")
     print(f"  Observation:    user(me={hcfg.user_observe_me},others={hcfg.user_observe_others}) ai(me={hcfg.ai_observe_me},others={hcfg.ai_observe_others})")
+    inject_bits = " ".join(
+        f"{label}={'on' if getattr(hcfg, attr, True) else 'off'}"
+        for label, attr in (
+            ("summary", "inject_session_summary"),
+            ("userRep", "inject_user_representation"),
+            ("userCard", "inject_user_card"),
+            ("aiRep", "inject_ai_representation"),
+            ("aiCard", "inject_ai_card"),
+        )
+    )
+    print(f"  Inject:         {inject_bits}")
     print(f"  Write freq:     {hcfg.write_frequency}")
 
     if hcfg.enabled and (hcfg.api_key or hcfg.base_url):

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -327,14 +327,9 @@ _OBSERVATION_PRESETS = {
 
 def _resolve_observation(
     mode: str,
-    observation_obj: dict | None,
+    observation_obj: Any,
 ) -> dict:
-    """Resolve per-peer observation booleans.
-
-    Config forms:
-      String shorthand:  ``"observationMode": "directional"``
-      Granular object:   ``"observation": {"user": {"observeMe": true, "observeOthers": true},
-                                           "ai": {"observeMe": true, "observeOthers": false}}``
+    """Resolve directional observation booleans from legacy mode + object.
 
     Granular fields override preset defaults.
     """
@@ -353,7 +348,25 @@ def _resolve_observation(
     }
 
 
+def _resolve_injection(inject_obj: Any) -> dict:
+    """Resolve per-layer context injection booleans.
 
+    Config form, all keys optional and defaulting true:
+    ``"inject": {"sessionSummary": true, "userRepresentation": true,
+    "userCard": true, "aiRepresentation": false, "aiCard": true}``.
+
+    This controls *what* prefetched Honcho context layers are injected into the
+    prompt. Raw data remains available through Honcho tools/CLI.
+    """
+    if not isinstance(inject_obj, dict):
+        inject_obj = {}
+    return {
+        "inject_session_summary": _resolve_bool(inject_obj.get("sessionSummary"), default=True),
+        "inject_user_representation": _resolve_bool(inject_obj.get("userRepresentation"), default=True),
+        "inject_user_card": _resolve_bool(inject_obj.get("userCard"), default=True),
+        "inject_ai_representation": _resolve_bool(inject_obj.get("aiRepresentation"), default=True),
+        "inject_ai_card": _resolve_bool(inject_obj.get("aiCard"), default=True),
+    }
 
 
 @dataclass
@@ -450,6 +463,14 @@ class HonchoClientConfig:
     user_observe_others: bool = True
     ai_observe_me: bool = True
     ai_observe_others: bool = True
+    # Per-layer prompt-injection gating for prefetched context. Defaults keep
+    # every layer injected (legacy behavior); explicit false suppresses noisy
+    # raw layers while leaving data available via tools/CLI.
+    inject_session_summary: bool = True
+    inject_user_representation: bool = True
+    inject_user_card: bool = True
+    inject_ai_representation: bool = True
+    inject_ai_card: bool = True
     # Session resolution
     session_strategy: str = "per-directory"
     session_peer_prefix: bool = False
@@ -726,6 +747,12 @@ class HonchoClientConfig:
                     or ("unified" if _explicitly_configured else "directional")
                 ),
                 host_block.get("observation") or raw.get("observation"),
+            ),
+            # Explicit key presence (not truthiness) so host-level
+            # ``"inject": {}`` means "host explicitly set, all defaults"
+            # rather than falling through to a root-level object.
+            **_resolve_injection(
+                host_block["inject"] if "inject" in host_block else raw.get("inject")
             ),
             session_strategy=session_strategy,
             session_peer_prefix=session_peer_prefix,

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -511,3 +511,130 @@ def test_hermes_version_is_valid():
     assert _HERMES_VERSION != "0.0.0", (
         "Version should resolve from hermes_cli.__version__, not the fallback"
     )
+
+
+def _signature_test_tool_call(extra=None, include_extra=True):
+    tool_call = {
+        "id": "call_1",
+        "type": "function",
+        "function": {"name": "get_weather", "arguments": "{}"},
+    }
+    if include_extra:
+        tool_call["extra_content"] = extra
+    return tool_call
+
+
+def test_tool_call_has_gemini_thought_signature_contract():
+    """The public signature check accepts exactly the shapes the adapter
+    replays as ``thoughtSignature`` and nothing else (#62332 review)."""
+    from agent.gemini_native_adapter import tool_call_has_gemini_thought_signature
+
+    for extra in (
+        {"google": {"thought_signature": "sig"}},
+        {"google": {"thoughtSignature": "sig"}},
+        {"google": "sig"},
+        {"thought_signature": "sig"},
+    ):
+        assert tool_call_has_gemini_thought_signature(
+            _signature_test_tool_call(extra)
+        ), f"extra_content={extra!r} should be a valid signature"
+
+    for extra in (
+        None,
+        {},
+        {"unrelated": {"x": 1}},
+        {"google": {}},
+        {"google": {"thought_signature": ""}},
+        "raw-string",
+    ):
+        assert not tool_call_has_gemini_thought_signature(
+            _signature_test_tool_call(extra)
+        ), f"extra_content={extra!r} should NOT be a valid signature"
+
+    assert not tool_call_has_gemini_thought_signature(
+        _signature_test_tool_call(include_extra=False))
+    assert not tool_call_has_gemini_thought_signature("not-a-dict")
+    assert not tool_call_has_gemini_thought_signature(None)
+
+
+def test_tool_call_has_signature_matches_translator_emission():
+    """The check and the request translator must never disagree: a tool call
+    passes the check iff translation emits a ``thoughtSignature`` part."""
+    from agent.gemini_native_adapter import (
+        _translate_tool_call_to_gemini,
+        tool_call_has_gemini_thought_signature,
+    )
+
+    shapes = (
+        {"google": {"thought_signature": "sig"}},
+        {"google": {"thoughtSignature": "sig"}},
+        {"google": "sig"},
+        {"thought_signature": "sig"},
+        None,
+        {},
+        {"unrelated": {"x": 1}},
+        {"google": {}},
+        {"google": {"thought_signature": ""}},
+        "raw-string",
+    )
+    for extra in shapes:
+        tool_call = _signature_test_tool_call(extra)
+        part = _translate_tool_call_to_gemini(tool_call)
+        assert ("thoughtSignature" in part) == tool_call_has_gemini_thought_signature(tool_call), (
+            f"check/translator disagreement for extra_content={extra!r}"
+        )
+
+
+def test_transcript_has_unsigned_gemini_tool_calls_scan_matches_replay():
+    """The transcript screen mirrors _build_gemini_contents: system/tool/
+    function roles never emit functionCall parts, malformed entries are
+    dropped, and any other role's unsigned tool call trips the screen."""
+    from agent.gemini_native_adapter import transcript_has_unsigned_gemini_tool_calls
+
+    signed = _signature_test_tool_call({"google": {"thought_signature": "sig"}})
+    unsigned = _signature_test_tool_call(include_extra=False)
+
+    # Unsigned assistant tool call → would 400 on replay.
+    assert transcript_has_unsigned_gemini_tool_calls(
+        [{"role": "assistant", "tool_calls": [unsigned]}])
+
+    # Fully signed history → replayable.
+    assert not transcript_has_unsigned_gemini_tool_calls(
+        [{"role": "assistant", "tool_calls": [signed]}])
+
+    # Roles the adapter skips before tool_calls translation cannot 400.
+    for role in ("system", "tool", "function"):
+        assert not transcript_has_unsigned_gemini_tool_calls(
+            [{"role": role, "tool_calls": [unsigned]}]
+        ), f"role={role} never emits functionCall parts"
+
+    # Non-assistant, non-skipped roles ARE replayed (adapter maps them to
+    # user-role contents and still translates tool_calls).
+    assert transcript_has_unsigned_gemini_tool_calls(
+        [{"role": "user", "tool_calls": [unsigned]}])
+
+    # Malformed shapes are dropped by translation, so they cannot block.
+    assert not transcript_has_unsigned_gemini_tool_calls(None)
+    assert not transcript_has_unsigned_gemini_tool_calls(
+        ["not-a-dict", {"role": "assistant", "tool_calls": "not-a-list"},
+         {"role": "assistant", "tool_calls": [None, 42]}])
+
+
+def test_transcript_screen_and_translator_share_case_insensitive_role_semantics():
+    """Mixed-case special roles must not slip unsigned function calls past
+    the screen while the translator replays them (#62332)."""
+    from agent.gemini_native_adapter import (
+        _build_gemini_contents,
+        transcript_has_unsigned_gemini_tool_calls,
+    )
+
+    unsigned = _signature_test_tool_call(include_extra=False)
+    for role in ("SYSTEM", "TOOL", "Function"):
+        messages = [{"role": role, "tool_calls": [unsigned]}]
+        assert not transcript_has_unsigned_gemini_tool_calls(messages)
+        contents, _ = _build_gemini_contents(messages)
+        assert all(
+            "functionCall" not in part
+            for content in contents
+            for part in content["parts"]
+        )

--- a/tests/hermes_cli/test_gemini_provider.py
+++ b/tests/hermes_cli/test_gemini_provider.py
@@ -354,3 +354,44 @@ class TestGeminiModelsDev:
         assert "gemma-3-27b-it" not in result
         assert "gemini-1.5-pro" not in result
         assert "gemini-2.0-flash" not in result
+
+
+# ── Fallback-path resolution transport (#62332) ──
+
+class TestGeminiExplicitArgResolutionTransport:
+    """Pin the transport contract the fallback guard relies on, through the
+    explicit-args path try_activate_fallback uses (fallback entries pass
+    base_url/api_key as explicit_* overrides): native GeminiNativeClient only
+    when the resolved base URL speaks Gemini's native REST API."""
+
+    def test_native_base_url_resolves_to_native_client(self):
+        from agent.auxiliary_client import resolve_provider_client
+        from agent.gemini_native_adapter import GeminiNativeClient
+
+        client, model = resolve_provider_client(
+            "gemini",
+            model="gemini-3.1-flash-lite",
+            explicit_api_key="test-key",
+            explicit_base_url="https://generativelanguage.googleapis.com/v1beta",
+        )
+        try:
+            assert isinstance(client, GeminiNativeClient)
+            assert model == "gemini-3.1-flash-lite"
+        finally:
+            client.close()
+
+    def test_openai_compat_base_url_resolves_to_plain_client(self):
+        from agent.auxiliary_client import resolve_provider_client
+        from agent.gemini_native_adapter import GeminiNativeClient
+
+        client, model = resolve_provider_client(
+            "gemini",
+            model="gemini-3.1-flash-lite",
+            explicit_api_key="test-key",
+            explicit_base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+        )
+        try:
+            assert client is not None
+            assert not isinstance(client, GeminiNativeClient)
+        finally:
+            client.close()

--- a/tests/honcho_plugin/test_cli.py
+++ b/tests/honcho_plugin/test_cli.py
@@ -791,3 +791,148 @@ class TestMigratePinKey:
         block = {"pinUserPeer": True}
         assert honcho_cli._migrate_pin_key(block) is False
         assert block == {"pinUserPeer": True}
+
+
+class TestCloneCarriesInjectGates:
+    """The ``inject`` layer gates must survive profile cloning/enabling.
+
+    Without propagation, a cloned profile silently reverts to injecting
+    every prefetched layer — exactly the noise the gates exist to
+    suppress (e.g. a stale AI self-representation).
+    """
+
+    _clone_env = TestCloneHonchoForProfile._setup_clone_env
+
+    def test_clone_inherits_inject_object(self, monkeypatch, tmp_path):
+        cfg = {
+            "apiKey": "***",
+            "hosts": {"hermes": {
+                "peerName": "alice",
+                "inject": {"aiRepresentation": False, "sessionSummary": False},
+            }},
+        }
+        honcho_cli, written = self._clone_env(monkeypatch, tmp_path, cfg)
+        ok = honcho_cli.clone_honcho_for_profile("coder")
+        assert ok is True
+        new_block = written["cfg"]["hosts"]["hermes_coder"]
+        assert new_block["inject"] == {
+            "aiRepresentation": False, "sessionSummary": False,
+        }
+
+    def test_clone_without_inject_stays_unset(self, monkeypatch, tmp_path):
+        cfg = {"apiKey": "***", "hosts": {"hermes": {"peerName": "alice"}}}
+        honcho_cli, written = self._clone_env(monkeypatch, tmp_path, cfg)
+        ok = honcho_cli.clone_honcho_for_profile("coder")
+        assert ok is True
+        assert "inject" not in written["cfg"]["hosts"]["hermes_coder"]
+
+    def test_enable_seeds_inject_from_default_block(self, monkeypatch, tmp_path):
+        import plugins.memory.honcho.cli as honcho_cli
+        cfg = {
+            "apiKey": "***",
+            "hosts": {"hermes": {
+                "aiPeer": "hermes",
+                "inject": {"userRepresentation": False},
+            }},
+        }
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text("{}")
+        monkeypatch.setattr(honcho_cli, "_read_config", lambda: cfg)
+        monkeypatch.setattr(honcho_cli, "_config_path", lambda: cfg_path)
+        monkeypatch.setattr(honcho_cli, "_host_key", lambda: "hermes_coder")
+        monkeypatch.setattr(honcho_cli, "_ensure_peer_exists", lambda host_key=None: True)
+        written = {}
+        monkeypatch.setattr(
+            honcho_cli, "_write_config", lambda c, path=None: written.setdefault("cfg", c),
+        )
+
+        honcho_cli.cmd_enable(SimpleNamespace())
+
+        block = written["cfg"]["hosts"]["hermes_coder"]
+        assert block["inject"] == {"userRepresentation": False}
+
+
+class TestSetupInjectLayersPrompt:
+    """The wizard's inject-layers question writes the cards-only preset,
+    resets to all-layers (including overriding a root-level object), and
+    leaves custom per-layer config untouched."""
+
+    _run_setup = TestSetupWizardDeploymentShape._run_setup
+
+    def _answers(self, inject_answer):
+        return [
+            "cloud",      # deployment
+            "",           # api key (keep)
+            "eri",        # peer name
+            "hermetika",  # ai peer
+            "hermes",     # workspace
+            "1",          # identity tree: just me
+            "",           # observation mode (keep)
+            "",           # write frequency (keep)
+            "",           # recall mode (keep)
+            "",           # context tokens (keep)
+            inject_answer,
+        ]
+
+    def test_cards_only_preset_written(self, monkeypatch, tmp_path):
+        from plugins.memory.honcho.cli import CARDS_ONLY_INJECT
+
+        host = self._run_setup(
+            monkeypatch, tmp_path, answers=self._answers("cards-only"))
+        assert host["inject"] == dict(CARDS_ONLY_INJECT)
+
+    def test_all_answer_clears_host_inject(self, monkeypatch, tmp_path):
+        initial_cfg = {
+            "apiKey": "***",
+            "hosts": {"hermes": {"inject": {"aiRepresentation": False}}},
+        }
+        host = self._run_setup(
+            monkeypatch, tmp_path, answers=self._answers("all"),
+            initial_cfg=initial_cfg)
+        assert "inject" not in host
+
+    def test_all_answer_overrides_root_inject_with_empty_host_object(
+        self, monkeypatch, tmp_path
+    ):
+        """With a root-level ``inject`` and no host object, popping the host
+        key is a no-op (resolution falls back to root, client.py:640) — the
+        wizard must write an explicit empty host object so 'all' actually
+        restores every layer."""
+        initial_cfg = {
+            "apiKey": "***",
+            "inject": {"aiRepresentation": False},
+            "hosts": {"hermes": {"peerName": "eri"}},
+        }
+        host = self._run_setup(
+            monkeypatch, tmp_path, answers=self._answers("all"),
+            initial_cfg=initial_cfg)
+        assert host["inject"] == {}
+
+    def test_root_inject_detected_as_current_state(self, monkeypatch, tmp_path):
+        """A root-level custom object is the effective config, so the wizard
+        must not misreport 'all'; the exhausted answer list falls back to the
+        prompt default ('custom'), which keeps the host block untouched."""
+        initial_cfg = {
+            "apiKey": "***",
+            "inject": {"aiRepresentation": False},
+            "hosts": {"hermes": {"peerName": "eri"}},
+        }
+        host = self._run_setup(
+            monkeypatch, tmp_path,
+            answers=["cloud", "", "eri", "hermetika", "hermes", "1"],
+            initial_cfg=initial_cfg)
+        assert "inject" not in host  # default "custom" keeps root config active
+
+    def test_custom_inject_preserved_on_enter(self, monkeypatch, tmp_path):
+        custom = {"userRepresentation": False}
+        initial_cfg = {
+            "apiKey": "***",
+            "hosts": {"hermes": {"inject": dict(custom)}},
+        }
+        # No scripted answer for the inject prompt: the harness falls back
+        # to the prompt default ("custom"), which must keep the object.
+        host = self._run_setup(
+            monkeypatch, tmp_path,
+            answers=["cloud", "", "eri", "hermetika", "hermes", "1"],
+            initial_cfg=initial_cfg)
+        assert host["inject"] == custom

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -690,6 +690,17 @@ class TestInjectionConfig:
             if flag != "inject_ai_representation":
                 assert getattr(cfg, flag) is True
 
+    def test_root_inject_applies_when_host_has_no_inject_key(self, tmp_path):
+        cfg = self._load(tmp_path, {
+            "apiKey": "k",
+            "inject": {"aiRepresentation": False},
+            "hosts": {"hermes": {"enabled": True}},
+        })
+        assert cfg.inject_ai_representation is False
+        for flag in self._ALL_FLAGS:
+            if flag != "inject_ai_representation":
+                assert getattr(cfg, flag) is True
+
     def test_empty_host_inject_wins_over_root(self, tmp_path):
         cfg = self._load(tmp_path, {
             "apiKey": "k",

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -652,6 +652,54 @@ class TestObservationModeMigration:
         assert cfg.ai_observe_others is True
 
 
+class TestInjectionConfig:
+    """Per-layer prompt-injection gating resolved from the "inject" object."""
+
+    _ALL_FLAGS = (
+        "inject_session_summary",
+        "inject_user_representation",
+        "inject_user_card",
+        "inject_ai_representation",
+        "inject_ai_card",
+    )
+
+    @staticmethod
+    def _load(tmp_path, payload):
+        cfg_file = tmp_path / "config.json"
+        cfg_file.write_text(json.dumps(payload))
+        return HonchoClientConfig.from_global_config(config_path=cfg_file)
+
+    def test_defaults_all_true_when_absent(self, tmp_path):
+        cfg = self._load(tmp_path, {
+            "apiKey": "k",
+            "hosts": {"hermes": {"enabled": True}},
+        })
+        for flag in self._ALL_FLAGS:
+            assert getattr(cfg, flag) is True
+
+    def test_host_partial_override_preserves_explicit_false(self, tmp_path):
+        cfg = self._load(tmp_path, {
+            "apiKey": "k",
+            "hosts": {"hermes": {
+                "enabled": True,
+                "inject": {"aiRepresentation": False},
+            }},
+        })
+        assert cfg.inject_ai_representation is False
+        for flag in self._ALL_FLAGS:
+            if flag != "inject_ai_representation":
+                assert getattr(cfg, flag) is True
+
+    def test_empty_host_inject_wins_over_root(self, tmp_path):
+        cfg = self._load(tmp_path, {
+            "apiKey": "k",
+            "inject": {"aiRepresentation": False},
+            "hosts": {"hermes": {"enabled": True, "inject": {}}},
+        })
+        for flag in self._ALL_FLAGS:
+            assert getattr(cfg, flag) is True
+
+
 class TestGetHonchoClient:
     def teardown_method(self):
         reset_honcho_client()

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -1340,6 +1340,32 @@ class TestBaseContextSummary:
             provider._prefetch_thread.join(timeout=1)
 
 
+class TestInjectionGating:
+    FULL_CTX = {
+        "summary": "Session summary text.",
+        "representation": "the user prefers concise technical summaries.",
+        "card": "IDENTITY: Name: Example User",
+        "ai_representation": "the assistant incorrectly inherited the user's food allergy",
+        "ai_card": "IDENTITY: Kind: Software agent",
+    }
+
+    @staticmethod
+    def _provider_with(**inject_flags):
+        from plugins.memory.honcho.client import HonchoClientConfig
+
+        provider = HonchoMemoryProvider()
+        provider._config = HonchoClientConfig(api_key="k", enabled=True, **inject_flags)
+        return provider
+
+    def test_ai_representation_can_be_suppressed_while_card_stays(self):
+        provider = self._provider_with(inject_ai_representation=False)
+        formatted = provider._format_first_turn_context(self.FULL_CTX)
+        assert "AI Self-Representation" not in formatted
+        assert "the assistant incorrectly inherited the user's food allergy" not in formatted
+        assert "AI Identity Card" in formatted
+        assert "IDENTITY: Kind: Software agent" in formatted
+
+
 class TestDialecticDepth:
     """Tests for the dialecticDepth multi-pass system."""
 

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -334,3 +334,57 @@ class TestFallbackChainDedup:
 
         assert ok is False
         mock_resolve.assert_not_called()
+
+
+# ── Gemini thought-signature fallback guard ────────────────────────────────
+
+
+class TestGeminiFallbackToolHistoryGuard:
+    def test_skips_gemini_after_unsigned_tool_calls_and_uses_next_fallback(self):
+        fbs = [
+            {"provider": "gemini", "model": "gemini-3.1-flash-lite"},
+            {"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        agent.provider = "anthropic"
+        agent.model = "claude-opus-4"
+        agent._last_api_messages_for_fallback = [
+            {
+                "role": "assistant",
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": "{}"},
+                }],
+            }
+        ]
+
+        called = []
+        def _resolve(provider, model=None, raw_codex=False, **kwargs):
+            called.append((provider, model))
+            return _mock_client(), model
+
+        with patch("agent.auxiliary_client.resolve_provider_client", side_effect=_resolve):
+            with patch("hermes_cli.model_normalize.normalize_model_for_provider", side_effect=lambda m, p: m):
+                ok = agent._try_activate_fallback()
+
+        assert ok is True
+        assert called == [("openrouter", "anthropic/claude-sonnet-4")]
+
+    def test_allows_gemini_before_tool_history(self):
+        agent = _make_agent(fallback_model={"provider": "gemini", "model": "gemini-3.1-flash-lite"})
+        agent.provider = "openrouter"
+        agent.model = "anthropic/claude-sonnet-4"
+        agent._last_api_messages_for_fallback = []
+
+        called = []
+        def _resolve(provider, model=None, raw_codex=False, **kwargs):
+            called.append((provider, model))
+            return _mock_client(), model
+
+        with patch("agent.auxiliary_client.resolve_provider_client", side_effect=_resolve):
+            with patch("hermes_cli.model_normalize.normalize_model_for_provider", side_effect=lambda m, p: m):
+                ok = agent._try_activate_fallback()
+
+        assert ok is True
+        assert called == [("gemini", "gemini-3.1-flash-lite")]

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -338,53 +338,262 @@ class TestFallbackChainDedup:
 
 # ── Gemini thought-signature fallback guard ────────────────────────────────
 
+GEMINI_OPENAI_COMPAT_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
+
+_NO_EXTRA = object()
+
+
+def _tool_call_history(extra_content=_NO_EXTRA):
+    """One assistant tool call; ``extra_content`` present only when passed."""
+    tool_call = {
+        "id": "call_1",
+        "type": "function",
+        "function": {"name": "terminal", "arguments": "{}"},
+    }
+    if extra_content is not _NO_EXTRA:
+        tool_call["extra_content"] = extra_content
+    return [{"role": "assistant", "tool_calls": [tool_call]}]
+
+
+def _gemini_routing_resolver(called, created=None):
+    """Fake resolve_provider_client mirroring the real gemini routing:
+    a GeminiNativeClient is returned only when the resolved base URL speaks
+    Gemini's native REST API (agent/auxiliary_client.py gemini branch).
+    """
+    from agent.gemini_native_adapter import (
+        DEFAULT_GEMINI_BASE_URL,
+        GeminiNativeClient,
+        is_native_gemini_base_url,
+    )
+
+    def _resolve(provider, model=None, raw_codex=False, **kwargs):
+        called.append((provider, model))
+        if provider in ("gemini", "google"):
+            base_url = kwargs.get("explicit_base_url") or DEFAULT_GEMINI_BASE_URL
+            if is_native_gemini_base_url(base_url):
+                client = GeminiNativeClient(api_key="test-key")
+                if created is not None:
+                    created.append(client)
+                return client, model
+            return _mock_client(base_url=base_url), model
+        return _mock_client(), model
+
+    return _resolve
+
+
+def _activate(agent, resolver):
+    with patch("agent.auxiliary_client.resolve_provider_client", side_effect=resolver):
+        with patch("hermes_cli.model_normalize.normalize_model_for_provider", side_effect=lambda m, p: m):
+            return agent._try_activate_fallback()
+
 
 class TestGeminiFallbackToolHistoryGuard:
+    def _agent_with_history(self, fbs, history):
+        agent = _make_agent(fallback_model=fbs)
+        agent.provider = "anthropic"
+        agent.model = "claude-opus-4"
+        agent.context_compressor = None  # keep activation tail offline
+        agent._last_api_messages_for_fallback = history
+        return agent
+
     def test_skips_gemini_after_unsigned_tool_calls_and_uses_next_fallback(self):
         fbs = [
             {"provider": "gemini", "model": "gemini-3.1-flash-lite"},
             {"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
         ]
-        agent = _make_agent(fallback_model=fbs)
-        agent.provider = "anthropic"
-        agent.model = "claude-opus-4"
-        agent._last_api_messages_for_fallback = [
+        agent = self._agent_with_history(fbs, _tool_call_history())
+
+        called = []
+        ok = _activate(agent, _gemini_routing_resolver(called))
+
+        assert ok is True
+        # Compatibility is decided from the *resolved* transport, so gemini is
+        # resolved first, then skipped in favor of the next entry.
+        assert called == [
+            ("gemini", "gemini-3.1-flash-lite"),
+            ("openrouter", "anthropic/claude-sonnet-4"),
+        ]
+        assert agent.provider == "openrouter"
+        assert agent.model == "anthropic/claude-sonnet-4"
+
+    def test_allows_gemini_before_tool_history(self):
+        from agent.gemini_native_adapter import GeminiNativeClient
+
+        agent = self._agent_with_history(
+            [{"provider": "gemini", "model": "gemini-3.1-flash-lite"}], [])
+
+        called = []
+        ok = _activate(agent, _gemini_routing_resolver(called))
+
+        assert ok is True
+        assert called == [("gemini", "gemini-3.1-flash-lite")]
+        assert agent.provider == "gemini"
+        assert isinstance(agent.client, GeminiNativeClient)
+
+    def test_gemini_openai_compat_endpoint_not_skipped(self):
+        """provider: gemini + Google /openai endpoint is NOT native — it can
+        replay unsigned tool calls and must not be screened (#62332 review)."""
+        fbs = [{
+            "provider": "gemini",
+            "model": "gemini-3.1-flash-lite",
+            "base_url": GEMINI_OPENAI_COMPAT_URL,
+        }]
+        agent = self._agent_with_history(fbs, _tool_call_history())
+
+        called = []
+        ok = _activate(agent, _gemini_routing_resolver(called))
+
+        assert ok is True
+        assert called == [("gemini", "gemini-3.1-flash-lite")]
+        assert agent.provider == "gemini"
+        assert agent.base_url == GEMINI_OPENAI_COMPAT_URL
+
+    def test_gemini_named_aggregator_model_not_skipped(self):
+        """A Gemini-named model on an aggregator is not a native transport
+        and must not be skipped merely for its name (#62332 review)."""
+        fbs = [{"provider": "openrouter", "model": "google/gemini-2.5-pro"}]
+        agent = self._agent_with_history(fbs, _tool_call_history())
+
+        called = []
+        ok = _activate(agent, _gemini_routing_resolver(called))
+
+        assert ok is True
+        assert called == [("openrouter", "google/gemini-2.5-pro")]
+        assert agent.provider == "openrouter"
+
+    def test_google_provider_alias_screened_like_gemini(self):
+        fbs = [
+            {"provider": "google", "model": "gemini-3.1-flash-lite"},
+            {"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+        ]
+        agent = self._agent_with_history(fbs, _tool_call_history())
+
+        called = []
+        ok = _activate(agent, _gemini_routing_resolver(called))
+
+        assert ok is True
+        assert called[0] == ("google", "gemini-3.1-flash-lite")
+        assert agent.provider == "openrouter"
+
+    def test_unsigned_extra_content_shapes_still_skip(self):
+        """Metadata presence alone is not a signature (#62332 review)."""
+        for extra in (
+            {},                                     # empty metadata
+            {"unrelated": {"x": 1}},                # non-signature metadata
+            {"google": {"thought_signature": ""}},  # empty signature value
+            "raw-string",                           # non-dict extra_content
+        ):
+            fbs = [
+                {"provider": "gemini", "model": "gemini-3.1-flash-lite"},
+                {"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+            ]
+            agent = self._agent_with_history(fbs, _tool_call_history(extra))
+
+            called = []
+            ok = _activate(agent, _gemini_routing_resolver(called))
+
+            assert ok is True, f"extra_content={extra!r}"
+            assert agent.provider == "openrouter", (
+                f"extra_content={extra!r} must not count as a Gemini signature"
+            )
+
+    def test_valid_signature_shapes_allow_native_gemini(self):
+        for extra in (
+            {"google": {"thought_signature": "sig-abc"}},
+            {"google": {"thoughtSignature": "sig-abc"}},
+            {"google": "sig-abc"},
+            {"thought_signature": "sig-abc"},
+        ):
+            agent = self._agent_with_history(
+                [{"provider": "gemini", "model": "gemini-3.1-flash-lite"}],
+                _tool_call_history(extra))
+
+            called = []
+            ok = _activate(agent, _gemini_routing_resolver(called))
+
+            assert ok is True, f"extra_content={extra!r}"
+            assert agent.provider == "gemini", (
+                f"extra_content={extra!r} is a valid signature and must not skip"
+            )
+
+    def test_tool_role_tool_calls_do_not_block(self):
+        """The native adapter never emits functionCall parts for system or
+        tool/function roles, so residual unsigned ``tool_calls`` there (e.g.
+        a provider echo) must not skip a viable native Gemini fallback."""
+        history = [
             {
                 "role": "assistant",
                 "tool_calls": [{
                     "id": "call_1",
                     "type": "function",
                     "function": {"name": "terminal", "arguments": "{}"},
+                    "extra_content": {"google": {"thought_signature": "sig"}},
                 }],
-            }
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "ok",
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": "{}"},
+                }],
+            },
         ]
+        agent = self._agent_with_history(
+            [{"provider": "gemini", "model": "gemini-3.1-flash-lite"}], history)
 
         called = []
-        def _resolve(provider, model=None, raw_codex=False, **kwargs):
-            called.append((provider, model))
-            return _mock_client(), model
-
-        with patch("agent.auxiliary_client.resolve_provider_client", side_effect=_resolve):
-            with patch("hermes_cli.model_normalize.normalize_model_for_provider", side_effect=lambda m, p: m):
-                ok = agent._try_activate_fallback()
+        ok = _activate(agent, _gemini_routing_resolver(called))
 
         assert ok is True
-        assert called == [("openrouter", "anthropic/claude-sonnet-4")]
+        assert agent.provider == "gemini"
 
-    def test_allows_gemini_before_tool_history(self):
-        agent = _make_agent(fallback_model={"provider": "gemini", "model": "gemini-3.1-flash-lite"})
-        agent.provider = "openrouter"
-        agent.model = "anthropic/claude-sonnet-4"
-        agent._last_api_messages_for_fallback = []
+    def test_malformed_history_entries_do_not_crash_or_block(self):
+        history = [
+            "not-a-dict",
+            {"role": "assistant", "tool_calls": "not-a-list"},
+            {"role": "assistant", "tool_calls": [None, 42, "call"]},
+        ]
+        agent = self._agent_with_history(
+            [{"provider": "gemini", "model": "gemini-3.1-flash-lite"}], history)
 
         called = []
-        def _resolve(provider, model=None, raw_codex=False, **kwargs):
-            called.append((provider, model))
-            return _mock_client(), model
-
-        with patch("agent.auxiliary_client.resolve_provider_client", side_effect=_resolve):
-            with patch("hermes_cli.model_normalize.normalize_model_for_provider", side_effect=lambda m, p: m):
-                ok = agent._try_activate_fallback()
+        ok = _activate(agent, _gemini_routing_resolver(called))
 
         assert ok is True
-        assert called == [("gemini", "gemini-3.1-flash-lite")]
+        # The native adapter emits no functionCall part for non-dict tool
+        # calls, so none of these can trigger the missing-signature 400.
+        assert agent.provider == "gemini"
+
+    def test_gemini_only_chain_exhausts_without_permanent_blacklist(self):
+        agent = self._agent_with_history(
+            [{"provider": "gemini", "model": "gemini-3.1-flash-lite"}],
+            _tool_call_history())
+        original_client = agent.client
+
+        called = []
+        ok = _activate(agent, _gemini_routing_resolver(called))
+
+        assert ok is False
+        assert agent.provider == "anthropic"
+        assert agent.model == "claude-opus-4"
+        assert agent.client is original_client
+        # Transcript-dependent skip must not permanently blacklist the entry.
+        assert getattr(agent, "_unavailable_fallback_keys", set()) == set()
+
+    def test_skipped_native_client_is_closed(self):
+        agent = self._agent_with_history(
+            [
+                {"provider": "gemini", "model": "gemini-3.1-flash-lite"},
+                {"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+            ],
+            _tool_call_history())
+
+        called, created = [], []
+        ok = _activate(agent, _gemini_routing_resolver(called, created))
+
+        assert ok is True
+        assert len(created) == 1
+        assert created[0].is_closed is True

--- a/website/docs/user-guide/features/honcho.md
+++ b/website/docs/user-guide/features/honcho.md
@@ -54,7 +54,7 @@ Get an API key at [honcho.dev](https://honcho.dev).
 
 ### Two-Layer Context Injection
 
-Every turn (in `hybrid` or `context` mode), Honcho assembles two layers of context injected into the system prompt:
+Every turn (in `hybrid` or `context` mode), Honcho assembles two layers of live context injected into the user message at API-call time to preserve prompt caching. Only a static mode header goes in the system prompt:
 
 1. **Base context** — session summary, user representation, user peer card, AI self-representation, and AI identity card. Refreshed on `contextCadence`. This is the "who is this user" layer.
 2. **Dialectic supplement** — LLM-synthesized reasoning about the user's current state and needs. Refreshed on `dialecticCadence`. This is the "what matters right now" layer.
@@ -116,12 +116,13 @@ When pointing Hermes at a self-hosted Honcho server, `hermes honcho setup` (and 
 |-----|---------|-------------|
 | `contextTokens` | `null` (uncapped) | Token budget for auto-injected context per turn. Set to an integer (e.g. 1200) to cap. Truncates at word boundaries |
 | `contextCadence` | `1` | Minimum turns between `context()` API calls (base layer refresh) |
+| `inject` | `{}` (all layers on) | Per-layer auto-injection gates: `sessionSummary`, `userRepresentation`, `userCard`, `aiRepresentation`, `aiCard` — each `true` by default. Resolves by whole-object presence (host block wins over root); data stays available via tools/CLI when a layer is off |
 | `dialecticCadence` | `2` | Minimum turns between `peer.chat()` LLM calls (dialectic layer). Recommended 1–5. In `tools` mode, irrelevant — model calls explicitly |
 | `dialecticDepth` | `1` | Number of `.chat()` passes per dialectic invocation. Clamped to 1–3 |
 | `dialecticDepthLevels` | `null` | Optional array of reasoning levels per pass, e.g. `["minimal", "low", "medium"]`. Overrides proportional defaults |
 | `dialecticReasoningLevel` | `'low'` | Base reasoning level: `minimal`, `low`, `medium`, `high`, `max` |
 | `dialecticDynamic` | `true` | When `true`, model can override reasoning level per-call via tool param |
-| `dialecticMaxChars` | `600` | Max chars of dialectic result injected into system prompt |
+| `dialecticMaxChars` | `600` | Max chars of dialectic result injected into the API-call-time user-message context |
 | `recallMode` | `'hybrid'` | `hybrid` (auto-inject + tools), `context` (inject only), `tools` (tools only) |
 | `writeFrequency` | `'async'` | When to flush messages: `async` (background thread), `turn` (sync), `session` (batch on end), or integer N |
 | `saveMessages` | `true` | Whether to persist messages to Honcho API |
@@ -140,7 +141,7 @@ When pointing Hermes at a self-hosted Honcho server, `hermes honcho setup` (and 
 - `global` — single session across all directories.
 
 **Recall mode** controls how memory flows into conversations:
-- `hybrid` — context auto-injected into system prompt AND tools available (model decides when to query).
+- `hybrid` — context auto-injected into the API-call-time user message and tools available (model decides when to query).
 - `context` — auto-injection only, tools hidden.
 - `tools` — tools only, no auto-injection. Agent must explicitly call `honcho_reasoning`, `honcho_search`, etc.
 

--- a/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-honcho.md
+++ b/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-honcho.md
@@ -387,8 +387,15 @@ Config file: `$HERMES_HOME/honcho.json` (profile-local) or `~/.honcho/config.jso
 | `injectionFrequency` | `every-turn` | `every-turn` or `first-turn` |
 | `contextCadence` | `1` | Min turns between context API calls |
 | `dialecticCadence` | `2` | Min turns between dialectic LLM calls (recommended 1–5) |
+| `inject.sessionSummary` | `true` | Auto-inject the session summary layer |
+| `inject.userRepresentation` | `true` | Auto-inject the generated user representation |
+| `inject.userCard` | `true` | Auto-inject the curated user peer card |
+| `inject.aiRepresentation` | `true` | Auto-inject the generated AI self-representation |
+| `inject.aiCard` | `true` | Auto-inject the curated AI identity card |
 
 The `contextTokens` budget is enforced at injection time. If the session summary + representation + card exceed the budget, Honcho trims the summary first, then the representation, preserving the card. This prevents context blowup in long sessions.
+
+The `inject` object gates which prefetched layers are auto-injected into the prompt; the underlying data stays available through the Honcho tools and CLI. It resolves by whole-object presence (host block wins over root when present; missing sub-keys default to `true`), so suppressing a single noisy layer — e.g. `"inject": {"aiRepresentation": false}` — keeps every other layer injected. `hermes honcho setup` offers an `all` / `cards-only` preset, and `hermes honcho status` shows the resolved per-layer state.
 
 ### Memory-context sanitization
 


### PR DESCRIPTION
## Summary

This PR fixes two prompt/context reliability issues that can affect provider fallback and Honcho-backed memory injection:

1. **Skip native-Gemini fallback when the replay transcript contains tool calls without Gemini thought signatures.**
   Native Gemini endpoints require provider-issued `thought_signature` metadata on replayed assistant function-call parts. Tool calls produced by non-Gemini providers do not have those signatures, so switching into native Gemini mid-transcript after tools have already run deterministically fails with an HTTP 400 instead of providing a useful fallback.

2. **Add Honcho `inject` layer gates for automatically injected context.**
   This lets deployments keep curated peer cards injected while suppressing noisier/generated layers such as raw user/AI representations or session summaries. The raw data remains available via Honcho tools/CLI; this only controls automatic prompt injection.

## Motivation

### Gemini fallback after tool use

A tool-using session can begin on any non-Gemini provider, successfully call tools, and then need to activate a configured Gemini fallback after the primary provider stalls or errors. At that point Hermes replays the existing transcript to the fallback provider. Native Gemini rejects replayed assistant function-call parts unless they carry Gemini `thought_signature` metadata:

```text
HTTP 400: Function call is missing a thought_signature in functionCall parts.
```

Because non-Gemini providers cannot produce Gemini thought signatures for earlier tool calls, this fallback path is guaranteed to fail once unsigned tool-call history exists. Skipping the incompatible native-Gemini entry lets Hermes continue to a later compatible fallback when one exists, or exhaust fallback cleanly instead of sending a known-bad request.

Related existing issue found during duplicate search: #36907 covers a different Gemini `thought_signature` cross-model fallback failure direction. This PR addresses the non-Gemini-to-Gemini replay case.

### Honcho context injection

Honcho exposes several context layers: session summary, user representation, user card, AI representation, and AI card. Curated cards are usually the highest-signal and safest layer to inject every turn. Generated representations can become stale or misattributed, especially the AI self-representation, and should be configurable independently from the cards.

Duplicate search did not find an open/closed PR for Honcho `inject` layer gates.

## Changes

### Fallback guard (updated per review)

Both inline review comments are addressed in `0cd5eee45`:

- Cache the exact outbound API message list on the agent before model calls.
- Screen fallback entries **after** `resolve_provider_client()` resolves them, and only when the resolved client is a `GeminiNativeClient` — the same predicate provider resolution itself uses. Provider/model labels play no part: a `provider: gemini` entry configured with Google's OpenAI-compat `/openai` endpoint and Gemini-named aggregator routes are never skipped.
- A native target is skipped only when the transcript actually contains a tool call lacking a valid Gemini thought signature. Screening reuses the adapter's own extraction contract via new public helpers in `agent/gemini_native_adapter.py` (`tool_call_has_gemini_thought_signature`, `transcript_has_unsigned_gemini_tool_calls`), colocated with the request translator so the screen and replay behavior cannot drift. Empty, unrelated, or malformed `extra_content` counts as unsigned; `system`/`tool`/`function` roles are exempt, exactly matching the adapter's replay scan.
- A skipped entry's resolved client is closed, and the skip is not added to the permanent-unavailability set (the incompatibility is transcript-dependent).
- Gemini fallback behavior is preserved when no incompatible tool history exists.

### Honcho injection gating

- Add `inject` config resolution in `HonchoClientConfig` with legacy-safe defaults (`true` for all layers).
- Supported keys:
  - `sessionSummary`
  - `userRepresentation`
  - `userCard`
  - `aiRepresentation`
  - `aiCard`
- Apply those gates in `_format_first_turn_context()`.
- Host-level `inject` wins by explicit key presence, so an empty host object means "host explicitly chooses defaults" instead of falling through to root config.

Example config:

```json
{
  "hosts": {
    "hermes": {
      "inject": {
        "sessionSummary": false,
        "userRepresentation": false,
        "userCard": true,
        "aiRepresentation": false,
        "aiCard": true
      }
    }
  }
}
```

### Honcho `inject` exposure (review follow-up)

Addressing the review suggestion to document/expose the new settings, `37aeeeabe` adds:

- Documentation for the five keys in the plugin README, the honcho skill, and the website feature page, including the whole-object host-over-root resolution semantics.
- An `Inject:` line in `hermes honcho status` showing the resolved per-layer state.
- A compact `all` / `cards-only` preset question in the `hermes honcho setup` context-injection block. Answering `all` writes an explicit empty host object when a root-level `inject` object exists, since host presence wins wholesale and popping the host key alone would silently leave root gating active.
- `inject` propagation through the profile clone/enable seeding tuples, consistent with `observation` and the other behavior-shaping keys, so new profiles keep the operator's injection preferences (rationale and a minimal-scope alternative are in a PR comment).

## Privacy / config hygiene

The regression tests use generic examples only. They do not include local file paths, personal names, real peer IDs, production cron IDs, tokens, or deployment-specific `honcho.json` content.

## Tested platforms

- Linux, Python 3.11.15

## Manual validation

Exercised in a local Linux gateway + cron deployment after restart. The originally failing code path no longer depends on sending an incompatible mixed-provider tool-call transcript to Gemini; configured fallback entries are now screened before activation. The review-round status surface was additionally smoke-tested end-to-end against an isolated `$HERMES_HOME` config to confirm the resolved per-layer `Inject:` rendering (including partial root-level objects).

## Tests

Regression coverage:

- **Resolved-transport screening:** `provider: gemini` on the `/openai` endpoint and a Gemini-named aggregator route both activate despite unsigned tool history; a `provider: google` alias entry is screened like `gemini`; a gemini-only chain exhausts without permanently blacklisting the entry; the skipped entry's resolved client is closed; explicit-args resolution transport (`resolve_provider_client` with native vs `/openai` base URLs) is pinned next to the existing gemini provider suite.
- **Signature shapes:** empty, unrelated, empty-string, and non-dict `extra_content` still skip; all supported signature shapes allow fallback; an equivalence test pins that the screen and the request translator can never disagree; unsigned `tool_calls` echoes on `tool`-role messages do not block; malformed history entries neither crash nor block.
- **Honcho gating:** default `inject` behavior stays legacy-compatible; explicit `false` in partial host-level config is preserved; host-level empty `inject` overrides root-level config; AI self-representation can be suppressed while the curated AI card stays injected.
- **Honcho exposure:** wizard preset write/reset/keep paths including root-object override and root-state detection; clone/enable propagation of the `inject` object.

Verified locally with:

```bash
scripts/run_tests.sh tests/run_agent/test_provider_fallback.py tests/agent/test_gemini_native_adapter.py \
  tests/agent/test_auxiliary_client.py tests/hermes_cli/test_gemini_provider.py tests/honcho_plugin \
  tests/test_honcho_client_config.py tests/run_agent/test_24996_fallback_exhaustion_cooldown.py \
  tests/run_agent/test_32646_fallback_429_after_timeout.py tests/run_agent/test_nous_fallback_unavailable.py \
  tests/run_agent/test_fallback_credential_isolation.py tests/run_agent/test_nous_429_fallback_reentry.py \
  tests/run_agent/test_init_fallback_on_exhausted_pool.py tests/run_agent/test_switch_model_fallback_prune.py -q
```

Result:

```text
825 tests passed, 0 failed
```

Also ran `python3 -m py_compile` over all touched source and test files, and `scripts/check-windows-footguns.py` over the changed product files (clean).