### PR TITLE
fix(agent): force plugin re-discovery when context engine not found on first try

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1749,11 +1749,23 @@ def init_agent(
         # Try general plugin system as fallback
         if _selected_engine is None:
             _candidate = None
+            _get_plugin_engine = None
             try:
-                from hermes_cli.plugins import get_plugin_context_engine
-                _candidate = get_plugin_context_engine()
+                from hermes_cli.plugins import get_plugin_context_engine as _get_plugin_engine
+                _candidate = _get_plugin_engine()
             except Exception:
                 _candidate = None
+            # If the plugin manager was already discovered before the
+            # context engine plugin registered (e.g. auxiliary agent init
+            # runs after an earlier call to get_plugin_context_engine
+            # returned None), force a re-discovery before giving up.
+            if (_candidate is None or _candidate.name != _engine_name) and _get_plugin_engine is not None:
+                try:
+                    from hermes_cli.plugins import discover_plugins as _disc_plugins
+                    _disc_plugins(force=True)
+                    _candidate = _get_plugin_engine()
+                except Exception:
+                    _candidate = None
             if _candidate is not None and _candidate.name == _engine_name:
                 # Deep-copy the shared plugin singleton so a child agent's
                 # update_model() can't mutate the parent's compressor (#42449).


### PR DESCRIPTION
Fixes #61839

## Problem

When the plugin manager is discovered *before* a context engine plugin registers itself (via `register_context_engine()`), `get_plugin_context_engine()` returns `None` — the stale cached state from the earlier discovery. The agent then logs a spurious warning:

```
Context engine 'context_chunking' not found — falling back to built-in compressor
```

even though a forced re-discovery would find the registered engine and the system works correctly after subsequent agent initializations.

## Fix

When the first `get_plugin_context_engine()` call fails to return a matching engine, call `discover_plugins(force=True)` to flush stale discovery state and re-scan before falling back to the built-in compressor. This ensures user-installed context engine plugins are always picked up, even when plugin discovery ran earlier from a different code path (e.g. `cli.py`, `gateway/config.py`, `model_tools.py`).

The fix is minimal — only adds the forced re-discovery attempt between the first failed lookup and the `"not found"` warning. All existing tests pass unchanged.