### PR TITLE
fix(desktop): shorten darwin pty helper path

### DIFF
--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -13,17 +13,22 @@ import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve, join } from 'node:path'
 import {
+  chmodSync,
   cpSync,
   existsSync,
   mkdirSync,
   readdirSync,
-  rmSync
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync
 } from 'node:fs'
 import { isMain } from './utils.mjs'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const projectRoot = resolve(here, '..')
 const require = createRequire(import.meta.url)
+const DARWIN_SHORT_HELPER_RELATIVE_PATH = '../../../bin/spawn-helper'
 
 /**
  * Locate node-pty's package root via real module resolution, so this
@@ -72,9 +77,74 @@ function copyBuildRelease(srcDir, destDir) {
       continue
     }
     if (entry.name === 'spawn-helper' || /\.(node|dll|exe)$/.test(entry.name)) {
-      cpSync(join(srcDir, entry.name), join(destDir, entry.name))
+      copyFileWithMode(join(srcDir, entry.name), join(destDir, entry.name))
     }
   }
+}
+
+function copyFileWithMode(srcPath, destPath) {
+  cpSync(srcPath, destPath)
+  chmodSync(destPath, statSync(srcPath).mode)
+}
+
+export function patchUnixTerminalForDarwinShortHelper(source) {
+  const marker = "helperPath = helperPath.replace('node_modules.asar', 'node_modules.asar.unpacked');"
+  if (!source.includes(marker) || source.includes(DARWIN_SHORT_HELPER_RELATIVE_PATH)) {
+    return source
+  }
+
+  const injected = `${marker}
+if (process.platform === 'darwin') {
+    const shortHelperPath = path.resolve(__dirname, '${DARWIN_SHORT_HELPER_RELATIVE_PATH}');
+    try {
+        if (fs.existsSync(shortHelperPath)) {
+            helperPath = shortHelperPath;
+        }
+    } catch {
+        // Ignore fallback lookup failures and keep node-pty's default helper path.
+    }
+}`
+  return source.replace(marker, injected)
+}
+
+function patchStagedUnixTerminal(destRoot) {
+  const unixTerminalPath = join(destRoot, 'lib', 'unixTerminal.js')
+  if (!existsSync(unixTerminalPath)) {
+    return false
+  }
+
+  const original = readFileSync(unixTerminalPath, 'utf8')
+  const patched = patchUnixTerminalForDarwinShortHelper(original)
+  if (patched === original) {
+    return false
+  }
+
+  writeFileSync(unixTerminalPath, patched, 'utf8')
+  return true
+}
+
+export function stageDarwinShortSpawnHelper(
+  destRoot,
+  { platform, arch, shortHelperPath = resolve(projectRoot, 'dist/bin/spawn-helper') } = {}
+) {
+  rmSync(shortHelperPath, { force: true })
+  if (platform !== 'darwin') {
+    return null
+  }
+
+  const candidates = [
+    join(destRoot, 'prebuilds', `${platform}-${arch}`, 'spawn-helper'),
+    join(destRoot, 'build', 'Release', 'spawn-helper')
+  ]
+  const sourcePath = candidates.find(existsSync)
+  if (!sourcePath) {
+    return null
+  }
+
+  mkdirSync(dirname(shortHelperPath), { recursive: true })
+  copyFileWithMode(sourcePath, shortHelperPath)
+  patchStagedUnixTerminal(destRoot)
+  return shortHelperPath
 }
 
 export function stageNodePty({ platform = process.platform, arch = process.arch } = {}) {
@@ -110,11 +180,11 @@ export function stageNodePty({ platform = process.platform, arch = process.arch 
         continue
       }
       if (entry.isFile() && /\.(node|dll|exe)$/.test(entry.name)) {
-        cpSync(join(prebuildDir, entry.name), join(destPrebuild, entry.name))
+        copyFileWithMode(join(prebuildDir, entry.name), join(destPrebuild, entry.name))
         continue
       }
       if (entry.name === 'spawn-helper') {
-        cpSync(join(prebuildDir, entry.name), join(destPrebuild, entry.name))
+        copyFileWithMode(join(prebuildDir, entry.name), join(destPrebuild, entry.name))
       }
     }
   } else {
@@ -125,6 +195,8 @@ export function stageNodePty({ platform = process.platform, arch = process.arch 
         `node-pty's published prebuilds cover ${platform}-${arch}.`
     )
   }
+
+  stageDarwinShortSpawnHelper(destRoot, { platform, arch })
 
   console.log(`[stage-native-deps] staged node-pty (${platform}-${arch}) -> ${destRoot}`)
   return destRoot

--- a/apps/desktop/scripts/stage-native-deps.test.mjs
+++ b/apps/desktop/scripts/stage-native-deps.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import {
+  patchUnixTerminalForDarwinShortHelper,
+  stageDarwinShortSpawnHelper
+} from '../scripts/stage-native-deps.mjs'
+
+test('patchUnixTerminalForDarwinShortHelper injects a darwin short-helper fallback once', () => {
+  const source = `const native = loadNativeModule('pty');
+let helperPath = native.dir + '/spawn-helper';
+helperPath = path.resolve(__dirname, helperPath);
+helperPath = helperPath.replace('app.asar', 'app.asar.unpacked');
+helperPath = helperPath.replace('node_modules.asar', 'node_modules.asar.unpacked');
+const DEFAULT_FILE = 'sh';`
+
+  const patched = patchUnixTerminalForDarwinShortHelper(source)
+  assert.match(patched, /process\.platform === 'darwin'/)
+  assert.match(patched, /fs\.existsSync\(shortHelperPath\)/)
+  assert.match(patched, /\.\.\/\.\.\/\.\.\/bin\/spawn-helper/)
+  assert.equal(patchUnixTerminalForDarwinShortHelper(patched), patched)
+})
+
+test('stageDarwinShortSpawnHelper copies a short helper and patches unixTerminal.js', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-stage-node-pty-'))
+  try {
+    const destRoot = path.join(tempRoot, 'dist', 'node_modules', 'node-pty')
+    const prebuildDir = path.join(destRoot, 'prebuilds', 'darwin-arm64')
+    const libDir = path.join(destRoot, 'lib')
+    const shortHelperPath = path.join(tempRoot, 'dist', 'bin', 'spawn-helper')
+
+    fs.mkdirSync(prebuildDir, { recursive: true })
+    fs.mkdirSync(libDir, { recursive: true })
+    fs.writeFileSync(path.join(prebuildDir, 'spawn-helper'), '#!/bin/sh\nexit 0\n', { mode: 0o755 })
+    fs.writeFileSync(
+      path.join(libDir, 'unixTerminal.js'),
+      `let helperPath = native.dir + '/spawn-helper';
+helperPath = path.resolve(__dirname, helperPath);
+helperPath = helperPath.replace('app.asar', 'app.asar.unpacked');
+helperPath = helperPath.replace('node_modules.asar', 'node_modules.asar.unpacked');
+`,
+      'utf8'
+    )
+
+    const staged = stageDarwinShortSpawnHelper(destRoot, {
+      platform: 'darwin',
+      arch: 'arm64',
+      shortHelperPath
+    })
+
+    assert.equal(staged, shortHelperPath)
+    assert.equal(fs.existsSync(shortHelperPath), true)
+    assert.match(fs.readFileSync(path.join(libDir, 'unixTerminal.js'), 'utf8'), /\.\.\/\.\.\/\.\.\/bin\/spawn-helper/)
+    assert.equal(fs.statSync(shortHelperPath).mode & 0o777, 0o755)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})

--- a/apps/desktop/scripts/test-desktop.mjs
+++ b/apps/desktop/scripts/test-desktop.mjs
@@ -89,10 +89,13 @@ function exists(target) {
 // dist/node_modules/node-pty, and dist/** is asarUnpacked (see package.json
 // build.asarUnpack), so in a packaged build it lands under
 // resources/app.asar.unpacked/dist/node_modules/node-pty — reachable by a bare
-// require('node-pty') from the bundle. Upstream node-pty 1.x is N-API based and
-// ships per-arch prebuilts under prebuilds/<platform>-<arch>/; nix/local builds
-// instead compile from source into build/Release/. The stage script copies
-// whichever is present, so we accept either as the native payload.
+// require('node-pty') from the bundle. On darwin we also ship a shorter
+// dist/bin/spawn-helper fallback and patch unixTerminal.js to prefer it, so
+// macOS 26 doesn't trip over the deeply nested helper path inside the app
+// bundle. Upstream node-pty 1.x is N-API based and ships per-arch prebuilts
+// under prebuilds/<platform>-<arch>/; nix/local builds instead compile from
+// source into build/Release/. The stage script copies whichever is present, so
+// we accept either as the native payload.
 function expectedNativeDepPaths() {
   const root = path.join(APP.resourcesPath, 'app.asar.unpacked', 'dist', 'node_modules', 'node-pty')
   const prebuildsDir = path.join(root, 'prebuilds', `${PLATFORM}-${ARCH}`)
@@ -101,7 +104,9 @@ function expectedNativeDepPaths() {
     packageJson: path.join(root, 'package.json'),
     prebuildsDir,
     buildReleaseDir,
-    libIndex: path.join(root, 'lib', 'index.js')
+    libIndex: path.join(root, 'lib', 'index.js'),
+    shortHelperPath: path.join(APP.resourcesPath, 'app.asar.unpacked', 'dist', 'bin', 'spawn-helper'),
+    unixTerminal: path.join(root, 'lib', 'unixTerminal.js')
   }
 }
 
@@ -356,6 +361,13 @@ function validateBundle() {
       .find(exists)
     if (!spawnHelper) {
       die(`Missing node-pty spawn-helper (required on darwin) in: ${nativeBinaryDirs.join(', ')}`)
+    }
+    if (!exists(native.shortHelperPath)) {
+      die(`Missing short-path darwin spawn-helper fallback: ${native.shortHelperPath}`)
+    }
+    const unixTerminal = fs.readFileSync(native.unixTerminal, 'utf8')
+    if (!unixTerminal.includes('../../../bin/spawn-helper')) {
+      die(`Missing darwin short-helper fallback patch in ${native.unixTerminal}`)
     }
   }
 


### PR DESCRIPTION
## Summary
- stage a second darwin `spawn-helper` copy under `dist/bin` during desktop packaging
- patch the staged `node-pty` `unixTerminal.js` to prefer that shorter helper path on macOS
- verify the packaging contract with focused staging tests and desktop bundle assertions

## Verification
- `node --test apps/desktop/scripts/stage-native-deps.test.mjs`
- `node --check apps/desktop/scripts/stage-native-deps.mjs`
- `node --check apps/desktop/scripts/stage-native-deps.test.mjs`
- `node --check apps/desktop/scripts/test-desktop.mjs`
- `git diff --check`

Closes #62429