### PR TITLE
fix(desktop): render description on inline approval card for plugin approvals

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
@@ -71,6 +71,16 @@ describe('PendingToolApproval', () => {
     expect(screen.getByRole('button', { name: /Reject/ })).toBeTruthy()
   })
 
+  it('shows description as context on the inline card for dangerous commands', () => {
+    setRequest('rm -rf /tmp/x')
+    render(<PendingToolApproval part={part('terminal')} />)
+
+    // The description ("dangerous command" from setRequest) is rendered.
+    expect(screen.getByText('dangerous command')).toBeTruthy()
+    // The Command toggle is present for real commands.
+    expect(screen.getByRole('button', { name: /Command/ })).toBeTruthy()
+  })
+
   it('sends approval.respond {choice: "once"} and clears the request on Run', async () => {
     const request = mockGateway()
     setRequest()
@@ -95,6 +105,24 @@ describe('PendingToolApproval', () => {
     fireEvent.click(screen.getByRole('button', { name: /Command/ }))
 
     expect(screen.getByText(longCommand)).toBeTruthy()
+  })
+
+  it('renders description on the inline card for plugin approvals', () => {
+    // Plugin approvals set `command` to a synthetic label; the real info is in
+    // `description`. The inline card must surface it so the user can see what
+    // they're approving (issue #62402).
+    $activeSessionId.set('sess-1')
+    setApprovalRequest({
+      command: '<terminal> (plugin approval rule)',
+      description: 'Plugin requires approval: run\npwd',
+      sessionId: 'sess-1'
+    })
+    render(<PendingToolApproval part={part('terminal')} />)
+
+    // Description is rendered as a context line on the inline card.
+    expect(screen.getByText(/Plugin requires approval: run.*pwd/)).toBeTruthy()
+    // The "Command" toggle must NOT appear — the synthetic label is useless.
+    expect(screen.queryByRole('button', { name: /Command/ })).toBeNull()
   })
 
   it('sends choice "deny" on Reject', async () => {

--- a/apps/desktop/src/components/assistant-ui/tool/approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.tsx
@@ -110,7 +110,12 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
   const busy = submitting !== null
   // false when the backend won't honor a permanent allow (tirith warning) → hide "Always allow".
   const allowPermanent = request.allowPermanent !== false
-  const hasCommand = request.command.trim().length > 0
+  // Plugin approvals set `command` to a synthetic label like
+  // "<terminal> (plugin approval rule)" — the real info lives in `description`.
+  // Hide the command expander in that case and let `description` carry the text.
+  const isSyntheticCommand = request.command.trim().startsWith('<')
+  const hasCommand = !isSyntheticCommand && request.command.trim().length > 0
+  const hasDescription = request.description.trim().length > 0
 
   const respond = useCallback(
     async (choice: ApprovalChoice) => {
@@ -171,6 +176,9 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
       className={cn(surface === 'inline' ? 'mt-1 ps-5' : 'mt-2')}
       data-slot={surface === 'inline' ? 'tool-approval-inline' : 'tool-approval-actions'}
     >
+      {hasDescription && (
+        <p className="mb-1.5 text-xs text-(--ui-text-tertiary)">{request.description.trim()}</p>
+      )}
       <div className="flex items-center gap-2.5">
         <div className="inline-flex h-6 items-stretch overflow-hidden rounded-md border border-primary/25 bg-primary/10 text-primary">
           <Button
@@ -255,7 +263,7 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
             <DialogDescription>{copy.alwaysDescription(request.description)}</DialogDescription>
           </DialogHeader>
 
-          {request.command.trim() && (
+          {hasCommand && (
             <pre className="max-h-32 overflow-auto whitespace-pre-wrap break-words rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-chat-surface-background) px-2.5 py-1.5 font-mono text-xs leading-snug text-foreground">
               {request.command.trim()}
             </pre>


### PR DESCRIPTION
## What does this PR do?

Fixes the desktop inline approval card showing a useless placeholder (`<terminal> (plugin approval rule)`) instead of the actual approval context when a plugin `pre_tool_call` hook escalates a tool call to the human-approval gate.

When a plugin returns `{"action": "approve"}`, the backend (`tools/approval.py:request_tool_approval`) sets the approval's `command` field to a synthetic label and puts the real info in `description`. The inline `ApprovalBar` only rendered `command` (in the "Command" expander) and never showed `description`, so users approved without seeing what they were approving.

## Related Issue

Fixes #62402

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/components/assistant-ui/tool/approval.tsx`:
  - Render `description` as a context `<p>` line on the inline `ApprovalBar` (the floating fallback bar already did this)
  - Detect synthetic plugin commands (starting with `<`) via `isSyntheticCommand` and set `hasCommand = false` for those, hiding the "Command" toggle and the `<pre>` block in the "Always allow" dialog
  - Use `hasCommand` consistently in the "Always allow" dialog instead of raw `request.command.trim()`

## How to Test

1. Add a `pre_tool_call` plugin rule that returns `{"action": "approve"}` for a command-bearing tool (e.g. `terminal`)
2. In the desktop app, trigger a tool call that matches the rule
3. On the inline approval card, the plugin's reason text (from `description`) is now visible as a context line
4. The "Command" toggle is hidden (the synthetic `<terminal> (plugin approval rule)` label is no longer shown)
5. For regular dangerous-command approvals (non-synthetic `command`), the description is also shown as context, and the "Command" toggle still works as before

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run tests and all tests pass (`vitest run --environment jsdom` — 18/18 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS (Linux)

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed
