### PR TITLE
fix(bash): graceful cd fallback when sandbox CWD is deleted

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -80,14 +80,35 @@ class TestWrapCommand:
         env._snapshot_ready = True
         wrapped = env._wrap_command("pwd", "-demo")
 
-        assert "builtin cd -- -demo || exit 126" in wrapped
+        assert "builtin cd -- -demo 2>/dev/null || { cd \"$HOME\" 2>/dev/null || cd /; }" in wrapped
 
-    def test_cd_failure_exit_126(self):
+    def test_cd_failure_graceful_fallback(self):
         env = _TestableEnv()
         env._snapshot_ready = True
         wrapped = env._wrap_command("ls", "/nonexistent")
 
-        assert "exit 126" in wrapped
+        assert "exit 126" not in wrapped
+        assert "cd \"$HOME\" 2>/dev/null || cd /" in wrapped
+
+    def test_cd_success_no_fallback_damages_flow(self):
+        env = _TestableEnv()
+        env._snapshot_ready = True
+        wrapped = env._wrap_command("echo ok", "/tmp")
+
+        cd_line = next(l for l in wrapped.split("\n") if "builtin cd" in l)
+        eval_line = next(l for l in wrapped.split("\n") if "eval" in l)
+        assert wrapped.index(cd_line) < wrapped.index(eval_line)
+        assert "cd -- /tmp" in cd_line or "cd -- '/tmp'" in cd_line
+        assert "cd \"$HOME\" 2>/dev/null || cd /" in cd_line
+
+    def test_exit_code_propagated_after_cd_fallback(self):
+        env = _TestableEnv()
+        env._snapshot_ready = True
+        wrapped = env._wrap_command("false", "/nonexistent")
+
+        assert "__hermes_ec=$?" in wrapped
+        assert "exit $__hermes_ec" in wrapped
+        assert "exit 126" not in wrapped
 
 
 class TestAtomicSnapshotWrite:

--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -303,7 +303,7 @@ class TestWrapCommandWindowsNativeCwd:
         env._snapshot_ready = True
         wrapped = env._wrap_command("pwd", r"C:\Users\liush")
 
-        assert "builtin cd -- /c/Users/liush || exit 126" in wrapped
+        assert "builtin cd -- /c/Users/liush 2>/dev/null || { cd \"$HOME\" 2>/dev/null || cd /; }" in wrapped
         assert r"builtin cd -- C:\Users\liush || exit 126" not in wrapped
 
     def test_init_session_bootstrap_converts_native_cwd_for_cd(self, monkeypatch):

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -498,7 +498,7 @@ class BaseEnvironment(ABC):
         # ``$HOME`` so suffixes with spaces remain a single shell word.
         quoted_cwd = self._quote_cwd_for_cd(cwd)
         # ``--`` keeps hyphen-prefixed directory names from being parsed as options.
-        parts.append(f"builtin cd -- {quoted_cwd} || exit 126")
+        parts.append(f"builtin cd -- {quoted_cwd} 2>/dev/null || {{ cd \"$HOME\" 2>/dev/null || cd /; }}")
 
         # Run the actual command
         parts.append(f"eval '{escaped}'")


### PR DESCRIPTION
## What

When a terminal sandbox (e.g., Docker container) is recreated and the current working directory is deleted, `_wrap_command()` in `tools/environments/base.py` does `builtin cd -- {cwd} || exit 126`. This permanently breaks all subsequent commands — even though `init_session()` already handles the same case gracefully with `|| true`.

## Related Issue

Closes #62169

## Type of Change

- [x] Bug fix

## Changes Made

Replaced `exit 126` with a graceful fallback chain:

```bash
builtin cd -- {cwd} 2>/dev/null || { cd "$HOME" 2>/dev/null || cd /; }
```

If CWD is deleted, the shell falls back to `$HOME`, then `/`. The command still runs and its exit code is correctly captured via `__hermes_ec=$?`.

- `tools/environments/base.py` — 1-line change in `_wrap_command()`
- `tests/tools/test_base_environment.py` — 3 updated + 2 new tests (graceful fallback, exit-code propagation)
- `tests/tools/test_local_env_windows_msys.py` — 1 updated assertion

## How to Test

```bash
scripts/run_tests.sh tests/tools/test_base_environment.py tests/tools/test_local_env_windows_msys.py
```

57 tests pass.

## Checklist

- [x] Tests pass (57 test cases)
- [x] Changes limited to files needed
- [x] Conventional commit: `fix(bash): ...`