### PR TITLE
fix(mcp-oauth): preserve refresh_token across token refresh cycles

### DIFF
--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -351,6 +351,14 @@ class HermesTokenStorage:
 
     async def set_tokens(self, tokens: "OAuthToken") -> None:
         payload = tokens.model_dump(mode="json", exclude_none=True)
+        # Per RFC 6749 section 6, a refresh response MAY omit refresh_token
+        # ("reuse the existing one"). When exclude_none=True drops it, the
+        # write would erase the stored refresh_token, killing all future
+        # refreshes. Carry it forward from the existing token file.
+        if "refresh_token" not in payload:
+            prev = _read_json(self._tokens_path())
+            if prev and prev.get("refresh_token"):
+                payload["refresh_token"] = prev["refresh_token"]
         # Persist an absolute ``expires_at`` so a process restart can
         # reconstruct the correct remaining TTL. Without this the MCP SDK's
         # ``_initialize`` reloads a relative ``expires_in`` which has no


### PR DESCRIPTION
## Summary

Per RFC 6749 section 6, an OAuth refresh response MAY omit `refresh_token` to signal "reuse the existing one". The MCP SDK's `model_dump(exclude_none=True)` drops the None field, and `set_tokens` overwrites the token file — erasing the stored `refresh_token` permanently.

After one such refresh, `can_refresh_token()` returns `False` and the MCP server dies until a full re-authorization.

## Root Cause

`HermesTokenStorage.set_tokens()` in `tools/mcp_oauth.py`:
```python
payload = tokens.model_dump(mode="json", exclude_none=True)
_write_json(self._tokens_path(), payload)  # overwrites without refresh_token
```

When the refresh response omits `refresh_token` (valid per RFC 6749 §6), `exclude_none=True` drops it, and the file write erases the stored value.

## Fix

Before writing, read the existing token file and carry forward the `refresh_token` when the new payload doesn't include one:

```python
if "refresh_token" not in payload:
    prev = _read_json(self._tokens_path())
    if prev and prev.get("refresh_token"):
        payload["refresh_token"] = prev["refresh_token"]
```

## Verification

1. `hermes mcp login <oauth-server>` — complete OAuth
2. Edit `mcp-tokens/<server>.json`, set `expires_at` to past timestamp
3. Trigger token refresh (`hermes mcp test <server>`)
4. Inspect token file — `refresh_token` should persist

Closes #62333