### PR TITLE
fix(providers): add fetch_models override for Gemini using ?key= query param auth (#62259)

### DIFF
--- a/plugins/model-providers/gemini/__init__.py
+++ b/plugins/model-providers/gemini/__init__.py
@@ -18,6 +18,54 @@ from providers.base import ProviderProfile
 class GeminiProfile(ProviderProfile):
     """Gemini — translate reasoning_config to thinking_config in extra_body."""
 
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Fetch live model list from the native Gemini API.
+
+        The native Gemini endpoint (generativelanguage.googleapis.com/v1beta)
+        does NOT accept Bearer auth — it requires the API key as a query
+        parameter ``?key=...``.  The response returns model ``name`` fields
+        with a ``models/`` prefix that must be stripped.
+
+        Resolution order for the endpoint URL:
+          1. base_url (caller override — user-configured model.base_url)
+          2. self.base_url (profile default)
+        """
+        effective_base = base_url or self.base_url
+        if not effective_base:
+            return None
+
+        url = effective_base.rstrip("/") + "/models"
+        if api_key:
+            url += f"?key={api_key}"
+
+        import json
+        import urllib.request
+
+        req = urllib.request.Request(url)
+        req.add_header("Accept", "application/json")
+        req.add_header("User-Agent", _profile_user_agent())
+        for k, v in self.default_headers.items():
+            req.add_header(k, v)
+
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                data = json.loads(resp.read().decode())
+            items = data.get("models", [])
+            return [m["name"].removeprefix("models/") for m in items if isinstance(m, dict) and "name" in m]
+        except Exception as exc:
+            import logging
+
+            logging.getLogger(__name__).debug(
+                "GeminiProfile.fetch_models: %s", exc
+            )
+            return None
+
     def build_extra_body(
         self, *, session_id: str | None = None, **context: Any
     ) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
Gemini live model discovery was broken because `ProviderProfile.fetch_models()` sends `Authorization: Bearer <key>` to the native Gemini endpoint. The native Gemini API rejects Bearer auth — it requires the key as a query parameter. The model picker silently fell back to 4 static models.

## Change
Added a `fetch_models()` override to `GeminiProfile` in `plugins/model-providers/gemini/__init__.py` that:
1. Sends GET to `{base_url}/models?key={api_key}` (no Bearer header)
2. Parses the native response `{"models": [{"name": "models/gemini-2.5-pro", ...}]}`
3. Strips the `models/` prefix from each name
4. Returns clean model IDs like `"gemini-2.5-pro"`, `"gemini-3.5-flash"`, etc.
5. Respects caller-provided `base_url` override before falling back to `self.base_url`

## Verification
52 provider tests pass.