### PR TITLE
fix(agent): add MiniMax M2.x to stale-stream reasoning timeout floors (300s) (#62353)

### DIFF
--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -112,6 +112,12 @@ _REASONING_STALE_TIMEOUT_FLOORS: tuple[tuple[str, int], ...] = (
     ("grok-4-fast-reasoning", 300),
     ("grok-4.20-reasoning", 300),
     ("grok-4-fast-non-reasoning", 180),
+    # MiniMax — M2.x reasoning models emit reasoning_content like
+    # DeepSeek V4 / Qwen QwQ but had no floor, getting killed at the
+    # default 180s chat-model stale timeout.  ``minimax-m2`` covers
+    # m2.5, m2.7, and future M2.x variants via the start-of-slug +
+    # end-or-separator regex on the slug-only component.
+    ("minimax-m2", 300),
 )
 
 


### PR DESCRIPTION
## Summary
MiniMax M2.x (reasoning model) was missing from `_REASONING_STALE_TIMEOUT_FLOORS`, receiving the default 180s chat-model stale-stream timeout. During extended thinking phases, MiniMax M2.7 routinely exceeds 180s without emitting a chunk, and the stale-stream detector kills the connection mid-think.

## Change
Added `("minimax-m2", 300),` to the timeout floors. The slug matches M2.5, M2.7, and future M2.x variants. 300s floor mirrors the QwQ/Grok reasoning tier.

## Verification
51 reasoning stale-timeout tests pass.