### PR TITLE
fix(gateway): notify home channels after supervisor restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6765,14 +6765,36 @@ class GatewayRunner:
             if active_agents:
                 self._increment_restart_failure_counts(set(active_agents.keys()))
 
-            if self._restart_requested and self._restart_command_source is None:
+            should_notify_home_on_next_boot = (
+                # Normal Hermes-managed restarts with no specific originating
+                # chat should announce the comeback to configured home channels.
+                (self._restart_requested and self._restart_command_source is None)
+                # External SIGTERM under supervisors such as systemd also comes
+                # back automatically, but it bypasses request_restart() and used
+                # to send only the shutdown half of the lifecycle. Persist the
+                # same marker so the next process can say it is back online.
+                or (
+                    getattr(self, "_signal_initiated_shutdown", False)
+                    and not self._restart_requested
+                )
+            )
+            if should_notify_home_on_next_boot:
                 try:
                     atomic_json_write(
                         _planned_restart_notification_path(),
                         {
                             "requested_at": time.time(),
-                            "via_service": bool(self._restart_via_service),
+                            "via_service": bool(
+                                self._restart_via_service
+                                or getattr(self, "_signal_initiated_shutdown", False)
+                            ),
                             "detached": bool(self._restart_detached),
+                            "reason": (
+                                "external_signal"
+                                if getattr(self, "_signal_initiated_shutdown", False)
+                                and not self._restart_requested
+                                else "planned_restart"
+                            ),
                         },
                         indent=None,
                     )

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -161,6 +162,24 @@ async def test_gateway_stop_launchd_service_restart_keeps_nonzero_exit(tmp_path,
         await runner.stop(restart=True, service_restart=True)
 
     assert runner._exit_code == GATEWAY_SERVICE_RESTART_EXIT_CODE
+
+
+@pytest.mark.asyncio
+async def test_unexpected_signal_writes_home_startup_marker(tmp_path, monkeypatch):
+    """External supervisor restarts should send the missing 'back online' half."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+    runner._signal_initiated_shutdown = True
+
+    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
+        await runner.stop()
+
+    marker = tmp_path / ".restart_pending.json"
+    assert marker.exists()
+    payload = json.loads(marker.read_text())
+    assert payload["reason"] == "external_signal"
+    assert payload["via_service"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Preserve home-channel startup notification markers for supervisor-driven restarts with no source chat
- Still suppress home broadcast for in-chat `/restart` flows
- Add regression coverage for unexpected signal shutdown markers

## Test Plan
- `scripts/run_tests.sh tests/gateway/test_gateway_shutdown.py` -> 15 passed
- `scripts/run_tests.sh --slice 3/8` on clean branch -> 4143 passed, 0 failed
- `scripts/run_tests.sh --slice 6/8` on clean branch -> 5014 passed, 1 flaky failure in `tests/tui_gateway/test_slash_worker_mcp_discovery.py`; reran that file and it passed
- `python -B -m compileall -q gateway/run.py tests/gateway/test_gateway_shutdown.py`
- `git diff --check`

Supersedes #62200, which was closed so CI would run fresh on this replacement PR.
