### PR TITLE
fix(desktop): stream remote attachments in bounded chunks

### DIFF
--- a/apps/desktop/electron/hardening.test.ts
+++ b/apps/desktop/electron/hardening.test.ts
@@ -6,8 +6,12 @@ import test from 'node:test'
 import { pathToFileURL } from 'node:url'
 
 import {
+  createFileSnapshotForIpc,
   DEFAULT_FETCH_TIMEOUT_MS,
   encryptDesktopSecret,
+  normalizeFileChunkReadRange,
+  readFileChunkForIpc,
+  releaseFileSnapshotForIpc,
   resolveDirectoryForIpc,
   resolveReadableFileForIpc,
   resolveRequestedPathForIpc,
@@ -28,6 +32,98 @@ test('resolveTimeoutMs falls back to defaults and accepts overrides', () => {
   assert.equal(resolveTimeoutMs(0), DEFAULT_FETCH_TIMEOUT_MS)
   assert.equal(resolveTimeoutMs(-25), DEFAULT_FETCH_TIMEOUT_MS)
   assert.equal(resolveTimeoutMs('2750'), 2750)
+})
+
+test('normalizeFileChunkReadRange accepts safe integers and rejects unsafe ranges', () => {
+  assert.deepEqual(normalizeFileChunkReadRange(0, 512), { offset: 0, maxBytes: 512 })
+  assert.deepEqual(normalizeFileChunkReadRange(7, undefined), { offset: 7, maxBytes: undefined })
+
+  for (const offset of [-1, 1.5, Number.MAX_SAFE_INTEGER + 1, Number.NaN]) {
+    assert.throws(() => normalizeFileChunkReadRange(offset, 512), /offset must be a non-negative safe integer/)
+  }
+  for (const maxBytes of [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, Number.NaN]) {
+    assert.throws(() => normalizeFileChunkReadRange(0, maxBytes), /maxBytes must be a positive safe integer/)
+  }
+})
+
+test('readFileChunkForIpc returns bounded bytes and stable file metadata', async t => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-desktop-chunk-'))
+  t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }))
+  const filePath = path.join(tempDir, 'notes.txt')
+  fs.writeFileSync(filePath, 'hello world', 'utf8')
+
+  const chunk = await readFileChunkForIpc(filePath, 2, 4)
+
+  assert.equal(chunk.buffer.toString('utf8'), 'llo ')
+  assert.equal(chunk.byteSize, 11)
+  assert.equal(chunk.bytesRead, 4)
+  assert.equal(chunk.done, false)
+  const sourceStat = fs.statSync(filePath)
+  const realStat = fs.statSync(chunk.realPath)
+  assert.equal(`${realStat.dev}:${realStat.ino}`, `${sourceStat.dev}:${sourceStat.ino}`)
+  assert.equal(typeof chunk.fileId, 'string')
+  assert.ok(chunk.fileId.length > 0)
+  assert.equal(Number.isFinite(chunk.mtimeMs), true)
+})
+
+test('readFileChunkForIpc opens the validated realpath after a symlink swap', async t => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-desktop-symlink-swap-'))
+  t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }))
+  const safePath = path.join(tempDir, 'safe.txt')
+  const otherPath = path.join(tempDir, 'other.txt')
+  const linkPath = path.join(tempDir, 'selected.txt')
+  fs.writeFileSync(safePath, 'SAFE', 'utf8')
+  fs.writeFileSync(otherPath, 'OTHER', 'utf8')
+
+  try {
+    fs.symlinkSync(safePath, linkPath, 'file')
+  } catch (error) {
+    const code = error && typeof error === 'object' ? error.code : ''
+    if (code === 'EPERM' || code === 'EACCES' || code === 'ENOTSUP') {
+      t.skip(`file symlinks unavailable on this host (${code})`)
+      return
+    }
+    throw error
+  }
+
+  const originalRealpath = fs.promises.realpath
+  let swapped = false
+  fs.promises.realpath = (async (requestedPath: fs.PathLike) => {
+    const result = await originalRealpath(requestedPath)
+    if (!swapped && path.resolve(String(requestedPath)) === path.resolve(linkPath)) {
+      swapped = true
+      fs.unlinkSync(linkPath)
+      fs.symlinkSync(otherPath, linkPath, 'file')
+    }
+    return result
+  }) as typeof fs.promises.realpath
+  t.after(() => {
+    fs.promises.realpath = originalRealpath
+  })
+
+  const chunk = await readFileChunkForIpc(linkPath, 0, 4)
+  assert.equal(chunk.buffer.toString('utf8'), 'SAFE')
+})
+
+test('file upload snapshot remains immutable after same-inode same-size source rewrite with restored mtime', async t => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-desktop-snapshot-'))
+  t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }))
+  const snapshotRoot = path.join(tempDir, 'snapshots')
+  const sourcePath = path.join(tempDir, 'selected.bin')
+  fs.writeFileSync(sourcePath, 'ABCDEFGH', 'utf8')
+  const sourceStat = fs.statSync(sourcePath)
+
+  const snapshot = await createFileSnapshotForIpc(sourcePath, snapshotRoot)
+
+  fs.writeFileSync(sourcePath, '12345678', 'utf8')
+  fs.utimesSync(sourcePath, sourceStat.atime, sourceStat.mtime)
+  const first = await readFileChunkForIpc(snapshot.path, 0, 4)
+  const second = await readFileChunkForIpc(snapshot.path, 4, 4)
+
+  assert.equal(first.buffer.toString('utf8') + second.buffer.toString('utf8'), 'ABCDEFGH')
+  assert.equal(snapshot.byteSize, 8)
+  assert.equal(await releaseFileSnapshotForIpc(snapshot.path, snapshotRoot), true)
+  assert.equal(fs.existsSync(snapshot.path), false)
 })
 
 test('encryptDesktopSecret requires available secure storage', () => {

--- a/apps/desktop/electron/hardening.ts
+++ b/apps/desktop/electron/hardening.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -5,6 +6,8 @@ import { fileURLToPath } from 'node:url'
 
 const DEFAULT_FETCH_TIMEOUT_MS = 15_000
 const DATA_URL_READ_MAX_BYTES = 16 * 1024 * 1024
+const FILE_CHUNK_READ_MAX_BYTES = 8 * 1024 * 1024
+const FILE_UPLOAD_SNAPSHOT_MAX_BYTES = 8 * 1024 * 1024 * 1024
 const TEXT_PREVIEW_SOURCE_MAX_BYTES = 64 * 1024 * 1024
 
 const SAFE_ENV_SUFFIXES = new Set(['dist', 'example', 'sample', 'template'])
@@ -21,6 +24,17 @@ function resolveTimeoutMs(timeoutMs, fallbackMs = DEFAULT_FETCH_TIMEOUT_MS) {
   }
 
   return fallback
+}
+
+function normalizeFileChunkReadRange(offset, maxBytes) {
+  if (!Number.isSafeInteger(offset) || offset < 0) {
+    throw ipcPathError('EINVAL', 'File attachment upload failed: offset must be a non-negative safe integer.')
+  }
+  if (maxBytes !== undefined && (!Number.isSafeInteger(maxBytes) || maxBytes <= 0)) {
+    throw ipcPathError('EINVAL', 'File attachment upload failed: maxBytes must be a positive safe integer.')
+  }
+
+  return { maxBytes, offset }
 }
 
 function encryptDesktopSecret(value, safeStorageApi) {
@@ -302,11 +316,171 @@ async function resolveReadableFileForIpc(
   return { realPath, resolvedPath, stat }
 }
 
+async function readFileChunkForIpc(filePath, offset, maxBytes = FILE_CHUNK_READ_MAX_BYTES) {
+  const range = normalizeFileChunkReadRange(offset, maxBytes)
+  const readLimit = Math.min(range.maxBytes ?? FILE_CHUNK_READ_MAX_BYTES, FILE_CHUNK_READ_MAX_BYTES)
+  const { realPath } = await resolveReadableFileForIpc(filePath, {
+    purpose: 'File attachment upload'
+  })
+  const handle = await fs.promises.open(realPath, 'r')
+
+  try {
+    const before = await handle.stat()
+
+    if (!before.isFile()) {
+      throw ipcPathError('EINVAL', 'File attachment upload failed: only regular files can be read.')
+    }
+    if (!Number.isSafeInteger(before.size)) {
+      throw ipcPathError('EFBIG', 'File attachment upload failed: file size exceeds the safe integer range.')
+    }
+
+    const remaining = Math.max(0, before.size - range.offset)
+    const requested = Math.min(readLimit, remaining)
+    const buffer = Buffer.alloc(requested)
+    const { bytesRead } = requested > 0 ? await handle.read(buffer, 0, requested, range.offset) : { bytesRead: 0 }
+    const after = await handle.stat()
+    const sameFile = before.dev === after.dev && before.ino === after.ino
+    const unchanged = sameFile && before.size === after.size && before.mtimeMs === after.mtimeMs
+
+    if (!unchanged) {
+      throw ipcPathError('ESTALE', 'File attachment upload failed: the file changed while it was being read.')
+    }
+
+    return {
+      buffer: buffer.subarray(0, bytesRead),
+      byteSize: after.size,
+      bytesRead,
+      done: range.offset + bytesRead >= after.size,
+      fileId: `${after.dev}:${after.ino}`,
+      mtimeMs: after.mtimeMs,
+      realPath
+    }
+  } finally {
+    await handle.close()
+  }
+}
+
+function fileSnapshotIdentity(stat) {
+  return `${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeMs}:${stat.ctimeMs}`
+}
+
+async function resolveFileSnapshotRoot(snapshotRoot) {
+  const root = path.resolve(String(snapshotRoot || ''))
+  await fs.promises.mkdir(root, { mode: 0o700, recursive: true })
+  const rootStat = await fs.promises.lstat(root)
+
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
+    throw ipcPathError('EINVAL', 'File attachment snapshot failed: unsafe snapshot directory.')
+  }
+
+  return root
+}
+
+async function createFileSnapshotForIpc(filePath, snapshotRoot) {
+  const root = await resolveFileSnapshotRoot(snapshotRoot)
+  const { realPath } = await resolveReadableFileForIpc(filePath, {
+    maxBytes: FILE_UPLOAD_SNAPSHOT_MAX_BYTES,
+    purpose: 'File attachment snapshot'
+  })
+  const snapshotPath = path.join(root, `${randomUUID()}.snapshot`)
+  let sourceHandle
+  let snapshotHandle
+
+  try {
+    sourceHandle = await fs.promises.open(realPath, 'r')
+    snapshotHandle = await fs.promises.open(snapshotPath, 'wx', 0o600)
+    const before = await sourceHandle.stat()
+
+    if (!before.isFile() || !Number.isSafeInteger(before.size)) {
+      throw ipcPathError('EINVAL', 'File attachment snapshot failed: source is not a regular bounded file.')
+    }
+
+    const buffer = Buffer.alloc(Math.min(1024 * 1024, Math.max(1, before.size)))
+    let offset = 0
+    while (offset < before.size) {
+      const requested = Math.min(buffer.length, before.size - offset)
+      const { bytesRead } = await sourceHandle.read(buffer, 0, requested, offset)
+      if (bytesRead <= 0) {
+        throw ipcPathError('ESTALE', 'File attachment snapshot failed: source changed while being copied.')
+      }
+      let written = 0
+      while (written < bytesRead) {
+        const result = await snapshotHandle.write(buffer, written, bytesRead - written, offset + written)
+        if (result.bytesWritten <= 0) {
+          throw ipcPathError('EIO', 'File attachment snapshot failed: snapshot write was incomplete.')
+        }
+        written += result.bytesWritten
+      }
+      offset += bytesRead
+    }
+
+    const overflow = Buffer.alloc(1)
+    const extra = await sourceHandle.read(overflow, 0, 1, before.size)
+    const after = await sourceHandle.stat()
+    if (extra.bytesRead !== 0 || fileSnapshotIdentity(after) !== fileSnapshotIdentity(before)) {
+      throw ipcPathError('ESTALE', 'File attachment snapshot failed: source changed while being copied.')
+    }
+
+    await snapshotHandle.sync()
+    const snapshotStat = await snapshotHandle.stat()
+    if (!snapshotStat.isFile() || snapshotStat.size !== before.size) {
+      throw ipcPathError('EIO', 'File attachment snapshot failed: snapshot size mismatch.')
+    }
+
+    return {
+      byteSize: snapshotStat.size,
+      fileId: `${snapshotStat.dev}:${snapshotStat.ino}`,
+      mtimeMs: snapshotStat.mtimeMs,
+      path: snapshotPath
+    }
+  } catch (error) {
+    try {
+      await fs.promises.unlink(snapshotPath)
+    } catch (cleanupError) {
+      if (cleanupError?.code !== 'ENOENT') {
+        throw ipcPathError('EIO', 'File attachment snapshot failed and its partial snapshot could not be removed.')
+      }
+    }
+    throw error
+  } finally {
+    await snapshotHandle?.close()
+    await sourceHandle?.close()
+  }
+}
+
+async function releaseFileSnapshotForIpc(snapshotPath, snapshotRoot) {
+  const root = await resolveFileSnapshotRoot(snapshotRoot)
+  const candidate = path.resolve(String(snapshotPath || ''))
+  if (path.dirname(candidate).toLowerCase() !== root.toLowerCase() || !/^[0-9a-f-]{36}\.snapshot$/i.test(path.basename(candidate))) {
+    throw ipcPathError('EINVAL', 'File attachment snapshot cleanup failed: invalid snapshot path.')
+  }
+
+  let stat
+  try {
+    stat = await fs.promises.lstat(candidate)
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      return true
+    }
+    throw error
+  }
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw ipcPathError('EINVAL', 'File attachment snapshot cleanup failed: unsafe snapshot file.')
+  }
+  await fs.promises.unlink(candidate)
+  return true
+}
+
 export {
+  createFileSnapshotForIpc,
   DATA_URL_READ_MAX_BYTES,
   DEFAULT_FETCH_TIMEOUT_MS,
   encryptDesktopSecret,
+  FILE_CHUNK_READ_MAX_BYTES,
+  normalizeFileChunkReadRange,
+  readFileChunkForIpc,
   rejectUnsafePathSyntax,
+  releaseFileSnapshotForIpc,
   resolveDirectoryForIpc,
   resolveReadableFileForIpc,
   resolveRequestedPathForIpc,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -85,9 +85,13 @@ import {
 import { gitRootForIpc } from './git-root'
 import { addWorktree, listBranches, listWorktrees, removeWorktree, switchBranch } from './git-worktree-ops'
 import {
+  createFileSnapshotForIpc,
   DATA_URL_READ_MAX_BYTES,
   DEFAULT_FETCH_TIMEOUT_MS,
   encryptDesktopSecret as encryptDesktopSecretStrict,
+  FILE_CHUNK_READ_MAX_BYTES,
+  readFileChunkForIpc,
+  releaseFileSnapshotForIpc,
   resolveReadableFileForIpc,
   resolveRequestedPathForIpc,
   resolveTimeoutMs,
@@ -95,6 +99,7 @@ import {
 } from './hardening'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
+import { createRendererHealthReporter } from './renderer-health'
 import {
   buildSessionWindowUrl,
   chatWindowWebPreferences,
@@ -800,6 +805,7 @@ function registerMediaProtocol() {
 }
 
 let mainWindow = null
+const rendererHealth = createRendererHealthReporter()
 let hermesProcess = null
 let connectionPromise = null
 // True while connection-config:apply soft-rehomes the primary — suppresses the
@@ -7307,6 +7313,9 @@ function createWindow() {
 
   mainWindow.webContents.on('render-process-gone', (_event, details) => {
     rememberLog(`[renderer] render-process-gone reason=${details?.reason} exitCode=${details?.exitCode}`)
+    if (details?.reason !== 'clean-exit') {
+      rendererHealth.fail(`render-process-gone:${details?.reason || 'unknown'}`)
+    }
 
     if (details?.reason === 'crashed' || details?.reason === 'oom') {
       const now = Date.now()
@@ -7335,7 +7344,15 @@ function createWindow() {
     }
   })
 
-  mainWindow.webContents.on('unresponsive', () => rememberLog('[renderer] webContents became unresponsive'))
+  mainWindow.webContents.on('unresponsive', () => {
+    rendererHealth.fail('renderer-unresponsive')
+    rememberLog('[renderer] webContents became unresponsive')
+  })
+  mainWindow.webContents.on('did-fail-load', (_event, errorCode, errorDescription, _url, isMainFrame) => {
+    if (isMainFrame) {
+      rendererHealth.fail(`did-fail-load:${errorCode}:${errorDescription}`)
+    }
+  })
 
   // Electron always passes the event first. The canonical (Electron 36+) shape
   // is (event, messageDetails); the deprecated positional shape is
@@ -7369,6 +7386,15 @@ function createWindow() {
     startHermes().catch(error => rememberLog(error.stack || error.message))
   })
 }
+
+// The updater trusts only an explicit handshake from the primary React tree.
+// Secondary session and pet-overlay webContents cannot mark startup healthy.
+ipcMain.on('hermes:renderer-ready', event => {
+  if (!mainWindow || mainWindow.isDestroyed() || event.sender !== mainWindow.webContents) {
+    return
+  }
+  rendererHealth.ready()
+})
 
 ipcMain.handle('hermes:connection', async (_event, profile) => ensureBackend(profile))
 // Reconnect-after-wake recovery. A REMOTE primary backend has no child process,
@@ -7987,6 +8013,18 @@ ipcMain.handle('hermes:notify', (_event, payload) => {
   return true
 })
 
+function fileUploadSnapshotRoot() {
+  return path.join(app.getPath('temp'), 'hermes-desktop-upload-snapshots')
+}
+
+ipcMain.handle('hermes:createFileUploadSnapshot', async (_event, filePath) =>
+  createFileSnapshotForIpc(filePath, fileUploadSnapshotRoot())
+)
+
+ipcMain.handle('hermes:releaseFileUploadSnapshot', async (_event, snapshotPath) =>
+  releaseFileSnapshotForIpc(snapshotPath, fileUploadSnapshotRoot())
+)
+
 ipcMain.handle('hermes:readFileDataUrl', async (_event, filePath) => {
   const { resolvedPath } = await resolveReadableFileForIpc(filePath, {
     maxBytes: DATA_URL_READ_MAX_BYTES,
@@ -7996,6 +8034,28 @@ ipcMain.handle('hermes:readFileDataUrl', async (_event, filePath) => {
   const data = await fs.promises.readFile(resolvedPath)
 
   return `data:${mimeTypeForPath(resolvedPath)};base64,${data.toString('base64')}`
+})
+
+ipcMain.handle('hermes:readFileChunkBase64', async (_event, payload: any = {}) => {
+  const filePath = typeof payload === 'string' ? payload : payload?.filePath
+  const offset = typeof payload === 'object' ? payload?.offset ?? 0 : 0
+  const maxBytes =
+    typeof payload === 'object' && payload?.maxBytes !== undefined
+      ? payload.maxBytes
+      : FILE_CHUNK_READ_MAX_BYTES
+  const chunk = await readFileChunkForIpc(filePath, offset, maxBytes)
+
+  return {
+    base64: chunk.buffer.toString('base64'),
+    byteSize: chunk.byteSize,
+    bytesRead: chunk.bytesRead,
+    done: chunk.done,
+    fileId: chunk.fileId,
+    mimeType: mimeTypeForPath(chunk.realPath),
+    mtimeMs: chunk.mtimeMs,
+    name: path.basename(chunk.realPath),
+    path: chunk.realPath
+  }
 })
 
 ipcMain.handle('hermes:readFileText', async (_event, filePath) => {
@@ -9007,6 +9067,15 @@ app.on('open-url', (event, url) => {
 })
 
 app.whenReady().then(() => {
+  const snapshotRoot = fileUploadSnapshotRoot()
+  try {
+    fs.rmSync(snapshotRoot, { force: true, recursive: true })
+    fs.mkdirSync(snapshotRoot, { mode: 0o700, recursive: true })
+  } catch (error) {
+    rememberLog(`File upload snapshot startup cleanup failed: ${error.message}`)
+    throw error
+  }
+
   if (IS_MAC) {
     Menu.setApplicationMenu(buildApplicationMenu())
   } else {
@@ -9085,6 +9154,11 @@ app.on('before-quit', () => {
 
   flushDesktopLogBufferSync()
   closePreviewWatchers()
+  try {
+    fs.rmSync(fileUploadSnapshotRoot(), { force: true, recursive: true })
+  } catch (error) {
+    rememberLog(`File upload snapshot cleanup failed during quit: ${error.message}`)
+  }
 
   // Kill open PTYs before environment teardown to avoid the node-pty#904
   // ThreadSafeFunction SIGABRT race.

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron'
 
 contextBridge.exposeInMainWorld('hermesDesktop', {
+  signalRendererReady: () => ipcRenderer.send('hermes:renderer-ready'),
   getConnection: profile => ipcRenderer.invoke('hermes:connection', profile),
   revalidateConnection: () => ipcRenderer.invoke('hermes:connection:revalidate'),
   touchBackend: profile => ipcRenderer.invoke('hermes:backend:touch', profile),
@@ -59,7 +60,11 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   api: request => ipcRenderer.invoke('hermes:api', request),
   notify: payload => ipcRenderer.invoke('hermes:notify', payload),
   requestMicrophoneAccess: () => ipcRenderer.invoke('hermes:requestMicrophoneAccess'),
+  createFileUploadSnapshot: filePath => ipcRenderer.invoke('hermes:createFileUploadSnapshot', filePath),
+  releaseFileUploadSnapshot: snapshotPath => ipcRenderer.invoke('hermes:releaseFileUploadSnapshot', snapshotPath),
   readFileDataUrl: filePath => ipcRenderer.invoke('hermes:readFileDataUrl', filePath),
+  readFileChunkBase64: (filePath, offset, maxBytes) =>
+    ipcRenderer.invoke('hermes:readFileChunkBase64', { filePath, offset, maxBytes }),
   readFileText: filePath => ipcRenderer.invoke('hermes:readFileText', filePath),
   selectPaths: options => ipcRenderer.invoke('hermes:selectPaths', options),
   writeClipboard: text => ipcRenderer.invoke('hermes:writeClipboard', text),

--- a/apps/desktop/electron/renderer-health.test.ts
+++ b/apps/desktop/electron/renderer-health.test.ts
@@ -1,0 +1,159 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import { createRendererHealthReporter } from './renderer-health'
+
+function tempRoot(tag: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `hermes-renderer-health-${tag}-`))
+}
+
+function readMarker(markerPath: string): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(markerPath, 'utf8'))
+}
+
+test('writes starting then explicit renderer-ready state with updater identity', () => {
+  const root = tempRoot('ready')
+  const markerPath = path.join(root, 'hermes-desktop-health-test.json')
+  const reporter = createRendererHealthReporter({
+    markerPath,
+    nonce: 'nonce-0123456789abcdef',
+    pid: 4242,
+    executable: 'C:\\Hermes\\Hermes.exe',
+    tempDir: root,
+    now: () => 1_000
+  })
+
+  assert.equal(reporter.enabled, true)
+  assert.deepEqual(readMarker(markerPath), {
+    schema: 1,
+    nonce: 'nonce-0123456789abcdef',
+    pid: 4242,
+    executable: 'C:\\Hermes\\Hermes.exe',
+    status: 'starting',
+    failure_count: 0,
+    failure_reason: null,
+    updated_at_ms: 1_000
+  })
+
+  reporter.ready()
+  assert.equal(readMarker(markerPath).status, 'ready')
+  assert.equal(readMarker(markerPath).failure_count, 0)
+})
+
+test('renderer failure is sticky across a later ready handshake', () => {
+  const root = tempRoot('failure')
+  const markerPath = path.join(root, 'hermes-desktop-health-test.json')
+  const reporter = createRendererHealthReporter({
+    markerPath,
+    nonce: 'nonce-0123456789abcdef',
+    pid: 4242,
+    executable: 'C:\\Hermes\\Hermes.exe',
+    tempDir: root,
+    now: () => 2_000
+  })
+
+  reporter.fail('render-process-gone:crashed')
+  let marker = readMarker(markerPath)
+  assert.equal(marker.status, 'failed')
+  assert.equal(marker.failure_count, 1)
+  assert.equal(marker.failure_reason, 'render-process-gone:crashed')
+
+  reporter.ready()
+  marker = readMarker(markerPath)
+  assert.equal(marker.status, 'ready')
+  assert.equal(marker.failure_count, 1, 'updater must still reject a recovered crash loop')
+  assert.equal(marker.failure_reason, 'render-process-gone:crashed')
+})
+
+test('uses the updater-provided temp root when TEMP and TMP differ', () => {
+  const root = tempRoot('env-temp-root')
+  const markerPath = path.join(root, 'hermes-desktop-health-test.json')
+  const previousMarker = process.env.HERMES_DESKTOP_HEALTH_MARKER
+  const previousNonce = process.env.HERMES_DESKTOP_HEALTH_NONCE
+  const previousTempDir = process.env.HERMES_DESKTOP_HEALTH_TEMP_DIR
+  try {
+    process.env.HERMES_DESKTOP_HEALTH_MARKER = markerPath
+    process.env.HERMES_DESKTOP_HEALTH_NONCE = 'nonce-0123456789abcdef'
+    process.env.HERMES_DESKTOP_HEALTH_TEMP_DIR = root
+    const reporter = createRendererHealthReporter({ pid: 4242 })
+    assert.equal(reporter.enabled, true)
+    assert.equal(readMarker(markerPath).status, 'starting')
+  } finally {
+    if (previousMarker === undefined) {
+      delete process.env.HERMES_DESKTOP_HEALTH_MARKER
+    } else {
+      process.env.HERMES_DESKTOP_HEALTH_MARKER = previousMarker
+    }
+    if (previousNonce === undefined) {
+      delete process.env.HERMES_DESKTOP_HEALTH_NONCE
+    } else {
+      process.env.HERMES_DESKTOP_HEALTH_NONCE = previousNonce
+    }
+    if (previousTempDir === undefined) {
+      delete process.env.HERMES_DESKTOP_HEALTH_TEMP_DIR
+    } else {
+      process.env.HERMES_DESKTOP_HEALTH_TEMP_DIR = previousTempDir
+    }
+  }
+})
+
+test('refuses marker paths outside the injected temp directory', () => {
+  const root = tempRoot('outside-root')
+  const outside = tempRoot('outside-target')
+  const markerPath = path.join(outside, 'hermes-desktop-health-test.json')
+  const reporter = createRendererHealthReporter({
+    markerPath,
+    nonce: 'nonce-0123456789abcdef',
+    tempDir: root
+  })
+
+  assert.equal(reporter.enabled, false)
+  reporter.ready()
+  assert.equal(fs.existsSync(markerPath), false)
+})
+
+test('refuses to follow a dangling symlink marker file', t => {
+  const root = tempRoot('dangling-symlink')
+  const outside = path.join(root, 'not-created.json')
+  const markerPath = path.join(root, 'hermes-desktop-health-test.json')
+  try {
+    fs.symlinkSync(outside, markerPath, 'file')
+  } catch (error) {
+    t.skip(`file symlink unavailable: ${String(error)}`)
+    return
+  }
+
+  const reporter = createRendererHealthReporter({
+    markerPath,
+    nonce: 'nonce-0123456789abcdef',
+    tempDir: root
+  })
+  assert.equal(reporter.enabled, false)
+  reporter.ready()
+  assert.equal(fs.existsSync(outside), false)
+})
+
+test('refuses to follow a symlink marker file', t => {
+  const root = tempRoot('symlink')
+  const outside = path.join(root, 'outside.json')
+  const markerPath = path.join(root, 'hermes-desktop-health-test.json')
+  fs.writeFileSync(outside, 'sentinel', 'utf8')
+  try {
+    fs.symlinkSync(outside, markerPath, 'file')
+  } catch (error) {
+    t.skip(`file symlink unavailable: ${String(error)}`)
+    return
+  }
+
+  const reporter = createRendererHealthReporter({
+    markerPath,
+    nonce: 'nonce-0123456789abcdef',
+    tempDir: root
+  })
+  assert.equal(reporter.enabled, false)
+  reporter.ready()
+  assert.equal(fs.readFileSync(outside, 'utf8'), 'sentinel')
+})

--- a/apps/desktop/electron/renderer-health.ts
+++ b/apps/desktop/electron/renderer-health.ts
@@ -1,0 +1,120 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+export type RendererHealthStatus = 'starting' | 'ready' | 'failed'
+
+export interface RendererHealthReporter {
+  readonly enabled: boolean
+  ready: () => void
+  fail: (reason: string) => void
+}
+
+interface RendererHealthReporterOptions {
+  markerPath?: string
+  nonce?: string
+  pid?: number
+  executable?: string
+  tempDir?: string
+  now?: () => number
+}
+
+const MARKER_BASENAME = /^hermes-desktop-health-[A-Za-z0-9-]+\.json$/
+const NONCE = /^[A-Za-z0-9-]{16,128}$/
+
+function samePath(left: string, right: string): boolean {
+  const normalize = (value: string) => {
+    const resolved = path.resolve(value)
+    return process.platform === 'win32' ? resolved.toLowerCase() : resolved
+  }
+  return normalize(left) === normalize(right)
+}
+
+function markerPathIsSafe(markerPath: string, tempDir: string): boolean {
+  if (!MARKER_BASENAME.test(path.basename(markerPath))) {
+    return false
+  }
+  if (!samePath(path.dirname(markerPath), tempDir)) {
+    return false
+  }
+
+  try {
+    if (!samePath(fs.realpathSync(path.dirname(markerPath)), fs.realpathSync(tempDir))) {
+      return false
+    }
+  } catch {
+    return false
+  }
+
+  let info: fs.Stats
+  try {
+    info = fs.lstatSync(markerPath)
+  } catch (error) {
+    return (error as NodeJS.ErrnoException)?.code === 'ENOENT'
+  }
+  if (!info.isFile() || info.isSymbolicLink()) {
+    return false
+  }
+  try {
+    return samePath(fs.realpathSync(markerPath), markerPath)
+  } catch {
+    return false
+  }
+}
+
+export function createRendererHealthReporter({
+  markerPath = process.env.HERMES_DESKTOP_HEALTH_MARKER || '',
+  nonce = process.env.HERMES_DESKTOP_HEALTH_NONCE || '',
+  pid = process.pid,
+  executable = process.execPath,
+  tempDir = process.env.HERMES_DESKTOP_HEALTH_TEMP_DIR || os.tmpdir(),
+  now = Date.now
+}: RendererHealthReporterOptions = {}): RendererHealthReporter {
+  let active = Boolean(markerPath && NONCE.test(nonce) && markerPathIsSafe(markerPath, tempDir))
+  let status: RendererHealthStatus = 'starting'
+  let failureCount = 0
+  let failureReason: string | null = null
+
+  const write = () => {
+    if (!active || !markerPathIsSafe(markerPath, tempDir)) {
+      active = false
+      return
+    }
+    try {
+      fs.writeFileSync(
+        markerPath,
+        JSON.stringify({
+          schema: 1,
+          nonce,
+          pid,
+          executable,
+          status,
+          failure_count: failureCount,
+          failure_reason: failureReason,
+          updated_at_ms: now()
+        }),
+        { encoding: 'utf8', mode: 0o600 }
+      )
+    } catch {
+      active = false
+    }
+  }
+
+  write()
+
+  return {
+    get enabled() {
+      return active
+    },
+    ready() {
+      status = 'ready'
+      write()
+    },
+    fail(reason: string) {
+      failureCount += 1
+      failureReason = String(reason || 'renderer-failure').slice(0, 256)
+      status = 'failed'
+      write()
+    }
+  }
+}

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -8,6 +8,8 @@ import { $composerAttachments, $composerDraft, type ComposerAttachment, setCompo
 import { $busy, $connection, $messages, $sessions, setSessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
+import type { GatewayRequest } from './utils'
+
 import { uploadComposerAttachment, usePromptActions } from '.'
 
 vi.mock('@/hermes', () => ({
@@ -23,6 +25,7 @@ vi.mock('@/hermes', () => ({
 // the stored sessions table and 404s on a runtime id. session.title accepts
 // the runtime id directly.
 const RUNTIME_SESSION_ID = 'rt-abc123'
+const FILE_ATTACH_CAPABILITIES = { contract: 5, request_id_cancel: true } as const
 
 function sessionInfo(overrides: Partial<SessionInfo> = {}): SessionInfo {
   return {
@@ -846,7 +849,488 @@ describe('usePromptActions file attachment sync', () => {
     }
   }
 
-  it('uploads file bytes via file.attach on a remote gateway and submits the rewritten ref', async () => {
+  function desktopWithSnapshot(readFileChunkBase64: NonNullable<Window['hermesDesktop']>['readFileChunkBase64']) {
+    return {
+      createFileUploadSnapshot: vi.fn(async (filePath: string) => ({ path: filePath })),
+      readFileChunkBase64,
+      releaseFileUploadSnapshot: vi.fn(async () => true)
+    }
+  }
+
+  it('uploads file bytes in chunks on a remote gateway and submits the rewritten ref', async () => {
+    $connection.set({ mode: 'remote' } as never)
+    const readFileDataUrl = vi.fn(async () => 'data:text/plain;base64,SHOULD_NOT_USE')
+    const snapshotPath = 'C:/Temp/hermes-upload.snapshot'
+    const createFileUploadSnapshot = vi.fn(async () => ({ path: snapshotPath }))
+    const releaseFileUploadSnapshot = vi.fn(async () => true)
+    const readFileChunkBase64 = vi.fn(async (_path: string, offset: number, maxBytes?: number) => {
+      if (offset === 0 && maxBytes === 1) {
+        return {
+          base64: 'aA==',
+          byteSize: 11,
+          bytesRead: 1,
+          done: false,
+          fileId: '1:2',
+          mtimeMs: 100,
+          path: '/Users/alice/Downloads/report.txt'
+        }
+      }
+
+      if (offset === 0) {
+        return {
+          base64: 'aGVsbG8=',
+          byteSize: 11,
+          bytesRead: 5,
+          done: false,
+          fileId: '1:2',
+          mtimeMs: 100,
+          path: '/Users/alice/Downloads/report.txt'
+        }
+      }
+
+      return {
+        base64: 'IHdvcmxk',
+        byteSize: 11,
+        bytesRead: 6,
+        done: true,
+        fileId: '1:2',
+        mtimeMs: 100,
+        path: '/Users/alice/Downloads/report.txt'
+      }
+    })
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { createFileUploadSnapshot, readFileChunkBase64, readFileDataUrl, releaseFileUploadSnapshot }
+    })
+
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'file.attach.capabilities') {
+        return FILE_ATTACH_CAPABILITIES as never
+      }
+      if (method === 'file.attach.begin') {
+        return { max_chunk_bytes: 8, received: 0, upload_id: 'upload-1' } as never
+      }
+
+      if (method === 'file.attach.chunk') {
+        return {
+          received: Number(params?.offset ?? 0) + (params?.content_base64 === 'aGVsbG8=' ? 5 : 6),
+          upload_id: 'upload-1'
+        } as never
+      }
+
+      if (method === 'file.attach.finish') {
+        return {
+          attached: true,
+          path: '/remote/work/.hermes/desktop-attachments/report.txt',
+          ref_text: '@file:.hermes/desktop-attachments/report.txt',
+          uploaded: true
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+    )
+
+    const ok = await handle!.submitText('convert this to epub', { attachments: [fileAttachment()] })
+
+    expect(ok).toBe(true)
+    expect(readFileDataUrl).not.toHaveBeenCalled()
+    expect(createFileUploadSnapshot).toHaveBeenCalledWith('/Users/alice/Downloads/report.txt')
+    expect(readFileChunkBase64).toHaveBeenNthCalledWith(1, snapshotPath, 0, 1)
+    expect(readFileChunkBase64).toHaveBeenNthCalledWith(2, snapshotPath, 0, 8)
+    expect(readFileChunkBase64).toHaveBeenNthCalledWith(3, snapshotPath, 5, 8)
+    expect(releaseFileUploadSnapshot).toHaveBeenCalledWith(snapshotPath)
+    expect(calls.map(c => c.method)).toEqual([
+      'file.attach.capabilities',
+      'file.attach.begin',
+      'file.attach.chunk',
+      'file.attach.chunk',
+      'file.attach.finish',
+      'prompt.submit'
+    ])
+    expect(calls[0]?.params).toEqual({ session_id: RUNTIME_SESSION_ID })
+    expect(calls[1]?.params).toEqual({
+      session_id: RUNTIME_SESSION_ID,
+      path: '/Users/alice/Downloads/report.txt',
+      name: 'report.txt',
+      request_id: expect.any(String),
+      size: 11
+    })
+    expect(calls[2]?.params).toMatchObject({
+      content_base64: 'aGVsbG8=',
+      offset: 0,
+      session_id: RUNTIME_SESSION_ID,
+      upload_id: 'upload-1'
+    })
+    expect(calls[3]?.params).toMatchObject({
+      content_base64: 'IHdvcmxk',
+      offset: 5,
+      session_id: RUNTIME_SESSION_ID,
+      upload_id: 'upload-1'
+    })
+    expect(calls[5]?.params).toEqual({
+      session_id: RUNTIME_SESSION_ID,
+      text: '@file:.hermes/desktop-attachments/report.txt\n\nconvert this to epub'
+    })
+  })
+
+  it('refuses resumable upload before begin when request-id cancellation is unavailable', async () => {
+    const metadata = {
+      base64: 'eA==',
+      byteSize: 1,
+      bytesRead: 1,
+      done: true,
+      fileId: '1:2',
+      mtimeMs: 100,
+      path: '/Users/alice/Downloads/report.txt'
+    }
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { readFileChunkBase64: vi.fn(async () => metadata) }
+    })
+    const methods: string[] = []
+    const requestGateway = vi.fn(async (method: string) => {
+      methods.push(method)
+      if (method === 'file.attach.capabilities') {
+        return { contract: 4, request_id_cancel: false } as never
+      }
+      if (method === 'file.attach.begin') {
+        return { max_chunk_bytes: 8, received: 0, upload_id: 'unsafe-upload' } as never
+      }
+      if (method === 'file.attach.chunk') {
+        return { received: 1, upload_id: 'unsafe-upload' } as never
+      }
+      if (method === 'file.attach.finish') {
+        return { attached: true, path: '/remote/report.txt', ref_text: '@file:report.txt', uploaded: true } as never
+      }
+      return {} as never
+    })
+
+    await expect(
+      uploadComposerAttachment(fileAttachment(), {
+        remote: true,
+        requestGateway,
+        sessionId: RUNTIME_SESSION_ID
+      })
+    ).rejects.toThrow(/request-id cancellation/i)
+
+    expect(methods).toEqual(['file.attach.capabilities'])
+  })
+
+  it('refuses resumable upload before begin when the capability contract is malformed', async () => {
+    const metadata = {
+      base64: 'eA==',
+      byteSize: 1,
+      bytesRead: 1,
+      done: true,
+      fileId: '1:2',
+      mtimeMs: 100,
+      path: '/Users/alice/Downloads/report.txt'
+    }
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { readFileChunkBase64: vi.fn(async () => metadata) }
+    })
+
+    const methods: string[] = []
+    const requestGateway = vi.fn(async (method: string) => {
+      methods.push(method)
+      if (method === 'file.attach.capabilities') {
+        return { contract: 'unknown', request_id_cancel: true } as never
+      }
+      if (method === 'file.attach.begin') {
+        return { upload_id: 'must-not-begin', chunk_bytes: 1 } as never
+      }
+      return {} as never
+    })
+
+    await expect(
+      uploadComposerAttachment(fileAttachment(), {
+        remote: true,
+        requestGateway,
+        sessionId: RUNTIME_SESSION_ID
+      })
+    ).rejects.toThrow(/request-id cancellation/i)
+
+    expect(methods).toEqual(['file.attach.capabilities'])
+  })
+
+  it('retries a timed-out begin with one stable idempotency key', async () => {
+    const metadata = {
+      base64: 'eA==',
+      byteSize: 1,
+      bytesRead: 1,
+      done: true,
+      fileId: '1:2',
+      mtimeMs: 100,
+      path: '/Users/alice/Downloads/report.txt'
+    }
+    const readFileChunkBase64 = vi.fn(async () => metadata)
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: desktopWithSnapshot(readFileChunkBase64)
+    })
+    const beginParams: Array<Record<string, unknown> | undefined> = []
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'file.attach.capabilities') {
+        return FILE_ATTACH_CAPABILITIES as never
+      }
+      if (method === 'file.attach.begin') {
+        beginParams.push(params)
+        if (beginParams.length === 1) {
+          throw new Error('request timed out: file.attach.begin')
+        }
+        return { max_chunk_bytes: 8, received: 0, upload_id: 'upload-begin-retry' } as never
+      }
+      if (method === 'file.attach.chunk') {
+        return { received: 1, upload_id: 'upload-begin-retry' } as never
+      }
+      if (method === 'file.attach.finish') {
+        return {
+          attached: true,
+          path: '/remote/work/report.txt',
+          ref_text: '@file:report.txt',
+          uploaded: true
+        } as never
+      }
+      return { cancelled: true } as never
+    })
+
+    const result = await uploadComposerAttachment(fileAttachment(), {
+      remote: true,
+      requestGateway,
+      sessionId: RUNTIME_SESSION_ID
+    })
+
+    expect(beginParams).toHaveLength(2)
+    expect(beginParams[0]?.request_id).toEqual(expect.any(String))
+    expect(beginParams[1]?.request_id).toBe(beginParams[0]?.request_id)
+    expect(result.refText).toBe('@file:report.txt')
+  })
+
+  it('cancels by request_id when every begin response is lost', async () => {
+    const metadata = {
+      base64: 'eA==',
+      byteSize: 1,
+      bytesRead: 1,
+      done: true,
+      fileId: '1:2',
+      mtimeMs: 100,
+      path: '/Users/alice/Downloads/report.txt'
+    }
+    const readFileChunkBase64 = vi.fn(async () => metadata)
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: desktopWithSnapshot(readFileChunkBase64)
+    })
+    const beginParams: Array<Record<string, unknown> | undefined> = []
+    const cancelParams: Array<Record<string, unknown> | undefined> = []
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'file.attach.capabilities') {
+        return FILE_ATTACH_CAPABILITIES as never
+      }
+      if (method === 'file.attach.begin') {
+        beginParams.push(params)
+        throw new Error('request timed out: file.attach.begin')
+      }
+      if (method === 'file.attach.cancel') {
+        cancelParams.push(params)
+        if (cancelParams.length === 1) {
+          throw new Error('request timed out: file.attach.cancel')
+        }
+        return { cancelled: true } as never
+      }
+      return {} as never
+    })
+
+    await expect(
+      uploadComposerAttachment(fileAttachment(), {
+        remote: true,
+        requestGateway,
+        sessionId: RUNTIME_SESSION_ID
+      })
+    ).rejects.toThrow(/timed out/i)
+
+    expect(beginParams).toHaveLength(3)
+    expect(beginParams.every(params => params?.request_id === beginParams[0]?.request_id)).toBe(true)
+    expect(cancelParams).toHaveLength(2)
+    expect(cancelParams[0]).toEqual({
+      request_id: beginParams[0]?.request_id,
+      session_id: RUNTIME_SESSION_ID
+    })
+    expect(cancelParams[1]).toEqual(cancelParams[0])
+  })
+
+  it('retries a timed-out chunk without restarting the whole upload', async () => {
+    const metadata = {
+      base64: 'eA==',
+      byteSize: 1,
+      bytesRead: 1,
+      done: true,
+      fileId: '1:2',
+      mtimeMs: 100,
+      path: '/Users/alice/Downloads/report.txt'
+    }
+    const readFileChunkBase64 = vi.fn(async () => metadata)
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: desktopWithSnapshot(readFileChunkBase64)
+    })
+    let chunkCalls = 0
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'file.attach.capabilities') {
+        return FILE_ATTACH_CAPABILITIES as never
+      }
+      if (method === 'file.attach.begin') {
+        return { max_chunk_bytes: 8, received: 0, upload_id: 'upload-retry' } as never
+      }
+      if (method === 'file.attach.chunk') {
+        chunkCalls += 1
+        if (chunkCalls === 1) {
+          throw new Error('request timed out: file.attach.chunk')
+        }
+        return { received: 1, upload_id: 'upload-retry' } as never
+      }
+      if (method === 'file.attach.finish') {
+        return {
+          attached: true,
+          path: '/remote/work/report.txt',
+          ref_text: '@file:report.txt',
+          uploaded: true
+        } as never
+      }
+      return { cancelled: true } as never
+    })
+
+    const result = await uploadComposerAttachment(fileAttachment(), {
+      remote: true,
+      requestGateway,
+      sessionId: RUNTIME_SESSION_ID
+    })
+
+    expect(chunkCalls).toBe(2)
+    expect(result.refText).toBe('@file:report.txt')
+    expect(requestGateway.mock.calls.map(call => call[0])).not.toContain('file.attach.cancel')
+  })
+
+  it('retries a timed-out idempotent finish', async () => {
+    const metadata = {
+      base64: 'eA==',
+      byteSize: 1,
+      bytesRead: 1,
+      done: true,
+      fileId: '1:2',
+      filePath: '/tmp/report.txt',
+      mtimeMs: 10,
+      name: 'report.txt'
+    }
+    const readFileChunkBase64 = vi.fn().mockResolvedValue(metadata)
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: desktopWithSnapshot(readFileChunkBase64)
+    })
+
+    let finishAttempts = 0
+    const calls: Array<{ method: string; params?: unknown }> = []
+    const requestGateway = vi.fn(async (method: string, params?: unknown) => {
+      calls.push({ method, params })
+      if (method === 'file.attach.capabilities') {
+        return FILE_ATTACH_CAPABILITIES as never
+      }
+      if (method === 'file.attach.begin') {
+        return { max_chunk_bytes: 8, received: 0, upload_id: 'upload-finish-retry' }
+      }
+      if (method === 'file.attach.chunk') {
+        return { received: 1, upload_id: 'upload-finish-retry' }
+      }
+      if (method === 'file.attach.finish') {
+        finishAttempts += 1
+        if (finishAttempts === 1) {
+          throw new Error('request timed out')
+        }
+        return {
+          attached: true,
+          name: 'report.txt',
+          path: '/workspace/report.txt',
+          ref_path: '.hermes/desktop-attachments/report.txt',
+          ref_text: '@file:.hermes/desktop-attachments/report.txt',
+          uploaded: true
+        }
+      }
+      return { cancelled: true }
+    }) as unknown as GatewayRequest
+
+    const result = await uploadComposerAttachment(fileAttachment(), {
+      remote: true,
+      requestGateway,
+      sessionId: 'session-finish-retry'
+    })
+
+    expect(result).toMatchObject({
+      attachedSessionId: 'session-finish-retry',
+      refText: '@file:.hermes/desktop-attachments/report.txt'
+    })
+    expect(calls.filter((call) => call.method === 'file.attach.finish')).toHaveLength(2)
+    expect(calls.some((call) => call.method === 'file.attach.cancel')).toBe(false)
+  })
+
+  it('cancels the upload when the selected file changes after the metadata probe', async () => {
+    const readFileChunkBase64 = vi
+      .fn()
+      .mockResolvedValueOnce({
+        base64: 'aA==',
+        byteSize: 5,
+        bytesRead: 1,
+        done: false,
+        fileId: '1:2',
+        mtimeMs: 100,
+        path: '/Users/alice/Downloads/report.txt'
+      })
+      .mockResolvedValueOnce({
+        base64: 'aGVsbG8=',
+        byteSize: 5,
+        bytesRead: 5,
+        done: true,
+        fileId: '1:3',
+        mtimeMs: 101,
+        path: '/Users/alice/Downloads/report.txt'
+      })
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: desktopWithSnapshot(readFileChunkBase64)
+    })
+    const methods: string[] = []
+    const requestGateway = vi.fn(async (method: string) => {
+      methods.push(method)
+      if (method === 'file.attach.capabilities') {
+        return FILE_ATTACH_CAPABILITIES as never
+      }
+      if (method === 'file.attach.begin') {
+        return { max_chunk_bytes: 8, received: 0, upload_id: 'upload-change' } as never
+      }
+      return { cancelled: true } as never
+    })
+
+    await expect(
+      uploadComposerAttachment(fileAttachment(), {
+        remote: true,
+        requestGateway,
+        sessionId: RUNTIME_SESSION_ID
+      })
+    ).rejects.toThrow(/changed while it was being uploaded/i)
+
+    expect(methods).toEqual(['file.attach.capabilities', 'file.attach.begin', 'file.attach.cancel'])
+  })
+
+  it('falls back to legacy file.attach data_url upload when chunk reads are unavailable', async () => {
     // Remote gateway can't read the client-disk path, so the desktop must upload
     // the bytes and submit the workspace-relative ref the gateway hands back —
     // not the original /Users/... path (which would dead-end as "outside the
@@ -861,6 +1345,10 @@ describe('usePromptActions file attachment sync', () => {
 
     const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
       calls.push({ method, params })
+
+      if (method === 'file.attach.capabilities') {
+        return FILE_ATTACH_CAPABILITIES as never
+      }
 
       if (method === 'file.attach') {
         return {
@@ -882,17 +1370,45 @@ describe('usePromptActions file attachment sync', () => {
     const ok = await handle!.submitText('convert this to epub', { attachments: [fileAttachment()] })
 
     expect(ok).toBe(true)
-    expect(calls.map(c => c.method)).toEqual(['file.attach', 'prompt.submit'])
-    expect(calls[0]?.params).toMatchObject({
+    expect(calls.map(c => c.method)).toEqual(['file.attach.capabilities', 'file.attach', 'prompt.submit'])
+    expect(calls[1]?.params).toMatchObject({
       session_id: RUNTIME_SESSION_ID,
       path: '/Users/alice/Downloads/report.txt',
       name: 'report.txt',
       data_url: 'data:text/plain;base64,aGVsbG8='
     })
-    expect(calls[1]?.params).toEqual({
+    expect(calls[2]?.params).toEqual({
       session_id: RUNTIME_SESSION_ID,
       text: '@file:.hermes/desktop-attachments/report.txt\n\nconvert this to epub'
     })
+  })
+
+  it('refuses legacy file.attach mutation when contract-5 capability cannot be proven', async () => {
+    $connection.set({ mode: 'remote' } as never)
+    const readFileDataUrl = vi.fn(async () => 'data:text/plain;base64,aGVsbG8=')
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { readFileDataUrl }
+    })
+    const methods: string[] = []
+    const requestGateway = vi.fn(async (method: string) => {
+      methods.push(method)
+      if (method === 'file.attach.capabilities') {
+        return { contract: Number.NaN, request_id_cancel: true } as never
+      }
+      throw new Error(`unexpected mutating method: ${method}`)
+    })
+
+    await expect(
+      uploadComposerAttachment(fileAttachment(), {
+        remote: true,
+        requestGateway,
+        sessionId: RUNTIME_SESSION_ID
+      })
+    ).rejects.toThrow(/request-id cancellation/i)
+
+    expect(methods).toEqual(['file.attach.capabilities'])
+    expect(readFileDataUrl).not.toHaveBeenCalled()
   })
 
   it('passes a path-less @file: ref straight through (no path = nothing to upload)', async () => {
@@ -1004,6 +1520,10 @@ describe('usePromptActions eager-upload races', () => {
 
     const requestGateway = vi.fn(async (method: string) => {
       methods.push(method)
+
+      if (method === 'file.attach.capabilities') {
+        return FILE_ATTACH_CAPABILITIES as never
+      }
 
       if (method === 'file.attach') {
         // Block until released so submit runs while the upload is in flight.
@@ -1239,7 +1759,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
 
     expect(ok).toBe(true)
     expect(calls.map(c => c.method)).toEqual(['prompt.submit', 'session.resume', 'prompt.submit'])
-    expect(calls[1]?.params).toEqual({ session_id: STORED_SESSION_ID })
+    expect(calls[1]?.params).toEqual({ session_id: STORED_SESSION_ID, source: 'desktop' })
     expect(calls[2]?.params).toEqual({
       session_id: RECOVERED_SESSION_ID,
       text: 'message during starved loop'
@@ -1338,6 +1858,10 @@ describe('usePromptActions eager attachment upload (drop-time)', () => {
     const requestGateway = vi.fn(async (method: string) => {
       calls.push(method)
 
+      if (method === 'file.attach.capabilities') {
+        return FILE_ATTACH_CAPABILITIES as never
+      }
+
       if (method === 'file.attach') {
         return {
           attached: true,
@@ -1433,7 +1957,7 @@ describe('uploadComposerAttachment remote read failures', () => {
       }
     })
 
-    const requestGateway = vi.fn(async () => ({}) as never)
+    const requestGateway = vi.fn(async () => FILE_ATTACH_CAPABILITIES as never)
 
     await expect(
       uploadComposerAttachment(
@@ -1442,8 +1966,12 @@ describe('uploadComposerAttachment remote read failures', () => {
       )
     ).rejects.toThrow('huge.csv is too large to upload to the remote gateway (max 16 MB).')
 
-    // The cap is hit before any gateway round-trip.
-    expect(requestGateway).not.toHaveBeenCalled()
+    expect(requestGateway).toHaveBeenCalledTimes(1)
+    expect(requestGateway).toHaveBeenCalledWith(
+      'file.attach.capabilities',
+      { session_id: RUNTIME_SESSION_ID },
+      120_000
+    )
   })
 
   it('passes non-cap read errors through unchanged', async () => {
@@ -1459,7 +1987,11 @@ describe('uploadComposerAttachment remote read failures', () => {
     await expect(
       uploadComposerAttachment(
         { id: 'file:gone', kind: 'file', label: 'gone.csv', path: '/abs/gone.csv' },
-        { remote: true, requestGateway: vi.fn(async () => ({}) as never), sessionId: RUNTIME_SESSION_ID }
+        {
+          remote: true,
+          requestGateway: vi.fn(async () => FILE_ATTACH_CAPABILITIES as never),
+          sessionId: RUNTIME_SESSION_ID
+        }
       )
     ).rejects.toThrow('ENOENT: no such file')
   })

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -5,6 +5,7 @@ import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 import { PROMPT_SUBMIT_REQUEST_TIMEOUT_MS, transcribeAudio } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { stripAnsi } from '@/lib/ansi'
+import { REQUIRED_BACKEND_CONTRACT } from '@/lib/backend-contract'
 import { branchGroupForUser, type ChatMessage, chatMessageText, textPart } from '@/lib/chat-messages'
 import { pathLabel, SLASH_COMMAND_RE } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
@@ -27,6 +28,8 @@ import { clearSessionTodos } from '@/store/todos'
 
 import type {
   ClientSessionState,
+  FileAttachBeginResponse,
+  FileAttachChunkResponse,
   FileAttachResponse,
   HandoffFailResponse,
   HandoffRequestResponse,
@@ -41,22 +44,223 @@ import {
   appendText,
   blobToDataUrl,
   delay,
+  FILE_ATTACH_CHUNK_BYTES,
+  FILE_ATTACH_REQUEST_TIMEOUT_MS,
   friendlyRemoteAttachError,
   type GatewayRequest,
   inlineErrorMessage,
   isSessionBusyError,
   isSessionNotFoundError,
+  readFileChunkBase64ForAttach,
   readFileDataUrlForAttach,
   readImageForRemoteAttach,
   type SubmitTextOptions,
   visibleUserIndexAtOrdinal,
   visibleUserOrdinal,
+  withFileAttachRetry,
   withSessionBusyRetry
 } from './utils'
 
 interface HandoffResult {
   ok: boolean
   error?: string
+}
+
+async function uploadRemoteFileAttachmentInChunks(
+  path: string,
+  label: string,
+  opts: { requestGateway: GatewayRequest; sessionId: string }
+): Promise<FileAttachResponse> {
+  const { requestGateway, sessionId } = opts
+  const desktop = window.hermesDesktop
+  const reader = desktop?.readFileChunkBase64
+  const createSnapshot = desktop?.createFileUploadSnapshot
+  const releaseSnapshot = desktop?.releaseFileUploadSnapshot
+
+  let capabilities: { contract?: number; request_id_cancel?: boolean }
+  try {
+    capabilities = await requestGateway(
+      'file.attach.capabilities',
+      { session_id: sessionId },
+      FILE_ATTACH_REQUEST_TIMEOUT_MS
+    )
+  } catch {
+    throw new Error('Remote gateway does not support safe request-id cancellation. Update the backend and try again.')
+  }
+  const capabilityContract = capabilities.contract
+  if (
+    typeof capabilityContract !== 'number' ||
+    !Number.isSafeInteger(capabilityContract) ||
+    capabilityContract < REQUIRED_BACKEND_CONTRACT ||
+    capabilities.request_id_cancel !== true
+  ) {
+    throw new Error('Remote gateway does not support safe request-id cancellation. Update the backend and try again.')
+  }
+
+  if (!reader) {
+    const dataUrl = await readFileDataUrlForAttach(path)
+
+    if (!dataUrl) {
+      throw new Error(`Could not read ${label}`)
+    }
+
+    return requestGateway<FileAttachResponse>(
+      'file.attach',
+      {
+        data_url: dataUrl,
+        name: label,
+        path,
+        session_id: sessionId
+      },
+      FILE_ATTACH_REQUEST_TIMEOUT_MS
+    )
+  }
+
+  if (!createSnapshot || !releaseSnapshot) {
+    throw new Error('Hermes Desktop cannot create an immutable upload snapshot. Update the desktop and try again.')
+  }
+
+  let requestId: string | null = null
+  let uploadId: string | null = null
+  let snapshotPath: string | null = null
+
+  try {
+    const snapshot = await createSnapshot(path)
+    if (!snapshot || typeof snapshot.path !== 'string' || !snapshot.path) {
+      throw new Error(`Could not create an immutable upload snapshot for ${label}`)
+    }
+    snapshotPath = snapshot.path
+    const probe = await readFileChunkBase64ForAttach(snapshotPath, 0, 1)
+
+    if (
+      !probe ||
+      !Number.isSafeInteger(probe.byteSize) ||
+      probe.byteSize < 0 ||
+      typeof probe.fileId !== 'string' ||
+      !probe.fileId ||
+      !Number.isFinite(probe.mtimeMs)
+    ) {
+      throw new Error(`Could not read ${label}`)
+    }
+
+    const expectedByteSize = probe.byteSize
+    const expectedFileId = probe.fileId
+    const expectedMtimeMs = probe.mtimeMs
+    requestId = crypto.randomUUID()
+    const begin = await withFileAttachRetry(() =>
+      requestGateway<FileAttachBeginResponse>(
+        'file.attach.begin',
+        {
+          name: label,
+          path,
+          request_id: requestId,
+          session_id: sessionId,
+          size: expectedByteSize
+        },
+        FILE_ATTACH_REQUEST_TIMEOUT_MS
+      )
+    )
+    uploadId = begin.upload_id || null
+
+    if (!uploadId) {
+      throw new Error(`Could not start upload for ${label}`)
+    }
+
+    const serverChunkBytes = Number(begin.max_chunk_bytes)
+    const chunkBytes =
+      Number.isFinite(serverChunkBytes) && serverChunkBytes > 0
+        ? Math.min(Math.floor(serverChunkBytes), FILE_ATTACH_CHUNK_BYTES)
+        : FILE_ATTACH_CHUNK_BYTES
+    let offset = 0
+
+    for (;;) {
+      const chunk = await readFileChunkBase64ForAttach(snapshotPath, offset, chunkBytes)
+
+      if (!chunk) {
+        throw new Error(`Could not read ${label}`)
+      }
+
+      if (
+        !Number.isSafeInteger(chunk.bytesRead) ||
+        chunk.bytesRead < 0 ||
+        chunk.bytesRead > chunkBytes ||
+        typeof chunk.done !== 'boolean' ||
+        chunk.byteSize !== expectedByteSize ||
+        chunk.fileId !== expectedFileId ||
+        chunk.mtimeMs !== expectedMtimeMs
+      ) {
+        throw new Error(`${label} changed while it was being uploaded. Please try again.`)
+      }
+
+      if (offset + chunk.bytesRead > expectedByteSize || (chunk.bytesRead > 0 && !chunk.base64)) {
+        throw new Error(`Could not read ${label}`)
+      }
+
+      if (chunk.bytesRead > 0) {
+        const progress = await withFileAttachRetry(() =>
+          requestGateway<FileAttachChunkResponse>(
+            'file.attach.chunk',
+            {
+              content_base64: chunk.base64,
+              offset,
+              session_id: sessionId,
+              upload_id: uploadId
+            },
+            FILE_ATTACH_REQUEST_TIMEOUT_MS
+          )
+        )
+        const received = Number(progress.received)
+        const expectedReceived = offset + chunk.bytesRead
+
+        if (!Number.isSafeInteger(received) || received !== expectedReceived) {
+          throw new Error(`Remote gateway returned invalid upload progress for ${label}`)
+        }
+
+        offset = received
+      }
+
+      if (chunk.done) {
+        if (offset !== expectedByteSize) {
+          throw new Error(`${label} changed while it was being uploaded. Please try again.`)
+        }
+
+        break
+      }
+
+      if (offset >= expectedByteSize || chunk.bytesRead === 0) {
+        throw new Error(`Could not read ${label}`)
+      }
+    }
+
+    return withFileAttachRetry(() =>
+      requestGateway<FileAttachResponse>(
+        'file.attach.finish',
+        {
+          session_id: sessionId,
+          upload_id: uploadId
+        },
+        FILE_ATTACH_REQUEST_TIMEOUT_MS
+      )
+    )
+  } catch (err) {
+    if (uploadId || requestId) {
+      await withFileAttachRetry(() =>
+        requestGateway(
+          'file.attach.cancel',
+          uploadId
+            ? { session_id: sessionId, upload_id: uploadId }
+            : { request_id: requestId, session_id: sessionId },
+          FILE_ATTACH_REQUEST_TIMEOUT_MS
+        )
+      ).catch(() => undefined)
+    }
+
+    throw err
+  } finally {
+    if (snapshotPath) {
+      await releaseSnapshot(snapshotPath).catch(() => undefined)
+    }
+  }
 }
 
 /**
@@ -119,26 +323,21 @@ export async function uploadComposerAttachment(
   }
 
   // Non-image file.
-  let dataUrl: string | null = null
+  let result: FileAttachResponse
 
   if (remote) {
     try {
-      dataUrl = await readFileDataUrlForAttach(path)
+      result = await uploadRemoteFileAttachmentInChunks(path, label, { requestGateway, sessionId })
     } catch (err) {
       throw friendlyRemoteAttachError(err, label)
     }
-
-    if (!dataUrl) {
-      throw new Error(`Could not read ${label}`)
-    }
+  } else {
+    result = await requestGateway<FileAttachResponse>('file.attach', {
+      name: label,
+      path,
+      session_id: sessionId
+    })
   }
-
-  const result = await requestGateway<FileAttachResponse>('file.attach', {
-    name: label,
-    path,
-    session_id: sessionId,
-    ...(dataUrl ? { data_url: dataUrl } : {})
-  })
 
   if (!result.attached || !result.ref_text) {
     throw new Error(result.message || `Could not attach ${label}`)

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
@@ -14,7 +14,8 @@ import {
   isSessionNotFoundError,
   slashStatusText,
   visibleUserIndexAtOrdinal,
-  visibleUserOrdinal
+  visibleUserOrdinal,
+  withFileAttachRetry
 } from './utils'
 
 describe('isSessionIdCandidate', () => {
@@ -79,7 +80,17 @@ describe('friendlyRemoteAttachError', () => {
     expect(err.message).toBe('pic.png is too large to upload to the remote gateway (max 16 MB).')
   })
 
-  it('passes non-cap errors through', () => {
+  it('rewrites a missing chunk RPC as a backend update requirement', () => {
+    const err = friendlyRemoteAttachError(
+      new Error('method not found: file.attach.begin'),
+      'deck.pptx'
+    )
+    expect(err.message).toBe(
+      'The remote Hermes backend is too old for large-file uploads. Update the backend and try again.'
+    )
+  })
+
+  it('passes unrelated errors through', () => {
     const original = new Error('something else')
     expect(friendlyRemoteAttachError(original, 'pic.png')).toBe(original)
   })
@@ -108,7 +119,40 @@ describe('appendText', () => {
   })
 })
 
-describe('visible user ordinals', () => {
+describe('file attachment retry', () => {
+  it('retries transient gateway failures and returns the eventual result', async () => {
+    let calls = 0
+    const result = await withFileAttachRetry(
+      async () => {
+        calls += 1
+        if (calls < 3) {
+          throw new Error('request timed out: file.attach.chunk')
+        }
+        return 'ok'
+      },
+      [0, 0]
+    )
+
+    expect(result).toBe('ok')
+    expect(calls).toBe(3)
+  })
+
+  it('does not retry permanent validation errors', async () => {
+    let calls = 0
+    await expect(
+      withFileAttachRetry(
+        async () => {
+          calls += 1
+          throw new Error('unexpected offset')
+        },
+        [0, 0]
+      )
+    ).rejects.toThrow('unexpected offset')
+    expect(calls).toBe(1)
+  })
+})
+
+describe('visible message ordinals', () => {
   const messages = [
     { role: 'user', hidden: false },
     { role: 'assistant' },

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -1,5 +1,6 @@
 import type { AppendMessage } from '@assistant-ui/react'
 
+import type { HermesReadFileChunkResult } from '@/global'
 import { translateNow, type Translations } from '@/i18n'
 import type { ChatMessage } from '@/lib/chat-messages'
 import { type CommandsCatalogLike, filterDesktopCommandsCatalog } from '@/lib/desktop-slash-commands'
@@ -115,6 +116,58 @@ export function imageFilenameFromPath(filePath: string): string {
   return filePath.split(/[\\/]/).filter(Boolean).pop() || 'image.png'
 }
 
+export const FILE_ATTACH_CHUNK_BYTES = 8 * 1024 * 1024
+export const FILE_ATTACH_REQUEST_TIMEOUT_MS = 120_000
+export const FILE_ATTACH_RETRY_DELAYS_MS = [500, 1_500] as const
+
+export function isTransientFileAttachError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+
+  return /request timed out|websocket.*(?:closed|disconnect|not connected)|connection.*(?:closed|reset|lost|refused)|network error|ECONNRESET|ECONNABORTED|ETIMEDOUT/i.test(
+    message
+  )
+}
+
+export async function withFileAttachRetry<T>(
+  call: () => Promise<T>,
+  retryDelays: readonly number[] = FILE_ATTACH_RETRY_DELAYS_MS
+): Promise<T> {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await call()
+    } catch (error) {
+      if (!isTransientFileAttachError(error) || attempt >= retryDelays.length) {
+        throw error
+      }
+
+      const retryDelay = Math.max(0, Number(retryDelays[attempt]) || 0)
+      if (retryDelay > 0) {
+        await delay(retryDelay)
+      }
+    }
+  }
+}
+
+export async function readFileChunkBase64ForAttach(
+  filePath: string,
+  offset: number,
+  maxBytes = FILE_ATTACH_CHUNK_BYTES
+): Promise<HermesReadFileChunkResult | null> {
+  const reader = window.hermesDesktop?.readFileChunkBase64
+
+  if (!reader) {
+    return null
+  }
+
+  const chunk = await reader(filePath, offset, maxBytes)
+
+  if (!chunk || typeof chunk.base64 !== 'string' || typeof chunk.bytesRead !== 'number') {
+    return null
+  }
+
+  return chunk
+}
+
 // Remote gateway: the local composer-image file lives on THIS machine's disk,
 // not the gateway's, so read the bytes here and upload them via
 // image.attach_bytes. Returns null when the file can't be read.
@@ -151,6 +204,16 @@ export async function readFileDataUrlForAttach(filePath: string): Promise<string
 // through unchanged.
 export function friendlyRemoteAttachError(err: unknown, label: string): Error {
   const message = err instanceof Error ? err.message : String(err)
+
+  if (
+    /(?:method not found|unknown method).*file\.attach\.(?:begin|chunk|finish|cancel)|file\.attach\.(?:begin|chunk|finish|cancel).*(?:method not found|unknown method)/i.test(
+      message
+    )
+  ) {
+    return new Error(
+      'The remote Hermes backend is too old for large-file uploads. Update the backend and try again.'
+    )
+  }
 
   if (!/too large/i.test(message)) {
     return err instanceof Error ? err : new Error(message)

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -41,6 +41,17 @@ export interface FileAttachResponse {
   name?: string
 }
 
+export interface FileAttachBeginResponse {
+  upload_id?: string
+  received?: number
+  max_chunk_bytes?: number
+}
+
+export interface FileAttachChunkResponse {
+  upload_id?: string
+  received?: number
+}
+
 export interface SlashExecResponse {
   output?: string
   warning?: string

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -10,6 +10,8 @@ export {}
 declare global {
   interface Window {
     hermesDesktop: {
+      // Explicit updater readiness handshake after the primary React tree commits.
+      signalRendererReady?: () => void
       // Resolve a backend connection. Omit `profile` (or pass the primary) for
       // the window's backend; pass a named profile to lazily spawn/reuse that
       // profile's backend from the pool.
@@ -74,7 +76,10 @@ declare global {
       api: <T>(request: HermesApiRequest) => Promise<T>
       notify: (payload: HermesNotification) => Promise<boolean>
       requestMicrophoneAccess: () => Promise<boolean>
+      createFileUploadSnapshot?: (filePath: string) => Promise<HermesFileUploadSnapshot>
+      releaseFileUploadSnapshot?: (snapshotPath: string) => Promise<boolean>
       readFileDataUrl: (filePath: string) => Promise<string>
+      readFileChunkBase64?: (filePath: string, offset: number, maxBytes?: number) => Promise<HermesReadFileChunkResult>
       readFileText: (filePath: string) => Promise<HermesReadFileTextResult>
       selectPaths: (options?: HermesSelectPathsOptions) => Promise<string[]>
       writeClipboard: (text: string) => Promise<boolean>
@@ -627,6 +632,25 @@ export interface HermesPreviewTarget {
   renderMode?: 'preview' | 'source'
   source: string
   url: string
+}
+
+export interface HermesFileUploadSnapshot {
+  byteSize?: number
+  fileId?: string
+  mtimeMs?: number
+  path: string
+}
+
+export interface HermesReadFileChunkResult {
+  base64: string
+  byteSize: number
+  bytesRead: number
+  done: boolean
+  fileId: string
+  mimeType?: string
+  mtimeMs: number
+  name?: string
+  path: string
 }
 
 export interface HermesReadFileTextResult {

--- a/apps/desktop/src/lib/backend-contract.ts
+++ b/apps/desktop/src/lib/backend-contract.ts
@@ -1,0 +1,1 @@
+export const REQUIRED_BACKEND_CONTRACT = 5

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -3,7 +3,7 @@ import './styles.css'
 import './store/translucency'
 
 import { QueryClientProvider } from '@tanstack/react-query'
-import { StrictMode } from 'react'
+import { StrictMode, useEffect } from 'react'
 import { createRoot } from 'react-dom/client'
 import { HashRouter } from 'react-router-dom'
 
@@ -16,6 +16,15 @@ import { queryClient } from './lib/query-client'
 import { ThemeProvider } from './themes/context'
 
 installClipboardShim()
+
+function RendererReadySignal() {
+  useEffect(() => {
+    const frame = window.requestAnimationFrame(() => window.hermesDesktop?.signalRendererReady?.())
+    return () => window.cancelAnimationFrame(frame)
+  }, [])
+
+  return null
+}
 
 // Dev-only: install __PERF_DRIVE__ + __PERF_PROBE__ on window so the
 // scripts/ harnesses can drive a synthetic stream + record render cost.
@@ -40,6 +49,7 @@ if (new URLSearchParams(window.location.search).get('win') === 'overlay') {
             <ThemeProvider>
               <HapticsProvider>
                 <HashRouter>
+                  <RendererReadySignal />
                   <App />
                 </HashRouter>
               </HapticsProvider>

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -120,7 +120,7 @@ describe('reportBackendContract', () => {
   })
 
   it('dismisses the toast when the backend meets the contract', () => {
-    reportBackendContract(2)
+    reportBackendContract(5)
     expect(dismissSpy).toHaveBeenCalledWith('backend-contract-skew')
     expect(notifySpy).not.toHaveBeenCalled()
   })
@@ -128,7 +128,7 @@ describe('reportBackendContract', () => {
   it('warns when the backend is behind (or reports no contract)', () => {
     reportBackendContract(undefined)
     expect(notifySpy).toHaveBeenCalledTimes(1)
-    reportBackendContract(1)
+    reportBackendContract(4)
     expect(notifySpy).toHaveBeenCalledTimes(2)
   })
 
@@ -160,8 +160,8 @@ describe('reportBackendContract', () => {
     lastToast().onDismiss()
     notifySpy.mockClear()
 
-    reportBackendContract(2) // backend updated → satisfied, snooze cleared
-    reportBackendContract(1) // a later regression must warn immediately
+    reportBackendContract(5) // backend updated → satisfied, snooze cleared
+    reportBackendContract(4) // a later regression must warn immediately
     expect(notifySpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -15,6 +15,7 @@ import type {
 } from '@/global'
 import { checkHermesUpdate, getActionStatus, updateHermes } from '@/hermes'
 import { translateNow } from '@/i18n'
+import { REQUIRED_BACKEND_CONTRACT } from '@/lib/backend-contract'
 import { persistString, storedString } from '@/lib/storage'
 import { dismissNotification, notify } from '@/store/notifications'
 import { $connection } from '@/store/session'
@@ -91,7 +92,9 @@ function isUpdateToastSnoozed(): boolean {
 // against. The backend reports its own value in session runtime info; a lower
 // value (or none — a pre-GUI checkout) means GUI<->backend skew.
 // v2: requires the file.attach RPC (remote-gateway non-image file upload).
-const REQUIRED_BACKEND_CONTRACT = 2
+// v3: requires file.attach.begin/chunk/finish/cancel resumable uploads.
+// v4: requires an idempotency key for file.attach.begin.
+// v5: requires request-id cancellation and a fail-closed capability handshake.
 const SKEW_TOAST_ID = 'backend-contract-skew'
 // The contract check runs on every session.resume (applyRuntimeInfo), so
 // without a snooze the warning re-popped on every thread the user opened, even

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5354,6 +5354,56 @@ def test_file_attach_chunk_rejects_when_disk_fills_after_begin(monkeypatch, tmp_
         server._sessions.pop("sid", None)
 
 
+def test_file_attach_chunk_rejects_temp_hardlink_identity_swap_before_write(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    victim = tmp_path / "outside-workspace-victim.bin"
+    victim.write_bytes(b"")
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    upload = None
+
+    try:
+        begin = server.handle_request(
+            {
+                "id": "begin",
+                "method": "file.attach.begin",
+                "params": {
+                    "request_id": str(uuid.uuid4()),
+                    "session_id": "sid",
+                    "name": "identity-swap.bin",
+                    "size": 4,
+                },
+            }
+        )
+        upload_id = begin["result"]["upload_id"]
+        upload = server._sessions["sid"]["_desktop_file_uploads"][upload_id]
+        temp_path = Path(upload["path"])
+        temp_path.unlink()
+        os.link(victim, temp_path)
+
+        chunk = server.handle_request(
+            {
+                "id": "chunk",
+                "method": "file.attach.chunk",
+                "params": {
+                    "session_id": "sid",
+                    "upload_id": upload_id,
+                    "offset": 0,
+                    "content_base64": base64.b64encode(b"evil").decode("ascii"),
+                },
+            }
+        )
+
+        assert chunk["error"]["code"] == 5028
+        assert "identity" in chunk["error"]["message"].lower()
+        assert victim.read_bytes() == b""
+    finally:
+        if isinstance(upload, dict):
+            server._release_upload_disk_reservation(upload)
+            Path(str(upload.get("path") or "")).unlink(missing_ok=True)
+        server._sessions.pop("sid", None)
+
+
 def test_file_attach_chunk_retry_is_idempotent_but_rejects_changed_bytes(tmp_path):
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -5406,7 +5456,7 @@ def test_file_attach_chunk_partial_write_truncate_failure_retains_ownership(monk
     server._sessions["sid"] = _session(cwd=str(workspace))
     original_open = Path.open
 
-    class _AppendShortHandle:
+    class _ShortWriteFailTruncateHandle:
         def __init__(self, handle):
             self._handle = handle
 
@@ -5420,20 +5470,6 @@ def test_file_attach_chunk_partial_write_truncate_failure_retains_ownership(monk
         def write(self, payload):
             return self._handle.write(payload[:1])
 
-        def __getattr__(self, name):
-            return getattr(self._handle, name)
-
-    class _FailTruncateHandle:
-        def __init__(self, handle):
-            self._handle = handle
-
-        def __enter__(self):
-            self._handle.__enter__()
-            return self
-
-        def __exit__(self, *args):
-            return self._handle.__exit__(*args)
-
         def truncate(self, _size):
             raise PermissionError("locked chunk rollback")
 
@@ -5442,10 +5478,8 @@ def test_file_attach_chunk_partial_write_truncate_failure_retains_ownership(monk
 
     def fail_chunk_rollback_open(path, mode="r", *args, **kwargs):
         handle = original_open(path, mode, *args, **kwargs)
-        if path.suffix == ".part" and mode == "ab":
-            return _AppendShortHandle(handle)
         if path.suffix == ".part" and mode == "r+b":
-            return _FailTruncateHandle(handle)
+            return _ShortWriteFailTruncateHandle(handle)
         return handle
 
     try:

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1,3 +1,6 @@
+import base64
+import concurrent.futures
+import contextlib
 import json
 import os
 import subprocess
@@ -5,6 +8,7 @@ import sys
 import threading
 import time
 import types
+import uuid
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
@@ -15,6 +19,16 @@ from hermes_constants import reset_hermes_home_override, set_hermes_home_overrid
 from hermes_cli.active_sessions import active_session_registry_snapshot
 from hermes_cli.browser_connect import ChromeDebugLaunch
 from tui_gateway import server
+
+
+@pytest.fixture(autouse=True)
+def _reset_file_attach_disk_reservations_between_tests():
+    """Tests often pop sessions directly; production uses teardown to release them."""
+    with server._file_attach_disk_reservation_lock:
+        server._file_attach_disk_reservations.clear()
+    yield
+    with server._file_attach_disk_reservation_lock:
+        server._file_attach_disk_reservations.clear()
 
 
 def test_session_create_rejects_at_active_session_limit(monkeypatch, tmp_path):
@@ -1754,7 +1768,7 @@ def test_make_agent_passes_configured_fallback_chain(monkeypatch):
 
     assert agent.model == "gpt-5.5"
     assert captured["fallback_model"] == fallback_chain
-    assert captured["platform"] == "tui"
+    assert captured["platform"] == "desktop"
 
 
 def test_background_agent_kwargs_preserves_full_fallback_chain(monkeypatch):
@@ -2332,7 +2346,7 @@ def test_ensure_session_db_row_persists_explicit_cwd(monkeypatch, tmp_path):
     server._ensure_session_db_row({"session_key": "k1", "cwd": str(tmp_path), "explicit_cwd": True})
 
     assert created == [
-        {"key": "k1", "source": "tui", "model": "test-model", "model_config": None, "cwd": str(tmp_path)}
+        {"key": "k1", "source": "desktop", "model": "test-model", "model_config": None, "cwd": str(tmp_path)}
     ]
 
 
@@ -2372,7 +2386,7 @@ def test_ensure_session_db_row_defaults_to_no_workspace(monkeypatch, tmp_path):
     server._ensure_session_db_row({"session_key": "k1", "cwd": str(tmp_path)})
 
     assert created == [
-        {"key": "k1", "source": "tui", "model": "test-model", "model_config": None, "cwd": None}
+        {"key": "k1", "source": "desktop", "model": "test-model", "model_config": None, "cwd": None}
     ]
 
 
@@ -4297,6 +4311,2056 @@ def test_file_attach_uploads_remote_file_into_session_workspace(monkeypatch, tmp
         server._sessions.pop("sid", None)
 
 
+def test_file_attach_data_url_rejects_partial_destination_write(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    fake_cli = types.ModuleType("cli")
+    fake_cli._detect_file_drop = lambda raw: None
+    fake_cli._split_path_input = lambda raw: (raw, "")
+    fake_cli._resolve_attachment_path = lambda raw: None
+    original_open = server._open_exclusive_attachment_file
+
+    class _ShortWriteHandle:
+        def __init__(self, handle):
+            self._handle = handle
+
+        def write(self, payload):
+            return self._handle.write(payload[:1])
+
+        def __getattr__(self, name):
+            return getattr(self._handle, name)
+
+    def short_write_open(path):
+        handle = original_open(path)
+        if path.name == "partial.bin":
+            return _ShortWriteHandle(handle)
+        return handle
+
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+    monkeypatch.setattr(server, "_open_exclusive_attachment_file", short_write_open)
+
+    try:
+        response = server.handle_request(
+            {
+                "id": "partial-write",
+                "method": "file.attach",
+                "params": {
+                    "session_id": "sid",
+                    "name": "partial.bin",
+                    "data_url": "data:application/octet-stream;base64,QUJDRA==",
+                },
+            }
+        )
+
+        assert "incomplete" in response["error"]["message"]
+        assert not (
+            workspace / ".hermes" / "desktop-attachments" / "partial.bin"
+        ).exists()
+        with server._file_attach_disk_reservation_lock:
+            assert not server._file_attach_disk_reservations
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_file_attach_data_url_partial_write_cleanup_failure_is_quarantined(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    fake_cli = types.ModuleType("cli")
+    fake_cli._detect_file_drop = lambda raw: None
+    fake_cli._split_path_input = lambda raw: (raw, "")
+    fake_cli._resolve_attachment_path = lambda raw: None
+    original_open = server._open_exclusive_attachment_file
+    original_unlink = Path.unlink
+
+    class _ShortWriteHandle:
+        def __init__(self, handle):
+            self._handle = handle
+
+        def write(self, payload):
+            return self._handle.write(payload[:1])
+
+        def __getattr__(self, name):
+            return getattr(self._handle, name)
+
+    def short_write_open(path):
+        handle = original_open(path)
+        if path.name == "partial-locked.bin":
+            return _ShortWriteHandle(handle)
+        return handle
+
+    def fail_partial_unlink(path, *args, **kwargs):
+        if path.name == "partial-locked.bin":
+            raise PermissionError("locked one-shot cleanup")
+        return original_unlink(path, *args, **kwargs)
+
+    def fail_partial_handle_delete(_handle):
+        raise PermissionError("locked one-shot handle cleanup")
+
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+    monkeypatch.setattr(server, "_open_exclusive_attachment_file", short_write_open)
+    monkeypatch.setattr(Path, "unlink", fail_partial_unlink)
+    if os.name == "nt":
+        monkeypatch.setattr(server, "_mark_open_attachment_for_delete", fail_partial_handle_delete)
+
+    try:
+        response = server.handle_request(
+            {
+                "id": "partial-cleanup",
+                "method": "file.attach",
+                "params": {
+                    "session_id": "sid",
+                    "name": "partial-locked.bin",
+                    "data_url": "data:application/octet-stream;base64,QUJDRA==",
+                },
+            }
+        )
+        partial = workspace / ".hermes" / "desktop-attachments" / "partial-locked.bin"
+
+        assert "cleanup" in response["error"]["message"].lower()
+        assert partial.exists()
+        assert len(server._file_attach_cleanup_quarantine) == 1
+        assert len(server._file_attach_disk_reservations) == 1
+    finally:
+        monkeypatch.setattr(server, "_open_exclusive_attachment_file", original_open)
+        monkeypatch.setattr(Path, "unlink", original_unlink)
+        server._sessions.pop("sid", None)
+        server._retry_file_attach_cleanup_quarantine()
+
+
+def test_file_attach_sanitizes_windows_reserved_and_oversized_names():
+    assert server._sanitize_attachment_name("CON.txt") == "_CON.txt"
+    assert server._sanitize_attachment_name("nul") == "_nul"
+
+    sanitized = server._sanitize_attachment_name(("a" * 300) + ".pptx")
+    assert len(sanitized) <= 180
+    assert sanitized.endswith(".pptx")
+
+
+def test_file_attach_capabilities_require_request_id_cancel_contract(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    server._sessions["sid"] = _session(cwd=str(workspace))
+
+    try:
+        response = server.handle_request(
+            {
+                "id": "capabilities",
+                "method": "file.attach.capabilities",
+                "params": {"session_id": "sid"},
+            }
+        )
+
+        assert server.DESKTOP_BACKEND_CONTRACT == 5
+        assert response["result"] == {
+            "contract": 5,
+            "request_id_cancel": True,
+        }
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_file_attach_max_chunk_bytes_honors_per_employee_env(monkeypatch):
+    monkeypatch.setenv("HERMES_FILE_ATTACH_MAX_CHUNK_BYTES", "524288")
+    assert server._file_attach_max_chunk_bytes() == 524288
+
+    monkeypatch.setenv("HERMES_FILE_ATTACH_MAX_CHUNK_BYTES", "not-a-number")
+    assert server._file_attach_max_chunk_bytes() == 8 * 1024 * 1024
+
+    monkeypatch.setenv("HERMES_FILE_ATTACH_MAX_CHUNK_BYTES", "1")
+    assert server._file_attach_max_chunk_bytes() == 64 * 1024
+
+
+def test_file_attach_begin_rejects_declared_size_over_limit(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    monkeypatch.setattr(server, "_file_attach_max_total_bytes", lambda: 10)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "begin",
+                "method": "file.attach.begin",
+                "params": {"request_id": str(uuid.uuid4()), "session_id": "sid", "name": "too-big.bin", "size": 11},
+            }
+        )
+
+        assert "error" in resp
+        assert "maximum file size" in resp["error"]["message"]
+        upload_dir = workspace / ".hermes" / "desktop-attachments" / ".uploads"
+        assert not upload_dir.exists() or not any(upload_dir.iterdir())
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_file_attach_chunk_rejects_undeclared_total_over_limit(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    monkeypatch.setattr(server, "_file_attach_max_total_bytes", lambda: 10)
+
+    try:
+        begin = server.handle_request(
+            {
+                "id": "begin",
+                "method": "file.attach.begin",
+                "params": {"request_id": str(uuid.uuid4()), "session_id": "sid", "name": "unknown-size.bin"},
+            }
+        )
+        upload_id = begin["result"]["upload_id"]
+        resp = server.handle_request(
+            {
+                "id": "chunk",
+                "method": "file.attach.chunk",
+                "params": {
+                    "session_id": "sid",
+                    "upload_id": upload_id,
+                    "offset": 0,
+                    "content_base64": "MDEyMzQ1Njc4OTA=",
+                },
+            }
+        )
+
+        assert "error" in resp
+        assert "maximum file size" in resp["error"]["message"]
+        upload = server._sessions["sid"]["_desktop_file_uploads"][upload_id]
+        assert Path(upload["path"]).stat().st_size == 0
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_file_attach_chunk_rejects_oversized_base64_before_decode(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    monkeypatch.setattr(server, "_file_attach_max_chunk_bytes", lambda: 4)
+
+    try:
+        begin = server.handle_request(
+            {
+                "id": "begin",
+                "method": "file.attach.begin",
+                "params": {"request_id": str(uuid.uuid4()), "session_id": "sid", "name": "oversized.bin"},
+            }
+        )
+        upload_id = begin["result"]["upload_id"]
+
+        def _must_not_decode(_content):
+            raise AssertionError("decoder must not run for an oversized encoded chunk")
+
+        monkeypatch.setattr(server, "_decode_attachment_data_url", _must_not_decode)
+        resp = server.handle_request(
+            {
+                "id": "chunk",
+                "method": "file.attach.chunk",
+                "params": {
+                    "session_id": "sid",
+                    "upload_id": upload_id,
+                    "offset": 0,
+                    "content_base64": "A" * 100,
+                },
+            }
+        )
+
+        assert "error" in resp
+        assert "encoded chunk too large" in resp["error"]["message"]
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_legacy_file_attach_rejects_data_url_over_total_limit(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    monkeypatch.setattr(server, "_file_attach_max_total_bytes", lambda: 10)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "legacy",
+                "method": "file.attach",
+                "params": {
+                    "session_id": "sid",
+                    "name": "legacy-too-big.bin",
+                    "data_url": "data:application/octet-stream;base64,MDEyMzQ1Njc4OTA=",
+                },
+            }
+        )
+
+        assert "error" in resp
+        assert "maximum file size" in resp["error"]["message"]
+        target = workspace / ".hermes" / "desktop-attachments" / "legacy-too-big.bin"
+        assert not target.exists()
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_legacy_file_attach_rejects_when_disk_capacity_is_insufficient(
+    monkeypatch, tmp_path
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    monkeypatch.setattr(server, "_file_attach_available_bytes", lambda _path: 5)
+    monkeypatch.setattr(server, "_file_attach_free_space_reserve_bytes", lambda: 0)
+
+    try:
+        response = server.handle_request(
+            {
+                "id": "legacy-no-space",
+                "method": "file.attach",
+                "params": {
+                    "session_id": "sid",
+                    "name": "legacy.bin",
+                    "data_url": "data:application/octet-stream;base64,MDEyMzQ1Njc4OQ==",
+                },
+            }
+        )
+
+        assert "free disk space" in response["error"]["message"]
+        target = workspace / ".hermes" / "desktop-attachments" / "legacy.bin"
+        assert not target.exists()
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_file_attach_begin_rejects_when_disk_capacity_is_insufficient(
+    monkeypatch, tmp_path
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    server._sessions["sid"] = _session(cwd=str(workspace))
+
+    monkeypatch.setattr(server, "_file_attach_available_bytes", lambda _path: 5)
+    monkeypatch.setattr(server, "_file_attach_free_space_reserve_bytes", lambda: 0)
+    response = server.handle_request(
+        {
+            "id": "begin-no-space",
+            "method": "file.attach.begin",
+            "params": {"request_id": str(uuid.uuid4()), "session_id": "sid", "name": "big.bin", "size": 10},
+        }
+    )
+
+    assert "free disk space" in response["error"]["message"]
+    assert not list(workspace.rglob("*.part"))
+
+
+def test_file_attach_begin_reserves_disk_capacity_across_sessions(
+    monkeypatch, tmp_path
+):
+    workspace_a = tmp_path / "workspace-a"
+    workspace_b = tmp_path / "workspace-b"
+    workspace_a.mkdir()
+    workspace_b.mkdir()
+    server._sessions["sid-a"] = _session(cwd=str(workspace_a))
+    server._sessions["sid-b"] = _session(cwd=str(workspace_b))
+    monkeypatch.setattr(server, "_file_attach_available_bytes", lambda _path: 6)
+    monkeypatch.setattr(server, "_file_attach_free_space_reserve_bytes", lambda: 2)
+    request_a = str(uuid.uuid4())
+    request_b = str(uuid.uuid4())
+
+    try:
+        first = server.handle_request(
+            {
+                "id": "begin-a",
+                "method": "file.attach.begin",
+                "params": {
+                    "request_id": request_a,
+                    "session_id": "sid-a",
+                    "name": "a.bin",
+                    "size": 4,
+                },
+            }
+        )
+        assert first["result"]["upload_id"] == uuid.UUID(request_a).hex
+
+        blocked = server.handle_request(
+            {
+                "id": "begin-b-blocked",
+                "method": "file.attach.begin",
+                "params": {
+                    "request_id": request_b,
+                    "session_id": "sid-b",
+                    "name": "b.bin",
+                    "size": 4,
+                },
+            }
+        )
+        assert "free disk space" in blocked["error"]["message"]
+
+        cancelled = server.handle_request(
+            {
+                "id": "cancel-a",
+                "method": "file.attach.cancel",
+                "params": {"session_id": "sid-a", "request_id": request_a},
+            }
+        )
+        assert cancelled["result"]["cancelled"] is True
+
+        accepted = server.handle_request(
+            {
+                "id": "begin-b-accepted",
+                "method": "file.attach.begin",
+                "params": {
+                    "request_id": request_b,
+                    "session_id": "sid-b",
+                    "name": "b.bin",
+                    "size": 4,
+                },
+            }
+        )
+        assert accepted["result"]["upload_id"] == uuid.UUID(request_b).hex
+    finally:
+        for sid in ("sid-a", "sid-b"):
+            session = server._sessions.pop(sid, None)
+            if session is not None:
+                server._cleanup_file_attach_uploads(session)
+
+
+def test_file_attach_chunk_rechecks_all_volume_reservations_when_free_space_drops(
+    monkeypatch, tmp_path
+):
+    workspace_a = tmp_path / "workspace-a"
+    workspace_b = tmp_path / "workspace-b"
+    workspace_a.mkdir()
+    workspace_b.mkdir()
+    server._sessions["sid-a"] = _session(cwd=str(workspace_a))
+    server._sessions["sid-b"] = _session(cwd=str(workspace_b))
+    available = 100
+    monkeypatch.setattr(server, "_file_attach_available_bytes", lambda _path: available)
+    monkeypatch.setattr(server, "_file_attach_free_space_reserve_bytes", lambda: 10)
+
+    try:
+        upload_ids = []
+        for sid in ("sid-a", "sid-b"):
+            begin = server.handle_request(
+                {
+                    "id": f"begin-{sid}",
+                    "method": "file.attach.begin",
+                    "params": {
+                        "request_id": str(uuid.uuid4()),
+                        "session_id": sid,
+                        "name": f"{sid}.bin",
+                        "size": 40,
+                    },
+                }
+            )
+            upload_ids.append(begin["result"]["upload_id"])
+
+        available = 70
+        chunk = server.handle_request(
+            {
+                "id": "chunk-a",
+                "method": "file.attach.chunk",
+                "params": {
+                    "session_id": "sid-a",
+                    "upload_id": upload_ids[0],
+                    "offset": 0,
+                    "content_base64": "QQ==",
+                },
+            }
+        )
+
+        assert "free disk space" in chunk["error"]["message"]
+        upload = server._sessions["sid-a"]["_desktop_file_uploads"][upload_ids[0]]
+        assert Path(upload["path"]).stat().st_size == 0
+        with server._file_attach_disk_reservation_lock:
+            assert sum(
+                int(entry.get("remaining") or 0)
+                for entry in server._file_attach_disk_reservations.values()
+            ) == 80
+    finally:
+        for sid in ("sid-a", "sid-b"):
+            session = server._sessions.pop(sid, None)
+            if session is not None:
+                server._cleanup_file_attach_uploads(session)
+
+
+def test_file_attach_begin_reservation_is_atomic_across_concurrent_sessions(
+    monkeypatch, tmp_path
+):
+    workspace_a = tmp_path / "workspace-a"
+    workspace_b = tmp_path / "workspace-b"
+    workspace_a.mkdir()
+    workspace_b.mkdir()
+    server._sessions["sid-a"] = _session(cwd=str(workspace_a))
+    server._sessions["sid-b"] = _session(cwd=str(workspace_b))
+    monkeypatch.setattr(server, "_file_attach_available_bytes", lambda _path: 6)
+    monkeypatch.setattr(server, "_file_attach_free_space_reserve_bytes", lambda: 2)
+    start = threading.Barrier(2)
+
+    def begin(sid, name):
+        start.wait()
+        return server.handle_request(
+            {
+                "id": f"begin-{sid}",
+                "method": "file.attach.begin",
+                "params": {
+                    "request_id": str(uuid.uuid4()),
+                    "session_id": sid,
+                    "name": name,
+                    "size": 4,
+                },
+            }
+        )
+
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            results = list(
+                pool.map(
+                    lambda args: begin(*args),
+                    (("sid-a", "a.bin"), ("sid-b", "b.bin")),
+                )
+            )
+        assert sum("result" in response for response in results) == 1
+        assert sum(
+            "free disk space" in response.get("error", {}).get("message", "")
+            for response in results
+        ) == 1
+    finally:
+        for sid in ("sid-a", "sid-b"):
+            session = server._sessions.pop(sid, None)
+            if session is not None:
+                server._cleanup_file_attach_uploads(session)
+
+
+def test_file_attach_begin_registration_rollback_failure_is_quarantined(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    session = _session(cwd=str(workspace))
+    server._sessions["sid"] = session
+    original_unlink = Path.unlink
+
+    class _FailSetUploads(dict):
+        def __setitem__(self, key, value):
+            raise RuntimeError("upload state registration failed")
+
+    uploads = _FailSetUploads()
+
+    def fail_part_unlink(path, *args, **kwargs):
+        if path.suffix == ".part":
+            raise PermissionError("locked begin rollback cleanup")
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(server, "_file_attach_uploads", lambda _session: uploads)
+    monkeypatch.setattr(Path, "unlink", fail_part_unlink)
+
+    try:
+        response = server.handle_request(
+            {
+                "id": "begin",
+                "method": "file.attach.begin",
+                "params": {
+                    "request_id": str(uuid.uuid4()),
+                    "session_id": "sid",
+                    "name": "begin-locked.bin",
+                    "size": 4,
+                },
+            }
+        )
+
+        assert "cleanup" in response["error"]["message"].lower()
+        assert len(server._file_attach_cleanup_quarantine) == 1
+        assert len(server._file_attach_disk_reservations) == 1
+        quarantined = next(iter(server._file_attach_cleanup_quarantine.values()))
+        assert Path(quarantined["path"]).exists()
+    finally:
+        monkeypatch.setattr(Path, "unlink", original_unlink)
+        server._sessions.pop("sid", None)
+        server._retry_file_attach_cleanup_quarantine()
+
+
+def test_file_attach_cancel_unlink_failure_retains_upload_and_reservation(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    request_id = str(uuid.uuid4())
+    original_unlink = Path.unlink
+
+    def fail_part_unlink(path, *args, **kwargs):
+        if path.suffix == ".part":
+            raise PermissionError("locked cleanup")
+        return original_unlink(path, *args, **kwargs)
+
+    try:
+        begin = server.handle_request(
+            {
+                "id": "begin",
+                "method": "file.attach.begin",
+                "params": {
+                    "request_id": request_id,
+                    "session_id": "sid",
+                    "name": "locked.bin",
+                    "size": 4,
+                },
+            }
+        )
+        upload_id = begin["result"]["upload_id"]
+        upload = server._sessions["sid"]["_desktop_file_uploads"][upload_id]
+        temp_path = Path(upload["path"])
+        reservation_token = upload["disk_reservation_token"]
+        monkeypatch.setattr(Path, "unlink", fail_part_unlink)
+
+        cancelled = server.handle_request(
+            {
+                "id": "cancel",
+                "method": "file.attach.cancel",
+                "params": {"session_id": "sid", "upload_id": upload_id},
+            }
+        )
+
+        assert "cleanup" in cancelled["error"]["message"].lower()
+        assert temp_path.exists()
+        assert server._sessions["sid"]["_desktop_file_uploads"][upload_id] is upload
+        assert reservation_token in server._file_attach_disk_reservations
+    finally:
+        monkeypatch.setattr(Path, "unlink", original_unlink)
+        session = server._sessions.pop("sid", None)
+        if session is not None:
+            server._cleanup_file_attach_uploads(session)
+
+
+def test_file_attach_stale_reap_unlink_failure_retains_upload_and_reservation(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    session = _session(cwd=str(workspace))
+    server._sessions["sid"] = session
+    original_unlink = Path.unlink
+
+    try:
+        begin = server.handle_request(
+            {
+                "id": "begin",
+                "method": "file.attach.begin",
+                "params": {
+                    "request_id": str(uuid.uuid4()),
+                    "session_id": "sid",
+                    "name": "stale.bin",
+                    "size": 4,
+                },
+            }
+        )
+        upload_id = begin["result"]["upload_id"]
+        upload = session["_desktop_file_uploads"][upload_id]
+        reservation_token = upload["disk_reservation_token"]
+        upload["updated_at"] = 0
+
+        def fail_part_unlink(path, *args, **kwargs):
+            if path.suffix == ".part":
+                raise PermissionError("locked stale cleanup")
+            return original_unlink(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "unlink", fail_part_unlink)
+        server._reap_stale_file_attach_uploads(session, now=time.time() + 10_000)
+
+        assert session["_desktop_file_uploads"][upload_id] is upload
+        assert reservation_token in server._file_attach_disk_reservations
+    finally:
+        monkeypatch.setattr(Path, "unlink", original_unlink)
+        server._sessions.pop("sid", None)
+        server._cleanup_file_attach_uploads(session)
+
+
+def test_file_attach_session_cleanup_unlink_failure_quarantines_ownership(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    session = _session(cwd=str(workspace))
+    server._sessions["sid"] = session
+    original_unlink = Path.unlink
+
+    try:
+        begin = server.handle_request(
+            {
+                "id": "begin",
+                "method": "file.attach.begin",
+                "params": {
+                    "request_id": str(uuid.uuid4()),
+                    "session_id": "sid",
+                    "name": "teardown.bin",
+                    "size": 4,
+                },
+            }
+        )
+        upload_id = begin["result"]["upload_id"]
+        upload = session["_desktop_file_uploads"][upload_id]
+        reservation_token = upload["disk_reservation_token"]
+
+        def fail_part_unlink(path, *args, **kwargs):
+            if path.suffix == ".part":
+                raise PermissionError("locked teardown cleanup")
+            return original_unlink(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "unlink", fail_part_unlink)
+        server._cleanup_file_attach_uploads(session)
+
+        assert upload_id not in session.get("_desktop_file_uploads", {})
+        assert server._file_attach_cleanup_quarantine[reservation_token] is upload
+        assert reservation_token in server._file_attach_disk_reservations
+    finally:
+        monkeypatch.setattr(Path, "unlink", original_unlink)
+        server._sessions.pop("sid", None)
+        server._cleanup_file_attach_uploads(session)
+        server._retry_file_attach_cleanup_quarantine()
+
+
+def test_file_attach_cancel_accepts_request_id_and_tombstones_it(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    request_id = str(uuid.uuid4())
+
+    try:
+        begin = server.handle_request(
+            {
+                "id": "begin",
+                "method": "file.attach.begin",
+                "params": {
+                    "request_id": request_id,
+                    "session_id": "sid",
+                    "name": "orphan.bin",
+                    "size": 4,
+                },
+            }
+        )
+        upload_id = begin["result"]["upload_id"]
+        temp_path = Path(server._sessions["sid"]["_desktop_file_uploads"][upload_id]["path"])
+
+        cancelled = server.handle_request(
+            {
+                "id": "cancel",
+                "method": "file.attach.cancel",
+                "params": {"session_id": "sid", "request_id": request_id},
+            }
+        )
+        assert cancelled["result"] == {"cancelled": True}
+        assert not temp_path.exists()
+
+        replay = server.handle_request(
+            {
+                "id": "begin-replay",
+                "method": "file.attach.begin",
+                "params": {
+                    "request_id": request_id,
+                    "session_id": "sid",
+                    "name": "orphan.bin",
+                    "size": 4,
+                },
+            }
+        )
+        assert "request_id already cancelled" in replay["error"]["message"]
+    finally:
+        session = server._sessions.pop("sid", None)
+        if session is not None:
+            server._cleanup_file_attach_uploads(session)
+
+
+def test_file_attach_cancel_tombstone_blocks_later_begin(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    request_id = str(uuid.uuid4())
+
+    try:
+        cancelled = server.handle_request(
+            {
+                "id": "cancel-first",
+                "method": "file.attach.cancel",
+                "params": {"session_id": "sid", "request_id": request_id},
+            }
+        )
+        assert cancelled["result"] == {"cancelled": True}
+
+        replay = server.handle_request(
+            {
+                "id": "begin-late",
+                "method": "file.attach.begin",
+                "params": {
+                    "request_id": request_id,
+                    "session_id": "sid",
+                    "name": "late.bin",
+                    "size": 1,
+                },
+            }
+        )
+        assert "request_id already cancelled" in replay["error"]["message"]
+        assert not list(workspace.rglob("*.part"))
+    finally:
+        session = server._sessions.pop("sid", None)
+        if session is not None:
+            server._cleanup_file_attach_uploads(session)
+
+
+def test_file_attach_begin_releases_reservation_when_temp_creation_fails(
+    monkeypatch, tmp_path
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    original_touch = Path.touch
+
+    def fail_part_touch(path, *args, **kwargs):
+        if path.suffix == ".part":
+            raise PermissionError("denied")
+        return original_touch(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "touch", fail_part_touch)
+
+    try:
+        response = server.handle_request(
+            {
+                "id": "begin",
+                "method": "file.attach.begin",
+                "params": {
+                    "request_id": str(uuid.uuid4()),
+                    "session_id": "sid",
+                    "name": "denied.bin",
+                    "size": 4,
+                },
+            }
+        )
+        assert "denied" in response["error"]["message"]
+        assert server._file_attach_disk_reservations == {}
+    finally:
+        session = server._sessions.pop("sid", None)
+        if session is not None:
+            server._cleanup_file_attach_uploads(session)
+
+
+def test_file_attach_cancel_tombstones_are_bounded(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    server._sessions["sid"] = _session(cwd=str(workspace))
+
+    try:
+        for index in range(65):
+            response = server.handle_request(
+                {
+                    "id": f"cancel-{index}",
+                    "method": "file.attach.cancel",
+                    "params": {
+                        "session_id": "sid",
+                        "request_id": str(uuid.uuid4()),
+                    },
+                }
+            )
+            assert response["result"]["cancelled"] is True
+        assert len(server._file_attach_cancelled_requests(server._sessions["sid"])) == 64
+    finally:
+        session = server._sessions.pop("sid", None)
+        if session is not None:
+            server._cleanup_file_attach_uploads(session)
+
+
+def test_file_attach_finish_publish_rollback_failure_tracks_all_owned_paths(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    original_unlink = Path.unlink
+
+    try:
+        begin = server.handle_request(
+            {
+                "id": "begin",
+                "method": "file.attach.begin",
+                "params": {
+                    "request_id": str(uuid.uuid4()),
+                    "session_id": "sid",
+                    "name": "publish-locked.bin",
+                    "size": 4,
+                },
+            }
+        )
+        upload_id = begin["result"]["upload_id"]
+        upload = server._sessions["sid"]["_desktop_file_uploads"][upload_id]
+        temp_path = Path(upload["path"])
+        reservation_token = upload["disk_reservation_token"]
+        chunk = server.handle_request(
+            {
+                "id": "chunk",
+                "method": "file.attach.chunk",
+                "params": {
+                    "session_id": "sid",
+                    "upload_id": upload_id,
+                    "offset": 0,
+                    "content_base64": "QUJDRA==",
+                },
+            }
+        )
+        assert chunk["result"]["received"] == 4
+        candidate = workspace / ".hermes" / "desktop-attachments" / "publish-locked.bin"
+
+        def fail_publish_unlink(path, *args, **kwargs):
+            if path == temp_path or path == candidate:
+                raise PermissionError(f"locked publish cleanup: {path.name}")
+            return original_unlink(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "unlink", fail_publish_unlink)
+        finish = server.handle_request(
+            {
+                "id": "finish",
+                "method": "file.attach.finish",
+                "params": {"session_id": "sid", "upload_id": upload_id},
+            }
+        )
+
+        assert "cleanup" in finish["error"]["message"].lower()
+        assert temp_path.exists()
+        assert candidate.exists()
+        assert str(candidate) in upload.get("cleanup_paths", [])
+        assert reservation_token in server._file_attach_disk_reservations
+
+        monkeypatch.setattr(Path, "unlink", original_unlink)
+        cancel = server.handle_request(
+            {
+                "id": "cancel",
+                "method": "file.attach.cancel",
+                "params": {"session_id": "sid", "upload_id": upload_id},
+            }
+        )
+        assert cancel["result"]["cancelled"] is True
+        assert not temp_path.exists()
+        assert not candidate.exists()
+        assert reservation_token not in server._file_attach_disk_reservations
+    finally:
+        monkeypatch.setattr(Path, "unlink", original_unlink)
+        session = server._sessions.pop("sid", None)
+        if session is not None:
+            server._cleanup_file_attach_uploads(session)
+
+
+def test_file_attach_finish_releases_unused_unknown_size_reservation(
+    monkeypatch, tmp_path
+):
+    workspace_a = tmp_path / "workspace-a"
+    workspace_b = tmp_path / "workspace-b"
+    workspace_a.mkdir()
+    workspace_b.mkdir()
+    server._sessions["sid-a"] = _session(cwd=str(workspace_a))
+    server._sessions["sid-b"] = _session(cwd=str(workspace_b))
+    monkeypatch.setattr(server, "_file_attach_available_bytes", lambda _path: 6)
+    monkeypatch.setattr(server, "_file_attach_free_space_reserve_bytes", lambda: 2)
+    monkeypatch.setattr(server, "_file_attach_max_total_bytes", lambda: 4)
+    request_a = str(uuid.uuid4())
+    request_b = str(uuid.uuid4())
+
+    try:
+        begin = server.handle_request(
+            {
+                "id": "begin-a",
+                "method": "file.attach.begin",
+                "params": {
+                    "request_id": request_a,
+                    "session_id": "sid-a",
+                    "name": "short.bin",
+                },
+            }
+        )
+        upload_id = begin["result"]["upload_id"]
+        chunk = server.handle_request(
+            {
+                "id": "chunk-a",
+                "method": "file.attach.chunk",
+                "params": {
+                    "content_base64": base64.b64encode(b"x").decode("ascii"),
+                    "offset": 0,
+                    "session_id": "sid-a",
+                    "upload_id": upload_id,
+                },
+            }
+        )
+        assert chunk["result"]["received"] == 1
+
+        still_blocked = server.handle_request(
+            {
+                "id": "begin-b-blocked",
+                "method": "file.attach.begin",
+                "params": {
+                    "request_id": request_b,
+                    "session_id": "sid-b",
+                    "name": "b.bin",
+                    "size": 4,
+                },
+            }
+        )
+        assert "free disk space" in still_blocked["error"]["message"]
+
+        finished = server.handle_request(
+            {
+                "id": "finish-a",
+                "method": "file.attach.finish",
+                "params": {"session_id": "sid-a", "upload_id": upload_id},
+            }
+        )
+        assert finished["result"]["attached"] is True
+
+        accepted = server.handle_request(
+            {
+                "id": "begin-b-accepted",
+                "method": "file.attach.begin",
+                "params": {
+                    "request_id": request_b,
+                    "session_id": "sid-b",
+                    "name": "b.bin",
+                    "size": 4,
+                },
+            }
+        )
+        assert accepted["result"]["upload_id"] == uuid.UUID(request_b).hex
+    finally:
+        for sid in ("sid-a", "sid-b"):
+            session = server._sessions.pop(sid, None)
+            if session is not None:
+                server._cleanup_file_attach_uploads(session)
+
+
+def test_file_attach_chunk_rejects_when_disk_fills_after_begin(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    available = iter((1000, 0))
+    monkeypatch.setattr(
+        server, "_file_attach_available_bytes", lambda _path: next(available)
+    )
+    monkeypatch.setattr(server, "_file_attach_free_space_reserve_bytes", lambda: 0)
+
+    try:
+        begin = server.handle_request(
+            {
+                "id": "begin",
+                "method": "file.attach.begin",
+                "params": {"request_id": str(uuid.uuid4()), "session_id": "sid", "name": "disk-fill.bin", "size": 4},
+            }
+        )
+        upload_id = begin["result"]["upload_id"]
+        response = server.handle_request(
+            {
+                "id": "chunk",
+                "method": "file.attach.chunk",
+                "params": {
+                    "session_id": "sid",
+                    "upload_id": upload_id,
+                    "offset": 0,
+                    "content_base64": "dGVzdA==",
+                },
+            }
+        )
+
+        assert "free disk space" in response["error"]["message"]
+        upload = server._sessions["sid"]["_desktop_file_uploads"][upload_id]
+        assert Path(upload["path"]).stat().st_size == 0
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_file_attach_chunk_retry_is_idempotent_but_rejects_changed_bytes(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    server._sessions["sid"] = _session(cwd=str(workspace))
+
+    try:
+        begin = server.handle_request(
+            {
+                "id": "begin",
+                "method": "file.attach.begin",
+                "params": {"request_id": str(uuid.uuid4()), "session_id": "sid", "name": "retry.txt", "size": 5},
+            }
+        )
+        upload_id = begin["result"]["upload_id"]
+        chunk_params = {
+            "session_id": "sid",
+            "upload_id": upload_id,
+            "offset": 0,
+            "content_base64": "aGVsbG8=",
+        }
+
+        first = server.handle_request(
+            {"id": "chunk-1", "method": "file.attach.chunk", "params": chunk_params}
+        )
+        retry = server.handle_request(
+            {"id": "chunk-2", "method": "file.attach.chunk", "params": chunk_params}
+        )
+        changed = server.handle_request(
+            {
+                "id": "chunk-3",
+                "method": "file.attach.chunk",
+                "params": {**chunk_params, "content_base64": "d29ybGQ="},
+            }
+        )
+
+        assert first["result"]["received"] == 5
+        assert retry["result"]["received"] == 5
+        assert retry["result"]["duplicate"] is True
+        assert "error" in changed
+        assert "unexpected offset" in changed["error"]["message"]
+        upload = server._sessions["sid"]["_desktop_file_uploads"][upload_id]
+        assert Path(upload["path"]).read_bytes() == b"hello"
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_file_attach_chunk_partial_write_truncate_failure_retains_ownership(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    original_open = Path.open
+
+    class _AppendShortHandle:
+        def __init__(self, handle):
+            self._handle = handle
+
+        def __enter__(self):
+            self._handle.__enter__()
+            return self
+
+        def __exit__(self, *args):
+            return self._handle.__exit__(*args)
+
+        def write(self, payload):
+            return self._handle.write(payload[:1])
+
+        def __getattr__(self, name):
+            return getattr(self._handle, name)
+
+    class _FailTruncateHandle:
+        def __init__(self, handle):
+            self._handle = handle
+
+        def __enter__(self):
+            self._handle.__enter__()
+            return self
+
+        def __exit__(self, *args):
+            return self._handle.__exit__(*args)
+
+        def truncate(self, _size):
+            raise PermissionError("locked chunk rollback")
+
+        def __getattr__(self, name):
+            return getattr(self._handle, name)
+
+    def fail_chunk_rollback_open(path, mode="r", *args, **kwargs):
+        handle = original_open(path, mode, *args, **kwargs)
+        if path.suffix == ".part" and mode == "ab":
+            return _AppendShortHandle(handle)
+        if path.suffix == ".part" and mode == "r+b":
+            return _FailTruncateHandle(handle)
+        return handle
+
+    try:
+        begin = server.handle_request(
+            {
+                "id": "begin",
+                "method": "file.attach.begin",
+                "params": {
+                    "request_id": str(uuid.uuid4()),
+                    "session_id": "sid",
+                    "name": "chunk-locked.bin",
+                    "size": 4,
+                },
+            }
+        )
+        upload_id = begin["result"]["upload_id"]
+        upload = server._sessions["sid"]["_desktop_file_uploads"][upload_id]
+        reservation_token = upload["disk_reservation_token"]
+        temp_path = Path(upload["path"])
+        monkeypatch.setattr(Path, "open", fail_chunk_rollback_open)
+
+        response = server.handle_request(
+            {
+                "id": "chunk",
+                "method": "file.attach.chunk",
+                "params": {
+                    "session_id": "sid",
+                    "upload_id": upload_id,
+                    "offset": 0,
+                    "content_base64": "QUJDRA==",
+                },
+            }
+        )
+
+        assert "error" in response, response
+        assert "cleanup" in response["error"]["message"].lower()
+        assert temp_path.stat().st_size == 1
+        assert upload["received"] == 0
+        assert server._sessions["sid"]["_desktop_file_uploads"][upload_id] is upload
+        assert reservation_token in server._file_attach_disk_reservations
+    finally:
+        monkeypatch.setattr(Path, "open", original_open)
+        session = server._sessions.pop("sid", None)
+        if session is not None:
+            server._cleanup_file_attach_uploads(session)
+
+
+def test_file_attach_session_teardown_removes_incomplete_temp_file(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    server._sessions["sid"] = _session(cwd=str(workspace))
+
+    begin = server.handle_request(
+        {
+            "id": "begin",
+            "method": "file.attach.begin",
+            "params": {"request_id": str(uuid.uuid4()), "session_id": "sid", "name": "abandoned.bin"},
+        }
+    )
+    upload_id = begin["result"]["upload_id"]
+    temp_path = Path(server._sessions["sid"]["_desktop_file_uploads"][upload_id]["path"])
+    assert temp_path.exists()
+    assert len(server._file_attach_disk_reservations) == 1
+
+    assert server._close_session_by_id("sid", end_reason="test") is True
+    assert not temp_path.exists()
+    assert server._file_attach_disk_reservations == {}
+
+
+def test_file_attach_rejects_symlinked_attachment_root(tmp_path):
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+    hermes_dir = workspace / ".hermes"
+    hermes_dir.mkdir()
+    attachment_root = hermes_dir / "desktop-attachments"
+    try:
+        attachment_root.symlink_to(outside, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlink unavailable: {exc}")
+    server._sessions["sid"] = _session(cwd=str(workspace))
+
+    try:
+        response = server.handle_request(
+            {
+                "id": "legacy",
+                "method": "file.attach",
+                "params": {
+                    "session_id": "sid",
+                    "name": "escape.bin",
+                    "data_url": "data:application/octet-stream;base64,eA==",
+                },
+            }
+        )
+        assert "unsafe attachment directory" in response["error"]["message"]
+        assert not (outside / "escape.bin").exists()
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_file_attach_begin_rejects_symlinked_upload_root(tmp_path):
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+    attachment_root = workspace / ".hermes" / "desktop-attachments"
+    attachment_root.mkdir(parents=True)
+    upload_root = attachment_root / ".uploads"
+    try:
+        upload_root.symlink_to(outside, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlink unavailable: {exc}")
+    server._sessions["sid"] = _session(cwd=str(workspace))
+
+    try:
+        response = server.handle_request(
+            {
+                "id": "begin",
+                "method": "file.attach.begin",
+                "params": {
+                    "request_id": str(uuid.uuid4()),
+                    "session_id": "sid",
+                    "name": "escape.bin",
+                    "size": 1,
+                },
+            }
+        )
+        assert "unsafe attachment directory" in response["error"]["message"]
+        assert not list(outside.iterdir())
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_file_attach_rejects_windows_junction_attachment_root(tmp_path):
+    if os.name != "nt":
+        pytest.skip("Windows junction test")
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+    hermes_dir = workspace / ".hermes"
+    hermes_dir.mkdir()
+    attachment_root = hermes_dir / "desktop-attachments"
+    created = subprocess.run(
+        ["cmd.exe", "/d", "/c", "mklink", "/J", str(attachment_root), str(outside)],
+        capture_output=True,
+        text=True,
+    )
+    if created.returncode != 0:
+        pytest.skip(f"junction unavailable: {created.stderr or created.stdout}")
+    server._sessions["sid"] = _session(cwd=str(workspace))
+
+    try:
+        response = server.handle_request(
+            {
+                "id": "legacy",
+                "method": "file.attach",
+                "params": {
+                    "session_id": "sid",
+                    "name": "junction-escape.bin",
+                    "data_url": "data:application/octet-stream;base64,eA==",
+                },
+            }
+        )
+        assert "unsafe attachment directory" in response["error"]["message"]
+        assert not (outside / "junction-escape.bin").exists()
+    finally:
+        server._sessions.pop("sid", None)
+        with contextlib.suppress(OSError):
+            attachment_root.rmdir()
+
+
+def test_atomic_attachment_write_cleans_up_if_root_is_swapped_after_precheck(
+    monkeypatch, tmp_path
+):
+    root = tmp_path / "workspace" / ".hermes" / "desktop-attachments"
+    outside = tmp_path / "outside"
+    root.mkdir(parents=True)
+    outside.mkdir()
+    original_open = server._open_exclusive_attachment_file
+    swapped = False
+
+    def swap_then_open(path):
+        nonlocal swapped
+        if not swapped and path.parent == root:
+            swapped = True
+            root.rmdir()
+            root.symlink_to(outside, target_is_directory=True)
+        return original_open(path)
+
+    monkeypatch.setattr(server, "_open_exclusive_attachment_file", swap_then_open)
+    with pytest.raises(ValueError, match="unsafe attachment"):
+        server._write_unique_attachment(
+            root, "escape.bin", 1, lambda handle: handle.write(b"x")
+        )
+    assert swapped is True
+    assert not (outside / "escape.bin").exists()
+
+
+def test_atomic_attachment_write_cleanup_stays_bound_to_open_file_after_destination_swap(
+    tmp_path,
+):
+    root = tmp_path / "workspace" / ".hermes" / "desktop-attachments"
+    displaced_root = root.with_name("desktop-attachments-displaced")
+    displaced_file = root / "race-displaced.bin"
+    root.mkdir(parents=True)
+    replacement_payload = b"do-not-delete-replacement"
+
+    def swap_destination_then_fail(handle):
+        assert handle.write(b"x") == 1
+        candidate = root / "race.bin"
+        if os.name == "nt":
+            candidate.rename(displaced_file)
+        else:
+            root.rename(displaced_root)
+            root.mkdir()
+        candidate.write_bytes(replacement_payload)
+        raise OSError("forced write failure after destination swap")
+
+    with pytest.raises(OSError, match="forced write failure after destination swap"):
+        server._write_unique_attachment(root, "race.bin", 1, swap_destination_then_fail)
+
+    assert (root / "race.bin").read_bytes() == replacement_payload
+    displaced_partial = displaced_file if os.name == "nt" else displaced_root / "race.bin"
+    if os.name == "nt":
+        assert not displaced_partial.exists()
+    else:
+        assert displaced_partial.read_bytes() == b"x"
+
+
+def test_atomic_attachment_write_rejects_replacement_before_success(tmp_path):
+    root = tmp_path / "workspace" / ".hermes" / "desktop-attachments"
+    displaced_file = root / "race-displaced.bin"
+    root.mkdir(parents=True)
+    replacement_payload = b"do-not-publish-replacement"
+
+    def swap_destination_then_return(handle):
+        assert handle.write(b"x") == 1
+        candidate = root / "race.bin"
+        candidate.rename(displaced_file)
+        candidate.write_bytes(replacement_payload)
+        return 1
+
+    with pytest.raises(OSError, match="attachment destination identity changed after open"):
+        server._write_unique_attachment(root, "race.bin", 1, swap_destination_then_return)
+
+    assert (root / "race.bin").read_bytes() == replacement_payload
+    if os.name == "nt":
+        assert not displaced_file.exists()
+    else:
+        assert displaced_file.read_bytes() == b"x"
+
+
+def test_atomic_attachment_publish_quarantines_identity_swap_without_deleting_replacement(
+    monkeypatch, tmp_path
+):
+    root = tmp_path / "workspace" / ".hermes" / "desktop-attachments"
+    root.mkdir(parents=True)
+    temp_path = root / "upload.part"
+    temp_path.write_bytes(b"complete")
+    displaced_file = root / "published-displaced.bin"
+    replacement_payload = b"do-not-delete-published-replacement"
+    original_link = os.link
+
+    def link_then_swap(source, destination, *args, **kwargs):
+        original_link(source, destination, *args, **kwargs)
+        candidate = Path(destination)
+        candidate.rename(displaced_file)
+        candidate.write_bytes(replacement_payload)
+
+    monkeypatch.setattr(os, "link", link_then_swap)
+    with pytest.raises(server._FileAttachCleanupError, match="identity changed"):
+        server._publish_unique_attachment(temp_path, root, "published.bin")
+
+    assert (root / "published.bin").read_bytes() == replacement_payload
+    assert temp_path.read_bytes() == b"complete"
+    assert displaced_file.read_bytes() == b"complete"
+
+
+def test_deferred_attachment_cleanup_rejects_quarantined_path_identity_swap(tmp_path):
+    root = tmp_path / "workspace" / ".hermes" / "desktop-attachments"
+    root.mkdir(parents=True)
+    primary = root / ".uploads" / "owned.part"
+    primary.parent.mkdir()
+    primary.write_bytes(b"primary")
+    candidate = root / "owned.bin"
+    candidate.write_bytes(b"owned")
+    primary_stat = os.lstat(primary)
+    candidate_stat = os.lstat(candidate)
+    upload = {
+        "path": str(primary),
+        "path_identity": [int(primary_stat.st_dev), int(primary_stat.st_ino)],
+        "cleanup_paths": [str(candidate)],
+        "cleanup_path_identities": {
+            str(candidate): [int(candidate_stat.st_dev), int(candidate_stat.st_ino)]
+        },
+    }
+    displaced = root / "owned-original.bin"
+    candidate.rename(displaced)
+    candidate.write_bytes(b"replacement")
+
+    assert server._unlink_file_attach_temp(upload) is False
+    assert candidate.read_bytes() == b"replacement"
+    assert displaced.read_bytes() == b"owned"
+    assert not primary.exists()
+    assert "identity" in str(upload.get("cleanup_error", "")).lower()
+
+    primary.write_bytes(b"new-primary")
+    candidate.unlink()
+    displaced.rename(candidate)
+    assert server._unlink_file_attach_temp(upload) is True
+    assert primary.read_bytes() == b"new-primary"
+    assert not candidate.exists()
+
+
+def test_atomic_attachment_write_does_not_unlink_when_exclusive_open_fails(
+    monkeypatch, tmp_path
+):
+    root = tmp_path / "workspace" / ".hermes" / "desktop-attachments"
+    root.mkdir(parents=True)
+    candidate = root / "protected.txt"
+    unlink_calls = []
+
+    def fail_open(path):
+        raise PermissionError("denied before create")
+
+    def record_unlink(self, *args, **kwargs):
+        unlink_calls.append(self)
+
+    monkeypatch.setattr(server, "_open_exclusive_attachment_file", fail_open)
+    monkeypatch.setattr(Path, "unlink", record_unlink)
+    with pytest.raises(PermissionError, match="denied before create"):
+        server._write_unique_attachment(root, candidate.name, 0, lambda handle: 0)
+    assert unlink_calls == []
+
+
+def test_file_attach_begin_requires_idempotency_key(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    server._sessions["sid"] = _session(cwd=str(workspace))
+
+    try:
+        response = server.handle_request(
+            {
+                "id": "begin",
+                "method": "file.attach.begin",
+                "params": {"session_id": "sid", "name": "missing-key.bin"},
+            }
+        )
+        assert response["error"]["code"] == 5028
+        assert "request_id required" in response["error"]["message"]
+        assert server._sessions["sid"].get("_desktop_file_uploads", {}) == {}
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_file_attach_begin_retry_recovers_state_without_consuming_slot(
+    monkeypatch, tmp_path
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    monkeypatch.setenv("HERMES_FILE_ATTACH_MAX_ACTIVE_UPLOADS", "1")
+    request_id = str(uuid.uuid4())
+    params = {
+        "request_id": request_id,
+        "session_id": "sid",
+        "name": "retry.bin",
+        "size": 5,
+    }
+
+    try:
+        first = server.handle_request(
+            {"id": "begin-1", "method": "file.attach.begin", "params": params}
+        )
+        upload_id = first["result"]["upload_id"]
+        chunk = server.handle_request(
+            {
+                "id": "chunk",
+                "method": "file.attach.chunk",
+                "params": {
+                    "session_id": "sid",
+                    "upload_id": upload_id,
+                    "offset": 0,
+                    "content_base64": base64.b64encode(b"hello").decode("ascii"),
+                },
+            }
+        )
+        assert chunk["result"]["received"] == 5
+        retry = server.handle_request(
+            {"id": "begin-2", "method": "file.attach.begin", "params": params}
+        )
+        assert retry["result"]["upload_id"] == upload_id
+        assert retry["result"]["received"] == 5
+        assert retry["result"]["duplicate"] is True
+        assert len(server._sessions["sid"]["_desktop_file_uploads"]) == 1
+
+        mismatched = server.handle_request(
+            {
+                "id": "begin-mismatch",
+                "method": "file.attach.begin",
+                "params": {**params, "name": "different.bin"},
+            }
+        )
+        assert mismatched["error"]["code"] == 5028
+        assert "different upload" in mismatched["error"]["message"]
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_file_attach_begin_limits_active_uploads_and_cancel_releases_slot(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    monkeypatch.setattr(server, "_file_attach_max_active_uploads", lambda: 2)
+
+    try:
+        upload_ids = []
+        for index in range(2):
+            begin = server.handle_request(
+                {
+                    "id": f"begin-{index}",
+                    "method": "file.attach.begin",
+                    "params": {"request_id": str(uuid.uuid4()), "session_id": "sid", "name": f"file-{index}.bin"},
+                }
+            )
+            upload_ids.append(begin["result"]["upload_id"])
+
+        rejected = server.handle_request(
+            {
+                "id": "begin-rejected",
+                "method": "file.attach.begin",
+                "params": {"request_id": str(uuid.uuid4()), "session_id": "sid", "name": "third.bin"},
+            }
+        )
+        assert "error" in rejected
+        assert "too many active uploads" in rejected["error"]["message"]
+
+        server.handle_request(
+            {
+                "id": "cancel",
+                "method": "file.attach.cancel",
+                "params": {"session_id": "sid", "upload_id": upload_ids[0]},
+            }
+        )
+        accepted = server.handle_request(
+            {
+                "id": "begin-accepted",
+                "method": "file.attach.begin",
+                "params": {"request_id": str(uuid.uuid4()), "session_id": "sid", "name": "replacement.bin"},
+            }
+        )
+        assert "error" not in accepted
+    finally:
+        server._close_session_by_id("sid", end_reason="test")
+
+
+def test_file_attach_begin_reaps_idle_upload_before_applying_active_limit(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    monkeypatch.setattr(server, "_file_attach_max_active_uploads", lambda: 1)
+    monkeypatch.setattr(server, "_file_attach_stale_seconds", lambda: 60.0)
+
+    try:
+        first = server.handle_request(
+            {
+                "id": "begin-old",
+                "method": "file.attach.begin",
+                "params": {"request_id": str(uuid.uuid4()), "session_id": "sid", "name": "old.bin"},
+            }
+        )
+        old_id = first["result"]["upload_id"]
+        old_upload = server._sessions["sid"]["_desktop_file_uploads"][old_id]
+        old_path = Path(old_upload["path"])
+        old_upload["updated_at"] = time.time() - 61
+
+        replacement = server.handle_request(
+            {
+                "id": "begin-new",
+                "method": "file.attach.begin",
+                "params": {"request_id": str(uuid.uuid4()), "session_id": "sid", "name": "new.bin"},
+            }
+        )
+
+        assert "error" not in replacement
+        assert old_id not in server._sessions["sid"]["_desktop_file_uploads"]
+        assert not old_path.exists()
+    finally:
+        server._close_session_by_id("sid", end_reason="test")
+
+
+def test_file_attach_concurrent_begin_cannot_bypass_active_limit(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    monkeypatch.setattr(server, "_file_attach_max_active_uploads", lambda: 1)
+    original_upload_dir = server._desktop_attachment_upload_dir
+    barrier = threading.Barrier(2)
+
+    def _synchronized_upload_dir(session):
+        try:
+            barrier.wait(timeout=0.5)
+        except threading.BrokenBarrierError:
+            pass
+        return original_upload_dir(session)
+
+    monkeypatch.setattr(server, "_desktop_attachment_upload_dir", _synchronized_upload_dir)
+
+    def _begin(index):
+        return server.handle_request(
+            {
+                "id": f"begin-{index}",
+                "method": "file.attach.begin",
+                "params": {"request_id": str(uuid.uuid4()), "session_id": "sid", "name": f"race-{index}.bin"},
+            }
+        )
+
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            responses = list(pool.map(_begin, range(2)))
+
+        assert sum("result" in response for response in responses) == 1
+        assert sum("error" in response for response in responses) == 1
+        assert len(server._sessions["sid"]["_desktop_file_uploads"]) == 1
+    finally:
+        server._close_session_by_id("sid", end_reason="test")
+
+
+def test_file_attach_concurrent_chunks_cannot_write_same_offset(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    begin = server.handle_request(
+        {
+            "id": "begin",
+            "method": "file.attach.begin",
+            "params": {"request_id": str(uuid.uuid4()), "session_id": "sid", "name": "chunk-race.bin"},
+        }
+    )
+    upload_id = begin["result"]["upload_id"]
+    original_decode = server._decode_attachment_data_url
+    barrier = threading.Barrier(2)
+
+    def _synchronized_decode(content):
+        try:
+            barrier.wait(timeout=0.5)
+        except threading.BrokenBarrierError:
+            pass
+        return original_decode(content)
+
+    monkeypatch.setattr(server, "_decode_attachment_data_url", _synchronized_decode)
+
+    def _chunk(index):
+        content = "aGVsbG8=" if index == 0 else "d29ybGQ="
+        return server.handle_request(
+            {
+                "id": f"chunk-{index}",
+                "method": "file.attach.chunk",
+                "params": {
+                    "session_id": "sid",
+                    "upload_id": upload_id,
+                    "offset": 0,
+                    "content_base64": content,
+                },
+            }
+        )
+
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            responses = list(pool.map(_chunk, range(2)))
+
+        assert sum("result" in response for response in responses) == 1
+        assert sum("error" in response for response in responses) == 1
+        upload = server._sessions["sid"]["_desktop_file_uploads"][upload_id]
+        assert Path(upload["path"]).stat().st_size == 5
+    finally:
+        server._close_session_by_id("sid", end_reason="test")
+
+
+def test_file_attach_finish_cannot_race_with_cancel(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    begin = server.handle_request(
+        {
+            "id": "begin",
+            "method": "file.attach.begin",
+            "params": {"request_id": str(uuid.uuid4()), "session_id": "sid", "name": "finish-race.txt", "size": 5},
+        }
+    )
+    upload_id = begin["result"]["upload_id"]
+    server.handle_request(
+        {
+            "id": "chunk",
+            "method": "file.attach.chunk",
+            "params": {
+                "session_id": "sid",
+                "upload_id": upload_id,
+                "offset": 0,
+                "content_base64": "aGVsbG8=",
+            },
+        }
+    )
+    original_publish = server._publish_unique_attachment
+    finish_entered = threading.Event()
+
+    def _blocked_publish(temp_path, root, name):
+        finish_entered.set()
+        time.sleep(0.2)
+        return original_publish(temp_path, root, name)
+
+    monkeypatch.setattr(server, "_publish_unique_attachment", _blocked_publish)
+
+    def _finish():
+        return server.handle_request(
+            {
+                "id": "finish",
+                "method": "file.attach.finish",
+                "params": {"session_id": "sid", "upload_id": upload_id},
+            }
+        )
+
+    def _cancel():
+        assert finish_entered.wait(timeout=1)
+        return server.handle_request(
+            {
+                "id": "cancel",
+                "method": "file.attach.cancel",
+                "params": {"session_id": "sid", "upload_id": upload_id},
+            }
+        )
+
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            finish_future = pool.submit(_finish)
+            cancel_future = pool.submit(_cancel)
+            finish = finish_future.result()
+            cancel = cancel_future.result()
+
+        assert "error" not in finish
+        assert finish["result"]["attached"] is True
+        assert cancel["result"] == {"cancelled": False, "completed": True}
+        assert Path(finish["result"]["path"]).read_bytes() == b"hello"
+    finally:
+        server._close_session_by_id("sid", end_reason="test")
+
+
+def test_file_attach_teardown_waits_for_inflight_chunk(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    begin = server.handle_request(
+        {
+            "id": "begin",
+            "method": "file.attach.begin",
+            "params": {"request_id": str(uuid.uuid4()), "session_id": "sid", "name": "teardown-race.bin"},
+        }
+    )
+    upload_id = begin["result"]["upload_id"]
+    temp_path = Path(server._sessions["sid"]["_desktop_file_uploads"][upload_id]["path"])
+    original_decode = server._decode_attachment_data_url
+    chunk_entered = threading.Event()
+
+    def _blocked_decode(content):
+        chunk_entered.set()
+        time.sleep(0.2)
+        return original_decode(content)
+
+    monkeypatch.setattr(server, "_decode_attachment_data_url", _blocked_decode)
+
+    def _chunk():
+        return server.handle_request(
+            {
+                "id": "chunk",
+                "method": "file.attach.chunk",
+                "params": {
+                    "session_id": "sid",
+                    "upload_id": upload_id,
+                    "offset": 0,
+                    "content_base64": "aGVsbG8=",
+                },
+            }
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        chunk_future = pool.submit(_chunk)
+        assert chunk_entered.wait(timeout=1)
+        close_future = pool.submit(server._close_session_by_id, "sid", end_reason="test")
+        chunk = chunk_future.result()
+        closed = close_future.result()
+
+    assert "error" not in chunk
+    assert chunk["result"]["received"] == 5
+    assert closed is True
+    assert not temp_path.exists()
+
+
+def test_file_attach_chunked_upload_finalizes_into_session_workspace(monkeypatch, tmp_path):
+    """Remote large-file path: upload chunks instead of a single 16 MB data_url."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.delenv("HERMES_FILE_ATTACH_MAX_CHUNK_BYTES", raising=False)
+    fake_cli = types.ModuleType("cli")
+    fake_cli._detect_file_drop = lambda raw: None
+    fake_cli._split_path_input = lambda raw: (raw, "")
+    fake_cli._resolve_attachment_path = lambda raw: None
+
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+
+    try:
+        begin = server.handle_request(
+            {
+                "id": "begin",
+                "method": "file.attach.begin",
+                "params": {
+                    "request_id": str(uuid.uuid4()),
+                    "session_id": "sid",
+                    "path": "/Users/alice/Downloads/report.txt",
+                    "name": "report.txt",
+                    "size": 11,
+                },
+            }
+        )
+        upload_id = begin["result"]["upload_id"]
+        assert begin["result"]["received"] == 0
+        assert begin["result"]["max_chunk_bytes"] >= 1024 * 1024
+
+        first = server.handle_request(
+            {
+                "id": "chunk-1",
+                "method": "file.attach.chunk",
+                "params": {
+                    "session_id": "sid",
+                    "upload_id": upload_id,
+                    "offset": 0,
+                    "content_base64": "aGVsbG8=",
+                },
+            }
+        )
+        assert first["result"]["received"] == 5
+
+        second = server.handle_request(
+            {
+                "id": "chunk-2",
+                "method": "file.attach.chunk",
+                "params": {
+                    "session_id": "sid",
+                    "upload_id": upload_id,
+                    "offset": 5,
+                    "content_base64": "IHdvcmxk",
+                },
+            }
+        )
+        assert second["result"]["received"] == 11
+
+        finish = server.handle_request(
+            {
+                "id": "finish",
+                "method": "file.attach.finish",
+                "params": {"session_id": "sid", "upload_id": upload_id},
+            }
+        )
+
+        stored = workspace / ".hermes" / "desktop-attachments" / "report.txt"
+        assert finish["result"]["attached"] is True
+        assert finish["result"]["uploaded"] is True
+        assert finish["result"]["path"] == str(stored)
+        assert finish["result"]["ref_text"] == "@file:.hermes/desktop-attachments/report.txt"
+        assert stored.read_text(encoding="utf-8") == "hello world"
+        assert upload_id not in server._sessions["sid"].get("_desktop_file_uploads", {})
+
+        finish_retry = server.handle_request(
+            {
+                "id": "finish-retry",
+                "method": "file.attach.finish",
+                "params": {"session_id": "sid", "upload_id": upload_id},
+            }
+        )
+        assert finish_retry["result"] == finish["result"]
+        assert [path.name for path in stored.parent.glob("report*.txt")] == ["report.txt"]
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_file_attach_concurrent_finish_across_sessions_never_overwrites(
+    monkeypatch, tmp_path
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    fake_cli = types.ModuleType("cli")
+    fake_cli._detect_file_drop = lambda raw: None
+    fake_cli._split_path_input = lambda raw: (raw, "")
+    fake_cli._resolve_attachment_path = lambda raw: None
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+    server._sessions["sid-a"] = _session(cwd=str(workspace))
+    server._sessions["sid-b"] = _session(cwd=str(workspace))
+
+    uploads = []
+    try:
+        for session_id, payload in (("sid-a", b"alpha"), ("sid-b", b"bravo")):
+            begin = server.handle_request(
+                {
+                    "id": f"begin-{session_id}",
+                    "method": "file.attach.begin",
+                    "params": {
+                        "request_id": str(uuid.uuid4()),
+                        "session_id": session_id,
+                        "name": "same.txt",
+                        "size": len(payload),
+                    },
+                }
+            )
+            upload_id = begin["result"]["upload_id"]
+            chunk = server.handle_request(
+                {
+                    "id": f"chunk-{session_id}",
+                    "method": "file.attach.chunk",
+                    "params": {
+                        "session_id": session_id,
+                        "upload_id": upload_id,
+                        "offset": 0,
+                        "content_base64": base64.b64encode(payload).decode("ascii"),
+                    },
+                }
+            )
+            assert chunk["result"]["received"] == len(payload)
+            uploads.append((session_id, upload_id, payload))
+
+        barrier = threading.Barrier(2)
+        real_link = server.os.link
+
+        def synchronized_link(source, target, *args, **kwargs):
+            if Path(target).name == "same.txt":
+                barrier.wait(timeout=10)
+            return real_link(source, target, *args, **kwargs)
+
+        monkeypatch.setattr(server.os, "link", synchronized_link)
+
+        def finish(item):
+            session_id, upload_id, payload = item
+            response = server.handle_request(
+                {
+                    "id": f"finish-{session_id}",
+                    "method": "file.attach.finish",
+                    "params": {"session_id": session_id, "upload_id": upload_id},
+                }
+            )
+            return response, payload
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            results = list(pool.map(finish, uploads))
+
+        paths = [Path(response["result"]["path"]) for response, _ in results]
+        assert len(set(paths)) == 2
+        assert {path.name for path in paths} == {"same.txt", "same-2.txt"}
+        for (response, expected), path in zip(results, paths, strict=True):
+            assert "error" not in response
+            assert path.read_bytes() == expected
+    finally:
+        server._sessions.pop("sid-a", None)
+        server._sessions.pop("sid-b", None)
+
+
+def test_file_attach_chunked_upload_cancel_removes_temp_file(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    fake_cli = types.ModuleType("cli")
+    fake_cli._detect_file_drop = lambda raw: None
+    fake_cli._split_path_input = lambda raw: (raw, "")
+    fake_cli._resolve_attachment_path = lambda raw: None
+
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+    request_id = str(uuid.uuid4())
+
+    try:
+        begin = server.handle_request(
+            {
+                "id": "begin",
+                "method": "file.attach.begin",
+                "params": {"request_id": request_id, "session_id": "sid", "name": "cancel.txt"},
+            }
+        )
+        upload_id = begin["result"]["upload_id"]
+        temp_path = workspace / ".hermes" / "desktop-attachments" / ".uploads" / f"{upload_id}.part"
+        assert temp_path.exists()
+
+        cancel = server.handle_request(
+            {
+                "id": "cancel",
+                "method": "file.attach.cancel",
+                "params": {"session_id": "sid", "upload_id": upload_id},
+            }
+        )
+
+        assert cancel["result"]["cancelled"] is True
+        assert not temp_path.exists()
+        assert upload_id not in server._sessions["sid"].get("_desktop_file_uploads", {})
+        delayed_begin = server.handle_request(
+            {
+                "id": "delayed-begin",
+                "method": "file.attach.begin",
+                "params": {"request_id": request_id, "session_id": "sid", "name": "cancel.txt"},
+            }
+        )
+        assert delayed_begin["error"]["code"] == 5028
+        assert "already cancelled" in delayed_begin["error"]["message"]
+        assert not temp_path.exists()
+    finally:
+        server._sessions.pop("sid", None)
+
+
 def test_file_attach_copies_gateway_visible_file_outside_workspace(monkeypatch, tmp_path):
     """Local case: gateway can see the file but it's outside the workspace → copy in."""
     workspace = tmp_path / "workspace"
@@ -4325,6 +6389,164 @@ def test_file_attach_copies_gateway_visible_file_outside_workspace(monkeypatch, 
         assert resp["result"]["uploaded"] is True
         assert resp["result"]["ref_text"] == "@file:.hermes/desktop-attachments/outside.txt"
         assert stored.read_text(encoding="utf-8") == "outside workspace"
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_file_attach_rejects_gateway_visible_source_that_grows_after_reservation(
+    monkeypatch, tmp_path
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    source = tmp_path / "growing.bin"
+    source.write_bytes(b"1234")
+    fake_cli = types.ModuleType("cli")
+    fake_cli._detect_file_drop = lambda raw: None
+    fake_cli._split_path_input = lambda raw: (raw, "")
+    fake_cli._resolve_attachment_path = lambda raw: source
+
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+    monkeypatch.setattr(server, "_file_attach_max_total_bytes", lambda: 8)
+    monkeypatch.setattr(server, "_file_attach_available_bytes", lambda _path: 100)
+    monkeypatch.setattr(server, "_file_attach_free_space_reserve_bytes", lambda: 0)
+    original_reserve = server._reserve_file_attach_disk_space
+
+    def reserve_then_grow(path, amount):
+        token = original_reserve(path, amount)
+        source.write_bytes(b"1234567890ABCD")
+        return token
+
+    monkeypatch.setattr(server, "_reserve_file_attach_disk_space", reserve_then_grow)
+
+    try:
+        response = server.handle_request(
+            {
+                "id": "growing-source",
+                "method": "file.attach",
+                "params": {"session_id": "sid", "path": str(source)},
+            }
+        )
+
+        assert "changed while being copied" in response["error"]["message"]
+        assert not (
+            workspace / ".hermes" / "desktop-attachments" / "growing.bin"
+        ).exists()
+        with server._file_attach_disk_reservation_lock:
+            assert not server._file_attach_disk_reservations
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_file_attach_source_copy_partial_write_cleanup_failure_is_quarantined(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    source = tmp_path / "source-locked.bin"
+    source.write_bytes(b"ABCD")
+    fake_cli = types.ModuleType("cli")
+    fake_cli._detect_file_drop = lambda raw: None
+    fake_cli._split_path_input = lambda raw: (raw, "")
+    fake_cli._resolve_attachment_path = lambda raw: source
+    original_open = server._open_exclusive_attachment_file
+    original_unlink = Path.unlink
+
+    class _ShortWriteHandle:
+        def __init__(self, handle):
+            self._handle = handle
+
+        def write(self, payload):
+            return self._handle.write(payload[:1])
+
+        def __getattr__(self, name):
+            return getattr(self._handle, name)
+
+    def short_target_open(path):
+        handle = original_open(path)
+        if path.name == source.name:
+            return _ShortWriteHandle(handle)
+        return handle
+
+    def fail_target_unlink(path, *args, **kwargs):
+        if path.name == source.name and path.parent.name == "desktop-attachments":
+            raise PermissionError("locked source-copy cleanup")
+        return original_unlink(path, *args, **kwargs)
+
+    def fail_target_handle_delete(_handle):
+        raise PermissionError("locked source-copy handle cleanup")
+
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+    monkeypatch.setattr(server, "_open_exclusive_attachment_file", short_target_open)
+    monkeypatch.setattr(Path, "unlink", fail_target_unlink)
+    if os.name == "nt":
+        monkeypatch.setattr(server, "_mark_open_attachment_for_delete", fail_target_handle_delete)
+
+    try:
+        response = server.handle_request(
+            {
+                "id": "source-partial-cleanup",
+                "method": "file.attach",
+                "params": {"session_id": "sid", "path": str(source), "name": source.name},
+            }
+        )
+        partial = workspace / ".hermes" / "desktop-attachments" / source.name
+
+        assert "cleanup" in response["error"]["message"].lower()
+        assert partial.exists()
+        assert len(server._file_attach_cleanup_quarantine) == 1
+        assert len(server._file_attach_disk_reservations) == 1
+    finally:
+        monkeypatch.setattr(server, "_open_exclusive_attachment_file", original_open)
+        monkeypatch.setattr(Path, "unlink", original_unlink)
+        server._sessions.pop("sid", None)
+        server._retry_file_attach_cleanup_quarantine()
+
+
+def test_file_attach_rejects_same_size_source_rewrite_after_reservation(
+    monkeypatch, tmp_path
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    source = tmp_path / "rewritten.bin"
+    source.write_bytes(b"good")
+    initial_stat = source.stat()
+    fake_cli = types.ModuleType("cli")
+    fake_cli._detect_file_drop = lambda raw: None
+    fake_cli._split_path_input = lambda raw: (raw, "")
+    fake_cli._resolve_attachment_path = lambda raw: source
+
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+    monkeypatch.setattr(server, "_file_attach_available_bytes", lambda _path: 100)
+    monkeypatch.setattr(server, "_file_attach_free_space_reserve_bytes", lambda: 0)
+    original_reserve = server._reserve_file_attach_disk_space
+
+    def reserve_then_rewrite(path, amount):
+        token = original_reserve(path, amount)
+        source.write_bytes(b"evil")
+        os.utime(
+            source,
+            ns=(initial_stat.st_atime_ns, initial_stat.st_mtime_ns + 1_000_000_000),
+        )
+        return token
+
+    monkeypatch.setattr(server, "_reserve_file_attach_disk_space", reserve_then_rewrite)
+
+    try:
+        response = server.handle_request(
+            {
+                "id": "rewritten-source",
+                "method": "file.attach",
+                "params": {"session_id": "sid", "path": str(source)},
+            }
+        )
+
+        assert "changed while being copied" in response["error"]["message"]
+        assert not (
+            workspace / ".hermes" / "desktop-attachments" / "rewritten.bin"
+        ).exists()
+        with server._file_attach_disk_reservation_lock:
+            assert not server._file_attach_disk_reservations
     finally:
         server._sessions.pop("sid", None)
 
@@ -5871,6 +8093,7 @@ def test_session_create_lazy_info_reports_desktop_contract(monkeypatch):
     info = resp["result"]["info"]
 
     assert info["desktop_contract"] == server.DESKTOP_BACKEND_CONTRACT
+    assert server.DESKTOP_BACKEND_CONTRACT == 5
 
     server._sessions.pop(resp["result"]["session_id"], None)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10102,29 +10102,36 @@ def _run_file_attach_reserved_write(token: str, path: Path, amount: int, writer)
         return result
 
 
-def _append_file_attach_reserved_chunk(token: str, path: Path, payload: bytes) -> None:
-    path_identity = _file_attach_object_identity(os.lstat(path))
-    initial_size = path.stat().st_size
-
+def _append_file_attach_reserved_chunk(
+    token: str,
+    path: Path,
+    expected_identity: tuple[int, int],
+    payload: bytes,
+) -> None:
     def _append() -> None:
-        try:
-            with path.open("ab") as handle:
-                written = handle.write(payload)
-            if written != len(payload):
-                raise OSError("attachment chunk write was incomplete")
-            _assert_safe_attachment_file(path)
-        except BaseException as write_error:
+        with path.open("r+b", buffering=0) as handle:
+            opened_stat = os.fstat(handle.fileno())
+            if _file_attach_object_identity(opened_stat) != expected_identity:
+                raise OSError("attachment destination identity changed after begin")
+            initial_size = int(opened_stat.st_size)
+            handle.seek(0, os.SEEK_END)
             try:
-                _assert_safe_attachment_file(path)
-                with path.open("r+b") as handle:
+                written = handle.write(payload)
+                if written != len(payload):
+                    raise OSError("attachment chunk write was incomplete")
+                if os.fstat(handle.fileno()).st_size != initial_size + len(payload):
+                    raise OSError("attachment chunk write size mismatch")
+                _assert_attachment_path_identity(path, expected_identity)
+            except BaseException as write_error:
+                try:
                     handle.truncate(initial_size)
-                if path.stat().st_size != initial_size:
-                    raise OSError("attachment rollback did not restore the original size")
-            except (OSError, ValueError) as cleanup_error:
-                raise _FileAttachCleanupError(
-                    path, path_identity, write_error, cleanup_error
-                ) from write_error
-            raise
+                    if os.fstat(handle.fileno()).st_size != initial_size:
+                        raise OSError("attachment rollback did not restore the original size")
+                except (OSError, ValueError) as cleanup_error:
+                    raise _FileAttachCleanupError(
+                        path, expected_identity, write_error, cleanup_error
+                    ) from write_error
+                raise
 
     _run_file_attach_reserved_write(token, path.parent, len(payload), _append)
 
@@ -10846,7 +10853,10 @@ def _(rid, params: dict) -> dict:
             raise ValueError("offset required")
         expected = int(upload.get("received") or 0)
         temp_path = Path(str(upload.get("path") or ""))
-        _assert_safe_attachment_file(temp_path)
+        temp_identity = _file_attach_expected_identity(
+            upload.get("path_identity"), label=str(temp_path)
+        )
+        _assert_attachment_path_identity(temp_path, temp_identity)
         try:
             actual_size = temp_path.stat().st_size
         except FileNotFoundError as exc:
@@ -10894,7 +10904,10 @@ def _(rid, params: dict) -> dict:
                 f"file exceeds maximum file size ({max_total_bytes} bytes)"
             )
         _append_file_attach_reserved_chunk(
-            str(upload.get("disk_reservation_token") or ""), temp_path, payload
+            str(upload.get("disk_reservation_token") or ""),
+            temp_path,
+            temp_identity,
+            payload,
         )
         received = expected + len(payload)
         upload["received"] = received

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3,11 +3,13 @@ import concurrent.futures
 import contextlib
 import contextvars
 import copy
+import hashlib
 import inspect
 import json
 import logging
 import os
 import queue
+import shutil
 import subprocess
 import sys
 import threading
@@ -698,6 +700,7 @@ def _teardown_session(session: dict | None, *, end_reason: str = "tui_close") ->
     """
     if not session:
         return
+    _cleanup_file_attach_uploads(session)
     _finalize_session(session, end_reason=end_reason)
     try:
         from tools.approval import unregister_gateway_notify
@@ -3307,7 +3310,10 @@ def _current_profile_name() -> str:
 # checkout), surfacing a one-click "update to align" prompt instead of failing
 # cryptically downstream. Bump whenever the desktop's backend contract changes.
 # v2: adds the file.attach RPC (remote-gateway non-image file upload).
-DESKTOP_BACKEND_CONTRACT = 2
+# v3: adds file.attach.begin/chunk/finish/cancel resumable uploads.
+# v4: makes begin idempotent and publishes attachments without overwrite races.
+# v5: requires request-id cancellation recovery and a fail-closed capability handshake.
+DESKTOP_BACKEND_CONTRACT = 5
 
 
 def _session_info(agent, session: dict | None = None) -> dict:
@@ -9778,33 +9784,623 @@ def _attachment_ref_path(session: dict, target: Path) -> str:
         return str(target.resolve())
 
 
+_FILE_ATTRIBUTE_REPARSE_POINT = 0x400
+
+
+def _file_attach_path_is_reparse(path: Path) -> bool:
+    try:
+        info = path.lstat()
+    except OSError:
+        return False
+    return path.is_symlink() or bool(
+        int(getattr(info, "st_file_attributes", 0) or 0)
+        & _FILE_ATTRIBUTE_REPARSE_POINT
+    )
+
+
+def _assert_safe_attachment_root(root: Path) -> Path:
+    """Reject symlink/junction roots and require workspace containment."""
+    lexical_root = Path(root)
+    attachment_root = (
+        lexical_root.parent if lexical_root.name == ".uploads" else lexical_root
+    )
+    hermes_root = attachment_root.parent
+    if attachment_root.name != "desktop-attachments" or hermes_root.name != ".hermes":
+        raise ValueError("unsafe attachment directory")
+    workspace = hermes_root.parent.resolve(strict=True)
+    check_paths = [hermes_root, attachment_root]
+    if lexical_root != attachment_root:
+        check_paths.append(lexical_root)
+    for candidate in check_paths:
+        if _file_attach_path_is_reparse(candidate):
+            raise ValueError("unsafe attachment directory: reparse point")
+        if not candidate.is_dir():
+            raise ValueError("unsafe attachment directory: not a directory")
+        try:
+            candidate.resolve(strict=True).relative_to(workspace)
+        except (OSError, ValueError) as exc:
+            raise ValueError("unsafe attachment directory: outside workspace") from exc
+    return workspace
+
+
+def _ensure_safe_attachment_subdir(workspace: Path, *parts: str) -> Path:
+    workspace = workspace.resolve(strict=True)
+    current = workspace
+    for part in parts:
+        candidate = current / part
+        if candidate.exists() or candidate.is_symlink():
+            if _file_attach_path_is_reparse(candidate) or not candidate.is_dir():
+                raise ValueError("unsafe attachment directory: reparse point or non-directory")
+        else:
+            candidate.mkdir()
+        if _file_attach_path_is_reparse(candidate):
+            raise ValueError("unsafe attachment directory: reparse point")
+        try:
+            candidate.resolve(strict=True).relative_to(workspace)
+        except (OSError, ValueError) as exc:
+            raise ValueError("unsafe attachment directory: outside workspace") from exc
+        current = candidate
+    _assert_safe_attachment_root(current)
+    return current
+
+
+def _assert_safe_attachment_file(path: Path) -> None:
+    workspace = _assert_safe_attachment_root(path.parent)
+    if _file_attach_path_is_reparse(path) or not path.is_file():
+        raise ValueError("unsafe attachment file")
+    try:
+        path.resolve(strict=True).relative_to(workspace)
+    except (OSError, ValueError) as exc:
+        raise ValueError("unsafe attachment file: outside workspace") from exc
+
+
+def _file_attach_object_identity(value: os.stat_result) -> tuple[int, int]:
+    return (int(value.st_dev), int(value.st_ino))
+
+
+def _file_attach_identity_record(identity: tuple[int, int]) -> list[int]:
+    return [int(identity[0]), int(identity[1])]
+
+
+def _file_attach_expected_identity(value: object, *, label: str) -> tuple[int, int]:
+    if (
+        not isinstance(value, (list, tuple))
+        or len(value) != 2
+        or isinstance(value[0], bool)
+        or isinstance(value[1], bool)
+    ):
+        raise ValueError(f"attachment cleanup identity metadata is missing for {label}")
+    try:
+        return (int(value[0]), int(value[1]))
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"attachment cleanup identity metadata is invalid for {label}"
+        ) from exc
+
+
+def _unlink_file_attach_temp(upload: dict) -> bool:
+    primary = Path(str(upload.get("path") or ""))
+    raw_cleanup_paths = upload.get("cleanup_paths")
+    raw_cleanup_identities = upload.get("cleanup_path_identities")
+    cleanup_identities = (
+        raw_cleanup_identities if isinstance(raw_cleanup_identities, dict) else {}
+    )
+    entries: list[tuple[Path, object]] = [
+        (primary, upload.get("path_identity"))
+    ]
+    if isinstance(raw_cleanup_paths, list):
+        entries.extend(
+            (Path(str(value)), cleanup_identities.get(str(value)))
+            for value in raw_cleanup_paths
+            if str(value)
+        )
+    raw_completed_paths = upload.get("cleanup_completed_paths")
+    completed_paths = (
+        {str(value) for value in raw_completed_paths if str(value)}
+        if isinstance(raw_completed_paths, list)
+        else set()
+    )
+    seen: set[str] = set()
+    try:
+        for path, raw_identity in entries:
+            key = os.path.normcase(str(path.resolve(strict=False)))
+            if key in seen:
+                continue
+            seen.add(key)
+            if key in completed_paths:
+                continue
+            expected_identity = _file_attach_expected_identity(
+                raw_identity, label=str(path)
+            )
+            if not os.path.lexists(path):
+                raise OSError(
+                    f"attachment cleanup identity was lost before deferred cleanup: {path}"
+                )
+            _unlink_attachment_path_if_identity(path, expected_identity)
+            completed_paths.add(key)
+            upload["cleanup_completed_paths"] = sorted(completed_paths)
+        upload.pop("cleanup_error", None)
+        upload.pop("cleanup_paths", None)
+        upload.pop("cleanup_path_identities", None)
+        upload.pop("cleanup_completed_paths", None)
+        upload.pop("path_identity", None)
+        return True
+    except (OSError, ValueError) as exc:
+        upload["cleanup_error"] = str(exc)
+        return False
+
+
 def _desktop_attachment_dir(session: dict) -> Path:
-    root = Path(_session_cwd(session)).resolve() / ".hermes" / "desktop-attachments"
-    root.mkdir(parents=True, exist_ok=True)
-    return root
+    workspace = Path(_session_cwd(session)).resolve(strict=True)
+    return _ensure_safe_attachment_subdir(
+        workspace, ".hermes", "desktop-attachments"
+    )
+
+
+def _desktop_attachment_upload_dir(session: dict) -> Path:
+    workspace = Path(_session_cwd(session)).resolve(strict=True)
+    return _ensure_safe_attachment_subdir(
+        workspace, ".hermes", "desktop-attachments", ".uploads"
+    )
+
+
+_FILE_ATTACH_DEFAULT_MAX_CHUNK_BYTES = 8 * 1024 * 1024
+_FILE_ATTACH_MIN_CHUNK_BYTES = 64 * 1024
+_FILE_ATTACH_DEFAULT_MAX_TOTAL_BYTES = 1024 * 1024 * 1024
+_FILE_ATTACH_MIN_TOTAL_BYTES = 16 * 1024 * 1024
+_FILE_ATTACH_MAX_TOTAL_BYTES_CAP = 8 * 1024 * 1024 * 1024
+_FILE_ATTACH_DEFAULT_MAX_ACTIVE_UPLOADS = 2
+_FILE_ATTACH_MAX_ACTIVE_UPLOADS_CAP = 8
+_FILE_ATTACH_DEFAULT_STALE_SECONDS = 30 * 60.0
+_FILE_ATTACH_MIN_STALE_SECONDS = 60.0
+_FILE_ATTACH_MAX_STALE_SECONDS = 24 * 60 * 60.0
+_FILE_ATTACH_DEFAULT_FREE_SPACE_RESERVE_BYTES = 256 * 1024 * 1024
+_FILE_ATTACH_MIN_FREE_SPACE_RESERVE_BYTES = 64 * 1024 * 1024
+_FILE_ATTACH_MAX_FREE_SPACE_RESERVE_BYTES = 4 * 1024 * 1024 * 1024
+_file_attach_disk_reservation_lock = threading.RLock()
+_file_attach_disk_reservations: dict[str, dict[str, Any]] = {}
+_file_attach_cleanup_quarantine: dict[str, dict[str, Any]] = {}
+
+
+def _file_attach_max_chunk_bytes() -> int:
+    """Return the per-process Desktop upload chunk limit with a safe clamp."""
+    raw = str(os.getenv("HERMES_FILE_ATTACH_MAX_CHUNK_BYTES", "") or "").strip()
+    try:
+        configured = int(raw) if raw else _FILE_ATTACH_DEFAULT_MAX_CHUNK_BYTES
+    except (TypeError, ValueError):
+        configured = _FILE_ATTACH_DEFAULT_MAX_CHUNK_BYTES
+    return max(
+        _FILE_ATTACH_MIN_CHUNK_BYTES,
+        min(configured, _FILE_ATTACH_DEFAULT_MAX_CHUNK_BYTES),
+    )
+
+
+def _file_attach_max_total_bytes() -> int:
+    """Return the configured per-file upload ceiling (default 1 GiB)."""
+    try:
+        desktop_cfg = _load_cfg().get("desktop") or {}
+        configured = int(
+            desktop_cfg.get("file_upload_max_bytes")
+            or _FILE_ATTACH_DEFAULT_MAX_TOTAL_BYTES
+        )
+    except (AttributeError, TypeError, ValueError):
+        configured = _FILE_ATTACH_DEFAULT_MAX_TOTAL_BYTES
+    return max(
+        _FILE_ATTACH_MIN_TOTAL_BYTES,
+        min(configured, _FILE_ATTACH_MAX_TOTAL_BYTES_CAP),
+    )
+
+
+def _file_attach_max_active_uploads() -> int:
+    """Return the bounded number of incomplete uploads allowed per session."""
+    try:
+        desktop_cfg = _load_cfg().get("desktop") or {}
+        configured = int(
+            desktop_cfg.get("file_upload_max_active")
+            or _FILE_ATTACH_DEFAULT_MAX_ACTIVE_UPLOADS
+        )
+    except (AttributeError, TypeError, ValueError):
+        configured = _FILE_ATTACH_DEFAULT_MAX_ACTIVE_UPLOADS
+    return max(1, min(configured, _FILE_ATTACH_MAX_ACTIVE_UPLOADS_CAP))
+
+
+def _file_attach_stale_seconds() -> float:
+    """Return the idle timeout used to reap abandoned upload state."""
+    try:
+        desktop_cfg = _load_cfg().get("desktop") or {}
+        configured = float(
+            desktop_cfg.get("file_upload_stale_seconds")
+            or _FILE_ATTACH_DEFAULT_STALE_SECONDS
+        )
+    except (AttributeError, TypeError, ValueError):
+        configured = _FILE_ATTACH_DEFAULT_STALE_SECONDS
+    return max(
+        _FILE_ATTACH_MIN_STALE_SECONDS,
+        min(configured, _FILE_ATTACH_MAX_STALE_SECONDS),
+    )
+
+
+def _file_attach_free_space_reserve_bytes() -> int:
+    """Return the disk space that attachments may never consume."""
+    try:
+        desktop_cfg = _load_cfg().get("desktop") or {}
+        configured = int(
+            desktop_cfg.get("file_upload_free_space_reserve_bytes")
+            or _FILE_ATTACH_DEFAULT_FREE_SPACE_RESERVE_BYTES
+        )
+    except (AttributeError, TypeError, ValueError):
+        configured = _FILE_ATTACH_DEFAULT_FREE_SPACE_RESERVE_BYTES
+    return max(
+        _FILE_ATTACH_MIN_FREE_SPACE_RESERVE_BYTES,
+        min(configured, _FILE_ATTACH_MAX_FREE_SPACE_RESERVE_BYTES),
+    )
+
+
+def _file_attach_available_bytes(path: Path) -> int:
+    return int(shutil.disk_usage(path).free)
+
+
+def _file_attach_disk_key(path: Path) -> int:
+    """Return the filesystem device identity shared by drive, UNC, and mount aliases."""
+    return int(path.resolve().stat().st_dev)
+
+
+def _reserve_file_attach_disk_space(path: Path, bytes_to_add: int) -> str:
+    """Atomically reserve future upload bytes across every session in this gateway."""
+    _retry_file_attach_cleanup_quarantine()
+    amount = max(0, int(bytes_to_add))
+    disk_key = _file_attach_disk_key(path)
+    token = uuid.uuid4().hex
+    with _file_attach_disk_reservation_lock:
+        already_reserved = sum(
+            int(entry.get("remaining") or 0)
+            for entry in _file_attach_disk_reservations.values()
+            if entry.get("disk_key") == disk_key
+        )
+        reserve = _file_attach_free_space_reserve_bytes()
+        required = already_reserved + amount + reserve
+        available = _file_attach_available_bytes(path)
+        if available < required:
+            raise ValueError(
+                "insufficient free disk space for attachment upload "
+                f"(required {required} bytes including {already_reserved} bytes "
+                f"reserved by active uploads, available {available} bytes)"
+            )
+        _file_attach_disk_reservations[token] = {
+            "disk_key": disk_key,
+            "remaining": amount,
+        }
+    return token
+
+
+def _run_file_attach_reserved_write(token: str, path: Path, amount: int, writer):
+    """Atomically defend the volume reserve, write bytes, and consume one reservation."""
+    amount = max(0, int(amount))
+    disk_key = _file_attach_disk_key(path)
+    with _file_attach_disk_reservation_lock:
+        entry = _file_attach_disk_reservations.get(token)
+        if not isinstance(entry, dict) or entry.get("disk_key") != disk_key:
+            raise RuntimeError("attachment upload has no matching disk reservation")
+        remaining = int(entry.get("remaining") or 0)
+        if amount > remaining:
+            raise RuntimeError("attachment upload exceeded its disk reservation")
+        reserved = sum(
+            int(candidate.get("remaining") or 0)
+            for candidate in _file_attach_disk_reservations.values()
+            if candidate.get("disk_key") == disk_key
+        )
+        required = reserved + _file_attach_free_space_reserve_bytes()
+        available = _file_attach_available_bytes(path)
+        if available < required:
+            raise ValueError(
+                "insufficient free disk space for attachment upload "
+                f"(required {required} bytes including {reserved} bytes "
+                f"reserved by active uploads, available {available} bytes)"
+            )
+        result = writer()
+        entry["remaining"] = remaining - amount
+        return result
+
+
+def _append_file_attach_reserved_chunk(token: str, path: Path, payload: bytes) -> None:
+    path_identity = _file_attach_object_identity(os.lstat(path))
+    initial_size = path.stat().st_size
+
+    def _append() -> None:
+        try:
+            with path.open("ab") as handle:
+                written = handle.write(payload)
+            if written != len(payload):
+                raise OSError("attachment chunk write was incomplete")
+            _assert_safe_attachment_file(path)
+        except BaseException as write_error:
+            try:
+                _assert_safe_attachment_file(path)
+                with path.open("r+b") as handle:
+                    handle.truncate(initial_size)
+                if path.stat().st_size != initial_size:
+                    raise OSError("attachment rollback did not restore the original size")
+            except (OSError, ValueError) as cleanup_error:
+                raise _FileAttachCleanupError(
+                    path, path_identity, write_error, cleanup_error
+                ) from write_error
+            raise
+
+    _run_file_attach_reserved_write(token, path.parent, len(payload), _append)
+
+
+def _release_file_attach_disk_reservation(token: str) -> None:
+    """Idempotently release one exact reservation without touching other uploads."""
+    if not token:
+        return
+    with _file_attach_disk_reservation_lock:
+        _file_attach_disk_reservations.pop(token, None)
+
+
+def _release_upload_disk_reservation(upload: dict) -> None:
+    token = str(upload.pop("disk_reservation_token", "") or "")
+    _release_file_attach_disk_reservation(token)
+
+
+def _quarantine_file_attach_cleanup(upload: dict) -> str:
+    token = str(upload.get("disk_reservation_token") or "")
+    if not token:
+        token = f"cleanup-{uuid.uuid4().hex}"
+    with _file_attach_disk_reservation_lock:
+        _file_attach_cleanup_quarantine[token] = upload
+    return token
+
+
+def _retry_file_attach_cleanup_quarantine() -> None:
+    with _file_attach_disk_reservation_lock:
+        for token, upload in list(_file_attach_cleanup_quarantine.items()):
+            if not isinstance(upload, dict) or not _unlink_file_attach_temp(upload):
+                continue
+            _release_upload_disk_reservation(upload)
+            _file_attach_cleanup_quarantine.pop(token, None)
 
 
 def _sanitize_attachment_name(name: str) -> str:
     import re as _re
 
-    candidate = Path(str(name or "").strip()).name
-    candidate = _re.sub(r"[\x00-\x1f]+", "_", candidate)
-    candidate = candidate.strip().strip(".")
-    return candidate or "attachment"
+    raw = str(name or "").strip().replace("\\", "/")
+    candidate = raw.rstrip("/").split("/")[-1] if raw else ""
+    candidate = _re.sub(r"[<>:\"/\\|?*\x00-\x1f]+", "_", candidate)
+    candidate = candidate.strip().strip(".") or "attachment"
+
+    stem = Path(candidate).stem
+    if _re.fullmatch(r"(?i:CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])", stem):
+        candidate = f"_{candidate}"
+
+    max_name_chars = 180
+    if len(candidate) > max_name_chars:
+        suffix = Path(candidate).suffix[:20]
+        stem = Path(candidate).stem
+        candidate = f"{stem[: max_name_chars - len(suffix)]}{suffix}"
+    return candidate
 
 
-def _unique_attachment_path(root: Path, filename: str) -> Path:
-    candidate = root / filename
-    if not candidate.exists():
-        return candidate
+def _attachment_path_candidates(root: Path, filename: str):
+    yield root / filename
     stem = Path(filename).stem or "attachment"
     suffix = Path(filename).suffix
     counter = 2
     while True:
-        next_candidate = root / f"{stem}-{counter}{suffix}"
-        if not next_candidate.exists():
-            return next_candidate
+        yield root / f"{stem}-{counter}{suffix}"
         counter += 1
+
+
+def _open_exclusive_attachment_file(path: Path):
+    if os.name != "nt":
+        return path.open("xb")
+
+    import ctypes
+    import msvcrt
+    from ctypes import wintypes
+
+    generic_write = 0x40000000
+    delete_access = 0x00010000
+    share_all = 0x00000001 | 0x00000002 | 0x00000004
+    create_new = 1
+    file_attribute_normal = 0x00000080
+    file_flag_open_reparse_point = 0x00200000
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    create_file = kernel32.CreateFileW
+    create_file.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    create_file.restype = wintypes.HANDLE
+    raw_handle = create_file(
+        str(path),
+        generic_write | delete_access,
+        share_all,
+        None,
+        create_new,
+        file_attribute_normal | file_flag_open_reparse_point,
+        None,
+    )
+    invalid_handle = ctypes.c_void_p(-1).value
+    if raw_handle == invalid_handle:
+        error = ctypes.get_last_error()
+        if error in {80, 183}:
+            raise FileExistsError(error, "attachment destination already exists", str(path))
+        raise ctypes.WinError(error)
+    try:
+        fd = msvcrt.open_osfhandle(raw_handle, os.O_WRONLY | os.O_BINARY)
+    except BaseException:
+        kernel32.CloseHandle(raw_handle)
+        raise
+    return os.fdopen(fd, "wb", buffering=0)
+
+
+def _mark_open_attachment_for_delete(handle) -> None:
+    if os.name != "nt":
+        raise OSError("open-handle attachment deletion is unavailable")
+
+    import ctypes
+    import msvcrt
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    set_information = kernel32.SetFileInformationByHandle
+    set_information.argtypes = [wintypes.HANDLE, ctypes.c_int, ctypes.c_void_p, wintypes.DWORD]
+    set_information.restype = wintypes.BOOL
+    disposition = wintypes.BOOL(True)
+    raw_handle = msvcrt.get_osfhandle(handle.fileno())
+    if not set_information(raw_handle, 4, ctypes.byref(disposition), ctypes.sizeof(disposition)):
+        raise ctypes.WinError(ctypes.get_last_error())
+
+
+class _FileAttachCleanupError(OSError):
+    def __init__(
+        self,
+        path: Path,
+        identity: tuple[int, int],
+        write_error: BaseException,
+        cleanup_error: BaseException,
+    ):
+        self.path = Path(path)
+        self.identity = identity
+        self.write_error = write_error
+        self.cleanup_error = cleanup_error
+        super().__init__(f"{write_error}; attachment cleanup failed: {cleanup_error}")
+
+
+def _assert_attachment_path_identity(path: Path, expected_identity: tuple[int, int]) -> None:
+    _assert_safe_attachment_file(path)
+    try:
+        current = os.lstat(path)
+    except FileNotFoundError as exc:
+        raise OSError("attachment destination no longer names the opened file") from exc
+    if _file_attach_object_identity(current) != expected_identity:
+        raise OSError("attachment destination identity changed after open")
+
+
+def _unlink_attachment_path_if_identity(
+    path: Path, expected_identity: tuple[int, int]
+) -> None:
+    _assert_attachment_path_identity(path, expected_identity)
+    path.unlink()
+    if os.path.lexists(path):
+        raise OSError("attachment cleanup did not remove the partial file")
+
+
+def _write_unique_attachment(
+    root: Path, filename: str, expected_size: int, writer
+) -> Path:
+    """Write an exact-size attachment without following reparse roots."""
+    expected_size = max(0, int(expected_size))
+    _assert_safe_attachment_root(root)
+    for candidate in _attachment_path_candidates(root, filename):
+        try:
+            handle = _open_exclusive_attachment_file(candidate)
+        except FileExistsError:
+            continue
+        opened_identity = _file_attach_object_identity(os.fstat(handle.fileno()))
+        try:
+            _assert_attachment_path_identity(candidate, opened_identity)
+            if writer(handle) != expected_size:
+                raise OSError("attachment write was incomplete")
+            handle.flush()
+            if os.fstat(handle.fileno()).st_size != expected_size:
+                raise OSError("attachment write did not persist the exact expected size")
+            _assert_attachment_path_identity(candidate, opened_identity)
+            handle.close()
+            return candidate
+        except BaseException as write_error:
+            try:
+                if not handle.closed and os.name == "nt":
+                    _mark_open_attachment_for_delete(handle)
+                    handle.close()
+                else:
+                    _unlink_attachment_path_if_identity(candidate, opened_identity)
+                    if not handle.closed:
+                        handle.close()
+            except (OSError, ValueError) as cleanup_error:
+                raise _FileAttachCleanupError(
+                    candidate, opened_identity, write_error, cleanup_error
+                ) from write_error
+            finally:
+                if not handle.closed:
+                    handle.close()
+            raise
+    raise RuntimeError("could not allocate attachment path")
+
+
+def _file_attach_stat_identity(value: os.stat_result) -> tuple[int, int, int, int, int]:
+    return (
+        int(value.st_dev),
+        int(value.st_ino),
+        int(value.st_size),
+        int(value.st_mtime_ns),
+        int(value.st_ctime_ns),
+    )
+
+
+def _copy_unique_attachment(
+    source: Path,
+    root: Path,
+    filename: str,
+    expected_identity: tuple[int, int, int, int, int],
+) -> Path:
+    expected_size = expected_identity[2]
+
+    def _copy(handle) -> int:
+        with source.open("rb") as source_handle:
+            before = os.fstat(source_handle.fileno())
+            if _file_attach_stat_identity(before) != expected_identity:
+                raise ValueError("source file changed while being copied")
+            remaining = expected_size
+            copied = 0
+            while remaining:
+                chunk = source_handle.read(min(1024 * 1024, remaining))
+                if not chunk:
+                    raise ValueError("source file changed while being copied")
+                if handle.write(chunk) != len(chunk):
+                    raise OSError("attachment copy was incomplete")
+                copied += len(chunk)
+                remaining -= len(chunk)
+            if source_handle.read(1):
+                raise ValueError("source file changed while being copied")
+            after = os.fstat(source_handle.fileno())
+            if _file_attach_stat_identity(after) != expected_identity:
+                raise ValueError("source file changed while being copied")
+            return copied
+
+    return _write_unique_attachment(root, filename, expected_size, _copy)
+
+
+def _publish_unique_attachment(temp_path: Path, root: Path, filename: str) -> Path:
+    """Atomically publish a complete temp file without following reparse roots."""
+    _assert_safe_attachment_file(temp_path)
+    temp_identity = _file_attach_object_identity(os.lstat(temp_path))
+    _assert_safe_attachment_root(root)
+    for candidate in _attachment_path_candidates(root, filename):
+        try:
+            os.link(temp_path, candidate)
+        except FileExistsError:
+            continue
+        try:
+            _assert_attachment_path_identity(candidate, temp_identity)
+            _unlink_attachment_path_if_identity(temp_path, temp_identity)
+        except BaseException as publish_error:
+            try:
+                if not os.path.lexists(candidate):
+                    raise OSError("published candidate identity was lost before cleanup")
+                _unlink_attachment_path_if_identity(candidate, temp_identity)
+            except (OSError, ValueError) as cleanup_error:
+                raise _FileAttachCleanupError(
+                    candidate, temp_identity, publish_error, cleanup_error
+                ) from publish_error
+            raise
+        return candidate
+    raise RuntimeError("could not allocate attachment path")
 
 
 def _resolve_gateway_attachment_path(raw: str) -> Path | None:
@@ -9824,7 +10420,9 @@ def _resolve_gateway_attachment_path(raw: str) -> Path | None:
     return Path(resolved).resolve() if resolved is not None else None
 
 
-def _decode_attachment_data_url(data_url: str) -> bytes:
+def _decode_attachment_data_url(
+    data_url: str, *, max_bytes: int | None = None
+) -> bytes:
     """Decode a ``data:<any-mime>;base64,<b64>`` payload to bytes.
 
     Unlike ``_decode_attach_base64`` (image-mime-specific), this accepts any
@@ -9840,10 +10438,44 @@ def _decode_attachment_data_url(data_url: str) -> bytes:
     if m:
         cleaned = m.group(1)
     cleaned = _re.sub(r"\s+", "", cleaned)
+    if max_bytes is not None:
+        max_encoded_chars = 4 * ((max_bytes + 2) // 3)
+        if len(cleaned) > max_encoded_chars:
+            raise ValueError(f"file exceeds maximum file size ({max_bytes} bytes)")
     try:
-        return _base64.b64decode(cleaned, validate=True)
+        payload = _base64.b64decode(cleaned, validate=True)
     except (ValueError, _binascii.Error) as exc:
         raise ValueError("invalid data_url payload") from exc
+    if max_bytes is not None and len(payload) > max_bytes:
+        raise ValueError(f"file exceeds maximum file size ({max_bytes} bytes)")
+    return payload
+
+
+def _run_one_shot_file_attach_write(
+    reservation_token: str,
+    upload_dir: Path,
+    amount: int,
+    writer,
+):
+    release_reservation = True
+    try:
+        return _run_file_attach_reserved_write(
+            reservation_token, upload_dir, amount, writer
+        )
+    except _FileAttachCleanupError as exc:
+        _quarantine_file_attach_cleanup(
+            {
+                "path": str(exc.path),
+                "path_identity": _file_attach_identity_record(exc.identity),
+                "disk_reservation_token": reservation_token,
+                "cleanup_error": str(exc.cleanup_error),
+            }
+        )
+        release_reservation = False
+        raise
+    finally:
+        if release_reservation:
+            _release_file_attach_disk_reservation(reservation_token)
 
 
 def _stage_session_file_attachment(
@@ -9873,18 +10505,501 @@ def _stage_session_file_attachment(
             resolved.relative_to(workspace)
             return resolved, False
         except ValueError:
-            payload = resolved.read_bytes()
-            filename = resolved.name
-    else:
-        if not data_url:
-            raise ValueError("file not found on gateway and no data_url provided")
-        payload = _decode_attachment_data_url(data_url)
-        filename = _sanitize_attachment_name(name or Path(str(raw_path or "")).name)
+            upload_dir = _desktop_attachment_dir(session)
+            source_stat = resolved.stat()
+            source_identity = _file_attach_stat_identity(source_stat)
+            source_size = source_identity[2]
+            max_total_bytes = _file_attach_max_total_bytes()
+            if source_size > max_total_bytes:
+                raise ValueError(
+                    f"file exceeds maximum file size ({max_total_bytes} bytes)"
+                )
+            reservation_token = _reserve_file_attach_disk_space(upload_dir, source_size)
+            target = _run_one_shot_file_attach_write(
+                reservation_token,
+                upload_dir,
+                source_size,
+                lambda: _copy_unique_attachment(
+                    resolved,
+                    upload_dir,
+                    _sanitize_attachment_name(resolved.name),
+                    source_identity,
+                ),
+            )
+            return target.resolve(), True
+
+    if not data_url:
+        raise ValueError("file not found on gateway and no data_url provided")
+    payload = _decode_attachment_data_url(
+        data_url, max_bytes=_file_attach_max_total_bytes()
+    )
+    filename = _sanitize_attachment_name(name or raw_path)
 
     upload_dir = _desktop_attachment_dir(session)
-    target = _unique_attachment_path(upload_dir, _sanitize_attachment_name(filename))
-    target.write_bytes(payload)
+    reservation_token = _reserve_file_attach_disk_space(upload_dir, len(payload))
+    target = _run_one_shot_file_attach_write(
+        reservation_token,
+        upload_dir,
+        len(payload),
+        lambda: _write_unique_attachment(
+            upload_dir,
+            _sanitize_attachment_name(filename),
+            len(payload),
+            lambda handle: handle.write(payload),
+        ),
+    )
     return target.resolve(), True
+
+
+def _file_attach_result(session: dict, stored_path: Path, uploaded: bool) -> dict:
+    ref_path = _attachment_ref_path(session, stored_path)
+    return {
+        "attached": True,
+        "name": stored_path.name,
+        "path": str(stored_path),
+        "ref_path": ref_path,
+        "ref_text": f"@file:{_format_ref_value(ref_path)}",
+        "uploaded": uploaded,
+    }
+
+
+def _file_attach_uploads(session: dict) -> dict:
+    uploads = session.setdefault("_desktop_file_uploads", {})
+    if not isinstance(uploads, dict):
+        uploads = {}
+        session["_desktop_file_uploads"] = uploads
+    return uploads
+
+
+def _file_attach_completed_results(session: dict) -> dict:
+    completed = session.setdefault("_desktop_file_upload_results", {})
+    if not isinstance(completed, dict):
+        completed = {}
+        session["_desktop_file_upload_results"] = completed
+    return completed
+
+
+def _file_attach_cancelled_requests(session: dict) -> dict:
+    cancelled = session.setdefault("_desktop_file_upload_cancelled", {})
+    if not isinstance(cancelled, dict):
+        cancelled = {}
+        session["_desktop_file_upload_cancelled"] = cancelled
+    return cancelled
+
+
+def _remember_file_attach_cancelled_request(session: dict, upload_id: str) -> None:
+    cancelled = _file_attach_cancelled_requests(session)
+    cancelled[upload_id] = time.time()
+    while len(cancelled) > 64:
+        oldest_id = min(cancelled, key=lambda item: float(cancelled[item] or 0))
+        cancelled.pop(oldest_id, None)
+
+
+def _remember_file_attach_result(session: dict, upload_id: str, result: dict) -> None:
+    completed = _file_attach_completed_results(session)
+    completed[upload_id] = {"completed_at": time.time(), "result": dict(result)}
+    while len(completed) > 16:
+        oldest_id = min(
+            completed,
+            key=lambda item: float(completed[item].get("completed_at") or 0),
+        )
+        completed.pop(oldest_id, None)
+
+
+def _file_attach_lock(session: dict) -> threading.RLock:
+    """Return the per-session lock that serializes upload state and file I/O."""
+    with _sessions_lock:
+        lock = session.get("_desktop_file_upload_lock")
+        if not isinstance(lock, type(threading.RLock())):
+            lock = threading.RLock()
+            session["_desktop_file_upload_lock"] = lock
+        return lock
+
+
+def _cleanup_file_attach_uploads(session: dict) -> None:
+    """Remove incomplete uploads, quarantining ownership when cleanup fails."""
+    with _file_attach_lock(session):
+        uploads = session.get("_desktop_file_uploads", {})
+        session.pop("_desktop_file_upload_results", None)
+        session.pop("_desktop_file_upload_cancelled", None)
+        if not isinstance(uploads, dict):
+            session.pop("_desktop_file_uploads", None)
+            return
+        for upload_id, upload in list(uploads.items()):
+            if not isinstance(upload, dict):
+                uploads.pop(upload_id, None)
+                continue
+            if _unlink_file_attach_temp(upload):
+                _release_upload_disk_reservation(upload)
+            else:
+                _quarantine_file_attach_cleanup(upload)
+            uploads.pop(upload_id, None)
+        if not uploads:
+            session.pop("_desktop_file_uploads", None)
+
+
+def _reap_stale_file_attach_uploads(
+    session: dict, *, now: float | None = None
+) -> None:
+    """Delete uploads that have been idle beyond the configured timeout."""
+    uploads = _file_attach_uploads(session)
+    cutoff = (time.time() if now is None else now) - _file_attach_stale_seconds()
+    for upload_id, upload in list(uploads.items()):
+        if not isinstance(upload, dict):
+            uploads.pop(upload_id, None)
+            continue
+        updated_at = float(upload.get("updated_at") or upload.get("created_at") or 0)
+        if updated_at > cutoff:
+            continue
+        if not _unlink_file_attach_temp(upload):
+            upload["updated_at"] = time.time() if now is None else now
+            continue
+        _release_upload_disk_reservation(upload)
+        uploads.pop(upload_id, None)
+
+    completed = session.get("_desktop_file_upload_results")
+    if isinstance(completed, dict):
+        for upload_id, cached in list(completed.items()):
+            completed_at = (
+                float(cached.get("completed_at") or 0)
+                if isinstance(cached, dict)
+                else 0
+            )
+            if completed_at <= cutoff:
+                completed.pop(upload_id, None)
+
+    cancelled = session.get("_desktop_file_upload_cancelled")
+    if isinstance(cancelled, dict):
+        for upload_id, cancelled_at in list(cancelled.items()):
+            if float(cancelled_at or 0) <= cutoff:
+                cancelled.pop(upload_id, None)
+
+
+def _optional_non_negative_int(value: Any, field: str) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field} must be an integer") from exc
+    if parsed < 0:
+        raise ValueError(f"{field} must be non-negative")
+    return parsed
+
+
+def _desktop_file_upload_by_id(session: dict, upload_id: str) -> dict:
+    uploads = _file_attach_uploads(session)
+    upload = uploads.get(upload_id)
+    if not isinstance(upload, dict):
+        raise ValueError("unknown upload_id")
+    return upload
+
+
+def _file_attach_request_id(params: dict) -> str:
+    raw = str(params.get("request_id", "") or "").strip()
+    if not raw:
+        raise ValueError("request_id required")
+    try:
+        return uuid.UUID(raw).hex
+    except (AttributeError, ValueError) as exc:
+        raise ValueError("request_id must be a UUID") from exc
+
+
+@method("file.attach.capabilities")
+def _(rid, params: dict) -> dict:
+    """Declare the recovery guarantees required by resumable Desktop uploads."""
+    _session, err = _sess(params, rid)
+    if err:
+        return err
+    return _ok(
+        rid,
+        {
+            "contract": DESKTOP_BACKEND_CONTRACT,
+            "request_id_cancel": True,
+        },
+    )
+
+
+@method("file.attach.begin")
+def _(rid, params: dict) -> dict:
+    """Begin a chunked non-image file upload from Desktop remote mode."""
+    session, err = _sess(params, rid)
+    if err:
+        return err
+    lock = _file_attach_lock(session)
+    lock.acquire()
+    try:
+        raw = str(params.get("path", "") or "").strip()
+        name = str(params.get("name", "") or "").strip()
+        filename = _sanitize_attachment_name(name or raw)
+        declared_size = _optional_non_negative_int(
+            params.get("size", params.get("byte_size")), "size"
+        )
+        upload_id = _file_attach_request_id(params)
+        max_total_bytes = _file_attach_max_total_bytes()
+        if declared_size is not None and declared_size > max_total_bytes:
+            raise ValueError(
+                f"file exceeds maximum file size ({max_total_bytes} bytes)"
+            )
+        uploads = _file_attach_uploads(session)
+        _reap_stale_file_attach_uploads(session)
+        existing = uploads.get(upload_id)
+        if isinstance(existing, dict):
+            if (
+                existing.get("filename") != filename
+                or existing.get("raw_path") != raw
+                or existing.get("declared_size") != declared_size
+            ):
+                raise ValueError("request_id already used for a different upload")
+            existing["updated_at"] = time.time()
+            return _ok(
+                rid,
+                {
+                    "upload_id": upload_id,
+                    "received": int(existing.get("received") or 0),
+                    "max_chunk_bytes": _file_attach_max_chunk_bytes(),
+                    "duplicate": True,
+                },
+            )
+        if upload_id in _file_attach_completed_results(session):
+            raise ValueError("request_id already completed")
+        if upload_id in _file_attach_cancelled_requests(session):
+            raise ValueError("request_id already cancelled")
+        max_active_uploads = _file_attach_max_active_uploads()
+        if len(uploads) >= max_active_uploads:
+            raise ValueError(
+                f"too many active uploads (limit {max_active_uploads})"
+            )
+        upload_dir = _desktop_attachment_upload_dir(session)
+        reservation_bytes = declared_size if declared_size is not None else max_total_bytes
+        reservation_token = _reserve_file_attach_disk_space(
+            upload_dir, reservation_bytes
+        )
+        temp_path = upload_dir / f"{upload_id}.part"
+        try:
+            temp_path.touch(exist_ok=False)
+        except FileExistsError as exc:
+            _release_file_attach_disk_reservation(reservation_token)
+            raise ValueError("request_id has unrecoverable upload state") from exc
+        except BaseException:
+            _release_file_attach_disk_reservation(reservation_token)
+            raise
+        temp_identity = _file_attach_object_identity(os.lstat(temp_path))
+        now = time.time()
+        try:
+            uploads[upload_id] = {
+                "created_at": now,
+                "updated_at": now,
+                "declared_size": declared_size,
+                "disk_reservation_token": reservation_token,
+                "filename": filename,
+                "path": str(temp_path),
+                "path_identity": _file_attach_identity_record(temp_identity),
+                "raw_path": raw,
+                "received": 0,
+            }
+        except BaseException as registration_error:
+            rollback_upload = {
+                "path": str(temp_path),
+                "path_identity": _file_attach_identity_record(temp_identity),
+                "disk_reservation_token": reservation_token,
+            }
+            if _unlink_file_attach_temp(rollback_upload):
+                _release_upload_disk_reservation(rollback_upload)
+                raise
+            cleanup_error = OSError(
+                str(rollback_upload.get("cleanup_error") or "unknown cleanup failure")
+            )
+            _quarantine_file_attach_cleanup(rollback_upload)
+            raise _FileAttachCleanupError(
+                temp_path, temp_identity, registration_error, cleanup_error
+            ) from registration_error
+        return _ok(
+            rid,
+            {
+                "upload_id": upload_id,
+                "received": 0,
+                "max_chunk_bytes": _file_attach_max_chunk_bytes(),
+            },
+        )
+    except Exception as e:
+        return _err(rid, 5028, str(e))
+    finally:
+        lock.release()
+
+
+@method("file.attach.chunk")
+def _(rid, params: dict) -> dict:
+    """Append one base64 chunk to an in-progress file.attach upload."""
+    session, err = _sess(params, rid)
+    if err:
+        return err
+    lock = _file_attach_lock(session)
+    lock.acquire()
+    try:
+        upload_id = str(params.get("upload_id", "") or "").strip()
+        if not upload_id:
+            raise ValueError("upload_id required")
+        upload = _desktop_file_upload_by_id(session, upload_id)
+        offset = _optional_non_negative_int(params.get("offset"), "offset")
+        if offset is None:
+            raise ValueError("offset required")
+        expected = int(upload.get("received") or 0)
+        temp_path = Path(str(upload.get("path") or ""))
+        _assert_safe_attachment_file(temp_path)
+        try:
+            actual_size = temp_path.stat().st_size
+        except FileNotFoundError as exc:
+            raise ValueError("upload temp file missing") from exc
+        if actual_size != expected:
+            raise ValueError("upload state mismatch")
+        content = str(params.get("content_base64", "") or "")
+        max_chunk_bytes = _file_attach_max_chunk_bytes()
+        max_encoded_chars = 4 * ((max_chunk_bytes + 2) // 3)
+        if len(content) > max_encoded_chars:
+            raise ValueError(
+                f"encoded chunk too large ({len(content)} chars; "
+                f"limit {max_encoded_chars} chars)"
+            )
+        payload = _decode_attachment_data_url(content)
+        if len(payload) > max_chunk_bytes:
+            raise ValueError(
+                f"chunk too large ({len(payload)} bytes; limit {max_chunk_bytes} bytes)"
+            )
+        payload_sha256 = hashlib.sha256(payload).hexdigest()
+        if offset != expected:
+            is_last_chunk_retry = (
+                offset == upload.get("last_chunk_offset")
+                and len(payload) == upload.get("last_chunk_size")
+                and payload_sha256 == upload.get("last_chunk_sha256")
+                and offset + len(payload) == expected
+            )
+            if is_last_chunk_retry:
+                upload["updated_at"] = time.time()
+                return _ok(
+                    rid,
+                    {
+                        "upload_id": upload_id,
+                        "received": expected,
+                        "duplicate": True,
+                    },
+                )
+            raise ValueError(f"unexpected offset {offset}; expected {expected}")
+        declared_size = upload.get("declared_size")
+        if declared_size is not None and expected + len(payload) > int(declared_size):
+            raise ValueError("chunk exceeds declared size")
+        max_total_bytes = _file_attach_max_total_bytes()
+        if expected + len(payload) > max_total_bytes:
+            raise ValueError(
+                f"file exceeds maximum file size ({max_total_bytes} bytes)"
+            )
+        _append_file_attach_reserved_chunk(
+            str(upload.get("disk_reservation_token") or ""), temp_path, payload
+        )
+        received = expected + len(payload)
+        upload["received"] = received
+        upload["updated_at"] = time.time()
+        upload["last_chunk_offset"] = offset
+        upload["last_chunk_size"] = len(payload)
+        upload["last_chunk_sha256"] = payload_sha256
+        return _ok(rid, {"upload_id": upload_id, "received": received})
+    except Exception as e:
+        return _err(rid, 5028, str(e))
+    finally:
+        lock.release()
+
+
+@method("file.attach.finish")
+def _(rid, params: dict) -> dict:
+    """Finalize a chunked Desktop file upload and return the normal @file ref."""
+    session, err = _sess(params, rid)
+    if err:
+        return err
+    upload_id = str(params.get("upload_id", "") or "").strip()
+    if not upload_id:
+        return _err(rid, 4015, "upload_id required")
+    lock = _file_attach_lock(session)
+    lock.acquire()
+    uploads = _file_attach_uploads(session)
+    try:
+        cached = _file_attach_completed_results(session).get(upload_id)
+        if isinstance(cached, dict) and isinstance(cached.get("result"), dict):
+            return _ok(rid, dict(cached["result"]))
+        upload = _desktop_file_upload_by_id(session, upload_id)
+        temp_path = Path(str(upload.get("path") or ""))
+        temp_identity = _file_attach_expected_identity(
+            upload.get("path_identity"), label=str(temp_path)
+        )
+        _assert_attachment_path_identity(temp_path, temp_identity)
+        received = int(upload.get("received") or 0)
+        actual_size = temp_path.stat().st_size
+        if actual_size != received:
+            raise ValueError("upload size mismatch")
+        declared_size = upload.get("declared_size")
+        if declared_size is not None and received != int(declared_size):
+            raise ValueError(f"upload incomplete ({received}/{declared_size} bytes)")
+        target = _publish_unique_attachment(
+            temp_path,
+            _desktop_attachment_dir(session),
+            _sanitize_attachment_name(str(upload.get("filename") or "attachment")),
+        )
+        _release_upload_disk_reservation(upload)
+        uploads.pop(upload_id, None)
+        result = _file_attach_result(session, target.resolve(), True)
+        _remember_file_attach_result(session, upload_id, result)
+        return _ok(rid, result)
+    except _FileAttachCleanupError as e:
+        cleanup_paths = upload.setdefault("cleanup_paths", [])
+        cleanup_identities = upload.setdefault("cleanup_path_identities", {})
+        candidate_path = str(e.path)
+        if isinstance(cleanup_paths, list) and candidate_path not in cleanup_paths:
+            cleanup_paths.append(candidate_path)
+        if isinstance(cleanup_identities, dict):
+            cleanup_identities[candidate_path] = _file_attach_identity_record(e.identity)
+        upload["cleanup_error"] = str(e.cleanup_error)
+        return _err(rid, 5028, str(e))
+    except Exception as e:
+        return _err(rid, 5028, str(e))
+    finally:
+        lock.release()
+
+
+@method("file.attach.cancel")
+def _(rid, params: dict) -> dict:
+    """Cancel by upload id or begin request id, including a lost begin response."""
+    session, err = _sess(params, rid)
+    if err:
+        return err
+    upload_id = str(params.get("upload_id", "") or "").strip()
+    request_id_raw = str(params.get("request_id", "") or "").strip()
+    try:
+        request_upload_id = _file_attach_request_id(params) if request_id_raw else ""
+    except ValueError as exc:
+        return _err(rid, 4015, str(exc))
+    if upload_id and request_upload_id and upload_id != request_upload_id:
+        return _err(rid, 4015, "upload_id and request_id do not match")
+    upload_id = upload_id or request_upload_id
+    if not upload_id:
+        return _err(rid, 4015, "upload_id or request_id required")
+    lock = _file_attach_lock(session)
+    lock.acquire()
+    try:
+        completed = _file_attach_completed_results(session)
+        if upload_id in completed:
+            return _ok(rid, {"cancelled": False, "completed": True})
+        uploads = _file_attach_uploads(session)
+        upload = uploads.get(upload_id)
+        if isinstance(upload, dict):
+            if not _unlink_file_attach_temp(upload):
+                detail = str(upload.get("cleanup_error") or "unknown cleanup failure")
+                return _err(rid, 5028, f"attachment cleanup failed: {detail}")
+            _release_upload_disk_reservation(upload)
+            uploads.pop(upload_id, None)
+        if request_upload_id or isinstance(upload, dict):
+            _remember_file_attach_cancelled_request(session, upload_id)
+        return _ok(rid, {"cancelled": True})
+    finally:
+        lock.release()
 
 
 @method("file.attach")
@@ -9918,18 +11033,7 @@ def _(rid, params: dict) -> dict:
         stored_path, uploaded = _stage_session_file_attachment(
             session, raw_path=raw, data_url=data_url, name=name
         )
-        ref_path = _attachment_ref_path(session, stored_path)
-        return _ok(
-            rid,
-            {
-                "attached": True,
-                "name": stored_path.name,
-                "path": str(stored_path),
-                "ref_path": ref_path,
-                "ref_text": f"@file:{_format_ref_value(ref_path)}",
-                "uploaded": uploaded,
-            },
-        )
+        return _ok(rid, _file_attach_result(session, stored_path, uploaded))
     except Exception as e:
         return _err(rid, 5028, str(e))
 


### PR DESCRIPTION
## What does this PR do?

Closes #62375.

Hermes Desktop currently reads a remote non-image attachment as one data URL and sends it in one `file.attach` request. That rejects files above the 16 MiB Electron cap and makes near-limit uploads vulnerable to memory amplification and ambiguous request timeouts.

This PR replaces that one-shot path with a bounded, retryable upload protocol:

- Desktop creates an immutable temporary snapshot of the selected file.
- Electron exposes bounded chunk reads from that snapshot.
- The UI uploads through idempotent `file.attach.begin`, `file.attach.chunk`, `file.attach.finish`, and `file.attach.cancel` RPCs.
- The gateway reserves aggregate capacity, writes chunks with bounded state, publishes destination filenames atomically across sessions, and performs identity-bound immediate/deferred cleanup.
- A versioned capability handshake gates the mutating protocol. Older or malformed gateway contracts fail closed before the first upload RPC.
- Renderer readiness is included in the Desktop update health contract so an update is not accepted solely because an Electron process exists.

## Why not only raise the limit?

A larger one-shot cap still base64-encodes the whole file in memory, sends one large JSON payload, and cannot safely distinguish an accepted request from a lost acknowledgement. Chunking keeps memory bounded and gives begin/chunk/finish/cancel explicit retry semantics.

## Safety and lifecycle properties

- stable idempotency keys are reused across ambiguous retries;
- begin acknowledgement loss remains recoverable/cancellable;
- committed chunk and finish retries do not duplicate bytes or files;
- active-upload count and aggregate disk reservations are bounded across sessions;
- filename publication is atomic across sessions sharing a workspace;
- source bytes come from an immutable snapshot rather than repeated opens of a mutable source path;
- destination containment rejects redirected/reparse parents;
- partial writes and cleanup failures retain ownership/reservations instead of publishing truncated files;
- deferred cleanup is bound to recorded file identity and preserves replacement files on mismatch;
- session teardown, cancellation, stale reaping, and retry tombstones share the same ownership rules.

## Related work

- #48662 hardens the legacy `readFileDataUrl` handler against TOCTOU. This PR preserves the same security goal for the new path by snapshotting once and reading bounded chunks from the snapshot.
- #51355 makes upload limits configurable. That is complementary, but it does not address one-shot base64 memory use or ambiguous retry/cancel behavior.

## Type of change

- [x] Bug fix
- [x] Feature
- [x] Security / correctness hardening
- [x] Tests

## How was this tested?

On Windows 10, rebased on the current `upstream/main`:

```text
pytest tests/test_tui_gateway_server.py -q
367 passed

node --import tsx --test electron/hardening.test.ts electron/renderer-health.test.ts
22 passed

npm run test:ui -- \
  src/app/session/hooks/use-prompt-actions/index.test.tsx \
  src/app/session/hooks/use-prompt-actions/utils.test.ts \
  src/store/updates.test.ts
94 passed

npm run typecheck
passed

npm exec -- eslint <changed TypeScript files> --quiet
passed

npm run build
passed

git diff --cached --check
passed
```

The staged change also passed an independent frozen-diff review with opening and closing identity checks before commit.

## Scope notes

- No employee-specific paths, credentials, deployment scripts, or enterprise configuration are included.
- The larger diff is test-heavy: 3,085 added test lines and 1,842 added production lines across the Desktop/Electron/Gateway state machine.
- Existing image-preview behavior remains on its existing path; the chunked protocol is used for remote attachment delivery.

## Checklist

- [x] Read `CONTRIBUTING.md`
- [x] Searched for duplicate issues and PRs
- [x] Linked the tracking issue
- [x] Added state-machine and adversarial regression coverage
- [x] Ran focused and sibling test suites
- [x] Ran typecheck, lint, build, and diff checks
- [x] Kept the contribution generic and free of private deployment data
