### PR TITLE
fix(gateway): surface startup failure reason to stderr so users see it in terminal/GUI (#62275)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20729,6 +20729,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         return False
     if runner.should_exit_cleanly:
         if runner.exit_reason:
+            print(f"Gateway startup failed: {runner.exit_reason}", file=sys.stderr)
             logger.error("Gateway exiting cleanly: %s", runner.exit_reason)
         # A clean exit that carries an explicit exit code (e.g. a fatal
         # config error stamped with GATEWAY_FATAL_CONFIG_EXIT_CODE) must


### PR DESCRIPTION
## Summary
When Gateway detects a platform config error (e.g. WhatsApp enabled but not paired), it exits immediately with an ERROR log message, but shows zero indication in the terminal or GUI. Users must dig through log files to find out why Gateway died.

## Change
Added `print(f"Gateway startup failed: {runner.exit_reason}", file=sys.stderr)` before the existing "Gateway exiting cleanly" log message. The error reason is now visible in the terminal/GUI immediately on startup failure.

## Verification
All gateway startup/exit/error tests pass.