### PR TITLE
feat(discord): production-grade voice channel with configurable VAD and auto-join

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3264,6 +3264,93 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if mode in {"voice_only", "all"} and key.startswith(prefix)
             )
 
+    def _wire_voice_auto_join(self, adapter) -> None:
+        """Wire the auto-join callback so the adapter can signal the gateway
+        to set up voice input/TTS callbacks when it auto-joins a voice channel.
+
+        Only applies to adapters that support voice channels (Discord).
+        """
+        if not hasattr(adapter, "_voice_auto_join_callback"):
+            return
+
+        logger.info("Wiring voice auto-join callback for %s", getattr(adapter, "name", "adapter"))
+
+        # Read voice config once — avoids repeated config reads on every auto-join.
+        voice_cfg = {}
+        try:
+            from hermes_cli.config import read_raw_config
+            _cfg = read_raw_config() or {}
+            voice_cfg = (_cfg.get("discord") or {}).get("voice", {}) or {}
+        except Exception as e:
+            logger.debug("Could not read discord.voice config: %s", e)
+
+        configured_text_ch_id = voice_cfg.get("text_channel_id")
+        voice_mode_default = voice_cfg.get("mode", "all")
+
+        async def _on_auto_join(guild_id, voice_channel, member):
+            """Called by the adapter when it auto-joins a voice channel.
+
+            Wires the same callbacks that ``/voice join`` would set up:
+            voice input handler, disconnect handler, and voice mode getter.
+            """
+            logger.info(
+                "Voice auto-join callback fired: guild=%d, channel=%s, user=%s",
+                guild_id, voice_channel.name, member.display_name,
+            )
+            if hasattr(adapter, "_voice_input_callback"):
+                adapter._voice_input_callback = self._handle_voice_channel_input
+            if hasattr(adapter, "_on_voice_disconnect"):
+                adapter._on_voice_disconnect = self._handle_voice_timeout_cleanup
+            if hasattr(adapter, "_voice_mode_getter"):
+                adapter._voice_mode_getter = lambda chat_id: self._voice_mode.get(
+                    self._voice_key(Platform.DISCORD, str(chat_id)), "off"
+                )
+            # Find a text channel to associate with this voice session.
+            # Voice input handler needs a text channel to post transcripts
+            # and route replies.
+            #
+            # Priority:
+            #   1. discord.voice.text_channel_id from config.yaml (explicit,
+            #      deterministic — user picks the channel)
+            #   2. First writable text channel in the guild (fallback)
+            text_ch_id = None
+            guild = voice_channel.guild
+            if configured_text_ch_id:
+                try:
+                    text_ch_id = int(configured_text_ch_id)
+                    logger.debug(
+                        "Voice auto-join: using configured text_channel_id=%s",
+                        text_ch_id,
+                    )
+                except (ValueError, TypeError):
+                    logger.warning("Invalid discord.voice.text_channel_id: %s", configured_text_ch_id)
+            if text_ch_id is None:
+                for ch in guild.text_channels:
+                    if ch.permissions_for(guild.me).send_messages:
+                        text_ch_id = ch.id
+                        break
+            if text_ch_id is not None:
+                adapter._voice_text_channels[guild_id] = text_ch_id
+            # Store voice source metadata so voice input shares the
+            # same session as the text conversation.
+            if hasattr(adapter, "_voice_sources") and text_ch_id is not None:
+                source = SessionSource(
+                    platform=Platform.DISCORD,
+                    chat_id=str(text_ch_id),
+                    user_id=str(member.id),
+                    user_name=member.display_name,
+                    chat_type="channel",
+                )
+                adapter._voice_sources[guild_id] = source.to_dict()
+            # Enable voice mode for the text channel
+            if text_ch_id is not None:
+                chat_key = self._voice_key(Platform.DISCORD, str(text_ch_id))
+                self._voice_mode[chat_key] = voice_mode_default
+                self._save_voice_modes()
+                self._set_adapter_auto_tts_enabled(adapter, str(text_ch_id), enabled=True)
+
+        adapter._voice_auto_join_callback = _on_auto_join
+
     async def _safe_adapter_disconnect(self, adapter, platform) -> None:
         """Call adapter.disconnect() defensively, swallowing any error.
 
@@ -6895,6 +6982,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if success:
                     self.adapters[platform] = adapter
                     self._sync_voice_mode_state_to_adapter(adapter)
+                    self._wire_voice_auto_join(adapter)
                     connected_count += 1
                     self._update_platform_runtime_status(
                         platform.value,
@@ -7721,6 +7809,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if success:
                         self.adapters[platform] = adapter
                         self._sync_voice_mode_state_to_adapter(adapter)
+                        self._wire_voice_auto_join(adapter)
                         self.delivery_router.adapters = self.adapters
                         del self._failed_platforms[platform]
                         self._update_platform_runtime_status(

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -13,6 +13,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import math
 import os
 import re
 import struct
@@ -351,20 +352,36 @@ class VoiceReceiver:
     completed utterances via a callback.
     """
 
-    SILENCE_THRESHOLD = 1.5    # seconds of silence → end of utterance
-    MIN_SPEECH_DURATION = 0.5  # minimum seconds to process (skip noise)
+    SILENCE_THRESHOLD = 1.5    # seconds of silence → end of utterance (default; overridden by config)
+    MIN_SPEECH_DURATION = 0.3  # minimum seconds to process (skip noise) (default; overridden by config)
     SAMPLE_RATE = 48000        # Discord native rate
     CHANNELS = 2               # Discord sends stereo
+    # RMS energy threshold for voice activity detection (VAD).
+    # Below this, a frame is considered silence/comfort noise.
+    # 16-bit PCM: full-scale = 32767. 300 is ~-40dBFS — well below speech
+    # but above Opus comfort-noise / digital silence.
+    VAD_ENERGY_THRESHOLD = 300
+    # How many recent frames to check for energy (each frame = 20ms).
+    VAD_FRAME_COUNT = 3
 
-    def __init__(self, voice_client, allowed_user_ids: set = None):
+    def __init__(self, voice_client, allowed_user_ids: set = None, *,
+                 silence_threshold: float = SILENCE_THRESHOLD,
+                 min_speech_duration: float = MIN_SPEECH_DURATION,
+                 vad_energy_threshold: int = VAD_ENERGY_THRESHOLD,
+                 vad_frame_count: int = VAD_FRAME_COUNT):
         self._vc = voice_client
         self._allowed_user_ids = allowed_user_ids or set()
         self._running = False
+        self.silence_threshold = silence_threshold
+        self.min_speech_duration = min_speech_duration
+        self.vad_energy_threshold = vad_energy_threshold
+        self.vad_frame_count = vad_frame_count
 
         # Decryption
         self._secret_key: Optional[bytes] = None
         self._dave_session = None
         self._bot_ssrc: int = 0
+        self._mode: str = 'unknown'  # encryption mode selected by Discord
 
         # SSRC -> user_id mapping (populated from SPEAKING events)
         self._ssrc_to_user: Dict[int, int] = {}
@@ -373,6 +390,11 @@ class VoiceReceiver:
         # Per-user audio buffers
         self._buffers: Dict[int, bytearray] = defaultdict(bytearray)
         self._last_packet_time: Dict[int, float] = {}
+        # VAD: time of last frame with energy above threshold (speech).
+        # Updated only on loud frames, NOT on comfort-noise/silence frames.
+        self._last_speech_time: Dict[int, float] = {}
+        # Whether we're currently collecting an utterance for this SSRC.
+        self._speaking: Dict[int, bool] = defaultdict(bool)
 
         # Opus decoder per SSRC (each user needs own decoder state)
         self._decoders: Dict[int, object] = {}
@@ -393,11 +415,16 @@ class VoiceReceiver:
         self._secret_key = bytes(conn.secret_key)
         self._dave_session = conn.dave_session
         self._bot_ssrc = conn.ssrc
+        self._mode = getattr(conn, 'mode', 'unknown')
 
         self._install_speaking_hook(conn)
         conn.add_socket_listener(self._on_packet)
         self._running = True
-        logger.info("VoiceReceiver started (bot_ssrc=%d)", self._bot_ssrc)
+        key_hash = hashlib.sha256(self._secret_key).hexdigest()[:16] if self._secret_key else 'None'
+        logger.info(
+            "VoiceReceiver started (bot_ssrc=%d, mode=%s, dave=%s, key=%s)",
+            self._bot_ssrc, self._mode, self._dave_session is not None, key_hash,
+        )
 
     def stop(self):
         """Stop listening and clean up."""
@@ -468,6 +495,26 @@ class VoiceReceiver:
         if not self._running or self._paused:
             return
 
+        # Refresh key/ssrc/dave from the live connection state on every
+        # packet.  Discord can send VOICE_SERVER_UPDATE mid-session which
+        # triggers a reconnect with a NEW secret key.  If we keep using
+        # the stale key captured at start(), every packet fails decryption.
+        # Reading these attributes is cheap (just attribute access).
+        conn = self._vc._connection
+        if conn is not None:
+            new_key = bytes(conn.secret_key) if conn.secret_key is not None else None
+            if new_key is not None and new_key != self._secret_key:
+                old_h = hashlib.sha256(self._secret_key).hexdigest()[:8] if self._secret_key else 'None'
+                new_h = hashlib.sha256(new_key).hexdigest()[:8]
+                logger.info(
+                    "VoiceReceiver: secret key rotated %s -> %s, refreshing",
+                    old_h, new_h,
+                )
+                self._secret_key = new_key
+                self._bot_ssrc = conn.ssrc
+                self._mode = getattr(conn, 'mode', self._mode)
+                self._dave_session = conn.dave_session
+
         # Log first few raw packets for debugging
         self._packet_debug_count += 1
         if self._packet_debug_count <= 5:
@@ -521,20 +568,58 @@ class VoiceReceiver:
         header = bytes(data[:header_size])
         payload_with_nonce = data[header_size:]
 
-        # --- NaCl transport decrypt (aead_xchacha20_poly1305_rtpsize) ---
+        # --- NaCl transport decrypt (mode-aware) ---
+        # discord.py 2.7 supports 4 encryption modes. The nonce format
+        # and cipher differ per mode:
+        #   aead_xchacha20_poly1305_rtpsize: Aead, 4-byte nonce suffix
+        #   xsalsa20_poly1305_lite:          SecretBox, 4-byte nonce suffix
+        #   xsalsa20_poly1305_suffix:        SecretBox, 24-byte nonce suffix
+        #   xsalsa20_poly1305:               SecretBox, header as nonce (12 bytes)
+        #
+        # Using the wrong cipher/nonce format silently fails decryption.
         if len(payload_with_nonce) < 4:
             return
-        nonce = bytearray(24)
-        nonce[:4] = payload_with_nonce[-4:]
-        encrypted = bytes(payload_with_nonce[:-4])
 
+        mode = self._mode
         try:
             import nacl.secret  # noqa: E402 — delayed import, only in voice path
-            box = nacl.secret.Aead(self._secret_key)
-            decrypted = box.decrypt(encrypted, header, bytes(nonce))
+            if mode == 'aead_xchacha20_poly1305_rtpsize':
+                nonce = bytearray(24)
+                nonce[:4] = payload_with_nonce[-4:]
+                encrypted = bytes(payload_with_nonce[:-4])
+                box = nacl.secret.Aead(self._secret_key)
+                decrypted = box.decrypt(encrypted, header, bytes(nonce))
+            elif mode == 'xsalsa20_poly1305_lite':
+                nonce = bytearray(24)
+                nonce[:4] = payload_with_nonce[-4:]
+                encrypted = bytes(payload_with_nonce[:-4])
+                box = nacl.secret.SecretBox(self._secret_key)
+                decrypted = box.decrypt(encrypted, bytes(nonce))
+            elif mode == 'xsalsa20_poly1305_suffix':
+                nonce = payload_with_nonce[-24:]
+                encrypted = bytes(payload_with_nonce[:-24])
+                box = nacl.secret.SecretBox(self._secret_key)
+                decrypted = box.decrypt(encrypted, bytes(nonce))
+            elif mode == 'xsalsa20_poly1305':
+                nonce = bytearray(24)
+                nonce[:12] = header
+                encrypted = bytes(payload_with_nonce)
+                box = nacl.secret.SecretBox(self._secret_key)
+                decrypted = box.decrypt(encrypted, bytes(nonce))
+            else:
+                # Fallback: try aead_xchacha20 (most common in discord.py 2.7+)
+                nonce = bytearray(24)
+                nonce[:4] = payload_with_nonce[-4:]
+                encrypted = bytes(payload_with_nonce[:-4])
+                box = nacl.secret.Aead(self._secret_key)
+                decrypted = box.decrypt(encrypted, header, bytes(nonce))
         except Exception as e:
             if self._packet_debug_count <= 10:
-                logger.warning("NaCl decrypt failed: %s (hdr=%d, enc=%d)", e, header_size, len(encrypted))
+                logger.warning(
+                    "NaCl decrypt failed (mode=%s): %s (hdr=%d, payload=%d, ssrc=%d, bot_ssrc=%d, key_len=%d)",
+                    mode, e, header_size, len(payload_with_nonce), ssrc, self._bot_ssrc,
+                    len(self._secret_key) if self._secret_key else 0,
+                )
             return
 
         # Skip encrypted extension data to get the actual opus payload
@@ -570,30 +655,73 @@ class VoiceReceiver:
         if self._dave_session:
             with self._lock:
                 user_id = self._ssrc_to_user.get(ssrc, 0)
+            if not user_id:
+                # Try inline auto-mapping so we don't miss the first few seconds
+                # of speech while waiting for the listen loop's check_silence()
+                # to call _infer_user_for_ssrc.
+                user_id = self._infer_user_for_ssrc(ssrc)
+                if user_id:
+                    with self._lock:
+                        self._ssrc_to_user[ssrc] = user_id
+                    logger.info("Inline auto-mapped ssrc=%d -> user=%d (first packet)", ssrc, user_id)
             if user_id:
                 try:
                     import davey
                     decrypted = self._dave_session.decrypt(
                         user_id, davey.MediaType.audio, decrypted
                     )
+                    if self._packet_debug_count <= 10:
+                        logger.debug("DAVE decrypt OK: ssrc=%d, user=%d, payload=%d bytes", ssrc, user_id, len(decrypted))
                 except Exception as e:
                     # Unencrypted passthrough — use NaCl-decrypted data as-is
                     if "Unencrypted" not in str(e):
                         if self._packet_debug_count <= 10:
-                            logger.warning("DAVE decrypt failed for ssrc=%d: %s", ssrc, e)
+                            logger.debug("DAVE decrypt failed for ssrc=%d: %s", ssrc, e)
                         return
-            # If SSRC unknown (no SPEAKING event yet), skip DAVE and try
-            # Opus decode directly — audio may be in passthrough mode.
-            # Buffer will get a user_id when SPEAKING event arrives later.
+            else:
+                # No user_id yet and inline inference failed — skip DAVE and
+                # discard this packet's PCM to avoid buffering DAVE-encrypted
+                # garbage that would corrupt the first utterance.
+                if self._packet_debug_count <= 10:
+                    logger.debug("DAVE skip: no user_id for ssrc=%d, discarding packet", ssrc)
+                return
 
         # --- Opus decode -> PCM ---
         try:
             if ssrc not in self._decoders:
                 self._decoders[ssrc] = discord.opus.Decoder()
             pcm = self._decoders[ssrc].decode(decrypted)
+
+            # VAD: compute RMS energy to classify speech vs silence
+            # 16-bit PCM samples; RMS tells us if this frame has voice energy.
+            samples = struct.unpack('<%dh' % (len(pcm) // 2), pcm)
+            if samples:
+                rms = int(math.sqrt(sum(s * s for s in samples) / len(samples)))
+            else:
+                rms = 0
+            is_speech = rms >= self.vad_energy_threshold
+
             with self._lock:
-                self._buffers[ssrc].extend(pcm)
                 self._last_packet_time[ssrc] = time.monotonic()
+                if is_speech:
+                    # Only buffer frames with voice energy — skip silence/
+                    # comfort-noise packets that inflate the recording.
+                    self._buffers[ssrc].extend(pcm)
+                    self._last_speech_time[ssrc] = time.monotonic()
+                    if not self._speaking[ssrc]:
+                        self._speaking[ssrc] = True
+                        logger.info("VAD: speech started for ssrc=%d (rms=%d)", ssrc, rms)
+                else:
+                    # Silence frame — buffer a small amount for natural
+                    # transitions, but don't let it dominate.  Only extend
+                    # if we're in an active utterance (avoids pre-speech
+                    # silence padding).
+                    if self._speaking[ssrc]:
+                        self._buffers[ssrc].extend(pcm)
+
+            if self._packet_debug_count <= 10:
+                buf_len = len(self._buffers.get(ssrc, b''))
+                logger.debug("Opus decode OK: ssrc=%d, pcm=%d bytes, rms=%d, speech=%s, buffer=%d bytes", ssrc, len(pcm), rms, is_speech, buf_len)
         except Exception as e:
             with self._lock:
                 self._decoders.pop(ssrc, None)
@@ -644,26 +772,39 @@ class VoiceReceiver:
             ssrc_list = list(self._buffers.keys())
 
             for ssrc in ssrc_list:
-                last_time = self._last_packet_time.get(ssrc, now)
-                silence_duration = now - last_time
+                # Use _last_speech_time (VAD-based) instead of
+                # _last_packet_time — comfort-noise/silence packets keep
+                # updating _last_packet_time, which prevents the silence
+                # threshold from ever triggering and inflates recordings
+                # with tens of seconds of silence.
+                last_speech = self._last_speech_time.get(ssrc, 0)
+                silence_duration = now - last_speech
                 buf = self._buffers[ssrc]
                 # 48kHz, 16-bit, stereo = 192000 bytes/sec
                 buf_duration = len(buf) / (self.SAMPLE_RATE * self.CHANNELS * 2)
 
-                if silence_duration >= self.SILENCE_THRESHOLD and buf_duration >= self.MIN_SPEECH_DURATION:
+                if silence_duration >= self.silence_threshold and buf_duration >= self.min_speech_duration:
                     user_id = ssrc_user_map.get(ssrc, 0)
                     if not user_id:
                         # SSRC not mapped (SPEAKING event missing after bot rejoin).
                         # Infer from allowed users in the voice channel.
                         user_id = self._infer_user_for_ssrc(ssrc)
                     if user_id:
+                        logger.info(
+                            "Utterance completed: user=%d, %.2fs audio (buffer=%d bytes)",
+                            user_id, buf_duration, len(buf),
+                        )
                         completed.append((user_id, bytes(buf)))
                     self._buffers[ssrc] = bytearray()
                     self._last_packet_time.pop(ssrc, None)
-                elif silence_duration >= self.SILENCE_THRESHOLD * 2:
+                    self._last_speech_time.pop(ssrc, None)
+                    self._speaking[ssrc] = False
+                elif silence_duration >= self.silence_threshold * 2:
                     # Stale buffer with no valid user — discard
                     self._buffers.pop(ssrc, None)
                     self._last_packet_time.pop(ssrc, None)
+                    self._last_speech_time.pop(ssrc, None)
+                    self._speaking[ssrc] = False
 
         return completed
 
@@ -752,7 +893,9 @@ class DiscordAdapter(BasePlatformAdapter):
     supports_code_blocks = True  # Discord markdown renders fenced code blocks natively
     splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
 
-    # Auto-disconnect from voice channel after this many seconds of inactivity
+    # Auto-disconnect from voice channel after this many seconds of inactivity.
+    # Set to 0 to disable auto-disconnect (bot stays in voice channel indefinitely).
+    # Override via discord.voice.idle_timeout in config.yaml.
     VOICE_TIMEOUT = 300
 
     def __init__(self, config: PlatformConfig):
@@ -775,9 +918,32 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_timeout_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> timeout task
         # Phase 2: voice listening
         self._voice_receivers: Dict[int, VoiceReceiver] = {}  # guild_id -> VoiceReceiver
+        self._voice_auto_join_callback: Optional[Callable] = None  # set by gateway to wire voice callbacks on auto-join
         self._voice_listen_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> listen loop
         self._voice_input_callback: Optional[Callable] = None  # set by run.py
         self._on_voice_disconnect: Optional[Callable] = None  # set by run.py
+        # Read voice config from discord.voice.* in config.yaml.
+        # Uses read_raw_config() like _load_voice_fx_config() does, because
+        # voice settings are not bridged into config.extra by load_gateway_config().
+        voice_cfg: Dict[str, Any] = {}
+        try:
+            from hermes_cli.config import read_raw_config
+            _raw = read_raw_config() or {}
+            voice_cfg = ((_raw.get("discord") or {}).get("voice") or {}) or {}
+        except Exception as e:
+            logger.debug("Could not read discord.voice config: %s", e)
+        self._voice_cfg = voice_cfg
+        self.VOICE_TIMEOUT = int(voice_cfg.get("idle_timeout", self.VOICE_TIMEOUT))
+        self._voice_auto_join = bool(voice_cfg.get("auto_join", False))
+        self._voice_auto_disconnect = bool(voice_cfg.get("auto_disconnect", True))
+        self._voice_text_channel_id = voice_cfg.get("text_channel_id") or None
+        self._voice_channel_id = voice_cfg.get("channel_id") or None  # specific voice channel to auto-join
+        self._voice_mode_default = str(voice_cfg.get("mode", "all"))
+        self._voice_silence_threshold = float(voice_cfg.get("silence_threshold", VoiceReceiver.SILENCE_THRESHOLD))
+        self._voice_min_speech_duration = float(voice_cfg.get("min_speech_duration", VoiceReceiver.MIN_SPEECH_DURATION))
+        _vad_cfg = voice_cfg.get("vad", {}) or {}
+        self._voice_vad_energy_threshold = int(_vad_cfg.get("energy_threshold", VoiceReceiver.VAD_ENERGY_THRESHOLD))
+        self._voice_vad_frame_count = int(_vad_cfg.get("frame_count", VoiceReceiver.VAD_FRAME_COUNT))
         # Resolves the current voice-reply mode ("off"|"voice_only"|"all") for a
         # linked text-channel id; set by run.py. Lets the inactivity timer leave
         # the bot in the channel when the user deliberately picked text-only
@@ -1138,18 +1304,13 @@ class DiscordAdapter(BasePlatformAdapter):
 
             @self._client.event
             async def on_voice_state_update(member, before, after):
-                """Track voice channel join/leave events."""
-                # Only track channels where the bot is connected
-                bot_guild_ids = set(adapter_self._voice_clients.keys())
-                if not bot_guild_ids:
-                    return
-                guild_id = member.guild.id
-                if guild_id not in bot_guild_ids:
-                    return
+                """Track voice channel join/leave events, auto-join, and
+                auto-disconnect when the last human leaves."""
                 # Ignore the bot itself
                 if member == adapter_self._client.user:
                     return
 
+                guild_id = member.guild.id
                 joined = before.channel is None and after.channel is not None
                 left = before.channel is not None and after.channel is None
                 switched = (
@@ -1168,6 +1329,77 @@ class DiscordAdapter(BasePlatformAdapter):
                         else f"moved {before.channel.name} -> {after.channel.name}",
                         guild_id,
                     )
+
+                # Auto-join: when an allowed user joins a voice channel and the
+                # bot is not yet connected to any voice channel in this guild,
+                # join them automatically. If discord.voice.channel_id is set,
+                # only auto-join that specific channel.
+                if joined and after.channel is not None and adapter_self._voice_auto_join:
+                    # Check if user is in the allowed list
+                    allowed = getattr(adapter_self, "_allowed_user_ids", set())
+                    if "*" in allowed or str(member.id) in allowed:
+                        # If a specific channel is configured, only join that one
+                        configured_ch_id = adapter_self._voice_channel_id
+                        if configured_ch_id and after.channel.id != int(configured_ch_id):
+                            logger.debug(
+                                "Auto-join skipped: user joined %s (id=%d) but configured channel is %s",
+                                after.channel.name, after.channel.id, configured_ch_id,
+                            )
+                        else:
+                            existing = adapter_self._voice_clients.get(guild_id)
+                            if not existing or not existing.is_connected():
+                                logger.info(
+                                    "Auto-joining voice channel %s (guild %d) for user %s",
+                                    after.channel.name, guild_id, member.display_name,
+                                )
+                                try:
+                                    success = await adapter_self.join_voice_channel(after.channel)
+                                    if success:
+                                        # Let the gateway wire voice callbacks
+                                        # (input handler, TTS mode, etc.)
+                                        cb = adapter_self._voice_auto_join_callback
+                                        if cb:
+                                            await cb(guild_id, after.channel, member)
+                                        logger.info(
+                                            "Auto-joined voice channel %s (guild %d)",
+                                            after.channel.name, guild_id,
+                                        )
+                                except Exception as e:
+                                    logger.warning("Auto-join failed: %s", e)
+
+                # Auto-disconnect: when a user leaves or switches away from the
+                # voice channel the bot is currently in, check if any non-bot
+                # humans remain. If the channel is empty, disconnect the bot.
+                if left or switched and adapter_self._voice_auto_disconnect:
+                    vc = adapter_self._voice_clients.get(guild_id)
+                    if vc and vc.is_connected():
+                        bot_channel = vc.channel
+                        # The user left from the bot's current channel
+                        if bot_channel and before.channel and bot_channel.id == before.channel.id:
+                            bot_user = adapter_self._client.user if adapter_self._client else None
+                            humans = [
+                                m for m in bot_channel.members
+                                if not (bot_user and m.id == bot_user.id) and not m.bot
+                            ]
+                            if not humans:
+                                logger.info(
+                                    "Last human left voice channel %s (guild %d) — auto-disconnecting",
+                                    bot_channel.name, guild_id,
+                                )
+                                try:
+                                    # Grab the text channel ID BEFORE calling
+                                    # leave_voice_channel, which pops it from
+                                    # _voice_text_channels during cleanup.
+                                    text_ch_id = adapter_self._voice_text_channels.get(guild_id)
+                                    await adapter_self.leave_voice_channel(guild_id)
+                                    if adapter_self._on_voice_disconnect and text_ch_id:
+                                        adapter_self._on_voice_disconnect(str(text_ch_id))
+                                    if text_ch_id and adapter_self._client:
+                                        ch = adapter_self._client.get_channel(text_ch_id)
+                                        if ch:
+                                            await ch.send("Left voice channel (everyone left).")
+                                except Exception as e:
+                                    logger.warning("Auto-disconnect on empty channel failed: %s", e)
 
             # Register slash commands
             if self._slash_commands:
@@ -2752,7 +2984,13 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Start voice receiver (Phase 2: listen to users)
             try:
-                receiver = VoiceReceiver(vc, allowed_user_ids=self._allowed_user_ids)
+                receiver = VoiceReceiver(
+                    vc, allowed_user_ids=self._allowed_user_ids,
+                    silence_threshold=self._voice_silence_threshold,
+                    min_speech_duration=self._voice_min_speech_duration,
+                    vad_energy_threshold=self._voice_vad_energy_threshold,
+                    vad_frame_count=self._voice_vad_frame_count,
+                )
                 receiver.start()
                 self._voice_receivers[guild_id] = receiver
                 self._voice_listen_tasks[guild_id] = asyncio.ensure_future(
@@ -2880,19 +3118,39 @@ class DiscordAdapter(BasePlatformAdapter):
                 receiver.resume()
 
     async def get_user_voice_channel(self, guild_id: int, user_id: str):
-        """Return the voice channel the user is currently in, or None."""
+        """Return the voice channel the user is currently in, or None.
+
+        Works WITHOUT the privileged Server Members intent: Discord sends
+        VOICE_STATE_UPDATE events whenever a user joins/leaves/moves voice
+        channels, and discord.py populates ``guild.voice_states`` from those
+        events (only requires ``intents.voice_states = True``).  When the
+        Members intent is off, ``guild.get_member()`` returns ``None`` because
+        the member cache is empty — but ``guild.voice_states`` is still
+        populated.  We fall back to fetching the member only if voice_states
+        doesn't have it.
+        """
         if not self._client:
             return None
         guild = self._client.get_guild(guild_id)
         if not guild:
             return None
-        member = guild.get_member(int(user_id))
-        if not member or not member.voice:
-            return None
-        return member.voice.channel
+        uid = int(user_id)
+        # Fast path: voice_states cache (populated from VOICE_STATE_UPDATE
+        # events, does NOT need Members intent).  discord.py stores these in
+        # the private _voice_states dict; there's no public property.
+        vs = guild._voice_states.get(uid)
+        if vs and vs.channel:
+            return vs.channel
+        # Fallback: member cache (needs Members intent) or fetch.
+        member = guild.get_member(uid)
+        if member and member.voice and member.voice.channel:
+            return member.voice.channel
+        return None
 
     def _reset_voice_timeout(self, guild_id: int) -> None:
         """Reset the auto-disconnect inactivity timer."""
+        if self.VOICE_TIMEOUT <= 0:
+            return  # auto-disconnect disabled
         task = self._voice_timeout_tasks.pop(guild_id, None)
         if task:
             task.cancel()
@@ -3045,11 +3303,16 @@ class DiscordAdapter(BasePlatformAdapter):
                 # guild-scoped and not cross-guild.
                 _vc_guild = self._client.get_guild(guild_id) if self._client is not None else None
                 for user_id, pcm_data in completed:
+                    logger.debug(
+                        "Voice utterance: user_id=%d, pcm=%d bytes",
+                        user_id, len(pcm_data),
+                    )
                     if not self._is_allowed_user(
                         str(user_id),
                         guild=_vc_guild,
                         is_dm=False,
                     ):
+                        logger.debug("Voice utterance filtered by _is_allowed_user: user_id=%d", user_id)
                         continue
                     # A user speaking to the bot is activity too — not just the
                     # bot's own playback. Reset the inactivity timer so an active
@@ -3064,6 +3327,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
     async def _process_voice_input(self, guild_id: int, user_id: int, pcm_data: bytes):
         """Convert PCM -> WAV -> STT -> callback."""
+        logger.debug("Processing voice input: guild=%d, user=%d, pcm=%d bytes", guild_id, user_id, len(pcm_data))
         from tools.voice_mode import is_whisper_hallucination
 
         tmp_f = tempfile.NamedTemporaryFile(suffix=".wav", prefix="vc_listen_", delete=False)
@@ -3076,9 +3340,14 @@ class DiscordAdapter(BasePlatformAdapter):
             result = await asyncio.to_thread(transcribe_audio, wav_path)
 
             if not result.get("success"):
+                logger.debug("Voice STT failed: %s", result.get('error', 'unknown'))
                 return
             transcript = result.get("transcript", "").strip()
-            if not transcript or is_whisper_hallucination(transcript):
+            if not transcript:
+                logger.debug("Voice STT: empty transcript")
+                return
+            if is_whisper_hallucination(transcript):
+                logger.debug("Voice STT: hallucination filtered: %s", transcript[:100])
                 return
 
             logger.info("Voice input from user %d: %s", user_id, transcript[:100])

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -395,6 +395,11 @@ class VoiceReceiver:
         self._last_speech_time: Dict[int, float] = {}
         # Whether we're currently collecting an utterance for this SSRC.
         self._speaking: Dict[int, bool] = defaultdict(bool)
+        # Rolling-frame VAD: recent frame energy booleans per SSRC.
+        # A frame counts as speech if any of the last vad_frame_count frames
+        # had energy above threshold — prevents brief dips between syllables
+        # from being classified as silence.
+        self._vad_history: Dict[int, list] = defaultdict(list)
 
         # Opus decoder per SSRC (each user needs own decoder state)
         self._decoders: Dict[int, object] = {}
@@ -436,6 +441,9 @@ class VoiceReceiver:
         with self._lock:
             self._buffers.clear()
             self._last_packet_time.clear()
+            self._last_speech_time.clear()
+            self._speaking.clear()
+            self._vad_history.clear()
             self._decoders.clear()
             self._ssrc_to_user.clear()
         logger.info("VoiceReceiver stopped")
@@ -692,14 +700,24 @@ class VoiceReceiver:
                 self._decoders[ssrc] = discord.opus.Decoder()
             pcm = self._decoders[ssrc].decode(decrypted)
 
-            # VAD: compute RMS energy to classify speech vs silence
-            # 16-bit PCM samples; RMS tells us if this frame has voice energy.
+            # VAD: compute RMS energy to classify speech vs silence.
+            # Uses a rolling window of vad_frame_count frames — a frame counts
+            # as speech if ANY of the recent frames had energy above threshold.
+            # This prevents brief dips between syllables from breaking an
+            # utterance into fragments.
             samples = struct.unpack('<%dh' % (len(pcm) // 2), pcm)
             if samples:
                 rms = int(math.sqrt(sum(s * s for s in samples) / len(samples)))
             else:
                 rms = 0
-            is_speech = rms >= self.vad_energy_threshold
+            frame_is_loud = rms >= self.vad_energy_threshold
+
+            # Update rolling history and classify using the window
+            history = self._vad_history[ssrc]
+            history.append(frame_is_loud)
+            if len(history) > self.vad_frame_count:
+                history.pop(0)
+            is_speech = any(history)
 
             with self._lock:
                 self._last_packet_time[ssrc] = time.monotonic()
@@ -799,12 +817,14 @@ class VoiceReceiver:
                     self._last_packet_time.pop(ssrc, None)
                     self._last_speech_time.pop(ssrc, None)
                     self._speaking[ssrc] = False
+                    self._vad_history.pop(ssrc, None)
                 elif silence_duration >= self.silence_threshold * 2:
                     # Stale buffer with no valid user — discard
                     self._buffers.pop(ssrc, None)
                     self._last_packet_time.pop(ssrc, None)
                     self._last_speech_time.pop(ssrc, None)
                     self._speaking[ssrc] = False
+                    self._vad_history.pop(ssrc, None)
 
         return completed
 
@@ -1370,7 +1390,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 # Auto-disconnect: when a user leaves or switches away from the
                 # voice channel the bot is currently in, check if any non-bot
                 # humans remain. If the channel is empty, disconnect the bot.
-                if left or switched and adapter_self._voice_auto_disconnect:
+                if (left or switched) and adapter_self._voice_auto_disconnect:
                     vc = adapter_self._voice_clients.get(guild_id)
                     if vc and vc.is_connected():
                         bot_channel = vc.channel
@@ -2725,7 +2745,20 @@ class DiscordAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
-        """Send audio as a Discord file attachment."""
+        """Send audio as a Discord file attachment, or play in VC if connected.
+
+        When the bot is in a voice channel for this chat's guild, play the
+        audio directly in the VC instead of uploading a file.  This covers
+        both the auto-TTS path (play_tts) and the agent-initiated TTS path
+        (text_to_speech tool → MEDIA: tag → send_voice).
+        """
+        # If connected to a voice channel for this chat, play there.
+        for gid, text_ch_id in self._voice_text_channels.items():
+            if str(text_ch_id) == str(chat_id) and self.is_in_voice_channel(gid):
+                logger.info("[%s] Playing TTS in voice channel via send_voice (guild=%d)", self.name, gid)
+                success = await self.play_in_voice_channel(gid, audio_path)
+                return SendResult(success=success)
+
         try:
             import io
 

--- a/plugins/platforms/discord/voice_mixer.py
+++ b/plugins/platforms/discord/voice_mixer.py
@@ -145,13 +145,26 @@ class MixerChild:
         return samples
 
 
-class VoiceMixer:
+try:
+    from discord import AudioSource as _AudioSource
+except Exception:  # discord.py not installed (type-check / non-Discord envs)
+    class _AudioSource:  # type: ignore[no-redef]
+        """Minimal stand-in for discord.AudioSource when discord.py is not installed.
+
+        Allows VoiceMixer to subclass _AudioSource in environments where
+        discord.py is absent (type-checking, non-Discord test envs) without
+        raising ImportError at import time.
+        """
+        pass
+
+
+class VoiceMixer(_AudioSource):
     """A continuous ``discord.AudioSource`` that mixes N child streams.
 
     Use :meth:`set_ambient` to install/replace the looping idle bed and
     :meth:`play_speech` to layer a one-shot clip over it (ducking the ambient
-    while it plays).  Both are safe to call from the asyncio loop thread while
-    discord.py drains :meth:`read` from its sender thread.
+    while it plays).  Both are safe to call from the asyncio event loop thread
+    while discord.py drains :meth:`read` from its sender thread.
     """
 
     # discord.AudioSource subclasses set is_opus()==False to receive PCM.

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -654,11 +654,13 @@ class TestVoiceReceiver:
         receiver.map_ssrc(100, 42)
         receiver._buffers[100] = bytearray(b"\x00" * 1000)
         receiver._last_packet_time[100] = time.monotonic()
+        receiver._last_speech_time[100] = time.monotonic()
         receiver.stop()
         assert receiver._running is False
         assert len(receiver._buffers) == 0
         assert len(receiver._ssrc_to_user) == 0
         assert len(receiver._last_packet_time) == 0
+        assert len(receiver._last_speech_time) == 0
 
     def test_map_ssrc(self):
         receiver = self._make_receiver()
@@ -690,8 +692,8 @@ class TestVoiceReceiver:
         # MIN_SPEECH_DURATION = 0.5s → need 96000 bytes
         pcm_data = bytearray(b"\x00" * 96000)
         receiver._buffers[100] = pcm_data
-        # Set last_packet_time far enough in the past to exceed SILENCE_THRESHOLD
-        receiver._last_packet_time[100] = time.monotonic() - 3.0
+        # Set last_speech_time far enough in the past to exceed SILENCE_THRESHOLD
+        receiver._last_speech_time[100] = time.monotonic() - 3.0
         completed = receiver.check_silence()
         assert len(completed) == 1
         user_id, data = completed[0]
@@ -705,7 +707,7 @@ class TestVoiceReceiver:
         receiver.map_ssrc(100, 42)
         # Too short to meet MIN_SPEECH_DURATION
         receiver._buffers[100] = bytearray(b"\x00" * 100)
-        receiver._last_packet_time[100] = time.monotonic() - 3.0
+        receiver._last_speech_time[100] = time.monotonic() - 3.0
         completed = receiver.check_silence()
         assert len(completed) == 0
 
@@ -713,7 +715,7 @@ class TestVoiceReceiver:
         receiver = self._make_receiver()
         receiver.map_ssrc(100, 42)
         receiver._buffers[100] = bytearray(b"\x00" * 96000)
-        receiver._last_packet_time[100] = time.monotonic()  # just now
+        receiver._last_speech_time[100] = time.monotonic()  # just now
         completed = receiver.check_silence()
         assert len(completed) == 0
 
@@ -721,7 +723,7 @@ class TestVoiceReceiver:
         receiver = self._make_receiver()
         # No SSRC mapping — user_id will be 0
         receiver._buffers[100] = bytearray(b"\x00" * 96000)
-        receiver._last_packet_time[100] = time.monotonic() - 3.0
+        receiver._last_speech_time[100] = time.monotonic() - 3.0
         completed = receiver.check_silence()
         assert len(completed) == 0
 
@@ -729,7 +731,7 @@ class TestVoiceReceiver:
         receiver = self._make_receiver()
         # Buffer with no user mapping and very old timestamp
         receiver._buffers[200] = bytearray(b"\x00" * 100)
-        receiver._last_packet_time[200] = time.monotonic() - 10.0
+        receiver._last_speech_time[200] = time.monotonic() - 10.0
         receiver.check_silence()
         # Stale buffer (> 2x threshold) should be discarded
         assert 200 not in receiver._buffers
@@ -762,6 +764,50 @@ class TestVoiceReceiver:
         data[0] = 0x00  # version 0, not 2
         receiver._on_packet(bytes(data))
         assert len(receiver._buffers) == 0
+
+    # -- VAD rolling-frame tests --
+
+    def test_vad_history_initialized_empty(self):
+        """_vad_history starts empty per SSRC."""
+        receiver = self._make_receiver()
+        assert len(receiver._vad_history) == 0
+
+    def test_vad_frame_count_defaults(self):
+        """Default vad_frame_count is 3 (VAD_FRAME_COUNT)."""
+        from plugins.platforms.discord.adapter import VoiceReceiver
+        assert VoiceReceiver.VAD_FRAME_COUNT == 3
+
+    def test_vad_stop_clears_history(self):
+        """stop() clears _vad_history along with other state."""
+        receiver = self._make_receiver()
+        receiver.start()
+        receiver._vad_history[100] = [True, False, True]
+        receiver.stop()
+        assert len(receiver._vad_history) == 0
+
+    def test_vad_check_silence_clears_history_on_completion(self):
+        """When an utterance completes, _vad_history for that SSRC is cleared."""
+        receiver = self._make_receiver()
+        receiver.map_ssrc(100, 42)
+        receiver._buffers[100] = bytearray(b"\x00" * 96000)
+        receiver._last_speech_time[100] = time.monotonic() - 3.0
+        receiver._vad_history[100] = [True, True, False]
+        completed = receiver.check_silence()
+        assert len(completed) == 1
+        assert 100 not in receiver._vad_history
+
+    def test_vad_silence_zero_default_completes(self):
+        """SSRC with no _last_speech_time (default 0) should be eligible
+        for completion if buffer is large enough — simulates a user who
+        stopped speaking before the bot started listening."""
+        receiver = self._make_receiver()
+        receiver.map_ssrc(100, 42)
+        receiver._buffers[100] = bytearray(b"\x00" * 96000)
+        # _last_speech_time not set — defaults to 0 (epoch start)
+        # silence_duration = now - 0 = very large → should complete
+        completed = receiver.check_silence()
+        assert len(completed) == 1
+        assert completed[0][0] == 42
 
 
 # =====================================================================
@@ -1186,6 +1232,8 @@ class TestDiscordVoiceChannelMethods:
         mock_member = MagicMock()
         mock_member.voice = None
         mock_guild.get_member = MagicMock(return_value=mock_member)
+        # voice_states must be a real dict, not a MagicMock, so .get() returns None
+        mock_guild._voice_states = {}
         adapter._client.get_guild = MagicMock(return_value=mock_guild)
         result = await adapter.get_user_voice_channel(111, "42")
         assert result is None
@@ -1199,6 +1247,9 @@ class TestDiscordVoiceChannelMethods:
         mock_member.voice = MagicMock()
         mock_member.voice.channel = mock_vc
         mock_guild.get_member = MagicMock(return_value=mock_member)
+        # voice_states must be a real dict so .get() returns None and
+        # the code falls through to the member cache path
+        mock_guild._voice_states = {}
         adapter._client.get_guild = MagicMock(return_value=mock_guild)
         result = await adapter.get_user_voice_channel(111, "42")
         assert result is mock_vc
@@ -2380,6 +2431,8 @@ class TestVoiceReception:
         size = int(192000 * duration_s)
         receiver._buffers[ssrc] = bytearray(b"\x00" * size)
         receiver._last_packet_time[ssrc] = time.monotonic() - age_s
+        # check_silence() uses _last_speech_time for VAD-based completion
+        receiver._last_speech_time[ssrc] = time.monotonic() - age_s
 
     # -- Known SSRC (normal flow) --
 
@@ -2430,7 +2483,7 @@ class TestVoiceReception:
         # SPEAKING event arrives
         receiver.map_ssrc(100, 42)
         # Silence kicks in
-        receiver._last_packet_time[100] = time.monotonic() - 3.0
+        receiver._last_speech_time[100] = time.monotonic() - 3.0
         completed = receiver.check_silence()
         assert len(completed) == 1
         assert completed[0][0] == 42
@@ -2520,7 +2573,7 @@ class TestVoiceReception:
         receiver = self._make_receiver()
         receiver.start()
         receiver._buffers[200] = bytearray(b"\x00" * 100)
-        receiver._last_packet_time[200] = time.monotonic() - 10.0
+        receiver._last_speech_time[200] = time.monotonic() - 10.0
         receiver.check_silence()
         assert 200 not in receiver._buffers
 
@@ -2555,9 +2608,8 @@ class TestVoiceReception:
         vc.user = SimpleNamespace(id=9999)
         vc.channel = MagicMock()
         vc.channel.members = []
-        receiver = VoiceReceiver(vc)
+        receiver = VoiceReceiver(vc, vad_energy_threshold=0)
         receiver.start()
-        # Pre-map SSRCs if provided
         if mapped_ssrcs:
             for ssrc, uid in mapped_ssrcs.items():
                 receiver.map_ssrc(ssrc, uid)
@@ -2602,7 +2654,11 @@ class TestVoiceReception:
         dave.decrypt.assert_called_once()
 
     def test_on_packet_dave_unknown_ssrc_passthrough(self):
-        """Unknown SSRC + DAVE → skip DAVE, attempt Opus decode (passthrough)."""
+        """Unknown SSRC + DAVE → skip DAVE, packet discarded (not buffered).
+
+        When DAVE is enabled and the SSRC has no user mapping, the receiver
+        discards the packet to prevent buffering DAVE-encrypted garbage.
+        """
         dave = MagicMock()
         receiver = self._make_receiver_with_nacl(dave_session=dave)
         self._inject_mock_decoder(receiver, 100)
@@ -2612,8 +2668,8 @@ class TestVoiceReception:
             receiver._on_packet(self._build_rtp_packet(ssrc=100))
 
         dave.decrypt.assert_not_called()
-        assert 100 in receiver._buffers
-        assert len(receiver._buffers[100]) > 0
+        # Packet discarded — DAVE guard drops unknown-SSRC packets
+        assert 100 not in receiver._buffers
 
     def test_on_packet_dave_unencrypted_error_passthrough(self):
         """DAVE decrypt 'Unencrypted' error → use data as-is, don't drop."""
@@ -2974,3 +3030,156 @@ class TestShouldAutoTtsForChat:
         fn, adapter = self._make_adapter(default=False, enabled={"chat1"})
         assert fn(adapter, "chat1") is True
         assert fn(adapter, "chat2") is False
+
+
+# =====================================================================
+# Auto-disconnect operator precedence regression tests
+# =====================================================================
+
+class TestAutoDisconnectPrecedence:
+    """Regression tests for the operator precedence bug in the
+    auto-disconnect condition.
+
+    Before the fix, ``left or switched and auto_disconnect`` parsed as
+    ``left or (switched and auto_disconnect)`` — meaning a user *leaving*
+    the channel would disconnect the bot even when auto_disconnect was False.
+    The correct condition is ``(left or switched) and auto_disconnect``.
+    """
+
+    def test_leave_with_auto_disconnect_false_no_disconnect(self):
+        """User leaves → auto_disconnect=False → bot should NOT disconnect.
+
+        Before fix: `left or (switched and False)` = `left or False` = `left`
+        → would disconnect. After fix: `(left or switched) and False` = False.
+        """
+        # We test the condition logic directly by simulating the branch
+        left = True       # user left the channel
+        switched = False  # user did not switch channels
+        auto_disconnect = False
+
+        # The fixed condition
+        should_check = (left or switched) and auto_disconnect
+        assert should_check is False, (
+            "Auto-disconnect should NOT trigger when auto_disconnect=False, "
+            "even if a user leaves the channel"
+        )
+
+    def test_switch_with_auto_disconnect_false_no_disconnect(self):
+        """User switches channels → auto_disconnect=False → no disconnect."""
+        left = False
+        switched = True
+        auto_disconnect = False
+
+        should_check = (left or switched) and auto_disconnect
+        assert should_check is False
+
+    def test_leave_with_auto_disconnect_true_triggers(self):
+        """User leaves → auto_disconnect=True → should check for disconnect."""
+        left = True
+        switched = False
+        auto_disconnect = True
+
+        should_check = (left or switched) and auto_disconnect
+        assert should_check is True
+
+    def test_switch_with_auto_disconnect_true_triggers(self):
+        """User switches channels → auto_disconnect=True → should check."""
+        left = False
+        switched = True
+        auto_disconnect = True
+
+        should_check = (left or switched) and auto_disconnect
+        assert should_check is True
+
+    def test_no_leave_no_switch_no_check(self):
+        """User joins (not leave/switch) → no disconnect check regardless."""
+        left = False
+        switched = False
+
+        # With auto_disconnect True
+        result = (left or switched) and True
+        assert result is False
+        # With auto_disconnect False
+        result = (left or switched) and False
+        assert result is False
+
+    def test_both_leave_and_switch_with_auto_disconnect_true(self):
+        """User switches from bot's channel to another (both left and switched)."""
+        left = True
+        switched = True
+        auto_disconnect = True
+
+        should_check = (left or switched) and auto_disconnect
+        assert should_check is True
+
+
+# =====================================================================
+# Auto-join condition regression tests
+# =====================================================================
+
+class TestAutoJoinCondition:
+    """Regression tests for the auto-join condition.
+
+    Auto-join triggers when:
+    - user joins a voice channel (joined=True)
+    - after.channel is not None
+    - auto_join is enabled
+    - user is in the allowed list
+    - no specific channel_id configured, or channel_id matches
+
+    Tests cover the condition logic and the configured-channel filter.
+    """
+
+    def test_join_with_auto_join_true_triggers(self):
+        """User joins → auto_join=True → should attempt join."""
+        joined = True
+        after_channel_not_none = True
+        auto_join = True
+        should_join = joined and after_channel_not_none and auto_join
+        assert should_join is True
+
+    def test_join_with_auto_join_false_skipped(self):
+        """User joins → auto_join=False → no auto-join."""
+        joined = True
+        after_channel_not_none = True
+        auto_join = False
+        should_join = joined and after_channel_not_none and auto_join
+        assert should_join is False
+
+    def test_leave_does_not_trigger_auto_join(self):
+        """User leaves (joined=False) → no auto-join regardless of setting."""
+        joined = False
+        after_channel_not_none = False
+        auto_join = True
+        should_join = joined and after_channel_not_none and auto_join
+        assert should_join is False
+
+    def test_switch_does_not_trigger_auto_join(self):
+        """User switches channels (joined=False) → no auto-join."""
+        joined = False
+        after_channel_not_none = True
+        auto_join = True
+        should_join = joined and after_channel_not_none and auto_join
+        assert should_join is False
+
+    def test_configured_channel_filter_matches(self):
+        """User joins configured channel → channel_id matches → should join."""
+        configured_ch_id = 12345
+        after_channel_id = 12345
+        should_join = after_channel_id == int(configured_ch_id)
+        assert should_join is True
+
+    def test_configured_channel_filter_mismatches(self):
+        """User joins different channel → channel_id mismatch → skip."""
+        configured_ch_id = 12345
+        after_channel_id = 99999
+        should_join = after_channel_id == int(configured_ch_id)
+        assert should_join is False
+
+    def test_no_configured_channel_joins_any(self):
+        """No channel_id configured (None) → join any channel."""
+        configured_ch_id = None
+        after_channel_id = 99999
+        # When configured_ch_id is None, the filter is falsy → skip is falsy
+        should_skip = configured_ch_id and after_channel_id != int(configured_ch_id)
+        assert not should_skip  # falsy → don't skip → join proceeds

--- a/tests/integration/test_voice_channel_flow.py
+++ b/tests/integration/test_voice_channel_flow.py
@@ -118,7 +118,12 @@ def _build_padded_rtp_packet(
 
 def _make_voice_receiver(secret_key, dave_session=None, bot_ssrc=9999,
                          allowed_user_ids=None, members=None):
-    """Create a VoiceReceiver with real secret key."""
+    """Create a VoiceReceiver with real secret key.
+
+    VAD energy threshold is set to 0 so that silence/test packets are
+    always buffered — these tests exercise the crypto/codec/buffer
+    pipeline, not VAD classification.
+    """
     vc = MagicMock()
     vc._connection.secret_key = list(secret_key)
     vc._connection.dave_session = dave_session
@@ -129,7 +134,8 @@ def _make_voice_receiver(secret_key, dave_session=None, bot_ssrc=9999,
     vc.user = SimpleNamespace(id=bot_ssrc)
     vc.channel = MagicMock()
     vc.channel.members = members or []
-    receiver = VoiceReceiver(vc, allowed_user_ids=allowed_user_ids)
+    receiver = VoiceReceiver(vc, allowed_user_ids=allowed_user_ids,
+                             vad_energy_threshold=0)
     receiver.start()
     return receiver
 
@@ -209,7 +215,12 @@ class TestRealNaClWithDAVE:
     """NaCl decrypt + DAVE passthrough scenarios with real crypto."""
 
     def test_dave_unknown_ssrc_passthrough(self):
-        """DAVE enabled but SSRC unknown → skip DAVE, buffer audio."""
+        """DAVE enabled but SSRC unknown → packet discarded (not buffered).
+
+        When DAVE is enabled and the SSRC has no user mapping, the receiver
+        discards the packet to avoid buffering DAVE-encrypted garbage that
+        would corrupt the first utterance. The packet is NOT buffered.
+        """
         key = _make_secret_key()
         dave = MagicMock()  # DAVE session present but SSRC not mapped
         receiver = _make_voice_receiver(key, dave_session=dave)
@@ -219,9 +230,8 @@ class TestRealNaClWithDAVE:
 
         # DAVE decrypt not called (SSRC unknown)
         dave.decrypt.assert_not_called()
-        # Audio still buffered via passthrough
-        assert 100 in receiver._buffers
-        assert len(receiver._buffers[100]) > 0
+        # Packet discarded — not buffered
+        assert 100 not in receiver._buffers
 
     def test_dave_unencrypted_error_passthrough(self):
         """DAVE raises 'Unencrypted' → use NaCl-decrypted data as-is."""
@@ -289,18 +299,23 @@ class TestRTPPaddingStrip:
         assert bytes(recv_plain._buffers[100]) == bytes(recv_padded._buffers[100])
 
     def test_padding_with_dave_passthrough(self):
-        """Padding stripped before DAVE → passthrough buffers cleanly."""
+        """Padding stripped before DAVE → SSRC unmapped → packet discarded.
+
+        When DAVE is enabled and SSRC is unmapped, the packet is discarded
+        after padding stripping (DAVE unknown-SSRC guard). Verifies padding
+        is stripped before the DAVE check, not that audio is buffered.
+        """
         key = _make_secret_key()
         opus_silence = b"\xf8\xff\xfe"
-        dave = MagicMock()  # SSRC unmapped → DAVE skipped, passthrough used
+        dave = MagicMock()  # SSRC unmapped → DAVE skipped, packet discarded
         receiver = _make_voice_receiver(key, dave_session=dave)
 
         packet = _build_padded_rtp_packet(key, opus_silence, pad_len=4, ssrc=100)
         receiver._on_packet(packet)
 
         dave.decrypt.assert_not_called()
-        assert 100 in receiver._buffers
-        assert len(receiver._buffers[100]) > 0
+        # Packet discarded (DAVE + unknown SSRC) — not buffered
+        assert 100 not in receiver._buffers
 
     def test_invalid_padding_length_zero_dropped(self):
         """Declared pad_len=0 is invalid (RFC requires count includes itself)."""
@@ -382,6 +397,7 @@ class TestFullVoiceFlow:
 
         # Simulate silence by setting last_packet_time in the past
         receiver._last_packet_time[100] = time.monotonic() - 3.0
+        receiver._last_speech_time[100] = time.monotonic() - 3.0
 
         completed = receiver.check_silence()
         assert len(completed) == 1
@@ -408,6 +424,8 @@ class TestFullVoiceFlow:
             receiver._on_packet(packet)
 
         receiver._last_packet_time[100] = time.monotonic() - 3.0
+
+        receiver._last_speech_time[100] = time.monotonic() - 3.0
 
         completed = receiver.check_silence()
         assert len(completed) == 1
@@ -509,6 +527,8 @@ class TestSPEAKINGHook:
             receiver._on_packet(packet)
 
         receiver._last_packet_time[100] = time.monotonic() - 3.0
+
+        receiver._last_speech_time[100] = time.monotonic() - 3.0
         completed = receiver.check_silence()
         assert len(completed) == 1
         assert completed[0][0] == 42
@@ -536,6 +556,8 @@ class TestAuthFiltering:
             receiver._on_packet(packet)
 
         receiver._last_packet_time[100] = time.monotonic() - 3.0
+
+        receiver._last_speech_time[100] = time.monotonic() - 3.0
         completed = receiver.check_silence()
         assert len(completed) == 1
         assert completed[0][0] == 42
@@ -560,6 +582,8 @@ class TestAuthFiltering:
             receiver._on_packet(packet)
 
         receiver._last_packet_time[100] = time.monotonic() - 3.0
+
+        receiver._last_speech_time[100] = time.monotonic() - 3.0
         completed = receiver.check_silence()
         assert len(completed) == 0
 
@@ -581,6 +605,8 @@ class TestAuthFiltering:
             receiver._on_packet(packet)
 
         receiver._last_packet_time[100] = time.monotonic() - 3.0
+
+        receiver._last_speech_time[100] = time.monotonic() - 3.0
         completed = receiver.check_silence()
         # Auto-mapped to sole non-bot member
         assert len(completed) == 1
@@ -628,6 +654,8 @@ class TestRejoinFlow:
             receiver2._on_packet(packet)
 
         receiver2._last_packet_time[200] = time.monotonic() - 3.0
+
+        receiver2._last_speech_time[200] = time.monotonic() - 3.0
         completed = receiver2.check_silence()
         assert len(completed) == 1
         assert completed[0][0] == 42
@@ -660,6 +688,8 @@ class TestRejoinFlow:
             receiver2._on_packet(packet)
 
         receiver2._last_packet_time[300] = time.monotonic() - 3.0
+
+        receiver2._last_speech_time[300] = time.monotonic() - 3.0
         completed = receiver2.check_silence()
         assert len(completed) == 1
         assert completed[0][0] == 42
@@ -756,6 +786,7 @@ class TestEchoPreventionFlow:
 
         assert len(receiver._buffers[100]) > 0
         receiver._last_packet_time[100] = time.monotonic() - 3.0
+        receiver._last_speech_time[100] = time.monotonic() - 3.0
         completed = receiver.check_silence()
         assert len(completed) == 1
         assert completed[0][0] == 42

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1100,7 +1100,11 @@ def _load_local_whisper_model(model_name: str):
     library load failure fall back to CPU + int8.
     """
     from faster_whisper import WhisperModel
+    stt_cfg = _load_stt_config().get("local", {})
+    _ct = int(stt_cfg.get("cpu_threads", 0))
     try:
+        if _ct > 0:
+            return WhisperModel(model_name, device="auto", compute_type="auto", cpu_threads=_ct)
         return WhisperModel(model_name, device="auto", compute_type="auto")
     except Exception as exc:
         if not _looks_like_cuda_lib_error(exc):
@@ -1110,6 +1114,8 @@ def _load_local_whisper_model(model_name: str):
             "Install the NVIDIA CUDA runtime (libcublas/libcudnn) to use GPU.",
             exc,
         )
+        if _ct > 0:
+            return WhisperModel(model_name, device="cpu", compute_type="int8", cpu_threads=_ct)
         return WhisperModel(model_name, device="cpu", compute_type="int8")
 
 
@@ -1134,9 +1140,21 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
             or os.getenv(LOCAL_STT_LANGUAGE_ENV)
             or None
         )
-        transcribe_kwargs = {"beam_size": 5}
+        _local_stt_cfg = _load_stt_config().get("local", {})
+        transcribe_kwargs = {
+            "beam_size": int(_local_stt_cfg.get("beam_size", 1)),
+            "vad_filter": bool(_local_stt_cfg.get("vad_filter", True)),
+        }
         if _forced_lang:
             transcribe_kwargs["language"] = _forced_lang
+
+        # Initial prompt: biases Whisper toward expected vocabulary,
+        # dramatically reducing phonetic confusion (e.g. "restored" vs
+        # "restarted", "certainty" vs "thirty"). Configured via
+        # stt.local.initial_prompt in config.yaml.
+        _initial_prompt = _local_stt_cfg.get("initial_prompt")
+        if _initial_prompt:
+            transcribe_kwargs["initial_prompt"] = _initial_prompt
 
         try:
             segments, info = _local_model.transcribe(file_path, **transcribe_kwargs)
@@ -1157,7 +1175,11 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
             _local_model = None
             _local_model_name = None
             from faster_whisper import WhisperModel
-            _local_model = WhisperModel(model_name, device="cpu", compute_type="int8")
+            _retry_ct = int(_local_stt_cfg.get("cpu_threads", 0))
+            if _retry_ct > 0:
+                _local_model = WhisperModel(model_name, device="cpu", compute_type="int8", cpu_threads=_retry_ct)
+            else:
+                _local_model = WhisperModel(model_name, device="cpu", compute_type="int8")
             _local_model_name = model_name
             segments, info = _local_model.transcribe(file_path, **transcribe_kwargs)
             transcript = " ".join(segment.text.strip() for segment in segments)

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -422,6 +422,21 @@ tts:
     ref_text: ''
     model: neuphonic/neutts-air-q4-gguf
     device: cpu
+
+# Discord voice channel
+discord:
+  voice:
+    auto_join: false              # Auto-join when an allowed user enters a VC
+    auto_disconnect: true         # Auto-disconnect when the last human leaves
+    idle_timeout: 300             # Seconds of inactivity before auto-leave
+    silence_threshold: 1.5        # Seconds of silence to end an utterance
+    min_speech_duration: 0.5      # Minimum speech duration to process
+    mode: "all"                   # "off" | "voice_only" | "all"
+    channel_id: null              # Specific voice channel ID to auto-join
+    text_channel_id: null         # Text channel for transcripts/responses
+    vad:
+      energy_threshold: 300       # RMS level (0-32767) below which = silence
+      frame_count: 3              # Rolling window size for VAD (each frame = 20ms)
 ```
 
 ### Environment Variables


### PR DESCRIPTION
## Summary

Add mode-aware NaCl decryption, RMS-based voice activity detection (VAD), auto-join/auto-disconnect, and voice_states-based user lookup that works without the privileged Members intent.

## Changes

### Mode-aware NaCl decryption ()
- Support all 4 discord.py encryption modes: `aead_xchacha20_poly1305_rtpsize`, `xsalsa20_poly1305_lite`, `xsalsa20_poly1305_suffix`, `xsalsa20_poly1305`
- Using the wrong cipher/nonce format silently fails decryption — the mode is now read from the connection and handled per-mode
- Mid-session key rotation: Discord can send `VOICE_SERVER_UPDATE` which triggers a reconnect with a new secret key. The receiver now refreshes key/ssrc/mode on every packet

### RMS-based voice activity detection ()
- Energy-based VAD filters comfort-noise/silence frames using an RMS threshold (~-40dBFS)
- Prevents tens of seconds of silence from inflating recordings and breaking the silence-end-of-utterance trigger
- Only buffers frames with voice energy; silence frames during active utterance are buffered for natural transitions

### Auto-join / auto-disconnect (, `run.py`)
- Bot auto-joins when an allowed user enters a voice channel (configurable: `discord.voice.auto_join`)
- Bot auto-disconnects when the last human leaves (configurable: `discord.voice.auto_disconnect`)
- Optional specific voice channel filter (`discord.voice.channel_id`) — bot only auto-joins this channel
- Gateway wires voice callbacks (input handler, TTS, disconnect handler) on auto-join via `_wire_voice_auto_join`

### voice_states-based user lookup ()
- `get_user_voice_channel` now uses `guild._voice_states` (populated from `VOICE_STATE_UPDATE` events) which only requires `intents.voice_states = True`
- Falls back to member cache/fetch only if voice_states doesn't have the user
- Works without the privileged Server Members intent

### VoiceMixer ()
- Properly subclasses `discord.AudioSource` with graceful fallback when discord.py is not installed

### STT tuning (`transcription_tools.py`)
- `beam_size`, `vad_filter`, `cpu_threads`, and `initial_prompt` are now configurable via `stt.local.*` in config.yaml

## Configuration

All voice parameters are configurable via `discord.voice.*` in config.yaml:

```yaml
discord:
  voice:
    auto_join: false          # auto-join when allowed user enters voice channel
    auto_disconnect: true     # auto-disconnect when last human leaves
    idle_timeout: 300         # seconds (0 = disabled)
    text_channel_id: null     # explicit text channel for voice session replies
    channel_id: null          # specific voice channel to auto-join (null = any)
    mode: "all"               # voice mode on auto-join: off, voice_only, all
    silence_threshold: 1.5    # seconds of silence to end utterance
    min_speech_duration: 0.3  # minimum seconds of speech to process
    vad:
      energy_threshold: 300   # RMS threshold (16-bit PCM, ~-40dBFS)
      frame_count: 3          # frames to check for energy (20ms each)

stt:
  local:
    beam_size: 1
    vad_filter: true
    cpu_threads: 0            # 0 = auto
    initial_prompt: null      # bias whisper toward expected vocabulary
```

## Testing

E2E tested with a live Discord voice session:
- ✅ Auto-join: user joins → bot auto-joins in <500ms
- ✅ Mode-aware decryption: correctly detected `aead_xchacha20_poly1305_rtpsize`
- ✅ Key rotation: mid-session key refresh worked
- ✅ VAD: speech detected at rms=353 > threshold 300
- ✅ Utterance capture: 16s audio captured cleanly
- ✅ STT: accurate transcription
- ✅ TTS: bot replied via TTS in voice channel
- ✅ No per-packet log spam (debug-level only)