### PR TITLE
fix: protect session transcripts from agent writes

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -118,6 +118,17 @@ def is_write_denied(path: str) -> bool:
             continue
 
     for base_real in hermes_dirs:
+        # Session transcripts are application-owned state.  Letting the agent's
+        # generic file tools rewrite state.db or legacy JSON snapshots can
+        # falsify conversation history and invalidate resume/compression state.
+        try:
+            if resolved == os.path.realpath(os.path.join(base_real, "state.db")):
+                return True
+            sessions_real = os.path.realpath(os.path.join(base_real, "sessions"))
+            if resolved == sessions_real or resolved.startswith(sessions_real + os.sep):
+                return True
+        except Exception:
+            pass
         try:
             mcp_real = os.path.realpath(os.path.join(base_real, mcp_tokens_dir_name))
             if resolved == mcp_real or resolved.startswith(mcp_real + os.sep):

--- a/tests/agent/test_file_safety_session_state.py
+++ b/tests/agent/test_file_safety_session_state.py
@@ -1,0 +1,73 @@
+"""Session transcript stores are read-only to agent file tools.
+
+Inspired by Claude Code 2.1.205's auto-mode rule preventing transcript
+manipulation. Hermes keeps canonical conversation history in state.db and may
+also emit legacy JSON snapshots under sessions/; agent tools must not rewrite
+or delete either store.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def fake_homes(tmp_path, monkeypatch):
+    import agent.file_safety as fs
+
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "work"
+    profile.mkdir(parents=True)
+    monkeypatch.setattr(fs, "_hermes_home_path", lambda: profile)
+    monkeypatch.setattr(fs, "_hermes_root_path", lambda: root)
+    return root, profile
+
+
+@pytest.mark.parametrize("relative", ["state.db", "sessions/session_abc.json"])
+def test_session_state_paths_are_write_denied(fake_homes, relative):
+    from agent.file_safety import is_write_denied
+
+    _root, profile = fake_homes
+    target = profile / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("existing transcript", encoding="utf-8")
+
+    assert is_write_denied(str(target)) is True
+
+
+def test_default_profile_state_db_is_write_denied_from_profile(fake_homes):
+    from agent.file_safety import is_write_denied
+
+    root, _profile = fake_homes
+    target = root / "state.db"
+    target.write_text("canonical transcript", encoding="utf-8")
+
+    assert is_write_denied(str(target)) is True
+
+
+def test_project_local_state_db_remains_writable(fake_homes, tmp_path):
+    from agent.file_safety import is_write_denied
+
+    target = tmp_path / "project" / "state.db"
+    target.parent.mkdir()
+    target.write_text("application database", encoding="utf-8")
+
+    assert is_write_denied(str(target)) is False
+
+
+def test_write_file_tool_preserves_existing_session_snapshot(fake_homes, monkeypatch):
+    import tools.file_tools as ft
+
+    _root, profile = fake_homes
+    target = profile / "sessions" / "session_abc.json"
+    target.parent.mkdir(parents=True)
+    target.write_text("original transcript", encoding="utf-8")
+    monkeypatch.setattr(ft, "_get_live_tracking_cwd", lambda task_id="default": None)
+
+    result = json.loads(ft.write_file_tool(str(target), "tampered"))
+
+    assert "error" in result
+    assert target.read_text(encoding="utf-8") == "original transcript"


### PR DESCRIPTION
## Summary
Hermes file tools can no longer rewrite canonical `state.db` conversation history or legacy JSON session snapshots, adapting Claude Code 2.1.205's transcript-tampering protection.

Source: https://github.com/anthropics/claude-code/releases/tag/v2.1.205

## How our implementation differs
| Claude Code | Hermes adaptation |
|---|---|
| Auto-mode rule blocks transcript tampering | Shared `agent.file_safety` deny applies consistently to file tools and ACP shims |
| Protects Claude Code transcript files | Protects active-profile and root `state.db`, plus `sessions/` snapshots |
| Auto-mode scoped | Always enforced because transcript integrity underpins resume and compression state |

## Changes
- `agent/file_safety.py`: deny writes to Hermes-owned transcript stores while leaving project-local `state.db` files writable
- Regression coverage for profile/root stores, snapshots, project databases, and real `write_file_tool` preservation

## Validation
| Check | Result |
|---|---|
| Targeted tests | 43 passed |
| Real-import E2E | transcript blocked/preserved; project `state.db` writable |
| Diff check | clean |

Root cause: Hermes protected credentials and pairing state but did not classify its conversation stores as application-owned write-protected state.

## Infographic
![Hermes transcript integrity guard](https://placehold.co/1200x675/101820/7dd3fc?text=Transcript+Integrity+Guard)
