### PR TITLE
fix(context-engine): clone plugin engines per agent

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1258,6 +1258,9 @@ def init_agent(
     
     # Track conversation messages for session logging
     agent._session_messages: List[Dict[str, Any]] = []
+    # General plugins register process-wide context-engine templates. Agents
+    # only own and tear down runtimes cloned from those templates.
+    agent._owns_context_engine = False
     # Responses encrypted reasoning replay state.  Some OpenAI-compatible
     # routes accept GPT-5 Responses requests but later reject replayed
     # encrypted reasoning blobs (HTTP 400 ``invalid_encrypted_content``).
@@ -1755,23 +1758,26 @@ def init_agent(
             except Exception:
                 _candidate = None
             if _candidate is not None and _candidate.name == _engine_name:
-                # Deep-copy the shared plugin singleton so a child agent's
-                # update_model() can't mutate the parent's compressor (#42449).
-                # Copy can fail for engines holding uncopyable state (locks, DB
-                # connections, clients); in that case fall back to the built-in
-                # compressor with an ACCURATE message rather than silently
-                # mislabelling it "not found".
-                import copy
+                # Clone the process-wide registered template before model or
+                # session binding so child agents cannot mutate parent state
+                # (#42449). The default hook preserves deepcopy isolation.
                 try:
-                    _selected_engine = copy.deepcopy(_candidate)
+                    _selected_engine = _candidate.clone_for_agent()
+                    if _selected_engine is None:
+                        raise ValueError("clone_for_agent() returned None")
+                    if _selected_engine is _candidate:
+                        raise ValueError(
+                            "clone_for_agent() returned the registered template"
+                        )
+                    agent._owns_context_engine = True
                 except Exception as _copy_err:
                     _copy_failed = True
                     _ra().logger.warning(
-                        "Context engine '%s' could not be safely copied for this "
+                        "Context engine '%s' could not be safely cloned for this "
                         "agent (%s) — falling back to built-in compressor. Plugin "
                         "engines that hold uncopyable state (locks, DB connections) "
-                        "should implement __deepcopy__ to copy only mutable budget "
-                        "state.",
+                        "should implement clone_for_agent() to create isolated "
+                        "runtime state.",
                         _engine_name, _copy_err,
                     )
                     _selected_engine = None

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -25,6 +25,7 @@ Lifecycle:
      gateway session expiry) — NOT per-turn
 """
 
+import copy
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List
 
@@ -104,6 +105,18 @@ class ContextEngine(ABC):
                 preserving information related to this topic.  Engines that
                 don't support it may simply ignore this argument.
         """
+
+    # -- Optional: agent instance lifecycle --------------------------------
+
+    def clone_for_agent(self) -> "ContextEngine":
+        """Return an isolated runtime engine for one agent.
+
+        Registered plugin engines are process-wide templates. The default
+        preserves the historical deepcopy isolation while allowing engines
+        with locks, connections, or other uncopyable state to override this
+        boundary explicitly.
+        """
+        return copy.deepcopy(self)
 
     # -- Optional: pre-flight check ----------------------------------------
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -3415,6 +3415,19 @@ class AIAgent:
         except Exception:
             pass
 
+    def _shutdown_owned_context_engine(self) -> None:
+        """Close this agent's cloned context-engine runtime once, if any."""
+        if not getattr(self, "_owns_context_engine", False):
+            return
+        self._owns_context_engine = False
+        try:
+            compressor = getattr(self, "context_compressor", None)
+            shutdown = getattr(compressor, "shutdown", None)
+            if callable(shutdown):
+                shutdown()
+        except Exception:
+            pass
+
     def release_clients(self) -> None:
         """Release LLM client resources WITHOUT tearing down session tool state.
 
@@ -3431,6 +3444,7 @@ class AIAgent:
           - OpenAI/httpx client pool (big chunk of held memory + sockets;
             the rebuilt agent gets a fresh client anyway)
           - Active child subagents (per-turn artefacts; safe to drop)
+          - Owned context-engine clone (the rebuilt agent gets a fresh clone)
 
         Safe to call multiple times.  Distinct from close() — which is the
         hard teardown for actual session boundaries (/new, /reset, session
@@ -3452,6 +3466,8 @@ class AIAgent:
                         pass
         except Exception:
             pass
+
+        self._shutdown_owned_context_engine()
 
         # Close the OpenAI/httpx client to release sockets immediately.
         try:
@@ -3518,7 +3534,12 @@ class AIAgent:
         except Exception:
             pass
 
-        # 6. Free conversation history.  Mirrors _release_evicted_agent_soft's
+        # 6. Close context-engine resources only when this agent owns a cloned
+        # runtime. Registered plugin templates are process-wide and may still
+        # be serving other cached agents.
+        self._shutdown_owned_context_engine()
+
+        # 7. Free conversation history.  Mirrors _release_evicted_agent_soft's
         # soft-eviction clear — close() is the hard teardown for true session
         # boundaries (/new, /reset, session expiry), so the message list won't
         # be reused.  Drops the reference proactively rather than waiting for

--- a/tests/agent/test_context_engine.py
+++ b/tests/agent/test_context_engine.py
@@ -142,6 +142,14 @@ class TestDefaults:
         engine = StubEngine()
         assert engine.should_compress_preflight([]) is False
 
+    def test_default_clone_for_agent_deepcopies_engine(self):
+        """The default clone hook preserves singleton isolation from #42449."""
+        engine = StubEngine(context_length=500_000)
+        clone = engine.clone_for_agent()
+
+        assert clone is not engine
+        assert clone.context_length == engine.context_length
+
 
 # ---------------------------------------------------------------------------
 # StubEngine behavior
@@ -401,31 +409,3 @@ class TestInitAgentDoesNotMutatePluginSingleton:
         assert selected is None
         # The original engine is untouched (no partial mutation).
         assert engine.context_length == 1_000_000
-
-    def test_agent_init_source_deepcopies_singleton_not_aliases(self):
-        """Source-pin guarding the production fix in agent/agent_init.py:
-        the plugin-singleton fallback MUST deepcopy the candidate, not alias
-        it (`_selected_engine = _candidate`). Full init_agent is too heavy to
-        drive here, so this pins the exact line so a future revert to direct
-        assignment fails CI. Regression for #42449."""
-        import inspect
-        import re
-        import agent.agent_init as _ai
-
-        src = inspect.getsource(_ai)
-        # The candidate fetched from the plugin singleton must be deep-copied
-        # before becoming _selected_engine (which is later mutated by
-        # update_model). A bare `_selected_engine = _candidate` is the bug.
-        assert re.search(
-            r"_selected_engine\s*=\s*(copy|_copy)\.deepcopy\(\s*_candidate\s*\)",
-            src,
-        ), (
-            "agent_init must deepcopy the plugin context-engine singleton "
-            "(`_selected_engine = copy.deepcopy(_candidate)`) — a bare "
-            "`_selected_engine = _candidate` re-introduces #42449 (child "
-            "update_model corrupts the parent's shared singleton)."
-        )
-        # And the bug-shape alias must NOT be present on that path.
-        assert not re.search(
-            r"_selected_engine\s*=\s*_candidate\b", src
-        ), "found the #42449 bug-shape alias `_selected_engine = _candidate`"

--- a/tests/run_agent/test_plugin_context_engine_init.py
+++ b/tests/run_agent/test_plugin_context_engine_init.py
@@ -4,6 +4,7 @@ Regression test for #9071 — plugin engines were never initialized with
 context_length, causing the CLI status bar to show 'ctx --'.
 """
 
+import threading
 from unittest.mock import MagicMock, patch
 
 from agent.context_engine import ContextEngine
@@ -35,6 +36,28 @@ class _ToolEngine(_StubEngine):
                 "parameters": {"type": "object", "properties": {}},
             }
         ]
+
+
+class _CustomCloneEngine(_StubEngine):
+    """Stateful singleton whose runtime must be created through its clone hook."""
+
+    def __init__(self):
+        self._lock = threading.RLock()
+        self.clones = []
+        self.shutdown_count = 0
+
+    def clone_for_agent(self):
+        clone = type(self)()
+        self.clones.append(clone)
+        return clone
+
+    def shutdown(self):
+        self.shutdown_count += 1
+
+
+class _AliasingCloneEngine(_StubEngine):
+    def clone_for_agent(self):
+        return self
 
 
 def test_plugin_engine_gets_context_length_on_init():
@@ -139,6 +162,74 @@ def test_plugin_engine_update_model_args():
     assert "model" in kw
     assert "provider" in kw
     assert "api_mode" in kw
+
+
+def test_general_plugin_engine_uses_custom_clone_and_closes_owned_runtime():
+    """Uncopyable plugin engines can define the explicit per-agent clone boundary."""
+    registered = _CustomCloneEngine()
+    cfg = {"context": {"engine": "stub"}, "agent": {}}
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.context_engine.load_context_engine", return_value=None),
+        patch("hermes_cli.plugins.get_plugin_context_engine", return_value=registered),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    clone = registered.clones[0]
+    assert agent.context_compressor is clone
+    assert clone.context_length == 204_800
+    assert registered.context_length == 0
+    assert agent._owns_context_engine is True
+
+    agent.release_clients()
+
+    assert clone.shutdown_count == 1
+    assert registered.shutdown_count == 0
+    assert agent._owns_context_engine is False
+
+    # Full close after soft eviction must not shut the clone down twice.
+    agent.close()
+    assert clone.shutdown_count == 1
+
+
+def test_general_plugin_engine_rejects_clone_that_aliases_registered_template():
+    registered = _AliasingCloneEngine()
+    cfg = {"context": {"engine": "stub"}, "agent": {}}
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.context_engine.load_context_engine", return_value=None),
+        patch("hermes_cli.plugins.get_plugin_context_engine", return_value=registered),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.context_compressor is not registered
+    assert agent._owns_context_engine is False
+    agent.close()
 
 
 def _codex_agent_kwargs():


### PR DESCRIPTION
### What does this PR do?

Adds an explicit per-agent clone contract for process-wide context-engine plugin templates and closes owned clone resources when an agent is closed or softly evicted. This is a current-main replacement for stale/conflicting #42683 and preserves the original contract direction proposed there by @the3asic.

Current main already deep-copies general-plugin context engines to prevent #42449's shared-singleton mutation. That fails for engines with locks, database handles, or other non-copyable runtime state. `ContextEngine.clone_for_agent()` keeps deepcopy as the default while allowing those engines to construct an isolated runtime explicitly.

### Related Issue

Related: #42449. Supersedes #42683.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

### Changes Made

- `agent/context_engine.py`
  - Add `clone_for_agent()` with a deepcopy default for backward-compatible isolation.
- `agent/agent_init.py`
  - Clone general-plugin templates before model/session binding; reject `None`, exceptions, and template aliases with safe built-in fallback.
- `run_agent.py`
  - Shut down only owned per-agent clones, idempotently, on full close and soft cache eviction.
- `tests/agent/test_context_engine.py`
  - Cover the default clone contract.
- `tests/run_agent/test_plugin_context_engine_init.py`
  - Cover custom cloning, template isolation, alias rejection, and one-time shutdown.

### How to Test

1. Run focused and relevant lifecycle validation:
   ```bash
   scripts/run_tests.sh tests/agent/test_context_engine.py tests/agent/test_context_engine_host_contract.py tests/run_agent/test_plugin_context_engine_init.py tests/run_agent/test_compression_boundary_hook.py tests/run_agent/test_openai_client_lifecycle.py tests/run_agent/test_switch_model_context.py tests/run_agent/test_commit_memory_session_context_engine.py tests/run_agent/test_compress_focus_plugin_fallback.py -- -q --tb=short
   ```
   Result: `66 passed, 0 failed`.

2. Run changed-file checks:
   ```bash
   ruff check agent/context_engine.py agent/agent_init.py run_agent.py tests/agent/test_context_engine.py tests/run_agent/test_plugin_context_engine_init.py
   python -m py_compile agent/context_engine.py agent/agent_init.py run_agent.py tests/agent/test_context_engine.py tests/run_agent/test_plugin_context_engine_init.py
   git diff --check origin/main...HEAD
   ```
   Result: all passed.

3. Manual exercise: not run against a live third-party context engine; focused tests exercise the real `AIAgent` initialization and soft-eviction lifecycle with a lock-holding custom clone engine.

### Validation Status

- Focused regression tests: passing, 66/66.
- Broader suite: not run; eight relevant host/lifecycle files passed.
- GitHub checks: pending publication.
- Full-suite checklist is intentionally unchecked because the full repository suite was not run locally.
- Tested on Linux 7.0.14 x86_64, Python 3.14.6.

### Checklist

- [x] Commit uses Conventional Commits.
- [x] Existing issues/PRs and competing implementations were searched.
- [x] The branch contains one scoped commit and no unrelated files.
- [x] Regression tests were added.
- [x] Documentation/config/tool-schema updates are N/A.
- [x] Cross-platform impact considered: standard Python object lifecycle/deepcopy behavior; no platform-specific code.
- [ ] Full `pytest tests/ -q` suite run locally.

### Screenshots / Logs

N/A; code-only lifecycle change.
