### PR TITLE
fix(agent): promote compact token unit when rounding overflows the mantissa

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1416,15 +1416,24 @@ def format_token_count_compact(value: int) -> str:
 
     sign = "-" if value < 0 else ""
     units = ((1_000_000_000, "B"), (1_000_000, "M"), (1_000, "K"))
-    for threshold, suffix in units:
+
+    def _mantissa(scaled: float) -> str:
+        if scaled < 10:
+            return f"{scaled:.2f}"
+        if scaled < 100:
+            return f"{scaled:.1f}"
+        return f"{scaled:.0f}"
+
+    for i, (threshold, suffix) in enumerate(units):
         if abs_value >= threshold:
-            scaled = abs_value / threshold
-            if scaled < 10:
-                text = f"{scaled:.2f}"
-            elif scaled < 100:
-                text = f"{scaled:.1f}"
-            else:
-                text = f"{scaled:.0f}"
+            text = _mantissa(abs_value / threshold)
+            # Rounding the mantissa to display precision can push it to 1000
+            # (e.g. 999_999 -> "1000K", 999_999_999 -> "1000M"). When that
+            # happens and a larger unit exists, promote so the mantissa stays
+            # within the formatter's [1, 1000) contract.
+            if float(text) >= 1_000 and i > 0:
+                threshold, suffix = units[i - 1]
+                text = _mantissa(abs_value / threshold)
             if "." in text:
                 text = text.rstrip("0").rstrip(".")
             return f"{sign}{text}{suffix}"

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1584,15 +1584,24 @@ def format_token_count_compact(value: int) -> str:
 
     sign = "-" if value < 0 else ""
     units = ((1_000_000_000, "B"), (1_000_000, "M"), (1_000, "K"))
-    for threshold, suffix in units:
+
+    def _mantissa(scaled: float) -> str:
+        if scaled < 10:
+            return f"{scaled:.2f}"
+        if scaled < 100:
+            return f"{scaled:.1f}"
+        return f"{scaled:.0f}"
+
+    for i, (threshold, suffix) in enumerate(units):
         if abs_value >= threshold:
-            scaled = abs_value / threshold
-            if scaled < 10:
-                text = f"{scaled:.2f}"
-            elif scaled < 100:
-                text = f"{scaled:.1f}"
-            else:
-                text = f"{scaled:.0f}"
+            text = _mantissa(abs_value / threshold)
+            # Rounding the mantissa to display precision can push it to 1000
+            # (e.g. 999_999 -> "1000K", 999_999_999 -> "1000M"). When that
+            # happens and a larger unit exists, promote so the mantissa stays
+            # within the formatter's [1, 1000) contract.
+            if float(text) >= 1_000 and i > 0:
+                threshold, suffix = units[i - 1]
+                text = _mantissa(abs_value / threshold)
             if "." in text:
                 text = text.rstrip("0").rstrip(".")
             return f"{sign}{text}{suffix}"

--- a/cli.py
+++ b/cli.py
@@ -166,27 +166,12 @@ def _reverse_alias_for_display(model_name: str) -> str:
 
 
 def format_token_count_compact(*args, **kwargs):
+    from agent.usage_pricing import (
+        format_token_count_compact as _format_token_count_compact,
+    )
+
     value = int(args[0] if args else kwargs.get("value", 0))
-    abs_value = abs(value)
-    if abs_value < 1_000:
-        return str(value)
-
-    sign = "-" if value < 0 else ""
-    units = ((1_000_000_000, "B"), (1_000_000, "M"), (1_000, "K"))
-    for threshold, suffix in units:
-        if abs_value >= threshold:
-            scaled = abs_value / threshold
-            if scaled < 10:
-                text = f"{scaled:.2f}"
-            elif scaled < 100:
-                text = f"{scaled:.1f}"
-            else:
-                text = f"{scaled:.0f}"
-            if "." in text:
-                text = text.rstrip("0").rstrip(".")
-            return f"{sign}{text}{suffix}"
-
-    return f"{value:,}"
+    return _format_token_count_compact(value)
 
 
 def is_table_divider(*args, **kwargs):

--- a/cli.py
+++ b/cli.py
@@ -169,27 +169,12 @@ def _reverse_alias_for_display(model_name: str) -> str:
 
 
 def format_token_count_compact(*args, **kwargs):
+    from agent.usage_pricing import (
+        format_token_count_compact as _format_token_count_compact,
+    )
+
     value = int(args[0] if args else kwargs.get("value", 0))
-    abs_value = abs(value)
-    if abs_value < 1_000:
-        return str(value)
-
-    sign = "-" if value < 0 else ""
-    units = ((1_000_000_000, "B"), (1_000_000, "M"), (1_000, "K"))
-    for threshold, suffix in units:
-        if abs_value >= threshold:
-            scaled = abs_value / threshold
-            if scaled < 10:
-                text = f"{scaled:.2f}"
-            elif scaled < 100:
-                text = f"{scaled:.1f}"
-            else:
-                text = f"{scaled:.0f}"
-            if "." in text:
-                text = text.rstrip("0").rstrip(".")
-            return f"{sign}{text}{suffix}"
-
-    return f"{value:,}"
+    return _format_token_count_compact(value)
 
 
 def is_table_divider(*args, **kwargs):

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from agent.usage_pricing import (
     CanonicalUsage,
     estimate_usage_cost,
+    format_token_count_compact,
     get_pricing_entry,
     normalize_usage,
     resolve_billing_route,
@@ -695,3 +696,16 @@ def test_vertex_default_model_estimates_cached_usage(monkeypatch):
 
     assert result.status == "estimated"
     assert result.amount_usd is not None and result.amount_usd > 0
+
+
+def test_format_token_count_compact_promotes_unit_on_rounding_overflow():
+    # Rounding the mantissa to display precision must not emit a value >= the
+    # next unit: 999_999 rounds to 1000K, which should promote to 1M (and the
+    # M->B boundary likewise). Regression for the [1, 1000) mantissa contract.
+    assert format_token_count_compact(999_999) == "1M"
+    assert format_token_count_compact(999_999_999) == "1B"
+    # Just below the rollover threshold stays in the smaller unit.
+    assert format_token_count_compact(999_499) == "999K"
+    # Normal (non-rollover) values are unchanged.
+    assert format_token_count_compact(260_000) == "260K"
+    assert format_token_count_compact(1_500_000) == "1.5M"

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -4,6 +4,7 @@ from agent.usage_pricing import (
     CanonicalUsage,
     format_cost_label,
     estimate_usage_cost,
+    format_token_count_compact,
     get_pricing_entry,
     normalize_usage,
     resolve_billing_route,
@@ -867,3 +868,19 @@ def test_flat_entries_unaffected_by_tier_machinery():
     )
     # 250k * $0.25/M + 10k * $1.50/M
     assert result.amount_usd == Decimal("0.0775")
+# ---------------------------------------------------------------------------
+# Compact token-count formatting
+# ---------------------------------------------------------------------------
+
+
+def test_format_token_count_compact_promotes_unit_on_rounding_overflow():
+    # Rounding the mantissa to display precision must not emit a value >= the
+    # next unit: 999_999 rounds to 1000K, which should promote to 1M (and the
+    # M->B boundary likewise). Regression for the [1, 1000) mantissa contract.
+    assert format_token_count_compact(999_999) == "1M"
+    assert format_token_count_compact(999_999_999) == "1B"
+    # Just below the rollover threshold stays in the smaller unit.
+    assert format_token_count_compact(999_499) == "999K"
+    # Normal (non-rollover) values are unchanged.
+    assert format_token_count_compact(260_000) == "260K"
+    assert format_token_count_compact(1_500_000) == "1.5M"

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -105,6 +105,26 @@ class TestCLIStatusBar:
         assert "-1" not in text
         assert "0/200K" in text
 
+    def test_status_bar_context_tokens_promote_unit_on_rounding_overflow(self):
+        """The status bar's compact token formatter must not emit a mantissa
+        that rounds up into the next unit: 999_999 context tokens rounds to
+        "1000K" and should render as "1M". Regression for the CLI status-bar
+        call path (cli.format_token_count_compact at cli.py:5100).
+        """
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=999_999,
+            context_length=200_000,
+        )
+
+        text = cli_obj._build_status_bar_text(width=120)
+        assert "1000K" not in text
+        assert "1M/200K" in text
+
     def test_input_height_counts_prompt_only_on_first_wrapped_row(self):
         # Regression for prompt_toolkit classic CLI resize glitches: the prompt
         # is inserted by BeforeInput only on logical line 0. At three terminal

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -121,6 +121,26 @@ class TestCLIStatusBar:
         assert "15m" in text
 
 
+    def test_status_bar_context_tokens_promote_unit_on_rounding_overflow(self):
+        """The status bar's compact token formatter must not emit a mantissa
+        that rounds up into the next unit: 999_999 context tokens rounds to
+        "1000K" and should render as "1M". Regression for the CLI status-bar
+        call path (cli.format_token_count_compact at cli.py:5100).
+        """
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=999_999,
+            context_length=200_000,
+        )
+
+        text = cli_obj._build_status_bar_text(width=120)
+        assert "1000K" not in text
+        assert "1M/200K" in text
+
     def test_input_height_counts_prompt_only_on_first_wrapped_row(self):
         # Regression for prompt_toolkit classic CLI resize glitches: the prompt
         # is inserted by BeforeInput only on logical line 0. At three terminal


### PR DESCRIPTION
## What does this PR do?

`format_token_count_compact` picks the unit from the **raw** value, then rounds the mantissa to display precision — but never re-checks that the rounded value still fits below the next unit:

```python
else:
    text = f"{scaled:.0f}"   # rounds 999.5..999.999 -> "1000"
```

For `abs_value` in `[999_500, 999_999]` the value fails the `>= 1_000_000` test, matches K, scales to `>= 999.5`, and `.0f` rounds to `"1000"` → `"1000K"` (should be `"1M"`). The same happens at the M→B boundary (`[999_500_000, 999_999_999]` → `"1000M"` instead of `"1B"`). This violates the formatter's own `[1, 1000)` mantissa contract and shows `"1000K"` in the CLI context-usage bar on a near-full 1M-context session.

Fix: after rounding, if the mantissa reached `1000` and a larger unit exists, promote to that larger unit and reformat (landing the mantissa at `1.00` → `"1M"`/`"1B"`). The top unit `B` needs no promotion (unreachable for token counts). The precision ladder and trailing-zero strip are unchanged for every non-rollover value.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/usage_pricing.py`: in `format_token_count_compact`, factor the precision ladder into a small `_mantissa` helper and, when the rounded mantissa reaches `1000` and a larger unit exists, promote to that unit and reformat.
- `tests/agent/test_usage_pricing.py`: add `test_format_token_count_compact_promotes_unit_on_rounding_overflow` covering both rollover boundaries plus non-rollover sanity values.

## How to Test

1. Before the fix: `format_token_count_compact(999_999)` → `"1000K"`; `format_token_count_compact(999_999_999)` → `"1000M"`.
2. After the fix: `"1M"` and `"1B"` respectively; `999_499` → `"999K"`, `260_000` → `"260K"`, `1_500_000` → `"1.5M"` unchanged.
3. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/agent/test_usage_pricing.py -q` → 16 passed. The new test fails-before / passes-after.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A