### PR TITLE
feat(plugins): add gateway service lifecycle

### DIFF
--- a/gateway/plugin_services.py
+++ b/gateway/plugin_services.py
@@ -1,0 +1,159 @@
+"""Plugin gateway-service lifecycle seam.
+
+Provides a minimal, host-owned interface between plugin-registered async
+services and the ``GatewayRunner``. Plugins register async services via
+``PluginContext.register_gateway_service``; the gateway starts them after
+all adapters have connected and the runner is running, and stops them
+before adapter disconnect.
+
+Design constraints:
+- The host owns the context; plugins never receive the ``GatewayRunner``.
+- Services see a read-only snapshot of connected adapters, keyed by
+  platform name string.
+- Services start exactly once per manager lifecycle and are never
+  re-triggered by reconnect logic.
+- Task handles are strongly retained and explicitly cancelled/awaited
+  on shutdown.
+- Startup and runtime failures are isolated per-service and logged with
+  provenance; a failing service never prevents others from starting.
+"""
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import TYPE_CHECKING, final
+
+if TYPE_CHECKING:
+    from gateway.platforms.base import BasePlatformAdapter
+
+logger = logging.getLogger(__name__)
+
+# Async service callable: receives a GatewayServiceContext, runs until
+# cancelled or until it returns naturally.
+GatewayServiceCallable = Callable[["GatewayServiceContext"], Awaitable[None]]
+
+
+@dataclass(frozen=True)
+class GatewayServiceRegistration:
+    """Immutable registration descriptor for a plugin gateway service.
+
+    Captures deterministic provenance at registration time so the host
+    can log, attribute, and audit the service independent of mutable
+    plugin state.
+    """
+
+    name: str
+    service: GatewayServiceCallable
+    plugin_name: str
+    plugin_key: str
+    source: str
+
+    @property
+    def provenance(self) -> str:
+        """Human-readable provenance string for logging."""
+        return f"{self.plugin_name} (key={self.plugin_key}, source={self.source})"
+
+
+@final
+class GatewayServiceContext:
+    """Host-owned minimal context passed to gateway services at start.
+
+    Exposes a read-only snapshot of successfully connected adapters,
+    keyed by platform name string. Does NOT expose the ``GatewayRunner``.
+    """
+
+    __slots__ = ("_adapters",)
+
+    def __init__(self, adapters: Mapping[str, "BasePlatformAdapter"]) -> None:
+        self._adapters = MappingProxyType(dict(adapters))
+
+    @property
+    def adapters(self) -> Mapping[str, "BasePlatformAdapter"]:
+        """Read-only mapping of connected platform adapters by name."""
+        return self._adapters
+
+
+@final
+class GatewayServiceManager:
+    """Lifecycle manager for plugin-registered gateway services.
+
+    Retains task handles, observes task exceptions and logs context,
+    re-raises cancellation, and is a no-op when there are no
+    registrations or no connected adapters. Services start exactly once
+    per instance lifecycle.
+    """
+
+    def __init__(self) -> None:
+        self._started: bool = False
+        self._tasks: list[asyncio.Task[None]] = []
+
+    @property
+    def started(self) -> bool:
+        return self._started
+
+    @property
+    def tasks(self) -> list[asyncio.Task[None]]:
+        return list(self._tasks)
+
+    async def start_services(
+        self,
+        registrations: Sequence[GatewayServiceRegistration],
+        adapters: Mapping[str, "BasePlatformAdapter"],
+    ) -> None:
+        """Start all registered gateway services.
+
+        No-op when already started, when there are no registrations, or
+        when there are no connected adapters. Each service runs in its
+        own task so a startup or runtime failure in one service is
+        isolated and logged without preventing others from starting.
+        """
+        if self._started:
+            return
+        if not registrations or not adapters:
+            return
+        self._started = True
+        ctx = GatewayServiceContext(adapters)
+        for reg in registrations:
+            task = asyncio.create_task(
+                self._run_service(reg, ctx),
+                name=f"gateway_service:{reg.name}",
+            )
+            self._tasks.append(task)
+            logger.info(
+                "Launched gateway service '%s' from %s",
+                reg.name,
+                reg.provenance,
+            )
+
+    async def _run_service(
+        self,
+        reg: GatewayServiceRegistration,
+        ctx: GatewayServiceContext,
+    ) -> None:
+        try:
+            await reg.service(ctx)
+        except asyncio.CancelledError:
+            logger.info("Gateway service '%s' cancelled", reg.name)
+            raise
+        except Exception:
+            logger.exception(
+                "Gateway service '%s' from %s raised an unhandled exception",
+                reg.name,
+                reg.provenance,
+            )
+
+    async def stop_services(self) -> None:
+        """Cancel and await all running service tasks.
+
+        Ensures all tasks are cancelled and awaited before returning.
+        No-op when there are no tasks.
+        """
+        if not self._tasks:
+            return
+        for task in self._tasks:
+            if not task.done():
+                _ = task.cancel()
+        _ = await asyncio.gather(*self._tasks, return_exceptions=True)
+        self._tasks.clear()

--- a/gateway/plugin_services.py
+++ b/gateway/plugin_services.py
@@ -8,12 +8,16 @@ before adapter disconnect.
 
 Design constraints:
 - The host owns the context; plugins never receive the ``GatewayRunner``.
-- Services see a read-only snapshot of connected adapters, keyed by
-  platform name string.
+- Services see a fresh read-only view of currently connected adapters
+  on each access, keyed by platform name string. The view reflects
+  reconnect-driven adapter changes without re-launching the service.
 - Services start exactly once per manager lifecycle and are never
   re-triggered by reconnect logic.
 - Task handles are strongly retained and explicitly cancelled/awaited
-  on shutdown.
+  on shutdown. A cancellation-suppressing service cannot block
+  shutdown beyond a host-owned timeout; it is detached from the bounded
+  shutdown wait but still observed (with provenance) when it eventually
+  completes.
 - Startup and runtime failures are isolated per-service and logged with
   provenance; a failing service never prevents others from starting.
 """
@@ -23,16 +27,29 @@ import logging
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import TYPE_CHECKING, final
+from typing import TYPE_CHECKING, Optional, final
 
 if TYPE_CHECKING:
     from gateway.platforms.base import BasePlatformAdapter
 
 logger = logging.getLogger(__name__)
 
+# Host-owned bounded shutdown timeout. Matches the gateway adapter
+# teardown default (gateway/run.py) but is intentionally a separate
+# constant: this bound is owned by the plugin-service lifecycle seam,
+# not the adapter teardown path, and must not be reconfigured by
+# adapter-specific env vars or user config.
+_SHUTDOWN_TIMEOUT_SECS: float = 5.0
+
 # Async service callable: receives a GatewayServiceContext, runs until
 # cancelled or until it returns naturally.
 GatewayServiceCallable = Callable[["GatewayServiceContext"], Awaitable[None]]
+
+# Host-supplied resolver returning the current connected-adapter
+# mapping. Called on each ``GatewayServiceContext.adapters`` access so
+# the service observes reconnect-driven adapter changes without ever
+# receiving the runner.
+AdaptersResolver = Callable[[], Mapping[str, "BasePlatformAdapter"]]
 
 
 @dataclass(frozen=True)
@@ -60,19 +77,33 @@ class GatewayServiceRegistration:
 class GatewayServiceContext:
     """Host-owned minimal context passed to gateway services at start.
 
-    Exposes a read-only snapshot of successfully connected adapters,
-    keyed by platform name string. Does NOT expose the ``GatewayRunner``.
+    Exposes a fresh read-only view of currently connected adapters,
+    keyed by platform name string. Each ``adapters`` access calls the
+    host-supplied resolver and returns a new ``MappingProxyType`` so
+    services observe reconnect-driven changes while each held reference
+    stays stable. Does NOT expose the ``GatewayRunner``.
     """
 
-    __slots__ = ("_adapters",)
+    __slots__ = ("_resolver",)
 
-    def __init__(self, adapters: Mapping[str, "BasePlatformAdapter"]) -> None:
-        self._adapters = MappingProxyType(dict(adapters))
+    def __init__(self, adapters_resolver: AdaptersResolver) -> None:
+        self._resolver = adapters_resolver
 
     @property
     def adapters(self) -> Mapping[str, "BasePlatformAdapter"]:
-        """Read-only mapping of connected platform adapters by name."""
-        return self._adapters
+        """Read-only mapping of currently connected platform adapters."""
+        return MappingProxyType(dict(self._resolver()))
+
+
+def _format_overdue_completion(task: asyncio.Task[None]) -> Optional[str]:
+    """Return a status string for a completed overdue task.
+
+    Returns None when the task is still pending (caller should not log).
+    """
+    if task.cancelled():
+        return "cancelled"
+    exc = task.exception()
+    return None if exc is None else f"failed: {exc!r}"
 
 
 @final
@@ -83,11 +114,25 @@ class GatewayServiceManager:
     re-raises cancellation, and is a no-op when there are no
     registrations or no connected adapters. Services start exactly once
     per instance lifecycle.
+
+    Shutdown is bounded by ``_SHUTDOWN_TIMEOUT_SECS``: a service that
+    suppresses cancellation is detached from the bounded wait, retained
+    for observation, and logged with provenance when it eventually
+    completes. The manager never blocks gateway shutdown indefinitely
+    and never leaves an overdue task unobserved.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, adapters_resolver: AdaptersResolver) -> None:
+        self._resolver = adapters_resolver
         self._started: bool = False
+        # Active service tasks, in launch order.
         self._tasks: list[asyncio.Task[None]] = []
+        # Task -> registration provenance for log attribution.
+        self._registrations: dict[asyncio.Task[None], GatewayServiceRegistration] = {}
+        # Overdue tasks: still running after shutdown timeout. Retained
+        # so they are not garbage-collected before completion and so
+        # eventual exceptions are observed via the done callback.
+        self._overdue_tasks: set[asyncio.Task[None]] = set()
 
     @property
     def started(self) -> bool:
@@ -97,30 +142,37 @@ class GatewayServiceManager:
     def tasks(self) -> list[asyncio.Task[None]]:
         return list(self._tasks)
 
+    @property
+    def overdue_tasks(self) -> list[asyncio.Task[None]]:
+        return list(self._overdue_tasks)
+
     async def start_services(
         self,
         registrations: Sequence[GatewayServiceRegistration],
-        adapters: Mapping[str, "BasePlatformAdapter"],
     ) -> None:
         """Start all registered gateway services.
 
         No-op when already started, when there are no registrations, or
-        when there are no connected adapters. Each service runs in its
-        own task so a startup or runtime failure in one service is
-        isolated and logged without preventing others from starting.
+        when the resolver reports no connected adapters. Each service
+        runs in its own task so a startup or runtime failure in one
+        service is isolated and logged without preventing others from
+        starting.
         """
         if self._started:
             return
-        if not registrations or not adapters:
+        if not registrations:
+            return
+        if not self._resolver():
             return
         self._started = True
-        ctx = GatewayServiceContext(adapters)
+        ctx = GatewayServiceContext(self._resolver)
         for reg in registrations:
             task = asyncio.create_task(
                 self._run_service(reg, ctx),
                 name=f"gateway_service:{reg.name}",
             )
             self._tasks.append(task)
+            self._registrations[task] = reg
             logger.info(
                 "Launched gateway service '%s' from %s",
                 reg.name,
@@ -144,16 +196,80 @@ class GatewayServiceManager:
                 reg.provenance,
             )
 
+    def _make_overdue_done_callback(
+        self,
+        task: asyncio.Task[None],
+        reg: GatewayServiceRegistration,
+    ) -> Callable[[asyncio.Task[None]], None]:
+        def _callback(_task: asyncio.Task[None]) -> None:
+            status = _format_overdue_completion(task)
+            if status is None:
+                logger.info(
+                    "Detached gateway service '%s' from %s completed after "
+                    "shutdown timeout",
+                    reg.name,
+                    reg.provenance,
+                )
+            elif status == "cancelled":
+                logger.info(
+                    "Detached gateway service '%s' from %s cancelled after "
+                    "shutdown timeout",
+                    reg.name,
+                    reg.provenance,
+                )
+            else:
+                logger.error(
+                    "Detached gateway service '%s' from %s raised after "
+                    "shutdown timeout",
+                    reg.name,
+                    reg.provenance,
+                    exc_info=task.exception(),
+                )
+            self._overdue_tasks.discard(task)
+            self._registrations.pop(task, None)
+
+        return _callback
+
     async def stop_services(self) -> None:
         """Cancel and await all running service tasks.
 
-        Ensures all tasks are cancelled and awaited before returning.
-        No-op when there are no tasks.
+        Bounds the wait at ``_SHUTDOWN_TIMEOUT_SECS``. Tasks that
+        suppress cancellation and are still pending after the timeout
+        are detached from the bounded wait: each is retained in
+        ``overdue_tasks``, gets a done callback that logs eventual
+        completion or failure with provenance, and is removed from
+        active tracking so the manager no longer owns it. No-op when
+        there are no active tasks.
         """
         if not self._tasks:
             return
         for task in self._tasks:
             if not task.done():
                 _ = task.cancel()
-        _ = await asyncio.gather(*self._tasks, return_exceptions=True)
+        done, pending = await asyncio.wait(
+            self._tasks, timeout=_SHUTDOWN_TIMEOUT_SECS
+        )
+        if done:
+            _ = await asyncio.gather(*done, return_exceptions=True)
+            # Done tasks are no longer owned by the manager; drop their
+            # provenance so _registrations cannot leak across shutdown.
+            for task in done:
+                self._registrations.pop(task, None)
+        for task in pending:
+            reg = self._registrations.get(task)
+            name = reg.name if reg else "(unknown)"
+            provenance = reg.provenance if reg else "(unknown)"
+            logger.warning(
+                "Gateway service '%s' from %s did not stop within %.1fs; "
+                "detaching from bounded shutdown. Eventual completion will "
+                "be observed but no longer blocks gateway shutdown.",
+                name,
+                provenance,
+                _SHUTDOWN_TIMEOUT_SECS,
+            )
+            task.add_done_callback(
+                self._make_overdue_done_callback(task, reg) if reg
+                else lambda _t: None
+            )
+            self._overdue_tasks.add(task)
         self._tasks.clear()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2989,7 +2989,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Key: Platform enum, Value: {"config": platform_config, "attempts": int, "next_retry": float}
         self._failed_platforms: Dict[Platform, Dict[str, Any]] = {}
 
-        self._plugin_service_manager = GatewayServiceManager()
+        self._plugin_service_manager = GatewayServiceManager(
+            self._plugin_service_adapters
+        )
 
         # Track pending /update prompt responses per session.
         # Key: session_key, Value: True when a prompt is waiting for user input.
@@ -6718,14 +6720,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
         return True
 
+    def _plugin_service_adapters(self) -> Dict[str, "BasePlatformAdapter"]:
+        """Build a string-keyed mapping of all connected adapters.
+
+        Primary adapters are keyed by ``platform.value``; secondary
+        profile adapters are keyed by ``f"{profile_name}/{platform.value}"``.
+        Called by the plugin-service manager on each
+        ``GatewayServiceContext.adapters`` access so services observe
+        reconnect-driven adapter changes without exposing the runner.
+        """
+        snapshot: Dict[str, "BasePlatformAdapter"] = {
+            platform.value: adapter for platform, adapter in self.adapters.items()
+        }
+        for profile_name, profile_map in self._profile_adapters.items():
+            for platform, adapter in profile_map.items():
+                snapshot[f"{profile_name}/{platform.value}"] = adapter
+        return snapshot
+
     async def _start_plugin_gateway_services(self) -> None:
         """Start plugin-registered gateway services after adapters connect.
 
-        Builds a string-keyed snapshot of all connected adapters (primary
-        and secondary-profile) and hands it to the service manager. No-op
-        when no plugins registered services or when no adapters connected.
-        The manager's started guard ensures exactly-once even across
-        reconnect-triggered calls.
+        No-op when no plugins registered services. The manager's
+        started guard ensures exactly-once even across
+        reconnect-triggered calls; reconnect-driven adapter changes
+        become visible to already-running services through the
+        context's resolver without launching a duplicate service.
         """
         from hermes_cli.plugins import get_plugin_manager
 
@@ -6735,15 +6754,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         mgr = getattr(self, "_plugin_service_manager", None)
         if mgr is None:
             return
-        adapters_snapshot = {
-            platform.value: adapter for platform, adapter in self.adapters.items()
-        }
-        for profile_name, profile_map in self._profile_adapters.items():
-            for platform, adapter in profile_map.items():
-                adapters_snapshot[f"{profile_name}/{platform.value}"] = adapter
-        await mgr.start_services(
-            registrations, adapters_snapshot,
-        )
+        await mgr.start_services(registrations)
 
     async def start(self) -> bool:
         """

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1767,6 +1767,7 @@ from gateway.platforms.base import (
     merge_pending_message_event,
     utf16_len,
 )
+from gateway.plugin_services import GatewayServiceManager
 from gateway.restart import (
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
     GATEWAY_FATAL_CONFIG_EXIT_CODE,
@@ -2800,6 +2801,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     _session_model_overrides: Dict[str, Dict[str, str]] = {}
     _session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
     _startup_restore_in_progress: bool = False
+    # Class-level default so borrowed/fake runners created via object.__new__
+    # in existing test harnesses don't AttributeError on stop(). Real runners
+    # overwrite this in __init__.
+    _plugin_service_manager: Optional["GatewayServiceManager"] = None
 
     def __init__(self, config: Optional[GatewayConfig] = None):
         global _gateway_runner_ref
@@ -2983,6 +2988,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Track platforms that failed to connect for background reconnection.
         # Key: Platform enum, Value: {"config": platform_config, "attempts": int, "next_retry": float}
         self._failed_platforms: Dict[Platform, Dict[str, Any]] = {}
+
+        self._plugin_service_manager = GatewayServiceManager()
 
         # Track pending /update prompt responses per session.
         # Key: session_key, Value: True when a prompt is waiting for user input.
@@ -6711,6 +6718,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
         return True
 
+    async def _start_plugin_gateway_services(self) -> None:
+        """Start plugin-registered gateway services after adapters connect.
+
+        Builds a string-keyed snapshot of all connected adapters (primary
+        and secondary-profile) and hands it to the service manager. No-op
+        when no plugins registered services or when no adapters connected.
+        The manager's started guard ensures exactly-once even across
+        reconnect-triggered calls.
+        """
+        from hermes_cli.plugins import get_plugin_manager
+
+        registrations = get_plugin_manager().get_gateway_services()
+        if not registrations:
+            return
+        mgr = getattr(self, "_plugin_service_manager", None)
+        if mgr is None:
+            return
+        adapters_snapshot = {
+            platform.value: adapter for platform, adapter in self.adapters.items()
+        }
+        for profile_name, profile_map in self._profile_adapters.items():
+            for platform, adapter in profile_map.items():
+                adapters_snapshot[f"{profile_name}/{platform.value}"] = adapter
+        await mgr.start_services(
+            registrations, adapters_snapshot,
+        )
+
     async def start(self) -> bool:
         """
         Start the gateway and all configured platform adapters.
@@ -7249,7 +7283,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         self._running = True
         self._update_runtime_status("running")
-        
+
+        await self._start_plugin_gateway_services()
+
         # Emit gateway:startup hook
         hook_count = len(self.hooks.loaded_hooks)
         if hook_count:
@@ -7944,6 +7980,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 platform.value,
                                 exc_info=True,
                             )
+
+                        # Give services a chance if none were started yet
+                        # (no adapter connected during initial start).
+                        # Manager's started guard prevents duplicates.
+                        await self._start_plugin_gateway_services()
                     # Check if the failure is non-retryable
                     elif adapter.has_fatal_error and not adapter.fatal_error_retryable:
                         self._update_platform_runtime_status(
@@ -8272,6 +8313,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     await self._cleanup_agent_resources_off_loop(
                         _agent, context="shutdown idle-cache"
                     )
+
+            _plugin_mgr = getattr(self, "_plugin_service_manager", None)
+            if _plugin_mgr is not None:
+                await _plugin_mgr.stop_services()
 
             for platform, adapter in list(self.adapters.items()):
                 await self._bounded_adapter_teardown(adapter, platform)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -44,12 +44,15 @@ import threading
 import types
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union, TYPE_CHECKING
 
 from hermes_constants import get_hermes_home
 from utils import env_var_enabled, fast_safe_load
 from hermes_cli.config import cfg_get
 from hermes_cli.middleware import OBSERVER_SCHEMA_VERSION, VALID_MIDDLEWARE
+
+if TYPE_CHECKING:
+    from gateway.plugin_services import GatewayServiceCallable, GatewayServiceRegistration
 
 
 def get_bundled_plugins_dir() -> Path:
@@ -322,6 +325,7 @@ class LoadedPlugin:
     hooks_registered: List[str] = field(default_factory=list)
     middleware_registered: List[str] = field(default_factory=list)
     commands_registered: List[str] = field(default_factory=list)
+    gateway_services_registered: List[str] = field(default_factory=list)
     enabled: bool = False
     error: Optional[str] = None
     # True for a bundled platform plugin recorded as a deferred (not-yet-
@@ -1238,6 +1242,58 @@ class PluginContext:
             self.manifest.name, qualified,
         )
 
+    def register_gateway_service(
+        self,
+        name: str,
+        service: "GatewayServiceCallable",
+    ) -> None:
+        """Register an async gateway service under a unique name.
+
+        The service is an ``async`` callable that receives a
+        ``GatewayServiceContext`` (a read-only snapshot of connected
+        adapters) and runs concurrently with the gateway. The host starts
+        it after adapters connect and stops it before adapter disconnect.
+
+        Later registrations with an already-claimed name are rejected
+        with a warning; the first registration wins.
+        """
+        from gateway.plugin_services import GatewayServiceRegistration
+
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("Gateway service name must be a non-empty string")
+        if not callable(service):
+            raise TypeError("Gateway service must be callable")
+        if not (
+            inspect.iscoroutinefunction(service)
+            or inspect.iscoroutinefunction(getattr(service, "__call__", None))
+        ):
+            raise TypeError(
+                "Gateway service must be an async callable "
+                "(an async function or an instance with "
+                "async def __call__)."
+            )
+        key = self.manifest.key or self.manifest.name
+        for existing in self._manager._gateway_services:
+            if existing.name == name:
+                logger.warning(
+                    "Gateway service '%s' already registered by %s; "
+                    "rejecting duplicate from plugin '%s'",
+                    name, existing.provenance, self.manifest.name,
+                )
+                return
+        reg = GatewayServiceRegistration(
+            name=name,
+            service=service,
+            plugin_name=self.manifest.name,
+            plugin_key=key,
+            source=self.manifest.source,
+        )
+        self._manager._gateway_services.append(reg)
+        logger.debug(
+            "Plugin %s registered gateway service: %s",
+            self.manifest.name, name,
+        )
+
 
 # ---------------------------------------------------------------------------
 # PluginManager
@@ -1269,6 +1325,14 @@ class PluginManager:
         # ``re.Pattern``, or a constraint dict); ``callback`` is an async
         # function with the slack_bolt signature ``(ack, body, action)``.
         self._slack_action_handlers: List[tuple] = []
+        # Plugin-registered gateway services: list of GatewayServiceRegistration
+        # descriptors. Duplicate names are rejected (first wins). Cleared on
+        # forced rediscovery. See PluginContext.register_gateway_service.
+        self._gateway_services: List["GatewayServiceRegistration"] = []
+
+    def get_gateway_services(self) -> Tuple["GatewayServiceRegistration", ...]:
+        """Return an immutable ordered snapshot of gateway-service registrations."""
+        return tuple(self._gateway_services)
 
     # -----------------------------------------------------------------------
     # Public
@@ -1298,6 +1362,7 @@ class PluginManager:
             self._plugin_skills.clear()
             self._aux_tasks.clear()
             self._slack_action_handlers.clear()
+            self._gateway_services.clear()
             self._context_engine = None
         # Set the flag up front as a re-entrancy guard (a plugin's register()
         # can transitively trigger discovery again), but reset it if the sweep
@@ -1787,6 +1852,9 @@ class PluginManager:
                 _mw_counts_before = {
                     kind: len(cbs) for kind, cbs in self._middleware.items()
                 }
+                _gw_services_before = {
+                    s.name for s in self._gateway_services
+                }
                 register_fn(ctx)
                 loaded.tools_registered = [
                     t for t in self._plugin_tool_names
@@ -1806,9 +1874,13 @@ class PluginManager:
                     c for c in self._plugin_commands
                     if self._plugin_commands[c].get("plugin") == manifest.name
                 ]
+                loaded.gateway_services_registered = [
+                    s.name for s in self._gateway_services
+                    if s.name not in _gw_services_before
+                ]
                 loaded.enabled = True
                 logger.debug(
-                    "  registered: %d tool(s), %d hook(s), %d middleware, %d slash command(s), %d CLI command(s)",
+                    "  registered: %d tool(s), %d hook(s), %d middleware, %d slash command(s), %d CLI command(s), %d gateway service(s)",
                     len(loaded.tools_registered),
                     len(loaded.hooks_registered),
                     len(loaded.middleware_registered),
@@ -1817,6 +1889,7 @@ class PluginManager:
                         1 for c in self._cli_commands
                         if self._cli_commands[c].get("plugin") == manifest.name
                     ),
+                    len(loaded.gateway_services_registered),
                 )
 
         except Exception as exc:
@@ -1992,6 +2065,7 @@ class PluginManager:
                     "hooks": len(loaded.hooks_registered),
                     "middleware": len(loaded.middleware_registered),
                     "commands": len(loaded.commands_registered),
+                    "gateway_services": len(loaded.gateway_services_registered),
                     "error": loaded.error,
                 }
             )

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1250,7 +1250,7 @@ class PluginContext:
         """Register an async gateway service under a unique name.
 
         The service is an ``async`` callable that receives a
-        ``GatewayServiceContext`` (a read-only snapshot of connected
+        ``GatewayServiceContext`` (a live read-only view of connected
         adapters) and runs concurrently with the gateway. The host starts
         it after adapters connect and stops it before adapter disconnect.
 

--- a/tests/gateway/test_plugin_gateway_runner_integration.py
+++ b/tests/gateway/test_plugin_gateway_runner_integration.py
@@ -1,0 +1,216 @@
+"""Runner integration tests for plugin gateway-service lifecycle.
+
+Exercises ``GatewayRunner._start_plugin_gateway_services`` directly:
+public API retrieval, string-keyed adapter snapshot (primary + secondary
+profile), exactly-once across reconnect, and sync-callback rejection at
+registration time. No network; coordination via asyncio Events/wait_for.
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+from gateway.plugin_services import (
+    GatewayServiceContext,
+    GatewayServiceManager,
+    GatewayServiceRegistration,
+)
+
+
+def _make_registration(name: str = "svc", *, service=None) -> GatewayServiceRegistration:
+    async def _default(ctx: GatewayServiceContext) -> None:
+        pass
+
+    return GatewayServiceRegistration(
+        name=name,
+        service=service or _default,
+        plugin_name="test_plugin",
+        plugin_key="test_plugin",
+        source="user",
+    )
+
+
+class TestGatewayRunnerIntegration:
+    """Runner helper: public API, string-keyed snapshot, exactly-once."""
+
+    @pytest.mark.asyncio
+    async def test_runner_uses_public_api_string_keys_once(self, monkeypatch):
+        from gateway import run as gateway_run
+        from gateway.config import Platform
+
+        started, captured, count = asyncio.Event(), {}, 0
+
+        async def svc(ctx):
+            nonlocal count
+            count += 1
+            captured.update(dict(ctx.adapters))
+            started.set()
+            await asyncio.Event().wait()
+
+        reg = _make_registration(service=svc)
+        calls = []
+
+        class FakePM:
+            def get_gateway_services(self):
+                calls.append(1)
+                return (reg,)
+
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: FakePM())
+        runner = object.__new__(gateway_run.GatewayRunner)
+        runner.adapters = {Platform.TELEGRAM: MagicMock(name="tg")}
+        runner._profile_adapters = {}
+        runner._plugin_service_manager = GatewayServiceManager()
+        await runner._start_plugin_gateway_services()
+        await runner._start_plugin_gateway_services()
+        await asyncio.wait_for(started.wait(), timeout=2)
+        assert count == 1 and set(captured) == {"telegram"} and calls
+        await runner._plugin_service_manager.stop_services()
+
+    @pytest.mark.asyncio
+    async def test_reconnect_launches_if_not_yet_started(self, monkeypatch):
+        from gateway import run as gateway_run
+        from gateway.config import Platform
+
+        started, count = asyncio.Event(), 0
+
+        async def svc(ctx):
+            nonlocal count
+            count += 1
+            started.set()
+            await asyncio.Event().wait()
+
+        reg = _make_registration(service=svc)
+
+        class FakePM:
+            def get_gateway_services(self):
+                return (reg,)
+
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: FakePM())
+        runner = object.__new__(gateway_run.GatewayRunner)
+        runner.adapters = {}
+        runner._profile_adapters = {}
+        runner._plugin_service_manager = GatewayServiceManager()
+
+        await runner._start_plugin_gateway_services()
+        assert count == 0
+
+        runner.adapters = {Platform.TELEGRAM: MagicMock(name="tg")}
+        await runner._start_plugin_gateway_services()
+        await asyncio.wait_for(started.wait(), timeout=2)
+        assert count == 1
+        await runner._plugin_service_manager.stop_services()
+
+    @pytest.mark.asyncio
+    async def test_second_reconnect_does_not_duplicate(self, monkeypatch):
+        from gateway import run as gateway_run
+        from gateway.config import Platform
+
+        count = 0
+        started = asyncio.Event()
+
+        async def svc(ctx):
+            nonlocal count
+            count += 1
+            started.set()
+            await asyncio.Event().wait()
+
+        reg = _make_registration(service=svc)
+
+        class FakePM:
+            def get_gateway_services(self):
+                return (reg,)
+
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: FakePM())
+        runner = object.__new__(gateway_run.GatewayRunner)
+        runner.adapters = {Platform.TELEGRAM: MagicMock(name="tg")}
+        runner._profile_adapters = {}
+        runner._plugin_service_manager = GatewayServiceManager()
+
+        await runner._start_plugin_gateway_services()
+        await asyncio.wait_for(started.wait(), timeout=2)
+        assert count == 1
+        await runner._start_plugin_gateway_services()
+        assert count == 1
+        await runner._plugin_service_manager.stop_services()
+
+    @pytest.mark.asyncio
+    async def test_secondary_profile_adapters_in_snapshot(self, monkeypatch):
+        from gateway import run as gateway_run
+        from gateway.config import Platform
+
+        captured, started = {}, asyncio.Event()
+
+        async def svc(ctx):
+            captured.update(dict(ctx.adapters))
+            started.set()
+            await asyncio.Event().wait()
+
+        reg = _make_registration(service=svc)
+
+        class FakePM:
+            def get_gateway_services(self):
+                return (reg,)
+
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: FakePM())
+        tg = MagicMock(name="tg")
+        sec = MagicMock(name="sec_discord")
+        runner = object.__new__(gateway_run.GatewayRunner)
+        runner.adapters = {Platform.TELEGRAM: tg}
+        runner._profile_adapters = {"work": {Platform.DISCORD: sec}}
+        runner._plugin_service_manager = GatewayServiceManager()
+
+        await runner._start_plugin_gateway_services()
+        await asyncio.wait_for(started.wait(), timeout=2)
+        assert captured.get("telegram") is tg
+        assert captured.get("work/discord") is sec
+        await runner._plugin_service_manager.stop_services()
+
+
+class TestNoManagerStopCompatibility:
+    """Borrowed/fake runners without ``_plugin_service_manager`` must
+    survive ``GatewayRunner.stop()`` without ``AttributeError``."""
+
+    @pytest.mark.asyncio
+    async def test_stop_safe_without_manager(self):
+        """A bare runner created via ``object.__new__`` that inherits the
+        class-level ``_plugin_service_manager = None`` default reaches the
+        stop line and the ``getattr`` fallback prevents ``AttributeError``."""
+        from gateway import run as gateway_run
+
+        runner = object.__new__(gateway_run.GatewayRunner)
+        runner._running = False
+        runner._draining = False
+        runner._restart_requested = False
+        runner._restart_detached = False
+        runner._restart_via_service = False
+        runner._stop_task = None
+        runner._exit_cleanly = False
+        runner._exit_with_failure = False
+        runner._exit_reason = None
+        runner._exit_code = None
+        runner._restart_drain_timeout = 0.01
+        runner._running_agents = {}
+        runner._running_agents_ts = {}
+        runner.adapters = {}
+        runner._background_tasks = set()
+        runner._failed_platforms = {}
+        runner._shutdown_event = asyncio.Event()
+        runner._pending_messages = {}
+        runner._pending_approvals = {}
+        runner._busy_ack_ts = {}
+
+        async def _noop(*args, **kwargs):
+            pass
+
+        runner._running_agent_count = lambda: 0
+        runner._active_cron_job_count = lambda: 0
+        runner._update_runtime_status = lambda *a, **k: None
+        runner._notify_active_sessions_of_shutdown = _noop
+
+        async def _drain_noop(timeout):
+            return {}, False
+
+        runner._drain_active_agents = _drain_noop
+        runner._finalize_shutdown_agents = _noop
+
+        await gateway_run.GatewayRunner.stop(runner)

--- a/tests/gateway/test_plugin_gateway_runner_integration.py
+++ b/tests/gateway/test_plugin_gateway_runner_integration.py
@@ -1,9 +1,10 @@
 """Runner integration tests for plugin gateway-service lifecycle.
 
 Exercises ``GatewayRunner._start_plugin_gateway_services`` directly:
-public API retrieval, string-keyed adapter snapshot (primary + secondary
-profile), exactly-once across reconnect, and sync-callback rejection at
-registration time. No network; coordination via asyncio Events/wait_for.
+public API retrieval, reconnect-aware adapter resolver (primary +
+secondary profile), exactly-once across reconnect, and sync-callback
+rejection at registration time. No network; coordination via asyncio
+Events/wait_for.
 """
 
 import asyncio
@@ -31,7 +32,7 @@ def _make_registration(name: str = "svc", *, service=None) -> GatewayServiceRegi
 
 
 class TestGatewayRunnerIntegration:
-    """Runner helper: public API, string-keyed snapshot, exactly-once."""
+    """Runner helper: public API, reconnect-aware resolver, exactly-once."""
 
     @pytest.mark.asyncio
     async def test_runner_uses_public_api_string_keys_once(self, monkeypatch):
@@ -59,7 +60,9 @@ class TestGatewayRunnerIntegration:
         runner = object.__new__(gateway_run.GatewayRunner)
         runner.adapters = {Platform.TELEGRAM: MagicMock(name="tg")}
         runner._profile_adapters = {}
-        runner._plugin_service_manager = GatewayServiceManager()
+        runner._plugin_service_manager = GatewayServiceManager(
+            runner._plugin_service_adapters
+        )
         await runner._start_plugin_gateway_services()
         await runner._start_plugin_gateway_services()
         await asyncio.wait_for(started.wait(), timeout=2)
@@ -89,7 +92,9 @@ class TestGatewayRunnerIntegration:
         runner = object.__new__(gateway_run.GatewayRunner)
         runner.adapters = {}
         runner._profile_adapters = {}
-        runner._plugin_service_manager = GatewayServiceManager()
+        runner._plugin_service_manager = GatewayServiceManager(
+            runner._plugin_service_adapters
+        )
 
         await runner._start_plugin_gateway_services()
         assert count == 0
@@ -124,7 +129,9 @@ class TestGatewayRunnerIntegration:
         runner = object.__new__(gateway_run.GatewayRunner)
         runner.adapters = {Platform.TELEGRAM: MagicMock(name="tg")}
         runner._profile_adapters = {}
-        runner._plugin_service_manager = GatewayServiceManager()
+        runner._plugin_service_manager = GatewayServiceManager(
+            runner._plugin_service_adapters
+        )
 
         await runner._start_plugin_gateway_services()
         await asyncio.wait_for(started.wait(), timeout=2)
@@ -157,12 +164,126 @@ class TestGatewayRunnerIntegration:
         runner = object.__new__(gateway_run.GatewayRunner)
         runner.adapters = {Platform.TELEGRAM: tg}
         runner._profile_adapters = {"work": {Platform.DISCORD: sec}}
-        runner._plugin_service_manager = GatewayServiceManager()
+        runner._plugin_service_manager = GatewayServiceManager(
+            runner._plugin_service_adapters
+        )
 
         await runner._start_plugin_gateway_services()
         await asyncio.wait_for(started.wait(), timeout=2)
         assert captured.get("telegram") is tg
         assert captured.get("work/discord") is sec
+        await runner._plugin_service_manager.stop_services()
+
+
+class TestGatewayRunnerReconnectAwareResolver:
+    """Reconnect-driven adapter changes become visible to already-running
+    services through the runner-provided resolver, without launching a
+    duplicate service."""
+
+    @pytest.mark.asyncio
+    async def test_running_service_sees_reconnect_change_and_stays_once(
+        self, monkeypatch
+    ):
+        """A currently-running service observes a reconnect-driven adapter
+        addition on a fresh .adapters access WHILE STILL RUNNING (before
+        any shutdown signal), invocation count stays at one, and the
+        task set does not change across reconnect."""
+        from gateway import run as gateway_run
+        from gateway.config import Platform
+
+        started = asyncio.Event()
+        read_now = asyncio.Event()
+        read_done = asyncio.Event()
+        observed = []
+        invocations = [0]
+
+        async def svc(ctx):
+            invocations[0] += 1
+            started.set()
+            observed.append(set(ctx.adapters.keys()))
+            await read_now.wait()
+            observed.append(set(ctx.adapters.keys()))
+            read_done.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                raise
+
+        reg = _make_registration(service=svc)
+
+        class FakePM:
+            def get_gateway_services(self):
+                return (reg,)
+
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: FakePM())
+        runner = object.__new__(gateway_run.GatewayRunner)
+        runner.adapters = {Platform.TELEGRAM: MagicMock(name="tg")}
+        runner._profile_adapters = {}
+        runner._plugin_service_manager = GatewayServiceManager(
+            runner._plugin_service_adapters
+        )
+
+        await runner._start_plugin_gateway_services()
+        await asyncio.wait_for(started.wait(), timeout=2)
+        assert observed == [{"telegram"}]
+        assert invocations[0] == 1
+        initial_tasks = list(runner._plugin_service_manager.tasks)
+
+        # Simulate reconnect: a new primary adapter appears, then the
+        # reconnect path re-invokes the start helper.
+        runner.adapters[Platform.DISCORD] = MagicMock(name="dc")
+        await runner._start_plugin_gateway_services()
+
+        # The running service observes the new adapter before shutdown.
+        read_now.set()
+        await asyncio.wait_for(read_done.wait(), timeout=2)
+        assert observed[-1] == {"telegram", "discord"}
+        assert invocations[0] == 1
+        assert runner._plugin_service_manager.tasks == initial_tasks
+
+        await runner._plugin_service_manager.stop_services()
+
+    @pytest.mark.asyncio
+    async def test_reconnect_does_not_launch_duplicate(self, monkeypatch):
+        from gateway import run as gateway_run
+        from gateway.config import Platform
+
+        count = 0
+        started = asyncio.Event()
+
+        async def svc(ctx):
+            nonlocal count
+            count += 1
+            started.set()
+            await asyncio.Event().wait()
+
+        reg = _make_registration(service=svc)
+
+        class FakePM:
+            def get_gateway_services(self):
+                return (reg,)
+
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: FakePM())
+        runner = object.__new__(gateway_run.GatewayRunner)
+        runner.adapters = {Platform.TELEGRAM: MagicMock(name="tg")}
+        runner._profile_adapters = {}
+        runner._plugin_service_manager = GatewayServiceManager(
+            runner._plugin_service_adapters
+        )
+
+        await runner._start_plugin_gateway_services()
+        await asyncio.wait_for(started.wait(), timeout=2)
+        assert count == 1
+        initial_tasks = runner._plugin_service_manager.tasks
+
+        # Reconnect: adapter set changes; helper is called again.
+        runner.adapters[Platform.DISCORD] = MagicMock(name="dc")
+        runner._profile_adapters["work"] = {Platform.SLACK: MagicMock(name="slk")}
+        await runner._start_plugin_gateway_services()
+
+        # Same task set — no duplicate launch.
+        assert count == 1
+        assert runner._plugin_service_manager.tasks == initial_tasks
         await runner._plugin_service_manager.stop_services()
 
 

--- a/tests/gateway/test_plugin_gateway_services.py
+++ b/tests/gateway/test_plugin_gateway_services.py
@@ -40,24 +40,66 @@ def _make_registration(
     )
 
 
+def _resolver(adapters):
+    """Build a resolver closure over the given adapters mapping.
+
+    Tests pass either a static dict or one they mutate to simulate
+    reconnect-driven adapter changes.
+    """
+    return lambda: adapters
+
+
+def _attach_drained_signal(tasks):
+    """Attach a done-callback that signals when every task has finished.
+
+    Callbacks fire in registration order; registering after the
+    manager's own overdue callback means our signal fires after the
+    manager has cleaned up its overdue/registration tracking.
+    """
+    signal = asyncio.Event()
+    remaining = [len(tasks)]
+
+    def _cb(_task):
+        remaining[0] -= 1
+        if remaining[0] <= 0:
+            signal.set()
+
+    for task in tasks:
+        task.add_done_callback(_cb)
+    return signal
+
+
 class TestGatewayServiceContext:
-    """Context exposes a read-only adapter snapshot, not the runner."""
+    """Context exposes a fresh read-only adapter view, not the runner."""
 
-    def test_adapters_read_only_snapshot(self):
+    def test_adapters_read_only_view(self):
         tg = MagicMock(name="tg")
-        ctx = GatewayServiceContext({"telegram": tg})
-        assert isinstance(ctx.adapters, MappingProxyType)
-        assert set(ctx.adapters.keys()) == {"telegram"}
-        assert ctx.adapters["telegram"] is tg
+        ctx = GatewayServiceContext(_resolver({"telegram": tg}))
+        view = ctx.adapters
+        assert isinstance(view, MappingProxyType)
+        assert set(view.keys()) == {"telegram"}
+        assert view["telegram"] is tg
 
-    def test_adapters_is_decoupled_from_source(self):
-        source = {"telegram": MagicMock()}
-        ctx = GatewayServiceContext(source)
-        source["discord"] = MagicMock()
-        assert "discord" not in ctx.adapters
+    def test_held_snapshot_is_decoupled_from_later_mutation(self):
+        """A held adapters reference is stable; later resolver changes
+        are visible only on a new access, never on the held snapshot."""
+        primary = {"telegram": MagicMock()}
+        ctx = GatewayServiceContext(_resolver(primary))
+        held = ctx.adapters
+        primary["discord"] = MagicMock()
+        assert "discord" not in held
+        assert "discord" in ctx.adapters
+
+    def test_adapters_reflects_resolver_changes_across_accesses(self):
+        """Reconnect-aware: each access reflects current resolver state."""
+        primary = {"telegram": MagicMock(name="tg")}
+        ctx = GatewayServiceContext(_resolver(primary))
+        assert set(ctx.adapters.keys()) == {"telegram"}
+        primary["discord"] = MagicMock(name="dc")
+        assert set(ctx.adapters.keys()) == {"telegram", "discord"}
 
     def test_context_does_not_expose_runner(self):
-        ctx = GatewayServiceContext({})
+        ctx = GatewayServiceContext(_resolver({}))
         assert not hasattr(ctx, "runner")
         assert not hasattr(ctx, "_runner")
 
@@ -66,16 +108,20 @@ class TestGatewayServiceManagerNoOp:
     """Manager is a no-op with no registrations or no adapters."""
 
     @pytest.mark.asyncio
-    async def test_noop_no_registrations_or_adapters(self):
-        mgr = GatewayServiceManager()
-        await mgr.start_services([], {"telegram": MagicMock()})
+    async def test_noop_no_registrations(self):
+        mgr = GatewayServiceManager(_resolver({"telegram": MagicMock()}))
+        await mgr.start_services([])
         assert not mgr.started and not mgr.tasks
-        await mgr.start_services([_make_registration()], {})
+
+    @pytest.mark.asyncio
+    async def test_noop_no_adapters(self):
+        mgr = GatewayServiceManager(_resolver({}))
+        await mgr.start_services([_make_registration()])
         assert not mgr.started and not mgr.tasks
 
     @pytest.mark.asyncio
     async def test_stop_noop_with_no_tasks(self):
-        mgr = GatewayServiceManager()
+        mgr = GatewayServiceManager(_resolver({}))
         await mgr.stop_services()
 
     @pytest.mark.asyncio
@@ -83,19 +129,20 @@ class TestGatewayServiceManagerNoOp:
         """A no-op call (no registrations) must not mark started; a later
         real call launches services exactly once."""
         started = asyncio.Event()
+        adapters = {"telegram": MagicMock()}
 
         async def svc(ctx):
             started.set()
             await asyncio.Event().wait()
 
         reg = _make_registration(service=svc)
-        mgr = GatewayServiceManager()
-        await mgr.start_services([], {"telegram": MagicMock()})
+        mgr = GatewayServiceManager(_resolver(adapters))
+        await mgr.start_services([])
         assert not mgr.started
-        await mgr.start_services([reg], {"telegram": MagicMock()})
+        await mgr.start_services([reg])
         assert mgr.started
         await asyncio.wait_for(started.wait(), timeout=2)
-        await mgr.start_services([reg], {"telegram": MagicMock()})
+        await mgr.start_services([reg])
         assert len(mgr.tasks) == 1
         await mgr.stop_services()
 
@@ -111,8 +158,8 @@ class TestGatewayServiceManagerLifecycle:
             started.set()
 
         reg = _make_registration(service=svc)
-        mgr = GatewayServiceManager()
-        await mgr.start_services([reg], {"telegram": MagicMock()})
+        mgr = GatewayServiceManager(_resolver({"telegram": MagicMock()}))
+        await mgr.start_services([reg])
         await asyncio.wait_for(started.wait(), timeout=2)
         await mgr.stop_services()
 
@@ -127,8 +174,8 @@ class TestGatewayServiceManagerLifecycle:
 
         adapter = MagicMock(name="my_adapter")
         reg = _make_registration(service=svc)
-        mgr = GatewayServiceManager()
-        await mgr.start_services([reg], {"telegram": adapter})
+        mgr = GatewayServiceManager(_resolver({"telegram": adapter}))
+        await mgr.start_services([reg])
         await asyncio.wait_for(seen.wait(), timeout=2)
         await mgr.stop_services()
         assert captured.get("adapters") == {"telegram": adapter}
@@ -136,30 +183,36 @@ class TestGatewayServiceManagerLifecycle:
     @pytest.mark.asyncio
     async def test_exactly_once_repeated_start(self):
         call_count = 0
+        entered = asyncio.Event()
 
         async def svc(ctx):
             nonlocal call_count
             call_count += 1
+            entered.set()
             await asyncio.Event().wait()
 
         reg = _make_registration(service=svc)
-        mgr = GatewayServiceManager()
-        await mgr.start_services([reg], {"telegram": MagicMock()})
-        await asyncio.sleep(0.01)
+        mgr = GatewayServiceManager(_resolver({"telegram": MagicMock()}))
+        await mgr.start_services([reg])
+        await asyncio.wait_for(entered.wait(), timeout=2)
         first_tasks = mgr.tasks
-        await mgr.start_services([reg], {"telegram": MagicMock()})
+        await mgr.start_services([reg])
         assert mgr.tasks == first_tasks
         assert call_count == 1
         await mgr.stop_services()
 
     @pytest.mark.asyncio
     async def test_strong_retention(self):
+        entered = asyncio.Event()
+
         async def svc(ctx):
+            entered.set()
             await asyncio.Event().wait()
 
         reg = _make_registration(service=svc)
-        mgr = GatewayServiceManager()
-        await mgr.start_services([reg], {"telegram": MagicMock()})
+        mgr = GatewayServiceManager(_resolver({"telegram": MagicMock()}))
+        await mgr.start_services([reg])
+        await asyncio.wait_for(entered.wait(), timeout=2)
         task_count = len(mgr.tasks)
         assert task_count == 1
         gc.collect()
@@ -181,12 +234,15 @@ class TestGatewayServiceManagerLifecycle:
                 raise
 
         reg = _make_registration(service=svc)
-        mgr = GatewayServiceManager()
-        await mgr.start_services([reg], {"telegram": MagicMock()})
+        mgr = GatewayServiceManager(_resolver({"telegram": MagicMock()}))
+        await mgr.start_services([reg])
         await asyncio.wait_for(service_started.wait(), timeout=2)
         await mgr.stop_services()
         assert cancel_seen.is_set()
         assert len(mgr.tasks) == 0
+        assert len(mgr.overdue_tasks) == 0
+        # Provenance ownership is released for normally cancelled tasks.
+        assert not mgr._registrations
 
 
 class TestGatewayServiceFailureIsolation:
@@ -203,14 +259,13 @@ class TestGatewayServiceFailureIsolation:
             healthy_started.set()
             await asyncio.Event().wait()
 
-        mgr = GatewayServiceManager()
+        mgr = GatewayServiceManager(_resolver({"telegram": MagicMock()}))
         with caplog.at_level(logging.ERROR, logger="gateway.plugin_services"):
             await mgr.start_services(
                 [
                     _make_registration(name="failing", service=failing),
                     _make_registration(name="healthy", service=healthy),
                 ],
-                {"telegram": MagicMock()},
             )
             await asyncio.wait_for(healthy_started.wait(), timeout=2)
         await mgr.stop_services()
@@ -222,16 +277,20 @@ class TestGatewayServiceFailureIsolation:
 
     @pytest.mark.asyncio
     async def test_runtime_failure_isolated_and_logged(self, caplog):
+        entered = asyncio.Event()
+
         async def svc(ctx):
+            entered.set()
             raise RuntimeError("runtime boom")
 
-        mgr = GatewayServiceManager()
+        mgr = GatewayServiceManager(_resolver({"telegram": MagicMock()}))
         with caplog.at_level(logging.ERROR, logger="gateway.plugin_services"):
             await mgr.start_services(
                 [_make_registration(name="boom", service=svc)],
-                {"telegram": MagicMock()},
             )
-            await asyncio.sleep(0.1)
+            # Service sets `entered` synchronously before raising; by the
+            # time we observe it, _run_service has caught and logged.
+            await asyncio.wait_for(entered.wait(), timeout=2)
         await mgr.stop_services()
         assert any(
             "unhandled exception" in r.getMessage()
@@ -244,7 +303,10 @@ class TestGatewayServiceFailureIsolation:
 
     @pytest.mark.asyncio
     async def test_startup_failure_logged_with_provenance(self, caplog):
+        entered = asyncio.Event()
+
         async def failing_svc(ctx):
+            entered.set()
             raise RuntimeError("oops")
 
         reg = _make_registration(
@@ -253,11 +315,221 @@ class TestGatewayServiceFailureIsolation:
             source="entrypoint",
             service=failing_svc,
         )
-        mgr = GatewayServiceManager()
+        mgr = GatewayServiceManager(_resolver({"telegram": MagicMock()}))
         with caplog.at_level(logging.ERROR, logger="gateway.plugin_services"):
-            await mgr.start_services([reg], {"telegram": MagicMock()})
-            await asyncio.sleep(0.1)
+            await mgr.start_services([reg])
+            await asyncio.wait_for(entered.wait(), timeout=2)
         await mgr.stop_services()
         msgs = [r.getMessage() for r in caplog.records]
         assert any("prov_svc" in m for m in msgs)
         assert any("my_plugin" in m for m in msgs)
+
+
+class TestGatewayServiceManagerBoundedShutdown:
+    """stop_services returns within the host timeout even when a service
+    suppresses cancellation; overdue tasks are detached, retained for
+    observation, and logged with provenance when they complete."""
+
+    @pytest.mark.asyncio
+    async def test_suppress_cancellation_detaches_overdue(
+        self, monkeypatch, caplog
+    ):
+        """Service that swallows CancelledError cannot block shutdown:
+        after the timeout it is detached, retained, and provenance-warned."""
+        import gateway.plugin_services as ps
+
+        monkeypatch.setattr(ps, "_SHUTDOWN_TIMEOUT_SECS", 0.05)
+
+        started = asyncio.Event()
+        suppress_seen = asyncio.Event()
+
+        async def suppressing(ctx):
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                suppress_seen.set()
+                await asyncio.Event().wait()
+
+        reg = _make_registration(
+            name="stuck",
+            plugin_name="overdue_plugin",
+            source="user",
+            service=suppressing,
+        )
+        mgr = ps.GatewayServiceManager(_resolver({"telegram": MagicMock()}))
+        await mgr.start_services([reg])
+        await asyncio.wait_for(started.wait(), timeout=2)
+
+        with caplog.at_level(logging.WARNING, logger="gateway.plugin_services"):
+            await mgr.stop_services()
+
+        assert suppress_seen.is_set()
+        assert not mgr.tasks
+        assert len(mgr.overdue_tasks) == 1
+        warnings = [
+            r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING
+        ]
+        assert any("stuck" in m and "did not stop" in m for m in warnings)
+        assert any("overdue_plugin" in m for m in warnings)
+
+        # Cleanup: register a drain signal AFTER the manager's overdue
+        # callback so our signal fires once the manager has cleaned up,
+        # then force the overdue task to a terminal state.
+        overdue_snapshot = list(mgr.overdue_tasks)
+        drained = _attach_drained_signal(overdue_snapshot)
+        for task in overdue_snapshot:
+            task.cancel()
+        await asyncio.wait_for(drained.wait(), timeout=2)
+        assert not mgr.overdue_tasks
+        assert not mgr._registrations
+
+    @pytest.mark.asyncio
+    async def test_overdue_failure_logged_via_done_callback(
+        self, monkeypatch, caplog
+    ):
+        """An overdue task that eventually raises must have its failure
+        logged with provenance by the done callback, then be cleaned up."""
+        import gateway.plugin_services as ps
+
+        monkeypatch.setattr(ps, "_SHUTDOWN_TIMEOUT_SECS", 0.05)
+
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def suppressing_then_fail(ctx):
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                pass
+            await release.wait()
+            raise RuntimeError("eventual overdue failure")
+
+        reg = _make_registration(
+            name="late_boom",
+            plugin_name="late_plugin",
+            source="user",
+            service=suppressing_then_fail,
+        )
+        mgr = ps.GatewayServiceManager(_resolver({"telegram": MagicMock()}))
+        await mgr.start_services([reg])
+        await asyncio.wait_for(started.wait(), timeout=2)
+
+        with caplog.at_level(logging.WARNING, logger="gateway.plugin_services"):
+            await mgr.stop_services()
+        assert len(mgr.overdue_tasks) == 1
+
+        overdue_snapshot = list(mgr.overdue_tasks)
+        drained = _attach_drained_signal(overdue_snapshot)
+        with caplog.at_level(logging.ERROR, logger="gateway.plugin_services"):
+            release.set()
+            await asyncio.wait_for(drained.wait(), timeout=2)
+
+        errors = [
+            r for r in caplog.records
+            if r.levelno >= logging.ERROR and r.exc_info
+        ]
+        assert any(
+            "late_boom" in r.getMessage()
+            and "late_plugin" in r.getMessage()
+            and "eventual overdue failure" in str(r.exc_info[1])
+            for r in errors
+        ), [(r.getMessage(), r.exc_info) for r in errors]
+        assert not mgr.overdue_tasks
+        assert not mgr._registrations
+
+    @pytest.mark.asyncio
+    async def test_overdue_normal_completion_logged_and_cleaned(
+        self, monkeypatch, caplog
+    ):
+        """An overdue task that completes normally is observed and removed."""
+        import gateway.plugin_services as ps
+
+        monkeypatch.setattr(ps, "_SHUTDOWN_TIMEOUT_SECS", 0.05)
+
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def suppressing_then_complete(ctx):
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                pass
+            await release.wait()
+
+        reg = _make_registration(
+            name="late_ok",
+            plugin_name="late_plugin",
+            source="user",
+            service=suppressing_then_complete,
+        )
+        mgr = ps.GatewayServiceManager(_resolver({"telegram": MagicMock()}))
+        await mgr.start_services([reg])
+        await asyncio.wait_for(started.wait(), timeout=2)
+
+        with caplog.at_level(logging.WARNING, logger="gateway.plugin_services"):
+            await mgr.stop_services()
+        assert len(mgr.overdue_tasks) == 1
+
+        overdue_snapshot = list(mgr.overdue_tasks)
+        drained = _attach_drained_signal(overdue_snapshot)
+        with caplog.at_level(logging.INFO, logger="gateway.plugin_services"):
+            release.set()
+            await asyncio.wait_for(drained.wait(), timeout=2)
+
+        assert not mgr.overdue_tasks
+        assert not mgr._registrations
+        assert any(
+            "late_ok" in r.getMessage() and "completed after" in r.getMessage()
+            for r in caplog.records
+        )
+
+
+class TestGatewayServiceReconnectAwareAdapters:
+    """A running service sees reconnect-driven adapter changes through
+    the resolver on each .adapters access, without a service restart."""
+
+    @pytest.mark.asyncio
+    async def test_running_service_observes_reconnect_change(self):
+        """A currently-running service observes a resolver-driven adapter
+        addition on a fresh .adapters access WHILE STILL RUNNING (before
+        any shutdown signal), and is started exactly once."""
+        started = asyncio.Event()
+        read_now = asyncio.Event()
+        read_done = asyncio.Event()
+        release = asyncio.Event()
+        observed = []
+        invocations = [0]
+
+        async def observing_svc(ctx):
+            invocations[0] += 1
+            started.set()
+            observed.append(set(ctx.adapters.keys()))
+            await read_now.wait()
+            observed.append(set(ctx.adapters.keys()))
+            read_done.set()
+            try:
+                await release.wait()
+            except asyncio.CancelledError:
+                raise
+
+        adapters = {"telegram": MagicMock(name="tg")}
+        reg = _make_registration(service=observing_svc)
+        mgr = GatewayServiceManager(_resolver(adapters))
+        await mgr.start_services([reg])
+        await asyncio.wait_for(started.wait(), timeout=2)
+        assert observed == [{"telegram"}]
+        assert invocations[0] == 1
+
+        # Simulate reconnect: a new platform appears.
+        adapters["discord"] = MagicMock(name="dc")
+
+        # Ask the running service to re-read; verify while still running.
+        read_now.set()
+        await asyncio.wait_for(read_done.wait(), timeout=2)
+        assert observed[-1] == {"telegram", "discord"}
+        assert invocations[0] == 1
+
+        await mgr.stop_services()

--- a/tests/gateway/test_plugin_gateway_services.py
+++ b/tests/gateway/test_plugin_gateway_services.py
@@ -1,0 +1,263 @@
+"""Tests for plugin gateway-service lifecycle seam.
+
+These tests exercise ``gateway.plugin_services`` — the host-owned
+lifecycle manager for plugin-registered async gateway services.
+No network access; all coordination uses asyncio Events and wait_for.
+"""
+
+import asyncio
+import gc
+import logging
+from types import MappingProxyType
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.plugin_services import (
+    GatewayServiceContext,
+    GatewayServiceManager,
+    GatewayServiceRegistration,
+)
+
+
+def _make_registration(
+    name: str = "svc",
+    *,
+    plugin_name: str = "test_plugin",
+    plugin_key: str = "test_plugin",
+    source: str = "user",
+    service=None,
+) -> GatewayServiceRegistration:
+    async def _default(ctx: GatewayServiceContext) -> None:
+        pass
+
+    return GatewayServiceRegistration(
+        name=name,
+        service=service or _default,
+        plugin_name=plugin_name,
+        plugin_key=plugin_key,
+        source=source,
+    )
+
+
+class TestGatewayServiceContext:
+    """Context exposes a read-only adapter snapshot, not the runner."""
+
+    def test_adapters_read_only_snapshot(self):
+        tg = MagicMock(name="tg")
+        ctx = GatewayServiceContext({"telegram": tg})
+        assert isinstance(ctx.adapters, MappingProxyType)
+        assert set(ctx.adapters.keys()) == {"telegram"}
+        assert ctx.adapters["telegram"] is tg
+
+    def test_adapters_is_decoupled_from_source(self):
+        source = {"telegram": MagicMock()}
+        ctx = GatewayServiceContext(source)
+        source["discord"] = MagicMock()
+        assert "discord" not in ctx.adapters
+
+    def test_context_does_not_expose_runner(self):
+        ctx = GatewayServiceContext({})
+        assert not hasattr(ctx, "runner")
+        assert not hasattr(ctx, "_runner")
+
+
+class TestGatewayServiceManagerNoOp:
+    """Manager is a no-op with no registrations or no adapters."""
+
+    @pytest.mark.asyncio
+    async def test_noop_no_registrations_or_adapters(self):
+        mgr = GatewayServiceManager()
+        await mgr.start_services([], {"telegram": MagicMock()})
+        assert not mgr.started and not mgr.tasks
+        await mgr.start_services([_make_registration()], {})
+        assert not mgr.started and not mgr.tasks
+
+    @pytest.mark.asyncio
+    async def test_stop_noop_with_no_tasks(self):
+        mgr = GatewayServiceManager()
+        await mgr.stop_services()
+
+    @pytest.mark.asyncio
+    async def test_noop_then_real_start_preserves_exact_once(self):
+        """A no-op call (no registrations) must not mark started; a later
+        real call launches services exactly once."""
+        started = asyncio.Event()
+
+        async def svc(ctx):
+            started.set()
+            await asyncio.Event().wait()
+
+        reg = _make_registration(service=svc)
+        mgr = GatewayServiceManager()
+        await mgr.start_services([], {"telegram": MagicMock()})
+        assert not mgr.started
+        await mgr.start_services([reg], {"telegram": MagicMock()})
+        assert mgr.started
+        await asyncio.wait_for(started.wait(), timeout=2)
+        await mgr.start_services([reg], {"telegram": MagicMock()})
+        assert len(mgr.tasks) == 1
+        await mgr.stop_services()
+
+
+class TestGatewayServiceManagerLifecycle:
+    """Core lifecycle contracts: start, exactly-once, retention, stop."""
+
+    @pytest.mark.asyncio
+    async def test_service_starts_with_connected_adapters(self):
+        started = asyncio.Event()
+
+        async def svc(ctx):
+            started.set()
+
+        reg = _make_registration(service=svc)
+        mgr = GatewayServiceManager()
+        await mgr.start_services([reg], {"telegram": MagicMock()})
+        await asyncio.wait_for(started.wait(), timeout=2)
+        await mgr.stop_services()
+
+    @pytest.mark.asyncio
+    async def test_context_passed_to_service_has_adapters(self):
+        seen = asyncio.Event()
+        captured = {}
+
+        async def svc(ctx):
+            captured["adapters"] = dict(ctx.adapters)
+            seen.set()
+
+        adapter = MagicMock(name="my_adapter")
+        reg = _make_registration(service=svc)
+        mgr = GatewayServiceManager()
+        await mgr.start_services([reg], {"telegram": adapter})
+        await asyncio.wait_for(seen.wait(), timeout=2)
+        await mgr.stop_services()
+        assert captured.get("adapters") == {"telegram": adapter}
+
+    @pytest.mark.asyncio
+    async def test_exactly_once_repeated_start(self):
+        call_count = 0
+
+        async def svc(ctx):
+            nonlocal call_count
+            call_count += 1
+            await asyncio.Event().wait()
+
+        reg = _make_registration(service=svc)
+        mgr = GatewayServiceManager()
+        await mgr.start_services([reg], {"telegram": MagicMock()})
+        await asyncio.sleep(0.01)
+        first_tasks = mgr.tasks
+        await mgr.start_services([reg], {"telegram": MagicMock()})
+        assert mgr.tasks == first_tasks
+        assert call_count == 1
+        await mgr.stop_services()
+
+    @pytest.mark.asyncio
+    async def test_strong_retention(self):
+        async def svc(ctx):
+            await asyncio.Event().wait()
+
+        reg = _make_registration(service=svc)
+        mgr = GatewayServiceManager()
+        await mgr.start_services([reg], {"telegram": MagicMock()})
+        task_count = len(mgr.tasks)
+        assert task_count == 1
+        gc.collect()
+        assert len(mgr.tasks) == task_count
+        assert all(not t.done() for t in mgr.tasks)
+        await mgr.stop_services()
+
+    @pytest.mark.asyncio
+    async def test_cancellation_awaits_before_return(self):
+        cancel_seen = asyncio.Event()
+        service_started = asyncio.Event()
+
+        async def svc(ctx):
+            service_started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                cancel_seen.set()
+                raise
+
+        reg = _make_registration(service=svc)
+        mgr = GatewayServiceManager()
+        await mgr.start_services([reg], {"telegram": MagicMock()})
+        await asyncio.wait_for(service_started.wait(), timeout=2)
+        await mgr.stop_services()
+        assert cancel_seen.is_set()
+        assert len(mgr.tasks) == 0
+
+
+class TestGatewayServiceFailureIsolation:
+    """Startup and runtime failures are isolated and logged per-service."""
+
+    @pytest.mark.asyncio
+    async def test_startup_failure_does_not_block_others(self, caplog):
+        healthy_started = asyncio.Event()
+
+        async def failing(ctx):
+            raise RuntimeError("startup boom")
+
+        async def healthy(ctx):
+            healthy_started.set()
+            await asyncio.Event().wait()
+
+        mgr = GatewayServiceManager()
+        with caplog.at_level(logging.ERROR, logger="gateway.plugin_services"):
+            await mgr.start_services(
+                [
+                    _make_registration(name="failing", service=failing),
+                    _make_registration(name="healthy", service=healthy),
+                ],
+                {"telegram": MagicMock()},
+            )
+            await asyncio.wait_for(healthy_started.wait(), timeout=2)
+        await mgr.stop_services()
+        assert healthy_started.is_set()
+        assert any(
+            r.exc_info and "startup boom" in str(r.exc_info[1])
+            for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_runtime_failure_isolated_and_logged(self, caplog):
+        async def svc(ctx):
+            raise RuntimeError("runtime boom")
+
+        mgr = GatewayServiceManager()
+        with caplog.at_level(logging.ERROR, logger="gateway.plugin_services"):
+            await mgr.start_services(
+                [_make_registration(name="boom", service=svc)],
+                {"telegram": MagicMock()},
+            )
+            await asyncio.sleep(0.1)
+        await mgr.stop_services()
+        assert any(
+            "unhandled exception" in r.getMessage()
+            for r in caplog.records
+        )
+        assert any(
+            r.exc_info and "runtime boom" in str(r.exc_info[1])
+            for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_startup_failure_logged_with_provenance(self, caplog):
+        async def failing_svc(ctx):
+            raise RuntimeError("oops")
+
+        reg = _make_registration(
+            name="prov_svc",
+            plugin_name="my_plugin",
+            source="entrypoint",
+            service=failing_svc,
+        )
+        mgr = GatewayServiceManager()
+        with caplog.at_level(logging.ERROR, logger="gateway.plugin_services"):
+            await mgr.start_services([reg], {"telegram": MagicMock()})
+            await asyncio.sleep(0.1)
+        await mgr.stop_services()
+        msgs = [r.getMessage() for r in caplog.records]
+        assert any("prov_svc" in m for m in msgs)
+        assert any("my_plugin" in m for m in msgs)

--- a/tests/gateway/test_startup_restart_race.py
+++ b/tests/gateway/test_startup_restart_race.py
@@ -6,6 +6,7 @@ import pytest
 import gateway.run as gateway_run
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.plugin_services import GatewayServiceManager
 from gateway.restart import (
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
     GATEWAY_SERVICE_RESTART_EXIT_CODE,
@@ -82,6 +83,7 @@ def make_startup_runner(tmp_path):
     runner._background_tasks = set()
     runner._failed_platforms = {}
     runner._voice_mode = {}
+    runner._plugin_service_manager = GatewayServiceManager()
 
     runner.hooks = MagicMock()
     runner.hooks.loaded_hooks = []

--- a/tests/gateway/test_startup_restart_race.py
+++ b/tests/gateway/test_startup_restart_race.py
@@ -83,7 +83,9 @@ def make_startup_runner(tmp_path):
     runner._background_tasks = set()
     runner._failed_platforms = {}
     runner._voice_mode = {}
-    runner._plugin_service_manager = GatewayServiceManager()
+    runner._plugin_service_manager = GatewayServiceManager(
+        runner._plugin_service_adapters
+    )
 
     runner.hooks = MagicMock()
     runner.hooks.loaded_hooks = []

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -2366,3 +2366,178 @@ class TestDispatchToolWithoutCliRef:
             assert calls[0][1].get("parent_agent") is None
         finally:
             registry.deregister("_test_dispatch_probe")
+
+
+# ── Gateway Service Registration ──────────────────────────────────────────
+
+
+class TestGatewayServiceRegistration:
+    """Tests for plugin gateway-service registration via PluginContext."""
+
+    def test_register_gateway_service_provenance(self):
+        """Registration captures plugin name, key, and source provenance."""
+        mgr = PluginManager()
+        manifest = PluginManifest(
+            name="my_plugin",
+            key="my_plugin_key",
+            source="user",
+        )
+        ctx = PluginContext(manifest, mgr)
+
+        async def my_service(svc_ctx):
+            pass
+
+        ctx.register_gateway_service("myservice", my_service)
+
+        services = mgr.get_gateway_services()
+        assert len(services) == 1
+        reg = services[0]
+        assert reg.name == "myservice"
+        assert reg.plugin_name == "my_plugin"
+        assert reg.plugin_key == "my_plugin_key"
+        assert reg.source == "user"
+        assert reg.service is my_service
+
+    def test_get_gateway_services_returns_immutable_tuple(self):
+        """Public retrieval returns a tuple (immutable snapshot)."""
+        mgr = PluginManager()
+        manifest = PluginManifest(name="p", key="p", source="user")
+        ctx = PluginContext(manifest, mgr)
+
+        async def svc(svc_ctx):
+            pass
+
+        ctx.register_gateway_service("s1", svc)
+        result = mgr.get_gateway_services()
+        assert isinstance(result, tuple)
+        assert len(result) == 1
+
+    def test_gateway_service_via_local_discovery(self, tmp_path, monkeypatch):
+        """A user-installed plugin registering a gateway service is discovered."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "gw_plugin",
+            register_body=(
+                "async def _svc(ctx):\n"
+                "        pass\n"
+                "    ctx.register_gateway_service('discovered_svc', _svc)"
+            ),
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        assert "gw_plugin" in mgr._plugins
+        loaded = mgr._plugins["gw_plugin"]
+        assert loaded.enabled
+        assert "discovered_svc" in loaded.gateway_services_registered
+        services = mgr.get_gateway_services()
+        assert len(services) == 1
+        reg = services[0]
+        assert reg.name == "discovered_svc"
+        assert reg.plugin_name == "gw_plugin"
+        assert reg.source == "user"
+
+    def test_duplicate_gateway_service_name_rejected(self):
+        """Later registration with a duplicate name is rejected; first wins."""
+        mgr = PluginManager()
+
+        async def service_a(svc_ctx):
+            pass
+
+        async def service_b(svc_ctx):
+            pass
+
+        ctx_a = PluginContext(
+            PluginManifest(name="plugin_a", key="plugin_a", source="user"), mgr,
+        )
+        ctx_a.register_gateway_service("shared_name", service_a)
+
+        ctx_b = PluginContext(
+            PluginManifest(name="plugin_b", key="plugin_b", source="user"), mgr,
+        )
+        ctx_b.register_gateway_service("shared_name", service_b)
+
+        services = mgr.get_gateway_services()
+        assert len(services) == 1
+        reg = services[0]
+        assert reg.service is service_a
+        assert reg.plugin_name == "plugin_a"
+
+    def test_gateway_services_cleared_on_force_rediscovery(
+        self, tmp_path, monkeypatch,
+    ):
+        """Force rediscovery clears the gateway services registry."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "temp_plugin",
+            register_body=(
+                "async def _svc(ctx):\n"
+                "        pass\n"
+                "    ctx.register_gateway_service('temp_svc', _svc)"
+            ),
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+        assert len(mgr.get_gateway_services()) == 1
+
+        import shutil
+        shutil.rmtree(plugins_dir / "temp_plugin")
+
+        mgr.discover_and_load(force=True)
+        assert len(mgr.get_gateway_services()) == 0
+
+    def test_entrypoint_provenance(self):
+        """Entrypoint-sourced plugins carry source='entrypoint' provenance."""
+        mgr = PluginManager()
+        manifest = PluginManifest(
+            name="pip_plugin",
+            key="pip_plugin",
+            source="entrypoint",
+        )
+        ctx = PluginContext(manifest, mgr)
+
+        async def svc(svc_ctx):
+            pass
+
+        ctx.register_gateway_service("pip_svc", svc)
+        assert mgr.get_gateway_services()[0].source == "entrypoint"
+
+    def test_sync_callback_rejected_at_registration(self):
+        """Synchronous callables are rejected before any side effect."""
+        mgr = PluginManager()
+        ctx = PluginContext(
+            PluginManifest(name="p", key="p", source="user"), mgr,
+        )
+
+        def sync_svc(svc_ctx):
+            return "not async"
+
+        register_service = getattr(ctx, "register_gateway_service")
+        with pytest.raises(TypeError, match="async"):
+            register_service("bad", sync_svc)
+        assert len(mgr.get_gateway_services()) == 0
+
+    def test_async_callable_instance_accepted(self):
+        """An instance with ``async def __call__`` is a valid service."""
+        mgr = PluginManager()
+        ctx = PluginContext(
+            PluginManifest(name="p", key="p", source="user"), mgr,
+        )
+
+        class CallableService:
+            async def __call__(self, svc_ctx):
+                return None
+
+        instance = CallableService()
+        ctx.register_gateway_service("instance-svc", instance)
+
+        services = mgr.get_gateway_services()
+        assert len(services) == 1
+        assert services[0].name == "instance-svc"
+        assert services[0].service is instance

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -274,6 +274,7 @@ def register(ctx):
 - `ctx.register_hook()` subscribes to lifecycle events
 - `ctx.register_cli_command()` registers a CLI subcommand (e.g. `hermes my-plugin <subcommand>`)
 - `ctx.register_command()` registers an in-session slash command (e.g. `/myplugin <args>` inside CLI / gateway chat) — see [Register slash commands](#register-slash-commands) below
+- `ctx.register_gateway_service(name, async_service)` registers an async service that runs alongside the gateway, with a read-only view of connected adapters — see [Register a gateway service](#register-a-gateway-service) below
 - `ctx.dispatch_tool(name, arguments)` — call any other tool (built-in or from another plugin) with the parent agent's context (approvals, credentials, task_id) wired up automatically. Useful from slash-command handlers that need to invoke `terminal`, `read_file`, or any other tool as if the model had called it directly.
 - If this function crashes, the plugin is disabled but Hermes continues fine
 
@@ -908,6 +909,50 @@ def register(ctx):
 - For multi-workspace deployments the handler fires for clicks from any connected workspace; use `body["team"]["id"]` if you need to scope behaviour.
 
 This is the public way for plugins to participate in Slack interactivity. Older plugins may patch `SlackAdapter.connect`; prefer this API instead.
+
+### Register a gateway service
+
+Plugins can register an async service that runs alongside the gateway. The service receives a read-only snapshot of successfully connected platform adapters and can interact with them directly.
+
+```python
+"""Plugin that logs the gateway's connected adapters at startup."""
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+async def log_connected_adapters(context):
+    """Log platform adapters connected at startup, then wait until cancelled."""
+    names = ", ".join(context.adapters.keys())
+    logger.info("Gateway service started; connected adapters: %s", names)
+    # Adapters is a static snapshot — see lifecycle below.
+    # Wait until shutdown cancels this task.
+    await asyncio.Event().wait()
+
+
+def register(ctx):
+    ctx.register_gateway_service(
+        "adapter-logger",
+        log_connected_adapters,
+    )
+```
+
+**Signature:** `ctx.register_gateway_service(name: str, service: Callable[..., Awaitable[None]]) -> None`
+
+**Lifecycle guarantees:**
+
+| Guarantee | Detail |
+|-----------|--------|
+| **Start timing** | The service is launched after all platform adapters have connected and the gateway runner has set its internal running flag. |
+| **Context** | The service receives a `GatewayServiceContext` whose `.adapters` property is a read-only mapping of connected platform adapters keyed by name. The context never exposes the gateway runner or any mutable runner state. |
+| **Run once** | Each service is started at most once per runner lifecycle. Reconnect events (disconnect + reconnect) do NOT restart the service. |
+| **Failure isolation** | Startup and runtime exceptions are logged with plugin provenance and do not prevent other services from starting or the gateway from continuing. |
+| **Shutdown** | On gateway stop, every running service task is cancelled and awaited before adapters disconnect. |
+| **Duplicate rejection** | If two plugins register a service with the same `name`, the second registration is rejected with a log warning and the original keeps running. |
+
+A plugin **cannot** use a gateway service to manipulate the runner, agent tools, system prompt, config, sessions, or the plugin registry. The service has access only to the adapter snapshot provided by the gateway.
 
 :::tip
 This guide covers **general plugins** (tools, hooks, slash commands, CLI commands). The sections below sketch the authoring pattern for each specialized plugin type; each links to its full guide for field reference and examples.

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -912,7 +912,7 @@ This is the public way for plugins to participate in Slack interactivity. Older 
 
 ### Register a gateway service
 
-Plugins can register an async service that runs alongside the gateway. The service receives a read-only snapshot of successfully connected platform adapters and can interact with them directly.
+Plugins can register an async service that runs alongside the gateway. The service receives a live, read-only view of successfully connected platform adapters and can interact with them directly.
 
 ```python
 """Plugin that logs the gateway's connected adapters at startup."""
@@ -927,7 +927,7 @@ async def log_connected_adapters(context):
     """Log platform adapters connected at startup, then wait until cancelled."""
     names = ", ".join(context.adapters.keys())
     logger.info("Gateway service started; connected adapters: %s", names)
-    # Adapters is a static snapshot — see lifecycle below.
+    # Adapters is a live read-only view — see lifecycle below.
     # Wait until shutdown cancels this task.
     await asyncio.Event().wait()
 
@@ -946,13 +946,13 @@ def register(ctx):
 | Guarantee | Detail |
 |-----------|--------|
 | **Start timing** | The service is launched after all platform adapters have connected and the gateway runner has set its internal running flag. |
-| **Context** | The service receives a `GatewayServiceContext` whose `.adapters` property is a read-only mapping of connected platform adapters keyed by name. The context never exposes the gateway runner or any mutable runner state. |
-| **Run once** | Each service is started at most once per runner lifecycle. Reconnect events (disconnect + reconnect) do NOT restart the service. |
+| **Context** | The service receives a `GatewayServiceContext` whose `.adapters` property returns a fresh read-only mapping of currently connected platform adapters keyed by name. Each access reflects the live adapter set — including adapters added by a later reconnect — without ever exposing the gateway runner or any mutable runner state. A held reference stays stable; only a new access sees the new state. |
+| **Run once** | Each service is started at most once per runner lifecycle. Reconnect events (disconnect + reconnect) do NOT restart the service; reconnect-driven adapter changes become visible through the next `.adapters` access. |
 | **Failure isolation** | Startup and runtime exceptions are logged with plugin provenance and do not prevent other services from starting or the gateway from continuing. |
-| **Shutdown** | On gateway stop, every running service task is cancelled and awaited before adapters disconnect. |
+| **Shutdown** | On gateway stop, every running service task is cancelled and awaited before adapters disconnect. A service that suppresses cancellation is detached after a host-owned bounded timeout so it cannot block shutdown; its eventual completion (or failure) is observed and logged with provenance. |
 | **Duplicate rejection** | If two plugins register a service with the same `name`, the second registration is rejected with a log warning and the original keeps running. |
 
-A plugin **cannot** use a gateway service to manipulate the runner, agent tools, system prompt, config, sessions, or the plugin registry. The service has access only to the adapter snapshot provided by the gateway.
+A plugin **cannot** use a gateway service to manipulate the runner, agent tools, system prompt, config, sessions, or the plugin registry. The service has access only to the live read-only adapter view provided by the gateway.
 
 :::tip
 This guide covers **general plugins** (tools, hooks, slash commands, CLI commands). The sections below sketch the authoring pattern for each specialized plugin type; each links to its full guide for field reference and examples.

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -102,6 +102,7 @@ Every `ctx.*` API below is available inside a plugin's `register(ctx)` function.
 | Add slash commands | `ctx.register_command(name, handler, description)` — adds `/name` in CLI and gateway sessions |
 | Dispatch tools from commands | `ctx.dispatch_tool(name, args)` — invokes a registered tool with parent-agent context auto-wired |
 | Add CLI commands | `ctx.register_cli_command(name, help, setup_fn, handler_fn)` — adds `hermes <plugin> <subcommand>` |
+| Register a gateway service | `ctx.register_gateway_service(name, async_service)` — starts an async service after adapters connect, with a read-only adapter snapshot. See [Register a gateway service](/developer-guide/plugins#register-a-gateway-service) |
 | Inject messages | `ctx.inject_message(content, role="user")` — see [Injecting Messages](#injecting-messages) |
 | Ship data files | `Path(__file__).parent / "data" / "file.yaml"` |
 | Bundle skills | `ctx.register_skill(name, path)` — namespaced as `plugin:skill`, loaded via `skill_view("plugin:skill")` |
@@ -225,6 +226,7 @@ The table above shows the four plugin categories, but within "General plugins" t
 | A **lifecycle hook** (pre/post LLM, session start/end, tool filter) | Python plugin — `ctx.register_hook()` | [Hooks reference](/user-guide/features/hooks) · [Build a Hermes Plugin](/developer-guide/plugins) |
 | A **slash command** for the CLI / gateway | Python plugin — `ctx.register_command()` | [Build a Hermes Plugin](/developer-guide/plugins) · [Extending the CLI](/developer-guide/extending-the-cli) |
 | A **subcommand** for `hermes <thing>` | Python plugin — `ctx.register_cli_command()` | [Extending the CLI](/developer-guide/extending-the-cli) |
+| A **gateway service** (async service that lives alongside the gateway) | Python plugin — `ctx.register_gateway_service()` | [Build a Hermes Plugin](/developer-guide/plugins#register-a-gateway-service) |
 | A bundled **skill** that your plugin ships | Python plugin — `ctx.register_skill()` | [Creating Skills](/developer-guide/creating-skills) |
 | An **inference backend** (LLM provider: OpenAI-compat, Codex, Anthropic-Messages, Bedrock) | Provider plugin — `register_provider(ProviderProfile(...))` in `plugins/model-providers/<name>/` | **[Model Provider Plugins](/developer-guide/model-provider-plugin)** · [Adding Providers](/developer-guide/adding-providers) |
 | A **gateway channel** (Discord / Telegram / IRC / Teams / etc.) | Platform plugin — `ctx.register_platform()` in `plugins/platforms/<name>/` | [Adding Platform Adapters](/developer-guide/adding-platform-adapters) |


### PR DESCRIPTION
## What does this PR do?

Adds a narrow, generic lifecycle seam for standalone plugins that need a long-lived asynchronous service alongside the messaging gateway.

Plugins can register an async service with `ctx.register_gateway_service(name, service)`. Hermes starts registered services after at least one gateway adapter connects, retains and observes their tasks, isolates service failures, and stops them before adapter teardown. Services receive a host-owned read-only adapter view that reflects later reconnects without exposing `GatewayRunner` or restarting the service.

Shutdown is bounded at five seconds. A plugin that suppresses cancellation cannot hang the gateway indefinitely; overdue completion remains observed and attributed to plugin provenance.

## Related Issue

Addresses #15006. This widens the generic standalone-plugin surface; it does not add a product-specific integration to core.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/plugins.py`: add deterministic, provenance-aware `register_gateway_service(...)` registration.
- `gateway/plugin_services.py`: add the host-owned service context and lifecycle manager.
- `gateway/run.py`: start services after adapter connection, expose reconnect-aware adapter resolution, and stop services before adapter teardown.
- `tests/`: cover registration/discovery, duplicate handling, exact-once startup, delayed initial connection, reconnect visibility, failure isolation, task retention, bounded cancellation, and runner shutdown ordering.
- `website/docs/`: document the generic standalone-plugin API and lifecycle guarantees.

## How to Test

1. Focused suite:
   ```bash
   /home/renekris/.hermes/hermes-agent/venv/bin/python -m pytest -q \
     tests/hermes_cli/test_plugins.py \
     tests/gateway/test_plugin_gateway_services.py \
     tests/gateway/test_plugin_gateway_runner_integration.py
   ```
   Controller result on WSL2/Python 3.13: `151 passed in 4.71s`.
2. Real user-local plugin lifecycle harness: `PASS` in the implementation lane.
3. `git diff --check origin/main...HEAD`: passed.
4. Canonical full suite: `scripts/run_tests.sh` completed with 18 failures across nine files. None is in the plugin-service implementation or focused test surface.
5. Baseline A/B classification: the identical nine failing files were run from an untouched `origin/main` worktree with the same isolated venv and canonical wrapper. Baseline produced the identical 18 failures in the identical files:
   - `tests/agent/test_copilot_acp_client.py` — 1
   - `tests/agent/test_skill_utils.py` — 1
   - `tests/gateway/test_agent_cache.py` — 1
   - `tests/gateway/test_startup_restart_race.py` — 1
   - `tests/hermes_cli/test_list_picker_providers.py` — 1
   - `tests/hermes_cli/test_model_switch_custom_providers.py` — 3
   - `tests/honcho_plugin/test_pin_peer_name.py` — 4
   - `tests/tools/test_skills_tool_discovery_cache.py` — 1
   - `tests/tools/test_voice_mode.py` — 5

   This establishes that the observed full-suite failures reproduce on current upstream `main` and are not introduced by this PR.
6. Startup-race classification: both PR head and untouched `origin/main` time out in the same file-level wrapper test; the exact isolated test passes. This PR does not claim to fix that unrelated timing behavior.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched existing issues and PRs; #15006 and related gateway-extension requests establish the generic consumer need, with no competing service-lifecycle PR found.
- [x] My PR contains only changes related to this plugin lifecycle surface.
- [ ] I've run `pytest tests/ -q` and all tests pass — canonical full suite has 18 baseline-equivalent failures, documented by the `origin/main` A/B comparison above.
- [x] I've added tests for my changes.
- [x] I've tested on WSL2 Ubuntu with Python 3.13.

### Documentation & Housekeeping

- [x] Relevant plugin documentation is updated.
- [x] `cli-config.yaml.example` is N/A; no config key was added.
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A; the existing generic plugin policy is unchanged.
- [x] Cross-platform impact was considered: implementation uses standard `asyncio`, mappings, and existing gateway lifecycle APIs.
- [x] Tool descriptions/schemas are N/A; no model tool was added or changed.

## Screenshots / Logs

Focused controller verification:

```text
151 passed in 4.71s
```

The PR is ready for upstream human and CI review; the baseline-equivalent full-suite failures above remain disclosed.