### PR TITLE
Fix desktop assistant text disappearing after empty completion event

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -358,6 +358,11 @@ export function useMessageStream({
 
         const replaceTextPart = (parts: ChatMessagePart[]) => {
           const visibleFinalText = stripGeneratedImageEchoes(finalText, generatedImageEchoSources(parts)).trim()
+
+          if (!visibleFinalText) {
+            return dedupeGeneratedImageEchoesInParts(parts)
+          }
+
           const dedupeReference = normalize(visibleFinalText)
 
           const kept = parts.filter(part => {
@@ -374,7 +379,7 @@ export function useMessageStream({
             return !(r && (dedupeReference.startsWith(r) || r.startsWith(dedupeReference)))
           })
 
-          return visibleFinalText ? [...kept, assistantTextPart(visibleFinalText)] : kept
+          return [...kept, assistantTextPart(visibleFinalText)]
         }
 
         const completeMessage = (message: ChatMessage): ChatMessage =>
@@ -429,8 +434,13 @@ export function useMessageStream({
         const hasInlineError = nextMessages.some(m => m.role === 'assistant' && m.error && !m.hidden)
         const lastVisible = [...nextMessages].reverse().find(m => !m.hidden)
         const unresolvedUserTail = lastVisible?.role === 'user'
+        const lastAssistant = [...nextMessages].reverse().find(m => m.role === 'assistant' && !m.hidden)
+        const hasVisibleAssistantText = Boolean(lastAssistant && chatMessageText(lastAssistant).trim())
         shouldHydrate =
-          !completionError && !hasInlineError && !unresolvedUserTail && (!state.sawAssistantPayload || !finalText)
+          !completionError &&
+          !hasInlineError &&
+          !unresolvedUserTail &&
+          (!state.sawAssistantPayload || (!finalText && !hasVisibleAssistantText))
 
         return {
           ...state,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/todo-cleanup.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/todo-cleanup.test.tsx
@@ -16,6 +16,7 @@ const SID = 'session-1'
 const todo = (id: string, status: TodoItem['status']): TodoItem => ({ content: `task ${id}`, id, status })
 
 let handleEvent: ((event: RpcEvent) => void) | null = null
+const hydrateFromStoredSession = vi.fn(async () => undefined)
 let latestState: ClientSessionState | null = null
 
 function Harness() {
@@ -25,7 +26,7 @@ function Harness() {
 
   const stream = useMessageStream({
     activeSessionIdRef,
-    hydrateFromStoredSession: vi.fn(async () => undefined),
+    hydrateFromStoredSession,
     queryClient: queryClientRef.current,
     refreshHermesConfig: vi.fn(async () => undefined),
     refreshSessions: vi.fn(async () => undefined),
@@ -57,6 +58,8 @@ const complete = () => act(() => handleEvent!({ payload: { text: 'done' }, sessi
 describe('useMessageStream turn-end todo cleanup', () => {
   beforeEach(() => {
     handleEvent = null
+    hydrateFromStoredSession.mockClear()
+    hydrateFromStoredSession.mockImplementation(async () => undefined)
     latestState = null
     clearSessionTodos(SID)
   })
@@ -109,6 +112,7 @@ describe('useMessageStream turn-end todo cleanup', () => {
     expect(assistant).toBeDefined()
     expect(chatMessageText(assistant!)).toBe('streamed answer')
     expect(assistant!.pending).toBe(false)
+    expect(hydrateFromStoredSession).not.toHaveBeenCalled()
     expect(latestState?.busy).toBe(false)
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/todo-cleanup.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/todo-cleanup.test.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClientSessionState } from '@/app/types'
+import { chatMessageText } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import type { TodoItem } from '@/lib/todos'
 import { $todosBySession, clearSessionTodos, setSessionTodos } from '@/store/todos'
@@ -15,6 +16,7 @@ const SID = 'session-1'
 const todo = (id: string, status: TodoItem['status']): TodoItem => ({ content: `task ${id}`, id, status })
 
 let handleEvent: ((event: RpcEvent) => void) | null = null
+let latestState: ClientSessionState | null = null
 
 function Harness() {
   const activeSessionIdRef = useRef<string | null>(SID)
@@ -32,6 +34,7 @@ function Harness() {
       const current = sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState()
       const next = updater(current)
       sessionStateByRuntimeIdRef.current.set(sessionId, next)
+      latestState = next
 
       return next
     }
@@ -54,6 +57,7 @@ const complete = () => act(() => handleEvent!({ payload: { text: 'done' }, sessi
 describe('useMessageStream turn-end todo cleanup', () => {
   beforeEach(() => {
     handleEvent = null
+    latestState = null
     clearSessionTodos(SID)
   })
 
@@ -89,5 +93,22 @@ describe('useMessageStream turn-end todo cleanup', () => {
     act(() => handleEvent!({ payload: { message: 'boom' }, session_id: SID, type: 'error' }))
 
     expect($todosBySession.get()[SID]).toBeUndefined()
+  })
+
+  it('keeps streamed assistant text when completion text is empty', async () => {
+    await mountStream()
+
+    act(() => {
+      handleEvent!({ payload: {}, session_id: SID, type: 'message.start' })
+      handleEvent!({ payload: { text: 'streamed answer' }, session_id: SID, type: 'message.delta' })
+      handleEvent!({ payload: { text: '' }, session_id: SID, type: 'message.complete' })
+    })
+
+    const assistant = latestState?.messages.find(message => message.role === 'assistant')
+
+    expect(assistant).toBeDefined()
+    expect(chatMessageText(assistant!)).toBe('streamed answer')
+    expect(assistant!.pending).toBe(false)
+    expect(latestState?.busy).toBe(false)
   })
 })


### PR DESCRIPTION
## What does this PR do?

Fixes a desktop chat rendering bug where the assistant response disappear after tool activity completed.

The desktop UI already received and rendered streamed assistant text from `message.delta`, but if the final `message.complete` event arrived with empty `text`, the completion handler removed the existing text parts and added nothing back. This made the turn look like tools ran successfully but no assistant response appeared.

This PR preserves already-streamed assistant text when the final completion text is empty.

## Related Issue

Related #62446

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `apps/desktop/src/app/session/hooks/use-message-stream/index.ts`
  - Preserve existing streamed assistant parts when `message.complete.text` has no visible final text.
  - Preserve existing message parts when completion text is empty, while keeping the existing text cleanup path intact.
  - Avoid hydrating over a turn that already has visible streamed assistant text.
- Updated `apps/desktop/src/app/session/hooks/use-message-stream/todo-cleanup.test.tsx`
  - Added a regression test for `message.delta("streamed answer")` followed by `message.complete("")`.
  - Verifies the empty-completion path does not hydrate over already-visible streamed assistant text.

## How to Test

1. Reproduce the frontend event sequence:
   - `message.start`
   - `message.delta({ text: "streamed answer" })`
   - `message.complete({ text: "" })`
2. Verify the assistant message still contains `streamed answer` after completion.
3. Run the focused test:

```bash
npm --workspace apps/desktop exec -- vitest run src/app/session/hooks/use-message-stream/todo-cleanup.test.tsx --environment jsdom --reporter=dot
```
