### PR TITLE
fix(agent): honor auxiliary fallback timeouts

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3612,10 +3612,11 @@ def _call_fallback_candidate_sync(
     caller can continue to the next fallback layer. Non-auth errors raise.
     """
     fb_base = str(getattr(fb_client, "base_url", "") or "")
+    fb_timeout = _get_configured_fallback_timeout(task or "", fb_label, effective_timeout)
     fb_kwargs = _build_call_kwargs(
         fb_label, fb_model, messages,
         temperature=temperature, max_tokens=max_tokens,
-        tools=tools, timeout=effective_timeout,
+        tools=tools, timeout=fb_timeout,
         extra_body=effective_extra_body, base_url=fb_base)
     try:
         return _validate_llm_response(
@@ -3630,7 +3631,7 @@ def _call_fallback_candidate_sync(
                 retry_kwargs = _build_call_kwargs(
                     fb_provider, retry_model or fb_model, messages,
                     temperature=temperature, max_tokens=max_tokens,
-                    tools=tools, timeout=effective_timeout,
+                    tools=tools, timeout=fb_timeout,
                     extra_body=effective_extra_body,
                     base_url=str(getattr(retry_client, "base_url", "") or fb_base))
                 try:
@@ -3667,10 +3668,11 @@ async def _call_fallback_candidate_async(
 ) -> Optional[Any]:
     """Async mirror of :func:`_call_fallback_candidate_sync`."""
     fb_base = str(getattr(fb_client, "base_url", "") or "")
+    fb_timeout = _get_configured_fallback_timeout(task or "", fb_label, effective_timeout)
     fb_kwargs = _build_call_kwargs(
         fb_label, fb_model, messages,
         temperature=temperature, max_tokens=max_tokens,
-        tools=tools, timeout=effective_timeout,
+        tools=tools, timeout=fb_timeout,
         extra_body=effective_extra_body, base_url=fb_base)
     try:
         return _validate_llm_response(
@@ -3686,7 +3688,7 @@ async def _call_fallback_candidate_async(
                 retry_kwargs = _build_call_kwargs(
                     fb_provider, retry_model or fb_model, messages,
                     temperature=temperature, max_tokens=max_tokens,
-                    tools=tools, timeout=effective_timeout,
+                    tools=tools, timeout=fb_timeout,
                     extra_body=effective_extra_body,
                     base_url=str(getattr(retry_client, "base_url", "") or fb_base))
                 try:
@@ -6066,6 +6068,37 @@ def _effective_aux_timeout(task: str, timeout: Optional[float]) -> float:
     if timeout is None and task == "compression":
         effective = max(effective, _COMPRESSION_TIMEOUT_FLOOR_SECONDS)
     return effective
+
+
+def _get_configured_fallback_timeout(
+    task: str,
+    provider_label: str,
+    default: float,
+) -> float:
+    """Read an optional timeout override from auxiliary.<task>.fallback_chain."""
+    if not task or not provider_label.startswith("fallback_chain["):
+        return default
+    try:
+        entry_index = int(provider_label.split("[", 1)[1].split("]", 1)[0])
+    except (IndexError, TypeError, ValueError):
+        return default
+
+    task_config = _get_auxiliary_task_config(task)
+    chain = task_config.get("fallback_chain")
+    if not isinstance(chain, list) or not (0 <= entry_index < len(chain)):
+        return default
+    entry = chain[entry_index]
+    if not isinstance(entry, dict):
+        return default
+
+    raw = entry.get("timeout")
+    if raw is None:
+        return default
+    try:
+        timeout = float(raw)
+    except (TypeError, ValueError):
+        return default
+    return timeout if timeout > 0 else default
 
 
 def _get_task_extra_body(task: str) -> Dict[str, Any]:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -522,6 +522,12 @@ prompt_caching:
 #     provider: "auto"
 #     model: ""
 #     timeout: 30
+#     # Optional: give a fallback provider a larger budget than the primary
+#     # task timeout when real transcripts need more time to finish.
+#     # fallback_chain:
+#     #   - provider: "custom"
+#     #     model: "deepseek-v4-flash"
+#     #     timeout: 90
 #     max_concurrency: 3    # Limit parallel summaries to reduce request-burst 429s
 #     extra_body: {}        # Provider-specific OpenAI-compatible request fields
 #                           # Example for providers that support request-body

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -33,6 +33,7 @@ from agent.auxiliary_client import (
     _resolve_auto,
     _resolve_task_provider_model,
     _resolve_xai_oauth_for_aux,
+    _get_configured_fallback_timeout,
     _CodexCompletionsAdapter,
     _pool_runtime_base_url,
 )
@@ -2473,6 +2474,36 @@ class TestAuxiliaryFallbackLayering:
         # Main agent fallback should NOT have been consulted — chain succeeded first
         main_called.assert_not_called()
 
+    def test_configured_chain_timeout_override_applies_to_fallback_call(self, monkeypatch):
+        """Configured fallback entries can carry their own timeout budget."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = self._make_payment_err()
+
+        chain_client = MagicMock()
+        chain_client.chat.completions.create.return_value = MagicMock(choices=[
+            MagicMock(message=MagicMock(content="from configured chain"))
+        ])
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "glm-4v-flash")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("glm", "glm-4v-flash", None, None, None)), \
+             patch("agent.auxiliary_client._try_configured_fallback_chain",
+                   return_value=(chain_client, "gpt-4o-mini", "fallback_chain[0](openai)")), \
+             patch("agent.auxiliary_client._get_configured_fallback_timeout",
+                   return_value=90.0), \
+             patch("agent.auxiliary_client._try_main_agent_model_fallback") as main_called:
+            call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        assert chain_client.chat.completions.create.called
+        assert chain_client.chat.completions.create.call_args.kwargs["timeout"] == 90.0
+        main_called.assert_not_called()
+
     def test_explicit_provider_falls_back_to_main_when_chain_exhausted(self, monkeypatch):
         """If configured fallback_chain returns nothing, main agent model is tried next."""
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
@@ -2638,6 +2669,25 @@ class TestAuxiliaryFallbackLayering:
         assert model == "gpt-5.4-mini"
         mock_openai.assert_called_once()
         assert mock_openai.call_args.kwargs["api_key"] == "codex-oauth-token"
+
+
+def test_get_configured_fallback_timeout_reads_entry_timeout():
+    with patch(
+        "agent.auxiliary_client._get_auxiliary_task_config",
+        return_value={
+            "fallback_chain": [
+                {"provider": "openai", "timeout": "90"},
+                {"provider": "custom"},
+                {"provider": "nous", "timeout": 0},
+            ]
+        },
+    ):
+        assert _get_configured_fallback_timeout(
+            "compression", "fallback_chain[0](openai)", 30.0) == 90.0
+        assert _get_configured_fallback_timeout(
+            "compression", "fallback_chain[1](custom)", 30.0) == 30.0
+        assert _get_configured_fallback_timeout(
+            "compression", "fallback_chain[2](nous)", 30.0) == 30.0
 
 
 class TestTryMainAgentModelFallback:


### PR DESCRIPTION
## Summary
- honor per-entry `auxiliary.<task>.fallback_chain[].timeout` overrides when a configured fallback provider is selected
- apply the same fallback timeout on the initial fallback call and the stale-credential retry path
- document the optional timeout override in `cli-config.yaml.example` and cover it with focused auxiliary-client tests

## Verification
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/agent/test_auxiliary_client.py -k "configured_chain_timeout_override_applies_to_fallback_call or get_configured_fallback_timeout_reads_entry_timeout or explicit_provider_uses_configured_chain_first or explicit_provider_falls_back_to_main_when_chain_exhausted or warning_emitted_when_all_fallbacks_exhausted"`
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m py_compile agent/auxiliary_client.py tests/agent/test_auxiliary_client.py`
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_client.py`
- `git diff --check`

Closes #62452