### PR TITLE
fix(desktop): refresh default-derived composer model

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -68,6 +68,7 @@ import {
   setCurrentBranch,
   setCurrentCwd,
   setCurrentModel,
+  setCurrentModelSource,
   setCurrentProvider,
   setMessages,
   setRememberedSessionId
@@ -1084,6 +1085,7 @@ export function DesktopController() {
             onMainModelChanged={(provider, model) => {
               setCurrentProvider(provider)
               setCurrentModel(model)
+              setCurrentModelSource('default')
               updateModelOptionsCache(provider, model, true)
               void refreshCurrentModel()
               void queryClient.invalidateQueries({ queryKey: ['model-options'] })

--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -3,7 +3,15 @@ import { cleanup, render, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getGlobalModelInfo } from '@/hermes'
-import { $activeSessionId, $currentModel, $currentProvider, setCurrentModel, setCurrentProvider } from '@/store/session'
+import {
+  $activeSessionId,
+  $currentModel,
+  $currentProvider,
+  getCurrentModelSource,
+  setCurrentModel,
+  setCurrentModelSource,
+  setCurrentProvider
+} from '@/store/session'
 
 import { useModelControls } from './use-model-controls'
 
@@ -55,6 +63,7 @@ describe('useModelControls', () => {
   beforeEach(() => {
     $activeSessionId.set(null)
     setCurrentModel('')
+    setCurrentModelSource('')
     setCurrentProvider('')
   })
 
@@ -63,6 +72,7 @@ describe('useModelControls', () => {
     vi.restoreAllMocks()
     $activeSessionId.set(null)
     setCurrentModel('')
+    setCurrentModelSource('')
     setCurrentProvider('')
   })
 
@@ -84,6 +94,7 @@ describe('useModelControls', () => {
 
     expect($currentModel.get()).toBe('openai/gpt-5.5')
     expect($currentProvider.get()).toBe('openai-codex')
+    expect(getCurrentModelSource()).toBe('default')
   })
 
   it('does not clobber the active session footer state with global model info', async () => {
@@ -149,6 +160,7 @@ describe('useModelControls', () => {
     // the gateway or the profile default here.
     expect($currentModel.get()).toBe('claude-sonnet-4.6')
     expect($currentProvider.get()).toBe('anthropic')
+    expect(getCurrentModelSource()).toBe('manual')
     expect(requestGateway).not.toHaveBeenCalled()
     expect(setGlobalModel).not.toHaveBeenCalled()
   })
@@ -171,6 +183,7 @@ describe('useModelControls', () => {
     // A user pick must survive the lifecycle refreshes that fire on boot / fresh
     // draft / session events.
     setCurrentModel('anthropic/claude-sonnet-4.6')
+    setCurrentModelSource('manual')
     setCurrentProvider('anthropic')
     await result.current.refreshCurrentModel()
     expect($currentModel.get()).toBe('anthropic/claude-sonnet-4.6')
@@ -178,5 +191,29 @@ describe('useModelControls', () => {
     // A profile swap forces a reseed to the new profile's default.
     await result.current.refreshCurrentModel(true)
     expect($currentModel.get()).toBe('openai/gpt-5.5')
+  })
+
+  it('refreshes legacy/default-derived composer state from the profile default', async () => {
+    setCurrentModel('openai/gpt-5.5')
+    setCurrentProvider('nous')
+    setCurrentModelSource('')
+    vi.mocked(getGlobalModelInfo).mockResolvedValue({ model: 'gpt-5.5', provider: 'openai-codex' })
+
+    const { result } = renderHook(() =>
+      useModelControls({
+        activeSessionId: null,
+        queryClient: new QueryClient(),
+        requestGateway: vi.fn()
+      })
+    )
+
+    expect(getCurrentModelSource()).toBe('')
+
+    await result.current.refreshCurrentModel()
+
+    expect(getGlobalModelInfo).toHaveBeenCalled()
+    expect($currentModel.get()).toBe('gpt-5.5')
+    expect($currentProvider.get()).toBe('openai-codex')
+    expect(getCurrentModelSource()).toBe('default')
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -4,7 +4,15 @@ import { useCallback } from 'react'
 import { getGlobalModelInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { notifyError } from '@/store/notifications'
-import { $activeSessionId, $currentModel, $currentProvider, setCurrentModel, setCurrentProvider } from '@/store/session'
+import {
+  $activeSessionId,
+  $currentModel,
+  $currentProvider,
+  getCurrentModelSource,
+  setCurrentModel,
+  setCurrentModelSource,
+  setCurrentProvider
+} from '@/store/session'
 import type { ModelOptionsResponse } from '@/types/hermes'
 
 interface ModelSelection {
@@ -46,13 +54,13 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
         return
       }
 
-      if (!force && $currentModel.get()) {
+      if (!force && $currentModel.get() && getCurrentModelSource() === 'manual') {
         return
       }
 
       const result = await getGlobalModelInfo()
 
-      if ($activeSessionId.get() || (!force && $currentModel.get())) {
+      if ($activeSessionId.get() || (!force && $currentModel.get() && getCurrentModelSource() === 'manual')) {
         return
       }
 
@@ -62,6 +70,10 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
 
       if (typeof result.provider === 'string') {
         setCurrentProvider(result.provider)
+      }
+
+      if (typeof result.model === 'string' || typeof result.provider === 'string') {
+        setCurrentModelSource('default')
       }
     } catch {
       // The delayed session.info event still updates this once the agent is ready.
@@ -81,9 +93,11 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
       // rather than leave the UI showing a model the backend never selected.
       const prevModel = $currentModel.get()
       const prevProvider = $currentProvider.get()
+      const prevSource = getCurrentModelSource()
 
       setCurrentModel(selection.model)
       setCurrentProvider(selection.provider)
+      setCurrentModelSource('manual')
       updateModelOptionsCache(selection.provider, selection.model, !activeSessionId)
 
       // No live session yet: the pick is pure UI state. session.create reads
@@ -105,6 +119,7 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
       } catch (err) {
         setCurrentModel(prevModel)
         setCurrentProvider(prevProvider)
+        setCurrentModelSource(prevSource)
         updateModelOptionsCache(prevProvider, prevModel, !activeSessionId)
         notifyError(err, copy.modelSwitchFailed)
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -8,6 +8,7 @@ import { persistBoolean, persistString, storedBoolean, storedString } from '@/li
 import type { SessionInfo, UsageStats } from '@/types/hermes'
 
 type Updater<T> = T | ((current: T) => T)
+export type ComposerModelSource = '' | 'default' | 'manual'
 
 const WORKSPACE_CWD_KEY = 'hermes.desktop.workspace-cwd'
 
@@ -18,6 +19,7 @@ const WORKSPACE_CWD_KEY = 'hermes.desktop.workspace-cwd'
 // that profile's default, while within a profile new chats keep your last pick.
 const COMPOSER_MODEL_KEY = 'hermes.desktop.composer.model'
 const COMPOSER_PROVIDER_KEY = 'hermes.desktop.composer.provider'
+const COMPOSER_MODEL_SOURCE_KEY = 'hermes.desktop.composer.model-source'
 const COMPOSER_EFFORT_KEY = 'hermes.desktop.composer.reasoning-effort'
 const COMPOSER_FAST_KEY = 'hermes.desktop.composer.fast'
 
@@ -317,6 +319,16 @@ export const setCurrentModel = (next: Updater<string>) => {
 export const setCurrentProvider = (next: Updater<string>) => {
   updateAtom($currentProvider, next)
   persistString(COMPOSER_PROVIDER_KEY, $currentProvider.get() || null)
+}
+
+export const getCurrentModelSource = (): ComposerModelSource => {
+  const source = storedString(COMPOSER_MODEL_SOURCE_KEY)
+
+  return source === 'default' || source === 'manual' ? source : ''
+}
+
+export const setCurrentModelSource = (source: ComposerModelSource) => {
+  persistString(COMPOSER_MODEL_SOURCE_KEY, source || null)
 }
 
 export const setCurrentReasoningEffort = (next: Updater<string>) => {


### PR DESCRIPTION
## Problem

Fixes #58498.

Desktop can persist the composer model/provider in localStorage and then send that pair on `session.create` as a per-session override. The same persistent slot was used for two different meanings:

- a real manual model-picker choice, which should persist across new chats/restarts
- a mirror of the profile default loaded from `/api/model/info`, which should keep following `config.yaml`

When the profile default changed outside the renderer (for example CLI/config now says `provider: openai-codex`, `default: gpt-5.5`), a stale default-derived composer value could still be sent as a no-session override. That matches the reporter's dump: `config.yaml` showed OpenAI Codex, while the desktop turn was built as `provider=nous model=openai/gpt-5.5`.

## Root Cause

`refreshCurrentModel()` skipped any non-empty composer model, because it could not tell a user picker choice from a default mirror. The second post-fetch race guard had the same unconditional skip.

## Fix

Add a tiny persisted source marker for the composer model:

- `manual` for explicit desktop model-picker selections
- `default` for profile-default refreshes and Settings -> Model saves
- missing/legacy source is treated as default-derived, so stale v0.18.0 localStorage can self-heal

`refreshCurrentModel()` now preserves only `manual` choices. Default-derived and legacy composer state refreshes from `/api/model/info`, so new Desktop chats stop overriding the correct OpenAI Codex config with a stale Nous route.

## Tests

- `npm --workspace apps/desktop run test:ui -- src/app/session/hooks/use-model-controls.test.tsx`
- `npm --workspace apps/desktop run typecheck`
- `cd apps/desktop && npx eslint src/app/desktop-controller.tsx src/app/session/hooks/use-model-controls.ts src/app/session/hooks/use-model-controls.test.tsx src/store/session.ts`

---

> Replaces #58527 (source branch was on kohoj fork, re-opened from yingliang-zhang fork to enable CI). Original author: @KohoJ