### PR TITLE
fix(desktop): sync $activeSessionId atom after session-recovery auto-retry

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { textPart } from '@/lib/chat-messages'
 import { $composerAttachments, $composerDraft, type ComposerAttachment, setComposerDraft } from '@/store/composer'
-import { $busy, $connection, $messages, $sessions, setSessions } from '@/store/session'
+import { $activeSessionId, $busy, $connection, $messages, $sessions, setSessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
 import { uploadComposerAttachment, usePromptActions } from '.'
@@ -1123,6 +1123,10 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(calls.map(c => c.method)).toEqual(['prompt.submit', 'session.resume', 'prompt.submit'])
     expect(calls[1]?.params).toEqual({ session_id: STORED_SESSION_ID, source: 'desktop' })
     expect(calls[2]?.params).toEqual({ session_id: RECOVERED_SESSION_ID, text: 'message after wake' })
+
+    // The atom must be updated alongside the ref so subsequent
+    // submits don't re-use the stale runtime id.
+    expect($activeSessionId.get()).toBe(RECOVERED_SESSION_ID)
   })
 
   it('resumes the stored session and retries once when session.interrupt reports "session not found"', async () => {
@@ -1166,6 +1170,10 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(calls[0]?.params).toEqual({ session_id: RUNTIME_SESSION_ID })
     expect(calls[1]?.params).toEqual({ session_id: STORED_SESSION_ID, source: 'desktop' })
     expect(calls[2]?.params).toEqual({ session_id: RECOVERED_SESSION_ID })
+
+    // The $activeSessionId atom must be synced after interrupt recovery so
+    // subsequent prompt.submit calls don't re-use the stale runtime id.
+    expect($activeSessionId.get()).toBe(RECOVERED_SESSION_ID)
   })
 
   it('surfaces the original error (no resume) when the failure is not "session not found"', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -21,7 +21,7 @@ import { resetSessionBackground } from '@/store/composer-status'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { clearPreviewArtifacts } from '@/store/preview-status'
 import { clearAllPrompts } from '@/store/prompts'
-import { $busy, $connection, $messages, setAwaitingResponse, setBusy, setMessages } from '@/store/session'
+import { $busy, $connection, $messages, setActiveSessionId, setAwaitingResponse, setBusy, setMessages } from '@/store/session'
 import { clearSessionSubagents } from '@/store/subagents'
 import { clearSessionTodos } from '@/store/todos'
 
@@ -556,6 +556,7 @@ export function usePromptActions({
           const recoveredId = resumed?.session_id
 
           if (recoveredId) {
+            setActiveSessionId(recoveredId)
             activeSessionIdRef.current = recoveredId
             await requestGateway('session.interrupt', { session_id: recoveredId })
             releaseBusy()

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -13,7 +13,7 @@ import {
 } from '@/store/composer'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { requestDesktopOnboarding } from '@/store/onboarding'
-import { setAwaitingResponse, setBusy, setMessages } from '@/store/session'
+import { setActiveSessionId, setAwaitingResponse, setBusy, setMessages } from '@/store/session'
 
 import type { ClientSessionState } from '../../../types'
 
@@ -365,6 +365,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             const recoveredId = resumed?.session_id
 
             if (recoveredId) {
+              setActiveSessionId(recoveredId)
               activeSessionIdRef.current = recoveredId
               await withSessionBusyRetry(() =>
                 requestGateway('prompt.submit', { session_id: recoveredId, text }, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)


### PR DESCRIPTION
## Problem

When `prompt.submit` returns "session not found" (stale runtime session ID after Gateway restart, WS orphan reap, or context compression), the frontend auto-recovers by calling `session.resume` to get a fresh runtime ID, then retries the submit.

However, the recovery only updates `activeSessionIdRef.current` (a ref) without calling `setActiveSessionId()` (the React atom).

The next `submitPrompt` call gets `sessionId` from `useStore($activeSessionId)` — the atom, which still holds the old stale runtime ID. So every other message fails with "session not found", creating a retry loop.

## Fix

Add `setActiveSessionId(recoveredId)` on the recovery path alongside the ref update.

**File:** `apps/desktop/src/app/session/hooks/use-prompt-actions.ts`

## Related Issues

Fixes #51058
Related: #38704, #44183, #47709
