### PR TITLE
fix(agent): stop repeated tool loops earlier

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -68,6 +68,7 @@ def _resolve_review_runtime(agent: Any) -> Dict[str, Any]:
         "command": getattr(agent, "acp_command", None),
         "args": list(getattr(agent, "acp_args", []) or []),
         "routed": False,
+        "max_iterations": 16,
     }
     try:
         from hermes_cli.config import load_config
@@ -76,6 +77,12 @@ def _resolve_review_runtime(agent: Any) -> Dict[str, Any]:
         return parent
     aux = cfg.get("auxiliary", {}) if isinstance(cfg.get("auxiliary"), dict) else {}
     task = aux.get("background_review", {}) if isinstance(aux.get("background_review"), dict) else {}
+    try:
+        review_max_iterations = int(task.get("max_iterations", 16))
+    except (TypeError, ValueError):
+        review_max_iterations = 16
+    review_max_iterations = max(1, min(review_max_iterations, 16))
+    parent["max_iterations"] = review_max_iterations
     task_provider = (str(task.get("provider", "")).strip() or None)
     task_model = (str(task.get("model", "")).strip() or None)
     task_base_url = (str(task.get("base_url", "")).strip() or None)
@@ -104,6 +111,7 @@ def _resolve_review_runtime(agent: Any) -> Dict[str, Any]:
             "command": rp.get("command"),
             "args": list(rp.get("args") or []),
             "routed": True,
+            "max_iterations": review_max_iterations,
         }
     except Exception as e:
         logger.debug("background-review aux routing failed (%s); using main model", e)
@@ -698,7 +706,7 @@ def _run_review_in_thread(
                 _fork_kwargs["acp_args"] = _rt.get("args") or []
             review_agent = AIAgent(
                 model=_rt.get("model") or agent.model,
-                max_iterations=16,
+                max_iterations=int(_rt.get("max_iterations") or 16),
                 quiet_mode=True,
                 platform=agent.platform,
                 provider=_rt.get("provider") or agent.provider,

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -24,6 +24,7 @@ IDEMPOTENT_TOOL_NAMES = frozenset(
         "web_search",
         "web_extract",
         "session_search",
+        "skill_view",
         "browser_snapshot",
         "browser_console",
         "browser_get_images",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1726,6 +1726,7 @@ DEFAULT_CONFIG = {
             "base_url": "",
             "api_key": "",
             "timeout": 120,
+            "max_iterations": 16,
             "extra_body": {},
         },
         "moa_reference": {

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -3,12 +3,30 @@
 import json
 
 from agent.tool_guardrails import (
+    IDEMPOTENT_TOOL_NAMES,
     ToolCallGuardrailConfig,
     ToolCallGuardrailController,
     ToolCallSignature,
     canonical_tool_args,
     classify_tool_failure,
 )
+
+
+def test_skill_view_is_idempotent_and_repeated_success_is_no_progress():
+    assert "skill_view" in IDEMPOTENT_TOOL_NAMES
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            no_progress_warn_after=1,
+            no_progress_block_after=2,
+        )
+    )
+    args = {"name": "job-tracker-app"}
+    result = '{"success":true,"content":"same skill"}'
+
+    assert controller.after_call("skill_view", args, result, failed=False).action == "warn"
+    assert controller.after_call("skill_view", args, result, failed=False).action == "warn"
+    assert controller.before_call("skill_view", args).code == "idempotent_no_progress_block"
 
 
 def test_tool_call_signature_hashes_canonical_nested_unicode_args_without_exposing_raw_args():

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -76,6 +76,47 @@ def test_background_review_shuts_down_memory_provider_before_close(monkeypatch):
     ]
 
 
+def test_background_review_uses_resolved_iteration_budget(monkeypatch):
+    import agent.background_review as bg_review
+
+    captured = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            pass
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(
+        bg_review,
+        "_resolve_review_runtime",
+        lambda _agent: {
+            "provider": "openai",
+            "model": "fake-model",
+            "routed": False,
+            "max_iterations": 4,
+        },
+    )
+
+    AIAgent._spawn_background_review(
+        _bare_agent(),
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
+
+    assert captured["max_iterations"] == 4
+
+
 def test_background_review_fork_opts_out_of_session_finalization(monkeypatch):
     """The review fork shares the parent's live session_id, so it must set
     ``_end_session_on_close = False``. Otherwise close() (now finalizing owned

--- a/tests/run_agent/test_background_review_cost_controls.py
+++ b/tests/run_agent/test_background_review_cost_controls.py
@@ -52,6 +52,22 @@ def test_routing_auto_inherits_parent_and_downgrades_codex_app_server():
     assert rt["api_mode"] == "codex_responses"  # downgraded so agent-loop tools dispatch
 
 
+def test_background_review_iteration_budget_is_configurable():
+    agent = _FakeAgent()
+    cfg = {
+        "auxiliary": {
+            "background_review": {
+                "provider": "auto",
+                "model": "",
+                "max_iterations": 4,
+            }
+        }
+    }
+    with patch("hermes_cli.config.load_config", return_value=cfg):
+        rt = br._resolve_review_runtime(agent)
+    assert rt["max_iterations"] == 4
+
+
 def test_routing_to_different_model_marks_routed_and_resolves_credentials():
     agent = _FakeAgent()
     cfg = {"auxiliary": {"background_review": {

--- a/tests/run_agent/test_background_review_cost_controls.py
+++ b/tests/run_agent/test_background_review_cost_controls.py
@@ -68,6 +68,34 @@ def test_background_review_iteration_budget_is_configurable():
     assert rt["max_iterations"] == 4
 
 
+def _iteration_budget(review_overrides):
+    agent = _FakeAgent()
+    cfg = {"auxiliary": {"background_review": {
+        "provider": "auto", "model": "", **review_overrides,
+    }}}
+    with patch("hermes_cli.config.load_config", return_value=cfg):
+        return br._resolve_review_runtime(agent)["max_iterations"]
+
+
+def test_iteration_budget_defaults_to_16_when_unset():
+    assert _iteration_budget({}) == 16
+
+
+def test_iteration_budget_clamps_to_its_1_16_bound():
+    assert _iteration_budget({"max_iterations": 1}) == 1     # lower bound accepted as-is
+    assert _iteration_budget({"max_iterations": 16}) == 16   # upper bound accepted as-is
+    assert _iteration_budget({"max_iterations": 0}) == 1     # below the bound clamps up
+    assert _iteration_budget({"max_iterations": -8}) == 1
+    assert _iteration_budget({"max_iterations": 17}) == 16   # above the bound clamps down
+    assert _iteration_budget({"max_iterations": 500}) == 16
+
+
+def test_iteration_budget_falls_back_to_default_on_invalid_values():
+    assert _iteration_budget({"max_iterations": "plenty"}) == 16  # ValueError → default
+    assert _iteration_budget({"max_iterations": None}) == 16      # TypeError → default
+    assert _iteration_budget({"max_iterations": "4"}) == 4        # numeric strings still parse
+
+
 def test_routing_to_different_model_marks_routed_and_resolves_credentials():
     agent = _FakeAgent()
     cfg = {"auxiliary": {"background_review": {

--- a/tests/tools/test_process_schema_guidance.py
+++ b/tests/tools/test_process_schema_guidance.py
@@ -1,0 +1,14 @@
+from tools.process_registry import PROCESS_SCHEMA
+
+
+def test_process_schema_forbids_invented_or_synchronous_session_ids():
+    description = PROCESS_SCHEMA["description"]
+    session_description = PROCESS_SCHEMA["parameters"]["properties"]["session_id"][
+        "description"
+    ]
+
+    assert "terminal(background=true)" in description
+    assert "finished synchronously" in description
+    assert "Never invent" in description
+    assert "not_found" in description
+    assert "terminal(background=true)" in session_description

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2142,6 +2142,11 @@ PROCESS_SCHEMA = {
     "name": "process",
     "description": (
         "Manage background processes started with terminal(background=true). "
+        "Use this tool only when that terminal call returned a real process session ID. "
+        "If terminal returned ordinary output plus exit_code, it finished synchronously "
+        "and there is no background process to poll. Never invent or guess a session ID. "
+        "If an ID returns not_found, call action='list' once or change strategy; never "
+        "retry the same missing ID unchanged. "
         "Actions: 'list' (show all), 'poll' (check status + new output), "
         "'log' (full output with pagination), 'wait' (block until done or timeout), "
         "'kill' (terminate), 'write' (send raw stdin data without newline), "
@@ -2157,7 +2162,7 @@ PROCESS_SCHEMA = {
             },
             "session_id": {
                 "type": "string",
-                "description": "Process session ID (from terminal background output). Required for all actions except 'list'."
+                "description": "Exact process session ID returned by terminal(background=true). Never use an invented ID or an ID from a synchronous terminal result. Required for all actions except 'list'."
             },
             "data": {
                 "type": "string",

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -282,6 +282,7 @@ auxiliary:
   background_review:
     provider: openrouter
     model: google/gemini-3-flash-preview   # auto (default) = main chat model
+    max_iterations: 8                      # review loop budget, 1–16 (default 16)
 ```
 
 When you point it at a model **different** from your main one, the review runs
@@ -291,6 +292,12 @@ replays a compact **digest** of the conversation (recent turns verbatim + a
 summary of older ones) rather than the full transcript — minimizing what it
 writes to the new cache. Capture holds: in testing, memory capture was
 identical and skill capture near-identical to the main-model review.
+
+`max_iterations` bounds the review fork's **agent-loop iterations** — its
+worst-case number of model calls per review. The default is `16`; out-of-range
+values clamp to the `1`–`16` range, and a non-numeric value falls back to the
+default. Lower it to cap the review's per-capture cost on slow or metered
+endpoints.
 
 Leave it at `auto` (or set it to your main model) and nothing changes — the
 review keeps running on the main model with the full warm-cache replay.


### PR DESCRIPTION
## Summary
- classify `skill_view` as idempotent so repeated successful reads trigger no-progress protection
- make the background-review iteration budget configurable, bounded to 1–16
- clarify that `process` IDs must come from `terminal(background=true)` and must not be invented or retried after `not_found`
- add regression coverage for all three behaviors

## Production incident
A local Hermes/Qwen agent repeated an invented `process` ID until the exact-failure guardrail fired, then repeated a nonexistent `skill_view` support path. Its background reviewer separately reread the same skill until exhausting 16/16 turns. The foreground thresholds remain user-configurable; this PR closes the global idempotency and background-budget gaps.

## Verification
- `14 passed`: tool guardrails
- `10 passed`: background review cost controls
- `12 passed`: background review lifecycle
- `1 passed`: process schema guidance
- `5 passed`: focused process registry checks
