### PR TITLE
feat(kanban): optional dispatch-pause file gate for spawns

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -25,6 +25,27 @@ from agent.i18n import t
 logger = logging.getLogger("gateway.run")
 
 
+
+# --- Dispatch-pause file (optional fleet/render gate) ---
+# When HERMES_KANBAN_DISPATCH_PAUSE_FILE is set, the dispatcher defers NEW
+# spawns while that file exists. Unset (default) => no behavior change.
+# Intended use: point at a GPU park / brain-swap flag so workers are not
+# spawned into a sleeping LLM provider (spawn-time resolution can pin them
+# to a CPU failback for the life of the worker).
+_DISPATCH_PAUSE_FILE = os.environ.get("HERMES_KANBAN_DISPATCH_PAUSE_FILE", "")
+
+
+def _dispatch_paused() -> bool:
+    """Return True if the configured dispatch-pause file exists."""
+    if not _DISPATCH_PAUSE_FILE:
+        return False
+    try:
+        os.stat(_DISPATCH_PAUSE_FILE)
+        return True
+    except OSError:
+        return False
+
+
 def _resolve_auto_decompose_settings(
     load_config: Callable[[], Any],
 ) -> "tuple[bool, int]":
@@ -939,6 +960,7 @@ class GatewayKanbanWatchersMixin:
         # usually means broken PATH, missing venv, or credential loss.
         HEALTH_WINDOW = 6
         bad_ticks = 0
+        pause_was_active = False  # edge-detect pause file for transition logs
         last_warn_at = 0
         # Avoid hot-looping corrupt-looking board DBs, but do not suppress
         # same-fingerprint retries forever: transient WAL/open races can
@@ -1226,6 +1248,27 @@ class GatewayKanbanWatchersMixin:
                 logger.exception("kanban dispatcher: zombie reaper failed")
 
             try:
+                # Dispatch-pause file (optional render/park gate): defer the whole
+                # tick while present so neither auto-decompose nor spawns run against
+                # an unstable/parked brain. No-op when env unset.
+                if _dispatch_paused():
+                    if not pause_was_active:
+                        pause_was_active = True
+                        logger.info(
+                            "kanban dispatcher: pause file %s present — deferring spawns",
+                            _DISPATCH_PAUSE_FILE,
+                        )
+                    try:
+                        await asyncio.sleep(min(1.0, interval))
+                    except asyncio.CancelledError:
+                        raise
+                    continue
+                elif pause_was_active:
+                    pause_was_active = False
+                    logger.info(
+                        "kanban dispatcher: pause file cleared — resuming spawns"
+                    )
+
                 # Re-read the auto-decompose toggle live each tick so a user
                 # flipping kanban.auto_decompose=false to STOP runaway fan-out
                 # takes effect on the next tick, not on gateway restart (#49638).

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6976,6 +6976,22 @@ def dispatch_once(
     boards tick in parallel. See :func:`_dispatch_tick_lock` for the
     cross-process / cross-platform mechanics.
     """
+    # Optional fleet/render gate: while HERMES_KANBAN_DISPATCH_PAUSE_FILE exists,
+    # every dispatch path (gateway, CLI, dashboard) skips the tick. Unset = no-op.
+    # dry_run is exempt so previews still work.
+    _pause_file = os.environ.get("HERMES_KANBAN_DISPATCH_PAUSE_FILE", "")
+    if _pause_file and not dry_run:
+        try:
+            os.stat(_pause_file)
+            _paused = True
+        except OSError:
+            _paused = False
+        if _paused:
+            print(
+                f"kanban dispatch: pause file {_pause_file} present — tick skipped",
+                file=sys.stderr,
+            )
+            return DispatchResult()
     try:
         db_path = kanban_db_path(board=board)
     except Exception:


### PR DESCRIPTION
## Summary
- Adds an optional **dispatch-pause file** gate controlled by `HERMES_KANBAN_DISPATCH_PAUSE_FILE`.
- When set, the embedded gateway dispatcher **and** `dispatch_once` skip ticks while that file exists.
- **Unset (default) = no behavior change** for upstream users.

## Why
Workers resolve their LLM provider at spawn time. If a GPU park / brain-swap is in progress and a worker is spawned against a sleeping endpoint, it can pin to a CPU failback for the life of the process. A file-based pause (pointed at the operator's park flag) stops new spawns without touching running workers, claims, or completions.

`dry_run` is exempt so previews still work. The gate lives in `dispatch_once` as well as the watcher so CLI/dashboard paths honor it too.

## Test plan
- [ ] With env **unset**: dispatcher and `hermes kanban dispatch` behave as before.
- [ ] With env set to a path that **does not exist**: no pause, normal ticks.
- [ ] With env set and file **created**: watcher logs pause and defers; `dispatch_once` prints skip and returns empty `DispatchResult`.
- [ ] Remove file: watcher logs resume; ticks continue.
- [ ] `dispatch_once(..., dry_run=True)` still runs while pause file is present.