### PR TITLE
fix(google_meet): add timeout to all subprocess.run calls in audio_bridge

### DIFF
--- a/plugins/google_meet/audio_bridge.py
+++ b/plugins/google_meet/audio_bridge.py
@@ -84,6 +84,7 @@ class AudioBridge:
                 try:
                     subprocess.run(
                         ["pactl", "unload-module", str(mod_id)],
+                        timeout=5,
                         check=False,
                         capture_output=True,
                         stdin=subprocess.DEVNULL,
@@ -109,6 +110,7 @@ class AudioBridge:
                     f"sink_name={sink_name}",
                     "sink_properties=device.description=HermesMeetSink",
                 ],
+                timeout=15,
                 check=True,
                 capture_output=True,
                 text=True,
@@ -134,6 +136,7 @@ class AudioBridge:
                     f"source_name={src_name}",
                     f"master={sink_name}.monitor",
                 ],
+                timeout=15,
                 check=True,
                 capture_output=True,
                 text=True,
@@ -143,6 +146,7 @@ class AudioBridge:
             # Roll back the null-sink we just created so we don't leak it.
             subprocess.run(
                 ["pactl", "unload-module", str(sink_mod_id)],
+                timeout=5,
                 check=False,
                 capture_output=True,
                 stdin=subprocess.DEVNULL,


### PR DESCRIPTION
## Summary

Added `timeout` to all 4 `subprocess.run()` calls in `plugins/google_meet/audio_bridge.py`.

## Problem

The `pactl` subprocess calls for creating/unloading virtual audio devices had no `timeout`. If PulseAudio/pipewire is in a bad state (common on Linux after suspend or pulse crash), these calls block forever, freezing the entire agent turn since the gateway process waits for the subprocess to return.

## Fix

- `_setup_linux()` load-module calls: `timeout=15` (reasonable for audio device creation)
- `teardown()` unload-module call: `timeout=5` (should be near-instant)
- Rollback unload-module on virtual-source failure: `timeout=5` (same)

## Testing
- Syntax check passed (py_compile)
- Behavior verified