### PR TITLE
fix(skills): reject empty skill names before resolver lookup

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -200,6 +200,34 @@ class TestGetCategoryFromPath:
             assert _get_category_from_path(skill_md) is None
 
 
+
+class TestSkillViewQualifiedLocalResolution:
+    def test_bare_slash_and_colon_qualified_names_resolve_identically(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        _make_skill(skills_dir, "meeting-prep", category="task-skills")
+
+        with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
+            bare = json.loads(skill_view("meeting-prep"))
+            slash = json.loads(skill_view("task-skills/meeting-prep"))
+            colon = json.loads(skill_view("task-skills:meeting-prep"))
+
+        assert bare["success"] is True
+        assert slash["success"] is True
+        assert colon["success"] is True
+        assert slash["name"] == bare["name"] == "meeting-prep"
+        assert colon["name"] == bare["name"]
+        assert slash["content"] == bare["content"]
+        assert colon["content"] == bare["content"]
+
+    def test_empty_skill_name_returns_required_error(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            result = json.loads(skill_view(""))
+
+        assert result["success"] is False
+        assert "skill name required" in result["error"].lower()
+        assert "not found" not in result["error"].lower()
+
+
 # ---------------------------------------------------------------------------
 # _find_all_skills
 # ---------------------------------------------------------------------------

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -192,6 +192,8 @@ def _skill_lookup_path_error(name: str) -> Optional[str]:
     if not isinstance(name, str):
         return "Skill name must be a string."
     candidate = name.strip()
+    if not candidate:
+        return "Skill name required."
     if (
         PurePosixPath(candidate).is_absolute()
         or PureWindowsPath(candidate).is_absolute()


### PR DESCRIPTION
## Summary

- reject empty and whitespace-only skill names before resolver lookup
- return a distinct `Skill name required.` validation error instead of a generic not-found result
- cover bare, slash-qualified, and colon-qualified local skill resolution in one regression test

## Testing

- `/Users/TJ/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_skills_tool.py -q`
- 91 passed

Upstream-Candidate: yes