### PR TITLE
fix(telegram): hide approval buttons when command preview truncated

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4566,13 +4566,6 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
-            cmd_preview = command[:3800] + "..." if len(command) > 3800 else command
-            text = (
-                f"⚠️ <b>Command Approval Required</b>\n\n"
-                f"<pre>{_html.escape(cmd_preview)}</pre>\n\n"
-                f"Reason: {_html.escape(description)}"
-            )
-
             # Resolve thread context for thread replies
             thread_id = self._metadata_thread_id(metadata)
 
@@ -4584,16 +4577,40 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._approval_counter = itertools.count(1)
             approval_id = next(self._approval_counter)
 
-            keyboard = InlineKeyboardMarkup([
-                [
-                    InlineKeyboardButton("✅ Allow Once", callback_data=f"ea:once:{approval_id}"),
-                    InlineKeyboardButton("✅ Session", callback_data=f"ea:session:{approval_id}"),
-                ],
-                [
-                    InlineKeyboardButton("✅ Always", callback_data=f"ea:always:{approval_id}"),
-                    InlineKeyboardButton("❌ Deny", callback_data=f"ea:deny:{approval_id}"),
-                ],
-            ])
+            cmd_preview = command[:3800] + "..." if len(command) > 3800 else command
+
+            if len(command) > 3800:
+                # Command too long for Telegram — hide approval buttons for security
+                text = (
+                    f"⚠️ <b>Command Too Long for Telegram Approval</b>\n\n"
+                    f"⚠️ This command ({len(command)} chars) exceeds Telegram's display limit.\n"
+                    f"Approval buttons are hidden to prevent authorization of unseen code.\n\n"
+                    f"<b>Visible preview:</b>\n"
+                    f"<pre>{_html.escape(cmd_preview)}</pre>\n\n"
+                    f"<b>Reason:</b> {_html.escape(description)}\n\n"
+                    f"<b>Workarounds:</b>\n"
+                    f"• Stage the full command as a temporary file and request approval for a short invocation\n"
+                    f"• Use the <code>/approve</code> slash command with the complete command"
+                )
+                keyboard = InlineKeyboardMarkup([
+                    [InlineKeyboardButton("❌ Deny", callback_data=f"ea:deny:{approval_id}")],
+                ])
+            else:
+                text = (
+                    f"⚠️ <b>Command Approval Required</b>\n\n"
+                    f"<pre>{_html.escape(cmd_preview)}</pre>\n\n"
+                    f"Reason: {_html.escape(description)}"
+                )
+                keyboard = InlineKeyboardMarkup([
+                    [
+                        InlineKeyboardButton("✅ Allow Once", callback_data=f"ea:once:{approval_id}"),
+                        InlineKeyboardButton("✅ Session", callback_data=f"ea:session:{approval_id}"),
+                    ],
+                    [
+                        InlineKeyboardButton("✅ Always", callback_data=f"ea:always:{approval_id}"),
+                        InlineKeyboardButton("❌ Deny", callback_data=f"ea:deny:{approval_id}"),
+                    ],
+                ])
 
             kwargs: Dict[str, Any] = {
                 "chat_id": normalize_telegram_chat_id(chat_id),

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -232,6 +232,117 @@ class TestTelegramExecApproval:
         kwargs = adapter._bot.send_message.call_args[1]
         assert "..." in kwargs["text"]
         assert len(kwargs["text"]) < 5000
+
+    @pytest.mark.asyncio
+    async def test_hides_approval_buttons_when_truncated(self):
+        """Regression test for #62359: long commands must not allow blind approval."""
+        import telegram
+        telegram.InlineKeyboardMarkup.reset_mock()
+        telegram.InlineKeyboardButton.reset_mock()
+
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 99
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        long_cmd = "x" * 5000
+        await adapter.send_exec_approval(
+            chat_id="12345", command=long_cmd, session_key="s"
+        )
+
+        kwargs = adapter._bot.send_message.call_args[1]
+        # Should show warning, not standard approval text
+        assert "Command Too Long for Telegram Approval" in kwargs["text"]
+        assert "Approval buttons are hidden" in kwargs["text"]
+        assert "5000 chars" in kwargs["text"]
+        # Should show only Deny button (check InlineKeyboardButton constructor calls)
+        assert telegram.InlineKeyboardButton.call_count == 1
+        button_call = telegram.InlineKeyboardButton.call_args
+        assert button_call[1]["callback_data"] == "ea:deny:1"
+        assert "Deny" in button_call[0][0]
+
+    @pytest.mark.asyncio
+    async def test_shows_all_buttons_for_short_commands(self):
+        """Verify short commands still show the full approval button set."""
+        import telegram
+        telegram.InlineKeyboardMarkup.reset_mock()
+        telegram.InlineKeyboardButton.reset_mock()
+
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 88
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        short_cmd = "echo hello"
+        await adapter.send_exec_approval(
+            chat_id="12345", command=short_cmd, session_key="s"
+        )
+
+        kwargs = adapter._bot.send_message.call_args[1]
+        # Should show standard approval text
+        assert "Command Approval Required" in kwargs["text"]
+        assert "Command Too Long" not in kwargs["text"]
+        # Should show all four buttons (check InlineKeyboardButton constructor calls)
+        assert telegram.InlineKeyboardButton.call_count == 4
+        # Collect all callback_data from button calls
+        callbacks = [
+            call.kwargs.get("callback_data") or call[1].get("callback_data")
+            for call in telegram.InlineKeyboardButton.call_args_list
+        ]
+        assert "ea:once:1" in callbacks
+        assert "ea:session:1" in callbacks
+        assert "ea:always:1" in callbacks
+        assert "ea:deny:1" in callbacks
+
+    @pytest.mark.asyncio
+    async def test_shows_all_buttons_for_exactly_3800_chars(self):
+        """Edge case: commands exactly at the limit should not be truncated."""
+        import telegram
+        telegram.InlineKeyboardMarkup.reset_mock()
+        telegram.InlineKeyboardButton.reset_mock()
+
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 77
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        exact_cmd = "x" * 3800
+        await adapter.send_exec_approval(
+            chat_id="12345", command=exact_cmd, session_key="s"
+        )
+
+        kwargs = adapter._bot.send_message.call_args[1]
+        # Should show standard approval text (not truncated)
+        assert "Command Approval Required" in kwargs["text"]
+        assert "Command Too Long" not in kwargs["text"]
+        # Should show all four buttons
+        assert telegram.InlineKeyboardButton.call_count == 4
+
+    @pytest.mark.asyncio
+    async def test_hides_approval_buttons_for_3801_chars(self):
+        """Edge case: commands just over the limit trigger truncation."""
+        import telegram
+        telegram.InlineKeyboardMarkup.reset_mock()
+        telegram.InlineKeyboardButton.reset_mock()
+
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 66
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        over_cmd = "x" * 3801
+        await adapter.send_exec_approval(
+            chat_id="12345", command=over_cmd, session_key="s"
+        )
+
+        kwargs = adapter._bot.send_message.call_args[1]
+        # Should show warning (truncated)
+        assert "Command Too Long for Telegram Approval" in kwargs["text"]
+        assert "3801 chars" in kwargs["text"]
+        # Should show only Deny button
+        assert telegram.InlineKeyboardButton.call_count == 1
+        button_call = telegram.InlineKeyboardButton.call_args
+        assert button_call[1]["callback_data"] == "ea:deny:1"
 # _handle_callback_query — approval button clicks
 # ===========================================================================
 


### PR DESCRIPTION
## What does this PR do?

Hermes should never ask a user to authorize a command that the approval surface cannot show completely. Previously, the Telegram adapter truncated commands longer than 3,800 characters but kept the approval buttons enabled, allowing blind authorization of unseen code — a security boundary violation.

This fix implements a fail-safe design: when a command exceeds Telegram's display limit (3,800 chars), the approval buttons (Allow Once, Session, Always) are hidden, leaving only the Deny button available. The user receives a clear warning with the command length and workaround suggestions (stage as file or use `/approve` with full command).

Commands that fit within the limit preserve the existing compact flow with all four buttons.

## Related Issue

Fixes #62359

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/platforms/telegram/adapter.py`: Modified `send_exec_approval()` to check command length before rendering approval UI. Commands > 3,800 chars show a warning message with only the Deny button; shorter commands show the standard four-button approval interface.
- `tests/gateway/test_telegram_approval_buttons.py`: Added 4 regression tests:
  - `test_hides_approval_buttons_when_truncated`: Verifies only Deny button for 5,000-char command
  - `test_shows_all_buttons_for_short_commands`: Verifies all four buttons for short commands
  - `test_shows_all_buttons_for_exactly_3800_chars`: Edge case — 3,800 chars should not trigger truncation
  - `test_hides_approval_buttons_for_3801_chars`: Edge case — 3,801 chars triggers truncation

## How to Test

1. Run the new regression tests:
   ```bash
   pytest tests/gateway/test_telegram_approval_buttons.py::TestTelegramExecApproval::test_hides_approval_buttons_when_truncated -v
   pytest tests/gateway/test_telegram_approval_buttons.py::TestTelegramExecApproval::test_shows_all_buttons_for_short_commands -v
   pytest tests/gateway/test_telegram_approval_buttons.py::TestTelegramExecApproval::test_shows_all_buttons_for_exactly_3800_chars -v
   pytest tests/gateway/test_telegram_approval_buttons.py::TestTelegramExecApproval::test_hides_approval_buttons_for_3801_chars -v
   ```
   Observed result: All tests pass

2. Run all Telegram approval tests to ensure no regressions:
   ```bash
   pytest tests/gateway/test_telegram_approval_buttons.py -v
   ```
   Observed result: All tests pass

3. (Integration test — optional, requires real Telegram bot): Trigger a dangerous command longer than 3,800 characters via Telegram. Observe that the approval message shows "Command Too Long for Telegram Approval" with only a Deny button, and no Allow/Session/Always buttons.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_telegram_approval_buttons.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A