### PR TITLE
fix(kanban): allow blocking tasks in 'todo' status

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5529,7 +5529,7 @@ def block_task(
     kind: Optional[str] = None,
     expected_run_id: Optional[int] = None,
 ) -> bool:
-    """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
+    """Transition ``running``/``ready``/``todo`` → ``blocked`` (or route elsewhere).
 
     ``kind`` (one of :data:`VALID_BLOCK_KINDS`, or ``None`` for a legacy
     un-typed block) drives routing instead of every block landing in one
@@ -5590,7 +5590,7 @@ def block_task(
                        worker_pid    = NULL,
                        block_kind    = ?
                  WHERE id = ?
-                   AND status IN ('running', 'ready')
+                   AND status IN ('running', 'ready', 'todo')
                 """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
                 (kind, task_id) if expected_run_id is None
                 else (kind, task_id, int(expected_run_id)),
@@ -5643,7 +5643,7 @@ def block_task(
                        block_kind    = ?,
                        block_recurrences = ?
                  WHERE id = ?
-                   AND status IN ('running', 'ready')
+                   AND status IN ('running', 'ready', 'todo')
                 """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
                 (kind, recurrences, task_id) if expected_run_id is None
                 else (kind, recurrences, task_id, int(expected_run_id)),
@@ -5681,7 +5681,7 @@ def block_task(
                            block_kind    = ?,
                            block_recurrences = ?
                      WHERE id = ?
-                       AND status IN ('running', 'ready')
+                       AND status IN ('running', 'ready', 'todo')
                     """,
                     (kind, recurrences, task_id),
                 )
@@ -5696,7 +5696,7 @@ def block_task(
                            block_kind    = ?,
                            block_recurrences = ?
                      WHERE id = ?
-                       AND status IN ('running', 'ready')
+                       AND status IN ('running', 'ready', 'todo')
                        AND current_run_id = ?
                     """,
                     (kind, recurrences, task_id, int(expected_run_id)),

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -4398,7 +4398,7 @@
         // dispatcher's claim_task path, which atomically creates the run row,
         // claim lock, and worker process metadata.
         b(tx(t, "block", "Block"),     { status: "blocked" },
-          task.status === "running" || task.status === "ready",
+          task.status === "running" || task.status === "ready" || task.status === "todo",
           getDestructiveConfirm(t, "blocked")),
         b(tx(t, "unblock", "Unblock"),   { status: "ready" },    task.status === "blocked"),
         b(tx(t, "complete", "Complete"),  { status: "done" },

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -161,3 +161,44 @@ def test_protocol_violation_loop_is_broken(kanban_home: Path) -> None:
 # (landed via #28754 / #28781).  The original PR shipped a duplicate test
 # here; dropped during salvage to avoid two assertions of the same contract.
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Regression: block_task from todo status (PR #62342)
+# ---------------------------------------------------------------------------
+
+
+def test_block_todo_child_stays_blocked_after_parent_completes(kanban_home: Path) -> None:
+    """A dependency-gated child in ``todo`` status that is explicitly
+    blocked must stay blocked after its parent completes.
+
+    Before #62342's fix, ``block_task`` refused to act on ``todo`` tasks
+    (SQL guard ``WHERE status IN ('running', 'ready')`` matched 0 rows),
+    so a user could not pre-block a ``todo`` child to prevent auto-dispatch
+    when its parents finished.  The dispatcher would promote the child to
+    ``ready`` and a worker could claim it before the user had a chance to
+    block it.
+
+    This test asserts the full path:
+    1. Create parent + child (child starts in ``todo``, gated by parent).
+    2. Block the child from ``todo`` — must succeed and set status to
+       ``blocked``.
+    3. Complete the parent.
+    4. ``recompute_ready`` must NOT promote the child (sticky block holds).
+    """
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent])
+        assert kb.get_task(conn, child).status == "todo"
+
+        # Block from todo — the new path enabled by PR #62342.
+        assert kb.block_task(conn, child, reason="pre-block: waiting on external input")
+        assert kb.get_task(conn, child).status == "blocked"
+
+        # Complete the parent — this would normally trigger promotion.
+        kb.complete_task(conn, parent, result="parent done")
+
+        # recompute_ready must respect the sticky block.
+        promoted = kb.recompute_ready(conn)
+        assert promoted == 0, "blocked todo child must not auto-promote after parent completes"
+        assert kb.get_task(conn, child).status == "blocked"

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -708,3 +708,43 @@ def test_specify_happy_path(client, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# PATCH /tasks/:id — blocking a task that is still in 'todo' (PR #62342)
+# ---------------------------------------------------------------------------
+
+
+def test_patch_blocks_dependency_gated_todo_task(client):
+    """The dashboard must be able to block a task while it is still 'todo'.
+
+    Before #62342, block_task()'s SQL guard matched only running/ready, so this
+    PATCH silently failed for a dependency-gated child: the user could not
+    pre-block work before its parents finished, and the task would be promoted
+    to 'ready' and claimed by a worker instead.
+    """
+    parent = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "parent"},
+    ).json()["task"]
+    child = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "child", "parents": [parent["id"]]},
+    ).json()["task"]
+    assert child["status"] == "todo", "child should be gated by its parent"
+
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{child['id']}",
+        json={"status": "blocked", "block_reason": "waiting on external input"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["task"]["status"] == "blocked"
+
+    # The block is sticky: completing the parent must not promote the child.
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{parent['id']}",
+        json={"status": "done"},
+    )
+    assert r.status_code == 200, r.text
+
+    board = client.get("/api/plugins/kanban/board").json()
+    blocked = next(c for c in board["columns"] if c["name"] == "blocked")
+    assert [t["id"] for t in blocked["tasks"]] == [child["id"]]
+    ready = next(c for c in board["columns"] if c["name"] == "ready")
+    assert child["id"] not in [t["id"] for t in ready["tasks"]]


### PR DESCRIPTION
## Problem

Tasks in `todo` status (waiting on parent dependencies) cannot be blocked — neither via the CLI (`hermes kanban block`), the dashboard drag-and-drop, nor the dashboard Block button in the task drawer.

### Root cause

`block_task()` in `hermes_cli/kanban_db.py` has 4 SQL UPDATE statements, all guarded by:

```sql
WHERE id = ? AND status IN ('running', 'ready')
```

A task in `todo` status matches 0 rows → `block_task` returns `False` → the backend raises HTTP 409 → the dashboard silently snaps the card back to its original column with no error message.

The dashboard frontend (`StatusActions` in `plugins/kanban/dashboard/dist/index.js`) compounds this by only enabling the Block button when `task.status === 'running' || task.status === 'ready'`, so the button appears disabled for `todo` tasks.

### Real-world impact

When using the kanban board for project work with dependency-linked tasks, a user cannot pre-block a `todo` task to prevent auto-dispatch when its parents complete. The task promotes to `ready` and the dispatcher claims it before the user has a chance to block it — which can trigger unwanted token usage on LLM-backed worker profiles.

## Fix

**Backend** (`hermes_cli/kanban_db.py`): Widen all 4 SQL guards inside `block_task()` from `('running', 'ready')` to `('running', 'ready', 'todo')`. Also updated the docstring.

**Frontend** (`plugins/kanban/dashboard/dist/index.js`): Enable the Block button for `todo` status tasks in the `StatusActions` component.

### Why this is safe

The existing `_has_sticky_block()` mechanism in `recompute_ready()` already prevents auto-promotion of tasks that have a `'blocked'` event from `block_task()`. So a blocked `todo` task stays blocked even when its parents complete — no changes needed to the promotion engine.

```
recompute_ready → _has_sticky_block → finds 'blocked' event → skips promotion
```

The 5th occurrence of `status IN ('running', 'ready')` at line ~6621 (the failure circuit breaker in `_record_task_failure`) is intentionally left unchanged — it only fires on running/ready tasks that have exhausted their retry limit.

## Verification

```python
# block_task from todo: returns True, status -> blocked, sticky block set
# recompute_ready: promoted 0 (sticky-blocked task not promoted)
# block from ready: still works (no regression)
# block from running: still works (no regression)
```

## Changes

- `hermes_cli/kanban_db.py`: 4 SQL guards widened + docstring updated (6 lines)
- `plugins/kanban/dashboard/dist/index.js`: Block button enabled condition expanded (1 line)

<!-- Test plan -->
## Test Plan

- [ ] Unit test: `block_task()` on a `todo` status task returns `True` and sets status to `blocked`
- [ ] Unit test: `recompute_ready()` does not promote a sticky-blocked `todo` task after parents complete
- [ ] Unit test: `block_task()` from `ready` and `running` still works (regression check)
- [ ] Manual: dashboard Block button is enabled and functional for `todo` status tasks