### PR TITLE
fix(desktop): set PYTHONIOENCODING=utf-8 on Windows to prevent Python backend UnicodeDecodeError crash

### DIFF
--- a/apps/desktop/electron/backend-env.test.ts
+++ b/apps/desktop/electron/backend-env.test.ts
@@ -65,6 +65,7 @@ test('buildDesktopBackendEnv extends PYTHONPATH and backend PATH together', () =
   assert.equal(env.PYTHONPATH, '/repo/hermes-agent:/existing/pythonpath')
   assert.ok(env.PATH.startsWith('/Users/test/.hermes/node/bin:/Users/test/.hermes/hermes-agent/venv/bin:'))
   assert.ok(env.PATH.includes('/opt/homebrew/bin'))
+  assert.equal(env.PYTHONIOENCODING, undefined, 'non-Windows platforms should not set PYTHONIOENCODING')
 })
 
 test('normalizeHermesHomeRoot maps profile homes back to the global Hermes root', () => {
@@ -98,6 +99,7 @@ test('Windows PATH casing and delimiter are preserved without POSIX sane entries
   assert.ok(env.Path.includes('\\venv\\Scripts;'))
   assert.ok(env.Path.includes(';C:\\Windows\\System32;C:\\Windows'))
   assert.equal(env.Path.includes('/opt/homebrew/bin'), false)
+  assert.equal(env.PYTHONIOENCODING, 'utf-8', 'Windows platform should set PYTHONIOENCODING to utf-8')
 })
 
 test('appendUniquePathEntries drops empty entries and keeps first occurrence', () => {

--- a/apps/desktop/electron/backend-env.ts
+++ b/apps/desktop/electron/backend-env.ts
@@ -94,7 +94,7 @@ function buildDesktopBackendEnv({
   currentEnv = process.env,
   platform = process.platform,
   pathModule = pathModuleForPlatform(platform)
-}: any = {}) {
+}: any = {}): Record<string, string> {
   const delimiter = delimiterForPlatform(platform)
   const currentPythonPath = currentEnv?.PYTHONPATH || ''
   const key = pathEnvKey(currentEnv, platform)
@@ -107,7 +107,8 @@ function buildDesktopBackendEnv({
       currentPath: currentPathValue(currentEnv, platform),
       platform,
       pathModule
-    })
+    }),
+    ...(platform === 'win32' ? { PYTHONIOENCODING: 'utf-8' } : {})
   }
 }
 


### PR DESCRIPTION
## Root Cause

`buildDesktopBackendEnv()` in `backend-env.ts` spawns the Python backend without `PYTHONIOENCODING`. On Chinese Windows, Python defaults to cp950, so backend stdout/stderr writing UTF-8 causes `_readerthread` to crash with `UnicodeDecodeError`. Electron interprets this as backend failure and auto-closes the Desktop app.

Found 293 occurrences of `UnicodeDecodeError` in `desktop.log`.

## Fix

Add `PYTHONIOENCODING=utf-8` to the environment object returned by `buildDesktopBackendEnv()` on `win32` only, preserving existing behavior on macOS and Linux.

## Testing

- Windows builds: `PYTHONIOENCODING` is set to `utf-8`
- macOS/Linux builds: `PYTHONIOENCODING` remains `undefined`

Signed-off-by: RheinhardtEddy