### PR TITLE
fix: accept api_key_env as fallback in custom provider resolution (#62254)

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -659,7 +659,8 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             # Match exact name or normalized name
             name_norm = _normalize_custom_provider_name(ep_name)
             # Resolve the API key from the env var name stored in key_env
-            key_env = str(entry.get("key_env", "") or "").strip()
+            # Accept api_key_env as fallback for consistency with gateway/run.py
+            key_env = str(entry.get("key_env") or entry.get("api_key_env") or "").strip()
             resolved_api_key = _getenv(key_env, "").strip() if key_env else ""
             # Fall back to inline api_key when key_env is absent or unresolvable
             if not resolved_api_key:
@@ -748,7 +749,8 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             "base_url": base_url.strip(),
             "api_key": str(entry.get("api_key", "") or "").strip(),
         }
-        key_env = str(entry.get("key_env", "") or "").strip()
+        # Accept api_key_env as fallback for consistency with gateway/run.py
+        key_env = str(entry.get("key_env") or entry.get("api_key_env") or "").strip()
         if key_env:
             result["key_env"] = key_env
         if provider_key:


### PR DESCRIPTION
fix: accept api_key_env as fallback in custom provider resolution

_get_named_custom_provider only reads key_env from custom_providers
config, silently ignoring api_key_env. The gateway (gateway/run.py:1962)
accepts both key_env and api_key_env, but the agent runtime does not.

Users configuring custom providers with the more intuitive api_key_env
field get silent 401 errors with zero diagnostic output.

Fix: accept api_key_env as a fallback in both the new-style providers
(L662) and legacy custom_providers (L751) code paths, matching the
gateway's behavior.

Fixes #62254
