### PR TITLE
feat(telegram): add config option to disable CJK rich-message guard

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1379,7 +1379,13 @@ class TelegramAdapter(BasePlatformAdapter):
         leaves overlapping draft/overlay glyph artifacts for CJK text (#47653).
         The legacy MarkdownV2 path renders the same text cleanly, so skip rich
         delivery up front until affected clients age out.
+
+        Users who want rich rendering (tables, task lists, etc.) for CJK
+        content can disable this guard via ``extra.cjk_rich_guard: false``
+        in the Telegram platform config.
         """
+        if not self.config.extra.get("cjk_rich_guard", True):
+            return False
         return bool(content and self._RICH_CJK_RE.search(content))
 
     def _needs_rich_rendering(self, content: str) -> bool:


### PR DESCRIPTION
## Problem

The `_has_telegram_desktop_cjk_rich_garble_shape` guard (added in ea056b0 to fix #47653) disables rich-message rendering for **ALL** content containing CJK characters. This means CJK users lose:
- Pipe tables (MarkdownV2 has no table syntax → tables get rewritten into bullet lists)
- GFM task lists
- Collapsible `<details>` blocks  
- Block math

For the ~1 billion users who write in Chinese/Japanese/Korean, this is a significant regression — tables are the most impactful rich-rendering feature, and they silently degrade to flat bullet lists.

## Solution

Add `extra.cjk_rich_guard` config option (default: `true`, preserving current behavior) so affected users can opt out:

```yaml
platforms:
  telegram:
    extra:
      cjk_rich_guard: false
```

## Changes

6 lines added to `_has_telegram_desktop_cjk_rich_garble_shape()` in `plugins/platforms/telegram/adapter.py`:

```python
if not self.config.extra.get("cjk_rich_guard", True):
    return False
```

- Default behavior: **unchanged** (guard active, same as today)
- Opt-in escape hatch for CJK users via platform config
- No new env vars, no core changes, follows the existing `config.extra` pattern used throughout the adapter

## Rationale

This guard was a blunt fix for a real Telegram Desktop rendering bug (#47653). But:
1. The bug affects a subset of Telegram Desktop versions — not all CJK users see garbling
2. The cost of the guard (no tables/structures for ALL CJK content) often outweighs the benefit
3. Users should be able to make this tradeoff themselves based on their client

A config option lets each user decide, rather than a blanket disable for an entire writing system.