### PR TITLE
feat(delegation): add configurable foreground execution

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2247,6 +2247,8 @@ DEFAULT_CONFIG = {
                                        # delegation units. New async dispatches beyond the cap
                                        # fall back to synchronous execution. Floor of 1, no ceiling.
                                        # (Replaces the deprecated max_async_children.)
+        "foreground_by_default": False,  # false = detached results re-enter as new turns;
+                                          # true = parent waits and synthesizes in the current turn
         # Orchestrator role controls (see tools/delegate_tool.py:_get_max_spawn_depth
         # and _get_orchestrator_enabled).  Floored at 1, no upper ceiling —
         # raise deliberately, each level multiplies API cost.

--- a/run_agent.py
+++ b/run_agent.py
@@ -5694,25 +5694,31 @@ class AIAgent:
             _strip_model_hidden_task_fields,
             delegate_task as _delegate_task,
         )
-        # Delegations from the top-level MODEL always run in the background —
-        # the model does not get to choose. delegate_task returns immediately
-        # with a handle (one per task) and each subagent's result re-enters the
-        # conversation as a new message when it finishes. This applies to BOTH
-        # a single task and a fan-out batch (each task becomes its own
-        # independent background subagent). The one exception:
-        #   - A delegation from an ORCHESTRATOR SUBAGENT (depth > 0) stays
-        #     synchronous: the orchestrator needs its workers' results within
-        #     its own turn to compose a summary, and a subagent doesn't own the
-        #     gateway session the async result would route back to.
-        # The schema-level `background` param is intentionally ignored here.
+        # Top-level MODEL delegation mode is configurable. Hermes' compatibility
+        # default remains asynchronous, but operators that need the parent to
+        # synthesize child findings before replying can set:
+        #
+        #   delegation.foreground_by_default: true
+        #
+        # Orchestrator subagents (depth > 0) always stay synchronous because
+        # they need their workers' results within their own turn and do not own
+        # a gateway session for detached completion routing. The model-facing
+        # `background` parameter remains ignored so this operator policy cannot
+        # be bypassed accidentally by model output.
+        from tools.delegate_tool import _load_config
+
         _is_subagent = getattr(self, "_delegate_depth", 0) > 0
+        _delegation_cfg = _load_config()
+        _foreground_by_default = is_truthy_value(
+            _delegation_cfg.get("foreground_by_default"), default=False
+        )
         return _delegate_task(
             goal=function_args.get("goal"),
             context=function_args.get("context"),
             tasks=_strip_model_hidden_task_fields(function_args.get("tasks")),
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
-            background=(not _is_subagent),
+            background=(False if _is_subagent else not _foreground_by_default),
             parent_agent=self,
         )
 

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -428,11 +428,8 @@ def test_delegate_task_background_batch_runs_as_one_unit(monkeypatch):
     assert _drain_one() is None
 
 
-def test_model_dispatch_forces_background():
-    """The MODEL-facing dispatch path forces background=True for any top-level
-    delegation (single task OR batch), and keeps it off for an orchestrator
-    subagent (depth > 0). Direct delegate_task() callers are unaffected (they
-    keep the synchronous default)."""
+def test_model_dispatch_respects_foreground_config_in_registry_fallback(monkeypatch):
+    """The registry fallback mirrors the live model dispatch policy."""
     import tools.delegate_tool as dt
     from unittest.mock import MagicMock
 
@@ -441,49 +438,89 @@ def test_model_dispatch_forces_background():
     sub = MagicMock()
     sub._delegate_depth = 1
 
-    # Registry-fallback helper: top-level always background, regardless of
-    # single vs batch; subagent never.
+    monkeypatch.setattr(dt, "_load_config", lambda: {})
     assert dt._model_background_value({"goal": "x"}, top) is True
     assert dt._model_background_value(
         {"tasks": [{"goal": "a"}, {"goal": "b"}]}, top
     ) is True
-    assert dt._model_background_value({"tasks": [{"goal": "a"}]}, top) is True
-    assert dt._model_background_value({"goal": "x"}, sub) is False
+
+    monkeypatch.setattr(dt, "_load_config", lambda: {"foreground_by_default": True})
+    assert dt._model_background_value({"goal": "x"}, top) is False
     assert dt._model_background_value(
-        {"tasks": [{"goal": "a"}, {"goal": "b"}]}, sub
+        {"tasks": [{"goal": "a"}, {"goal": "b"}]}, top
     ) is False
+    assert dt._model_background_value({"goal": "x"}, sub) is False
 
 
-def test_run_agent_dispatch_forces_background():
-    """run_agent._dispatch_delegate_task — the live model path — forces
-    background on for any top-level delegation (single OR batch) and off for a
-    subagent."""
+def test_tool_description_reflects_foreground_config(monkeypatch):
+    """The model receives accurate lifecycle guidance for the configured mode."""
+    import tools.delegate_tool as dt
+
+    monkeypatch.setattr(dt, "_load_config", lambda: {"foreground_by_default": True})
+    foreground_description = dt._build_top_level_description()
+    assert "parent waits" in foreground_description
+    assert "RUN IN THE BACKGROUND" not in foreground_description
+
+    monkeypatch.setattr(dt, "_load_config", lambda: {})
+    background_description = dt._build_top_level_description()
+    assert "RUN IN THE BACKGROUND" in background_description
+
+
+def test_run_agent_dispatch_respects_foreground_by_default_config():
+    """Top-level model delegation follows delegation.foreground_by_default;
+    orchestrator children always remain synchronous so they can synthesize."""
     from unittest.mock import patch
     import run_agent
 
+    captured = {}
+
     class _FakeAgent:
         _delegate_depth = 0
-
-    captured = {}
 
     def _fake_delegate(**kwargs):
         captured.update(kwargs)
         return "{}"
 
-    with patch("tools.delegate_tool.delegate_task", _fake_delegate):
+    with (
+        patch("tools.delegate_tool.delegate_task", _fake_delegate),
+        patch("tools.delegate_tool._load_config", return_value={"foreground_by_default": True}),
+    ):
         agent = _FakeAgent()
         run_agent.AIAgent._dispatch_delegate_task(agent, {"goal": "x"})
-        assert captured["background"] is True
+        assert captured["background"] is False
 
         run_agent.AIAgent._dispatch_delegate_task(
             agent, {"tasks": [{"goal": "a"}, {"goal": "b"}]}
         )
-        assert captured["background"] is True
+        assert captured["background"] is False
 
         sub = _FakeAgent()
         sub._delegate_depth = 1
         run_agent.AIAgent._dispatch_delegate_task(sub, {"goal": "x"})
         assert captured["background"] is False
+
+
+def test_run_agent_dispatch_defaults_to_background_for_compatibility():
+    """Without the new config, preserve Hermes' current async default."""
+    from unittest.mock import patch
+    import run_agent
+
+    captured = {}
+
+    class _FakeAgent:
+        _delegate_depth = 0
+
+    def _fake_delegate(**kwargs):
+        captured.update(kwargs)
+        return "{}"
+
+    with (
+        patch("tools.delegate_tool.delegate_task", _fake_delegate),
+        patch("tools.delegate_tool._load_config", return_value={}),
+    ):
+        run_agent.AIAgent._dispatch_delegate_task(_FakeAgent(), {"goal": "x"})
+
+    assert captured["background"] is True
 
 
 def test_dispatch_never_forwards_model_toolsets():

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3217,6 +3217,29 @@ def _build_top_level_description() -> str:
         orchestrator_on = _get_orchestrator_enabled()
     except Exception:
         orchestrator_on = True
+    try:
+        foreground_by_default = is_truthy_value(
+            _load_config().get("foreground_by_default"), default=False
+        )
+    except Exception:
+        foreground_by_default = False
+
+    if foreground_by_default:
+        lifecycle_clause = (
+            "BOTH MODES RUN IN THE FOREGROUND. The parent waits for every child "
+            "to finish and receives the consolidated results in its current turn "
+            "so it can verify and synthesize them before replying. Orchestrator "
+            "subagents also wait for their children.\n\n"
+        )
+    else:
+        lifecycle_clause = (
+            "BOTH MODES RUN IN THE BACKGROUND. delegate_task returns immediately — "
+            "you and the user keep working, and each subagent's full result "
+            "re-enters the conversation as its own new message when it finishes. A "
+            "batch is just N independent background subagents (N handles, each "
+            "completes on its own). Do NOT wait or poll; just continue with other "
+            "work after dispatching.\n\n"
+        )
 
     if max_depth >= 2 and orchestrator_on:
         nesting_clause = (
@@ -3250,12 +3273,7 @@ def _build_top_level_description() -> str:
         f"2. Batch (parallel): provide 'tasks' array with up to {max_children} "
         f"items concurrently for this user (configured via "
         f"delegation.max_concurrent_children in config.yaml). {nesting_clause}\n\n"
-        "BOTH MODES RUN IN THE BACKGROUND. delegate_task returns immediately — "
-        "you and the user keep working, and each subagent's full result "
-        "re-enters the conversation as its own new message when it finishes. A "
-        "batch is just N independent background subagents (N handles, each "
-        "completes on its own). Do NOT wait or poll; just continue with other "
-        "work after dispatching.\n\n"
+        f"{lifecycle_clause}"
         "WHEN TO USE delegate_task:\n"
         "- Reasoning-heavy subtasks (debugging, code review, research synthesis)\n"
         "- Tasks that would flood your context with intermediate data\n"
@@ -3438,13 +3456,12 @@ DELEGATE_TASK_SCHEMA = {
             "background": {
                 "type": "boolean",
                 "description": (
-                    "DEPRECATED / IGNORED. Single-task delegations always run "
-                    "in the background automatically — you do not need to (and "
-                    "cannot) opt in or out. The result re-enters the "
-                    "conversation as a new message when the subagent finishes; "
-                    "just continue working in the meantime. Setting this has no "
-                    "effect; the parameter remains only for backward "
-                    "compatibility."
+                    "DEPRECATED / IGNORED. Top-level delegation mode is operator-controlled "
+                    "by delegation.foreground_by_default. When false or unset (Hermes "
+                    "compatibility default), results re-enter as new turns. When true, "
+                    "the parent waits and receives results in its current turn for "
+                    "synthesis. Orchestrator subagents always wait for their children. "
+                    "This parameter remains only for backward compatibility."
                 ),
             },
         },
@@ -3460,17 +3477,19 @@ from tools.registry import registry, tool_error
 def _model_background_value(args: dict, parent_agent=None) -> bool:
     """Background flag for the MODEL-facing dispatch path (registry fallback).
 
-    Delegations from the top-level agent always run in the background — the
-    model does not choose. This applies to both a single task and a fan-out
-    batch (each task becomes its own independent background subagent). The one
-    exception is a delegation from an orchestrator subagent (depth > 0), which
-    needs its workers' results within its own turn. The live path is
-    ``run_agent._dispatch_delegate_task``; this lambda mirrors it for the rare
+    Top-level delegation follows the operator-controlled
+    ``delegation.foreground_by_default`` policy; the model does not choose.
+    Delegation from an orchestrator subagent (depth > 0) is always synchronous
+    because it needs its workers' results within its own turn. The live path is
+    ``run_agent._dispatch_delegate_task``; this helper mirrors it for the rare
     case the intercept is bypassed. Direct Python callers of ``delegate_task``
     keep the historical synchronous default.
     """
     is_subagent = getattr(parent_agent, "_delegate_depth", 0) > 0
-    return not is_subagent
+    foreground_by_default = is_truthy_value(
+        _load_config().get("foreground_by_default"), default=False
+    )
+    return False if is_subagent else not foreground_by_default
 
 
 _MODEL_HIDDEN_TASK_FIELDS = {"acp_command", "acp_args"}


### PR DESCRIPTION
## Summary
- add `delegation.foreground_by_default` with a backward-compatible `false` default
- let top-level parents wait for child results in the current turn when enabled
- keep orchestrator children synchronous and model-supplied `background` ignored
- make the dynamic tool description and registry fallback honor the same policy

## Motivation
Some command-center workflows need delegated research/review findings before the parent responds. Native async re-entry is useful, but forcing it globally prevents same-turn verification and synthesis. This preserves the current async default while making lifecycle behavior operator-configurable.

## Verification
- `python -m pytest tests/tools/test_async_delegation.py tests/tools/test_delegate.py -q` — 179 passed
- `python -m py_compile run_agent.py tools/delegate_tool.py hermes_cli/config.py`
- `git diff --check`

## Compatibility
No behavior changes unless `delegation.foreground_by_default: true` is explicitly configured.