### PR TITLE
feat(web): add automatic search fallback to DuckDuckGo (ddgs) on provider failure

### DIFF
--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -720,24 +720,36 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                 "Web search via %s: '%s' (limit: %d)",
                 provider.name, query, limit,
             )
+            response_data = None
             try:
                 response_data = provider.search(query, limit)
                 if not response_data or not response_data.get("success", True):
                     error_detail = response_data.get("error") if response_data else "Empty response"
-                    raise Exception(f"Provider search returned success=False: {error_detail}")
+                    if error_detail == "Interrupted":
+                        pass
+                    else:
+                        raise Exception(f"Provider search returned success=False: {error_detail}")
             except Exception as search_exc:
+                from tools.interrupt import is_interrupted
+                if is_interrupted():
+                    raise search_exc
+
                 if provider.name != "ddgs":
                     logger.warning(
                         "Web search via %s failed: %s. Falling back to ddgs.",
                         provider.name, search_exc,
                     )
                     ddg_provider = _wsp_get_provider("ddgs")
-                    if ddg_provider and ddg_provider.supports_search():
+                    if ddg_provider and ddg_provider.supports_search() and ddg_provider.is_available():
                         logger.info(
                             "Web search via fallback ddgs: '%s' (limit: %d)",
                             query, limit,
                         )
-                        response_data = ddg_provider.search(query, limit)
+                        fallback_data = ddg_provider.search(query, limit)
+                        if fallback_data and fallback_data.get("success", True):
+                            response_data = fallback_data
+                        else:
+                            raise search_exc
                     else:
                         raise search_exc
                 else:

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -720,7 +720,28 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                 "Web search via %s: '%s' (limit: %d)",
                 provider.name, query, limit,
             )
-            response_data = provider.search(query, limit)
+            try:
+                response_data = provider.search(query, limit)
+                if not response_data or not response_data.get("success", True):
+                    error_detail = response_data.get("error") if response_data else "Empty response"
+                    raise Exception(f"Provider search returned success=False: {error_detail}")
+            except Exception as search_exc:
+                if provider.name != "ddgs":
+                    logger.warning(
+                        "Web search via %s failed: %s. Falling back to ddgs.",
+                        provider.name, search_exc,
+                    )
+                    ddg_provider = _wsp_get_provider("ddgs")
+                    if ddg_provider and ddg_provider.supports_search():
+                        logger.info(
+                            "Web search via fallback ddgs: '%s' (limit: %d)",
+                            query, limit,
+                        )
+                        response_data = ddg_provider.search(query, limit)
+                    else:
+                        raise search_exc
+                else:
+                    raise search_exc
 
         debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
         result_json = json.dumps(response_data, indent=2, ensure_ascii=False)


### PR DESCRIPTION
### Summary
This PR introduces an automatic search failover mechanism to the `web_search_tool`. If the primary configured search provider (e.g. `brave-free`, `tavily`, etc.) raises an exception or returns a non-successful response (e.g., due to rate limits or API quota exhaustion), the tool now logs a warning and transparently falls back to the DuckDuckGo (`ddgs`) provider to satisfy the query.

### Rationale
Currently, if a user's configured search backend runs out of API credits or hits rate limits, the `web_search_tool` immediately crashes and returns a tool error. This halts the agent's reasoning loop and interrupts the user's task. 
Since `ddgs` requires no API keys and is highly reliable, routing failed search requests to it as a secondary option significantly improves the robustness and resilience of the agent during long-running tasks.

### Changes
- Wrapped the primary `provider.search` execution in a `try-except` block.
- Validated the returned `response_data` dictionary to check for `success=False` states.
- If a failure is encountered (and the current provider is not already `ddgs`), it attempts to resolve and query the `ddgs` provider.
- If the fallback succeeds, the agent proceeds without interruption. If it fails, the original exception is re-raised.