### PR TITLE
fix(feishu): sanitize unsupported markdown and route tables through post/md

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -156,9 +156,27 @@ _MARKDOWN_HINT_RE = re.compile(
     re.MULTILINE,
 )
 # Detect markdown tables: a line starting with | followed by a separator line.
-# Feishu post-type 'md' elements do not render tables, so we force text mode.
 _MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+_MARKDOWN_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
+_MARKDOWN_FOOTNOTE_REF_RE = re.compile(r"\[\^([^\]]+)\]")
+_MARKDOWN_FOOTNOTE_DEF_RE = re.compile(r"^\[\^([^\]]+)\]:\s*(.*)$")
+_MARKDOWN_HIGHLIGHT_RE = re.compile(r"==([^=\n]+)==")
+_MARKDOWN_INLINE_CODE_RE = re.compile(r"`([^`\n]+)`")
+_HTML_DETAILS_RE = re.compile(
+    r"<details(?:\s+[^>]*)?>\s*<summary(?:\s+[^>]*)?>(.*?)</summary>(.*?)</details>",
+    re.IGNORECASE | re.DOTALL,
+)
+_HTML_SIMPLE_TAG_RE = re.compile(
+    r"</?(?:kbd|mark|span|div)(?:\s+[^>]*)?>",
+    re.IGNORECASE,
+)
+_HTML_IMG_RE = re.compile(r"<img\b([^>]*)/?>\s*(?:</img>)?", re.IGNORECASE)
+_HTML_ATTR_RE = re.compile(r"\b([a-zA-Z_:][-a-zA-Z0-9_:.]*)\s*=\s*([\"'])(.*?)\2")
+_HTML_SUMMARY_RE = re.compile(r"<summary>(.*?)</summary>", re.IGNORECASE)
+_HTML_DETAILS_TAG_RE = re.compile(r"</?details>", re.IGNORECASE)
+_MERMAID_START_RE = re.compile(r"^(?:graph|flowchart)\s+(?:LR|RL|TB|TD|BT)\b", re.IGNORECASE)
+_MERMAID_EDGE_RE = re.compile(r"(-->|---|==>|-.->)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
 _MENTION_RE = re.compile(r"@_user_\d+")
@@ -555,6 +573,121 @@ def _coerce_int(value: Any, default: Optional[int] = None, min_value: int = 0) -
 def _coerce_required_int(value: Any, default: int, min_value: int = 0) -> int:
     parsed = _coerce_int(value, default=default, min_value=min_value)
     return default if parsed is None else parsed
+
+
+def _split_markdown_table_row(line: str) -> List[str]:
+    row = line.strip()
+    if row.startswith("|"):
+        row = row[1:]
+    if row.endswith("|"):
+        row = row[:-1]
+    return [cell.strip() for cell in row.split("|")]
+
+
+def _is_markdown_table_separator(line: str) -> bool:
+    cells = _split_markdown_table_row(line)
+    return bool(cells) and all(
+        bool(re.fullmatch(r":?-{3,}:?", cell.strip()))
+        for cell in cells
+    )
+
+
+def _is_markdown_table_start(lines: Sequence[str], index: int) -> bool:
+    return (
+        index + 1 < len(lines)
+        and "|" in lines[index]
+        and "|" in lines[index + 1]
+        and _is_markdown_table_separator(lines[index + 1])
+    )
+
+
+def _unwrap_feishu_unsupported_html(text: str) -> str:
+    def _format_details(match: re.Match[str]) -> str:
+        title = _HTML_SIMPLE_TAG_RE.sub("", match.group(1)).strip() or "详情"
+        body = _HTML_SIMPLE_TAG_RE.sub("", match.group(2)).strip()
+        return f"**{title}**\n{body}" if body else f"**{title}**"
+
+    unwrapped = _HTML_DETAILS_RE.sub(_format_details, text)
+    unwrapped = _HTML_SUMMARY_RE.sub(lambda m: m.group(1).strip(), unwrapped)
+    unwrapped = _HTML_DETAILS_TAG_RE.sub("", unwrapped)
+    unwrapped = _HTML_SIMPLE_TAG_RE.sub("", unwrapped)
+    return unwrapped
+
+
+def _rewrite_html_image_tag(match: re.Match[str]) -> str:
+    attrs = {
+        key.lower(): value.strip()
+        for key, _quote, value in _HTML_ATTR_RE.findall(match.group(1) or "")
+    }
+    src = attrs.get("src", "")
+    if not src:
+        return ""
+    alt = attrs.get("alt") or "未命名图片"
+    return f"图片：{alt.strip()}（{src.strip()}）"
+
+
+def _is_probable_mermaid_line(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped:
+        return False
+    return bool(
+        _MERMAID_START_RE.match(stripped)
+        or _MERMAID_EDGE_RE.search(stripped)
+        or stripped in {"subgraph", "end"}
+        or stripped.startswith(("classDef ", "class ", "style ", "linkStyle "))
+    )
+
+
+def _sanitize_feishu_markdown(content: str) -> str:
+    """Rewrite only syntax that Feishu post md explicitly cannot render."""
+    if not content:
+        return content
+
+    normalized = _unwrap_feishu_unsupported_html(content.replace("\r\n", "\n"))
+    lines = normalized.splitlines()
+    output: List[str] = []
+    in_code_block = False
+    index = 0
+
+    while index < len(lines):
+        raw_line = lines[index]
+        stripped = raw_line.strip()
+        if _MARKDOWN_FENCE_OPEN_RE.match(stripped) or _MARKDOWN_FENCE_CLOSE_RE.match(stripped):
+            in_code_block = not in_code_block
+            output.append(raw_line)
+            index += 1
+            continue
+
+        if not in_code_block and _MERMAID_START_RE.match(stripped):
+            mermaid_lines = [raw_line]
+            index += 1
+            while index < len(lines) and _is_probable_mermaid_line(lines[index]):
+                mermaid_lines.append(lines[index])
+                index += 1
+            output.append("流程图（Mermaid 源码，飞书不会渲染为图）：")
+            output.append("```text")
+            output.extend(mermaid_lines)
+            output.append("```")
+            continue
+
+        if in_code_block:
+            output.append(raw_line)
+            index += 1
+            continue
+
+        line = raw_line
+        line = _HTML_IMG_RE.sub(_rewrite_html_image_tag, line)
+        line = _MARKDOWN_IMAGE_RE.sub(
+            lambda m: f"图片：{(m.group(1) or '未命名图片').strip()}（{m.group(2).strip()}）",
+            line,
+        )
+        line = _MARKDOWN_HIGHLIGHT_RE.sub(r"**\1**", line)
+        line = re.sub(r"</?(?:sup|sub)>", "", line, flags=re.IGNORECASE)
+        line = _unwrap_feishu_unsupported_html(line)
+        output.append(line)
+        index += 1
+
+    return "\n".join(output).strip()
 
 
 # ---------------------------------------------------------------------------
@@ -1917,7 +2050,7 @@ class FeishuAdapter(BasePlatformAdapter):
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
                         msg_type="text",
-                        payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                        payload=json.dumps({"text": _strip_markdown_to_plain_text(_sanitize_feishu_markdown(chunk))}, ensure_ascii=False),
                         reply_to=reply_to,
                         metadata=metadata,
                     )
@@ -1930,7 +2063,7 @@ class FeishuAdapter(BasePlatformAdapter):
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
                         msg_type="text",
-                        payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                        payload=json.dumps({"text": _strip_markdown_to_plain_text(_sanitize_feishu_markdown(chunk))}, ensure_ascii=False),
                         reply_to=reply_to,
                         metadata=metadata,
                     )
@@ -1964,7 +2097,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 logger.warning("[Feishu] Invalid post update payload rejected by API; falling back to plain text")
                 fallback_body = self._build_update_message_body(
                     msg_type="text",
-                    content=json.dumps({"text": _strip_markdown_to_plain_text(content)}, ensure_ascii=False),
+                    content=json.dumps({"text": _strip_markdown_to_plain_text(_sanitize_feishu_markdown(content))}, ensure_ascii=False),
                 )
                 fallback_request = self._build_update_message_request(message_id=message_id, request_body=fallback_body)
                 fallback_response = await self._run_blocking(self._client.im.v1.message.update, fallback_request)
@@ -2154,6 +2287,20 @@ class FeishuAdapter(BasePlatformAdapter):
         tmp_path = response_path.with_suffix(".tmp")
         tmp_path.write_text(answer)
         tmp_path.replace(response_path)
+
+    @staticmethod
+    def extract_images(content: str) -> tuple[List[tuple[str, str]], str]:
+        """Keep inline image markup in Feishu text instead of auto-uploading it.
+
+        BasePlatformAdapter extracts Markdown/HTML image URLs and sends them as
+        native attachments. That works for platforms with cheap URL media sends,
+        but Feishu must first download and upload remote images, which can make
+        normal text replies block on arbitrary third-party image URLs. The
+        Feishu send path sanitizes image markup into readable text links later.
+        Explicit MEDIA/local-file delivery and direct send_image/send_image_file
+        still use the native upload flow.
+        """
+        return [], content
 
     async def send_voice(
         self,
@@ -4522,15 +4669,12 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
-        if _MARKDOWN_HINT_RE.search(content):
-            return "post", _build_markdown_post_payload(content)
-        text_payload = {"text": content}
+        safe_content = _sanitize_feishu_markdown(content)
+        if _MARKDOWN_TABLE_RE.search(safe_content):
+            return "post", _build_markdown_post_payload(safe_content)
+        if _MARKDOWN_HINT_RE.search(safe_content):
+            return "post", _build_markdown_post_payload(safe_content)
+        text_payload = {"text": safe_content}
         return "text", json.dumps(text_payload, ensure_ascii=False)
 
     async def _send_uploaded_file_message(


### PR DESCRIPTION
## Problem

The Feishu adapter forced markdown tables into plain-text mode (`msg_type="text"`), rendering them as raw pipe characters on the client. Other unsupported syntax (HTML `<details>`/`<summary>`, `<kbd>`, `<mark>`, `<span>`, `<sup>`/`<sub>`, `==highlight==`, Mermaid diagrams, inline images) passed through unmodified, causing blank or malformed output.

## Root Cause

`_build_outbound_payload` detected markdown tables via `_MARKDOWN_TABLE_RE` and routed them to plain text (commit `8e18d1031`). No sanitization layer existed for other Feishu-unsupported syntax.

## Changes

- **Route tables through `post/md`** instead of forcing plain-text mode. Feishu post `md` elements support GFM tables.
- **Add `_sanitize_feishu_markdown()`** — rewrites unsupported syntax into Feishu-compatible equivalents:
  - `==highlight==` → `**bold**`
  - `<details>/<summary>` → `**title**\nbody`
  - `<kbd>`, `<mark>`, `<span>`, `<div>` → stripped
  - `<sup>`/`<sub>` → stripped
  - Mermaid blocks → fenced `text` code block with descriptive label
  - Inline markdown/HTML images → readable text links
  - Code blocks are skipped (preserved as-is)
- **Override `extract_images()`** to skip auto-downloading third-party image URLs that would block text replies on the Feishu send path. Explicit `MEDIA:` / `send_image` / `send_image_file` still use the native upload flow.
- **Apply sanitization in all text-fallback paths** so even degraded messages are clean.

## Test Plan

- [ ] Send a message containing a GFM table — verify it renders as a table, not raw pipes
- [ ] Send a message with `==highlight==` — verify it renders as bold
- [ ] Send a message with `<details><summary>` — verify it renders as bold title + body
- [ ] Send a message with a Mermaid diagram — verify it renders as a text code block
- [ ] Send a message with inline image markdown — verify it renders as a text link, not blank
- [ ] Send a plain text message — verify no regression
- [ ] Send a message with code blocks — verify code blocks are preserved unchanged

## Notes

- The `_MARKDOWN_TABLE_RE` workaround (commit `8e18d1031`, 2026-04-22) is superseded by this change.
- No changes to interactive card or approval button code paths.
- Fallback chain remains: `post/md` → `text` (with sanitization).