### PR TITLE
fix(codex): route commentary/analysis narration to a dedicated display lane

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -292,6 +292,7 @@ def init_agent(
     tool_complete_callback: callable = None,
     thinking_callback: callable = None,
     reasoning_callback: callable = None,
+    commentary_callback: callable = None,
     clarify_callback: callable = None,
     read_terminal_callback: callable = None,
     step_callback: callable = None,
@@ -527,6 +528,7 @@ def init_agent(
     agent.suppress_status_output = False
     agent.thinking_callback = thinking_callback
     agent.reasoning_callback = reasoning_callback
+    agent.commentary_callback = commentary_callback
     agent.clarify_callback = clarify_callback
     agent.read_terminal_callback = read_terminal_callback
     agent.step_callback = step_callback

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -980,6 +980,23 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
             except Exception:
                 pass
 
+    # Codex commentary/analysis narration: deliver the whole text exactly
+    # once when the live delta stream didn't already (``codex_responses``
+    # always streams internally, so gate on actual delivery rather than on
+    # stream-callback registration — that proxy both double-fired in
+    # callback-without-streaming configs and dropped the concrete-response
+    # compat path).  Display-only — commentary never enters the message
+    # dict's content/reasoning fields (the exact phase-bearing items ride
+    # codex_message_items below).
+    commentary_text = getattr(assistant_message, "commentary", None)
+    if commentary_text and not getattr(agent, "_codex_commentary_delivered", False):
+        commentary_cb = getattr(agent, "commentary_callback", None) or agent.reasoning_callback
+        if commentary_cb:
+            try:
+                commentary_cb(_sanitize_surrogates(commentary_text))
+            except Exception:
+                pass
+
     # Sanitize surrogates from API response — some models (e.g. Kimi/GLM via Ollama)
     # can return invalid surrogate code points that crash json.dumps() on persist.
     _raw_content = assistant_message.content or ""

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -1005,6 +1005,37 @@ def _extract_responses_message_text(item: Any) -> str:
     return "".join(chunks).strip()
 
 
+def commentary_text_from_message_items(items: Any) -> str:
+    """Join Codex commentary/analysis narration from persisted message items.
+
+    Commentary is never stored in ``reasoning``/``reasoning_content`` — the
+    durable record is the phase-bearing ``codex_message_items`` kept for
+    Responses replay. Display surfaces (TUI gateway reload, CLI recap,
+    messaging show_reasoning) derive the narration from those items via this
+    helper. Accepts the decoded list or the JSON-encoded column value.
+    """
+    if isinstance(items, str):
+        try:
+            items = json.loads(items)
+        except (json.JSONDecodeError, TypeError):
+            return ""
+    if not isinstance(items, list):
+        return ""
+    parts: List[str] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        phase = item.get("phase")
+        if not isinstance(phase, str) or phase.strip().lower() not in {"commentary", "analysis"}:
+            continue
+        for part in item.get("content") or []:
+            if isinstance(part, dict):
+                text = part.get("text")
+                if isinstance(text, str) and text.strip():
+                    parts.append(text)
+    return "\n\n".join(parts).strip()
+
+
 def _extract_responses_reasoning_text(item: Any) -> str:
     """Extract a compact reasoning text from a Responses reasoning item."""
     summary = getattr(item, "summary", None)
@@ -1112,6 +1143,7 @@ def _normalize_codex_response(
 
     content_parts: List[str] = []
     reasoning_parts: List[str] = []
+    commentary_parts: List[str] = []
     reasoning_items_raw: List[Dict[str, Any]] = []
     message_items_raw: List[Dict[str, Any]] = []
     tool_calls: List[Any] = []
@@ -1181,11 +1213,13 @@ def _normalize_codex_response(
                 # (Codex CLI excludes it from last-message extraction; issues
                 # #24933 / #41293).  Keep it out of assistant content so it
                 # can't be concatenated into — or leak as — the final response,
-                # but surface it through the reasoning channel so the CLI/
-                # gateway display it like thinking text.  The exact message
-                # item is still preserved below for replay/cache continuity.
+                # and out of the reasoning lane so genuine chain-of-thought
+                # summaries and user-facing narration stay semantically
+                # distinct (persisted ``reasoning`` fields must hold reasoning
+                # only).  The exact message item is still preserved below for
+                # replay/cache continuity.
                 if is_commentary_phase:
-                    reasoning_parts.append(message_text)
+                    commentary_parts.append(message_text)
                 else:
                     content_parts.append(message_text)
                 raw_message_item: Dict[str, Any] = {
@@ -1328,6 +1362,7 @@ def _normalize_codex_response(
         reasoning="\n\n".join(reasoning_parts).strip() if reasoning_parts else None,
         reasoning_content=None,
         reasoning_details=None,
+        commentary="\n\n".join(commentary_parts).strip() if commentary_parts else None,
         codex_reasoning_items=reasoning_items_raw or None,
         codex_message_items=message_items_raw or None,
     )

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -600,6 +600,7 @@ def _consume_codex_event_stream(
     model: str,
     on_text_delta=None,
     on_reasoning_delta=None,
+    on_commentary_delta=None,
     on_first_delta=None,
     on_event=None,
     interrupt_check=None,
@@ -632,6 +633,9 @@ def _consume_codex_event_stream(
       once a function_call event is seen (so tool-call turns don't bleed text
       into the chat).
     * ``on_reasoning_delta(str)`` — fires per ``response.reasoning.*.delta``.
+    * ``on_commentary_delta(str)`` — fires per ``response.output_text.delta``
+      belonging to a ``commentary``/``analysis``-phase message item: mid-turn
+      progress narration, distinct from both reasoning and the final answer.
     * ``on_first_delta()`` — one-shot, fires on the first text delta only.
     * ``on_event(event)`` — fires for every event before any other processing.
       Used for watchdog activity, debug logging, anything wire-shape-agnostic.
@@ -678,8 +682,9 @@ def _consume_codex_event_stream(
         # Track the phase of the active streamed message item.  Codex/Harmony
         # ``commentary``/``analysis`` text is mid-turn preamble/progress
         # narration, never the final answer.  We still collect completed output
-        # items for replay, but route those deltas to the reasoning callback so
-        # they display like thinking text instead of assistant content.
+        # items for replay, but route those deltas to the dedicated commentary
+        # callback so they display in their own lane instead of being conflated
+        # with genuine reasoning or assistant content.
         if event_type == "response.output_item.added":
             item = _event_field(event, "item")
             item_type = _item_field(item, "type", "")
@@ -696,13 +701,13 @@ def _consume_codex_event_stream(
             delta_text = _event_field(event, "delta", "")
             is_commentary_delta = active_message_phase in {"commentary", "analysis"}
             if delta_text and is_commentary_delta:
-                # Commentary streams through the reasoning channel, not the
-                # visible answer stream (and stays out of output_text).
-                if on_reasoning_delta is not None:
+                # Commentary streams through its own channel, not the visible
+                # answer stream (and stays out of output_text).
+                if on_commentary_delta is not None:
                     try:
-                        on_reasoning_delta(delta_text)
+                        on_commentary_delta(delta_text)
                     except Exception:
-                        logger.debug("Codex stream on_reasoning_delta raised", exc_info=True)
+                        logger.debug("Codex stream on_commentary_delta raised", exc_info=True)
             elif delta_text:
                 collected_text_deltas.append(delta_text)
                 if not has_tool_calls:
@@ -829,6 +834,9 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
     max_stream_retries = 1
     # Accumulate streamed text so callers / compat shims can read it.
     agent._codex_streamed_text_parts: list = []
+    # Reset the once-only commentary guard for this API call — see
+    # _fire_commentary_delta / build_assistant_message.
+    agent._codex_commentary_delivered = False
 
     def _on_text_delta(text: str) -> None:
         agent._codex_streamed_text_parts.append(text)
@@ -836,6 +844,9 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
 
     def _on_reasoning_delta(text: str) -> None:
         agent._fire_reasoning_delta(text)
+
+    def _on_commentary_delta(text: str) -> None:
+        agent._fire_commentary_delta(text)
 
     def _on_event(event: Any) -> None:
         # TTFB watchdog and activity touch — runs once per SSE event.
@@ -876,6 +887,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                     model=api_kwargs.get("model"),
                     on_text_delta=_on_text_delta,
                     on_reasoning_delta=_on_reasoning_delta,
+                    on_commentary_delta=_on_commentary_delta,
                     on_first_delta=on_first_delta,
                     on_event=_on_event,
                     interrupt_check=_interrupt_check,

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -414,6 +414,10 @@ class ResponsesApiTransport(ProviderTransport):
             provider_data["codex_message_items"] = msg.codex_message_items
         if msg and hasattr(msg, "reasoning_details") and msg.reasoning_details:
             provider_data["reasoning_details"] = msg.reasoning_details
+        if msg and getattr(msg, "commentary", None):
+            # Mid-turn commentary/analysis narration — its own semantic lane,
+            # never merged into reasoning or the final answer.
+            provider_data["commentary"] = msg.commentary
 
         return NormalizedResponse(
             content=msg.content if msg else None,

--- a/agent/transports/types.py
+++ b/agent/transports/types.py
@@ -143,6 +143,12 @@ class NormalizedResponse:
         pd = self.provider_data or {}
         return pd.get("codex_message_items")
 
+    @property
+    def commentary(self) -> str | None:
+        """Codex commentary/analysis narration — distinct from reasoning."""
+        pd = self.provider_data or {}
+        return pd.get("commentary")
+
 
 # ---------------------------------------------------------------------------
 # Factory helpers

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -421,10 +421,29 @@ def finalize_turn(
             last_reasoning = msg["reasoning"]
             break
 
+    # Codex commentary narration for the same turn window. It is no longer
+    # flattened into ``reasoning`` (dedicated lane; see codex_runtime), so
+    # recap surfaces that read this result (CLI post-turn box, messaging
+    # show_reasoning) get it from here. Aggregated chronologically — the
+    # narration typically spans several tool-call steps in one turn.
+    last_commentary = None
+    _commentary_chunks: list = []
+    from agent.codex_responses_adapter import commentary_text_from_message_items
+    for msg in reversed(messages):
+        if msg.get("role") == "user":
+            break  # turn boundary — don't cross into prior turns
+        if msg.get("role") == "assistant" and msg.get("codex_message_items"):
+            chunk = commentary_text_from_message_items(msg.get("codex_message_items"))
+            if chunk:
+                _commentary_chunks.append(chunk)
+    if _commentary_chunks:
+        last_commentary = "\n\n".join(reversed(_commentary_chunks))
+
     # Build result with interrupt info if applicable
     result = {
         "final_response": final_response,
         "last_reasoning": last_reasoning,
+        "last_commentary": last_commentary,
         "messages": messages,
         "api_calls": api_call_count,
         "completed": completed,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/commentary.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/commentary.test.tsx
@@ -1,0 +1,150 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { COMMENTARY_PART_TYPE, commentaryPartText } from '@/lib/chat-messages'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './index'
+
+const SID = 'session-1'
+
+let handleEvent: ((event: RpcEvent) => void) | null = null
+let sessionStates: Map<string, ClientSessionState> | null = null
+
+function Harness() {
+  const activeSessionIdRef = useRef<string | null>(SID)
+  const sessionStateByRuntimeIdRef = useRef(new Map<string, ClientSessionState>())
+  const queryClientRef = useRef(new QueryClient())
+
+  sessionStates = sessionStateByRuntimeIdRef.current
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    sessionStateByRuntimeIdRef,
+    updateSessionState: (sessionId, updater) => {
+      const current = sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState()
+      const next = updater(current)
+      sessionStateByRuntimeIdRef.current.set(sessionId, next)
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    handleEvent = stream.handleGatewayEvent
+  }, [stream.handleGatewayEvent])
+
+  return null
+}
+
+async function mountStream() {
+  render(<Harness />)
+  await waitFor(() => expect(handleEvent).not.toBeNull())
+}
+
+const send = (event: RpcEvent) => act(() => handleEvent!(event))
+
+const assistantMessage = () => {
+  const messages = sessionStates?.get(SID)?.messages ?? []
+
+  return messages.find(message => message.role === 'assistant')
+}
+
+describe('useMessageStream commentary lane', () => {
+  beforeEach(() => {
+    handleEvent = null
+    sessionStates = null
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('routes commentary.delta into a commentary part, never the reasoning part', async () => {
+    await mountStream()
+
+    send({ payload: { text: 'Planning the fix' }, session_id: SID, type: 'reasoning.delta' })
+    send({ payload: { text: 'Reading the screenshot first.' }, session_id: SID, type: 'commentary.delta' })
+    send({ payload: { text: 'The total is $42.' }, session_id: SID, type: 'message.complete' })
+
+    const message = assistantMessage()
+    expect(message).toBeDefined()
+
+    const reasoningParts = message!.parts.filter(part => part.type === 'reasoning')
+    const commentaryParts = message!.parts.filter(part => part.type === COMMENTARY_PART_TYPE)
+    const textParts = message!.parts.filter(part => part.type === 'text')
+
+    expect(reasoningParts).toHaveLength(1)
+    expect((reasoningParts[0] as { text: string }).text).toBe('Planning the fix')
+    expect(commentaryParts).toHaveLength(1)
+    expect(commentaryPartText(commentaryParts[0])).toBe('Reading the screenshot first.')
+    expect(textParts).toHaveLength(1)
+    expect((textParts[0] as { text: string }).text).toBe('The total is $42.')
+  })
+
+  it('preserves reasoning → commentary → tool → commentary → answer ordering', async () => {
+    await mountStream()
+
+    send({ payload: { text: 'Planning' }, session_id: SID, type: 'reasoning.delta' })
+    send({ payload: { text: 'Checking the logs first.' }, session_id: SID, type: 'commentary.delta' })
+    // Tool events flush queued deltas synchronously, freezing the segment.
+    send({
+      payload: { name: 'terminal', tool_id: 'call_1' },
+      session_id: SID,
+      type: 'tool.start'
+    })
+    send({
+      payload: { name: 'terminal', result: 'ok', tool_id: 'call_1' },
+      session_id: SID,
+      type: 'tool.complete'
+    })
+    send({ payload: { text: 'Now writing the summary.' }, session_id: SID, type: 'commentary.delta' })
+    send({ payload: { text: 'All done.' }, session_id: SID, type: 'message.complete' })
+
+    const message = assistantMessage()
+    expect(message).toBeDefined()
+
+    const partTypes = message!.parts.map(part => part.type)
+    expect(partTypes).toEqual(['reasoning', COMMENTARY_PART_TYPE, 'tool-call', COMMENTARY_PART_TYPE, 'text'])
+    expect(commentaryPartText(message!.parts[1])).toBe('Checking the logs first.')
+    expect(commentaryPartText(message!.parts[3])).toBe('Now writing the summary.')
+    expect((message!.parts[4] as { text: string }).text).toBe('All done.')
+  })
+
+  it('keeps commentary above the answer when both lanes land in one flush window', async () => {
+    await mountStream()
+
+    // No tool event between these, so both lanes batch into the same
+    // delta-flush window; commentary must still render above the answer.
+    send({ payload: { text: 'Wrapping up now.' }, session_id: SID, type: 'commentary.delta' })
+    send({ payload: { text: 'The answer.' }, session_id: SID, type: 'message.delta' })
+    send({ payload: { text: 'The answer.' }, session_id: SID, type: 'message.complete' })
+
+    const message = assistantMessage()
+    expect(message!.parts.map(part => part.type)).toEqual([COMMENTARY_PART_TYPE, 'text'])
+    expect(commentaryPartText(message!.parts[0])).toBe('Wrapping up now.')
+  })
+
+  it('coalesces consecutive commentary deltas into one part per segment', async () => {
+    await mountStream()
+
+    send({ payload: { text: 'Reading ' }, session_id: SID, type: 'commentary.delta' })
+    send({ payload: { text: 'the file.' }, session_id: SID, type: 'commentary.delta' })
+    send({ payload: { text: 'Done.' }, session_id: SID, type: 'message.complete' })
+
+    const message = assistantMessage()
+    const commentaryParts = message!.parts.filter(part => part.type === COMMENTARY_PART_TYPE)
+
+    expect(commentaryParts).toHaveLength(1)
+    expect(commentaryPartText(commentaryParts[0])).toBe('Reading the file.')
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -54,6 +54,7 @@ interface GatewayEventDeps {
   lastCwdInfoSessionRef: MutableRefObject<string | null>
   nativeSubagentSessionsRef: MutableRefObject<Set<string>>
   appendAssistantDelta: (sessionId: string, delta: string) => void
+  appendCommentaryDelta: (sessionId: string, delta: string) => void
   appendReasoningDelta: (sessionId: string, delta: string, replace?: boolean) => void
   completeAssistantMessage: (sessionId: string, text: string) => void
   failAssistantMessage: (sessionId: string, errorMessage: string) => void
@@ -78,6 +79,7 @@ interface GatewayEventDeps {
 export function useGatewayEventHandler(deps: GatewayEventDeps) {
   const {
     appendAssistantDelta,
+    appendCommentaryDelta,
     appendReasoningDelta,
     activeSessionIdRef,
     compactedTurnRef,
@@ -282,6 +284,17 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
       } else if (event.type === 'reasoning.available') {
         if (sessionId) {
           appendReasoningDelta(sessionId, coerceThinkingText(payload?.text), true)
+        }
+
+        if (isActiveEvent) {
+          setPetActivity({ reasoning: true })
+        }
+      } else if (event.type === 'commentary.delta') {
+        // Codex commentary/analysis narration — user-facing mid-turn progress.
+        // Its own lane ("Working" disclosure), never appendReasoningDelta:
+        // the Thinking disclosure is reserved for genuine model reasoning.
+        if (sessionId) {
+          appendCommentaryDelta(sessionId, coerceGatewayText(payload?.text))
         }
 
         if (isActiveEvent) {
@@ -649,6 +662,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
     },
     [
       appendAssistantDelta,
+      appendCommentaryDelta,
       appendReasoningDelta,
       activeSessionIdRef,
       compactedTurnRef,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -4,11 +4,13 @@ import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 import { translateNow } from '@/i18n'
 import {
   appendAssistantTextPart,
+  appendCommentaryPart,
   appendReasoningPart,
   assistantTextPart,
   type ChatMessage,
   type ChatMessagePart,
   chatMessageText,
+  commentaryPart,
   type GatewayEventPayload,
   reasoningPart,
   renderMediaTags,
@@ -50,6 +52,7 @@ interface MessageStreamOptions {
 
 interface QueuedStreamDeltas {
   assistant: string
+  commentary: string
   reasoning: string
 }
 
@@ -155,19 +158,32 @@ export function useMessageStream({
 
         queue.delete(id)
 
-        if (queued.assistant) {
-          mutateStream(
-            id,
-            parts => dedupeGeneratedImageEchoesInParts(appendAssistantTextPart(parts, queued.assistant)),
-            () => [assistantTextPart(queued.assistant)]
-          )
-        }
-
+        // Flush in semantic order — reasoning, then commentary, then answer
+        // text. Within a segment the model thinks, narrates, and only then
+        // answers (Codex item order: reasoning → commentary → final_answer),
+        // so when several lanes land in the same flush window the parts must
+        // not seed in reverse (e.g. the Working lane below the answer).
         if (queued.reasoning) {
           mutateStream(
             id,
             parts => appendReasoningPart(parts, queued.reasoning),
             () => [reasoningPart(queued.reasoning)]
+          )
+        }
+
+        if (queued.commentary) {
+          mutateStream(
+            id,
+            parts => appendCommentaryPart(parts, queued.commentary),
+            () => [commentaryPart(queued.commentary)]
+          )
+        }
+
+        if (queued.assistant) {
+          mutateStream(
+            id,
+            parts => dedupeGeneratedImageEchoesInParts(appendAssistantTextPart(parts, queued.assistant)),
+            () => [assistantTextPart(queued.assistant)]
           )
         }
       }
@@ -216,7 +232,7 @@ export function useMessageStream({
         return
       }
 
-      const queued = queuedDeltasRef.current.get(sessionId) ?? { assistant: '', reasoning: '' }
+      const queued = queuedDeltasRef.current.get(sessionId) ?? { assistant: '', commentary: '', reasoning: '' }
       queued[key] += delta
       queuedDeltasRef.current.set(sessionId, queued)
       scheduleDeltaFlush()
@@ -247,6 +263,17 @@ export function useMessageStream({
       }
 
       queueDelta(sessionId, 'assistant', delta)
+    },
+    [queueDelta]
+  )
+
+  const appendCommentaryDelta = useCallback(
+    (sessionId: string, delta: string) => {
+      if (!delta) {
+        return
+      }
+
+      queueDelta(sessionId, 'commentary', delta)
     },
     [queueDelta]
   )
@@ -515,6 +542,7 @@ export function useMessageStream({
 
   const handleGatewayEvent = useGatewayEventHandler({
     appendAssistantDelta,
+    appendCommentaryDelta,
     appendReasoningDelta,
     activeSessionIdRef,
     compactedTurnRef,
@@ -532,6 +560,7 @@ export function useMessageStream({
 
   return {
     appendAssistantDelta,
+    appendCommentaryDelta,
     appendReasoningDelta,
     completeAssistantMessage,
     handleGatewayEvent,

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1,5 +1,5 @@
 import { getSession } from '@/hermes'
-import { type ChatMessage, chatMessageText } from '@/lib/chat-messages'
+import { type ChatMessage, chatMessageText, COMMENTARY_PART_TYPE } from '@/lib/chat-messages'
 import { normalizePersonalityValue } from '@/lib/chat-runtime'
 import { embeddedImageUrls, textWithoutEmbeddedImages } from '@/lib/embedded-images'
 import { requestDesktopOnboarding } from '@/store/onboarding'
@@ -41,13 +41,36 @@ function withAppendedText(message: ChatMessage, suffix: string): ChatMessage {
 }
 
 function preserveReasoningParts(message: ChatMessage, previous: ChatMessage): ChatMessage {
-  if (message.parts.some(part => part.type === 'reasoning')) {
-    return message
+  let parts = message.parts
+
+  // Reasoning and commentary (the Codex "Working" lane) are preserved
+  // independently — a hydrated message may carry one but not the other.
+  // Preserved reasoning leads; preserved commentary slots after any
+  // reasoning already present, so the final order is always reasoning →
+  // commentary → visible text, matching the live-streamed layout.
+  if (!parts.some(part => part.type === 'reasoning')) {
+    const lane = previous.parts.filter(part => part.type === 'reasoning')
+
+    if (lane.length) {
+      parts = [...lane, ...parts]
+    }
   }
 
-  const reasoningParts = previous.parts.filter(part => part.type === 'reasoning')
+  if (!parts.some(part => part.type === COMMENTARY_PART_TYPE)) {
+    const lane = previous.parts.filter(part => part.type === COMMENTARY_PART_TYPE)
 
-  return reasoningParts.length ? { ...message, parts: [...reasoningParts, ...message.parts] } : message
+    if (lane.length) {
+      let insertAt = 0
+
+      while (insertAt < parts.length && parts[insertAt].type === 'reasoning') {
+        insertAt += 1
+      }
+
+      parts = [...parts.slice(0, insertAt), ...lane, ...parts.slice(insertAt)]
+    }
+  }
+
+  return parts === message.parts ? message : { ...message, parts }
 }
 
 function chatMessagesEquivalent(a: ChatMessage, b: ChatMessage): boolean {

--- a/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
@@ -41,10 +41,14 @@ const ChainToolFallback: FC<ToolCallMessagePartProps> = props => {
 
 const ThinkingDisclosure: FC<{
   children: ReactNode
+  /** Header label; defaults to the "Thinking" string. The commentary lane
+   *  passes "Working" to keep narration visually distinct from reasoning. */
+  label?: ReactNode
   messageRunning?: boolean
   pending?: boolean
+  slot?: string
   timerKey?: string
-}> = ({ children, messageRunning = false, pending = false, timerKey }) => {
+}> = ({ children, label, messageRunning = false, pending = false, slot = 'aui_thinking-disclosure', timerKey }) => {
   const { t } = useI18n()
   // `null` = no explicit user toggle yet, defer to the streaming default.
   // The default is "auto-open while streaming, auto-collapse when done" so
@@ -91,7 +95,7 @@ const ThinkingDisclosure: FC<{
   return (
     <div
       className="text-[length:var(--conversation-tool-font-size)] text-(--ui-text-tertiary)"
-      data-slot="aui_thinking-disclosure"
+      data-slot={slot}
       ref={enterRef}
     >
       <DisclosureRow onToggle={() => setUserOpen(!open)} open={open}>
@@ -102,7 +106,7 @@ const ThinkingDisclosure: FC<{
               pending && 'shimmer text-foreground/55'
             )}
           >
-            {t.assistant.thread.thinking}
+            {label ?? t.assistant.thread.thinking}
           </span>
           {pending && (
             <ActivityTimerText
@@ -174,6 +178,43 @@ const ReasoningAccordionGroup: FC<{ children?: ReactNode; endIndex: number; star
   )
 }
 
+// Codex commentary/analysis narration — the "Working" lane. Reuses the
+// disclosure chrome from Thinking but stays a separate surface so genuine
+// reasoning and user-facing progress narration never share a header. The
+// part arrives as assistant-ui's `data` part (name: "commentary"); its
+// status is `running` only while it is the last part of a running message,
+// which is exactly the live-streaming window.
+const CommentaryDataPart: FC<{ data?: { text?: unknown }; status?: { type: string } }> = ({ data, status }) => {
+  const { t } = useI18n()
+  const messageId = useAuiState(s => s.message.id)
+  const messageRunning = useAuiState(s => s.message.status?.type === 'running')
+  const threadRunning = useAuiState(s => s.thread.isRunning)
+  const text = typeof data?.text === 'string' ? data.text : ''
+  const pending = threadRunning && messageRunning && status?.type === 'running'
+
+  // Empty narration renders no header — same rule as the reasoning group.
+  if (!text.trim()) {
+    return null
+  }
+
+  return (
+    <ThinkingDisclosure
+      label={t.assistant.thread.working}
+      messageRunning={messageRunning}
+      pending={pending}
+      slot="aui_commentary-disclosure"
+      timerKey={`commentary:${messageId}`}
+    >
+      <MarkdownTextContent
+        containerClassName="text-xs leading-snug text-muted-foreground/85"
+        containerProps={{ 'data-slot': 'aui_commentary-text' } as ComponentProps<'div'>}
+        isRunning={pending}
+        text={text.trimStart()}
+      />
+    </ThinkingDisclosure>
+  )
+}
+
 const ReasoningTextPart: FC<{ text: string; status?: { type: string } }> = ({ text, status }) => {
   const displayText = text.trimStart()
   const messageRunning = useAuiState(s => s.message.status?.type === 'running')
@@ -197,6 +238,7 @@ const ReasoningTextPart: FC<{ text: string; status?: { type: string } }> = ({ te
 // remount, but combined with the previous ToolFallback group-swap it was a
 // big chunk of the per-delta work.
 export const MESSAGE_PARTS_COMPONENTS = {
+  data: { by_name: { commentary: CommentaryDataPart } },
   Reasoning: ReasoningTextPart,
   ReasoningGroup: ReasoningAccordionGroup,
   Text: MarkdownText,

--- a/apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx
@@ -185,6 +185,27 @@ function assistantSeparatedReasoningMessage(): ThreadMessage {
   } as ThreadMessage
 }
 
+function assistantCommentaryMessage(): ThreadMessage {
+  return {
+    id: 'assistant-commentary-1',
+    role: 'assistant',
+    content: [
+      { type: 'reasoning', text: ' Planning the analysis.', status: { type: 'complete' } },
+      { type: 'data', name: 'commentary', data: { text: 'Reading the screenshot first.' } },
+      { type: 'text', text: 'The total is $42.' }
+    ],
+    status: { type: 'complete', reason: 'stop' },
+    createdAt,
+    metadata: {
+      unstable_state: null,
+      unstable_annotations: [],
+      unstable_data: [],
+      steps: [],
+      custom: {}
+    }
+  } as ThreadMessage
+}
+
 function assistantTodoMessage(
   todos: Array<{ content: string; id: string; status: 'cancelled' | 'completed' | 'in_progress' | 'pending' }>,
   running = true
@@ -364,6 +385,20 @@ function GroupedReasoningHarness() {
   )
 }
 
+function CommentaryHarness() {
+  const runtime = useExternalStoreRuntime<ThreadMessage>({
+    messages: [assistantCommentaryMessage()],
+    isRunning: false,
+    onNew: async () => {}
+  })
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  )
+}
+
 function IntroHarness() {
   const runtime = useExternalStoreRuntime<ThreadMessage>({
     messages: [],
@@ -511,6 +546,31 @@ describe('assistant-ui streaming renderer', () => {
     expect(reasoningParts.length).toBe(2)
     expect(reasoningParts[0]?.textContent).toBe('First thought.')
     expect(reasoningParts[1]?.textContent).toBe('Second thought.')
+  })
+
+  it('renders Codex commentary in a separate Working disclosure, not under Thinking', () => {
+    const { container } = render(<CommentaryHarness />)
+    const ui = within(container)
+
+    const thinkingDisclosures = container.querySelectorAll('[data-slot="aui_thinking-disclosure"]')
+    const commentaryDisclosures = container.querySelectorAll('[data-slot="aui_commentary-disclosure"]')
+    expect(thinkingDisclosures.length).toBe(1)
+    expect(commentaryDisclosures.length).toBe(1)
+
+    // Working lane opens to the narration text.
+    fireEvent.click(ui.getByRole('button', { name: /working/i }))
+    expect(container.querySelector('[data-slot="aui_commentary-text"]')?.textContent).toBe(
+      'Reading the screenshot first.'
+    )
+
+    // Thinking lane holds only the genuine reasoning.
+    fireEvent.click(ui.getByRole('button', { name: /thinking/i }))
+    const reasoningText = container.querySelector('[data-slot="aui_reasoning-text"]')?.textContent ?? ''
+    expect(reasoningText).toBe('Planning the analysis.')
+    expect(reasoningText).not.toContain('screenshot')
+
+    // Final answer renders as normal chat text.
+    expect(container.textContent).toContain('The total is $42.')
   })
 
   it('does not reopen an earlier completed thinking group when a later group is running', () => {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2261,6 +2261,7 @@ export const en: Translations = {
           : `Will resume when ${count} background tasks finish`,
       thinking: 'Thinking',
       today: time => `Today, ${time}`,
+      working: 'Working',
       yesterday: time => `Yesterday, ${time}`,
       copy: 'Copy',
       refresh: 'Refresh',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2207,6 +2207,7 @@ export const ja = defineLocale({
           : `${count} 件のバックグラウンドタスクの完了後に再開します`,
       thinking: '考え中',
       today: time => `今日 ${time}`,
+      working: '作業中',
       yesterday: time => `昨日 ${time}`,
       copy: 'コピー',
       refresh: '更新',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1891,6 +1891,7 @@ export interface Translations {
       resumeWhenBackgroundDone: (count: number) => string
       thinking: string
       today: (time: string) => string
+      working: string
       yesterday: (time: string) => string
       copy: string
       refresh: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2140,6 +2140,7 @@ export const zhHant = defineLocale({
         count === 1 ? '背景工作完成後將自動繼續' : `${count} 個背景工作完成後將自動繼續`,
       thinking: '思考中',
       today: time => `今天，${time}`,
+      working: '工作中',
       yesterday: time => `昨天，${time}`,
       copy: '複製',
       refresh: '重新整理',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2424,6 +2424,7 @@ export const zh: Translations = {
         count === 1 ? '后台任务完成后将自动继续' : `${count} 个后台任务完成后将自动继续`,
       thinking: '思考中',
       today: time => `今天，${time}`,
+      working: '工作中',
       yesterday: time => `昨天，${time}`,
       copy: '复制',
       refresh: '刷新',

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -3,8 +3,11 @@ import { describe, expect, it } from 'vitest'
 import type { ChatMessage, ChatMessagePart } from './chat-messages'
 import {
   appendAssistantTextPart,
+  appendCommentaryPart,
   appendReasoningPart,
   chatMessageText,
+  COMMENTARY_PART_TYPE,
+  commentaryPartText,
   preserveLocalAssistantErrors,
   renderMediaTags,
   toChatMessages,
@@ -219,6 +222,154 @@ describe('interleaved reasoning/text coalescing', () => {
     expect(parts.map(p => p.type)).toEqual(['reasoning', 'tool-call', 'reasoning'])
     expect((parts[0] as { text: string }).text).toBe('before tool')
     expect((parts[2] as { text: string }).text).toBe('after tool')
+  })
+
+  it('coalesces commentary deltas across interleaved reasoning/text', () => {
+    // Codex Working-lane narration behaves like the other streaming
+    // channels: transparent to text/reasoning within a segment so a
+    // reasoning burst can't shred one narration sentence into two parts.
+    let parts: ChatMessagePart[] = appendCommentaryPart([], 'Reading ')
+    parts = appendReasoningPart(parts, 'planning')
+    parts = appendCommentaryPart(parts, 'the file.')
+
+    expect(parts.map(p => p.type)).toEqual([COMMENTARY_PART_TYPE, 'reasoning'])
+    expect(commentaryPartText(parts[0])).toBe('Reading the file.')
+    expect((parts[1] as { text: string }).text).toBe('planning')
+  })
+
+  it('keeps text contiguous across an interleaved commentary burst', () => {
+    let parts: ChatMessagePart[] = appendAssistantTextPart([], 'Let me ')
+    parts = appendCommentaryPart(parts, 'checking...')
+    parts = appendAssistantTextPart(parts, 'finish the sentence.')
+
+    expect(parts.map(p => p.type)).toEqual(['text', COMMENTARY_PART_TYPE])
+    expect((parts[0] as { text: string }).text).toBe('Let me finish the sentence.')
+  })
+
+  it('does not merge commentary across a tool call', () => {
+    let parts: ChatMessagePart[] = appendCommentaryPart([], 'before tool')
+    parts = upsertToolPart(parts, { name: 'read_file', tool_id: 'tc-1' }, 'running')
+    parts = appendCommentaryPart(parts, 'after tool')
+
+    expect(parts.map(p => p.type)).toEqual([COMMENTARY_PART_TYPE, 'tool-call', COMMENTARY_PART_TYPE])
+    expect(commentaryPartText(parts[0])).toBe('before tool')
+    expect(commentaryPartText(parts[2])).toBe('after tool')
+  })
+})
+
+describe('commentary reload mapping', () => {
+  it('maps a stored commentary field into the Working lane ahead of the tool step', () => {
+    // The realistic Codex reload shape: a commentary-bearing tool-call turn
+    // (empty content) followed by the tool result and the final answer.
+    const messages = toChatMessages([
+      {
+        role: 'assistant',
+        commentary: 'Reading the screenshot first.',
+        content: '',
+        reasoning: 'Planning the analysis',
+        timestamp: 1
+      },
+      { role: 'tool', content: 'analyzed', tool_call_id: 'tc-1', tool_name: 'vision_analyze', timestamp: 2 },
+      { role: 'assistant', content: 'The total is $42.', timestamp: 3 }
+    ])
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0].parts.map(p => p.type)).toEqual([
+      'reasoning',
+      COMMENTARY_PART_TYPE,
+      'tool-call',
+      'text'
+    ])
+    expect(commentaryPartText(messages[0].parts[1])).toBe('Reading the screenshot first.')
+  })
+
+  it('keeps a commentary-only assistant turn visible', () => {
+    const messages = toChatMessages([
+      { role: 'assistant', commentary: 'Checking the logs.', content: '', timestamp: 1 }
+    ])
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0].parts.map(p => p.type)).toEqual([COMMENTARY_PART_TYPE])
+  })
+
+  it('derives commentary from raw codex_message_items (JSON string, DB-row shape)', () => {
+    // The /api/sessions/{id}/messages hydration path ships raw DB rows:
+    // codex_message_items arrives as a JSON string and there is no derived
+    // commentary field.
+    const items = JSON.stringify([
+      {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'Reading the screenshot first.' }],
+        id: 'msg_1',
+        phase: 'commentary'
+      }
+    ])
+    const messages = toChatMessages([
+      {
+        role: 'assistant',
+        codex_message_items: items,
+        content: '',
+        reasoning: 'Planning',
+        timestamp: 1,
+        tool_calls: [{ id: 'tc-1', function: { name: 'terminal', arguments: '{}' } }]
+      },
+      { role: 'tool', content: 'ok', tool_call_id: 'tc-1', tool_name: 'terminal', timestamp: 2 },
+      { role: 'assistant', content: 'Done.', timestamp: 3 }
+    ])
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0].parts.map(p => p.type)).toEqual(['reasoning', COMMENTARY_PART_TYPE, 'tool-call', 'text'])
+    expect(commentaryPartText(messages[0].parts[1])).toBe('Reading the screenshot first.')
+  })
+
+  it('does not double-render legacy sessions that flattened commentary into reasoning', () => {
+    // Pre-split rows (e.g. state.db id=46579): the narration lives BOTH in the
+    // reasoning column and in the phase-bearing codex_message_items. The
+    // Working lane owns it; the Thinking lane keeps only genuine reasoning.
+    const narration =
+      'I’m reading the screenshot itself before I put numbers around it.'
+    const legacyReasoning = `**Planning image-based pricing analysis**\n\n<!-- -->\n**Reviewing model routing**\n\n<!-- -->\n\n${narration}`
+    const items = JSON.stringify([
+      {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: narration }],
+        id: 'msg_legacy',
+        phase: 'commentary'
+      }
+    ])
+
+    const messages = toChatMessages([
+      { role: 'assistant', codex_message_items: items, content: '', reasoning: legacyReasoning, timestamp: 1 }
+    ])
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0].parts.map(p => p.type)).toEqual(['reasoning', COMMENTARY_PART_TYPE])
+    const reasoningText = (messages[0].parts[0] as { text: string }).text
+    expect(reasoningText).toContain('Planning image-based pricing analysis')
+    expect(reasoningText).not.toContain('screenshot')
+    expect(commentaryPartText(messages[0].parts[1])).toBe(narration)
+  })
+
+  it('does not derive commentary from final_answer items on raw rows', () => {
+    const items = JSON.stringify([
+      {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'Done.' }],
+        phase: 'final_answer'
+      }
+    ])
+    const messages = toChatMessages([
+      { role: 'assistant', codex_message_items: items, content: 'Done.', timestamp: 1 }
+    ])
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0].parts.map(p => p.type)).toEqual(['text'])
   })
 })
 

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -91,6 +91,106 @@ export function reasoningPart(text: string): ChatMessagePart {
   return { type: 'reasoning', text }
 }
 
+/** Codex commentary/analysis narration — user-facing mid-turn progress,
+ *  semantically distinct from reasoning and from the final answer. Rides
+ *  assistant-ui's data-part extension point (the part union is closed) and
+ *  renders via `MESSAGE_PARTS_COMPONENTS.data.by_name.commentary`. */
+export const COMMENTARY_PART_TYPE = 'data-commentary' as const
+
+export function commentaryPart(text: string): ChatMessagePart {
+  return { type: COMMENTARY_PART_TYPE, data: { text } }
+}
+
+export function commentaryPartText(part: ChatMessagePart): string {
+  if (part.type !== COMMENTARY_PART_TYPE) {
+    return ''
+  }
+
+  const data = (part as { data?: { text?: unknown } }).data
+
+  return typeof data?.text === 'string' ? data.text : ''
+}
+
+const COMMENTARY_PHASES = new Set(['commentary', 'analysis'])
+
+/** Commentary text for a stored message: the gateway's derived field when
+ *  present, otherwise reconstructed from the persisted phase-bearing
+ *  codex_message_items (raw DB rows ship those as a JSON string). */
+export function commentaryFromSessionMessage(message: SessionMessage): string {
+  if (typeof message.commentary === 'string' && message.commentary.trim()) {
+    return message.commentary
+  }
+
+  let items = message.codex_message_items
+
+  if (typeof items === 'string') {
+    try {
+      items = JSON.parse(items)
+    } catch {
+      return ''
+    }
+  }
+
+  if (!Array.isArray(items)) {
+    return ''
+  }
+
+  const texts: string[] = []
+
+  for (const item of items) {
+    if (!item || typeof item !== 'object') {
+      continue
+    }
+
+    const { content, phase } = item as { content?: unknown; phase?: unknown }
+
+    if (typeof phase !== 'string' || !COMMENTARY_PHASES.has(phase.trim().toLowerCase()) || !Array.isArray(content)) {
+      continue
+    }
+
+    for (const part of content) {
+      const text = part && typeof part === 'object' ? (part as { text?: unknown }).text : undefined
+
+      if (typeof text === 'string' && text.trim()) {
+        texts.push(text)
+      }
+    }
+  }
+
+  return texts.join('\n\n').trim()
+}
+
+/** Sessions persisted before the commentary/reasoning split stored the
+ *  narration flattened INTO the reasoning column while the same text also
+ *  lives in codex_message_items. Deriving the Working lane on reload would
+ *  then show the narration twice, so remove commentary chunks from the
+ *  reasoning display. Substring-guarded (min length) so a coincidental
+ *  short overlap can't eat genuine reasoning. */
+export function stripCommentaryFromReasoning(reasoning: string, commentary: string): string {
+  if (!reasoning || !commentary) {
+    return reasoning
+  }
+
+  let result = reasoning
+
+  for (const chunk of commentary.split('\n\n')) {
+    const candidate = chunk.trim()
+
+    if (candidate.length >= 12 && result.includes(candidate)) {
+      result = result.replace(candidate, '')
+    }
+  }
+
+  if (result === reasoning) {
+    return reasoning
+  }
+
+  return result
+    .replace(/(\n\s*<!--\s*-->\s*)+(\n|$)/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+}
+
 const MEDIA_LINE_RE = /(^|\n)[\t ]*[`"']?MEDIA:\s*(?<line>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?[\t ]*(\n|$)/g
 
 const MEDIA_TAG_RE = /[`"']?MEDIA:\s*(?<inline>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?/g
@@ -190,40 +290,62 @@ function displayContentForMessage(role: SessionMessage['role'], content: unknown
   return [refs.join('\n'), visibleText].filter(Boolean).join('\n\n') || visibleText
 }
 
-const STREAM_PART: Record<'reasoning' | 'text', (text: string) => ChatMessagePart> = {
+type StreamChannel = 'commentary' | 'reasoning' | 'text'
+
+const STREAM_PART: Record<StreamChannel, (text: string) => ChatMessagePart> = {
+  commentary: commentaryPart,
   reasoning: reasoningPart,
   text: textPart
 }
 
+const STREAM_PART_TYPE: Record<StreamChannel, ChatMessagePart['type']> = {
+  commentary: COMMENTARY_PART_TYPE,
+  reasoning: 'reasoning',
+  text: 'text'
+}
+
+// Streaming channels are mutually transparent (see appendStreamPart below);
+// any other part type bounds the current segment.
+const STREAM_TRANSPARENT_TYPES = new Set<string>(['text', 'reasoning', COMMENTARY_PART_TYPE])
+
+function appendStreamDelta(part: ChatMessagePart, delta: string): ChatMessagePart {
+  if (part.type === COMMENTARY_PART_TYPE) {
+    return commentaryPart(`${commentaryPartText(part)}${delta}`)
+  }
+
+  return { ...part, text: `${(part as { text: string }).text}${delta}` } as ChatMessagePart
+}
+
 // Coalesce a streaming delta into the most recent same-type part within the
 // current segment, where a segment is bounded by any non-streaming part (a
-// tool call, image, …). The opposite streaming channel (text <-> reasoning) is
-// transparent, so a reasoning burst between two content deltas can't shred one
-// sentence into text / Thinking / text — the fragmentation models that
-// interleave reasoning_content + content otherwise produce. Tool calls still
-// open a fresh part, preserving narration order across steps.
+// tool call, image, …). The other streaming channels (text <-> reasoning <->
+// commentary) are transparent, so a reasoning burst between two content deltas
+// can't shred one sentence into text / Thinking / text — the fragmentation
+// models that interleave reasoning_content + content otherwise produce. Tool
+// calls still open a fresh part, preserving narration order across steps.
 function appendStreamPart(
   parts: ChatMessagePart[],
-  type: 'reasoning' | 'text',
+  channel: StreamChannel,
   delta: string
 ): { index: number; parts: ChatMessagePart[] } {
   const next = [...parts]
+  const partType = STREAM_PART_TYPE[channel]
 
   for (let i = next.length - 1; i >= 0; i--) {
     const part = next[i]
 
-    if (part.type === type) {
-      next[i] = { ...part, text: `${(part as { text: string }).text}${delta}` } as ChatMessagePart
+    if (part.type === partType) {
+      next[i] = appendStreamDelta(part, delta)
 
       return { index: i, parts: next }
     }
 
-    if (part.type !== 'text' && part.type !== 'reasoning') {
+    if (!STREAM_TRANSPARENT_TYPES.has(part.type)) {
       break
     }
   }
 
-  next.push(STREAM_PART[type](delta))
+  next.push(STREAM_PART[channel](delta))
 
   return { index: next.length - 1, parts: next }
 }
@@ -234,6 +356,10 @@ export function appendTextPart(parts: ChatMessagePart[], delta: string): ChatMes
 
 export function appendReasoningPart(parts: ChatMessagePart[], delta: string): ChatMessagePart[] {
   return appendStreamPart(parts, 'reasoning', delta).parts
+}
+
+export function appendCommentaryPart(parts: ChatMessagePart[], delta: string): ChatMessagePart[] {
+  return appendStreamPart(parts, 'commentary', delta).parts
 }
 
 export function appendAssistantTextPart(parts: ChatMessagePart[], delta: string): ChatMessagePart[] {
@@ -770,13 +896,24 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
     const displayContent = displayContentForMessage(message.role, content)
     const parts: ChatMessagePart[] = []
 
-    const reasoning =
+    const rawReasoning =
       message.reasoning ||
       message.reasoning_content ||
       (typeof message.reasoning_details === 'string' ? message.reasoning_details : '')
 
+    // Codex commentary narration: mid-turn progress that precedes tool calls
+    // and the final answer — its own "Working" lane between reasoning and the
+    // text part. Legacy rows flattened the same narration into reasoning, so
+    // the reasoning display drops it to avoid a Thinking/Working double-up.
+    const commentary = message.role === 'assistant' ? commentaryFromSessionMessage(message) : ''
+    const reasoning = commentary ? stripCommentaryFromReasoning(rawReasoning, commentary) : rawReasoning
+
     if (reasoning && message.role === 'assistant') {
       parts.push(reasoningPart(reasoning))
+    }
+
+    if (commentary) {
+      parts.push(commentaryPart(commentary))
     }
 
     if (displayContent) {

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1194,7 +1194,8 @@ text-* variant utilities. */ .btn-arc {
    chevron column to escape into), so their headers and bodies share a
    common left edge with the model's text. */
 [data-slot='aui_assistant-message-content'] > [data-slot='tool-block'],
-[data-slot='aui_assistant-message-content'] > [data-slot='aui_thinking-disclosure'] {
+[data-slot='aui_assistant-message-content'] > [data-slot='aui_thinking-disclosure'],
+[data-slot='aui_assistant-message-content'] > [data-slot='aui_commentary-disclosure'] {
   width: 100%;
   max-width: 100%;
 }
@@ -1297,7 +1298,8 @@ text-* variant utilities. */ .btn-arc {
    stays at full strength; scaffolding lifts back to full opacity on
    hover/focus so it stays legible when the user actually wants to read it. */
 [data-slot='tool-block'],
-[data-slot='aui_thinking-disclosure'] {
+[data-slot='aui_thinking-disclosure'],
+[data-slot='aui_commentary-disclosure'] {
   background: transparent !important;
 }
 
@@ -1309,6 +1311,7 @@ text-* variant utilities. */ .btn-arc {
    it impossible to keep one row lit (an open diff) while its siblings faded.
    With the fade per-row, each row hovers/focuses independently. */
 [data-slot='aui_assistant-message-content'] > [data-slot='aui_thinking-disclosure'],
+[data-slot='aui_assistant-message-content'] > [data-slot='aui_commentary-disclosure'],
 [data-slot='aui_assistant-message-content'] [data-slot='tool-block'][data-tool-row] {
   opacity: 0.67;
   transition: opacity 120ms ease-out;
@@ -1318,6 +1321,7 @@ text-* variant utilities. */ .btn-arc {
    focus a mouse click leaves on the disclosure toggle, which kept a row lit
    after you clicked to collapse it; `:has(:focus-visible)` excludes that. */
 [data-slot='aui_assistant-message-content'] > [data-slot='aui_thinking-disclosure']:is(:hover, :has(:focus-visible)),
+[data-slot='aui_assistant-message-content'] > [data-slot='aui_commentary-disclosure']:is(:hover, :has(:focus-visible)),
 [data-slot='aui_assistant-message-content'] [data-slot='tool-block'][data-tool-row]:is(:hover, :has(:focus-visible)) {
   opacity: 1;
 }
@@ -1389,11 +1393,16 @@ text-* variant utilities. */ .btn-arc {
    rhythm so split-out text parts don't look like a big gap. */
 /* Scaffolding adjacent to anything → roomy block gap. */
 [data-slot='aui_assistant-message-content']
-  > :is([data-slot='tool-block'], [data-slot='aui_thinking-disclosure'])
-  + :is([data-slot='tool-block'], [data-slot='aui_thinking-disclosure'], .aui-md),
+  > :is([data-slot='tool-block'], [data-slot='aui_thinking-disclosure'], [data-slot='aui_commentary-disclosure'])
+  + :is(
+    [data-slot='tool-block'],
+    [data-slot='aui_thinking-disclosure'],
+    [data-slot='aui_commentary-disclosure'],
+    .aui-md
+  ),
 [data-slot='aui_assistant-message-content']
   > .aui-md
-  + :is([data-slot='tool-block'], [data-slot='aui_thinking-disclosure']) {
+  + :is([data-slot='tool-block'], [data-slot='aui_thinking-disclosure'], [data-slot='aui_commentary-disclosure']) {
   margin-top: var(--turn-block-gap);
 }
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -364,7 +364,15 @@ export interface SessionInfo {
 }
 
 export interface SessionMessage {
+  /** Exact Codex assistant message items (with phase/id) persisted for
+   *  Responses replay. Raw DB rows deliver this as a JSON string; gateway
+   *  history delivers it decoded. Commentary derives from it on reload. */
+  codex_message_items?: unknown
   codex_reasoning_items?: unknown
+  /** Codex commentary/analysis narration — user-facing mid-turn progress,
+   *  derived server-side from phase-bearing codex_message_items. Distinct
+   *  from reasoning: renders in the "Working" lane, not "Thinking". */
+  commentary?: null | string
   content: unknown
   context?: unknown
   name?: string

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -7,6 +7,7 @@ export type GatewayEventName =
   | 'thinking.delta'
   | 'reasoning.delta'
   | 'reasoning.available'
+  | 'commentary.delta'
   | 'status.update'
   | 'tool.start'
   | 'tool.progress'

--- a/cli.py
+++ b/cli.py
@@ -12655,6 +12655,25 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     else:
                         display_reasoning = reasoning.strip()
                     _cprint(f"\n{r_top}\n{_DIM}{display_reasoning}{_RST}\n{r_bot}")
+                # Codex commentary narration recap. No longer folded into
+                # ``reasoning`` (it rides its own lane end-to-end), so give it
+                # its own dim box — mirrors the desktop's "Working" disclosure.
+                # Same gate as the reasoning box: skipped when streaming
+                # already showed it live via the reasoning callback fallback.
+                commentary = result.get("last_commentary")
+                if commentary:
+                    w = self._scrollback_box_width()
+                    c_label = " Working "
+                    c_fill = w - 2 - len(c_label)
+                    c_top = f"{_DIM}┌─{c_label}{'─' * max(c_fill - 1, 0)}┐{_RST}"
+                    c_bot = f"{_DIM}└{'─' * (w - 2)}┘{_RST}"
+                    lines = commentary.strip().splitlines()
+                    if len(lines) > 10 and not getattr(self, "reasoning_full", False):
+                        display_commentary = "\n".join(lines[:10])
+                        display_commentary += f"\n{_DIM}  ... ({len(lines) - 10} more lines — /reasoning full to show){_RST}"
+                    else:
+                        display_commentary = commentary.strip()
+                    _cprint(f"\n{c_top}\n{_DIM}{display_commentary}{_RST}\n{c_bot}")
 
             if response and not response_previewed:
                 # Use skin engine for label/color with fallback

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11712,6 +11712,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
             if _show_reasoning_effective and response and not _intentional_silence:
                 last_reasoning = agent_result.get("last_reasoning")
+                # Codex commentary narration is no longer folded into
+                # ``reasoning`` (dedicated lane); keep the opt-in reasoning
+                # display surfacing it for messaging platforms by appending
+                # it after any genuine reasoning.
+                last_commentary = agent_result.get("last_commentary")
+                if last_commentary:
+                    last_reasoning = (
+                        f"{last_reasoning.strip()}\n\n{last_commentary}"
+                        if last_reasoning
+                        else last_commentary
+                    )
                 if last_reasoning:
                     # Collapse long reasoning to keep messages readable
                     lines = last_reasoning.strip().splitlines()

--- a/run_agent.py
+++ b/run_agent.py
@@ -448,6 +448,7 @@ class AIAgent:
         tool_complete_callback: callable = None,
         thinking_callback: callable = None,
         reasoning_callback: callable = None,
+        commentary_callback: callable = None,
         clarify_callback: callable = None,
         read_terminal_callback: callable = None,
         step_callback: callable = None,
@@ -524,6 +525,7 @@ class AIAgent:
             tool_complete_callback=tool_complete_callback,
             thinking_callback=thinking_callback,
             reasoning_callback=reasoning_callback,
+            commentary_callback=commentary_callback,
             clarify_callback=clarify_callback,
             read_terminal_callback=read_terminal_callback,
             step_callback=step_callback,
@@ -4739,6 +4741,25 @@ class AIAgent:
         if cb is not None:
             try:
                 cb(text)
+            except Exception:
+                pass
+
+    def _fire_commentary_delta(self, text: str) -> None:
+        """Fire commentary callback if registered.
+
+        Codex ``commentary``/``analysis`` narration is user-facing mid-turn
+        progress, semantically distinct from reasoning.  Surfaces that don't
+        register a dedicated commentary lane (CLI, ACP) fall back to the
+        reasoning display so the narration isn't silently dropped.
+        """
+        cb = getattr(self, "commentary_callback", None) or self.reasoning_callback
+        if cb is not None:
+            try:
+                cb(text)
+                # Once-only guard: build_assistant_message's whole-text
+                # fallback checks this so commentary that already streamed
+                # live is never re-delivered (reset per Codex stream call).
+                self._codex_commentary_delivered = True
             except Exception:
                 pass
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -629,7 +629,7 @@ def test_run_codex_stream_returns_collected_items_when_stream_ends_without_termi
     assert response.output == [output_item]
 
 
-def test_consume_codex_stream_routes_commentary_phase_deltas_to_reasoning(monkeypatch):
+def test_consume_codex_stream_routes_commentary_phase_deltas_to_commentary_callback(monkeypatch):
     from agent.codex_runtime import _consume_codex_event_stream
 
     commentary_item = SimpleNamespace(
@@ -647,6 +647,7 @@ def test_consume_codex_stream_routes_commentary_phase_deltas_to_reasoning(monkey
     )
     streamed = []
     reasoning_streamed = []
+    commentary_streamed = []
 
     response = _consume_codex_event_stream(
         _FakeCreateStream([
@@ -667,12 +668,199 @@ def test_consume_codex_stream_routes_commentary_phase_deltas_to_reasoning(monkey
         model="gpt-5-codex",
         on_text_delta=streamed.append,
         on_reasoning_delta=reasoning_streamed.append,
+        on_commentary_delta=commentary_streamed.append,
     )
 
+    # Commentary narration is its own semantic lane: never the visible answer
+    # stream, and never conflated with genuine reasoning.
     assert streamed == []
-    assert reasoning_streamed == ["I’ll call the tool now."]
+    assert reasoning_streamed == []
+    assert commentary_streamed == ["I’ll call the tool now."]
     assert response.output == [commentary_item, function_item]
     assert response.output_text == ""
+
+
+def test_consume_codex_stream_keeps_reasoning_and_commentary_lanes_distinct(monkeypatch):
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    streamed = []
+    reasoning_streamed = []
+    commentary_streamed = []
+
+    response = _consume_codex_event_stream(
+        _FakeCreateStream([
+            SimpleNamespace(type="response.created"),
+            SimpleNamespace(type="response.reasoning_summary_text.delta", delta="Planning the fix"),
+            SimpleNamespace(
+                type="response.output_item.added",
+                item=SimpleNamespace(type="message", phase="commentary"),
+            ),
+            SimpleNamespace(type="response.output_text.delta", delta="Reading the screenshot first."),
+            SimpleNamespace(
+                type="response.output_item.added",
+                item=SimpleNamespace(type="message", phase="final_answer"),
+            ),
+            SimpleNamespace(type="response.output_text.delta", delta="Here is the answer."),
+            SimpleNamespace(type="response.completed", response=SimpleNamespace(status="completed")),
+        ]),
+        model="gpt-5-codex",
+        on_text_delta=streamed.append,
+        on_reasoning_delta=reasoning_streamed.append,
+        on_commentary_delta=commentary_streamed.append,
+    )
+
+    assert reasoning_streamed == ["Planning the fix"]
+    assert commentary_streamed == ["Reading the screenshot first."]
+    assert streamed == ["Here is the answer."]
+    assert response.output_text == "Here is the answer."
+
+
+def _commentary_stream_events():
+    return [
+        SimpleNamespace(type="response.created"),
+        SimpleNamespace(
+            type="response.output_item.added",
+            item=SimpleNamespace(type="message", phase="commentary"),
+        ),
+        SimpleNamespace(type="response.output_text.delta", delta="Checking the logs."),
+        SimpleNamespace(type="response.completed", response=SimpleNamespace(status="completed")),
+    ]
+
+
+def test_run_codex_stream_fires_commentary_callback(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    commentary_seen = []
+    reasoning_seen = []
+    agent.commentary_callback = commentary_seen.append
+    agent.reasoning_callback = reasoning_seen.append
+
+    def _fake_create(**kwargs):
+        assert kwargs.get("stream") is True
+        return _FakeCreateStream(_commentary_stream_events())
+
+    agent.client = SimpleNamespace(responses=SimpleNamespace(create=_fake_create))
+
+    agent._run_codex_stream(_codex_request_kwargs())
+
+    assert commentary_seen == ["Checking the logs."]
+    assert reasoning_seen == []
+
+
+def test_run_codex_stream_commentary_falls_back_to_reasoning_callback(monkeypatch):
+    """Surfaces without a commentary lane (CLI/ACP) keep showing narration
+    in their thinking display instead of silently dropping it."""
+    agent = _build_agent(monkeypatch)
+    reasoning_seen = []
+    agent.commentary_callback = None
+    agent.reasoning_callback = reasoning_seen.append
+
+    def _fake_create(**kwargs):
+        assert kwargs.get("stream") is True
+        return _FakeCreateStream(_commentary_stream_events())
+
+    agent.client = SimpleNamespace(responses=SimpleNamespace(create=_fake_create))
+
+    agent._run_codex_stream(_codex_request_kwargs())
+
+    assert reasoning_seen == ["Checking the logs."]
+
+
+def _commentary_assistant_message(text="Checking the logs."):
+    return SimpleNamespace(
+        content="",
+        tool_calls=None,
+        reasoning=None,
+        reasoning_content=None,
+        reasoning_details=None,
+        commentary=text,
+        codex_reasoning_items=None,
+        codex_message_items=[
+            {
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": text}],
+                "phase": "commentary",
+            }
+        ],
+    )
+
+
+def test_build_assistant_message_commentary_fallback_fires_once(monkeypatch):
+    """Contract: commentary appears exactly once. The whole-text fallback in
+    build_assistant_message fires only when the live delta stream did NOT
+    already deliver it (gated on _codex_commentary_delivered, not on stream
+    callback registration)."""
+    from agent.chat_completion_helpers import build_assistant_message
+
+    agent = _build_agent(monkeypatch)
+    seen = []
+    agent.commentary_callback = seen.append
+
+    # Not delivered live (e.g. concrete-response compat path) -> fallback fires.
+    agent._codex_commentary_delivered = False
+    msg = build_assistant_message(agent, _commentary_assistant_message(), "stop")
+    assert seen == ["Checking the logs."]
+    # Commentary never enters the message dict's reasoning/content fields.
+    assert not (msg.get("reasoning") or "")
+    assert not (msg.get("content") or "")
+
+    # Already streamed live -> no duplicate delivery.
+    seen.clear()
+    agent._codex_commentary_delivered = True
+    build_assistant_message(agent, _commentary_assistant_message(), "stop")
+    assert seen == []
+
+
+def test_run_conversation_result_exposes_last_commentary(monkeypatch):
+    """The turn result carries the narration for recap surfaces (CLI post-turn
+    box, messaging show_reasoning) now that it no longer rides reasoning."""
+    agent = _build_agent(monkeypatch)
+    responses = [
+        _codex_commentary_message_response("I'll inspect the repo structure first."),
+        _codex_tool_call_response(),
+        _codex_message_response("Architecture summary complete."),
+    ]
+    monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: responses.pop(0))
+
+    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id, *_args):
+        for call in assistant_message.tool_calls:
+            messages.append({"role": "tool", "tool_call_id": call.id, "content": '{"ok":true}'})
+
+    monkeypatch.setattr(agent, "_execute_tool_calls", _fake_execute_tool_calls)
+
+    result = agent.run_conversation("analyze repo")
+
+    assert result["completed"] is True
+    assert result["last_commentary"] == "I'll inspect the repo structure first."
+    assert not (result.get("last_reasoning") or "")
+
+
+def test_commentary_text_from_message_items_accepts_json_string():
+    from agent.codex_responses_adapter import commentary_text_from_message_items
+    import json as _json
+
+    items = [
+        {
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [{"type": "output_text", "text": "Reading the file."}],
+            "phase": "commentary",
+        },
+        {
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [{"type": "output_text", "text": "The answer."}],
+            "phase": "final_answer",
+        },
+    ]
+
+    assert commentary_text_from_message_items(items) == "Reading the file."
+    assert commentary_text_from_message_items(_json.dumps(items)) == "Reading the file."
+    assert commentary_text_from_message_items(None) == ""
+    assert commentary_text_from_message_items("not json") == ""
 
 
 def test_consume_codex_stream_keeps_final_answer_phase_deltas(monkeypatch):
@@ -1638,7 +1826,9 @@ def test_normalize_codex_response_marks_commentary_only_message_as_incomplete(mo
 
     assert finish_reason == "incomplete"
     assert (assistant_message.content or "") == ""
-    assert "inspect the repository" in (assistant_message.reasoning or "")
+    # Commentary must not contaminate the reasoning lane; it gets its own field.
+    assert (assistant_message.reasoning or "") == ""
+    assert "inspect the repository" in (assistant_message.commentary or "")
     assert assistant_message.codex_message_items
     assert assistant_message.codex_message_items[0]["phase"] == "commentary"
     assert "inspect the repository" in assistant_message.codex_message_items[0]["content"][0]["text"]
@@ -1655,8 +1845,54 @@ def test_normalize_codex_response_does_not_fallback_to_output_text_for_commentar
 
     assert finish_reason == "incomplete"
     assert (assistant_message.content or "") == ""
-    assert "call the tool" in (assistant_message.reasoning or "")
+    assert (assistant_message.reasoning or "") == ""
+    assert "call the tool" in (assistant_message.commentary or "")
     assert assistant_message.codex_message_items[0]["phase"] == "commentary"
+
+
+def test_normalize_codex_response_separates_commentary_reasoning_and_final_answer(monkeypatch):
+    from agent.codex_responses_adapter import _normalize_codex_response
+
+    response = SimpleNamespace(
+        status="completed",
+        output=[
+            SimpleNamespace(
+                type="reasoning",
+                id="rs_001",
+                encrypted_content="enc_abc123",
+                summary=[SimpleNamespace(type="summary_text", text="Planning the analysis")],
+            ),
+            SimpleNamespace(
+                type="message",
+                phase="commentary",
+                status="completed",
+                id="msg_commentary",
+                content=[SimpleNamespace(type="output_text", text="Reading the screenshot first.")],
+            ),
+            SimpleNamespace(
+                type="message",
+                phase="final_answer",
+                status="completed",
+                id="msg_final",
+                content=[SimpleNamespace(type="output_text", text="The total is $42.")],
+            ),
+        ],
+    )
+
+    assistant_message, finish_reason = _normalize_codex_response(response)
+
+    assert finish_reason == "stop"
+    # Final answer stays the assistant content, with no commentary concatenated.
+    assert assistant_message.content == "The total is $42."
+    # True reasoning keeps the reasoning lane to itself.
+    assert assistant_message.reasoning == "Planning the analysis"
+    # Commentary rides its own field.
+    assert assistant_message.commentary == "Reading the screenshot first."
+    # Exact phase-bearing items survive for Responses replay / prompt cache.
+    phases = [item.get("phase") for item in assistant_message.codex_message_items]
+    assert phases == ["commentary", "final_answer"]
+    assert assistant_message.codex_message_items[0]["id"] == "msg_commentary"
+
 
 def test_normalize_codex_response_final_answer_overrides_top_level_incomplete(monkeypatch):
     from agent.codex_responses_adapter import _normalize_codex_response

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -1770,3 +1770,112 @@ def test_slow_completion_does_not_block_fast_handler(completion_method, server):
     assert fast_elapsed < 0.5, f"fast handler blocked for {fast_elapsed:.2f}s behind {completion_method}"
 
     released.set()
+
+
+# ── Codex commentary lane ────────────────────────────────────────────
+
+
+def test_agent_cbs_commentary_callback_emits_commentary_delta(server, monkeypatch):
+    """Codex commentary narration gets its own event, never reasoning.delta."""
+    emitted = []
+    monkeypatch.setattr(
+        server, "_emit", lambda event, sid, payload=None: emitted.append((event, sid, payload))
+    )
+
+    cbs = server._agent_cbs("sid-1")
+    assert "commentary_callback" in cbs
+    cbs["commentary_callback"]("Reading the screenshot first.")
+
+    assert emitted == [
+        ("commentary.delta", "sid-1", {"text": "Reading the screenshot first."})
+    ]
+
+
+def _commentary_item(text, phase="commentary"):
+    return {
+        "type": "message",
+        "role": "assistant",
+        "status": "completed",
+        "content": [{"type": "output_text", "text": text}],
+        "id": "msg_1",
+        "phase": phase,
+    }
+
+
+def test_history_to_messages_derives_commentary_from_codex_message_items(server):
+    """Reload reconstructs the Working lane from phase-bearing message items.
+
+    A Codex commentary turn persists with empty content + tool_calls; it must
+    survive _history_to_messages instead of being elided like other
+    content-less tool-call turns, and the commentary text must ride a
+    dedicated field (not reasoning).
+    """
+    history = [
+        {"role": "user", "content": "analyze this"},
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning": "**Planning image-based pricing analysis**",
+            "tool_calls": [
+                {"id": "call_1", "function": {"name": "vision_analyze", "arguments": "{}"}}
+            ],
+            "codex_message_items": [_commentary_item("Reading the screenshot first.")],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "done"},
+        {"role": "assistant", "content": "The total is $42."},
+    ]
+
+    messages = server._history_to_messages(history)
+
+    assert messages == [
+        {"role": "user", "text": "analyze this"},
+        {
+            "role": "assistant",
+            "text": "",
+            "reasoning": "**Planning image-based pricing analysis**",
+            "commentary": "Reading the screenshot first.",
+        },
+        {
+            "role": "tool",
+            "name": "vision_analyze",
+            "context": server._tool_ctx("vision_analyze", {}),
+        },
+        {"role": "assistant", "text": "The total is $42."},
+    ]
+
+
+def test_history_to_messages_ignores_final_answer_phase_items(server):
+    """final_answer items are the normal answer, not commentary."""
+    history = [
+        {
+            "role": "assistant",
+            "content": "The total is $42.",
+            "codex_message_items": [
+                _commentary_item("The total is $42.", phase="final_answer")
+            ],
+        },
+    ]
+
+    messages = server._history_to_messages(history)
+
+    assert messages == [{"role": "assistant", "text": "The total is $42."}]
+
+
+def test_history_to_messages_still_elides_plain_toolcall_turns(server):
+    """Non-commentary content-less tool-call turns keep their existing elision."""
+    history = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "call_1", "function": {"name": "terminal", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+    ]
+
+    messages = server._history_to_messages(history)
+
+    assert messages == [
+        {"role": "tool", "name": "terminal", "context": server._tool_ctx("terminal", {})}
+    ]

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3878,6 +3878,12 @@ def _agent_cbs(sid: str) -> dict:
             sid,
             {"text": text, **({"verbose": True} if _session_verbose(sid) else {})},
         ),
+        # Codex commentary/analysis narration: user-facing mid-turn progress,
+        # semantically distinct from reasoning — its own event so the client
+        # can render a "Working" lane instead of the "Thinking" disclosure.
+        "commentary_callback": lambda text: _emit(
+            "commentary.delta", sid, {"text": text}
+        ),
         "status_callback": lambda kind, text=None: _status_update(
             sid, str(kind), None if text is None else str(text)
         ),
@@ -4911,6 +4917,19 @@ def _coerce_message_text(content: Any) -> str:
     return str(content)
 
 
+def _commentary_from_message(m: dict) -> str:
+    """Join Codex commentary/analysis narration from persisted message items.
+
+    Commentary is never stored in ``reasoning``/``reasoning_content`` — the
+    only durable record is the phase-bearing ``codex_message_items`` kept for
+    Responses replay. Derive the display text from those items so reloads
+    reconstruct the "Working" lane without a schema change.
+    """
+    from agent.codex_responses_adapter import commentary_text_from_message_items
+
+    return commentary_text_from_message_items(m.get("codex_message_items"))
+
+
 def _history_to_messages(history: list[dict]) -> list[dict]:
     messages = []
     tool_call_args = {}
@@ -4922,6 +4941,7 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
         if role not in {"user", "assistant", "tool", "system"}:
             continue
         content_text = _coerce_message_text(m.get("content"))
+        commentary_text = _commentary_from_message(m) if role == "assistant" else ""
         if role == "assistant" and m.get("tool_calls"):
             for tc in m["tool_calls"]:
                 fn = tc.get("function", {})
@@ -4932,7 +4952,10 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
                     except (json.JSONDecodeError, TypeError):
                         args = {}
                     tool_call_args[tc_id] = (fn["name"], args)
-            if not content_text.strip():
+            # Content-less tool-call turns are normally elided (the tool
+            # messages themselves render the turn), but Codex commentary
+            # narration precedes its tool calls and must survive reload.
+            if not content_text.strip() and not commentary_text:
                 continue
         if role == "tool":
             tc_id = m.get("tool_call_id", "")
@@ -4959,13 +4982,15 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
         has_reasoning = role == "assistant" and any(
             m.get(key) for key in reasoning_keys
         )
-        if not content_text.strip() and not has_reasoning:
+        if not content_text.strip() and not has_reasoning and not commentary_text:
             continue
         msg = {"role": role, "text": content_text}
         if role == "assistant":
             for key in reasoning_keys:
                 if key in m and m.get(key) is not None:
                     msg[key] = m.get(key)
+            if commentary_text:
+                msg["commentary"] = commentary_text
         messages.append(msg)
 
     return messages
@@ -9084,6 +9109,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     session["model_override"] = _restore
 
             last_reasoning = None
+            last_commentary = None
             status_note = None
             if isinstance(result, dict):
                 if isinstance(result.get("messages"), list):
@@ -9143,6 +9169,9 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 lr = result.get("last_reasoning")
                 if isinstance(lr, str) and lr.strip():
                     last_reasoning = lr.strip()
+                lc = result.get("last_commentary")
+                if isinstance(lc, str) and lc.strip():
+                    last_commentary = lc.strip()
             else:
                 raw = str(result)
                 status = "complete"
@@ -9150,6 +9179,11 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             payload = {"text": raw, "usage": _get_usage(agent), "status": status}
             if last_reasoning:
                 payload["reasoning"] = last_reasoning
+            if last_commentary:
+                # Codex narration recap — parallels ``reasoning``; the desktop
+                # already received it live via commentary.delta and ignores
+                # this, but protocol clients get the completed-turn value.
+                payload["commentary"] = last_commentary
             if status_note:
                 payload["warning"] = status_note
             rendered = render_message(raw, cols)

--- a/ui-tui/README.md
+++ b/ui-tui/README.md
@@ -277,6 +277,7 @@ Primary event types the client handles today:
 | `thinking.delta`           | `{ text }`                                                                  |
 | `reasoning.delta`          | `{ text, verbose? }`                                                        |
 | `reasoning.available`      | `{ text, verbose? }`                                                        |
+| `commentary.delta`         | `{ text }` — Codex mid-turn narration (desktop: "Working" lane)             |
 | `status.update`            | `{ kind, text }`                                                            |
 | `notification.show`        | `{ id, key, kind, level, text, ttl_ms? }`                                   |
 | `notification.clear`       | `{ key }`                                                                   |

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -360,6 +360,19 @@ describe('createGatewayEventHandler', () => {
     expect(appended[appended.length - 1]).toMatchObject({ role: 'assistant', text: 'final answer' })
   })
 
+  it('folds commentary.delta into the thinking lane so Codex narration stays visible', () => {
+    const appended: Msg[] = []
+    const narration = 'Reading the screenshot before I put numbers around it.'
+
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    onEvent({ payload: { text: narration }, type: 'commentary.delta' } as any)
+    onEvent({ payload: { text: 'final answer' }, type: 'message.complete' } as any)
+
+    expect(appended[0]?.thinking).toBe(narration)
+    expect(appended[appended.length - 1]).toMatchObject({ role: 'assistant', text: 'final answer' })
+  })
+
   it('filters spinner/status-only reasoning noise from completed thinking', () => {
     const appended: Msg[] = []
     const streamed = '(¬_¬) synthesizing...\nactual plan\n( ͡° ͜ʖ ͡°) pondering...\nnext step'

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -683,6 +683,16 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         return
 
+      case 'commentary.delta':
+        // Codex commentary/analysis narration. The desktop renders it in a
+        // dedicated "Working" lane; the TUI folds it into the thinking lane
+        // so the narration stays visible (parity with the pre-split display).
+        if (ev.payload?.text) {
+          turnController.recordReasoningDelta(ev.payload.text, false)
+        }
+
+        return
+
       case 'reasoning.available':
         turnController.recordReasoningAvailable(String(ev.payload?.text ?? ''), Boolean(ev.payload?.verbose))
 

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -659,6 +659,7 @@ export type GatewayEvent =
       session_id?: string
       type: 'reasoning.delta' | 'reasoning.available'
     }
+  | { payload?: { text?: string }; session_id?: string; type: 'commentary.delta' }
   | {
       payload: { count?: number; index?: number; label?: string; text?: string }
       session_id?: string


### PR DESCRIPTION
## Problem

GPT-5.x Codex Responses turns emit user-facing mid-turn narration as `commentary`/`analysis`-phase message items. The transport flattened that narration into the reasoning channel, so:

- the Desktop rendered casual narration inside the **Thinking** disclosure alongside genuine reasoning summaries, and
- the narration was persisted into the `reasoning` / `reasoning_content` DB columns (observed live: an assistant row with genuine summary headings and casual narration concatenated in one reasoning blob).

## Fix: a dedicated commentary lane, end to end

- **agent**: `on_commentary_delta` in `_consume_codex_event_stream`; the Responses adapter collects commentary separately (never into `reasoning_parts` or content); `commentary_callback` plumbing with a reasoning-display fallback for surfaces without the new lane; a once-only delivery guard so live deltas and the whole-text fallback cannot double-fire; turn results expose `last_commentary`.
- **tui_gateway**: new `commentary.delta` event; `message.complete` carries a commentary recap; `_history_to_messages` derives commentary from persisted `codex_message_items` so reloads reconstruct the lane (and commentary-bearing content-less tool-call turns survive elision).
- **desktop**: commentary renders as a `data-commentary` part under a **Working** disclosure (i18n en/ja/zh/zh-Hant); third streaming lane with semantic flush order (reasoning -> commentary -> text); reload derivation from raw `codex_message_items` rows; legacy sessions strip already-flattened narration from the reasoning display to avoid a double-render.
- **ui-tui**: `commentary.delta` folds into the thinking lane (display parity).
- **cli/messaging**: post-turn **Working** recap box; `show_reasoning` platforms append narration after genuine reasoning.

Exact Codex message items (phase + ids + status) are preserved in `codex_message_items`, so Responses replay and prompt-cache continuity are untouched, and no DB migration is needed.

## Verification

- Python: `test_run_agent_codex_responses` (15+ new commentary tests), `test_provider_parity`, `tui_gateway/test_protocol` (+4 new), `test_last_reasoning_per_turn` all green; full `tests/run_agent` + `tests/tui_gateway` sweep shows no regressions vs a clean-HEAD baseline.
- Desktop: vitest suites for chat-messages / use-message-stream (new `commentary.test.tsx`) / streaming render green; typecheck and production build pass.
- ui-tui: handler suite green (new commentary test); typecheck passes.
- Live end-to-end on `gpt-5.6-sol` through the real gateway: 102 `commentary.delta` events with zero leakage into `reasoning.delta`; clean final answer; `session.resume` reconstructs the narration; DB rows persist commentary turns with empty `reasoning`/`content` and `phase: commentary` items only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)