### PR TITLE
fix(feishu): honor config group access rules

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -246,6 +246,50 @@ class GatewayAuthorizationMixin:
             return any(str(item).strip() for item in sender_allow)
         return False
 
+    def _adapter_group_has_explicit_access_rule(
+        self,
+        platform: Optional[Platform],
+        chat_id: Optional[str],
+        *,
+        profile: Optional[str] = None,
+    ) -> bool:
+        """Whether an exact chat ID has an active config-driven access rule.
+
+        An explicit ``group_rules.<chat_id>`` entry is itself a chat allowlist:
+        ``policy: open`` opens only that named chat, not every group or DM. The
+        adapter enforces the rule before dispatch, so a message reaching the
+        gateway has already passed any sender allowlist, blacklist, or admin
+        restriction attached to it.
+        """
+        if not platform or not chat_id:
+            return False
+        adapter = self._authorization_adapter(platform, profile)
+        rules = getattr(adapter, "_group_rules", None) if adapter is not None else None
+        if rules is None:
+            config = getattr(self, "config", None)
+            platform_cfg = (
+                config.platforms.get(platform)
+                if config is not None and hasattr(config, "platforms")
+                else None
+            )
+            extra = getattr(platform_cfg, "extra", None) if platform_cfg else None
+            if isinstance(extra, dict):
+                rules = extra.get("group_rules")
+        if not isinstance(rules, dict):
+            return False
+
+        rule = rules.get(str(chat_id))
+        if isinstance(rule, dict):
+            policy = rule.get("policy", "open")
+        else:
+            policy = getattr(rule, "policy", None)
+        return str(policy or "").strip().lower() in {
+            "open",
+            "allowlist",
+            "blacklist",
+            "admin_only",
+        }
+
     def _pairing_store_for(self, source: "SessionSource"):
         """Pick the per-profile PairingStore for a source, falling back to global.
 
@@ -341,6 +385,21 @@ class GatewayAuthorizationMixin:
                     }
                     if "*" in allowed_group_ids or source.chat_id in allowed_group_ids:
                         return True
+
+            # Config-driven per-group rules are also explicit chat-scoped
+            # authorization. Trust them only for adapters that enforce their own
+            # intake policy and only for an exact active rule; a top-level/default
+            # ``group_policy: open`` remains insufficient and still falls through
+            # to the normal fail-closed user allowlist checks below.
+            if self._adapter_enforces_own_access_policy(
+                source.platform,
+                profile=source.profile,
+            ) and self._adapter_group_has_explicit_access_rule(
+                source.platform,
+                source.chat_id,
+                profile=source.profile,
+            ):
+                return True
 
         # Bots admitted by {PLATFORM}_ALLOW_BOTS bypass the human allowlist (#4466).
         # Checked before the no-user-id guard below: some platforms deliver

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2412,22 +2412,26 @@ class BasePlatformAdapter(ABC):
     def enforces_own_access_policy(self) -> bool:
         """Whether this adapter gates inbound access before dispatch.
 
-        Some adapters (WeCom, Weixin, Yuanbao, QQBot, WhatsApp) implement a
+        Some adapters (WeCom, Weixin, Yuanbao, QQBot, WhatsApp, Feishu) implement a
         documented config-driven access surface — ``dm_policy`` / ``group_policy`` /
-        ``allow_from`` / ``group_allow_from`` in ``PlatformConfig.extra`` — and
+        ``allow_from`` / ``group_allow_from`` / ``group_rules`` in
+        ``PlatformConfig.extra`` — and
         enforce it at intake: a message is dropped inside the adapter and never
         reaches the gateway unless it already passed that policy.
 
         The gateway's env-based allowlist check runs *after* the adapter. When
         no env allowlist is configured, the gateway consults this flag so it can
-        honor a config-only ``dm_policy: allowlist`` / ``allow_from`` (which the
-        adapter already enforced) instead of double-denying it. Crucially, the
+        honor a config-only ``dm_policy: allowlist`` / ``allow_from`` or exact
+        per-group rule (which the adapter already enforced) instead of
+        double-denying it. Crucially, the
         flag alone is NOT "already authorized": these adapters default
         ``dm_policy`` / ``group_policy`` to ``"open"``, which forwards every
         sender, so the gateway trusts the adapter only when its effective policy
         for the chat type is an actual ``"allowlist"`` restriction — never for
         ``"open"`` (that would be the network-exposed fail-open SECURITY.md §2.6
-        forbids). Open access still requires an explicit
+        forbids). An exact ``group_rules.<chat_id>`` entry is different: the
+        named chat is itself an explicit allowlist boundary. Broad open access
+        still requires an explicit
         ``{PLATFORM}_ALLOW_ALL_USERS`` / ``GATEWAY_ALLOW_ALL_USERS`` opt-in.
 
         Adapters that own their access policy override this to return ``True``.

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1434,6 +1434,11 @@ class FeishuAdapter(BasePlatformAdapter):
     # is almost certain.
     _SPLIT_THRESHOLD = 4000
 
+    @property
+    def enforces_own_access_policy(self) -> bool:
+        """Feishu gates group access at intake through ``group_rules``."""
+        return True
+
     # =========================================================================
     # Lifecycle — init / settings / connect / disconnect
     # =========================================================================

--- a/tests/gateway/test_config_driven_access_policy.py
+++ b/tests/gateway/test_config_driven_access_policy.py
@@ -1,8 +1,9 @@
 """Tests for config-driven platform access policies at the gateway layer.
 
-Background (#34515): WeCom, Weixin, Yuanbao, QQBot, and WhatsApp expose a
+Background (#34515): WeCom, Weixin, Yuanbao, QQBot, WhatsApp, and Feishu expose a
 documented config-driven access surface (``dm_policy`` / ``group_policy`` /
-``allow_from`` / ``group_allow_from`` in ``PlatformConfig.extra``) and enforce
+``allow_from`` / ``group_allow_from`` / ``group_rules`` in
+``PlatformConfig.extra``) and enforce
 it at intake —
 a message is dropped inside the adapter and never reaches the gateway unless it
 already passed that policy.
@@ -113,6 +114,7 @@ def test_base_adapter_defaults_to_not_owning_access_policy():
         ("gateway.platforms.yuanbao", "YuanbaoAdapter"),
         ("gateway.platforms.qqbot.adapter", "QQAdapter"),
         ("plugins.platforms.whatsapp.adapter", "WhatsAppAdapter"),
+        ("plugins.platforms.feishu.adapter", "FeishuAdapter"),
     ],
 )
 def test_own_policy_adapters_declare_the_flag(module_path, class_name):

--- a/tests/gateway/test_feishu_bot_auth_bypass.py
+++ b/tests/gateway/test_feishu_bot_auth_bypass.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from gateway.config import GatewayConfig, PlatformConfig
 from gateway.session import Platform, SessionSource
 
 
@@ -21,6 +22,8 @@ def _isolate_feishu_env(monkeypatch):
         "FEISHU_ALLOW_BOTS",
         "FEISHU_ALLOWED_USERS",
         "FEISHU_ALLOW_ALL_USERS",
+        "FEISHU_GROUP_POLICY",
+        "FEISHU_ALLOWED_GROUP_USERS",
         "TELEGRAM_ALLOW_BOTS",
         "GATEWAY_ALLOW_ALL_USERS",
         "GATEWAY_ALLOWED_USERS",
@@ -34,6 +37,23 @@ def _make_bare_runner():
     runner = object.__new__(GatewayRunner)
     runner.pairing_store = SimpleNamespace(is_approved=lambda *_a, **_kw: False)
     return runner
+
+
+def _make_group_rule_runner(group_rules, **extra):
+    from plugins.platforms.feishu.adapter import FeishuAdapter
+
+    platform_config = PlatformConfig(
+        enabled=True,
+        extra={"group_rules": group_rules, **extra},
+    )
+    adapter = FeishuAdapter(platform_config)
+    runner = _make_bare_runner()
+    runner.adapters = {Platform.FEISHU: adapter}
+    runner._profile_adapters = {}
+    runner.config = GatewayConfig(
+        platforms={Platform.FEISHU: platform_config},
+    )
+    return runner, adapter
 
 
 def _make_feishu_bot_source(open_id: str = "ou_peer"):
@@ -97,6 +117,73 @@ def test_feishu_human_still_checked_against_allowlist_when_bot_policy_set(monkey
 
     assert runner._is_user_authorized(_make_feishu_human_source("ou_stranger")) is False
     assert runner._is_user_authorized(_make_feishu_human_source("ou_human")) is True
+
+
+def test_explicit_open_group_rule_authorizes_only_that_chat(monkeypatch):
+    monkeypatch.setenv("FEISHU_ALLOWED_USERS", "ou_dm_owner")
+    runner, adapter = _make_group_rule_runner({
+        "oc_1": {"policy": "open"},
+    })
+
+    assert adapter.enforces_own_access_policy is True
+    assert runner._is_user_authorized(_make_feishu_human_source("ou_guest")) is True
+
+    other_group = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_2",
+        chat_type="group",
+        user_id="ou_guest",
+        user_name="Guest",
+    )
+    dm = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_dm",
+        chat_type="dm",
+        user_id="ou_guest",
+        user_name="Guest",
+    )
+    assert runner._is_user_authorized(other_group) is False
+    assert runner._is_user_authorized(dm) is False
+
+
+def test_disabled_group_rule_does_not_authorize_chat(monkeypatch):
+    monkeypatch.setenv("FEISHU_ALLOWED_USERS", "ou_dm_owner")
+    runner, _adapter = _make_group_rule_runner({
+        "oc_1": {"policy": "disabled"},
+    })
+
+    assert runner._is_user_authorized(_make_feishu_human_source("ou_guest")) is False
+
+
+def test_default_open_group_policy_is_not_a_chat_allowlist(monkeypatch):
+    monkeypatch.setenv("FEISHU_ALLOWED_USERS", "ou_dm_owner")
+    runner, _adapter = _make_group_rule_runner(
+        {}, default_group_policy="open",
+    )
+
+    assert runner._is_user_authorized(_make_feishu_human_source("ou_guest")) is False
+
+
+def test_explicit_sender_allowlist_is_enforced_before_gateway_authorization(monkeypatch):
+    monkeypatch.setenv("FEISHU_ALLOWED_USERS", "ou_dm_owner")
+    runner, adapter = _make_group_rule_runner({
+        "oc_1": {
+            "policy": "allowlist",
+            "allowlist": ["ou_group_member"],
+        },
+    })
+    allowed_sender = SimpleNamespace(
+        open_id="ou_group_member", user_id=None,
+    )
+    denied_sender = SimpleNamespace(
+        open_id="ou_guest", user_id=None,
+    )
+
+    assert adapter._allow_group_message(allowed_sender, "oc_1") is True
+    assert adapter._allow_group_message(denied_sender, "oc_1") is False
+    assert runner._is_user_authorized(
+        _make_feishu_human_source("ou_group_member")
+    ) is True
 
 
 def test_feishu_bot_bypass_does_not_leak_to_other_platforms(monkeypatch):

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -524,6 +524,12 @@ platforms:
 | `admin_only` | Only users in the global `admins` list can use the bot in this group |
 | `disabled` | Bot ignores all messages in this group |
 
+An explicit `group_rules` entry also authorizes that chat at the gateway layer.
+For example, `policy: open` allows everyone in that named group without granting
+those users DM access or access from any other group. The top-level/default
+`group_policy: open` does not provide this authorization; broad access still
+requires an explicit allow-all setting.
+
 Set `require_mention: false` on a `group_rules` entry to skip the @-mention requirement for that specific chat. When omitted, the chat inherits the global `FEISHU_REQUIRE_MENTION` value.
 
 Groups not listed in `group_rules` fall back to `default_group_policy` (defaults to the value of `FEISHU_GROUP_POLICY`).


### PR DESCRIPTION
## Summary

Makes Feishu's existing `config.yaml` `group_rules` access policy authoritative at the gateway layer.

An exact `group_rules.<chat_id>` entry is a chat-scoped allowlist. In particular, `policy: open` allows everyone in that named group without granting DM access or access from other groups.

Supersedes #61376, which introduced a new environment variable for the same behavior.

## Details

- Declares that the Feishu adapter enforces its config-driven group policy at intake.
- Lets gateway authorization trust only exact, active `group_rules` entries that already passed adapter policy.
- Supports existing `open`, `allowlist`, `blacklist`, and `admin_only` rules.
- Does not trust `disabled` rules.
- Does not treat top-level/default `group_policy: open` as authorization.
- Preserves existing DM, pairing, global allowlist, and profile-isolation behavior.
- Documents the chat-scoped authorization semantics.

No new environment variable or configuration surface is introduced.

## Validation

- `scripts/run_tests.sh tests/gateway/test_feishu_bot_auth_bypass.py tests/gateway/test_config_driven_access_policy.py tests/gateway/test_feishu.py tests/gateway/test_multiplex_profile_authz.py -q`
- Result: 298 passed
- `ruff check` on changed Python files
- `git diff --check`
