### PR TITLE
fix(telegram): retry transient media uploads

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1261,6 +1261,94 @@ class TelegramAdapter(BasePlatformAdapter):
                 stack.append(context)
         return False
 
+    @classmethod
+    def _should_retry_media_upload(cls, error: Exception) -> bool:
+        """Return True when a failed media upload is safe to retry.
+
+        PTB normally wraps httpx transport failures in ``NetworkError``, but
+        tests and custom request transports can surface the original httpx
+        exception. Generic timeouts are deliberately excluded because the
+        upload may already have reached Telegram; connect/pool timeouts are
+        safe because the request was not sent.
+        """
+        if cls._looks_like_connect_timeout(error) or cls._looks_like_pool_timeout(
+            error
+        ):
+            return True
+
+        seen: set[int] = set()
+        stack: list[BaseException] = [error]
+        while stack:
+            cur = stack.pop()
+            ident = id(cur)
+            if ident in seen:
+                continue
+            seen.add(ident)
+            name = cur.__class__.__name__.lower()
+            if name in {
+                "readerror",
+                "writeerror",
+                "connecterror",
+                "remoteprotocolerror",
+            }:
+                return True
+            if name == "timedout":
+                return False
+            cause = getattr(cur, "__cause__", None)
+            context = getattr(cur, "__context__", None)
+            if cause is not None:
+                stack.append(cause)
+            if context is not None:
+                stack.append(context)
+
+        return cls._looks_like_network_error(error)
+
+    async def _send_media_upload_with_retry(
+        self,
+        send_fn: Any,
+        send_kwargs: Dict[str, Any],
+        file_arg: str,
+        file_path: str,
+        metadata: Optional[Dict[str, Any]],
+        reply_to_message_id: Optional[int],
+        media_label: str,
+    ) -> Any:
+        """Send local media, reopening the file for transient retries."""
+        for upload_attempt in range(3):
+            try:
+                # A failed multipart upload can leave the stream at EOF, so
+                # every retry must give PTB/httpx a fresh file handle.
+                with open(file_path, "rb") as media_file:
+                    attempt_kwargs = dict(send_kwargs)
+                    attempt_kwargs[file_arg] = media_file
+                    return await self._send_with_dm_topic_reply_anchor_retry(
+                        send_fn,
+                        attempt_kwargs,
+                        metadata,
+                        reply_to_message_id,
+                        media_label,
+                        reset_media=lambda: media_file.seek(0),
+                    )
+            except Exception as upload_error:
+                if (
+                    upload_attempt >= 2
+                    or not self._should_retry_media_upload(upload_error)
+                ):
+                    raise
+                wait = 2 ** upload_attempt
+                logger.warning(
+                    "[%s] Transient Telegram %s upload error "
+                    "(attempt %d/3), retrying in %ds: %s",
+                    self.name,
+                    media_label,
+                    upload_attempt + 1,
+                    wait,
+                    _redact_telegram_error_text(upload_error),
+                )
+                await asyncio.sleep(wait)
+
+        raise RuntimeError(f"Telegram {media_label} upload retry loop exhausted")
+
     def _coerce_bool_extra(self, key: str, default: bool = False) -> bool:
         value = self.config.extra.get(key) if getattr(self.config, "extra", None) else None
         if value is None:
@@ -6163,23 +6251,22 @@ class TelegramAdapter(BasePlatformAdapter):
                 reply_to_mode=self._reply_to_mode
             )
 
-            with open(file_path, "rb") as f:
-                msg = await self._send_with_dm_topic_reply_anchor_retry(
-                    self._bot.send_document,
-                    {
-                        "chat_id": normalize_telegram_chat_id(chat_id),
-                        "document": f,
-                        "filename": display_name,
-                        "caption": caption[:1024] if caption else None,
-                        "reply_to_message_id": reply_to_id,
-                        **thread_kwargs,
-                        **self._notification_kwargs(metadata),
-                    },
-                    metadata,
-                    reply_to_id,
-                    "document",
-                    reset_media=lambda: f.seek(0),
-                )
+            msg = await self._send_media_upload_with_retry(
+                self._bot.send_document,
+                {
+                    "chat_id": normalize_telegram_chat_id(chat_id),
+                    "filename": display_name,
+                    "caption": caption[:1024] if caption else None,
+                    "reply_to_message_id": reply_to_id,
+                    **thread_kwargs,
+                    **self._notification_kwargs(metadata),
+                },
+                "document",
+                file_path,
+                metadata,
+                reply_to_id,
+                "document",
+            )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
             logger.warning(
@@ -6214,22 +6301,21 @@ class TelegramAdapter(BasePlatformAdapter):
                 reply_to_message_id=reply_to_id,
                 reply_to_mode=self._reply_to_mode
             )
-            with open(video_path, "rb") as f:
-                msg = await self._send_with_dm_topic_reply_anchor_retry(
-                    self._bot.send_video,
-                    {
-                        "chat_id": normalize_telegram_chat_id(chat_id),
-                        "video": f,
-                        "caption": caption[:1024] if caption else None,
-                        "reply_to_message_id": reply_to_id,
-                        **thread_kwargs,
-                        **self._notification_kwargs(metadata),
-                    },
-                    metadata,
-                    reply_to_id,
-                    "video",
-                    reset_media=lambda: f.seek(0),
-                )
+            msg = await self._send_media_upload_with_retry(
+                self._bot.send_video,
+                {
+                    "chat_id": normalize_telegram_chat_id(chat_id),
+                    "caption": caption[:1024] if caption else None,
+                    "reply_to_message_id": reply_to_id,
+                    **thread_kwargs,
+                    **self._notification_kwargs(metadata),
+                },
+                "video",
+                video_path,
+                metadata,
+                reply_to_id,
+                "video",
+            )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
             logger.warning(

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1265,43 +1265,13 @@ class TelegramAdapter(BasePlatformAdapter):
     def _should_retry_media_upload(cls, error: Exception) -> bool:
         """Return True when a failed media upload is safe to retry.
 
-        PTB normally wraps httpx transport failures in ``NetworkError``, but
-        tests and custom request transports can surface the original httpx
-        exception. Generic timeouts are deliberately excluded because the
-        upload may already have reached Telegram; connect/pool timeouts are
-        safe because the request was not sent.
+        Only connect and pool timeouts establish that the request was not
+        sent. Read, write, and protocol failures are delivery-ambiguous and
+        must not resend a non-idempotent attachment.
         """
-        if cls._looks_like_connect_timeout(error) or cls._looks_like_pool_timeout(
+        return cls._looks_like_connect_timeout(error) or cls._looks_like_pool_timeout(
             error
-        ):
-            return True
-
-        seen: set[int] = set()
-        stack: list[BaseException] = [error]
-        while stack:
-            cur = stack.pop()
-            ident = id(cur)
-            if ident in seen:
-                continue
-            seen.add(ident)
-            name = cur.__class__.__name__.lower()
-            if name in {
-                "readerror",
-                "writeerror",
-                "connecterror",
-                "remoteprotocolerror",
-            }:
-                return True
-            if name == "timedout":
-                return False
-            cause = getattr(cur, "__cause__", None)
-            context = getattr(cur, "__context__", None)
-            if cause is not None:
-                stack.append(cause)
-            if context is not None:
-                stack.append(context)
-
-        return cls._looks_like_network_error(error)
+        )
 
     async def _send_media_upload_with_retry(
         self,

--- a/tests/gateway/test_telegram_document_retry.py
+++ b/tests/gateway/test_telegram_document_retry.py
@@ -27,10 +27,10 @@ def _make_connected_adapter() -> TelegramAdapter:
         ("send_video", "send_video", "video", ".mp4"),
     ],
 )
-async def test_media_upload_retries_read_error_with_fresh_file_handle(
+async def test_media_upload_retries_connect_timeout_with_fresh_file_handle(
     monkeypatch, tmp_path, adapter_method, bot_method, file_arg, suffix
 ):
-    """A transient read failure should reopen and retry the upload once."""
+    """A pre-send connect timeout should reopen and retry the upload once."""
     adapter = _make_connected_adapter()
     file_path = tmp_path / f"attachment{suffix}"
     file_bytes = b"valid media bytes"
@@ -43,7 +43,7 @@ async def test_media_upload_retries_read_error_with_fresh_file_handle(
         attempts.append((media_file, media_file.tell()))
         if len(attempts) == 1:
             media_file.read()
-            raise httpx.ReadError("peer reset during upload")
+            raise httpx.ConnectTimeout("connection was never established")
         assert media_file.read() == file_bytes
         return SimpleNamespace(message_id=321)
 
@@ -64,6 +64,40 @@ async def test_media_upload_retries_read_error_with_fresh_file_handle(
     assert [position for _document, position in attempts] == [0, 0]
     sleep.assert_awaited_once_with(1)
     fallback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "upload_error",
+    [
+        httpx.ReadError("peer reset while reading the response"),
+        httpx.WriteError("connection failed while writing the request"),
+        httpx.RemoteProtocolError("invalid server response"),
+    ],
+    ids=["read-error", "write-error", "remote-protocol-error"],
+)
+async def test_send_document_does_not_retry_ambiguous_transport_failure(
+    monkeypatch, tmp_path, upload_error
+):
+    """Delivery-ambiguous transport failures must not resend an attachment."""
+    adapter = _make_connected_adapter()
+    file_path = tmp_path / "report.zip"
+    file_path.write_bytes(b"valid archive bytes")
+
+    adapter._bot.send_document = AsyncMock(side_effect=upload_error)
+    sleep = AsyncMock()
+    monkeypatch.setattr("plugins.platforms.telegram.adapter.asyncio.sleep", sleep)
+    fallback = AsyncMock(
+        return_value=SendResult(success=False, error="attachment fallback")
+    )
+    monkeypatch.setattr(BasePlatformAdapter, "send_document", fallback)
+
+    result = await adapter.send_document("123", str(file_path))
+
+    assert result.success is False
+    adapter._bot.send_document.assert_awaited_once()
+    sleep.assert_not_awaited()
+    fallback.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_document_retry.py
+++ b/tests/gateway/test_telegram_document_retry.py
@@ -1,0 +1,94 @@
+"""Regression coverage for transient Telegram media upload failures."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+def _make_connected_adapter() -> TelegramAdapter:
+    adapter = TelegramAdapter(
+        PlatformConfig(enabled=True, token="123456:test-token", extra={})
+    )
+    adapter._bot = MagicMock()
+    return adapter
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("adapter_method", "bot_method", "file_arg", "suffix"),
+    [
+        ("send_document", "send_document", "document", ".zip"),
+        ("send_video", "send_video", "video", ".mp4"),
+    ],
+)
+async def test_media_upload_retries_read_error_with_fresh_file_handle(
+    monkeypatch, tmp_path, adapter_method, bot_method, file_arg, suffix
+):
+    """A transient read failure should reopen and retry the upload once."""
+    adapter = _make_connected_adapter()
+    file_path = tmp_path / f"attachment{suffix}"
+    file_bytes = b"valid media bytes"
+    file_path.write_bytes(file_bytes)
+
+    attempts = []
+
+    async def upload(**kwargs):
+        media_file = kwargs[file_arg]
+        attempts.append((media_file, media_file.tell()))
+        if len(attempts) == 1:
+            media_file.read()
+            raise httpx.ReadError("peer reset during upload")
+        assert media_file.read() == file_bytes
+        return SimpleNamespace(message_id=321)
+
+    setattr(adapter._bot, bot_method, upload)
+    sleep = AsyncMock()
+    monkeypatch.setattr("plugins.platforms.telegram.adapter.asyncio.sleep", sleep)
+    fallback = AsyncMock(
+        return_value=SendResult(success=False, error="attachment fallback")
+    )
+    monkeypatch.setattr(BasePlatformAdapter, "send_document", fallback)
+
+    result = await getattr(adapter, adapter_method)("123", str(file_path))
+
+    assert result.success is True
+    assert result.message_id == "321"
+    assert len(attempts) == 2
+    assert attempts[0][0] is not attempts[1][0]
+    assert [position for _document, position in attempts] == [0, 0]
+    sleep.assert_awaited_once_with(1)
+    fallback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_document_does_not_retry_ambiguous_timeout(
+    monkeypatch, tmp_path
+):
+    """A generic timeout may follow a successful upload, so do not resend it."""
+    adapter = _make_connected_adapter()
+    file_path = tmp_path / "report.zip"
+    file_path.write_bytes(b"valid archive bytes")
+
+    timed_out = type("TimedOut", (Exception,), {})
+    adapter._bot.send_document = AsyncMock(
+        side_effect=timed_out("timed out waiting for Telegram response")
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr("plugins.platforms.telegram.adapter.asyncio.sleep", sleep)
+    fallback = AsyncMock(
+        return_value=SendResult(success=False, error="attachment fallback")
+    )
+    monkeypatch.setattr(BasePlatformAdapter, "send_document", fallback)
+
+    result = await adapter.send_document("123", str(file_path))
+
+    assert result.success is False
+    adapter._bot.send_document.assert_awaited_once()
+    sleep.assert_not_awaited()
+    fallback.assert_awaited_once()


### PR DESCRIPTION
## Summary

- retry Telegram document and video uploads up to three attempts only when a connect or pool timeout proves the request was not sent
- reopen the local file for every safe retry so PTB/httpx receives a fresh stream instead of an exhausted multipart handle
- treat read, write, protocol, and generic timeout failures as delivery-ambiguous to avoid duplicate user-visible attachments

## Root Cause

`TelegramAdapter.send_document()` and `send_video()` made a single upload attempt. Even connect and pool timeouts that establish the request never reached Telegram immediately fell through to the base adapter's text-only attachment warning. Retrying the same open file would also be unsafe because a failed multipart request can leave its stream at EOF.

## Tests

- `scripts/run_tests.sh tests/gateway/test_telegram_document_retry.py tests/gateway/test_telegram_documents.py tests/gateway/test_telegram_error_redaction.py -q` (54 passed)
- `python3 -m py_compile plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_document_retry.py`
- `git diff --check`

Refs #62079
