### PR TITLE
fix(gateway): honor per-run model override in POST /v1/runs (#33072)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1241,6 +1241,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_complete_callback=None,
         gateway_session_key: Optional[str] = None,
         route: Optional[Dict[str, Any]] = None,
+        model_override: Optional[str] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -1261,6 +1262,13 @@ class APIServerAdapter(BasePlatformAdapter):
         routing).  When set — and no session ``/model`` override exists for
         this session — its model/provider/api_key/base_url override the
         global defaults for this agent instance only.
+
+        ``model_override`` is an explicit per-request model name (e.g. the
+        ``model`` field of ``POST /v1/runs``) that does not correspond to a
+        configured ``model_routes`` alias.  When set — and no session
+        ``/model`` override exists — it replaces the resolved model for this
+        single agent instantiation only; no global state is mutated and no
+        other callers are affected (fixes #33072).
         """
         from run_agent import AIAgent
         from gateway.run import (
@@ -1332,6 +1340,15 @@ class APIServerAdapter(BasePlatformAdapter):
                 "api_server model route skipped: session /model override wins for %s",
                 gateway_session_key or session_id,
             )
+
+        # Explicit per-request model override (POST /v1/runs `model` field)
+        # that is not a configured model_routes alias. A session /model
+        # override still wins (mirrors the route precedence above), and a
+        # matched route (which set `model` already) takes priority over a
+        # bare override string.
+        if model_override and not session_override and not route:
+            model = model_override
+            logger.debug("api_server per-run model override applied: model=%s", model)
 
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
@@ -4284,6 +4301,10 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Per-client model routing for /v1/runs (see model_routes).
         route = self._resolve_route(body.get("model"))
+        # A `model` value that is not a configured route alias is still a
+        # valid per-run model override (#33072); forward it explicitly.
+        requested_model = (body.get("model") or "").strip() or None
+        run_model_override = requested_model if route is None else None
 
         async def _run_and_close():
             try:
@@ -4295,6 +4316,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     tool_progress_callback=event_cb,
                     gateway_session_key=gateway_session_key,
                     route=route,
+                    model_override=run_model_override,
                 )
                 self._active_run_agents[run_id] = agent
 

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -660,3 +660,135 @@ class TestRunsModelOverride:
 
                 mock_create.assert_called_once()
                 assert mock_create.call_args.kwargs["model_override"] is None
+
+
+def _make_routing_adapter(routes) -> APIServerAdapter:
+    config = PlatformConfig(enabled=True, extra={"model_routes": routes})
+    return APIServerAdapter(config)
+
+
+def _patch_create_agent_runtime(monkeypatch, fake_agent_cls):
+    """Stub every external dependency of _create_agent (captured-agent pattern)."""
+    monkeypatch.setattr("run_agent.AIAgent", fake_agent_cls)
+    monkeypatch.setattr(
+        "gateway.run._resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_key": "sk-global",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "global/model")
+    monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+    monkeypatch.setattr(
+        "gateway.run.GatewayRunner._load_reasoning_config", staticmethod(lambda: {})
+    )
+    monkeypatch.setattr(
+        "gateway.run.GatewayRunner._load_fallback_model", staticmethod(lambda: None)
+    )
+    monkeypatch.setattr("gateway.run._current_max_iterations", lambda: 90)
+    monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
+
+
+class TestCreateAgentModelOverridePrecedence:
+    """Direct _create_agent AIAgent(model=...) capture for #33072 precedence."""
+
+    def test_bare_model_override_sets_aiagent_model(self, monkeypatch):
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        _patch_create_agent_runtime(monkeypatch, FakeAgent)
+        adapter = _make_routing_adapter({"alias": {"model": "route/model"}})
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+        monkeypatch.setattr(adapter, "_session_model_override_for", lambda *_: None)
+
+        agent = adapter._create_agent(
+            session_id="s1",
+            route=None,
+            model_override="claude-haiku-4-5-20251001",
+        )
+
+        assert isinstance(agent, FakeAgent)
+        assert captured["model"] == "claude-haiku-4-5-20251001"
+
+    def test_route_beats_bare_model_override(self, monkeypatch):
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        _patch_create_agent_runtime(monkeypatch, FakeAgent)
+        routes = {
+            "alias": {
+                "model": "route/model",
+                "api_key": "sk-route",
+                "base_url": "https://route.example/v1",
+            }
+        }
+        adapter = _make_routing_adapter(routes)
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+        monkeypatch.setattr(adapter, "_session_model_override_for", lambda *_: None)
+
+        agent = adapter._create_agent(
+            session_id="s1",
+            route=adapter._resolve_route("alias"),
+            model_override="claude-haiku-4-5-20251001",
+        )
+
+        assert isinstance(agent, FakeAgent)
+        # Matched model_routes entry wins over bare per-run override string.
+        assert captured["model"] == "route/model"
+        assert captured["api_key"] == "sk-route"
+
+    def test_session_override_beats_route_and_bare_override(self, monkeypatch):
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        _patch_create_agent_runtime(monkeypatch, FakeAgent)
+        adapter = _make_routing_adapter(
+            {"alias": {"model": "route/model", "api_key": "sk-route"}}
+        )
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+        monkeypatch.setattr(
+            adapter,
+            "_session_model_override_for",
+            lambda key: {"model": "session/override-model"},
+        )
+
+        agent = adapter._create_agent(
+            session_id="s1",
+            route=adapter._resolve_route("alias"),
+            model_override="claude-haiku-4-5-20251001",
+        )
+
+        assert isinstance(agent, FakeAgent)
+        # Session /model wins: route and bare override must not rewrite model.
+        # Session-scoped /model is applied outside _create_agent (GatewayRunner),
+        # so here we keep the global model construction path.
+        assert captured["model"] == "global/model"
+        assert captured["api_key"] == "sk-global"
+
+    def test_no_override_keeps_global_model(self, monkeypatch):
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        _patch_create_agent_runtime(monkeypatch, FakeAgent)
+        adapter = _make_routing_adapter({})
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+        monkeypatch.setattr(adapter, "_session_model_override_for", lambda *_: None)
+
+        agent = adapter._create_agent(session_id="s1")
+
+        assert isinstance(agent, FakeAgent)
+        assert captured["model"] == "global/model"

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -599,3 +599,64 @@ class TestStopRun:
                 body = await events_resp.text()
                 # Stream should have received run.failed and closed
                 assert "run.failed" in body or "stream closed" in body
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/runs — per-run `model` override (#33072)
+# ---------------------------------------------------------------------------
+
+
+class TestRunsModelOverride:
+    @staticmethod
+    async def _drain(cli, run_id):
+        for _ in range(20):
+            status_resp = await cli.get(f"/v1/runs/{run_id}")
+            status = await status_resp.json()
+            if status["status"] == "completed":
+                return status
+            await asyncio.sleep(0.05)
+        return status
+
+    @pytest.mark.asyncio
+    async def test_model_override_forwarded_to_create_agent(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "which model", "model": "claude-haiku-4-5-20251001"},
+                )
+                data = await resp.json()
+                await self._drain(cli, data["run_id"])
+
+                mock_create.assert_called_once()
+                assert (
+                    mock_create.call_args.kwargs["model_override"]
+                    == "claude-haiku-4-5-20251001"
+                )
+
+    @pytest.mark.asyncio
+    async def test_no_model_field_leaves_override_none(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                data = await resp.json()
+                await self._drain(cli, data["run_id"])
+
+                mock_create.assert_called_once()
+                assert mock_create.call_args.kwargs["model_override"] is None


### PR DESCRIPTION
## Problem

`POST /v1/runs` accepts a `model` field documented as a per-run model override, but unless that value matches a preconfigured `model_routes` alias it is silently dropped — the agent always runs with the `config.yaml` default. The requested model is echoed back in `GET /v1/runs/{run_id}` but never used for the actual LLM call. Issue #33072 is still open.

**Root cause:** `_handle_runs()` resolves `body.get("model")` only through `_resolve_route()` (static `model_routes` config). A bare per-request model name has no path into `_create_agent()`, which unconditionally uses `_resolve_gateway_model()`.

## Fix

- Add an optional `model_override: Optional[str] = None` parameter to `_create_agent()`. When set — and no session `/model` override exists and no `model_routes` route matched — it replaces the resolved model for that single agent instantiation only. No global state is mutated; no other callers are affected.
- In `_handle_runs()`, forward `body.get("model")` as `model_override` when it is not a configured route alias.
- Precedence preserved: session `/model` override > `model_routes` route > explicit per-run override > config default.

## Testing

```
python3 -m pytest tests/gateway/test_api_server_runs.py -q
# 25 passed
```

New tests in `TestRunsModelOverride`:
- `test_model_override_forwarded_to_create_agent` — a `model` field reaches `_create_agent(model_override=...)`.
- `test_no_model_field_leaves_override_none` — omitting `model` keeps override None.

---

Supersedes #33096 (same fix; that PR went stale/conflicting after `_create_agent` gained the `route` model-routing parameter on main — this is a clean re-implementation on current main that integrates with the route precedence).