### PR TITLE
fix(gateway): deduplicate WSL service PATH entries

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2530,6 +2530,18 @@ def _build_user_local_paths(home: Path, path_entries: list[str]) -> list[str]:
     return [p for p in candidates if p not in path_entries and Path(p).exists()]
 
 
+def _service_path_entry_key(entry: str) -> str:
+    """Return a stable comparison key for generated service PATH entries."""
+    normalized = entry.rstrip("/") or entry
+    if is_wsl() and normalized.startswith("/mnt/"):
+        return normalized.lower()
+    return normalized
+
+
+def _normalize_service_path_entry(entry: str) -> str:
+    return entry.rstrip("/") or entry
+
+
 def _build_wsl_interop_paths(path_entries: list[str]) -> list[str]:
     """Return WSL Windows interop PATH entries for generated systemd units.
 
@@ -2562,11 +2574,13 @@ def _build_wsl_interop_paths(path_entries: list[str]) -> list[str]:
             candidates.append(entry)
 
     result: list[str] = []
-    seen = set(path_entries)
+    seen = {_service_path_entry_key(entry) for entry in path_entries}
     for entry in candidates:
-        if entry and entry not in seen:
-            seen.add(entry)
-            result.append(entry)
+        normalized = _normalize_service_path_entry(entry)
+        key = _service_path_entry_key(normalized)
+        if normalized and key not in seen:
+            seen.add(key)
+            result.append(normalized)
     return result
 
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -503,12 +503,21 @@ class TestGeneratedSystemdUnits:
             "PATH",
             "/usr/local/bin:/mnt/c/WINDOWS/system32:/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/",
         )
-        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: None)
+
+        def fake_which(cmd):
+            if cmd == "powershell.exe":
+                return "/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/powershell.exe"
+            return None
+
+        monkeypatch.setattr(gateway_cli.shutil, "which", fake_which)
 
         unit = gateway_cli.generate_systemd_unit(system=False)
+        path_line = next(line for line in unit.splitlines() if line.startswith('Environment="PATH='))
 
         assert "/mnt/c/WINDOWS/system32" in unit
-        assert "/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/" in unit
+        assert "/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0" in unit
+        assert "/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/" not in path_line
+        assert path_line.count("/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0") == 1
 
     def test_user_unit_omits_windows_interop_paths_outside_wsl(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "is_wsl", lambda: False)


### PR DESCRIPTION
## Summary

- normalize generated service PATH entries before persisting them
- deduplicate WSL-mounted Windows paths case-insensitively and ignore trailing-slash variants
- cover duplicates introduced by inherited `PATH`, executable discovery, and fallback paths

## Root cause

WSL can expose the same Windows directory with different casing or a trailing slash. The systemd unit generator previously compared raw strings, so equivalent paths such as `/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/` and `/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0` could both be written to the service `PATH`.

## Impact

Generated WSL systemd units keep a stable, non-duplicated `PATH`. Behavior outside WSL is unchanged.

## Validation

- `uv run ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py`
- `uv run pytest -q tests/hermes_cli/test_gateway_service.py` (188 passed)