### PR TITLE
fix(web): retemplate stale env-backed api keys

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -59,6 +59,7 @@ from hermes_cli.config import (
     OPTIONAL_ENV_VARS,
     clear_model_endpoint_credentials,
     get_config_path,
+    get_env_value,
     get_env_path,
     get_hermes_home,
     load_config,
@@ -5209,6 +5210,42 @@ _EMPTY_MODEL_INFO: dict = {
 }
 
 
+def _retemplate_matching_api_keys(obj: Any, *, old_value: str, env_var: str) -> Any:
+    """Replace stale inline ``api_key`` values with ``${ENV_VAR}`` templates."""
+    if isinstance(obj, dict):
+        updated: Dict[str, Any] = {}
+        for key, value in obj.items():
+            if key == "api_key" and isinstance(value, str) and value == old_value:
+                updated[key] = f"${{{env_var}}}"
+            else:
+                updated[key] = _retemplate_matching_api_keys(
+                    value,
+                    old_value=old_value,
+                    env_var=env_var,
+                )
+        return updated
+    if isinstance(obj, list):
+        return [
+            _retemplate_matching_api_keys(item, old_value=old_value, env_var=env_var)
+            for item in obj
+        ]
+    return obj
+
+
+def _scrub_stale_inline_api_keys_for_env_var(env_var: str, old_value: str) -> bool:
+    """Re-template config.yaml api_key fields shadowing a rotated env secret."""
+    if not old_value:
+        return False
+    raw = read_raw_config()
+    if not isinstance(raw, dict) or not raw:
+        return False
+    updated = _retemplate_matching_api_keys(raw, old_value=old_value, env_var=env_var)
+    if updated == raw:
+        return False
+    save_config(updated)
+    return True
+
+
 @app.get("/api/model/info")
 def get_model_info(profile: Optional[str] = None):
     """Return resolved model metadata for the currently configured model.
@@ -6092,7 +6129,17 @@ async def get_env_vars(profile: Optional[str] = None):
 async def set_env_var(body: EnvVarUpdate, profile: Optional[str] = None):
     try:
         with _profile_scope(body.profile or profile):
+            old_value = ""
+            key_upper = body.key.upper()
+            if (
+                OPTIONAL_ENV_VARS.get(body.key, {}).get("password")
+                or key_upper.endswith(("_API_KEY", "_TOKEN"))
+                or key_upper.startswith("TERMINAL_SSH")
+            ):
+                old_value = str(get_env_value(body.key) or "").strip()
             save_env_value(body.key, body.value)
+            if old_value and body.value != old_value:
+                _scrub_stale_inline_api_keys_for_env_var(body.key, old_value)
         return {"ok": True, "key": body.key}
     except ValueError as exc:
         # save_env_value raises ValueError for invalid names and for keys

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1984,6 +1984,44 @@ class TestWebServerEndpoints:
         # Should contain known env var names
         assert any(k.endswith("_API_KEY") or k.endswith("_TOKEN") for k in data.keys())
 
+    def test_put_env_retemplates_stale_inline_api_keys(self):
+        """Updating a provider key via /api/env must stop stale config.yaml
+        literals from shadowing the new .env value."""
+        from hermes_constants import get_hermes_home
+
+        hermes_home = get_hermes_home()
+        (hermes_home / "config.yaml").write_text(
+            "model:\n"
+            "  provider: custom\n"
+            "  base_url: https://proxy.example.com/v1\n"
+            "  api_key: sk-old-inline\n"
+            "providers:\n"
+            "  proxy:\n"
+            "    name: Proxy\n"
+            "    base_url: https://proxy.example.com/v1\n"
+            "    api_key: sk-old-inline\n"
+            "custom_providers:\n"
+            "  - name: Proxy\n"
+            "    base_url: https://proxy.example.com/v1\n"
+            "    api_key: sk-old-inline\n",
+            encoding="utf-8",
+        )
+        (hermes_home / ".env").write_text("OPENAI_API_KEY=sk-old-inline\n", encoding="utf-8")
+
+        resp = self.client.put(
+            "/api/env",
+            json={"key": "OPENAI_API_KEY", "value": "sk-new-live"},
+        )
+        assert resp.status_code == 200
+
+        env_text = (hermes_home / ".env").read_text(encoding="utf-8")
+        config_text = (hermes_home / "config.yaml").read_text(encoding="utf-8")
+
+        assert "OPENAI_API_KEY=sk-new-live" in env_text
+        assert "api_key: ${OPENAI_API_KEY}" in config_text
+        assert "sk-old-inline" not in config_text
+        assert "sk-new-live" not in config_text
+
     def test_get_env_vars_marks_channel_managed_keys(self):
         from hermes_cli.web_server import _channel_managed_env_keys
 


### PR DESCRIPTION
## What does this PR do?

When a user updates an env-backed API key in the web settings UI, Hermes writes the new `.env` value but could leave the old secret copied inline in `config.yaml`. This patch re-templates any matching stale inline `api_key` values back to `${ENV_VAR}` right after the env value changes, which keeps the live config aligned with the updated secret and avoids auth failures caused by the old persisted key.

## Related Issue

Fixes #62269

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add post-update config scrubbing in `hermes_cli/web_server.py` for stale inline `api_key` values that still match the previous env secret
- Re-template matching keys inside nested config dict/list structures instead of overwriting unrelated inline secrets
- Add a regression test in `tests/hermes_cli/test_web_server.py` covering `.env` updates plus `config.yaml` cleanup

## How to Test

1. Run `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/hermes_cli/test_web_server.py -k 'put_env_retemplates_stale_inline_api_keys or get_env_vars'`
2. Run `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/hermes_cli/test_config_env_refs.py`
3. Confirm the new regression keeps `config.yaml` templated as `${OPENAI_API_KEY}` after `PUT /api/env` updates the env secret

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Targeted verification passed:
  - `py_compile` on `hermes_cli/web_server.py` and `tests/hermes_cli/test_web_server.py`
  - `7 passed, 367 deselected` in the targeted web server pytest slice
  - `6 passed` in `tests/hermes_cli/test_config_env_refs.py`
  - `git diff --check`
