### PR TITLE
feat: harden TheWon runtime rollout gates

### DIFF
--- a/agent/blackbox_bridge.py
+++ b/agent/blackbox_bridge.py
@@ -1,0 +1,238 @@
+"""Best-effort bridge from Hermes session persistence to TheWon Blackbox.
+
+TheWon treats blackbox raw logs as the non-lossy audit layer that must exist
+*before* any context compression/summary can safely discard live context.  This
+module intentionally sits below the agent loop, at SessionDB persistence, so CLI,
+gateway, cron mirrors, and future frontends all flow through one append-only
+recorder without adding model tools or changing prompts.
+
+The bridge is config-gated and fail-open: if TheWon is absent or the recorder
+raises, Hermes session persistence must continue unaffected.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import threading
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+_lock = threading.Lock()
+_recorder: Any = None
+_recorder_key: tuple[str, str] | None = None
+_disabled_reason: str | None = None
+
+
+def _safe_text(value: Any, *, limit: int = 200_000) -> str:
+    """Return a searchable, JSON-safe text representation for blackbox data."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        text = value
+    elif isinstance(value, list):
+        parts: list[str] = []
+        for item in value:
+            if isinstance(item, dict):
+                if item.get("type") in (None, "text", "input_text"):
+                    parts.append(str(item.get("text") or ""))
+                elif item.get("type") in {"image", "image_url", "input_image"}:
+                    parts.append("[image]")
+                else:
+                    parts.append(json.dumps(item, ensure_ascii=False, default=str))
+            else:
+                parts.append(str(item))
+        text = "\n".join(p for p in parts if p)
+    else:
+        try:
+            text = json.dumps(value, ensure_ascii=False, default=str)
+        except Exception:
+            text = str(value)
+    if len(text) > limit:
+        return text[:limit] + f"\n[blackbox_bridge truncated at {limit} chars]"
+    return text
+
+
+def _load_cfg() -> dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+    except Exception as exc:
+        logger.debug("blackbox_bridge: config load failed: %s", exc)
+        return {}
+    section = cfg.get("blackbox") if isinstance(cfg, dict) else {}
+    return section if isinstance(section, dict) else {}
+
+
+def _enabled(cfg: dict[str, Any]) -> bool:
+    value = cfg.get("enabled", False)
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _resolve_thewon_system(cfg: dict[str, Any]) -> Path:
+    raw = cfg.get("thewon_system") or os.getenv("THEWON_SYSTEM") or "/Users/elroy/TheWon/System"
+    return Path(str(raw)).expanduser().resolve()
+
+
+def _get_recorder(cfg: dict[str, Any]) -> Any:
+    """Return a cached BlackboxRecorder or None when disabled/unavailable."""
+    global _recorder, _recorder_key, _disabled_reason
+    if not _enabled(cfg):
+        return None
+
+    agent_id = str(cfg.get("agent_id") or "VN").strip() or "VN"
+    thewon_system = _resolve_thewon_system(cfg)
+    key = (agent_id, str(thewon_system))
+
+    with _lock:
+        if _recorder is not None and _recorder_key == key:
+            return _recorder
+        try:
+            system_root = thewon_system.parent / "00_System"
+            if str(system_root) not in sys.path:
+                sys.path.insert(0, str(system_root))
+            os.environ.setdefault("THEWON_SYSTEM", str(thewon_system))
+            from shared.blackbox_recorder import BlackboxRecorder  # type: ignore[import-not-found]
+
+            _recorder = BlackboxRecorder(agent_id)
+            _recorder_key = key
+            _disabled_reason = None
+            return _recorder
+        except Exception as exc:
+            _recorder = None
+            _recorder_key = None
+            _disabled_reason = str(exc)
+            logger.warning("TheWon blackbox bridge unavailable: %s", exc)
+            return None
+
+
+def record_session_message(
+    *,
+    session_id: str,
+    message_id: Optional[int],
+    role: str,
+    content: Any = None,
+    tool_name: Optional[str] = None,
+    tool_calls: Any = None,
+    tool_call_id: Optional[str] = None,
+    token_count: Optional[int] = None,
+    finish_reason: Optional[str] = None,
+    platform_message_id: Optional[str] = None,
+    observed: bool = False,
+    timestamp: Any = None,
+) -> None:
+    """Append one Hermes message to TheWon raw blackbox, best-effort."""
+    cfg = _load_cfg()
+    rec = _get_recorder(cfg)
+    if rec is None:
+        return
+
+    role = str(role or "unknown")
+    content_text = _safe_text(content)
+    data = {
+        "source": "hermes_state",
+        "message_role": role,
+        "content_text": content_text,
+        "message_id": message_id,
+        "platform_message_id": platform_message_id,
+        "tool_name": tool_name,
+        "tool_calls": tool_calls,
+        "tool_call_id": tool_call_id,
+        "token_count": token_count,
+        "finish_reason": finish_reason,
+        "observed": bool(observed),
+    }
+    if timestamp is not None:
+        data["message_timestamp"] = str(timestamp)
+
+    # Keep events semantically queryable while preserving exact fields in data.
+    if role == "user":
+        event_type = "input"
+    elif role == "assistant":
+        event_type = "output"
+    elif role == "tool" or tool_name:
+        event_type = "tool_call"
+    else:
+        event_type = "message"
+
+    try:
+        rec.record(
+            {
+                "type": event_type,
+                "session": session_id,
+                "project": cfg.get("project"),
+                "tags": ["hermes", "session_db", "raw"],
+                "severity": "info",
+                "data": data,
+            },
+            session_id=session_id,
+            request_id=str(platform_message_id or message_id or session_id),
+        )
+    except Exception as exc:
+        logger.debug("TheWon blackbox message record failed: %s", exc)
+
+
+def record_transcript_event(
+    *,
+    session_id: str,
+    event_type: str,
+    messages: list[dict[str, Any]] | None = None,
+    extra: Optional[dict[str, Any]] = None,
+) -> None:
+    """Record transcript-level events such as compression/rewrite boundaries."""
+    cfg = _load_cfg()
+    rec = _get_recorder(cfg)
+    if rec is None:
+        return
+
+    messages = messages or []
+    preview_parts: list[str] = []
+    for msg in messages[:20]:
+        role = msg.get("role", "unknown") if isinstance(msg, dict) else "unknown"
+        content = msg.get("content") if isinstance(msg, dict) else msg
+        text = _safe_text(content, limit=8_000)
+        if text:
+            preview_parts.append(f"[{role}] {text}")
+    content_text = "\n\n".join(preview_parts)
+    data = {
+        "source": "hermes_state",
+        "event": event_type,
+        "message_count": len(messages),
+        "content_text": content_text,
+    }
+    if extra:
+        data.update(extra)
+    try:
+        rec.record(
+            {
+                "type": event_type,
+                "session": session_id,
+                "project": cfg.get("project"),
+                "tags": ["hermes", "session_db", "compression" if "compact" in event_type or "compress" in event_type else "rewrite"],
+                "severity": "info",
+                "data": data,
+            },
+            session_id=session_id,
+            request_id=f"{session_id}:{event_type}",
+        )
+    except Exception as exc:
+        logger.debug("TheWon blackbox transcript event failed: %s", exc)
+
+
+def status() -> dict[str, Any]:
+    """Small diagnostic surface for tests/manual smoke checks."""
+    cfg = _load_cfg()
+    return {
+        "enabled": _enabled(cfg),
+        "agent_id": cfg.get("agent_id") or "VN",
+        "thewon_system": str(_resolve_thewon_system(cfg)),
+        "recorder_ready": _get_recorder(cfg) is not None if _enabled(cfg) else False,
+        "disabled_reason": _disabled_reason,
+    }

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -357,13 +357,25 @@ def run_codex_app_server_turn(
         should_review_skills = True
         agent._iters_since_skill = 0
 
+    final_text = turn.final_text
+    if final_text and not turn.interrupted:
+        try:
+            from agent.thewon_precheck import apply_precheck_response_block
+
+            final_text = apply_precheck_response_block(
+                final_text,
+                getattr(agent, "_thewon_precheck_bundle", None),
+            )
+        except Exception:
+            logger.debug("TheWon precheck response block failed on codex app-server path", exc_info=True)
+
     # External memory provider sync (mirrors line ~15439). Skipped on
     # interrupt/error to avoid feeding partial transcripts to memory.
     if not turn.interrupted and turn.error is None:
         try:
             agent._sync_external_memory_for_turn(
                 original_user_message=original_user_message,
-                final_response=turn.final_text,
+                final_response=final_text,
                 interrupted=False,
                 messages=messages,
             )
@@ -374,7 +386,7 @@ def run_codex_app_server_turn(
     # path (line ~15449). Only fires when a trigger actually tripped AND
     # we have a real final response.
     if (
-        turn.final_text
+        final_text
         and not turn.interrupted
         and (should_review_memory or should_review_skills)
     ):
@@ -388,7 +400,7 @@ def run_codex_app_server_turn(
             logger.debug("background review spawn raised", exc_info=True)
 
     return {
-        "final_response": turn.final_text,
+        "final_response": final_text,
         "messages": messages,
         "api_calls": api_calls,
         "completed": not turn.interrupted and turn.error is None,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -575,6 +575,28 @@ def run_conversation(
     _plugin_user_context = _ctx.plugin_user_context
     _ext_prefetch_cache = _ctx.ext_prefetch_cache
 
+    # TheWon L0.5 runtime precheck (KH + LLM Wiki). This is current-turn
+    # ephemeral context only: it does not mutate the stable system prompt or
+    # persisted user message, preserving prompt-cache invariants.
+    _thewon_precheck_context = ""
+    try:
+        from agent.thewon_precheck import format_precheck_context, run_thewon_precheck
+
+        agent._thewon_precheck_bundle = run_thewon_precheck(
+            original_user_message,
+            agent_code="Hermes",
+        )
+        _thewon_precheck_context = format_precheck_context(
+            agent._thewon_precheck_bundle
+        )
+    except Exception as _tw_precheck_err:
+        logger.warning("TheWon KH+Wiki precheck hook failed: %s", _tw_precheck_err)
+        agent._thewon_precheck_bundle = {
+            "required": False,
+            "query": str(original_user_message)[:500],
+            "errors": [f"precheck hook failed: {_tw_precheck_err!r}"],
+        }
+
     # Main conversation loop counters (pure locals consumed by the loop below).
     api_call_count = 0
     final_response = None
@@ -593,8 +615,11 @@ def run_conversation(
     # See agent/transports/codex_app_server_session.py for the adapter
     # and references/codex-app-server-runtime.md for the rationale.
     if agent.api_mode == "codex_app_server":
+        _codex_user_message = user_message
+        if _thewon_precheck_context and isinstance(_codex_user_message, str):
+            _codex_user_message = _codex_user_message + "\n\n" + _thewon_precheck_context
         return agent._run_codex_app_server_turn(
-            user_message=user_message,
+            user_message=_codex_user_message,
             original_user_message=original_user_message,
             messages=messages,
             effective_task_id=effective_task_id,
@@ -767,6 +792,8 @@ def run_conversation(
                         _injections.append(_fenced)
                 if _plugin_user_context:
                     _injections.append(_plugin_user_context)
+                if _thewon_precheck_context:
+                    _injections.append(_thewon_precheck_context)
                 if _injections:
                     _base = api_msg.get("content", "")
                     if isinstance(_base, str):

--- a/agent/thewon_precheck.py
+++ b/agent/thewon_precheck.py
@@ -1,0 +1,284 @@
+"""TheWon KH + LLM Wiki precheck runtime enforcement.
+
+This module is intentionally edge-gated: it activates only for TheWon-adjacent
+requests on machines that have the user's TheWon runtime installed.  It does
+not add a model tool and does not mutate the stable system prompt; the precheck
+bundle is injected as ephemeral current-turn user context and mirrored in the
+final response as an evidence block.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+THEWON_KEYWORDS = (
+    "thewon",
+    "the won",
+    "hermes",
+    "openclaw",
+    "min-a",
+    "mina",
+    "민아",
+    "bac",
+    "sac",
+    "named agent",
+    "worker",
+    "knowledgehub",
+    "knowledge hub",
+    "llm wiki",
+    "wikirouter",
+    "blackbox",
+    "ssot",
+    "gatekeeper",
+    "quality gate",
+    "qg",
+    "6hats",
+    "thinktank",
+    "vault",
+    "obsidian",
+    "rdf",
+    "hwpx",
+    "hwp",
+    "재무모델",
+    "에이전트",
+    "고도화",
+    "정본",
+    "반영",
+    "절차",
+    "품질",
+    "거버넌스",
+    "위키",
+    "하네스",
+)
+
+
+@dataclass
+class TheWonPrecheckBundle:
+    required: bool
+    query: str
+    kh_summary: str = ""
+    wiki_source: str = ""
+    wiki_reason: str = ""
+    wiki_hits: list[dict[str, Any]] = field(default_factory=list)
+    read_files: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    kh_query_executed: bool = False
+    wiki_route_executed: bool = False
+    relevant_sources_read: bool = False
+    unresolved_items_declared: bool = True
+    source_mode_declared: bool = True
+
+    @property
+    def ok(self) -> bool:
+        if not self.required:
+            return False
+        return all(
+            [
+                self.kh_query_executed,
+                self.wiki_route_executed,
+                self.relevant_sources_read,
+                self.unresolved_items_declared,
+                self.source_mode_declared,
+            ]
+        )
+
+    def precheck_object(self) -> dict[str, bool]:
+        return {
+            "kh_query_executed": self.kh_query_executed,
+            "wiki_route_executed": self.wiki_route_executed,
+            "relevant_sources_read": self.relevant_sources_read,
+            "unresolved_items_declared": self.unresolved_items_declared,
+            "source_mode_declared": self.source_mode_declared,
+        }
+
+
+def _message_to_text(message: Any) -> str:
+    if isinstance(message, str):
+        return message
+    if isinstance(message, list):
+        parts: list[str] = []
+        for item in message:
+            if isinstance(item, dict):
+                text = item.get("text") or item.get("content")
+                if isinstance(text, str):
+                    parts.append(text)
+            elif isinstance(item, str):
+                parts.append(item)
+        return "\n".join(parts)
+    return str(message or "")
+
+
+def should_run_thewon_precheck(user_message: Any) -> bool:
+    text = _message_to_text(user_message).lower()
+    return any(keyword in text for keyword in THEWON_KEYWORDS)
+
+
+def _ensure_thewon_import_paths() -> bool:
+    candidates = [
+        Path.home() / "TheWon",
+        Path.home() / "TheWon" / "System",
+    ]
+    added = False
+    for path in candidates:
+        if path.exists():
+            s = str(path)
+            if s not in sys.path:
+                sys.path.insert(0, s)
+                added = True
+    return any(path.exists() for path in candidates) or added
+
+
+def _hit_to_dict(hit: Any) -> dict[str, Any]:
+    return {
+        "title": getattr(hit, "title", None),
+        "confidence": getattr(hit, "confidence", None),
+        "score": getattr(hit, "score", None),
+        "path": getattr(hit, "path", None),
+    }
+
+
+def run_thewon_precheck(user_message: Any, *, agent_code: str = "Hermes") -> TheWonPrecheckBundle:
+    """Run KH + WikiRouter precheck for a TheWon-adjacent user message.
+
+    Returns a bundle even on failure; callers can surface the errors instead of
+    silently skipping the gate.
+    """
+    text = _message_to_text(user_message).strip()
+    required = should_run_thewon_precheck(text)
+    bundle = TheWonPrecheckBundle(required=required, query=text[:500])
+    if not required:
+        return bundle
+
+    if not _ensure_thewon_import_paths():
+        bundle.errors.append("TheWon path not found; KH/Wiki precheck could not import runtime")
+        return bundle
+
+    try:
+        from System.shared.knowledge_hub import KnowledgeHub  # type: ignore
+
+        bundle.kh_summary = KnowledgeHub(agent_code=agent_code).smart_ask_formatted(
+            text,
+            top_k_per_source=3,
+            min_sources=2,
+        )
+        bundle.kh_query_executed = True
+    except Exception as exc:  # pragma: no cover - defensive runtime path
+        bundle.errors.append(f"KnowledgeHub failed: {exc!r}")
+        logger.warning("TheWon KnowledgeHub precheck failed: %s", exc)
+
+    try:
+        from System.shared.wiki_router import WikiRouter  # type: ignore
+
+        route = WikiRouter().route(text, threshold=0.2)
+        bundle.wiki_route_executed = True
+        bundle.wiki_source = str(route.get("source") or "")
+        bundle.wiki_reason = str(route.get("reason") or "")
+        hits = route.get("hits") or []
+        bundle.wiki_hits = [_hit_to_dict(hit) for hit in hits[:5]]
+        # Read top relevant wiki pages to make the precheck an actual source read,
+        # not just a router metadata lookup.  Keep it small to avoid context bloat.
+        for hit in hits[:3]:
+            path = getattr(hit, "path", None)
+            if not path:
+                continue
+            try:
+                p = Path(str(path))
+                if p.exists() and p.is_file():
+                    # Touch/read enough to verify accessibility without dumping contents.
+                    _ = p.read_text(encoding="utf-8", errors="replace")[:2000]
+                    bundle.read_files.append(str(p))
+                    bundle.relevant_sources_read = True
+            except Exception as exc:  # pragma: no cover - defensive runtime path
+                bundle.errors.append(f"Wiki read failed for {path}: {exc!r}")
+    except Exception as exc:  # pragma: no cover - defensive runtime path
+        bundle.errors.append(f"WikiRouter failed: {exc!r}")
+        logger.warning("TheWon WikiRouter precheck failed: %s", exc)
+
+    return bundle
+
+
+def format_precheck_context(bundle: TheWonPrecheckBundle | dict[str, Any] | None) -> str:
+    """Compact context injected into the current user turn for the model."""
+    if not bundle:
+        return ""
+    if isinstance(bundle, dict):
+        bundle = TheWonPrecheckBundle(**bundle)
+    if not bundle.required:
+        return ""
+    payload = {
+        "precheck_object": bundle.precheck_object(),
+        "precheck_pass": bundle.ok,
+        "kh": bundle.kh_summary or "(KnowledgeHub: no result or failed)",
+        "wiki_source": bundle.wiki_source,
+        "wiki_reason": bundle.wiki_reason,
+        "wiki_hits": bundle.wiki_hits[:3],
+        "read_files": bundle.read_files[:3],
+        "errors": bundle.errors,
+    }
+    return "[TheWon KH+LLM Wiki precheck]\n" + json.dumps(
+        payload,
+        ensure_ascii=False,
+        indent=2,
+    )
+
+
+def format_precheck_response_block(bundle: TheWonPrecheckBundle | dict[str, Any] | None) -> str:
+    """User-visible evidence block prefixed to final responses."""
+    if not bundle:
+        return ""
+    if isinstance(bundle, dict):
+        bundle = TheWonPrecheckBundle(**bundle)
+    if not bundle.required:
+        return ""
+
+    kh = (bundle.kh_summary or "(KnowledgeHub: 관련 정보 없음)").strip()
+    hit_titles = []
+    for hit in bundle.wiki_hits[:3]:
+        title = hit.get("title") or "untitled"
+        confidence = hit.get("confidence") or "?"
+        hit_titles.append(f"{title} ({confidence})")
+    wiki_line = "; ".join(hit_titles) if hit_titles else "관련 hit 없음"
+    read_line = "; ".join(Path(p).name for p in bundle.read_files[:3]) if bundle.read_files else "읽은 Wiki 파일 없음"
+    missing = "; ".join(bundle.errors) if bundle.errors else "없음"
+
+    return (
+        "[Precheck]\n"
+        f"Object: {json.dumps(bundle.precheck_object(), ensure_ascii=False)}\n"
+        f"Gate: {'PASS' if bundle.ok else 'FAIL'}\n"
+        f"KH: {kh}\n"
+        f"LLM Wiki: source={bundle.wiki_source or 'n/a'}; {wiki_line}\n"
+        f"Read: {read_line}\n"
+        "Source mode: KH + WikiRouter + live file read\n"
+        f"미확인: {missing}"
+    )
+
+
+def apply_precheck_response_block(
+    final_response: str | None,
+    bundle: TheWonPrecheckBundle | dict[str, Any] | None,
+) -> str | None:
+    if not final_response:
+        return final_response
+    if bundle and isinstance(bundle, dict):
+        bundle = TheWonPrecheckBundle(**bundle)
+    block = format_precheck_response_block(bundle)
+    if not block:
+        return final_response
+    if "[Precheck]" in final_response[:500]:
+        return final_response
+    if isinstance(bundle, TheWonPrecheckBundle) and bundle.required and not bundle.ok:
+        return (
+            block
+            + "\n\n"
+            + "⛔ TheWon runtime hard gate blocked the final answer because "
+            + "the mandatory KH + LLM Wiki precheck object did not pass. "
+            + "Fix the unresolved precheck items above, then retry."
+        )
+    return block + "\n\n" + final_response

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -310,6 +310,22 @@ def finalize_turn(
 
     _response_transformed = False
 
+    # TheWon runtime enforcement: if this was a TheWon-adjacent request,
+    # surface the KH+LLM Wiki precheck evidence in the final response even if
+    # the model forgets. This is deliberately after turn-completion/file
+    # mutation footers and before plugin transforms so plugins still see the
+    # user-visible text.
+    if final_response and not interrupted:
+        try:
+            from agent.thewon_precheck import apply_precheck_response_block
+
+            final_response = apply_precheck_response_block(
+                final_response,
+                getattr(agent, "_thewon_precheck_bundle", None),
+            )
+        except Exception as _tw_precheck_err:
+            logger.debug("TheWon precheck response block failed: %s", _tw_precheck_err)
+
     # Plugin hook: transform_llm_output
     # Fired once per turn after the tool-calling loop completes.
     # Plugins can transform the LLM's output text before it's returned.

--- a/cron/gateway_lifecycle_guard.py
+++ b/cron/gateway_lifecycle_guard.py
@@ -1,0 +1,42 @@
+"""Gateway lifecycle command guard for cron jobs.
+
+Cron normally runs inside the gateway process. A cron job that restarts/stops
+that same gateway can SIGTERM the scheduler mid-turn and create an auto-resume
+restart loop under launchd/systemd. Keep this guard in the cron package (not the
+CLI) so every creation path and runtime script execution path shares it.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Patterns that indicate a cron job targets the Hermes gateway lifecycle.
+# Deliberately specific: do not block normal prompts that merely mention an
+# unrelated gateway and restart events (e.g. API gateway incident summaries).
+GATEWAY_LIFECYCLE_PATTERNS = re.compile(
+    r"(?i)"
+    r"(hermes\s+gateway\s+(restart|stop|start))"
+    r"|(launchctl\s+(kickstart|bootout|bootstrap|unload|load|stop|restart)\s+.*hermes)"
+    r"|(systemctl\s+(-\S+\s+)*(restart|stop|start)\s+.*hermes)"
+    r"|(p?kill\s+.*hermes.*gateway)"
+)
+
+
+BLOCK_MESSAGE = (
+    "Blocked: cron job contains a gateway lifecycle command "
+    "(restart/stop/kill). This is blocked to prevent restart loops (#30719). "
+    "Use `hermes gateway restart` from a shell outside the gateway."
+)
+
+
+def contains_gateway_lifecycle_command(text: str | None) -> bool:
+    """Return True if *text* contains a Hermes gateway lifecycle command."""
+    if not text:
+        return False
+    return bool(GATEWAY_LIFECYCLE_PATTERNS.search(str(text)))
+
+
+def assert_no_gateway_lifecycle_command(text: str | None) -> None:
+    """Raise ValueError when *text* contains a blocked gateway lifecycle command."""
+    if contains_gateway_lifecycle_command(text):
+        raise ValueError(BLOCK_MESSAGE)

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -38,6 +38,7 @@ logger = logging.getLogger(__name__)
 
 from hermes_time import now as _hermes_now
 from utils import atomic_replace
+from cron.gateway_lifecycle_guard import assert_no_gateway_lifecycle_command
 
 try:
     from croniter import croniter
@@ -197,6 +198,39 @@ def _coerce_job_text(value: Any, fallback: str = "") -> str:
     if value is None:
         return fallback
     return str(value)
+
+
+def _read_cron_script_for_lifecycle_scan(script: Optional[str]) -> str:
+    """Best-effort read of a cron script for gateway lifecycle validation."""
+    if not script:
+        return ""
+    try:
+        scripts_dir = (HERMES_DIR / "scripts").resolve()
+        raw = Path(str(script)).expanduser()
+        path = raw.resolve() if raw.is_absolute() else (scripts_dir / raw).resolve()
+        path.relative_to(scripts_dir)
+        if path.is_file():
+            return path.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        # Missing/unreadable scripts are handled elsewhere. This guard is a
+        # safety net, not a replacement for existing path/existence validation.
+        return ""
+    return ""
+
+
+def _assert_job_has_no_gateway_lifecycle(job: Dict[str, Any]) -> None:
+    """Reject cron records that would restart/stop the gateway from cron."""
+    combined = "\n".join(
+        part
+        for part in (
+            _coerce_job_text(job.get("prompt")),
+            _coerce_job_text(job.get("name")),
+            _coerce_job_text(job.get("script")),
+            _read_cron_script_for_lifecycle_scan(job.get("script")),
+        )
+        if part
+    )
+    assert_no_gateway_lifecycle_command(combined)
 
 
 def _schedule_display_for_job(job: Dict[str, Any]) -> str:
@@ -974,6 +1008,8 @@ def create_job(
     if normalized_attach is not None:
         job["attach_to_session"] = normalized_attach
 
+    _assert_job_has_no_gateway_lifecycle(job)
+
     with _jobs_lock():
         jobs = load_jobs()
         jobs.append(job)
@@ -1088,6 +1124,9 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
 
             if updated.get("enabled", True) and updated.get("state") != "paused" and not updated.get("next_run_at"):
                 updated["next_run_at"] = compute_next_run(updated["schedule"])
+
+            if updated.get("enabled", True) and updated.get("state") != "paused":
+                _assert_job_has_no_gateway_lifecycle(updated)
 
             jobs[i] = updated
             save_jobs(jobs)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -39,6 +39,7 @@ from typing import List, Optional
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from hermes_constants import get_hermes_home
+from cron.gateway_lifecycle_guard import assert_no_gateway_lifecycle_command
 from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import load_config, _expand_env_vars
 from hermes_time import now as _hermes_now
@@ -1594,6 +1595,14 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
     if not path.is_file():
         return False, f"Script path is not a file: {path}"
 
+    try:
+        script_text = path.read_text(encoding="utf-8", errors="replace")
+        assert_no_gateway_lifecycle_command(f"{script_path}\n{script_text}")
+    except ValueError as exc:
+        return False, str(exc)
+    except OSError as exc:
+        return False, f"Script could not be read: {path}: {exc}"
+
     script_timeout = _get_script_timeout()
 
     # Pick an interpreter by extension.  Bash for .sh/.bash, Python for
@@ -1968,6 +1977,26 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     """
     job_id = job["id"]
     job_name = str(job.get("name") or job.get("prompt") or job_id or "cron job")
+
+    try:
+        assert_no_gateway_lifecycle_command(
+            "\n".join(
+                str(part)
+                for part in (job.get("prompt"), job.get("name"), job.get("script"))
+                if part
+            )
+        )
+    except ValueError as exc:
+        now_iso = _hermes_now().strftime("%Y-%m-%d %H:%M:%S")
+        blocked_doc = (
+            f"# Cron Job: {job_name}\n\n"
+            f"**Job ID:** {job_id}\n"
+            f"**Run Time:** {now_iso}\n"
+            "**Status:** BLOCKED\n\n"
+            f"{exc}\n"
+        )
+        logger.warning("Job '%s' blocked by gateway lifecycle guard: %s", job_id, exc)
+        return False, blocked_doc, "", str(exc)
 
     # ---------------------------------------------------------------
     # no_agent short-circuit — the script IS the job, no LLM involvement.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -103,6 +103,160 @@ def _gateway_surface_passes_raw_text(platform: Any) -> bool:
     return _gateway_platform_value(platform) in _GATEWAY_RAW_TEXT_PLATFORMS
 
 
+def _csv_env_values(*names: str) -> set[str]:
+    """Return comma/space-separated env allowlist values without logging them."""
+    values: set[str] = set()
+    for name in names:
+        raw = os.getenv(name, "")
+        for item in re.split(r"[,\s]+", raw):
+            item = item.strip()
+            if item:
+                values.add(item)
+    return values
+
+
+def _thewon_tw_mina_task_duplicate_guard() -> Optional[str]:
+    """Return a user-safe reason when another /tw-mina-task owner is active."""
+    handler = os.getenv("THEWON_TW_MINA_TASK_HANDLER", "gateway").strip().lower()
+    socket_active = os.getenv("THEWON_SOCKET_MODE_BRIDGE_ACTIVE", "").strip().lower()
+    if handler and handler not in {"gateway", "hermes_gateway", "hermes-slack-gateway"}:
+        return "disabled because THEWON_TW_MINA_TASK_HANDLER selects a non-gateway owner"
+    if socket_active in {"1", "true", "yes", "on"}:
+        return "disabled because THEWON_SOCKET_MODE_BRIDGE_ACTIVE is set"
+    return None
+
+
+def _authorize_thewon_tw_mina_task_user(user_id: str) -> tuple[bool, str]:
+    """Fail-closed allowlist for the deployment-specific TheWon task command."""
+    allowed = _csv_env_values("THEWON_TW_MINA_TASK_ALLOWED_USERS")
+    source = "THEWON_TW_MINA_TASK_ALLOWED_USERS"
+    if not allowed:
+        allowed = _csv_env_values("SLACK_ALLOWED_USERS")
+        source = "SLACK_ALLOWED_USERS"
+    if not allowed:
+        return False, "no command allowlist configured"
+    if "*" in allowed:
+        return True, source
+    if user_id and user_id in allowed:
+        return True, source
+    return False, source
+
+
+def _post_thewon_mina_task_to_workflow_router(event: Any, user_args: str) -> Dict[str, Any]:
+    """Forward Slack /tw-mina-task to the local TheWon workflow router.
+
+    This is intentionally a narrow deployment bridge, not a new model tool:
+    the existing gateway already receives the Slack slash-like message, and the
+    TheWon router already owns parent/thread/QG creation.  Keep secrets local,
+    never print them, and return only non-secret request metadata.
+    """
+    import urllib.request
+    import uuid
+
+    source = getattr(event, "source", None)
+    platform_value = _gateway_platform_value(getattr(source, "platform", None))
+    if platform_value != "slack":
+        raise PermissionError("/tw-mina-task is only enabled for Slack events")
+
+    duplicate_reason = _thewon_tw_mina_task_duplicate_guard()
+    if duplicate_reason:
+        raise RuntimeError(duplicate_reason)
+
+    channel_id = getattr(source, "chat_id", None) or "C0BFGRSM3K8"
+    user_id = getattr(source, "user_id", None) or "unknown"
+    user_name = getattr(source, "user_name", None) or user_id
+    allowed, allow_source = _authorize_thewon_tw_mina_task_user(user_id)
+    if not allowed:
+        raise PermissionError(f"Slack user is not allowed to run /tw-mina-task ({allow_source})")
+
+    route = "thewon-workflow-router"
+    route_file = _hermes_home / "webhook_subscriptions.json"
+    data = json.loads(route_file.read_text())
+    try:
+        secret = data[route]["secret"]
+    except KeyError as exc:
+        raise RuntimeError(f"Missing webhook route secret for {route!r}") from exc
+    if not secret:
+        raise RuntimeError(f"Webhook route {route!r} has empty secret")
+
+    message_id = getattr(event, "message_id", None)
+    request_id = f"slack-gateway-{message_id or uuid.uuid4()}"
+    title = (user_args.split("\n", 1)[0].strip() if user_args else "Min-A Slack 작업 요청")
+    bridge_owner = "hermes_slack_gateway_command"
+
+    envelope = {
+        "schema_version": "thewon.workflow.v1",
+        "event_type": "workflow_submission",
+        "workflow_type": "task_request",
+        "request_id": request_id,
+        "submitted_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "submitted_by": {
+            "slack_user_id": user_id,
+            "display_name": user_name,
+        },
+        "source": {
+            "platform": platform_value,
+            "workspace_id": os.environ.get("SLACK_TEAM_ID", "T0APGAC3AGJ"),
+            "channel_id": channel_id,
+            "thread_ts": getattr(event, "reply_to_message_id", None),
+            "workflow_name": "TW - Min-A 작업 요청 (Hermes Slack gateway /tw-mina-task)",
+            "bridge": bridge_owner,
+            "route_owner": bridge_owner,
+            "allowlist_source": allow_source,
+        },
+        "routing": {
+            "target_channel": "C0BFGRSM3K8",
+            "parent_ts": None,
+            "priority": "P2",
+            "due_at": None,
+            "sensitivity": "internal",
+        },
+        "payload": {
+            "title": title[:120],
+            "project": "TheWon",
+            "context": user_args or "Slack gateway /tw-mina-task request",
+            "deliverable": "agent_cao parent/thread + QG checklist",
+            "sources": ["Hermes Slack gateway /tw-mina-task"],
+            "assignees": ["Min-A"],
+            "split_policy": "auto",
+            "route_owner": bridge_owner,
+        },
+        "qg": {
+            "criteria": [
+                "Hermes Slack gateway received /tw-mina-task",
+                "Slack user allowlist enforced",
+                "Duplicate route owner guard passed",
+                "Hermes router accepted payload",
+                "agent_cao parent/thread created or clear WARN",
+                "no secret exposed",
+            ],
+            "pass_threshold": 95,
+            "hard_gates": ["no_secret_exposure", "allowed_slack_user", "single_route_owner"],
+        },
+        "ssot": {"target": "none", "vault_path": None},
+    }
+
+    body = json.dumps(envelope, ensure_ascii=False).encode("utf-8")
+    req = urllib.request.Request(
+        "http://localhost:8644/webhooks/thewon-workflow-router",
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "X-Gitlab-Token": secret,
+            "X-Request-ID": request_id,
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=20) as resp:
+        response_body = resp.read().decode("utf-8")
+        return {
+            "request_id": request_id,
+            "status": resp.status,
+            "body": response_body,
+            "route_owner": bridge_owner,
+        }
+
+
 _GATEWAY_PROVIDER_ERROR_RE = re.compile(
     r"("  # infrastructure/provider error preambles, not ordinary assistant prose
     r"api\s+(?:call\s+)?failed"
@@ -8859,6 +9013,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         return f"Quick command '/{command}' has no target defined."
                 else:
                     return f"Quick command '/{command}' has unsupported type (supported: 'exec', 'alias')."
+
+        # TheWon Min-A task intake (Slack /tw-mina-task)
+        #
+        # Slack message-command text reaches the Hermes Slack gateway before the
+        # separate Socket Mode bridge in this deployment.  Handle the command at
+        # the gateway waist and forward the same workflow envelope to the local
+        # Hermes webhook router instead of returning the generic unknown-command
+        # notice.
+        if command == "tw-mina-task":
+            try:
+                user_args = event.get_command_args().strip()
+                result = await asyncio.to_thread(
+                    _post_thewon_mina_task_to_workflow_router,
+                    event,
+                    user_args,
+                )
+                return (
+                    "Min-A router accepted `/tw-mina-task` "
+                    f"`{result['request_id']}` (HTTP {result['status']})."
+                )
+            except Exception as e:
+                logger.warning("/tw-mina-task gateway bridge failed: %s", e)
+                return f"Min-A router bridge WARN: {type(e).__name__}: {e}"
 
         # Plugin-registered slash commands
         if command:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -906,6 +906,16 @@ DEFAULT_CONFIG = {
     # sessions (no live client) so accumulated agents don't pile up under memory
     # pressure. Reopening one re-resumes it from disk. 0/null disables.
     "max_live_sessions": 16,
+    # Optional append-only audit bridge. When enabled, every message persisted
+    # to Hermes state.db is also mirrored to TheWon OTel-style Blackbox raw logs
+    # before context compression can compact the live transcript. Fail-open:
+    # Blackbox write failures never block Hermes session persistence.
+    "blackbox": {
+        "enabled": False,
+        "agent_id": "VN",
+        "thewon_system": "/Users/elroy/TheWon/System",
+        "project": "TheWon",
+    },
     "agent": {
         "max_turns": 90,
         # Inactivity timeout for gateway agent execution (seconds).

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -6,7 +6,6 @@ pause/resume/run/remove, status, and tick.
 """
 
 import json
-import re
 import sys
 from pathlib import Path
 from typing import Iterable, List, Optional
@@ -14,25 +13,11 @@ from typing import Iterable, List, Optional
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 sys.path.insert(0, str(PROJECT_ROOT))
 
-from hermes_cli.colors import Colors, color
-
-# Patterns that indicate a cron job targets the gateway lifecycle.
-# Matches commands that restart/stop the gateway or its service manager.
-# Deliberately specific — a bare "gateway ... restart" catch-all would block
-# legitimate prompts that merely mention an unrelated gateway (e.g. "summarize
-# the API gateway logs and report restart events").
-_GATEWAY_LIFECYCLE_PATTERNS = re.compile(
-    r"(?i)"
-    r"(hermes\s+gateway\s+(restart|stop|start))"
-    r"|(launchctl\s+(kickstart|unload|load|stop|restart)\s+.*hermes)"
-    r"|(systemctl\s+(-\S+\s+)*(restart|stop|start)\s+.*hermes)"
-    r"|(p?kill\s+.*hermes.*gateway)"
+from cron.gateway_lifecycle_guard import (
+    BLOCK_MESSAGE,
+    contains_gateway_lifecycle_command as _contains_gateway_lifecycle_command,
 )
-
-
-def _contains_gateway_lifecycle_command(text: str) -> bool:
-    """Return True if *text* contains a gateway lifecycle command pattern."""
-    return bool(_GATEWAY_LIFECYCLE_PATTERNS.search(text))
+from hermes_cli.colors import Colors, color
 
 
 def _normalize_skills(single_skill=None, skills: Optional[Iterable[str]] = None) -> Optional[List[str]]:
@@ -257,13 +242,7 @@ def cron_create(args):
         except (OSError, UnicodeDecodeError):
             pass
     if _contains_gateway_lifecycle_command(combined):
-        print(color(
-            "Blocked: cron job contains a gateway lifecycle command "
-            "(restart/stop/kill).\n"
-            "This is blocked to prevent restart loops (#30719).\n"
-            "Use `hermes gateway restart` from a shell outside the gateway.",
-            Colors.RED,
-        ))
+        print(color(BLOCK_MESSAGE, Colors.RED))
         return 1
 
     result = _cron_api(

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -504,7 +504,12 @@ def find_alias_for_profile(profile_name: str) -> Optional[str]:
         return None
     canon = normalize_profile_name(profile_name)
     is_windows = sys.platform == "win32"
-    needle = f"hermes -p {canon}"
+    # Match the profile argument as a complete shell token. A plain substring
+    # check ("hermes -p research" in content) falsely treats wrappers for
+    # similarly-prefixed profiles like "researcher" as aliases for "research".
+    target_pattern = re.compile(
+        rf"(?:^|\s)(?:\S*/)?hermes(?:\.exe)?\s+-p\s+{re.escape(canon)}(?=$|[\s\"%])"
+    )
 
     custom: Optional[str] = None
     profile_named: Optional[str] = None
@@ -520,7 +525,7 @@ def find_alias_for_profile(profile_name: str) -> Optional[str]:
             content = entry.read_text()
         except (OSError, UnicodeDecodeError):
             continue
-        if needle not in content:
+        if not target_pattern.search(content):
             continue
         alias = entry.stem if is_windows else entry.name
         if alias == canon:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2812,7 +2812,27 @@ class SessionDB:
                 )
             return msg_id
 
-        return self._execute_write(_do)
+        msg_id = self._execute_write(_do)
+        try:
+            from agent.blackbox_bridge import record_session_message
+
+            record_session_message(
+                session_id=session_id,
+                message_id=msg_id,
+                role=role,
+                content=content,
+                tool_name=tool_name,
+                tool_calls=tool_calls,
+                tool_call_id=tool_call_id,
+                token_count=token_count,
+                finish_reason=finish_reason,
+                platform_message_id=platform_message_id,
+                observed=observed,
+                timestamp=timestamp,
+            )
+        except Exception as exc:
+            logger.debug("blackbox bridge append_message hook failed: %s", exc)
+        return msg_id
 
     def _insert_message_rows(self, conn, session_id: str, messages: List[Dict[str, Any]]) -> tuple[int, int]:
         """Insert *messages* as fresh active rows for *session_id*.
@@ -2924,6 +2944,17 @@ class SessionDB:
             )
 
         self._execute_write(_do)
+        try:
+            from agent.blackbox_bridge import record_transcript_event
+
+            record_transcript_event(
+                session_id=session_id,
+                event_type="transcript_rewrite",
+                messages=messages,
+                extra={"reason": "replace_messages"},
+            )
+        except Exception as exc:
+            logger.debug("blackbox bridge replace_messages hook failed: %s", exc)
 
     def archive_and_compact(
         self, session_id: str, compacted_messages: List[Dict[str, Any]]
@@ -2975,7 +3006,19 @@ class SessionDB:
             )
             return inserted
 
-        return self._execute_write(_do)
+        inserted = self._execute_write(_do)
+        try:
+            from agent.blackbox_bridge import record_transcript_event
+
+            record_transcript_event(
+                session_id=session_id,
+                event_type="context_compaction",
+                messages=compacted_messages,
+                extra={"active_message_count": inserted},
+            )
+        except Exception as exc:
+            logger.debug("blackbox bridge archive_and_compact hook failed: %s", exc)
+        return inserted
 
 
     def get_messages(

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -792,6 +792,13 @@ class DiscordAdapter(BasePlatformAdapter):
         # chunk only, default), "all" (reply-reference on every chunk).
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
         self._slash_commands: bool = self.config.extra.get("slash_commands", True)
+        # Bridge config.yaml discord.allow_bots to the existing Discord bot-message
+        # filter/authz env knob. Values: none | mentions | all.
+        _allow_bots_cfg = self.config.extra.get("allow_bots")
+        if _allow_bots_cfg is not None and not os.getenv("DISCORD_ALLOW_BOTS"):
+            _allow_bots_value = str(_allow_bots_cfg).lower().strip()
+            if _allow_bots_value in {"none", "mentions", "all"}:
+                os.environ["DISCORD_ALLOW_BOTS"] = _allow_bots_value
         # In-memory cache of the bot's last message ID per channel, used by
         # history backfill to skip the full scan on hot paths.  Falls back to
         # scanning channel.history() on cache miss (cold start / restart).
@@ -799,6 +806,7 @@ class DiscordAdapter(BasePlatformAdapter):
         # Persistent set of bot-authored lifecycle/status message IDs that
         # should not act as conversational history boundaries after restart.
         self._nonconversational_messages = _DiscordNonConversationalMessageTracker()
+        self._handoff_thread_watch_tasks: Dict[str, asyncio.Task] = {}
 
     def _handle_bot_task_done(self, task: asyncio.Task) -> None:
         """Surface post-startup discord.py task exits to the gateway supervisor.
@@ -1088,6 +1096,18 @@ class DiscordAdapter(BasePlatformAdapter):
                 await self._handle_message(message, role_authorized=_role_authorized)
 
             @self._client.event
+            async def on_thread_create(thread):
+                """Join and hydrate threads created from messages we sent.
+
+                Other Hermes agents often auto-thread a mention-triggered
+                handoff by creating a thread from our parent-channel message.
+                Discord does not reliably deliver follow-up messages in that
+                thread to this bot until it has joined the thread, so a
+                parent-channel-only listener can miss the other agent's reply.
+                """
+                await adapter_self._maybe_join_and_hydrate_handoff_thread(thread)
+
+            @self._client.event
             async def on_voice_state_update(member, before, after):
                 """Track voice channel join/leave events."""
                 # Only track channels where the bot is connected
@@ -1259,6 +1279,55 @@ class DiscordAdapter(BasePlatformAdapter):
             return "same slash-command fingerprint already synced"
         return None
 
+    async def _remote_slash_commands_match_desired(self) -> bool:
+        """Return True when Discord's live global commands match the local tree.
+
+        The cached fingerprint is only a local desired-state fingerprint.  If a
+        previous safe sync was interrupted between command deletes/recreates, or
+        Discord accepted only part of a mutation sequence, the cache can say the
+        desired tree was synced while the live app-command set is missing one
+        command.  Verify the live command set before honoring the skip cache.
+        """
+        if not self._client:
+            return True
+        tree = self._client.tree
+        desired_payloads = [command.to_dict(tree) for command in tree.get_commands()]
+        desired_by_key = {
+            (int(payload.get("type", 1) or 1), str(payload.get("name", "") or "").lower()): payload
+            for payload in desired_payloads
+        }
+        existing_commands = await tree.fetch_commands()
+        existing_by_key = {
+            (
+                int(getattr(getattr(command, "type", None), "value", getattr(command, "type", 1)) or 1),
+                str(command.name or "").lower(),
+            ): command
+            for command in existing_commands
+        }
+        if set(existing_by_key) != set(desired_by_key):
+            missing = sorted(name for (_typ, name) in set(desired_by_key) - set(existing_by_key))
+            extra = sorted(name for (_typ, name) in set(existing_by_key) - set(desired_by_key))
+            logger.warning(
+                "[%s] Discord slash command drift detected before cached skip: missing=%s extra=%s",
+                self.name,
+                missing[:10],
+                extra[:10],
+            )
+            return False
+        for key, desired in desired_by_key.items():
+            current_payload = self._canonicalize_app_command_payload(
+                self._existing_command_to_payload(existing_by_key[key])
+            )
+            desired_payload = self._canonicalize_app_command_payload(desired)
+            if current_payload != desired_payload:
+                logger.warning(
+                    "[%s] Discord slash command drift detected before cached skip: changed=%s",
+                    self.name,
+                    key[1],
+                )
+                return False
+        return True
+
     def _record_command_sync_attempt(self, app_id: Any, fingerprint: str) -> None:
         state = self._read_command_sync_state()
         state[self._command_sync_state_key(app_id)] = {
@@ -1383,8 +1452,25 @@ class DiscordAdapter(BasePlatformAdapter):
             fingerprint = self._desired_command_sync_fingerprint()
             skip_reason = self._command_sync_skip_reason(app_id, fingerprint)
             if skip_reason:
-                logger.info("[%s] Skipping Discord slash command sync: %s", self.name, skip_reason)
-                return
+                if skip_reason == "same slash-command fingerprint already synced":
+                    try:
+                        if await self._remote_slash_commands_match_desired():
+                            logger.info("[%s] Skipping Discord slash command sync: %s", self.name, skip_reason)
+                            return
+                        logger.warning(
+                            "[%s] Cached Discord slash command sync state is stale; reconciling live commands",
+                            self.name,
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            "[%s] Could not verify live Discord slash commands before cached skip: %s",
+                            self.name,
+                            e,
+                        )
+                        return
+                else:
+                    logger.info("[%s] Skipping Discord slash command sync: %s", self.name, skip_reason)
+                    return
             self._record_command_sync_attempt(app_id, fingerprint)
 
             http = getattr(self._client, "http", None)
@@ -1786,6 +1872,9 @@ class DiscordAdapter(BasePlatformAdapter):
                     self._nonconversational_messages.mark_many(message_ids)
                 elif not _looks_like_nonconversational_history_message(content):
                     self._last_self_message_id[_target_id] = message_ids[-1]
+                    if not thread_id:
+                        for _mid in message_ids:
+                            self._watch_handoff_thread_for_message(chat_id, _mid)
 
             return SendResult(
                 success=True,
@@ -4570,6 +4659,142 @@ class DiscordAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
     # Auto-thread helpers
     # ------------------------------------------------------------------
+
+    def _watch_handoff_thread_for_message(self, parent_chat_id: str, message_id: str) -> None:
+        """Poll briefly for a thread created from one of our sent messages."""
+        if not self._client or not parent_chat_id or not message_id:
+            return
+        if message_id in self._handoff_thread_watch_tasks:
+            return
+        task = asyncio.create_task(self._handoff_thread_watch_loop(parent_chat_id, message_id))
+        self._handoff_thread_watch_tasks[message_id] = task
+        task.add_done_callback(lambda _task, _mid=message_id: self._handoff_thread_watch_tasks.pop(_mid, None))
+
+    async def _handoff_thread_watch_loop(self, parent_chat_id: str, message_id: str) -> None:
+        """Join/hydrate an auto-thread whose id matches a sent message id."""
+        for _ in range(40):
+            await asyncio.sleep(3)
+            if not self._client:
+                return
+            thread = None
+            with suppress(Exception):
+                thread = self._client.get_channel(int(message_id))
+            if thread is None:
+                with suppress(Exception):
+                    thread = await self._client.fetch_channel(int(message_id))
+            if thread is None:
+                continue
+            if self._get_parent_channel_id(thread) != str(parent_chat_id):
+                return
+            await self._maybe_join_and_hydrate_handoff_thread(thread)
+            return
+
+    async def _maybe_join_and_hydrate_handoff_thread(self, thread: Any) -> None:
+        """Join other-agent auto-threads that originate from our messages.
+
+        Discord auto-thread handoffs create a thread whose id is the starter
+        message id.  When another bot creates that thread from a message this
+        bot sent, discord.py may not deliver subsequent thread messages until
+        this bot joins the thread.  Join the thread, then replay the latest
+        bot-authored replies so the normal message handler can continue the
+        cross-agent turn.
+        """
+        if not self._client or isinstance(thread, getattr(discord, "DMChannel", ())):
+            return
+
+        thread_id = str(getattr(thread, "id", "") or "")
+        if not thread_id:
+            return
+
+        parent_id = self._get_parent_channel_id(thread)
+        if not parent_id:
+            return
+
+        parent_channel = getattr(thread, "parent", None)
+        if parent_channel is None:
+            with suppress(Exception):
+                parent_channel = self._client.get_channel(int(parent_id))
+        if parent_channel is None:
+            with suppress(Exception):
+                parent_channel = await self._client.fetch_channel(int(parent_id))
+        if parent_channel is None:
+            return
+
+        starter = None
+        fetch_message = getattr(parent_channel, "fetch_message", None)
+        if fetch_message is not None:
+            with suppress(Exception):
+                starter = await fetch_message(int(thread_id))
+
+        self_user = getattr(self._client, "user", None)
+        self_id = str(getattr(self_user, "id", "") or "")
+        starter_author_id = str(getattr(getattr(starter, "author", None), "id", "") or "")
+        starter_from_self = bool(self_id and starter_author_id == self_id)
+        starter_mentions_self = bool(self_user and starter and self_user in (getattr(starter, "mentions", []) or []))
+
+        # Only auto-join threads that are plausibly part of a handoff to us:
+        # either they were created from a message we sent, or the starter
+        # explicitly mentioned us.  This keeps random public threads out of the
+        # agent loop.
+        if not starter_from_self and not starter_mentions_self:
+            return
+
+        join = getattr(thread, "join", None)
+        if join is not None:
+            with suppress(Exception):
+                await join()
+
+        self._threads.mark(thread_id)
+
+        messages: list[Any] = []
+        history = getattr(thread, "history", None)
+        if history is None:
+            return
+        try:
+            hist = history(limit=20, oldest_first=True)
+            if hasattr(hist, "__aiter__"):
+                async for msg in hist:
+                    messages.append(msg)
+            else:
+                if asyncio.iscoroutine(hist):
+                    hist = await hist
+                messages.extend(list(hist or []))
+        except Exception as exc:
+            logger.debug("[%s] Could not hydrate Discord handoff thread %s: %s", self.name, thread_id, exc)
+            return
+
+        allow_bots = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
+        for msg in messages:
+            msg_id = str(getattr(msg, "id", "") or "")
+            if not msg_id or msg_id == thread_id:
+                continue
+            if getattr(msg, "author", None) == self_user:
+                continue
+            if not (getattr(msg, "content", None) or getattr(msg, "attachments", None)):
+                continue
+
+            author_is_bot = bool(getattr(getattr(msg, "author", None), "bot", False))
+            if author_is_bot:
+                if allow_bots == "none":
+                    continue
+                msg_mentions_self = bool(self_user and self_user in (getattr(msg, "mentions", []) or []))
+                if allow_bots == "mentions" and not msg_mentions_self and not starter_from_self:
+                    continue
+            else:
+                # Hydration exists for bot-to-bot handoffs.  Human messages
+                # enter through normal on_message delivery/authorization.
+                continue
+
+            if self._dedup.is_duplicate(msg_id):
+                continue
+            logger.info(
+                "[%s] Hydrating Discord handoff thread %s with message %s from %s",
+                self.name,
+                thread_id,
+                msg_id,
+                getattr(getattr(msg, "author", None), "display_name", None) or getattr(getattr(msg, "author", None), "name", "unknown"),
+            )
+            await self._handle_message(msg)
 
     async def _auto_create_thread(self, message: 'DiscordMessage') -> Optional[Any]:
         """Create a thread from a user message for auto-threading.

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -61,6 +61,7 @@ class FakeTextChannel:
         self.name = name
         self.guild = SimpleNamespace(name=guild_name)
         self.topic = None
+        self.fetch_message = AsyncMock()
 
 
 class FakeThread:
@@ -71,12 +72,26 @@ class FakeThread:
         self.parent_id = getattr(parent, "id", None)
         self.guild = getattr(parent, "guild", None) or SimpleNamespace(name=guild_name)
         self.topic = None
+        self.join = AsyncMock()
+        self.history = AsyncMock(return_value=[])
 
 
 @pytest.fixture
 def adapter(monkeypatch):
     monkeypatch.setattr(discord_platform.discord, "DMChannel", FakeDMChannel, raising=False)
     monkeypatch.setattr(discord_platform.discord, "Thread", FakeThread, raising=False)
+    for env_name in (
+        "DISCORD_ALLOWED_CHANNELS",
+        "DISCORD_IGNORED_CHANNELS",
+        "DISCORD_FREE_RESPONSE_CHANNELS",
+        "DISCORD_NO_THREAD_CHANNELS",
+        "DISCORD_AUTO_THREAD",
+        "DISCORD_REQUIRE_MENTION",
+        "DISCORD_THREAD_REQUIRE_MENTION",
+        "DISCORD_ALLOW_BOTS",
+        "DISCORD_HISTORY_BACKFILL",
+    ):
+        monkeypatch.delenv(env_name, raising=False)
 
     config = PlatformConfig(enabled=True, token="fake-token")
     adapter = DiscordAdapter(config)
@@ -279,6 +294,75 @@ async def test_no_thread_with_auto_thread_disabled_is_noop(adapter, monkeypatch)
 
     adapter._auto_create_thread.assert_not_awaited()
     adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handoff_thread_created_from_self_message_is_joined_and_hydrated(adapter, monkeypatch):
+    """Other-agent auto-thread replies to our starter message are replayed."""
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "mentions")
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_HISTORY_BACKFILL", "false")
+
+    self_user = adapter._client.user
+    self_user.bot = True
+    self_user.display_name = "Vanila"
+    parent = FakeTextChannel(channel_id=800, name="ops")
+    starter = make_message(
+        channel=parent,
+        content="<@1518118944009883858> 루나 테스트",
+        mentions=[SimpleNamespace(id=1518118944009883858, bot=True)],
+    )
+    starter.id = 999
+    starter.author = self_user
+    parent.fetch_message = AsyncMock(return_value=starter)
+
+    lunar = SimpleNamespace(id=1518118944009883858, bot=True, display_name="Lunar", name="Lunar")
+    thread = FakeThread(channel_id=999, name="루나 테스트", parent=parent)
+    thread.join = AsyncMock()
+    reply = make_message(
+        channel=thread,
+        content="<@999> VANILA_LUNA_RETEST_OK",
+        mentions=[self_user],
+    )
+    reply.id = 1001
+    reply.author = lunar
+
+    thread.history = AsyncMock(return_value=[reply])
+
+    await adapter._maybe_join_and_hydrate_handoff_thread(thread)
+
+    thread.join.assert_awaited_once()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "VANILA_LUNA_RETEST_OK"
+    assert event.source.chat_type == "thread"
+    assert event.source.chat_id == "999"
+    assert event.source.parent_chat_id == "800"
+    assert event.source.is_bot is True
+
+
+@pytest.mark.asyncio
+async def test_handoff_thread_ignores_unrelated_threads(adapter, monkeypatch):
+    """Random public threads should not be joined or replayed."""
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "mentions")
+
+    self_user = adapter._client.user
+    parent = FakeTextChannel(channel_id=800, name="ops")
+    other_user = SimpleNamespace(id=123, bot=False, display_name="Other", name="Other")
+    starter = make_message(channel=parent, content="not for us", mentions=[])
+    starter.id = 1234
+    starter.author = other_user
+    parent.fetch_message = AsyncMock(return_value=starter)
+
+    thread = FakeThread(channel_id=1234, name="unrelated", parent=parent)
+    thread.join = AsyncMock()
+    thread.history = AsyncMock(return_value=[])
+
+    await adapter._maybe_join_and_hydrate_handoff_thread(thread)
+
+    thread.join.assert_not_awaited()
+    adapter.handle_message.assert_not_awaited()
 
 
 # ── config.py bridging ───────────────────────────────────────────────

--- a/tests/gateway/test_unknown_command.py
+++ b/tests/gateway/test_unknown_command.py
@@ -6,6 +6,7 @@ delegate_task call instead of telling the user the command doesn't exist).
 """
 
 from datetime import datetime
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -16,18 +17,18 @@ from gateway.platforms.base import MessageEvent
 from gateway.session import SessionEntry, SessionSource, build_session_key
 
 
-def _make_source() -> SessionSource:
+def _make_source(platform: Platform = Platform.TELEGRAM, user_id: str = "u1") -> SessionSource:
     return SessionSource(
-        platform=Platform.TELEGRAM,
-        user_id="u1",
+        platform=platform,
+        user_id=user_id,
         chat_id="c1",
         user_name="tester",
         chat_type="dm",
     )
 
 
-def _make_event(text: str) -> MessageEvent:
-    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+def _make_event(text: str, *, platform: Platform = Platform.TELEGRAM, user_id: str = "u1") -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(platform, user_id), message_id="m1")
 
 
 def _make_runner():
@@ -104,6 +105,167 @@ async def test_unknown_slash_command_returns_guidance(monkeypatch):
     assert "Unknown command" in result
     assert "/definitely-not-a-command" in result
     assert "/commands" in result
+    runner._run_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_twon_mina_task_command_forwards_to_router(monkeypatch):
+    """The deployment-specific /tw-mina-task command should be handled before
+    the generic unknown-command guard."""
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError("/tw-mina-task leaked through to the agent")
+    )
+
+    captured = {}
+
+    def _fake_forward(event, user_args):
+        captured["event"] = event
+        captured["user_args"] = user_args
+        return {
+            "request_id": "slack-gateway-test",
+            "status": 202,
+            "body": "{}",
+            "route_owner": "hermes_slack_gateway_command",
+        }
+
+    monkeypatch.setattr(gateway_run, "_post_thewon_mina_task_to_workflow_router", _fake_forward)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(
+        _make_event("/tw-mina-task Socket Mode bridge live smoke", platform=Platform.SLACK)
+    )
+
+    assert result is not None
+    assert "Min-A router accepted" in result
+    assert "slack-gateway-test" in result
+    assert captured["user_args"] == "Socket Mode bridge live smoke"
+    runner._run_agent.assert_not_called()
+
+
+
+def test_twon_mina_task_helper_enforces_allowlist_and_route_owner(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    route_dir = tmp_path / "hermes"
+    route_dir.mkdir()
+    (route_dir / "webhook_subscriptions.json").write_text(
+        json.dumps({"thewon-workflow-router": {"secret": "dummy-secret"}}),
+        encoding="utf-8",
+    )
+    captured = {}
+
+    class _FakeResponse:
+        status = 202
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def read(self):
+            return b'{"status":"accepted"}'
+
+    def _fake_urlopen(req, timeout):
+        captured["timeout"] = timeout
+        captured["headers"] = dict(req.header_items())
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return _FakeResponse()
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", route_dir)
+    monkeypatch.setenv("THEWON_TW_MINA_TASK_ALLOWED_USERS", "u1")
+    monkeypatch.delenv("THEWON_SOCKET_MODE_BRIDGE_ACTIVE", raising=False)
+    monkeypatch.setenv("THEWON_TW_MINA_TASK_HANDLER", "gateway")
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+
+    result = gateway_run._post_thewon_mina_task_to_workflow_router(
+        _make_event("/tw-mina-task Hardened path", platform=Platform.SLACK, user_id="u1"),
+        "Hardened path",
+    )
+
+    assert result["status"] == 202
+    assert result["route_owner"] == "hermes_slack_gateway_command"
+    assert captured["timeout"] == 20
+    assert captured["headers"]["X-gitlab-token"] == "dummy-secret"
+    envelope = captured["body"]
+    assert envelope["source"]["route_owner"] == "hermes_slack_gateway_command"
+    assert envelope["source"]["allowlist_source"] == "THEWON_TW_MINA_TASK_ALLOWED_USERS"
+    assert envelope["payload"]["route_owner"] == "hermes_slack_gateway_command"
+    assert "allowed_slack_user" in envelope["qg"]["hard_gates"]
+    assert "single_route_owner" in envelope["qg"]["hard_gates"]
+
+
+@pytest.mark.asyncio
+async def test_twon_mina_task_rejects_non_slack_event(monkeypatch):
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError("/tw-mina-task leaked through to the agent")
+    )
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", "u1")
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("/tw-mina-task nope"))
+
+    assert result is not None
+    assert "Min-A router bridge WARN" in result
+    assert "only enabled for Slack" in result
+    runner._run_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_twon_mina_task_requires_allowed_slack_user(monkeypatch):
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError("/tw-mina-task leaked through to the agent")
+    )
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", "someone-else")
+    monkeypatch.delenv("THEWON_TW_MINA_TASK_ALLOWED_USERS", raising=False)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(
+        _make_event("/tw-mina-task blocked", platform=Platform.SLACK, user_id="u1")
+    )
+
+    assert result is not None
+    assert "Min-A router bridge WARN" in result
+    assert "not allowed" in result
+    runner._run_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_twon_mina_task_duplicate_route_guard(monkeypatch):
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError("/tw-mina-task leaked through to the agent")
+    )
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", "u1")
+    monkeypatch.setenv("THEWON_SOCKET_MODE_BRIDGE_ACTIVE", "true")
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(
+        _make_event("/tw-mina-task duplicate", platform=Platform.SLACK, user_id="u1")
+    )
+
+    assert result is not None
+    assert "Min-A router bridge WARN" in result
+    assert "SOCKET_MODE_BRIDGE_ACTIVE" in result
     runner._run_agent.assert_not_called()
 
 

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -38,6 +38,8 @@ class TestGatewayLifecyclePattern:
 
     @pytest.mark.parametrize("text", [
         "launchctl kickstart gui/501/ai.hermes.gateway",
+        "launchctl bootout gui/501/ai.hermes.gateway",
+        "launchctl bootstrap gui/501 ~/Library/LaunchAgents/ai.hermes.gateway.plist",
         "launchctl unload ~/Library/LaunchAgents/ai.hermes.gateway.plist",
         "launchctl stop ai.hermes.gateway",
         "systemctl restart hermes-gateway",
@@ -188,6 +190,68 @@ class TestCronCreateLifecycleBlock:
         # the error message is about prompt/skill, NOT about "Blocked".
         out = capsys.readouterr().out
         assert "Blocked" not in out
+
+    def test_api_create_blocks_gateway_lifecycle_prompt(self):
+        from cron.jobs import create_job
+
+        with pytest.raises(ValueError, match="restart loops"):
+            create_job(
+                prompt="Run launchctl bootout gui/501/ai.hermes.gateway",
+                schedule="30m",
+            )
+
+    def test_api_create_blocks_gateway_lifecycle_script(self, tmp_path, monkeypatch):
+        from cron.jobs import create_job
+        import cron.jobs as jobs
+
+        hermes_home = tmp_path / "home"
+        scripts_dir = hermes_home / "scripts"
+        scripts_dir.mkdir(parents=True)
+        script = scripts_dir / "restart_gateway.sh"
+        script.write_text("#!/usr/bin/env bash\nlaunchctl kickstart -k gui/501/ai.hermes.gateway\n")
+        monkeypatch.setattr(jobs, "HERMES_DIR", hermes_home)
+        monkeypatch.setattr(jobs, "CRON_DIR", hermes_home / "cron")
+        monkeypatch.setattr(jobs, "JOBS_FILE", hermes_home / "cron" / "jobs.json")
+        monkeypatch.setattr(jobs, "OUTPUT_DIR", hermes_home / "cron" / "output")
+
+        with pytest.raises(ValueError, match="restart loops"):
+            create_job(
+                prompt="",
+                schedule="30m",
+                script="restart_gateway.sh",
+                no_agent=True,
+            )
+
+    def test_scheduler_runtime_blocks_gateway_lifecycle_script(self, tmp_path, monkeypatch):
+        import cron.scheduler as scheduler
+
+        hermes_home = tmp_path / "home"
+        scripts_dir = hermes_home / "scripts"
+        scripts_dir.mkdir(parents=True)
+        script = scripts_dir / "late_restart.sh"
+        script.write_text("#!/usr/bin/env bash\nhermes gateway restart\n")
+        monkeypatch.setattr(scheduler, "_hermes_home", hermes_home)
+
+        ok, output = scheduler._run_job_script("late_restart.sh")
+
+        assert ok is False
+        assert "Blocked" in output
+        assert "restart loops" in output
+
+    def test_scheduler_runtime_blocks_legacy_gateway_lifecycle_prompt(self):
+        import cron.scheduler as scheduler
+
+        ok, doc, final, err = scheduler.run_job({
+            "id": "legacybad001",
+            "name": "legacy bad restart job",
+            "prompt": "run hermes gateway restart",
+            "no_agent": False,
+        })
+
+        assert ok is False
+        assert final == ""
+        assert "Blocked" in doc
+        assert "restart loops" in str(err)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -876,6 +876,16 @@ class TestFindAliasForProfile:
         from hermes_cli.profiles import find_alias_for_profile
         assert find_alias_for_profile("steve") is None
 
+    def test_prefix_profile_name_does_not_match_longer_profile(self, profile_env, monkeypatch):
+        # Regression: a wrapper for `researcher` must not display as an alias
+        # for the shorter `research` profile just because the old lookup used a
+        # substring search for "hermes -p research".
+        monkeypatch.setattr("sys.platform", "darwin")
+        from hermes_cli.profiles import create_wrapper_script, find_alias_for_profile
+        create_wrapper_script("researcher")
+        assert find_alias_for_profile("research") is None
+        assert find_alias_for_profile("researcher") == "researcher"
+
     def test_ignores_unrelated_files(self, profile_env, monkeypatch):
         # ~/.local/bin commonly holds unrelated binaries; they must not match.
         monkeypatch.setattr("sys.platform", "darwin")

--- a/tests/test_thewon_precheck.py
+++ b/tests/test_thewon_precheck.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+
+from agent import thewon_precheck as tp
+
+
+def test_should_run_thewon_precheck_detects_thewon_terms():
+    assert tp.should_run_thewon_precheck("TheWon 에이전트 고도화 절차 만들자")
+    assert tp.should_run_thewon_precheck("LLM Wiki를 실제 적용해")
+    assert not tp.should_run_thewon_precheck("일반적인 파이썬 문법 질문")
+
+
+def test_apply_precheck_response_block_prefixes_response():
+    bundle = tp.TheWonPrecheckBundle(
+        required=True,
+        query="TheWon 에이전트",
+        kh_summary="[harness] 1건",
+        wiki_source="wiki",
+        wiki_reason="hit",
+        wiki_hits=[{"title": "Universal LLM Wiki Usage", "confidence": "high"}],
+        read_files=["/tmp/universal-llm-wiki-usage.md"],
+        kh_query_executed=True,
+        wiki_route_executed=True,
+        relevant_sources_read=True,
+    )
+
+    response = tp.apply_precheck_response_block("본문", bundle)
+
+    assert response is not None
+    assert response.startswith("[Precheck]")
+    assert "KH: [harness] 1건" in response
+    assert "Universal LLM Wiki Usage (high)" in response
+    assert response.endswith("본문")
+
+
+def test_run_thewon_precheck_uses_kh_and_wiki(monkeypatch, tmp_path):
+    monkeypatch.setattr(tp, "_ensure_thewon_import_paths", lambda: True)
+
+    wiki_file = tmp_path / "wiki.md"
+    wiki_file.write_text("# Wiki\ncontent", encoding="utf-8")
+
+    class FakeKnowledgeHub:
+        def __init__(self, agent_code=None):
+            self.agent_code = agent_code
+
+        def smart_ask_formatted(self, query, top_k_per_source=3, min_sources=2):
+            return "[harness] 1건"
+
+    class Hit:
+        title = "Universal LLM Wiki Usage"
+        confidence = "high"
+        score = 0.42
+        path = str(wiki_file)
+
+    class FakeWikiRouter:
+        def route(self, query, threshold=0.2):
+            return {"source": "wiki", "reason": "fake", "hits": [Hit()]}
+
+    system_mod = types.ModuleType("System")
+    shared_mod = types.ModuleType("System.shared")
+    kh_mod = types.ModuleType("System.shared.knowledge_hub")
+    setattr(kh_mod, "KnowledgeHub", FakeKnowledgeHub)
+    wiki_mod = types.ModuleType("System.shared.wiki_router")
+    setattr(wiki_mod, "WikiRouter", FakeWikiRouter)
+
+    monkeypatch.setitem(sys.modules, "System", system_mod)
+    monkeypatch.setitem(sys.modules, "System.shared", shared_mod)
+    monkeypatch.setitem(sys.modules, "System.shared.knowledge_hub", kh_mod)
+    monkeypatch.setitem(sys.modules, "System.shared.wiki_router", wiki_mod)
+
+    bundle = tp.run_thewon_precheck("TheWon 에이전트 절차", agent_code="Hermes")
+
+    assert bundle.required is True
+    assert bundle.kh_summary == "[harness] 1건"
+    assert bundle.wiki_source == "wiki"
+    assert bundle.wiki_hits[0]["title"] == "Universal LLM Wiki Usage"
+    assert bundle.read_files == [str(wiki_file)]
+    assert bundle.kh_query_executed is True
+    assert bundle.wiki_route_executed is True
+    assert bundle.relevant_sources_read is True
+    assert bundle.ok is True
+    assert bundle.errors == []
+
+
+def test_format_precheck_context_is_ephemeral_and_compact():
+    bundle = tp.TheWonPrecheckBundle(
+        required=True,
+        query="TheWon",
+        kh_summary="[harness] 1건",
+        wiki_source="wiki",
+        wiki_reason="fake",
+        wiki_hits=[{"title": "A", "confidence": "high"}],
+        read_files=["/tmp/a.md"],
+        kh_query_executed=True,
+        wiki_route_executed=True,
+        relevant_sources_read=True,
+    )
+
+    context = tp.format_precheck_context(bundle)
+
+    assert context.startswith("[TheWon KH+LLM Wiki precheck]")
+    assert '"kh": "[harness] 1건"' in context
+    assert '"wiki_source": "wiki"' in context
+    assert '"precheck_pass": true' in context
+
+
+def test_apply_precheck_response_block_blocks_when_required_object_incomplete():
+    bundle = tp.TheWonPrecheckBundle(
+        required=True,
+        query="TheWon",
+        kh_summary="",
+        wiki_source="",
+        errors=["KnowledgeHub failed"],
+    )
+
+    response = tp.apply_precheck_response_block("모델이 만든 일반 답변", bundle)
+
+    assert response is not None
+    assert "Gate: FAIL" in response
+    assert "runtime hard gate blocked" in response
+    assert "모델이 만든 일반 답변" not in response
+
+
+def test_codex_app_server_path_applies_precheck_block(monkeypatch):
+    from agent import codex_runtime
+
+    bundle = tp.TheWonPrecheckBundle(
+        required=True,
+        query="TheWon",
+        kh_summary="[harness] 1건",
+        wiki_source="wiki",
+        wiki_hits=[{"title": "A", "confidence": "high"}],
+        read_files=["/tmp/a.md"],
+        kh_query_executed=True,
+        wiki_route_executed=True,
+        relevant_sources_read=True,
+    )
+
+    class FakeSession:
+        def run_turn(self, user_input):
+            assert "TheWon" in user_input
+            return SimpleNamespace(
+                projected_messages=[],
+                tool_iterations=0,
+                final_text="본문",
+                interrupted=False,
+                error=None,
+                thread_id="thread-1",
+                turn_id="turn-1",
+                should_retire=False,
+            )
+
+    agent = SimpleNamespace(
+        _codex_session=FakeSession(),
+        _iters_since_skill=0,
+        _skill_nudge_interval=0,
+        valid_tool_names=set(),
+        _thewon_precheck_bundle=bundle,
+        _sync_external_memory_for_turn=lambda **kwargs: None,
+        _spawn_background_review=lambda **kwargs: None,
+    )
+    monkeypatch.setattr(codex_runtime, "_record_codex_app_server_usage", lambda agent, turn: {})
+
+    result = codex_runtime.run_codex_app_server_turn(
+        agent,
+        user_message="TheWon 요청",
+        original_user_message="TheWon 요청",
+        messages=[],
+        effective_task_id="task-1",
+    )
+
+    assert result["final_response"].startswith("[Precheck]")
+    assert "Gate: PASS" in result["final_response"]
+    assert result["final_response"].endswith("본문")

--- a/tests/tools/test_slack_api_tool.py
+++ b/tests/tools/test_slack_api_tool.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from tools.slack_api_tool import check_slack_api_requirements, slack_api_tool
+from toolsets import resolve_toolset
+
+
+def test_check_slack_api_requirements_requires_bot_token(monkeypatch):
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+    assert check_slack_api_requirements() is False
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
+    assert check_slack_api_requirements() is True
+
+
+def test_hermes_slack_toolset_includes_slack_api():
+    assert "slack_api" in resolve_toolset("hermes-slack")
+    assert "slack_api" in resolve_toolset("slack")
+
+
+def test_replies_requires_valid_channel(monkeypatch):
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
+    payload = json.loads(slack_api_tool(action="replies", channel="bad", thread_ts="1783504790.412029"))
+    assert payload["ok"] is False
+    assert "channel must be" in payload["error"]
+
+
+def test_history_returns_sanitized_messages(monkeypatch):
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
+
+    def fake_post_form(method, params):
+        assert method == "conversations.history"
+        assert params["channel"] == "C0BFGRSM3K8"
+        return {
+            "ok": True,
+            "messages": [
+                {
+                    "type": "message",
+                    "user": "U123",
+                    "ts": "1783504790.412029",
+                    "text": "parent",
+                    "reply_count": 2,
+                    "files": [
+                        {
+                            "id": "F1",
+                            "name": "doc.pdf",
+                            "title": "Doc",
+                            "mimetype": "application/pdf",
+                            "size": 123,
+                            "url_private": "https://files.slack.com/files-pri/T/F/doc.pdf",
+                        }
+                    ],
+                }
+            ],
+        }
+
+    with patch("tools.slack_api_tool._post_form", side_effect=fake_post_form):
+        payload = json.loads(slack_api_tool(action="history", channel="C0BFGRSM3K8"))
+
+    assert payload["ok"] is True
+    assert payload["messages"][0]["reply_count"] == 2
+    assert payload["messages"][0]["files"][0]["id"] == "F1"
+
+
+def test_send_posts_thread_reply(monkeypatch):
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
+
+    def fake_post_json(method, payload):
+        assert method == "chat.postMessage"
+        assert payload == {
+            "channel": "C0BFGRSM3K8",
+            "thread_ts": "1783504790.412029",
+            "text": "hello",
+        }
+        return {"ok": True, "channel": "C0BFGRSM3K8", "ts": "1783504791.000000"}
+
+    with patch("tools.slack_api_tool._post_json", side_effect=fake_post_json):
+        payload = json.loads(
+            slack_api_tool(
+                action="send",
+                channel="C0BFGRSM3K8",
+                thread_ts="1783504790.412029",
+                text="hello",
+            )
+        )
+
+    assert payload == {
+        "ok": True,
+        "channel": "C0BFGRSM3K8",
+        "ts": "1783504791.000000",
+        "thread_ts": "1783504790.412029",
+        "error": None,
+    }

--- a/tools/slack_api_tool.py
+++ b/tools/slack_api_tool.py
@@ -1,0 +1,325 @@
+"""Slack Web API tool for thread-safe workspace operations.
+
+This tool is intentionally scoped to Slack's Web API primitives that an agent
+needs for reliable workspace work: channel discovery, message history, thread
+replies, file metadata, posting replies, and reactions.  It is exposed only in
+Slack-oriented toolsets (not the global core toolset) so the model-tool surface
+stays narrow.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import urllib.parse
+import urllib.request
+from typing import Any, Dict, List, Optional
+
+from agent.redact import redact_sensitive_text
+from tools.registry import registry
+
+_SLACK_API_BASE = "https://slack.com/api/"
+_CHANNEL_RE = re.compile(r"^[CGD][A-Z0-9]{8,}$")
+_TS_RE = re.compile(r"^\d{10}\.\d{6}$")
+_SAFE_CHANNEL_TYPES = "public_channel,private_channel,im,mpim"
+
+
+def check_slack_api_requirements() -> bool:
+    """Expose the tool only when a Slack bot token is configured."""
+    return bool(os.getenv("SLACK_BOT_TOKEN"))
+
+
+def _token() -> str:
+    token = os.getenv("SLACK_BOT_TOKEN")
+    if not token:
+        raise RuntimeError("SLACK_BOT_TOKEN is not configured")
+    return token
+
+
+def _clean_error(text: Any) -> str:
+    return redact_sensitive_text(str(text))
+
+
+def _post_form(method: str, params: Dict[str, Any]) -> Dict[str, Any]:
+    body = urllib.parse.urlencode({k: v for k, v in params.items() if v is not None}).encode()
+    req = urllib.request.Request(
+        _SLACK_API_BASE + method,
+        data=body,
+        headers={
+            "Authorization": f"Bearer {_token()}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _post_json(method: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    body = json.dumps({k: v for k, v in payload.items() if v is not None}).encode()
+    req = urllib.request.Request(
+        _SLACK_API_BASE + method,
+        data=body,
+        headers={
+            "Authorization": f"Bearer {_token()}",
+            "Content-Type": "application/json; charset=utf-8",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _public_user(user: Dict[str, Any]) -> Dict[str, Any]:
+    profile = user.get("profile") or {}
+    return {
+        "id": user.get("id"),
+        "name": user.get("name"),
+        "real_name": user.get("real_name") or profile.get("real_name"),
+        "display_name": profile.get("display_name"),
+        "is_bot": user.get("is_bot"),
+        "deleted": user.get("deleted"),
+        "team_id": user.get("team_id"),
+    }
+
+
+def _public_channel(ch: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "id": ch.get("id"),
+        "name": ch.get("name"),
+        "is_channel": ch.get("is_channel"),
+        "is_group": ch.get("is_group"),
+        "is_im": ch.get("is_im"),
+        "is_mpim": ch.get("is_mpim"),
+        "is_private": ch.get("is_private"),
+        "is_member": ch.get("is_member"),
+        "is_archived": ch.get("is_archived"),
+        "num_members": ch.get("num_members"),
+        "topic": (ch.get("topic") or {}).get("value"),
+        "purpose": (ch.get("purpose") or {}).get("value"),
+    }
+
+
+def _public_file(f: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "id": f.get("id"),
+        "name": f.get("name"),
+        "title": f.get("title"),
+        "mimetype": f.get("mimetype"),
+        "filetype": f.get("filetype"),
+        "size": f.get("size"),
+        "url_private": f.get("url_private"),
+        "created": f.get("created"),
+        "user": f.get("user"),
+    }
+
+
+def _public_message(m: Dict[str, Any], include_blocks: bool = False) -> Dict[str, Any]:
+    out: Dict[str, Any] = {
+        "type": m.get("type"),
+        "subtype": m.get("subtype"),
+        "user": m.get("user"),
+        "bot_id": m.get("bot_id"),
+        "username": m.get("username"),
+        "ts": m.get("ts"),
+        "thread_ts": m.get("thread_ts"),
+        "reply_count": m.get("reply_count"),
+        "latest_reply": m.get("latest_reply"),
+        "text": m.get("text"),
+    }
+    if m.get("files"):
+        out["files"] = [_public_file(f) for f in m.get("files", [])]
+    if include_blocks and m.get("blocks"):
+        out["blocks"] = m.get("blocks")
+    return {k: v for k, v in out.items() if v not in (None, [], {})}
+
+
+def _require_channel(channel: Optional[str]) -> str:
+    if not channel or not _CHANNEL_RE.match(channel):
+        raise ValueError("channel must be a Slack conversation ID starting with C/G/D")
+    return channel
+
+
+def _require_ts(ts: Optional[str], name: str = "ts") -> str:
+    if not ts or not _TS_RE.match(ts):
+        raise ValueError(f"{name} must be a Slack timestamp like 1783504790.412029")
+    return ts
+
+
+def _paginate(method: str, base: Dict[str, Any], collection_key: str, limit: int, max_pages: int) -> List[Dict[str, Any]]:
+    items: List[Dict[str, Any]] = []
+    cursor = None
+    pages = 0
+    while pages < max_pages and len(items) < limit:
+        page_limit = min(200, max(1, limit - len(items)))
+        params = dict(base, limit=page_limit)
+        if cursor:
+            params["cursor"] = cursor
+        res = _post_form(method, params)
+        if not res.get("ok"):
+            raise RuntimeError(f"Slack API {method} failed: {res.get('error')}")
+        items.extend(res.get(collection_key) or [])
+        cursor = (res.get("response_metadata") or {}).get("next_cursor")
+        pages += 1
+        if not cursor:
+            break
+    return items[:limit]
+
+
+def slack_api_tool(
+    action: str,
+    channel: Optional[str] = None,
+    thread_ts: Optional[str] = None,
+    ts: Optional[str] = None,
+    text: Optional[str] = None,
+    query: Optional[str] = None,
+    user: Optional[str] = None,
+    emoji: Optional[str] = None,
+    limit: int = 50,
+    include_blocks: bool = False,
+    types: str = _SAFE_CHANNEL_TYPES,
+    max_pages: int = 5,
+    oldest: Optional[str] = None,
+    latest: Optional[str] = None,
+) -> str:
+    """Handle Slack Web API actions and return compact JSON."""
+    try:
+        limit = max(1, min(int(limit or 50), 200))
+        max_pages = max(1, min(int(max_pages or 5), 10))
+        action = (action or "").strip()
+
+        if action == "auth_test":
+            res = _post_form("auth.test", {})
+            return json.dumps({k: res.get(k) for k in ("ok", "team", "team_id", "user", "user_id", "bot_id", "url")}, ensure_ascii=False)
+
+        if action == "list_channels":
+            channels = _paginate(
+                "conversations.list",
+                {"types": types or _SAFE_CHANNEL_TYPES, "exclude_archived": "true"},
+                "channels",
+                limit,
+                max_pages,
+            )
+            if query:
+                q = query.lower()
+                channels = [c for c in channels if q in (c.get("name") or "").lower() or q in (c.get("id") or "").lower()]
+            return json.dumps({"ok": True, "channels": [_public_channel(c) for c in channels]}, ensure_ascii=False)
+
+        if action == "channel_info":
+            res = _post_form("conversations.info", {"channel": _require_channel(channel)})
+            if not res.get("ok"):
+                raise RuntimeError(res.get("error"))
+            return json.dumps({"ok": True, "channel": _public_channel(res.get("channel") or {})}, ensure_ascii=False)
+
+        if action == "history":
+            messages = _paginate(
+                "conversations.history",
+                {"channel": _require_channel(channel), "oldest": oldest, "latest": latest, "inclusive": "true"},
+                "messages",
+                limit,
+                max_pages,
+            )
+            return json.dumps({"ok": True, "channel": channel, "messages": [_public_message(m, include_blocks) for m in messages]}, ensure_ascii=False)
+
+        if action == "replies":
+            messages = _paginate(
+                "conversations.replies",
+                {"channel": _require_channel(channel), "ts": _require_ts(thread_ts or ts, "thread_ts"), "oldest": oldest, "latest": latest, "inclusive": "true"},
+                "messages",
+                limit,
+                max_pages,
+            )
+            return json.dumps({"ok": True, "channel": channel, "thread_ts": thread_ts or ts, "messages": [_public_message(m, include_blocks) for m in messages]}, ensure_ascii=False)
+
+        if action == "send":
+            if not text:
+                raise ValueError("text is required for send")
+            res = _post_json("chat.postMessage", {"channel": _require_channel(channel), "thread_ts": thread_ts, "text": text})
+            return json.dumps({"ok": res.get("ok"), "channel": res.get("channel"), "ts": res.get("ts"), "thread_ts": thread_ts, "error": res.get("error")}, ensure_ascii=False)
+
+        if action == "react":
+            if not emoji:
+                raise ValueError("emoji is required for react")
+            res = _post_form("reactions.add", {"channel": _require_channel(channel), "timestamp": _require_ts(ts), "name": emoji.strip(":")})
+            return json.dumps({"ok": res.get("ok"), "error": res.get("error")}, ensure_ascii=False)
+
+        if action == "user_info":
+            if not user:
+                raise ValueError("user is required for user_info")
+            res = _post_form("users.info", {"user": user})
+            if not res.get("ok"):
+                raise RuntimeError(res.get("error"))
+            return json.dumps({"ok": True, "user": _public_user(res.get("user") or {})}, ensure_ascii=False)
+
+        if action == "files":
+            params: Dict[str, Any] = {"channel": channel, "user": user, "ts_from": oldest, "ts_to": latest}
+            res = _post_form("files.list", {k: v for k, v in params.items() if v})
+            if not res.get("ok"):
+                raise RuntimeError(res.get("error"))
+            files = (res.get("files") or [])[:limit]
+            return json.dumps({"ok": True, "files": [_public_file(f) for f in files]}, ensure_ascii=False)
+
+        raise ValueError(f"Unknown action: {action}")
+    except Exception as exc:
+        return json.dumps({"ok": False, "error": _clean_error(exc)}, ensure_ascii=False)
+
+
+SLACK_API_SCHEMA = {
+    "name": "slack_api",
+    "description": (
+        "Use Slack Web API for thread-safe workspace work: list channels, read "
+        "channel history, read thread replies, send parent/thread messages, add "
+        "reactions, inspect users, and list files. Always call replies when a "
+        "message has reply_count or when auditing a Slack thread."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["auth_test", "list_channels", "channel_info", "history", "replies", "send", "react", "user_info", "files"],
+                "description": "Slack operation to perform.",
+            },
+            "channel": {"type": "string", "description": "Slack conversation ID (C..., G..., or D...)."},
+            "thread_ts": {"type": "string", "description": "Parent message timestamp for thread replies or posting into a thread."},
+            "ts": {"type": "string", "description": "Message timestamp for reactions or as a thread timestamp fallback."},
+            "text": {"type": "string", "description": "Message text for action='send'."},
+            "query": {"type": "string", "description": "Case-insensitive channel name/id filter for list_channels."},
+            "user": {"type": "string", "description": "Slack user ID for user_info or files filtering."},
+            "emoji": {"type": "string", "description": "Emoji name for react, with or without colons."},
+            "limit": {"type": "integer", "description": "Maximum items to return (1-200).", "default": 50},
+            "include_blocks": {"type": "boolean", "description": "Include raw Slack blocks in message output; normally false to save tokens.", "default": False},
+            "types": {"type": "string", "description": "Conversation types for list_channels.", "default": _SAFE_CHANNEL_TYPES},
+            "max_pages": {"type": "integer", "description": "Pagination pages to fetch (1-10).", "default": 5},
+            "oldest": {"type": "string", "description": "Slack timestamp lower bound for history/replies/files."},
+            "latest": {"type": "string", "description": "Slack timestamp upper bound for history/replies/files."},
+        },
+        "required": ["action"],
+    },
+}
+
+
+registry.register(
+    name="slack_api",
+    toolset="slack",
+    schema=SLACK_API_SCHEMA,
+    handler=lambda args, **kw: slack_api_tool(
+        action=args.get("action", ""),
+        channel=args.get("channel"),
+        thread_ts=args.get("thread_ts"),
+        ts=args.get("ts"),
+        text=args.get("text"),
+        query=args.get("query"),
+        user=args.get("user"),
+        emoji=args.get("emoji"),
+        limit=args.get("limit", 50),
+        include_blocks=bool(args.get("include_blocks", False)),
+        types=args.get("types", _SAFE_CHANNEL_TYPES),
+        max_pages=args.get("max_pages", 5),
+        oldest=args.get("oldest"),
+        latest=args.get("latest"),
+    ),
+    check_fn=check_slack_api_requirements,
+    requires_env=["SLACK_BOT_TOKEN"],
+    description="Slack Web API read/write/thread tool",
+    emoji="💼",
+    max_result_size_chars=24000,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -464,8 +464,14 @@ TOOLSETS = {
     },
     
     "hermes-slack": {
-        "description": "Slack bot toolset - full access for workspace use (terminal has safety checks)",
-        "tools": _HERMES_CORE_TOOLS,
+        "description": "Slack bot toolset - full access for workspace use (terminal has safety checks) plus Slack Web API",
+        "tools": _HERMES_CORE_TOOLS + ["slack_api"],
+        "includes": []
+    },
+
+    "slack": {
+        "description": "Slack Web API tools (channels, threads, messages, files, reactions)",
+        "tools": ["slack_api"],
         "includes": []
     },
     


### PR DESCRIPTION
## Summary

This PR packages the K043–K055 TheWon runtime rollout hardening work into a clean execution branch.

Included areas:
- TheWon KH + LLM Wiki precheck runtime hook and final-response enforcement
- Gateway lifecycle/restart-loop guard for cron/gateway safety
- Slack `/tw-mina-task` gateway bridge with duplicate-owner/allowlist guardrails
- Slack Web API toolset
- Discord multi-agent/channel control fixes
- Profile alias boundary fix

## Verification

Clean execution worktree: `/Users/elroy/.hermes/worktrees/hermes-k055-clean-exec-20260711-0343`

Local commit:
- `5705056266c1442a8b427fd8fbebc19727281c11`

Gates already run:
- `git diff --check`: PASS
- `py_compile` targeted runtime files: PASS
- targeted regression suite: `234 passed in 6.25s`
- post-rollout K054 watchdog: PASS
  - `failed_probes=[]`
  - targeted runtime suite: `44 passed in 0.90s`
  - K050 E2E dry-run smoke: PASS
  - gateway log scan: `error_count=0`

Secret scan:
- No secret values found.
- Two `secret` hits classified as code/key-reference false positives only.

## Non-claims / rollout boundaries

- No public HTTPS exposure activated.
- No standalone Socket Mode namespace cutover performed.
- No Slack app/scope/token mutation performed.
- No live canonical mutation by the K054 watchdog.
- Production rollout after merge still needs final post-merge smoke.
