### PR TITLE
 register vertex in PROVIDER_REGISTRY to enable auxiliary tasks

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -271,6 +271,10 @@ _PROVIDER_ALIASES = {
     "tokenhub": "tencent-tokenhub",
     "tencent-cloud": "tencent-tokenhub",
     "tencentmaas": "tencent-tokenhub",
+    "google-vertex": "vertex",
+    "vertex-ai": "vertex",
+    "gcp-vertex": "vertex",
+    "vertexai": "vertex",
 }
 
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -452,7 +452,9 @@ try:
     for _pp in _list_providers_for_registry():
         if _pp.name in PROVIDER_REGISTRY:
             continue
-        if _pp.auth_type != "api_key" or not _pp.env_vars:
+        if _pp.auth_type != "api_key" and _pp.auth_type != "vertex":
+            continue
+        if _pp.auth_type == "api_key" and not _pp.env_vars:
             continue
         # Skip providers that need custom token resolution or are special-cased
         # in resolve_provider() (copilot/kimi/zai have bespoke token refresh;
@@ -466,7 +468,7 @@ try:
         PROVIDER_REGISTRY[_pp.name] = ProviderConfig(
             id=_pp.name,
             name=_pp.display_name or _pp.name,
-            auth_type="api_key",
+            auth_type=_pp.auth_type or "api_key",
             inference_base_url=_pp.base_url,
             api_key_env_vars=_api_key_vars or _pp.env_vars,
             base_url_env_var=_base_url_var or "",

--- a/tests/hermes_cli/test_vertex_provider.py
+++ b/tests/hermes_cli/test_vertex_provider.py
@@ -98,3 +98,34 @@ def test_vertex_extra_body_empty_without_reasoning():
 
     p = get_provider_profile("vertex")
     assert p.build_extra_body(model="google/gemini-3-flash-preview") == {}
+
+
+def test_vertex_provider_registry_admission():
+    from hermes_cli.auth import PROVIDER_REGISTRY
+
+    assert "vertex" in PROVIDER_REGISTRY
+    pconfig = PROVIDER_REGISTRY["vertex"]
+    assert pconfig.id == "vertex"
+    assert pconfig.auth_type == "vertex"
+
+
+def test_resolve_provider_client_vertex_reaches_handler(monkeypatch):
+    import agent.vertex_adapter as va
+    from agent.auxiliary_client import resolve_provider_client
+
+    monkeypatch.setattr(va, "has_vertex_credentials", lambda: True)
+    monkeypatch.setattr(
+        va, "get_vertex_config",
+        lambda: ("fake-oauth-token", "https://aiplatform.googleapis.com/v1beta1/projects/p/locations/global/endpoints/openapi"),
+    )
+
+    client, resolved_model = resolve_provider_client(
+        provider="vertex",
+        model="google/gemini-3.1-pro-preview",
+    )
+
+    assert client is not None
+    assert resolved_model == "google/gemini-3.1-pro-preview"
+    assert client.api_key == "fake-oauth-token"
+    assert str(client.base_url).rstrip("/") == "https://aiplatform.googleapis.com/v1beta1/projects/p/locations/global/endpoints/openapi"
+

--- a/tests/hermes_cli/test_vertex_provider.py
+++ b/tests/hermes_cli/test_vertex_provider.py
@@ -129,3 +129,11 @@ def test_resolve_provider_client_vertex_reaches_handler(monkeypatch):
     assert client.api_key == "fake-oauth-token"
     assert str(client.base_url).rstrip("/") == "https://aiplatform.googleapis.com/v1beta1/projects/p/locations/global/endpoints/openapi"
 
+
+def test_vertex_aux_aliases():
+    from agent.auxiliary_client import _normalize_aux_provider
+
+    for alias in ("google-vertex", "vertex-ai", "gcp-vertex", "vertexai", "Vertex", "VERTEX"):
+        assert _normalize_aux_provider(alias) == "vertex"
+
+


### PR DESCRIPTION

## Related Issues
- Fixes #61852 (Every auxiliary task silently fails on `provider: vertex`)

- Fixes the title generation failure described in #56906 (`hermes doctor` fails / no chat titles when using vertex)

- Fixes https://github.com/NousResearch/hermes-agent/issues/56810 at root cause lvel

## Problem
On Vertex-only deployments, every auxiliary task (`title_generation`, `vision_analyze`, context compression, `session_search`) fails with a `RuntimeError: No LLM provider configured for task=... provider=auto` error.

This happens because `PROVIDER_REGISTRY` auto-extension inside `hermes_cli/auth.py` filtered out non-`api_key` provider profiles. Because Google Vertex AI specifies `auth_type="vertex"` and has no static environment keys, it was excluded from `PROVIDER_REGISTRY`. When auxiliary tasks called `res

## Changed made
Allow the `"vertex"` `auth_type` to pass through registration in `hermes_cli/auth.py` and register it with its native `_pp.auth_type` rather than hardcoding `"api_key"`.

```python
# hermes_cli/auth.py
        if _pp.auth_type != "api_key" and _pp.auth_type != "vertex":
            continue
        if _pp.auth_type == "api_key" and not _pp.env_vars:
            continue
...
        PROVIDER_REGISTRY[_pp.name] = ProviderConfig(
            id=_pp.name,
            name=_pp.display_name or _pp.name,
            auth_type=_pp.auth_type or "api_key",
            inference_base_url=_pp.base_url,
            ...
        )
```

This successfully registers `"vertex"` as a first-class `ProviderConfig`, allowing `resolve_provider_client` to route successfully through the `pconfig.auth_type == "vertex"` branch and resolve auxiliary failures.


