### PR TITLE
fix(feishu): mention topic starters in thread replies

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -66,6 +66,13 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
     if thread_id is None:
         return None
     metadata = {"thread_id": thread_id}
+    if _platform_name(getattr(source, "platform", None)) == "feishu":
+        user_id = getattr(source, "feishu_topic_starter_user_id", None)
+        if user_id:
+            metadata["feishu_at_user_id"] = str(user_id)
+            user_name = getattr(source, "feishu_topic_starter_user_name", None)
+            if user_name:
+                metadata["feishu_at_user_name"] = str(user_name)
     if _platform_name(getattr(source, "platform", None)) == "telegram" and getattr(source, "chat_type", None) == "dm":
         metadata["telegram_dm_topic_reply_fallback"] = True
         tid = str(thread_id)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14442,13 +14442,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         reply_to_message_id: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """Build the metadata dict platforms need for thread-aware replies."""
-        return self._thread_metadata_for_target(
+        metadata = self._thread_metadata_for_target(
             getattr(source, "platform", None),
             getattr(source, "chat_id", None),
             getattr(source, "thread_id", None),
             chat_type=getattr(source, "chat_type", None),
             reply_to_message_id=reply_to_message_id or getattr(source, "message_id", None),
         )
+        if metadata is None:
+            return None
+        if getattr(source, "platform", None) == Platform.FEISHU:
+            user_id = getattr(source, "feishu_topic_starter_user_id", None)
+            if user_id:
+                metadata["feishu_at_user_id"] = str(user_id)
+                user_name = getattr(source, "feishu_topic_starter_user_name", None)
+                if user_name:
+                    metadata["feishu_at_user_name"] = str(user_name)
+        return metadata
 
     def _thread_metadata_for_target(
         self,
@@ -18105,21 +18115,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # sent via the reply API with reply_in_thread=true. Status/interim,
             # approval, and stream-consumer paths usually only receive metadata,
             # so carry the triggering message id as a Feishu-specific fallback.
-            _status_thread_metadata: Optional[Dict[str, Any]] = {
-                "thread_id": _progress_thread_id,
-                "reply_to_message_id": event_message_id,
-            }
-            if getattr(source, "feishu_topic_starter_user_id", None):
-                _status_thread_metadata["feishu_at_user_id"] = str(
-                    getattr(source, "feishu_topic_starter_user_id")
-                )
-                _feishu_starter_name = getattr(
-                    source, "feishu_topic_starter_user_name", None
-                )
-                if _feishu_starter_name:
-                    _status_thread_metadata["feishu_at_user_name"] = str(
-                        _feishu_starter_name
-                    )
+            _status_thread_metadata = self._thread_metadata_for_source(
+                source, event_message_id
+            ) or {"thread_id": _progress_thread_id}
+            _status_thread_metadata["reply_to_message_id"] = event_message_id
         else:
             _status_thread_metadata = self._thread_metadata_for_source(source, event_message_id) if _progress_thread_id else None
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18109,6 +18109,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "thread_id": _progress_thread_id,
                 "reply_to_message_id": event_message_id,
             }
+            if getattr(source, "feishu_topic_starter_user_id", None):
+                _status_thread_metadata["feishu_at_user_id"] = str(
+                    getattr(source, "feishu_topic_starter_user_id")
+                )
+                _feishu_starter_name = getattr(
+                    source, "feishu_topic_starter_user_name", None
+                )
+                if _feishu_starter_name:
+                    _status_thread_metadata["feishu_at_user_name"] = str(
+                        _feishu_starter_name
+                    )
         else:
             _status_thread_metadata = self._thread_metadata_for_source(source, event_message_id) if _progress_thread_id else None
 

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3282,13 +3282,9 @@ class FeishuAdapter(BasePlatformAdapter):
         if self._bot_identity().matches(open_id=open_id, user_id=user_id, name=user_name):
             return None
 
-        mention_id = (
-            str(sender_profile.get("user_id") or "").strip()
-            or str(sender_profile.get("user_id_alt") or "").strip()
-        )
-        if not mention_id:
+        if not open_id:
             return None
-        return mention_id, user_name
+        return open_id, user_name
 
     async def _process_inbound_message(
         self,

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -52,6 +52,7 @@ import collections
 import concurrent.futures
 import hashlib
 import hmac
+import html
 import itertools
 import json
 import logging
@@ -164,6 +165,8 @@ _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
 _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
 _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
+_OUTBOUND_AT_USER_ID_METADATA = "feishu_at_user_id"
+_OUTBOUND_AT_USER_NAME_METADATA = "feishu_at_user_name"
 # ---------------------------------------------------------------------------
 # Media type sets and upload constants
 # ---------------------------------------------------------------------------
@@ -1495,6 +1498,7 @@ class FeishuAdapter(BasePlatformAdapter):
         # Update prompt button state (prompt_id → {session_key, message_id, chat_id})
         self._update_prompt_state: Dict[int, Dict[str, str]] = {}
         self._update_prompt_counter = itertools.count(1)
+        self._outbound_at_by_message_id: Dict[str, tuple[str, str]] = {}
         # Feishu reaction deletion requires the opaque reaction_id returned
         # by create, so we cache it per message_id.
         self._pending_processing_reactions: "OrderedDict[str, str]" = OrderedDict()
@@ -1898,10 +1902,15 @@ class FeishuAdapter(BasePlatformAdapter):
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
         last_response = None
+        outbound_at_ref = self._outbound_at_ref_from_metadata(metadata)
 
         try:
-            for chunk in chunks:
+            for index, chunk in enumerate(chunks):
+                chunk_at_ref = outbound_at_ref if index == 0 else None
                 msg_type, payload = self._build_outbound_payload(chunk)
+                msg_type, payload = self._apply_outbound_at_to_payload(
+                    msg_type, payload, chunk_at_ref,
+                )
                 try:
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
@@ -1913,11 +1922,16 @@ class FeishuAdapter(BasePlatformAdapter):
                 except Exception as exc:
                     if msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
                         raise
+                    fallback_msg_type, fallback_payload = self._apply_outbound_at_to_payload(
+                        "text",
+                        json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                        chunk_at_ref,
+                    )
                     logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
-                        msg_type="text",
-                        payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                        msg_type=fallback_msg_type,
+                        payload=fallback_payload,
                         reply_to=reply_to,
                         metadata=metadata,
                     )
@@ -1926,14 +1940,23 @@ class FeishuAdapter(BasePlatformAdapter):
                     and not self._response_succeeded(response)
                     and _POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or ""))
                 ):
+                    fallback_msg_type, fallback_payload = self._apply_outbound_at_to_payload(
+                        "text",
+                        json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                        chunk_at_ref,
+                    )
                     logger.warning("[Feishu] Post payload rejected by API response; falling back to plain text")
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
-                        msg_type="text",
-                        payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                        msg_type=fallback_msg_type,
+                        payload=fallback_payload,
                         reply_to=reply_to,
                         metadata=metadata,
                     )
+                self._remember_outbound_at(
+                    self._extract_response_field(response, "message_id"),
+                    chunk_at_ref,
+                )
                 last_response = response
 
             return self._finalize_send_result(last_response, "send failed")
@@ -1956,15 +1979,22 @@ class FeishuAdapter(BasePlatformAdapter):
         content = self.format_message(content)
         try:
             msg_type, payload = self._build_outbound_payload(content)
+            at_ref = getattr(self, "_outbound_at_by_message_id", {}).get(str(message_id))
+            msg_type, payload = self._apply_outbound_at_to_payload(msg_type, payload, at_ref)
             body = self._build_update_message_body(msg_type=msg_type, content=payload)
             request = self._build_update_message_request(message_id=message_id, request_body=body)
             response = await self._run_blocking(self._client.im.v1.message.update, request)
             result = self._finalize_send_result(response, "update failed")
             if not result.success and msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
+                fallback_msg_type, fallback_payload = self._apply_outbound_at_to_payload(
+                    "text",
+                    json.dumps({"text": _strip_markdown_to_plain_text(content)}, ensure_ascii=False),
+                    at_ref,
+                )
                 logger.warning("[Feishu] Invalid post update payload rejected by API; falling back to plain text")
                 fallback_body = self._build_update_message_body(
-                    msg_type="text",
-                    content=json.dumps({"text": _strip_markdown_to_plain_text(content)}, ensure_ascii=False),
+                    msg_type=fallback_msg_type,
+                    content=fallback_payload,
                 )
                 fallback_request = self._build_update_message_request(message_id=message_id, request_body=fallback_body)
                 fallback_response = await self._run_blocking(self._client.im.v1.message.update, fallback_request)
@@ -3226,6 +3256,40 @@ class FeishuAdapter(BasePlatformAdapter):
         _extra = getattr(_config, "extra", None) or {}
         return resolve_channel_prompt(_extra, chat_id, parent_id)
 
+    def _topic_starter_at_ref(
+        self,
+        *,
+        message: Any,
+        sender_id: Any,
+        sender_profile: Dict[str, Optional[str]],
+        is_bot: bool,
+        thread_id: Optional[str],
+        reply_to_message_id: Optional[str],
+    ) -> Optional[tuple[str, str]]:
+        if is_bot or not thread_id or not reply_to_message_id:
+            return None
+        root_id = str(getattr(message, "root_id", "") or "").strip()
+        if not root_id:
+            return None
+        if str(thread_id) != root_id:
+            return None
+        if str(reply_to_message_id) != root_id:
+            return None
+
+        open_id = str(getattr(sender_id, "open_id", "") or "").strip()
+        user_id = str(getattr(sender_id, "user_id", "") or "").strip()
+        user_name = str(sender_profile.get("user_name") or "").strip()
+        if self._bot_identity().matches(open_id=open_id, user_id=user_id, name=user_name):
+            return None
+
+        mention_id = (
+            str(sender_profile.get("user_id") or "").strip()
+            or str(sender_profile.get("user_id_alt") or "").strip()
+        )
+        if not mention_id:
+            return None
+        return mention_id, user_name
+
     async def _process_inbound_message(
         self,
         *,
@@ -3293,6 +3357,19 @@ class FeishuAdapter(BasePlatformAdapter):
             user_id_alt=sender_profile["user_id_alt"],
             is_bot=is_bot,
         )
+        topic_starter_at_ref = self._topic_starter_at_ref(
+            message=message,
+            sender_id=sender_id,
+            sender_profile=sender_profile,
+            is_bot=is_bot,
+            thread_id=thread_id,
+            reply_to_message_id=reply_to_message_id,
+        )
+        if topic_starter_at_ref is not None:
+            user_id, user_name = topic_starter_at_ref
+            setattr(source, "feishu_topic_starter_user_id", user_id)
+            if user_name:
+                setattr(source, "feishu_topic_starter_user_name", user_name)
         normalized = MessageEvent(
             text=text,
             message_type=inbound_type,
@@ -4524,6 +4601,68 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
     # Outbound payload construction and send pipeline
     # =========================================================================
+
+    @staticmethod
+    def _outbound_at_ref_from_metadata(
+        metadata: Optional[Dict[str, Any]],
+    ) -> Optional[tuple[str, str]]:
+        if not metadata:
+            return None
+        if not (metadata.get("notify") or metadata.get("expect_edits")):
+            return None
+        user_id = str(metadata.get(_OUTBOUND_AT_USER_ID_METADATA) or "").strip()
+        if not user_id:
+            return None
+        user_name = str(metadata.get(_OUTBOUND_AT_USER_NAME_METADATA) or "").strip()
+        return user_id, user_name
+
+    @staticmethod
+    def _apply_outbound_at_to_payload(
+        msg_type: str,
+        payload: str,
+        at_ref: Optional[tuple[str, str]],
+    ) -> tuple[str, str]:
+        if not at_ref:
+            return msg_type, payload
+        user_id, user_name = at_ref
+        if msg_type == "text":
+            try:
+                data = json.loads(payload)
+            except json.JSONDecodeError:
+                data = {"text": ""}
+            text = str(data.get("text") or "")
+            escaped_user_id = html.escape(user_id, quote=True)
+            data["text"] = f'<at user_id="{escaped_user_id}"></at> {text}'
+            return "text", json.dumps(data, ensure_ascii=False)
+
+        if msg_type != "post":
+            return msg_type, payload
+
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError:
+            data = {"zh_cn": {"content": [[{"tag": "md", "text": ""}]]}}
+        zh_cn = data.setdefault("zh_cn", {})
+        rows = zh_cn.setdefault("content", [])
+        at_element: Dict[str, str] = {"tag": "at", "user_id": user_id}
+        if user_name:
+            at_element["user_name"] = user_name
+        rows.insert(0, [at_element, {"tag": "text", "text": " "}])
+        return "post", json.dumps(data, ensure_ascii=False)
+
+    def _remember_outbound_at(self, message_id: Optional[str], at_ref: Optional[tuple[str, str]]) -> None:
+        if not message_id or not at_ref:
+            return
+        store = getattr(self, "_outbound_at_by_message_id", None)
+        if store is None:
+            store = {}
+            self._outbound_at_by_message_id = store
+        store[str(message_id)] = at_ref
+        while len(store) > _FEISHU_BOT_MSG_TRACK_SIZE:
+            try:
+                store.pop(next(iter(store)))
+            except StopIteration:
+                break
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
         # Feishu post-type 'md' elements do not render markdown tables; sending

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3273,8 +3273,10 @@ class FeishuAdapter(BasePlatformAdapter):
             return None
         if str(thread_id) != root_id:
             return None
-        if str(reply_to_message_id) != root_id:
-            return None
+
+        # A user can reply to a later bot message in the root reply chain.
+        # Feishu leaves thread_id empty in that case, so Hermes still creates a
+        # new topic from root_id even though parent_id is not the root message.
 
         open_id = str(getattr(sender_id, "open_id", "") or "").strip()
         user_id = str(getattr(sender_id, "user_id", "") or "").strip()

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2185,6 +2185,145 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertTrue(captured["request"].request_body.reply_in_thread)
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_send_thread_topic_reply_at_mentions_human_trigger(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def reply(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_reply"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="收到，我来处理。",
+                    reply_to="om_root",
+                    metadata={
+                        "thread_id": "om_root",
+                        "notify": True,
+                        "feishu_at_user_id": "ou_human",
+                        "feishu_at_user_name": "员工 B",
+                    },
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["request"].request_body.msg_type, "text")
+        payload = json.loads(captured["request"].request_body.content)
+        self.assertEqual(
+            payload["text"],
+            '<at user_id="ou_human"></at> 收到，我来处理。',
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_markdown_thread_topic_reply_uses_post_at_element(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def reply(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_reply"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="**收到**，我来处理。",
+                    reply_to="om_root",
+                    metadata={
+                        "thread_id": "om_root",
+                        "notify": True,
+                        "feishu_at_user_id": "ou_human",
+                        "feishu_at_user_name": "员工 B",
+                    },
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["request"].request_body.msg_type, "post")
+        payload = json.loads(captured["request"].request_body.content)
+        self.assertEqual(
+            payload["zh_cn"]["content"][0],
+            [
+                {"tag": "at", "user_id": "ou_human", "user_name": "员工 B"},
+                {"tag": "text", "text": " "},
+            ],
+        )
+        self.assertEqual(
+            payload["zh_cn"]["content"][1],
+            [{"tag": "md", "text": "**收到**，我来处理。"}],
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_edit_preserves_thread_topic_at_mention(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._outbound_at_by_message_id = {"om_reply": ("ou_human", "员工 B")}
+        captured = {}
+
+        class _MessageAPI:
+            def update(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_reply"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.edit_message(
+                    chat_id="oc_chat",
+                    message_id="om_reply",
+                    content="更新后的内容",
+                )
+            )
+
+        self.assertTrue(result.success)
+        payload = json.loads(captured["request"].request_body.content)
+        self.assertEqual(
+            payload["text"],
+            '<at user_id="ou_human"></at> 更新后的内容',
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_retries_transient_failure(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter
@@ -4771,6 +4910,176 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
             )
         )
         adapter._dispatch_inbound_event.assert_not_called()
+
+    def test_root_reply_records_human_sender_for_topic_starter_at(self):
+        adapter = self._build_adapter()
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={
+                "user_id": "ou_human",
+                "user_name": "员工 B",
+                "user_id_alt": None,
+            }
+        )
+
+        def _source(**kwargs):
+            return SimpleNamespace(**kwargs)
+
+        adapter.build_source = Mock(side_effect=_source)
+        bot_mention = SimpleNamespace(
+            key="@_user_1",
+            id=SimpleNamespace(open_id="ou_bot", user_id=""),
+            name="Hermes",
+        )
+        message = SimpleNamespace(
+            content=json.dumps({"text": "@_user_1 看一下"}),
+            message_type="text",
+            message_id="om_reply",
+            mentions=[bot_mention],
+            chat_id="oc_chat",
+            parent_id="om_root",
+            upper_message_id=None,
+            root_id="om_root",
+            thread_id=None,
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_human", user_id="", union_id=""),
+                chat_type="group",
+                message_id="om_reply",
+                is_bot=False,
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.call_args.args[0]
+        self.assertEqual(event.source.thread_id, "om_root")
+        self.assertEqual(event.source.feishu_topic_starter_user_id, "ou_human")
+        self.assertEqual(event.source.feishu_topic_starter_user_name, "员工 B")
+
+    def test_root_reply_with_explicit_thread_id_records_topic_starter_at(self):
+        adapter = self._build_adapter()
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={
+                "user_id": "ou_human",
+                "user_name": "员工 B",
+                "user_id_alt": None,
+            }
+        )
+        adapter.build_source = Mock(side_effect=lambda **kwargs: SimpleNamespace(**kwargs))
+        bot_mention = SimpleNamespace(
+            key="@_user_1",
+            id=SimpleNamespace(open_id="ou_bot", user_id=""),
+            name="Hermes",
+        )
+        message = SimpleNamespace(
+            content=json.dumps({"text": "@_user_1 看一下"}),
+            message_type="text",
+            message_id="om_reply",
+            mentions=[bot_mention],
+            chat_id="oc_chat",
+            parent_id="om_root",
+            upper_message_id=None,
+            root_id="om_root",
+            thread_id="om_root",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_human", user_id="", union_id=""),
+                chat_type="group",
+                message_id="om_reply",
+                is_bot=False,
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.call_args.args[0]
+        self.assertEqual(event.source.feishu_topic_starter_user_id, "ou_human")
+
+    def test_root_reply_does_not_record_bot_sender_for_topic_starter_at(self):
+        adapter = self._build_adapter()
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={
+                "user_id": "ou_other_bot",
+                "user_name": "Other Bot",
+                "user_id_alt": None,
+            }
+        )
+        adapter.build_source = Mock(side_effect=lambda **kwargs: SimpleNamespace(**kwargs))
+        bot_mention = SimpleNamespace(
+            key="@_user_1",
+            id=SimpleNamespace(open_id="ou_bot", user_id=""),
+            name="Hermes",
+        )
+        message = SimpleNamespace(
+            content=json.dumps({"text": "@_user_1 看一下"}),
+            message_type="text",
+            message_id="om_reply",
+            mentions=[bot_mention],
+            chat_id="oc_chat",
+            parent_id="om_root",
+            upper_message_id=None,
+            root_id="om_root",
+            thread_id=None,
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_other_bot", user_id="", union_id=""),
+                chat_type="group",
+                message_id="om_reply",
+                is_bot=True,
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.call_args.args[0]
+        self.assertFalse(hasattr(event.source, "feishu_topic_starter_user_id"))
+
+    def test_existing_thread_does_not_record_topic_starter_at(self):
+        adapter = self._build_adapter()
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={
+                "user_id": "ou_human",
+                "user_name": "员工 B",
+                "user_id_alt": None,
+            }
+        )
+        adapter.build_source = Mock(side_effect=lambda **kwargs: SimpleNamespace(**kwargs))
+        bot_mention = SimpleNamespace(
+            key="@_user_1",
+            id=SimpleNamespace(open_id="ou_bot", user_id=""),
+            name="Hermes",
+        )
+        message = SimpleNamespace(
+            content=json.dumps({"text": "@_user_1 看一下"}),
+            message_type="text",
+            message_id="om_reply",
+            mentions=[bot_mention],
+            chat_id="oc_chat",
+            parent_id="om_previous_topic_message",
+            upper_message_id=None,
+            root_id="om_root",
+            thread_id="om_root",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_human", user_id="", union_id=""),
+                chat_type="group",
+                message_id="om_reply",
+                is_bot=False,
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.call_args.args[0]
+        self.assertFalse(hasattr(event.source, "feishu_topic_starter_user_id"))
 
 
 class TestFeishuFetchMessageText(unittest.TestCase):

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -4967,7 +4967,7 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
         )
         adapter._dispatch_inbound_event.assert_not_called()
 
-    def test_root_reply_records_human_sender_for_topic_starter_at(self):
+    def test_nested_root_reply_records_human_sender_for_topic_starter_at(self):
         adapter = self._build_adapter()
         adapter._resolve_sender_profile = AsyncMock(
             return_value={
@@ -4992,7 +4992,7 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
             message_id="om_reply",
             mentions=[bot_mention],
             chat_id="oc_chat",
-            parent_id="om_root",
+            parent_id="om_previous_bot_reply",
             upper_message_id=None,
             root_id="om_root",
             thread_id=None,
@@ -5015,6 +5015,7 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
 
         event = adapter._dispatch_inbound_event.call_args.args[0]
         self.assertEqual(event.source.thread_id, "om_root")
+        self.assertEqual(event.reply_to_message_id, "om_previous_bot_reply")
         self.assertEqual(event.source.feishu_topic_starter_user_id, "ou_human")
         self.assertEqual(event.source.feishu_topic_starter_user_name, "员工 B")
 
@@ -5124,7 +5125,7 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
             parent_id="om_previous_topic_message",
             upper_message_id=None,
             root_id="om_root",
-            thread_id="om_root",
+            thread_id="omt_existing_topic",
         )
 
         asyncio.run(
@@ -5139,6 +5140,7 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
         )
 
         event = adapter._dispatch_inbound_event.call_args.args[0]
+        self.assertEqual(event.source.thread_id, "omt_existing_topic")
         self.assertFalse(hasattr(event.source, "feishu_topic_starter_user_id"))
 
 

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -723,6 +723,25 @@ def _admits_group(adapter, message, sender_id, chat_id=""):
 
 
 class TestAdapterBehavior(unittest.TestCase):
+    @staticmethod
+    def _both_id_topic_starter_at_ref(adapter):
+        return adapter._topic_starter_at_ref(
+            message=SimpleNamespace(root_id="om_root"),
+            sender_id=SimpleNamespace(
+                open_id="ou_human",
+                user_id="u_human",
+                union_id="on_human",
+            ),
+            sender_profile={
+                "user_id": "u_human",
+                "user_name": "员工 B",
+                "user_id_alt": "on_human",
+            },
+            is_bot=False,
+            thread_id="om_root",
+            reply_to_message_id="om_root",
+        )
+
     @patch.dict(os.environ, {}, clear=True)
     def test_build_event_handler_registers_reaction_and_card_processors(self):
         from gateway.config import PlatformConfig
@@ -2190,6 +2209,9 @@ class TestAdapterBehavior(unittest.TestCase):
         from plugins.platforms.feishu.adapter import FeishuAdapter
 
         adapter = FeishuAdapter(PlatformConfig())
+        at_ref = self._both_id_topic_starter_at_ref(adapter)
+        self.assertEqual(at_ref, ("ou_human", "员工 B"))
+        at_user_id, at_user_name = at_ref
         captured = {}
 
         class _MessageAPI:
@@ -2216,8 +2238,8 @@ class TestAdapterBehavior(unittest.TestCase):
                     metadata={
                         "thread_id": "om_root",
                         "notify": True,
-                        "feishu_at_user_id": "ou_human",
-                        "feishu_at_user_name": "员工 B",
+                        "feishu_at_user_id": at_user_id,
+                        "feishu_at_user_name": at_user_name,
                     },
                 )
             )
@@ -2229,6 +2251,7 @@ class TestAdapterBehavior(unittest.TestCase):
             payload["text"],
             '<at user_id="ou_human"></at> 收到，我来处理。',
         )
+        self.assertNotIn('<at user_id="u_human">', payload["text"])
 
     @patch.dict(os.environ, {}, clear=True)
     def test_send_markdown_thread_topic_reply_uses_post_at_element(self):
@@ -2236,6 +2259,9 @@ class TestAdapterBehavior(unittest.TestCase):
         from plugins.platforms.feishu.adapter import FeishuAdapter
 
         adapter = FeishuAdapter(PlatformConfig())
+        at_ref = self._both_id_topic_starter_at_ref(adapter)
+        self.assertEqual(at_ref, ("ou_human", "员工 B"))
+        at_user_id, at_user_name = at_ref
         captured = {}
 
         class _MessageAPI:
@@ -2262,8 +2288,8 @@ class TestAdapterBehavior(unittest.TestCase):
                     metadata={
                         "thread_id": "om_root",
                         "notify": True,
-                        "feishu_at_user_id": "ou_human",
-                        "feishu_at_user_name": "员工 B",
+                        "feishu_at_user_id": at_user_id,
+                        "feishu_at_user_name": at_user_name,
                     },
                 )
             )
@@ -2278,10 +2304,40 @@ class TestAdapterBehavior(unittest.TestCase):
                 {"tag": "text", "text": " "},
             ],
         )
+        self.assertNotEqual(
+            payload["zh_cn"]["content"][0][0]["user_id"],
+            "u_human",
+        )
         self.assertEqual(
             payload["zh_cn"]["content"][1],
             [{"tag": "md", "text": "**收到**，我来处理。"}],
         )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_topic_starter_without_open_id_does_not_create_mention(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        at_ref = adapter._topic_starter_at_ref(
+            message=SimpleNamespace(root_id="om_root"),
+            sender_id=SimpleNamespace(
+                open_id="",
+                user_id="u_human",
+                union_id="on_human",
+            ),
+            sender_profile={
+                "user_id": "u_human",
+                "user_name": "员工 B",
+                "user_id_alt": "on_human",
+            },
+            is_bot=False,
+            thread_id="om_root",
+            reply_to_message_id="om_root",
+        )
+
+        self.assertIsNone(at_ref)
 
     @patch.dict(os.environ, {}, clear=True)
     def test_edit_preserves_thread_topic_at_mention(self):
@@ -4915,9 +4971,9 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
         adapter = self._build_adapter()
         adapter._resolve_sender_profile = AsyncMock(
             return_value={
-                "user_id": "ou_human",
+                "user_id": "u_human",
                 "user_name": "员工 B",
-                "user_id_alt": None,
+                "user_id_alt": "on_human",
             }
         )
 
@@ -4946,7 +5002,11 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
             adapter._process_inbound_message(
                 data=message,
                 message=message,
-                sender_id=SimpleNamespace(open_id="ou_human", user_id="", union_id=""),
+                sender_id=SimpleNamespace(
+                    open_id="ou_human",
+                    user_id="u_human",
+                    union_id="on_human",
+                ),
                 chat_type="group",
                 message_id="om_reply",
                 is_bot=False,

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -472,6 +472,8 @@ async def test_run_agent_feishu_progress_replies_inside_existing_thread(monkeypa
         chat_type="group",
         thread_id="topic_17585",
     )
+    source.feishu_topic_starter_user_id = "ou_human"
+    source.feishu_topic_starter_user_name = "Alice"
 
     result = await runner._run_agent(
         message="hello",
@@ -486,7 +488,11 @@ async def test_run_agent_feishu_progress_replies_inside_existing_thread(monkeypa
     assert result["final_response"] == "done"
     assert adapter.sent
     assert adapter.sent[0]["reply_to"] == "om_triggering_user_message"
-    assert adapter.sent[0]["metadata"] == {"thread_id": "topic_17585"}
+    assert adapter.sent[0]["metadata"] == {
+        "thread_id": "topic_17585",
+        "feishu_at_user_id": "ou_human",
+        "feishu_at_user_name": "Alice",
+    }
     assert adapter.edits
     assert adapter.edits[0]["message_id"] == "progress-1"
 


### PR DESCRIPTION
## Summary

- detect the human sender whose root-chain reply starts a Feishu topic
- carry that identity through both base-adapter and `GatewayRunner` thread metadata
- prepend a native Feishu `@` element to the first user-visible text or post chunk
- preserve the mention when a streamed response is edited or a post falls back to text

## Root cause

A Feishu reply can create a new topic while replying to a later bot message in the same root reply chain. In that event, `root_id` identifies the topic route, `message.thread_id` can be absent, and `parent_id` can differ from `root_id`. Hermes retained the root-based thread route but discarded the triggering human identity before outbound delivery, so the response appeared inside the new topic without explicitly notifying that person.

## Behavior

The mention is recorded only for a human reply that Hermes routes into a new root-scoped topic. Both direct root replies and nested replies to later messages in the root chain are supported. Replies already carrying a distinct Feishu topic ID such as `omt_...` are ignored, as are bot-authored events. The native mention uses only the event's `sender_id.open_id`; events without an open ID are not mentioned.

Outbound mentions are limited to the first notify-worthy or editable message chunk so typing and tool-progress updates do not repeatedly ping the user. The mention is retained when that message is edited or when a post payload falls back to text.

## Validation

- rebased onto `upstream/main` at `226e8de82`
- `uv run ruff check gateway/platforms/base.py gateway/run.py plugins/platforms/feishu/adapter.py tests/gateway/test_feishu.py tests/gateway/test_run_progress_topics.py`
- `scripts/run_tests.sh tests/gateway/test_feishu.py tests/gateway/test_run_progress_topics.py -q` (254 passed)