### PR TITLE
feat(agent): add cross-surface message timestamps

### DIFF
--- a/agent/message_timestamps.py
+++ b/agent/message_timestamps.py
@@ -1,0 +1,246 @@
+"""Render user-message timestamps in model context exactly once.
+
+All Hermes surfaces can add temporal context while persisted message content stays
+clean, so replay never accumulates ``[timestamp] [timestamp] ...`` prefixes.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+
+def message_timestamps_enabled(config: Optional[dict]) -> bool:
+    """Resolve the canonical global opt-in with gateway compatibility."""
+    if not isinstance(config, dict):
+        return False
+
+    configured = config.get("message_timestamps")
+    if configured is not None:
+        return (
+            bool(configured.get("enabled", False))
+            if isinstance(configured, dict)
+            else bool(configured)
+        )
+
+    gateway = config.get("gateway")
+    if not isinstance(gateway, dict):
+        return False
+    legacy = gateway.get("message_timestamps")
+    return (
+        bool(legacy.get("enabled", False))
+        if isinstance(legacy, dict)
+        else bool(legacy)
+    )
+
+
+def render_turn_with_message_timestamps(
+    history: Optional[List[Dict[str, Any]]],
+    user_message: Any,
+    *,
+    config: Optional[dict],
+    current_timestamp: Any = None,
+    tz=None,
+) -> Tuple[List[Dict[str, Any]], Any, Optional[float]]:
+    """Return model-only timestamp rendering without mutating caller data."""
+    rendered_history = [dict(message) for message in (history or [])]
+    if not message_timestamps_enabled(config):
+        return rendered_history, user_message, None
+
+    for message in rendered_history:
+        if message.get("role") == "user":
+            message["content"] = _render_user_message_content(
+                message.get("content"),
+                message.get("timestamp"),
+                tz=tz,
+            )
+
+    effective_timestamp = coerce_message_timestamp(
+        time.time() if current_timestamp is None else current_timestamp,
+        tz=tz,
+    )
+    user_message = _render_user_message_content(
+        user_message,
+        effective_timestamp,
+        tz=tz,
+    )
+    return rendered_history, user_message, effective_timestamp
+
+
+def _render_user_message_content(content: Any, ts_value: Any, tz=None) -> Any:
+    """Copy and timestamp plain text or OpenAI-style structured content."""
+    if isinstance(content, str):
+        return render_user_content_with_timestamp(content, ts_value, tz=tz)
+    if not isinstance(content, list):
+        return content
+
+    parts = [dict(part) if isinstance(part, dict) else part for part in content]
+    for part in parts:
+        if isinstance(part, dict) and part.get("type") == "text":
+            text = part.get("text")
+            if isinstance(text, str):
+                part["text"] = render_user_content_with_timestamp(
+                    text, ts_value, tz=tz
+                )
+                return parts
+
+    prefix = format_message_timestamp(ts_value, tz=tz)
+    if prefix:
+        parts.insert(0, {"type": "text", "text": prefix})
+    return parts
+
+
+# Current gateway format: [Tue 2026-04-28 13:40:53 CEST]
+_HUMAN_TIMESTAMP_RE = re.compile(
+    r"^\[(?P<dow>[A-Z][a-z]{2}) "
+    r"(?P<date>\d{4}-\d{2}-\d{2}) "
+    r"(?P<time>\d{2}:\d{2}:\d{2})"
+    r"(?: (?P<tz>[A-Za-z0-9_+\-/:]+))?\]\s*"
+)
+
+# Older gateway format: [2026-04-13T17:02:06+0200] or [+02:00]
+_ISO_TIMESTAMP_RE = re.compile(
+    r"^\[(?P<iso>\d{4}-\d{2}-\d{2}T[^\]]+)\]\s*"
+)
+
+
+def coerce_message_timestamp(ts_value: Any, tz=None) -> Optional[float]:
+    """Coerce a timestamp-like value to Unix epoch seconds.
+
+    Accepts Unix epoch numbers, datetime objects, ISO strings, and the gateway's
+    bracketed human-readable timestamp format. Returns ``None`` when the value
+    cannot be interpreted.
+    """
+    if ts_value is None:
+        return None
+
+    if isinstance(ts_value, (int, float)):
+        return float(ts_value)
+
+    if hasattr(ts_value, "timestamp"):
+        try:
+            return float(ts_value.timestamp())
+        except Exception:
+            return None
+
+    if isinstance(ts_value, str):
+        text = ts_value.strip()
+        if not text:
+            return None
+        parsed = _parse_timestamp_prefix(text, tz=tz)
+        if parsed is not None:
+            return parsed
+        try:
+            return float(text)
+        except (TypeError, ValueError):
+            pass
+        try:
+            dt = datetime.fromisoformat(text)
+        except (TypeError, ValueError):
+            try:
+                dt = datetime.strptime(text, "%Y-%m-%dT%H:%M:%S%z")
+            except (TypeError, ValueError):
+                return None
+        if dt.tzinfo is None:
+            if tz is not None:
+                dt = dt.replace(tzinfo=tz)
+            else:
+                dt = dt.astimezone()
+        return float(dt.timestamp())
+
+    return None
+
+
+def format_message_timestamp(ts_value: Any, tz=None) -> str:
+    """Format a timestamp value as ``[Tue 2026-04-28 13:40:53 CEST]``."""
+    epoch = coerce_message_timestamp(ts_value, tz=tz)
+    if epoch is None:
+        return ""
+    if tz is not None:
+        dt = datetime.fromtimestamp(epoch, tz=tz)
+    else:
+        dt = datetime.fromtimestamp(epoch).astimezone()
+    return "[" + dt.strftime("%a %Y-%m-%d %H:%M:%S %Z") + "]"
+
+
+def strip_leading_message_timestamps(content: str, tz=None) -> Tuple[str, Optional[float]]:
+    """Strip one or more leading gateway timestamp prefixes from ``content``.
+
+    Returns ``(clean_content, embedded_epoch)``.  If multiple timestamp prefixes
+    are present, the timestamp closest to the actual message text wins.  That
+    preserves the original platform-send time for legacy contaminated rows like
+    ``[processing time] [platform time] [sender] message``.
+    """
+    if not isinstance(content, str) or not content:
+        return content, None
+
+    text = content
+    embedded_epoch: Optional[float] = None
+
+    while True:
+        match = _HUMAN_TIMESTAMP_RE.match(text) or _ISO_TIMESTAMP_RE.match(text)
+        if not match:
+            break
+        parsed = _parse_timestamp_match(match, tz=tz)
+        if parsed is not None:
+            embedded_epoch = parsed
+        text = text[match.end():]
+
+    return text, embedded_epoch
+
+
+def render_user_content_with_timestamp(content: str, ts_value: Any = None, tz=None) -> str:
+    """Render a user message for LLM context with exactly one timestamp prefix.
+
+    Existing leading timestamp prefixes are removed first.  If such a prefix was
+    present, its parsed time wins over ``ts_value``; otherwise ``ts_value`` is
+    formatted and prepended.  If no timestamp is available, the cleaned content is
+    returned unchanged.
+    """
+    clean_content, embedded_epoch = strip_leading_message_timestamps(content, tz=tz)
+    effective_ts = embedded_epoch if embedded_epoch is not None else ts_value
+    prefix = format_message_timestamp(effective_ts, tz=tz)
+    if not prefix:
+        return clean_content
+    if clean_content:
+        return f"{prefix} {clean_content}"
+    return prefix
+
+
+def _parse_timestamp_prefix(text: str, tz=None) -> Optional[float]:
+    match = _HUMAN_TIMESTAMP_RE.match(text) or _ISO_TIMESTAMP_RE.match(text)
+    if not match:
+        return None
+    return _parse_timestamp_match(match, tz=tz)
+
+
+def _parse_timestamp_match(match: re.Match, tz=None) -> Optional[float]:
+    if "iso" in match.groupdict() and match.group("iso"):
+        iso_text = match.group("iso")
+        try:
+            dt = datetime.fromisoformat(iso_text)
+        except ValueError:
+            try:
+                dt = datetime.strptime(iso_text, "%Y-%m-%dT%H:%M:%S%z")
+            except ValueError:
+                return None
+        if dt.tzinfo is None:
+            if tz is not None:
+                dt = dt.replace(tzinfo=tz)
+            else:
+                dt = dt.astimezone()
+        return float(dt.timestamp())
+
+    date_part = match.group("date")
+    time_part = match.group("time")
+    try:
+        dt = datetime.strptime(f"{date_part} {time_part}", "%Y-%m-%d %H:%M:%S")
+    except ValueError:
+        return None
+    if tz is not None:
+        dt = dt.replace(tzinfo=tz)
+    else:
+        dt = dt.astimezone()
+    return float(dt.timestamp())

--- a/agent/message_timestamps.py
+++ b/agent/message_timestamps.py
@@ -19,11 +19,12 @@ def message_timestamps_enabled(config: Optional[dict]) -> bool:
 
     configured = config.get("message_timestamps")
     if configured is not None:
-        return (
-            bool(configured.get("enabled", False))
-            if isinstance(configured, dict)
-            else bool(configured)
-        )
+        if isinstance(configured, dict):
+            enabled = configured.get("enabled")
+            if enabled is not None:
+                return bool(enabled)
+        else:
+            return bool(configured)
 
     gateway = config.get("gateway")
     if not isinstance(gateway, dict):
@@ -51,11 +52,19 @@ def render_turn_with_message_timestamps(
 
     for message in rendered_history:
         if message.get("role") == "user":
+            timestamp = message.get("timestamp")
             message["content"] = _render_user_message_content(
                 message.get("content"),
-                message.get("timestamp"),
+                timestamp,
                 tz=tz,
             )
+            # ``api_content`` wins over ``content`` at the final API boundary.
+            # Render the sidecar too, otherwise persisted prefetch/plugin bytes
+            # silently erase the timestamp we just added to historical context.
+            if isinstance(message.get("api_content"), str):
+                message["api_content"] = render_user_content_with_timestamp(
+                    message["api_content"], timestamp, tz=tz
+                )
 
     effective_timestamp = coerce_message_timestamp(
         time.time() if current_timestamp is None else current_timestamp,

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -813,6 +813,31 @@ def build_turn_context(
     if isinstance(persist_user_message, str):
         persist_user_message = sanitize_surrogates(persist_user_message)
 
+    # Preserve clean input for transcripts before adding timestamp context.
+    original_user_message = (
+        persist_user_message if persist_user_message is not None else user_message
+    )
+    try:
+        from agent.message_timestamps import render_turn_with_message_timestamps
+        from hermes_cli.config import load_config
+        from hermes_time import get_timezone
+
+        conversation_history, user_message, rendered_timestamp = (
+            render_turn_with_message_timestamps(
+                conversation_history,
+                user_message,
+                config=load_config(),
+                current_timestamp=persist_user_timestamp,
+                tz=get_timezone(),
+            )
+        )
+        if rendered_timestamp is not None:
+            if persist_user_message is None:
+                persist_user_message = original_user_message
+            persist_user_timestamp = rendered_timestamp
+    except Exception:
+        logger.debug("message timestamp rendering skipped", exc_info=True)
+
     effective_task_id, turn_id = _bind_turn_identity(
         agent, task_id, stream_callback, persist_user_message,
         persist_user_timestamp, persist_user_platform_id,

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -819,14 +819,14 @@ def build_turn_context(
     )
     try:
         from agent.message_timestamps import render_turn_with_message_timestamps
-        from hermes_cli.config import load_config
+        from hermes_cli.config import load_config_readonly
         from hermes_time import get_timezone
 
         conversation_history, user_message, rendered_timestamp = (
             render_turn_with_message_timestamps(
                 conversation_history,
                 user_message,
-                config=load_config(),
+                config=load_config_readonly(),
                 current_timestamp=persist_user_timestamp,
                 tz=get_timezone(),
             )

--- a/gateway/message_timestamps.py
+++ b/gateway/message_timestamps.py
@@ -1,108 +1,19 @@
-"""Helpers for rendering gateway message timestamps exactly once.
+"""Backward-compatible imports for gateway timestamp helpers.
 
-Gateway messages need timestamps in the LLM context for temporal awareness, but
-persisted message content should stay clean so replay does not accumulate
-``[timestamp] [timestamp] ...`` prefixes across turns.
+The implementation lives at the agent layer so every Hermes surface can render
+the same clean, timestamp-aware model context.
 """
 
-from __future__ import annotations
-
-import re
-from datetime import datetime
-from typing import Any, Optional, Tuple
-
-
-# Leading timestamp prefix, either the current human format
-# ``[Tue 2026-04-28 13:40:53 CEST]`` or the older ISO one
-# ``[2026-04-13T17:02:06+0200]`` / ``[...+02:00]`` (human tried first).
-_TIMESTAMP_PREFIX_RE = re.compile(
-    r"^\[(?:"
-    r"(?P<dow>[A-Z][a-z]{2}) "
-    r"(?P<date>\d{4}-\d{2}-\d{2}) "
-    r"(?P<time>\d{2}:\d{2}:\d{2})"
-    r"(?: (?P<tz>[A-Za-z0-9_+\-/:]+))?"
-    r"|(?P<iso>\d{4}-\d{2}-\d{2}T[^\]]+)"
-    r")\]\s*"
+from agent.message_timestamps import (  # noqa: F401
+    coerce_message_timestamp,
+    format_message_timestamp,
+    render_user_content_with_timestamp,
+    strip_leading_message_timestamps,
 )
 
-
-def _localize(dt: datetime, tz) -> float:
-    """Epoch for ``dt``; naive values take ``tz`` if given, else the local zone."""
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=tz) if tz is not None else dt.astimezone()
-    return float(dt.timestamp())
-
-
-def _parse_iso(text: str, tz=None) -> Optional[float]:
-    """Parse an ISO-8601 string (incl. ``+0200`` offsets fromisoformat rejects)."""
-    for parse in (datetime.fromisoformat, lambda t: datetime.strptime(t, "%Y-%m-%dT%H:%M:%S%z")):
-        try:
-            return _localize(parse(text), tz)
-        except (TypeError, ValueError):
-            continue
-    return None
-
-
-def _parse_timestamp_match(match: re.Match, tz=None) -> Optional[float]:
-    if match.group("iso"):
-        return _parse_iso(match.group("iso"), tz)
-    try:
-        dt = datetime.strptime(f"{match.group('date')} {match.group('time')}", "%Y-%m-%d %H:%M:%S")
-    except ValueError:
-        return None
-    return _localize(dt, tz)
-
-
-def coerce_message_timestamp(ts_value: Any, tz=None) -> Optional[float]:
-    """Epoch seconds from a number, datetime, ISO string, or the gateway's bracketed
-    format; ``None`` when uninterpretable."""
-    if isinstance(ts_value, (int, float)):
-        return float(ts_value)
-    if hasattr(ts_value, "timestamp"):
-        try:
-            return float(ts_value.timestamp())
-        except Exception:
-            return None
-    text = ts_value.strip() if isinstance(ts_value, str) else ""
-    if not text:
-        return None
-    match = _TIMESTAMP_PREFIX_RE.match(text)
-    parsed = _parse_timestamp_match(match, tz=tz) if match is not None else None
-    if parsed is not None:
-        return parsed
-    try:
-        return float(text)
-    except (TypeError, ValueError):
-        return _parse_iso(text, tz)
-
-
-def format_message_timestamp(ts_value: Any, tz=None) -> str:
-    """Format a timestamp value as ``[Tue 2026-04-28 13:40:53 CEST]``."""
-    epoch = coerce_message_timestamp(ts_value, tz=tz)
-    if epoch is None:
-        return ""
-    dt = datetime.fromtimestamp(epoch, tz=tz) if tz is not None else datetime.fromtimestamp(epoch).astimezone()
-    return f"[{dt.strftime('%a %Y-%m-%d %H:%M:%S %Z')}]"
-
-
-def strip_leading_message_timestamps(content: str, tz=None) -> Tuple[str, Optional[float]]:
-    """Strip leading gateway timestamp prefixes → ``(clean_content, embedded_epoch)``.
-    With several prefixes the one closest to the text wins, preserving the platform-send
-    time of legacy rows like ``[processing time] [platform time] [sender] message``."""
-    if not isinstance(content, str) or not content:
-        return content, None
-    text, embedded_epoch = content, None
-    while (match := _TIMESTAMP_PREFIX_RE.match(text)) is not None:
-        parsed = _parse_timestamp_match(match, tz=tz)
-        if parsed is not None:
-            embedded_epoch = parsed
-        text = text[match.end():]
-    return text, embedded_epoch
-
-
-def render_user_content_with_timestamp(content: str, ts_value: Any = None, tz=None) -> str:
-    """Render a user message for LLM context with exactly one timestamp prefix; an
-    existing prefix is stripped and its parsed time wins over ``ts_value``."""
-    clean_content, embedded_epoch = strip_leading_message_timestamps(content, tz=tz)
-    prefix = format_message_timestamp(ts_value if embedded_epoch is None else embedded_epoch, tz=tz)
-    return f"{prefix} {clean_content}" if prefix and clean_content else (prefix or clean_content)
+__all__ = [
+    "coerce_message_timestamp",
+    "format_message_timestamp",
+    "render_user_content_with_timestamp",
+    "strip_leading_message_timestamps",
+]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1131,17 +1131,10 @@ def _is_slack_ignored_channel(config: Any, chat_id: Any) -> bool:
 
 
 def _message_timestamps_enabled(user_config: Optional[dict]) -> bool:
-    """True when gateway.message_timestamps.enabled is opted in (default OFF: changes what the model sees)."""
-    if not isinstance(user_config, dict):
-        return False
-    gw = user_config.get("gateway")
-    if not isinstance(gw, dict):
-        return False
-    mt = gw.get("message_timestamps")
-    if isinstance(mt, dict):
-        return bool(mt.get("enabled", False))
-    # Allow a bare ``message_timestamps: true`` shorthand.
-    return bool(mt)
+    """Compatibility wrapper for the shared cross-surface config resolver."""
+    from agent.message_timestamps import message_timestamps_enabled
+
+    return message_timestamps_enabled(user_config)
 
 
 def _build_gateway_agent_history(

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -46,6 +46,12 @@ DEFAULT_CONFIG = {
         # terminal's session (tmux/kitty/wezterm pane, tty). false = resume globally most-recent.
         "terminal_continue": True,
     },
+    # Global message timestamp opt-in. ``None`` preserves compatibility with
+    # legacy gateway.message_timestamps.enabled when the top-level setting is
+    # not explicitly chosen by the user.
+    "message_timestamps": {
+        "enabled": None,
+    },
     "agent": {
         # Turn cap. null = unlimited (default; caps caused silent mid-task truncation). Positive int
         # caps; "none"/"unlimited"/"inf"/0/-1 also mean unlimited (resolve_turn_limit).

--- a/tests/agent/test_message_timestamps.py
+++ b/tests/agent/test_message_timestamps.py
@@ -1,0 +1,88 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from agent.message_timestamps import (
+    message_timestamps_enabled,
+    render_turn_with_message_timestamps,
+)
+
+
+BERLIN = ZoneInfo("Europe/Berlin")
+
+
+def _epoch(year, month, day, hour, minute, second):
+    return datetime(year, month, day, hour, minute, second, tzinfo=BERLIN).timestamp()
+
+
+def test_global_setting_is_canonical_with_gateway_compatibility():
+    assert message_timestamps_enabled({"message_timestamps": {"enabled": True}}) is True
+    assert message_timestamps_enabled(
+        {"gateway": {"message_timestamps": {"enabled": True}}}
+    ) is True
+    assert message_timestamps_enabled(
+        {
+            "message_timestamps": {"enabled": False},
+            "gateway": {"message_timestamps": {"enabled": True}},
+        }
+    ) is False
+
+
+def test_render_turn_timestamps_history_and_current_user_without_mutating_input():
+    prior_ts = _epoch(2026, 4, 28, 13, 40, 53)
+    current_ts = _epoch(2026, 4, 28, 13, 42, 10)
+    history = [
+        {"role": "user", "content": "earlier", "timestamp": prior_ts},
+        {"role": "assistant", "content": "reply"},
+    ]
+
+    rendered_history, rendered_user, persisted_ts = render_turn_with_message_timestamps(
+        history,
+        "now",
+        config={"message_timestamps": {"enabled": True}},
+        current_timestamp=current_ts,
+        tz=BERLIN,
+    )
+
+    assert history[0]["content"] == "earlier"
+    assert rendered_history[0]["content"] == "[Tue 2026-04-28 13:40:53 CEST] earlier"
+    assert rendered_history[1]["content"] == "reply"
+    assert rendered_user == "[Tue 2026-04-28 13:42:10 CEST] now"
+    assert persisted_ts == current_ts
+
+
+def test_render_turn_is_identity_preserving_when_disabled():
+    history = [{"role": "user", "content": "clean", "timestamp": 1.0}]
+
+    rendered_history, rendered_user, persisted_ts = render_turn_with_message_timestamps(
+        history,
+        "current",
+        config={},
+        current_timestamp=2.0,
+        tz=BERLIN,
+    )
+
+    assert rendered_history == history
+    assert rendered_history is not history
+    assert rendered_user == "current"
+    assert persisted_ts is None
+
+
+def test_render_turn_timestamps_structured_user_content_without_touching_image_part():
+    current_ts = _epoch(2026, 4, 28, 13, 42, 10)
+    image_part = {"type": "image_url", "image_url": {"url": "data:image/png;base64,AA=="}}
+    user_message = [
+        {"type": "text", "text": "describe this"},
+        image_part,
+    ]
+
+    _, rendered_user, _ = render_turn_with_message_timestamps(
+        [],
+        user_message,
+        config={"message_timestamps": {"enabled": True}},
+        current_timestamp=current_ts,
+        tz=BERLIN,
+    )
+
+    assert user_message[0]["text"] == "describe this"
+    assert rendered_user[0]["text"] == "[Tue 2026-04-28 13:42:10 CEST] describe this"
+    assert rendered_user[1] == image_part

--- a/tests/agent/test_message_timestamps.py
+++ b/tests/agent/test_message_timestamps.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
@@ -5,6 +6,8 @@ from agent.message_timestamps import (
     message_timestamps_enabled,
     render_turn_with_message_timestamps,
 )
+from agent.turn_context import substitute_api_content
+from hermes_cli.config import DEFAULT_CONFIG, load_config_readonly
 
 
 BERLIN = ZoneInfo("Europe/Berlin")
@@ -25,6 +28,32 @@ def test_global_setting_is_canonical_with_gateway_compatibility():
             "gateway": {"message_timestamps": {"enabled": True}},
         }
     ) is False
+
+
+def test_default_config_declares_global_setting_without_masking_legacy_fallback():
+    config = deepcopy(DEFAULT_CONFIG)
+
+    assert "message_timestamps" in config
+    config["gateway"]["message_timestamps"]["enabled"] = True
+    assert message_timestamps_enabled(config) is True
+
+    config["message_timestamps"]["enabled"] = False
+    assert message_timestamps_enabled(config) is False
+
+
+def test_loaded_legacy_gateway_config_survives_default_merge(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "gateway:\n  message_timestamps:\n    enabled: true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    config = load_config_readonly()
+
+    assert "message_timestamps" in config
+    assert message_timestamps_enabled(config) is True
 
 
 def test_render_turn_timestamps_history_and_current_user_without_mutating_input():
@@ -48,6 +77,32 @@ def test_render_turn_timestamps_history_and_current_user_without_mutating_input(
     assert rendered_history[1]["content"] == "reply"
     assert rendered_user == "[Tue 2026-04-28 13:42:10 CEST] now"
     assert persisted_ts == current_ts
+
+
+def test_rendered_history_keeps_timestamp_when_api_sidecar_is_substituted():
+    prior_ts = _epoch(2026, 4, 28, 13, 40, 53)
+    history = [
+        {
+            "role": "user",
+            "content": "earlier",
+            "api_content": "earlier\n\n<memory-context>prior context</memory-context>",
+            "timestamp": prior_ts,
+        }
+    ]
+
+    rendered_history, _, _ = render_turn_with_message_timestamps(
+        history,
+        "now",
+        config={"message_timestamps": {"enabled": True}},
+        current_timestamp=_epoch(2026, 4, 28, 13, 42, 10),
+        tz=BERLIN,
+    )
+    api_message = dict(rendered_history[0])
+    substitute_api_content(api_message)
+
+    assert history[0]["api_content"].startswith("earlier")
+    assert api_message["content"].startswith("[Tue 2026-04-28 13:40:53 CEST]")
+    assert "<memory-context>prior context</memory-context>" in api_message["content"]
 
 
 def test_render_turn_is_identity_preserving_when_disabled():

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -382,8 +382,12 @@ def test_global_message_timestamps_decorate_model_context_but_persist_clean_text
 
     with (
         patch(
-            "hermes_cli.config.load_config",
+            "hermes_cli.config.load_config_readonly",
             return_value={"message_timestamps": {"enabled": True}},
+        ),
+        patch(
+            "hermes_cli.config.load_config",
+            side_effect=AssertionError("turn hot path must use readonly config"),
         ),
         patch("hermes_time.get_timezone", return_value=tz),
         patch("agent.message_timestamps.time.time", return_value=current_ts),

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -370,8 +370,32 @@ def test_pending_cli_message_uses_clean_override_for_api_local_note():
 
 
 
+def test_global_message_timestamps_decorate_model_context_but_persist_clean_text():
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
 
+    tz = ZoneInfo("Europe/Berlin")
+    prior_ts = datetime(2026, 4, 28, 13, 40, 53, tzinfo=tz).timestamp()
+    current_ts = datetime(2026, 4, 28, 13, 42, 10, tzinfo=tz).timestamp()
+    agent = _FakeAgent()
+    history = [{"role": "user", "content": "earlier", "timestamp": prior_ts}]
 
+    with (
+        patch(
+            "hermes_cli.config.load_config",
+            return_value={"message_timestamps": {"enabled": True}},
+        ),
+        patch("hermes_time.get_timezone", return_value=tz),
+        patch("agent.message_timestamps.time.time", return_value=current_ts),
+    ):
+        ctx = _build(agent, user_message="now", conversation_history=history)
+
+    assert history[0]["content"] == "earlier"
+    assert ctx.messages[0]["content"] == "[Tue 2026-04-28 13:40:53 CEST] earlier"
+    assert ctx.messages[-1]["content"] == "[Tue 2026-04-28 13:42:10 CEST] now"
+    assert ctx.original_user_message == "now"
+    assert agent._persist_user_message_override == "now"
+    assert agent._persist_user_message_timestamp == current_ts
 
 
 def test_recall_indicator_emitted_when_memory_injected():

--- a/tests/gateway/test_message_timestamps.py
+++ b/tests/gateway/test_message_timestamps.py
@@ -49,6 +49,17 @@ def test_message_timestamps_enabled_defaults_off():
     )
 
 
+def test_global_message_timestamps_setting_is_canonical_with_gateway_compatibility():
+    from gateway.run import _message_timestamps_enabled
+
+    assert _message_timestamps_enabled({"message_timestamps": {"enabled": True}}) is True
+    assert _message_timestamps_enabled(
+        {
+            "message_timestamps": {"enabled": False},
+            "gateway": {"message_timestamps": {"enabled": True}},
+        }
+    ) is False
+
 def test_build_history_injects_only_when_enabled():
     from gateway.run import _build_gateway_agent_history
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6933,6 +6933,38 @@ class TestPersistUserMessageOverride:
         ]
         assert batch[0]["content"] == "Hello there"
 
+    def test_persist_session_uses_clean_structured_override_for_timestamped_turn(
+        self, agent
+    ):
+        agent._session_db = MagicMock()
+        agent.session_id = "session-123"
+        agent._last_flushed_db_idx = 0
+        agent._persist_user_message_idx = 0
+        agent._persist_user_message_timestamp = 1777376530.0
+        clean_content = [
+            {"type": "text", "text": "What color is this?"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,AAAA"},
+            },
+        ]
+        timestamped_content = [
+            {
+                "type": "text",
+                "text": "[Tue 2026-04-28 13:42:10 CEST] What color is this?",
+            },
+            clean_content[1],
+        ]
+        agent._persist_user_message_override = clean_content
+        messages = [{"role": "user", "content": timestamped_content}]
+
+        agent._persist_session(messages, [])
+
+        assert messages[0]["content"] == timestamped_content
+        first_db_write = agent._session_db.append_message.call_args_list[0].kwargs
+        assert first_db_write["content"] == "What color is this?\n[screenshot]"
+        assert first_db_write["timestamp"] == 1777376530.0
+
 
 class TestReasoningReplayForStrictProviders:
     """Assistant replay must preserve provider-native reasoning fields."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6937,6 +6937,8 @@ class TestPersistUserMessageOverride:
         self, agent
     ):
         agent._session_db = MagicMock()
+        agent._session_db_created = True
+        agent._session_json_enabled = False
         agent.session_id = "session-123"
         agent._last_flushed_db_idx = 0
         agent._persist_user_message_idx = 0
@@ -6958,12 +6960,12 @@ class TestPersistUserMessageOverride:
         agent._persist_user_message_override = clean_content
         messages = [{"role": "user", "content": timestamped_content}]
 
-        agent._persist_session(messages, [])
+        agent._flush_messages_to_session_db(messages, [])
 
         assert messages[0]["content"] == timestamped_content
-        first_db_write = agent._session_db.append_message.call_args_list[0].kwargs
-        assert first_db_write["content"] == "What color is this?\n[screenshot]"
-        assert first_db_write["timestamp"] == 1777376530.0
+        batch = agent._session_db.append_messages_batch.call_args.kwargs["messages"]
+        assert batch[0]["content"] == "What color is this?\n[screenshot]"
+        assert batch[0]["timestamp"] == 1777376530.0
 
 
 class TestReasoningReplayForStrictProviders:

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -473,10 +473,21 @@ temporal reasoning ("you asked this morning…", noticing a long gap). It is
 **not** added to assistant messages or the system prompt.
 
 ```yaml
+message_timestamps:
+  enabled: true
+```
+
+This agent-wide setting applies consistently to CLI/TUI, Desktop, and gateway
+channels. Existing gateway-only configurations remain supported as a
+backward-compatible fallback:
+
+```yaml
 gateway:
   message_timestamps:
-    enabled: false   # set true to show send-times to the model
+    enabled: true
 ```
+
+When both spellings are present, the top-level setting is authoritative.
 
 Persisted transcripts always stay clean — the timestamp is stored as message
 metadata regardless of this toggle, so enabling it later also surfaces


### PR DESCRIPTION
## Summary

- promote user-message timestamp rendering from the gateway into shared agent turn assembly
- add an agent-wide `message_timestamps.enabled` opt-in while preserving `gateway.message_timestamps.enabled` as a compatibility fallback
- keep persisted transcript content clean, including structured/multimodal turns
- preserve timestamps through `api_content` replay sidecars used for prompt-cache fidelity
- retain gateway imports through a compatibility re-export

## Behavior

```yaml
message_timestamps:
  enabled: true
```

When both global and legacy gateway settings are present, the global setting is authoritative. The merged default uses an internal `None` sentinel so an existing gateway-only opt-in remains effective when the global key is absent. Timestamps are rendered only into user-message model context; assistant/system messages and stored transcript content remain unchanged.

## Tests

Rebased onto current `origin/main` (`ed5e17f4b86da0c4f09c0694757b6074ae6b9d16`) at head `cdf6b188431ac6d509a504c934d45f14dfcd8057` on 2026-08-12.

- `scripts/run_tests.sh tests/agent/test_message_timestamps.py tests/agent/test_turn_context.py tests/gateway/test_message_timestamps.py tests/run_agent/test_run_agent.py tests/hermes_cli/test_config.py -q`
  - 346 passed, 0 failed
- Python compilation for all changed Python files
- `git diff --check origin/main...HEAD`

Coverage includes:

- real `config.yaml` loading through an isolated temporary `HERMES_HOME`
- global-setting precedence and legacy gateway fallback after default merging
- historical and current user-message rendering
- structured/multimodal persistence with clean transcript content
- `api_content` substitution at the final API boundary, preserving both timestamps and memory/plugin context
- regression protection against copying config in the per-turn hot path

## Relation to the broader time-awareness work

This PR addresses the **cross-surface message timestamp** slice of the larger temporal-awareness effort:

- #10421 — core feature request for reliable turn-level time awareness
- #17476 — consolidation tracker for one cache-safe ephemeral runtime-context path
- #17459 — parent time-awareness/tool-advisory umbrella
- #15872 / #32942 — complementary live-current-time (`now`) injection work
- #41425 — complementary propagation of stored timestamps for replayed historical messages

The scope here is the shared agent rendering/configuration seam: promote the existing gateway behavior to all surfaces, preserve clean transcripts and prompt-cache-safe `api_content` replay, and retain the gateway setting as a compatibility fallback. It does not try to replace live-current-time injection or independently redesign historical state loading; those slices should converge on this shared turn-assembly contract rather than introduce parallel timestamp formats.

## Manual validation

Dogfooded on a local integration branch with:

```yaml
message_timestamps:
  enabled: true
gateway:
  message_timestamps:
    enabled: false
```

Validated timestamp awareness without clock-tool calls across:

- Hermes Desktop
- WebUI consumed by a phone client
- Telegram gateway

This also verifies that the canonical global key takes precedence over the disabled legacy gateway key.


## Refresh verification — 2026-09-07

Rebased onto upstream `08b140d14e6c1d49f9b7ad02c9437fe940d54d65`, head `9cd12fca66e1410554a306a962fecbc77597c6ac`. Reconciled the extracted turn-context and gateway structure while preserving timestamp opt-in, gateway fallback, clean persistence and API-content replay.

Parent-run `scripts/run_tests.sh tests/agent/test_message_timestamps.py tests/agent/test_turn_context.py tests/gateway/test_message_timestamps.py tests/run_agent/test_run_agent.py -q`: **325 passed, 1 failed**. The failure is `TestAnthropicInterruptHandler::test_interruptible_anthropic_interrupt_never_closes_shared_client`, which cannot initialize because this test environment lacks the optional `anthropic` SDK. The run also reported a `_BarrierDB.flush_token_counts` thread warning. This is NOT an all-green full-suite claim. The timestamp, turn-context and gateway timestamp files passed 32 tests; the run-agent file passed 293 with that one dependency failure. `git diff --check` passed. No fresh live gateway/desktop test performed.
