### PR TITLE
feat(desktop): list config-defined command TTS/STT providers in settings

### DIFF
--- a/apps/desktop/src/app/settings/helpers.test.ts
+++ b/apps/desktop/src/app/settings/helpers.test.ts
@@ -174,5 +174,98 @@ describe('settings helpers', () => {
       expect(opts).toContain('my-custom-command-tts')
       expect(opts).toContain('xai')
     })
+
+    it('surfaces user-defined command-type TTS providers (canonical providers nesting + legacy)', () => {
+      const withCustom: HermesConfigRecord = {
+        tts: {
+          provider: 'neutts',
+          // canonical location the runtime resolves first: tts.providers.<name>
+          providers: {
+            higgs8: { type: 'command', command: 'curl …' },
+            indextts2: { type: 'command', command: 'curl …' },
+            // `type:` is optional at runtime — a bare command block still qualifies
+            typeless: { command: 'curl …' },
+            // misconfigured: type:command but no command → NOT a runtime provider
+            noop: { type: 'command' }
+          },
+          // back-compat: a top-level tts.<name> command block still resolves at runtime
+          mylegacy: { type: 'command', command: 'curl …' },
+          // a non-command block (built-in config) must NOT be offered as a provider
+          edge: { voice: 'en-US-JennyNeural' }
+        }
+      }
+
+      const opts = enumOptionsFor('tts.provider', 'neutts', withCustom)
+      expect(opts).toContain('higgs8') // canonical providers.<name>
+      expect(opts).toContain('indextts2') // canonical providers.<name>
+      expect(opts).toContain('typeless') // command block with no type: still surfaced
+      expect(opts).toContain('mylegacy') // legacy top-level tts.<name>
+      expect(opts).toContain('elevenlabs') // built-ins preserved
+      expect(opts).not.toContain('noop') // type:command with no command is excluded
+      // 'edge' appears once (the built-in), not duplicated by the config block
+      expect(opts!.filter(o => o === 'edge')).toHaveLength(1)
+      // the 'providers' container itself is never offered as a provider name
+      expect(opts).not.toContain('providers')
+    })
+
+    it('surfaces command-type STT providers too (canonical providers nesting)', () => {
+      const withCustom: HermesConfigRecord = {
+        stt: {
+          provider: 'local',
+          providers: { myasr: { type: 'command', command: 'curl …' } }
+        }
+      }
+
+      const opts = enumOptionsFor('stt.provider', 'local', withCustom)
+      expect(opts).toContain('myasr')
+      expect(opts).toContain('local')
+      expect(opts).not.toContain('providers')
+    })
+
+    // The runtime rejects a built-in name as a command provider before any config
+    // lookup, so such a block must never be offered — including the names the
+    // display list omits (`deepinfra` for TTS; `deepinfra`/`local_command` for
+    // STT), where filtering on ENUM_OPTIONS instead of the runtime's built-in set
+    // would wrongly offer a provider that can never dispatch.
+    it('never offers a built-in name as a command provider, even one absent from the dropdown list', () => {
+      const shadowing: HermesConfigRecord = {
+        tts: {
+          provider: 'edge',
+          providers: {
+            // built-in and absent from ENUM_OPTIONS['tts.provider']
+            deepinfra: { type: 'command', command: 'curl …' },
+            // built-in guard is case-insensitive at runtime (provider.lower())
+            EDGE: { type: 'command', command: 'curl …' },
+            // a genuine custom provider alongside them still surfaces
+            higgs8: { type: 'command', command: 'curl …' }
+          }
+        }
+      }
+
+      const opts = enumOptionsFor('tts.provider', 'edge', shadowing)
+      expect(opts).not.toContain('deepinfra')
+      expect(opts).not.toContain('EDGE')
+      expect(opts).toContain('higgs8')
+      expect(opts!.filter(o => o === 'edge')).toHaveLength(1)
+    })
+
+    it('never offers a built-in STT name absent from the dropdown list as a command provider', () => {
+      const shadowing: HermesConfigRecord = {
+        stt: {
+          provider: 'local',
+          providers: {
+            // both are built-in STT names omitted from ENUM_OPTIONS['stt.provider']
+            local_command: { type: 'command', command: 'curl …' },
+            deepinfra: { type: 'command', command: 'curl …' },
+            myasr: { type: 'command', command: 'curl …' }
+          }
+        }
+      }
+
+      const opts = enumOptionsFor('stt.provider', 'local', shadowing)
+      expect(opts).not.toContain('local_command')
+      expect(opts).not.toContain('deepinfra')
+      expect(opts).toContain('myasr')
+    })
   })
 })

--- a/apps/desktop/src/app/settings/helpers.ts
+++ b/apps/desktop/src/app/settings/helpers.ts
@@ -1,4 +1,4 @@
-import { asText } from '@/lib/text'
+import { asText, normalize } from '@/lib/text'
 import type { HermesConfigRecord, ToolsetInfo } from '@/types/hermes'
 
 import { BUILTIN_PERSONALITIES, ENUM_OPTIONS, PROVIDER_GROUPS } from './constants'
@@ -132,13 +132,119 @@ function personalityOptions(config: HermesConfigRecord): string[] {
   return [...new Set(['', ...BUILTIN_PERSONALITIES, ...customNames])]
 }
 
+// Built-in provider names, mirroring `tts_tool.py:BUILTIN_TTS_PROVIDERS` and
+// `transcription_tools.py:BUILTIN_STT_PROVIDERS`. The runtime rejects a built-in
+// name as a command provider before any config lookup
+// (`_resolve_command_provider_config`: `key = provider.lower().strip()`, then
+// `if key in BUILTIN_*_PROVIDERS: return None`), so a ``providers.edge`` block
+// declaring ``type: command`` still dispatches to native Edge.
+//
+// These are deliberately NOT derived from `ENUM_OPTIONS`, which is a *display*
+// list and already drifts from the runtime sets: it omits `deepinfra` (TTS) and
+// `deepinfra`/`local_command` (STT). Filtering on the display list would offer
+// those names as command providers that the runtime would never honour.
+const BUILTIN_TTS_PROVIDERS = new Set([
+  'edge',
+  'elevenlabs',
+  'openai',
+  'minimax',
+  'xai',
+  'mistral',
+  'gemini',
+  'neutts',
+  'kittentts',
+  'piper',
+  'deepinfra'
+])
+
+const BUILTIN_STT_PROVIDERS = new Set([
+  'local',
+  'local_command',
+  'groq',
+  'openai',
+  'mistral',
+  'xai',
+  'elevenlabs',
+  'deepinfra'
+])
+
+// A user-declared command provider, mirroring the runtime discriminator
+// (`tts_tool.py:_is_command_provider_config` / `transcription_tools.py`): `type`
+// is OPTIONAL and case/space-insensitive (absent or normalizing to "command"),
+// and `command` MUST be a non-empty string. So a canonical block written as just
+// ``{ command: "curl …" }`` with no ``type:`` — a fully valid runtime provider
+// under ``providers.*`` — qualifies too, while built-in blocks (which carry
+// ``voice``/``model`` and no ``command``) and the ``providers`` container itself
+// (no ``command``) are skipped.
+function isCommandProvider(value: unknown): boolean {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+
+  const record = value as Record<string, unknown>
+  const type = normalize(record.type)
+
+  if (type !== '' && type !== 'command') {
+    return false
+  }
+
+  return typeof record.command === 'string' && record.command.trim() !== ''
+}
+
+// Names of user-defined command providers, so the settings dropdown can offer
+// them alongside the built-ins instead of only whichever one is currently active
+// (otherwise, once you switch away from a custom provider it drops off the list
+// and can only be reselected by hand-editing config.yaml).
+//
+// Mirrors the runtime's dual resolution (`tts_tool.py:_get_named_provider_config`,
+// `transcription_tools.py`): the CANONICAL location is nested —
+// ``tts.providers.<name>`` / ``stt.providers.<name>`` — with a back-compat
+// fallback to a top-level ``tts.<name>`` / ``stt.<name>`` block. We enumerate
+// both (deduped), keeping only sections that satisfy isCommandProvider and whose
+// name the runtime would actually resolve as a command provider — built-ins are
+// excluded case-insensitively, matching the runtime's `provider.lower().strip()`
+// guard, so a ``providers.EDGE`` command block is not offered.
+function commandProviderNames(config: HermesConfigRecord, section: 'tts' | 'stt'): string[] {
+  const builtins = section === 'tts' ? BUILTIN_TTS_PROVIDERS : BUILTIN_STT_PROVIDERS
+  const names = new Set<string>()
+
+  for (const path of [`${section}.providers`, section]) {
+    const block = getNested(config, path)
+
+    if (!block || typeof block !== 'object' || Array.isArray(block)) {
+      continue
+    }
+
+    for (const [name, value] of Object.entries(block as Record<string, unknown>)) {
+      if (isCommandProvider(value) && !builtins.has(normalize(name))) {
+        names.add(name)
+      }
+    }
+  }
+
+  return [...names]
+}
+
 export function enumOptionsFor(
   key: string,
   value: unknown,
   config: HermesConfigRecord,
   dynamicOptions?: string[]
 ): string[] | undefined {
-  const opts = dynamicOptions ?? (key === 'display.personality' ? personalityOptions(config) : ENUM_OPTIONS[key])
+  let opts = dynamicOptions ?? (key === 'display.personality' ? personalityOptions(config) : ENUM_OPTIONS[key])
+
+  // Merge in user-defined command-type providers so custom local TTS/STT
+  // backends declared in config.yaml are selectable, not just the built-ins.
+  // The `includes` guard keeps the list duplicate-free should the display list
+  // ever carry a name we also enumerate.
+  if (!dynamicOptions && opts && (key === 'tts.provider' || key === 'stt.provider')) {
+    const section = key.slice(0, 3) as 'tts' | 'stt'
+    const custom = commandProviderNames(config, section).filter(name => !opts!.includes(name))
+
+    if (custom.length > 0) {
+      opts = [...opts, ...custom]
+    }
+  }
 
   if (!opts) {
     return undefined


### PR DESCRIPTION

## Problem

Settings → Voice → Text-To-Speech Provider (and the STT equivalent) list the built-in providers plus whatever value is currently set. Custom `type: command` providers defined in `config.yaml` aren't offered, so:

- they can't be selected from the UI at all, and
- once you switch away from a custom provider it disappears from the list, and the only way back is hand-editing `config.yaml`.

This bites anyone running a local command-backed TTS/STT engine, e.g. a self-hosted OpenAI-compatible voice server wired up as a `command` provider.

## Fix

`enumOptionsFor` (`apps/desktop/src/app/settings/helpers.ts`) merges in the names of user-defined command providers, so local command-backed engines appear alongside the built-ins and can be switched freely.

Enumeration mirrors the runtime's own resolution, so the dropdown can only offer a name the runtime would honour:

- **Location.** `commandProviderNames` reads the canonical `tts.providers.<name>` / `stt.providers.<name>`, plus the back-compat top-level `tts.<name>` / `stt.<name>` block, deduped - matching `_get_named_provider_config` (`tools/tts_tool.py`) and `_get_named_stt_provider_config` (`tools/transcription_tools.py`).
- **Shape.** The command check mirrors `_is_command_provider_config`: `type` is optional and case/space-insensitive (absent or normalising to `command`), with a required non-empty `command`. Non-command blocks (a built-in's own settings sub-object) and the `providers` container are not offered.
- **Built-in names.** Excluded case-insensitively against the runtime's `BUILTIN_TTS_PROVIDERS` / `BUILTIN_STT_PROVIDERS`, matching the `provider.lower().strip()` guard in `_resolve_command_provider_config` (`tools/tts_tool.py:472`). `ENUM_OPTIONS` is a display list and isn't a substitute here: it omits `deepinfra` (TTS) and `deepinfra` / `local_command` (STT), so filtering on it would offer a `providers.deepinfra` command block as selectable while the runtime dispatches to the native backend.

Existing behaviour is unchanged: built-ins, then the current value appended if unknown. Nothing about provider dispatch changes.

Scope is providers declared in `config.yaml`. Plugin-registered provider names live in the runtime registry (`hermes_cli/plugins.py`) and would need a backend API to surface, so they're out of this diff.

## Tests

`helpers.test.ts` covers, for both TTS and STT: custom command providers surfacing from the canonical `providers` nesting and the legacy top-level shape; a bare `{ command: … }` block with no `type:`; a misconfigured `{ type: command }` with no `command` excluded; a non-command block coinciding with a built-in name not duplicated; the `providers` container not offered; and built-in names never offered as command providers, including the ones the display list omits. The last two cases fail on the previous filter.

Desktop settings suite: 70 passing. `eslint` clean on the changed lines. Rebased onto main; `tsc --noEmit` shows four pre-existing errors in `assistant-ui` files, unchanged from a stock main checkout and untouched here.

## Related

#50081 and #50612 added command-type providers; this makes them selectable from the settings UI. Adjacent settings/config UX: #50698.

Prior art on these dropdowns, which I should have cited when filing:

- #41232 (merged) added the pickers to `ENUM_OPTIONS`. Static list, so it can't carry a config-defined name; on main such a provider is visible only while it's the active value.
- #40338 (@lost9999, five weeks older) targets the same gap in `hermes_cli/web_server.py`. That schema doesn't reach the desktop picker - `ConfigField` resolves `enumOptions ?? schema.options` (`config-settings.tsx:119`), so `ENUM_OPTIONS` wins for these keys. The sweeper review there (2026-07-14) asked for the merge to be implemented in the desktop resolver, which is what this does. Happy to fold this into #40338 if maintainers prefer one vehicle.
