### PR TITLE
fix(agent): honor HERMES_IGNORE_USER_CONFIG for memory provider plugin

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1354,69 +1354,77 @@ def init_agent(
     # Reads memory.provider from config to select which plugin to activate.
     agent._memory_manager = None
     if not skip_memory:
-        try:
-            _mem_provider_name = mem_config.get("provider", "") if mem_config else ""
+        # --ignore-user-config: skip memory provider even when skip_memory
+        # isn't explicitly set, because memory.provider is a user config value
+        # and should be ignored along with the rest of config.yaml.
+        if os.environ.get("HERMES_IGNORE_USER_CONFIG") == "1":
+            _ra().logger.debug(
+                "HERMES_IGNORE_USER_CONFIG=1: skipping memory provider plugin"
+            )
+        else:
+            try:
+                _mem_provider_name = mem_config.get("provider", "") if mem_config else ""
 
-            if _mem_provider_name and _mem_provider_name.strip():
-                from agent.memory_manager import MemoryManager as _MemoryManager
-                from plugins.memory import load_memory_provider as _load_mem
-                agent._memory_manager = _MemoryManager()
-                _mp = _load_mem(_mem_provider_name)
-                if _mp and _mp.is_available():
-                    agent._memory_manager.add_provider(_mp)
-                if agent._memory_manager.providers:
-                    _init_kwargs = {
-                        "session_id": agent.session_id,
-                        "platform": platform or "cli",
-                        "hermes_home": str(get_hermes_home()),
-                        "agent_context": "primary",
-                    }
-                    if _init_kwargs["platform"] == "cli":
-                        _init_kwargs["warning_callback"] = agent._emit_warning
-                        _init_kwargs["status_callback"] = agent._emit_status
-                    # Thread session title for memory provider scoping
-                    # (e.g. honcho uses this to derive chat-scoped session keys)
-                    if agent._session_db:
+                if _mem_provider_name and _mem_provider_name.strip():
+                    from agent.memory_manager import MemoryManager as _MemoryManager
+                    from plugins.memory import load_memory_provider as _load_mem
+                    agent._memory_manager = _MemoryManager()
+                    _mp = _load_mem(_mem_provider_name)
+                    if _mp and _mp.is_available():
+                        agent._memory_manager.add_provider(_mp)
+                    if agent._memory_manager.providers:
+                        _init_kwargs = {
+                            "session_id": agent.session_id,
+                            "platform": platform or "cli",
+                            "hermes_home": str(get_hermes_home()),
+                            "agent_context": "primary",
+                        }
+                        if _init_kwargs["platform"] == "cli":
+                            _init_kwargs["warning_callback"] = agent._emit_warning
+                            _init_kwargs["status_callback"] = agent._emit_status
+                        # Thread session title for memory provider scoping
+                        # (e.g. honcho uses this to derive chat-scoped session keys)
+                        if agent._session_db:
+                            try:
+                                _st = agent._session_db.get_session_title(agent.session_id)
+                                if _st:
+                                    _init_kwargs["session_title"] = _st
+                            except Exception:
+                                pass
+                        # Thread gateway user identity for per-user memory scoping
+                        if agent._user_id:
+                            _init_kwargs["user_id"] = agent._user_id
+                        if agent._user_id_alt:
+                            _init_kwargs["user_id_alt"] = agent._user_id_alt
+                        if agent._user_name:
+                            _init_kwargs["user_name"] = agent._user_name
+                        if agent._chat_id:
+                            _init_kwargs["chat_id"] = agent._chat_id
+                        if agent._chat_name:
+                            _init_kwargs["chat_name"] = agent._chat_name
+                        if agent._chat_type:
+                            _init_kwargs["chat_type"] = agent._chat_type
+                        if agent._thread_id:
+                            _init_kwargs["thread_id"] = agent._thread_id
+                        # Thread gateway session key for stable per-chat Honcho session isolation
+                        if agent._gateway_session_key:
+                            _init_kwargs["gateway_session_key"] = agent._gateway_session_key
+                        # Profile identity for per-profile provider scoping
                         try:
-                            _st = agent._session_db.get_session_title(agent.session_id)
-                            if _st:
-                                _init_kwargs["session_title"] = _st
+                            from hermes_cli.profiles import get_active_profile_name
+                            _profile = get_active_profile_name()
+                            _init_kwargs["agent_identity"] = _profile
+                            _init_kwargs["agent_workspace"] = "hermes"
                         except Exception:
                             pass
-                    # Thread gateway user identity for per-user memory scoping
-                    if agent._user_id:
-                        _init_kwargs["user_id"] = agent._user_id
-                    if agent._user_id_alt:
-                        _init_kwargs["user_id_alt"] = agent._user_id_alt
-                    if agent._user_name:
-                        _init_kwargs["user_name"] = agent._user_name
-                    if agent._chat_id:
-                        _init_kwargs["chat_id"] = agent._chat_id
-                    if agent._chat_name:
-                        _init_kwargs["chat_name"] = agent._chat_name
-                    if agent._chat_type:
-                        _init_kwargs["chat_type"] = agent._chat_type
-                    if agent._thread_id:
-                        _init_kwargs["thread_id"] = agent._thread_id
-                    # Thread gateway session key for stable per-chat Honcho session isolation
-                    if agent._gateway_session_key:
-                        _init_kwargs["gateway_session_key"] = agent._gateway_session_key
-                    # Profile identity for per-profile provider scoping
-                    try:
-                        from hermes_cli.profiles import get_active_profile_name
-                        _profile = get_active_profile_name()
-                        _init_kwargs["agent_identity"] = _profile
-                        _init_kwargs["agent_workspace"] = "hermes"
-                    except Exception:
-                        pass
-                    agent._memory_manager.initialize_all(**_init_kwargs)
-                    _ra().logger.info("Memory provider '%s' activated", _mem_provider_name)
-                else:
-                    _ra().logger.debug("Memory provider '%s' not found or not available", _mem_provider_name)
-                    agent._memory_manager = None
-        except Exception as _mpe:
-            _ra().logger.warning("Memory provider plugin init failed: %s", _mpe)
-            agent._memory_manager = None
+                        agent._memory_manager.initialize_all(**_init_kwargs)
+                        _ra().logger.info("Memory provider '%s' activated", _mem_provider_name)
+                    else:
+                        _ra().logger.debug("Memory provider '%s' not found or not available", _mem_provider_name)
+                        agent._memory_manager = None
+            except Exception as _mpe:
+                _ra().logger.warning("Memory provider plugin init failed: %s", _mpe)
+                agent._memory_manager = None
 
     from agent.memory_manager import inject_memory_provider_tools as _inject_memory_provider_tools
     _inject_memory_provider_tools(agent)


### PR DESCRIPTION
## Problem

`--ignore-user-config` is documented as "skip user config.yaml and use built-in defaults". But it still loads the configured memory provider plugin (e.g. Honcho). When `memory.provider: honcho` is set in the user's `config.yaml` and `~/.hermes/honcho.json` is present, `--ignore-user-config` still initializes the Honcho client and issues live HTTP requests to the configured Honcho backend.

Root cause: `agent_init.py` calls `config.py::load_config()` which always reads the user's `config.yaml` regardless of the `HERMES_IGNORE_USER_CONFIG` env var. So the user's `memory.provider` value leaks through even when the CLI config layer (`cli.py::load_cli_config()`) already skipped the user config.

## Fix

In `agent_init.py`, before loading the external memory provider plugin, check `os.environ.get("HERMES_IGNORE_USER_CONFIG") == "1"` and skip the plugin entirely if set. This is the same defense-in-depth pattern as the existing `skip_memory` gate (which covers `--ignore-rules` and `--safe-mode`).

For `--safe-mode`: sets `HERMES_IGNORE_RULES=1` → `skip_memory=True` → Honcho blocked (already worked).
For `--ignore-user-config`: now also blocks Honcho via the new `HERMES_IGNORE_USER_CONFIG` check.

## Related

Closes #62406

## Test Plan

All 24 relevant tests pass:
- `test_memory_provider_init.py` — 4 tests
- `test_safe_mode.py` — 8 tests
- `test_ignore_user_config_flags.py` — 12 tests