### PR TITLE
fix(install): validate SSH clone by checking .git directory before accepting

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1271,9 +1271,13 @@ clone_repo() {
         # Try SSH first (for private repo access), fall back to HTTPS
         # GIT_SSH_COMMAND disables interactive prompts and sets a short timeout
         # so SSH fails fast instead of hanging when no key is configured.
+        # Validate the clone by checking .git + files: on some environments
+        # (e.g. Lightning.ai) git clone via SSH can exit 0 without producing
+        # any checkout, causing the installer to skip the HTTPS fallback.
         log_info "Trying SSH clone..."
         if GIT_SSH_COMMAND="ssh -o BatchMode=yes -o ConnectTimeout=5" \
-           git clone --depth 1 --branch "$BRANCH" "$REPO_URL_SSH" "$INSTALL_DIR" 2>/dev/null; then
+           git clone --depth 1 --branch "$BRANCH" "$REPO_URL_SSH" "$INSTALL_DIR" 2>/dev/null \
+           && [ -d "$INSTALL_DIR/.git" ] && [ -n "$(ls -A "$INSTALL_DIR" 2>/dev/null | head -5)" ]; then
             log_success "Cloned via SSH"
         else
             rm -rf "$INSTALL_DIR" 2>/dev/null  # Clean up partial SSH clone


### PR DESCRIPTION
Fixes #62132

## Problem
The Hermes installer (install.sh) tries SSH first, then falls back to HTTPS if SSH fails. On Lightning.ai Ubuntu VM studios (and potentially other environments), `git clone` via SSH can exit with code 0 but produce no valid clone — no .git directory, no checked-out files. Since the script trusts only the exit code, it skips the HTTPS fallback and the install fails at the repo cloning step.

Root cause: when the SSH connection fails ("Permission denied (publickey)") but the Git transport layer still reports exit 0 in certain configurations, the directory is left empty.

## Fix
Add `&& [ -d "$INSTALL_DIR/.git" ]` after the SSH `git clone` command so a hollow clone (exit 0 but no actual checkout) is treated as a failure and falls through to the HTTPS fallback.