### PR TITLE
fix(memory): gate Honcho plugin initialization behind --safe-mode / --ignore-user-config (#62406)

### DIFF
--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -188,7 +188,14 @@ def load_memory_provider(name: str) -> Optional["MemoryProvider"]:
     precedence on name collisions.
 
     Returns None if the provider is not found or fails to load.
+
+    When ``HERMES_SAFE_MODE`` is active, all memory providers are
+    skipped — no plugin code is imported or executed.
     """
+    from utils import env_var_enabled
+    if env_var_enabled("HERMES_SAFE_MODE"):
+        logger.debug("HERMES_SAFE_MODE=1 — memory provider loading skipped")
+        return None
     provider_dir = find_provider_dir(name)
     if not provider_dir:
         logger.debug("Memory provider '%s' not found in bundled or user plugins", name)
@@ -342,7 +349,14 @@ def _get_active_memory_provider() -> Optional[str]:
     Returns the provider name (e.g. ``"honcho"``) or None if no
     external provider is configured.  Lightweight — only reads config,
     no plugin loading.
+
+    When ``HERMES_IGNORE_USER_CONFIG`` or ``HERMES_SAFE_MODE`` is set,
+    the user's ``memory.provider`` config is explicitly being ignored,
+    so this returns None regardless of what config.yaml contains.
     """
+    from utils import env_var_enabled
+    if env_var_enabled("HERMES_IGNORE_USER_CONFIG") or env_var_enabled("HERMES_SAFE_MODE"):
+        return None
     try:
         from hermes_cli.config import load_config
         config = load_config()


### PR DESCRIPTION
## Summary
`--safe-mode` is documented as "disable ALL customizations — user config, AGENTS.md/memory injection, plugins, and MCP servers". But with `~/.hermes/honcho.json` present, a `--safe-mode` one-shot still initialized the Honcho memory client and issued live HTTP requests to the configured Honcho backend.

## Root Cause
`_get_active_memory_provider()` in `plugins/memory/__init__.py` called `load_config()` which does not check `HERMES_IGNORE_USER_CONFIG`. So `memory.provider: honcho` was still read from user's config even in safe mode.

## Change
Added two guards in `plugins/memory/__init__.py`:
1. **`_get_active_memory_provider()`**: Early return `None` when `HERMES_IGNORE_USER_CONFIG` or `HERMES_SAFE_MODE` is set
2. **`load_memory_provider()`**: Early return `None` when `HERMES_SAFE_MODE` is active

## Verification
574 tests pass across safe_mode, ignore_user_config, memory_provider, and plugins/memory test files.