### PR TITLE
test(model): isolate custom-provider grouping tests from live discovery

### DIFF
--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -664,6 +664,7 @@ def test_list_authenticated_providers_groups_same_endpoint(monkeypatch):
              "api_key": "ollama", "model": "qwen3-coder"},
         ],
         max_models=50,
+        probe_custom_providers=False,
     )
 
     custom_groups = [p for p in providers if p.get("is_user_defined")]
@@ -748,6 +749,7 @@ def test_list_authenticated_providers_distinct_endpoints_stay_separate(monkeypat
              "api_key": "ollama", "model": "qwen3-coder"},
         ],
         max_models=50,
+        probe_custom_providers=False,
     )
 
     custom_groups = [p for p in providers if p.get("is_user_defined")]
@@ -841,6 +843,7 @@ def test_list_authenticated_providers_total_models_reflects_grouped_count(monkey
         user_providers={},
         custom_providers=entries,
         max_models=4,
+        probe_custom_providers=False,
     )
 
     groups = [p for p in providers if p.get("is_user_defined")]


### PR DESCRIPTION
## Summary

- Disable live custom-provider probing in three model-picker tests whose assertions cover configured grouping behavior.
- Keep the existing dedicated live-probe tests unchanged.
- Make the grouping suite deterministic on hosts that run a real Ollama or OpenAI-compatible endpoint at the fixture URL.

## Problem

Three tests build custom-provider fixtures around `http://localhost:11434/v1` and assert the configured model names, grouping, and total model count. `list_authenticated_providers()` may probe that endpoint by default. On a machine with Ollama listening there, live models replace the fixture models and the tests fail based on the host's current catalog rather than the invariant they are named for.

On untouched `origin/main`, the hermetic wrapper reproduced exactly three failures:

- `test_list_authenticated_providers_groups_same_endpoint`
- `test_list_authenticated_providers_distinct_endpoints_stay_separate`
- `test_list_authenticated_providers_total_models_reflects_grouped_count`

Baseline result: **38 passed, 3 failed**.

## Fix

Pass `probe_custom_providers=False` in those three tests. This keeps their inputs limited to the configured fixtures while preserving live discovery coverage in the probe-specific tests elsewhere in the same file.

## Verification

```bash
python scripts/run_tests_parallel.py tests/hermes_cli/test_model_switch_custom_providers.py -q
git diff --check origin/main...HEAD
```

Result:

- **41 passed, 0 failed**
- `git diff --check` passed

## Scope and risk

- Test-only change: three added keyword arguments in one file.
- No production behavior changes.
- Dedicated probe behavior coverage remains enabled.
