### PR TITLE
Fix Desktop model defaults and GPT labels

### DIFF
--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -100,3 +100,40 @@ describe('ModelMenuPanel MoA presets', () => {
     expect(onSelectModel).toHaveBeenCalledWith({ model: 'BeastMode', provider: 'moa' })
   })
 })
+
+describe('ModelMenuPanel configured defaults', () => {
+  it('renders an inactive GPT model with its configured Fast High defaults', async () => {
+    getGlobalModelOptions.mockResolvedValue({
+      model: 'gpt-5.6-sol',
+      provider: 'custom:helix-gpt-5.6',
+      providers: [
+        {
+          name: 'Helix LiteLLM · Responses',
+          slug: 'custom:helix-gpt-5.6',
+          models: ['gpt-5.6-sol', 'gpt-5.6-terra'],
+          capabilities: {
+            'gpt-5.6-sol': {
+              fast: true,
+              reasoning: true,
+              fast_default: true,
+              reasoning_default: 'high'
+            },
+            'gpt-5.6-terra': {
+              fast: true,
+              reasoning: true,
+              fast_default: true,
+              reasoning_default: 'high'
+            }
+          }
+        }
+      ]
+    })
+    $currentModel.set('gpt-5.6-sol')
+    $currentProvider.set('custom:helix-gpt-5.6')
+    renderPanel()
+
+    const terra = await findByText(document.body, 'GPT-5.6 Terra')
+    const item = terra.closest('[role="menuitem"]') ?? terra.parentElement
+    expect(item?.textContent).toContain('Fast High')
+  })
+})

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -172,8 +172,10 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
 
     await applyModelPreset(
       {
-        effort: (caps?.reasoning ?? true) ? (preset.effort ?? 'medium') : undefined,
-        fast: (caps?.fast ?? false) ? (preset.fast ?? false) : undefined
+        effort: (caps?.reasoning ?? true)
+          ? (preset.effort ?? caps?.reasoning_default ?? 'medium')
+          : undefined,
+        fast: (caps?.fast ?? false) ? (preset.fast ?? caps?.fast_default ?? false) : undefined
       },
       { failMessage: t.shell.modelOptions.updateFailed, request: requestGateway, sessionId: activeSessionId }
     )
@@ -253,8 +255,12 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
                 // defaults when unset). Row label AND submenu read from these so
                 // they never disagree.
                 const preset = modelPresets[modelPresetKey(group.provider.slug, family.id)] ?? {}
-                const effEffort = isCurrent ? currentReasoningEffort : (preset.effort ?? '')
-                const effFast = isCurrent ? currentFastMode : (preset.fast ?? false)
+                const effEffort = isCurrent
+                  ? currentReasoningEffort
+                  : (preset.effort ?? caps?.reasoning_default ?? '')
+                const effFast = isCurrent
+                  ? currentFastMode
+                  : (preset.fast ?? caps?.fast_default ?? false)
 
                 const fastControl = resolveFastControl(
                   activeId ?? family.id,

--- a/apps/desktop/src/lib/model-status-label.test.ts
+++ b/apps/desktop/src/lib/model-status-label.test.ts
@@ -13,6 +13,9 @@ describe('model-status-label', () => {
     expect(displayModelName('openai/gpt-5.5-fast')).toBe('GPT-5.5')
     expect(displayModelName('deepseek/deepseek-v4-pro-thinking')).toBe('Deepseek V4 Pro')
     expect(displayModelName('openai/gpt-5.5')).toBe('GPT-5.5')
+    expect(displayModelName('gpt-5.6-sol')).toBe('GPT-5.6 Sol')
+    expect(displayModelName('gpt-5.6-terra')).toBe('GPT-5.6 Terra')
+    expect(displayModelName('gpt-5.6-luna')).toBe('GPT-5.6 Luna')
   })
 
   it('strips trailing date-pin snapshots from the display name', () => {
@@ -23,6 +26,7 @@ describe('model-status-label', () => {
   it('maps reasoning effort to compact labels', () => {
     expect(reasoningEffortLabel('high')).toBe('High')
     expect(reasoningEffortLabel('xhigh')).toBe('Max')
+    expect(reasoningEffortLabel('max')).toBe('Max')
     expect(reasoningEffortLabel('')).toBe('')
   })
 

--- a/apps/desktop/src/lib/model-status-label.ts
+++ b/apps/desktop/src/lib/model-status-label.ts
@@ -6,7 +6,8 @@ const REASONING_LABELS: Record<string, string> = {
   low: 'Low',
   medium: 'Med',
   high: 'High',
-  xhigh: 'Max'
+  xhigh: 'Max',
+  max: 'Max'
 }
 
 export function reasoningEffortLabel(effort: string): string {
@@ -61,7 +62,10 @@ function prettifyBase(base: string): string {
   }
 
   if (/^gpt-/i.test(base)) {
-    return base.replace(/^gpt-/i, 'GPT-')
+    const [version = '', ...suffix] = base.replace(/^gpt-/i, '').split('-')
+    const qualifier = titleCase(suffix.join(' '))
+
+    return `GPT-${version}${qualifier ? ` ${qualifier}` : ''}`
   }
 
   if (/^gemini-/i.test(base)) {

--- a/apps/desktop/src/store/model-presets.test.ts
+++ b/apps/desktop/src/store/model-presets.test.ts
@@ -1,9 +1,14 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { $modelPresets, applyModelPreset, getModelPreset, modelPresetKey, setModelPreset } from './model-presets'
+import { $currentFastMode, $currentReasoningEffort } from './session'
 
 describe('model presets', () => {
-  beforeEach(() => $modelPresets.set({}))
+  beforeEach(() => {
+    $modelPresets.set({})
+    $currentReasoningEffort.set('')
+    $currentFastMode.set(false)
+  })
 
   it('round-trips a preset and merges patches without dropping prior fields', () => {
     setModelPreset('anthropic', 'claude-opus-4-8', { effort: 'high' })
@@ -35,7 +40,7 @@ describe('model presets', () => {
     expect(calls).toEqual([{ method: 'config.set', params: { key: 'reasoning', session_id: 's1', value: 'high' } }])
   })
 
-  it('no-ops without a session so selecting a model cannot mutate global config', async () => {
+  it('updates pre-session composer controls without mutating global config', async () => {
     const calls: { method: string; params?: Record<string, unknown> }[] = []
 
     const request = async <T>(method: string, params?: Record<string, unknown>) => {
@@ -47,5 +52,7 @@ describe('model presets', () => {
     await applyModelPreset({ effort: 'high', fast: true }, { failMessage: 'x', request, sessionId: null })
 
     expect(calls).toEqual([])
+    expect($currentReasoningEffort.get()).toBe('high')
+    expect($currentFastMode.get()).toBe(true)
   })
 })

--- a/apps/desktop/src/store/model-presets.ts
+++ b/apps/desktop/src/store/model-presets.ts
@@ -8,8 +8,8 @@ import { setCurrentFastMode, setCurrentReasoningEffort } from './session'
 const STORAGE_KEY = 'hermes.desktop.model-presets'
 
 /** Per-model reasoning/fast preset, remembered globally across sessions and
- *  re-applied to the session whenever that model is selected. Unset dimensions
- *  fall back to the Hermes default (medium effort, no fast). */
+ *  re-applied to the session whenever that model is selected. The picker
+ *  supplies configured model/profile defaults for unset dimensions. */
 export interface ModelPreset {
   effort?: string
   fast?: boolean
@@ -60,16 +60,18 @@ export async function applyModelPreset(
   { effort, fast }: ModelPreset,
   ctx: { failMessage: string; request: RequestGateway; sessionId: null | string }
 ): Promise<void> {
-  if (!ctx.sessionId) {
-    return
-  }
-
   if (effort !== undefined) {
     setCurrentReasoningEffort(effort)
   }
 
   if (fast !== undefined) {
     setCurrentFastMode(fast)
+  }
+
+  // Pre-session choices are composer state only. session.create ships these
+  // values as per-session overrides; never write the profile from this path.
+  if (!ctx.sessionId) {
+    return
   }
 
   try {

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -278,6 +278,9 @@ export interface ModelOptionProvider {
 export interface ModelCapabilities {
   fast: boolean
   reasoning: boolean
+  /** Effective profile/model default used when no Desktop preset exists. */
+  fast_default?: boolean
+  reasoning_default?: string
 }
 
 export interface ModelOptionsResponse {

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -52,6 +52,8 @@ class ConfigContext:
     current_base_url: str
     user_providers: dict
     custom_providers: list
+    default_reasoning_effort: str = ""
+    default_fast: bool = False
 
     def with_overrides(
         self,
@@ -96,12 +98,18 @@ def load_picker_context() -> ConfigContext:
         current_provider = ""
         current_base_url = ""
     raw = cfg.get("providers")
+    agent_cfg = cfg.get("agent")
+    if not isinstance(agent_cfg, dict):
+        agent_cfg = {}
     return ConfigContext(
         current_provider=current_provider,
         current_model=current_model,
         current_base_url=current_base_url,
         user_providers=raw if isinstance(raw, dict) else {},
         custom_providers=get_compatible_custom_providers(cfg),
+        default_reasoning_effort=str(agent_cfg.get("reasoning_effort") or ""),
+        default_fast=str(agent_cfg.get("service_tier") or "").lower()
+        in {"fast", "priority"},
     )
 
 
@@ -242,7 +250,7 @@ def build_models_payload(
     if pricing:
         _apply_pricing(rows, force_fresh_nous_tier=force_fresh_nous_tier)
     if capabilities:
-        _apply_capabilities(rows)
+        _apply_capabilities(rows, ctx)
 
     return {
         "providers": rows,
@@ -251,7 +259,50 @@ def build_models_payload(
     }
 
 
-def _apply_capabilities(rows: list[dict]) -> None:
+def _configured_model_defaults(
+    ctx: ConfigContext, slug: str, model: str
+) -> tuple[str, bool | None]:
+    """Resolve presentation defaults from the configured model policy.
+
+    Named custom providers are stored without their ``custom:`` runtime
+    prefix.  A model-level ``session_controls`` record is authoritative when
+    present; otherwise the profile-wide agent defaults remain the fallback.
+    """
+
+    provider = ctx.user_providers.get(slug)
+    if not isinstance(provider, dict) and slug.startswith("custom:"):
+        provider = ctx.user_providers.get(slug.removeprefix("custom:"))
+    if not isinstance(provider, dict):
+        provider = {}
+    models = provider.get("models")
+    record = models.get(model) if isinstance(models, dict) else None
+    controls = record.get("session_controls") if isinstance(record, dict) else None
+    controls = controls if isinstance(controls, dict) else {}
+
+    reasoning = controls.get("reasoning")
+    reasoning_default = ctx.default_reasoning_effort
+    if isinstance(reasoning, dict):
+        mode = reasoning.get("mode")
+        if mode == "fixed":
+            reasoning_default = str(reasoning.get("value") or reasoning_default)
+        elif mode == "selectable":
+            reasoning_default = str(reasoning.get("default") or reasoning_default)
+
+    fast = controls.get("fast")
+    fast_default: bool | None = ctx.default_fast
+    if isinstance(fast, dict):
+        mode = fast.get("mode")
+        if mode == "none":
+            fast_default = None
+        elif mode == "fixed":
+            fast_default = str(fast.get("value") or "").lower() == "fast"
+        elif mode == "selectable":
+            fast_default = str(fast.get("default") or "").lower() == "fast"
+
+    return reasoning_default, fast_default
+
+
+def _apply_capabilities(rows: list[dict], ctx: ConfigContext) -> None:
     """Attach a ``{model: {fast, reasoning}}`` map to each provider row.
 
     `fast` mirrors ``model_supports_fast_mode`` (the same gate the runtime
@@ -269,7 +320,7 @@ def _apply_capabilities(rows: list[dict]) -> None:
 
     for row in rows:
         slug = row.get("slug") or ""
-        caps: dict[str, dict[str, bool]] = {}
+        caps: dict[str, dict[str, object]] = {}
 
         for model in row.get("models") or []:
             reasoning = True
@@ -281,10 +332,17 @@ def _apply_capabilities(rows: list[dict]) -> None:
                 except Exception:
                     reasoning = True
 
-            caps[model] = {
-                "fast": bool(model_supports_fast_mode(model)),
+            supports_fast = bool(model_supports_fast_mode(model))
+            defaults = _configured_model_defaults(ctx, slug, model)
+            item: dict[str, object] = {
+                "fast": supports_fast,
                 "reasoning": reasoning,
             }
+            if reasoning and defaults[0]:
+                item["reasoning_default"] = defaults[0]
+            if supports_fast and defaults[1] is not None:
+                item["fast_default"] = defaults[1]
+            caps[model] = item
 
         row["capabilities"] = caps
 

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -117,6 +117,15 @@ def test_load_picker_context_empty_config():
     assert ctx.custom_providers == []
 
 
+def test_load_picker_context_carries_agent_control_defaults():
+    cfg = _cfg()
+    cfg["agent"] = {"reasoning_effort": "high", "service_tier": "fast"}
+    with patch("hermes_cli.config.load_config", return_value=cfg):
+        ctx = load_picker_context()
+    assert ctx.default_reasoning_effort == "high"
+    assert ctx.default_fast is True
+
+
 # ─── with_overrides ────────────────────────────────────────────────────
 
 
@@ -617,6 +626,67 @@ def test_payload_shape_compatible_with_modelpickerdialog_frontend():
     for row in payload["providers"]:
         missing = required_keys - row.keys()
         assert not missing, f"row {row['slug']} missing keys: {missing}"
+
+
+def test_capabilities_include_configured_model_control_defaults():
+    model = "gpt-5.6-terra"
+    rows = [
+        {
+            "slug": "custom:helix-gpt-5.6",
+            "name": "Helix LiteLLM",
+            "models": [model],
+            "total_models": 1,
+            "is_current": True,
+            "is_user_defined": True,
+            "source": "user-config",
+        }
+    ]
+    ctx = ConfigContext(
+        current_provider="custom:helix-gpt-5.6",
+        current_model=model,
+        current_base_url="http://localhost:4000/v1",
+        user_providers={
+            "helix-gpt-5.6": {
+                "models": {
+                    model: {
+                        "session_controls": {
+                            "reasoning": {
+                                "mode": "selectable",
+                                "allowed": ["low", "medium", "high"],
+                                "default": "high",
+                            },
+                            "fast": {
+                                "mode": "selectable",
+                                "allowed": ["normal", "fast"],
+                                "default": "fast",
+                            },
+                        }
+                    }
+                }
+            }
+        },
+        custom_providers=[],
+        default_reasoning_effort="medium",
+        default_fast=False,
+    )
+    with (
+        _list_auth_returning(rows),
+        patch("hermes_cli.models.model_supports_fast_mode", return_value=True),
+        patch("agent.models_dev.get_model_capabilities", return_value=None),
+    ):
+        payload = build_models_payload(ctx, capabilities=True)
+
+    provider = next(
+        row
+        for row in payload["providers"]
+        if row["slug"] == "custom:helix-gpt-5.6"
+    )
+    assert provider["capabilities"][model] == {
+        "fast": True,
+        "reasoning": True,
+        "fast_default": True,
+        "reasoning_default": "high",
+    }
 
 
 # ─── Aggregator dedup (issue #45954) ───────────────────────────────────


### PR DESCRIPTION
## What changed

- expose configured per-model reasoning and Fast defaults through the existing `model.options` capability records
- render inactive Desktop model rows from those authoritative defaults instead of generic Medium/Normal fallbacks
- apply the same defaults to pre-session composer state without writing global config
- format qualified GPT IDs as product names such as `GPT-5.6 Sol`, `GPT-5.6 Terra`, and `GPT-5.6 Luna`

## Why

Desktop currently labels an inactive custom GPT model as `Med` even when its configured and effective default is Fast High. Selecting that row can then show Fast High in the footer, making the picker contradict the live session. The GPT formatter also preserves lowercase suffixes from API IDs.

The root cause is that `model.options` exposes support booleans but not configured defaults, while the Desktop hard-codes Medium/Normal whenever no local preset exists.

## Behavior

Model-level `session_controls` remain authoritative when present. Existing profile-wide agent defaults are the fallback. Explicit Desktop presets continue to win. A pre-session selection updates only sticky composer state and is sent as a per-session override by `session.create`; it does not mutate the profile.

The intentional behavior where the last explicitly selected Desktop model remains sticky across new sessions is unchanged.

## Validation

- `42 passed` — `tests/hermes_cli/test_inventory.py`
- `7 passed` — gateway and REST `model_options` tests
- `20 passed` — focused Desktop formatter, preset, and model-menu tests
- Desktop TypeScript typecheck
- Desktop ESLint
- Ruff on changed Python files
- exact live-profile readback: GPT-5.6 Sol/Terra/Luna each resolve to reasoning High and Fast enabled

The full Desktop UI command also reports pre-existing failures on untouched current `main`; focused affected tests, typecheck, and lint are green.
