### PR TITLE
fix(docker): skip redundant stage2 chown walks

### DIFF
--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -220,6 +220,11 @@ chown_hermes_tree() {
         echo "[stage2] Warning: chown $target failed (rootless container?) — continuing"
 }
 
+tree_has_non_hermes_owner() {
+    target="$1"
+    find "$target" \( ! -user hermes -o ! -group hermes \) -print -quit 2>/dev/null | grep -q .
+}
+
 needs_chown=false
 if [ "$(stat -c %u "$HERMES_HOME" 2>/dev/null)" != "$actual_hermes_uid" ]; then
     needs_chown=true
@@ -243,7 +248,7 @@ if [ "$needs_chown" = true ]; then
     # created and managed exclusively by hermes (see the s6-setuidgid mkdir
     # -p block below for the canonical list).
     for sub in cron sessions logs hooks memories skills skins plans workspace home profiles pairing platforms/pairing lazy-packages; do
-        if [ -e "$HERMES_HOME/$sub" ]; then
+        if [ -e "$HERMES_HOME/$sub" ] && tree_has_non_hermes_owner "$HERMES_HOME/$sub"; then
             chown_hermes_tree "$HERMES_HOME/$sub"
         fi
     done
@@ -273,9 +278,10 @@ fi
 # are invoked via `docker exec <container> hermes …` (which defaults
 # to root unless `-u` is passed), and that breaks the cont-init
 # reconciler (02-reconcile-profiles) which runs as hermes and walks
-# the profiles dir. Idempotent; skipped on rootless containers where
-# chown would fail.
-if [ -d "$HERMES_HOME/profiles" ]; then
+# the profiles dir. Skip the recursive walk when the tree is already
+# owned correctly so warm boots do not rescan huge profile caches.
+# Idempotent; skipped on rootless containers where chown would fail.
+if [ -d "$HERMES_HOME/profiles" ] && tree_has_non_hermes_owner "$HERMES_HOME/profiles"; then
     chown_hermes_tree "$HERMES_HOME/profiles"
 fi
 

--- a/tests/tools/test_stage2_hook_symlink_chown.py
+++ b/tests/tools/test_stage2_hook_symlink_chown.py
@@ -143,3 +143,11 @@ def test_stage2_skips_top_level_chown_for_symlinked_hermes_home(
     stage2_text: str,
 ) -> None:
     assert 'refuse_symlinked_path "chown" "$HERMES_HOME"' in stage2_text
+
+
+def test_stage2_skips_recursive_repairs_when_tree_is_already_owned(
+    stage2_text: str,
+) -> None:
+    assert "tree_has_non_hermes_owner() {" in stage2_text
+    assert 'if [ -e "$HERMES_HOME/$sub" ] && tree_has_non_hermes_owner "$HERMES_HOME/$sub"; then' in stage2_text
+    assert 'if [ -d "$HERMES_HOME/profiles" ] && tree_has_non_hermes_owner "$HERMES_HOME/profiles"; then' in stage2_text


### PR DESCRIPTION
## What does this PR do?

Prevents Docker warm boots from doing expensive recursive `chown -R` walks across Hermes-managed trees when those trees are already owned by `hermes`. The main user-visible win is for large `profiles/` trees: stage2 still repairs ownership when a root-context write actually left mismatched owners behind, but it now skips the recursive scan entirely when the tree is already clean.

## Related Issue

Fixes #62208

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a `tree_has_non_hermes_owner()` helper in `docker/stage2-hook.sh` that cheaply detects whether a tree has any non-`hermes` owner/group entries.
- Gate the targeted stage2 recursive ownership repairs behind that check so `cron`, `logs`, `profiles`, and the other Hermes-managed trees are only walked when ownership actually needs repair.
- Gate the unconditional profile-tree repair path with the same mismatch check so warm boots do not rescan large profile caches unnecessarily.
- Add a regression assertion in `tests/tools/test_stage2_hook_symlink_chown.py` that keeps those ownership guards present.

## How to Test

1. Run `bash -n docker/stage2-hook.sh`.
2. Run `pytest tests/tools/test_stage2_hook_symlink_chown.py -q`.
3. Confirm the new helper and guards are present, and that the existing symlink-safety tests still pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS local checkout with targeted shell/pytest proof

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `bash -n docker/stage2-hook.sh`
- `pytest tests/tools/test_stage2_hook_symlink_chown.py -q` → `7 passed`
- `git diff --check`
