### PR TITLE
fix(cli): preserve model overrides before chat subcommand

### DIFF
--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -271,12 +271,27 @@ def build_top_level_parser():
     chat_parser.add_argument(
         "--image", help="Optional local image path to attach to a single query"
     )
+    # `default=argparse.SUPPRESS` on flags that are ALSO declared on the
+    # top-level parser: when the user writes `hermes -m foo chat`, argparse
+    # first sets `args.model = "foo"` from the top-level parser, then
+    # dispatches to the chat subparser. Without SUPPRESS the chat subparser's
+    # own default (`None`) would silently clobber the top-level value because
+    # the subparser shares the same namespace and `dest`. SUPPRESS keeps the
+    # subparser action a no-op unless the user actually passes the flag after
+    # the subcommand. Matches the pattern already used for `-s/--skills` and
+    # the relaunch-inherited flags `-r/--resume`, `-c/--continue`,
+    # `-w/--worktree`, `--yolo`, etc. (see tests/hermes_cli/
+    # test_argparse_flag_propagation.py).
     _inherited_flag(
         chat_parser,
-        "-m", "--model", help="Model to use (e.g., anthropic/claude-sonnet-4)",
+        "-m", "--model",
+        default=argparse.SUPPRESS,
+        help="Model to use (e.g., anthropic/claude-sonnet-4)",
     )
     chat_parser.add_argument(
-        "-t", "--toolsets", help="Comma-separated toolsets to enable"
+        "-t", "--toolsets",
+        default=argparse.SUPPRESS,
+        help="Comma-separated toolsets to enable",
     )
     _inherited_flag(
         chat_parser,
@@ -293,7 +308,7 @@ def build_top_level_parser():
         # are also valid values, and runtime resolution (resolve_runtime_provider)
         # handles validation/error reporting consistently with the top-level
         # `--provider` flag.
-        default=None,
+        default=argparse.SUPPRESS,
         help="Inference provider (default: auto). Built-in or a user-defined name from `providers:` in config.yaml.",
     )
     chat_parser.add_argument(
@@ -401,14 +416,14 @@ def build_top_level_parser():
         chat_parser,
         "--tui",
         action="store_true",
-        default=False,
+        default=argparse.SUPPRESS,
         help="Launch the modern TUI instead of the classic REPL",
     )
     _inherited_flag(
         chat_parser,
         "--cli",
         action="store_true",
-        default=False,
+        default=argparse.SUPPRESS,
         help="Force the classic prompt_toolkit REPL (overrides display.interface=tui)",
     )
     _inherited_flag(
@@ -416,7 +431,7 @@ def build_top_level_parser():
         "--dev",
         dest="tui_dev",
         action="store_true",
-        default=False,
+        default=argparse.SUPPRESS,
         help="With --tui: run TypeScript sources via tsx (skip dist build)",
     )
 

--- a/tests/hermes_cli/test_argparse_flag_propagation.py
+++ b/tests/hermes_cli/test_argparse_flag_propagation.py
@@ -219,3 +219,121 @@ print(json.dumps(results))
                 f"stderr: {entry['stderr']}"
             )
             assert "unrecognized arguments" not in entry["stderr"]
+
+
+class TestChatSubparserInheritedValueFlags:
+    """Verify -t/--toolsets, -m/--model and --provider survive parent→chat
+    subparser dispatch.
+
+    Regression test for #28780: `hermes -t web chat` silently dropped the
+    toolset because the chat subparser re-declared `-t/--toolsets` with
+    `default=None`, which clobbered the top-level parser's value during
+    subparser dispatch.
+
+    Uses the real `hermes_cli._parser.build_top_level_parser()` rather than
+    the hand-rolled replica above so this also fails if the production
+    parser drifts back to `default=None` on these flags.
+    """
+
+    @pytest.fixture
+    def real_parser(self):
+        from hermes_cli._parser import build_top_level_parser
+        parser, _subparsers, _chat = build_top_level_parser()
+        return parser
+
+    @pytest.mark.parametrize("flag,attr,value", [
+        ("-t", "toolsets", "web"),
+        ("--toolsets", "toolsets", "web,terminal"),
+        ("-m", "model", "anthropic/claude-sonnet-4"),
+        ("--model", "model", "openai/gpt-4"),
+        ("--provider", "provider", "openrouter"),
+    ])
+    def test_flag_before_chat_is_preserved(self, real_parser, flag, attr, value):
+        args, _ = real_parser.parse_known_args([flag, value, "chat"])
+        assert getattr(args, attr, None) == value, (
+            f"`hermes {flag} {value} chat` lost the flag — got "
+            f"{getattr(args, attr, None)!r}, expected {value!r}"
+        )
+
+    @pytest.mark.parametrize("flag,attr,value", [
+        ("-t", "toolsets", "web"),
+        ("--toolsets", "toolsets", "web,terminal"),
+        ("-m", "model", "anthropic/claude-sonnet-4"),
+        ("--model", "model", "openai/gpt-4"),
+        ("--provider", "provider", "openrouter"),
+    ])
+    def test_flag_after_chat_still_works(self, real_parser, flag, attr, value):
+        args, _ = real_parser.parse_known_args(["chat", flag, value])
+        assert getattr(args, attr, None) == value
+
+    def test_no_flag_leaves_attrs_at_top_level_default(self, real_parser):
+        """When the user passes none of the inherited flags, the top-level
+        parser's `default=None` still seeds the namespace — the SUPPRESS on
+        the subparser must not remove existing attributes."""
+        args, _ = real_parser.parse_known_args(["chat"])
+        assert getattr(args, "toolsets", "MISSING") is None
+        assert getattr(args, "model", "MISSING") is None
+        assert getattr(args, "provider", "MISSING") is None
+
+    def test_all_three_flags_before_chat(self, real_parser):
+        """Issue #28780 reporter's case generalized: passing every inherited
+        value flag before `chat` must preserve all of them simultaneously."""
+        args, _ = real_parser.parse_known_args([
+            "-t", "web",
+            "-m", "anthropic/claude-sonnet-4",
+            "--provider", "openrouter",
+            "chat",
+        ])
+        assert args.toolsets == "web"
+        assert args.model == "anthropic/claude-sonnet-4"
+        assert args.provider == "openrouter"
+
+    @pytest.mark.parametrize("flag,attr", [
+        ("--tui", "tui"),
+        ("--cli", "cli"),
+        ("--dev", "tui_dev"),
+    ])
+    def test_store_true_flag_before_chat_is_preserved(
+        self, real_parser, flag, attr,
+    ):
+        """`--tui` / `--cli` / `--dev` are store_true flags inherited by chat; the same
+        SUPPRESS contract applies. Without it, the subparser's `default=False`
+        would clobber the parent's `True` when used as `hermes --tui chat`."""
+        args, _ = real_parser.parse_known_args([flag, "chat"])
+        assert getattr(args, attr, None) is True, (
+            f"`hermes {flag} chat` lost the flag — got "
+            f"{getattr(args, attr, None)!r}, expected True"
+        )
+
+    def test_chat_subparser_inherited_value_flags_use_suppress(self):
+        """Contract test for the underlying invariant.
+
+        Any chat-subparser flag whose `dest` also exists on the top-level
+        parser MUST declare `default=argparse.SUPPRESS`, otherwise the
+        subparser silently overwrites the top-level value with its own
+        default during dispatch. This is the structural class behind #28780.
+        """
+        from hermes_cli._parser import build_top_level_parser
+        parser, _subparsers, chat_parser = build_top_level_parser()
+
+        top_level_dests = {
+            a.dest for a in parser._actions
+            if a.option_strings and a.dest != "help"
+        }
+
+        offenders = []
+        for action in chat_parser._actions:
+            if not action.option_strings or action.dest == "help":
+                continue
+            if action.dest not in top_level_dests:
+                continue
+            if action.default is not argparse.SUPPRESS:
+                offenders.append((action.option_strings, action.dest, action.default))
+
+        assert not offenders, (
+            "Chat subparser redeclares these top-level flags without "
+            "default=argparse.SUPPRESS; they will silently clobber the "
+            "top-level value when used as `hermes <flag> <value> chat`:\n  "
+            + "\n  ".join(f"{opts} dest={dest} default={d!r}"
+                          for opts, dest, d in offenders)
+        )

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -125,6 +125,51 @@ def test_default_spawn_never_boots_the_tui(monkeypatch, tmp_path):
     assert "HERMES_TUI" not in captured["env"]
 
 
+def test_default_spawn_model_override_survives_real_cli_parse(monkeypatch, tmp_path):
+    """The dispatcher's pre-``chat`` model flag must reach ``args.model``.
+
+    This is an integration contract between Kanban's worker argv builder and
+    the real CLI parser. A parser default once erased the explicit override,
+    silently sending the worker to its profile default or fallback instead.
+    """
+    root = tmp_path / ".hermes"
+    (root / "profiles" / "elias").mkdir(parents=True)
+    root.joinpath("config.yaml").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    from hermes_cli import kanban_db as kb
+    from hermes_cli._parser import build_top_level_parser
+
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+    captured = {}
+
+    class FakeProc:
+        pid = 4244
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["cmd"] = list(cmd)
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    task = _make_task(kb, assignee="elias")
+    task.model_override = "gpt-5.6-sol"
+    kb._default_spawn(task, str(workspace))
+
+    parser, _subparsers, _chat_parser = build_top_level_parser()
+    # Profile selection is attached by the outer CLI bootstrap rather than
+    # build_top_level_parser(); remove that already-validated prefix and parse
+    # the worker flags/subcommand through the real shared parser.
+    assert captured["cmd"][1:3] == ["-p", "elias"]
+    args = parser.parse_args(captured["cmd"][3:])
+
+    assert args.command == "chat"
+    assert args.model == "gpt-5.6-sol"
+    assert args.query == "work kanban task t_spawn_tools"
+
+
 def test_resolve_worker_cli_toolsets_uses_profile_home_not_parent_config(monkeypatch, tmp_path):
     root = tmp_path / ".hermes"
     profile = root / "profiles" / "elias"


### PR DESCRIPTION
## Summary
Kanban workers and other `hermes <flags> chat` invocations now preserve explicit model, provider, toolset, TUI, CLI, and dev flags instead of silently reverting to defaults.

The chat subparser assigned its own absent-value defaults after the root parser had already parsed flags placed before `chat`. That dropped the dispatcher’s `-m <model_override>` and could send a worker to its profile default or configured fallback instead.

## Changes
- `hermes_cli/_parser.py`: make every root/chat shared flag suppress its subparser default so explicit root values survive
- `tests/hermes_cli/test_argparse_flag_propagation.py`: test both flag positions, composition, boolean flags, and the shared-destination invariant against the real parser
- Salvages the earliest complete implementation from #28795 by @briandevans; #28799 independently found the same full bug class, and #61235 later identified the Kanban symptom

## Validation
| | Before | After |
|---|---|---|
| `hermes -m gpt-5.6-sol chat -q ...` | parsed `model=None` | parsed `model=gpt-5.6-sol` |
| `hermes --provider openai-codex chat` | parsed `provider=None` | parsed `provider=openai-codex` |
| `hermes -t web chat` | parsed `toolsets=None` | parsed `toolsets=web` |
| Post-`chat` flags | worked | still work |

- Direct real-parser probe passed for model, provider, and toolsets in both supported positions
- Targeted test file: `tests/hermes_cli/test_argparse_flag_propagation.py`

Fixes #28780.

## Infographic

![kanban-model-routing-override-secured](https://v3b.fal.media/files/b/0aa1c43e/LZK9JSf_v4uO-byr8Ptx8_E46kkm7d.png)
