### PR TITLE
fix(context): preserve messages when summary quota is exhausted

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -35,6 +35,37 @@ from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
 
+
+_SUMMARY_ACCESS_OR_QUOTA_ERROR_SUBSTRINGS: tuple[str, ...] = (
+    "invalid api key",
+    "invalid x-api-key",
+    "unauthorized",
+    "authentication",
+    "insufficient_quota",
+    "quota exceeded",
+    "quota_exceeded",
+    "out of funds",
+    "out of credits",
+    "out of credit",
+    "out of extra usage",
+)
+
+
+def _is_summary_access_or_quota_error(exc: Exception) -> bool:
+    """Return True for non-retryable summary auth, permission, or quota errors."""
+
+    status = getattr(exc, "status_code", None) or getattr(
+        getattr(exc, "response", None), "status_code", None
+    )
+    if status in {401, 402, 403}:
+        return True
+
+    err_text = str(exc).lower()
+    if "api key" in err_text and ("invalid" in err_text or "blocked" in err_text):
+        return True
+    return any(marker in err_text for marker in _SUMMARY_ACCESS_OR_QUOTA_ERROR_SUBSTRINGS)
+
+
 HISTORICAL_TASK_HEADING = "## Historical Task Snapshot"
 HISTORICAL_IN_PROGRESS_HEADING = "## Historical In-Progress State"
 HISTORICAL_PENDING_ASKS_HEADING = "## Historical Pending User Asks"
@@ -2129,24 +2160,15 @@ This compaction should PRIORITISE preserving all information related to the focu
             # back to the main model instead of entering a 60-second cooldown.
             # See issue #18458.
             _is_streaming_closed = _is_connection_error(e)
-            # Authentication / permission failures (401/403) are NOT transient
-            # and NOT fixable by retrying the same request: the credential is
-            # invalid/blocked/expired or the endpoint is wrong (e.g. a prod
-            # token sent to a staging inference URL). Flag them so compress()
-            # aborts and preserves the session instead of rotating into a
+            # Authentication, permission, and exhausted-quota failures are NOT
+            # transient or fixable by retrying the same request. Flag them so
+            # compress() preserves the session instead of rotating into a
             # degraded child with a placeholder summary. We still allow the
             # one-shot fallback to the MAIN model below when the failure came
-            # from a distinct auxiliary summary_model (its dedicated creds may
-            # be the only broken thing); only a failure on the main model — or
-            # a fallback that also auth-fails — makes the abort stick.
-            _is_auth_error = (
-                _status in {401, 403}
-                or "invalid api key" in _err_str
-                or "invalid x-api-key" in _err_str
-                or ("api key" in _err_str and ("invalid" in _err_str or "blocked" in _err_str))
-                or "unauthorized" in _err_str
-                or "authentication" in _err_str
-            )
+            # from a distinct auxiliary summary_model; only a failure on the
+            # main model — or a fallback that also access/quota-fails — makes
+            # the abort stick.
+            _is_auth_error = _is_summary_access_or_quota_error(e)
             if _is_auth_error:
                 self._last_summary_auth_failure = True
             if _is_json_decode and not _is_model_not_found and not _is_timeout:

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -26,6 +26,7 @@ from typing import Any, Dict, List, Optional
 
 from agent.auxiliary_client import call_llm, _is_connection_error, aux_interrupt_protection
 from agent.context_engine import ContextEngine
+from agent.error_classifier import FailoverReason, classify_api_error
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
     get_model_context_length,
@@ -36,11 +37,7 @@ from agent.redact import redact_sensitive_text
 logger = logging.getLogger(__name__)
 
 
-_SUMMARY_ACCESS_OR_QUOTA_ERROR_SUBSTRINGS: tuple[str, ...] = (
-    "invalid api key",
-    "invalid x-api-key",
-    "unauthorized",
-    "authentication",
+_SUMMARY_PERMANENT_QUOTA_MARKERS: tuple[str, ...] = (
     "insufficient_quota",
     "quota exceeded",
     "quota_exceeded",
@@ -54,6 +51,12 @@ _SUMMARY_ACCESS_OR_QUOTA_ERROR_SUBSTRINGS: tuple[str, ...] = (
 def _is_summary_access_or_quota_error(exc: Exception) -> bool:
     """Return True for non-retryable summary auth, permission, or quota errors."""
 
+    classified = classify_api_error(exc)
+    if classified.reason is FailoverReason.rate_limit:
+        return False
+    if classified.reason in {FailoverReason.auth, FailoverReason.auth_permanent}:
+        return True
+
     status = getattr(exc, "status_code", None) or getattr(
         getattr(exc, "response", None), "status_code", None
     )
@@ -61,9 +64,9 @@ def _is_summary_access_or_quota_error(exc: Exception) -> bool:
         return True
 
     err_text = str(exc).lower()
-    if "api key" in err_text and ("invalid" in err_text or "blocked" in err_text):
-        return True
-    return any(marker in err_text for marker in _SUMMARY_ACCESS_OR_QUOTA_ERROR_SUBSTRINGS)
+    if classified.reason is FailoverReason.billing:
+        return any(marker in err_text for marker in _SUMMARY_PERMANENT_QUOTA_MARKERS)
+    return any(marker in err_text for marker in _SUMMARY_PERMANENT_QUOTA_MARKERS)
 
 
 HISTORICAL_TASK_HEADING = "## Historical Task Snapshot"

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -816,6 +816,7 @@ class TestAuthFailureAborts:
             "billing portal is temporarily unavailable",
             "usage limit documentation could not be loaded",
             "rate limit exceeded; retry later",
+            "quota exceeded, please retry after the window resets",
             "request timed out",
         ],
     )
@@ -859,6 +860,29 @@ class TestAuthFailureAborts:
         assert c._last_summary_auth_failure is True
         assert c._last_compress_aborted is True
         assert c._last_summary_fallback_used is False
+
+    def test_402_quota_with_retry_uses_existing_fallback(self):
+        """A reset-window quota remains transient instead of aborting compression."""
+        err = StubProviderError(
+            "quota exceeded, please retry after the window resets",
+            status_code=402,
+        )
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=2,
+                protect_last_n=2,
+                abort_on_summary_failure=False,
+            )
+        msgs = self._msgs(12)
+        with patch("agent.context_compressor.call_llm", side_effect=err):
+            result = c.compress(msgs, current_tokens=999999, force=True)
+
+        assert result != msgs
+        assert c._last_summary_auth_failure is False
+        assert c._last_compress_aborted is False
+        assert c._last_summary_fallback_used is True
 
     def test_generate_summary_flags_auth_failure(self):
         with patch("agent.context_compressor.get_model_context_length", return_value=100000):

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -9,8 +9,16 @@ from agent.context_compressor import (
     HISTORICAL_TASK_HEADING,
     SUMMARY_PREFIX,
     COMPRESSED_SUMMARY_METADATA_KEY,
+    _is_summary_access_or_quota_error,
 )
 from hermes_state import SessionDB
+
+
+class StubProviderError(Exception):
+    def __init__(self, message, *, status_code=None, response=None):
+        super().__init__(message)
+        self.status_code = status_code
+        self.response = response
 
 
 @pytest.fixture()
@@ -781,12 +789,76 @@ class TestAuthFailureAborts:
         ]
 
     def _auth_err(self, status=401):
-        err = Exception(
+        return StubProviderError(
             f"Error code: {status} - "
-            "{'status': 401, 'message': 'Your API key is invalid, blocked or out of funds.'}"
+            "{'status': 401, 'message': 'Your API key is invalid, blocked or out of funds.'}",
+            status_code=status,
         )
-        err.status_code = status
-        return err
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "insufficient_quota",
+            "quota exceeded",
+            "quota_exceeded",
+            "out of funds",
+            "out of credits",
+            "out of credit",
+            "out of extra usage",
+        ],
+    )
+    def test_quota_classifier_accepts_explicit_provider_signals(self, message):
+        assert _is_summary_access_or_quota_error(Exception(message)) is True
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "billing portal is temporarily unavailable",
+            "usage limit documentation could not be loaded",
+            "rate limit exceeded; retry later",
+            "request timed out",
+        ],
+    )
+    def test_quota_classifier_rejects_transient_or_ambiguous_messages(self, message):
+        assert _is_summary_access_or_quota_error(Exception(message)) is False
+
+    @pytest.mark.parametrize("status", [401, 402, 403])
+    def test_access_classifier_accepts_non_retryable_http_statuses(self, status):
+        err = StubProviderError(
+            "provider rejected summary request",
+            status_code=status,
+        )
+        assert _is_summary_access_or_quota_error(err) is True
+
+    def test_classifier_reads_response_status_code(self):
+        err = StubProviderError(
+            "provider rejected summary request",
+            response=MagicMock(status_code=402),
+        )
+        assert _is_summary_access_or_quota_error(err) is True
+
+    def test_400_out_of_extra_usage_aborts_instead_of_dropping_context(self):
+        """Quota exhaustion preserves the original messages for a later retry."""
+        err = StubProviderError(
+            "Error code: 400 - {'error': {'message': 'out of extra usage'}}",
+            status_code=400,
+        )
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=2,
+                protect_last_n=2,
+                abort_on_summary_failure=False,
+            )
+        msgs = self._msgs(12)
+        with patch("agent.context_compressor.call_llm", side_effect=err):
+            result = c.compress(msgs, current_tokens=999999, force=True)
+
+        assert result == msgs
+        assert c._last_summary_auth_failure is True
+        assert c._last_compress_aborted is True
+        assert c._last_summary_fallback_used is False
 
     def test_generate_summary_flags_auth_failure(self):
         with patch("agent.context_compressor.get_model_context_length", return_value=100000):


### PR DESCRIPTION
## Summary

- Classify explicit authentication, permission, payment-required, and exhausted-quota summary failures as non-retryable.
- Preserve the original message history instead of using the static fallback that drops the middle context window.
- Add focused positive and negative classifier coverage plus an end-to-end compression regression.

## Problem

Context compression already aborts safely for authentication failures, but provider-specific quota failures can arrive as HTTP 400 responses. A response such as `out of extra usage` currently falls through to the generic summary-failure path. With `abort_on_summary_failure=False`, that path inserts static fallback context and removes the middle message window.

A reproduction against untouched `origin/main` produced:

```text
preserved_original_messages: false
input_count: 12
output_count: 6
auth_failure_flag: false
compress_aborted: false
fallback_used: true
```

Quota exhaustion is not fixed by retrying the same request. Preserving the session allows it to recover after quota or model configuration changes without silently losing context.

## Fix

Extract `_is_summary_access_or_quota_error()` as a small adapter over the existing canonical `classify_api_error()` taxonomy. It treats canonical authentication and permanent billing classifications as terminal while preserving canonical `rate_limit` results as transient. A narrow local marker set covers provider wording aliases not yet recognized centrally.

The adapter classifies:

- HTTP `401`, `402`, and `403`, including response-level status codes, unless the canonical classifier identifies a transient quota/reset response.
- Existing explicit authentication signals.
- Explicit permanent quota signals such as `insufficient_quota`, bare `quota exceeded`, `out of funds`, `out of credits`, and `out of extra usage`.

The classifier intentionally does **not** match broad phrases such as bare `billing` or `usage limit`. Messages carrying retry/reset signals—such as `quota exceeded, please retry after the window resets`—retain the existing transient fallback behavior.

The existing auxiliary-summary-model behavior remains unchanged: a distinct auxiliary model may fall back once to the main model; the abort sticks only when the active/main summary path also fails with a non-retryable access or quota error.

## Verification

```bash
python scripts/run_tests_parallel.py tests/agent/test_context_compressor.py tests/agent/test_error_classifier.py -q
git diff --check origin/main...HEAD
```

Result:

- **362 passed, 0 failed**
- `git diff --check` passed

Coverage includes:

- Seven explicit permanent quota-message variants.
- Negative transient and ambiguous-message cases.
- Direct and response-level `401/402/403` status handling.
- End-to-end proof that HTTP 400 `out of extra usage` preserves all original messages and avoids the static fallback.
- End-to-end proof that a 402 quota response carrying retry/reset language retains the existing transient fallback path.
- The canonical error-classifier suite, including its billing-versus-rate-limit distinction.
- Existing auth, network, auxiliary-model fallback, and generic-failure behavior.

## Scope and risk

- No new configuration or user-facing surface.
- Generic and transient failures retain existing behavior.
- The classifier uses a deliberately narrow explicit signal set to reduce false positives.
- The existing `_last_summary_auth_failure` state name is retained to avoid broadening the PR into a state-model refactor.
