### PR TITLE
fix(uninstall): sweep full uninstall leftovers

### DIFF
--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -7,6 +7,7 @@ Provides options for:
 """
 
 import os
+import platform
 import shutil
 import subprocess
 import sys
@@ -285,6 +286,130 @@ def uninstall_gateway_service():
             log_warn(f"Could not check Windows gateway service: {e}")
 
     return stopped_something
+
+
+def _remove_path(target: Path) -> bool:
+    """Remove a file, symlink, or directory if it exists."""
+    if not target.exists() and not target.is_symlink():
+        return False
+
+    if target.is_dir() and not target.is_symlink():
+        shutil.rmtree(target)
+    else:
+        target.unlink(missing_ok=True)
+
+    return True
+
+
+def full_uninstall_extra_paths(
+    hermes_home: Path,
+    *,
+    home: Path | None = None,
+    system_name: str | None = None,
+    system_applications: Path | None = None,
+) -> list[Path]:
+    """Return desktop/cache paths that full uninstall should also sweep."""
+    home = home or Path.home()
+    system_name = system_name or platform.system()
+    system_applications = system_applications or Path("/Applications")
+
+    candidates = [
+        home / ".cache" / "hermes",
+        home / ".config" / "hermes",
+        home / ".local" / "share" / "hermes",
+    ]
+
+    if system_name == "Darwin":
+        library = home / "Library"
+        candidates.extend(
+            [
+                home / "Applications" / "Hermes.app",
+                system_applications / "Hermes.app",
+                library / "Application Support" / "Hermes",
+                library / "Caches" / "Hermes",
+                library / "Caches" / "com.nousresearch.hermes",
+                library / "Caches" / "hermes-setup",
+                library / "Caches" / "com.nousresearch.hermes.setup",
+                library / "Logs" / "Hermes",
+                library / "Preferences" / "com.nousresearch.hermes.plist",
+                library / "WebKit" / "com.nousresearch.hermes",
+                library / "WebKit" / "hermes-setup",
+                library / "WebKit" / "com.nousresearch.hermes.setup",
+                library / "HTTPStorages" / "com.nousresearch.hermes",
+                library / "Saved Application State" / "com.nousresearch.hermes.savedState",
+            ]
+        )
+
+    unique: list[Path] = []
+    seen: set[Path] = set()
+    for candidate in candidates:
+        if candidate == hermes_home or candidate in seen:
+            continue
+        seen.add(candidate)
+        unique.append(candidate)
+
+    return unique
+
+
+def remove_full_uninstall_leftovers(
+    hermes_home: Path,
+    *,
+    home: Path | None = None,
+    system_name: str | None = None,
+    system_applications: Path | None = None,
+) -> list[Path]:
+    """Remove desktop/cache state that lives outside ``hermes_home``."""
+    removed: list[Path] = []
+    for target in full_uninstall_extra_paths(
+        hermes_home,
+        home=home,
+        system_name=system_name,
+        system_applications=system_applications,
+    ):
+        try:
+            if _remove_path(target):
+                removed.append(target)
+        except Exception as e:
+            log_warn(f"Could not remove {target}: {e}")
+    return removed
+
+
+def remove_legacy_macos_launchd_plists(*, home: Path | None = None) -> list[Path]:
+    """Unload and remove legacy launchd plists outside the active profile."""
+    launch_agents_dir = (home or Path.home()) / "Library" / "LaunchAgents"
+    if not launch_agents_dir.exists():
+        return []
+
+    removed: list[Path] = []
+    uid = str(os.getuid()) if hasattr(os, "getuid") else None
+
+    for pattern in ("ai.hermes.gateway*.plist", "io.nousresearch.hermes-agent.gateway*.plist"):
+        for plist_path in sorted(launch_agents_dir.glob(pattern)):
+            label = plist_path.stem
+            if uid:
+                try:
+                    subprocess.run(
+                        ["launchctl", "bootout", f"gui/{uid}/{label}"],
+                        capture_output=True,
+                        check=False,
+                    )
+                except Exception:
+                    pass
+            try:
+                subprocess.run(
+                    ["launchctl", "unload", str(plist_path)],
+                    capture_output=True,
+                    check=False,
+                )
+            except Exception:
+                pass
+            try:
+                plist_path.unlink(missing_ok=True)
+                removed.append(plist_path)
+            except Exception as e:
+                log_warn(f"Could not remove {plist_path}: {e}")
+
+    return removed
 
 
 # ============================================================================
@@ -725,6 +850,15 @@ def _print_uninstall_dry_run(*, project_root: Path, hermes_home: Path, full_unin
     print(f"  • Code checkout: {project_root}")
     if full_uninstall:
         print(f"  • Hermes config/data: {hermes_home}")
+        extra_paths = full_uninstall_extra_paths(hermes_home)
+        if extra_paths:
+            print("  • Extra cache / desktop state:")
+            for path in extra_paths:
+                print(f"    - {path}")
+        if platform.system() == "Darwin":
+            print("  • Legacy macOS launchd plists matching:")
+            print("    - ~/Library/LaunchAgents/ai.hermes.gateway*.plist")
+            print("    - ~/Library/LaunchAgents/io.nousresearch.hermes-agent.gateway*.plist")
         if _is_default_hermes_home(hermes_home):
             profiles = _discover_named_profiles()
             if profiles:
@@ -750,7 +884,8 @@ def _perform_uninstall(
     Steps: stop gateway → strip PATH (rc files + Windows registry) → remove the
     ``hermes`` wrapper + node symlinks → remove the desktop Chat GUI artifacts →
     delete the code checkout → (Windows) remove PortableGit/Node → optionally
-    wipe ``$HERMES_HOME`` data and named profiles on full uninstall.
+    wipe ``$HERMES_HOME`` data, extra desktop/cache state, and named profiles
+    on full uninstall.
     """
     print()
     print(color("Uninstalling...", Colors.CYAN, Colors.BOLD))
@@ -874,6 +1009,23 @@ def _perform_uninstall(
         if remove_profiles and named_profiles:
             for prof in named_profiles:
                 _uninstall_profile(prof)
+
+        if platform.system() == "Darwin":
+            log_info("Removing legacy macOS launch agents...")
+            removed_plists = remove_legacy_macos_launchd_plists()
+            if removed_plists:
+                for plist_path in removed_plists:
+                    log_success(f"Removed {plist_path}")
+            else:
+                log_info("No legacy macOS launch agents found")
+
+        log_info("Removing extra cache and desktop state...")
+        removed_leftovers = remove_full_uninstall_leftovers(hermes_home)
+        if removed_leftovers:
+            for path in removed_leftovers:
+                log_success(f"Removed {path}")
+        else:
+            log_info("No extra cache or desktop state found")
 
         log_info("Removing configuration and data...")
         try:

--- a/tests/hermes_cli/test_uninstall.py
+++ b/tests/hermes_cli/test_uninstall.py
@@ -1,0 +1,89 @@
+from hermes_cli import uninstall
+
+
+def test_full_uninstall_extra_paths_include_macos_desktop_state(tmp_path):
+    home = tmp_path / "home"
+    hermes_home = home / ".hermes"
+    app_root = tmp_path / "Applications"
+
+    paths = uninstall.full_uninstall_extra_paths(
+        hermes_home,
+        home=home,
+        system_name="Darwin",
+        system_applications=app_root,
+    )
+
+    expected = {
+        home / ".cache" / "hermes",
+        home / ".config" / "hermes",
+        home / ".local" / "share" / "hermes",
+        home / "Applications" / "Hermes.app",
+        app_root / "Hermes.app",
+        home / "Library" / "Application Support" / "Hermes",
+        home / "Library" / "Caches" / "com.nousresearch.hermes",
+        home / "Library" / "Preferences" / "com.nousresearch.hermes.plist",
+        home / "Library" / "Saved Application State" / "com.nousresearch.hermes.savedState",
+    }
+
+    assert expected.issubset(set(paths))
+    assert hermes_home not in paths
+
+
+def test_remove_full_uninstall_leftovers_removes_existing_targets(tmp_path):
+    home = tmp_path / "home"
+    hermes_home = home / ".hermes"
+    app_root = tmp_path / "Applications"
+
+    cache_dir = home / ".cache" / "hermes"
+    pref_file = home / "Library" / "Preferences" / "com.nousresearch.hermes.plist"
+    app_bundle = app_root / "Hermes.app"
+
+    cache_dir.mkdir(parents=True)
+    pref_file.parent.mkdir(parents=True)
+    pref_file.write_text("plist", encoding="utf-8")
+    app_bundle.mkdir(parents=True)
+
+    removed = uninstall.remove_full_uninstall_leftovers(
+        hermes_home,
+        home=home,
+        system_name="Darwin",
+        system_applications=app_root,
+    )
+
+    assert cache_dir in removed
+    assert pref_file in removed
+    assert app_bundle in removed
+    assert not cache_dir.exists()
+    assert not pref_file.exists()
+    assert not app_bundle.exists()
+
+
+def test_remove_legacy_macos_launchd_plists_boots_out_and_unlinks(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    launch_agents = home / "Library" / "LaunchAgents"
+    plist_a = launch_agents / "ai.hermes.gateway.plist"
+    plist_b = launch_agents / "io.nousresearch.hermes-agent.gateway-old.plist"
+    plist_a.parent.mkdir(parents=True)
+    plist_a.write_text("plist-a", encoding="utf-8")
+    plist_b.write_text("plist-b", encoding="utf-8")
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return None
+
+    monkeypatch.setattr(uninstall.subprocess, "run", fake_run)
+    monkeypatch.setattr(uninstall.os, "getuid", lambda: 501, raising=False)
+
+    removed = uninstall.remove_legacy_macos_launchd_plists(home=home)
+
+    assert removed == [plist_a, plist_b]
+    assert not plist_a.exists()
+    assert not plist_b.exists()
+    assert ["launchctl", "bootout", "gui/501/ai.hermes.gateway"] in calls
+    assert [
+        "launchctl",
+        "bootout",
+        "gui/501/io.nousresearch.hermes-agent.gateway-old",
+    ] in calls


### PR DESCRIPTION
## What does this PR do?

Extends `hermes uninstall --full` so it also removes the extra Hermes state that currently survives outside `HERMES_HOME`, especially on macOS desktop installs. The uninstaller now sweeps XDG cache/config/share leftovers, unloads and removes legacy launchd plists, and deletes common macOS app/cache/WebKit/state paths such as `~/Library/Application Support/Hermes`, `~/Library/Caches/com.nousresearch.hermes`, and `~/Library/Saved Application State/com.nousresearch.hermes.savedState`.

## Related Issue

Fixes #62209

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `full_uninstall_extra_paths()` and `remove_full_uninstall_leftovers()` in `hermes_cli/uninstall.py` to sweep leftover XDG/macOS desktop state outside `HERMES_HOME` during full uninstall.
- Added `remove_legacy_macos_launchd_plists()` so full uninstall also unloads and removes lingering `ai.hermes.gateway*.plist` and `io.nousresearch.hermes-agent.gateway*.plist` entries under `~/Library/LaunchAgents`.
- Extended uninstall dry-run output to show the extra full-uninstall cleanup surface.
- Added `tests/hermes_cli/test_uninstall.py` covering the new macOS path inventory, extra-path removal, and legacy launchd plist cleanup.

## How to Test

1. Run `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/hermes_cli/test_uninstall.py -q`
2. Run `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m py_compile hermes_cli/uninstall.py tests/hermes_cli/test_uninstall.py`
3. Optionally dry-run `hermes uninstall --full --dry-run` and confirm the extra XDG/macOS paths are listed.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `pytest tests/hermes_cli/test_uninstall.py -q` → `3 passed in 0.26s`
- `python -m py_compile hermes_cli/uninstall.py tests/hermes_cli/test_uninstall.py` passed
- `git diff --check` passed
