### PR TITLE
feat(proxy): add authenticated OpenAI Codex upstream

### DIFF
--- a/hermes_cli/proxy/adapters/__init__.py
+++ b/hermes_cli/proxy/adapters/__init__.py
@@ -9,12 +9,14 @@ from typing import Dict, Type
 
 from hermes_cli.proxy.adapters.base import UpstreamAdapter
 from hermes_cli.proxy.adapters.nous_portal import NousPortalAdapter
+from hermes_cli.proxy.adapters.openai_codex import OpenAICodexAdapter
 from hermes_cli.proxy.adapters.xai import XAIGrokAdapter
 
 # Registry of available adapter classes keyed by provider name as used on
 # the ``hermes proxy start --provider <name>`` CLI flag.
 ADAPTERS: Dict[str, Type[UpstreamAdapter]] = {
     "nous": NousPortalAdapter,
+    "openai-codex": OpenAICodexAdapter,
     "xai": XAIGrokAdapter,
 }
 

--- a/hermes_cli/proxy/adapters/base.py
+++ b/hermes_cli/proxy/adapters/base.py
@@ -14,8 +14,8 @@ The proxy server is otherwise provider-agnostic.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import FrozenSet, Optional
+from dataclasses import dataclass, field
+from typing import FrozenSet, Mapping, Optional
 
 
 @dataclass(frozen=True)
@@ -33,6 +33,9 @@ class UpstreamCredential:
 
     expires_at: Optional[str] = None
     """ISO-8601 expiry timestamp for the bearer, when known. Informational."""
+
+    extra_headers: Mapping[str, str] = field(default_factory=dict)
+    """Provider-required headers applied after inbound headers are filtered."""
 
 
 class UpstreamAdapter(ABC):

--- a/hermes_cli/proxy/adapters/openai_codex.py
+++ b/hermes_cli/proxy/adapters/openai_codex.py
@@ -1,0 +1,88 @@
+"""OpenAI Codex OAuth upstream adapter."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import FrozenSet, Optional
+
+from hermes_cli.auth import resolve_codex_runtime_credentials
+from hermes_cli.proxy.adapters.base import UpstreamAdapter, UpstreamCredential
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE_URL = "https://chatgpt.com/backend-api/codex"
+_ALLOWED_PATHS: FrozenSet[str] = frozenset({"/responses", "/models"})
+
+
+class OpenAICodexAdapter(UpstreamAdapter):
+    """Proxy upstream for ChatGPT Codex via Hermes-managed OAuth credentials."""
+
+    auth_hint = "hermes auth add openai-codex --type oauth"
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+
+    @property
+    def name(self) -> str:
+        return "openai-codex"
+
+    @property
+    def display_name(self) -> str:
+        return "OpenAI Codex OAuth"
+
+    @property
+    def allowed_paths(self) -> FrozenSet[str]:
+        return _ALLOWED_PATHS
+
+    def is_authenticated(self) -> bool:
+        try:
+            resolved = resolve_codex_runtime_credentials(refresh_if_expiring=False)
+        except Exception:
+            return False
+        return bool(resolved and resolved.get("api_key"))
+
+    def get_credential(self) -> UpstreamCredential:
+        with self._lock:
+            return self._resolve_credential(force_refresh=False)
+
+    def get_retry_credential(
+        self,
+        *,
+        failed_credential: UpstreamCredential,
+        status_code: int,
+    ) -> Optional[UpstreamCredential]:
+        if status_code != 401:
+            return None
+        with self._lock:
+            refreshed = self._resolve_credential(force_refresh=True)
+        if refreshed.bearer == failed_credential.bearer:
+            return None
+        logger.info("proxy: Codex upstream returned 401; retrying with refreshed OAuth token")
+        return refreshed
+
+    @staticmethod
+    def _resolve_credential(*, force_refresh: bool) -> UpstreamCredential:
+        resolved = resolve_codex_runtime_credentials(
+            force_refresh=force_refresh,
+            refresh_if_expiring=True,
+        )
+        bearer = str((resolved or {}).get("api_key") or "").strip()
+        if not bearer:
+            raise RuntimeError(
+                "No OpenAI Codex OAuth credentials found. Run "
+                "`hermes auth add openai-codex --type oauth` first."
+            )
+        base_url = str((resolved or {}).get("base_url") or _DEFAULT_BASE_URL).strip()
+        # Codex's Cloudflare edge requires first-party originator headers; the
+        # helper also extracts ChatGPT-Account-ID from the OAuth JWT when present.
+        from agent.auxiliary_client import _codex_cloudflare_headers
+
+        return UpstreamCredential(
+            bearer=bearer,
+            base_url=base_url.rstrip("/") or _DEFAULT_BASE_URL,
+            extra_headers=_codex_cloudflare_headers(bearer),
+        )
+
+
+__all__ = ["OpenAICodexAdapter"]

--- a/hermes_cli/proxy/cli.py
+++ b/hermes_cli/proxy/cli.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import logging
 import sys
+from pathlib import Path
 from typing import Any
 
 from hermes_cli.proxy.adapters import ADAPTERS, get_adapter
@@ -16,6 +18,23 @@ from hermes_cli.proxy.server import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _read_downstream_token_file(path: str) -> str:
+    token_path = Path(path).expanduser()
+    token = token_path.read_text(encoding="utf-8").strip()
+    if not token:
+        raise ValueError(f"Proxy auth token file is empty: {token_path}")
+    return token
+
+
+def _is_loopback_host(host: str) -> bool:
+    if host.strip().lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
 
 
 def _print_aiohttp_missing() -> None:
@@ -54,19 +73,48 @@ def cmd_proxy_start(args: Any) -> int:
 
     host = getattr(args, "host", None) or DEFAULT_HOST
     port = getattr(args, "port", None) or DEFAULT_PORT
+    token_file_value = getattr(args, "auth_token_file", None)
+    token_file = token_file_value if isinstance(token_file_value, str) else None
+    downstream_token = None
+    if token_file:
+        try:
+            downstream_token = _read_downstream_token_file(token_file)
+        except (OSError, ValueError) as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 2
+    if not _is_loopback_host(host) and not downstream_token:
+        print(
+            "Error: non-loopback proxy binds require --auth-token-file. "
+            "Refusing to expose subscription credentials through an unauthenticated proxy.",
+            file=sys.stderr,
+        )
+        return 2
+
+    auth_message = (
+        "  Downstream auth: required (token file)\n"
+        if downstream_token
+        else "  Downstream auth: unrestricted (loopback-only bind)\n"
+    )
 
     print(
         f"Starting Hermes proxy for {adapter.display_name}\n"
         f"  Listening on:  http://{host}:{port}/v1\n"
         f"  Forwarding to: (resolved per-request from your subscription)\n"
-        f"  Use any bearer token in the client — the proxy attaches your real credential.\n"
+        f"{auth_message}"
         f"\n"
         f"Press Ctrl+C to stop.",
         file=sys.stderr,
     )
 
     try:
-        asyncio.run(run_server(adapter, host=host, port=port))
+        asyncio.run(
+            run_server(
+                adapter,
+                host=host,
+                port=port,
+                downstream_token=downstream_token,
+            )
+        )
     except KeyboardInterrupt:
         print("\nproxy: stopped", file=sys.stderr)
     except OSError as exc:
@@ -123,7 +171,8 @@ def cmd_proxy(args: Any) -> int:
         "OAuth-authenticated provider credentials to outbound requests.\n"
         "\n"
         "Subcommands:\n"
-        "  hermes proxy start [--provider nous|xai] [--host 127.0.0.1] [--port 8645]\n"
+        "  hermes proxy start [--provider nous|openai-codex|xai] [--host 127.0.0.1] [--port 8645]\n"
+        "      [--auth-token-file PATH]\n"
         "      Run the proxy in the foreground.\n"
         "  hermes proxy status\n"
         "      Show which upstream adapters are ready.\n"

--- a/hermes_cli/proxy/server.py
+++ b/hermes_cli/proxy/server.py
@@ -12,6 +12,7 @@ or rewrite request/response bodies. It's a credential-attaching forwarder.
 from __future__ import annotations
 
 import asyncio
+import hmac
 import logging
 import signal
 from typing import Optional
@@ -85,7 +86,11 @@ def _filter_response_headers(headers) -> dict:
     return out
 
 
-def create_app(adapter: UpstreamAdapter) -> "web.Application":
+def create_app(
+    adapter: UpstreamAdapter,
+    *,
+    downstream_token: Optional[str] = None,
+) -> "web.Application":
     """Build the aiohttp application bound to a specific upstream adapter."""
     if not AIOHTTP_AVAILABLE:
         raise RuntimeError(
@@ -109,6 +114,16 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
         )
 
     async def handle_proxy(request: "web.Request") -> "web.StreamResponse":
+        if downstream_token:
+            supplied = request.headers.get("Authorization", "")
+            expected = f"Bearer {downstream_token}"
+            if not hmac.compare_digest(supplied, expected):
+                return _json_error(
+                    401,
+                    "A valid proxy bearer token is required.",
+                    code="proxy_auth_failed",
+                )
+
         # Extract the path *after* /v1
         rel_path = request.match_info.get("tail", "")
         rel_path = "/" + rel_path.lstrip("/")
@@ -144,6 +159,9 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
 
             fwd_headers = _filter_request_headers(request.headers)
             fwd_headers["Authorization"] = f"{active_cred.token_type} {active_cred.bearer}"
+            # Provider headers are trusted adapter output and intentionally
+            # override any same-named values supplied by the downstream client.
+            fwd_headers.update(active_cred.extra_headers)
 
             logger.debug(
                 "proxy: forwarding %s %s -> %s (body=%d bytes)",
@@ -249,6 +267,8 @@ async def run_server(
     host: str = DEFAULT_HOST,
     port: int = DEFAULT_PORT,
     shutdown_event: Optional[asyncio.Event] = None,
+    *,
+    downstream_token: Optional[str] = None,
 ) -> None:
     """Run the proxy in the current event loop until shutdown_event is set.
 
@@ -260,7 +280,7 @@ async def run_server(
             "pip install 'hermes-agent[messaging]' or `pip install aiohttp`."
         )
 
-    app = create_app(adapter)
+    app = create_app(adapter, downstream_token=downstream_token)
     runner = web.AppRunner(app, access_log=None)
     await runner.setup()
     site = web.TCPSite(runner, host=host, port=port)

--- a/hermes_cli/subcommands/gateway.py
+++ b/hermes_cli/subcommands/gateway.py
@@ -321,7 +321,7 @@ def build_gateway_parser(
     proxy_start.add_argument(
         "--provider",
         default="nous",
-        help="Upstream provider: nous or xai (default: nous). See `hermes proxy providers`.",
+        help="Upstream provider: nous, openai-codex, or xai (default: nous). See `hermes proxy providers`.",
     )
     proxy_start.add_argument(
         "--host",
@@ -333,6 +333,14 @@ def build_gateway_parser(
         type=int,
         default=None,
         help="Bind port (default: 8645)",
+    )
+    proxy_start.add_argument(
+        "--auth-token-file",
+        default=None,
+        help=(
+            "Read the downstream bearer token from this file. Required for "
+            "non-loopback binds such as 0.0.0.0."
+        ),
     )
 
     proxy_subparsers.add_parser(

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -29,6 +29,28 @@ from tools.registry import tool_error
 logger = logging.getLogger(__name__)
 
 
+# Gateway-internal notifications can arrive through the same user-role channel
+# as genuine user messages. They are execution metadata, not conversation, and
+# must never become durable personal memory. Keep this deliberately anchored:
+# a human discussing one of these strings mid-message is still valid input.
+_INTERNAL_GATEWAY_TURN_RE = re.compile(
+    r"^\s*(?:"
+    r"\[ASYNC (?:BATCH|DELEGATION) COMPLETE\]|"
+    r"\[CONTEXT COMPACTION(?:\s*[—-]\s*REFERENCE ONLY)?\]|"
+    r"\[PRIOR CONTEXT(?:\s*[—-]\s*FOR REFERENCE ONLY)?\]|"
+    r"\[Your active task list was preserved across context compression\]|"
+    r"A background fan-out of \d+ subagent\(s\) you dispatched earlier has finished\.|"
+    r"A background (?:process|subagent|delegation) .* (?:has )?(?:finished|completed)\."
+    r")",
+    re.IGNORECASE,
+)
+
+
+def _is_internal_gateway_turn(text: str) -> bool:
+    """Return True for machine-generated gateway/delegation notifications."""
+    return bool(_INTERNAL_GATEWAY_TURN_RE.match(text or ""))
+
+
 # ---------------------------------------------------------------------------
 # Tool schemas (moved from tools/honcho_tools.py)
 # ---------------------------------------------------------------------------
@@ -1219,6 +1241,14 @@ class HonchoMemoryProvider(MemoryProvider):
         """
         if self._cron_skipped:
             return
+        # ``saveMessages`` is the operator's hard write gate. Previously it
+        # was parsed into HonchoClientConfig but never enforced here, so a
+        # cached hybrid provider kept writing even after containment was set.
+        if self._config and not getattr(self._config, "save_messages", True):
+            return
+        if _is_internal_gateway_turn(user_content):
+            logger.debug("Honcho sync skipped machine-generated gateway turn")
+            return
         if self._recall_mode == "tools" and not self._session_ready():
             return
         if not self._session_ready():
@@ -1228,6 +1258,8 @@ class HonchoMemoryProvider(MemoryProvider):
         msg_limit = self._config.message_max_chars if self._config else 25000
         clean_user_content = sanitize_context(user_content or "").strip()
         clean_assistant_content = sanitize_context(assistant_content or "").strip()
+        if not clean_user_content or not clean_assistant_content:
+            return
 
         def _sync():
             try:

--- a/tests/hermes_cli/test_proxy.py
+++ b/tests/hermes_cli/test_proxy.py
@@ -14,6 +14,7 @@ import pytest
 from hermes_cli.proxy.adapters import ADAPTERS, get_adapter
 from hermes_cli.proxy.adapters.base import UpstreamAdapter, UpstreamCredential
 from hermes_cli.proxy.adapters.nous_portal import NousPortalAdapter
+from hermes_cli.proxy.adapters.openai_codex import OpenAICodexAdapter
 from hermes_cli.proxy.adapters.xai import XAIGrokAdapter
 
 
@@ -30,6 +31,10 @@ def test_registry_lists_xai():
     assert "xai" in ADAPTERS
 
 
+def test_registry_lists_openai_codex():
+    assert "openai-codex" in ADAPTERS
+
+
 def test_get_adapter_returns_instance():
     adapter = get_adapter("nous")
     assert isinstance(adapter, NousPortalAdapter)
@@ -42,6 +47,14 @@ def test_get_adapter_returns_xai_instance():
     assert isinstance(adapter, UpstreamAdapter)
 
 
+def test_get_adapter_returns_openai_codex_instance():
+    adapter = get_adapter("openai-codex")
+    assert adapter.__class__.__name__ == "OpenAICodexAdapter"
+    assert isinstance(adapter, UpstreamAdapter)
+    assert adapter.name == "openai-codex"
+    assert "/responses" in adapter.allowed_paths
+
+
 def test_get_adapter_case_insensitive():
     assert isinstance(get_adapter("NOUS"), NousPortalAdapter)
     assert isinstance(get_adapter("  Nous  "), NousPortalAdapter)
@@ -51,6 +64,68 @@ def test_get_adapter_case_insensitive():
 def test_get_adapter_unknown_provider_raises():
     with pytest.raises(ValueError, match="anthropic"):
         get_adapter("anthropic")  # not yet implemented
+
+
+# ---------------------------------------------------------------------------
+# OpenAI Codex adapter
+# ---------------------------------------------------------------------------
+
+
+def test_openai_codex_adapter_metadata():
+    adapter = OpenAICodexAdapter()
+    assert adapter.name == "openai-codex"
+    assert adapter.display_name == "OpenAI Codex OAuth"
+    assert adapter.allowed_paths == frozenset({"/responses", "/models"})
+
+
+def test_openai_codex_adapter_resolves_runtime_credential_with_required_headers():
+    resolved = {
+        "api_key": "codex-oauth-token",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+    }
+    required_headers = {
+        "originator": "codex_cli_rs",
+        "User-Agent": "codex_cli_rs/0.0.0 (Hermes Agent)",
+    }
+    with (
+        patch(
+            "hermes_cli.proxy.adapters.openai_codex.resolve_codex_runtime_credentials",
+            return_value=resolved,
+        ) as resolver,
+        patch(
+            "agent.auxiliary_client._codex_cloudflare_headers",
+            return_value=required_headers,
+        ),
+    ):
+        cred = OpenAICodexAdapter().get_credential()
+
+    resolver.assert_called_once_with(force_refresh=False, refresh_if_expiring=True)
+    assert cred.bearer == "codex-oauth-token"
+    assert cred.base_url == "https://chatgpt.com/backend-api/codex"
+    assert cred.extra_headers == required_headers
+
+
+def test_openai_codex_adapter_retries_401_with_forced_refresh():
+    adapter = OpenAICodexAdapter()
+    with patch.object(
+        adapter,
+        "_resolve_credential",
+        return_value=UpstreamCredential(
+            bearer="fresh-token",
+            base_url="https://chatgpt.com/backend-api/codex",
+        ),
+    ) as resolver:
+        result = adapter.get_retry_credential(
+            failed_credential=UpstreamCredential(
+                bearer="stale-token",
+                base_url="https://chatgpt.com/backend-api/codex",
+            ),
+            status_code=401,
+        )
+
+    assert result is not None
+    assert result.bearer == "fresh-token"
+    resolver.assert_called_once_with(force_refresh=True)
 
 
 # ---------------------------------------------------------------------------
@@ -582,12 +657,14 @@ class FakeAdapter(UpstreamAdapter):
 
     def __init__(self, base_url: str, bearer: str = "test-bearer",
                  allowed=None, raise_on_credential=False,
-                 retry_bearer: str | None = None):
+                 retry_bearer: str | None = None,
+                 extra_headers: dict[str, str] | None = None):
         self._base_url = base_url
         self._bearer = bearer
         self._allowed = frozenset(allowed or ["/chat/completions"])
         self._raise = raise_on_credential
         self._retry_bearer = retry_bearer
+        self._extra_headers = extra_headers or {}
         self.calls = 0
         self.retry_calls = 0
 
@@ -609,6 +686,7 @@ class FakeAdapter(UpstreamAdapter):
         return UpstreamCredential(
             bearer=self._bearer, base_url=self._base_url,
             expires_at="2099-01-01T00:00:00Z",
+            extra_headers=self._extra_headers,
         )
 
     def get_retry_credential(self, *, failed_credential, status_code):
@@ -641,6 +719,8 @@ def _build_fake_upstream(captured: Dict[str, Any]) -> "web.Application":
             "method": request.method,
             "path": request.path,
             "auth": request.headers.get("Authorization"),
+            "originator": request.headers.get("originator"),
+            "account_id": request.headers.get("ChatGPT-Account-ID"),
             "body": body.decode("utf-8") if body else "",
         })
         return web.json_response({"echoed": True, "path": request.path})
@@ -845,9 +925,113 @@ def test_server_strips_client_auth_header():
     asyncio.run(run())
 
 
+def test_server_forwards_adapter_extra_headers_over_client_values():
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        adapter = FakeAdapter(
+            f"{upstream_base}/v1",
+            bearer="codex-token",
+            extra_headers={
+                "originator": "codex_cli_rs",
+                "ChatGPT-Account-ID": "account-123",
+            },
+        )
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions",
+                    json={},
+                    headers={
+                        "originator": "untrusted-client",
+                        "ChatGPT-Account-ID": "wrong-account",
+                    },
+                ) as resp:
+                    assert resp.status == 200
+                    await resp.read()
+            request = captured["requests"][0]
+            assert request["originator"] == "codex_cli_rs"
+            assert request["account_id"] == "account-123"
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_server_requires_configured_downstream_bearer():
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        adapter = FakeAdapter(f"{upstream_base}/v1")
+        proxy_runner, proxy_base = await _start_runner(
+            create_app(adapter, downstream_token="bridge-secret")
+        )
+        try:
+            async with aiohttp.ClientSession() as session:
+                for headers in ({}, {"Authorization": "Bearer wrong"}):
+                    async with session.post(
+                        f"{proxy_base}/v1/chat/completions",
+                        json={},
+                        headers=headers,
+                    ) as resp:
+                        assert resp.status == 401
+                        body = await resp.json()
+                        assert body["error"]["type"] == "proxy_auth_failed"
+
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions",
+                    json={},
+                    headers={"Authorization": "Bearer bridge-secret"},
+                ) as resp:
+                    assert resp.status == 200
+                    await resp.read()
+
+            assert len(captured["requests"]) == 1
+            assert captured["requests"][0]["auth"] == "Bearer test-bearer"
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
 # ---------------------------------------------------------------------------
 # CLI handlers
 # ---------------------------------------------------------------------------
+
+
+def test_proxy_token_file_is_trimmed_and_must_be_nonempty(tmp_path):
+    from hermes_cli.proxy.cli import _read_downstream_token_file
+
+    token_file = tmp_path / "proxy.token"
+    token_file.write_text("  bridge-secret\n")
+    assert _read_downstream_token_file(str(token_file)) == "bridge-secret"
+
+    token_file.write_text("\n")
+    with pytest.raises(ValueError, match="empty"):
+        _read_downstream_token_file(str(token_file))
+
+
+def test_cmd_proxy_start_refuses_non_loopback_without_token_file(capsys):
+    from hermes_cli.proxy.cli import cmd_proxy_start
+
+    args = MagicMock()
+    args.provider = "nous"
+    args.host = "0.0.0.0"
+    args.port = 8645
+    args.auth_token_file = None
+    adapter = MagicMock()
+    adapter.is_authenticated.return_value = True
+    adapter.display_name = "Test Provider"
+    adapter.name = "nous"
+
+    with patch("hermes_cli.proxy.cli.get_adapter", return_value=adapter):
+        rc = cmd_proxy_start(args)
+
+    assert rc == 2
+    assert "--auth-token-file" in capsys.readouterr().err
 
 
 def test_cmd_proxy_status_runs(capsys, tmp_path, monkeypatch):

--- a/tests/test_honcho_startup_fail_open.py
+++ b/tests/test_honcho_startup_fail_open.py
@@ -6,6 +6,7 @@ import json
 import threading
 import time
 from types import SimpleNamespace
+from typing import Any, cast
 
 from plugins.memory.honcho import HonchoMemoryProvider
 
@@ -28,6 +29,7 @@ def _configured_hybrid_config() -> _FakeHonchoConfig:
         reasoning_level_cap="high",
         context_tokens=None,
         message_max_chars=25000,
+        save_messages=True,
         session_strategy="per-directory",
     )
 
@@ -225,6 +227,77 @@ def test_honcho_sync_turn_waits_for_full_background_startup(monkeypatch):
             provider._prefetch_thread.join(timeout=1)
 
     assert provider._session_initialized is True
+
+
+def _ready_sync_provider(*, save_messages: bool = True):
+    added = []
+
+    class Session:
+        def add_message(self, role, content):
+            added.append((role, content))
+
+    class Manager:
+        def get_or_create(self, session_key):
+            return Session()
+
+        def _flush_session(self, session):
+            pass
+
+    provider = HonchoMemoryProvider()
+    cfg = _configured_hybrid_config()
+    cfg.save_messages = save_messages
+    unsafe_provider = cast(Any, provider)
+    unsafe_provider._config = cfg
+    unsafe_provider._manager = Manager()
+    provider._session_key = "test-session"
+    provider._session_initialized = True
+    return provider, added
+
+
+def test_honcho_sync_turn_honors_save_messages_false():
+    provider, added = _ready_sync_provider(save_messages=False)
+
+    provider.sync_turn("remember me", "acknowledged")
+
+    assert provider._sync_thread is None
+    assert added == []
+
+
+def test_honcho_sync_turn_drops_internal_gateway_notifications():
+    provider, added = _ready_sync_provider()
+    internal_turns = [
+        "[ASYNC BATCH COMPLETE]\nreview output",
+        "[CONTEXT COMPACTION — REFERENCE ONLY]\nsummary",
+        "[Your active task list was preserved across context compression]\n- task",
+        (
+            "A background fan-out of 1 subagent(s) you dispatched earlier has "
+            "finished. All ran in parallel."
+        ),
+    ]
+
+    for user_content in internal_turns:
+        provider.sync_turn(user_content, "technical status report")
+
+    assert provider._sync_thread is None
+    assert added == []
+
+
+def test_honcho_sync_turn_strips_memory_context_but_keeps_user_text():
+    provider, added = _ready_sync_provider()
+    user_content = (
+        "What should I remember?\n\n"
+        "<memory-context>\n[System note: recalled context]\nold data\n"
+        "</memory-context>"
+    )
+
+    provider.sync_turn(user_content, "Remember the explicit preference only.")
+    assert provider._sync_thread is not None
+    provider._sync_thread.join(timeout=1)
+
+    assert added == [
+        ("user", "What should I remember?"),
+        ("assistant", "Remember the explicit preference only."),
+    ]
 
 
 def test_honcho_system_prompt_advertises_active_while_background_init_runs(monkeypatch):


### PR DESCRIPTION
## Summary

- add an `openai-codex` upstream adapter to the local OpenAI-compatible proxy
- resolve and refresh existing Hermes Codex OAuth credentials without exposing them downstream
- forward provider-required Codex headers with adapter-owned precedence
- support configured downstream bearer authentication for Docker-accessible binds
- refuse non-loopback startup unless `--auth-token-file` is configured

## Security boundary

The downstream bearer is read from a file and compared in constant time. The downstream `Authorization` header is never forwarded to Codex; it is replaced with the refreshed upstream OAuth credential. Required provider headers override downstream-supplied values.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_proxy.py` — 48 passed
- `ruff check hermes_cli/proxy hermes_cli/subcommands/gateway.py tests/hermes_cli/test_proxy.py` — passed
- live launchd-managed proxy smoke:
  - unauthenticated `/v1/responses` returned `401 proxy_auth_failed`
  - authenticated Luna Responses stream returned exactly `LAUNCHD_OK`
  - health reported authenticated `OpenAI Codex OAuth` upstream

## Deployment note

This PR does not add or store any OAuth credential or downstream token in the repository. Runtime secrets remain outside Git in a mode-0600 token file and Hermes's existing credential store.
