### PR TITLE
fix(delegate): reject batch task with null/non-string goal instead of crashing

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -262,6 +262,10 @@ class TestDelegateTask(unittest.TestCase):
         self.assertIn("error", result)
         self.assertIn("depth limit", result["error"].lower())
 
+    def test_task_null_goal(self):
+        parent = _make_mock_parent()
+        result = json.loads(delegate_task(tasks=[{"goal": None}], parent_agent=parent))
+        self.assertIn("error", result)
 
     def test_child_inherits_runtime_credentials(self):
         parent = _make_mock_parent(depth=0)

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -266,6 +266,9 @@ class TestDelegateTask(unittest.TestCase):
         parent = _make_mock_parent()
         result = json.loads(delegate_task(tasks=[{"goal": None}], parent_agent=parent))
         self.assertIn("error", result)
+        # A present-but-null goal must return the same actionable message as
+        # the absent-key case, not crash with an opaque AttributeError.
+        self.assertIn("Task 0 is missing a 'goal'", result["error"])
 
     def test_child_inherits_runtime_credentials(self):
         parent = _make_mock_parent(depth=0)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2894,7 +2894,8 @@ def delegate_task(
             return tool_error(
                 f"Task {i} must be an object, got {type(task).__name__}."
             )
-        if not task.get("goal", "").strip():
+        goal_val = task.get("goal")
+        if not (isinstance(goal_val, str) and goal_val.strip()):
             return tool_error(f"Task {i} is missing a 'goal'.")
 
     overall_start = time.monotonic()


### PR DESCRIPTION
## What does this PR do?

Batch `delegate_task(tasks=[...])` crashes with an uncaught `AttributeError` when a task carries `goal: null` (or any non-string value), because the per-task validator does `task.get("goal", "").strip()` — the `""` default only applies when the KEY is **absent**, so a present-but-`None` goal returns `None` and `.strip()` raises `AttributeError: 'NoneType' object has no attribute 'strip'`. That crashes the entire delegated turn instead of returning the actionable "Task N is missing a 'goal'" error the absent-key case already gives.

A model emitting `{"goal": null, ...}` is a routine LLM shape error on the hottest delegation fan-out surface. The single-goal path already guards its type (`elif goal and isinstance(goal, str) and goal.strip():`); this makes the batch path do the same, so `null` / int / other non-string goals all get the same clean `tool_error` as an absent key.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/delegate_tool.py`: in the batch per-task validator loop, replace `task.get("goal", "").strip()` with an `isinstance(goal_val, str) and goal_val.strip()` guard (mirrors the single-goal path). Preserves the exact absent-key behavior and also rejects null / non-string goals with the same clean error.
- `tests/tools/test_delegate.py`: add `test_task_null_goal` beside the existing `test_task_missing_goal`.

## How to Test

1. Before the fix: `delegate_task(tasks=[{"goal": None}], parent_agent=...)` raises `AttributeError: 'NoneType' object has no attribute 'strip'`.
2. After the fix: it returns `{"error": "Task 0 is missing a 'goal'."}` — same as the absent-key case.
3. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/tools/test_delegate.py -q` → 158 passed. `test_task_null_goal` fails-before / passes-after; `test_task_missing_goal` unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A