### PR TITLE
fix(tui): add ctrl-c exit toggle

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1844,6 +1844,10 @@ DEFAULT_CONFIG = {
         # TUI busy indicator style: kaomoji (default), emoji, unicode (braille
         # spinner), or ascii.  Live-swappable via `/indicator <style>`.
         "tui_status_indicator": "kaomoji",
+        # TUI only: when true (default), an idle Ctrl+C keeps the historical
+        # one-press exit behavior. Set false to ignore idle Ctrl+C so only
+        # agent interrupts / input clears still fire.
+        "exit_on_ctrl_c": True,
         # Seconds between prompt_toolkit redraws in the classic CLI when idle.
         # Default 1.0 keeps the wall-clock status-bar read-outs (idle-since-
         # last-turn) ticking and keeps the bottom chrome alive during idle —

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -39,6 +39,7 @@ describe('applyDisplay', () => {
     expect(setBell).toHaveBeenCalledWith(true)
     expect(s.compact).toBe(true)
     expect(s.detailsMode).toBe('expanded')
+    expect(s.exitOnCtrlC).toBe(true)
     expect(s.inlineDiffs).toBe(false)
     expect(s.showReasoning).toBe(true)
     expect(s.statusBar).toBe('off')
@@ -62,6 +63,7 @@ describe('applyDisplay', () => {
 
     const s = $uiState.get()
     expect(setBell).toHaveBeenCalledWith(false)
+    expect(s.exitOnCtrlC).toBe(true)
     expect(s.inlineDiffs).toBe(true)
     expect(s.showReasoning).toBe(false)
     expect(s.statusBar).toBe('top')
@@ -290,6 +292,26 @@ describe('applyDisplay → busy_input_mode', () => {
 
     applyDisplay({ config: { display: { busy_input_mode: 'drop' } } }, setBell)
     expect($uiState.get().busyInputMode).toBe('queue')
+  })
+})
+
+describe('applyDisplay → exit_on_ctrl_c', () => {
+  beforeEach(() => {
+    resetUiState()
+  })
+
+  it('threads display.exit_on_ctrl_c into $uiState', () => {
+    const setBell = vi.fn()
+
+    applyDisplay({ config: { display: { exit_on_ctrl_c: false } } }, setBell)
+    expect($uiState.get().exitOnCtrlC).toBe(false)
+  })
+
+  it('defaults idle Ctrl+C exit to on when the toggle is missing', () => {
+    const setBell = vi.fn()
+
+    applyDisplay({ config: { display: {} } }, setBell)
+    expect($uiState.get().exitOnCtrlC).toBe(true)
   })
 })
 

--- a/ui-tui/src/__tests__/useInputHandlers.test.ts
+++ b/ui-tui/src/__tests__/useInputHandlers.test.ts
@@ -4,6 +4,7 @@ import {
   applyVoiceRecordResponse,
   handleIdleHotkeyExit,
   shouldAllowIdleHotkeyExit,
+  shouldExitOnIdleCtrlC,
   shouldFallThroughForScroll
 } from '../app/useInputHandlers.js'
 
@@ -54,6 +55,17 @@ describe('shouldAllowIdleHotkeyExit', () => {
 
   it('disables idle exit hotkeys in dashboard chat', () => {
     expect(shouldAllowIdleHotkeyExit(true)).toBe(false)
+  })
+})
+
+describe('shouldExitOnIdleCtrlC', () => {
+  it('keeps the legacy idle Ctrl+C exit when the toggle is unset or true', () => {
+    expect(shouldExitOnIdleCtrlC()).toBe(true)
+    expect(shouldExitOnIdleCtrlC(true)).toBe(true)
+  })
+
+  it('suppresses idle Ctrl+C exit when display.exit_on_ctrl_c is false', () => {
+    expect(shouldExitOnIdleCtrlC(false)).toBe(false)
   })
 })
 

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -164,6 +164,7 @@ export interface UiState {
   compact: boolean
   detailsMode: DetailsMode
   detailsModeCommandOverride: boolean
+  exitOnCtrlC: boolean
   info: null | SessionInfo
   liveSessionCount: number
   inlineDiffs: boolean

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -13,6 +13,7 @@ const buildUiState = (): UiState => ({
   compact: false,
   detailsMode: 'collapsed',
   detailsModeCommandOverride: false,
+  exitOnCtrlC: true,
   indicatorStyle: DEFAULT_INDICATOR_STYLE,
   info: null,
   liveSessionCount: 0,

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -221,6 +221,7 @@ export const applyDisplay = (
     compact: !!d.tui_compact,
     detailsMode: resolveDetailsMode(d),
     detailsModeCommandOverride: false,
+    exitOnCtrlC: d.exit_on_ctrl_c !== false,
     indicatorStyle: normalizeIndicatorStyle(d.tui_status_indicator),
     inlineDiffs: d.inline_diffs !== false,
     mouseTracking: normalizeMouseTracking(d),

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -26,6 +26,7 @@ const isCtrl = (key: { ctrl: boolean }, ch: string, target: string) => key.ctrl 
 const DASHBOARD_NEW_SESSION_MESSAGE = 'starting a fresh dashboard chat...'
 
 export const shouldAllowIdleHotkeyExit = (dashboardTuiMode = DASHBOARD_TUI_MODE) => !dashboardTuiMode
+export const shouldExitOnIdleCtrlC = (exitOnCtrlC = true) => exitOnCtrlC
 
 export function handleIdleHotkeyExit(
   actions: Pick<InputHandlerActions, 'die' | 'sys'>,
@@ -529,6 +530,10 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
 
       if (cState.input || cState.inputBuf.length) {
         return cActions.clearIn()
+      }
+
+      if (!shouldExitOnIdleCtrlC(live.exitOnCtrlC)) {
+        return
       }
 
       return handleIdleHotkeyExit(actions, DASHBOARD_TUI_MODE, () => {

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -155,6 +155,7 @@ export interface ConfigDisplayConfig {
   bell_on_complete?: boolean
   busy_input_mode?: string
   details_mode?: string
+  exit_on_ctrl_c?: boolean
   inline_diffs?: boolean
   mouse_tracking?: boolean | null | number | string
   sections?: Record<string, string>


### PR DESCRIPTION
## Summary
- add `display.exit_on_ctrl_c` with a default of `true`
- thread the toggle into the standalone TUI UI state
- suppress idle `Ctrl+C` exit when the toggle is `false` while keeping busy interrupts and input clearing unchanged

## Testing
- `cd ui-tui && npm exec vitest run src/__tests__/useConfigSync.test.ts src/__tests__/useInputHandlers.test.ts`
- `cd ui-tui && npm exec eslint src/app/useConfigSync.ts src/app/useInputHandlers.ts src/app/interfaces.ts src/app/uiStore.ts src/gatewayTypes.ts src/__tests__/useConfigSync.test.ts src/__tests__/useInputHandlers.test.ts`
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m py_compile hermes_cli/config.py`
- `git diff --check`

Closes #62450