### PR TITLE
fix(cron): let inherited jobs follow global model

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -34,7 +34,7 @@ except ImportError:  # pragma: no cover - non-Windows
 from datetime import datetime, timedelta
 from pathlib import Path
 from hermes_constants import get_hermes_home
-from typing import Optional, Dict, List, Any, Set, Tuple, Union
+from typing import Optional, Dict, List, Any, Set, Union
 
 logger = logging.getLogger(__name__)
 
@@ -927,45 +927,6 @@ def _normalize_workdir(workdir: Optional[str]) -> Optional[str]:
     return str(resolved)
 
 
-def _resolve_default_model_snapshot() -> Optional[str]:
-    """Resolve the global default model the same way the cron ticker does.
-
-    Mirrors the unpinned-model resolution in ``cron/scheduler.py`` ``run_job``:
-    read ``config.yaml`` ``model.default`` (or the ``model`` alias / bare string
-    form), applying the managed-scope overlay and env expansion. Used by
-    ``create_job`` to snapshot the default model for unpinned jobs so a later
-    swap of the global default is detected at fire time (#44585).
-
-    Returns the resolved model string, or ``None`` if config is missing/empty
-    or resolution fails (fail-open — caller treats ``None`` as "no snapshot").
-    """
-    try:
-        import yaml
-        from hermes_cli.config import _expand_env_vars
-
-        cfg_path = get_hermes_home() / "config.yaml"
-        if not cfg_path.exists():
-            return None
-        with cfg_path.open(encoding="utf-8") as f:
-            cfg = yaml.safe_load(f) or {}
-        try:
-            from hermes_cli import managed_scope
-            cfg = managed_scope.apply_managed_overlay(cfg)
-        except Exception:
-            pass
-        cfg = _expand_env_vars(cfg)
-        model_cfg = cfg.get("model") or {}
-        if isinstance(model_cfg, str):
-            return model_cfg.strip() or None
-        if isinstance(model_cfg, dict):
-            default = model_cfg.get("default") or model_cfg.get("model")
-            if isinstance(default, str):
-                return default.strip() or None
-        return None
-    except Exception:
-        return None
-
-
 def _normalize_job_optional_text(value: Any, *, strip_trailing_slash: bool = False) -> Optional[str]:
     if not isinstance(value, str):
         return None
@@ -973,61 +934,6 @@ def _normalize_job_optional_text(value: Any, *, strip_trailing_slash: bool = Fal
     if strip_trailing_slash:
         text = text.rstrip("/")
     return text or None
-
-
-def _compute_provider_model_snapshots(
-    *,
-    provider: Any,
-    model: Any,
-    base_url: Any,
-    no_agent: Any,
-) -> Tuple[Optional[str], Optional[str]]:
-    """Snapshot unpinned inference axes for the provider/model drift guard.
-
-    Agent cron jobs with unpinned provider/model follow global config at fire
-    time. Capture the current resolution for each unpinned axis so a later
-    global switch fails closed instead of silently changing spend. Pinned axes
-    and no-agent script jobs intentionally carry no snapshot.
-    """
-    normalized_provider = _normalize_job_optional_text(provider)
-    normalized_model = _normalize_job_optional_text(model)
-    normalized_base_url = _normalize_job_optional_text(
-        base_url,
-        strip_trailing_slash=True,
-    )
-    if bool(no_agent):
-        return None, None
-
-    provider_snapshot: Optional[str] = None
-    model_snapshot: Optional[str] = None
-    if normalized_provider is None:
-        try:
-            from hermes_cli.runtime_provider import resolve_runtime_provider
-
-            runtime_kwargs = {"requested": None}
-            if normalized_base_url:
-                runtime_kwargs["explicit_base_url"] = normalized_base_url
-            snap = resolve_runtime_provider(**runtime_kwargs)
-            snap_provider = str(snap.get("provider") or "").strip().lower()
-            provider_snapshot = snap_provider or None
-        except Exception:
-            provider_snapshot = None
-    if normalized_model is None:
-        try:
-            model_snapshot = _resolve_default_model_snapshot() or None
-        except Exception:
-            model_snapshot = None
-    return provider_snapshot, model_snapshot
-
-
-def _normalized_inference_axes(job: Dict[str, Any]) -> Tuple[Optional[str], Optional[str], Optional[str], bool]:
-    """Return the stored inference-routing fields in their semantic form."""
-    return (
-        _normalize_job_optional_text(job.get("provider")),
-        _normalize_job_optional_text(job.get("model")),
-        _normalize_job_optional_text(job.get("base_url"), strip_trailing_slash=True),
-        bool(job.get("no_agent")),
-    )
 
 
 def create_job(
@@ -1154,13 +1060,6 @@ def create_job(
 
     label_source = (prompt_text or (normalized_skills[0] if normalized_skills else None) or (normalized_script if normalized_no_agent else None)) or "cron job"
 
-    provider_snapshot, model_snapshot = _compute_provider_model_snapshots(
-        provider=normalized_provider,
-        model=normalized_model,
-        base_url=normalized_base_url,
-        no_agent=normalized_no_agent,
-    )
-
     next_run_at = compute_next_run(parsed_schedule)
     if parsed_schedule.get("kind") == "once" and next_run_at is None:
         run_at = parsed_schedule.get("run_at") or schedule
@@ -1183,11 +1082,6 @@ def create_job(
         "skill": normalized_skills[0] if normalized_skills else None,
         "model": normalized_model,
         "provider": normalized_provider,
-        # Provider/model resolution captured at creation for unpinned jobs
-        # (#44585). None for pinned axes, no_agent jobs, resolution failures, and
-        # any pre-existing job written before these fields existed (back-compat).
-        "provider_snapshot": provider_snapshot,
-        "model_snapshot": model_snapshot,
         "base_url": normalized_base_url,
         "script": normalized_script,
         "no_agent": normalized_no_agent,
@@ -1309,12 +1203,8 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                 else:
                     updates["workdir"] = _normalize_workdir(_wd)
 
-            previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})
             schedule_changed = "schedule" in updates
-            inference_fields_changed = bool(
-                {"provider", "model", "base_url", "no_agent"}.intersection(updates)
-            ) and _normalized_inference_axes(updated) != previous_inference_axes
 
             if "skills" in updates or "skill" in updates:
                 normalized_skills = _normalize_skill_list(updated.get("skill"), updated.get("skills"))
@@ -1357,16 +1247,6 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                             f"{ONESHOT_GRACE_SECONDS}s in the past and cannot be scheduled."
                         )
                     updated["next_run_at"] = updated_next_run
-
-            if inference_fields_changed:
-                provider_snapshot, model_snapshot = _compute_provider_model_snapshots(
-                    provider=updated.get("provider"),
-                    model=updated.get("model"),
-                    base_url=updated.get("base_url"),
-                    no_agent=updated.get("no_agent"),
-                )
-                updated["provider_snapshot"] = provider_snapshot
-                updated["model_snapshot"] = model_snapshot
 
             if updated.get("enabled", True) and updated.get("state") != "paused" and not updated.get("next_run_at"):
                 next_run = compute_next_run(updated["schedule"])

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2950,60 +2950,6 @@ def run_job(
             message = format_runtime_provider_error(exc)
             raise RuntimeError(message) from exc
 
-        # Provider/model-drift fail-closed guard (#44585).
-        #
-        # An UNPINNED job (no explicit job["provider"]/["model"]) follows the
-        # global default, which can change after the job was created — a switch
-        # to a paid PROVIDER (e.g. nous) OR a paid MODEL on the same provider
-        # (e.g. claude-fable-5 on openrouter). Without a guard the job would
-        # silently inherit that change and spend real money on every tick — the
-        # $7.73 incident named BOTH a provider and a model.
-        #
-        # create_job() snapshots whatever resolution would have picked at
-        # creation for each unpinned axis (job["provider_snapshot"] /
-        # job["model_snapshot"]). Here, for each axis that (a) has a snapshot and
-        # (b) is unpinned and (c) currently resolves to a DIFFERENT value, we
-        # fail closed: skip this run, make NO paid call, and deliver a loud,
-        # actionable alert telling the user to pin the axis explicitly.
-        #
-        # Back-compat: an axis with no snapshot (pre-existing jobs, no_agent, or
-        # any axis whose creation-time resolution failed) behaves exactly as
-        # before — the guard never engages for it. Pinned axes are unaffected.
-        _drift: list[str] = []
-        _provider_snapshot = (job.get("provider_snapshot") or "").strip().lower()
-        if _provider_snapshot and not (job.get("provider") or "").strip():
-            _current_provider = str(runtime.get("provider") or "").strip().lower()
-            if _current_provider and _current_provider != _provider_snapshot:
-                _drift.append(
-                    f"provider '{_provider_snapshot}' -> '{_current_provider}'"
-                )
-        _model_snapshot = (job.get("model_snapshot") or "").strip().lower()
-        if _model_snapshot and not (job.get("model") or "").strip():
-            _current_model = str(model or "").strip().lower()
-            if _current_model and _current_model != _model_snapshot:
-                _drift.append(
-                    f"model '{_model_snapshot}' -> '{_current_model}'"
-                )
-        if _drift:
-            _changes = "; ".join(_drift)
-            logger.warning(
-                "Job '%s': SKIPPED — global inference config drifted since "
-                "creation (%s) and this job is unpinned. Skipped to prevent "
-                "unintended spend. Pin explicitly to proceed: "
-                "`cronjob action=update job_id=%s provider=<p> model=<m>`.",
-                job_id,
-                _changes,
-                job_id,
-            )
-            raise RuntimeError(
-                f"Skipped to prevent unintended spend: global inference config "
-                f"drifted since this job was created ({_changes}), and this job "
-                f"is unpinned. No inference call was made. To run on the new "
-                f"config, pin it explicitly: `cronjob action=update "
-                f"job_id={job_id} provider=<provider> model=<model>` "
-                f"(or pin the original values to keep them). See #44585."
-            )
-
         fallback_model = get_fallback_chain(_cfg) or None
         credential_pool = None
         runtime_provider = str(runtime.get("provider") or "").strip().lower()

--- a/tests/cron/test_cron_provider_pin.py
+++ b/tests/cron/test_cron_provider_pin.py
@@ -1,30 +1,18 @@
-"""Provider-drift fail-closed guard for cron jobs (#44585).
+"""Cron inference routing: inherited, pinned, and no-agent jobs.
 
-Background: an UNPINNED cron job follows the global default provider. If that
-global state is changed (e.g. a temporary switch to a paid provider like
-nous/claude-fable-5), the job would silently inherit it on its next tick and
-spend real money — the $7.73 incident.
+An agent-backed job with no explicit provider/model must follow the current
+main inference configuration on every run. Explicit per-job values remain
+pinned. ``no_agent`` jobs bypass inference entirely.
 
-The fix has two halves:
-  - create_job() snapshots the provider resolution WOULD pick at creation into
-    job["provider_snapshot"] (only for unpinned, agent-backed jobs).
-  - run_job() fails closed when an unpinned job's CURRENTLY-resolved provider
-    differs from that snapshot: it skips the run, makes no paid call, and
-    delivers a loud actionable error.
-
-These tests exercise the full run_job path (real imports, mocked AIAgent +
-resolve_runtime_provider against a temp HERMES_HOME) and the create_job
-snapshot capture. They are load-bearing: without the guard, cases (b) call the
-agent and "succeed" instead of failing closed.
+Legacy ``provider_snapshot`` / ``model_snapshot`` fields may still exist in
+jobs.json after upgrades; they must not change inherited routing semantics.
 """
 
+import contextlib
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
-
-# Ensure project root is importable.
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from cron.scheduler import run_job
@@ -32,224 +20,33 @@ from cron.scheduler import run_job
 
 def _base_job(**overrides):
     job = {
-        "id": "pin-test",
-        "name": "pin test",
+        "id": "routing-test",
+        "name": "routing test",
         "prompt": "hello",
         "model": None,
         "provider": None,
-        "provider_snapshot": None,
         "base_url": None,
     }
     job.update(overrides)
     return job
 
 
-def _run_with_current_provider(job, current_provider, tmp_path):
-    """Drive run_job with resolve_runtime_provider pinned to ``current_provider``.
-
-    Returns (success, output, final_response, error, agent_constructed).
-    """
-    fake_db = MagicMock()
-    with patch("cron.scheduler._hermes_home", tmp_path), \
-         patch("cron.scheduler._resolve_origin", return_value=None), \
-         patch("hermes_cli.env_loader.load_hermes_dotenv"), \
-         patch("hermes_cli.env_loader.reset_secret_source_cache"), \
-         patch("hermes_state.SessionDB", return_value=fake_db), \
-         patch(
-             "hermes_cli.runtime_provider.resolve_runtime_provider",
-             return_value={
-                 "api_key": "test-key",
-                 "base_url": "https://example.invalid/v1",
-                 "provider": current_provider,
-                 "api_mode": "chat_completions",
-             },
-         ), \
-         patch("run_agent.AIAgent") as mock_agent_cls:
-        mock_agent = MagicMock()
-        mock_agent.run_conversation.return_value = {"final_response": "ok"}
-        mock_agent_cls.return_value = mock_agent
-
-        success, output, final_response, error = run_job(job)
-        agent_constructed = mock_agent_cls.called
-
-    return success, output, final_response, error, agent_constructed
-
-
-class TestProviderDriftGuard:
-    def test_a_unpinned_snapshot_matches_runs_normally(self, tmp_path):
-        """(a) Unpinned job whose snapshot == current provider → runs normally."""
-        job = _base_job(provider_snapshot="openrouter")
-        success, output, final_response, error, agent_constructed = \
-            _run_with_current_provider(job, "openrouter", tmp_path)
-
-        assert success is True
-        assert error is None
-        assert final_response == "ok"
-        assert agent_constructed is True
-
-    def test_b_unpinned_snapshot_differs_fails_closed(self, tmp_path):
-        """(b) Unpinned job whose snapshot != current provider → fail closed.
-
-        The paid call must NOT be made (AIAgent never constructed) and the
-        delivered error must name both providers and tell the user to pin.
-        """
-        job = _base_job(provider_snapshot="openrouter")
-        success, output, final_response, error, agent_constructed = \
-            _run_with_current_provider(job, "nous", tmp_path)
-
-        # Fail closed: no agent constructed, no inference call.
-        assert agent_constructed is False
-        assert success is False
-        assert error is not None
-
-        # Loud + actionable: names both providers, mentions spend + pinning.
-        blob = f"{error}\n{output}".lower()
-        assert "openrouter" in blob
-        assert "nous" in blob
-        assert "spend" in blob
-        assert "cronjob action=update" in blob
-        assert "44585" in blob
-
-    def test_c_no_snapshot_runs_backcompat(self, tmp_path):
-        """(c) Pre-existing job with NO provider_snapshot → runs (back-compat).
-
-        Even though the current provider differs from anything, a job without a
-        snapshot must behave exactly as before this fix: the guard never engages.
-        """
-        # A job dict that predates the field entirely (key absent, not None).
-        job = _base_job()
-        job.pop("provider_snapshot", None)
-        success, output, final_response, error, agent_constructed = \
-            _run_with_current_provider(job, "nous", tmp_path)
-
-        assert success is True
-        assert error is None
-        assert agent_constructed is True
-
-    def test_c2_snapshot_none_runs_backcompat(self, tmp_path):
-        """(c') Job with provider_snapshot explicitly None → runs (back-compat)."""
-        job = _base_job(provider_snapshot=None)
-        success, output, final_response, error, agent_constructed = \
-            _run_with_current_provider(job, "nous", tmp_path)
-
-        assert success is True
-        assert error is None
-        assert agent_constructed is True
-
-    def test_d_explicitly_pinned_runs_regardless_of_drift(self, tmp_path):
-        """(d) Explicitly-pinned job (job["provider"] set) → runs regardless.
-
-        A pinned job does not follow global state, so even a snapshot/current
-        mismatch must not skip it. (Snapshot would normally be None for pinned
-        jobs, but we set a mismatching one to prove the pin wins.)
-        """
-        job = _base_job(provider="openrouter", provider_snapshot="anthropic")
-        # Current resolution differs from the (stale) snapshot, but the job is
-        # pinned, so the guard must not engage.
-        success, output, final_response, error, agent_constructed = \
-            _run_with_current_provider(job, "nous", tmp_path)
-
-        assert success is True
-        assert error is None
-        assert agent_constructed is True
-
-
-class TestCreateJobSnapshot:
-    """create_job captures provider_snapshot for unpinned agent jobs only."""
-
-    @staticmethod
-    def _isolate_storage(monkeypatch):
-        """Patch cron.jobs storage so create_job never touches the real store."""
-        import contextlib
-        import cron.jobs as jobs
-
-        @contextlib.contextmanager
-        def _noop_lock():
-            yield
-
-        monkeypatch.setattr(jobs, "_jobs_lock", _noop_lock, raising=True)
-        monkeypatch.setattr(jobs, "load_jobs", lambda: [], raising=True)
-        monkeypatch.setattr(jobs, "save_jobs", lambda j: None, raising=True)
-        return jobs
-
-    def test_unpinned_job_captures_snapshot(self, monkeypatch):
-        jobs = self._isolate_storage(monkeypatch)
-
-        with patch(
-            "hermes_cli.runtime_provider.resolve_runtime_provider",
-            return_value={"provider": "openrouter"},
-        ):
-            job = jobs.create_job(prompt="do a thing", schedule="every 1 hour")
-
-        assert job["provider"] is None
-        assert job["provider_snapshot"] == "openrouter"
-
-    def test_pinned_job_skips_snapshot(self, monkeypatch):
-        jobs = self._isolate_storage(monkeypatch)
-
-        resolver = MagicMock(return_value={"provider": "openrouter"})
-        with patch("hermes_cli.runtime_provider.resolve_runtime_provider", resolver):
-            job = jobs.create_job(
-                prompt="do a thing", schedule="every 1 hour", provider="nous"
-            )
-
-        # Explicit provider → pinned → no snapshot needed, and resolution skipped.
-        assert job["provider"] == "nous"
-        assert job["provider_snapshot"] is None
-        resolver.assert_not_called()
-
-    def test_snapshot_resolution_error_fails_open_to_none(self, monkeypatch):
-        """If resolution raises at creation, snapshot is None — creation never breaks."""
-        jobs = self._isolate_storage(monkeypatch)
-
-        with patch(
-            "hermes_cli.runtime_provider.resolve_runtime_provider",
-            side_effect=RuntimeError("no creds"),
-        ):
-            job = jobs.create_job(prompt="do a thing", schedule="every 1 hour")
-
-        assert job["provider_snapshot"] is None
-
-    def test_unpinned_model_captures_model_snapshot(self, monkeypatch, tmp_path):
-        """An unpinned model captures config.yaml model.default into model_snapshot."""
-        jobs = self._isolate_storage(monkeypatch)
-        (tmp_path / "config.yaml").write_text("model:\n  default: llama-3.3-70b:free\n")
-        monkeypatch.setattr(
-            "cron.jobs.get_hermes_home", lambda: tmp_path, raising=True
-        )
-        with patch(
-            "hermes_cli.runtime_provider.resolve_runtime_provider",
-            return_value={"provider": "openrouter"},
-        ):
-            job = jobs.create_job(prompt="do a thing", schedule="every 1 hour")
-        assert job["model"] is None
-        assert job["model_snapshot"] == "llama-3.3-70b:free"
-
-    def test_pinned_model_skips_model_snapshot(self, monkeypatch, tmp_path):
-        """An explicit model → pinned → no model_snapshot captured."""
-        jobs = self._isolate_storage(monkeypatch)
-        (tmp_path / "config.yaml").write_text("model:\n  default: llama-3.3-70b:free\n")
-        monkeypatch.setattr(
-            "cron.jobs.get_hermes_home", lambda: tmp_path, raising=True
-        )
-        with patch(
-            "hermes_cli.runtime_provider.resolve_runtime_provider",
-            return_value={"provider": "openrouter"},
-        ):
-            job = jobs.create_job(
-                prompt="do a thing", schedule="every 1 hour", model="my-model"
-            )
-        assert job["model"] == "my-model"
-        assert job["model_snapshot"] is None
-
-
-def _run_with_current_provider_and_model(job, current_provider, current_model, tmp_path):
-    """Drive run_job with resolved provider pinned and config.yaml model.default
-    set to ``current_model`` (the unpinned-model fire-time source)."""
+def _run_agent_job(job, current_provider, current_model, tmp_path):
+    """Run one agent-backed job against controlled global inference config."""
     (tmp_path / "config.yaml").write_text(
-        f"model:\n  default: {current_model}\n"
+        f"model:\n  default: {current_model}\n",
+        encoding="utf-8",
     )
     fake_db = MagicMock()
+
+    def _resolve_runtime_provider(*, requested=None, **_kwargs):
+        return {
+            "api_key": "test-key",
+            "base_url": "https://example.invalid/v1",
+            "provider": requested or current_provider,
+            "api_mode": "chat_completions",
+        }
+
     with patch("cron.scheduler._hermes_home", tmp_path), \
          patch("cron.scheduler._get_hermes_home", return_value=tmp_path), \
          patch("cron.scheduler._resolve_origin", return_value=None), \
@@ -258,79 +55,114 @@ def _run_with_current_provider_and_model(job, current_provider, current_model, t
          patch("hermes_state.SessionDB", return_value=fake_db), \
          patch(
              "hermes_cli.runtime_provider.resolve_runtime_provider",
-             return_value={
-                 "api_key": "test-key",
-                 "base_url": "https://example.invalid/v1",
-                 "provider": current_provider,
-                 "api_mode": "chat_completions",
-             },
+             side_effect=_resolve_runtime_provider,
          ), \
          patch("run_agent.AIAgent") as mock_agent_cls:
         mock_agent = MagicMock()
         mock_agent.run_conversation.return_value = {"final_response": "ok"}
         mock_agent_cls.return_value = mock_agent
+
         success, output, final_response, error = run_job(job)
-        agent_constructed = mock_agent_cls.called
-    return success, output, final_response, error, agent_constructed
-
-
-class TestModelDriftGuard:
-    """#44585 C1: model drift on the SAME provider must also fail closed —
-    the incident named a model (claude-fable-5), and an unpinned job reads
-    config.yaml model.default fresh every tick independently of provider."""
-
-    def test_model_drift_same_provider_fails_closed(self, tmp_path):
-        # Provider unchanged (openrouter==openrouter), but the global default
-        # MODEL swapped to a premium model since creation → must fail closed.
-        job = _base_job(
-            provider_snapshot="openrouter",
-            model_snapshot="llama-3.3-70b-instruct:free",
+        agent_kwargs = (
+            mock_agent_cls.call_args.kwargs if mock_agent_cls.called else None
         )
-        success, output, final_response, error, agent_constructed = \
-            _run_with_current_provider_and_model(
-                job, "openrouter", "claude-fable-5", tmp_path
-            )
-        assert agent_constructed is False, "paid call must not be made on model drift"
-        assert success is False
-        blob = f"{error}\n{output}".lower()
-        assert "claude-fable-5" in blob
-        assert "llama-3.3-70b-instruct:free" in blob
-        assert "44585" in blob
 
-    def test_model_snapshot_matches_runs(self, tmp_path):
-        # Default model unchanged → runs normally.
-        job = _base_job(
-            provider_snapshot="openrouter",
-            model_snapshot="llama-3.3-70b-instruct:free",
-        )
-        success, output, final_response, error, agent_constructed = \
-            _run_with_current_provider_and_model(
-                job, "openrouter", "llama-3.3-70b-instruct:free", tmp_path
-            )
-        assert agent_constructed is True
-        assert success is True
+    return success, output, final_response, error, agent_kwargs
 
-    def test_pinned_model_bypasses_guard(self, tmp_path):
-        # Explicit job["model"] → not unpinned → no model-drift skip even if the
-        # global default differs from any snapshot.
+
+class TestCronInferenceRouting:
+    def test_unpinned_job_follows_current_global_provider_and_model(self, tmp_path):
         job = _base_job(
-            provider_snapshot="openrouter",
+            # Stale fields from the removed drift guard must be ignored.
+            provider_snapshot="old-provider",
             model_snapshot="old-model",
-            model="my-pinned-model",
         )
-        success, output, final_response, error, agent_constructed = \
-            _run_with_current_provider_and_model(
-                job, "openrouter", "claude-fable-5", tmp_path
-            )
-        assert agent_constructed is True
-        assert success is True
 
-    def test_no_model_snapshot_backcompat(self, tmp_path):
-        # Pre-existing job without model_snapshot → no model-drift skip.
-        job = _base_job(provider_snapshot="openrouter")  # no model_snapshot key set to a value
-        success, output, final_response, error, agent_constructed = \
-            _run_with_current_provider_and_model(
-                job, "openrouter", "claude-fable-5", tmp_path
-            )
-        assert agent_constructed is True
+        success, _output, final_response, error, agent_kwargs = _run_agent_job(
+            job,
+            current_provider="current-provider",
+            current_model="current-model",
+            tmp_path=tmp_path,
+        )
+
         assert success is True
+        assert error is None
+        assert final_response == "ok"
+        assert agent_kwargs is not None
+        assert agent_kwargs["provider"] == "current-provider"
+        assert agent_kwargs["model"] == "current-model"
+
+    def test_explicit_provider_and_model_remain_pinned(self, tmp_path):
+        job = _base_job(
+            provider="pinned-provider",
+            model="pinned-model",
+            provider_snapshot="old-provider",
+            model_snapshot="old-model",
+        )
+
+        success, _output, _final_response, error, agent_kwargs = _run_agent_job(
+            job,
+            current_provider="current-provider",
+            current_model="current-model",
+            tmp_path=tmp_path,
+        )
+
+        assert success is True
+        assert error is None
+        assert agent_kwargs is not None
+        assert agent_kwargs["provider"] == "pinned-provider"
+        assert agent_kwargs["model"] == "pinned-model"
+
+
+class TestCronJobStorage:
+    @staticmethod
+    def _isolate_storage(monkeypatch):
+        import cron.jobs as jobs
+
+        @contextlib.contextmanager
+        def _noop_lock():
+            yield
+
+        monkeypatch.setattr(jobs, "_jobs_lock", _noop_lock, raising=True)
+        monkeypatch.setattr(jobs, "load_jobs", lambda: [], raising=True)
+        monkeypatch.setattr(jobs, "save_jobs", lambda _jobs: None, raising=True)
+        return jobs
+
+    def test_unpinned_job_stores_no_inference_snapshot(self, monkeypatch):
+        jobs = self._isolate_storage(monkeypatch)
+
+        job = jobs.create_job(prompt="do a thing", schedule="every 1 hour")
+
+        assert job["provider"] is None
+        assert job["model"] is None
+        assert "provider_snapshot" not in job
+        assert "model_snapshot" not in job
+
+    def test_explicit_provider_and_model_are_stored(self, monkeypatch):
+        jobs = self._isolate_storage(monkeypatch)
+
+        job = jobs.create_job(
+            prompt="do a thing",
+            schedule="every 1 hour",
+            provider="pinned-provider",
+            model="pinned-model",
+        )
+
+        assert job["provider"] == "pinned-provider"
+        assert job["model"] == "pinned-model"
+
+    def test_no_agent_job_has_no_inference_routing(self, monkeypatch):
+        jobs = self._isolate_storage(monkeypatch)
+
+        job = jobs.create_job(
+            prompt="ignored",
+            schedule="every 1 hour",
+            script="watchers/example.py",
+            no_agent=True,
+        )
+
+        assert job["no_agent"] is True
+        assert job["provider"] is None
+        assert job["model"] is None
+        assert "provider_snapshot" not in job
+        assert "model_snapshot" not in job

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -535,17 +535,10 @@ async def test_dashboard_cron_context_from_is_profile_scoped(isolated_profiles):
 
 
 @pytest.mark.asyncio
-async def test_update_cron_job_refreshes_snapshots_when_unpinning(
+async def test_update_cron_job_unpins_provider_and_model(
     isolated_profiles,
-    monkeypatch,
 ):
-    from hermes_cli import runtime_provider, web_server
-
-    monkeypatch.setattr(
-        runtime_provider,
-        "resolve_runtime_provider",
-        lambda **kwargs: {"provider": "worker-provider"},
-    )
+    from hermes_cli import web_server
 
     job = web_server._call_cron_for_profile(
         "worker_alpha",
@@ -556,9 +549,6 @@ async def test_update_cron_job_refreshes_snapshots_when_unpinning(
         provider="fixed-provider",
         model="fixed-model",
     )
-
-    assert job["provider_snapshot"] is None
-    assert job["model_snapshot"] is None
 
     updated = await web_server.update_cron_job(
         job["id"],
@@ -573,23 +563,15 @@ async def test_update_cron_job_refreshes_snapshots_when_unpinning(
 
     assert updated["provider"] is None
     assert updated["model"] is None
-    assert updated["provider_snapshot"] == "worker-provider"
-    assert updated["model_snapshot"] == "test-model"
+    assert "provider_snapshot" not in updated
+    assert "model_snapshot" not in updated
 
 
 @pytest.mark.asyncio
-async def test_dashboard_cron_noop_inference_fields_keep_existing_snapshots(
+async def test_dashboard_cron_noop_inference_fields_stay_inherited(
     isolated_profiles,
-    monkeypatch,
 ):
-    from hermes_cli import runtime_provider, web_server
-
-    current_provider = {"name": "initial-provider"}
-    monkeypatch.setattr(
-        runtime_provider,
-        "resolve_runtime_provider",
-        lambda **kwargs: {"provider": current_provider["name"]},
-    )
+    from hermes_cli import web_server
 
     job = web_server._call_cron_for_profile(
         "worker_alpha",
@@ -597,15 +579,6 @@ async def test_dashboard_cron_noop_inference_fields_keep_existing_snapshots(
         prompt="managed by named profile",
         schedule="every 1h",
         name="dashboard-edit-job",
-    )
-
-    assert job["provider_snapshot"] == "initial-provider"
-    assert job["model_snapshot"] == "test-model"
-
-    current_provider["name"] = "changed-provider"
-    (isolated_profiles["worker_alpha"] / "config.yaml").write_text(
-        "model: changed-model\n",
-        encoding="utf-8",
     )
 
     updated = await web_server.update_cron_job(
@@ -623,22 +596,17 @@ async def test_dashboard_cron_noop_inference_fields_keep_existing_snapshots(
     )
 
     assert updated["name"] == "dashboard-edit-job-renamed"
-    assert updated["provider_snapshot"] == "initial-provider"
-    assert updated["model_snapshot"] == "test-model"
+    assert updated["provider"] is None
+    assert updated["model"] is None
+    assert "provider_snapshot" not in updated
+    assert "model_snapshot" not in updated
 
 
 @pytest.mark.asyncio
-async def test_update_cron_job_clears_snapshots_for_no_agent(
+async def test_update_cron_job_switches_to_no_agent_without_inference_routing(
     isolated_profiles,
-    monkeypatch,
 ):
-    from hermes_cli import runtime_provider, web_server
-
-    monkeypatch.setattr(
-        runtime_provider,
-        "resolve_runtime_provider",
-        lambda **kwargs: {"provider": "worker-provider"},
-    )
+    from hermes_cli import web_server
     scripts_dir = isolated_profiles["worker_alpha"] / "scripts"
     scripts_dir.mkdir()
     (scripts_dir / "collect.py").write_text("print('ok')\n", encoding="utf-8")
@@ -651,9 +619,6 @@ async def test_update_cron_job_clears_snapshots_for_no_agent(
         name="agent-to-script-job",
     )
 
-    assert job["provider_snapshot"] == "worker-provider"
-    assert job["model_snapshot"] == "test-model"
-
     updated = await web_server.update_cron_job(
         job["id"],
         web_server.CronJobUpdate(
@@ -665,8 +630,11 @@ async def test_update_cron_job_clears_snapshots_for_no_agent(
         profile="worker_alpha",
     )
 
-    assert updated["provider_snapshot"] is None
-    assert updated["model_snapshot"] is None
+    assert updated["no_agent"] is True
+    assert updated["provider"] is None
+    assert updated["model"] is None
+    assert "provider_snapshot" not in updated
+    assert "model_snapshot" not in updated
 
 
 @pytest.mark.asyncio

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1024,7 +1024,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "model": {
                 "type": "object",
-                "description": "Optional per-job model override. If provider is omitted, the current main provider is pinned at creation time so the job stays stable.",
+                "description": "Optional per-job model override. Omit this object entirely to inherit the current main provider and model on every run. When overriding the model, include a provider to pin both explicitly; if provider is omitted, the current main provider is pinned at creation time.",
                 "properties": {
                     "provider": {
                         "type": "string",

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -21,8 +21,14 @@ Cron jobs can:
 
 All of this is available to Hermes itself through the `cronjob` tool, so you can create, pause, edit, and remove jobs by asking in plain language — no CLI required.
 
-:::tip
-At creation, an unpinned job (one you don't give an explicit `provider`/`model`) follows the global default selected by `hermes model` — and Hermes **snapshots** that provider and model on the job. If the global default later changes, the job **fails closed**: it skips the run, makes no inference call, and sends an alert telling you to pin the provider/model explicitly (`cronjob action=update job_id=… provider=… model=…`) to proceed. This prevents an unattended job from silently inheriting a switch to a paid provider/model and spending money you didn't intend (#44585). To make a job deliberately track your global default, pin it to the new values after changing them. `hermes setup --portal` is the lowest-friction option for unattended runs since OAuth refresh is automatic. See [Nous Portal](/integrations/nous-portal).
+:::tip Model selection
+Cron jobs support three inference modes:
+
+- **Inherited:** omit the per-job `provider` and `model`. The job resolves the current global defaults selected by `hermes model` on every run, including after those defaults change.
+- **Pinned:** set an explicit per-job `provider` and `model` when a job should keep using a specific route for cost, latency, or capability reasons.
+- **No-agent:** set `no_agent: true` with a script. Hermes skips inference entirely and delivers the script's stdout verbatim.
+
+Changing the global default never pauses or blocks inherited jobs. Use a pinned job, rather than an inherited one, when an unattended automation must not follow future global model changes.
 :::
 
 :::warning


### PR DESCRIPTION
## Summary

- restore true inheritance when a cron omits provider/model
- keep explicit per-job provider/model overrides pinned
- keep no-agent jobs inference-free
- ignore legacy provider/model snapshot fields instead of blocking runs
- document the three routing modes

## Motivation

An unpinned cron currently snapshots the global inference config at creation and later fails closed when that global config changes. That contradicts the meaning of an inherited setting and turns routine model changes into recurring cron failures.

## Validation

- `python -m pytest tests/cron/ tests/tools/test_cronjob_tools.py tests/hermes_cli/test_web_server_cron_profiles.py -o addopts= -q`
- 762 passed, 3 pre-existing warnings
- `git diff HEAD^ --check`
