### PR TITLE
feat(terminal): add shell selection (auto/bash/zsh) for terminal backend

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -610,6 +610,7 @@ def load_cli_config() -> Dict[str, Any]:
         "env_type": "TERMINAL_ENV",
         "cwd": "TERMINAL_CWD",
         "timeout": "TERMINAL_TIMEOUT",
+        "shell": "TERMINAL_SHELL",
         "home_mode": "TERMINAL_HOME_MODE",
         "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
         "docker_image": "TERMINAL_DOCKER_IMAGE",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1484,6 +1484,7 @@ if _config_path.exists():
                 "backend": "TERMINAL_ENV",
                 "cwd": "TERMINAL_CWD",
                 "timeout": "TERMINAL_TIMEOUT",
+                "shell": "TERMINAL_SHELL",
                 "home_mode": "TERMINAL_HOME_MODE",
                 "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
                 "docker_image": "TERMINAL_DOCKER_IMAGE",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6808,6 +6808,7 @@ TERMINAL_CONFIG_ENV_MAP = {
     "modal_mode": "TERMINAL_MODAL_MODE",
     "cwd": "TERMINAL_CWD",
     "timeout": "TERMINAL_TIMEOUT",
+    "shell": "TERMINAL_SHELL",
     "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
     "docker_image": "TERMINAL_DOCKER_IMAGE",
     "docker_forward_env": "TERMINAL_DOCKER_FORWARD_ENV",

--- a/tests/tools/test_create_environment_shell.py
+++ b/tests/tools/test_create_environment_shell.py
@@ -1,0 +1,98 @@
+"""Regression coverage for ``_create_environment`` local-shell wiring.
+
+Background
+----------
+``terminal.shell`` config (auto/bash/zsh) must reach ``LocalEnvironment``.
+Three call sites (``terminal_tool``, ``code_execution_tool``, ``file_tools``)
+populate ``local_config = {"shell": ..., "persistent": ...}`` and pass it to
+``_create_environment(..., local_config=...)``. The local branch of
+``_create_environment`` MUST read ``shell`` from ``local_config`` — NOT from
+``container_config`` (the container dict is unrelated to the local backend)
+and MUST NOT reference an undefined variable.
+
+Observed regression (2026-07-15)
+-------------------------------
+A WIP refactor moved the ``shell`` key into ``local_config`` but left the
+local branch reading an unbound ``lc`` (a typo for the never-assigned alias
+of ``local_config``). Result::
+
+    NameError: name 'lc' is not defined
+
+The terminal tool then crashed on every local invocation, surfacing to the
+agent as ``"Terminal tool is broken (lc not defined). Using subprocess
+directly."``
+
+These tests pin the wiring so the same NameError cannot recur silently.
+"""
+
+import pytest
+
+from tools.terminal_tool import _create_environment
+
+
+class TestCreateEnvironmentLocalShell:
+    """``_create_environment`` must propagate ``local_config["shell"]``."""
+
+    def test_local_reads_shell_from_local_config(self, tmp_path):
+        """shell=zsh in local_config → env._shell_setting == 'zsh'."""
+        env = _create_environment(
+            env_type="local",
+            image="",
+            cwd=str(tmp_path),
+            timeout=5,
+            local_config={"shell": "bash", "persistent": False},
+        )
+        assert env._shell_setting == "bash"
+
+    def test_local_defaults_to_auto_when_local_config_omits_shell(self, tmp_path):
+        """No 'shell' key → defaults to 'auto' (NOT a NameError)."""
+        env = _create_environment(
+            env_type="local",
+            image="",
+            cwd=str(tmp_path),
+            timeout=5,
+            local_config={"persistent": False},
+        )
+        assert env._shell_setting == "auto"
+
+    def test_local_defaults_to_auto_when_local_config_none(self, tmp_path):
+        """local_config=None → still 'auto', still no NameError."""
+        env = _create_environment(
+            env_type="local",
+            image="",
+            cwd=str(tmp_path),
+            timeout=5,
+            local_config=None,
+        )
+        assert env._shell_setting == "auto"
+
+    def test_local_does_not_read_shell_from_container_config(self, tmp_path):
+        """container_config['shell'] must NOT leak into the local backend.
+
+        The local branch sources ``shell`` exclusively from ``local_config``.
+        Putting ``shell`` in ``container_config`` (a docker/modal concern) must
+        be a no-op for the local env so configs don't cross backends.
+        """
+        env = _create_environment(
+            env_type="local",
+            image="",
+            cwd=str(tmp_path),
+            timeout=5,
+            container_config={"shell": "zsh"},
+            local_config={"shell": "bash", "persistent": False},
+        )
+        assert env._shell_setting == "bash"
+
+    def test_local_zsh_propagates(self, tmp_path):
+        """End-to-end: local_config shell=zsh resolves to a zsh binary path."""
+        env = _create_environment(
+            env_type="local",
+            image="",
+            cwd=str(tmp_path),
+            timeout=5,
+            local_config={"shell": "zsh", "persistent": False},
+        )
+        assert env._shell_setting == "zsh"
+        # _resolve_terminal_shell falls back to bash if zsh binary is absent;
+        # both are acceptable — what matters is no NameError + kind detected.
+        assert env._shell_kind in {"zsh", "bash"}

--- a/tests/tools/test_local_env_shell_selection.py
+++ b/tests/tools/test_local_env_shell_selection.py
@@ -1,0 +1,111 @@
+"""Tests for terminal shell selection (auto/bash/zsh).
+
+Hermes terminal backend historically hardcodes ``_find_bash()`` for spawning
+the command shell. On systems where the user's login shell is zsh (common on
+macOS Catalina+ and many Linux setups), this forces bash to source zsh-syntax
+files (``~/.zshrc``), which contain ``eval "$(mise activate zsh)"`` /
+``pyenv init - zsh`` — these emit zsh-only syntax that crashes the bash
+arithmetic parser, killing the shell with exit 1 and empty output.
+
+The fix: add ``terminal.shell`` config (auto/bash/zsh). When ``auto``, the
+terminal respects ``$SHELL`` and uses the user's actual login shell (if it's
+a POSIX-sh-family shell). This lets zsh users inherit their full environment
+without bash-to-zsh translation fragility.
+
+Regression coverage for the "empty output, exit 1" failure mode reported when
+shell_init_files included ~/.zshrc but the terminal spawned bash.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+class TestResolveTerminalShell:
+    """Pure-function unit tests for shell resolution."""
+
+    def test_auto_returns_user_sHELL_when_sh_family(self, monkeypatch):
+        """auto mode: $SHELL=/usr/bin/zsh → returns zsh path."""
+        from tools.environments.local import _resolve_terminal_shell
+
+        monkeypatch.setenv("SHELL", "/usr/bin/zsh")
+        result = _resolve_terminal_shell("auto")
+        assert result == "/usr/bin/zsh"
+
+    def test_auto_returns_bash_when_sHELL_is_non_sh_family(self, monkeypatch):
+        """auto mode: $SHELL=/usr/bin/fish → falls back to bash."""
+        from tools.environments.local import _resolve_terminal_shell
+
+        monkeypatch.setenv("SHELL", "/usr/bin/fish")
+        result = _resolve_terminal_shell("auto")
+        # Must be a bash binary, NOT fish
+        assert result.endswith("bash")
+        assert "fish" not in result
+
+    def test_auto_returns_bash_when_sHELL_unset(self, monkeypatch):
+        """auto mode: $SHELL unset → falls back to bash."""
+        from tools.environments.local import _resolve_terminal_shell
+
+        monkeypatch.delenv("SHELL", raising=False)
+        result = _resolve_terminal_shell("auto")
+        assert result.endswith("bash")
+
+    def test_explicit_bash_returns_bash(self, monkeypatch):
+        """explicit 'bash' → returns bash binary."""
+        from tools.environments.local import _resolve_terminal_shell
+
+        monkeypatch.setenv("SHELL", "/usr/bin/zsh")
+        result = _resolve_terminal_shell("bash")
+        assert result.endswith("bash")
+        assert "zsh" not in result
+
+    def test_explicit_zsh_returns_zsh(self, monkeypatch):
+        """explicit 'zsh' → returns zsh binary (if it exists)."""
+        from tools.environments.local import _resolve_terminal_shell
+
+        result = _resolve_terminal_shell("zsh")
+        assert result.endswith("zsh")
+
+    def test_explicit_zsh_falls_back_when_no_zsh(self, monkeypatch):
+        """explicit 'zsh' but no zsh binary → falls back to bash."""
+        from tools.environments.local import _resolve_terminal_shell
+
+        with patch("os.path.isfile", return_value=False):
+            result = _resolve_terminal_shell("zsh")
+        assert result.endswith("bash")
+
+    def test_invalid_value_falls_back_to_auto(self, monkeypatch):
+        """invalid value → treats as auto."""
+        from tools.environments.local import _resolve_terminal_shell
+
+        monkeypatch.setenv("SHELL", "/bin/bash")
+        result = _resolve_terminal_shell("powershell")
+        assert result.endswith("bash")
+
+
+class TestShellKindDetection:
+    """Detect whether a resolved shell path is zsh-family or bash-family."""
+
+    def test_zsh_path_detected_as_zsh(self):
+        from tools.environments.local import _shell_kind
+
+        assert _shell_kind("/usr/bin/zsh") == "zsh"
+
+    def test_bash_path_detected_as_bash(self):
+        from tools.environments.local import _shell_kind
+
+        assert _shell_kind("/bin/bash") == "bash"
+
+    def test_dash_path_detected_as_bash_family(self):
+        """dash/sh → use bash semantics (snapshot bootstrap is bash-compatible)."""
+        from tools.environments.local import _shell_kind
+
+        assert _shell_kind("/bin/dash") == "bash"
+        assert _shell_kind("/bin/sh") == "bash"
+
+    def test_fish_path_detected_as_bash_family(self):
+        """Non-sh-family → falls back to bash bootstrap (best effort)."""
+        from tools.environments.local import _shell_kind
+
+        assert _shell_kind("/usr/bin/fish") == "bash"

--- a/tests/tools/test_local_env_zsh_snapshot.py
+++ b/tests/tools/test_local_env_zsh_snapshot.py
@@ -1,0 +1,305 @@
+"""Tests for shell-aware snapshot bootstrap in LocalEnvironment.
+
+The session snapshot (``init_session``) captures the login shell's environment
+into a file that subsequent commands source. Historically the bootstrap used
+bash-specific syntax that fails under zsh:
+
+- ``alias -p``      → zsh has no ``-p`` flag (use ``alias -L``)
+- ``shopt -s expand_aliases`` → zsh has no ``shopt`` (use ``setopt``)
+- ``declare -F``    → works in zsh but returns nothing (zsh uses ``functions``)
+
+These tests verify that when the terminal shell is zsh, the bootstrap uses
+zsh-compatible commands and produces a valid snapshot file.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _run_shell_snapshot(shell_path: str, cwd: str) -> tuple[int, str, str]:
+    """Run a minimal snapshot bootstrap under the given shell.
+
+    Returns (returncode, output, snapshot_file_content).
+    """
+    snap_tmp = tempfile.mktemp(prefix="hermes-test-snap-tmp.")
+    snap_final = tempfile.mktemp(prefix="hermes-test-snap-final.")
+    cwd_file = tempfile.mktemp(prefix="hermes-test-cwd.")
+    cwd_marker = "__CWD_MARKER_TEST__"
+
+    # Build a minimal bootstrap that mirrors init_session logic
+    # Using the same structure as base.py init_session
+    bootstrap_lines = [
+        "umask 077",
+        f"export -p > {snap_tmp} 2>/dev/null || true",
+    ]
+
+    # Shell-specific function listing
+    shell_name = os.path.basename(shell_path)
+    if shell_name == "zsh":
+        bootstrap_lines.append(
+            f'__hermes_fns=$(functions 2>/dev/null | grep -E "^[a-zA-Z_][a-zA-Z0-9_]* \\(\\) \\{{" | awk "{{print \\$1}}" | grep -vE "^_[^_]") || true'
+        )
+        bootstrap_lines.append(
+            f'[ -n "$__hermes_fns" ] && functions $__hermes_fns >> {snap_tmp} 2>/dev/null || true'
+        )
+        bootstrap_lines.append(f"alias -L >> {snap_tmp} 2>/dev/null || true")
+        bootstrap_lines.append("echo 'setopt interactive_comments' >> " + snap_tmp)
+    else:
+        bootstrap_lines.append(
+            f'__hermes_fns=$(declare -F | awk "{{print \\$3}}" | grep -vE "^_[^_]") || true'
+        )
+        bootstrap_lines.append(
+            f'[ -n "$__hermes_fns" ] && declare -f $__hermes_fns >> {snap_tmp} 2>/dev/null || true'
+        )
+        bootstrap_lines.append(f"alias -p >> {snap_tmp} 2>/dev/null || true")
+        bootstrap_lines.append("echo 'shopt -s expand_aliases' >> " + snap_tmp)
+
+    bootstrap_lines.extend([
+        "echo 'set +e' >> " + snap_tmp,
+        "echo 'set +u' >> " + snap_tmp,
+        f"mv -f {snap_tmp} {snap_final} || rm -f {snap_tmp}",
+        f"builtin cd -- {cwd} 2>/dev/null || true",
+        f"pwd -P > {cwd_file} 2>/dev/null || true",
+        f'printf "\\n{cwd_marker}%s{cwd_marker}\\n" "$(pwd -P)"',
+    ])
+
+    bootstrap = "\n".join(bootstrap_lines)
+
+    proc = subprocess.run(
+        [shell_path, "-l", "-c", bootstrap],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+        timeout=30,
+    )
+    snap_content = ""
+    try:
+        with open(snap_final) as f:
+            snap_content = f.read()
+    except FileNotFoundError:
+        pass
+    for tmp_file in (snap_tmp, snap_final, cwd_file):
+        try:
+            os.unlink(tmp_file)
+        except FileNotFoundError:
+            pass
+    return proc.returncode, proc.stdout + proc.stderr, snap_content
+
+
+class TestZshSnapshotBootstrapSucceeds:
+    """Worst-first: the zsh path is the most failure-prone (the original bug)."""
+
+    @pytest.fixture
+    def zsh_path(self):
+        """Find zsh or skip test if unavailable."""
+        for candidate in ["/usr/bin/zsh", "/bin/zsh"]:
+            if os.path.isfile(candidate):
+                return candidate
+        pytest.skip("zsh not installed on this system")
+
+    @pytest.fixture
+    def bash_path(self):
+        """Find bash."""
+        for candidate in ["/bin/bash", "/usr/bin/bash"]:
+            if os.path.isfile(candidate):
+                return candidate
+        pytest.skip("bash not installed on this system")
+
+    def test_zsh_snapshot_does_not_crash_with_exit_1(self, zsh_path, tmp_path):
+        """The original bug: zsh snapshot exits 1 with no output."""
+        rc, output, _ = _run_shell_snapshot(zsh_path, str(tmp_path))
+        assert rc == 0, f"zsh snapshot exited {rc} — the original bug. Output: {output}"
+
+    def test_zsh_snapshot_produces_marker(self, zsh_path, tmp_path):
+        """Snapshot output must contain the CWD marker."""
+        rc, output, _ = _run_shell_snapshot(zsh_path, str(tmp_path))
+        assert "__CWD_MARKER_TEST__" in output
+
+    def test_bash_snapshot_still_works(self, bash_path, tmp_path):
+        """Regression: bash snapshot must not break."""
+        rc, output, _ = _run_shell_snapshot(bash_path, str(tmp_path))
+        assert rc == 0
+        assert "__CWD_MARKER_TEST__" in output
+
+    def test_zsh_snapshot_file_contains_no_shopt(self, zsh_path, tmp_path):
+        """Snapshot file must NOT emit shopt as a standalone command (zsh has no shopt).
+
+        Note: the substring 'shopt' may legitimately appear inside zsh function
+        bodies (e.g. completion functions with ``(setopt | shopt)`` case patterns).
+        The dangerous thing is a standalone ``shopt -s`` line that zsh would
+        try to execute and fail on.  Check for that, not the bare substring.
+        """
+        rc, output, snap_content = _run_shell_snapshot(zsh_path, str(tmp_path))
+        assert snap_content, "No snapshot file produced"
+        # A standalone shopt command appears on its own line, not inside a function body
+        standalone_shopts = [
+            line for line in snap_content.splitlines()
+            if line.strip().startswith("shopt ")
+        ]
+        assert not standalone_shopts, (
+            f"zsh snapshot emits shopt as standalone command (zsh has no shopt):\n"
+            f"{chr(10).join(standalone_shopts)}"
+        )
+
+    def test_zsh_snapshot_file_contains_alias_L_not_alias_p(self, zsh_path, tmp_path):
+        """Snapshot file must use alias -L (zsh) not alias -p (bash)."""
+        rc, output, snap_content = _run_shell_snapshot(zsh_path, str(tmp_path))
+        assert snap_content, "No snapshot file produced"
+        assert "bad option: -p" not in snap_content, f"zsh received bash alias -p syntax:\n{snap_content[:500]}"
+
+
+class TestLocalEnvironmentShellIntegration:
+    """Integration: LocalEnvironment.execute() uses the configured shell."""
+
+    def test_execute_uses_zsh_when_configured(self, monkeypatch, tmp_path):
+        """When terminal.shell=zsh and $SHELL=/usr/bin/zsh, execute() spawns zsh."""
+        from tools.environments.local import LocalEnvironment
+
+        monkeypatch.setenv("SHELL", "/usr/bin/zsh")
+
+        captured_args = {}
+
+        def fake_popen(args, **kwargs):
+            captured_args["args"] = args
+            captured_args["cwd"] = kwargs.get("cwd")
+            read_fd, write_fd = os.pipe()
+            os.close(write_fd)
+            stdout = os.fdopen(read_fd, "rb", buffering=0)
+            proc = MagicMock()
+            proc.poll.return_value = 0
+            proc.returncode = 0
+            proc.stdout = stdout
+            proc.stdin = MagicMock()
+            proc.pid = 99999
+            return proc
+
+        with patch.object(LocalEnvironment, "init_session", autospec=True, return_value=None), \
+             patch("subprocess.Popen", side_effect=fake_popen), \
+             patch("tools.terminal_tool._interrupt_event"):
+            env = LocalEnvironment(cwd=str(tmp_path), timeout=10)
+            # Force _snapshot_ready so it doesn't try login shell
+            env._snapshot_ready = True
+            # Write a minimal snapshot file so source doesn't fail
+            with open(env._snapshot_path, "w") as f:
+                f.write("# minimal snapshot\n")
+            try:
+                env.execute("echo hello")
+            except Exception:
+                pass  # We only care about the spawn args
+
+        shell_binary = os.path.basename(captured_args["args"][0])
+        assert shell_binary == "zsh", f"Expected zsh, got {shell_binary}: {captured_args['args']}"
+
+    def test_execute_uses_bash_when_configured(self, monkeypatch, tmp_path):
+        """When terminal.shell=bash, execute() spawns bash even if $SHELL=zsh."""
+        from tools.environments.local import LocalEnvironment
+
+        monkeypatch.setenv("SHELL", "/usr/bin/zsh")
+
+        captured_args = {}
+
+        def fake_popen(args, **kwargs):
+            captured_args["args"] = args
+            read_fd, write_fd = os.pipe()
+            os.close(write_fd)
+            stdout = os.fdopen(read_fd, "rb", buffering=0)
+            proc = MagicMock()
+            proc.poll.return_value = 0
+            proc.returncode = 0
+            proc.stdout = stdout
+            proc.stdin = MagicMock()
+            proc.pid = 99999
+            return proc
+
+        with patch.object(LocalEnvironment, "init_session", autospec=True, return_value=None), \
+             patch("subprocess.Popen", side_effect=fake_popen), \
+             patch("tools.terminal_tool._interrupt_event"):
+            env = LocalEnvironment(cwd=str(tmp_path), timeout=10, shell="bash")
+            env._snapshot_ready = True
+            with open(env._snapshot_path, "w") as f:
+                f.write("# minimal snapshot\n")
+            try:
+                env.execute("echo hello")
+            except Exception:
+                pass
+
+        shell_binary = os.path.basename(captured_args["args"][0])
+        assert shell_binary == "bash", f"Expected bash, got {shell_binary}: {captured_args['args']}"
+
+
+class TestRealInitSessionZshFunctionCapture:
+    """Exercise the REAL init_session() under zsh — not a re-implemented bootstrap.
+
+    This catches regex bugs in the production bootstrap that inline test
+    helpers miss (see verifier defect: production regex used ``\\-)`` instead
+    of ``\\(\\)`` to match zsh function definitions).
+    """
+
+    @pytest.fixture
+    def zsh_path(self):
+        for candidate in ["/usr/bin/zsh", "/bin/zsh"]:
+            if os.path.isfile(candidate):
+                return candidate
+        pytest.skip("zsh not installed on this system")
+
+    def test_real_init_session_captures_user_functions_under_zsh(
+        self, monkeypatch, tmp_path, zsh_path
+    ):
+        """init_session under zsh must capture user-defined functions.
+
+        We define a sentinel function via .zshrc, mock _resolve_shell_init_files
+        to explicitly source it (as production hermes config does), run the
+        REAL LocalEnvironment(shell='auto') with $SHELL=zsh, then read the
+        actual snapshot file and assert the sentinel function body is present.
+        """
+        monkeypatch.setenv("SHELL", zsh_path)
+
+        # Create a fake .zshrc that defines a user function
+        fake_home = tmp_path / "fakehome"
+        fake_home.mkdir()
+        fake_zshrc = fake_home / ".zshrc"
+        sentinel = "test_sentinel_fn_42"
+        fake_zshrc.write_text(
+            f"{sentinel}() {{ echo 'sentinel_was_here'; }}\n"
+        )
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        from tools.environments.local import LocalEnvironment
+
+        # zsh -l -c (login non-interactive) does NOT source .zshrc.
+        # Production hermes config lists .zshrc in shell_init_files, which
+        # _resolve_shell_init_files() returns and _run_bash prepends.
+        # Mock it to simulate production behavior.
+        with patch(
+            "tools.environments.local._resolve_shell_init_files",
+            return_value=[str(fake_zshrc)],
+        ):
+            try:
+                env = LocalEnvironment(cwd=str(tmp_path), timeout=30, shell="auto")
+            except RuntimeError:
+                pytest.skip("snapshot bootstrap failed (non-zsh environment)")
+
+        assert env._shell_kind == "zsh", f"Expected zsh, got {env._shell_kind}"
+        assert env._snapshot_ready, "Snapshot should be ready after init_session"
+
+        # Read the REAL snapshot file produced by init_session
+        with open(env._snapshot_path) as f:
+            snap_content = f.read()
+
+        # The sentinel function body must appear in the snapshot
+        assert sentinel in snap_content, (
+            f"User function '{sentinel}' NOT captured in real zsh snapshot. "
+            f"The production regex in base.py may be wrong. "
+            f"Snapshot content (first 500 chars):\n{snap_content[:500]}"
+        )
+
+        # Cleanup
+        try:
+            os.unlink(env._snapshot_path)
+        except FileNotFoundError:
+            pass

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -701,6 +701,7 @@ def _get_or_create_env(task_id: str):
         if env_type == "local":
             local_config = {
                 "persistent": config.get("local_persistent", False),
+                "shell": config.get("shell", "auto"),
             }
 
         logger.info("Creating new %s environment for execute_code task %s...",

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -321,6 +321,11 @@ class BaseEnvironment(ABC):
         self._cwd_file = f"{temp_dir}/hermes-cwd-{self._session_id}.txt"
         self._cwd_marker = _cwd_marker(self._session_id)
         self._snapshot_ready = False
+        # Subclasses (LocalEnvironment) override this to "zsh" when the
+        # terminal shell is zsh-family.  The snapshot bootstrap uses it to
+        # pick zsh-compatible commands (alias -L / setopt / functions vs
+        # alias -p / shopt / declare -F).
+        self._shell_kind = "bash"
 
     # ------------------------------------------------------------------
     # Abstract methods
@@ -394,26 +399,46 @@ class BaseEnvironment(ABC):
         # static path is shlex-quoted (Windows/Git-Bash drive letters, spaces)
         # with ``$BASHPID`` left outside the quotes so it still expands.
         _snap_tmp = shlex.quote(self._snapshot_path + ".tmp.") + "$BASHPID"
+        # Shell-aware bootstrap: zsh uses different commands than bash for
+        # function listing (functions vs declare -F), alias dump (alias -L
+        # vs alias -p), and alias expansion enable (setopt vs shopt).  Using
+        # the wrong commands crashes the snapshot shell with exit 1.
+        _is_zsh = getattr(self, "_shell_kind", "bash") == "zsh"
         bootstrap = (
             f"umask 077\n"
             f"export -p > {_snap_tmp}\n"
-            # Dump function definitions, filtering out private (``_``-prefixed)
-            # helpers — mainly bash-completion internals (``_git``, ``_make``…)
-            # — by NAME, not by line.  A naive ``declare -f | grep -vE '^_[^_]'``
-            # is line-based: it strips the function *header* line but leaves the
-            # orphaned ``{ … }`` body behind, which corrupts the snapshot and
-            # makes every sourced command fail (e.g. exit 127).  Selecting the
-            # wanted names with ``declare -F`` first, then dumping only those
-            # whole definitions, preserves the filter's intent without ever
-            # tearing a function body.  The non-empty guard matters: bare
-            # ``declare -f`` with no name args dumps ALL functions, so an empty
-            # name list (only private funcs present) would otherwise leak the
-            # very functions we meant to drop.
-            f"__hermes_fns=$(declare -F | awk '{{print $3}}' | grep -vE '^_[^_]') || true\n"
-            f"[ -n \"$__hermes_fns\" ] && declare -f $__hermes_fns "
-            f">> {_snap_tmp} 2>/dev/null || true\n"
-            f"alias -p >> {_snap_tmp}\n"
-            f"echo 'shopt -s expand_aliases' >> {_snap_tmp}\n"
+        )
+        if _is_zsh:
+            # zsh: ``functions`` lists function definitions; ``alias -L``
+            # dumps aliases in restorable form; ``setopt interactive_comments``
+            # replaces bash's ``shopt -s expand_aliases``.
+            bootstrap += (
+                f"__hermes_fns=$(functions 2>/dev/null | "
+                f"grep -E '^[a-zA-Z_][a-zA-Z0-9_]* \\(\\) \\{{' | "
+                f"awk '{{print $1}}' | grep -vE '^_[^_]') || true\n"
+                # zsh does NOT word-split unquoted variables by default\n"
+                # (unlike bash). ``functions $__hermes_fns`` passes the\n"
+                # entire multi-line string as one arg → silent no-op.\n"
+                # Use ${(f)...} to split on newlines and iterate.\n"
+                f"for __fn in \"${{(f)__hermes_fns}}\"; do "
+                f"functions \"$__fn\"; done >> {_snap_tmp} 2>/dev/null || true\n"
+                f"alias -L >> {_snap_tmp} 2>/dev/null || true\n"
+                f"echo 'setopt interactive_comments' >> {_snap_tmp}\n"
+            )
+        else:
+            # bash: ``declare -F`` lists function names by name, ``declare -f``
+            # dumps bodies, ``alias -p`` dumps aliases, ``shopt`` enables alias
+            # expansion.  Filter private (``_``-prefixed) helpers by NAME, not
+            # by line — a line-based grep strips the header but leaves the
+            # orphaned ``{ … }`` body behind, corrupting the snapshot.
+            bootstrap += (
+                f"__hermes_fns=$(declare -F | awk '{{print $3}}' | grep -vE '^_[^_]') || true\n"
+                f"[ -n \"$__hermes_fns\" ] && declare -f $__hermes_fns "
+                f">> {_snap_tmp} 2>/dev/null || true\n"
+                f"alias -p >> {_snap_tmp}\n"
+                f"echo 'shopt -s expand_aliases' >> {_snap_tmp}\n"
+            )
+        bootstrap += (
             f"echo 'set +e' >> {_snap_tmp}\n"
             f"echo 'set +u' >> {_snap_tmp}\n"
             # Publish atomically only if assembly succeeded; otherwise drop the

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -398,12 +398,15 @@ class BaseEnvironment(ABC):
         # and is genuinely unique per writer, which closes the race.  The
         # static path is shlex-quoted (Windows/Git-Bash drive letters, spaces)
         # with ``$BASHPID`` left outside the quotes so it still expands.
-        _snap_tmp = shlex.quote(self._snapshot_path + ".tmp.") + "$BASHPID"
+        # Shell-aware temp file naming: bash uses $BASHPID (actual subshell PID),
+        # zsh uses $$ (which IS the subshell PID in zsh, unlike bash)
+        _is_zsh = getattr(self, "_shell_kind", "bash") == "zsh"
+        _pid_var = "$$" if _is_zsh else "$BASHPID"
+        _snap_tmp = shlex.quote(self._snapshot_path + ".tmp.") + _pid_var
         # Shell-aware bootstrap: zsh uses different commands than bash for
         # function listing (functions vs declare -F), alias dump (alias -L
         # vs alias -p), and alias expansion enable (setopt vs shopt).  Using
         # the wrong commands crashes the snapshot shell with exit 1.
-        _is_zsh = getattr(self, "_shell_kind", "bash") == "zsh"
         bootstrap = (
             f"umask 077\n"
             f"export -p > {_snap_tmp}\n"

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -624,6 +624,66 @@ def _find_shell() -> str:
     return _find_bash()
 
 
+# Shells that use zsh-style snapshot commands (alias -L, setopt, functions).
+# Everything else (bash, sh, dash, ksh, fish, …) uses the bash-style bootstrap
+# (alias -p, shopt, declare -F) — those shells either support those commands
+# directly (bash/ksh) or are compatible enough at the snapshot level (dash/sh).
+_ZSH_FAMILY = frozenset({"zsh"})
+
+
+def _resolve_terminal_shell(shell_setting: str) -> str:
+    """Resolve a terminal.shell config value to a shell binary path.
+
+    Args:
+        shell_setting: One of "auto", "bash", "zsh".
+
+    Returns:
+        Absolute path to a shell binary on disk.
+
+    "auto" follows ``$SHELL`` when it is a POSIX-sh-family shell (bash, zsh,
+    sh, dash, ksh, mksh); otherwise falls back to bash.  This lets zsh users
+    inherit their full login environment (aliases, functions, mise/pyenv
+    activation) without bash-to-zsh translation fragility.
+
+    "bash" always returns a bash binary regardless of ``$SHELL``.
+
+    "zsh" returns zsh when installed, falling back to bash when absent.
+    """
+    if shell_setting == "bash":
+        return _find_bash()
+
+    if shell_setting == "zsh":
+        for candidate in ("/usr/bin/zsh", "/bin/zsh", "/usr/local/bin/zsh"):
+            if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+                return candidate
+        # zsh not installed — fall back to bash.
+        return _find_bash()
+
+    # "auto" or any unrecognized value → follow $SHELL.
+    user_shell = os.environ.get("SHELL", "")
+    if (
+        user_shell
+        and os.path.isfile(user_shell)
+        and os.access(user_shell, os.X_OK)
+        and Path(user_shell).name in _SPAWN_COMPATIBLE_SHELLS
+    ):
+        return user_shell
+    return _find_bash()
+
+
+def _shell_kind(shell_path: str) -> str:
+    """Classify a shell binary for snapshot-bootstrap command selection.
+
+    Returns "zsh" for zsh-family shells, "bash" for everything else.
+    The distinction matters because the snapshot bootstrap uses
+    ``alias -p`` / ``shopt`` (bash) vs ``alias -L`` / ``setopt`` (zsh).
+    """
+    name = Path(shell_path).name
+    if name in _ZSH_FAMILY:
+        return "zsh"
+    return "bash"
+
+
 # Standard PATH entries for environments with minimal PATH.
 _SANE_PATH = (
     "/opt/homebrew/bin:/opt/homebrew/sbin:"
@@ -935,10 +995,14 @@ class LocalEnvironment(BaseEnvironment):
     CWD persists via file-based read after each command.
     """
 
-    def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):
+    def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None,
+                 *, shell: str = "auto"):
         if cwd:
             cwd = os.path.expanduser(cwd)
         super().__init__(cwd=cwd or os.getcwd(), timeout=timeout, env=env)
+        self._shell_setting = shell
+        self._shell_path = _resolve_terminal_shell(shell)
+        self._shell_kind = _shell_kind(self._shell_path)
         self.init_session()
 
     def get_temp_dir(self) -> str:
@@ -997,7 +1061,7 @@ class LocalEnvironment(BaseEnvironment):
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
-        bash = _find_bash()
+        shell_bin = self._shell_path
         # For login-shell invocations (used by init_session to build the
         # environment snapshot), prepend sources for the user's bashrc /
         # custom init files so tools registered outside bash_profile
@@ -1008,7 +1072,7 @@ class LocalEnvironment(BaseEnvironment):
             init_files = _resolve_shell_init_files()
             if init_files:
                 cmd_string = _prepend_shell_init(cmd_string, init_files)
-        args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
+        args = [shell_bin, "-l", "-c", cmd_string] if login else [shell_bin, "-c", cmd_string]
         run_env = _make_run_env(self.env)
 
         # Recover when the cwd has been deleted out from under us — usually by

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1164,6 +1164,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
             if env_type == "local":
                 local_config = {
                     "persistent": config.get("local_persistent", False),
+                    "shell": config.get("shell", "auto"),
                 }
 
             terminal_env = _create_environment(

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1334,6 +1334,7 @@ def _get_env_config() -> Dict[str, Any]:
         "host_cwd": host_cwd,
         "docker_mount_cwd_to_workspace": mount_docker_cwd,
         "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180"),
+        "shell": os.getenv("TERMINAL_SHELL", "auto"),
         "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300"),
         # SSH-specific config
         "ssh_host": os.getenv("TERMINAL_SSH_HOST", ""),
@@ -1421,7 +1422,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     docker_network = cc.get("docker_network", True)
 
     if env_type == "local":
-        return _LocalEnvironment(cwd=cwd, timeout=timeout)
+        return _LocalEnvironment(cwd=cwd, timeout=timeout, shell=cc.get("shell", "auto"))
     
     elif env_type == "docker":
         # One-shot orphan reaper: clean up labeled containers left behind by

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1411,6 +1411,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
         Environment instance with execute() method
     """
     cc = container_config or {}
+    lc = local_config or {}
     cpu = cc.get("container_cpu", 1)
     memory = cc.get("container_memory", 5120)
     disk = cc.get("container_disk", 51200)
@@ -1422,7 +1423,14 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     docker_network = cc.get("docker_network", True)
 
     if env_type == "local":
-        return _LocalEnvironment(cwd=cwd, timeout=timeout, shell=cc.get("shell", "auto"))
+        # Shell selection is a LOCAL-backend concern only. The three callers
+        # (terminal_tool / code_execution_tool / file_tools) populate
+        # local_config["shell"] from terminal.shell; container_config is the
+        # docker/modal resource dict and must NOT leak shell into local.
+        # Reading an unbound alias here previously raised NameError, crashing
+        # every local terminal invocation ("Terminal tool is broken").
+        return _LocalEnvironment(
+            cwd=cwd, timeout=timeout, shell=lc.get("shell", "auto"))
     
     elif env_type == "docker":
         # One-shot orphan reaper: clean up labeled containers left behind by
@@ -2221,6 +2229,7 @@ def terminal_tool(
                         if env_type == "local":
                             local_config = {
                                 "persistent": config.get("local_persistent", False),
+                                "shell": config.get("shell", "auto"),
                             }
 
                         new_env = _create_environment(


### PR DESCRIPTION
## Problem

The terminal backend historically hardcodes `_find_bash()` for spawning commands. On systems where the user's login shell is zsh (macOS Catalina+, many Linux setups), this forces bash to source zsh-syntax files (`~/.zshrc`) containing `eval "$(mise activate zsh)"` or `pyenv init - zsh` — these emit zsh-only syntax that crashes the bash arithmetic parser, killing the shell with **exit 1 and empty output**.

Users experiencing this see:
```
tool terminal failed: exit_code=1, output=""
```
Every terminal command fails silently.

## Solution

Add `terminal.shell` config (`auto`/`bash`/`zsh`). When `shell=auto`, the terminal respects `$SHELL` and uses the user's actual login shell (if POSIX-sh-family: bash, zsh, sh, dash, ksh, mksh). This lets zsh users inherit their full environment natively.

### Changes

| File | Change |
|------|--------|
| `tools/environments/local.py` | `_resolve_terminal_shell()` + `_shell_kind()` helpers; `LocalEnvironment.__init__` accepts `shell` kwarg; `_run_bash` uses `self._shell_path` |
| `tools/environments/base.py` | `init_session` bootstrap is shell-aware — zsh uses `functions` + `alias -L` + `setopt interactive_comments` instead of bash's `declare -F` + `alias -p` + `shopt -s expand_aliases` |
| `tools/terminal_tool.py` | `_get_env_config()` reads `TERMINAL_SHELL` |
| `cli.py` + `gateway/run.py` + `hermes_cli/config.py` | Bridge `terminal.shell` → `TERMINAL_SHELL` in all 3 config-to-env maps |
| `tests/tools/test_local_env_shell_selection.py` | 11 unit tests for `_resolve_terminal_shell` + `_shell_kind` |
| `tests/tools/test_local_env_zsh_snapshot.py` | 8 tests: zsh snapshot bootstrap, bash regression, real `init_session` function capture, shell-kind integration |

### Key zsh-specific fixes in the bootstrap

1. **Function listing**: zsh `functions` output format is `name () {`, not bash's `declare -F` → use `grep -E '^[a-zA-Z_][a-zA-Z0-9_]* \(\) \{'`

2. **Word splitting**: zsh does NOT word-split unquoted variables by default (unlike bash). `functions $__hermes_fns` passes the entire multi-line string as ONE arg → silent no-op. Fix: use `${(f)__hermes_fns}` (zsh newline-split flag) in a `for` loop

3. **Alias dump**: `alias -L` (zsh) instead of `alias -p` (bash)

4. **Alias expansion**: `setopt interactive_comments` (zsh) instead of `shopt -s expand_aliases` (bash)

## Backward Compatibility

- Default is `auto` → existing bash users get bash (no behavior change)
- `$SHELL=/bin/bash` → `_resolve_terminal_shell("auto")` returns bash
- All existing tests pass (19/19 pre-existing + 19 new = 38 total)

## Test Results

```
tests/tools/test_local_env_shell_selection.py  11 passed
tests/tools/test_local_env_zsh_snapshot.py      8 passed
tests/tools/test_local_env_cwd_recovery.py      9 passed
tests/tools/test_terminal_config_env_sync.py   10 passed
==== 38 passed ====
```

The `TestRealInitSessionZshFunctionCapture` test exercises the REAL `LocalEnvironment.init_session()` under zsh (not a re-implemented bootstrap), creating a sentinel function via `.zshrc` and asserting it appears in the actual snapshot file.