### PR TITLE
fix(approval): allow verifier temp cleanup

### DIFF
--- a/agent/verification_stop.py
+++ b/agent/verification_stop.py
@@ -289,7 +289,7 @@ def build_verify_on_stop_nudge(
             + "), read any failure, repair the code, and summarize what passed."
         )
     else:
-        temp_dir = tempfile.gettempdir()
+        temp_dir = os.path.realpath(tempfile.gettempdir())
         command_instruction = (
             "No canonical test/lint/build command was detected. Create a focused "
             f"temporary verification script under `{temp_dir}` using an OS-safe "

--- a/tests/agent/test_verification_stop.py
+++ b/tests/agent/test_verification_stop.py
@@ -260,6 +260,27 @@ def test_no_suite_nudge_requests_temp_script(tmp_path, monkeypatch):
     assert "creative UI/visual work" in nudge
 
 
+def test_no_suite_nudge_uses_canonical_temp_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "package.json").write_text("{}", encoding="utf-8")
+    real_temp = tmp_path / "real-temp"
+    real_temp.mkdir()
+    linked_temp = tmp_path / "linked-temp"
+    linked_temp.symlink_to(real_temp, target_is_directory=True)
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(linked_temp))
+
+    nudge = build_verify_on_stop_nudge(
+        session_id="s1",
+        changed_paths=[str(project / "src" / "app.ts")],
+    )
+
+    assert nudge is not None
+    assert str(real_temp) in nudge
+    assert str(linked_temp) not in nudge
+
+
 def test_verify_guidance_can_be_disabled(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
     _node_project(tmp_path)

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -2,6 +2,7 @@
 
 import ast
 import os
+import tempfile
 import threading
 import time
 from pathlib import Path
@@ -81,6 +82,53 @@ class TestDetectDangerousRm:
         assert is_dangerous is True
         assert key is not None
         assert "delete" in desc.lower()
+
+    def test_nonrecursive_verification_artifact_cleanup_is_not_dangerous(self):
+        with mock_patch("tempfile.gettempdir", return_value="/tmp"):
+            for prefix in ("hermes-verify-", "hermes-ad-hoc-"):
+                assert detect_dangerous_command(f"rm -f /tmp/{prefix}example.py") == (
+                    False,
+                    None,
+                    None,
+                )
+
+    def test_symlinked_temp_dir_only_exempts_canonical_target(self, tmp_path):
+        real_temp = tmp_path / "real-temp"
+        real_temp.mkdir()
+        linked_temp = tmp_path / "linked-temp"
+        linked_temp.symlink_to(real_temp, target_is_directory=True)
+        basename = "hermes-verify-example.py"
+
+        with mock_patch("tempfile.gettempdir", return_value=str(linked_temp)):
+            assert detect_dangerous_command(f"rm -f {linked_temp / basename}")[0] is True
+            assert detect_dangerous_command(f"rm -f {real_temp / basename}") == (
+                False,
+                None,
+                None,
+            )
+
+    def test_verification_cleanup_exemption_rejects_broader_deletions(self):
+        commands = (
+            "rm -rf /tmp/hermes-verify-example.py",
+            "rm -f /tmp/hermes-verify-example.py /tmp/other.py",
+            "rm -f /tmp/nested/hermes-verify-example.py",
+            "rm -f /tmp/nested/../hermes-verify-example.py",
+            "rm -f /tmp/./hermes-verify-example.py",
+            "rm -f /tmp//hermes-verify-example.py",
+            "rm -f /tmp/a/../../tmp/hermes-verify-example.py",
+            "rm -f /var/tmp/hermes-verify-example.py",
+            "rm -f /tmp/unrelated.py",
+            "rm -f /tmp/hermes-verify-*",
+            "rm -f /tmp/hermes-verify-$(touch>/tmp/pwned).py",
+            "rm -f /tmp/hermes-ad-hoc-`touch>/tmp/pwned`.py",
+            "rm -f /tmp/hermes-verify-example.py; touch /tmp/pwned",
+        )
+        with mock_patch("tempfile.gettempdir", return_value="/tmp"):
+            for command in commands:
+                is_dangerous, key, desc = detect_dangerous_command(command)
+                assert is_dangerous is True, command
+                assert key is not None, command
+                assert "delete" in desc.lower(), command
 
 
 class TestWindowsShellDestructiveCommands:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -17,6 +17,7 @@ import os
 import re
 import shlex
 import sys
+import tempfile
 import threading
 import time
 import unicodedata
@@ -1383,12 +1384,36 @@ def _command_detection_variants(command: str):
         yield variant
 
 
+def _is_verification_artifact_cleanup(command: str) -> bool:
+    """Return whether *command* only removes one Hermes ad-hoc temp script."""
+    try:
+        argv = shlex.split(command, posix=True)
+    except ValueError:
+        return False
+    if len(argv) != 3 or argv[0] != "rm" or argv[1] != "-f":
+        return False
+
+    operand = argv[2]
+    temp_dir = os.path.realpath(tempfile.gettempdir())
+    basename = os.path.basename(operand)
+    if operand != os.path.join(temp_dir, basename):
+        return False
+
+    target = os.path.realpath(operand)
+    if os.path.dirname(target) != temp_dir:
+        return False
+    return re.fullmatch(r"hermes-(?:verify|ad-hoc)-[A-Za-z0-9_.-]+", basename) is not None
+
+
 def detect_dangerous_command(command: str) -> tuple:
     """Check if a command matches any dangerous patterns.
 
     Returns:
         (is_dangerous, pattern_key, description) or (False, None, None)
     """
+    if _is_verification_artifact_cleanup(command):
+        return (False, None, None)
+
     for command_variant in _command_detection_variants(command):
         command_lower = command_variant.lower()
         for pattern_re, description in DANGEROUS_PATTERNS_COMPILED:


### PR DESCRIPTION
## Summary

- allow a standalone `rm -f` cleanup for exactly one Hermes verifier artifact in the OS temp directory
- keep recursive deletion, multiple operands, nested/alternate paths, traversal, redundant path components, unrelated files, globbing, shell substitution, command tails, and compound commands behind approval
- add positive and adversarial regression coverage

Closes #62377.

## Problem

`agent/verification_stop.py` mandates an ad-hoc script under `tempfile.gettempdir()` and asks the agent to clean it up. On Linux that produces a command such as:

```bash
rm -f /tmp/hermes-verify-abc123.py
```

The generic absolute-path `rm` detector classifies that required cleanup as dangerous, so the prescribed verification workflow can require human approval merely to remove the artifact Hermes required.

## Security boundary

The exemption parses the whole command with `shlex` and requires all of the following:

- exactly three tokens
- literal `rm -f`
- one target only
- the unmodified operand is exactly `tempfile.gettempdir()/basename` (no traversal, nested path, `.` component, or repeated separator)
- the resolved target remains directly under the resolved temp directory
- basename fully matches `hermes-(verify|ad-hoc)-[A-Za-z0-9_.-]+`

Compound commands deliberately remain gated.

## Testing

- canonical targeted runner: **351 passed, 0 failed**
- Ruff on touched files: **passed**
- adversarial command matrix/regressions cover recursive flags, multiple operands, nested/alternate paths, traversal, redundant components, unrelated files, globs, `$()` substitution, backticks, and command tails
- canonical full suite: **40,177 passed, 7 unrelated environment-dependent failures** across Copilot HOME isolation, WeCom optional XML support, Mistral lazy installation, and audio-device detection. No failures touch approval or verification code.

## Review follow-up

An independent security review rejected the first revision because canonicalizing before structural validation accepted traversal-bearing operands. The current revision validates the raw operand first and retains canonicalization only as an additional containment check. A second independent review found that a mutable symlink in TMPDIR could still be retargeted between approval and execution; the guard and exemption now both use the canonical temp-directory spelling, while the symlink alias remains gated.

## Duplicate search

Searched open and closed issues/PRs for `hermes-verify`, temp cleanup, and approval; no existing fix found.