### PR TITLE
fix(security): strip credentials across model redirects

### DIFF
--- a/hermes_cli/azure_detect.py
+++ b/hermes_cli/azure_detect.py
@@ -46,6 +46,8 @@ from urllib import request as urllib_request
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
 
+from hermes_cli.urllib_security import open_credentialed_url
+
 logger = logging.getLogger(__name__)
 
 
@@ -158,7 +160,7 @@ def _http_get_json(url: str,
     _apply_auth_headers(req, token, mode)
     req.add_header("User-Agent", "hermes-agent/azure-detect")
     try:
-        with urllib_request.urlopen(req, timeout=timeout) as resp:
+        with open_credentialed_url(req, timeout=timeout) as resp:
             body = resp.read()
             try:
                 return resp.status, json.loads(body.decode("utf-8", errors="replace"))
@@ -269,7 +271,7 @@ def _probe_anthropic_messages(base_url: str,
     req.add_header("content-type", "application/json")
     req.add_header("User-Agent", "hermes-agent/azure-detect")
     try:
-        with urllib_request.urlopen(req, timeout=6.0) as resp:
+        with open_credentialed_url(req, timeout=6.0) as resp:
             # Should never 200 — "probe" isn't a real deployment.  But
             # if it does, the endpoint definitely speaks Anthropic.
             return resp.status < 500

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -29,6 +29,40 @@ COPILOT_EDITOR_VERSION = "vscode/1.104.1"
 COPILOT_REASONING_EFFORTS_GPT5 = ["minimal", "low", "medium", "high"]
 COPILOT_REASONING_EFFORTS_O_SERIES = ["low", "medium", "high"]
 
+_CREDENTIAL_REDIRECT_HEADERS = {
+    "authorization",
+    "x-api-key",
+    "api-key",
+    "x-goog-api-key",
+    "cookie",
+}
+
+
+class _StripCredentialRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Drop credential headers when urllib follows redirects to another host."""
+
+    def __init__(self, original_host: str):
+        self._original_host = original_host
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        new_host = (urllib.parse.urlparse(newurl).hostname or "").lower()
+        if new_host and new_host != self._original_host:
+            clean_headers = {
+                name: value
+                for name, value in req.header_items()
+                if name.lower() not in _CREDENTIAL_REDIRECT_HEADERS
+            }
+            return urllib.request.Request(newurl, headers=clean_headers, method="GET")
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def _urlopen_model_catalog_request(req: urllib.request.Request, *, timeout: float):
+    if not any(name.lower() in _CREDENTIAL_REDIRECT_HEADERS for name, _ in req.header_items()):
+        return urllib.request.urlopen(req, timeout=timeout)
+    original_host = (urllib.parse.urlparse(req.full_url).hostname or "").lower()
+    opener = urllib.request.build_opener(_StripCredentialRedirectHandler(original_host))
+    return opener.open(req, timeout=timeout)
+
 
 # Fallback OpenRouter snapshot used when the live catalog is unavailable.
 # (model_id, display description shown in menus)
@@ -921,7 +955,7 @@ def fetch_nous_recommended_models(
             url,
             headers={"Accept": "application/json"},
         )
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
             data = json.loads(resp.read().decode())
         if not isinstance(data, dict):
             data = {}
@@ -1398,7 +1432,7 @@ def fetch_openrouter_models(
             "https://openrouter.ai/api/v1/models",
             headers={"Accept": "application/json"},
         )
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
             payload = json.loads(resp.read().decode())
     except Exception:
         return list(_openrouter_catalog_cache or fallback)
@@ -1519,7 +1553,7 @@ def fetch_models_with_pricing(
 
     try:
         req = urllib.request.Request(url, headers=headers)
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
             payload = json.loads(resp.read().decode())
     except Exception:
         _pricing_cache[cache_key] = {}
@@ -1633,7 +1667,7 @@ def _fetch_novita_pricing(
 
     try:
         req = urllib.request.Request(url, headers=headers)
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
             payload = json.loads(resp.read().decode())
     except Exception:
         _pricing_cache[cache_key] = {}
@@ -2747,7 +2781,7 @@ def _fetch_anthropic_models(
             _anthropic_models_url(base_url),
             headers=h,
         )
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
             return json.loads(resp.read().decode())
 
     try:
@@ -2862,7 +2896,7 @@ def fetch_github_model_catalog(
     for headers in attempts:
         req = urllib.request.Request(COPILOT_MODELS_URL, headers=headers)
         try:
-            with urllib.request.urlopen(req, timeout=timeout) as resp:
+            with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
                 data = json.loads(resp.read().decode())
                 items = _payload_items(data)
                 models: list[dict[str, Any]] = []
@@ -2979,7 +3013,7 @@ def _lmstudio_fetch_raw_models(
     headers = _lmstudio_request_headers(api_key)
     request = urllib.request.Request(server_root + "/api/v1/models", headers=headers)
     try:
-        with urllib.request.urlopen(request, timeout=timeout) as resp:
+        with _urlopen_model_catalog_request(request, timeout=timeout) as resp:
             payload = json.loads(resp.read().decode())
     except urllib.error.HTTPError as exc:
         if exc.code in {401, 403}:
@@ -3591,7 +3625,7 @@ def probe_api_models(
         tried.append(url)
         req = urllib.request.Request(url, headers=headers)
         try:
-            with urllib.request.urlopen(req, timeout=timeout) as resp:
+            with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
                 data = json.loads(resp.read().decode())
                 return {
                     "models": [m.get("id", "") for m in data.get("data", [])],

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, NamedTuple, Optional
 
 from hermes_cli import __version__ as _HERMES_VERSION
+from hermes_cli.urllib_security import open_credentialed_url
 
 # Identify ourselves so endpoints fronted by Cloudflare's Browser Integrity
 # Check (error 1010) don't reject the default ``Python-urllib/*`` signature.
@@ -29,43 +30,9 @@ COPILOT_EDITOR_VERSION = "vscode/1.104.1"
 COPILOT_REASONING_EFFORTS_GPT5 = ["minimal", "low", "medium", "high"]
 COPILOT_REASONING_EFFORTS_O_SERIES = ["low", "medium", "high"]
 
-_CREDENTIAL_REDIRECT_HEADERS = {
-    "authorization",
-    "x-api-key",
-    "api-key",
-    "x-goog-api-key",
-    "cookie",
-}
-
-_ORIGINAL_URLOPEN = urllib.request.urlopen
-
-
-class _StripCredentialRedirectHandler(urllib.request.HTTPRedirectHandler):
-    """Drop credential headers when urllib follows redirects to another host."""
-
-    def __init__(self, original_host: str):
-        self._original_host = original_host
-
-    def redirect_request(self, req, fp, code, msg, headers, newurl):
-        new_host = (urllib.parse.urlparse(newurl).hostname or "").lower()
-        if new_host and new_host != self._original_host:
-            clean_headers = {
-                name: value
-                for name, value in req.header_items()
-                if name.lower() not in _CREDENTIAL_REDIRECT_HEADERS
-            }
-            return urllib.request.Request(newurl, headers=clean_headers, method="GET")
-        return super().redirect_request(req, fp, code, msg, headers, newurl)
-
-
 def _urlopen_model_catalog_request(req: urllib.request.Request, *, timeout: float):
-    if urllib.request.urlopen is not _ORIGINAL_URLOPEN:
-        return urllib.request.urlopen(req, timeout=timeout)
-    if not any(name.lower() in _CREDENTIAL_REDIRECT_HEADERS for name, _ in req.header_items()):
-        return urllib.request.urlopen(req, timeout=timeout)
-    original_host = (urllib.parse.urlparse(req.full_url).hostname or "").lower()
-    opener = urllib.request.build_opener(_StripCredentialRedirectHandler(original_host))
-    return opener.open(req, timeout=timeout)
+    """Open catalog requests without forwarding headers across origins."""
+    return open_credentialed_url(req, timeout=timeout)
 
 
 # Fallback OpenRouter snapshot used when the live catalog is unavailable.
@@ -3154,15 +3121,13 @@ def ensure_lmstudio_model_loaded(
     load_headers = dict(headers)
     load_headers["Content-Type"] = "application/json"
     try:
-        with urllib.request.urlopen(
-            urllib.request.Request(
-                server_root + "/api/v1/models/load",
-                data=body,
-                headers=load_headers,
-                method="POST",
-            ),
-            timeout=timeout,
-        ) as resp:
+        load_request = urllib.request.Request(
+            server_root + "/api/v1/models/load",
+            data=body,
+            headers=load_headers,
+            method="POST",
+        )
+        with _urlopen_model_catalog_request(load_request, timeout=timeout) as resp:
             resp.read()
     except Exception:
         return None

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -37,6 +37,8 @@ _CREDENTIAL_REDIRECT_HEADERS = {
     "cookie",
 }
 
+_ORIGINAL_URLOPEN = urllib.request.urlopen
+
 
 class _StripCredentialRedirectHandler(urllib.request.HTTPRedirectHandler):
     """Drop credential headers when urllib follows redirects to another host."""
@@ -57,6 +59,8 @@ class _StripCredentialRedirectHandler(urllib.request.HTTPRedirectHandler):
 
 
 def _urlopen_model_catalog_request(req: urllib.request.Request, *, timeout: float):
+    if urllib.request.urlopen is not _ORIGINAL_URLOPEN:
+        return urllib.request.urlopen(req, timeout=timeout)
     if not any(name.lower() in _CREDENTIAL_REDIRECT_HEADERS for name, _ in req.header_items()):
         return urllib.request.urlopen(req, timeout=timeout)
     original_host = (urllib.parse.urlparse(req.full_url).hostname or "").lower()

--- a/hermes_cli/urllib_security.py
+++ b/hermes_cli/urllib_security.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import urllib.parse
 import urllib.request
 from collections.abc import Callable, Iterable
@@ -58,18 +59,38 @@ class SafeCredentialRedirectHandler(urllib.request.HTTPRedirectHandler):
         return redirected
 
 
+def _secure_opener_from_installed_policy(original_url: str):
+    """Clone the installed opener's handlers, replacing redirect policy only."""
+    installed = getattr(urllib.request, "_opener", None)
+    if installed is None:
+        installed = urllib.request.build_opener()
+
+    handlers = [
+        copy.copy(handler)
+        for handler in getattr(installed, "handlers", ())
+        if not isinstance(handler, urllib.request.HTTPRedirectHandler)
+    ]
+    handlers.append(SafeCredentialRedirectHandler(original_url))
+    return urllib.request.build_opener(*handlers)
+
+
 def open_credentialed_url(
     request: urllib.request.Request,
     *,
     timeout: float,
-    opener_factory: Callable[..., Any] = urllib.request.build_opener,
+    opener_factory: Callable[..., Any] | None = None,
 ):
     """Open a request without forwarding credentials across origins.
 
-    ``opener_factory`` is an explicit instrumentation/test seam. Security is
+    The default preserves an application-installed opener's proxy, TLS,
+    cookies, custom protocol handlers, and instrumentation while replacing its
+    redirect handler. ``opener_factory`` is an explicit test seam; security is
     never disabled based on global ``urlopen`` identity.
     """
-    opener = opener_factory(SafeCredentialRedirectHandler(request.full_url))
+    if opener_factory is None:
+        opener = _secure_opener_from_installed_policy(request.full_url)
+    else:
+        opener = opener_factory(SafeCredentialRedirectHandler(request.full_url))
     return opener.open(request, timeout=timeout)
 
 

--- a/hermes_cli/urllib_security.py
+++ b/hermes_cli/urllib_security.py
@@ -58,6 +58,28 @@ class SafeCredentialRedirectHandler(urllib.request.HTTPRedirectHandler):
         return redirected
 
 
+class _CrossOriginRequestSanitizer(urllib.request.BaseHandler):
+    """Strip headers after installed request processors have run."""
+
+    # Request processors run in ascending order. Keep this last so an installed
+    # cookie/auth/instrumentation processor cannot re-add a secret after the
+    # redirect handler sanitizes the new Request.
+    handler_order = 1_000_000_000
+
+    def __init__(self, original_url: str) -> None:
+        self._original_origin = url_origin(original_url)
+
+    def _sanitize(self, request: urllib.request.Request):
+        if url_origin(request.full_url) != self._original_origin:
+            for name, _value in list(request.header_items()):
+                if name.lower() not in _CROSS_ORIGIN_SAFE_HEADERS:
+                    request.remove_header(name)
+        return request
+
+    http_request = _sanitize
+    https_request = _sanitize
+
+
 def _secure_opener_from_installed_policy(original_url: str):
     """Clone the installed opener's handlers, replacing redirect policy only."""
     installed = getattr(urllib.request, "_opener", None)
@@ -70,8 +92,17 @@ def _secure_opener_from_installed_policy(original_url: str):
         if not isinstance(handler, urllib.request.HTTPRedirectHandler)
     ]
     handlers.append(SafeCredentialRedirectHandler(original_url))
+    handlers.append(_CrossOriginRequestSanitizer(original_url))
     secured = urllib.request.build_opener(*handlers)
-    secured.addheaders = list(getattr(installed, "addheaders", ()))
+    # OpenerDirector injects addheaders after request processors, which would
+    # bypass the sanitizer on redirects. Carry them on the initial request
+    # instead, then leave the rebuilt opener's late-injection list empty.
+    setattr(
+        secured,
+        "_hermes_initial_addheaders",
+        list(getattr(installed, "addheaders", ())),
+    )
+    secured.addheaders = []
     return secured
 
 
@@ -90,6 +121,9 @@ def open_credentialed_url(
     """
     if opener_factory is None:
         opener = _secure_opener_from_installed_policy(request.full_url)
+        for name, value in getattr(opener, "_hermes_initial_addheaders", ()):
+            if not request.has_header(name):
+                request.add_header(name, value)
     else:
         opener = opener_factory(SafeCredentialRedirectHandler(request.full_url))
     return opener.open(request, timeout=timeout)

--- a/hermes_cli/urllib_security.py
+++ b/hermes_cli/urllib_security.py
@@ -64,7 +64,10 @@ class _CrossOriginRequestSanitizer(urllib.request.BaseHandler):
     # Request processors run in ascending order. Keep this last so an installed
     # cookie/auth/instrumentation processor cannot re-add a secret after the
     # redirect handler sanitizes the new Request.
-    handler_order = 1_000_000_000
+    # Infinity is greater than every finite handler order. If an installed
+    # processor also uses infinity, stable sorting keeps this appended handler
+    # after it, so sanitization still owns the final request boundary.
+    handler_order = float("inf")  # type: ignore[assignment]
 
     def __init__(self, original_url: str) -> None:
         self._original_origin = url_origin(original_url)

--- a/hermes_cli/urllib_security.py
+++ b/hermes_cli/urllib_security.py
@@ -18,14 +18,13 @@ def url_origin(url: str) -> tuple[str, str, int | None]:
     """Return a normalized (scheme, hostname, effective port) origin."""
     parsed = urllib.parse.urlparse(url)
     scheme = (parsed.scheme or "").lower()
-    try:
-        port = parsed.port
-    except ValueError:
-        port = None
+    # Accessing ``parsed.port`` validates malformed/non-numeric ports. Let the
+    # ValueError fail the request closed instead of collapsing it to a default.
+    port = parsed.port
     return (
         scheme,
         (parsed.hostname or "").lower().rstrip("."),
-        port or _DEFAULT_PORTS.get(scheme),
+        port if port is not None else _DEFAULT_PORTS.get(scheme),
     )
 
 

--- a/hermes_cli/urllib_security.py
+++ b/hermes_cli/urllib_security.py
@@ -1,0 +1,80 @@
+"""Security policy for credential-bearing stdlib urllib requests."""
+
+from __future__ import annotations
+
+import urllib.parse
+import urllib.request
+from collections.abc import Callable, Iterable
+from typing import Any
+
+# Headers safe to forward to a different origin. Everything else is dropped:
+# custom provider headers routinely carry credentials under arbitrary names.
+_CROSS_ORIGIN_SAFE_HEADERS = frozenset({"accept", "user-agent"})
+_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+
+def url_origin(url: str) -> tuple[str, str, int | None]:
+    """Return a normalized (scheme, hostname, effective port) origin."""
+    parsed = urllib.parse.urlparse(url)
+    scheme = (parsed.scheme or "").lower()
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
+    return (
+        scheme,
+        (parsed.hostname or "").lower().rstrip("."),
+        port or _DEFAULT_PORTS.get(scheme),
+    )
+
+
+class SafeCredentialRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Preserve request headers only while redirects stay on one origin."""
+
+    def __init__(
+        self,
+        original_url: str,
+        *,
+        cross_origin_safe_headers: Iterable[str] = _CROSS_ORIGIN_SAFE_HEADERS,
+    ) -> None:
+        self._original_origin = url_origin(original_url)
+        self._cross_origin_safe_headers = frozenset(
+            str(name).lower() for name in cross_origin_safe_headers
+        )
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        # Let urllib enforce status/method semantics first (notably 307/308).
+        redirected = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if redirected is None:
+            return None
+
+        resolved_url = urllib.parse.urljoin(req.full_url, newurl)
+        if url_origin(resolved_url) != self._original_origin:
+            # Use an allowlist rather than guessing credential header names.
+            # normalize_extra_headers permits arbitrary secret-bearing names.
+            for name, _value in list(redirected.header_items()):
+                if name.lower() not in self._cross_origin_safe_headers:
+                    redirected.remove_header(name)
+        return redirected
+
+
+def open_credentialed_url(
+    request: urllib.request.Request,
+    *,
+    timeout: float,
+    opener_factory: Callable[..., Any] = urllib.request.build_opener,
+):
+    """Open a request without forwarding credentials across origins.
+
+    ``opener_factory`` is an explicit instrumentation/test seam. Security is
+    never disabled based on global ``urlopen`` identity.
+    """
+    opener = opener_factory(SafeCredentialRedirectHandler(request.full_url))
+    return opener.open(request, timeout=timeout)
+
+
+__all__ = [
+    "SafeCredentialRedirectHandler",
+    "open_credentialed_url",
+    "url_origin",
+]

--- a/hermes_cli/urllib_security.py
+++ b/hermes_cli/urllib_security.py
@@ -70,7 +70,9 @@ def _secure_opener_from_installed_policy(original_url: str):
         if not isinstance(handler, urllib.request.HTTPRedirectHandler)
     ]
     handlers.append(SafeCredentialRedirectHandler(original_url))
-    return urllib.request.build_opener(*handlers)
+    secured = urllib.request.build_opener(*handlers)
+    secured.addheaders = list(getattr(installed, "addheaders", ()))
+    return secured
 
 
 def open_credentialed_url(

--- a/plugins/model-providers/anthropic/__init__.py
+++ b/plugins/model-providers/anthropic/__init__.py
@@ -4,6 +4,7 @@ import json
 import logging
 import urllib.request
 
+from hermes_cli.urllib_security import open_credentialed_url
 from providers import register_provider
 from providers.base import ProviderProfile
 
@@ -28,7 +29,7 @@ class AnthropicProfile(ProviderProfile):
             req.add_header("x-api-key", api_key)
             req.add_header("anthropic-version", "2023-06-01")
             req.add_header("Accept", "application/json")
-            with urllib.request.urlopen(req, timeout=timeout) as resp:
+            with open_credentialed_url(req, timeout=timeout) as resp:
                 data = json.loads(resp.read().decode())
             return [
                 m["id"]

--- a/providers/base.py
+++ b/providers/base.py
@@ -210,25 +210,32 @@ class ProviderProfile:
 
         # urllib keeps every header — including Authorization — when it
         # follows a redirect, so a catalog endpoint answering 3xx to a
-        # different host would receive the provider API key.  Drop
-        # credential headers on cross-host redirects.
+        # different origin would receive the provider API key.  Drop
+        # credential headers on cross-origin redirects.  Origin = scheme +
+        # hostname + effective port: a different port on the same host can
+        # be a different service, so it must not inherit credentials either.
         sensitive = {"authorization", "x-api-key", "api-key", "x-goog-api-key", "cookie"}
-        original_host = (urllib.parse.urlparse(url).hostname or "").lower()
 
-        class _StripAuthOnCrossHostRedirect(urllib.request.HTTPRedirectHandler):
+        def _origin(target_url: str) -> tuple:
+            parsed = urllib.parse.urlparse(target_url)
+            scheme = (parsed.scheme or "").lower()
+            port = parsed.port or {"http": 80, "https": 443}.get(scheme)
+            return scheme, (parsed.hostname or "").lower(), port
+
+        original_origin = _origin(url)
+
+        class _StripAuthOnCrossOriginRedirect(urllib.request.HTTPRedirectHandler):
             def redirect_request(self, redirected, fp, code, msg, hdrs, newurl):
                 new_req = super().redirect_request(
                     redirected, fp, code, msg, hdrs, newurl
                 )
-                if new_req is not None:
-                    new_host = (urllib.parse.urlparse(newurl).hostname or "").lower()
-                    if new_host != original_host:
-                        for header in list(new_req.headers):
-                            if header.lower() in sensitive:
-                                new_req.remove_header(header)
+                if new_req is not None and _origin(newurl) != original_origin:
+                    for header in list(new_req.headers):
+                        if header.lower() in sensitive:
+                            new_req.remove_header(header)
                 return new_req
 
-        opener = urllib.request.build_opener(_StripAuthOnCrossHostRedirect())
+        opener = urllib.request.build_opener(_StripAuthOnCrossOriginRedirect())
 
         try:
             with opener.open(req, timeout=timeout) as resp:

--- a/providers/base.py
+++ b/providers/base.py
@@ -194,6 +194,7 @@ class ProviderProfile:
             url = effective_base.rstrip("/") + "/models"
 
         import json
+        import urllib.parse
         import urllib.request
 
         req = urllib.request.Request(url)
@@ -207,8 +208,30 @@ class ProviderProfile:
         for k, v in self.default_headers.items():
             req.add_header(k, v)
 
+        # urllib keeps every header — including Authorization — when it
+        # follows a redirect, so a catalog endpoint answering 3xx to a
+        # different host would receive the provider API key.  Drop
+        # credential headers on cross-host redirects.
+        sensitive = {"authorization", "x-api-key", "api-key", "x-goog-api-key", "cookie"}
+        original_host = (urllib.parse.urlparse(url).hostname or "").lower()
+
+        class _StripAuthOnCrossHostRedirect(urllib.request.HTTPRedirectHandler):
+            def redirect_request(self, redirected, fp, code, msg, hdrs, newurl):
+                new_req = super().redirect_request(
+                    redirected, fp, code, msg, hdrs, newurl
+                )
+                if new_req is not None:
+                    new_host = (urllib.parse.urlparse(newurl).hostname or "").lower()
+                    if new_host != original_host:
+                        for header in list(new_req.headers):
+                            if header.lower() in sensitive:
+                                new_req.remove_header(header)
+                return new_req
+
+        opener = urllib.request.build_opener(_StripAuthOnCrossHostRedirect())
+
         try:
-            with urllib.request.urlopen(req, timeout=timeout) as resp:
+            with opener.open(req, timeout=timeout) as resp:
                 data = json.loads(resp.read().decode())
             items = data if isinstance(data, list) else data.get("data", [])
             return [m["id"] for m in items if isinstance(m, dict) and "id" in m]

--- a/providers/base.py
+++ b/providers/base.py
@@ -194,8 +194,9 @@ class ProviderProfile:
             url = effective_base.rstrip("/") + "/models"
 
         import json
-        import urllib.parse
         import urllib.request
+
+        from hermes_cli.urllib_security import open_credentialed_url
 
         req = urllib.request.Request(url)
         if api_key:
@@ -208,37 +209,8 @@ class ProviderProfile:
         for k, v in self.default_headers.items():
             req.add_header(k, v)
 
-        # urllib keeps every header — including Authorization — when it
-        # follows a redirect, so a catalog endpoint answering 3xx to a
-        # different origin would receive the provider API key.  Drop
-        # credential headers on cross-origin redirects.  Origin = scheme +
-        # hostname + effective port: a different port on the same host can
-        # be a different service, so it must not inherit credentials either.
-        sensitive = {"authorization", "x-api-key", "api-key", "x-goog-api-key", "cookie"}
-
-        def _origin(target_url: str) -> tuple:
-            parsed = urllib.parse.urlparse(target_url)
-            scheme = (parsed.scheme or "").lower()
-            port = parsed.port or {"http": 80, "https": 443}.get(scheme)
-            return scheme, (parsed.hostname or "").lower(), port
-
-        original_origin = _origin(url)
-
-        class _StripAuthOnCrossOriginRedirect(urllib.request.HTTPRedirectHandler):
-            def redirect_request(self, redirected, fp, code, msg, hdrs, newurl):
-                new_req = super().redirect_request(
-                    redirected, fp, code, msg, hdrs, newurl
-                )
-                if new_req is not None and _origin(newurl) != original_origin:
-                    for header in list(new_req.headers):
-                        if header.lower() in sensitive:
-                            new_req.remove_header(header)
-                return new_req
-
-        opener = urllib.request.build_opener(_StripAuthOnCrossOriginRedirect())
-
         try:
-            with opener.open(req, timeout=timeout) as resp:
+            with open_credentialed_url(req, timeout=timeout) as resp:
                 data = json.loads(resp.read().decode())
             items = data if isinstance(data, list) else data.get("data", [])
             return [m["id"] for m in items if isinstance(m, dict) and "id" in m]

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -1215,7 +1215,7 @@ class TestNovitaProvider:
             return _FakeResp()
 
         monkeypatch.setattr(
-            models_mod.urllib.request, "urlopen", fake_urlopen
+            models_mod, "_urlopen_model_catalog_request", fake_urlopen
         )
 
         # First call hits the network.

--- a/tests/hermes_cli/test_azure_detect.py
+++ b/tests/hermes_cli/test_azure_detect.py
@@ -188,7 +188,7 @@ def test_probe_openai_models_tries_multiple_api_versions():
 def test_http_get_json_on_urlerror_returns_zero_none():
     """Network failure returns (0, None), never raises."""
     import urllib.error
-    with patch("hermes_cli.azure_detect.urllib_request.urlopen",
+    with patch("hermes_cli.azure_detect.open_credentialed_url",
                side_effect=urllib.error.URLError("dns fail")):
         status, body = azure_detect._http_get_json("https://bad.example/", "k")
     assert status == 0
@@ -199,7 +199,7 @@ def test_http_get_json_on_http_error_returns_code_none():
     """HTTP 4xx/5xx returns (code, None)."""
     import urllib.error
     err = urllib.error.HTTPError("https://x/", 403, "Forbidden", {}, None)
-    with patch("hermes_cli.azure_detect.urllib_request.urlopen", side_effect=err):
+    with patch("hermes_cli.azure_detect.open_credentialed_url", side_effect=err):
         status, body = azure_detect._http_get_json("https://x/", "k")
     assert status == 403
     assert body is None

--- a/tests/hermes_cli/test_custom_provider_extra_headers.py
+++ b/tests/hermes_cli/test_custom_provider_extra_headers.py
@@ -165,7 +165,7 @@ def test_fetch_api_models_sends_extra_headers_to_models_probe(monkeypatch):
         }
         return FakeResponse()
 
-    monkeypatch.setattr(models_mod.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(models_mod, "_urlopen_model_catalog_request", fake_urlopen)
 
     models = models_mod.fetch_api_models(
         "proxy-key",

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -236,7 +236,7 @@ class TestProviderModelIds:
                 }
             },
         ), patch(
-            "hermes_cli.models.urllib.request.urlopen",
+            "hermes_cli.models._urlopen_model_catalog_request",
             return_value=_Resp(),
         ) as mock_urlopen:
             assert provider_model_ids("anthropic") == ["enterprise-claude"]
@@ -275,7 +275,7 @@ class TestFetchApiModels:
         assert fetch_api_models("key", None) is None
 
     def test_returns_none_on_network_error(self):
-        with patch("hermes_cli.models.urllib.request.urlopen", side_effect=Exception("timeout")):
+        with patch("hermes_cli.models._urlopen_model_catalog_request", side_effect=Exception("timeout")):
             assert fetch_api_models("key", "https://example.com/v1") is None
 
     def test_probe_api_models_tries_v1_fallback(self):
@@ -297,7 +297,7 @@ class TestFetchApiModels:
                 return _Resp()
             raise Exception("404")
 
-        with patch("hermes_cli.models.urllib.request.urlopen", side_effect=_fake_urlopen):
+        with patch("hermes_cli.models._urlopen_model_catalog_request", side_effect=_fake_urlopen):
             probe = probe_api_models("key", "http://localhost:8000")
 
         assert calls == ["http://localhost:8000/models", "http://localhost:8000/v1/models"]
@@ -316,7 +316,7 @@ class TestFetchApiModels:
             def read(self):
                 return b'{"data": [{"id": "gpt-5.4", "model_picker_enabled": true, "supported_endpoints": ["/responses"], "capabilities": {"type": "chat", "supports": {"reasoning_effort": ["low", "medium", "high"]}}}, {"id": "claude-sonnet-4.6", "model_picker_enabled": true, "supported_endpoints": ["/chat/completions"], "capabilities": {"type": "chat", "supports": {"reasoning_effort": ["low", "medium", "high"]}}}, {"id": "text-embedding-3-small", "model_picker_enabled": true, "capabilities": {"type": "embedding"}}]}'
 
-        with patch("hermes_cli.models.urllib.request.urlopen", return_value=_Resp()) as mock_urlopen:
+        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()) as mock_urlopen:
             probe = probe_api_models("gh-token", "https://api.githubcopilot.com")
 
         assert mock_urlopen.call_args[0][0].full_url == "https://api.githubcopilot.com/models"
@@ -335,7 +335,7 @@ class TestFetchApiModels:
             def read(self):
                 return b'{"data": [{"id": "gpt-5.4", "model_picker_enabled": true, "supported_endpoints": ["/responses"], "capabilities": {"type": "chat", "supports": {"reasoning_effort": ["low", "medium", "high"]}}}, {"id": "text-embedding-3-small", "model_picker_enabled": true, "capabilities": {"type": "embedding"}}]}'
 
-        with patch("hermes_cli.models.urllib.request.urlopen", return_value=_Resp()):
+        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()):
             catalog = fetch_github_model_catalog("gh-token")
 
         assert catalog is not None
@@ -749,7 +749,7 @@ class TestValidateApiFallback:
             b']}'
         )
 
-        with patch("hermes_cli.models.urllib.request.urlopen", return_value=mock_resp):
+        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=mock_resp):
             models = fetch_lmstudio_models(base_url="http://localhost:1234/v1")
 
         assert models == ["publisher/chat-model"]
@@ -760,7 +760,7 @@ class TestValidateApiFallback:
         mock_resp.__exit__.return_value = False
         mock_resp.read.return_value = b'{"models":[{"key":"publisher/chat-model","type":"llm"}]}'
 
-        with patch("hermes_cli.models.urllib.request.urlopen", return_value=mock_resp) as mock_urlopen:
+        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=mock_resp) as mock_urlopen:
             models = fetch_lmstudio_models(base_url="http://localhost:1234/api/v1")
 
         request = mock_urlopen.call_args[0][0]
@@ -778,7 +778,7 @@ class TestValidateApiFallback:
             b']}'
         )
 
-        with patch("hermes_cli.models.urllib.request.urlopen", return_value=mock_resp):
+        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=mock_resp):
             result = validate_requested_model(
                 "publisher/embed-model",
                 "lmstudio",
@@ -802,7 +802,7 @@ class TestValidateApiFallback:
             fp=None,
         )
 
-        with patch("hermes_cli.models.urllib.request.urlopen", side_effect=http_error):
+        with patch("hermes_cli.models._urlopen_model_catalog_request", side_effect=http_error):
             with pytest.raises(AuthError) as excinfo:
                 fetch_lmstudio_models(base_url="http://localhost:1234/v1")
 
@@ -812,7 +812,7 @@ class TestValidateApiFallback:
 
     def test_fetch_lmstudio_models_returns_empty_on_network_error(self):
         with patch(
-            "hermes_cli.models.urllib.request.urlopen",
+            "hermes_cli.models._urlopen_model_catalog_request",
             side_effect=ConnectionRefusedError(),
         ):
             models = fetch_lmstudio_models(base_url="http://localhost:1234/v1")
@@ -830,7 +830,7 @@ class TestValidateApiFallback:
             fp=None,
         )
 
-        with patch("hermes_cli.models.urllib.request.urlopen", side_effect=http_error):
+        with patch("hermes_cli.models._urlopen_model_catalog_request", side_effect=http_error):
             result = validate_requested_model(
                 "publisher/chat-model",
                 "lmstudio",
@@ -843,7 +843,7 @@ class TestValidateApiFallback:
 
     def test_validate_lmstudio_distinguishes_unreachable(self):
         with patch(
-            "hermes_cli.models.urllib.request.urlopen",
+            "hermes_cli.models._urlopen_model_catalog_request",
             side_effect=ConnectionRefusedError(),
         ):
             result = validate_requested_model(
@@ -910,7 +910,7 @@ class TestProbeApiModelsUserAgent:
 
         body = b'{"data":[{"id":"claude-opus-4.7"}]}'
         with patch(
-            "hermes_cli.models.urllib.request.urlopen",
+            "hermes_cli.models._urlopen_model_catalog_request",
             return_value=self._make_mock_response(body),
         ) as mock_urlopen:
             result = probe_api_models("sk-test", "https://example.com/v1")
@@ -932,7 +932,7 @@ class TestProbeApiModelsUserAgent:
 
         body = b'{"data":[]}'
         with patch(
-            "hermes_cli.models.urllib.request.urlopen",
+            "hermes_cli.models._urlopen_model_catalog_request",
             return_value=self._make_mock_response(body),
         ) as mock_urlopen:
             probe_api_models(None, "https://example.com/v1")

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -1,5 +1,6 @@
 """Tests for the hermes_cli models module."""
 
+import urllib.request
 from unittest.mock import patch, MagicMock
 
 from hermes_cli.nous_account import NousPortalAccountInfo
@@ -78,6 +79,7 @@ class TestFetchOpenRouterModels:
             ("qwen/qwen3.7-max", ""),
             ("nvidia/nemotron-3-super-120b-a12b:free", "free"),
         ]
+
 
     def test_falls_back_to_static_snapshot_on_fetch_failure(self, monkeypatch):
         monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
@@ -969,3 +971,43 @@ class TestCodexSoftAcceptPlausibilityGate:
         r = validate_requested_model("gpt-5.5", "openai-codex")
         assert r["accepted"] is True
         assert r["recognized"] is True
+
+
+class TestModelCatalogRedirectCredentialStripping:
+    def test_cross_host_redirect_strips_provider_credentials(self):
+        req = urllib.request.Request("https://models.example.test/v1/models")
+        req.add_header("Authorization", "Bearer sk-model-secret")
+        req.add_header("x-api-key", "anthropic-secret")
+        req.add_header("Cookie", "session=secret")
+        req.add_header("User-Agent", "hermes-test")
+
+        handler = _models_mod._StripCredentialRedirectHandler("models.example.test")
+        redirected = handler.redirect_request(
+            req, None, 302, "Found", {}, "https://attacker.example.test/leak"
+        )
+
+        redirected_headers = {
+            key.lower(): value
+            for key, value in redirected.header_items()
+        }
+        assert "authorization" not in redirected_headers
+        assert "x-api-key" not in redirected_headers
+        assert "cookie" not in redirected_headers
+        assert redirected_headers["user-agent"] == "hermes-test"
+
+    def test_same_host_redirect_preserves_provider_credentials(self):
+        req = urllib.request.Request("https://models.example.test/v1/models")
+        req.add_header("Authorization", "Bearer sk-model-secret")
+        req.add_header("x-api-key", "anthropic-secret")
+
+        handler = _models_mod._StripCredentialRedirectHandler("models.example.test")
+        redirected = handler.redirect_request(
+            req, None, 302, "Found", {}, "https://models.example.test/v1/models/"
+        )
+
+        redirected_headers = {
+            key.lower(): value
+            for key, value in redirected.header_items()
+        }
+        assert redirected_headers["authorization"] == "Bearer sk-model-secret"
+        assert redirected_headers["x-api-key"] == "anthropic-secret"

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -1,6 +1,5 @@
 """Tests for the hermes_cli models module."""
 
-import urllib.request
 from unittest.mock import patch, MagicMock
 
 from hermes_cli.nous_account import NousPortalAccountInfo
@@ -71,7 +70,7 @@ class TestFetchOpenRouterModels:
                 return b'{"data":[{"id":"anthropic/claude-opus-4.8","pricing":{"prompt":"0.000015","completion":"0.000075"}},{"id":"qwen/qwen3.7-max","pricing":{"prompt":"0.000000325","completion":"0.00000195"}},{"id":"nvidia/nemotron-3-super-120b-a12b:free","pricing":{"prompt":"0","completion":"0"}}]}'
 
         monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
-        with patch("hermes_cli.models.urllib.request.urlopen", return_value=_Resp()):
+        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()):
             models = fetch_openrouter_models(force_refresh=True)
 
         assert models == [
@@ -83,7 +82,7 @@ class TestFetchOpenRouterModels:
 
     def test_falls_back_to_static_snapshot_on_fetch_failure(self, monkeypatch):
         monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
-        with patch("hermes_cli.models.urllib.request.urlopen", side_effect=OSError("boom")):
+        with patch("hermes_cli.models._urlopen_model_catalog_request", side_effect=OSError("boom")):
             models = fetch_openrouter_models(force_refresh=True)
 
         assert models == OPENROUTER_MODELS
@@ -128,7 +127,10 @@ class TestFetchOpenRouterModels:
             ],
         )
         monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
-        with patch("hermes_cli.models.urllib.request.urlopen", return_value=_Resp()):
+        with (
+            patch("hermes_cli.model_catalog.get_curated_openrouter_models", return_value=[]),
+            patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()),
+        ):
             models = fetch_openrouter_models(force_refresh=True)
 
         ids = [mid for mid, _ in models]
@@ -162,7 +164,7 @@ class TestFetchOpenRouterModels:
                 )
 
         monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
-        with patch("hermes_cli.models.urllib.request.urlopen", return_value=_Resp()):
+        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()):
             models = fetch_openrouter_models(force_refresh=True)
 
         ids = [mid for mid, _ in models]
@@ -781,7 +783,7 @@ class TestNousRecommendedModels:
     def test_fetch_caches_per_portal_url(self):
         from hermes_cli.models import fetch_nous_recommended_models
         mock_cm = self._mock_urlopen(self._SAMPLE_PAYLOAD)
-        with patch("urllib.request.urlopen", return_value=mock_cm) as mock_urlopen:
+        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=mock_cm) as mock_urlopen:
             a = fetch_nous_recommended_models("https://portal.example.com")
             b = fetch_nous_recommended_models("https://portal.example.com")
         assert a == self._SAMPLE_PAYLOAD
@@ -791,21 +793,21 @@ class TestNousRecommendedModels:
     def test_fetch_cache_is_keyed_per_portal(self):
         from hermes_cli.models import fetch_nous_recommended_models
         mock_cm = self._mock_urlopen(self._SAMPLE_PAYLOAD)
-        with patch("urllib.request.urlopen", return_value=mock_cm) as mock_urlopen:
+        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=mock_cm) as mock_urlopen:
             fetch_nous_recommended_models("https://portal.example.com")
             fetch_nous_recommended_models("https://portal.staging-nousresearch.com")
         assert mock_urlopen.call_count == 2  # different portals → separate fetches
 
     def test_fetch_returns_empty_on_network_failure(self):
         from hermes_cli.models import fetch_nous_recommended_models
-        with patch("urllib.request.urlopen", side_effect=OSError("boom")):
+        with patch("hermes_cli.models._urlopen_model_catalog_request", side_effect=OSError("boom")):
             result = fetch_nous_recommended_models("https://portal.example.com")
         assert result == {}
 
     def test_fetch_force_refresh_bypasses_cache(self):
         from hermes_cli.models import fetch_nous_recommended_models
         mock_cm = self._mock_urlopen(self._SAMPLE_PAYLOAD)
-        with patch("urllib.request.urlopen", return_value=mock_cm) as mock_urlopen:
+        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=mock_cm) as mock_urlopen:
             fetch_nous_recommended_models("https://portal.example.com")
             fetch_nous_recommended_models("https://portal.example.com", force_refresh=True)
         assert mock_urlopen.call_count == 2
@@ -971,43 +973,3 @@ class TestCodexSoftAcceptPlausibilityGate:
         r = validate_requested_model("gpt-5.5", "openai-codex")
         assert r["accepted"] is True
         assert r["recognized"] is True
-
-
-class TestModelCatalogRedirectCredentialStripping:
-    def test_cross_host_redirect_strips_provider_credentials(self):
-        req = urllib.request.Request("https://models.example.test/v1/models")
-        req.add_header("Authorization", "Bearer sk-model-secret")
-        req.add_header("x-api-key", "anthropic-secret")
-        req.add_header("Cookie", "session=secret")
-        req.add_header("User-Agent", "hermes-test")
-
-        handler = _models_mod._StripCredentialRedirectHandler("models.example.test")
-        redirected = handler.redirect_request(
-            req, None, 302, "Found", {}, "https://attacker.example.test/leak"
-        )
-
-        redirected_headers = {
-            key.lower(): value
-            for key, value in redirected.header_items()
-        }
-        assert "authorization" not in redirected_headers
-        assert "x-api-key" not in redirected_headers
-        assert "cookie" not in redirected_headers
-        assert redirected_headers["user-agent"] == "hermes-test"
-
-    def test_same_host_redirect_preserves_provider_credentials(self):
-        req = urllib.request.Request("https://models.example.test/v1/models")
-        req.add_header("Authorization", "Bearer sk-model-secret")
-        req.add_header("x-api-key", "anthropic-secret")
-
-        handler = _models_mod._StripCredentialRedirectHandler("models.example.test")
-        redirected = handler.redirect_request(
-            req, None, 302, "Found", {}, "https://models.example.test/v1/models/"
-        )
-
-        redirected_headers = {
-            key.lower(): value
-            for key, value in redirected.header_items()
-        }
-        assert redirected_headers["authorization"] == "Bearer sk-model-secret"
-        assert redirected_headers["x-api-key"] == "anthropic-secret"

--- a/tests/hermes_cli/test_urllib_security.py
+++ b/tests/hermes_cli/test_urllib_security.py
@@ -254,6 +254,47 @@ def test_explicit_opener_factory_is_instrumentable_without_security_bypass():
     assert calls == [("https://models.example.test/models", 7)]
 
 
+def test_installed_custom_opener_policy_is_preserved(monkeypatch):
+    opened = []
+
+    class FooHandler(urllib.request.BaseHandler):
+        def foo_open(self, request):
+            opened.append(request.full_url)
+            return _Response(b"custom")
+
+    installed = urllib.request.build_opener(FooHandler())
+    monkeypatch.setattr(urllib.request, "_opener", installed)
+
+    request = urllib.request.Request(
+        "foo://models.example.test/catalog", headers={"Authorization": "secret"}
+    )
+    with open_credentialed_url(request, timeout=3) as response:
+        assert response.read() == b"custom"
+    assert opened == ["foo://models.example.test/catalog"]
+
+
+def test_installed_proxy_handler_is_preserved(monkeypatch):
+    installed = urllib.request.build_opener(
+        urllib.request.ProxyHandler({"https": "http://proxy.example.test:8443"})
+    )
+    monkeypatch.setattr(urllib.request, "_opener", installed)
+
+    from hermes_cli.urllib_security import _secure_opener_from_installed_policy
+
+    secured = _secure_opener_from_installed_policy(
+        "https://models.example.test/catalog"
+    )
+    proxy_handlers = [
+        handler
+        for handler in getattr(secured, "handlers", ())
+        if isinstance(handler, urllib.request.ProxyHandler)
+    ]
+    assert proxy_handlers
+    assert getattr(proxy_handlers[0], "proxies", {}) == {
+        "https": "http://proxy.example.test:8443"
+    }
+
+
 def test_probe_api_models_drops_custom_credentials_on_wire():
     from hermes_cli.models import probe_api_models
 

--- a/tests/hermes_cli/test_urllib_security.py
+++ b/tests/hermes_cli/test_urllib_security.py
@@ -270,7 +270,18 @@ def test_installed_custom_opener_policy_is_preserved(monkeypatch):
             return _Response(b"custom")
 
     installed = urllib.request.build_opener(FooHandler())
+    installed.addheaders = [
+        ("X-Trace-Policy", "installed"),
+        ("User-agent", "enterprise-client"),
+    ]
     monkeypatch.setattr(urllib.request, "_opener", installed)
+
+    from hermes_cli.urllib_security import _secure_opener_from_installed_policy
+
+    secured = _secure_opener_from_installed_policy(
+        "foo://models.example.test/catalog"
+    )
+    assert secured.addheaders == installed.addheaders
 
     request = urllib.request.Request(
         "foo://models.example.test/catalog", headers={"Authorization": "secret"}
@@ -300,6 +311,57 @@ def test_installed_proxy_handler_is_preserved(monkeypatch):
     assert getattr(proxy_handlers[0], "proxies", {}) == {
         "https": "http://proxy.example.test:8443"
     }
+
+
+def test_multihop_redirects_never_resurrect_credentials():
+    request = urllib.request.Request(
+        "https://a.example.test/models", headers=_credential_headers()
+    )
+    handler = SafeCredentialRedirectHandler(request.full_url)
+
+    same_origin = handler.redirect_request(
+        request,
+        None,
+        302,
+        "Found",
+        {},
+        "https://a.example.test/step-two",
+    )
+    assert same_origin is not None
+    same_headers = {
+        name.lower(): value for name, value in same_origin.header_items()
+    }
+    assert "authorization" in same_headers
+
+    cross_origin = handler.redirect_request(
+        same_origin,
+        None,
+        302,
+        "Found",
+        {},
+        "https://b.example.test/step-three",
+    )
+    assert cross_origin is not None
+    cross_headers = {
+        name.lower(): value for name, value in cross_origin.header_items()
+    }
+    assert "authorization" not in cross_headers
+    assert "cf-access-client-secret" not in cross_headers
+
+    returned = handler.redirect_request(
+        cross_origin,
+        None,
+        302,
+        "Found",
+        {},
+        "https://a.example.test/final",
+    )
+    assert returned is not None
+    returned_headers = {
+        name.lower(): value for name, value in returned.header_items()
+    }
+    assert "authorization" not in returned_headers
+    assert "cf-access-client-secret" not in returned_headers
 
 
 def test_probe_api_models_drops_custom_credentials_on_wire():

--- a/tests/hermes_cli/test_urllib_security.py
+++ b/tests/hermes_cli/test_urllib_security.py
@@ -329,6 +329,8 @@ def test_installed_request_processor_cannot_resurrect_cross_origin_secret(
     _RecordingHandler.redirect_to = f"http://localhost:{sink.server_port}/sink"
 
     class SecretProcessor(urllib.request.BaseHandler):
+        handler_order = float("inf")  # type: ignore[assignment]
+
         def http_request(self, request):
             request.add_header("X-Installed-Secret", "must-not-cross")
             return request
@@ -479,6 +481,50 @@ def test_anthropic_profile_drops_x_api_key_on_redirect(monkeypatch):
     _, headers = _RecordingHandler.requests[-1]
     assert "x-api-key" not in headers
     assert headers["accept"] == "application/json"
+
+
+def test_azure_catalog_probe_drops_api_key_and_bearer_on_redirect():
+    from hermes_cli import azure_detect
+
+    source = _server()
+    sink = _server()
+    _RecordingHandler.requests = []
+    _RecordingHandler.redirect_status = 302
+    _RecordingHandler.redirect_to = f"http://localhost:{sink.server_port}/sink"
+    try:
+        status, body = azure_detect._http_get_json(
+            f"http://127.0.0.1:{source.server_port}/redirect", "azure-secret", timeout=3
+        )
+    finally:
+        source.shutdown()
+        sink.shutdown()
+
+    assert status == 200
+    assert body == {"data": []}
+    _, headers = _RecordingHandler.requests[-1]
+    assert "authorization" not in headers
+    assert "api-key" not in headers
+
+
+def test_azure_anthropic_probe_drops_api_key_and_bearer_on_redirect():
+    from hermes_cli import azure_detect
+
+    sink = _server()
+    source = ThreadingHTTPServer(("127.0.0.1", 0), _LmStudioSourceHandler)
+    Thread(target=source.serve_forever, daemon=True).start()
+    _RecordingHandler.requests = []
+    _LmStudioSourceHandler.redirect_to = f"http://localhost:{sink.server_port}/sink"
+    try:
+        azure_detect._probe_anthropic_messages(
+            f"http://127.0.0.1:{source.server_port}", "azure-secret"
+        )
+    finally:
+        source.shutdown()
+        sink.shutdown()
+
+    _, headers = _RecordingHandler.requests[-1]
+    assert "authorization" not in headers
+    assert "api-key" not in headers
 
 
 def test_lmstudio_load_post_drops_bearer_on_redirect(monkeypatch):

--- a/tests/hermes_cli/test_urllib_security.py
+++ b/tests/hermes_cli/test_urllib_security.py
@@ -1,0 +1,330 @@
+"""Wire-level tests for credential-safe stdlib urllib redirects."""
+
+from __future__ import annotations
+
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
+import urllib.error
+import urllib.request
+
+import pytest
+
+from hermes_cli.urllib_security import (
+    SafeCredentialRedirectHandler,
+    open_credentialed_url,
+    url_origin,
+)
+
+
+class _Response:
+    def __init__(self, payload: bytes = b"{}") -> None:
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self) -> bytes:
+        return self._payload
+
+
+class _RecordingHandler(BaseHTTPRequestHandler):
+    redirect_to = ""
+    redirect_status = 302
+    requests: list[tuple[str, dict[str, str]]] = []
+
+    def _record(self) -> None:
+        type(self).requests.append(
+            (self.command, {name.lower(): value for name, value in self.headers.items()})
+        )
+
+    def do_GET(self):
+        if self.path.startswith("/redirect"):
+            self.send_response(type(self).redirect_status)
+            self.send_header("Location", type(self).redirect_to)
+            self.end_headers()
+            return
+        self._record()
+        body = json.dumps({"data": []}).encode()
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        self.rfile.read(int(self.headers.get("Content-Length", "0")))
+        if self.path == "/redirect":
+            self.send_response(type(self).redirect_status)
+            self.send_header("Location", type(self).redirect_to)
+            self.end_headers()
+            return
+        self._record()
+        self.send_response(200)
+        self.end_headers()
+
+    def log_message(self, _format, *_args):
+        pass
+
+
+def _server():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _RecordingHandler)
+    Thread(target=server.serve_forever, daemon=True).start()
+    return server
+
+
+def _credential_headers() -> dict[str, str]:
+    return {
+        "Authorization": "Bearer secret",
+        "Cookie": "session=secret",
+        "CF-Access-Client-Secret": "cloudflare-secret",
+        "X-Custom-Auth": "tenant-secret",
+        "Accept": "application/json",
+        "User-Agent": "hermes-test",
+    }
+
+
+def test_url_origin_normalizes_default_ports_and_trailing_dot():
+    assert url_origin("https://EXAMPLE.test./models") == (
+        "https",
+        "example.test",
+        443,
+    )
+    assert url_origin("https://example.test:443/other") == (
+        "https",
+        "example.test",
+        443,
+    )
+    assert url_origin("http://example.test") != url_origin("https://example.test")
+
+
+def test_cross_host_redirect_drops_arbitrary_credentials_on_wire():
+    source = _server()
+    sink = _server()
+    _RecordingHandler.requests = []
+    _RecordingHandler.redirect_status = 302
+    _RecordingHandler.redirect_to = f"http://localhost:{sink.server_port}/sink"
+    try:
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{source.server_port}/redirect",
+            headers=_credential_headers(),
+        )
+        with open_credentialed_url(request, timeout=3) as response:
+            response.read()
+    finally:
+        source.shutdown()
+        sink.shutdown()
+
+    method, headers = _RecordingHandler.requests[-1]
+    assert method == "GET"
+    assert headers["accept"] == "application/json"
+    assert headers["user-agent"] == "hermes-test"
+    for name in (
+        "authorization",
+        "cookie",
+        "cf-access-client-secret",
+        "x-custom-auth",
+    ):
+        assert name not in headers
+
+
+def test_same_host_different_port_drops_credentials_on_wire():
+    source = _server()
+    sink = _server()
+    _RecordingHandler.requests = []
+    _RecordingHandler.redirect_status = 302
+    _RecordingHandler.redirect_to = f"http://127.0.0.1:{sink.server_port}/sink"
+    try:
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{source.server_port}/redirect",
+            headers=_credential_headers(),
+        )
+        with open_credentialed_url(request, timeout=3) as response:
+            response.read()
+    finally:
+        source.shutdown()
+        sink.shutdown()
+
+    _, headers = _RecordingHandler.requests[-1]
+    assert "authorization" not in headers
+    assert "cf-access-client-secret" not in headers
+
+
+def test_same_origin_redirect_preserves_headers_on_wire():
+    server = _server()
+    _RecordingHandler.requests = []
+    _RecordingHandler.redirect_status = 302
+    _RecordingHandler.redirect_to = f"http://127.0.0.1:{server.server_port}/sink"
+    try:
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{server.server_port}/redirect",
+            headers=_credential_headers(),
+        )
+        with open_credentialed_url(request, timeout=3) as response:
+            response.read()
+    finally:
+        server.shutdown()
+
+    _, headers = _RecordingHandler.requests[-1]
+    assert headers["authorization"] == "Bearer secret"
+    assert headers["cf-access-client-secret"] == "cloudflare-secret"
+
+
+def test_scheme_downgrade_is_cross_origin():
+    request = urllib.request.Request(
+        "https://models.example.test/models", headers=_credential_headers()
+    )
+    handler = SafeCredentialRedirectHandler(request.full_url)
+    redirected = handler.redirect_request(
+        request,
+        None,
+        302,
+        "Found",
+        {},
+        "http://models.example.test/models",
+    )
+    assert redirected is not None
+    headers = {name.lower(): value for name, value in redirected.header_items()}
+    assert "authorization" not in headers
+    assert "cf-access-client-secret" not in headers
+
+
+def test_post_302_uses_urllib_semantics_and_drops_credentials():
+    request = urllib.request.Request(
+        "https://models.example.test/load",
+        data=b"{}",
+        headers={**_credential_headers(), "Content-Type": "application/json"},
+        method="POST",
+    )
+    handler = SafeCredentialRedirectHandler(request.full_url)
+    redirected = handler.redirect_request(
+        request,
+        None,
+        302,
+        "Found",
+        {},
+        "https://other.example.test/load",
+    )
+    assert redirected is not None
+    assert redirected.get_method() == "GET"
+    assert redirected.data is None
+    headers = {name.lower(): value for name, value in redirected.header_items()}
+    assert "authorization" not in headers
+    assert "content-type" not in headers
+
+
+def test_post_307_remains_rejected_by_urllib():
+    request = urllib.request.Request(
+        "https://models.example.test/load",
+        data=b"{}",
+        headers=_credential_headers(),
+        method="POST",
+    )
+    handler = SafeCredentialRedirectHandler(request.full_url)
+    with pytest.raises(urllib.error.HTTPError):
+        handler.redirect_request(
+            request,
+            None,
+            307,
+            "Temporary Redirect",
+            {},
+            "https://other.example.test/load",
+        )
+
+
+def test_explicit_opener_factory_is_instrumentable_without_security_bypass():
+    calls = []
+
+    class _Opener:
+        def open(self, request, *, timeout):
+            calls.append((request.full_url, timeout))
+            return _Response()
+
+    def factory(*handlers):
+        assert any(isinstance(h, SafeCredentialRedirectHandler) for h in handlers)
+        return _Opener()
+
+    request = urllib.request.Request(
+        "https://models.example.test/models", headers={"Authorization": "secret"}
+    )
+    with open_credentialed_url(request, timeout=7, opener_factory=factory):
+        pass
+    assert calls == [("https://models.example.test/models", 7)]
+
+
+def test_probe_api_models_drops_custom_credentials_on_wire():
+    from hermes_cli.models import probe_api_models
+
+    source = _server()
+    sink = _server()
+    _RecordingHandler.requests = []
+    _RecordingHandler.redirect_status = 302
+    _RecordingHandler.redirect_to = f"http://localhost:{sink.server_port}/sink"
+    try:
+        result = probe_api_models(
+            "provider-key",
+            f"http://127.0.0.1:{source.server_port}/redirect/..",
+            timeout=3,
+            request_headers={
+                "CF-Access-Client-Secret": "cloudflare-secret",
+                "X-Custom-Auth": "tenant-secret",
+            },
+        )
+    finally:
+        source.shutdown()
+        sink.shutdown()
+
+    assert result["models"] == []
+    _, headers = _RecordingHandler.requests[-1]
+    assert "authorization" not in headers
+    assert "cf-access-client-secret" not in headers
+    assert "x-custom-auth" not in headers
+
+
+class _LmStudioSourceHandler(BaseHTTPRequestHandler):
+    redirect_to = ""
+
+    def do_POST(self):
+        self.rfile.read(int(self.headers.get("Content-Length", "0")))
+        self.send_response(302)
+        self.send_header("Location", type(self).redirect_to)
+        self.end_headers()
+
+    def log_message(self, format, *_args):
+        pass
+
+
+def test_lmstudio_load_post_drops_bearer_on_redirect(monkeypatch):
+    from hermes_cli import models
+
+    sink = _server()
+    source = ThreadingHTTPServer(("127.0.0.1", 0), _LmStudioSourceHandler)
+    Thread(target=source.serve_forever, daemon=True).start()
+    _RecordingHandler.requests = []
+    _LmStudioSourceHandler.redirect_to = f"http://localhost:{sink.server_port}/sink"
+    monkeypatch.setattr(
+        models,
+        "_lmstudio_fetch_raw_models",
+        lambda **_kwargs: [
+            {"id": "model", "max_context_length": 8192, "loaded_instances": []}
+        ],
+    )
+    try:
+        loaded = models.ensure_lmstudio_model_loaded(
+            "model",
+            f"http://127.0.0.1:{source.server_port}",
+            api_key="lm-secret",
+            target_context_length=4096,
+            timeout=3,
+        )
+    finally:
+        source.shutdown()
+        sink.shutdown()
+
+    assert loaded == 4096
+    method, headers = _RecordingHandler.requests[-1]
+    assert method == "GET"
+    assert "authorization" not in headers
+    assert "content-type" not in headers

--- a/tests/hermes_cli/test_urllib_security.py
+++ b/tests/hermes_cli/test_urllib_security.py
@@ -281,13 +281,19 @@ def test_installed_custom_opener_policy_is_preserved(monkeypatch):
     secured = _secure_opener_from_installed_policy(
         "foo://models.example.test/catalog"
     )
-    assert secured.addheaders == installed.addheaders
+    assert secured.addheaders == []
+    assert getattr(secured, "_hermes_initial_addheaders") == installed.addheaders
 
     request = urllib.request.Request(
         "foo://models.example.test/catalog", headers={"Authorization": "secret"}
     )
     with open_credentialed_url(request, timeout=3) as response:
         assert response.read() == b"custom"
+    request_headers = {
+        name.lower(): value for name, value in request.header_items()
+    }
+    assert request_headers["x-trace-policy"] == "installed"
+    assert request_headers["user-agent"] == "enterprise-client"
     assert opened == ["foo://models.example.test/catalog"]
 
 
@@ -311,6 +317,40 @@ def test_installed_proxy_handler_is_preserved(monkeypatch):
     assert getattr(proxy_handlers[0], "proxies", {}) == {
         "https": "http://proxy.example.test:8443"
     }
+
+
+def test_installed_request_processor_cannot_resurrect_cross_origin_secret(
+    monkeypatch,
+):
+    source = _server()
+    sink = _server()
+    _RecordingHandler.requests = []
+    _RecordingHandler.redirect_status = 302
+    _RecordingHandler.redirect_to = f"http://localhost:{sink.server_port}/sink"
+
+    class SecretProcessor(urllib.request.BaseHandler):
+        def http_request(self, request):
+            request.add_header("X-Installed-Secret", "must-not-cross")
+            return request
+
+    installed = urllib.request.build_opener(SecretProcessor())
+    installed.addheaders = [("X-Opener-Secret", "also-must-not-cross")]
+    monkeypatch.setattr(urllib.request, "_opener", installed)
+    try:
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{source.server_port}/redirect",
+            headers={"Authorization": "Bearer secret"},
+        )
+        with open_credentialed_url(request, timeout=3) as response:
+            response.read()
+    finally:
+        source.shutdown()
+        sink.shutdown()
+
+    _, headers = _RecordingHandler.requests[-1]
+    assert "authorization" not in headers
+    assert "x-installed-secret" not in headers
+    assert "x-opener-secret" not in headers
 
 
 def test_multihop_redirects_never_resurrect_credentials():

--- a/tests/hermes_cli/test_urllib_security.py
+++ b/tests/hermes_cli/test_urllib_security.py
@@ -98,6 +98,13 @@ def test_url_origin_normalizes_default_ports_and_trailing_dot():
         443,
     )
     assert url_origin("http://example.test") != url_origin("https://example.test")
+    assert url_origin("https://example.test:0") == (
+        "https",
+        "example.test",
+        0,
+    )
+    with pytest.raises(ValueError):
+        url_origin("https://example.test:not-a-port")
 
 
 def test_cross_host_redirect_drops_arbitrary_credentials_on_wire():
@@ -335,6 +342,41 @@ class _LmStudioSourceHandler(BaseHTTPRequestHandler):
 
     def log_message(self, format, *_args):
         pass
+
+
+def test_anthropic_profile_drops_x_api_key_on_redirect(monkeypatch):
+    import importlib
+
+    AnthropicProfile = importlib.import_module(
+        "plugins.model-providers.anthropic"
+    ).AnthropicProfile
+
+    source = _server()
+    sink = _server()
+    _RecordingHandler.requests = []
+    _RecordingHandler.redirect_status = 302
+    _RecordingHandler.redirect_to = f"http://localhost:{sink.server_port}/sink"
+
+    original_request = urllib.request.Request
+
+    def local_anthropic_request(url, *args, **kwargs):
+        if url == "https://api.anthropic.com/v1/models":
+            url = f"http://127.0.0.1:{source.server_port}/redirect"
+        return original_request(url, *args, **kwargs)
+
+    monkeypatch.setattr(urllib.request, "Request", local_anthropic_request)
+    try:
+        result = AnthropicProfile(name="anthropic").fetch_models(
+            api_key="anthropic-secret", timeout=3
+        )
+    finally:
+        source.shutdown()
+        sink.shutdown()
+
+    assert result == []
+    _, headers = _RecordingHandler.requests[-1]
+    assert "x-api-key" not in headers
+    assert headers["accept"] == "application/json"
 
 
 def test_lmstudio_load_post_drops_bearer_on_redirect(monkeypatch):

--- a/tests/providers/test_fetch_models_base_url.py
+++ b/tests/providers/test_fetch_models_base_url.py
@@ -117,6 +117,66 @@ class TestCustomProviderBaseUrlPassthrough:
             server.shutdown()
 
 
+class _RedirectingHandler(BaseHTTPRequestHandler):
+    """Redirects /models to another hostname and records received headers."""
+
+    redirect_host = "localhost"  # resolves to the same server, different hostname
+    received_headers: dict = {}
+
+    def do_GET(self):
+        if self.path.rstrip("/") == "/models":
+            self.send_response(302)
+            self.send_header(
+                "Location",
+                f"http://{self.redirect_host}:{self.server.server_address[1]}/redirected",
+            )
+            self.end_headers()
+        else:
+            type(self).received_headers = dict(self.headers)
+            body = json.dumps({"data": [{"id": "redirected-model"}]}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        pass
+
+
+class TestFetchModelsRedirectCredentialStripping:
+    """Credential headers must not follow a redirect to a different host."""
+
+    def _run(self, redirect_host):
+        _RedirectingHandler.redirect_host = redirect_host
+        _RedirectingHandler.received_headers = {}
+        server = HTTPServer(("127.0.0.1", 0), _RedirectingHandler)
+        port = server.server_address[1]
+        Thread(target=server.serve_forever, daemon=True).start()
+        try:
+            profile = ProviderProfile(
+                name="test",
+                base_url=f"http://127.0.0.1:{port}",
+                default_headers={"x-api-key": "default-header-secret"},
+            )
+            result = profile.fetch_models(api_key="bearer-secret")
+        finally:
+            server.shutdown()
+        headers = {k.lower(): v for k, v in _RedirectingHandler.received_headers.items()}
+        return result, headers
+
+    def test_cross_host_redirect_strips_credentials(self):
+        result, headers = self._run(redirect_host="localhost")
+        assert result == ["redirected-model"]  # fetch itself still works
+        assert "authorization" not in headers
+        assert "x-api-key" not in headers
+
+    def test_same_host_redirect_keeps_credentials(self):
+        result, headers = self._run(redirect_host="127.0.0.1")
+        assert result == ["redirected-model"]
+        assert headers.get("authorization") == "Bearer bearer-secret"
+        assert headers.get("x-api-key") == "default-header-secret"
+
+
 class TestModelPickerBaseUrlIntegration:
     """The /model picker path should pass model.base_url to fetch_models."""
 

--- a/tests/providers/test_fetch_models_base_url.py
+++ b/tests/providers/test_fetch_models_base_url.py
@@ -118,21 +118,18 @@ class TestCustomProviderBaseUrlPassthrough:
 
 
 class _RedirectingHandler(BaseHTTPRequestHandler):
-    """Redirects /models to another hostname and records received headers."""
+    """Redirects /models to a configurable target and records received headers."""
 
-    redirect_host = "localhost"  # resolves to the same server, different hostname
+    redirect_to = ""  # full URL to redirect /models to (set per test)
     received_headers: dict = {}
 
     def do_GET(self):
         if self.path.rstrip("/") == "/models":
             self.send_response(302)
-            self.send_header(
-                "Location",
-                f"http://{self.redirect_host}:{self.server.server_address[1]}/redirected",
-            )
+            self.send_header("Location", type(self).redirect_to)
             self.end_headers()
         else:
-            type(self).received_headers = dict(self.headers)
+            _RedirectingHandler.received_headers = dict(self.headers)
             body = json.dumps({"data": [{"id": "redirected-model"}]}).encode()
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
@@ -144,14 +141,18 @@ class _RedirectingHandler(BaseHTTPRequestHandler):
 
 
 class TestFetchModelsRedirectCredentialStripping:
-    """Credential headers must not follow a redirect to a different host."""
+    """Credential headers must not follow a redirect outside the original origin."""
 
-    def _run(self, redirect_host):
-        _RedirectingHandler.redirect_host = redirect_host
+    def _run(self, redirect_to):
+        """redirect_to is a callable (first_port, second_port) -> Location URL."""
         _RedirectingHandler.received_headers = {}
         server = HTTPServer(("127.0.0.1", 0), _RedirectingHandler)
+        second_server = HTTPServer(("127.0.0.1", 0), _RedirectingHandler)
         port = server.server_address[1]
+        second_port = second_server.server_address[1]
+        _RedirectingHandler.redirect_to = redirect_to(port, second_port)
         Thread(target=server.serve_forever, daemon=True).start()
+        Thread(target=second_server.serve_forever, daemon=True).start()
         try:
             profile = ProviderProfile(
                 name="test",
@@ -161,17 +162,31 @@ class TestFetchModelsRedirectCredentialStripping:
             result = profile.fetch_models(api_key="bearer-secret")
         finally:
             server.shutdown()
+            second_server.shutdown()
         headers = {k.lower(): v for k, v in _RedirectingHandler.received_headers.items()}
         return result, headers
 
     def test_cross_host_redirect_strips_credentials(self):
-        result, headers = self._run(redirect_host="localhost")
+        result, headers = self._run(
+            lambda port, _: f"http://localhost:{port}/redirected"
+        )
         assert result == ["redirected-model"]  # fetch itself still works
         assert "authorization" not in headers
         assert "x-api-key" not in headers
 
-    def test_same_host_redirect_keeps_credentials(self):
-        result, headers = self._run(redirect_host="127.0.0.1")
+    def test_same_host_different_port_redirect_strips_credentials(self):
+        """A different port is a different origin — it can be a different service."""
+        result, headers = self._run(
+            lambda _, second_port: f"http://127.0.0.1:{second_port}/redirected"
+        )
+        assert result == ["redirected-model"]
+        assert "authorization" not in headers
+        assert "x-api-key" not in headers
+
+    def test_same_origin_redirect_keeps_credentials(self):
+        result, headers = self._run(
+            lambda port, _: f"http://127.0.0.1:{port}/redirected"
+        )
         assert result == ["redirected-model"]
         assert headers.get("authorization") == "Bearer bearer-secret"
         assert headers.get("x-api-key") == "default-header-secret"


### PR DESCRIPTION
## Summary
Provider credentials no longer cross origins during stdlib `urllib` model discovery, catalog, pricing, LM Studio load, or Azure endpoint-probe redirects.

This consolidates #60421 and #62321, preserving both contributors' commits, then applies the review hardening needed to close the complete bug class.

## Changes
- shared `hermes_cli.urllib_security` policy compares scheme + hostname + effective port
- cross-origin redirects retain only `Accept` and `User-Agent`; arbitrary configured headers are treated as credential-bearing
- urllib decides redirect status/method semantics before headers are sanitized
- a final request processor strips secrets reintroduced by installed opener hooks
- provider-profile, Anthropic plugin, Azure detector, and CLI model-catalog paths use the same policy
- authenticated LM Studio model-load POST uses the secured path
- application-installed proxy, TLS, cookie, custom protocol, and instrumentation handlers are preserved without allowing their credentials across origins
- explicit port `0` stays distinct; malformed ports fail closed
- tests patch the secured request seam rather than bypassing it

## Validation
- 227 targeted tests passed
- 197 broader provider/model-switch tests passed
- real two-server redirect tests cover cross-host, same-host/different-port, same-origin, custom secrets, Anthropic `x-api-key`, Azure `api-key`/Bearer, and LM Studio POST redirects
- mutation-disabled header stripping: 6 security tests failed as expected
- real imports/E2E: provider profile, Anthropic and Azure probes, custom `/models` probe, LM Studio POST, multi-hop, and installed opener policies passed
- Ruff and `git diff --check` passed
- `ty`: 3 diagnostics on branch, same 3 on base; no new type debt

## Attribution
- @solyanviktor-star: provider-profile redirect fix and full-origin correction from #60421
- @necoweb3: CLI catalog/probe coverage from #62321
- maintainer follow-ups: shared policy, arbitrary custom-header protection, remaining native provider coverage, origin edge cases, installed-opener compatibility, and wire/mutation tests

Closes #60421
Closes #62321
