### PR TITLE
fix(xai): recover legacy encrypted replay failures

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1147,6 +1147,7 @@ def _classify_400(
             "encrypted content for item" in error_msg
             and "could not be verified" in error_msg
         )
+        or "could not decrypt the provided encrypted_content" in error_msg
     ):
         return result_fn(
             FailoverReason.invalid_encrypted_content,

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -841,6 +841,26 @@ class TestClassifyApiError:
         assert result.retryable is True
         assert result.should_fallback is False
 
+    def test_xai_invalid_encrypted_content_wording_uses_replay_recovery(self):
+        e = MockAPIError(
+            "Error code: 400 - Could not decrypt the provided encrypted_content. "
+            "Ensure the value is the unmodified encrypted_content from a previous response.",
+            status_code=400,
+            body={
+                "code": "Client specified an invalid argument",
+                "error": (
+                    "Could not decrypt the provided encrypted_content. Ensure the value "
+                    "is the unmodified encrypted_content from a previous response."
+                ),
+            },
+        )
+
+        result = classify_api_error(e, provider="xai-oauth", model="grok-4.3")
+
+        assert result.reason == FailoverReason.invalid_encrypted_content
+        assert result.retryable is True
+        assert result.should_fallback is False
+
     def test_invalid_encrypted_content_broad_message_match_does_not_catch_generic_parse_error(self):
         message = "Encrypted content could not be decrypted or parsed."
         e = MockAPIError(


### PR DESCRIPTION
## Summary
Legacy xAI Responses sessions now recognize xAI's encrypted-replay rejection and retry on the same provider with replay state stripped before fallback.

Prospective cross-provider switches were already protected by issuer tagging, but pre-fix persisted reasoning items are intentionally unstamped. xAI's exact 400 wording did not match the existing `invalid_encrypted_content` classifier, so those sessions still fell through to generic format-error fallback.

## Changes
- Classify `Could not decrypt the provided encrypted_content` as invalid encrypted replay state.
- Reuse the existing one-shot request-local recovery path; no transcript rewrite or provider-locked persistence.
- Add the exact xAI error envelope as a regression.

## Validation
| Check | Result |
|---|---|
| Error classifier + Responses recovery suites | 324 passed |
| RED regression before fix | Exact xAI message classified as `format_error` |
| GREEN regression after fix | Same-provider replay recovery selected |
| `git diff --check` | Clean |

Closes the remaining legacy-session edge of #32617.

## Infographic

![Legacy replay recovery](https://v3b.fal.media/files/b/0aa1c472/_dXFKlkw2hzpljeJIBUA3_FeRLAzCs.png)
