### PR TITLE
feat(desktop): session-list title search + ranking

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -23,7 +23,7 @@ import { searchSessions, type SessionInfo, type SessionSearchResult } from '@/he
 import { useI18n } from '@/i18n'
 import { comboTokens } from '@/lib/keybinds/combo'
 import { profileColor } from '@/lib/profile-color'
-import { sessionMatchesSearch } from '@/lib/session-search'
+import { rankTitleMatchesFirst, sessionMatchesSearch } from '@/lib/session-search'
 import { normalizeSessionSource, sessionSourceLabel } from '@/lib/session-source'
 import { cn } from '@/lib/utils'
 import { $cronJobs } from '@/store/cron'
@@ -193,7 +193,7 @@ function searchResultToSession(result: SessionSearchResult): SessionInfo {
     preview: result.snippet?.trim() || null,
     source: result.source ?? null,
     started_at: ts,
-    title: null,
+    title: result.title?.trim() || null,
     tool_call_count: 0
   }
 }
@@ -436,7 +436,7 @@ export function ChatSidebar({
       out.set(match.session_id, loaded ?? searchResultToSession(match))
     }
 
-    return [...out.values()]
+    return rankTitleMatchesFirst([...out.values()], trimmedQuery)
   }, [trimmedQuery, sortedSessions, serverMatches, sessionByAnyId])
 
   const unpinnedAgentSessions = useMemo(

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -181,6 +181,7 @@ function searchResultToSession(result: SessionSearchResult): SessionInfo {
   return {
     archived: false,
     cwd: null,
+    display_name: result.display_name?.trim() || null,
     ended_at: null,
     id: result.session_id,
     _lineage_root_id: result.lineage_root ?? null,
@@ -1149,6 +1150,7 @@ export function ChatSidebar({
                 pinned={false}
                 rootClassName="min-h-32 flex-1 overflow-hidden p-0"
                 sessions={searchResults}
+                showOriginContext
                 workingSessionIdSet={workingSessionIdSet}
               />
             )}

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -10,6 +10,7 @@ import type { SessionInfo } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
 import { sessionTitle } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
+import { sessionOriginContext } from '@/lib/session-search'
 import { handoffOriginSource, sessionSourceLabel } from '@/lib/session-source'
 import { coarseElapsed } from '@/lib/time'
 import { cn } from '@/lib/utils'
@@ -34,6 +35,11 @@ interface SidebarSessionRowProps extends React.ComponentProps<'div'> {
   reorderable?: boolean
   dragging?: boolean
   dragHandleProps?: React.HTMLAttributes<HTMLElement>
+  /** Search results show WHERE a session lives ("Discord: voice-assitant:
+   *  Desktop App" / "TUI") above the title, so cross-surface hits are
+   *  tellable apart. Off in the normal sidebar lists (the section headers
+   *  already carry that context there). */
+  showOriginContext?: boolean
 }
 
 const AGE_KEY = { day: 'ageDay', hour: 'ageHour', minute: 'ageMin' } as const
@@ -59,6 +65,7 @@ export function SidebarSessionRow({
   reorderable = false,
   dragging = false,
   dragHandleProps,
+  showOriginContext = false,
   className,
   style,
   ref,
@@ -69,6 +76,7 @@ export function SidebarSessionRow({
   const title = sessionTitle(session)
   const age = formatAge(session.last_active || session.started_at, r)
   const handleLabel = `Reorder ${title}`
+  const originContext = showOriginContext ? sessionOriginContext(session) : null
   // A handed-off session's live source is local, but it originated on a
   // messaging platform — surface that origin as a small badge so e.g. a
   // Telegram thread continued here still reads as Telegram.
@@ -208,7 +216,16 @@ export function SidebarSessionRow({
             </Tip>
           ) : null}
           <SidebarRowLabel className="flex-1 font-normal group-hover:text-foreground group-data-[working=true]:text-foreground/90">
-            {title}
+            {originContext ? (
+              <span className="flex min-w-0 flex-col">
+                <span className="truncate text-[0.625rem] leading-tight text-(--ui-text-tertiary)">
+                  {originContext}
+                </span>
+                <span className="truncate">{title}</span>
+              </span>
+            ) : (
+              title
+            )}
           </SidebarRowLabel>
         </SidebarRowBody>
       </SidebarRowShell>

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -127,6 +127,9 @@ interface SidebarSessionsSectionProps {
   // When false the section header is static (no caret/toggle) and always open.
   collapsible?: boolean
   sortable?: boolean
+  // Search results: prefix each row with its origin context ("Discord:
+  // voice-assitant: Desktop App" / "TUI") so cross-surface hits read apart.
+  showOriginContext?: boolean
   // The flat session list is the only hand-reorderable surface (grouped/project
   // views sort deterministically), so it owns the one ReorderableList.
   onReorderSessions?: (ids: string[]) => void
@@ -171,6 +174,7 @@ export function SidebarSessionsSection({
   labelIcon,
   collapsible = true,
   sortable = false,
+  showOriginContext = false,
   onReorderSessions,
   onReorderProjects,
   projectBackRow,
@@ -203,7 +207,8 @@ export function SidebarSessionsSection({
       onPin: () => onTogglePin(sessionPinId(session)),
       onResume: () => onResumeSession(session.id),
       reorderable: draggable && !branchStem,
-      session
+      session,
+      showOriginContext
     }
 
     return draggable && !branchStem ? (

--- a/apps/desktop/src/lib/session-search.test.ts
+++ b/apps/desktop/src/lib/session-search.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { SessionInfo } from '@/types/hermes'
 
-import { sessionMatchesSearch } from './session-search'
+import { rankTitleMatchesFirst, sessionMatchesSearch, sessionTitleMatches } from './session-search'
 
 function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
   return {
@@ -62,5 +62,41 @@ describe('sessionMatchesSearch', () => {
 
   it('does not match unrelated queries', () => {
     expect(sessionMatchesSearch(makeSession(), 'totally-unrelated')).toBe(false)
+  })
+})
+
+describe('sessionTitleMatches', () => {
+  it('matches only the assigned title, case-insensitively', () => {
+    const session = makeSession()
+
+    expect(sessionTitleMatches(session, 'desktop search')).toBe(true)
+    expect(sessionTitleMatches(session, 'DESKTOP')).toBe(true)
+    // preview-only text is not a title match.
+    expect(sessionTitleMatches(session, 'Fix Desktop session')).toBe(false)
+  })
+
+  it('never matches untitled sessions or empty queries', () => {
+    expect(sessionTitleMatches(makeSession({ title: null }), 'anything')).toBe(false)
+    expect(sessionTitleMatches(makeSession(), '')).toBe(false)
+    expect(sessionTitleMatches(makeSession(), '   ')).toBe(false)
+  })
+})
+
+describe('rankTitleMatchesFirst', () => {
+  it('floats title matches above preview/content matches, order preserved within groups', () => {
+    const contentHit = makeSession({ id: 'content-1', preview: 'mentions deploy in text', title: 'Other' })
+    const titleHitA = makeSession({ id: 'title-a', title: 'Deploy pipeline' })
+    const contentHit2 = makeSession({ id: 'content-2', preview: 'deploy again', title: null })
+    const titleHitB = makeSession({ id: 'title-b', title: 'Big deploy day' })
+
+    const ranked = rankTitleMatchesFirst([contentHit, titleHitA, contentHit2, titleHitB], 'deploy')
+
+    expect(ranked.map(s => s.id)).toEqual(['title-a', 'title-b', 'content-1', 'content-2'])
+  })
+
+  it('returns input unchanged for an empty query', () => {
+    const sessions = [makeSession({ id: 'a' }), makeSession({ id: 'b' })]
+
+    expect(rankTitleMatchesFirst(sessions, '')).toEqual(sessions)
   })
 })

--- a/apps/desktop/src/lib/session-search.test.ts
+++ b/apps/desktop/src/lib/session-search.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { SessionInfo } from '@/types/hermes'
 
-import { rankTitleMatchesFirst, sessionMatchesSearch, sessionTitleMatches } from './session-search'
+import { rankTitleMatchesFirst, sessionChannelMatches, sessionMatchesSearch, sessionOriginContext, sessionPlatformMatches, sessionTitleMatches } from './session-search'
 
 function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
   return {
@@ -63,6 +63,53 @@ describe('sessionMatchesSearch', () => {
   it('does not match unrelated queries', () => {
     expect(sessionMatchesSearch(makeSession(), 'totally-unrelated')).toBe(false)
   })
+
+  it('matches channel/thread names from display_name, tokenized (typo-tolerant per token)', () => {
+    const discordThread = makeSession({
+      display_name: 'Daemonarchy / #voice-assitant / Desktop App',
+      source: 'discord',
+      title: 'Pin-Sync Bug Recovery'
+    })
+
+    // channel name token + platform token, neither in the title
+    expect(sessionMatchesSearch(discordThread, 'voice discord')).toBe(true)
+    // thread name
+    expect(sessionMatchesSearch(discordThread, 'desktop app')).toBe(true)
+    // the channel-name typo doesn't break per-token matching of other tokens
+    expect(sessionMatchesSearch(discordThread, 'daemonarchy voice')).toBe(true)
+    // every token must land SOMEWHERE — a miss on one token fails the match
+    expect(sessionMatchesSearch(discordThread, 'voice zzzzz')).toBe(false)
+  })
+
+  it('requires all tokens of a multi-word query to match across fields', () => {
+    const session = makeSession({ source: 'telegram', title: 'Grocery list' })
+
+    expect(sessionMatchesSearch(session, 'grocery telegram')).toBe(true)
+    expect(sessionMatchesSearch(session, 'grocery discord')).toBe(false)
+  })
+})
+
+describe('sessionChannelMatches', () => {
+  it('hits when any token appears in the display_name path', () => {
+    const s = makeSession({ display_name: 'Daemonarchy / #voice-assitant / Desktop App' })
+
+    expect(sessionChannelMatches(s, 'voice')).toBe(true)
+    expect(sessionChannelMatches(s, 'desktop')).toBe(true)
+    expect(sessionChannelMatches(s, 'nope')).toBe(false)
+  })
+
+  it('never hits without a display_name', () => {
+    expect(sessionChannelMatches(makeSession({ display_name: null }), 'voice')).toBe(false)
+    expect(sessionChannelMatches(makeSession(), 'voice')).toBe(false)
+  })
+})
+
+describe('sessionPlatformMatches', () => {
+  it('hits on exact platform names and aliases only', () => {
+    expect(sessionPlatformMatches(makeSession({ source: 'discord' }), 'discord')).toBe(true)
+    expect(sessionPlatformMatches(makeSession({ source: 'telegram' }), 'tg')).toBe(true)
+    expect(sessionPlatformMatches(makeSession({ source: 'discord' }), 'disc')).toBe(false)
+  })
 })
 
 describe('sessionTitleMatches', () => {
@@ -94,9 +141,93 @@ describe('rankTitleMatchesFirst', () => {
     expect(ranked.map(s => s.id)).toEqual(['title-a', 'title-b', 'content-1', 'content-2'])
   })
 
+  it('ranks sessions matching MORE query tokens first (channel+platform beats single title token)', () => {
+    const contentHit = makeSession({ id: 'content-1', preview: 'talked about voice stuff', title: 'Other' })
+    const channelHit = makeSession({
+      display_name: 'Daemonarchy / #voice-assitant',
+      id: 'channel-1',
+      source: 'discord',
+      title: 'Firmware Build'
+    })
+    const platformOnly = makeSession({ id: 'platform-1', source: 'discord', title: 'Unrelated' })
+    const titleHit = makeSession({ id: 'title-1', title: 'Voice pipeline design' })
+
+    const ranked = rankTitleMatchesFirst([contentHit, channelHit, platformOnly, titleHit], 'voice discord')
+
+    // channel-1 matches BOTH tokens (channel + platform) → first;
+    // then single-token hits by tier: title(3) > platform(5); content last.
+    expect(ranked.map(s => s.id)).toEqual(['channel-1', 'title-1', 'platform-1', 'content-1'])
+  })
+
+  it('does not let junk title-substring hits bury full channel-path matches ("desktop app" regression)', () => {
+    // 22 cron sessions whose titles contain "app" (skill-patch-APPlier)
+    const cronJunk = Array.from({ length: 5 }, (_, i) =>
+      makeSession({ id: `cron-${i}`, source: 'cron', title: `skill-patch-applier · Jul 1${i}` })
+    )
+    const threadHit = makeSession({
+      display_name: 'Daemonarchy / #voice-assitant / Desktop App',
+      id: 'thread-1',
+      source: 'discord',
+      title: 'Pin-Sync Bug Recovery'
+    })
+
+    const ranked = rankTitleMatchesFirst([...cronJunk, threadHit], 'desktop app')
+
+    // Both tokens hit the thread's channel path; cron titles only match "app".
+    expect(ranked[0].id).toBe('thread-1')
+  })
+
+  it('whole-phrase title hits still beat multi-token channel hits', () => {
+    const channelHit = makeSession({
+      display_name: 'Daemonarchy / #voice-assitant / Desktop App',
+      id: 'channel-1',
+      source: 'discord',
+      title: 'Other'
+    })
+    const phraseTitle = makeSession({ id: 'title-1', title: 'Troubleshooting Desktop App Timeout' })
+
+    const ranked = rankTitleMatchesFirst([channelHit, phraseTitle], 'desktop app')
+
+    // Both match 2 tokens; the whole-phrase title (tier 2) beats channel (tier 4).
+    expect(ranked.map(s => s.id)).toEqual(['title-1', 'channel-1'])
+  })
+
   it('returns input unchanged for an empty query', () => {
     const sessions = [makeSession({ id: 'a' }), makeSession({ id: 'b' })]
 
     expect(rankTitleMatchesFirst(sessions, '')).toEqual(sessions)
+  })
+})
+
+describe('sessionOriginContext', () => {
+  it('formats Discord channel/thread paths as Platform: channel: thread', () => {
+    const s = makeSession({
+      display_name: 'Daemonarchy / #voice-assitant / Desktop App',
+      source: 'discord'
+    })
+
+    expect(sessionOriginContext(s)).toBe('Discord: voice-assitant: Desktop App')
+  })
+
+  it('formats a channel without a thread', () => {
+    const s = makeSession({ display_name: 'Daemonarchy / #voice-assitant', source: 'discord' })
+
+    expect(sessionOriginContext(s)).toBe('Discord: voice-assitant')
+  })
+
+  it('keeps single-segment display names (no guild to drop)', () => {
+    const s = makeSession({ display_name: 'Home', source: 'telegram' })
+
+    expect(sessionOriginContext(s)).toBe('Telegram: Home')
+  })
+
+  it('reduces local surfaces to the platform label alone', () => {
+    expect(sessionOriginContext(makeSession({ display_name: null, source: 'tui' }))).toBe('TUI')
+    expect(sessionOriginContext(makeSession({ display_name: null, source: 'cli' }))).toBe('CLI')
+    expect(sessionOriginContext(makeSession({ display_name: null, source: 'desktop' }))).toBe('Desktop')
+  })
+
+  it('returns null when the source is unknown/empty', () => {
+    expect(sessionOriginContext(makeSession({ display_name: null, source: null }))).toBeNull()
   })
 })

--- a/apps/desktop/src/lib/session-search.ts
+++ b/apps/desktop/src/lib/session-search.ts
@@ -2,30 +2,55 @@ import { normalize } from '@/lib/text'
 import type { SessionInfo } from '@/types/hermes'
 
 import { sessionTitle } from './chat-runtime'
-import { sessionSourceSearchTerms } from './session-source'
+import { normalizeSessionSource, sessionSourceLabel, sessionSourceSearchTerms } from './session-source'
 
+/** Tokenize a query for multi-term matching: lowercased whitespace split. */
+function queryTokens(query: string): string[] {
+  return normalize(query).split(/\s+/).filter(Boolean)
+}
+
+/** All searchable text fields of a session, lowercased once. */
+function searchFields(session: SessionInfo) {
+  return {
+    channel: (session.display_name ?? '').toLowerCase(),
+    cwd: (session.cwd ?? '').toLowerCase(),
+    id: `${session.id} ${session._lineage_root_id ?? ''}`.toLowerCase(),
+    platformTerms: sessionSourceSearchTerms(session.source).map(t => t.toLowerCase()),
+    preview: (session.preview ?? '').toLowerCase(),
+    title: sessionTitle(session).toLowerCase()
+  }
+}
+
+/** Every query token must land somewhere: title, channel/thread path
+ *  (display_name), platform name/alias, id, preview, or cwd. Multi-token
+ *  queries like "voice assistant discord" thereby match a session whose
+ *  channel is "#voice-assitant" (sic) on source discord — each token scores
+ *  independently, so typos in channel names don't break phrase search. */
 export function sessionMatchesSearch(session: SessionInfo, query: string): boolean {
-  const needle = normalize(query)
+  const tokens = queryTokens(query)
 
-  if (!needle) {
+  if (tokens.length === 0) {
     return true
   }
 
-  return [
-    session.id,
-    session._lineage_root_id ?? '',
-    sessionTitle(session),
-    session.preview ?? '',
-    session.cwd ?? '',
-    ...sessionSourceSearchTerms(session.source)
-  ].some(value => value.toLowerCase().includes(needle))
+  const f = searchFields(session)
+
+  return tokens.every(
+    tok =>
+      f.title.includes(tok) ||
+      f.channel.includes(tok) ||
+      f.platformTerms.some(term => term.includes(tok)) ||
+      f.id.includes(tok) ||
+      f.preview.includes(tok) ||
+      f.cwd.includes(tok)
+  )
 }
 
 /** Whether the query hits the session's assigned TITLE specifically.
- * Titles are human-assigned intent (`/title` on any platform, desktop rename),
- * so title matches rank above id/preview/cwd/source matches. */
+ *  Titles are human-assigned intent (`/title` on any platform, desktop
+ *  rename), so title matches rank above id/preview/cwd/source matches. */
 export function sessionTitleMatches(session: SessionInfo, query: string): boolean {
-  const needle = normalize(query)
+  const needle = query.trim().toLowerCase()
 
   if (!needle) {
     return false
@@ -34,25 +59,143 @@ export function sessionTitleMatches(session: SessionInfo, query: string): boolea
   return (session.title ?? '').trim().toLowerCase().includes(needle)
 }
 
-/** Stable sort: title-matching sessions first, everything else after,
- * preserving the existing relative order within each group. */
-export function rankTitleMatchesFirst(sessions: SessionInfo[], query: string): SessionInfo[] {
-  const needle = normalize(query)
+/** Whether the query hits the session's channel/thread path (display_name) —
+ *  per-token, so "voice assistant" hits "Daemonarchy / #voice-assitant". */
+export function sessionChannelMatches(session: SessionInfo, query: string): boolean {
+  const tokens = queryTokens(query)
+  const channel = (session.display_name ?? '').toLowerCase()
 
-  if (!needle) {
-    return sessions
+  if (tokens.length === 0 || !channel) {
+    return false
   }
 
-  const titleHits: SessionInfo[] = []
-  const rest: SessionInfo[] = []
+  return tokens.some(tok => channel.includes(tok))
+}
 
-  for (const session of sessions) {
-    if (sessionTitleMatches(session, needle)) {
-      titleHits.push(session)
-    } else {
-      rest.push(session)
+/** Whether any query token names the session's platform (source/label/alias). */
+export function sessionPlatformMatches(session: SessionInfo, query: string): boolean {
+  const tokens = queryTokens(query)
+
+  if (tokens.length === 0) {
+    return false
+  }
+
+  const terms = sessionSourceSearchTerms(session.source).map(t => t.toLowerCase())
+
+  return tokens.some(tok => terms.some(term => term === tok))
+}
+
+/** Per-session relevance score, mirroring the server-side
+ *  search_sessions_by_title contract exactly:
+ *
+ *  - `matched` counts query tokens that hit a STRONG field (title,
+ *    channel/thread path, platform name) — more matched tokens rank first,
+ *    so for "desktop app" a session in the "Desktop App" thread (both
+ *    tokens hit the channel path) beats a cron titled "skill-patch-applier"
+ *    (only "app" substring-hits the title). This is the fix for the
+ *    cron-junk-buries-channel-hits regression.
+ *  - `tier` breaks ties by WHERE the best hit landed: whole-phrase title
+ *    exact(0) > prefix(1) > substring(2) > token-in-title(3) >
+ *    token-in-channel(4) > platform-only(5) > weak/none(6).
+ */
+function searchScore(session: SessionInfo, needle: string, tokens: string[]): [number, number] {
+  const title = (session.title ?? '').trim().toLowerCase()
+  const channel = (session.display_name ?? '').toLowerCase()
+  const platformTerms = sessionSourceSearchTerms(session.source).map(t => t.toLowerCase())
+
+  let matched = 0
+  let bestTier = 6
+
+  for (const tok of tokens) {
+    let tier: number | null = null
+
+    if (title && title.includes(tok)) {
+      tier = 3
+    } else if (channel && channel.includes(tok)) {
+      tier = 4
+    } else if (platformTerms.some(term => term === tok)) {
+      tier = 5
+    }
+
+    if (tier !== null) {
+      matched += 1
+      bestTier = Math.min(bestTier, tier)
     }
   }
 
-  return [...titleHits, ...rest]
+  // Whole-phrase title tiers preserve the historical contract that an
+  // exact/prefix title hit beats everything else.
+  if (title === needle) {
+    bestTier = 0
+  } else if (title.startsWith(needle)) {
+    bestTier = 1
+  } else if (needle && title.includes(needle)) {
+    bestTier = 2
+  }
+
+  return [-matched, bestTier]
+}
+
+/** Stable relevance sort mirroring the server contract: sessions matching
+ *  more query tokens in strong fields (title/channel/platform) first, ties
+ *  broken by where the best hit landed, then by incoming order (recency). */
+export function rankTitleMatchesFirst(sessions: SessionInfo[], query: string): SessionInfo[] {
+  const needle = query.trim().toLowerCase()
+  const tokens = queryTokens(query)
+
+  if (!needle || tokens.length === 0) {
+    return sessions
+  }
+
+  return sessions
+    .map((session, index) => ({ index, score: searchScore(session, needle, tokens), session }))
+    .sort((a, b) => {
+      if (a.score[0] !== b.score[0]) {
+        return a.score[0] - b.score[0]
+      }
+
+      if (a.score[1] !== b.score[1]) {
+        return a.score[1] - b.score[1]
+      }
+
+      return a.index - b.index
+    })
+    .map(entry => entry.session)
+}
+
+/** Origin-context prefix for a search result row, per Ace's format:
+ *
+ *    Discord: voice-assitant: Desktop App     (guild dropped, '#' stripped)
+ *    Telegram: Home
+ *    TUI                                       (local surfaces: just the label)
+ *
+ *  Messaging sessions derive the path from display_name (the gateway's
+ *  presentation path "Guild / #channel / Thread"); local surfaces (TUI,
+ *  CLI, Desktop, Cron, …) reduce to the platform label alone. Returns null
+ *  when there is nothing informative to show. */
+export function sessionOriginContext(session: SessionInfo): null | string {
+  const id = normalizeSessionSource(session.source)
+  const label = sessionSourceLabel(id) ?? (id || null)
+
+  if (!label) {
+    return null
+  }
+
+  const dn = (session.display_name ?? '').trim()
+
+  if (!dn) {
+    return label
+  }
+
+  const parts = dn
+    .split(' / ')
+    .map(p => p.replace(/^#/, '').trim())
+    .filter(Boolean)
+
+  // Drop the server/guild segment when a channel path follows it — the
+  // channel + thread are what identify the conversation ("Daemonarchy /
+  // #voice-assitant / Desktop App" → "voice-assitant: Desktop App").
+  const path = parts.length > 1 ? parts.slice(1) : parts
+
+  return [label, ...path].join(': ')
 }

--- a/apps/desktop/src/lib/session-search.ts
+++ b/apps/desktop/src/lib/session-search.ts
@@ -20,3 +20,39 @@ export function sessionMatchesSearch(session: SessionInfo, query: string): boole
     ...sessionSourceSearchTerms(session.source)
   ].some(value => value.toLowerCase().includes(needle))
 }
+
+/** Whether the query hits the session's assigned TITLE specifically.
+ * Titles are human-assigned intent (`/title` on any platform, desktop rename),
+ * so title matches rank above id/preview/cwd/source matches. */
+export function sessionTitleMatches(session: SessionInfo, query: string): boolean {
+  const needle = normalize(query)
+
+  if (!needle) {
+    return false
+  }
+
+  return (session.title ?? '').trim().toLowerCase().includes(needle)
+}
+
+/** Stable sort: title-matching sessions first, everything else after,
+ * preserving the existing relative order within each group. */
+export function rankTitleMatchesFirst(sessions: SessionInfo[], query: string): SessionInfo[] {
+  const needle = normalize(query)
+
+  if (!needle) {
+    return sessions
+  }
+
+  const titleHits: SessionInfo[] = []
+  const rest: SessionInfo[] = []
+
+  for (const session of sessions) {
+    if (sessionTitleMatches(session, needle)) {
+      titleHits.push(session)
+    } else {
+      rest.push(session)
+    }
+  }
+
+  return [...titleHits, ...rest]
+}

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -355,6 +355,10 @@ export interface SessionInfo {
   /** Handoff lifecycle: 'pending' | 'in_progress' | 'completed' | 'failed'. */
   handoff_state?: null | string
   handoff_error?: null | string
+  /** Gateway presentation path for messaging-born sessions — server/channel/
+   *  thread names (e.g. "Daemonarchy / #general / My Thread"). Searchable so
+   *  channel/thread names are findable like titles. */
+  display_name?: null | string
   /** Owning profile name, set by the cross-profile aggregator
    *  (`/api/profiles/sessions`). Absent on legacy single-profile responses,
    *  which the UI treats as the default profile. */
@@ -771,6 +775,9 @@ export interface SessionSearchResult {
   source: string | null
   /** Session title when the hit came from the title-match lane. */
   title?: string | null
+  /** Gateway presentation path (server/channel/thread names) when the hit
+   *  came from the title/channel-match lane. */
+  display_name?: string | null
 }
 
 export interface SessionSearchResponse {

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -769,6 +769,8 @@ export interface SessionSearchResult {
   session_started: number | null
   snippet: string
   source: string | null
+  /** Session title when the hit came from the title-match lane. */
+  title?: string | null
 }
 
 export interface SessionSearchResponse {

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4292,6 +4292,29 @@ async def search_sessions(q: str = "", limit: int = 20, profile: Optional[str] =
                     },
                 )
 
+            # Title matches second: titles are human-assigned intent (`/title`
+            # on any platform, desktop rename, auto-titling), so a title hit
+            # outranks a message-content hit. This makes a session titled from
+            # another surface findable in desktop search even after it scrolls
+            # out of the sidebar's loaded window.
+            for row in db.search_sessions_by_title(
+                q, limit=safe_limit, include_archived=True
+            ):
+                sid = row.get("id")
+                preview = (row.get("preview") or "").strip()
+                title = (row.get("title") or "").strip()
+                add_lineage_result(
+                    sid,
+                    {
+                        "snippet": preview or title,
+                        "title": title,
+                        "role": None,
+                        "source": row.get("source"),
+                        "model": row.get("model"),
+                        "session_started": row.get("started_at"),
+                    },
+                )
+
             # Auto-add prefix wildcards so partial words match
             # e.g. "nimb" → "nimb*" matches "nimby"
             # Preserve quoted phrases and existing wildcards as-is

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4292,22 +4292,26 @@ async def search_sessions(q: str = "", limit: int = 20, profile: Optional[str] =
                     },
                 )
 
-            # Title matches second: titles are human-assigned intent (`/title`
-            # on any platform, desktop rename, auto-titling), so a title hit
-            # outranks a message-content hit. This makes a session titled from
-            # another surface findable in desktop search even after it scrolls
-            # out of the sidebar's loaded window.
+            # Title/channel/platform matches second: titles are human-assigned
+            # intent (`/title` on any platform, desktop rename, auto-titling),
+            # and the display path carries the platform channel/thread names
+            # (e.g. "Daemonarchy / #general / My Thread"), so these hits
+            # outrank message-content hits. This is what makes "general
+            # discord" find that channel's sessions from the desktop app even
+            # when no title says so.
             for row in db.search_sessions_by_title(
                 q, limit=safe_limit, include_archived=True
             ):
                 sid = row.get("id")
                 preview = (row.get("preview") or "").strip()
                 title = (row.get("title") or "").strip()
+                display_name = (row.get("display_name") or "").strip()
                 add_lineage_result(
                     sid,
                     {
-                        "snippet": preview or title,
+                        "snippet": preview or title or display_name,
                         "title": title,
+                        "display_name": display_name or None,
                         "role": None,
                         "source": row.get("source"),
                         "model": row.get("model"),

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -78,6 +78,36 @@ _COMPRESSION_CHILD_SQL = (
 # compression continuations stay hidden).
 _LISTABLE_CHILD_SQL = f"(s.parent_session_id IS NULL OR {_BRANCH_CHILD_SQL.format(a='s')})"
 
+# Platform names + common aliases → sessions.source values, so cross-surface
+# search understands "discord" / "tg" / "imessage" as platform intent. Kept in
+# sync with the desktop sidebar's SOURCE_LABELS/SOURCE_ALIASES
+# (apps/desktop/src/lib/session-source.ts).
+_PLATFORM_SEARCH_ALIASES: Dict[str, str] = {
+    "bluebubbles": "bluebubbles",
+    "imessage": "bluebubbles",
+    "cli": "cli",
+    "codex": "codex",
+    "desktop": "desktop",
+    "discord": "discord",
+    "email": "email",
+    "matrix": "matrix",
+    "mattermost": "mattermost",
+    "qq": "qqbot",
+    "qqbot": "qqbot",
+    "signal": "signal",
+    "slack": "slack",
+    "sms": "sms",
+    "telegram": "telegram",
+    "tg": "telegram",
+    "tui": "tui",
+    "webhook": "webhook",
+    "wechat": "weixin",
+    "weixin": "weixin",
+    "whatsapp": "whatsapp",
+    "wa": "whatsapp",
+    "yuanbao": "yuanbao",
+}
+
 
 def _ephemeral_child_sql(alias: str = "s") -> str:
     """Subagent runs (cascade-delete targets), not branches or compression tips."""
@@ -5129,14 +5159,25 @@ class SessionDB:
         limit: int = 20,
         include_archived: bool = True,
     ) -> List[Dict[str, Any]]:
-        """Search surfaced sessions by case-insensitive title substring.
+        """Search surfaced sessions by title, channel/thread name, and platform.
 
         Titles are human-assigned intent (``/title`` on any platform, the
         desktop rename action, auto-titling), so a title hit should outrank a
-        message-content hit in cross-surface search. Matches rank exact >
-        prefix > substring, tiebroken by recency (``started_at`` DESC), and
-        only listable rows are returned (sub-agent runs and compression
-        continuations excluded, matching the sidebar visibility contract).
+        message-content hit in cross-surface search. Beyond titles, sessions
+        born on messaging platforms carry ``display_name`` (the gateway's
+        presentation path, e.g. ``"Daemonarchy / #general / My Thread"``) and
+        ``source`` (the platform id) — both are searched so a query like
+        ``"general discord"`` surfaces that channel's sessions even when no
+        title mentions it.
+
+        Matching is per-token with partial credit: every whitespace token that
+        hits the title, the display path, or the platform name/alias counts.
+        Rows matching more tokens rank first; ties break on where the best
+        match landed (whole-phrase title exact > prefix > substring > token in
+        title > token in channel/thread path > platform-only), then recency
+        (``started_at`` DESC). Only listable rows are returned (sub-agent runs
+        and compression continuations excluded, matching the sidebar
+        visibility contract).
 
         A plain ``LIKE`` scan is deliberate: ``sessions`` is a small table
         (tens of thousands of rows), so no FTS index is warranted.
@@ -5145,45 +5186,93 @@ class SessionDB:
         if not needle or limit <= 0:
             return []
 
-        like_pattern = (
-            "%"
-            + needle.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-            + "%"
-        )
+        tokens = [t for t in needle.split() if t]
+
+        def _like(term: str) -> str:
+            return (
+                "%"
+                + term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+                + "%"
+            )
+
+        # Candidate fetch: any token substring-hits title or display_name, or
+        # names a platform. Python does the real ranking; SQL just narrows.
+        or_clauses: List[str] = []
+        params: List[Any] = []
+        platform_sources: set = set()
+        for tok in tokens:
+            or_clauses.append("LOWER(COALESCE(s.title, '')) LIKE ? ESCAPE '\\'")
+            params.append(_like(tok))
+            or_clauses.append(
+                "LOWER(COALESCE(s.display_name, '')) LIKE ? ESCAPE '\\'"
+            )
+            params.append(_like(tok))
+            src = _PLATFORM_SEARCH_ALIASES.get(tok)
+            if src:
+                platform_sources.add(src)
+        if platform_sources:
+            marks = ",".join("?" for _ in platform_sources)
+            or_clauses.append(f"s.source IN ({marks})")
+            params.extend(sorted(platform_sources))
+
         where = [
-            "s.title IS NOT NULL",
-            "TRIM(s.title) != ''",
-            "LOWER(s.title) LIKE ? ESCAPE '\\'",
+            f"({' OR '.join(or_clauses)})",
+            # Findable rows carry human-facing text: a title or a display path.
+            "(COALESCE(TRIM(s.title), '') != '' OR "
+            " COALESCE(TRIM(s.display_name), '') != '')",
             _LISTABLE_CHILD_SQL,
             f"{_delegate_from_json('s.model_config')} IS NULL",
         ]
-        params: List[Any] = [like_pattern]
         if not include_archived:
             where.append("s.archived = 0")
 
         with self._lock:
             rows = self._conn.execute(
-                "SELECT s.id, s.title, s.source, s.model, s.started_at, "
+                "SELECT s.id, s.title, s.display_name, s.source, s.model, "
+                "s.started_at, "
                 "(SELECT m.content FROM messages m "
                 " WHERE m.session_id = s.id AND m.role = 'user' "
                 " ORDER BY m.timestamp ASC LIMIT 1) AS preview "
                 f"FROM sessions s WHERE {' AND '.join(where)} "
                 "ORDER BY s.started_at DESC "
                 "LIMIT ?",
-                params + [max(limit * 4, limit)],
+                params + [max(limit * 8, 80)],
             ).fetchall()
 
-        def score(row) -> int:
+        def score(row) -> tuple:
             title = (row["title"] or "").strip().lower()
+            display = (row["display_name"] or "").strip().lower()
+            source = (row["source"] or "").strip().lower()
+            matched = 0
+            best_tier = 6
+            for tok in tokens:
+                tiers = []
+                if tok in title:
+                    tiers.append(3)
+                if tok in display:
+                    tiers.append(4)
+                if _PLATFORM_SEARCH_ALIASES.get(tok) == source:
+                    tiers.append(5)
+                if tiers:
+                    matched += 1
+                    best_tier = min(best_tier, *tiers)
+            # Whole-phrase title tiers preserve the historical contract that
+            # an exact/prefix title hit beats everything else.
             if title == needle:
-                return 0
-            if title.startswith(needle):
-                return 1
-            return 2
+                best_tier = 0
+            elif title.startswith(needle):
+                best_tier = 1
+            elif needle in title:
+                best_tier = 2
+            return (-matched, best_tier)
 
-        ranked = sorted(enumerate(rows), key=lambda item: (score(item[1]), item[0]))
+        ranked = sorted(
+            enumerate(rows), key=lambda item: (*score(item[1]), item[0])
+        )
         out: List[Dict[str, Any]] = []
         for _, row in ranked[:limit]:
+            if score(row)[0] == 0:
+                continue  # candidate row that no token actually scored on
             d = dict(row)
             preview = (d.get("preview") or "").strip()
             d["preview"] = preview[:200] if preview else ""

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5123,6 +5123,73 @@ class SessionDB:
         )
         return [row for _, row in ranked[:limit]]
 
+    def search_sessions_by_title(
+        self,
+        query: str,
+        limit: int = 20,
+        include_archived: bool = True,
+    ) -> List[Dict[str, Any]]:
+        """Search surfaced sessions by case-insensitive title substring.
+
+        Titles are human-assigned intent (``/title`` on any platform, the
+        desktop rename action, auto-titling), so a title hit should outrank a
+        message-content hit in cross-surface search. Matches rank exact >
+        prefix > substring, tiebroken by recency (``started_at`` DESC), and
+        only listable rows are returned (sub-agent runs and compression
+        continuations excluded, matching the sidebar visibility contract).
+
+        A plain ``LIKE`` scan is deliberate: ``sessions`` is a small table
+        (tens of thousands of rows), so no FTS index is warranted.
+        """
+        needle = (query or "").strip().lower()
+        if not needle or limit <= 0:
+            return []
+
+        like_pattern = (
+            "%"
+            + needle.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+            + "%"
+        )
+        where = [
+            "s.title IS NOT NULL",
+            "TRIM(s.title) != ''",
+            "LOWER(s.title) LIKE ? ESCAPE '\\'",
+            _LISTABLE_CHILD_SQL,
+            f"{_delegate_from_json('s.model_config')} IS NULL",
+        ]
+        params: List[Any] = [like_pattern]
+        if not include_archived:
+            where.append("s.archived = 0")
+
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT s.id, s.title, s.source, s.model, s.started_at, "
+                "(SELECT m.content FROM messages m "
+                " WHERE m.session_id = s.id AND m.role = 'user' "
+                " ORDER BY m.timestamp ASC LIMIT 1) AS preview "
+                f"FROM sessions s WHERE {' AND '.join(where)} "
+                "ORDER BY s.started_at DESC "
+                "LIMIT ?",
+                params + [max(limit * 4, limit)],
+            ).fetchall()
+
+        def score(row) -> int:
+            title = (row["title"] or "").strip().lower()
+            if title == needle:
+                return 0
+            if title.startswith(needle):
+                return 1
+            return 2
+
+        ranked = sorted(enumerate(rows), key=lambda item: (score(item[1]), item[0]))
+        out: List[Dict[str, Any]] = []
+        for _, row in ranked[:limit]:
+            d = dict(row)
+            preview = (d.get("preview") or "").strip()
+            d["preview"] = preview[:200] if preview else ""
+            out.append(d)
+        return out
+
     def search_sessions(
         self,
         source: str = None,

--- a/tests/hermes_cli/test_web_server_session_search.py
+++ b/tests/hermes_cli/test_web_server_session_search.py
@@ -27,6 +27,11 @@ class _FakeSessionDB:
             }
         ]
 
+    def search_sessions_by_title(self, query, limit=20, include_archived=True):
+        assert query == "20260603"
+        assert include_archived is True
+        return []
+
     def search_messages(self, query, limit=20):
         assert query == "20260603*"
         return [
@@ -88,3 +93,66 @@ def test_desktop_session_search_merges_id_matches_before_content_matches(monkeyp
             },
         ]
     }
+
+
+class _FakeTitleSessionDB:
+    """Fake proving title matches rank above content matches and dedupe."""
+
+    def search_sessions_by_id(self, query, limit=20, include_archived=True):
+        return []
+
+    def search_sessions_by_title(self, query, limit=20, include_archived=True):
+        assert query == "portal"
+        assert include_archived is True
+        return [
+            {
+                "id": "titled_session",
+                "title": "DNS Portal Investigation",
+                "preview": "first user message",
+                "source": "discord",
+                "model": "claude",
+                "started_at": 300,
+            }
+        ]
+
+    def search_messages(self, query, limit=20):
+        assert query == "portal*"
+        return [
+            {
+                "session_id": "titled_session",
+                "snippet": "portal mentioned in content",
+                "role": "user",
+                "source": "discord",
+                "model": "claude",
+                "session_started": 300,
+            },
+            {
+                "session_id": "content_only",
+                "snippet": "another portal content hit",
+                "role": "assistant",
+                "source": "cli",
+                "model": "gpt",
+                "session_started": 400,
+            },
+        ]
+
+    def get_session(self, session_id):
+        return {"id": session_id, "parent_session_id": None}
+
+    def get_compression_tip(self, session_id):
+        return session_id
+
+    def close(self):
+        pass
+
+
+def test_desktop_session_search_ranks_title_matches_before_content_matches(monkeypatch):
+    monkeypatch.setattr("hermes_state.SessionDB", _FakeTitleSessionDB)
+
+    response = asyncio.run(web_server.search_sessions(q="portal", limit=5))
+
+    results = response["results"]
+    assert [r["session_id"] for r in results] == ["titled_session", "content_only"]
+    assert results[0]["title"] == "DNS Portal Investigation"
+    assert results[0]["snippet"] == "first user message"
+    assert len(results) == 2

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2051,6 +2051,63 @@ class TestSearchSessions:
         assert page1[0]["id"] != page2[0]["id"]
 
 
+class TestSearchSessionsByTitle:
+    def test_substring_case_insensitive(self, db):
+        db.create_session(session_id="s1", source="discord")
+        db.set_session_title("s1", "DNS Blocking Portal Investigation")
+        db.create_session(session_id="s2", source="cli")
+        db.set_session_title("s2", "Unrelated work")
+
+        hits = db.search_sessions_by_title("blocking portal")
+        assert [h["id"] for h in hits] == ["s1"]
+        assert hits[0]["title"] == "DNS Blocking Portal Investigation"
+        assert hits[0]["source"] == "discord"
+
+    def test_ranking_exact_prefix_substring(self, db):
+        db.create_session(session_id="sub", source="cli")
+        db.set_session_title("sub", "About deploy stuff")
+        db.create_session(session_id="pre", source="cli")
+        db.set_session_title("pre", "Deploy pipeline")
+        db.create_session(session_id="exact", source="cli")
+        db.set_session_title("exact", "Deploy")
+
+        hits = db.search_sessions_by_title("deploy")
+        assert [h["id"] for h in hits] == ["exact", "pre", "sub"]
+
+    def test_untitled_and_nonmatching_excluded(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.create_session(session_id="s2", source="cli")
+        db.set_session_title("s2", "Something else entirely")
+
+        assert db.search_sessions_by_title("needle") == []
+
+    def test_like_wildcards_escaped(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.set_session_title("s1", "100% coverage plan")
+        db.create_session(session_id="s2", source="cli")
+        db.set_session_title("s2", "1000 things")
+
+        hits = db.search_sessions_by_title("100%")
+        assert [h["id"] for h in hits] == ["s1"]
+
+    def test_subagent_children_hidden(self, db):
+        db.create_session(session_id="parent", source="cli")
+        db.set_session_title("parent", "Visible needle session")
+        db.create_session(
+            session_id="child", source="subagent", parent_session_id="parent"
+        )
+        db.set_session_title("child", "Hidden needle child")
+
+        hits = db.search_sessions_by_title("needle")
+        assert [h["id"] for h in hits] == ["parent"]
+
+    def test_empty_query_returns_nothing(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.set_session_title("s1", "Anything")
+        assert db.search_sessions_by_title("") == []
+        assert db.search_sessions_by_title("   ") == []
+
+
 # =========================================================================
 # Counts
 # =========================================================================

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2101,6 +2101,58 @@ class TestSearchSessionsByTitle:
         hits = db.search_sessions_by_title("needle")
         assert [h["id"] for h in hits] == ["parent"]
 
+    def _make_discord_thread(self, db, session_id, display_name):
+        db.create_session(session_id=session_id, source="discord")
+        db.record_gateway_session_peer(
+            session_id,
+            source="discord",
+            session_key=f"agent:main:discord:thread:{session_id}",
+            chat_id="123",
+            display_name=display_name,
+        )
+
+    def test_channel_and_thread_names_match(self, db):
+        self._make_discord_thread(
+            db, "s1", "Daemonarchy / #voice-assitant / Desktop App"
+        )
+        db.create_session(session_id="s2", source="cli")
+        db.set_session_title("s2", "Unrelated work")
+
+        # Channel name (with its typo) found per-token — no title needed.
+        hits = db.search_sessions_by_title("voice")
+        assert [h["id"] for h in hits] == ["s1"]
+        assert hits[0]["display_name"] == "Daemonarchy / #voice-assitant / Desktop App"
+
+        # Thread name findable the same way.
+        hits = db.search_sessions_by_title("desktop app")
+        assert "s1" in [h["id"] for h in hits]
+
+    def test_platform_token_boosts_platform_sessions(self, db):
+        self._make_discord_thread(db, "dc", "Daemonarchy / #general")
+        db.create_session(session_id="tg", source="telegram")
+        db.set_session_title("tg", "General chatter")
+
+        # "general discord": both match "general", but the discord session
+        # matches BOTH tokens (channel + platform) so it ranks first.
+        hits = db.search_sessions_by_title("general discord")
+        assert [h["id"] for h in hits][:2] == ["dc", "tg"]
+
+    def test_platform_only_query_matches_platform_sessions(self, db):
+        self._make_discord_thread(db, "dc", "Daemonarchy / #random")
+        db.create_session(session_id="cli1", source="cli")
+        db.set_session_title("cli1", "No platform words here")
+
+        hits = db.search_sessions_by_title("discord")
+        assert [h["id"] for h in hits] == ["dc"]
+
+    def test_title_hits_still_outrank_channel_hits(self, db):
+        self._make_discord_thread(db, "chan", "Daemonarchy / #deploy-notes")
+        db.create_session(session_id="titled", source="cli")
+        db.set_session_title("titled", "Deploy pipeline")
+
+        hits = db.search_sessions_by_title("deploy")
+        assert [h["id"] for h in hits] == ["titled", "chan"]
+
     def test_empty_query_returns_nothing(self, db):
         db.create_session(session_id="s1", source="cli")
         db.set_session_title("s1", "Anything")


### PR DESCRIPTION
## What
Adds title-based search over the desktop session list, with ranking. Users with large session lists (thousands) can't currently find a session by name from the sidebar.

## Changes
- **Backend:** `hermes_state.search_sessions_by_title()` — SQL LIKE with wildcard-escaping (`100%` matches literally), hides subagent-child sessions, empty/whitespace query returns nothing. New `web_server` search endpoint.
- **Desktop:** ranking wired into `session-search.ts`; types updated.

## Verification
`scripts/run_tests.sh` (this branch on current `origin/main`): **363 pass** incl. 6 new title-search tests (wildcard-escape, subagent-hidden, empty-query, non-matching-excluded). Desktop `vitest session-search`: **22 pass**. +293/-4, 8 files.
