### PR TITLE
fix: bound prompt cache routing keys

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -13,6 +13,24 @@ from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall
 
 
+def _bounded_prompt_cache_key(value: Any) -> Optional[str]:
+    """Return a provider-safe cache key without changing session identity.
+
+    OpenAI limits ``prompt_cache_key`` to 64 characters. External gateways may
+    supply longer namespaced session identifiers through request overrides, so
+    hash only oversized values at the final provider boundary.
+    """
+    if value is None:
+        return None
+    key = str(value).strip()
+    if not key:
+        return None
+    if len(key) <= 64:
+        return key
+    digest = hashlib.sha256(key.encode("utf-8", errors="replace")).hexdigest()[:60]
+    return f"pck_{digest}"
+
+
 def _content_cache_key(instructions: str, tools: Optional[List[Dict[str, Any]]]) -> Optional[str]:
     """Content-address the prompt cache key from the static request prefix.
 
@@ -296,6 +314,17 @@ class ResponsesApiTransport(ProviderTransport):
         if request_overrides:
             kwargs.update(request_overrides)
 
+        # Request overrides are intentionally merged last, but an external
+        # gateway can use that surface to supply a full namespaced session ID
+        # as ``prompt_cache_key``. Normalize the final provider-facing value so
+        # OpenAI's 64-character limit cannot reject otherwise valid sessions.
+        if "prompt_cache_key" in kwargs:
+            bounded_cache_key = _bounded_prompt_cache_key(kwargs["prompt_cache_key"])
+            if bounded_cache_key:
+                kwargs["prompt_cache_key"] = bounded_cache_key
+            else:
+                kwargs.pop("prompt_cache_key", None)
+
         # xAI Responses API rejects ``service_tier`` (HTTP 400 "Argument not
         # supported: service_tier") — hit when ``/fast`` priority-processing
         # mode lingers from a prior model in the same session, or when a
@@ -329,7 +358,7 @@ class ResponsesApiTransport(ProviderTransport):
             # remain high.  Send session_id / x-client-request-id as HTTP
             # headers while keeping ``prompt_cache_key`` in the body for
             # standard OpenAI routing as a belt-and-braces fallback.
-            cache_scope_id = str(session_id or "").strip()
+            cache_scope_id = _bounded_prompt_cache_key(session_id)
             if cache_scope_id:
                 existing_extra_headers = kwargs.get("extra_headers")
                 merged_extra_headers: Dict[str, str] = {}
@@ -373,6 +402,17 @@ class ResponsesApiTransport(ProviderTransport):
                 merged_extra_body.update(existing_extra_body)
             merged_extra_body.setdefault("prompt_cache_key", cache_key)
             kwargs["extra_body"] = merged_extra_body
+
+        # xAI carries the cache key inside extra_body rather than as a typed
+        # top-level argument. Apply the same final-boundary normalization after
+        # merging caller overrides so long external session keys are safe there too.
+        extra_body = kwargs.get("extra_body")
+        if isinstance(extra_body, dict) and "prompt_cache_key" in extra_body:
+            bounded_cache_key = _bounded_prompt_cache_key(extra_body["prompt_cache_key"])
+            if bounded_cache_key:
+                extra_body["prompt_cache_key"] = bounded_cache_key
+            else:
+                extra_body.pop("prompt_cache_key", None)
 
         return kwargs
 

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -112,6 +112,29 @@ class TestCodexBuildKwargs:
         )
         assert kw1["prompt_cache_key"] == kw2["prompt_cache_key"]
 
+    def test_long_caller_cache_key_is_bounded_after_request_overrides(self, transport):
+        """External session bridges may override prompt_cache_key with their full
+        namespaced session key. Bound that final provider-facing value to OpenAI's
+        64-character limit without changing the caller's session identifier."""
+        long_key = (
+            "paperclip:company:f4188af0-bfc1-4a44-9c3e-fb6aff1106d3:"
+            "agent:2baeddd2-ea8b-4467-8381-2901e3cf3f5a:"
+            "issue:44192c5a-d50b-4281-b30c-f77457d62481"
+        )
+        assert len(long_key) == 140
+
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            session_id=long_key,
+            request_overrides={"prompt_cache_key": long_key},
+        )
+
+        assert kw["prompt_cache_key"].startswith("pck_")
+        assert len(kw["prompt_cache_key"]) <= 64
+        assert kw["prompt_cache_key"] != long_key
+
     def test_github_responses_no_cache_key(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(
@@ -164,6 +187,21 @@ class TestCodexBuildKwargs:
         assert eb.get("prompt_cache_key") == "caller-override"
         assert eb.get("other_field") == 42
 
+    def test_xai_long_caller_cache_key_is_bounded(self, transport):
+        long_key = "paperclip:" + "x" * 130
+        kw = transport.build_kwargs(
+            model="grok-4.3",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            session_id=long_key,
+            is_xai_responses=True,
+            request_overrides={"extra_body": {"prompt_cache_key": long_key}},
+        )
+
+        cache_key = kw["extra_body"]["prompt_cache_key"]
+        assert cache_key.startswith("pck_")
+        assert len(cache_key) <= 64
+
     def test_max_tokens(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(
@@ -197,6 +235,23 @@ class TestCodexBuildKwargs:
         headers = kw.get("extra_headers", {})
         assert headers.get("session_id") == "conv-codex-1"
         assert headers.get("x-client-request-id") == "conv-codex-1"
+
+    def test_codex_backend_bounds_long_cache_scope_headers(self, transport):
+        """The ChatGPT backend treats cache-scope headers as prompt cache keys,
+        so external namespaced session IDs must be bounded at this boundary too."""
+        long_session_id = "paperclip:" + "x" * 130
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            session_id=long_session_id,
+            is_codex_backend=True,
+        )
+
+        headers = kw["extra_headers"]
+        assert headers["session_id"].startswith("pck_")
+        assert headers["x-client-request-id"] == headers["session_id"]
+        assert len(headers["session_id"]) <= 64
 
     def test_codex_backend_no_headers_without_session_id(self, transport):
         messages = [{"role": "user", "content": "Hi"}]


### PR DESCRIPTION
## Summary
- bound oversized provider-facing `prompt_cache_key` values to deterministic 64-character hashes
- apply the same bound to xAI `extra_body.prompt_cache_key`
- bound ChatGPT Codex cache-scope headers, which the backend treats as prompt-cache routing keys
- preserve short caller keys and full internal Hermes session identity

## Root cause
External gateways can use namespaced session IDs longer than OpenAI’s 64-character `prompt_cache_key` limit. Paperclip issue-scoped keys are 140 characters. Hermes safely content-addressed the body key, but late request overrides and Codex cache-scope headers could still send the raw long session key.

## Verification
- `63 passed`: `tests/agent/transports/test_codex_transport.py`
- `85 passed`: `tests/run_agent/test_run_agent_codex_responses.py`
- live authenticated `/v1/runs` with the original 140-character issue-scoped key completed successfully (`LONG_KEY_OK`) after restart

No session identifiers or credentials are included in the patch.