### PR TITLE
feat: support api_mode in model_aliases for direct alias resolution

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7948,6 +7948,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             save_config_value("model.default", result.new_model)
             if result.provider_changed:
                 save_config_value("model.provider", result.target_provider)
+            # Persist alias-derived credentials so they survive session restarts.
+            # Direct aliases carry explicit base_url and api_mode; persist them
+            # to config.yaml so the runtime picks them up on the next turn.
+            # When switching to a non-alias model, clear stale alias values so
+            # they don't leak into unrelated providers (GitHub #62470).
+            if result.resolved_via_alias:
+                if result.base_url:
+                    save_config_value("model.base_url", result.base_url)
+                if result.api_mode:
+                    save_config_value("model.api_mode", result.api_mode)
+            else:
+                save_config_value("model.base_url", "")
+                save_config_value("model.api_mode", "")
             _cprint("    Saved to config.yaml (--global)")
         else:
             _cprint("    (session only — add --global to persist)")

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -238,6 +238,7 @@ class DirectAlias(NamedTuple):
     model: str
     provider: str
     base_url: str
+    api_mode: str = ""
 
 
 # Built-in direct aliases (can be extended via config.yaml model_aliases:)
@@ -281,9 +282,10 @@ def _load_direct_aliases() -> dict[str, DirectAlias]:
                 model = entry.get("model", "")
                 provider = entry.get("provider", "custom")
                 base_url = entry.get("base_url", "")
+                api_mode = entry.get("api_mode", "")
                 if model:
                     merged[name.strip().lower()] = DirectAlias(
-                        model=model, provider=provider, base_url=base_url,
+                        model=model, provider=provider, base_url=base_url, api_mode=api_mode,
                     )
 
         # --- model.aliases (string-based format, from config set) ---
@@ -1251,7 +1253,10 @@ def switch_model(
         _da = DIRECT_ALIASES.get(resolved_alias)
         if _da is not None and _da.base_url:
             base_url = _da.base_url
-            api_mode = ""  # clear so determine_api_mode re-detects from URL
+            if _da.api_mode:
+                api_mode = _da.api_mode
+            else:
+                api_mode = ""  # clear so determine_api_mode re-detects from URL
             if not api_key:
                 api_key = "no-key-required"
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2810,6 +2810,14 @@ def _persist_model_switch(result) -> None:
         # removal without needing a key-delete. Leaving the old value would
         # route the new model at the previous custom host (#48305).
         save_config_value("model.base_url", None)
+    if result.api_mode:
+        save_config_value("model.api_mode", result.api_mode)
+    else:
+        # Same coalesce pattern as base_url: api_mode in config.yaml is only
+        # read by _provider_supports_explicit_api_mode when it matches the
+        # configured provider, and _parse_api_mode returns None for None/null,
+        # so null is equivalent to absent (GitHub #62470).
+        save_config_value("model.api_mode", None)
 
 
 def _apply_model_switch(


### PR DESCRIPTION
## Summary

Allow `model_aliases` entries in config.yaml to specify an explicit `api_mode` (e.g. `chat_completions`, `anthropic_messages`) alongside `model`, `provider`, and `base_url`.

When an alias has `api_mode` set, it overrides the URL-based auto-detection of the API mode. This is particularly useful for endpoints like Kimi `/coding` that support both OpenAI-compatible (Chat Completions) and Anthropic Messages protocols but URL-detection hard-codes `anthropic_messages`.

## Changes

1. **`DirectAlias` class** — Added `api_mode: str = ""` field (defaults to empty/auto-detect)
2. **`_load_direct_aliases()`** — Reads `api_mode` from each alias entry in config.yaml
3. **`switch_model()`** — When a direct alias has `api_mode` set, uses it instead of unconditionally clearing api_mode and re-detecting from URL

## Example config.yaml

```yaml
model_aliases:
  kimi-code:
    model: kimi-for-coding
    provider: kimi-coding
    base_url: https://api.kimi.com/coding/v1
    api_mode: chat_completions
```

Then `/model kimi-code` switches to the Kimi model with OpenAI-compatible protocol, without polluting the top-level `model:` section with an `api_mode` that could leak to other providers.

## Backward compatibility

- Aliases without `api_mode` behave exactly as before — base_url overrides the runtime URL and api_mode is cleared for re-detection.
- Existing alias configs are unaffected.