### PR TITLE
fix(gateway): register Matrix direct invites

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -2875,18 +2875,74 @@ class MatrixAdapter(BasePlatformAdapter):
         """Auto-join rooms when invited."""
 
         room_id = str(getattr(event, "room_id", ""))
+        sender = str(getattr(event, "sender", ""))
+        content = getattr(event, "content", None)
+        is_direct = bool(
+            getattr(content, "is_direct", False)
+            or (isinstance(content, dict) and content.get("is_direct"))
+        )
 
         logger.info(
             "Matrix: invited to %s — joining",
             room_id,
         )
-        await self._join_room_by_id(room_id)
+        await self._join_room_by_id(
+            room_id,
+            direct_user_id=sender if is_direct else None,
+        )
 
-    async def _join_room_by_id(self, room_id: str) -> bool:
+    async def _mark_room_direct(self, room_id: str, user_id: str) -> None:
+        """Persist a direct-room invite in this account's ``m.direct`` data."""
+        if not self._client or not room_id or not user_id:
+            return
+
+        direct_data: Dict[str, Any] = {}
+        try:
+            resp = await self._client.get_account_data("m.direct")
+            content = getattr(resp, "content", resp)
+            if isinstance(content, dict):
+                direct_data = dict(content)
+        except Exception as exc:
+            logger.warning(
+                "Matrix: could not read m.direct before registering %s: %s",
+                room_id,
+                exc,
+            )
+            return
+
+        rooms = direct_data.get(user_id)
+        user_rooms = list(rooms) if isinstance(rooms, list) else []
+        if room_id not in user_rooms:
+            user_rooms.append(room_id)
+            direct_data[user_id] = user_rooms
+            try:
+                await self._client.set_account_data("m.direct", direct_data)
+            except Exception as exc:
+                logger.warning(
+                    "Matrix: could not persist direct room %s for %s: %s",
+                    room_id,
+                    user_id,
+                    exc,
+                )
+                return
+
+        self._dm_rooms[room_id] = True
+        self._room_identities.pop(room_id, None)
+        self._room_identity_cached_at.pop(room_id, None)
+        logger.info("Matrix: registered %s as a direct room with %s", room_id, user_id)
+
+    async def _join_room_by_id(
+        self,
+        room_id: str,
+        *,
+        direct_user_id: Optional[str] = None,
+    ) -> bool:
         """Join a room by ID and refresh local caches on success."""
         if not room_id:
             return False
         if room_id in self._joined_rooms:
+            if direct_user_id:
+                await self._mark_room_direct(room_id, direct_user_id)
             return True
         try:
             await self._client.join_room(RoomID(room_id))
@@ -2895,6 +2951,8 @@ class MatrixAdapter(BasePlatformAdapter):
             self._room_identity_cached_at.pop(room_id, None)
             logger.info("Matrix: joined %s", room_id)
             await self._refresh_dm_cache()
+            if direct_user_id:
+                await self._mark_room_direct(room_id, direct_user_id)
             return True
         except Exception as exc:
             logger.warning("Matrix: error joining %s: %s", room_id, exc)
@@ -2906,11 +2964,28 @@ class MatrixAdapter(BasePlatformAdapter):
         invites = rooms.get("invite", {})
         if not isinstance(invites, dict):
             return
-        for room_id in invites:
+        for room_id, invite_data in invites.items():
             if room_id in self._joined_rooms:
                 continue
+            direct_user_id = None
+            invite_state = (
+                invite_data.get("invite_state", {})
+                if isinstance(invite_data, dict)
+                else {}
+            )
+            events = invite_state.get("events", []) if isinstance(invite_state, dict) else []
+            for event in events:
+                if not isinstance(event, dict) or event.get("type") != "m.room.member":
+                    continue
+                content = event.get("content", {})
+                if isinstance(content, dict) and content.get("is_direct"):
+                    direct_user_id = str(event.get("sender", "")) or None
+                    break
             logger.info("Matrix: reconciling pending invite for %s", room_id)
-            await self._join_room_by_id(str(room_id))
+            await self._join_room_by_id(
+                str(room_id),
+                direct_user_id=direct_user_id,
+            )
 
     # ------------------------------------------------------------------
     # Reactions (send, receive, processing lifecycle)

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -585,6 +585,100 @@ class TestMatrixDmDetection:
             "!room_b:ex.org": False,
         }
 
+    @pytest.mark.asyncio
+    async def test_direct_invite_is_persisted_to_m_direct(self):
+        self.adapter._client = MagicMock()
+        self.adapter._client.join_room = AsyncMock()
+        self.adapter._client.get_account_data = AsyncMock(
+            return_value=MagicMock(content={"@alice:ex.org": ["!old:ex.org"]})
+        )
+        self.adapter._client.set_account_data = AsyncMock()
+
+        event = types.SimpleNamespace(
+            room_id="!new:ex.org",
+            sender="@alice:ex.org",
+            content={"membership": "invite", "is_direct": True},
+        )
+
+        await self.adapter._on_invite(event)
+
+        self.adapter._client.set_account_data.assert_awaited_once_with(
+            "m.direct",
+            {"@alice:ex.org": ["!old:ex.org", "!new:ex.org"]},
+        )
+        assert self.adapter._dm_rooms["!new:ex.org"] is True
+
+    @pytest.mark.asyncio
+    async def test_pending_direct_invite_is_persisted_to_m_direct(self):
+        self.adapter._client = MagicMock()
+        self.adapter._client.join_room = AsyncMock()
+        self.adapter._client.get_account_data = AsyncMock(
+            return_value=MagicMock(content={})
+        )
+        self.adapter._client.set_account_data = AsyncMock()
+
+        await self.adapter._join_pending_invites({
+            "rooms": {
+                "invite": {
+                    "!new:ex.org": {
+                        "invite_state": {
+                            "events": [{
+                                "type": "m.room.member",
+                                "sender": "@alice:ex.org",
+                                "content": {"membership": "invite", "is_direct": True},
+                            }]
+                        }
+                    }
+                }
+            }
+        })
+
+        self.adapter._client.set_account_data.assert_awaited_once_with(
+            "m.direct",
+            {"@alice:ex.org": ["!new:ex.org"]},
+        )
+        assert self.adapter._dm_rooms["!new:ex.org"] is True
+
+    @pytest.mark.asyncio
+    async def test_group_invite_does_not_modify_m_direct(self):
+        self.adapter._client = MagicMock()
+        self.adapter._client.join_room = AsyncMock()
+        self.adapter._client.get_account_data = AsyncMock(
+            return_value=MagicMock(content={})
+        )
+        self.adapter._client.set_account_data = AsyncMock()
+
+        event = types.SimpleNamespace(
+            room_id="!group:ex.org",
+            sender="@alice:ex.org",
+            content={"membership": "invite", "is_direct": False},
+        )
+
+        await self.adapter._on_invite(event)
+
+        self.adapter._client.set_account_data.assert_not_awaited()
+        assert self.adapter._dm_rooms.get("!group:ex.org") is not True
+
+    @pytest.mark.asyncio
+    async def test_direct_invite_read_failure_does_not_overwrite_m_direct(self):
+        self.adapter._client = MagicMock()
+        self.adapter._client.join_room = AsyncMock()
+        self.adapter._client.get_account_data = AsyncMock(
+            side_effect=RuntimeError("account data unavailable")
+        )
+        self.adapter._client.set_account_data = AsyncMock()
+
+        event = types.SimpleNamespace(
+            room_id="!new:ex.org",
+            sender="@alice:ex.org",
+            content={"membership": "invite", "is_direct": True},
+        )
+
+        await self.adapter._on_invite(event)
+
+        self.adapter._client.set_account_data.assert_not_awaited()
+        assert self.adapter._dm_rooms.get("!new:ex.org") is not True
+
 
 # ---------------------------------------------------------------------------
 # Reply fallback stripping


### PR DESCRIPTION
## What does this PR do?

Matrix direct-message classification relies on the bot account's `m.direct`
account data. Element marks a room as direct on the invite event, but the
Matrix adapter previously discarded that signal when auto-joining. The room
was therefore classified as a group and required an `@mention`, even though it
was a one-to-one chat.

This change preserves the invite's `is_direct` flag and inviter, joins the
room, adds the room to the bot account's existing `m.direct` mapping, and
refreshes the local DM cache immediately. It handles both live invite events
and pending invites reconciled after a gateway restart. Existing account data
is never overwritten when it cannot be read.

Related: #51804 contains a broader Matrix room-context series that also works
on `m.direct`. This PR is a focused standalone fix against current `main` and
additionally covers the pending-invite reconciliation path.

## Related Issue

No issue filed; reproduced on a self-hosted Synapse deployment with Element
Web and the Hermes Matrix gateway.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Preserve `is_direct` and the inviter when processing live Matrix invites.
- Parse the same metadata for pending invites after gateway restart.
- Merge the room into existing `m.direct` account data and refresh DM caches.
- Avoid account-data writes when the current `m.direct` mapping cannot be read.
- Add regression coverage for live direct invites, pending direct invites,
  group invites, and account-data read failures.

## How to Test

1. Configure the Matrix gateway with `matrix.require_mention: true`.
2. From Element, start a new unencrypted direct chat and invite the bot.
3. Send a message without mentioning the bot; it should respond as a DM.
4. Restart the gateway with a pending direct invite and verify the room is
   still added to the bot account's `m.direct` mapping.

Automated validation:

```text
venv/bin/python -m pytest tests/gateway/test_matrix.py -q
234 passed in 14.30s
```

Manual validation: Linux, self-hosted Synapse, Element Web, unencrypted Matrix
room. The bot account's `m.direct` mapping was updated and the gateway replied
without an `@mention` after restart.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing PRs and linked the related broader draft above.
- [x] My PR contains only changes related to this fix.
- [x] I've run the focused Matrix adapter test suite and all tests pass.
- [x] I've added tests for the bug fix.
- [x] I've tested on Linux.

### Documentation & Housekeeping

- [x] Documentation changes are not required; behavior now matches Matrix DM semantics.
- [x] No configuration keys changed.
- [x] No architecture or contributor workflow changed.
- [x] Cross-platform impact considered; the change only uses Matrix client APIs.
- [x] No tool descriptions or schemas changed.
