### PR TITLE
fix(pricing): correct deepseek-v4-pro rates (4x overcharge) and add v4-flash

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -470,12 +470,23 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         "deepseek",
         "deepseek-v4-pro",
     ): PricingEntry(
-        input_cost_per_million=Decimal("1.74"),
-        output_cost_per_million=Decimal("3.48"),
-        cache_read_cost_per_million=Decimal("0.0145"),
+        input_cost_per_million=Decimal("0.435"),
+        output_cost_per_million=Decimal("0.87"),
+        cache_read_cost_per_million=Decimal("0.003625"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-05-12",
+        pricing_version="deepseek-pricing-2026-07-10",
+    ),
+    (
+        "deepseek",
+        "deepseek-v4-flash",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.14"),
+        output_cost_per_million=Decimal("0.28"),
+        cache_read_cost_per_million=Decimal("0.0028"),
+        source="official_docs_snapshot",
+        source_url="https://api-docs.deepseek.com/quick_start/pricing",
+        pricing_version="deepseek-pricing-2026-07-10",
     ),
     # Google Gemini
     (

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -224,6 +224,10 @@ def test_deepseek_v4_pro_pricing_entry_exists():
     Before this fix, deepseek-v4-pro sessions showed as unknown cost
     in hermes insights because the _OFFICIAL_DOCS_PRICING table had no
     entry for that model.  See #24218.
+
+    Rates below are the official DeepSeek published prices:
+    https://api-docs.deepseek.com/quick_start/pricing
+    (V4-Pro: $0.435 input / $0.87 output / $0.003625 cache-hit per 1M).
     """
     entry = get_pricing_entry(
         "deepseek-v4-pro",
@@ -233,9 +237,24 @@ def test_deepseek_v4_pro_pricing_entry_exists():
     assert entry is not None
     assert entry.input_cost_per_million is not None
     assert entry.output_cost_per_million is not None
-    assert float(entry.input_cost_per_million) == 1.74
-    assert float(entry.output_cost_per_million) == 3.48
-    assert float(entry.cache_read_cost_per_million) == 0.0145
+    assert float(entry.input_cost_per_million) == 0.435
+    assert float(entry.output_cost_per_million) == 0.87
+    assert float(entry.cache_read_cost_per_million) == 0.003625
+
+
+def test_deepseek_v4_flash_pricing_entry_exists():
+    """deepseek-v4-flash must also carry a pricing entry.
+
+    It is a common default/fallback model; without an entry its sessions
+    price as ``unknown``.  Official rates: $0.14 input / $0.28 output /
+    $0.0028 cache-hit per 1M.
+    """
+    entry = get_pricing_entry("deepseek-v4-flash", provider="deepseek")
+
+    assert entry is not None
+    assert float(entry.input_cost_per_million) == 0.14
+    assert float(entry.output_cost_per_million) == 0.28
+    assert float(entry.cache_read_cost_per_million) == 0.0028
 
 
 def test_deepseek_v4_pro_estimate_usage_cost():
@@ -248,8 +267,8 @@ def test_deepseek_v4_pro_estimate_usage_cost():
 
     assert result.status == "estimated"
     assert result.amount_usd is not None
-    # 1M input × $1.74/M + 500K output × $3.48/M = $1.74 + $1.74 = $3.48
-    assert float(result.amount_usd) == 3.48
+    # 1M input × $0.435/M + 500K output × $0.87/M = $0.435 + $0.435 = $0.87
+    assert float(result.amount_usd) == 0.87
 
 
 def test_bedrock_claude_rows_all_carry_cache_pricing():


### PR DESCRIPTION
## Summary

`deepseek-v4-pro` is priced in `_OFFICIAL_DOCS_PRICING` at **$1.74 input / $3.48 output / $0.0145 cache-hit** per 1M tokens — exactly **4×** the official published rate. DeepSeek's docs list V4-Pro at **$0.435 / $0.87 / $0.003625** ([source](https://api-docs.deepseek.com/quick_start/pricing), verified 2026-07-10). Every ratio is 4.0×, so the entry is a stale pre-April-2026 snapshot that survived a later price cut.

Impact: every `deepseek-v4-pro` session is overcharged 4× everywhere cost is surfaced — `/usage`, `/insights`, and the session cost-tracking path (`session_estimated_cost_usd`).

Also adds the missing **`deepseek-v4-flash`** entry ($0.14 / $0.28 / $0.0028). It's a common default/fallback model and previously priced as `unknown`.

## Changes

- `agent/usage_pricing.py` — correct v4-pro rates to official docs; add v4-flash entry.
- `tests/agent/test_usage_pricing.py` — the two existing regression tests hardcoded the stale 4× values (`== 1.74`, `== 3.48`), which would have locked the bug in. Updated to assert the official rates; added a v4-flash entry test.

## Verification

```
1M in + 500K out @ v4-pro: 1_000_000×0.435/1e6 + 500_000×0.87/1e6 = $0.87  (was $3.48)
```

All three DeepSeek pricing tests pass against the corrected table.

## Test plan

- [x] `tests/agent/test_usage_pricing.py` DeepSeek cases pass
- [x] Rates cross-checked against https://api-docs.deepseek.com/quick_start/pricing
