### PR TITLE
fix(compaction): stop ineffective compaction loops

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -113,6 +113,15 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
 
     usage = getattr(turn, "token_usage_last", None)
     if not isinstance(usage, dict) or not usage:
+        compressor = getattr(agent, "context_compressor", None)
+        if (
+            compressor is not None
+            and getattr(compressor, "awaiting_real_usage_after_compression", False)
+        ):
+            # No usage means this turn cannot adjudicate the pending compaction.
+            # Consume the marker so a later unrelated reading is not charged to
+            # it and preflight deferral cannot stay latched indefinitely.
+            compressor.update_from_response({})
         if agent._session_db and agent.session_id:
             try:
                 if not agent._session_db_created:

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -276,6 +276,11 @@ def _record_codex_app_server_compaction(
             compressor, "compression_count", 0
         ) + 1
         compressor.last_compression_rough_tokens = approx_tokens or 0
+        # The app server has already completed a real compaction boundary. Its
+        # usage update (when supplied) is therefore the same real-vs-real
+        # effectiveness verdict used by the normal compression path.
+        if hasattr(compressor, "_verify_compaction_cleared_threshold"):
+            compressor._verify_compaction_cleared_threshold = True
         if not getattr(turn, "token_usage_last", None):
             compressor.last_prompt_tokens = -1
             compressor.last_completion_tokens = 0

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2840,10 +2840,21 @@ This compaction should PRIORITISE preserving all information related to the focu
         # Only need head + 3 tail messages minimum (token budget decides the real tail size)
         _min_for_compress = self._protect_head_size(messages) + 3 + 1
         if n_messages <= _min_for_compress:
+            # Record the no-op, exactly as the sibling "no compressable window"
+            # branch below does (#40803). Returning without touching the
+            # anti-thrashing counter leaves should_compress() saying True on a
+            # transcript that can never shrink: when the prompt sits above the
+            # threshold because of the incompressible floor (system prompt +
+            # tool schemas), every subsequent turn re-fires a compaction that
+            # returns here unchanged, and the CLI appears frozen.
+            self._ineffective_compression_count += 1
+            self._last_compression_savings_pct = 0.0
             if not self.quiet_mode:
                 logger.warning(
-                    "Cannot compress: only %d messages (need > %d)",
+                    "Cannot compress: only %d messages (need > %d). "
+                    "ineffective_compression_count=%d",
                     n_messages, _min_for_compress,
+                    self._ineffective_compression_count,
                 )
             return messages
 
@@ -3139,12 +3150,43 @@ This compaction should PRIORITISE preserving all information related to the focu
         compressed = _strip_historical_media(compressed)
 
         new_estimate = estimate_messages_tokens_rough(compressed)
-        saved_estimate = display_tokens - new_estimate
 
-        # Anti-thrashing: track compression effectiveness
-        savings_pct = (saved_estimate / display_tokens * 100) if display_tokens > 0 else 0
+        # Anti-thrashing: measure effectiveness on a like-for-like basis.
+        #
+        # ``display_tokens`` is usually ``current_tokens`` — the provider's real
+        # prompt count, which includes the system prompt and tool schemas.
+        # ``new_estimate`` covers the messages ONLY. Comparing the two makes a
+        # compaction that freed almost nothing look like it saved ~96%, so the
+        # counter below resets every pass and the anti-thrashing guard is dead
+        # code. Compaction can only shrink messages, so score it against the
+        # messages it was given.
+        pre_estimate = estimate_messages_tokens_rough(messages)
+        saved_estimate = pre_estimate - new_estimate
+        savings_pct = (saved_estimate / pre_estimate * 100) if pre_estimate > 0 else 0
         self._last_compression_savings_pct = savings_pct
-        if savings_pct < 10:
+
+        # Effectiveness is "did we get the prompt under the threshold?", not
+        # "did the message list shrink?". ``should_compress()`` trips on the
+        # FULL prompt, but compaction can only shrink messages: the system
+        # prompt and tool schemas are an incompressible floor. When that floor
+        # alone meets the threshold — a too-small context_length makes this
+        # trivially true — every pass can shrink messages by a healthy margin,
+        # reset the counter here, and still leave the prompt over the line, so
+        # the next turn compacts again, forever. Score against the goal.
+        incompressible_floor = max(0, display_tokens - pre_estimate)
+        projected_prompt = incompressible_floor + new_estimate
+        if projected_prompt >= self.threshold_tokens:
+            self._ineffective_compression_count += 1
+            if not self.quiet_mode:
+                logger.warning(
+                    "Compaction cannot clear the threshold: ~%d incompressible "
+                    "tokens (system prompt + tool schemas) + ~%d compressed "
+                    "messages >= %d threshold. Shrinking messages further "
+                    "cannot help. ineffective_compression_count=%d",
+                    incompressible_floor, new_estimate, self.threshold_tokens,
+                    self._ineffective_compression_count,
+                )
+        elif savings_pct < 10:
             self._ineffective_compression_count += 1
         else:
             self._ineffective_compression_count = 0

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -737,6 +737,7 @@ class ContextCompressor(ContextEngine):
         self._last_compression_savings_pct = 100.0
         self._ineffective_compression_count = 0
         self._verify_compaction_cleared_threshold = False
+        self._last_compression_made_progress = False
         self._summary_failure_cooldown_until = 0.0  # transient errors must not block a fresh session
         self._last_summary_error = None
         self._last_compress_aborted = False
@@ -773,6 +774,7 @@ class ContextCompressor(ContextEngine):
         self._last_compression_savings_pct = 100.0
         self._ineffective_compression_count = 0
         self._verify_compaction_cleared_threshold = False
+        self._last_compression_made_progress = False
         self._summary_failure_cooldown_until = 0.0
         self._last_compress_aborted = False
         self._context_probed = False
@@ -947,6 +949,7 @@ class ContextCompressor(ContextEngine):
         self.awaiting_real_usage_after_compression = False
         self._ineffective_compression_count = 0
         self._verify_compaction_cleared_threshold = False
+        self._last_compression_made_progress = False
 
     # When the MINIMUM_CONTEXT_LENGTH floor meets/exceeds a small context
     # window, compacting at the percentage (50% → 32K of a 64K window) wastes
@@ -1134,9 +1137,12 @@ class ContextCompressor(ContextEngine):
         # Anti-thrashing: track whether last compression was effective
         self._last_compression_savings_pct: float = 100.0
         self._ineffective_compression_count: int = 0
-        # Set by compress(); consumed by should_compress() to check the next
-        # real reading against the threshold. See should_compress().
+        # Set after a completed compression boundary; consumed by the next
+        # provider-reported prompt count in update_from_response().
         self._verify_compaction_cleared_threshold: bool = False
+        # Lets the boundary wrapper distinguish a completed rewrite from a
+        # no-op/abort without inferring progress from message-list length.
+        self._last_compression_made_progress: bool = False
         self._summary_failure_cooldown_until: float = 0.0
         self._last_summary_error: Optional[str] = None
         # When summary generation fails and a static fallback is inserted,
@@ -1183,6 +1189,10 @@ class ContextCompressor(ContextEngine):
             if self.last_prompt_tokens < self.threshold_tokens:
                 if self.awaiting_real_usage_after_compression and self.last_compression_rough_tokens > 0:
                     self.last_rough_tokens_when_real_prompt_fit = self.last_compression_rough_tokens
+                # Any real provider reading below the trigger proves the prompt
+                # fits again. Clear the episode latch even when this response was
+                # not the one immediately following compaction.
+                self._ineffective_compression_count = 0
             else:
                 self.last_rough_tokens_when_real_prompt_fit = 0
 
@@ -1296,9 +1306,9 @@ class ContextCompressor(ContextEngine):
         if self._ineffective_compression_count >= 2:
             if not self.quiet_mode:
                 logger.warning(
-                    "Compression skipped — last %d compressions saved <10%% each. "
-                    "Consider /new to start a fresh session, or /compress <topic> "
-                    "for focused compression.",
+                    "Compression skipped — last %d compaction attempts did not "
+                    "restore enough context headroom. Consider /new to start a "
+                    "fresh session, or /compress <topic> for focused compression.",
                     self._ineffective_compression_count,
                 )
             return False
@@ -2862,6 +2872,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         self._last_aux_model_failure_error = None
         self._last_aux_model_failure_model = None
         self._last_compress_aborted = False
+        self._last_compression_made_progress = False
         # NOTE: do NOT reset _last_summary_auth_failure or
         # _last_summary_network_failure here.  These flags are set by
         # _generate_summary() on a terminal failure and are already cleared on
@@ -3207,11 +3218,11 @@ This compaction should PRIORITISE preserving all information related to the focu
         savings_pct = (saved_estimate / pre_estimate * 100) if pre_estimate > 0 else 0
         self._last_compression_savings_pct = savings_pct
 
-        # Only ever INCREMENT here. The reset lives in should_compress(), which
-        # is the one place that sees the same measure the trigger uses; see
-        # ``_verify_compaction_cleared_threshold``.
-        if savings_pct < 10:
-            self._ineffective_compression_count += 1
+        # Message-only savings are diagnostic. The anti-thrashing verdict is
+        # owned by the next provider-reported prompt count, which answers the
+        # actual question: did this completed boundary get under the threshold?
+        # Counting a low message-savings estimate here as well would give one
+        # compaction two strikes when that real reading remains over threshold.
 
         if not self.quiet_mode:
             logger.info(
@@ -3228,5 +3239,6 @@ This compaction should PRIORITISE preserving all information related to the focu
         # are positional; this single terminal sweep makes it structural so a
         # future copy site cannot re-leak the marker into the child-session flush.
         _strip_persistence_markers(compressed)
+        self._last_compression_made_progress = True
 
         return compressed

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1185,6 +1185,42 @@ class ContextCompressor(ContextEngine):
                     self.last_rough_tokens_when_real_prompt_fit = self.last_compression_rough_tokens
             else:
                 self.last_rough_tokens_when_real_prompt_fit = 0
+
+            # Anti-thrashing verdict, judged HERE because this is the only place
+            # that sees the provider's real prompt count for the just-compacted
+            # conversation. Effectiveness is "did the prompt get under the
+            # threshold?", not "did the message list shrink?": compaction can
+            # only shrink messages, while the system prompt and tool schemas are
+            # an incompressible floor (with 50+ tools, 20-30K tokens — see
+            # #14695). When that floor alone meets the threshold, every pass
+            # shrinks messages by a healthy margin yet leaves the prompt over the
+            # line, so the next turn compacts again, forever.
+            #
+            # It must NOT live in should_compress(): that runs twice per turn
+            # with two different measures (a rough preflight estimate and the
+            # real post-response count, #36718), and the rough one can dip below
+            # the threshold and reset the strike every turn, re-opening the loop.
+            # Keying on real usage compares like with like and fires exactly once
+            # per compaction.
+            if self._verify_compaction_cleared_threshold:
+                if self.last_prompt_tokens >= self.threshold_tokens:
+                    self._ineffective_compression_count += 1
+                    if not self.quiet_mode:
+                        logger.warning(
+                            "Compaction did not clear the threshold: %d real "
+                            "tokens still >= %d. The incompressible prompt "
+                            "(system prompt + tool schemas) may already exceed "
+                            "it, in which case shrinking messages cannot help. "
+                            "ineffective_compression_count=%d",
+                            self.last_prompt_tokens, self.threshold_tokens,
+                            self._ineffective_compression_count,
+                        )
+                else:
+                    self._ineffective_compression_count = 0
+        # Consume the pending-verification flag once real usage arrives, whether
+        # or not prompt_tokens was reported, so a usage-less response can't leave
+        # it armed for a later, unrelated reading.
+        self._verify_compaction_cleared_threshold = False
         self.awaiting_real_usage_after_compression = False
 
     def should_defer_preflight_to_real_usage(self, rough_tokens: int) -> bool:
@@ -1237,41 +1273,8 @@ class ContextCompressor(ContextEngine):
         where each pass removes only 1-2 messages.
         """
         tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
-
-        # Verify the previous compaction against the SAME measure this method
-        # gates on. Effectiveness is "did the prompt get under the threshold?",
-        # not "did the message list shrink?": compaction can only shrink
-        # messages, while the system prompt and tool schemas are an
-        # incompressible floor (with 50+ tools, 20-30K tokens — see #14695).
-        # When that floor alone meets the threshold, every pass can shrink
-        # messages by a healthy margin and still leave the prompt over the line,
-        # so the next turn compacts again, forever.
-        #
-        # Both sides of this comparison are the caller's own token count, so it
-        # is immune to the skew between a rough estimate and the provider's real
-        # tokenizer — an analytic "floor = real_prompt - rough_estimate" is not,
-        # and would misread that skew as an incompressible floor.
         if tokens < self.threshold_tokens:
-            # The prompt fits. Whatever happened before, we are not thrashing.
-            self._ineffective_compression_count = 0
-            self._verify_compaction_cleared_threshold = False
             return False
-
-        # Past this point the prompt is over the threshold. If a compaction just
-        # ran, it failed to clear it — one strike. Two strikes and we stop and
-        # tell the user, instead of compacting on every turn forever.
-        if self._verify_compaction_cleared_threshold:
-            self._verify_compaction_cleared_threshold = False
-            self._ineffective_compression_count += 1
-            if not self.quiet_mode:
-                logger.warning(
-                    "Compaction did not clear the threshold: %d tokens still "
-                    ">= %d. The incompressible prompt (system prompt + tool "
-                    "schemas) may already exceed it, in which case shrinking "
-                    "messages cannot help. ineffective_compression_count=%d",
-                    tokens, self.threshold_tokens,
-                    self._ineffective_compression_count,
-                )
         # Do not trigger compression while the summary LLM is in cooldown.
         # On a 429/transient failure _generate_summary() sets a cooldown and
         # returns None; compress() then inserts a static fallback marker and

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2854,12 +2854,6 @@ This compaction should PRIORITISE preserving all information related to the focu
                 running so a manual ``/compress`` can retry immediately after
                 an auto-compression abort.  Auto-compress callers pass False.
         """
-        # A compaction attempt is running: have should_compress() verify, against
-        # the next real reading, that it actually cleared the threshold. Set on
-        # every path (including the early no-op returns below) so a pass that
-        # changed nothing is still held to account.
-        self._verify_compaction_cleared_threshold = True
-
         # Reset per-call summary failure state — callers inspect these fields
         # after compress() returns to decide whether to surface a warning.
         self._last_summary_dropped_count = 0

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -736,6 +736,7 @@ class ContextCompressor(ContextEngine):
         self._last_aux_model_failure_model = None
         self._last_compression_savings_pct = 100.0
         self._ineffective_compression_count = 0
+        self._verify_compaction_cleared_threshold = False
         self._summary_failure_cooldown_until = 0.0  # transient errors must not block a fresh session
         self._last_summary_error = None
         self._last_compress_aborted = False
@@ -771,6 +772,7 @@ class ContextCompressor(ContextEngine):
         self._last_aux_model_failure_model = None
         self._last_compression_savings_pct = 100.0
         self._ineffective_compression_count = 0
+        self._verify_compaction_cleared_threshold = False
         self._summary_failure_cooldown_until = 0.0
         self._last_compress_aborted = False
         self._context_probed = False
@@ -944,6 +946,7 @@ class ContextCompressor(ContextEngine):
         self.last_compression_rough_tokens = 0
         self.awaiting_real_usage_after_compression = False
         self._ineffective_compression_count = 0
+        self._verify_compaction_cleared_threshold = False
 
     # When the MINIMUM_CONTEXT_LENGTH floor meets/exceeds a small context
     # window, compacting at the percentage (50% → 32K of a 64K window) wastes
@@ -1131,6 +1134,9 @@ class ContextCompressor(ContextEngine):
         # Anti-thrashing: track whether last compression was effective
         self._last_compression_savings_pct: float = 100.0
         self._ineffective_compression_count: int = 0
+        # Set by compress(); consumed by should_compress() to check the next
+        # real reading against the threshold. See should_compress().
+        self._verify_compaction_cleared_threshold: bool = False
         self._summary_failure_cooldown_until: float = 0.0
         self._last_summary_error: Optional[str] = None
         # When summary generation fails and a static fallback is inserted,
@@ -1231,8 +1237,41 @@ class ContextCompressor(ContextEngine):
         where each pass removes only 1-2 messages.
         """
         tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
+
+        # Verify the previous compaction against the SAME measure this method
+        # gates on. Effectiveness is "did the prompt get under the threshold?",
+        # not "did the message list shrink?": compaction can only shrink
+        # messages, while the system prompt and tool schemas are an
+        # incompressible floor (with 50+ tools, 20-30K tokens — see #14695).
+        # When that floor alone meets the threshold, every pass can shrink
+        # messages by a healthy margin and still leave the prompt over the line,
+        # so the next turn compacts again, forever.
+        #
+        # Both sides of this comparison are the caller's own token count, so it
+        # is immune to the skew between a rough estimate and the provider's real
+        # tokenizer — an analytic "floor = real_prompt - rough_estimate" is not,
+        # and would misread that skew as an incompressible floor.
         if tokens < self.threshold_tokens:
+            # The prompt fits. Whatever happened before, we are not thrashing.
+            self._ineffective_compression_count = 0
+            self._verify_compaction_cleared_threshold = False
             return False
+
+        # Past this point the prompt is over the threshold. If a compaction just
+        # ran, it failed to clear it — one strike. Two strikes and we stop and
+        # tell the user, instead of compacting on every turn forever.
+        if self._verify_compaction_cleared_threshold:
+            self._verify_compaction_cleared_threshold = False
+            self._ineffective_compression_count += 1
+            if not self.quiet_mode:
+                logger.warning(
+                    "Compaction did not clear the threshold: %d tokens still "
+                    ">= %d. The incompressible prompt (system prompt + tool "
+                    "schemas) may already exceed it, in which case shrinking "
+                    "messages cannot help. ineffective_compression_count=%d",
+                    tokens, self.threshold_tokens,
+                    self._ineffective_compression_count,
+                )
         # Do not trigger compression while the summary LLM is in cooldown.
         # On a 429/transient failure _generate_summary() sets a cooldown and
         # returns None; compress() then inserts a static fallback marker and
@@ -2812,6 +2851,12 @@ This compaction should PRIORITISE preserving all information related to the focu
                 running so a manual ``/compress`` can retry immediately after
                 an auto-compression abort.  Auto-compress callers pass False.
         """
+        # A compaction attempt is running: have should_compress() verify, against
+        # the next real reading, that it actually cleared the threshold. Set on
+        # every path (including the early no-op returns below) so a pass that
+        # changed nothing is still held to account.
+        self._verify_compaction_cleared_threshold = True
+
         # Reset per-call summary failure state — callers inspect these fields
         # after compress() returns to decide whether to surface a warning.
         self._last_summary_dropped_count = 0
@@ -3165,31 +3210,11 @@ This compaction should PRIORITISE preserving all information related to the focu
         savings_pct = (saved_estimate / pre_estimate * 100) if pre_estimate > 0 else 0
         self._last_compression_savings_pct = savings_pct
 
-        # Effectiveness is "did we get the prompt under the threshold?", not
-        # "did the message list shrink?". ``should_compress()`` trips on the
-        # FULL prompt, but compaction can only shrink messages: the system
-        # prompt and tool schemas are an incompressible floor. When that floor
-        # alone meets the threshold — a too-small context_length makes this
-        # trivially true — every pass can shrink messages by a healthy margin,
-        # reset the counter here, and still leave the prompt over the line, so
-        # the next turn compacts again, forever. Score against the goal.
-        incompressible_floor = max(0, display_tokens - pre_estimate)
-        projected_prompt = incompressible_floor + new_estimate
-        if projected_prompt >= self.threshold_tokens:
+        # Only ever INCREMENT here. The reset lives in should_compress(), which
+        # is the one place that sees the same measure the trigger uses; see
+        # ``_verify_compaction_cleared_threshold``.
+        if savings_pct < 10:
             self._ineffective_compression_count += 1
-            if not self.quiet_mode:
-                logger.warning(
-                    "Compaction cannot clear the threshold: ~%d incompressible "
-                    "tokens (system prompt + tool schemas) + ~%d compressed "
-                    "messages >= %d threshold. Shrinking messages further "
-                    "cannot help. ineffective_compression_count=%d",
-                    incompressible_floor, new_estimate, self.threshold_tokens,
-                    self._ineffective_compression_count,
-                )
-        elif savings_pct < 10:
-            self._ineffective_compression_count += 1
-        else:
-            self._ineffective_compression_count = 0
 
         if not self.quiet_mode:
             logger.info(

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -961,6 +961,12 @@ def compress_context(
         agent.context_compressor.last_prompt_tokens = -1
         agent.context_compressor.last_completion_tokens = 0
         agent.context_compressor.awaiting_real_usage_after_compression = True
+        # Arm the effectiveness verdict only after the full compaction boundary
+        # succeeds. Exceptions and aborted/no-op attempts return before here, so
+        # unrelated later usage cannot be charged to an attempt that never took
+        # effect. External engines without the private flag stay untouched.
+        if hasattr(agent.context_compressor, "_verify_compaction_cleared_threshold"):
+            agent.context_compressor._verify_compaction_cleared_threshold = True
 
         # Clear the file-read dedup cache.  After compression the original
         # read content is summarised away — if the model re-reads the same

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -673,6 +673,20 @@ def compress_context(
         finally:
             _release_lock()
 
+    # A compressor that returns the exact input object made no structural
+    # progress. Do not rotate/rewrite the session or arm post-compression
+    # deferral in that case; its own anti-thrash counter records the no-op.
+    if compressed is messages:
+        logger.info(
+            "Compression made no progress (session=%s) — skipping boundary rewrite.",
+            agent.session_id or "none",
+        )
+        _existing_sp = getattr(agent, "_cached_system_prompt", None)
+        if not _existing_sp:
+            _existing_sp = agent._build_system_prompt(system_message)
+        _release_lock()
+        return messages, _existing_sp
+
     try:
         summary_error = getattr(agent.context_compressor, "_last_summary_error", None)
         if summary_error:
@@ -961,11 +975,11 @@ def compress_context(
         agent.context_compressor.last_prompt_tokens = -1
         agent.context_compressor.last_completion_tokens = 0
         agent.context_compressor.awaiting_real_usage_after_compression = True
-        # Arm the effectiveness verdict only after the full compaction boundary
-        # succeeds. Exceptions and aborted/no-op attempts return before here, so
-        # unrelated later usage cannot be charged to an attempt that never took
-        # effect. External engines without the private flag stay untouched.
-        if hasattr(agent.context_compressor, "_verify_compaction_cleared_threshold"):
+        # Arm the effectiveness verdict only after a completed rewrite crosses
+        # the full compaction boundary. Exceptions, aborts, and no-op attempts
+        # leave this false, so unrelated later usage cannot be charged to an
+        # attempt that never changed the transcript.
+        if getattr(agent.context_compressor, "_last_compression_made_progress", False):
             agent.context_compressor._verify_compaction_cleared_threshold = True
 
         # Clear the file-read dedup cache.  After compression the original

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1098,7 +1098,11 @@ def _compress_context_via_codex_app_server(
             approx_tokens=approx_tokens,
             force=True,
         )
-        if getattr(result, "token_usage_last", None):
+        # An empty usage report must consume the pending post-compaction verdict
+        # rather than leaving preflight deferral armed until some unrelated later
+        # Codex turn supplies usage. Minimal external test engines may not expose
+        # the ContextEngine update hook; preserve their existing bookkeeping.
+        if hasattr(agent.context_compressor, "update_from_response"):
             _record_codex_app_server_usage(agent, result)
     except Exception:
         logger.debug("codex compaction bookkeeping failed", exc_info=True)

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1074,7 +1074,7 @@ def _compress_context_via_codex_app_server(
             pass
         agent._codex_session = None
 
-    if getattr(result, "error", None):
+    if getattr(result, "interrupted", False) or getattr(result, "error", None):
         try:
             agent._emit_warning(
                 f"⚠ Codex app-server compaction failed: {result.error}"

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2109,7 +2109,19 @@ def run_conversation(
                         "reasoning_tokens": canonical_usage.reasoning_tokens,
                     }
                     agent.context_compressor.update_from_response(usage_dict)
+                elif getattr(
+                    agent.context_compressor,
+                    "awaiting_real_usage_after_compression",
+                    False,
+                ):
+                    # A response with no usage cannot adjudicate whether the
+                    # prior compaction cleared the threshold. Consume the pending
+                    # verdict now so a much later, unrelated reading is not
+                    # charged to that old compaction, and so preflight deferral
+                    # does not remain latched indefinitely.
+                    agent.context_compressor.update_from_response({})
 
+                if hasattr(response, 'usage') and response.usage:
                     # Cache discovered context length after successful call.
                     # Only persist limits confirmed by the provider (parsed
                     # from the error message), not guessed probe tiers.

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -755,22 +755,22 @@ class CodexAppServerSession:
                 turn_obj = (note.get("params") or {}).get("turn") or {}
                 result.turn_id = turn_obj.get("id") or result.turn_id
                 turn_status = turn_obj.get("status")
-                if turn_status and turn_status not in {"completed", "interrupted"}:
+                if turn_status == "interrupted":
+                    result.interrupted = True
+                    result.error = result.error or "compact turn interrupted"
+                elif turn_status and turn_status != "completed":
                     err_obj = turn_obj.get("error")
-                    if err_obj:
-                        err_msg = _format_responses_error(err_obj, str(turn_status))
-                        stderr_blob = "\n".join(
-                            self._client.stderr_tail(40)
+                    err_msg = _format_responses_error(err_obj, str(turn_status))
+                    stderr_blob = "\n".join(self._client.stderr_tail(40))
+                    hint = _classify_oauth_failure(err_msg, stderr_blob)
+                    if hint is not None:
+                        result.error = hint
+                        result.should_retire = True
+                    else:
+                        result.error = self._format_error_with_stderr(
+                            f"compact turn ended status={turn_status}",
+                            err_msg,
                         )
-                        hint = _classify_oauth_failure(err_msg, stderr_blob)
-                        if hint is not None:
-                            result.error = hint
-                            result.should_retire = True
-                        else:
-                            result.error = self._format_error_with_stderr(
-                                f"compact turn ended status={turn_status}",
-                                err_msg,
-                            )
 
         if not turn_complete and not result.interrupted:
             self._issue_interrupt(result.turn_id)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "iganapolsky@gmail.com": "IgorGanapolsky",  # PR #62125 salvage (compaction anti-thrash threshold verification)
     "wilsonkinyuam@gmail.com": "WilsonKinyua",  # PR #62052 (tui: persist unflushed conversations on disconnect/restart)
     "humphreysun98@gmail.com": "HumphreySun98",  # PR #61142 salvage (web: null web/backend config value guards)
     "sonxi@nous.local": "17324393074",  # PR #53196 salvage (tools_config: known_plugin_toolsets null guard; commit under unlinked local identity)

--- a/tests/agent/test_compaction_anti_thrash.py
+++ b/tests/agent/test_compaction_anti_thrash.py
@@ -162,6 +162,7 @@ class TestFutilityGuard:
 
         assert len(out) < before, "a long transcript must still compact"
         assert cc._last_compression_savings_pct > 10
+        assert cc._last_compression_made_progress is True
         assert cc._ineffective_compression_count == 0
 
     def test_no_false_positive_under_tokenizer_skew(self):
@@ -188,6 +189,26 @@ class TestFutilityGuard:
         assert cc._ineffective_compression_count == 0, (
             "tokenizer skew must not be mistaken for an incompressible floor"
         )
+
+    def test_latched_counter_resets_after_any_real_prompt_fits(self):
+        cc = _compressor(threshold_tokens=24_576)
+        cc._ineffective_compression_count = 2
+
+        cc.update_from_response({"prompt_tokens": 20_000})
+
+        assert cc._ineffective_compression_count == 0
+        assert cc.should_compress(33_564)
+
+    def test_usage_less_response_consumes_pending_verdict(self):
+        cc = _compressor(threshold_tokens=24_576)
+        cc._verify_compaction_cleared_threshold = True
+        cc.awaiting_real_usage_after_compression = True
+
+        cc.update_from_response({})
+
+        assert cc._verify_compaction_cleared_threshold is False
+        assert cc.awaiting_real_usage_after_compression is False
+        assert cc._ineffective_compression_count == 0
 
     def test_a_failed_pass_records_exactly_one_strike(self):
         """A compaction that leaves the real prompt over the threshold: one strike.
@@ -226,4 +247,5 @@ class TestMinimumMessagesBranch:
         out = cc.compress(msgs, current_tokens=100_000)
 
         assert len(out) == len(msgs), "nothing should have been compressed"
+        assert cc._last_compression_made_progress is False
         assert cc._ineffective_compression_count == before + 1

--- a/tests/agent/test_compaction_anti_thrash.py
+++ b/tests/agent/test_compaction_anti_thrash.py
@@ -15,14 +15,20 @@ Two defects made it dead code:
 
 Together these made a mis-sized context window present as a hung CLI rather than a
 warning. Effectiveness is now scored against the goal -- did the prompt get under the
-threshold? -- and the check is made in ``should_compress()`` against the caller's own
-token count on both sides.
+threshold? -- judged in ``update_from_response()``, the one place that sees the
+provider's real prompt count for the just-compacted conversation.
 
-That last detail matters. An analytic ``floor = current_tokens - rough_estimate(messages)``
-looks equivalent and is not: it silently absorbs the skew between the rough estimator and
-the provider's real tokenizer, reports it as incompressible overhead, and disables
-compaction on a perfectly healthy session. ``test_no_false_positive_under_tokenizer_skew``
-pins that.
+Two subtleties this pins:
+
+* The verdict must NOT live in ``should_compress()``. That runs twice per turn with
+  two different measures (a rough preflight estimate and the real post-response count,
+  #36718); the rough one can dip below the threshold and reset the strike every turn,
+  re-opening the loop. ``test_rough_preflight_reading_does_not_reopen_the_loop``.
+
+* It must not be computed analytically as ``floor = current_tokens - rough_estimate``.
+  That subtracts an estimate from a real count, absorbs the tokenizer skew into "floor",
+  and disables compaction on a healthy session.
+  ``test_no_false_positive_under_tokenizer_skew``.
 """
 import pytest
 
@@ -50,6 +56,22 @@ def _messages(n: int, size: int = 1500) -> list:
         role = "user" if i % 2 == 0 else "assistant"
         msgs.append({"role": role, "content": f"m{i} " + "z" * size})
     return msgs
+
+
+def _turn(cc, msgs, real_prompt_tokens):
+    """One agent turn as conversation_loop drives it.
+
+    should_compress() gates on the real prompt count; if it fires, compress()
+    runs and the provider then reports real usage for the shorter conversation.
+    The anti-thrashing verdict is judged in update_from_response() against that
+    real count -- not inside should_compress(), which is called twice per turn
+    with two different measures. Returns (msgs, did_compact).
+    """
+    if not cc.should_compress(real_prompt_tokens):
+        return msgs, False
+    msgs = cc.compress(msgs, current_tokens=real_prompt_tokens)
+    cc.update_from_response({"prompt_tokens": real_prompt_tokens})
+    return msgs, True
 
 
 class TestSavingsBasis:
@@ -88,21 +110,47 @@ class TestFutilityGuard:
         cc = _compressor(threshold_tokens=24_576)
         msgs = _messages(14)
         # Full prompt is far above threshold and dominated by system + tools,
-        # so it never drops no matter how much the message list shrinks.
+        # so the real count never drops no matter how the message list shrinks.
         real_prompt_tokens = 33_564
 
         fired = 0
         for _ in range(6):
-            if cc.should_compress(real_prompt_tokens):
+            msgs, did = _turn(cc, msgs, real_prompt_tokens)
+            if did:
                 fired += 1
-                msgs = cc.compress(msgs, current_tokens=real_prompt_tokens)
                 msgs.append({"role": "user", "content": "next " + "w" * 4000})
 
         assert cc._ineffective_compression_count >= 2
         assert not cc.should_compress(real_prompt_tokens), (
-            "compaction that cannot clear the threshold must stop and warn"
+            "compaction that cannot clear the threshold must stop"
         )
         assert fired <= 3, f"expected the loop to break early, compacted {fired}x"
+
+    def test_rough_preflight_reading_does_not_reopen_the_loop(self):
+        """should_compress() runs twice per turn with two different measures.
+
+        The pre-API gate uses a rough estimate that can dip below the threshold;
+        the post-response gate uses the real count that does not. If the verdict
+        lived in should_compress(), the rough reading would reset the strike
+        every turn and the loop would never stop. Judging it in
+        update_from_response() (real-vs-real) closes that hole.
+        """
+        cc = _compressor(threshold_tokens=24_576)
+        msgs = _messages(13)
+        rough, real = 20_000, 33_564  # rough dips under; real never does
+
+        fired = 0
+        for _ in range(8):
+            cc.should_compress(rough)          # pre-API gate (rough)
+            msgs, did = _turn(cc, msgs, real)  # post-response gate (real) + usage
+            if did:
+                fired += 1
+                msgs.append({"role": "user", "content": "more " + "w" * 3000})
+
+        assert fired <= 2, (
+            f"a sub-threshold rough reading must not re-open the loop; "
+            f"compacted {fired}x"
+        )
 
     def test_effective_compaction_still_resets_the_counter(self):
         """A compaction that gets the prompt under the threshold is not thrashing."""
@@ -131,26 +179,34 @@ class TestFutilityGuard:
         real_prompt = floor + int(skew * estimate_messages_tokens_rough(msgs))
         assert cc.should_compress(real_prompt)
         msgs = cc.compress(msgs, current_tokens=real_prompt)
-        real_prompt = floor + int(skew * estimate_messages_tokens_rough(msgs))
+        real_after = floor + int(skew * estimate_messages_tokens_rough(msgs))
+        cc.update_from_response({"prompt_tokens": real_after})  # provider's real count
 
-        assert real_prompt < cc.threshold_tokens, "compaction really did clear it"
-        assert not cc.should_compress(real_prompt)
+        assert real_after < cc.threshold_tokens, "compaction really did clear it"
         assert cc._ineffective_compression_count == 0, (
             "tokenizer skew must not be mistaken for an incompressible floor"
         )
 
-    def test_counter_resets_once_the_prompt_fits_again(self):
-        """One failed pass must not permanently disable compaction."""
+    def test_a_failed_pass_records_exactly_one_strike(self):
+        """A compaction that leaves the real prompt over the threshold: one strike.
+
+        The verdict is judged once, when the provider reports real usage — not on
+        every should_compress() reading.
+        """
         cc = _compressor(threshold_tokens=24_576)
         msgs = _messages(14)
 
-        cc.should_compress(33_564)
+        assert cc.should_compress(33_564)
         cc.compress(msgs, current_tokens=33_564)
-        cc.should_compress(33_564)                 # still over -> 1 strike
+        assert cc._ineffective_compression_count == 0, "no verdict before real usage"
+
+        cc.update_from_response({"prompt_tokens": 33_564})  # still over
         assert cc._ineffective_compression_count == 1
 
-        cc.should_compress(1_000)                  # now under -> forgiven
-        assert cc._ineffective_compression_count == 0
+        # A later reading, rough or real, must not add phantom strikes.
+        cc.should_compress(33_564)
+        cc.should_compress(20_000)
+        assert cc._ineffective_compression_count == 1
 
 
 class TestMinimumMessagesBranch:

--- a/tests/agent/test_compaction_anti_thrash.py
+++ b/tests/agent/test_compaction_anti_thrash.py
@@ -1,0 +1,125 @@
+"""The anti-thrashing guard must actually fire.
+
+Two defects made it dead code:
+
+1. Effectiveness was scored as ``(current_tokens - estimate(compressed)) / current_tokens``.
+   ``current_tokens`` is the provider's FULL prompt (system prompt + tool schemas +
+   messages); ``estimate(compressed)`` covers messages only. The mixed basis reported
+   ~96% savings on every pass, so ``_ineffective_compression_count`` reset each time.
+
+2. Even scored correctly, message shrinkage is the wrong yardstick. ``should_compress()``
+   trips on the full prompt, but compaction can only shrink messages. When the
+   incompressible floor alone meets the threshold, each pass can shrink messages by a
+   healthy margin, reset the counter, and still leave the prompt over the line -- so the
+   next turn compacts again, forever.
+
+Together these made a mis-sized context window present as a hung CLI rather than a
+warning. Effectiveness is now scored against the goal: did the prompt get under the
+threshold?
+"""
+import pytest
+
+from agent.context_compressor import ContextCompressor
+
+
+def _compressor(threshold_tokens: int) -> ContextCompressor:
+    cc = ContextCompressor(
+        model="test-model",
+        threshold_percent=0.75,
+        protect_first_n=5,
+        protect_last_n=20,
+        quiet_mode=True,
+        config_context_length=40960,
+        provider="test",
+    )
+    cc.threshold_tokens = threshold_tokens  # pin; don't couple to window math
+    cc._generate_summary = lambda *a, **k: "Summary of earlier turns."
+    return cc
+
+
+def _messages(n: int, size: int = 1500) -> list:
+    msgs = [{"role": "system", "content": "sys"}]
+    for i in range(n):
+        role = "user" if i % 2 == 0 else "assistant"
+        msgs.append({"role": role, "content": f"m{i} " + "z" * size})
+    return msgs
+
+
+class TestSavingsBasis:
+    def test_savings_does_not_depend_on_current_tokens(self):
+        """Savings is a property of the messages, not of the caller's token count.
+
+        Before the fix, passing the full-prompt count made an identical compaction
+        report a wildly higher savings percentage.
+        """
+        msgs = _messages(14)
+
+        a = _compressor(threshold_tokens=24_576)
+        a.compress([m.copy() for m in msgs], current_tokens=100_000)
+        with_full_prompt = a._last_compression_savings_pct
+
+        b = _compressor(threshold_tokens=24_576)
+        b.compress([m.copy() for m in msgs], current_tokens=None)
+        messages_only = b._last_compression_savings_pct
+
+        assert with_full_prompt == pytest.approx(messages_only, abs=0.01), (
+            "savings must be scored on a messages-vs-messages basis; got "
+            f"{with_full_prompt:.1f}% with a full-prompt count vs "
+            f"{messages_only:.1f}% without"
+        )
+
+    def test_no_op_compaction_is_not_reported_as_huge_savings(self):
+        cc = _compressor(threshold_tokens=24_576)
+        msgs = _messages(4, size=10)  # below the minimum compressible size
+        cc.compress(msgs, current_tokens=100_000)
+        assert cc._last_compression_savings_pct < 50
+
+
+class TestFutilityGuard:
+    def test_stops_when_floor_alone_meets_threshold(self):
+        """Incompressible floor >= threshold -> shrinking messages cannot help."""
+        cc = _compressor(threshold_tokens=24_576)
+        msgs = _messages(14)
+        # Full prompt is far above threshold and dominated by system + tools.
+        real_prompt_tokens = 33_564
+
+        fired = 0
+        for _ in range(6):
+            if cc.should_compress(real_prompt_tokens):
+                fired += 1
+                msgs = cc.compress(msgs, current_tokens=real_prompt_tokens)
+                msgs.append({"role": "user", "content": "next " + "w" * 4000})
+
+        assert cc._ineffective_compression_count >= 2
+        assert not cc.should_compress(real_prompt_tokens), (
+            "compaction that cannot clear the threshold must stop and warn"
+        )
+        assert fired <= 3, f"expected the loop to break early, compacted {fired}x"
+
+    def test_effective_compaction_still_resets_the_counter(self):
+        """A compaction that gets the prompt under the threshold is not thrashing."""
+        cc = _compressor(threshold_tokens=750_000)
+        msgs = _messages(120, size=2000)
+        before = len(msgs)
+        out = cc.compress(msgs, current_tokens=None)
+
+        assert len(out) < before, "a long transcript must still compact"
+        assert cc._last_compression_savings_pct > 10
+        assert cc._ineffective_compression_count == 0
+
+
+class TestMinimumMessagesBranch:
+    def test_too_few_messages_records_an_ineffective_pass(self):
+        """Returning the transcript unchanged must move the anti-thrash state.
+
+        Otherwise should_compress() keeps saying True about a transcript that can
+        never shrink, and every turn re-enters a no-op compaction.
+        """
+        cc = _compressor(threshold_tokens=1)
+        msgs = _messages(3, size=10)
+        before = cc._ineffective_compression_count
+
+        out = cc.compress(msgs, current_tokens=100_000)
+
+        assert len(out) == len(msgs), "nothing should have been compressed"
+        assert cc._ineffective_compression_count == before + 1

--- a/tests/agent/test_compaction_anti_thrash.py
+++ b/tests/agent/test_compaction_anti_thrash.py
@@ -70,6 +70,7 @@ def _turn(cc, msgs, real_prompt_tokens):
     if not cc.should_compress(real_prompt_tokens):
         return msgs, False
     msgs = cc.compress(msgs, current_tokens=real_prompt_tokens)
+    cc._verify_compaction_cleared_threshold = True
     cc.update_from_response({"prompt_tokens": real_prompt_tokens})
     return msgs, True
 
@@ -180,6 +181,7 @@ class TestFutilityGuard:
         assert cc.should_compress(real_prompt)
         msgs = cc.compress(msgs, current_tokens=real_prompt)
         real_after = floor + int(skew * estimate_messages_tokens_rough(msgs))
+        cc._verify_compaction_cleared_threshold = True
         cc.update_from_response({"prompt_tokens": real_after})  # provider's real count
 
         assert real_after < cc.threshold_tokens, "compaction really did clear it"
@@ -198,6 +200,7 @@ class TestFutilityGuard:
 
         assert cc.should_compress(33_564)
         cc.compress(msgs, current_tokens=33_564)
+        cc._verify_compaction_cleared_threshold = True
         assert cc._ineffective_compression_count == 0, "no verdict before real usage"
 
         cc.update_from_response({"prompt_tokens": 33_564})  # still over

--- a/tests/agent/test_compaction_anti_thrash.py
+++ b/tests/agent/test_compaction_anti_thrash.py
@@ -14,8 +14,15 @@ Two defects made it dead code:
    next turn compacts again, forever.
 
 Together these made a mis-sized context window present as a hung CLI rather than a
-warning. Effectiveness is now scored against the goal: did the prompt get under the
-threshold?
+warning. Effectiveness is now scored against the goal -- did the prompt get under the
+threshold? -- and the check is made in ``should_compress()`` against the caller's own
+token count on both sides.
+
+That last detail matters. An analytic ``floor = current_tokens - rough_estimate(messages)``
+looks equivalent and is not: it silently absorbs the skew between the rough estimator and
+the provider's real tokenizer, reports it as incompressible overhead, and disables
+compaction on a perfectly healthy session. ``test_no_false_positive_under_tokenizer_skew``
+pins that.
 """
 import pytest
 
@@ -80,7 +87,8 @@ class TestFutilityGuard:
         """Incompressible floor >= threshold -> shrinking messages cannot help."""
         cc = _compressor(threshold_tokens=24_576)
         msgs = _messages(14)
-        # Full prompt is far above threshold and dominated by system + tools.
+        # Full prompt is far above threshold and dominated by system + tools,
+        # so it never drops no matter how much the message list shrinks.
         real_prompt_tokens = 33_564
 
         fired = 0
@@ -105,6 +113,43 @@ class TestFutilityGuard:
 
         assert len(out) < before, "a long transcript must still compact"
         assert cc._last_compression_savings_pct > 10
+        assert cc._ineffective_compression_count == 0
+
+    def test_no_false_positive_under_tokenizer_skew(self):
+        """The provider's real count exceeds the rough estimate; that is not a floor.
+
+        An analytic `floor = real_prompt - rough_estimate` misreads tokenizer skew
+        as incompressible overhead and disables compaction on a healthy session.
+        The check must compare the caller's own measure on both sides.
+        """
+        from agent.context_compressor import estimate_messages_tokens_rough
+
+        skew, floor = 1.6, 30_000
+        cc = _compressor(threshold_tokens=150_000)
+        msgs = _messages(160, size=2500)
+
+        real_prompt = floor + int(skew * estimate_messages_tokens_rough(msgs))
+        assert cc.should_compress(real_prompt)
+        msgs = cc.compress(msgs, current_tokens=real_prompt)
+        real_prompt = floor + int(skew * estimate_messages_tokens_rough(msgs))
+
+        assert real_prompt < cc.threshold_tokens, "compaction really did clear it"
+        assert not cc.should_compress(real_prompt)
+        assert cc._ineffective_compression_count == 0, (
+            "tokenizer skew must not be mistaken for an incompressible floor"
+        )
+
+    def test_counter_resets_once_the_prompt_fits_again(self):
+        """One failed pass must not permanently disable compaction."""
+        cc = _compressor(threshold_tokens=24_576)
+        msgs = _messages(14)
+
+        cc.should_compress(33_564)
+        cc.compress(msgs, current_tokens=33_564)
+        cc.should_compress(33_564)                 # still over -> 1 strike
+        assert cc._ineffective_compression_count == 1
+
+        cc.should_compress(1_000)                  # now under -> forgiven
         assert cc._ineffective_compression_count == 0
 
 

--- a/tests/agent/test_compress_focus.py
+++ b/tests/agent/test_compress_focus.py
@@ -23,6 +23,8 @@ def _make_compressor():
     compressor.compression_count = 0
     compressor.last_prompt_tokens = 0
     compressor._previous_summary = None
+    compressor._ineffective_compression_count = 0
+    compressor._verify_compaction_cleared_threshold = False
     compressor._summary_failure_cooldown_until = 0.0
     compressor.summary_model = None
     compressor.model = "test-model"

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -528,6 +528,24 @@ class TestCompactThread:
         assert r.token_usage_last["totalTokens"] == 12
         assert r.model_context_window == 200000
 
+    def test_compact_thread_interrupted_returns_non_success(self):
+        client = FakeClient()
+        client.queue_notification(
+            "turn/started",
+            threadId="thread-fake-001",
+            turn={"id": "compact-turn-1"},
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-fake-001",
+            turn={"id": "compact-turn-1", "status": "interrupted", "error": None},
+        )
+
+        result = make_session(client).compact_thread(turn_timeout=2.0)
+
+        assert result.interrupted is True
+        assert result.error == "compact turn interrupted"
+
     def test_compact_thread_failure_returns_error(self):
         client = FakeClient()
         from agent.transports.codex_app_server import CodexAppServerError

--- a/tests/run_agent/test_codex_app_server_compaction.py
+++ b/tests/run_agent/test_codex_app_server_compaction.py
@@ -102,6 +102,8 @@ def test_codex_app_server_manual_compression_routes_to_codex_thread():
     assert agent._codex_session.calls == 1
     assert agent.context_compressor.compression_count == 1
     assert agent.context_compressor.last_compression_rough_tokens == 100000
+    # This minimal fake compressor does not implement update_from_response(),
+    # so the runtime preserves its existing pending-usage bookkeeping here.
     assert agent.context_compressor.last_prompt_tokens == -1
     assert agent.context_compressor.last_completion_tokens == 0
     assert agent.context_compressor.awaiting_real_usage_after_compression is True

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -157,8 +157,10 @@ class TestRunConversationCodexPath:
 
         assert result["completed"] is True
         assert agent.context_compressor.compression_count == 1
-        assert agent.context_compressor.last_prompt_tokens == -1
-        assert agent.context_compressor.awaiting_real_usage_after_compression is True
+        # The app-server omitted usage, so the runtime consumes the pending
+        # post-compaction verdict instead of deferring preflight indefinitely.
+        assert agent.context_compressor.last_prompt_tokens == 0
+        assert agent.context_compressor.awaiting_real_usage_after_compression is False
         assert events == [
             (
                 "session:compress",

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -143,6 +143,13 @@ class TestRunConversationCodexPath:
                 turn_id="turn-compact-1",
                 thread_id="thread-compact-1",
                 compacted=True,
+                token_usage_last={
+                    "totalTokens": 300_000,
+                    "inputTokens": 300_000,
+                    "cachedInputTokens": 0,
+                    "outputTokens": 0,
+                    "reasoningOutputTokens": 0,
+                },
             )
 
         monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
@@ -157,10 +164,11 @@ class TestRunConversationCodexPath:
 
         assert result["completed"] is True
         assert agent.context_compressor.compression_count == 1
-        # The app-server omitted usage, so the runtime consumes the pending
-        # post-compaction verdict instead of deferring preflight indefinitely.
-        assert agent.context_compressor.last_prompt_tokens == 0
+        # A compacted turn with real usage is judged against that same real
+        # prompt count, exactly like a normal completed compression boundary.
+        assert agent.context_compressor.last_prompt_tokens == 300_000
         assert agent.context_compressor.awaiting_real_usage_after_compression is False
+        assert agent.context_compressor._ineffective_compression_count == 1
         assert events == [
             (
                 "session:compress",


### PR DESCRIPTION
## Summary
Compaction now backs off after two completed boundaries whose provider-reported prompt usage remains over the threshold, preventing repeated summary calls when the prompt has an incompressible floor.

## Changes
- Preserve @IgorGanapolsky's compaction accounting and real-usage threshold-verdict work from #62125.
- Count a completed compaction once, at the following provider usage report; no-op and aborted attempts do not create a delayed verdict.
- Consume pending state when a provider or Codex app-server omits usage, so preflight deferral cannot remain latched.
- Reset the anti-thrash latch on any later real prompt that fits below the threshold.
- Add the contributor email mapping required by attribution checks.

## What we did not carry forward from #62125
The original PR's final commit reverted its production implementation, leaving a tests-only branch. This salvage retains the three substantive contributor commits, then applies a separate maintainer fixture fix and lifecycle hardening.

## Validation
| Check | Result |
|---|---|
| Compaction, boundary, concurrent-fork, and Codex targeted tests | 252 passed, 1 deselected baseline failure unrelated to this PR |
| Ruff, py_compile, diff check, contributor audit | passed |
| Real-import compaction probe | two futile completed boundaries produce two strikes; no-op does not arm a delayed verdict; missing usage clears pending state |

Closes #62125.

Credits @IgorGanapolsky for the substantive anti-thrash implementation; the contributor commits are preserved as authored commits.