### PR TITLE
fix(codex): normalize runtime base URLs

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -122,6 +122,22 @@ QWEN_OAUTH_CLIENT_ID = "f0304373b74a44d2b584a3fb70ca9e56"
 QWEN_OAUTH_TOKEN_URL = "https://chat.qwen.ai/api/v1/oauth2/token"
 QWEN_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
 DEFAULT_SPOTIFY_ACCOUNTS_BASE_URL = "https://accounts.spotify.com"
+
+
+def normalize_codex_base_url(base_url: str) -> str:
+    """Normalize Codex base URLs to the endpoint shape Hermes expects."""
+    normalized = str(base_url or "").strip().rstrip("/")
+    if not normalized:
+        return DEFAULT_CODEX_BASE_URL
+    if normalized.endswith("/codex/responses"):
+        return normalized[: -len("/responses")]
+    if normalized.endswith("/codex"):
+        return normalized
+    if normalized.endswith("/backend-api/v1"):
+        normalized = normalized[: -len("/v1")]
+    if normalized.endswith("/backend-api"):
+        return f"{normalized}/codex"
+    return normalized
 DEFAULT_SPOTIFY_API_BASE_URL = "https://api.spotify.com/v1"
 DEFAULT_SPOTIFY_REDIRECT_URI = "http://127.0.0.1:43827/spotify/callback"
 SPOTIFY_DOCS_URL = "https://hermes-agent.nousresearch.com/docs/user-guide/features/spotify"
@@ -3715,7 +3731,7 @@ def resolve_codex_runtime_credentials(
                 tokens = _refresh_codex_auth_tokens(tokens, refresh_timeout_seconds)
                 access_token = str(tokens.get("access_token", "") or "").strip()
 
-    base_url = (
+    base_url = normalize_codex_base_url(
         os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
         or DEFAULT_CODEX_BASE_URL
     )

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -22,6 +22,7 @@ from hermes_cli.auth import (
     _agent_key_is_usable,
     _nous_inference_env_override,
     format_auth_error,
+    normalize_codex_base_url,
     resolve_provider,
     resolve_nous_runtime_credentials,
     resolve_codex_runtime_credentials,
@@ -411,7 +412,7 @@ def _resolve_runtime_from_pool_entry(
     api_mode = "chat_completions"
     if provider == "openai-codex":
         api_mode = "codex_responses"
-        base_url = base_url or DEFAULT_CODEX_BASE_URL
+        base_url = normalize_codex_base_url(base_url or DEFAULT_CODEX_BASE_URL)
     elif provider == "xai-oauth":
         api_mode = "codex_responses"
         base_url = base_url or DEFAULT_XAI_OAUTH_BASE_URL
@@ -1392,7 +1393,7 @@ def _resolve_explicit_runtime(
         }
 
     if provider == "openai-codex":
-        base_url = explicit_base_url or DEFAULT_CODEX_BASE_URL
+        base_url = normalize_codex_base_url(explicit_base_url or DEFAULT_CODEX_BASE_URL)
         api_key = explicit_api_key
         last_refresh = None
         if not api_key:
@@ -1400,7 +1401,9 @@ def _resolve_explicit_runtime(
             api_key = creds.get("api_key", "")
             last_refresh = creds.get("last_refresh")
             if not explicit_base_url:
-                base_url = creds.get("base_url", "").rstrip("/") or base_url
+                base_url = normalize_codex_base_url(
+                    creds.get("base_url", "").rstrip("/") or base_url
+                )
         return {
             "provider": "openai-codex",
             "api_mode": "codex_responses",


### PR DESCRIPTION
## Summary
- normalize Codex URLs that end in `/codex/responses` to the `/codex` base
- normalize `/backend-api` and `/backend-api/v1` inputs to the Codex endpoint
- apply the normalization consistently to environment, pool, and explicit runtime credentials

## Tests
- `pytest -q tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_auth_codex_provider.py` (181 passed)
- Codex auxiliary regression tests (9 passed)
- `pytest -q tests/run_agent/test_run_agent_codex_responses.py` (85 passed)