### PR TITLE
fix(cron): convert Windows backslash script path to MSYS form for git-bash

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2011,27 +2011,6 @@ def _get_script_timeout() -> int:
     return _DEFAULT_SCRIPT_TIMEOUT
 
 
-def _bash_arg_for_script_path(script_path: str, platform: str = sys.platform) -> str:
-    """Return the argv[1] git-bash expects for a given script path.
-
-    On POSIX this is the path unchanged. On Windows the script path uses
-    backslashes (``C:\\Users\\...\\x.sh``). Git-Bash treats ``\\`` as an
-    escape char, collapsing the path to ``C:Users...`` so the file is never
-    found (exit 127). Convert to the MSYS form git-bash expects
-    (``/c/Users/...``) before invoking bash.
-
-    The ``platform`` argument defaults to ``sys.platform`` but is
-    injectable so this Windows-only branch can be regression-tested
-    deterministically on any OS.
-    """
-    if platform != "win32":
-        return script_path
-    bash_path = script_path.replace("\\", "/")
-    if len(bash_path) >= 2 and bash_path[1] == ":":
-        bash_path = "/" + bash_path[0].lower() + bash_path[2:]
-    return bash_path
-
-
 def _run_job_script(script_path: str) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
@@ -2110,7 +2089,16 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
                 "On Windows, install Git for Windows (which ships Git Bash) "
                 "or rewrite the script as Python (.py)."
             )
-        argv = [_bash, _bash_arg_for_script_path(str(path))]
+        # On Windows the script path uses backslashes (C:\Users\...\x.sh).
+        # Git-Bash treats '\' as an escape char, collapsing the path to
+        # "C:Users..." so the file is never found (exit 127). Convert to the
+        # MSYS form git-bash expects (/c/Users/...) before invoking bash.
+        bash_path = str(path)
+        if sys.platform == "win32":
+            bash_path = bash_path.replace("\\", "/")
+            if len(bash_path) >= 2 and bash_path[1] == ":":
+                bash_path = "/" + bash_path[0].lower() + bash_path[2:]
+        argv = [_bash, bash_path]
     else:
         argv = [sys.executable, str(path)]
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2089,7 +2089,16 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
                 "On Windows, install Git for Windows (which ships Git Bash) "
                 "or rewrite the script as Python (.py)."
             )
-        argv = [_bash, str(path)]
+        # On Windows the script path uses backslashes (C:\Users\...\x.sh).
+        # Git-Bash treats '\' as an escape char, collapsing the path to
+        # "C:Users..." so the file is never found (exit 127). Convert to the
+        # MSYS form git-bash expects (/c/Users/...) before invoking bash.
+        bash_path = str(path)
+        if sys.platform == "win32":
+            bash_path = bash_path.replace("\\", "/")
+            if len(bash_path) >= 2 and bash_path[1] == ":":
+                bash_path = "/" + bash_path[0].lower() + bash_path[2:]
+        argv = [_bash, bash_path]
     else:
         argv = [sys.executable, str(path)]
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2011,6 +2011,27 @@ def _get_script_timeout() -> int:
     return _DEFAULT_SCRIPT_TIMEOUT
 
 
+def _bash_arg_for_script_path(script_path: str, platform: str = sys.platform) -> str:
+    """Return the argv[1] git-bash expects for a given script path.
+
+    On POSIX this is the path unchanged. On Windows the script path uses
+    backslashes (``C:\\Users\\...\\x.sh``). Git-Bash treats ``\\`` as an
+    escape char, collapsing the path to ``C:Users...`` so the file is never
+    found (exit 127). Convert to the MSYS form git-bash expects
+    (``/c/Users/...``) before invoking bash.
+
+    The ``platform`` argument defaults to ``sys.platform`` but is
+    injectable so this Windows-only branch can be regression-tested
+    deterministically on any OS.
+    """
+    if platform != "win32":
+        return script_path
+    bash_path = script_path.replace("\\", "/")
+    if len(bash_path) >= 2 and bash_path[1] == ":":
+        bash_path = "/" + bash_path[0].lower() + bash_path[2:]
+    return bash_path
+
+
 def _run_job_script(script_path: str) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
@@ -2089,16 +2110,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
                 "On Windows, install Git for Windows (which ships Git Bash) "
                 "or rewrite the script as Python (.py)."
             )
-        # On Windows the script path uses backslashes (C:\Users\...\x.sh).
-        # Git-Bash treats '\' as an escape char, collapsing the path to
-        # "C:Users..." so the file is never found (exit 127). Convert to the
-        # MSYS form git-bash expects (/c/Users/...) before invoking bash.
-        bash_path = str(path)
-        if sys.platform == "win32":
-            bash_path = bash_path.replace("\\", "/")
-            if len(bash_path) >= 2 and bash_path[1] == ":":
-                bash_path = "/" + bash_path[0].lower() + bash_path[2:]
-        argv = [_bash, bash_path]
+        argv = [_bash, _bash_arg_for_script_path(str(path))]
     else:
         argv = [sys.executable, str(path)]
 

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -333,48 +333,20 @@ def test_run_job_script_path_traversal_still_blocked(hermes_env):
 
 # ---------------------------------------------------------------------------
 # Regression coverage for the Windows-only path conversion (#62516)
+#
+# @teknium1 asked for a focused Windows regression test that captures the
+# argv passed to bash and asserts a native C:\... script path is converted
+# to /c/..., while retaining an assertion that POSIX argv is unchanged.
 # ---------------------------------------------------------------------------
 
 
-def test_bash_arg_converts_windows_drive_path_to_msys_form():
-    """A native C:\\... script path must become /c/... for git-bash.
+def test_run_job_script_windows_argv_uses_msys_path(hermes_env, monkeypatch):
+    """On Windows a native C:\\... script path must be passed to bash as /c/...
 
-    Without this, git-bash treats '\\' as an escape and collapses the
-    path to "C:Users..." -> exit 127 (script never found).
-    """
-    from cron.scheduler import _bash_arg_for_script_path
-
-    converted = _bash_arg_for_script_path(
-        "C:\\Users\\filip\\AppData\\Local\\hermes\\scripts\\nightly.sh",
-        platform="win32",
-    )
-    assert converted == "/c/Users/filip/AppData/Local/hermes/scripts/nightly.sh"
-    # No backslashes survive — that is what git-bash would have mangled.
-    assert "\\" not in converted
-
-
-def test_bash_arg_lowercases_windows_drive_letter():
-    """The drive letter must be lowercased in MSYS form (/c, not /C)."""
-    from cron.scheduler import _bash_arg_for_script_path
-
-    assert _bash_arg_for_script_path("D:\jobs\run.bash", platform="win32") == "/d/jobs/run.bash"
-
-
-def test_bash_arg_posix_path_unchanged():
-    """POSIX paths must be passed through untouched (no conversion)."""
-    from cron.scheduler import _bash_arg_for_script_path
-
-    posix_path = "/home/filip/.hermes/scripts/backup.sh"
-    assert _bash_arg_for_script_path(posix_path, platform="linux") == posix_path
-    assert _bash_arg_for_script_path(posix_path, platform="darwin") == posix_path
-
-
-def test_run_job_script_windows_argv_passes_msys_path(hermes_env, monkeypatch):
-    """End-to-end: on Windows the argv handed to bash is /c/... (no backslash).
-
-    Captures subprocess.run so we assert the path actually passed to git-bash,
-    regressing the original exit-127 failure where a native C:\\... path was
-    collapsed to "C:Users...".
+    Regression for the original exit-127 failure: git-bash treats '\\' as an
+    escape char and collapsed ``C:\\Users\\...`` to ``C:Users...`` so the
+    script was never found. Capture subprocess.run and assert the argv handed
+    to git-bash is the MSYS form with no backslashes.
     """
     import subprocess as _subprocess
 
@@ -386,15 +358,14 @@ def test_run_job_script_windows_argv_passes_msys_path(hermes_env, monkeypatch):
     captured = {}
 
     def fake_run(argv, *args, **kwargs):
-        captured["argv"] = argv
-        # Emulate git-bash succeeding on the (converted) path.
-        result = _subprocess.CompletedProcess(argv, 0, "ok\n", "")
-        return result
+        captured["argv"] = list(argv)
+        return _subprocess.CompletedProcess(argv, 0, "ok\n", "")
 
     monkeypatch.setattr(_subprocess, "run", fake_run)
-    # Force the Windows branch regardless of the host platform.
-    monkeypatch.setattr("sys.platform", "win32")
+    # Force the Windows branch regardless of the host platform, and provide a
+    # bash so the test does not depend on a local git-bash install.
     monkeypatch.setattr("cron.scheduler.sys.platform", "win32")
+    monkeypatch.setattr("cron.scheduler.shutil.which", lambda name: "/usr/bin/bash")
 
     ok, output = _run_job_script("nightly.sh")
     assert ok is True
@@ -404,4 +375,41 @@ def test_run_job_script_windows_argv_passes_msys_path(hermes_env, monkeypatch):
     script_arg = argv[1]
     assert script_arg.startswith("/c/")
     assert "\\" not in script_arg
+
+
+def test_run_job_script_posix_argv_unchanged(hermes_env, monkeypatch):
+    """POSIX: the resolved script path is passed to the interpreter untouched.
+
+    The Windows-only backslash/MSYS conversion must NOT run on POSIX, so the
+    path handed to the interpreter is the literal resolved path with no
+    drive-letter or ``/c/`` transformation.
+    """
+    import subprocess as _subprocess
+
+    from cron.scheduler import _run_job_script
+
+    script_path = hermes_env / "scripts" / "nightly.sh"
+    script_path.write_text('printf "ok\\n"\n')
+
+    captured = {}
+
+    def fake_run(argv, *args, **kwargs):
+        captured["argv"] = list(argv)
+        return _subprocess.CompletedProcess(argv, 0, "ok\n", "")
+
+    monkeypatch.setattr(_subprocess, "run", fake_run)
+    # Force the POSIX branch regardless of the host platform, and provide a
+    # bash so the test does not depend on a local git-bash install.
+    monkeypatch.setattr("cron.scheduler.sys.platform", "linux")
+    monkeypatch.setattr("cron.scheduler.shutil.which", lambda name: "/usr/bin/bash")
+
+    ok, output = _run_job_script("nightly.sh")
+    assert ok is True
+    argv = captured["argv"]
+    assert len(argv) == 2
+    # The Windows MSYS conversion (C:\... -> /c/...) must not have been applied.
+    assert not argv[1].startswith("/c/")
+    # The path is passed through verbatim (= the resolved script path).
+    expected = str((hermes_env / "scripts" / "nightly.sh").resolve())
+    assert argv[1] == expected
 

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -329,3 +329,79 @@ def test_run_job_script_path_traversal_still_blocked(hermes_env):
     ok, output = _run_job_script("/etc/passwd")
     assert ok is False
     assert "Blocked" in output or "outside" in output
+
+
+# ---------------------------------------------------------------------------
+# Regression coverage for the Windows-only path conversion (#62516)
+# ---------------------------------------------------------------------------
+
+
+def test_bash_arg_converts_windows_drive_path_to_msys_form():
+    """A native C:\\... script path must become /c/... for git-bash.
+
+    Without this, git-bash treats '\\' as an escape and collapses the
+    path to "C:Users..." -> exit 127 (script never found).
+    """
+    from cron.scheduler import _bash_arg_for_script_path
+
+    converted = _bash_arg_for_script_path(
+        "C:\\Users\\filip\\AppData\\Local\\hermes\\scripts\\nightly.sh",
+        platform="win32",
+    )
+    assert converted == "/c/Users/filip/AppData/Local/hermes/scripts/nightly.sh"
+    # No backslashes survive — that is what git-bash would have mangled.
+    assert "\\" not in converted
+
+
+def test_bash_arg_lowercases_windows_drive_letter():
+    """The drive letter must be lowercased in MSYS form (/c, not /C)."""
+    from cron.scheduler import _bash_arg_for_script_path
+
+    assert _bash_arg_for_script_path("D:\jobs\run.bash", platform="win32") == "/d/jobs/run.bash"
+
+
+def test_bash_arg_posix_path_unchanged():
+    """POSIX paths must be passed through untouched (no conversion)."""
+    from cron.scheduler import _bash_arg_for_script_path
+
+    posix_path = "/home/filip/.hermes/scripts/backup.sh"
+    assert _bash_arg_for_script_path(posix_path, platform="linux") == posix_path
+    assert _bash_arg_for_script_path(posix_path, platform="darwin") == posix_path
+
+
+def test_run_job_script_windows_argv_passes_msys_path(hermes_env, monkeypatch):
+    """End-to-end: on Windows the argv handed to bash is /c/... (no backslash).
+
+    Captures subprocess.run so we assert the path actually passed to git-bash,
+    regressing the original exit-127 failure where a native C:\\... path was
+    collapsed to "C:Users...".
+    """
+    import subprocess as _subprocess
+
+    from cron.scheduler import _run_job_script
+
+    script_path = hermes_env / "scripts" / "nightly.sh"
+    script_path.write_text('printf "ok\\n"\n')
+
+    captured = {}
+
+    def fake_run(argv, *args, **kwargs):
+        captured["argv"] = argv
+        # Emulate git-bash succeeding on the (converted) path.
+        result = _subprocess.CompletedProcess(argv, 0, "ok\n", "")
+        return result
+
+    monkeypatch.setattr(_subprocess, "run", fake_run)
+    # Force the Windows branch regardless of the host platform.
+    monkeypatch.setattr("sys.platform", "win32")
+    monkeypatch.setattr("cron.scheduler.sys.platform", "win32")
+
+    ok, output = _run_job_script("nightly.sh")
+    assert ok is True
+    argv = captured["argv"]
+    # argv == [git-bash, <script-arg>]
+    assert len(argv) == 2
+    script_arg = argv[1]
+    assert script_arg.startswith("/c/")
+    assert "\\" not in script_arg
+


### PR DESCRIPTION
## Summary
Fixes `.sh`/`.bash` cron jobs failing on Windows with exit 127 ("No such file or directory"). The scheduler passed a Windows backslash path directly to git-bash, which treats `\` as an escape and collapses the path so the script is never found.

## Root cause
In `cron/scheduler.py`, `_run_job_script()` did `argv = [_bash, str(path)]`. On Windows `str(path)` is a backslash path (`C:\Users\...\x.sh`); git-bash collapses it to `C:Users...` → exit 127. The script never runs. `.py` cron scripts are unaffected (run via `sys.executable`).

## Fix
Normalize the path to MSYS form (`/c/Users/...`) when `sys.platform == "win32"`, guarded so POSIX behavior is unchanged.

## Test plan
- [x] Reproduced: nightly `.sh` cron job failed exit 127 on Windows 10
- [x] After patch: same job runs via `hermes cron run` → success, pushes to GitHub
- [x] `ast.parse` clean; no change to POSIX path handling
- [x] Regression tests added in `tests/cron/test_cron_no_agent.py`: `test_run_job_script_windows_argv_uses_msys_path` captures the argv passed to `subprocess.run` and asserts a native `C:\...` script path is converted to `/c/...` (no backslashes); `test_run_job_script_posix_argv_unchanged` asserts the POSIX argv is passed through verbatim.

Refs #62514

🤖 Generated with [Claude Code](https://claude.com/claude-code)
