### PR TITLE
fix(tools): allow cleanup of Hermes-owned temp files without approval

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -82,6 +82,63 @@ class TestDetectDangerousRm:
         assert key is not None
         assert "delete" in desc.lower()
 
+    def test_rm_f_hermes_verify_temp_allowed(self):
+        """Hermes-owned verify temp file cleanup does not require approval."""
+        import tempfile
+        temp_dir = tempfile.gettempdir()
+        cmd = f"rm -f {temp_dir}/hermes-verify-abc123.py"
+        is_dangerous, key, desc = detect_dangerous_command(cmd)
+        assert is_dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_rm_force_hermes_ad_hoc_temp_allowed(self):
+        """Hermes-owned ad-hoc temp file cleanup with long flag does not require approval."""
+        import tempfile
+        temp_dir = tempfile.gettempdir()
+        cmd = f"rm --force {temp_dir}/hermes-ad-hoc-example.sh"
+        is_dangerous, key, desc = detect_dangerous_command(cmd)
+        assert is_dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_rm_f_non_temp_dir_requires_approval(self):
+        """rm -f outside temp directory requires approval."""
+        is_dangerous, key, desc = detect_dangerous_command("rm -f /home/user/file.txt")
+        assert is_dangerous is True
+        assert key is not None
+        assert "delete in root path" == desc
+
+    def test_rm_f_non_hermes_prefix_requires_approval(self):
+        """rm -f for non-Hermes file requires approval."""
+        import tempfile
+        temp_dir = tempfile.gettempdir()
+        cmd = f"rm -f {temp_dir}/other-file.txt"
+        is_dangerous, key, desc = detect_dangerous_command(cmd)
+        assert is_dangerous is True
+        assert key is not None
+        assert "delete in root path" == desc
+
+    def test_rm_recursive_temp_requires_approval(self):
+        """Recursive deletion requires approval even in temp directory."""
+        import tempfile
+        temp_dir = tempfile.gettempdir()
+        cmd = f"rm -rf {temp_dir}/hermes-verify-test"
+        is_dangerous, key, desc = detect_dangerous_command(cmd)
+        assert is_dangerous is True
+        assert key is not None
+        # The -rf flag matches both patterns; delete in root path catches it first
+        assert "delete" in desc.lower()
+
+    def test_rm_f_multiple_operands_requires_approval(self):
+        """rm -f with multiple operands requires approval."""
+        import tempfile
+        temp_dir = tempfile.gettempdir()
+        cmd = f"rm -f {temp_dir}/hermes-verify-1.py {temp_dir}/hermes-verify-2.py"
+        is_dangerous, key, desc = detect_dangerous_command(cmd)
+        assert is_dangerous is True
+        assert key is not None
+
 
 class TestWindowsShellDestructiveCommands:
     def test_cmd_del_requires_approval(self):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -14,9 +14,11 @@ import functools
 import hashlib
 import logging
 import os
+import pathlib
 import re
 import shlex
 import sys
+import tempfile
 import threading
 import time
 import unicodedata
@@ -1383,12 +1385,73 @@ def _command_detection_variants(command: str):
         yield variant
 
 
+def _is_hermes_temp_cleanup_command(command: str) -> bool:
+    """Check if a command is a safe cleanup of Hermes-owned temp files.
+
+    Returns True only when:
+    - Command is `rm -f` or `rm --force` with exactly one operand
+    - Operand is under the OS temp directory
+    - Filename starts with `hermes-verify-` or `hermes-ad-hoc-`
+
+    This allows verify-on-stop's mandated cleanup without approval,
+    while gating broader deletions.
+    """
+    try:
+        # Parse the command using shlex to handle quotes/escapes
+        parts = shlex.split(command)
+        if len(parts) < 2:
+            return False
+
+        # Check command is `rm` with `-f` or `--force`
+        if parts[0] != "rm":
+            return False
+
+        has_force_flag = False
+        operand_idx = 1
+        while operand_idx < len(parts) and parts[operand_idx].startswith("-"):
+            if parts[operand_idx] in ("-f", "--force"):
+                has_force_flag = True
+            elif parts[operand_idx] in ("-r", "-rf", "-fr", "--recursive"):
+                # Recursive deletions are never safe
+                return False
+            operand_idx += 1
+
+        if not has_force_flag or operand_idx >= len(parts):
+            return False
+
+        # Must have exactly one operand
+        if len(parts) != operand_idx + 1:
+            return False
+
+        target_path = pathlib.Path(parts[operand_idx]).expanduser()
+        target_dir = target_path.parent.resolve()
+        temp_dir = pathlib.Path(tempfile.gettempdir()).resolve()
+
+        # Target must be under temp directory
+        if target_dir != temp_dir:
+            return False
+
+        # Filename must start with allowed prefixes
+        basename = target_path.name
+        if not (basename.startswith("hermes-verify-") or basename.startswith("hermes-ad-hoc-")):
+            return False
+
+        return True
+    except Exception:
+        # On any parsing error, fall back to safe (deny)
+        return False
+
+
 def detect_dangerous_command(command: str) -> tuple:
     """Check if a command matches any dangerous patterns.
 
     Returns:
         (is_dangerous, pattern_key, description) or (False, None, None)
     """
+    # Allow Hermes-owned temp file cleanup without approval
+    if _is_hermes_temp_cleanup_command(command):
+        return (False, None, None)
+
     for command_variant in _command_detection_variants(command):
         command_lower = command_variant.lower()
         for pattern_re, description in DANGEROUS_PATTERNS_COMPILED:


### PR DESCRIPTION
## What does this PR do?

When verify-on-stop mandates creating and cleaning up temporary verification scripts under the OS temp directory (e.g., `hermes-verify-abc123.py`), the cleanup command `rm -f /tmp/hermes-verify-abc123.py` triggers the dangerous-command detector because it matches the `delete in root path` pattern. This creates approval friction for a cleanup step that Hermes itself prescribed, causing two safety policies to compose into mandatory approval friction for the normal workflow one of them mandates.

This change adds a pre-check in `detect_dangerous_command()` that allows non-recursive `rm -f` or `rm --force` commands targeting single files under the OS temp directory when the filename starts with `hermes-verify-` or `hermes-ad-hoc-`. Recursive deletions, multiple operands, files outside the temp directory, and non-Hermes prefixes remain blocked.

The helper function `_is_hermes_temp_cleanup_command()` uses strict validation:
- Parses with shlex to handle quotes/escapes
- Rejects recursive flags (`-r`, `-rf`, `-fr`, `--recursive`)
- Requires exactly one operand
- Verifies the operand's parent directory is exactly the OS temp directory
- Checks the filename prefix
- Falls back to safe (deny) on any parsing error

## Related Issue

Fixes #62377

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/approval.py`: Add `_is_hermes_temp_cleanup_command()` helper and call it in `detect_dangerous_command()` before pattern matching. Import `pathlib` and `tempfile`.
- `tests/tools/test_approval.py`: Add 6 regression tests covering positive cases (allowed cleanup with both `-f` and `--force`) and negative cases (recursive, wrong location, wrong prefix, multiple operands).

## How to Test

1. Run the approval test suite: `pytest tests/tools/test_approval.py::TestDetectDangerousRm -v` — all 8 tests should pass.
2. Verify that `rm -f /tmp/hermes-verify-*.py` commands are not flagged as dangerous:
   ```python
   from tools.approval import detect_dangerous_command
   import tempfile
   cmd = f"rm -f {tempfile.gettempdir()}/hermes-verify-abc123.py"
   is_dangerous, key, desc = detect_dangerous_command(cmd)
   assert is_dangerous is False
   assert key is None
   assert desc is None
   ```
3. Verify that broader deletions remain blocked:
   - `rm -rf /tmp/hermes-verify-test` — blocked (recursive)
   - `rm -f /home/user/file.txt` — blocked (not in temp dir)
   - `rm -f /tmp/other-file.txt` — blocked (wrong prefix)
   - `rm -f /tmp/hermes-verify-1.py /tmp/hermes-verify-2.py` — blocked (multiple operands)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tools/test_approval.py -q` and all tests pass (304 tests)
- [x] I've added tests for my changes (6 regression tests)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline docstring added)
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `pathlib.Path` and `tempfile.gettempdir()` are cross-platform
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

N/A

## Screenshots / Logs

Test output:
```
tests/tools/test_approval.py::TestDetectDangerousRm::test_rm_f_hermes_verify_temp_allowed PASSED
tests/tools/test_approval.py::TestDetectDangerousRm::test_rm_force_hermes_ad_hoc_temp_allowed PASSED
tests/tools/test_approval.py::TestDetectDangerousRm::test_rm_f_non_temp_dir_requires_approval PASSED
tests/tools/test_approval.py::TestDetectDangerousRm::test_rm_f_non_hermes_prefix_requires_approval PASSED
tests/tools/test_approval.py::TestDetectDangerousRm::test_rm_recursive_temp_requires_approval PASSED
tests/tools/test_approval.py::TestDetectDangerousRm::test_rm_f_multiple_operands_requires_approval PASSED
============================= 304 passed in 7.37s ==============================
```