### PR TITLE
fix: add MiniMax M2.x to reasoning stale-stream timeout floor (#62353)

### DIFF
--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -108,6 +108,12 @@ _REASONING_STALE_TIMEOUT_FLOORS: tuple[tuple[str, int], ...] = (
     ("grok-4-fast-reasoning", 300),
     ("grok-4.20-reasoning", 300),
     ("grok-4-fast-non-reasoning", 180),
+    # MiniMax M2.x — reasoning models that emit ``reasoning_content``
+    # blocks before first content token (cf. #17924).  Extended
+    # thinking phases routinely exceed the default 180s chat-model
+    # stale-stream timeout, causing mid-think connection kills
+    # (observed: 180s kill on a 6-min audit task, #62353).
+    ("minimax-m2", 300),
 )
 
 


### PR DESCRIPTION
## What

Add `minimax-m2` to `_REASONING_STALE_TIMEOUT_FLOORS` in `agent/reasoning_timeouts.py` with a 300s floor.

## Why

MiniMax M2.7 is a reasoning model that emits `reasoning_content` blocks before its first content token (confirmed by #17924). Without a stale-stream floor, it receives the default 180s chat-model timeout, which kills connections mid-think on tasks exceeding ~3 minutes.

**Observed:** stale-stream detector killed a MiniMax M2.7 subagent at exactly 180s during a 6-minute audit task, producing an empty 44-char response and zero files written (#62353).

## Fix

One-line addition to the timeout floor table:

```python
("minimax-m2", 300),
```

The slug `minimax-m2` matches `minimax-m2.7`, `minimax-m2-pro`, etc. via the existing regex separator anchor (`^minimax-m2(?:$|[\-._])`).

300s floor matches the same tier as Qwen QwQ and xAI Grok reasoning variants.

## Testing

```python
from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
assert get_reasoning_stale_timeout_floor("minimax/minimax-m2.7") == 300.0
assert get_reasoning_stale_timeout_floor("minimax-m2") == 300.0
assert get_reasoning_stale_timeout_floor("minimax-m2-pro") == 300.0
```

Fixes #62353