### PR TITLE
fix(model-switch): fail early on unauthenticated OpenRouter routes

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1254,35 +1254,35 @@ def switch_model(
         direct_hint = ""
         if "/" in raw_input:
             vendor, bare_model = raw_input.split("/", 1)
-            direct_provider = resolve_provider_full(
-                vendor.strip(), user_providers, custom_providers
+            vendor_slug = vendor.strip().lower()
+            vendor_prefix = f"{vendor_slug}-"
+            authenticated = get_authenticated_provider_slugs(
+                current_provider=current_provider,
+                user_providers=user_providers,
+                custom_providers=custom_providers,
             )
-            if direct_provider is None or direct_provider.id == "openrouter":
-                vendor_prefix = f"{vendor.strip().lower()}-"
-                authenticated = get_authenticated_provider_slugs(
-                    current_provider=current_provider,
-                    user_providers=user_providers,
-                    custom_providers=custom_providers,
+            candidates = sorted(
+                authenticated,
+                key=lambda provider: provider != current_provider,
+            )
+            direct_provider = None
+            for candidate in candidates:
+                if candidate != vendor_slug and not candidate.startswith(vendor_prefix):
+                    continue
+                resolved = resolve_provider_full(
+                    candidate, user_providers, custom_providers
                 )
-                candidates = sorted(
-                    authenticated,
-                    key=lambda provider: provider != current_provider,
-                )
-                for candidate in candidates:
-                    if candidate != vendor.strip().lower() and not candidate.startswith(
-                        vendor_prefix
-                    ):
-                        continue
-                    resolved = resolve_provider_full(
-                        candidate, user_providers, custom_providers
-                    )
-                    if resolved is not None and resolved.id != "openrouter":
-                        direct_provider = resolved
-                        break
+                if resolved is not None and resolved.id != "openrouter":
+                    direct_provider = resolved
+                    break
             if direct_provider is not None and direct_provider.id != "openrouter":
                 direct_hint = (
                     f" To use {direct_provider.name} directly, run "
                     f"`/model {bare_model.strip()} --provider {direct_provider.id}`."
+                )
+            else:
+                direct_hint = (
+                    f" No authenticated direct provider for `{vendor_slug}` is available."
                 )
         return ModelSwitchResult(
             success=False,

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1245,6 +1245,57 @@ def switch_model(
         except Exception:
             pass
 
+    # Do not persist a provider switch that cannot make its first request.
+    # Vendor-qualified model IDs such as ``anthropic/claude-fable-5`` are
+    # OpenRouter slugs, so auto-detection can move a working native session to
+    # OpenRouter even when no OpenRouter credential exists.  The old behavior
+    # confirmed the switch and failed only on the next message with HTTP 401.
+    if target_provider == "openrouter" and not str(api_key or "").strip():
+        direct_hint = ""
+        if "/" in raw_input:
+            vendor, bare_model = raw_input.split("/", 1)
+            direct_provider = resolve_provider_full(
+                vendor.strip(), user_providers, custom_providers
+            )
+            if direct_provider is None or direct_provider.id == "openrouter":
+                vendor_prefix = f"{vendor.strip().lower()}-"
+                authenticated = get_authenticated_provider_slugs(
+                    current_provider=current_provider,
+                    user_providers=user_providers,
+                    custom_providers=custom_providers,
+                )
+                candidates = sorted(
+                    authenticated,
+                    key=lambda provider: provider != current_provider,
+                )
+                for candidate in candidates:
+                    if candidate != vendor.strip().lower() and not candidate.startswith(
+                        vendor_prefix
+                    ):
+                        continue
+                    resolved = resolve_provider_full(
+                        candidate, user_providers, custom_providers
+                    )
+                    if resolved is not None and resolved.id != "openrouter":
+                        direct_provider = resolved
+                        break
+            if direct_provider is not None and direct_provider.id != "openrouter":
+                direct_hint = (
+                    f" To use {direct_provider.name} directly, run "
+                    f"`/model {bare_model.strip()} --provider {direct_provider.id}`."
+                )
+        return ModelSwitchResult(
+            success=False,
+            new_model=new_model,
+            target_provider=target_provider,
+            provider_label=provider_label,
+            is_global=is_global,
+            error_message=(
+                "OpenRouter credentials are required before switching to "
+                f"`{new_model}`. Configure OpenRouter first.{direct_hint}"
+            ),
+        )
+
     # --- Direct alias override: use exact base_url from the alias if set ---
     if resolved_alias:
         _ensure_direct_aliases()

--- a/tests/hermes_cli/test_model_switch_openrouter_auth.py
+++ b/tests/hermes_cli/test_model_switch_openrouter_auth.py
@@ -1,0 +1,101 @@
+"""Regression tests for OpenRouter auth validation during ``/model``."""
+
+from unittest.mock import patch
+
+from hermes_cli.model_switch import switch_model
+
+
+_ACCEPTED = {
+    "accepted": True,
+    "persist": True,
+    "recognized": True,
+    "message": None,
+}
+
+
+def test_auto_detected_openrouter_switch_fails_before_persisting_without_credentials(
+    tmp_path, monkeypatch
+):
+    """Exercise real model detection and runtime auth in an isolated home."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    for name in ("OPENROUTER_API_KEY", "OPENAI_API_KEY"):
+        monkeypatch.delenv(name, raising=False)
+
+    result = switch_model(
+        raw_input="anthropic/claude-fable-5",
+        current_provider="openai-codex",
+        current_model="gpt-5.6-sol",
+    )
+
+    assert result.success is False
+    assert result.target_provider == "openrouter"
+    assert "OpenRouter credentials" in result.error_message
+    assert "--provider anthropic" in result.error_message
+
+
+def test_auto_detected_openrouter_switch_still_accepts_resolved_credentials():
+    """Keep intentional OpenRouter setups working regardless of key source."""
+    with (
+        patch("hermes_cli.model_switch.resolve_alias", return_value=None),
+        patch("hermes_cli.model_switch.list_provider_models", return_value=[]),
+        patch(
+            "hermes_cli.models.detect_provider_for_model",
+            return_value=("openrouter", "anthropic/claude-fable-5"),
+        ),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "provider": "openrouter",
+                "api_key": "resolved-openrouter-credential",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_mode": "chat_completions",
+            },
+        ),
+        patch("hermes_cli.models.validate_requested_model", return_value=_ACCEPTED),
+        patch("hermes_cli.model_switch.get_model_info", return_value=None),
+        patch("hermes_cli.model_switch.get_model_capabilities", return_value=None),
+    ):
+        result = switch_model(
+            raw_input="anthropic/claude-fable-5",
+            current_provider="openai-codex",
+            current_model="gpt-5.6-sol",
+        )
+
+    assert result.success is True
+    assert result.target_provider == "openrouter"
+    assert result.api_key == "resolved-openrouter-credential"
+
+
+def test_openai_slug_suggests_authenticated_direct_codex_route():
+    """Legacy ``openai`` aliasing must not hide an available direct route."""
+    with (
+        patch("hermes_cli.model_switch.resolve_alias", return_value=None),
+        patch("hermes_cli.model_switch.list_provider_models", return_value=[]),
+        patch(
+            "hermes_cli.models.detect_provider_for_model",
+            return_value=("openrouter", "openai/gpt-5.6-sol"),
+        ),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "provider": "openrouter",
+                "api_key": "",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_mode": "chat_completions",
+            },
+        ),
+        patch(
+            "hermes_cli.model_switch.get_authenticated_provider_slugs",
+            return_value=["openai-codex"],
+        ),
+    ):
+        result = switch_model(
+            raw_input="openai/gpt-5.6-sol",
+            current_provider="openai-codex",
+            current_model="gpt-5.6-terra",
+        )
+
+    assert result.success is False
+    assert "--provider openai-codex" in result.error_message

--- a/tests/hermes_cli/test_model_switch_openrouter_auth.py
+++ b/tests/hermes_cli/test_model_switch_openrouter_auth.py
@@ -23,16 +23,55 @@ def test_auto_detected_openrouter_switch_fails_before_persisting_without_credent
     for name in ("OPENROUTER_API_KEY", "OPENAI_API_KEY"):
         monkeypatch.delenv(name, raising=False)
 
-    result = switch_model(
-        raw_input="anthropic/claude-fable-5",
-        current_provider="openai-codex",
-        current_model="gpt-5.6-sol",
-    )
+    with patch(
+        "hermes_cli.model_switch.get_authenticated_provider_slugs",
+        return_value=[],
+    ):
+        result = switch_model(
+            raw_input="anthropic/claude-fable-5",
+            current_provider="openai-codex",
+            current_model="gpt-5.6-sol",
+        )
 
     assert result.success is False
     assert result.target_provider == "openrouter"
     assert "OpenRouter credentials" in result.error_message
+    assert "No authenticated direct provider for `anthropic`" in result.error_message
+    assert "--provider anthropic" not in result.error_message
+
+
+def test_anthropic_slug_suggests_authenticated_direct_anthropic_route():
+    """Only advertise the native vendor route when it is authenticated."""
+    with (
+        patch("hermes_cli.model_switch.resolve_alias", return_value=None),
+        patch("hermes_cli.model_switch.list_provider_models", return_value=[]),
+        patch(
+            "hermes_cli.models.detect_provider_for_model",
+            return_value=("openrouter", "anthropic/claude-fable-5"),
+        ),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "provider": "openrouter",
+                "api_key": "",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_mode": "chat_completions",
+            },
+        ),
+        patch(
+            "hermes_cli.model_switch.get_authenticated_provider_slugs",
+            return_value=["anthropic"],
+        ),
+    ):
+        result = switch_model(
+            raw_input="anthropic/claude-fable-5",
+            current_provider="openai-codex",
+            current_model="gpt-5.6-sol",
+        )
+
+    assert result.success is False
     assert "--provider anthropic" in result.error_message
+    assert "No authenticated direct provider" not in result.error_message
 
 
 def test_auto_detected_openrouter_switch_still_accepts_resolved_credentials():


### PR DESCRIPTION
## Summary

- Reject `/model` switches to OpenRouter when runtime resolution produced no usable credential.
- Fail before the unusable session/global override is persisted and before the next message falls back.
- Suggest an authenticated direct provider for vendor-qualified slugs, e.g. `claude-fable-5 --provider anthropic` or `gpt-5.6-sol --provider openai-codex`.
- Preserve valid OpenRouter setups regardless of where runtime credential resolution found the key.

## Reproduction

Starting on `openai-codex`, run:

```text
/model anthropic/claude-fable-5 --session
```

`anthropic/claude-fable-5` is an OpenRouter slug. Without an OpenRouter credential, Hermes previously confirmed the switch, persisted it, then failed the first request with `401 Missing Authentication header` and activated the fallback on every later turn.

## Scope and prior work

Related to #11057 and the provider-routing class fixed in #37175.

Unlike closed #11077, this change does not reject `OPENAI_API_KEY` as a credential source. It trusts the existing runtime resolver: any resolved credential keeps working; only an empty resolved credential fails early.

## Verification

- Regression test failed on current `main` before the implementation.
- `59 passed` across the new tests and surrounding model-switch suites.
- Ruff passed on both changed files.
- Windows footgun scan passed on both changed files.
- `git diff --check` passed.
- Independent review found no remaining blockers.

Tested on macOS with Python 3.12.