### PR TITLE
fix(email): declare splits_long_messages to prevent cron output truncation

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -422,6 +422,8 @@ def _extract_attachments(
 class EmailAdapter(BasePlatformAdapter):
     """Email gateway adapter using IMAP (receive) and SMTP (send)."""
 
+    splits_long_messages = True  # SMTP has no practical per-message limit; send() full content
+
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.EMAIL)
 


### PR DESCRIPTION
Fixes #61990

## Problem
Email delivery truncates outgoing messages at ~4000 characters. The `EmailAdapter` does not declare `splits_long_messages = True`, so cron job output sent via email is hard-truncated with a `[... truncated, full output saved to ...]` footer — even though SMTP has no practical per-message length limit at that scale.

## Fix
Add `splits_long_messages = True` to the `EmailAdapter` class. This tells the gateway delivery pipeline that the adapter handles long messages natively (SMTP supports multi-megabyte payloads), so the 4000-char truncation is skipped.

## Verification
- The adapter's own `MAX_MESSAGE_LENGTH = 50_000` confirms SMTP can handle large payloads.
- Other platform adapters (Slack, Telegram, Discord, Feishu, WhatsApp, etc.) already set this flag.
- No code changes needed in `send()` — it already delivers the full body via SMTP.