### PR TITLE
fix(desktop): re-baseline session-context drift after new-chat creation (#54527 regression)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -610,6 +610,62 @@ describe('usePromptActions submit / queue drain semantics', () => {
     expect(accepted).toBe(false)
     expect(requestGateway).not.toHaveBeenCalledWith('prompt.submit', expect.anything())
   })
+
+  it('does not abort the first message of a new chat when creation mutates the context (#52253)', async () => {
+    // Regression: commit 7acaff5ef (#54527) pinned the session context and
+    // aborts the submit if it drifts. createBackendSessionForSend legitimately
+    // assigns the new stored/runtime session to the context refs and navigates
+    // to the new route — that self-induced change is NOT a user switching
+    // sessions, so the submit must proceed on the first Enter. Before the fix
+    // the drift guard tripped immediately after creation, dropping the message
+    // and requiring a second Enter.
+    const storedSessionId = 'stored-new'
+    const routeTokens = ['/chat', `/chat/${storedSessionId}`]
+    let routeIdx = 0
+
+    const activeSessionIdRef = { current: null as string | null }
+    const selectedStoredSessionIdRef = { current: null as string | null }
+    const getRouteToken = () => routeTokens[Math.min(routeIdx, routeTokens.length - 1)]
+
+    const createBackendSessionForSend = vi.fn(async () => {
+      activeSessionIdRef.current = RUNTIME_SESSION_ID
+      selectedStoredSessionIdRef.current = storedSessionId
+      routeIdx += 1 // simulate the navigate(sessionRoute(stored)) side effect
+
+      return RUNTIME_SESSION_ID
+    })
+
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        createBackendSessionForSend={createBackendSessionForSend}
+        getRouteToken={getRouteToken}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={null}
+      />
+    )
+
+    // Single Enter of a brand-new chat must send without returning false.
+    const accepted = await handle!.submitText('first message of a new chat')
+
+    expect(createBackendSessionForSend).toHaveBeenCalledTimes(1)
+    expect(accepted).toBe(true)
+    expect(requestGateway).toHaveBeenCalledWith(
+      'prompt.submit',
+      {
+        session_id: RUNTIME_SESSION_ID,
+        text: 'first message of a new chat'
+      },
+      1_800_000
+    )
+  })
 })
 
 describe('usePromptActions steerPrompt', () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -118,17 +118,21 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // Pin the session context for the whole async submit pipeline. Without
       // this, a fast session switch during session.resume / file.attach can
       // redirect the user's text into a different chat (#54527).
-      const startingActiveSessionId = activeSessionIdRef.current
-      const startingStoredSessionId = selectedStoredSessionIdRef.current
-      const startingRouteToken = getRouteToken()
+      const captureContext = () => ({
+        activeSessionId: activeSessionIdRef.current,
+        storedSessionId: selectedStoredSessionIdRef.current,
+        routeToken: getRouteToken()
+      })
+
+      let startingContext = captureContext()
 
       const sessionContextDrifted = (): boolean =>
-        selectedStoredSessionIdRef.current !== startingStoredSessionId ||
-        getRouteToken() !== startingRouteToken
+        selectedStoredSessionIdRef.current !== startingContext.storedSessionId ||
+        getRouteToken() !== startingContext.routeToken
 
       // One submit in flight per session — drop any concurrent re-fire so a
       // stalled turn can't stack the same prompt into multiple real turns.
-      const submitLockKey = startingStoredSessionId || startingActiveSessionId || '__pending_new__'
+      const submitLockKey = startingContext.storedSessionId || startingContext.activeSessionId || '__pending_new__'
 
       if (_submitInFlight.has(submitLockKey)) {
         return false
@@ -179,7 +183,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             // (what made drained-after-interrupt sends go silent).
             interrupted: false
           }),
-          startingStoredSessionId
+          startingContext.storedSessionId
         )
 
       // After sync rewrites refs, refresh the optimistic message in place so the
@@ -191,7 +195,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             ...state,
             messages: state.messages.map(message => (message.id === optimisticId ? buildUserMessage() : message))
           }),
-          startingStoredSessionId
+          startingContext.storedSessionId
         )
 
       const dropOptimistic = (sid: null | string) => {
@@ -210,7 +214,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             awaitingResponse: false,
             pendingBranchGroup: null
           }),
-          startingStoredSessionId
+          startingContext.storedSessionId
         )
       }
 
@@ -234,7 +238,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         setMessages(current => [...current, buildUserMessage()])
       }
 
-      if (!sessionId && startingStoredSessionId) {
+      if (!sessionId && startingContext.storedSessionId) {
         // A stored session is SELECTED but its runtime binding is gone (the
         // live session was orphan-reaped, or a timeout/reconnect cleared
         // activeSessionId). Continuing the selected conversation must mean
@@ -244,7 +248,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         // new-chat draft).
         try {
           const resumed = await requestGateway<{ session_id: string }>('session.resume', {
-            session_id: startingStoredSessionId
+            session_id: startingContext.storedSessionId
           })
 
           if (sessionContextDrifted()) {
@@ -280,6 +284,14 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
           return false
         }
+
+        // createBackendSessionForSend legitimately assigns the new session to
+        // the context refs and navigates to its route. That is the expected
+        // context now — not a user switching away mid-submit — so re-baseline
+        // the drift baseline here. Without this, the #54527 guard trips on the
+        // submit's own side effect and aborts the first message of every new
+        // chat, forcing a second Enter (#52253 class of regression).
+        startingContext = captureContext()
 
         if (sessionContextDrifted()) {
           return abortForSessionSwitch(sessionId)
@@ -324,7 +336,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         } catch (firstErr) {
           if (
             (isSessionNotFoundError(firstErr) || isGatewayTimeoutError(firstErr)) &&
-            startingStoredSessionId
+            startingContext.storedSessionId
           ) {
             // Re-register the session in the gateway and get a fresh live ID.
             // Timeouts recover the same way as "session not found": a starved
@@ -332,7 +344,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             // the stored session is fine — resume + retry instead of erroring
             // out and losing the session binding.
             const resumed = await requestGateway<{ session_id: string }>('session.resume', {
-              session_id: startingStoredSessionId,
+              session_id: startingContext.storedSessionId,
               source: 'desktop'
             })
 


### PR DESCRIPTION
## Summary

Fixes a regression where the **first message of a new chat** requires **two Enters** to send: the prompt lands in the session title bar but isn't submitted until a second press.

Introduced by `7acaff5ef` (PR #54527, "pin session context during async prompt submit"). That PR added a `sessionContextDrifted()` guard that aborts the submit if the session-context refs change mid-pipeline (to stop a fast user session-switch redirecting text into the wrong chat). For a new chat, `createBackendSessionForSend` *legitimately* assigns the new session to the context refs and navigates — so the guard tripped on the submit's own side effect and aborted, returning `false`. That `false` re-loaded the draft into the composer (the title was already seeded via `upsertOptimisticSession`). Second Enter succeeded because the refs were now set and creation was skipped.

## Fix

Re-baseline the drift baseline immediately after `createBackendSessionForSend` resolves, before the drift check. The later `sessionContextDrifted()` checks (after `syncAttachmentsForSubmit`, after `session.resume`, and the resume recovery path) still catch a *genuine* user navigation, so #54527's protection is preserved.

## Verification

- Added regression test `does not abort the first message of a new chat when creation mutates the context (#52253)` in `use-prompt-actions/index.test.tsx`. Confirmed it **fails on the pre-fix code** and **passes with the fix** (not a tautology).
- Full `index.test.tsx` suite: **43 passed**.
- `tsc --noEmit`: no errors in changed files.
- Diagnosis and the fix were validated by cross-vendor review (Gemini + GPT-OSS), which found no BLOCKERs.

## Scope

Desktop only (`apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts` + test). New chats on every first message.

Closes #62481
