### PR TITLE
fix(auth): reject scheme-downgraded portal_base_url in resolve_nous_access_token

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -5935,10 +5935,23 @@ def resolve_nous_access_token(
             ).rstrip("/")
 
             parsed_portal_url = urlparse(portal_base_url)
-            if parsed_portal_url.hostname and parsed_portal_url.hostname not in _NOUS_PORTAL_ALLOWED_HOSTS:
+            portal_host = parsed_portal_url.hostname
+            loopback_http = (
+                parsed_portal_url.scheme == "http"
+                and portal_host in {"localhost", "127.0.0.1"}
+            )
+            trusted_scheme = (
+                parsed_portal_url.scheme == "https" or loopback_http
+            )
+            if (
+                not portal_host
+                or portal_host not in _NOUS_PORTAL_ALLOWED_HOSTS
+                or not trusted_scheme
+            ):
                 logger.warning(
-                    "auth: ignoring invalid portal_base_url %r (host %r not in allowlist), using default",
-                    portal_base_url, parsed_portal_url.hostname,
+                    "auth: ignoring invalid portal_base_url %r "
+                    "(host %r or scheme not allowed), using default",
+                    portal_base_url, portal_host,
                 )
                 portal_base_url = DEFAULT_NOUS_PORTAL_URL
 

--- a/tests/hermes_cli/test_auth_nous_provider.py
+++ b/tests/hermes_cli/test_auth_nous_provider.py
@@ -1025,6 +1025,49 @@ class TestStalePortalBaseUrlMigration:
 
 
 
+    def test_runtime_rejects_http_for_production_portal(self, tmp_path, monkeypatch):
+        """An allowlisted production host is still unsafe over plain HTTP.
+
+        resolve_nous_access_token() and resolve_nous_runtime_credentials() are
+        twin allowlist checks on the same portal_base_url field (see
+        test_runtime_credentials_rejects_http_for_production_portal). Both
+        POST the refresh_token bearer to portal_base_url on refresh, so both
+        must reject a scheme-downgraded value even when the hostname is
+        allowlisted, not just an off-allowlist hostname.
+        """
+        from hermes_cli import auth as auth_mod
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _setup_nous_auth(
+            tmp_path,
+            access_token="expired-access",
+            refresh_token="valid-refresh",
+            expires_at="2025-01-01T00:00:00+00:00",
+        )
+        auth_file = tmp_path / "auth.json"
+        store = json.loads(auth_file.read_text())
+        store["providers"]["nous"]["portal_base_url"] = (
+            "http://portal.nousresearch.com"
+        )
+        auth_file.write_text(json.dumps(store, indent=2))
+
+        refresh_calls = []
+
+        def _fake_refresh_access_token(*, client, portal_base_url, client_id, refresh_token):
+            del client, client_id, refresh_token
+            refresh_calls.append(portal_base_url)
+            return {
+                "access_token": "refreshed-access",
+                "refresh_token": "new-refresh",
+                "expires_in": 3600,
+            }
+
+        monkeypatch.setattr(auth_mod, "_refresh_access_token", _fake_refresh_access_token)
+
+        token = auth_mod.resolve_nous_access_token()
+        assert token == "refreshed-access"
+        assert len(refresh_calls) == 1
+        assert refresh_calls[0] == auth_mod.DEFAULT_NOUS_PORTAL_URL
 
     def test_runtime_credentials_rejects_http_for_production_portal(
         self, tmp_path, monkeypatch,


### PR DESCRIPTION
## What does this PR do?
`resolve_nous_access_token()` and `resolve_nous_runtime_credentials()` are twin allowlist checks on the same stored/network-sourced `portal_base_url` field (both `hermes_cli/auth.py`) — both POST the user's `refresh_token` bearer to this URL on refresh, so both must reject a poisoned value before using it.

A same-day fix to `resolve_nous_runtime_credentials()` hardened the allowlist check to validate the URL **scheme**, not just the hostname (require `https`, or `http` only for `localhost`/`127.0.0.1`). That hardened one twin but not the other: `resolve_nous_access_token()` still only checks `parsed_portal_url.hostname not in _NOUS_PORTAL_ALLOWED_HOSTS`, so an allowlisted hostname served over plain HTTP (e.g. a cross-profile shared-state value poisoned to `http://portal.nousresearch.com`) passes through unchanged — sending the refresh_token bearer in cleartext, exploitable by a network-level MITM per the original `#27612`/`#30611` threat model ("prevent bearer token exfiltration").

This also closes a secondary gap: the old check only fired `if parsed_portal_url.hostname` (truthy), so a malformed `portal_base_url` with no parseable hostname passed through unvalidated. The new check rejects that too, matching the sibling function exactly.

`resolve_nous_access_token()` is not an edge case — it backs `tools/managed_tool_gateway.py`, `hermes_cli/nous_account.py`, `hermes_cli/dashboard_register.py`, `hermes_cli/nous_billing.py`, the Chronos cron provider (`plugins/cron_providers/chronos/_nas_client.py`), and the relay self-provisioning enroll flow (`gateway/relay/__init__.py`).

## Related Issue
N/A — found while investigating today's `resolve_nous_runtime_credentials()` scheme-validation commit and checking for sibling call sites reading the same `portal_base_url` field. Not a duplicate of open PR #57644, which targets a third, distinct function (`refresh_nous_oauth_pure`) and explicitly mirrors this function's *old* (pre-hardening) pattern rather than modifying it.

## Type of Change
- [x] 🐛 Bug fix
- [x] 🔒 Security fix

## Changes Made
- `hermes_cli/auth.py`: `resolve_nous_access_token()`'s allowlist check now validates scheme in addition to hostname, mirroring `resolve_nous_runtime_credentials()` exactly.
- `tests/hermes_cli/test_auth_nous_provider.py`: add `test_runtime_rejects_http_for_production_portal`.

## How to Test
```
pytest tests/hermes_cli/test_auth_nous_provider.py -v
```
All 74 tests in the file pass. Mutation-verified: reverting the fix reproduces the failure — `http://portal.nousresearch.com` is passed straight through to the refresh call instead of healing to `DEFAULT_NOUS_PORTAL_URL`. Also ran the full related test surface (`test_dashboard_register.py`, `test_nous_portal_staging_allowlist.py`, `test_nous_account.py`, `test_nous_inference_url_validation.py`, `test_auth_commands.py`, `test_billing_scope_stepup.py`, `test_proxy.py`, `test_status*.py`, `gateway/relay/test_identity_token_resolver.py`, `gateway/relay/test_self_provision.py`) — 209 passed, 1 skipped, no regressions.

## Checklist
- [x] Read the Contributing Guide
- [x] Conventional Commits format
- [x] No duplicate PR
- [x] Single logical change
- [x] Tests added
- [x] Cross-platform: N/A (pure Python URL parsing)