### PR TITLE
feat(fallback): add manual provider selection

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -324,6 +324,8 @@ def init_agent(
     parent_session_id: str = None,
     iteration_budget: "IterationBudget" = None,
     fallback_model: Dict[str, Any] = None,
+    fallback_auto_activate: bool = True,
+    fallback_selection_interactive: Optional[bool] = None,
     credential_pool=None,
     checkpoints_enabled: bool = False,
     checkpoint_max_snapshots: int = 20,
@@ -528,6 +530,12 @@ def init_agent(
     agent.thinking_callback = thinking_callback
     agent.reasoning_callback = reasoning_callback
     agent.clarify_callback = clarify_callback
+    # Activation policy must exist before client construction because the
+    # constructor itself has a legacy authentication-recovery path.
+    agent._fallback_auto_activate = bool(fallback_auto_activate)
+    # ``None`` defers interactivity detection until activation time; explicit
+    # ``False`` is the fail-closed override for noninteractive runtimes.
+    agent._fallback_selection_interactive = fallback_selection_interactive
     agent.read_terminal_callback = read_terminal_callback
     agent.step_callback = step_callback
     agent.stream_delta_callback = stream_delta_callback
@@ -989,13 +997,22 @@ def init_agent(
                     except Exception:
                         pass
                     # --- Init-time fallback (#17929) ---
+                    # This runs before an interactive agent/callback exists.
+                    # Preserve legacy eager recovery in automatic mode, but
+                    # never spend through another route when manual consent is
+                    # configured.
                     _fb_entries = []
-                    if isinstance(fallback_model, list):
+                    if agent._fallback_auto_activate and isinstance(fallback_model, list):
                         _fb_entries = [
                             f for f in fallback_model
                             if isinstance(f, dict) and f.get("provider") and f.get("model")
                         ]
-                    elif isinstance(fallback_model, dict) and fallback_model.get("provider") and fallback_model.get("model"):
+                    elif (
+                        agent._fallback_auto_activate
+                        and isinstance(fallback_model, dict)
+                        and fallback_model.get("provider")
+                        and fallback_model.get("model")
+                    ):
                         _fb_entries = [fallback_model]
                     _fb_resolved = False
                     for _fb in _fb_entries:
@@ -1142,6 +1159,8 @@ def init_agent(
     agent._fallback_activated = getattr(agent, "_fallback_activated", False)
     # Legacy attribute kept for backward compat (tests, external callers)
     agent._fallback_model = agent._fallback_chain[0] if agent._fallback_chain else None
+    agent._fallback_manual_attempted = False
+    agent._fallback_manual_selected_index = None
     if agent._fallback_chain and not agent.quiet_mode:
         if len(agent._fallback_chain) == 1:
             fb = agent._fallback_chain[0]

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1157,14 +1157,15 @@ def restore_primary_runtime(agent) -> bool:
         agent._fallback_index = 0
         return False
 
-    manual_turn_route = (
+    manual_restore_required = (
         getattr(agent, "_fallback_manual_selected_index", None) is not None
+        or not getattr(agent, "_fallback_auto_activate", True)
     )
     if (
         getattr(agent, "_rate_limited_until", 0) > time.monotonic()
-        and not manual_turn_route
+        and not manual_restore_required
     ):
-        return False  # automatic fallback remains active during primary cooldown
+        return False  # automatic policy keeps fallback active during primary cooldown
 
     rt = agent._primary_runtime
     try:

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1157,8 +1157,14 @@ def restore_primary_runtime(agent) -> bool:
         agent._fallback_index = 0
         return False
 
-    if getattr(agent, "_rate_limited_until", 0) > time.monotonic():
-        return False  # primary still in rate-limit cooldown, stay on fallback
+    manual_turn_route = (
+        getattr(agent, "_fallback_manual_selected_index", None) is not None
+    )
+    if (
+        getattr(agent, "_rate_limited_until", 0) > time.monotonic()
+        and not manual_turn_route
+    ):
+        return False  # automatic fallback remains active during primary cooldown
 
     rt = agent._primary_runtime
     try:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1234,8 +1234,163 @@ def _fallback_entry_unavailable_without_network(agent, fb: dict) -> Optional[str
     return None
 
 
+def _fallback_entry_matches_current(agent, fb: dict) -> bool:
+    """Return whether *fb* resolves to the route that just failed."""
+
+    fb_provider = str(fb.get("provider") or "").strip().lower()
+    fb_model = str(fb.get("model") or "").strip()
+    if not fb_provider or not fb_model:
+        return True
+    current_provider = str(getattr(agent, "provider", "") or "").strip().lower()
+    current_model = str(getattr(agent, "model", "") or "").strip()
+    if fb_provider == current_provider and fb_model == current_model:
+        return True
+    current_base_url = str(getattr(agent, "base_url", "") or "").rstrip("/").lower()
+    fb_base_url = str(fb.get("base_url") or "").strip().rstrip("/").lower()
+    return bool(
+        fb_base_url
+        and current_base_url
+        and fb_base_url == current_base_url
+        and fb_model == current_model
+    )
+
+
+def _fallback_choice_label(fb: dict) -> str:
+    """Render an unambiguous choice without exposing endpoint credentials."""
+
+    from urllib.parse import urlsplit, urlunsplit
+
+    provider = str(fb.get("provider") or "?").strip()
+    model = str(fb.get("model") or "?").strip()
+    base_url = str(fb.get("base_url") or "").strip().rstrip("/")
+    if base_url:
+        try:
+            parts = urlsplit(base_url)
+            if parts.scheme and parts.hostname:
+                host = parts.hostname
+                if ":" in host:
+                    host = f"[{host}]"
+                if parts.port:
+                    host = f"{host}:{parts.port}"
+                # Paths can carry bearer tokens just as query strings and
+                # userinfo can. Show only the endpoint origin; if that makes
+                # two routes indistinguishable, the duplicate-label guard
+                # fails closed instead of exposing credentials.
+                base_url = urlunsplit((parts.scheme, host, "", "", ""))
+            else:
+                base_url = "[custom endpoint]"
+        except ValueError:
+            base_url = "[custom endpoint]"
+    suffix = f" ({base_url})" if base_url else ""
+    return f"Continue with {model} via {provider}{suffix}"
+
+
+def _try_activate_manual_fallback(
+    agent, reason: "FailoverReason | None" = None
+) -> bool:
+    """Prompt once and attempt exactly the route selected for this turn."""
+
+    if getattr(agent, "_fallback_manual_attempted", False):
+        return False
+    chain = list(getattr(agent, "_fallback_chain", None) or [])
+    if not chain:
+        return False
+    if getattr(agent, "_fallback_selection_interactive", None) is False:
+        return False
+    callback = getattr(agent, "clarify_callback", None)
+    if not callable(callback):
+        return False
+    agent._fallback_manual_attempted = True
+
+    unavailable = getattr(agent, "_unavailable_fallback_keys", set()) or set()
+    candidates: list[tuple[int, dict, str]] = []
+    for index, fb in enumerate(chain):
+        if not isinstance(fb, dict):
+            continue
+        if _fallback_entry_key(fb) in unavailable:
+            continue
+        if _fallback_entry_unavailable_without_network(agent, fb):
+            continue
+        if _fallback_entry_matches_current(agent, fb):
+            continue
+        candidates.append((index, fb, _fallback_choice_label(fb)))
+
+    if not candidates:
+        buffer_status = getattr(agent, "_buffer_status", None)
+        if callable(buffer_status):
+            buffer_status("No eligible manual fallback routes remain for this turn.")
+        return False
+    from tools.clarify_tool import MAX_CHOICES
+
+    if len(candidates) > MAX_CHOICES:
+        logger.error(
+            "Manual fallback has %d choices, exceeding clarify limit %d",
+            len(candidates),
+            MAX_CHOICES,
+        )
+        buffer_status = getattr(agent, "_buffer_status", None)
+        if callable(buffer_status):
+            buffer_status(
+                f"Manual fallback supports at most {MAX_CHOICES} choices; "
+                "reduce the configured chain or enable automatic fallback."
+            )
+        return False
+
+    labels = [label for _, _, label in candidates]
+    if len(set(labels)) != len(labels):
+        logger.error("Manual fallback choices are ambiguous after safe rendering")
+        buffer_status = getattr(agent, "_buffer_status", None)
+        if callable(buffer_status):
+            buffer_status(
+                "Manual fallback choices are ambiguous; make provider/model/endpoint routes unique."
+            )
+        return False
+    try:
+        answer = callback(
+            "Primary model failed. Select a fallback route for this turn:", labels
+        )
+    except Exception as exc:
+        logger.warning("Manual fallback selection failed: %s", exc)
+        return False
+
+    answer_text = str(answer or "").strip()
+    numeric_choices = {str(i): label for i, label in enumerate(labels, start=1)}
+    selected_label = numeric_choices.get(answer_text, answer_text)
+    selected = next(
+        (item for item in candidates if item[2] == selected_label), None
+    )
+    if selected is None:
+        return False
+
+    selected_index, selected_entry, _ = selected
+    agent._fallback_manual_selected_index = selected_index
+    original_chain = agent._fallback_chain
+    original_index = agent._fallback_index
+    activated = False
+    try:
+        # Reuse the full route activation path with a one-entry chain. Its
+        # recursive skip behavior can exhaust only the selected route and can
+        # never cascade to a different user-visible choice.
+        agent._fallback_chain = [selected_entry]
+        agent._fallback_index = 0
+        activated = _try_activate_next_fallback(agent, reason)
+        return activated
+    finally:
+        agent._fallback_chain = original_chain
+        agent._fallback_index = selected_index + 1 if activated else original_index
+
 
 def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool:
+    """Activate a fallback automatically or through manual selection."""
+
+    if not getattr(agent, "_fallback_auto_activate", True):
+        return _try_activate_manual_fallback(agent, reason)
+    return _try_activate_next_fallback(agent, reason)
+
+
+def _try_activate_next_fallback(
+    agent, reason: "FailoverReason | None" = None
+) -> bool:
     """Switch to the next fallback model/provider in the chain.
 
     Called when the current model is failing after retries.  Swaps the
@@ -1282,11 +1437,11 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         agent._unavailable_fallback_keys = unavailable
     if fb_key in unavailable:
         logger.debug("Fallback skip: %s previously marked unavailable", fb_key)
-        return agent._try_activate_fallback(reason)
+        return _try_activate_next_fallback(agent, reason)
     fb_provider = (fb.get("provider") or "").strip().lower()
     fb_model = (fb.get("model") or "").strip()
     if not fb_provider or not fb_model:
-        return agent._try_activate_fallback(reason)  # skip invalid, try next
+        return _try_activate_next_fallback(agent, reason)  # skip invalid, try next
 
     local_skip_reason = _fallback_entry_unavailable_without_network(agent, fb)
     if local_skip_reason:
@@ -1297,7 +1452,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             fb_model,
             local_skip_reason,
         )
-        return agent._try_activate_fallback(reason)
+        return _try_activate_next_fallback(agent, reason)
 
     # Skip entries that resolve to the current (provider, model) — falling
     # back to the same backend that just failed loops the failure. Compare
@@ -1312,7 +1467,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             "Fallback skip: chain entry %s/%s matches current provider/model",
             fb_provider, fb_model,
         )
-        return agent._try_activate_fallback(reason)
+        return _try_activate_next_fallback(agent, reason)
     if (
         fb_base_url_for_dedup
         and current_base_url
@@ -1323,7 +1478,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             "Fallback skip: chain entry base_url %s matches current backend",
             fb_base_url_for_dedup,
         )
-        return agent._try_activate_fallback(reason)
+        return _try_activate_next_fallback(agent, reason)
 
     # Use centralized router for client construction.
     # raw_codex=True because the main agent needs direct responses.stream()
@@ -1355,7 +1510,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 "Fallback to %s failed: provider not configured",
                 fb_provider)
             unavailable.add(fb_key)
-            return agent._try_activate_fallback(reason)  # try next in chain
+            return _try_activate_next_fallback(agent, reason)  # try next in chain
         try:
             from hermes_cli.model_normalize import normalize_model_for_provider
 
@@ -1575,7 +1730,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         if fb_provider == "nous":
             unavailable.add(fb_key)
         logger.error("Failed to activate fallback %s: %s", fb_model, e)
-        return agent._try_activate_fallback(reason)  # try next in chain
+        return _try_activate_next_fallback(agent, reason)  # try next in chain
 
 
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -602,6 +602,8 @@ def run_conversation(
     _plugin_user_context = _ctx.plugin_user_context
     _ext_prefetch_cache = _ctx.ext_prefetch_cache
 
+    agent._reset_turn_scoped_fallback_state()
+
     # Main conversation loop counters (pure locals consumed by the loop below).
     api_call_count = 0
     final_response = None
@@ -1123,7 +1125,12 @@ def run_conversation(
                         agent._buffer_vprint(
                             f"⏳ {_nous_msg} Trying fallback..."
                         )
-                        agent._buffer_status(f"⏳ {_nous_msg}")
+                        agent._buffer_status(
+                            agent._fallback_attempt_status(
+                                f"⏳ {_nous_msg}",
+                                manual_text=f"⏳ {_nous_msg} Select a fallback route to continue.",
+                            )
+                        )
                         if agent._try_activate_fallback():
                             active_system_prompt = _sync_failover_system_message(
                                 agent, api_messages, active_system_prompt)
@@ -1468,15 +1475,20 @@ def run_conversation(
                     # Eager fallback: empty/malformed responses are a common
                     # rate-limit symptom.  Switch to fallback immediately
                     # rather than retrying with extended backoff.
-                    if agent._fallback_index < len(agent._fallback_chain):
-                        agent._buffer_status("⚠️ Empty/malformed response — switching to fallback...")
-                    if agent._try_activate_fallback():
-                        active_system_prompt = _sync_failover_system_message(
-                            agent, api_messages, active_system_prompt)
-                        retry_count = 0
-                        compression_attempts = 0
-                        _retry.primary_recovery_attempted = False
-                        continue
+                    if agent._has_pending_fallback():
+                        agent._buffer_status(
+                            agent._fallback_attempt_status(
+                                "⚠️ Empty/malformed response — switching to fallback...",
+                                manual_text="⚠️ Empty/malformed response — selecting fallback route...",
+                            )
+                        )
+                        if agent._try_activate_fallback():
+                            active_system_prompt = _sync_failover_system_message(
+                                agent, api_messages, active_system_prompt)
+                            retry_count = 0
+                            compression_attempts = 0
+                            _retry.primary_recovery_attempted = False
+                            continue
 
                     # Check for error field in response (some providers include this)
                     error_msg = "Unknown"
@@ -1542,7 +1554,12 @@ def run_conversation(
                     if retry_count >= max_retries:
                         # Try fallback before giving up
                         if agent._has_pending_fallback():
-                            agent._buffer_status(f"⚠️ Max retries ({max_retries}) for invalid responses — trying fallback...")
+                            agent._buffer_status(
+                                agent._fallback_attempt_status(
+                                    f"⚠️ Max retries ({max_retries}) for invalid responses — trying fallback...",
+                                    manual_text=f"⚠️ Max retries ({max_retries}) for invalid responses — selecting fallback route...",
+                                )
+                            )
                         if agent._try_activate_fallback():
                             active_system_prompt = _sync_failover_system_message(
                                 agent, api_messages, active_system_prompt)
@@ -1697,7 +1714,10 @@ def run_conversation(
                     # refuse); otherwise surface the refusal terminally.
                     if agent._has_pending_fallback():
                         agent._buffer_status(
-                            "⚠️ Model declined to respond (safety refusal) — trying fallback..."
+                            agent._fallback_attempt_status(
+                                "⚠️ Model declined to respond (safety refusal) — trying fallback...",
+                                manual_text="⚠️ Model declined to respond (safety refusal) — selecting fallback route...",
+                            )
                         )
                     if agent._try_activate_fallback():
                         active_system_prompt = _sync_failover_system_message(
@@ -1858,15 +1878,21 @@ def run_conversation(
                         )
                         if (
                             _cf_terminated
-                            and agent._fallback_index < len(agent._fallback_chain)
+                            and agent._has_pending_fallback()
                         ):
                             agent._vprint(
-                                f"{agent.log_prefix}🛡️  Content filter terminated "
-                                f"stream — activating fallback provider...",
+                                f"{agent.log_prefix}"
+                                + agent._fallback_attempt_status(
+                                    "🛡️  Content filter terminated stream — activating fallback provider...",
+                                    manual_text="🛡️  Content filter terminated stream — selecting fallback route...",
+                                ),
                                 force=True,
                             )
                             agent._emit_status(
-                                "Content filter terminated stream; switching to fallback..."
+                                agent._fallback_attempt_status(
+                                    "Content filter terminated stream; switching to fallback...",
+                                    manual_text="Content filter terminated stream; selecting fallback route...",
+                                )
                             )
                             if agent._try_activate_fallback():
                                 # Roll the partial content (if any was already
@@ -3168,7 +3194,7 @@ def run_conversation(
                     is_rate_limited
                     or (_is_transport_failure and retry_count >= 2)
                 )
-                if _should_fallback and agent._fallback_index < len(agent._fallback_chain):
+                if _should_fallback and agent._has_pending_fallback():
                     # Don't eagerly fallback if credential pool rotation may
                     # still recover.  See _pool_may_recover_from_rate_limit
                     # for the single-credential-pool exception.  Fixes #11314.
@@ -3190,19 +3216,32 @@ def run_conversation(
                                 "upstream_provider", "aggregator"
                             )
                             agent._buffer_status(
-                                f"⚠️ Upstream {_upstream_name} rate-limited — "
-                                "switching to fallback model..."
+                                agent._fallback_attempt_status(
+                                    f"⚠️ Upstream {_upstream_name} rate-limited — switching to fallback model...",
+                                    manual_text=f"⚠️ Upstream {_upstream_name} rate-limited — selecting fallback route...",
+                                )
                             )
                         elif classified.reason == FailoverReason.billing:
                             agent._buffer_status(
-                                "⚠️ Billing or credits exhausted — switching to fallback provider..."
+                                agent._fallback_attempt_status(
+                                    "⚠️ Billing or credits exhausted — switching to fallback provider...",
+                                    manual_text="⚠️ Billing or credits exhausted — selecting fallback route...",
+                                )
                             )
                         elif _is_transport_failure:
                             agent._buffer_status(
-                                "⚠️ Provider unreachable — switching to fallback provider..."
+                                agent._fallback_attempt_status(
+                                    "⚠️ Provider unreachable — switching to fallback provider...",
+                                    manual_text="⚠️ Provider unreachable — selecting fallback route...",
+                                )
                             )
                         else:
-                            agent._buffer_status("⚠️ Rate limited — switching to fallback provider...")
+                            agent._buffer_status(
+                                agent._fallback_attempt_status(
+                                    "⚠️ Rate limited — switching to fallback provider...",
+                                    manual_text="⚠️ Rate limited — selecting fallback route...",
+                                )
+                            )
                         if agent._try_activate_fallback(reason=classified.reason):
                             active_system_prompt = _sync_failover_system_message(
                                 agent, api_messages, active_system_prompt)
@@ -3229,12 +3268,14 @@ def run_conversation(
                 if (
                     classified.is_auth
                     and not _retry.auth_failover_attempted
-                    and agent._fallback_index < len(agent._fallback_chain)
+                    and agent._has_pending_fallback()
                 ):
                     _retry.auth_failover_attempted = True
                     agent._buffer_status(
-                        "🔐 Authentication failed and could not be refreshed — "
-                        "switching to fallback provider..."
+                        agent._fallback_attempt_status(
+                            "🔐 Authentication failed and could not be refreshed — switching to fallback provider...",
+                            manual_text="🔐 Authentication failed and could not be refreshed — selecting fallback route...",
+                        )
                     )
                     if agent._try_activate_fallback(reason=classified.reason):
                         active_system_prompt = _sync_failover_system_message(
@@ -3718,11 +3759,26 @@ def run_conversation(
                     # abort silently (#35314, #17446).
                     if agent._has_pending_fallback():
                         if classified.reason == FailoverReason.content_policy_blocked:
-                            agent._buffer_status("⚠️ Provider safety filter blocked this request — trying fallback...")
+                            agent._buffer_status(
+                                agent._fallback_attempt_status(
+                                    "⚠️ Provider safety filter blocked this request — trying fallback...",
+                                    manual_text="⚠️ Provider safety filter blocked this request — selecting fallback route...",
+                                )
+                            )
                         elif classified.reason == FailoverReason.ssl_cert_verification:
-                            agent._buffer_status("⚠️ TLS certificate verification failed — trying fallback...")
+                            agent._buffer_status(
+                                agent._fallback_attempt_status(
+                                    "⚠️ TLS certificate verification failed — trying fallback...",
+                                    manual_text="⚠️ TLS certificate verification failed — selecting fallback route...",
+                                )
+                            )
                         else:
-                            agent._buffer_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
+                            agent._buffer_status(
+                                agent._fallback_attempt_status(
+                                    f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...",
+                                    manual_text=f"⚠️ Non-retryable error (HTTP {status_code}) — selecting fallback route...",
+                                )
+                            )
                     if agent._try_activate_fallback():
                         active_system_prompt = _sync_failover_system_message(
                             agent, api_messages, active_system_prompt)
@@ -3920,7 +3976,12 @@ def run_conversation(
                         continue
                     # Try fallback before giving up entirely
                     if agent._has_pending_fallback():
-                        agent._buffer_status(f"⚠️ Max retries ({max_retries}) exhausted — trying fallback...")
+                        agent._buffer_status(
+                            agent._fallback_attempt_status(
+                                f"⚠️ Max retries ({max_retries}) exhausted — trying fallback...",
+                                manual_text=f"⚠️ Max retries ({max_retries}) exhausted — selecting fallback route...",
+                            )
+                        )
                     if agent._try_activate_fallback():
                         active_system_prompt = _sync_failover_system_message(
                             agent, api_messages, active_system_prompt)
@@ -4991,7 +5052,7 @@ def run_conversation(
                     # chain.  This covers the case where a model
                     # (e.g. GLM-4.5-Air) consistently returns empty
                     # due to context degradation or provider issues.
-                    if _truly_empty and agent._fallback_chain:
+                    if _truly_empty and agent._has_pending_fallback():
                         logger.warning(
                             "Empty response after %d retries — "
                             "attempting fallback (model=%s, provider=%s)",
@@ -4999,8 +5060,10 @@ def run_conversation(
                             agent.provider,
                         )
                         agent._buffer_status(
-                            "⚠️ Model returning empty responses — "
-                            "switching to fallback provider..."
+                            agent._fallback_attempt_status(
+                                "⚠️ Model returning empty responses — switching to fallback provider...",
+                                manual_text="⚠️ Model returning empty responses — selecting fallback route...",
+                            )
                         )
                         if agent._try_activate_fallback():
                             active_system_prompt = _sync_failover_system_message(

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -157,8 +157,25 @@ def build_turn_context(
     # turn on that paid route or publishing it process-wide.
     manual_restore_required = bool(
         getattr(agent, "_fallback_activated", False)
-        and getattr(agent, "_fallback_manual_selected_index", None) is not None
+        and (
+            getattr(agent, "_fallback_manual_selected_index", None) is not None
+            or not getattr(agent, "_fallback_auto_activate", True)
+        )
     )
+    clear_aux_runtime = None
+    if manual_restore_required:
+        try:
+            from agent.auxiliary_client import clear_runtime_main as clear_aux_runtime
+            # Remove the previous one-turn route before restore. If restore or
+            # publication fails, auxiliary calls must see no route rather than
+            # retain the manually selected provider process-wide.
+            clear_aux_runtime()
+        except Exception as exc:
+            raise RuntimeError(
+                "Could not clear the previous manual auxiliary runtime; "
+                "refusing to start a new turn."
+            ) from exc
+
     restored = agent._restore_primary_runtime()
     if manual_restore_required and not restored:
         raise RuntimeError(
@@ -176,8 +193,20 @@ def build_turn_context(
             api_key=getattr(agent, "api_key", "") or "",
             api_mode=getattr(agent, "api_mode", "") or "",
         )
-    except Exception:
-        pass
+    except Exception as exc:
+        if manual_restore_required:
+            if clear_aux_runtime is not None:
+                try:
+                    clear_aux_runtime()
+                except Exception:
+                    logger.exception(
+                        "Failed to clear auxiliary runtime after primary publication failure"
+                    )
+            raise RuntimeError(
+                "Could not publish the restored primary runtime; refusing to "
+                "start a new turn after manual fallback."
+            ) from exc
+        logger.debug("auxiliary main runtime publication skipped", exc_info=True)
 
     # Tag log records on this thread with the session ID for ``hermes logs``.
     set_session_context(agent.session_id)

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -151,7 +151,22 @@ def build_turn_context(
     # null; rebuilding from scratch" warning and a needless first-turn prefix
     # cache miss. (Issue #45499.)
 
-    # Tell auxiliary_client what the live main provider/model are for this turn.
+    # Restore a previous turn's runtime before publishing the live main route
+    # to auxiliary_client. A manual choice is explicit consent for one turn;
+    # if its required restore fails, abort rather than silently starting a new
+    # turn on that paid route or publishing it process-wide.
+    manual_restore_required = bool(
+        getattr(agent, "_fallback_activated", False)
+        and getattr(agent, "_fallback_manual_selected_index", None) is not None
+    )
+    restored = agent._restore_primary_runtime()
+    if manual_restore_required and not restored:
+        raise RuntimeError(
+            "Could not restore the primary runtime after the previous manual "
+            "fallback; refusing to start a new turn."
+        )
+
+    # Tell auxiliary_client what the resulting live provider/model are.
     try:
         from agent.auxiliary_client import set_runtime_main
         set_runtime_main(
@@ -169,9 +184,6 @@ def build_turn_context(
 
     # Bind the skill write-origin ContextVar for this thread.
     set_current_write_origin(getattr(agent, "_memory_write_origin", "assistant_tool"))
-
-    # Restore the primary runtime if the previous turn activated fallback.
-    agent._restore_primary_runtime()
 
     # Between-turns MCP refresh: an MCP server that finished connecting since
     # the previous turn (slow HTTP/OAuth servers routinely take 2-6s on a cold

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -139,6 +139,22 @@ model:
 #         stale_timeout_seconds: 1800  # Longer non-stream stale timeout for slow large-context turns
 
 # =============================================================================
+# Primary Provider Fallback (optional)
+# =============================================================================
+# `auto_activate: false` asks you to choose one route for the current turn.
+# Set it to true for ordered automatic fallback. Existing configs that omit
+# the key keep the historical automatic behavior.
+#
+# fallback:
+#   auto_activate: false
+#
+# fallback_providers:
+#   - provider: openrouter
+#     model: anthropic/claude-sonnet-4
+#   - provider: xai
+#     model: grok-4
+
+# =============================================================================
 # OpenRouter Provider Routing (only applies when using OpenRouter)
 # =============================================================================
 # Control how requests are routed across providers on OpenRouter.

--- a/cli.py
+++ b/cli.py
@@ -51,7 +51,7 @@ os.environ["HERMES_QUIET"] = "1"  # Our own modules
 
 import yaml
 
-from hermes_cli.fallback_config import get_fallback_chain
+from hermes_cli.fallback_config import get_fallback_auto_activate, get_fallback_chain
 from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
 from hermes_cli.cli_commands_mixin import CLICommandsMixin
 
@@ -3951,6 +3951,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # Merge new ``fallback_providers`` entries with any legacy
         # ``fallback_model`` entries so old configs still participate.
         self._fallback_model = get_fallback_chain(CLI_CONFIG)
+        self._fallback_auto_activate = get_fallback_auto_activate(CLI_CONFIG)
 
         # Signature of the currently-initialised agent's runtime.  Used to
         # rebuild the agent when provider / model / base_url changes across

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -42,7 +42,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import load_config, _expand_env_vars
-from hermes_cli.fallback_config import get_fallback_chain
+from hermes_cli.fallback_config import get_fallback_auto_activate, get_fallback_chain
 from hermes_time import now as _hermes_now
 
 logger = logging.getLogger(__name__)
@@ -2915,6 +2915,7 @@ def run_job(
         # off-host call is ever made with a stored key.
         _guard_job_credential_exfil(job)
 
+        fallback_auto_activate = get_fallback_auto_activate(_cfg)
         try:
             # Do not inject HERMES_INFERENCE_PROVIDER here. resolve_runtime_provider()
             # already prefers persisted config over stale shell/env overrides when
@@ -2928,6 +2929,8 @@ def run_job(
                 runtime_kwargs["explicit_base_url"] = job.get("base_url")
             runtime = resolve_runtime_provider(**runtime_kwargs)
         except AuthError as auth_exc:
+            if not fallback_auto_activate:
+                raise RuntimeError(format_runtime_provider_error(auth_exc)) from auth_exc
             # Primary provider auth failed — try fallback chain before giving up.
             logger.warning("Job '%s': primary auth failed (%s), trying fallback", job_id, auth_exc)
             fb_list = get_fallback_chain(_cfg)
@@ -3055,6 +3058,8 @@ def run_job(
             reasoning_config=reasoning_config,
             prefill_messages=prefill_messages,
             fallback_model=fallback_model,
+            fallback_auto_activate=fallback_auto_activate,
+            fallback_selection_interactive=False,
             credential_pool=credential_pool,
             providers_allowed=pr.get("only"),
             providers_ignored=pr.get("ignore"),

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1358,6 +1358,8 @@ class APIServerAdapter(BasePlatformAdapter):
             tool_complete_callback=tool_complete_callback,
             session_db=self._ensure_session_db(),
             fallback_model=fallback_model,
+            fallback_auto_activate=GatewayRunner._load_fallback_auto_activate(),
+            fallback_selection_interactive=False,
             reasoning_config=reasoning_config,
             gateway_session_key=gateway_session_key,
         )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -57,7 +57,7 @@ from agent.async_utils import safe_schedule_threadsafe
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from agent.i18n import t
 from hermes_cli.config import cfg_get
-from hermes_cli.fallback_config import get_fallback_chain
+from hermes_cli.fallback_config import get_fallback_auto_activate, get_fallback_chain
 
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in
@@ -1952,6 +1952,8 @@ def _try_resolve_fallback_provider() -> dict | None:
             return None
         with open(cfg_path, encoding="utf-8") as _f:
             cfg = _y.safe_load(_f) or {}
+        if not get_fallback_auto_activate(cfg):
+            return None
         fb_list = get_fallback_chain(cfg)
         if not fb_list:
             return None
@@ -2835,6 +2837,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._restart_drain_timeout = self._load_restart_drain_timeout()
         self._provider_routing = self._load_provider_routing()
         self._fallback_model = self._load_fallback_model()
+        self._fallback_auto_activate = self._load_fallback_auto_activate()
 
         # Wire process registry into session store for reset protection.
         # A background process older than the configured threshold (default 24h,
@@ -5013,6 +5016,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             pass
         return None
 
+    @staticmethod
+    def _load_fallback_auto_activate() -> bool:
+        """Load the fallback activation policy, preserving legacy automatic mode."""
+        try:
+            import yaml as _y
+
+            cfg_path = _hermes_home / "config.yaml"
+            if cfg_path.exists():
+                with open(cfg_path, encoding="utf-8") as _f:
+                    return get_fallback_auto_activate(_y.safe_load(_f) or {})
+        except Exception:
+            pass
+        return True
+
     def _refresh_fallback_model(self) -> list | None:
         """Re-read fallback_providers from disk for the next agent create/reuse.
 
@@ -5032,6 +5049,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             cfg_path = _hermes_home / "config.yaml"
             if not cfg_path.exists():
                 self._fallback_model = None
+                self._fallback_auto_activate = True
                 return self._fallback_model
             with open(cfg_path, encoding="utf-8") as _f:
                 cfg = _y.safe_load(_f) or {}
@@ -5043,25 +5061,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             return self._fallback_model
         self._fallback_model = get_fallback_chain(cfg) or None
+        self._fallback_auto_activate = get_fallback_auto_activate(cfg)
         return self._fallback_model
 
     @staticmethod
-    def _apply_fallback_chain_to_agent(agent: Any, chain: list | None) -> None:
+    def _apply_fallback_chain_to_agent(
+        agent: Any, chain: list | None, auto_activate: bool = True
+    ) -> None:
         """Keep a cached agent's fallback chain aligned with current config.
 
-        Skips rewrite while a cooldown is holding the agent on an already-
-        activated fallback provider — ``restore_primary_runtime`` owns that
-        turn-scoped lifecycle. When primary is active (or cooldown expired),
-        replace the chain so mid-uptime ``fallback_providers`` edits take
-        effect without requiring a gateway restart (#60955).
+        Automatic fallback keeps its current chain while a cooldown is holding
+        the agent on an activated route. Manual selection is strictly one-turn,
+        so config edits still replace its future choices while the selected
+        runtime remains active until ``restore_primary_runtime`` runs.
         """
         if agent is None:
             return
         new_chain = list(chain or [])
+        agent._fallback_auto_activate = bool(auto_activate)
         rate_limited_until = getattr(agent, "_rate_limited_until", 0) or 0
         if (
             getattr(agent, "_fallback_activated", False)
             and rate_limited_until > time.monotonic()
+            and getattr(agent, "_fallback_manual_selected_index", None) is None
         ):
             return
         old_chain = list(getattr(agent, "_fallback_chain", []) or [])
@@ -13363,6 +13385,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_db=getattr(self._session_db, "_db", self._session_db),
                     # Reload from disk — do not reuse the startup snapshot (#60955).
                     fallback_model=self._refresh_fallback_model(),
+                    fallback_auto_activate=self._fallback_auto_activate,
+                    fallback_selection_interactive=False,
                 )
                 try:
                     return agent.run_conversation(
@@ -18194,6 +18218,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if reused_cached_agent and agent is not None:
                 self._apply_fallback_chain_to_agent(
                     agent, self._refresh_fallback_model(),
+                    self._fallback_auto_activate,
                 )
 
             # Lock released — now schedule cleanup of any cross-process-evicted
@@ -18250,6 +18275,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_db=getattr(self._session_db, "_db", self._session_db),
                     # Reload from disk — do not reuse the startup snapshot (#60955).
                     fallback_model=self._refresh_fallback_model(),
+                    fallback_auto_activate=self._fallback_auto_activate,
+                    fallback_selection_interactive=True,
                 )
                 if _cache_lock and _cache is not None:
                     with _cache_lock:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5081,7 +5081,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         agent._fallback_auto_activate = bool(auto_activate)
         rate_limited_until = getattr(agent, "_rate_limited_until", 0) or 0
         if (
-            getattr(agent, "_fallback_activated", False)
+            bool(auto_activate)
+            and getattr(agent, "_fallback_activated", False)
             and rate_limited_until > time.monotonic()
             and getattr(agent, "_fallback_manual_selected_index", None) is None
         ):

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -46,8 +46,14 @@ class CLIAgentSetupMixin:
         except Exception as exc:
             _primary_exc = exc
 
-        # Primary provider auth failed — try fallback providers before giving up.
-        if runtime is None and _primary_exc is not None:
+        # Primary provider auth failed — automatic mode may try configured
+        # fallbacks. Manual mode has no agent/clarification surface yet, so it
+        # must fail closed rather than silently replacing the primary runtime.
+        if (
+            runtime is None
+            and _primary_exc is not None
+            and getattr(self, "_fallback_auto_activate", True)
+        ):
             from hermes_cli.auth import AuthError
             if isinstance(_primary_exc, AuthError):
                 _fb_chain = self._fallback_model if isinstance(self._fallback_model, list) else []
@@ -375,6 +381,7 @@ class CLIAgentSetupMixin:
                 reasoning_callback=self._current_reasoning_callback(),
 
                 fallback_model=self._fallback_model,
+                fallback_auto_activate=getattr(self, "_fallback_auto_activate", True),
                 thinking_callback=self._on_thinking,
                 checkpoints_enabled=self.checkpoints_enabled,
                 checkpoint_max_snapshots=self.checkpoint_max_snapshots,

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1660,6 +1660,10 @@ class CLICommandsMixin:
                     provider_data_collection=self._provider_data_collection,
                     openrouter_min_coding_score=self._openrouter_min_coding_score,
                     fallback_model=self._fallback_model,
+                    fallback_auto_activate=getattr(
+                        self, "_fallback_auto_activate", True
+                    ),
+                    fallback_selection_interactive=False,
                 )
                 # Silence raw spinner; route thinking through TUI widget when no foreground agent is active.
                 bg_agent._print_fn = lambda *_a, **_kw: None

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5204,7 +5204,7 @@ def check_config_version() -> Tuple[int, int]:
 # Fields that are valid at root level of config.yaml
 _KNOWN_ROOT_KEYS = {
     "_config_version", "model", "providers", "fallback_model",
-    "fallback_providers", "credential_pool_strategies", "toolsets",
+    "fallback_providers", "fallback", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "moa", "custom_providers", "context", "memory", "gateway",
     "sessions", "streaming", "updates", "mcp_servers",
@@ -5293,6 +5293,25 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
                         f"custom_providers[{i}] is missing 'base_url' field",
                         "Add the API endpoint URL, e.g.: base_url: https://api.example.com/v1",
                     ))
+
+    # ── fallback activation policy ───────────────────────────────────────
+    if "fallback" in config:
+        fallback_cfg = config["fallback"]
+        if not isinstance(fallback_cfg, dict):
+            issues.append(ConfigIssue(
+                "error",
+                f"fallback should be a YAML mapping, got {type(fallback_cfg).__name__}",
+                "Change to:\n  fallback:\n    auto_activate: false",
+            ))
+        elif (
+            "auto_activate" in fallback_cfg
+            and not isinstance(fallback_cfg["auto_activate"], bool)
+        ):
+            issues.append(ConfigIssue(
+                "error",
+                "fallback.auto_activate should be a boolean",
+                "Use: auto_activate: true or auto_activate: false (without quotes)",
+            ))
 
     # ── fallback_model: single dict OR list of dicts (chain) ─────────────
     fb = config.get("fallback_model")

--- a/hermes_cli/fallback_cmd.py
+++ b/hermes_cli/fallback_cmd.py
@@ -1,8 +1,8 @@
 """
 hermes fallback — manage the fallback provider chain.
 
-Fallback providers are tried in order when the primary model fails with
-rate-limit, overload, or connection errors. See:
+Fallback providers are offered for selection or tried in order when the primary
+model fails with rate-limit, overload, or connection errors. See:
 https://hermes-agent.nousresearch.com/docs/user-guide/features/fallback-providers
 
 Subcommands:
@@ -11,6 +11,7 @@ Subcommands:
                            then append the selection to the chain
   hermes fallback remove   Pick an entry to delete from the chain
   hermes fallback clear    Remove all fallback entries
+  hermes fallback auto     Set automatic activation on or off
 
 Storage: ``fallback_providers`` in ``~/.hermes/config.yaml`` (top-level, list of
 ``{provider, model, base_url?, api_mode?}`` dicts).  The legacy single-dict
@@ -21,7 +22,7 @@ from __future__ import annotations
 import copy
 from typing import Any, Dict, List, Optional
 
-from hermes_cli.fallback_config import get_fallback_chain
+from hermes_cli.fallback_config import get_fallback_auto_activate, get_fallback_chain
 
 
 # ---------------------------------------------------------------------------
@@ -105,13 +106,19 @@ def _restore_auth_active_provider(value: Any) -> None:
 # ---------------------------------------------------------------------------
 
 def cmd_fallback_list(args) -> None:  # noqa: ARG001
-    """Print the current fallback chain."""
+    """Print the current fallback chain and activation mode."""
     from hermes_cli.config import load_config
 
     config = load_config()
     chain = _read_chain(config)
+    mode = (
+        "Automatic"
+        if get_fallback_auto_activate(config)
+        else "Manual selection"
+    )
 
     print()
+    print(f"  Mode: {mode}")
     if not chain:
         print("  No fallback providers configured.")
         print()
@@ -127,7 +134,10 @@ def cmd_fallback_list(args) -> None:  # noqa: ARG001
     for i, entry in enumerate(chain, 1):
         print(f"    {i}. {_format_entry(entry)}")
     print()
-    print("  Tried in order when the primary fails (rate-limit, 5xx, connection errors).")
+    if get_fallback_auto_activate(config):
+        print("  Tried in order when the primary fails (rate-limit, 5xx, connection errors).")
+    else:
+        print("  Offered for manual selection when the primary fails.")
     print("  Docs: https://hermes-agent.nousresearch.com/docs/user-guide/features/fallback-providers")
     print()
 
@@ -204,6 +214,7 @@ def cmd_fallback_add(args) -> None:
 
     final_cfg = load_config()
     chain = _read_chain(final_cfg)
+    first_entry = not chain
 
     # Reject exact-duplicate fallback entries.
     for existing in chain:
@@ -215,11 +226,25 @@ def cmd_fallback_add(args) -> None:
 
     chain.append(new_entry)
     _write_chain(final_cfg, chain)
+    if first_entry:
+        fallback_cfg = final_cfg.get("fallback")
+        if not isinstance(fallback_cfg, dict):
+            fallback_cfg = {}
+        fallback_cfg.setdefault("auto_activate", False)
+        final_cfg["fallback"] = fallback_cfg
     save_config(final_cfg)
 
     print()
     print(f"  Added fallback: {_format_entry(new_entry)}")
     print(f"  Chain is now {len(chain)} {'entry' if len(chain) == 1 else 'entries'} long.")
+    automatic = get_fallback_auto_activate(final_cfg)
+    print(f"  Mode: {'Automatic' if automatic else 'Manual selection'}")
+    if not automatic:
+        print(
+            "  Cron, API, background, and delegated runs are noninteractive and "
+            "fail closed in this mode."
+        )
+        print("  Use `hermes fallback auto on` to enable noninteractive failover.")
     print()
     print("  Run `hermes fallback list` to view, or `hermes fallback remove` to delete.")
 
@@ -311,6 +336,32 @@ def cmd_fallback_clear(args) -> None:  # noqa: ARG001
     print()
 
 
+def cmd_fallback_auto(args) -> None:
+    """Enable automatic activation or switch to interactive selection."""
+
+    from hermes_cli.config import load_config, save_config
+
+    mode = str(getattr(args, "mode", "") or "").strip().lower()
+    if mode not in {"on", "off"}:
+        raise SystemExit("Usage: hermes fallback auto {on|off}")
+    config = load_config()
+    fallback_cfg = config.get("fallback")
+    if not isinstance(fallback_cfg, dict):
+        fallback_cfg = {}
+    fallback_cfg["auto_activate"] = mode == "on"
+    config["fallback"] = fallback_cfg
+    save_config(config)
+    if mode == "on":
+        print("Automatic fallback enabled.")
+    else:
+        print("Manual fallback selection enabled.")
+        print(
+            "Cron, API, background, and delegated runs are noninteractive and "
+            "will fail closed."
+        )
+        print("Use `hermes fallback auto on` to enable noninteractive failover.")
+
+
 def _numbered_pick(question: str, choices: List[str]) -> Optional[int]:
     """Fallback numbered-list picker when curses is unavailable."""
     print(question)
@@ -348,7 +399,9 @@ def cmd_fallback(args) -> None:
         cmd_fallback_remove(args)
     elif sub == "clear":
         cmd_fallback_clear(args)
+    elif sub == "auto":
+        cmd_fallback_auto(args)
     else:
         print(f"Unknown fallback subcommand: {sub}")
-        print("Use one of: list, add, remove, clear")
+        print("Use one of: list, add, remove, clear, auto")
         raise SystemExit(2)

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -70,3 +70,25 @@ def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
             chain.append(entry)
 
     return chain
+
+
+def get_fallback_auto_activate(config: dict[str, Any] | None) -> bool:
+    """Return whether configured fallback routes auto-activate.
+
+    Missing keys default to ``True`` for backward compatibility with existing
+    ``fallback_providers`` users.
+    """
+
+    config = config or {}
+    if "fallback" not in config:
+        return True
+    fallback_cfg = config["fallback"]
+    if not isinstance(fallback_cfg, dict):
+        return False
+    if "auto_activate" not in fallback_cfg:
+        return True
+
+    value = fallback_cfg["auto_activate"]
+    # A present-but-invalid value is an explicit configuration error. Prefer
+    # manual/fail-closed behavior over silently spending through another route.
+    return value if isinstance(value, bool) else False

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12856,11 +12856,11 @@ def main():
 
     fallback_parser = subparsers.add_parser(
         "fallback",
-        help="Manage fallback providers (tried when the primary model fails)",
+        help="Manage fallback providers (offered or tried when the primary fails)",
         description=(
-            "Manage the fallback provider chain.  Fallback providers are tried "
-            "in order when the primary model fails with rate-limit, overload, or "
-            "connection errors.  See: "
+            "Manage the fallback provider chain. Fallback providers are offered or tried "
+            "automatically according to fallback.auto_activate when the primary model "
+            "fails with rate-limit, overload, or connection errors. See: "
             "https://hermes-agent.nousresearch.com/docs/user-guide/features/fallback-providers"
         ),
     )
@@ -12882,6 +12882,15 @@ def main():
     fallback_subparsers.add_parser(
         "clear",
         help="Remove all fallback entries",
+    )
+    fallback_auto_parser = fallback_subparsers.add_parser(
+        "auto",
+        help="Enable automatic fallback or use interactive selection",
+    )
+    fallback_auto_parser.add_argument(
+        "mode",
+        choices=["on", "off"],
+        help="on: try routes automatically; off: prompt before continuing",
     )
     fallback_parser.set_defaults(func=cmd_fallback)
 

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -28,7 +28,7 @@ from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from typing import Optional
 
-from hermes_cli.fallback_config import get_fallback_chain
+from hermes_cli.fallback_config import get_fallback_auto_activate, get_fallback_chain
 
 
 def _normalize_toolsets(toolsets: object = None) -> list[str] | None:
@@ -396,6 +396,8 @@ def _run_agent(
         session_db=session_db,
         credential_pool=runtime.get("credential_pool"),
         fallback_model=_fb or None,
+        fallback_auto_activate=get_fallback_auto_activate(cfg),
+        fallback_selection_interactive=False,
         # Interactive callbacks are intentionally NOT wired beyond this
         # one.  In oneshot mode there's no user sitting at a terminal:
         #   - clarify  → returns a synthetic "pick a default" instruction

--- a/run_agent.py
+++ b/run_agent.py
@@ -480,6 +480,8 @@ class AIAgent:
         parent_session_id: str = None,
         iteration_budget: "IterationBudget" = None,
         fallback_model: Dict[str, Any] = None,
+        fallback_auto_activate: bool = True,
+        fallback_selection_interactive: Optional[bool] = None,
         credential_pool=None,
         checkpoints_enabled: bool = False,
         checkpoint_max_snapshots: int = 20,
@@ -556,6 +558,8 @@ class AIAgent:
             parent_session_id=parent_session_id,
             iteration_budget=iteration_budget,
             fallback_model=fallback_model,
+            fallback_auto_activate=fallback_auto_activate,
+            fallback_selection_interactive=fallback_selection_interactive,
             credential_pool=credential_pool,
             checkpoints_enabled=checkpoints_enabled,
             checkpoint_max_snapshots=checkpoint_max_snapshots,
@@ -4784,8 +4788,39 @@ class AIAgent:
         ``try_activate_fallback`` (#35314, #17446).
         """
         chain = getattr(self, "_fallback_chain", None) or []
+        if self._uses_manual_fallback_selection():
+            return bool(
+                chain
+                and not getattr(self, "_fallback_manual_attempted", False)
+                and getattr(self, "_fallback_selection_interactive", None) is not False
+                and callable(getattr(self, "clarify_callback", None))
+            )
         index = getattr(self, "_fallback_index", 0)
         return index < len(chain)
+
+    def _uses_manual_fallback_selection(self) -> bool:
+        """Whether fallback selection should prompt instead of auto-advancing."""
+
+        chain = getattr(self, "_fallback_chain", None) or []
+        return bool(chain) and not bool(getattr(self, "_fallback_auto_activate", True))
+
+    def _fallback_attempt_status(
+        self,
+        automatic_text: str,
+        *,
+        manual_text: str | None = None,
+    ) -> str:
+        """Return the correct pre-attempt status for auto vs manual fallback."""
+
+        if self._uses_manual_fallback_selection() and self._has_pending_fallback():
+            return manual_text or automatic_text
+        return automatic_text
+
+    def _reset_turn_scoped_fallback_state(self) -> None:
+        """Clear per-turn manual fallback selection state."""
+
+        self._fallback_manual_attempted = False
+        self._fallback_manual_selected_index = None
 
     # ── Per-turn primary restoration ─────────────────────────────────────
 

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -69,6 +69,8 @@ class _FakeAgent:
         self._memory_write_origin = "assistant_tool"
         self._stream_context_scrubber = None
         self._stream_think_scrubber = None
+        self._fallback_activated = False
+        self._fallback_manual_selected_index: int | None = None
         # Attributes the prologue assigns; recorded for assertions.
         self._invalid_tool_retries = -1
         self._vision_supported = None
@@ -188,6 +190,51 @@ def test_applies_agent_side_effects():
     # task/turn ids assigned on the agent.
     assert agent._current_task_id
     assert agent._current_turn_id
+
+
+def test_manual_fallback_restores_before_aux_runtime_is_published():
+    agent = _FakeAgent()
+    agent.provider = "openrouter"
+    agent.model = "fallback/model"
+    agent.base_url = "https://fallback.example/v1"
+    agent.api_key = "fb"
+    agent._fallback_activated = True
+    agent._fallback_manual_selected_index = 0
+
+    def restore_primary():
+        agent.provider = "anthropic"
+        agent.model = "primary/model"
+        agent.base_url = "https://api.anthropic.com"
+        agent.api_key = "pk"
+        agent._fallback_activated = False
+        return True
+
+    agent._restore_primary_runtime = MagicMock(side_effect=restore_primary)
+
+    with patch("agent.auxiliary_client.set_runtime_main") as publish:
+        _build(agent)
+
+    agent._restore_primary_runtime.assert_called_once_with()
+    publish.assert_called_once_with(
+        "anthropic",
+        "primary/model",
+        base_url="https://api.anthropic.com",
+        api_key="pk",
+        api_mode="chat_completions",
+    )
+
+
+def test_manual_fallback_restore_failure_aborts_new_turn():
+    agent = _FakeAgent()
+    agent._fallback_activated = True
+    agent._fallback_manual_selected_index = 0
+    agent._restore_primary_runtime = MagicMock(return_value=False)
+
+    with patch("agent.auxiliary_client.set_runtime_main") as publish:
+        with pytest.raises(RuntimeError, match="restore the primary runtime"):
+            _build(agent)
+
+    publish.assert_not_called()
 
 
 def test_task_id_passthrough():

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -224,16 +224,83 @@ def test_manual_fallback_restores_before_aux_runtime_is_published():
     )
 
 
+def test_manual_fallback_aux_publish_failure_aborts_and_clears():
+    agent = _FakeAgent()
+    agent._fallback_activated = True
+    agent._fallback_manual_selected_index = 0
+    events = []
+
+    def restore_primary():
+        agent.provider = "anthropic"
+        agent.model = "primary/model"
+        agent.base_url = "https://api.anthropic.com"
+        agent.api_key = "pk"
+        agent._fallback_activated = False
+        return True
+
+    def publish_failure(*_args, **_kwargs):
+        events.append("publish")
+        raise RuntimeError("publish failed")
+
+    agent._restore_primary_runtime = MagicMock(side_effect=restore_primary)
+
+    with (
+        patch(
+            "agent.auxiliary_client.clear_runtime_main",
+            side_effect=lambda: events.append("clear"),
+        ),
+        patch(
+            "agent.auxiliary_client.set_runtime_main",
+            side_effect=publish_failure,
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="publish the restored primary runtime"):
+            _build(agent)
+
+    assert events == ["clear", "publish", "clear"]
+
+
 def test_manual_fallback_restore_failure_aborts_new_turn():
     agent = _FakeAgent()
     agent._fallback_activated = True
     agent._fallback_manual_selected_index = 0
     agent._restore_primary_runtime = MagicMock(return_value=False)
 
-    with patch("agent.auxiliary_client.set_runtime_main") as publish:
+    with (
+        patch("agent.auxiliary_client.clear_runtime_main") as clear,
+        patch("agent.auxiliary_client.set_runtime_main") as publish,
+    ):
         with pytest.raises(RuntimeError, match="restore the primary runtime"):
             _build(agent)
 
+    clear.assert_called_once_with()
+    publish.assert_not_called()
+
+
+def test_manual_policy_restore_failure_aborts_auto_selected_route():
+    agent = _FakeAgent()
+    agent._fallback_activated = True
+    agent._fallback_manual_selected_index = None
+    setattr(agent, "_fallback_auto_activate", False)
+    events = []
+
+    def restore_failure():
+        events.append("restore")
+        return False
+
+    agent._restore_primary_runtime = MagicMock(side_effect=restore_failure)
+
+    with (
+        patch(
+            "agent.auxiliary_client.clear_runtime_main",
+            side_effect=lambda: events.append("clear"),
+        ),
+        patch("agent.auxiliary_client.set_runtime_main") as publish,
+    ):
+        with pytest.raises(RuntimeError, match="restore the primary runtime"):
+            _build(agent)
+
+    assert events == ["clear", "restore"]
     publish.assert_not_called()
 
 

--- a/tests/cli/test_cli_manual_fallback.py
+++ b/tests/cli/test_cli_manual_fallback.py
@@ -1,0 +1,33 @@
+"""CLI bootstrap behavior for manual provider fallback."""
+
+from unittest.mock import MagicMock, patch
+
+from hermes_cli.auth import AuthError
+from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
+
+
+class _FakeCLI(CLIAgentSetupMixin):
+    requested_provider = "openai-codex"
+    _explicit_api_key = None
+    _explicit_base_url = None
+    _fallback_model = [{"provider": "openrouter", "model": "gpt-5.4"}]
+    _fallback_auto_activate = False
+    model = "gpt-5.4"
+
+
+def test_manual_mode_auth_failure_does_not_auto_resolve_fallback():
+    cli = _FakeCLI()
+
+    with patch(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        side_effect=AuthError("token expired"),
+    ) as resolve, patch("cli.ChatConsole", return_value=MagicMock()):
+        assert cli._ensure_runtime_credentials() is False
+
+    resolve.assert_called_once_with(
+        requested="openai-codex",
+        explicit_api_key=None,
+        explicit_base_url=None,
+    )
+    assert cli.requested_provider == "openai-codex"
+    assert cli.model == "gpt-5.4"

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -3973,6 +3973,10 @@ class TestModelRoutesAgentCreation:
                 captured.update(kwargs)
 
         _patch_create_agent_runtime(monkeypatch, captured, FakeAgent)
+        monkeypatch.setattr(
+            "gateway.run.GatewayRunner._load_fallback_auto_activate",
+            lambda: False,
+        )
         adapter = _make_routing_adapter(
             {"alias": {
                 "model": "minimax/minimax-m1",
@@ -3991,6 +3995,8 @@ class TestModelRoutesAgentCreation:
         assert captured["model"] == "minimax/minimax-m1"
         assert captured["api_key"] == "sk-route"
         assert captured["base_url"] == "https://route.example/v1"
+        assert captured["fallback_auto_activate"] is False
+        assert captured["fallback_selection_interactive"] is False
 
     def test_route_provider_resolves_provider_credentials(self, monkeypatch):
         captured = {}

--- a/tests/gateway/test_auth_fallback.py
+++ b/tests/gateway/test_auth_fallback.py
@@ -71,6 +71,32 @@ class TestResolveRuntimeAgentKwargsAuthFallback:
             with pytest.raises(RuntimeError):
                 _resolve_runtime_agent_kwargs()
 
+    def test_auth_error_manual_mode_does_not_auto_resolve_fallback(
+        self, tmp_path, monkeypatch
+    ):
+        """Before an agent exists there is no interactive surface, so fail closed."""
+        from hermes_cli.auth import AuthError
+
+        (tmp_path / "config.yaml").write_text(
+            "model:\n  provider: openai-codex\n"
+            "fallback:\n  auto_activate: false\n"
+            "fallback_providers:\n"
+            "  - provider: openrouter\n"
+            "    model: meta-llama/llama-4-maverick\n"
+        )
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=AuthError("token expired"),
+        ) as resolve:
+            from gateway.run import _resolve_runtime_agent_kwargs
+
+            with pytest.raises(RuntimeError):
+                _resolve_runtime_agent_kwargs()
+
+        resolve.assert_called_once()
+
     def test_legacy_fallback_is_appended_after_fallback_providers(self, tmp_path, monkeypatch):
         """When both keys exist, the legacy entry still participates in resolution."""
         config_path = tmp_path / "config.yaml"

--- a/tests/gateway/test_fallback_chain_reload.py
+++ b/tests/gateway/test_fallback_chain_reload.py
@@ -139,11 +139,40 @@ def test_apply_fallback_chain_skips_while_cooldown_holds_fallback():
     GatewayRunner._apply_fallback_chain_to_agent(
         agent,
         [{"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"}],
-        auto_activate=False,
+        auto_activate=True,
     )
 
     assert agent._fallback_chain == live
     assert agent._fallback_index == 1
+    assert agent._fallback_activated is True
+    assert agent._fallback_auto_activate is True
+
+
+def test_apply_fallback_chain_auto_to_manual_updates_during_cooldown():
+    """Switching to manual mode must replace future choices immediately."""
+    from gateway.run import GatewayRunner
+
+    live = [{"provider": "deepseek", "model": "deepseek-v4-flash"}]
+    updated = [
+        {"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"}
+    ]
+    agent = SimpleNamespace(
+        _fallback_chain=live,
+        _fallback_model=live[0],
+        _fallback_index=1,
+        _fallback_activated=True,
+        _fallback_auto_activate=True,
+        _fallback_manual_selected_index=None,
+        _rate_limited_until=time.monotonic() + 30,
+        _unavailable_fallback_keys=set(),
+    )
+
+    GatewayRunner._apply_fallback_chain_to_agent(
+        agent, updated, auto_activate=False
+    )
+
+    assert agent._fallback_chain == updated
+    assert agent._fallback_model == updated[0]
     assert agent._fallback_activated is True
     assert agent._fallback_auto_activate is False
 

--- a/tests/gateway/test_fallback_chain_reload.py
+++ b/tests/gateway/test_fallback_chain_reload.py
@@ -21,6 +21,8 @@ def test_refresh_fallback_model_rereads_config(tmp_path, monkeypatch):
     monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
     cfg = tmp_path / "config.yaml"
     cfg.write_text(
+        "fallback:\n"
+        "  auto_activate: false\n"
         "fallback_providers:\n"
         "  - provider: deepseek\n"
         "    model: deepseek-v4-flash\n"
@@ -35,6 +37,7 @@ def test_refresh_fallback_model_rereads_config(tmp_path, monkeypatch):
 
     assert chain == [{"provider": "deepseek", "model": "deepseek-v4-flash"}]
     assert runner._fallback_model == chain
+    assert runner._fallback_auto_activate is False
 
     cfg.write_text(
         "fallback_providers:\n"
@@ -46,6 +49,7 @@ def test_refresh_fallback_model_rereads_config(tmp_path, monkeypatch):
         {"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"}
     ]
     assert runner._fallback_model == updated
+    assert runner._fallback_auto_activate is True
 
 
 def test_refresh_fallback_model_clears_when_config_removed(tmp_path, monkeypatch):
@@ -110,10 +114,13 @@ def test_apply_fallback_chain_updates_primary_agent():
         _rate_limited_until=0,
     )
     chain = [{"provider": "deepseek", "model": "deepseek-v4-flash"}]
-    GatewayRunner._apply_fallback_chain_to_agent(agent, chain)
+    GatewayRunner._apply_fallback_chain_to_agent(
+        agent, chain, auto_activate=False
+    )
 
     assert agent._fallback_chain == chain
     assert agent._fallback_model == chain[0]
+    assert agent._fallback_auto_activate is False
     assert agent._fallback_index == 0
 
 
@@ -132,11 +139,38 @@ def test_apply_fallback_chain_skips_while_cooldown_holds_fallback():
     GatewayRunner._apply_fallback_chain_to_agent(
         agent,
         [{"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"}],
+        auto_activate=False,
     )
 
     assert agent._fallback_chain == live
     assert agent._fallback_index == 1
     assert agent._fallback_activated is True
+    assert agent._fallback_auto_activate is False
+
+
+def test_apply_fallback_chain_clears_manual_routes_during_cooldown():
+    """A manual route may stay active until restore, but stale choices must not."""
+    from gateway.run import GatewayRunner
+
+    live = [{"provider": "deepseek", "model": "deepseek-v4-flash"}]
+    agent = SimpleNamespace(
+        _fallback_chain=live,
+        _fallback_model=live[0],
+        _fallback_index=1,
+        _fallback_activated=True,
+        _fallback_manual_selected_index=0,
+        _rate_limited_until=time.monotonic() + 30,
+        _unavailable_fallback_keys=set(),
+    )
+
+    GatewayRunner._apply_fallback_chain_to_agent(
+        agent, [], auto_activate=False
+    )
+
+    assert agent._fallback_chain == []
+    assert agent._fallback_model is None
+    assert agent._fallback_activated is True
+    assert agent._fallback_manual_selected_index == 0
 
 
 def test_apply_fallback_chain_updates_after_cooldown_expires():

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -95,6 +95,29 @@ class TestCustomProvidersValidation:
         assert len(issues) == 0
 
 
+class TestFallbackActivationValidation:
+    def test_fallback_section_must_be_mapping(self):
+        issues = validate_config_structure({"fallback": []})
+        assert any(
+            i.severity == "error" and "fallback" in i.message and "mapping" in i.message
+            for i in issues
+        )
+
+    def test_auto_activate_must_be_boolean(self):
+        issues = validate_config_structure(
+            {"fallback": {"auto_activate": "false"}}
+        )
+        assert any(
+            i.severity == "error" and "auto_activate" in i.message and "boolean" in i.message
+            for i in issues
+        )
+
+    def test_valid_manual_policy_has_no_issue(self):
+        assert validate_config_structure(
+            {"fallback": {"auto_activate": False}}
+        ) == []
+
+
 class TestFallbackModelValidation:
     """fallback_model should be a top-level dict with provider + model."""
 

--- a/tests/hermes_cli/test_fallback_cmd.py
+++ b/tests/hermes_cli/test_fallback_cmd.py
@@ -508,3 +508,141 @@ class TestArgparseWiring:
         assert "add" in out
         assert "remove" in out
         assert "clear" in out
+
+
+class TestAutoModeCommand:
+    def test_invalid_explicit_auto_activate_fails_closed(self):
+        from hermes_cli.fallback_config import get_fallback_auto_activate
+
+        assert get_fallback_auto_activate({}) is True
+        assert get_fallback_auto_activate({"fallback": False}) is False
+        assert get_fallback_auto_activate(
+            {"fallback": {"auto_activate": "false"}}
+        ) is False
+
+    def test_first_add_to_empty_chain_persists_manual_mode(
+        self, isolated_home, capsys
+    ):
+        _write_config(
+            isolated_home,
+            {"model": {"provider": "anthropic", "default": "claude-sonnet-4-6"}},
+        )
+
+        def fake_picker(args=None):
+            from hermes_cli.config import load_config, save_config
+
+            cfg = load_config()
+            cfg["model"] = {
+                "provider": "openrouter",
+                "default": "gpt-5.4",
+            }
+            save_config(cfg)
+
+        with patch("hermes_cli.main.select_provider_and_model", side_effect=fake_picker), patch(
+            "hermes_cli.main._require_tty"
+        ):
+            from hermes_cli.fallback_cmd import cmd_fallback_add
+
+            cmd_fallback_add(types.SimpleNamespace())
+
+        cfg = _read_config(isolated_home)
+        assert cfg["fallback"]["auto_activate"] is False
+        out = capsys.readouterr().out
+        assert "Mode: Manual selection" in out
+        assert "noninteractive" in out
+        assert "hermes fallback auto on" in out
+
+    def test_add_to_existing_chain_without_mode_keeps_legacy_automatic(self, isolated_home):
+        _write_config(
+            isolated_home,
+            {
+                "model": {"provider": "anthropic", "default": "claude-sonnet-4-6"},
+                "fallback_providers": [{"provider": "openai", "model": "gpt-4o"}],
+            },
+        )
+
+        def fake_picker(args=None):
+            from hermes_cli.config import load_config, save_config
+
+            cfg = load_config()
+            cfg["model"] = {
+                "provider": "openrouter",
+                "default": "gpt-5.4",
+            }
+            save_config(cfg)
+
+        with patch("hermes_cli.main.select_provider_and_model", side_effect=fake_picker), patch(
+            "hermes_cli.main._require_tty"
+        ):
+            from hermes_cli.fallback_cmd import cmd_fallback_add
+
+            cmd_fallback_add(types.SimpleNamespace())
+
+        cfg = _read_config(isolated_home)
+        assert "fallback" not in cfg or "auto_activate" not in cfg.get("fallback", {})
+
+    def test_list_shows_manual_selection_mode(self, isolated_home, capsys):
+        _write_config(
+            isolated_home,
+            {
+                "model": {"provider": "anthropic", "default": "claude-sonnet-4-6"},
+                "fallback": {"auto_activate": False},
+                "fallback_providers": [{"provider": "openrouter", "model": "gpt-5.4"}],
+            },
+        )
+
+        from hermes_cli.fallback_cmd import cmd_fallback_list
+
+        cmd_fallback_list(types.SimpleNamespace())
+        out = capsys.readouterr().out
+        assert "Mode: Manual selection" in out
+
+    def test_list_defaults_to_automatic_mode_when_key_missing(self, isolated_home, capsys):
+        _write_config(
+            isolated_home,
+            {
+                "model": {"provider": "anthropic", "default": "claude-sonnet-4-6"},
+                "fallback_providers": [{"provider": "openrouter", "model": "gpt-5.4"}],
+            },
+        )
+
+        from hermes_cli.fallback_cmd import cmd_fallback_list
+
+        cmd_fallback_list(types.SimpleNamespace())
+        out = capsys.readouterr().out
+        assert "Mode: Automatic" in out
+
+    def test_auto_command_round_trips_config(self, isolated_home, capsys):
+        _write_config(isolated_home, {})
+
+        from hermes_cli.fallback_cmd import cmd_fallback
+
+        cmd_fallback(types.SimpleNamespace(fallback_command="auto", mode="off"))
+        cfg = _read_config(isolated_home)
+        assert cfg["fallback"]["auto_activate"] is False
+
+        cmd_fallback(types.SimpleNamespace(fallback_command="auto", mode="on"))
+        cfg = _read_config(isolated_home)
+        assert cfg["fallback"]["auto_activate"] is True
+
+        out = capsys.readouterr().out
+        assert "Automatic fallback enabled." in out
+        assert "Manual fallback selection enabled." in out
+        assert "will fail closed" in out
+        assert "hermes fallback auto on" in out
+
+    def test_help_lists_auto_subcommand(self):
+        import subprocess
+        import sys
+
+        result = subprocess.run(
+            [sys.executable, "-m", "hermes_cli.main", "fallback", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        out = result.stdout + result.stderr
+        assert "auto" in out
+        assert "offered or tried" in out

--- a/tests/run_agent/test_init_fallback_on_exhausted_pool.py
+++ b/tests/run_agent/test_init_fallback_on_exhausted_pool.py
@@ -67,3 +67,34 @@ def test_init_raises_when_no_fallback_configured():
                 skip_memory=True,
                 fallback_model=None,
             )
+
+
+def test_init_manual_mode_does_not_resolve_fallback():
+    """Constructor-time auth recovery has no clarification surface; fail closed."""
+    calls = []
+
+    def fake_resolve(provider, model=None, raw_codex=False, **kwargs):
+        calls.append(provider)
+        return None, None
+
+    with patch("agent.auxiliary_client.resolve_provider_client", side_effect=fake_resolve), \
+         patch("run_agent.get_tool_definitions", return_value=_make_tool_defs()), \
+         patch("run_agent.check_toolset_requirements", return_value={}), \
+         patch("run_agent.OpenAI", return_value=MagicMock()):
+        with pytest.raises(RuntimeError, match="no API key was found"):
+            AIAgent(
+                provider="alibaba-coding-plan",
+                model="qwen3.6-plus",
+                api_key=None,
+                base_url=None,
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                fallback_model=[
+                    {"provider": "tencent-token-plan", "model": "kimi2.5"}
+                ],
+                fallback_auto_activate=False,
+                fallback_selection_interactive=False,
+            )
+
+    assert "tencent-token-plan" not in calls

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -644,6 +644,31 @@ class TestRateLimitCooldown:
         assert result is False
         assert agent._fallback_activated is True  # still on fallback
 
+    def test_manual_selection_restores_primary_despite_cooldown(self):
+        """An explicit one-turn route choice must not pin the next turn."""
+        agent = _make_agent(
+            fallback_model={
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+            },
+        )
+        mock_client = _mock_resolve()
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, None),
+        ):
+            agent._try_activate_fallback()
+
+        setattr(agent, "_fallback_manual_selected_index", 0)
+        setattr(agent, "_rate_limited_until", time.monotonic() + 60)
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            result = agent._restore_primary_runtime()
+
+        assert result is True
+        assert getattr(agent, "_fallback_activated") is False
+        assert getattr(agent, "provider") == "custom"
+
     def test_restore_allowed_after_cooldown_expires(self):
         """Once the cooldown window passes, restore proceeds normally."""
         agent = _make_agent(

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -669,6 +669,32 @@ class TestRateLimitCooldown:
         assert getattr(agent, "_fallback_activated") is False
         assert getattr(agent, "provider") == "custom"
 
+    def test_manual_policy_restores_auto_selected_route_despite_cooldown(self):
+        """Turning manual mode on must end a cached automatic fallback route."""
+        agent = _make_agent(
+            fallback_model={
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+            },
+        )
+        mock_client = _mock_resolve()
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, None),
+        ):
+            agent._try_activate_fallback()
+
+        assert getattr(agent, "_fallback_manual_selected_index", None) is None
+        setattr(agent, "_fallback_auto_activate", False)
+        setattr(agent, "_rate_limited_until", time.monotonic() + 60)
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            result = agent._restore_primary_runtime()
+
+        assert result is True
+        assert getattr(agent, "_fallback_activated") is False
+        assert getattr(agent, "provider") == "custom"
+
     def test_restore_allowed_after_cooldown_expires(self):
         """Once the cooldown window passes, restore proceeds normally."""
         agent = _make_agent(

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -5,12 +5,22 @@ the new list-based ``fallback_providers`` config format and chain
 advancement through multiple providers.
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from run_agent import AIAgent, _pool_may_recover_from_rate_limit
 
 
-def _make_agent(fallback_model=None):
+def _make_agent(
+    fallback_model=None,
+    *,
+    fallback_auto_activate=True,
+    fallback_selection_interactive=False,
+    clarify_callback=None,
+    **agent_kwargs,
+):
     """Create a minimal AIAgent with optional fallback config."""
     with (
         patch("run_agent.get_tool_definitions", return_value=[]),
@@ -24,6 +34,10 @@ def _make_agent(fallback_model=None):
             skip_context_files=True,
             skip_memory=True,
             fallback_model=fallback_model,
+            fallback_auto_activate=fallback_auto_activate,
+            fallback_selection_interactive=fallback_selection_interactive,
+            clarify_callback=clarify_callback,
+            **agent_kwargs,
         )
         agent.client = MagicMock()
         return agent
@@ -333,4 +347,362 @@ class TestFallbackChainDedup:
             ok = agent._try_activate_fallback()
 
         assert ok is False
+        mock_resolve.assert_not_called()
+
+
+class TestManualFallbackSelection:
+    def test_manual_mode_with_empty_effective_chain_does_not_prompt(self):
+        clarify = MagicMock(return_value="should not be used")
+        fbs = [{"provider": "openrouter", "model": "z-ai/glm-4.7"}]
+        agent = _make_agent(
+            fallback_model=fbs,
+            fallback_auto_activate=False,
+            fallback_selection_interactive=True,
+            clarify_callback=clarify,
+        )
+        agent.provider = "openrouter"
+        agent.model = "z-ai/glm-4.7"
+        agent.base_url = "https://openrouter.ai/api/v1"
+
+        with patch("agent.auxiliary_client.resolve_provider_client") as mock_resolve:
+            ok = agent._try_activate_fallback()
+
+        assert ok is False
+        clarify.assert_not_called()
+        mock_resolve.assert_not_called()
+
+    def test_manual_mode_uses_only_selected_route(self):
+        fbs = [
+            {
+                "provider": "anthropic",
+                "model": "claude-sonnet-4-6",
+                "base_url": "https://api.anthropic.com",
+            },
+            {
+                "provider": "openrouter",
+                "model": "anthropic/claude-opus-4.1",
+                "base_url": "https://openrouter.ai/api/v1",
+            },
+        ]
+        selected_label = (
+            "Continue with anthropic/claude-opus-4.1 via openrouter "
+            "(https://openrouter.ai)"
+        )
+        clarify = MagicMock(return_value="2")
+        agent = _make_agent(
+            fallback_model=fbs,
+            fallback_auto_activate=False,
+            fallback_selection_interactive=True,
+            clarify_callback=clarify,
+        )
+
+        called = []
+
+        def _resolve(provider, model=None, raw_codex=False, **kwargs):
+            called.append((provider, model, kwargs.get("explicit_base_url")))
+            return _mock_client(base_url=kwargs.get("explicit_base_url") or ""), model
+
+        with patch("agent.auxiliary_client.resolve_provider_client", side_effect=_resolve):
+            with patch(
+                "hermes_cli.model_normalize.normalize_model_for_provider",
+                side_effect=lambda m, p: m,
+            ):
+                ok = agent._try_activate_fallback()
+
+        assert ok is True
+        clarify.assert_called_once_with(
+            "Primary model failed. Select a fallback route for this turn:",
+            [
+                "Continue with claude-sonnet-4-6 via anthropic (https://api.anthropic.com)",
+                selected_label,
+            ],
+        )
+        assert called == [
+            ("openrouter", "anthropic/claude-opus-4.1", "https://openrouter.ai/api/v1")
+        ]
+        assert agent.provider == "openrouter"
+        assert agent.model == "anthropic/claude-opus-4.1"
+
+    @pytest.mark.parametrize(
+        "response",
+        [
+            "",
+            "[user did not respond within 2m]",
+            "[clarify prompt could not be delivered]",
+            "not a valid choice",
+            "0",
+            "2",
+        ],
+    )
+    def test_manual_mode_unmatched_response_fails_closed(self, response):
+        agent = _make_agent(
+            fallback_model=[{"provider": "openai", "model": "gpt-4o"}],
+            fallback_auto_activate=False,
+            fallback_selection_interactive=True,
+            clarify_callback=MagicMock(return_value=response),
+        )
+
+        with patch("agent.auxiliary_client.resolve_provider_client") as mock_resolve:
+            ok = agent._try_activate_fallback()
+
+        assert ok is False
+        mock_resolve.assert_not_called()
+
+    def test_manual_selection_state_resets_for_next_turn(self):
+        agent = _make_agent(
+            fallback_model=[{"provider": "openai", "model": "gpt-4o"}],
+            fallback_auto_activate=False,
+            fallback_selection_interactive=True,
+            clarify_callback=MagicMock(),
+        )
+        agent._fallback_manual_attempted = True
+        agent._fallback_manual_selected_index = 0
+
+        agent._reset_turn_scoped_fallback_state()
+
+        assert agent._fallback_manual_attempted is False
+        assert agent._fallback_manual_selected_index is None
+
+    def test_two_turn_rate_limit_restores_primary_and_prompts_again(self):
+        """Manual consent is one turn and run_conversation re-arms it next turn."""
+
+        class RateLimitError(Exception):
+            status_code = 429
+
+            def __init__(self):
+                super().__init__("Error code: 429 - rate limit exceeded")
+                self.response = SimpleNamespace(headers={})
+                self.body = {"error": {"message": "rate limit exceeded"}}
+
+        def response(text):
+            message = SimpleNamespace(content=text, tool_calls=None)
+            choice = SimpleNamespace(message=message, finish_reason="stop")
+            return SimpleNamespace(
+                choices=[choice], model="fallback/model", usage=None
+            )
+
+        clarify = MagicMock(side_effect=["1", "1"])
+        agent = _make_agent(
+            fallback_model=[{"provider": "openai", "model": "gpt-4o"}],
+            fallback_auto_activate=False,
+            fallback_selection_interactive=True,
+            clarify_callback=clarify,
+            provider="custom",
+            model="primary-model",
+        )
+        agent._api_max_retries = 1
+        calls = []
+
+        def api_call(_kwargs):
+            calls.append((agent.provider, agent.model))
+            if len(calls) in {1, 3}:
+                raise RateLimitError()
+            return response(f"fallback turn {len(calls) // 2}")
+
+        fallback_client = _mock_client()
+        with (
+            patch.object(agent, "_interruptible_api_call", side_effect=api_call),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch("run_agent.OpenAI", return_value=MagicMock()),
+            patch("agent.agent_runtime_helpers.time.sleep"),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(fallback_client, "gpt-4o"),
+            ),
+            patch(
+                "hermes_cli.model_normalize.normalize_model_for_provider",
+                side_effect=lambda model, provider: model,
+            ),
+            patch(
+                "agent.model_metadata.get_model_context_length",
+                return_value=200000,
+            ),
+        ):
+            first = agent.run_conversation("turn one")
+            second = agent.run_conversation(
+                "turn two", conversation_history=first["messages"]
+            )
+
+        assert first["completed"] is True
+        assert second["completed"] is True
+        assert calls == [
+            ("custom", "primary-model"),
+            ("openai", "gpt-4o"),
+            ("custom", "primary-model"),
+            ("openai", "gpt-4o"),
+        ]
+        assert clarify.call_count == 2
+
+    def test_manual_mode_supports_callback_attached_after_init(self):
+        label = "Continue with gpt-4o via openai"
+        agent = _make_agent(
+            fallback_model=[{"provider": "openai", "model": "gpt-4o"}],
+            fallback_auto_activate=False,
+            fallback_selection_interactive=None,
+            clarify_callback=None,
+        )
+        agent.clarify_callback = MagicMock(return_value=label)
+
+        assert agent._has_pending_fallback() is True
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(), "gpt-4o"),
+        ):
+            with patch(
+                "hermes_cli.model_normalize.normalize_model_for_provider",
+                side_effect=lambda m, p: m,
+            ):
+                assert agent._try_activate_fallback() is True
+
+    def test_manual_mode_noninteractive_fails_closed_even_with_callback(self):
+        clarify = MagicMock(
+            return_value="Continue with gpt-4o via openai"
+        )
+        agent = _make_agent(
+            fallback_model=[{"provider": "openai", "model": "gpt-4o"}],
+            fallback_auto_activate=False,
+            fallback_selection_interactive=False,
+            clarify_callback=clarify,
+        )
+
+        with patch("agent.auxiliary_client.resolve_provider_client") as mock_resolve:
+            ok = agent._try_activate_fallback()
+
+        assert ok is False
+        clarify.assert_not_called()
+        mock_resolve.assert_not_called()
+
+    def test_manual_mode_selected_route_failure_does_not_cascade(self):
+        fbs = [
+            {"provider": "broken", "model": "bad-route"},
+            {"provider": "openai", "model": "gpt-4o"},
+        ]
+        clarify = MagicMock(return_value="Continue with bad-route via broken")
+        agent = _make_agent(
+            fallback_model=fbs,
+            fallback_auto_activate=False,
+            fallback_selection_interactive=True,
+            clarify_callback=clarify,
+        )
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(None, None),
+        ) as mock_resolve:
+            ok = agent._try_activate_fallback()
+
+        assert ok is False
+        mock_resolve.assert_called_once()
+
+    def test_manual_mode_never_cascades_after_selected_route_activation(self):
+        label = "Continue with gpt-4o via openai"
+        clarify = MagicMock(return_value=label)
+        agent = _make_agent(
+            fallback_model=[
+                {"provider": "openai", "model": "gpt-4o"},
+                {"provider": "zai", "model": "glm-4.7"},
+            ],
+            fallback_auto_activate=False,
+            fallback_selection_interactive=True,
+            clarify_callback=clarify,
+        )
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(), "gpt-4o"),
+        ) as mock_resolve:
+            with patch(
+                "hermes_cli.model_normalize.normalize_model_for_provider",
+                side_effect=lambda m, p: m,
+            ):
+                assert agent._try_activate_fallback() is True
+                assert agent._try_activate_fallback() is False
+
+        clarify.assert_called_once()
+        mock_resolve.assert_called_once()
+
+    def test_manual_mode_redacts_base_url_credentials_from_choices(self):
+        safe_label = (
+            "Continue with gpt-4o via custom (https://api.example)"
+        )
+        clarify = MagicMock(return_value=safe_label)
+        agent = _make_agent(
+            fallback_model=[
+                {
+                    "provider": "custom",
+                    "model": "gpt-4o",
+                    "base_url": "https://user:password@api.example/token-secret/v1?api_key=secret",
+                }
+            ],
+            fallback_auto_activate=False,
+            fallback_selection_interactive=True,
+            clarify_callback=clarify,
+        )
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(), "gpt-4o"),
+        ):
+            with patch(
+                "hermes_cli.model_normalize.normalize_model_for_provider",
+                side_effect=lambda m, p: m,
+            ):
+                assert agent._try_activate_fallback() is True
+
+        choices = clarify.call_args.args[1]
+        assert choices == [safe_label]
+        assert "password" not in choices[0]
+        assert "secret" not in choices[0]
+
+    def test_manual_mode_renders_ipv6_origin_safely(self):
+        safe_label = (
+            "Continue with gpt-4o via custom (https://[2001:db8::1]:8443)"
+        )
+        clarify = MagicMock(return_value=safe_label)
+        agent = _make_agent(
+            fallback_model=[
+                {
+                    "provider": "custom",
+                    "model": "gpt-4o",
+                    "base_url": (
+                        "https://user:password@[2001:db8::1]:8443/secret/v1"
+                    ),
+                }
+            ],
+            fallback_auto_activate=False,
+            fallback_selection_interactive=True,
+            clarify_callback=clarify,
+        )
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(), "gpt-4o"),
+        ):
+            with patch(
+                "hermes_cli.model_normalize.normalize_model_for_provider",
+                side_effect=lambda m, p: m,
+            ):
+                assert agent._try_activate_fallback() is True
+
+        assert clarify.call_args.args[1] == [safe_label]
+
+    def test_manual_mode_fails_closed_when_choice_limit_exceeded(self):
+        clarify = MagicMock(return_value="should not be used")
+        agent = _make_agent(
+            fallback_model=[
+                {"provider": f"provider-{idx}", "model": f"model-{idx}"}
+                for idx in range(5)
+            ],
+            fallback_auto_activate=False,
+            fallback_selection_interactive=True,
+            clarify_callback=clarify,
+        )
+
+        with patch("agent.auxiliary_client.resolve_provider_client") as mock_resolve:
+            ok = agent._try_activate_fallback()
+
+        assert ok is False
+        clarify.assert_not_called()
         mock_resolve.assert_not_called()

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8759,6 +8759,35 @@ class TestResolveRuntimeWithFallback:
         )
         assert result == fallback_runtime
 
+    def test_auth_error_manual_mode_fails_closed_before_agent_exists(
+        self, monkeypatch
+    ):
+        from hermes_cli.auth import AuthError
+
+        calls = []
+
+        def fake_resolve(**kwargs):
+            calls.append(kwargs.get("requested"))
+            raise AuthError("No credentials")
+
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve,
+        )
+        monkeypatch.setattr(server, "_load_fallback_auto_activate", lambda: False)
+        monkeypatch.setattr(
+            server,
+            "_load_fallback_model",
+            lambda: [{"provider": "deepseek", "model": "deepseek-v4-pro"}],
+        )
+
+        import pytest
+
+        with pytest.raises(AuthError, match="No credentials"):
+            server._resolve_runtime_with_fallback({"requested": "openai-codex"})
+
+        assert calls == ["openai-codex"]
+
     def test_auth_error_all_fallbacks_fail_raises(self, monkeypatch):
         """When all fallbacks also fail, re-raise the original AuthError."""
         from hermes_cli.auth import AuthError

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -3116,6 +3116,7 @@ class TestFallbackModelInheritance(unittest.TestCase):
         parent = _make_mock_parent(depth=0)
         fallback_entry = {"provider": "openrouter", "model": "gpt-4o-mini", "api_key": "sk-or-x"}
         parent._fallback_chain = [fallback_entry]
+        parent._fallback_auto_activate = False
 
         with patch("run_agent.AIAgent") as MockAgent:
             MockAgent.return_value = MagicMock()
@@ -3132,6 +3133,8 @@ class TestFallbackModelInheritance(unittest.TestCase):
 
         _, kwargs = MockAgent.call_args
         self.assertEqual(kwargs["fallback_model"], [fallback_entry])
+        self.assertFalse(kwargs["fallback_auto_activate"])
+        self.assertFalse(kwargs["fallback_selection_interactive"])
 
     def test_child_gets_no_fallback_when_parent_chain_empty(self):
         """When parent._fallback_chain is empty, fallback_model is None."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1330,6 +1330,10 @@ def _build_child_agent(
         reasoning_config=child_reasoning,
         prefill_messages=getattr(parent_agent, "prefill_messages", None),
         fallback_model=parent_fallback,
+        fallback_auto_activate=bool(
+            getattr(parent_agent, "_fallback_auto_activate", True)
+        ),
+        fallback_selection_interactive=False,
         enabled_toolsets=child_toolsets,
         quiet_mode=True,
         ephemeral_system_prompt=child_prompt,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4128,15 +4128,19 @@ def _parse_tui_skills_env() -> list[str]:
 def _load_fallback_model():
     """Return the configured fallback chain for TUI-created agents.
 
-    Delegates to the shared ``get_fallback_chain`` helper so the TUI path
-    stays in parity with ``HermesCLI.__init__`` and ``gateway/run.py``:
-    ``fallback_providers`` is the primary source of truth and keeps its
-    order, with legacy ``fallback_model`` entries merged in afterwards
-    (deduped on provider/model/base_url).
+    Delegates to the shared helper so legacy and current keys stay in parity
+    with the CLI and messaging gateway.
     """
     from hermes_cli.fallback_config import get_fallback_chain
 
     return get_fallback_chain(_load_cfg())
+
+
+def _load_fallback_auto_activate() -> bool:
+    """Return the primary fallback activation policy for new TUI agents."""
+    from hermes_cli.fallback_config import get_fallback_auto_activate
+
+    return get_fallback_auto_activate(_load_cfg())
 
 
 def _agent_fallback_model(agent):
@@ -4183,6 +4187,10 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
         "platform": "tui",
         "session_db": _get_db(),
         "fallback_model": _agent_fallback_model(agent),
+        "fallback_auto_activate": getattr(
+            agent, "_fallback_auto_activate", _load_fallback_auto_activate()
+        ),
+        "fallback_selection_interactive": False,
     }
 
 
@@ -4444,6 +4452,8 @@ def _resolve_runtime_with_fallback(
     try:
         return resolve_runtime_provider(**kwargs)
     except AuthError as primary_exc:
+        if not _load_fallback_auto_activate():
+            raise
         fb_chain = _load_fallback_model() or []
         for entry in fb_chain:
             if not isinstance(entry, dict):
@@ -4632,6 +4642,7 @@ def _make_agent(
         skip_context_files=is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")),
         skip_memory=is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")),
         fallback_model=_load_fallback_model(),
+        fallback_auto_activate=_load_fallback_auto_activate(),
         **_agent_cbs(sid),
     )
 

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -512,12 +512,13 @@ Outputs are concatenated in the order listed.
 
 ## Provider recovery
 
-Cron jobs inherit your configured fallback providers and credential pool rotation. If the primary API key is rate-limited or the provider returns an error, the cron agent can:
+Cron jobs inherit your configured fallback providers and credential pool rotation. Cron is noninteractive, so provider fallback activates only when `fallback.auto_activate: true` (or when an existing config omits the key and keeps the historical automatic behavior). With manual mode enabled, cron fails closed instead of choosing a paid route without consent.
 
-- **Fall back to an alternate provider** if you have `fallback_providers` (or the legacy `fallback_model`) configured in `config.yaml`
-- **Rotate to the next credential** in your [credential pool](/user-guide/configuration#credential-pool-strategies) for the same provider
+- **Automatic provider fallback:** run `hermes fallback auto on`, or set `fallback.auto_activate: true`, to try `fallback_providers` (or the legacy `fallback_model`) in order.
+- **Manual provider fallback:** `fallback.auto_activate: false` is intended for interactive CLI/Gateway/TUI turns; cron does not display a choice prompt.
+- **Credential rotation:** [credential pool](/user-guide/configuration#credential-pool-strategies) rotation remains independent and can try the next credential for the same provider.
 
-This means cron jobs that run at high frequency or during peak hours are more resilient — a single rate-limited key won't fail the entire run.
+For high-frequency or peak-hour jobs that must continue unattended, explicitly enable automatic fallback. Otherwise, a rate-limited primary may end that cron run without activating another provider.
 
 ## Schedule formats
 

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -1,6 +1,6 @@
 ---
 title: Fallback Providers
-description: Configure automatic failover to backup LLM providers when your primary model is unavailable.
+description: Configure automatic or user-selected failover to backup LLM providers when your primary model is unavailable.
 sidebar_label: Fallback Providers
 sidebar_position: 8
 ---
@@ -10,14 +10,14 @@ sidebar_position: 8
 Hermes Agent has three layers of resilience that keep your sessions running when providers hit issues:
 
 1. **[Credential pools](./credential-pools.md)** — rotate across multiple API keys for the *same* provider (tried first)
-2. **Primary model fallback** — automatically switches to a *different* provider:model when your main model fails
+2. **Primary model fallback** — automatically switches to, or asks you to select, a *different* provider:model when your main model fails
 3. **Auxiliary task fallback** — independent provider resolution for side tasks like vision, compression, and web extraction
 
 Credential pools handle same-provider rotation (e.g., multiple OpenRouter keys). This page covers cross-provider fallback. Both are optional and work independently.
 
 ## Primary Model Fallback
 
-When your main LLM provider encounters errors — rate limits, server overload, auth failures, connection drops — Hermes can automatically switch to a backup provider:model pair mid-session without losing your conversation.
+When your main LLM provider encounters errors — rate limits, server overload, auth failures, connection drops — Hermes can either switch automatically or ask you which backup provider:model pair should continue the current turn. Your conversation is preserved in both modes.
 
 ### Configuration
 
@@ -27,17 +27,30 @@ The easiest path is the interactive manager:
 hermes fallback
 ```
 
-`hermes fallback` reuses the provider picker from `hermes model` — same provider list, same credential prompts, same validation. Use the subcommands `add`, `list` (alias `ls`), `remove` (alias `rm`), and `clear` to manage the chain. Changes persist under the top-level `fallback_providers:` list in `config.yaml`.
+`hermes fallback` reuses the provider picker from `hermes model` — same provider list, same credential prompts, same validation. Use the subcommands `add`, `list` (alias `ls`), `remove` (alias `rm`), `clear`, and `auto on|off` to manage the chain and activation mode. Changes persist under the top-level `fallback_providers:` list and `fallback.auto_activate` in `config.yaml`.
+
+The first fallback added through the CLI defaults to **manual selection**. Enable ordered automatic failover explicitly with:
+
+```bash
+hermes fallback auto on
+```
 
 If you'd rather edit the YAML directly, add a top-level `fallback_providers` list to `~/.hermes/config.yaml`:
 
 ```yaml
+fallback:
+  auto_activate: false  # ask before using a configured fallback
+
 fallback_providers:
   - provider: openrouter
     model: anthropic/claude-sonnet-4
 ```
 
 Each entry requires both `provider` and `model`. Entries missing either field are ignored.
+
+`auto_activate: false` displays one provider-neutral clarification choice per configured route. Labels are generated from `provider`, `model`, and (when present) a safe endpoint origin derived from `base_url`; URL userinfo, paths, queries, and fragments are never shown. There is no separate label or ID setting. Manual mode supports up to four choices, matching the shared clarification UI limit. It never truncates a longer chain silently: reduce the chain to four entries or enable automatic mode.
+
+For backward compatibility, existing configs that have a fallback chain but omit `fallback.auto_activate` keep the historical automatic behavior. Chains created by the CLI write `auto_activate: false` explicitly.
 
 :::note `fallback_model` vs `fallback_providers`
 `fallback_providers` (plural, list) is the current config shape and supports multiple fallbacks tried in order. `fallback_model` (singular) is the legacy single-fallback key — Hermes still honors it for back-compat, but `hermes fallback` writes the current `fallback_providers` key and migrates legacy config on write. When both are set, `fallback_providers` takes priority.
@@ -98,7 +111,7 @@ fallback_providers:
 
 ### When Fallback Triggers
 
-The fallback activates automatically when the primary model fails with:
+Fallback handling starts when the primary model fails with:
 
 - **Rate limits** (HTTP 429) — after exhausting retry attempts
 - **Server errors** (HTTP 500, 502, 503) — after exhausting retry attempts
@@ -106,7 +119,9 @@ The fallback activates automatically when the primary model fails with:
 - **Not found** (HTTP 404) — immediately
 - **Invalid responses** — when the API returns malformed or empty responses repeatedly
 
-When triggered, Hermes:
+With `fallback.auto_activate: true`, Hermes walks the configured chain in order. With `false`, Hermes asks once during the turn and attempts only the selected route. Closing or timing out the prompt, returning an unmatched answer, running without an interactive clarification surface, or failing to activate the selected route all fail closed — Hermes does not silently move to another provider.
+
+When a route is activated, Hermes:
 
 1. Resolves credentials for the fallback provider
 2. Builds a new API client
@@ -119,8 +134,10 @@ The switch is seamless — your conversation history, tool calls, and context ar
 Prompt caches are keyed to the model (and on most providers, the account) serving the request. When fallback fires, the new provider:model has no cached prefix for your conversation, so the next request re-reads the entire history at full input-token price instead of the ~75–90% discounted cached rate. The same applies when the turn ends and the primary is restored — that first request back on the primary is a full re-read too (unless the primary's cache TTL hasn't expired). This is unavoidable — it's the cost of staying alive through an outage — but it's why a long session that bounces between providers can cost noticeably more than one that stays put.
 :::
 
-:::info Per-Turn, Not Per-Session
-Fallback is **turn-scoped**: each new user message starts with the primary model restored. If the primary fails mid-turn, fallback activates for that turn only. On the next message, Hermes tries the primary again. Within a single turn, fallback activates at most once — if the fallback also fails, normal error handling takes over (retries, then error message). This prevents cascading failover loops within a turn while giving the primary model a fresh chance every turn.
+:::info Turn scope
+Manual fallback is **strictly turn-scoped**: a selected route is used only for the failing turn, and each new user message starts with the primary model restored—even when the failure armed a rate-limit cooldown. Manual mode prompts at most once and never cascades from the selected route to another route.
+
+Automatic mode keeps its existing behavior: it may walk the configured chain during a turn, and a short rate-limit cooldown can keep the active fallback for a later message until the primary is eligible again. Outside that cooldown, the primary is restored on the next turn. These rules prevent failover loops while preserving automatic recovery from an unavailable primary.
 :::
 
 ### Examples
@@ -165,13 +182,17 @@ fallback_providers:
 
 ### Where Fallback Works
 
-| Context | Fallback Supported |
-|---------|-------------------|
-| CLI sessions | ✔ |
-| Messaging gateway (Telegram, Discord, etc.) | ✔ |
-| Subagent delegation | ✔ (subagents inherit the parent fallback chain) |
-| Cron jobs | ✔ (cron agents inherit configured fallback providers) |
-| Auxiliary tasks on `provider: auto` | ✔ (try per-task fallback, then the main fallback chain before built-in aux discovery) |
+| Context | Automatic mode | Manual selection |
+|---------|----------------|------------------|
+| CLI sessions | ✔ | ✔ |
+| Messaging gateway (Telegram, Discord, Slack, etc.) | ✔ | ✔, through the shared clarification UI |
+| TUI/Desktop sessions | ✔ | ✔ |
+| API server | ✔ | Fails closed (no interactive clarification surface) |
+| Subagent delegation | ✔ (inherits the parent policy and chain) | Fails closed |
+| Cron jobs | ✔ (inherits configured fallback providers) | Fails closed |
+| Auxiliary tasks on `provider: auto` | ✔ (try per-task fallback, then the main fallback chain before built-in aux discovery) | Independent policy |
+
+`fallback.auto_activate` controls the **primary agent** fallback path. Auxiliary tasks retain their independent provider-resolution policy. Manual selection is available only after an interactive agent surface exists; a primary authentication failure during CLI/Gateway/TUI bootstrap therefore fails closed before any route is activated.
 
 :::tip
 There are no environment variables for the primary fallback chain — configure it exclusively through `config.yaml` or `hermes fallback`. This is intentional: fallback configuration is a deliberate choice, not something a stale shell export should override.


### PR DESCRIPTION
## What does this PR do?

Adds a provider-neutral manual activation policy for the existing primary-provider fallback chain.

State matrix:

1. no valid routes → no prompt or fallback
2. routes + `fallback.auto_activate: false` → ask the user which route to use for this turn
3. routes + `fallback.auto_activate: true` → preserve the existing ordered automatic fallback behavior

Omitting `auto_activate` remains backward-compatible (`true`). The first route added with `hermes fallback add` defaults a new chain to manual mode.

## Why?

Interactive users need explicit consent before a rate/usage failure shifts traffic and spend to another provider. Noninteractive paths must never wait for a prompt or silently spend on another route.

## Main changes

- add `fallback.auto_activate` config parsing, validation, example config, and `hermes fallback auto on|off`
- route manual selection through the existing clarification callback in CLI, TUI, Slack/Telegram/etc.
- accept both exact labels and strict 1-based numeric responses used by WhatsApp native buttons
- keep manual selection strictly turn-scoped; restore and publish primary runtime before the next turn
- fail closed if required primary restoration fails
- gate constructor/CLI bootstrap auth recovery so manual mode never silently adopts a fallback as primary
- propagate policy into Gateway/API/Cron/oneshot/delegated-child paths; noninteractive paths fail closed
- refresh cached Gateway chains without retaining removed manual routes during cooldown
- redact endpoint userinfo/path/query/fragment; show only safe origin; fail closed on duplicate or over-limit choices
- document platform behavior, cron implications, safety boundaries, and diagnostics

## Safety invariants

- no API key, credential, URL userinfo, path token, query, or fragment is rendered in choices
- at most four choices are shown; ambiguous labels fail closed
- a failed/cancelled/unmatched selection does not cascade to another provider
- manual bootstrap auth failures fail closed because no agent/clarification surface exists yet
- Cron, API, background, oneshot, and delegated children never prompt

## Testing

- related 13-file suite → **711 passed** via canonical per-file runner and shared pytest processes with hash seeds 0/1/2 (no global-state or ordering leak)
- `python -m pytest tests/tools/test_delegate.py::TestFallbackModelInheritance -q` → **2 passed**
- WhatsApp/Telegram native-choice adapter suites → **124 passed**
- isolated `HERMES_HOME` CLI smoke (`config path` → `fallback auto off` → `fallback list`) → **passed**
- delayed review gaps fixed in `6a23b6192`: auto→manual cached-route restoration and stale auxiliary-route clearing; final immutable-diff fresh review → **PASS**
- final related 15-file suite → **745 passed** via canonical runner and shared pytest processes with hash seeds 1/2
- `uvx ruff check .` → **passed**
- CI `ty` diff emulation → **0 new issues**
- `python scripts/check-windows-footguns.py --all` → **passed (754 files)**
- `python -m py_compile <all changed Python files>` → **passed**
- `npm run lint:diagrams && npm run build` in an isolated docs worktree → **passed** (pre-existing broken-link warnings only)
- `uv lock --check`, common-ancestor check, and contributor-email condition → **passed**
- `git diff --check` → **passed**
- staged-diff credential scan → **0 potential secret hits**
- canonical full suite at final head `6a23b6192` → **23 failures in 11 files**; none is feature-specific:
  - the same 11-file focused batch gives head **23** vs predecessor `0b528a9af` **22**; the only delta is an unrelated atomic shell-snapshot concurrency flake, reproduced on both revisions (head 2/5 failures, predecessor 3/5)
  - parent commit previously reproduced **21 failures in 9 files**
  - the extra auxiliary 0.14s timing assertion fails **5/5 on both parent and feature**; the extra mem0 file passes focused rerun (**55 passed**)

Focused coverage includes two real `run_conversation()` turns: primary 429 → numeric manual choice → selected fallback success → next-turn primary restore → prompt re-armed.

## Related work

- Complements #61943 (generic Slack clarification UI); it does not duplicate platform UI work.
- #27858 changes automatic fallback timing, #30909 improves visibility, and #54748 adds routing tiers; none provides this activation-consent policy.

## Compatibility

- Existing configurations without `fallback.auto_activate` remain automatic.
- Existing automatic fallback chain semantics remain unchanged.
- Manual mode is opt-in for existing chains and the safe default only for newly CLI-created chains.

## Checklist

- [x] Tests added/updated for the changed behavior
- [x] Public docs and `cli-config.yaml.example` updated
- [x] No credentials or private artifacts included
- [x] No new dependency
- [x] Backward-compatible default for existing configs
