### PR TITLE
fix(gateway): honor group/thread session isolation precedence in is_shared_multi_user_session

### DIFF
--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -269,10 +269,18 @@ or each get their own private session.
 def is_shared_multi_user_session(source, *, group_sessions_per_user, thread_sessions_per_user):
     if source.chat_type == "dm":
         return False  # DMs are always private
-    if source.thread_id:
-        return not thread_sessions_per_user  # Threads: shared unless per-user
-    return not group_sessions_per_user       # Groups: isolated unless shared
+    # Mirror build_session_key()'s precedence: start from the group isolation
+    # setting, then relax it inside a thread unless thread_sessions_per_user is
+    # set. A thread is isolated only when BOTH flags are True.
+    isolate_user = group_sessions_per_user
+    if source.thread_id and not thread_sessions_per_user:
+        isolate_user = False
+    return not isolate_user
 ```
+
+This tracks `build_session_key()` exactly (`gateway/session.py`): the group
+setting is the base, and a thread only stays per-user isolated when both
+`group_sessions_per_user` and `thread_sessions_per_user` are enabled.
 
 ### Summary
 
@@ -280,7 +288,7 @@ def is_shared_multi_user_session(source, *, group_sessions_per_user, thread_sess
 |---|---|---|
 | DM | Private (never shared) | N/A |
 | Group/Channel | Per-user isolation | `group_sessions_per_user` (default: True) |
-| Thread (forum, discord) | Shared (all participants see same context) | `thread_sessions_per_user` (default: False) |
+| Thread (forum, discord) | Shared (all participants see same context) | Isolated only when `group_sessions_per_user` **and** `thread_sessions_per_user` (default: False) |
 
 ### Impact on System Prompt
 

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -278,9 +278,14 @@ def is_shared_multi_user_session(source, *, group_sessions_per_user, thread_sess
     return not isolate_user
 ```
 
-This tracks `build_session_key()` exactly (`gateway/session.py`): the group
-setting is the base, and a thread only stays per-user isolated when both
-`group_sessions_per_user` and `thread_sessions_per_user` are enabled.
+This tracks `build_session_key()`'s group/thread isolation **precedence** — not
+its full key string (`gateway/session.py`): the group setting is the base, and a
+thread only stays per-user isolated when both `group_sessions_per_user` and
+`thread_sessions_per_user` are enabled. The helper deliberately stays
+configuration-scoped: when no `user_id_alt`/`user_id` is present,
+`build_session_key()` omits the per-user identifier it would otherwise append
+and the key is shared by construction, so the helper reports that configuration
+decision rather than reconstructing the literal key.
 
 ### Summary
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -995,15 +995,19 @@ def is_shared_multi_user_session(
 
     Mirrors the isolation rules in :func:`build_session_key`:
       - DMs are never shared.
-      - Threads are shared unless ``thread_sessions_per_user`` is True.
       - Non-thread group/channel sessions are shared unless
         ``group_sessions_per_user`` is True (default: True = isolated).
+      - Threads follow the same group/thread isolation as
+        ``build_session_key``: a thread is isolated only when BOTH
+        ``group_sessions_per_user`` and ``thread_sessions_per_user`` are
+        True; otherwise it is shared.
     """
     if source.chat_type == "dm":
         return False
-    if source.thread_id:
-        return not thread_sessions_per_user
-    return not group_sessions_per_user
+    isolate_user = group_sessions_per_user
+    if source.thread_id and not thread_sessions_per_user:
+        isolate_user = False
+    return not isolate_user
 
 
 def _session_key_namespace(profile: Optional[str]) -> str:

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -16,6 +16,7 @@ from gateway.session import (
     build_session_context_prompt,
     build_session_key,
     canonical_whatsapp_identifier,
+    is_shared_multi_user_session,
     neutralize_untrusted_inline_text,
 )
 
@@ -728,6 +729,44 @@ class TestWhatsAppSessionKeyConsistency:
         assert build_session_key(alice) == build_session_key(bob)
         assert "alice" not in build_session_key(alice)
         assert "bob" not in build_session_key(bob)
+    def test_shared_helper_matches_build_session_key_group_thread(self):
+        """is_shared_multi_user_session must mirror build_session_key's
+        isolation precedence — not its full key string.
+
+        The helper tracks the isolation *decision* (whether build_session_key
+        would append a per-user participant_id), which stays configuration-
+        scoped: when no participant ID is present the key is shared by
+        construction, so the helper deliberately reports shared rather than
+        reconstructing the literal key. In the group_sessions_per_user=False +
+        thread_sessions_per_user=True combo, build_session_key emits a SHARED
+        thread key (no participant_id), so the helper must report the session
+        shared. Regression: the old thread branch dropped the group factor and
+        wrongly reported isolated, making the resume IDOR gate deny a
+        legitimate co-member.
+        """
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="guild-123",
+            chat_type="group",
+            thread_id="thread-9",
+            user_id="alice",
+            user_name="Alice",
+        )
+        key = build_session_key(
+            source,
+            group_sessions_per_user=False,
+            thread_sessions_per_user=True,
+        )
+        shared = is_shared_multi_user_session(
+            source,
+            group_sessions_per_user=False,
+            thread_sessions_per_user=True,
+        )
+        # The key carries no participant_id, so the session is genuinely shared.
+        assert "alice" not in key
+        assert shared is True
+        # Tie the helper to the actual key: shared iff participant absent.
+        assert shared == ("alice" not in key)
 
 
 class TestSlackWorkspaceSessionKeys:


### PR DESCRIPTION
## What does this PR do?

`is_shared_multi_user_session` documents that it "mirrors the isolation rules in `build_session_key`", but its thread branch drops a factor that `build_session_key` keeps:

```python
# is_shared_multi_user_session (before)
if source.thread_id:
    return not thread_sessions_per_user   # ignores group_sessions_per_user
```

`build_session_key` decides per-user isolation as:

```python
isolate_user = group_sessions_per_user
if source.thread_id and not thread_sessions_per_user:
    isolate_user = False
if isolate_user and participant_id:
    key_parts.append(str(participant_id))
```

So for a thread, the key is per-user **iff `group_sessions_per_user and thread_sessions_per_user`**. The helper's thread branch ignores `group_sessions_per_user`, diverging in exactly one combo: thread present + `group_sessions_per_user=False` + `thread_sessions_per_user=True`. There `build_session_key` emits a **shared** key (no participant_id), but the helper returns `False` (claims isolated).

Impact for admins running "groups shared, threads per-user": a co-member of an actually-shared thread session is reported isolated, so the resume IDOR gate (`_origin_matches_caller`) fail-closes and **denies a legitimate member**, and that thread's multi-user context/attribution handling is silently skipped.

Fix computes `isolate_user` identically to `build_session_key`. This preserves all currently-correct combos and flips only the divergent one. The docstring bullet is reconciled to state threads follow the same group/thread isolation as `build_session_key`.

Mirrors `build_session_key`'s precedence: `isolate_user = group_sessions_per_user`, then forced to `False` when `thread_id and not thread_sessions_per_user`.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/session.py`: rewrite the thread branch of `is_shared_multi_user_session` to compute `isolate_user` the same way `build_session_key` does, and reconcile the docstring.
- `tests/gateway/test_session.py`: add `test_shared_helper_matches_build_session_key_group_thread`, which ties the helper's result to the actual key (`shared == (participant_id not in key)`) for the divergent combo.

## How to Test

1. Before the fix, for a group thread source with `group_sessions_per_user=False, thread_sessions_per_user=True`: `build_session_key(...)` produces a shared key (no participant) but `is_shared_multi_user_session(...)` returns `False`.
2. After the fix, the helper returns `True`, matching the key.
3. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/gateway/test_session.py -q` → 109 passed. The new test fails-before / passes-after; no other session test regresses.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A