### PR TITLE
fix(matrix): split lazy e2ee deps

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1,8 +1,8 @@
 """Matrix gateway adapter.
 
 Connects to any Matrix homeserver (self-hosted or matrix.org) via the
-mautrix Python SDK.  Supports optional end-to-end encryption (E2EE)
-when installed with ``pip install "mautrix[encryption]"``.
+mautrix Python SDK. Supports optional end-to-end encryption (E2EE)
+when ``python-olm`` is installed alongside the base Matrix deps.
 
 Environment variables:
     MATRIX_HOMESERVER           Homeserver URL (e.g. https://matrix.example.org)
@@ -355,10 +355,33 @@ _OUTBOUND_MENTION_RE = re.compile(
     r"(?<![\w/])(@[0-9A-Za-z._=/-]+:[0-9A-Za-z.-]+(?::\d+)?)"
 )
 
+_MATRIX_BASE_INSTALL_HINT = (
+    "Install with: pip install mautrix asyncpg aiosqlite aiohttp-socks"
+)
 _E2EE_INSTALL_HINT = (
-    "Install with: pip install 'mautrix[encryption]' asyncpg aiosqlite  "
+    "Install with: pip install python-olm "
     "(requires libolm C library)"
 )
+
+
+def _matrix_manual_install_command(enable_e2ee: bool) -> str:
+    command = "uv pip install mautrix asyncpg aiosqlite aiohttp-socks"
+    if enable_e2ee:
+        command += " python-olm"
+    return command
+
+
+def _ensure_matrix_e2ee_deps() -> bool:
+    """Best-effort lazy install for optional Matrix E2EE support."""
+    if _check_e2ee_deps():
+        return True
+    try:
+        from tools.lazy_deps import ensure as _lazy_ensure
+        _lazy_ensure("platform.matrix.e2ee", prompt=False)
+    except Exception as exc:
+        logger.debug("Matrix: failed to lazy-install E2EE deps: %s", exc)
+        return False
+    return _check_e2ee_deps()
 
 _MATRIX_IMAGE_FILENAME_EXTS = frozenset({
     ".jpg",
@@ -665,13 +688,10 @@ def _pre_sanitize_matrix_markdown(text: str) -> str:
 def check_matrix_requirements() -> bool:
     """Return True if the Matrix adapter can be used.
 
-    Lazy-installs the full ``platform.matrix`` feature group via
-    ``tools.lazy_deps.ensure_and_bind`` whenever any of the declared
-    packages (mautrix, Markdown, aiosqlite, asyncpg, aiohttp-socks) is
-    missing — not just mautrix itself.  Previously this short-circuited on
-    ``import mautrix``, which left the other four packages uninstalled
-    forever and broke E2EE connect with ``No module named 'asyncpg'``
-    (#31116).  Rebinds module-level type globals on success.
+    Lazy-installs the base ``platform.matrix`` feature group via
+    ``tools.lazy_deps.ensure_and_bind`` whenever any declared runtime
+    package is missing, then opportunistically lazy-installs the separate
+    ``platform.matrix.e2ee`` feature when encryption is requested.
     """
     token = os.getenv("MATRIX_ACCESS_TOKEN", "")
     password = os.getenv("MATRIX_PASSWORD", "")
@@ -684,10 +704,10 @@ def check_matrix_requirements() -> bool:
         logger.warning("Matrix: MATRIX_HOMESERVER not set")
         return False
 
-    # Check whether any package in the platform.matrix feature group is
-    # missing.  ``feature_missing`` is cheap (per-spec importlib.metadata
-    # lookups) and correctly handles ``mautrix[encryption]`` by stripping
-    # the extras marker before checking the bare package.
+    # Check whether any package in the base platform.matrix feature group is
+    # missing. ``feature_missing`` is cheap (per-spec importlib.metadata
+    # lookups) and catches partial installs like "mautrix present but
+    # asyncpg missing" (#31116).
     try:
         from tools.lazy_deps import feature_missing, ensure_and_bind
         missing = feature_missing("platform.matrix")
@@ -720,15 +740,14 @@ def check_matrix_requirements() -> bool:
             return False
         if not ensure_and_bind("platform.matrix", _import, globals(), prompt=False):
             logger.warning(
-                "Matrix: required packages not installed (%s). "
-                "Run: pip install 'mautrix[encryption]' asyncpg aiosqlite "
-                "Markdown aiohttp-socks",
+                "Matrix: required base packages not installed (%s). %s",
                 ", ".join(missing) if missing else "platform.matrix",
+                _MATRIX_BASE_INSTALL_HINT,
             )
             return False
 
     e2ee_mode = _resolve_e2ee_mode()
-    if e2ee_mode == "required" and not _check_e2ee_deps():
+    if e2ee_mode == "required" and not _ensure_matrix_e2ee_deps():
         logger.error(
             "Matrix: E2EE is required but dependencies are missing. %s. "
             "Without this, encrypted rooms will not work. "
@@ -736,7 +755,7 @@ def check_matrix_requirements() -> bool:
             _E2EE_INSTALL_HINT,
         )
         return False
-    if e2ee_mode == "optional" and not _check_e2ee_deps():
+    if e2ee_mode == "optional" and not _ensure_matrix_e2ee_deps():
         logger.warning(
             "Matrix: E2EE optional but dependencies are missing. %s",
             _E2EE_INSTALL_HINT,
@@ -4477,35 +4496,42 @@ def interactive_setup() -> None:
             save_env_value("MATRIX_ENCRYPTION", "true")
             print_success("E2EE enabled")
 
-        matrix_pkg = "mautrix[encryption]" if want_e2ee else "mautrix"
+        manual_install = _matrix_manual_install_command(want_e2ee)
         try:
             from tools.lazy_deps import ensure as _lazy_ensure, feature_missing
-            _missing_before = feature_missing("platform.matrix")
+            _missing_before = list(feature_missing("platform.matrix"))
+            if want_e2ee and not _check_e2ee_deps():
+                _missing_before.extend(feature_missing("platform.matrix.e2ee"))
             if _missing_before:
-                print_info(f"Installing {matrix_pkg} (+ {len(_missing_before)} runtime deps)...")
+                print_info(
+                    f"Installing Matrix runtime deps (+ {len(_missing_before)} package(s))..."
+                )
                 try:
                     _lazy_ensure("platform.matrix", prompt=False)
-                    print_success(f"{matrix_pkg} installed")
+                    if want_e2ee and not _check_e2ee_deps():
+                        _lazy_ensure("platform.matrix.e2ee", prompt=False)
+                    print_success("Matrix runtime deps installed")
                 except Exception as exc:
                     print_warning(
-                        "Install failed — run manually: pip install "
-                        "'mautrix[encryption]' asyncpg aiosqlite Markdown aiohttp-socks"
+                        f"Install failed — run manually: {manual_install}"
                     )
                     print_info(f"  Error: {exc}")
         except ImportError:
             try:
                 __import__("mautrix")
             except ImportError:
-                print_info(f"Installing {matrix_pkg}...")
+                print_info("Installing Matrix runtime deps...")
                 from hermes_cli.tools_config import _pip_install
 
-                result = _pip_install([matrix_pkg])
+                packages = ["mautrix", "asyncpg", "aiosqlite", "aiohttp-socks"]
+                if want_e2ee:
+                    packages.append("python-olm")
+                result = _pip_install(packages)
                 if result.returncode == 0:
-                    print_success(f"{matrix_pkg} installed")
+                    print_success("Matrix runtime deps installed")
                 else:
                     print_warning(
-                        f"Install failed — run manually: uv pip install "
-                        f"'{matrix_pkg}' asyncpg aiosqlite Markdown aiohttp-socks"
+                        f"Install failed — run manually: {manual_install}"
                     )
 
         print_info("🔒 Security: Restrict who can use your bot")
@@ -4600,7 +4626,7 @@ def register(ctx) -> None:
         check_fn=check_matrix_requirements,
         is_connected=_is_connected,
         required_env=["MATRIX_HOMESERVER", "MATRIX_ACCESS_TOKEN"],
-        install_hint="pip install 'mautrix[encryption]'",
+        install_hint="pip install mautrix asyncpg aiosqlite aiohttp-socks",
         setup_fn=interactive_setup,
         apply_yaml_config_fn=_apply_yaml_config,
         allowed_users_env="MATRIX_ALLOWED_USERS",

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1255,7 +1255,8 @@ class TestMatrixRequirements:
 
         import plugins.platforms.matrix.adapter as matrix_mod
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=False), \
-             patch("tools.lazy_deps.feature_missing", return_value=()):
+             patch("tools.lazy_deps.feature_missing", return_value=()), \
+             patch("tools.lazy_deps.ensure", side_effect=RuntimeError("blocked")):
             assert matrix_mod.check_matrix_requirements() is False
 
     def test_check_requirements_e2ee_optional_no_deps_ok(self, monkeypatch):
@@ -1266,10 +1267,12 @@ class TestMatrixRequirements:
         monkeypatch.delenv("MATRIX_ENCRYPTION", raising=False)
 
         import plugins.platforms.matrix.adapter as matrix_mod
-        with patch.object(matrix_mod, "_check_e2ee_deps", return_value=False), \
+        with patch.object(matrix_mod, "_check_e2ee_deps", side_effect=[False, True]), \
              patch("tools.lazy_deps.feature_missing", return_value=()), \
-             patch("tools.lazy_deps.ensure_and_bind", return_value=True):
+             patch("tools.lazy_deps.ensure_and_bind", return_value=True), \
+             patch("tools.lazy_deps.ensure", return_value=None) as ensure:
             assert matrix_mod.check_matrix_requirements() is True
+        ensure.assert_called_once_with("platform.matrix.e2ee", prompt=False)
 
     def test_check_requirements_encryption_false_no_e2ee_deps_ok(self, monkeypatch):
         """Without encryption, missing E2EE deps should not block startup."""
@@ -1292,6 +1295,19 @@ class TestMatrixRequirements:
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=True), \
              patch("tools.lazy_deps.feature_missing", return_value=()):
             assert matrix_mod.check_matrix_requirements() is True
+
+    def test_check_requirements_encryption_true_lazy_installs_e2ee(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_ACCESS_TOKEN", "syt_test")
+        monkeypatch.setenv("MATRIX_HOMESERVER", "https://matrix.example.org")
+        monkeypatch.setenv("MATRIX_ENCRYPTION", "true")
+
+        import plugins.platforms.matrix.adapter as matrix_mod
+        with patch.object(matrix_mod, "_check_e2ee_deps", side_effect=[False, True]), \
+             patch("tools.lazy_deps.feature_missing", return_value=()), \
+             patch("tools.lazy_deps.ensure", return_value=None) as ensure:
+            assert matrix_mod.check_matrix_requirements() is True
+
+        ensure.assert_called_once_with("platform.matrix.e2ee", prompt=False)
 
     def test_check_e2ee_deps_requires_asyncpg(self, monkeypatch):
         """E2EE deps check must reject when asyncpg is missing — even if olm is present.

--- a/tests/gateway/test_matrix_plugin_setup.py
+++ b/tests/gateway/test_matrix_plugin_setup.py
@@ -1,0 +1,84 @@
+"""Tests for the Matrix plugin's interactive_setup wizard."""
+
+import hermes_cli.config as config_mod
+import hermes_cli.cli_output as cli_output_mod
+from plugins.platforms.matrix.adapter import interactive_setup
+
+
+def _patch_setup_io(monkeypatch, prompts, yes_no_answers, saved):
+    prompt_iter = iter(prompts)
+    yes_no_iter = iter(yes_no_answers)
+    monkeypatch.setattr(config_mod, "get_env_value", lambda key: saved.get(key, ""))
+    monkeypatch.setattr(config_mod, "save_env_value", lambda k, v: saved.update({k: v}))
+    monkeypatch.setattr(cli_output_mod, "prompt", lambda *_a, **_kw: next(prompt_iter))
+    monkeypatch.setattr(
+        cli_output_mod,
+        "prompt_yes_no",
+        lambda *_a, **_kw: next(yes_no_iter),
+    )
+    for name in ("print_header", "print_info", "print_success", "print_warning"):
+        monkeypatch.setattr(cli_output_mod, name, lambda *_a, **_kw: None)
+
+
+def test_interactive_setup_non_e2ee_only_installs_base_feature(monkeypatch):
+    saved = {}
+    calls = []
+    _patch_setup_io(
+        monkeypatch,
+        [
+            "https://matrix.example.org",
+            "syt_token",
+            "@bot:example.org",
+            "",
+            "",
+        ],
+        [False],
+        saved,
+    )
+    monkeypatch.setattr(
+        "tools.lazy_deps.feature_missing",
+        lambda feature: ("mautrix==0.21.0",) if feature == "platform.matrix" else (),
+    )
+    monkeypatch.setattr(
+        "tools.lazy_deps.ensure",
+        lambda feature, **_kw: calls.append(feature),
+    )
+
+    interactive_setup()
+
+    assert calls == ["platform.matrix"]
+    assert "MATRIX_ENCRYPTION" not in saved
+
+
+def test_interactive_setup_e2ee_installs_base_and_e2ee_features(monkeypatch):
+    saved = {}
+    calls = []
+    _patch_setup_io(
+        monkeypatch,
+        [
+            "https://matrix.example.org",
+            "syt_token",
+            "@bot:example.org",
+            "",
+            "",
+        ],
+        [True],
+        saved,
+    )
+    monkeypatch.setattr(
+        "tools.lazy_deps.feature_missing",
+        lambda feature: ("missing",),
+    )
+    monkeypatch.setattr(
+        "tools.lazy_deps.ensure",
+        lambda feature, **_kw: calls.append(feature),
+    )
+    monkeypatch.setattr(
+        "plugins.platforms.matrix.adapter._check_e2ee_deps",
+        lambda: False,
+    )
+
+    interactive_setup()
+
+    assert calls == ["platform.matrix", "platform.matrix.e2ee"]
+    assert saved["MATRIX_ENCRYPTION"] == "true"

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -103,6 +103,13 @@ class TestAllowlist:
     def test_feature_install_command_unknown(self):
         assert ld.feature_install_command("not.real") is None
 
+    def test_matrix_base_feature_excludes_python_olm(self):
+        assert all(
+            ld._pkg_name_from_spec(spec) != "python-olm"
+            for spec in ld.LAZY_DEPS["platform.matrix"]
+        )
+        assert ld.LAZY_DEPS["platform.matrix.e2ee"] == ("python-olm==3.2.16",)
+
 
 # ---------------------------------------------------------------------------
 # allow_lazy_installs gating

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -173,7 +173,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "aiohttp==3.14.1",  # CVE-2026-34513/34518/34519/34520/34525 + 34993(RCE)/47265
     ),
     "platform.matrix": (
-        "mautrix[encryption]==0.21.0",
+        "mautrix==0.21.0",
         "aiosqlite==0.22.1",
         "asyncpg==0.31.0",
         "aiohttp-socks==0.11.0",
@@ -182,6 +182,9 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         # satisfies both — pin the patched floor here too, like platform.discord.
         "aiohttp==3.14.1",  # CVE-2026-34513/34518/34519/34520/34525 + 34993(RCE)/47265
     ),
+    # Matrix E2EE is split from the base gateway deps so non-E2EE setups do
+    # not have to build python-olm when mautrix needs a version refresh.
+    "platform.matrix.e2ee": ("python-olm==3.2.16",),
     "platform.dingtalk": (
         "dingtalk-stream==0.24.3",
         "alibabacloud-dingtalk==2.2.42",


### PR DESCRIPTION
## Summary
- split Matrix lazy deps so the base runtime no longer pulls `python-olm`
- lazy-install `platform.matrix.e2ee` only when Matrix encryption is requested
- align Matrix setup/install hints and add focused regressions

Closes #62401

## Verification
- python -m py_compile tools/lazy_deps.py plugins/platforms/matrix/adapter.py tests/tools/test_lazy_deps.py tests/gateway/test_matrix.py tests/gateway/test_matrix_plugin_setup.py
- pytest tests/tools/test_lazy_deps.py -k "matrix_base_feature_excludes_python_olm or extras_block or windows_matrix or feature_install_command"
- pytest tests/gateway/test_matrix.py -k "check_requirements_encryption_true_no_e2ee_deps or check_requirements_e2ee_optional_no_deps_ok or check_requirements_encryption_true_lazy_installs_e2ee or check_requirements_runs_lazy_install_when_partial or check_requirements_encryption_false_no_e2ee_deps_ok"
- pytest tests/gateway/test_matrix_plugin_setup.py -q
- git diff --check