### PR TITLE
fix dashboard backup output argument

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11672,7 +11672,7 @@ async def run_backup(body: BackupRequest):
     args = ["backup"]
     archive: Optional[Path] = None
     if body.output:
-        args.append(body.output.strip())
+        args.extend(["--output", body.output.strip()])
     else:
         archive = _new_dashboard_backup_path()
         try:
@@ -11682,7 +11682,7 @@ async def run_backup(body: BackupRequest):
                 status_code=500,
                 detail=f"Could not create backup directory: {exc}",
             )
-        args.append(str(archive))
+        args.extend(["--output", str(archive)])
     try:
         proc = _spawn_hermes_action(args, "backup")
     except Exception as exc:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2230,7 +2230,7 @@ class TestWebServerEndpoints:
 
         assert data["name"] == "backup"
         assert captured["name"] == "backup"
-        assert captured["args"] == ["backup", str(archive)]
+        assert captured["args"] == ["backup", "--output", str(archive)]
         assert archive.parent == get_hermes_home() / "backups"
         assert archive.name.startswith("hermes-backup-")
         assert archive.suffix == ".zip"
@@ -2257,8 +2257,29 @@ class TestWebServerEndpoints:
         archive = Path(resp.json()["archive"])
 
         assert archive.parent == hosted_home / "backups"
-        assert captured["args"] == ["backup", str(archive)]
+        assert captured["args"] == ["backup", "--output", str(archive)]
         assert archive.parent.is_dir()
+
+    def test_ops_backup_passes_explicit_output_flag(self, tmp_path, monkeypatch):
+        import hermes_cli.web_server as ws
+
+        output = tmp_path / "requested-backup.zip"
+        captured = {}
+
+        def fake_spawn(subcommand, name):
+            captured["args"] = subcommand
+            captured["name"] = name
+            from types import SimpleNamespace as NS
+            return NS(pid=12345)
+
+        monkeypatch.setattr(ws, "_spawn_hermes_action", fake_spawn)
+
+        resp = self.client.post("/api/ops/backup", json={"output": str(output)})
+
+        assert resp.status_code == 200
+        assert captured["name"] == "backup"
+        assert captured["args"] == ["backup", "--output", str(output)]
+        assert "archive" not in resp.json()
 
     def test_ops_backup_download_streams_dashboard_backup(self, tmp_path):
         import hermes_cli.web_server as ws


### PR DESCRIPTION
## Summary

- Pass dashboard backup archive paths with `--output` when spawning `hermes backup`.
- Cover both generated dashboard archives and explicitly supplied output paths.

## Root cause

The dashboard API passed the archive path as a positional argument, but the `backup` CLI parser only accepts an output path through `--output` / `-o`. Clicking Create backup therefore spawned an invalid command.

## Validation

- `uv run --extra dev pytest tests/hermes_cli/test_web_server.py`
