### PR TITLE
fix(memory): redact Hindsight retain payloads

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -44,6 +44,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List
 
 from agent.memory_provider import MemoryProvider
+from agent.redact import redact_sensitive_text
 from hermes_constants import get_hermes_home
 from tools.registry import tool_error
 from hermes_cli.config import cfg_get
@@ -427,6 +428,19 @@ def _normalize_retain_tags(value: Any) -> List[str]:
         seen.add(tag)
         normalized.append(tag)
     return normalized
+
+
+def _redact_retain_value(value: Any) -> Any:
+    """Copy a retain payload value, redacting every nested string value."""
+    if isinstance(value, str):
+        return redact_sensitive_text(value, force=True)
+    if isinstance(value, dict):
+        return {key: _redact_retain_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_redact_retain_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_redact_retain_value(item) for item in value)
+    return value
 
 
 _OBSERVATION_SCOPE_KEYWORDS = {"per_tag", "combined", "all_combinations"}
@@ -1575,17 +1589,26 @@ class HindsightMemoryProvider(MemoryProvider):
         *,
         context: str | None = None,
         document_id: str | None = None,
-        metadata: Dict[str, str] | None = None,
+        metadata: Dict[str, Any] | None = None,
         tags: List[str] | None = None,
         retain_async: bool | None = None,
     ) -> Dict[str, Any]:
+        """Build a sanitized content payload without altering protocol identity.
+
+        All content-bearing fields, including metadata values, are recursively
+        scanned. Trusted structural fields (bank_id, document_id, and
+        retain/update mode) remain unchanged so routing and append identity
+        cannot be altered by redaction. Metadata keys are trusted schema names.
+        """
         kwargs: Dict[str, Any] = {
             "bank_id": self._bank_id,
-            "content": content,
-            "metadata": metadata or self._build_metadata(message_count=1, turn_index=self._turn_index),
+            "content": _redact_retain_value(content),
+            "metadata": _redact_retain_value(
+                metadata or self._build_metadata(message_count=1, turn_index=self._turn_index)
+            ),
         }
         if context is not None:
-            kwargs["context"] = context
+            kwargs["context"] = _redact_retain_value(context)
         if document_id:
             kwargs["document_id"] = document_id
         if retain_async is not None:
@@ -1595,9 +1618,9 @@ class HindsightMemoryProvider(MemoryProvider):
             if tag not in merged_tags:
                 merged_tags.append(tag)
         if merged_tags:
-            kwargs["tags"] = merged_tags
+            kwargs["tags"] = _redact_retain_value(merged_tags)
         if self._observation_scopes:
-            kwargs["observation_scopes"] = self._observation_scopes
+            kwargs["observation_scopes"] = _redact_retain_value(self._observation_scopes)
         return kwargs
 
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -652,6 +652,127 @@ class TestToolHandlers:
         assert "bank_id" not in item
         assert "retain_async" not in item
 
+    def test_retain_redacts_user_strings_without_mutating_inputs(
+        self, provider, monkeypatch
+    ):
+        secret = "sk-" + "A" * 48
+        metadata = {
+            "nested": {"credential": secret, "count": 3, "enabled": True},
+            "items": [secret, None, 7],
+            "source": "hermes",
+        }
+        original_metadata = {
+            "nested": dict(metadata["nested"]),
+            "items": list(metadata["items"]),
+            "source": metadata["source"],
+        }
+        monkeypatch.setattr(provider, "_build_metadata", lambda **kwargs: metadata)
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+
+        provider.handle_tool_call(
+            "hindsight_retain",
+            {
+                "content": f"token={secret}",
+                "context": f"credential {secret}",
+                "tags": [f"auth:{secret}", "ordinary-tag"],
+            },
+        )
+
+        item = provider._client.aretain_batch.call_args.kwargs["items"][0]
+        assert secret not in item["content"]
+        assert secret not in item["context"]
+        assert secret not in item["tags"][0]
+        assert item["tags"][1] == "ordinary-tag"
+        assert secret not in item["metadata"]["nested"]["credential"]
+        assert secret not in item["metadata"]["items"][0]
+        assert item["metadata"]["nested"]["count"] == 3
+        assert item["metadata"]["nested"]["enabled"] is True
+        assert item["metadata"]["items"][1:] == [None, 7]
+        assert item["metadata"]["source"] == "hermes"
+        assert metadata == original_metadata
+
+    def test_retain_preserves_ordinary_top_level_metadata_byte_for_byte(
+        self, provider, monkeypatch
+    ):
+        metadata = {
+            "source": "hermes/public-handler",
+            "timestamp": "2026-07-10T12:34:56.789Z",
+            "retained_at": "2026-07-10T12:34:57.123Z",
+        }
+        monkeypatch.setattr(provider, "_build_metadata", lambda **kwargs: metadata)
+
+        provider.handle_tool_call("hindsight_retain", {"content": "remember this"})
+
+        item_metadata = provider._client.aretain_batch.call_args.kwargs["items"][0]["metadata"]
+        assert item_metadata == metadata
+
+    def test_retain_redacts_secret_shaped_metadata_at_every_depth(
+        self, provider, monkeypatch
+    ):
+        source = "sk-" + "D" * 48
+        timestamp = "sk-" + "E" * 48
+        retained_at = "sk-" + "F" * 48
+        metadata = {
+            "source": source,
+            "timestamp": timestamp,
+            "retained_at": retained_at,
+            "nested": {
+                "source": source,
+                "timestamp": timestamp,
+                "retained_at": retained_at,
+            },
+        }
+        monkeypatch.setattr(provider, "_build_metadata", lambda **kwargs: metadata)
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+
+        provider.handle_tool_call("hindsight_retain", {"content": "remember this"})
+
+        item_metadata = provider._client.aretain_batch.call_args.kwargs["items"][0]["metadata"]
+        assert source not in item_metadata["source"]
+        assert timestamp not in item_metadata["timestamp"]
+        assert retained_at not in item_metadata["retained_at"]
+        assert source not in item_metadata["nested"]["source"]
+        assert timestamp not in item_metadata["nested"]["timestamp"]
+        assert retained_at not in item_metadata["nested"]["retained_at"]
+
+    def test_build_retain_kwargs_preserves_structural_identifiers(self, provider):
+        provider._bank_id = "bank/sk-" + "G" * 48
+        document_id = "document/sk-" + "H" * 48
+
+        kwargs = provider._build_retain_kwargs(
+            "ordinary content",
+            document_id=document_id,
+            retain_async=False,
+        )
+
+        assert kwargs["bank_id"] == provider._bank_id
+        assert kwargs["document_id"] == document_id
+        assert kwargs["retain_async"] is False
+
+    def test_retain_preserves_environment_lookups_and_ordinary_metadata(
+        self, provider, monkeypatch
+    ):
+        metadata = {
+            "configuration": {"api_key": "os.getenv('OPENAI_API_KEY')"},
+            "label": "ordinary metadata",
+        }
+        monkeypatch.setattr(provider, "_build_metadata", lambda **kwargs: metadata)
+
+        provider.handle_tool_call(
+            "hindsight_retain",
+            {
+                "content": "api_key=os.getenv('OPENAI_API_KEY')",
+                "context": "ordinary context",
+                "tags": ["ordinary-tag"],
+            },
+        )
+
+        item = provider._client.aretain_batch.call_args.kwargs["items"][0]
+        assert item["content"] == "api_key=os.getenv('OPENAI_API_KEY')"
+        assert item["context"] == "ordinary context"
+        assert item["tags"] == ["ordinary-tag"]
+        assert item["metadata"] == metadata
+
     def test_retain_with_tags(self, provider_with_config):
         p = provider_with_config(retain_tags=["pref", "ui"])
         p.handle_tool_call("hindsight_retain", {"content": "likes dark mode"})
@@ -677,6 +798,18 @@ class TestToolHandlers:
         p.handle_tool_call("hindsight_retain", {"content": "likes dark mode"})
         item = p._client.aretain_batch.call_args.kwargs["items"][0]
         assert item["observation_scopes"] == "per_tag"
+
+    def test_retain_redacts_custom_observation_scope_tags(
+        self, provider_with_config, monkeypatch
+    ):
+        secret = "sk-" + "C" * 48
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+        p = provider_with_config(observation_scopes=[[f"credential:{secret}"]])
+
+        p.handle_tool_call("hindsight_retain", {"content": "likes dark mode"})
+
+        item = p._client.aretain_batch.call_args.kwargs["items"][0]
+        assert secret not in item["observation_scopes"][0][0]
 
     def test_retain_omits_observation_scopes_by_default(self, provider):
         provider.handle_tool_call("hindsight_retain", {"content": "hello"})
@@ -862,6 +995,25 @@ class TestPrefetch:
 
 
 class TestSyncTurn:
+    def test_sync_turn_redacts_content_and_preserves_structural_fields(
+        self, provider, monkeypatch
+    ):
+        secret = "sk-" + "B" * 48
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+        provider._retain_context = f"conversation {secret}"
+        provider._retain_tags = [f"credential:{secret}"]
+
+        provider.sync_turn(f"my token is {secret}", f"received {secret}")
+        provider._retain_queue.join()
+
+        call_kwargs = provider._client.aretain_batch.call_args.kwargs
+        item = call_kwargs["items"][0]
+        assert secret not in item["content"]
+        assert secret not in item["context"]
+        assert secret not in item["tags"][0]
+        assert call_kwargs["document_id"].startswith("test-session-")
+        assert item["metadata"]["retained_at"].endswith("Z")
+
     def test_sync_turn_retains_metadata_rich_turn(self, provider_with_config):
         p = provider_with_config(
             retain_tags=["conv", "session1"],


### PR DESCRIPTION
## Summary

- apply Hermes' existing `redact_sensitive_text(..., force=True)` at the centralized Hindsight retain-payload boundary
- recursively sanitize content, context, metadata values, tags, and custom observation scopes
- cover automatic turn retention, explicit `hindsight_retain`, and session-switch flushes through the shared payload builder
- preserve trusted protocol/routing fields such as bank and document IDs so append identity is unchanged
- add regression coverage for nested structures, input immutability, global-redaction opt-out, false-positive preservation, and previously identified metadata/scope bypasses

## Security rationale

Hindsight retains user/assistant content in an external persistent memory service. Several Hermes tool and persistence boundaries already use the shared redactor, but raw user content and explicit Hindsight retains did not have a final provider-level redaction pass. This patch adds defense in depth immediately before data reaches the Hindsight client.

The provider uses `force=True` intentionally so disabling display/log redaction does not silently disable external-memory egress protection.

## Test plan

- [x] `python -m pytest tests/plugins/memory/test_hindsight_provider.py tests/agent/test_redact.py -q` — 272 passed
- [x] `python -m ruff check plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py`
- [x] `git diff --check`
- [x] independent specification review
- [x] independent security/code-quality review

`./scripts/run_tests.sh` was also run locally. It reported unrelated environment/pre-existing failures across 23 untouched files, including temporary Git commit signing failures, unavailable lazy-installed Mistral dependencies, audio-device assumptions, HOME/profile assumptions, and filesystem mtime/cache timing. The changed Hindsight and redactor suites passed independently.
