### PR TITLE
feat(api-server): add split runtime tool channel

### DIFF
--- a/agent/split_runtime_router.py
+++ b/agent/split_runtime_router.py
@@ -4,14 +4,15 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import time
 from typing import Any, Optional
 
 from gateway.tool_channel_state import (
     cancel_tool_request,
     get_current_split_runtime,
-    has_attached_client,
     submit_tool_request,
+    wait_for_attached_client,
 )
 from tools.execution_target import ExecutionTarget, infer_execution_target
 from tools.registry import registry
@@ -85,9 +86,18 @@ def route_tool_locally(
             code="split_runtime_missing_tool_call_id",
         )
 
-    if not session_key or not has_attached_client(session_key):
+    try:
+        timeout = float(cfg.get("request_timeout_seconds", 300.0))
+    except (TypeError, ValueError):
+        timeout = 300.0
+    if not math.isfinite(timeout):
+        timeout = 300.0
+    timeout = max(0.1, timeout)
+    deadline = time.monotonic() + timeout
+
+    if not session_key or not wait_for_attached_client(session_key, timeout):
         return _tool_error(
-            "Split-runtime local execution requested, but no local executor is attached to this run.",
+            f"Split-runtime local execution requested, but no local executor attached within {timeout:g}s.",
             code="split_runtime_no_executor",
             tool_call_id=call_id,
         )
@@ -111,14 +121,22 @@ def route_tool_locally(
             tool_call_id=call_id,
         )
 
-    try:
-        timeout = float(cfg.get("request_timeout_seconds", 300.0))
-    except (TypeError, ValueError):
-        timeout = 300.0
-    timeout = max(0.1, timeout)
+    request_id = str(pending.request["request_id"])
 
-    if not pending.event.wait(timeout=timeout):
-        cancel_tool_request(session_key, call_id)
+    def _notify_request_finished(last_event: str) -> None:
+        callback = cfg.get("_request_state_callback")
+        if callable(callback):
+            try:
+                callback(last_event, request_id)
+            except Exception:
+                logger.debug("split-runtime request-state callback failed", exc_info=True)
+
+    remaining = max(0.0, deadline - time.monotonic())
+    if not pending.event.wait(timeout=remaining):
+        cancelled = cancel_tool_request(session_key, request_id)
+        if not cancelled and pending.result is not None:
+            return pending.result
+        _notify_request_finished("tool.timeout")
         return _tool_error(
             f"Split-runtime local executor did not return a result within {timeout:g}s.",
             code="split_runtime_tool_timeout",
@@ -126,6 +144,7 @@ def route_tool_locally(
         )
 
     if pending.result is None:
+        _notify_request_finished("tool.disconnected")
         return _tool_error(
             "Split-runtime local executor disconnected before returning a result.",
             code="split_runtime_executor_disconnected",

--- a/agent/split_runtime_router.py
+++ b/agent/split_runtime_router.py
@@ -1,0 +1,135 @@
+"""Split-runtime routing seam for registry-backed tool calls."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any, Optional
+
+from gateway.tool_channel_state import (
+    cancel_tool_request,
+    get_current_split_runtime,
+    has_attached_client,
+    submit_tool_request,
+)
+from tools.execution_target import ExecutionTarget, infer_execution_target
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+_NOT_ROUTED = object()
+
+
+def _tool_error(message: str, *, code: str, tool_call_id: Optional[str] = None) -> str:
+    payload = {"error": message, "code": code}
+    if tool_call_id:
+        payload["tool_call_id"] = tool_call_id
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def should_route_tool_locally(function_name: str) -> bool:
+    """Return True when the active split-runtime context owns this tool.
+
+    Callers use this to distinguish normal server execution from fail-closed
+    split-runtime failures. If this returns True, the server must not silently
+    fall back to registry.dispatch after a routing error.
+    """
+
+    cfg = get_current_split_runtime()
+    if not cfg or not cfg.get("enabled"):
+        return False
+    entry = registry.get_entry(function_name)
+    return infer_execution_target(
+        entry,
+        enabled=True,
+        routed_toolsets=cfg.get("routed_toolsets"),
+    ) is ExecutionTarget.LOCAL
+
+
+def route_tool_locally(
+    function_name: str,
+    function_args: dict[str, Any],
+    tool_call_id: Optional[str],
+    *,
+    task_id: str = "",
+    session_id: str = "",
+    turn_id: str = "",
+    api_request_id: str = "",
+) -> Any:
+    """Return a local tool result string, or ``_NOT_ROUTED``.
+
+    This is called inside the existing tool-execution middleware, after request
+    mutation and pre-tool blocks but before ``registry.dispatch``. It only acts
+    when API-server split runtime bound an enabled config in this context.
+    """
+
+    cfg = get_current_split_runtime()
+    if not cfg or not cfg.get("enabled"):
+        return _NOT_ROUTED
+
+    if not should_route_tool_locally(function_name):
+        return _NOT_ROUTED
+
+    try:
+        from tools.approval import get_current_session_key
+
+        session_key = get_current_session_key(default="")
+    except Exception:
+        session_key = ""
+
+    call_id = str(tool_call_id or "").strip()
+    if not call_id:
+        return _tool_error(
+            "Split-runtime local execution requires a tool_call_id.",
+            code="split_runtime_missing_tool_call_id",
+        )
+
+    if not session_key or not has_attached_client(session_key):
+        return _tool_error(
+            "Split-runtime local execution requested, but no local executor is attached to this run.",
+            code="split_runtime_no_executor",
+            tool_call_id=call_id,
+        )
+
+    request = {
+        "v": 1,
+        "tool_call_id": call_id,
+        "tool_name": function_name,
+        "arguments": function_args if isinstance(function_args, dict) else {},
+        "session_id": session_id or "",
+        "task_id": task_id or "",
+        "turn_id": turn_id or "",
+        "api_request_id": api_request_id or "",
+        "created_at": time.time(),
+    }
+    pending = submit_tool_request(session_key, request)
+    if pending is None:
+        return _tool_error(
+            "Split-runtime local executor is not available for this run.",
+            code="split_runtime_executor_unavailable",
+            tool_call_id=call_id,
+        )
+
+    try:
+        timeout = float(cfg.get("request_timeout_seconds", 300.0))
+    except (TypeError, ValueError):
+        timeout = 300.0
+    timeout = max(0.1, timeout)
+
+    if not pending.event.wait(timeout=timeout):
+        cancel_tool_request(session_key, call_id)
+        return _tool_error(
+            f"Split-runtime local executor did not return a result within {timeout:g}s.",
+            code="split_runtime_tool_timeout",
+            tool_call_id=call_id,
+        )
+
+    if pending.result is None:
+        return _tool_error(
+            "Split-runtime local executor disconnected before returning a result.",
+            code="split_runtime_executor_disconnected",
+            tool_call_id=call_id,
+        )
+
+    return pending.result

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -66,6 +66,45 @@ def _budget_for_agent(agent) -> BudgetConfig:
     except Exception:
         return DEFAULT_BUDGET
 
+
+def _tool_result_storage_target(tool_name: str, effective_task_id: str):
+    """Return `(env, inline_only)` for execution-target-aware result storage."""
+
+    env = get_active_env(effective_task_id)
+    try:
+        from gateway.tool_channel_state import get_current_split_runtime
+
+        if get_current_split_runtime():
+            # In a split-runtime turn, even server-tool artifacts are
+            # unreachable through the client-routed read_file tool.
+            return None, True
+    except Exception:
+        logging.warning(
+            "Could not resolve result-storage target for %s; using inline-only output",
+            tool_name,
+            exc_info=True,
+        )
+        return None, True
+    return env, False
+
+
+def _tool_result_is_local(tool_name: str) -> bool:
+    """Whether this result came from a client-routed tool call."""
+
+    try:
+        from agent.split_runtime_router import should_route_tool_locally
+
+        return should_route_tool_locally(tool_name)
+    except Exception:
+        try:
+            from gateway.tool_channel_state import get_current_split_runtime
+            from tools.execution_target import LOCAL_ROUTABLE_TOOLS
+
+            return bool(get_current_split_runtime()) and tool_name in LOCAL_ROUTABLE_TOOLS
+        except Exception:
+            return False
+
+
 # Maximum number of concurrent worker threads for parallel tool execution.
 # Mirrors the constant in ``run_agent`` for tests/imports that look here.
 _MAX_TOOL_WORKERS = 8
@@ -820,6 +859,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             spinner.stop(f"⚡ {completed}/{num_tools} tools completed in {total_dur:.1f}s total")
 
     # ── Post-execution: display per-tool results ─────────────────────
+    inline_only_tool_call_ids: set[str] = set()
     for i, (tc, name, args, middleware_trace, block_result, blocked_by_guardrail) in enumerate(parsed_calls):
         r = results[i]
         blocked = False
@@ -938,15 +978,23 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             except Exception as cb_err:
                 logging.debug(f"Tool complete callback error: {cb_err}")
 
+        result_is_local = _tool_result_is_local(name)
+        result_env, inline_only = _tool_result_storage_target(name, effective_task_id)
+        if inline_only:
+            inline_only_tool_call_ids.add(tc.id)
         function_result = maybe_persist_tool_result(
             content=function_result,
             tool_name=name,
             tool_use_id=tc.id,
-            env=get_active_env(effective_task_id),
+            env=result_env,
             config=_tool_budget,
         ) if not _is_multimodal_tool_result(function_result) else function_result
 
-        subdir_hints = agent._subdirectory_hints.check_tool_call(name, args)
+        subdir_hints = (
+            ""
+            if result_is_local
+            else agent._subdirectory_hints.check_tool_call(name, args)
+        )
         if subdir_hints:
             if _is_multimodal_tool_result(function_result):
                 # Append the hint to the text summary part so the model
@@ -998,7 +1046,12 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     num_tools = len(parsed_calls)
     if num_tools > 0:
         turn_tool_msgs = messages[-num_tools:]
-        enforce_turn_budget(turn_tool_msgs, env=get_active_env(effective_task_id), config=_tool_budget)
+        enforce_turn_budget(
+            turn_tool_msgs,
+            env=get_active_env(effective_task_id),
+            config=_tool_budget,
+            inline_only_tool_call_ids=inline_only_tool_call_ids,
+        )
 
     # ── /steer injection ──────────────────────────────────────────────
     # Append any pending user steer text to the last tool result so the
@@ -1013,6 +1066,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     """Execute tool calls sequentially (original behavior). Used for single calls or interactive tools."""
     # Resolve the context-scaled tool-output budget once per turn.
     _tool_budget = _budget_for_agent(agent)
+    inline_only_tool_call_ids: set[str] = set()
     for i, tool_call in enumerate(assistant_message.tool_calls, 1):
         # SAFETY: check interrupt BEFORE starting each tool.
         # If the user sent "stop" during a previous tool's execution,
@@ -1623,16 +1677,27 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             except Exception as cb_err:
                 logging.debug(f"Tool complete callback error: {cb_err}")
 
+        result_is_local = _tool_result_is_local(function_name)
+        result_env, inline_only = _tool_result_storage_target(
+            function_name,
+            effective_task_id,
+        )
+        if inline_only:
+            inline_only_tool_call_ids.add(tool_call.id)
         function_result = maybe_persist_tool_result(
             content=function_result,
             tool_name=function_name,
             tool_use_id=tool_call.id,
-            env=get_active_env(effective_task_id),
+            env=result_env,
             config=_tool_budget,
         ) if not _is_multimodal_tool_result(function_result) else function_result
 
         # Discover subdirectory context files from tool arguments
-        subdir_hints = agent._subdirectory_hints.check_tool_call(function_name, function_args)
+        subdir_hints = (
+            ""
+            if result_is_local
+            else agent._subdirectory_hints.check_tool_call(function_name, function_args)
+        )
         if subdir_hints:
             if _is_multimodal_tool_result(function_result):
                 _append_subdir_hint_to_multimodal(function_result, subdir_hints)
@@ -1705,7 +1770,12 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     # ── Per-turn aggregate budget enforcement ─────────────────────────
     num_tools_seq = len(assistant_message.tool_calls)
     if num_tools_seq > 0:
-        enforce_turn_budget(messages[-num_tools_seq:], env=get_active_env(effective_task_id), config=_tool_budget)
+        enforce_turn_budget(
+            messages[-num_tools_seq:],
+            env=get_active_env(effective_task_id),
+            config=_tool_budget,
+            inline_only_tool_call_ids=inline_only_tool_call_ids,
+        )
 
     # ── /steer injection ──────────────────────────────────────────────
     # See _execute_tool_calls_parallel for the rationale. Same hook,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -33,15 +33,19 @@ Requires:
 """
 
 import asyncio
+import concurrent.futures
+from contextvars import ContextVar
 import hashlib
 import hmac
 import json
 import logging
 import math
 import os
+import queue
 import socket as _socket
 import re
 import sqlite3
+import threading
 import time
 import uuid
 from pathlib import Path
@@ -65,6 +69,82 @@ from gateway.platforms.base import (
 from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
+
+_ACTIVE_API_RUN_WORKERS: Dict[str, threading.Event] = {}
+_ACTIVE_API_RUN_WORKERS_LOCK = threading.Lock()
+_RUN_STATUS_FENCES = frozenset({"stopping", "completed", "failed", "cancelled"})
+
+
+class _AgentAdmissionReservation:
+    __slots__ = ("generation", "pending")
+
+    def __init__(self, generation: int):
+        self.generation = generation
+        self.pending = True
+
+
+class _DaemonThreadPoolExecutor(concurrent.futures.Executor):
+    """Small daemon-worker executor for bounded, externally interruptible runs."""
+
+    def __init__(self, max_workers: int, thread_name_prefix: str):
+        self._queue: "queue.Queue[Optional[tuple]]" = queue.Queue()
+        self._shutdown = False
+        self._lock = threading.Lock()
+        self._threads = [
+            threading.Thread(
+                target=self._worker,
+                name=f"{thread_name_prefix}_{index}",
+                daemon=True,
+            )
+            for index in range(max_workers)
+        ]
+        for thread in self._threads:
+            thread.start()
+
+    def _worker(self) -> None:
+        while True:
+            item = self._queue.get()
+            if item is None:
+                return
+            future, fn, args, kwargs = item
+            if not future.set_running_or_notify_cancel():
+                continue
+            try:
+                future.set_result(fn(*args, **kwargs))
+            except BaseException as exc:
+                future.set_exception(exc)
+
+    def submit(self, fn, /, *args, **kwargs):
+        with self._lock:
+            if self._shutdown:
+                raise RuntimeError("cannot schedule new futures after shutdown")
+            future = concurrent.futures.Future()
+            self._queue.put((future, fn, args, kwargs))
+            return future
+
+    def shutdown(self, wait: bool = True, *, cancel_futures: bool = False) -> None:
+        with self._lock:
+            if not self._shutdown:
+                self._shutdown = True
+                if cancel_futures:
+                    while True:
+                        try:
+                            item = self._queue.get_nowait()
+                        except queue.Empty:
+                            break
+                        if item is not None:
+                            item[0].cancel()
+                for _thread in self._threads:
+                    self._queue.put(None)
+        if wait:
+            for thread in self._threads:
+                thread.join()
+
+
+_API_CAPACITY_RESERVED: ContextVar[Optional[_AgentAdmissionReservation]] = ContextVar(
+    "api_server_capacity_reserved",
+    default=None,
+)
 
 
 def _hermes_version() -> str:
@@ -902,6 +982,14 @@ class APIServerAdapter(BasePlatformAdapter):
         # Active split-runtime tool session key for each run_id. Shares the
         # per-run isolation namespace used by approvals, never caller session_id.
         self._run_tool_sessions: Dict[str, str] = {}
+        self._run_split_runtime_active: Dict[str, bool] = {}
+        # Tracks the actual executor thread separately from its cancellable
+        # asyncio wrapper so /stop cannot release capacity while Python work
+        # is still running.
+        self._run_worker_done: Dict[str, threading.Event] = {}
+        self._run_worker_futures: Dict[str, "concurrent.futures.Future"] = {}
+        self._run_executor: Optional[_DaemonThreadPoolExecutor] = None
+        self._request_executor: Optional[_DaemonThreadPoolExecutor] = None
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
         # Concurrency cap shared across all agent-serving endpoints
         # (/v1/chat/completions, /v1/responses, /v1/runs). Read from
@@ -915,6 +1003,11 @@ class APIServerAdapter(BasePlatformAdapter):
         # Number of in-flight runs on the non-streaming chat/responses paths
         # (the /v1/runs path tracks its own in-flight set via _run_streams).
         self._inflight_agent_runs: int = 0
+        self._active_request_agents: Dict[str, Any] = {}
+        self._active_request_agents_lock = threading.Lock()
+        self._pending_agent_admissions: int = 0
+        self._accepting_agent_requests: bool = True
+        self._agent_admission_generation: int = 0
 
     @staticmethod
     def _parse_cors_origins(value: Any) -> tuple[str, ...]:
@@ -1003,6 +1096,35 @@ class APIServerAdapter(BasePlatformAdapter):
         if not math.isfinite(timeout):
             timeout = 300.0
         return enabled and bool(routed_toolsets), routed_toolsets, max(0.1, timeout)
+
+    def _split_runtime_is_effective(
+        self,
+        enabled_toolsets: Optional[List[str]] = None,
+    ) -> bool:
+        """Return whether this server can expose the configured local tools."""
+
+        if not self._split_runtime_enabled:
+            return False
+        if enabled_toolsets is not None:
+            return "file" in enabled_toolsets
+        try:
+            from gateway.run import _load_gateway_config
+            from hermes_cli.tools_config import _get_platform_tools
+
+            return "file" in _get_platform_tools(_load_gateway_config(), "api_server")
+        except Exception as exc:
+            logger.error("Failed to resolve API-server toolsets for split runtime", exc_info=True)
+            raise RuntimeError(
+                "Split runtime is enabled, but the API-server toolset configuration "
+                "could not be resolved"
+            ) from exc
+
+    def _run_uses_split_runtime(self, run_id: str) -> bool:
+        """Return the run snapshot, resolving live config only before it exists."""
+
+        if run_id in self._run_split_runtime_active:
+            return self._run_split_runtime_active[run_id]
+        return self._split_runtime_is_effective()
 
     @staticmethod
     def _resolve_model_name(explicit: str) -> str:
@@ -1305,6 +1427,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_complete_callback=None,
         gateway_session_key: Optional[str] = None,
         route: Optional[Dict[str, Any]] = None,
+        enabled_toolsets: Optional[List[str]] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -1397,8 +1520,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 gateway_session_key or session_id,
             )
 
-        user_config = _load_gateway_config()
-        enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+        if enabled_toolsets is None:
+            user_config = _load_gateway_config()
+            enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+        else:
+            enabled_toolsets = list(enabled_toolsets)
 
         max_iterations = _current_max_iterations()
 
@@ -1529,12 +1655,9 @@ class APIServerAdapter(BasePlatformAdapter):
         if auth_err:
             return auth_err
 
-        from gateway.run import _load_gateway_config
-        from hermes_cli.tools_config import _get_platform_tools
         from tools.execution_target import LOCAL_ROUTABLE_TOOLS
 
-        enabled_toolsets = _get_platform_tools(_load_gateway_config(), "api_server")
-        split_runtime_active = self._split_runtime_enabled and "file" in enabled_toolsets
+        split_runtime_active = self._split_runtime_is_effective()
         split_runtime_tools = sorted(LOCAL_ROUTABLE_TOOLS) if split_runtime_active else []
 
         return web.json_response({
@@ -1964,6 +2087,18 @@ class APIServerAdapter(BasePlatformAdapter):
         return web.json_response({"object": "hermes.session", "session": self._session_response(fork)}, status=201)
 
     async def _handle_session_chat(self, request: "web.Request") -> "web.Response":
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        rejected, token = self._reserve_agent_admission()
+        if rejected is not None:
+            return rejected
+        try:
+            return await self._handle_session_chat_admitted(request)
+        finally:
+            self._release_agent_admission(token)
+
+    async def _handle_session_chat_admitted(self, request: "web.Request") -> "web.Response":
         """POST /api/sessions/{session_id}/chat — one synchronous agent turn."""
         auth_err = self._check_auth(request)
         if auth_err:
@@ -1978,6 +2113,11 @@ class APIServerAdapter(BasePlatformAdapter):
         body, err = await self._read_json_body(request)
         if err:
             return err
+        if not self._agent_admission_is_current():
+            return web.json_response(
+                _openai_error("API server is draining", code="server_draining"),
+                status=503,
+            )
         user_message, err = _session_chat_user_message(body)
         if err is not None:
             return err
@@ -2008,6 +2148,21 @@ class APIServerAdapter(BasePlatformAdapter):
         )
 
     async def _handle_session_chat_stream(self, request: "web.Request") -> "web.StreamResponse":
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        rejected, token = self._reserve_agent_admission()
+        if rejected is not None:
+            return rejected
+        try:
+            return await self._handle_session_chat_stream_admitted(request)
+        finally:
+            self._release_agent_admission(token)
+
+    async def _handle_session_chat_stream_admitted(
+        self,
+        request: "web.Request",
+    ) -> "web.StreamResponse":
         """POST /api/sessions/{session_id}/chat/stream — SSE wrapper over _run_agent."""
         auth_err = self._check_auth(request)
         if auth_err:
@@ -2022,6 +2177,11 @@ class APIServerAdapter(BasePlatformAdapter):
         body, err = await self._read_json_body(request)
         if err:
             return err
+        if not self._agent_admission_is_current():
+            return web.json_response(
+                _openai_error("API server is draining", code="server_draining"),
+                status=503,
+            )
         user_message, err = _session_chat_user_message(body)
         if err is not None:
             return err
@@ -2149,21 +2309,36 @@ class APIServerAdapter(BasePlatformAdapter):
         return response
 
     async def _handle_chat_completions(self, request: "web.Request") -> "web.Response":
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        rejected, token = self._reserve_agent_admission()
+        if rejected is not None:
+            return rejected
+        try:
+            return await self._handle_chat_completions_admitted(request)
+        finally:
+            self._release_agent_admission(token)
+
+    async def _handle_chat_completions_admitted(
+        self,
+        request: "web.Request",
+    ) -> "web.Response":
         """POST /v1/chat/completions — OpenAI Chat Completions format."""
         auth_err = self._check_auth(request)
         if auth_err:
             return auth_err
-
-        # Bound total in-flight agent runs (configurable; #7483).
-        limited = self._concurrency_limited_response()
-        if limited is not None:
-            return limited
 
         # Parse request body
         try:
             body = await request.json()
         except (json.JSONDecodeError, Exception):
             return web.json_response(_openai_error("Invalid JSON in request body"), status=400)
+        if not self._agent_admission_is_current():
+            return web.json_response(
+                _openai_error("API server is draining", code="server_draining"),
+                status=503,
+            )
 
         messages = body.get("messages")
         if not messages or not isinstance(messages, list):
@@ -3285,15 +3460,22 @@ class APIServerAdapter(BasePlatformAdapter):
         return response
 
     async def _handle_responses(self, request: "web.Request") -> "web.Response":
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        rejected, token = self._reserve_agent_admission()
+        if rejected is not None:
+            return rejected
+        try:
+            return await self._handle_responses_admitted(request)
+        finally:
+            self._release_agent_admission(token)
+
+    async def _handle_responses_admitted(self, request: "web.Request") -> "web.Response":
         """POST /v1/responses — OpenAI Responses API format."""
         auth_err = self._check_auth(request)
         if auth_err:
             return auth_err
-
-        # Bound total in-flight agent runs (configurable; #7483).
-        limited = self._concurrency_limited_response()
-        if limited is not None:
-            return limited
 
         # Long-term memory scope header (see chat_completions for details).
         gateway_session_key, key_err = self._parse_session_key_header(request)
@@ -3307,6 +3489,11 @@ class APIServerAdapter(BasePlatformAdapter):
             return web.json_response(
                 {"error": {"message": "Invalid JSON in request body", "type": "invalid_request_error"}},
                 status=400,
+            )
+        if not self._agent_admission_is_current():
+            return web.json_response(
+                _openai_error("API server is draining", code="server_draining"),
+                status=503,
             )
 
         raw_input = body.get("input")
@@ -4064,8 +4251,26 @@ class APIServerAdapter(BasePlatformAdapter):
         limit = self._max_concurrent_runs
         if limit <= 0:
             return None
-        inflight = self._inflight_agent_runs + sum(
-            1 for task in self._active_run_tasks.values() if not task.done()
+        active_run_ids = {
+            run_id
+            for run_id, task in self._active_run_tasks.items()
+            if not task.done()
+        }
+        active_run_ids.update(
+            run_id
+            for run_id, done in self._run_worker_done.items()
+            if not done.is_set()
+        )
+        with _ACTIVE_API_RUN_WORKERS_LOCK:
+            active_run_ids.update(
+                run_id
+                for run_id, done in _ACTIVE_API_RUN_WORKERS.items()
+                if not done.is_set()
+            )
+        inflight = (
+            self._inflight_agent_runs
+            + self._pending_agent_admissions
+            + len(active_run_ids)
         )
         if inflight >= limit:
             return web.json_response(
@@ -4078,6 +4283,62 @@ class APIServerAdapter(BasePlatformAdapter):
                 headers={"Retry-After": "1"},
             )
         return None
+
+    def _reserve_agent_admission(self):
+        """Reserve capacity before an agent-serving route awaits its body."""
+        if not self._accepting_agent_requests:
+            return (
+                web.json_response(
+                    _openai_error("API server is draining", code="server_draining"),
+                    status=503,
+                ),
+                None,
+            )
+        limited = self._concurrency_limited_response()
+        if limited is not None:
+            return limited, None
+        self._pending_agent_admissions += 1
+        reservation = _AgentAdmissionReservation(self._agent_admission_generation)
+        return None, (_API_CAPACITY_RESERVED.set(reservation), reservation)
+
+    def _release_agent_admission(self, token) -> None:
+        if token is None:
+            return
+        context_token, reservation = token
+        _API_CAPACITY_RESERVED.reset(context_token)
+        if reservation.pending:
+            reservation.pending = False
+            self._pending_agent_admissions = max(0, self._pending_agent_admissions - 1)
+
+    def _agent_admission_is_current(self) -> bool:
+        reservation = _API_CAPACITY_RESERVED.get()
+        return (
+            self._accepting_agent_requests
+            and reservation is not None
+            and reservation.generation == self._agent_admission_generation
+        )
+
+    def _get_run_executor(self) -> _DaemonThreadPoolExecutor:
+        """Return the adapter-owned executor for structured `/v1/runs` work."""
+
+        if self._run_executor is None:
+            max_workers = self._max_concurrent_runs if self._max_concurrent_runs > 0 else 10
+            self._run_executor = _DaemonThreadPoolExecutor(
+                max_workers=max(1, max_workers),
+                thread_name_prefix="hermes-api-run",
+            )
+        return self._run_executor
+
+    def _get_request_executor(self) -> _DaemonThreadPoolExecutor:
+        """Return the executor for non-structured agent-serving routes."""
+
+        if self._request_executor is None:
+            max_workers = self._max_concurrent_runs if self._max_concurrent_runs > 0 else 10
+            self._request_executor = _DaemonThreadPoolExecutor(
+                max_workers=max(1, max_workers),
+                thread_name_prefix="hermes-api-request",
+            )
+        return self._request_executor
 
     @staticmethod
     def _bind_api_server_session(
@@ -4141,6 +4402,13 @@ class APIServerAdapter(BasePlatformAdapter):
         another thread to stop in-progress LLM calls.
         """
         loop = asyncio.get_running_loop()
+        request_worker_id = f"request_{uuid.uuid4().hex}"
+        reservation = _API_CAPACITY_RESERVED.get()
+        admission_generation = (
+            reservation.generation
+            if reservation is not None
+            else self._agent_admission_generation
+        )
 
         def _run():
             from gateway.session_context import clear_session_vars
@@ -4150,6 +4418,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 session_key=gateway_session_key or session_id or "",
                 session_id=session_id or "",
             )
+            agent = None
             try:
                 agent = self._create_agent(
                     ephemeral_system_prompt=ephemeral_system_prompt,
@@ -4161,6 +4430,17 @@ class APIServerAdapter(BasePlatformAdapter):
                     gateway_session_key=gateway_session_key,
                     route=route,
                 )
+                with self._active_request_agents_lock:
+                    self._active_request_agents[request_worker_id] = agent
+                if (
+                    not self._accepting_agent_requests
+                    or admission_generation != self._agent_admission_generation
+                ):
+                    try:
+                        agent.interrupt("API server disconnecting")
+                    except Exception:
+                        pass
+                    raise RuntimeError("API server is draining")
                 if agent_ref is not None:
                     agent_ref[0] = agent
                 effective_task_id = session_id or str(uuid.uuid4())
@@ -4182,13 +4462,40 @@ class APIServerAdapter(BasePlatformAdapter):
                     result["session_id"] = _eff_sid
                 return result, usage
             finally:
+                with self._active_request_agents_lock:
+                    if self._active_request_agents.get(request_worker_id) is agent:
+                        self._active_request_agents.pop(request_worker_id, None)
                 clear_session_vars(tokens)
 
+        if self._agent_admission_is_current() and reservation is not None and reservation.pending:
+            reservation.pending = False
+            self._pending_agent_admissions = max(0, self._pending_agent_admissions - 1)
         self._inflight_agent_runs += 1
+
+        def _release_capacity() -> None:
+            self._inflight_agent_runs = max(0, self._inflight_agent_runs - 1)
+
+        def _run_tracked():
+            try:
+                return _run()
+            finally:
+                try:
+                    loop.call_soon_threadsafe(_release_capacity)
+                except RuntimeError:
+                    _release_capacity()
+
         try:
-            return await loop.run_in_executor(None, _run)
-        finally:
-            self._inflight_agent_runs -= 1
+            worker_future = self._get_request_executor().submit(_run_tracked)
+            future = asyncio.wrap_future(worker_future, loop=loop)
+        except Exception:
+            _release_capacity()
+            raise
+        try:
+            return await future
+        except asyncio.CancelledError:
+            if worker_future.cancel():
+                _release_capacity()
+            raise
 
     # ------------------------------------------------------------------
     # /v1/runs — structured event streaming
@@ -4215,16 +4522,24 @@ class APIServerAdapter(BasePlatformAdapter):
     def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
         """Return a tool_progress_callback that pushes structured events to the run's SSE queue."""
         def _push(event: Dict[str, Any]) -> None:
-            self._set_run_status(
-                run_id,
-                self._run_statuses.get(run_id, {}).get("status", "running"),
-                last_event=event.get("event"),
-            )
-            q = self._run_streams.get(run_id)
-            if q is None:
-                return
+            def _emit() -> None:
+                status_entry = self._run_statuses.get(run_id)
+                if status_entry is None:
+                    return
+                current_status = status_entry.get("status", "running")
+                if current_status in _RUN_STATUS_FENCES:
+                    return
+                self._set_run_status(
+                    run_id,
+                    current_status,
+                    last_event=event.get("event"),
+                )
+                q = self._run_streams.get(run_id)
+                if q is not None:
+                    q.put_nowait(event)
+
             try:
-                loop.call_soon_threadsafe(q.put_nowait, event)
+                loop.call_soon_threadsafe(_emit)
             except Exception:
                 pass
 
@@ -4259,6 +4574,20 @@ class APIServerAdapter(BasePlatformAdapter):
         return _callback
 
     async def _handle_runs(self, request: "web.Request") -> "web.Response":
+        """Reserve capacity before any request-body await, then start a run."""
+
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        rejected, token = self._reserve_agent_admission()
+        if rejected is not None:
+            return rejected
+        try:
+            return await self._handle_runs_admitted(request)
+        finally:
+            self._release_agent_admission(token)
+
+    async def _handle_runs_admitted(self, request: "web.Request") -> "web.Response":
         """POST /v1/runs — start an agent run, return run_id immediately."""
         auth_err = self._check_auth(request)
         if auth_err:
@@ -4269,16 +4598,15 @@ class APIServerAdapter(BasePlatformAdapter):
         if key_err is not None:
             return key_err
 
-        # Enforce concurrency limit (shared across all agent-serving
-        # endpoints; configurable via gateway.api_server.max_concurrent_runs).
-        limited = self._concurrency_limited_response()
-        if limited is not None:
-            return limited
-
         try:
             body = await request.json()
         except Exception:
             return web.json_response(_openai_error("Invalid JSON"), status=400)
+        if not self._agent_admission_is_current():
+            return web.json_response(
+                _openai_error("API server is draining", code="server_draining"),
+                status=503,
+            )
 
         raw_input = body.get("input")
         if not raw_input:
@@ -4343,6 +4671,23 @@ class APIServerAdapter(BasePlatformAdapter):
         # concurrent runs can intentionally share them, and resolving an
         # approval for one run must not unblock another run's dangerous command.
         approval_session_key = run_id
+        try:
+            from gateway.run import _load_gateway_config
+            from hermes_cli.tools_config import _get_platform_tools
+
+            run_enabled_toolsets = sorted(
+                _get_platform_tools(_load_gateway_config(), "api_server")
+            )
+        except Exception:
+            logger.exception("Failed to snapshot API-server toolsets for run admission")
+            return web.json_response(
+                _openai_error(
+                    "API-server toolset configuration could not be resolved",
+                    code="toolset_resolution_failed",
+                ),
+                status=500,
+            )
+        split_runtime_active = self._split_runtime_is_effective(run_enabled_toolsets)
         ephemeral_system_prompt = instructions
         loop = asyncio.get_running_loop()
         q: "asyncio.Queue[Optional[Dict]]" = asyncio.Queue()
@@ -4350,7 +4695,12 @@ class APIServerAdapter(BasePlatformAdapter):
         self._run_streams[run_id] = q
         self._run_streams_created[run_id] = created_at
         self._run_approval_sessions[run_id] = approval_session_key
-        self._run_tool_sessions[run_id] = approval_session_key
+        self._run_split_runtime_active[run_id] = split_runtime_active
+        if split_runtime_active:
+            self._run_tool_sessions[run_id] = approval_session_key
+        worker_done = threading.Event()
+        worker_done.set()
+        self._run_worker_done[run_id] = worker_done
 
         event_cb = self._make_run_event_callback(run_id, loop)
 
@@ -4389,8 +4739,9 @@ class APIServerAdapter(BasePlatformAdapter):
                     tool_progress_callback=event_cb,
                     gateway_session_key=gateway_session_key,
                     route=route,
+                    enabled_toolsets=run_enabled_toolsets,
                 )
-                if self._split_runtime_enabled and getattr(agent, "api_mode", "") == "codex_app_server":
+                if split_runtime_active and getattr(agent, "api_mode", "") == "codex_app_server":
                     error_msg = (
                         "Split runtime is not supported by the codex_app_server runtime; "
                         "that runtime executes file operations inside the server-side Codex process."
@@ -4413,6 +4764,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._active_run_agents[run_id] = agent
 
                 def _approval_notify(approval_data: Dict[str, Any]) -> None:
+                    if self._run_statuses.get(run_id, {}).get("status") in _RUN_STATUS_FENCES:
+                        return
                     event = dict(approval_data or {})
                     # Redact credentials from the command before it enters the
                     # SSE/API event stream — same egress bug as #48456, second
@@ -4421,20 +4774,27 @@ class APIServerAdapter(BasePlatformAdapter):
                     if "command" in event:
                         from gateway.run import _redact_approval_command
 
-                        event["command"] = _redact_approval_command(event.get("command"))
+                        event["command"] = _redact_approval_command(str(event["command"]))
                     event.update({
                         "event": "approval.request",
                         "run_id": run_id,
                         "timestamp": time.time(),
                         "choices": ["once", "session", "always", "deny"],
                     })
-                    self._set_run_status(
-                        run_id,
-                        "waiting_for_approval",
-                        last_event="approval.request",
-                    )
+
+                    def _emit() -> None:
+                        status_entry = self._run_statuses.get(run_id)
+                        if status_entry is None or status_entry.get("status") in _RUN_STATUS_FENCES:
+                            return
+                        self._set_run_status(
+                            run_id,
+                            "waiting_for_approval",
+                            last_event="approval.request",
+                        )
+                        q.put_nowait(event)
+
                     try:
-                        loop.call_soon_threadsafe(q.put_nowait, event)
+                        loop.call_soon_threadsafe(_emit)
                     except Exception:
                         pass
 
@@ -4442,8 +4802,11 @@ class APIServerAdapter(BasePlatformAdapter):
                     def _update() -> None:
                         from gateway.tool_channel_state import pending_tool_request_count
 
-                        current = self._run_statuses.get(run_id, {}).get("status")
-                        if current in {"completed", "failed", "cancelled"}:
+                        status_entry = self._run_statuses.get(run_id)
+                        if status_entry is None:
+                            return
+                        current = status_entry.get("status")
+                        if current in _RUN_STATUS_FENCES:
                             return
                         status = (
                             "waiting_for_tool_result"
@@ -4460,10 +4823,9 @@ class APIServerAdapter(BasePlatformAdapter):
 
                     loop.call_soon_threadsafe(_update)
 
-                def _run_sync():
+                def _run_sync_inner():
                     from gateway.session_context import clear_session_vars
                     from gateway.tool_channel_state import (
-                        close_tool_channel,
                         reset_current_split_runtime,
                         set_current_split_runtime,
                     )
@@ -4488,7 +4850,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         )
                         register_gateway_notify(approval_session_key, _approval_notify)
                         split_runtime_token = set_current_split_runtime({
-                            "enabled": self._split_runtime_enabled,
+                            "enabled": split_runtime_active,
                             "routed_toolsets": self._split_runtime_toolsets,
                             "request_timeout_seconds": self._split_runtime_request_timeout,
                             "_request_state_callback": _request_state_callback,
@@ -4501,7 +4863,6 @@ class APIServerAdapter(BasePlatformAdapter):
                     finally:
                         try:
                             unregister_gateway_notify(approval_session_key)
-                            close_tool_channel(approval_session_key)
                         finally:
                             if split_runtime_token is not None:
                                 try:
@@ -4525,7 +4886,31 @@ class APIServerAdapter(BasePlatformAdapter):
                     }
                     return r, u
 
-                result, usage = await asyncio.get_running_loop().run_in_executor(None, _run_sync)
+                def _run_sync():
+                    try:
+                        return _run_sync_inner()
+                    finally:
+                        worker_done.set()
+                        self._active_run_agents.pop(run_id, None)
+                        with _ACTIVE_API_RUN_WORKERS_LOCK:
+                            if _ACTIVE_API_RUN_WORKERS.get(run_id) is worker_done:
+                                _ACTIVE_API_RUN_WORKERS.pop(run_id, None)
+
+                worker_done.clear()
+                with _ACTIVE_API_RUN_WORKERS_LOCK:
+                    _ACTIVE_API_RUN_WORKERS[run_id] = worker_done
+                try:
+                    worker_future = self._get_run_executor().submit(_run_sync)
+                except BaseException:
+                    worker_done.set()
+                    with _ACTIVE_API_RUN_WORKERS_LOCK:
+                        if _ACTIVE_API_RUN_WORKERS.get(run_id) is worker_done:
+                            _ACTIVE_API_RUN_WORKERS.pop(run_id, None)
+                    raise
+                self._run_worker_futures[run_id] = worker_future
+                # Keep queued/running Python work alive after the asyncio
+                # wrapper is cancelled so worker_done remains authoritative.
+                result, usage = await asyncio.shield(asyncio.wrap_future(worker_future))
                 # Check for structured failure (non-retryable client errors like
                 # 401/400 return failed=True instead of raising, so the except
                 # block below never fires — issue #15561).
@@ -4595,8 +4980,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 # If the asyncio wrapper is cancelled (for example via
                 # /stop), the executor thread can still be blocked waiting
                 # on an approval Event.  Unregistering here releases those
-                # waits immediately; the in-thread unregister is harmlessly
-                # idempotent on normal completion.
+                # waits immediately. Channel closure occurs only after the
+                # terminal run status above has been published.
                 try:
                     from gateway.tool_channel_state import close_tool_channel
                     from tools.approval import unregister_gateway_notify
@@ -4610,7 +4995,8 @@ class APIServerAdapter(BasePlatformAdapter):
                     q.put_nowait(None)
                 except Exception:
                     pass
-                self._active_run_agents.pop(run_id, None)
+                if worker_done.is_set():
+                    self._active_run_agents.pop(run_id, None)
                 self._active_run_tasks.pop(run_id, None)
                 self._run_approval_sessions.pop(run_id, None)
                 self._run_tool_sessions.pop(run_id, None)
@@ -4655,6 +5041,7 @@ class APIServerAdapter(BasePlatformAdapter):
             return auth_err
 
         run_id = request.match_info["run_id"]
+        run_split_runtime_active = self._run_uses_split_runtime(run_id)
 
         # Allow subscribing slightly before the run is registered (race condition window)
         for _ in range(20):
@@ -4675,7 +5062,7 @@ class APIServerAdapter(BasePlatformAdapter):
         )
         stream_kind = "tool_executor" if wants_executor else "events"
 
-        if wants_executor and not self._split_runtime_enabled:
+        if wants_executor and not run_split_runtime_active:
             return web.json_response(
                 _openai_error(
                     "Split runtime is not enabled for this API server.",
@@ -4703,7 +5090,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     )
 
         consumer_lease: Optional[tuple[str, str]] = None
-        if wants_executor or self._split_runtime_enabled:
+        if wants_executor or run_split_runtime_active:
             existing_consumer = self._run_event_consumers.get(run_id)
             if existing_consumer is not None:
                 existing_kind = (
@@ -4740,7 +5127,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     if not is_tool_request_pending(executor_session_key or "", request_id):
                         return
                     current = self._run_statuses.get(run_id, {}).get("status")
-                    if current in {"completed", "failed", "cancelled"}:
+                    if current in _RUN_STATUS_FENCES:
                         return
                     self._set_run_status(
                         run_id,
@@ -4800,11 +5187,12 @@ class APIServerAdapter(BasePlatformAdapter):
                         timeout=write_timeout,
                     )
                     break
-                if event.get("event") == "tool.request" and executor_session_key:
+                if event.get("event") == "tool.request":
                     from gateway.tool_channel_state import is_tool_request_pending
 
+                    channel_session_key = executor_session_key or run_id
                     if not is_tool_request_pending(
-                        executor_session_key,
+                        channel_session_key,
                         str(event.get("request_id") or ""),
                     ):
                         continue
@@ -4851,6 +5239,14 @@ class APIServerAdapter(BasePlatformAdapter):
             body = await request.json()
         except Exception:
             return web.json_response(_openai_error("Invalid JSON"), status=400)
+        if self._run_statuses.get(run_id, {}).get("status") in _RUN_STATUS_FENCES:
+            return web.json_response(
+                _openai_error(
+                    f"Run is no longer accepting approvals: {run_id}",
+                    code="approval_not_active",
+                ),
+                status=409,
+            )
 
         raw_choice = str(body.get("choice", "")).strip().lower()
         aliases = {"approve": "once", "approved": "once", "allow": "once"}
@@ -4928,7 +5324,7 @@ class APIServerAdapter(BasePlatformAdapter):
             return auth_err
 
         run_id = request.match_info["run_id"]
-        if not self._split_runtime_enabled:
+        if not self._run_uses_split_runtime(run_id):
             return web.json_response(
                 _openai_error(
                     "Split runtime is not enabled for this API server.",
@@ -4968,6 +5364,11 @@ class APIServerAdapter(BasePlatformAdapter):
             )
 
         session_key = self._run_tool_sessions.get(run_id)
+        if not session_key and status.get("status") in _RUN_STATUS_FENCES:
+            # Terminal close removes the active mapping but retains resolved
+            # request IDs until the bounded status-TTL sweep, so a client may
+            # safely retry after losing the original HTTP response.
+            session_key = run_id
         if not session_key:
             return web.json_response(
                 _openai_error(
@@ -5021,7 +5422,7 @@ class APIServerAdapter(BasePlatformAdapter):
         response_status = "duplicate" if outcome == "duplicate" else "resolved"
         if outcome == "resolved":
             current_status = self._run_statuses.get(run_id, {}).get("status")
-            if current_status not in {"completed", "failed", "cancelled"}:
+            if current_status not in _RUN_STATUS_FENCES:
                 run_status = (
                     "waiting_for_tool_result"
                     if pending_tool_request_count(session_key) > 0
@@ -5057,9 +5458,20 @@ class APIServerAdapter(BasePlatformAdapter):
         run_id = request.match_info["run_id"]
         agent = self._active_run_agents.get(run_id)
         task = self._active_run_tasks.get(run_id)
+        current_status = self._run_statuses.get(run_id, {}).get("status")
 
         if agent is None and task is None:
             return web.json_response(_openai_error(f"Run not found: {run_id}", code="run_not_found"), status=404)
+        if current_status == "stopping":
+            return web.json_response({"run_id": run_id, "status": "stopping"})
+        if current_status in {"completed", "failed", "cancelled"}:
+            return web.json_response(
+                _openai_error(
+                    f"Run is already terminal: {run_id}",
+                    code="run_not_active",
+                ),
+                status=409,
+            )
 
         self._set_run_status(run_id, "stopping", last_event="run.stopping")
 
@@ -5068,6 +5480,15 @@ class APIServerAdapter(BasePlatformAdapter):
                 agent.interrupt("Stop requested via API")
             except Exception:
                 pass
+
+        worker_future = self._run_worker_futures.get(run_id)
+        if worker_future is not None and worker_future.cancel():
+            worker_done = self._run_worker_done.get(run_id)
+            if worker_done is not None:
+                worker_done.set()
+            with _ACTIVE_API_RUN_WORKERS_LOCK:
+                if _ACTIVE_API_RUN_WORKERS.get(run_id) is worker_done:
+                    _ACTIVE_API_RUN_WORKERS.pop(run_id, None)
 
         if task is not None and not task.done():
             task.cancel()
@@ -5102,6 +5523,10 @@ class APIServerAdapter(BasePlatformAdapter):
                     run_id not in self._active_run_tasks
                     or self._active_run_tasks[run_id].done()
                 )
+                and (
+                    run_id not in self._run_worker_done
+                    or self._run_worker_done[run_id].is_set()
+                )
             ]
             for run_id in stale:
                 logger.debug("[api_server] sweeping orphaned run %s", run_id)
@@ -5128,15 +5553,29 @@ class APIServerAdapter(BasePlatformAdapter):
                 for run_id, status in list(self._run_statuses.items())
                 if status.get("status") in {"completed", "failed", "cancelled"}
                 and now - float(status.get("updated_at", 0) or 0) > self._RUN_STATUS_TTL
+                and (
+                    run_id not in self._run_worker_done
+                    or self._run_worker_done[run_id].is_set()
+                )
             ]
             for run_id in stale_statuses:
                 self._run_statuses.pop(run_id, None)
+                self._run_split_runtime_active.pop(run_id, None)
+                worker_done = self._run_worker_done.get(run_id)
+                if worker_done is None or worker_done.is_set():
+                    self._run_worker_done.pop(run_id, None)
+                    self._run_worker_futures.pop(run_id, None)
                 try:
                     from gateway.tool_channel_state import clear_tool_channel_state
 
                     clear_tool_channel_state(run_id)
                 except Exception:
                     pass
+
+            for run_id, worker_done in list(self._run_worker_done.items()):
+                if worker_done.is_set() and run_id not in self._active_run_tasks:
+                    self._run_worker_done.pop(run_id, None)
+                    self._run_worker_futures.pop(run_id, None)
 
     # ------------------------------------------------------------------
     # BasePlatformAdapter interface
@@ -5186,6 +5625,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Start the aiohttp web server."""
+        self._accepting_agent_requests = True
         if not AIOHTTP_AVAILABLE:
             logger.warning("[%s] aiohttp not installed", self.name)
             return False
@@ -5313,7 +5753,81 @@ class APIServerAdapter(BasePlatformAdapter):
         and turns the whole gateway into a zombie
         (OSError: [Errno 24] Too many open files, #37011).
         """
+        self._accepting_agent_requests = False
+        self._agent_admission_generation += 1
         self._mark_disconnected()
+        with self._active_request_agents_lock:
+            request_agents = list(self._active_request_agents.values())
+        for agent in request_agents:
+            try:
+                agent.interrupt("API server disconnecting")
+            except Exception:
+                pass
+        active_run_ids = set(self._active_run_tasks) | set(self._run_worker_futures)
+        for run_id in active_run_ids:
+            agent = self._active_run_agents.get(run_id)
+            if agent is not None:
+                try:
+                    agent.interrupt("API server disconnecting")
+                except Exception:
+                    pass
+            try:
+                from gateway.tool_channel_state import close_tool_channel
+                from tools.approval import unregister_gateway_notify
+
+                session_key = self._run_approval_sessions.get(run_id, run_id)
+                unregister_gateway_notify(session_key)
+                close_tool_channel(session_key)
+            except Exception:
+                pass
+            task = self._active_run_tasks.get(run_id)
+            if task is not None and not task.done():
+                task.cancel()
+            worker_future = self._run_worker_futures.get(run_id)
+            if worker_future is not None and worker_future.cancel():
+                worker_done = self._run_worker_done.get(run_id)
+                if worker_done is not None:
+                    worker_done.set()
+                with _ACTIVE_API_RUN_WORKERS_LOCK:
+                    _ACTIVE_API_RUN_WORKERS.pop(run_id, None)
+
+        # Gateway teardown wraps disconnect() in a 5s outer timeout. Keep the
+        # worker-drain grace well inside that budget so listener/runner cleanup
+        # always gets a chance to run even when a Python worker is stubborn.
+        deadline = asyncio.get_running_loop().time() + 0.5
+        while (
+            any(
+                not done.is_set()
+                for run_id, done in self._run_worker_done.items()
+                if run_id in active_run_ids
+            )
+            or self._inflight_agent_runs > 0
+        ) and asyncio.get_running_loop().time() < deadline:
+            await asyncio.sleep(0.05)
+        still_running = [
+            run_id
+            for run_id, done in self._run_worker_done.items()
+            if run_id in active_run_ids and not done.is_set()
+        ]
+        if still_running:
+            logger.warning(
+                "[%s] %d API run worker(s) still draining after disconnect: %s",
+                self.name,
+                len(still_running),
+                ", ".join(still_running),
+            )
+        if self._inflight_agent_runs > 0:
+            logger.warning(
+                "[%s] %d request worker(s) still draining after disconnect",
+                self.name,
+                self._inflight_agent_runs,
+            )
+        if self._run_executor is not None:
+            self._run_executor.shutdown(wait=False, cancel_futures=True)
+            self._run_executor = None
+        if self._request_executor is not None:
+            self._request_executor.shutdown(wait=False, cancel_futures=True)
+            self._request_executor = None
         if self._response_store is not None:
             try:
                 self._response_store.close()

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -37,6 +37,7 @@ import hashlib
 import hmac
 import json
 import logging
+import math
 import os
 import socket as _socket
 import re
@@ -546,7 +547,10 @@ class ResponseStore:
 
 _CORS_HEADERS = {
     "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
-    "Access-Control-Allow-Headers": "Authorization, Content-Type, Idempotency-Key",
+    "Access-Control-Allow-Headers": (
+        "Authorization, Content-Type, Idempotency-Key, "
+        "X-Hermes-Tool-Executor, X-Hermes-Tool-Executor-Token"
+    ),
 }
 
 
@@ -880,11 +884,10 @@ class APIServerAdapter(BasePlatformAdapter):
         self._response_store = ResponseStore()
         # Active run streams: run_id -> asyncio.Queue of SSE event dicts
         self._run_streams: Dict[str, "asyncio.Queue[Optional[Dict]]"] = {}
-        # Active event-stream consumer kind for each run_id. PR1 allows a single
-        # /events consumer because the legacy run-events channel is one queue;
-        # this prevents observers and local executors from stealing each other's
-        # events.
-        self._run_event_consumers: Dict[str, str] = {}
+        # Active split-runtime event-stream consumer lease for each run_id. The
+        # legacy channel is one queue, so split mode cannot safely fan out an
+        # executor plus independent observers.
+        self._run_event_consumers: Dict[str, tuple[str, str]] = {}
         # Creation timestamps for orphaned-run TTL sweep
         self._run_streams_created: Dict[str, float] = {}
         # Active run agent/task references for stop support
@@ -986,16 +989,6 @@ class APIServerAdapter(BasePlatformAdapter):
             if flat_key in extra:
                 cfg[key] = extra[flat_key]
 
-        env_enabled = os.getenv("API_SERVER_SPLIT_RUNTIME_ENABLED", "").strip()
-        if env_enabled:
-            cfg["enabled"] = env_enabled
-        env_toolsets = os.getenv("API_SERVER_SPLIT_RUNTIME_TOOLSETS", "").strip()
-        if env_toolsets:
-            cfg["routed_toolsets"] = env_toolsets
-        env_timeout = os.getenv("API_SERVER_SPLIT_RUNTIME_TIMEOUT_SECONDS", "").strip()
-        if env_timeout:
-            cfg["request_timeout_seconds"] = env_timeout
-
         from tools.execution_target import LOCAL_ROUTABLE_TOOLSETS, normalize_routed_toolsets
         from utils import is_truthy_value
 
@@ -1007,7 +1000,9 @@ class APIServerAdapter(BasePlatformAdapter):
             timeout = float(cfg.get("request_timeout_seconds", 300.0))
         except (TypeError, ValueError):
             timeout = 300.0
-        return enabled, routed_toolsets, max(0.1, timeout)
+        if not math.isfinite(timeout):
+            timeout = 300.0
+        return enabled and bool(routed_toolsets), routed_toolsets, max(0.1, timeout)
 
     @staticmethod
     def _resolve_model_name(explicit: str) -> str:
@@ -1534,6 +1529,14 @@ class APIServerAdapter(BasePlatformAdapter):
         if auth_err:
             return auth_err
 
+        from gateway.run import _load_gateway_config
+        from hermes_cli.tools_config import _get_platform_tools
+        from tools.execution_target import LOCAL_ROUTABLE_TOOLS
+
+        enabled_toolsets = _get_platform_tools(_load_gateway_config(), "api_server")
+        split_runtime_active = self._split_runtime_enabled and "file" in enabled_toolsets
+        split_runtime_tools = sorted(LOCAL_ROUTABLE_TOOLS) if split_runtime_active else []
+
         return web.json_response({
             "object": "hermes.api_server.capabilities",
             "platform": "hermes-agent",
@@ -1545,9 +1548,21 @@ class APIServerAdapter(BasePlatformAdapter):
             "runtime": {
                 "mode": "server_agent",
                 "tool_execution": "server",
-                "runs_tool_execution": "split" if self._split_runtime_enabled else "server",
-                "split_runtime": bool(self._split_runtime_enabled),
-                "split_runtime_toolsets": sorted(self._split_runtime_toolsets) if self._split_runtime_enabled else [],
+                "runs_tool_execution": "split" if split_runtime_active else "server",
+                "split_runtime": bool(split_runtime_active),
+                "split_runtime_toolsets": sorted(self._split_runtime_toolsets) if split_runtime_active else [],
+                "split_runtime_tools": split_runtime_tools,
+                "split_runtime_protocol": (
+                    {
+                        "version": 1,
+                        "correlation_key": "request_id",
+                        "single_events_consumer": True,
+                        "delegation_supported": False,
+                        "unsupported_api_modes": ["codex_app_server"],
+                    }
+                    if split_runtime_active
+                    else None
+                ),
                 "description": (
                     "The API server creates a server-side Hermes AIAgent. "
                     "Chat Completions and Responses tools execute on the API-server host. "
@@ -1565,10 +1580,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_events_sse": True,
                 "run_stop": True,
                 "run_approval_response": True,
-                "run_tool_result": bool(self._split_runtime_enabled),
+                "run_tool_result": bool(split_runtime_active),
                 "tool_progress_events": True,
                 "approval_events": True,
-                "tool_request_events": bool(self._split_runtime_enabled),
+                "tool_request_events": bool(split_runtime_active),
                 "session_resources": True,
                 "session_chat": True,
                 "session_chat_streaming": True,
@@ -4042,13 +4057,16 @@ class APIServerAdapter(BasePlatformAdapter):
         The cap bounds total in-flight agent activity across every
         agent-serving endpoint: the non-streaming chat/responses paths
         (tracked by ``_inflight_agent_runs``) plus the ``/v1/runs`` streaming
-        path (tracked by ``_run_streams``). A configured value of 0 disables
+        path (tracked by active run tasks). Retained event buffers do not consume
+        execution capacity after their agent finishes. A configured value of 0 disables
         the cap entirely.
         """
         limit = self._max_concurrent_runs
         if limit <= 0:
             return None
-        inflight = self._inflight_agent_runs + len(self._run_streams)
+        inflight = self._inflight_agent_runs + sum(
+            1 for task in self._active_run_tasks.values() if not task.done()
+        )
         if inflight >= limit:
             return web.json_response(
                 _openai_error(
@@ -4372,6 +4390,26 @@ class APIServerAdapter(BasePlatformAdapter):
                     gateway_session_key=gateway_session_key,
                     route=route,
                 )
+                if self._split_runtime_enabled and getattr(agent, "api_mode", "") == "codex_app_server":
+                    error_msg = (
+                        "Split runtime is not supported by the codex_app_server runtime; "
+                        "that runtime executes file operations inside the server-side Codex process."
+                    )
+                    q.put_nowait({
+                        "event": "run.failed",
+                        "run_id": run_id,
+                        "timestamp": time.time(),
+                        "error": error_msg,
+                        "code": "split_runtime_incompatible_runtime",
+                    })
+                    self._set_run_status(
+                        run_id,
+                        "failed",
+                        error=error_msg,
+                        code="split_runtime_incompatible_runtime",
+                        last_event="run.failed",
+                    )
+                    return
                 self._active_run_agents[run_id] = agent
 
                 def _approval_notify(approval_data: Dict[str, Any]) -> None:
@@ -4400,12 +4438,34 @@ class APIServerAdapter(BasePlatformAdapter):
                     except Exception:
                         pass
 
+                def _request_state_callback(last_event: str, request_id: str) -> None:
+                    def _update() -> None:
+                        from gateway.tool_channel_state import pending_tool_request_count
+
+                        current = self._run_statuses.get(run_id, {}).get("status")
+                        if current in {"completed", "failed", "cancelled"}:
+                            return
+                        status = (
+                            "waiting_for_tool_result"
+                            if pending_tool_request_count(approval_session_key) > 0
+                            else "running"
+                        )
+                        self._set_run_status(run_id, status, last_event=last_event)
+                        q.put_nowait({
+                            "event": last_event,
+                            "run_id": run_id,
+                            "request_id": request_id,
+                            "timestamp": time.time(),
+                        })
+
+                    loop.call_soon_threadsafe(_update)
+
                 def _run_sync():
                     from gateway.session_context import clear_session_vars
                     from gateway.tool_channel_state import (
+                        close_tool_channel,
                         reset_current_split_runtime,
                         set_current_split_runtime,
-                        unregister_tool_notify,
                     )
                     from tools.approval import (
                         register_gateway_notify,
@@ -4431,6 +4491,7 @@ class APIServerAdapter(BasePlatformAdapter):
                             "enabled": self._split_runtime_enabled,
                             "routed_toolsets": self._split_runtime_toolsets,
                             "request_timeout_seconds": self._split_runtime_request_timeout,
+                            "_request_state_callback": _request_state_callback,
                         })
                         r = agent.run_conversation(
                             user_message=user_message,
@@ -4440,7 +4501,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     finally:
                         try:
                             unregister_gateway_notify(approval_session_key)
-                            unregister_tool_notify(approval_session_key)
+                            close_tool_channel(approval_session_key)
                         finally:
                             if split_runtime_token is not None:
                                 try:
@@ -4537,11 +4598,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 # waits immediately; the in-thread unregister is harmlessly
                 # idempotent on normal completion.
                 try:
-                    from gateway.tool_channel_state import unregister_tool_notify
+                    from gateway.tool_channel_state import close_tool_channel
                     from tools.approval import unregister_gateway_notify
 
                     unregister_gateway_notify(approval_session_key)
-                    unregister_tool_notify(approval_session_key)
+                    close_tool_channel(approval_session_key)
                 except Exception:
                     pass
                 # Sentinel: signal SSE stream to close
@@ -4553,7 +4614,6 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._active_run_tasks.pop(run_id, None)
                 self._run_approval_sessions.pop(run_id, None)
                 self._run_tool_sessions.pop(run_id, None)
-                self._run_event_consumers.pop(run_id, None)
 
         task = asyncio.create_task(_run_and_close())
         self._active_run_tasks[run_id] = task
@@ -4614,37 +4674,54 @@ class APIServerAdapter(BasePlatformAdapter):
             or _coerce_request_bool(request.headers.get("X-Hermes-Tool-Executor"), default=False)
         )
         stream_kind = "tool_executor" if wants_executor else "events"
-        existing_consumer = self._run_event_consumers.get(run_id)
-        if existing_consumer is not None:
+
+        if wants_executor and not self._split_runtime_enabled:
             return web.json_response(
                 _openai_error(
-                    f"Run already has an active events consumer ({existing_consumer}). PR1 split runtime supports one /events stream per run.",
-                    code="run_events_consumer_conflict",
+                    "Split runtime is not enabled for this API server.",
+                    code="split_runtime_disabled",
                 ),
                 status=409,
             )
-        self._run_event_consumers[run_id] = stream_kind
-
         if wants_executor:
-            if not self._split_runtime_enabled:
-                self._run_event_consumers.pop(run_id, None)
-                return web.json_response(
-                    _openai_error(
-                        "Split runtime is not enabled for this API server.",
-                        code="split_runtime_disabled",
-                    ),
-                    status=409,
-                )
             executor_session_key = self._run_tool_sessions.get(run_id)
             if not executor_session_key:
-                self._run_event_consumers.pop(run_id, None)
+                run_status = self._run_statuses.get(run_id, {}).get("status")
+                if run_status in {"completed", "failed", "cancelled"}:
+                    # A fast terminal run may finish before the client can use
+                    # the run_id to attach. Let it drain lifecycle events as an
+                    # observer; there can no longer be a tool request to answer.
+                    wants_executor = False
+                    stream_kind = "events"
+                else:
+                    return web.json_response(
+                        _openai_error(
+                            f"Run has no active split-runtime tool session: {run_id}",
+                            code="tool_result_not_active",
+                        ),
+                        status=409,
+                    )
+
+        consumer_lease: Optional[tuple[str, str]] = None
+        if wants_executor or self._split_runtime_enabled:
+            existing_consumer = self._run_event_consumers.get(run_id)
+            if existing_consumer is not None:
+                existing_kind = (
+                    existing_consumer[0]
+                    if isinstance(existing_consumer, tuple)
+                    else str(existing_consumer)
+                )
                 return web.json_response(
                     _openai_error(
-                        f"Run has no active split-runtime tool session: {run_id}",
-                        code="tool_result_not_active",
+                        f"Run already has an active events consumer ({existing_kind}).",
+                        code="run_events_consumer_conflict",
                     ),
                     status=409,
                 )
+            consumer_lease = (stream_kind, uuid.uuid4().hex)
+            self._run_event_consumers[run_id] = consumer_lease
+
+        if wants_executor:
             client_token = (request.headers.get("X-Hermes-Tool-Executor-Token") or "").strip()
             notify_loop = asyncio.get_running_loop()
 
@@ -4656,20 +4733,33 @@ class APIServerAdapter(BasePlatformAdapter):
                     "timestamp": time.time(),
                     "v": 1,
                 })
-                self._set_run_status(
-                    run_id,
-                    "waiting_for_tool_result",
-                    last_event="tool.request",
-                )
+                def _emit() -> None:
+                    from gateway.tool_channel_state import is_tool_request_pending
+
+                    request_id = str(event.get("request_id") or "")
+                    if not is_tool_request_pending(executor_session_key or "", request_id):
+                        return
+                    current = self._run_statuses.get(run_id, {}).get("status")
+                    if current in {"completed", "failed", "cancelled"}:
+                        return
+                    self._set_run_status(
+                        run_id,
+                        "waiting_for_tool_result",
+                        last_event="tool.request",
+                    )
+                    q.put_nowait(event)
+
                 try:
-                    notify_loop.call_soon_threadsafe(q.put_nowait, event)
+                    notify_loop.call_soon_threadsafe(_emit)
                 except Exception:
                     pass
 
             from gateway.tool_channel_state import register_tool_notify
 
+            assert executor_session_key is not None
             if not register_tool_notify(executor_session_key, _tool_notify, client_token):
-                self._run_event_consumers.pop(run_id, None)
+                if consumer_lease and self._run_event_consumers.get(run_id) == consumer_lease:
+                    self._run_event_consumers.pop(run_id, None)
                 return web.json_response(
                     _openai_error(
                         f"Run already has an attached split-runtime tool executor: {run_id}",
@@ -4679,29 +4769,50 @@ class APIServerAdapter(BasePlatformAdapter):
                 )
             executor_attached = True
 
-        response = web.StreamResponse(
-            status=200,
-            headers={
-                "Content-Type": "text/event-stream",
-                "Cache-Control": "no-cache",
-                "X-Accel-Buffering": "no",
-            },
-        )
-        await response.prepare(request)
-
+        sse_headers = {
+            "Content-Type": "text/event-stream",
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        }
+        origin = request.headers.get("Origin", "")
+        cors = self._cors_headers_for_origin(origin) if origin else None
+        if cors:
+            sse_headers.update(cors)
+        response = web.StreamResponse(status=200, headers=sse_headers)
+        stream_closed = False
+        write_timeout = 15.0
         try:
+            await response.prepare(request)
             while True:
                 try:
                     event = await asyncio.wait_for(q.get(), timeout=30.0)
                 except asyncio.TimeoutError:
-                    await response.write(b": keepalive\n\n")
+                    await asyncio.wait_for(
+                        response.write(b": keepalive\n\n"),
+                        timeout=write_timeout,
+                    )
                     continue
                 if event is None:
                     # Run finished — send final SSE comment and close
-                    await response.write(b": stream closed\n\n")
+                    stream_closed = True
+                    await asyncio.wait_for(
+                        response.write(b": stream closed\n\n"),
+                        timeout=write_timeout,
+                    )
                     break
+                if event.get("event") == "tool.request" and executor_session_key:
+                    from gateway.tool_channel_state import is_tool_request_pending
+
+                    if not is_tool_request_pending(
+                        executor_session_key,
+                        str(event.get("request_id") or ""),
+                    ):
+                        continue
                 payload = f"data: {json.dumps(event)}\n\n"
-                await response.write(payload.encode())
+                await asyncio.wait_for(
+                    response.write(payload.encode()),
+                    timeout=write_timeout,
+                )
         except Exception as exc:
             logger.debug("[api_server] SSE stream error for run %s: %s", run_id, exc)
         finally:
@@ -4712,10 +4823,12 @@ class APIServerAdapter(BasePlatformAdapter):
                     unregister_tool_notify(executor_session_key, client_token=client_token)
                 except Exception:
                     pass
-            if self._run_event_consumers.get(run_id) == stream_kind:
+            if consumer_lease and self._run_event_consumers.get(run_id) == consumer_lease:
                 self._run_event_consumers.pop(run_id, None)
-            self._run_streams.pop(run_id, None)
-            self._run_streams_created.pop(run_id, None)
+            status = self._run_statuses.get(run_id, {}).get("status")
+            if stream_closed or status in {"completed", "failed", "cancelled"}:
+                self._run_streams.pop(run_id, None)
+                self._run_streams_created.pop(run_id, None)
 
         return response
 
@@ -4835,11 +4948,20 @@ class APIServerAdapter(BasePlatformAdapter):
         except Exception:
             return web.json_response(_openai_error("Invalid JSON"), status=400)
 
-        tool_call_id = str(body.get("tool_call_id") or "").strip()
-        if not tool_call_id or "result" not in body:
+        if not isinstance(body, dict):
             return web.json_response(
                 _openai_error(
-                    "Invalid tool result; expected non-empty tool_call_id and result",
+                    "Invalid tool result; expected a JSON object",
+                    code="invalid_tool_result",
+                ),
+                status=400,
+            )
+
+        request_id = str(body.get("request_id") or "").strip()
+        if not request_id or "result" not in body:
+            return web.json_response(
+                _openai_error(
+                    "Invalid tool result; expected non-empty request_id and result",
                     code="invalid_tool_result",
                 ),
                 status=400,
@@ -4872,14 +4994,17 @@ class APIServerAdapter(BasePlatformAdapter):
 
         try:
             from agent.redact import redact_sensitive_text
-            from gateway.tool_channel_state import resolve_tool_result
+            from gateway.tool_channel_state import pending_tool_request_count, resolve_tool_result
 
             raw_result = body.get("result")
             if isinstance(raw_result, str):
-                result = redact_sensitive_text(raw_result)
+                result = redact_sensitive_text(raw_result, file_read=True)
             else:
-                result = redact_sensitive_text(json.dumps(raw_result, ensure_ascii=False))
-            outcome = resolve_tool_result(session_key, tool_call_id, result)
+                result = redact_sensitive_text(
+                    json.dumps(raw_result, ensure_ascii=False),
+                    file_read=True,
+                )
+            outcome = resolve_tool_result(session_key, request_id, result)
         except Exception as exc:
             logger.exception("[api_server] tool-result resolution failed for run %s", run_id)
             return web.json_response(_openai_error(str(exc)), status=500)
@@ -4895,7 +5020,14 @@ class APIServerAdapter(BasePlatformAdapter):
 
         response_status = "duplicate" if outcome == "duplicate" else "resolved"
         if outcome == "resolved":
-            self._set_run_status(run_id, "running", last_event="tool.result")
+            current_status = self._run_statuses.get(run_id, {}).get("status")
+            if current_status not in {"completed", "failed", "cancelled"}:
+                run_status = (
+                    "waiting_for_tool_result"
+                    if pending_tool_request_count(session_key) > 0
+                    else "running"
+                )
+                self._set_run_status(run_id, run_status, last_event="tool.result")
             q = self._run_streams.get(run_id)
             if q is not None:
                 try:
@@ -4903,7 +5035,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         "event": "tool.result",
                         "run_id": run_id,
                         "timestamp": time.time(),
-                        "tool_call_id": tool_call_id,
+                        "request_id": request_id,
                         "status": response_status,
                     })
                 except Exception:
@@ -4912,7 +5044,7 @@ class APIServerAdapter(BasePlatformAdapter):
         return web.json_response({
             "object": "hermes.run.tool_result_response",
             "run_id": run_id,
-            "tool_call_id": tool_call_id,
+            "request_id": request_id,
             "status": response_status,
         })
 
@@ -4965,17 +5097,22 @@ class APIServerAdapter(BasePlatformAdapter):
                 run_id
                 for run_id, created_at in list(self._run_streams_created.items())
                 if now - created_at > self._RUN_STREAM_TTL
+                and run_id not in self._run_event_consumers
+                and (
+                    run_id not in self._active_run_tasks
+                    or self._active_run_tasks[run_id].done()
+                )
             ]
             for run_id in stale:
                 logger.debug("[api_server] sweeping orphaned run %s", run_id)
                 try:
-                    from gateway.tool_channel_state import unregister_tool_notify
+                    from gateway.tool_channel_state import close_tool_channel
                     from tools.approval import unregister_gateway_notify
 
                     approval_session_key = self._run_approval_sessions.get(run_id)
                     if approval_session_key:
                         unregister_gateway_notify(approval_session_key)
-                        unregister_tool_notify(approval_session_key)
+                        close_tool_channel(approval_session_key)
                 except Exception:
                     pass
                 self._run_streams.pop(run_id, None)
@@ -4994,6 +5131,12 @@ class APIServerAdapter(BasePlatformAdapter):
             ]
             for run_id in stale_statuses:
                 self._run_statuses.pop(run_id, None)
+                try:
+                    from gateway.tool_channel_state import clear_tool_channel_state
+
+                    clear_tool_channel_state(run_id)
+                except Exception:
+                    pass
 
     # ------------------------------------------------------------------
     # BasePlatformAdapter interface

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -18,6 +18,7 @@ Exposes an HTTP server with endpoints:
 - GET  /v1/runs/{run_id}           — retrieve current run status
 - GET  /v1/runs/{run_id}/events    — SSE stream of structured lifecycle events
 - POST /v1/runs/{run_id}/approval — resolve a pending run approval
+- POST /v1/runs/{run_id}/tool_result — resolve a pending split-runtime tool request
 - POST /v1/runs/{run_id}/stop       — interrupt a running agent
 - GET  /health                     — health check
 - GET  /health/detailed            — rich status for cross-container dashboard probing
@@ -879,6 +880,11 @@ class APIServerAdapter(BasePlatformAdapter):
         self._response_store = ResponseStore()
         # Active run streams: run_id -> asyncio.Queue of SSE event dicts
         self._run_streams: Dict[str, "asyncio.Queue[Optional[Dict]]"] = {}
+        # Active event-stream consumer kind for each run_id. PR1 allows a single
+        # /events consumer because the legacy run-events channel is one queue;
+        # this prevents observers and local executors from stealing each other's
+        # events.
+        self._run_event_consumers: Dict[str, str] = {}
         # Creation timestamps for orphaned-run TTL sweep
         self._run_streams_created: Dict[str, float] = {}
         # Active run agent/task references for stop support
@@ -890,6 +896,9 @@ class APIServerAdapter(BasePlatformAdapter):
         # resolves requests by session key, while API clients address the
         # in-flight run by run_id.
         self._run_approval_sessions: Dict[str, str] = {}
+        # Active split-runtime tool session key for each run_id. Shares the
+        # per-run isolation namespace used by approvals, never caller session_id.
+        self._run_tool_sessions: Dict[str, str] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
         # Concurrency cap shared across all agent-serving endpoints
         # (/v1/chat/completions, /v1/responses, /v1/runs). Read from
@@ -897,6 +906,9 @@ class APIServerAdapter(BasePlatformAdapter):
         # the cap. Bounds CPU / memory / upstream-LLM-quota exhaustion
         # from a request flood (#7483).
         self._max_concurrent_runs: int = self._resolve_max_concurrent_runs()
+        self._split_runtime_enabled, self._split_runtime_toolsets, self._split_runtime_request_timeout = (
+            self._resolve_split_runtime_config(extra)
+        )
         # Number of in-flight runs on the non-streaming chat/responses paths
         # (the /v1/runs path tracks its own in-flight set via _run_streams).
         self._inflight_agent_runs: int = 0
@@ -939,6 +951,63 @@ class APIServerAdapter(BasePlatformAdapter):
         except Exception:
             return default
         return max(0, value)
+
+    @staticmethod
+    def _resolve_split_runtime_config(extra: Optional[Dict[str, Any]] = None) -> tuple[bool, frozenset[str], float]:
+        """Read experimental /v1/runs split-runtime config.
+
+        Config lives under gateway.api_server.split_runtime. Platform extra can
+        override it in tests or embedded adapters via either a nested
+        ``split_runtime`` mapping or flat ``split_runtime_*`` keys.
+        """
+
+        cfg: Dict[str, Any] = {}
+        try:
+            from hermes_cli.config import cfg_get, load_config
+
+            raw = cfg_get(
+                load_config(),
+                "gateway",
+                "api_server",
+                "split_runtime",
+                default={},
+            )
+            if isinstance(raw, dict):
+                cfg.update(raw)
+        except Exception:
+            pass
+
+        extra = extra or {}
+        nested = extra.get("split_runtime")
+        if isinstance(nested, dict):
+            cfg.update(nested)
+        for key in ("enabled", "routed_toolsets", "request_timeout_seconds"):
+            flat_key = f"split_runtime_{key}"
+            if flat_key in extra:
+                cfg[key] = extra[flat_key]
+
+        env_enabled = os.getenv("API_SERVER_SPLIT_RUNTIME_ENABLED", "").strip()
+        if env_enabled:
+            cfg["enabled"] = env_enabled
+        env_toolsets = os.getenv("API_SERVER_SPLIT_RUNTIME_TOOLSETS", "").strip()
+        if env_toolsets:
+            cfg["routed_toolsets"] = env_toolsets
+        env_timeout = os.getenv("API_SERVER_SPLIT_RUNTIME_TIMEOUT_SECONDS", "").strip()
+        if env_timeout:
+            cfg["request_timeout_seconds"] = env_timeout
+
+        from tools.execution_target import LOCAL_ROUTABLE_TOOLSETS, normalize_routed_toolsets
+        from utils import is_truthy_value
+
+        enabled = is_truthy_value(cfg.get("enabled", False))
+        routed_toolsets = normalize_routed_toolsets(
+            cfg.get("routed_toolsets", LOCAL_ROUTABLE_TOOLSETS)
+        )
+        try:
+            timeout = float(cfg.get("request_timeout_seconds", 300.0))
+        except (TypeError, ValueError):
+            timeout = 300.0
+        return enabled, routed_toolsets, max(0.1, timeout)
 
     @staticmethod
     def _resolve_model_name(explicit: str) -> str:
@@ -1476,11 +1545,14 @@ class APIServerAdapter(BasePlatformAdapter):
             "runtime": {
                 "mode": "server_agent",
                 "tool_execution": "server",
-                "split_runtime": False,
+                "runs_tool_execution": "split" if self._split_runtime_enabled else "server",
+                "split_runtime": bool(self._split_runtime_enabled),
+                "split_runtime_toolsets": sorted(self._split_runtime_toolsets) if self._split_runtime_enabled else [],
                 "description": (
-                    "The API server creates a server-side Hermes AIAgent; "
-                    "tools execute on the API-server host unless a future "
-                    "explicit split-runtime mode is enabled."
+                    "The API server creates a server-side Hermes AIAgent. "
+                    "Chat Completions and Responses tools execute on the API-server host. "
+                    "/v1/runs can route allowlisted tools to an attached local executor "
+                    "when split runtime is enabled."
                 ),
             },
             "features": {
@@ -1493,8 +1565,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_events_sse": True,
                 "run_stop": True,
                 "run_approval_response": True,
+                "run_tool_result": bool(self._split_runtime_enabled),
                 "tool_progress_events": True,
                 "approval_events": True,
+                "tool_request_events": bool(self._split_runtime_enabled),
                 "session_resources": True,
                 "session_chat": True,
                 "session_chat_streaming": True,
@@ -1519,6 +1593,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_status": {"method": "GET", "path": "/v1/runs/{run_id}"},
                 "run_events": {"method": "GET", "path": "/v1/runs/{run_id}/events"},
                 "run_approval": {"method": "POST", "path": "/v1/runs/{run_id}/approval"},
+                "run_tool_result": {"method": "POST", "path": "/v1/runs/{run_id}/tool_result"},
                 "run_stop": {"method": "POST", "path": "/v1/runs/{run_id}/stop"},
                 "skills": {"method": "GET", "path": "/v1/skills"},
                 "toolsets": {"method": "GET", "path": "/v1/toolsets"},
@@ -4257,6 +4332,7 @@ class APIServerAdapter(BasePlatformAdapter):
         self._run_streams[run_id] = q
         self._run_streams_created[run_id] = created_at
         self._run_approval_sessions[run_id] = approval_session_key
+        self._run_tool_sessions[run_id] = approval_session_key
 
         event_cb = self._make_run_event_callback(run_id, loop)
 
@@ -4326,6 +4402,11 @@ class APIServerAdapter(BasePlatformAdapter):
 
                 def _run_sync():
                     from gateway.session_context import clear_session_vars
+                    from gateway.tool_channel_state import (
+                        reset_current_split_runtime,
+                        set_current_split_runtime,
+                        unregister_tool_notify,
+                    )
                     from tools.approval import (
                         register_gateway_notify,
                         reset_current_session_key,
@@ -4335,6 +4416,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
                     effective_task_id = session_id or run_id
                     approval_token = None
+                    split_runtime_token = None
                     session_tokens = []
                     try:
                         # Bind approval/session identity for this API run via
@@ -4345,6 +4427,11 @@ class APIServerAdapter(BasePlatformAdapter):
                             session_key=approval_session_key,
                         )
                         register_gateway_notify(approval_session_key, _approval_notify)
+                        split_runtime_token = set_current_split_runtime({
+                            "enabled": self._split_runtime_enabled,
+                            "routed_toolsets": self._split_runtime_toolsets,
+                            "request_timeout_seconds": self._split_runtime_request_timeout,
+                        })
                         r = agent.run_conversation(
                             user_message=user_message,
                             conversation_history=conversation_history,
@@ -4353,7 +4440,13 @@ class APIServerAdapter(BasePlatformAdapter):
                     finally:
                         try:
                             unregister_gateway_notify(approval_session_key)
+                            unregister_tool_notify(approval_session_key)
                         finally:
+                            if split_runtime_token is not None:
+                                try:
+                                    reset_current_split_runtime(split_runtime_token)
+                                except Exception:
+                                    pass
                             if approval_token is not None:
                                 try:
                                     reset_current_session_key(approval_token)
@@ -4444,9 +4537,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 # waits immediately; the in-thread unregister is harmlessly
                 # idempotent on normal completion.
                 try:
+                    from gateway.tool_channel_state import unregister_tool_notify
                     from tools.approval import unregister_gateway_notify
 
                     unregister_gateway_notify(approval_session_key)
+                    unregister_tool_notify(approval_session_key)
                 except Exception:
                     pass
                 # Sentinel: signal SSE stream to close
@@ -4457,6 +4552,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._active_run_agents.pop(run_id, None)
                 self._active_run_tasks.pop(run_id, None)
                 self._run_approval_sessions.pop(run_id, None)
+                self._run_tool_sessions.pop(run_id, None)
+                self._run_event_consumers.pop(run_id, None)
 
         task = asyncio.create_task(_run_and_close())
         self._active_run_tasks[run_id] = task
@@ -4508,6 +4605,79 @@ class APIServerAdapter(BasePlatformAdapter):
             return web.json_response(_openai_error(f"Run not found: {run_id}", code="run_not_found"), status=404)
 
         q = self._run_streams[run_id]
+        executor_attached = False
+        executor_session_key: Optional[str] = None
+        client_token = ""
+
+        wants_executor = (
+            _coerce_request_bool(request.query.get("tool_executor"), default=False)
+            or _coerce_request_bool(request.headers.get("X-Hermes-Tool-Executor"), default=False)
+        )
+        stream_kind = "tool_executor" if wants_executor else "events"
+        existing_consumer = self._run_event_consumers.get(run_id)
+        if existing_consumer is not None:
+            return web.json_response(
+                _openai_error(
+                    f"Run already has an active events consumer ({existing_consumer}). PR1 split runtime supports one /events stream per run.",
+                    code="run_events_consumer_conflict",
+                ),
+                status=409,
+            )
+        self._run_event_consumers[run_id] = stream_kind
+
+        if wants_executor:
+            if not self._split_runtime_enabled:
+                self._run_event_consumers.pop(run_id, None)
+                return web.json_response(
+                    _openai_error(
+                        "Split runtime is not enabled for this API server.",
+                        code="split_runtime_disabled",
+                    ),
+                    status=409,
+                )
+            executor_session_key = self._run_tool_sessions.get(run_id)
+            if not executor_session_key:
+                self._run_event_consumers.pop(run_id, None)
+                return web.json_response(
+                    _openai_error(
+                        f"Run has no active split-runtime tool session: {run_id}",
+                        code="tool_result_not_active",
+                    ),
+                    status=409,
+                )
+            client_token = (request.headers.get("X-Hermes-Tool-Executor-Token") or "").strip()
+            notify_loop = asyncio.get_running_loop()
+
+            def _tool_notify(tool_data: Dict[str, Any]) -> None:
+                event = dict(tool_data or {})
+                event.update({
+                    "event": "tool.request",
+                    "run_id": run_id,
+                    "timestamp": time.time(),
+                    "v": 1,
+                })
+                self._set_run_status(
+                    run_id,
+                    "waiting_for_tool_result",
+                    last_event="tool.request",
+                )
+                try:
+                    notify_loop.call_soon_threadsafe(q.put_nowait, event)
+                except Exception:
+                    pass
+
+            from gateway.tool_channel_state import register_tool_notify
+
+            if not register_tool_notify(executor_session_key, _tool_notify, client_token):
+                self._run_event_consumers.pop(run_id, None)
+                return web.json_response(
+                    _openai_error(
+                        f"Run already has an attached split-runtime tool executor: {run_id}",
+                        code="tool_executor_conflict",
+                    ),
+                    status=409,
+                )
+            executor_attached = True
 
         response = web.StreamResponse(
             status=200,
@@ -4535,6 +4705,15 @@ class APIServerAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.debug("[api_server] SSE stream error for run %s: %s", run_id, exc)
         finally:
+            if executor_attached and executor_session_key:
+                try:
+                    from gateway.tool_channel_state import unregister_tool_notify
+
+                    unregister_tool_notify(executor_session_key, client_token=client_token)
+                except Exception:
+                    pass
+            if self._run_event_consumers.get(run_id) == stream_kind:
+                self._run_event_consumers.pop(run_id, None)
             self._run_streams.pop(run_id, None)
             self._run_streams_created.pop(run_id, None)
 
@@ -4629,6 +4808,114 @@ class APIServerAdapter(BasePlatformAdapter):
             "resolved": resolved,
         })
 
+    async def _handle_run_tool_result(self, request: "web.Request") -> "web.Response":
+        """POST /v1/runs/{run_id}/tool_result — resolve a pending local tool request."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        run_id = request.match_info["run_id"]
+        if not self._split_runtime_enabled:
+            return web.json_response(
+                _openai_error(
+                    "Split runtime is not enabled for this API server.",
+                    code="split_runtime_disabled",
+                ),
+                status=409,
+            )
+        status = self._run_statuses.get(run_id)
+        if status is None:
+            return web.json_response(
+                _openai_error(f"Run not found: {run_id}", code="run_not_found"),
+                status=404,
+            )
+
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response(_openai_error("Invalid JSON"), status=400)
+
+        tool_call_id = str(body.get("tool_call_id") or "").strip()
+        if not tool_call_id or "result" not in body:
+            return web.json_response(
+                _openai_error(
+                    "Invalid tool result; expected non-empty tool_call_id and result",
+                    code="invalid_tool_result",
+                ),
+                status=400,
+            )
+
+        session_key = self._run_tool_sessions.get(run_id)
+        if not session_key:
+            return web.json_response(
+                _openai_error(
+                    f"Run has no active split-runtime tool session: {run_id}",
+                    code="tool_result_not_active",
+                ),
+                status=409,
+            )
+        try:
+            from gateway.tool_channel_state import tool_result_authorized
+
+            client_token = (request.headers.get("X-Hermes-Tool-Executor-Token") or "").strip()
+            if not tool_result_authorized(session_key, client_token):
+                return web.json_response(
+                    _openai_error(
+                        "Tool result executor token does not match the attached local executor.",
+                        code="tool_result_executor_mismatch",
+                    ),
+                    status=403,
+                )
+        except Exception as exc:
+            logger.debug("[api_server] tool-result executor-token check failed for run %s: %s", run_id, exc)
+            return web.json_response(_openai_error("Tool result executor-token check failed"), status=500)
+
+        try:
+            from agent.redact import redact_sensitive_text
+            from gateway.tool_channel_state import resolve_tool_result
+
+            raw_result = body.get("result")
+            if isinstance(raw_result, str):
+                result = redact_sensitive_text(raw_result)
+            else:
+                result = redact_sensitive_text(json.dumps(raw_result, ensure_ascii=False))
+            outcome = resolve_tool_result(session_key, tool_call_id, result)
+        except Exception as exc:
+            logger.exception("[api_server] tool-result resolution failed for run %s", run_id)
+            return web.json_response(_openai_error(str(exc)), status=500)
+
+        if outcome == "unknown":
+            return web.json_response(
+                _openai_error(
+                    f"Run has no pending split-runtime tool request: {run_id}",
+                    code="tool_result_not_pending",
+                ),
+                status=409,
+            )
+
+        response_status = "duplicate" if outcome == "duplicate" else "resolved"
+        if outcome == "resolved":
+            self._set_run_status(run_id, "running", last_event="tool.result")
+            q = self._run_streams.get(run_id)
+            if q is not None:
+                try:
+                    q.put_nowait({
+                        "event": "tool.result",
+                        "run_id": run_id,
+                        "timestamp": time.time(),
+                        "tool_call_id": tool_call_id,
+                        "status": response_status,
+                    })
+                except Exception:
+                    pass
+
+        return web.json_response({
+            "object": "hermes.run.tool_result_response",
+            "run_id": run_id,
+            "tool_call_id": tool_call_id,
+            "status": response_status,
+        })
+
     async def _handle_stop_run(self, request: "web.Request") -> "web.Response":
         """POST /v1/runs/{run_id}/stop — interrupt a running agent."""
         auth_err = self._check_auth(request)
@@ -4682,18 +4969,22 @@ class APIServerAdapter(BasePlatformAdapter):
             for run_id in stale:
                 logger.debug("[api_server] sweeping orphaned run %s", run_id)
                 try:
+                    from gateway.tool_channel_state import unregister_tool_notify
                     from tools.approval import unregister_gateway_notify
 
                     approval_session_key = self._run_approval_sessions.get(run_id)
                     if approval_session_key:
                         unregister_gateway_notify(approval_session_key)
+                        unregister_tool_notify(approval_session_key)
                 except Exception:
                     pass
                 self._run_streams.pop(run_id, None)
                 self._run_streams_created.pop(run_id, None)
+                self._run_event_consumers.pop(run_id, None)
                 self._active_run_agents.pop(run_id, None)
                 self._active_run_tasks.pop(run_id, None)
                 self._run_approval_sessions.pop(run_id, None)
+                self._run_tool_sessions.pop(run_id, None)
 
             stale_statuses = [
                 run_id
@@ -4806,6 +5097,7 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_get("/v1/runs/{run_id}", self._handle_get_run)
             self._app.router.add_get("/v1/runs/{run_id}/events", self._handle_run_events)
             self._app.router.add_post("/v1/runs/{run_id}/approval", self._handle_run_approval)
+            self._app.router.add_post("/v1/runs/{run_id}/tool_result", self._handle_run_tool_result)
             self._app.router.add_post("/v1/runs/{run_id}/stop", self._handle_stop_run)
             # Store the adapter after native routes are registered. Local Hermes-Relay
             # bootstrap shims use this key as a feature-detection hook; registering

--- a/gateway/tool_channel_state.py
+++ b/gateway/tool_channel_state.py
@@ -9,8 +9,12 @@ between the tool worker thread and the HTTP/SSE handlers.
 from __future__ import annotations
 
 import contextvars
+import hmac
+import json
+import math
 import threading
 import time
+import uuid
 from typing import Any, Callable, Dict, Optional
 
 from tools.execution_target import LOCAL_ROUTABLE_TOOLSETS, normalize_routed_toolsets
@@ -29,10 +33,12 @@ class _ToolRequestEntry:
 
 
 _lock = threading.Lock()
+_attached_condition = threading.Condition(_lock)
 _tool_queues: dict[str, list[_ToolRequestEntry]] = {}
 _tool_notify: dict[str, Callable[[dict[str, Any]], None]] = {}
 _seen_results: dict[str, set[str]] = {}
 _attached_clients: dict[str, str] = {}
+_closed_channels: set[str] = set()
 
 _split_runtime_config: contextvars.ContextVar[Optional[dict[str, Any]]] = contextvars.ContextVar(
     "split_runtime_config",
@@ -53,6 +59,8 @@ def set_current_split_runtime(config: Optional[dict[str, Any]]) -> contextvars.T
         try:
             timeout = float(normalized.get("request_timeout_seconds", 300.0))
         except (TypeError, ValueError):
+            timeout = 300.0
+        if not math.isfinite(timeout):
             timeout = 300.0
         normalized["request_timeout_seconds"] = max(0.1, timeout)
     return _split_runtime_config.set(normalized)
@@ -80,14 +88,23 @@ def register_tool_notify(session_key: str, cb: Callable[[dict[str, Any]], None],
     if not session_key:
         return False
     token = client_token or ""
-    with _lock:
+    with _attached_condition:
+        if session_key in _closed_channels:
+            return False
         existing = _attached_clients.get(session_key)
         if existing is not None:
             return False
         _attached_clients[session_key] = token
         _tool_notify[session_key] = cb
         _seen_results.setdefault(session_key, set())
+        _attached_condition.notify_all()
         return True
+
+
+def _constant_time_token_equal(left: str, right: str) -> bool:
+    """Compare arbitrary Unicode executor tokens without timing leaks."""
+
+    return hmac.compare_digest(left.encode("utf-8"), right.encode("utf-8"))
 
 
 def unregister_tool_notify(session_key: str, client_token: Optional[str] = None) -> bool:
@@ -98,14 +115,18 @@ def unregister_tool_notify(session_key: str, client_token: Optional[str] = None)
     executor after reconnect.
     """
 
-    with _lock:
+    with _attached_condition:
         existing = _attached_clients.get(session_key)
-        if client_token is not None and existing not in {None, ""} and existing != client_token:
+        if (
+            client_token is not None
+            and existing not in {None, ""}
+            and not _constant_time_token_equal(existing or "", client_token)
+        ):
             return False
         _tool_notify.pop(session_key, None)
         _attached_clients.pop(session_key, None)
-        _seen_results.pop(session_key, None)
         entries = _tool_queues.pop(session_key, [])
+        _attached_condition.notify_all()
     for entry in entries:
         entry.event.set()
     return True
@@ -120,7 +141,7 @@ def tool_result_authorized(session_key: str, client_token: Optional[str]) -> boo
 
     with _lock:
         existing = _attached_clients.get(session_key)
-    return not existing or existing == (client_token or "")
+    return not existing or _constant_time_token_equal(existing, client_token or "")
 
 
 def has_attached_client(session_key: str) -> bool:
@@ -130,17 +151,69 @@ def has_attached_client(session_key: str) -> bool:
         return session_key in _attached_clients and session_key in _tool_notify
 
 
+def pending_tool_request_count(session_key: str) -> int:
+    """Return the number of unresolved requests for an attached executor."""
+
+    with _lock:
+        return len(_tool_queues.get(session_key, ()))
+
+
+def is_tool_request_pending(session_key: str, request_id: str) -> bool:
+    """Return whether ``request_id`` is still pending for this run channel."""
+
+    with _lock:
+        return any(
+            str(entry.request.get("request_id") or "") == request_id
+            for entry in _tool_queues.get(session_key, ())
+        )
+
+
+def wait_for_attached_client(session_key: str, timeout: float) -> bool:
+    """Wait for a local executor attachment without polling.
+
+    This closes the HTTP ordering gap where a run can call a routed tool before
+    the client receives its ``run_id`` and attaches the executor SSE stream.
+    """
+
+    if not session_key:
+        return False
+    try:
+        wait_timeout = float(timeout)
+    except (TypeError, ValueError):
+        wait_timeout = 0.0
+    if not math.isfinite(wait_timeout):
+        wait_timeout = 0.0
+    with _attached_condition:
+        _attached_condition.wait_for(
+            lambda: (
+                session_key in _closed_channels
+                or (session_key in _attached_clients and session_key in _tool_notify)
+            ),
+            timeout=max(0.0, wait_timeout),
+        )
+        return (
+            session_key not in _closed_channels
+            and session_key in _attached_clients
+            and session_key in _tool_notify
+        )
+
+
 def submit_tool_request(session_key: str, request: dict[str, Any]) -> Optional[_ToolRequestEntry]:
     """Queue a tool request and notify the attached executor.
 
     Returns the pending entry, or ``None`` when no executor is attached or the
-    notify callback failed synchronously.
+    notify callback failed synchronously. The broker always mints a unique wire
+    ``request_id``; model-provided ``tool_call_id`` remains metadata only.
     """
 
     if not session_key:
         return None
-    entry = _ToolRequestEntry(dict(request or {}))
+    request_payload = dict(request or {})
+    request_payload["request_id"] = f"toolreq_{uuid.uuid4().hex}"
+    entry = _ToolRequestEntry(request_payload)
     with _lock:
+        if session_key in _closed_channels:
+            return None
         cb = _tool_notify.get(session_key)
         if cb is None or session_key not in _attached_clients:
             return None
@@ -148,22 +221,22 @@ def submit_tool_request(session_key: str, request: dict[str, Any]) -> Optional[_
     try:
         cb(entry.request)
     except Exception:
-        cancel_tool_request(session_key, str(entry.request.get("tool_call_id") or ""))
+        cancel_tool_request(session_key, str(entry.request["request_id"]))
         return None
     return entry
 
 
-def cancel_tool_request(session_key: str, tool_call_id: str) -> bool:
+def cancel_tool_request(session_key: str, request_id: str) -> bool:
     """Remove a still-pending request after timeout or notify failure."""
 
-    if not session_key or not tool_call_id:
+    if not session_key or not request_id:
         return False
     with _lock:
         queue = _tool_queues.get(session_key)
         if not queue:
             return False
         for index, entry in enumerate(list(queue)):
-            if str(entry.request.get("tool_call_id") or "") == tool_call_id:
+            if str(entry.request.get("request_id") or "") == request_id:
                 queue.pop(index)
                 if not queue:
                     _tool_queues.pop(session_key, None)
@@ -172,24 +245,24 @@ def cancel_tool_request(session_key: str, tool_call_id: str) -> bool:
     return False
 
 
-def resolve_tool_result(session_key: str, tool_call_id: str, result: Any) -> str:
+def resolve_tool_result(session_key: str, request_id: str, result: Any) -> str:
     """Resolve one pending local-executor request.
 
     Returns ``resolved``, ``duplicate``, or ``unknown``.
     """
 
-    if not session_key or not tool_call_id:
+    if not session_key or not request_id:
         return "unknown"
     with _lock:
         seen = _seen_results.setdefault(session_key, set())
-        if tool_call_id in seen:
+        if request_id in seen:
             return "duplicate"
         queue = _tool_queues.get(session_key)
         if not queue:
             return "unknown"
         target: Optional[_ToolRequestEntry] = None
         for index, entry in enumerate(list(queue)):
-            if str(entry.request.get("tool_call_id") or "") == tool_call_id:
+            if str(entry.request.get("request_id") or "") == request_id:
                 target = entry
                 queue.pop(index)
                 break
@@ -197,32 +270,48 @@ def resolve_tool_result(session_key: str, tool_call_id: str, result: Any) -> str
             return "unknown"
         if not queue:
             _tool_queues.pop(session_key, None)
-        seen.add(tool_call_id)
-
-    if isinstance(result, str):
-        target.result = result
-    else:
-        import json
-
-        target.result = json.dumps(result, ensure_ascii=False)
-    target.event.set()
+        seen.add(request_id)
+        if isinstance(result, str):
+            target.result = result
+        else:
+            target.result = json.dumps(result, ensure_ascii=False)
+        target.event.set()
     return "resolved"
 
 
 def clear_tool_channel_state(session_key: Optional[str] = None) -> None:
     """Test/helper cleanup for one session or all split-runtime state."""
 
-    with _lock:
+    with _attached_condition:
         if session_key is None:
             entries = [entry for queue in _tool_queues.values() for entry in queue]
             _tool_queues.clear()
             _tool_notify.clear()
             _seen_results.clear()
             _attached_clients.clear()
+            _closed_channels.clear()
         else:
             entries = _tool_queues.pop(session_key, [])
             _tool_notify.pop(session_key, None)
             _seen_results.pop(session_key, None)
             _attached_clients.pop(session_key, None)
+            _closed_channels.discard(session_key)
+        _attached_condition.notify_all()
+    for entry in entries:
+        entry.event.set()
+
+
+def close_tool_channel(session_key: str) -> None:
+    """Terminally close a run channel and wake every blocked tool worker."""
+
+    if not session_key:
+        return
+    with _attached_condition:
+        _closed_channels.add(session_key)
+        _tool_notify.pop(session_key, None)
+        _attached_clients.pop(session_key, None)
+        _seen_results.pop(session_key, None)
+        entries = _tool_queues.pop(session_key, [])
+        _attached_condition.notify_all()
     for entry in entries:
         entry.event.set()

--- a/gateway/tool_channel_state.py
+++ b/gateway/tool_channel_state.py
@@ -310,7 +310,6 @@ def close_tool_channel(session_key: str) -> None:
         _closed_channels.add(session_key)
         _tool_notify.pop(session_key, None)
         _attached_clients.pop(session_key, None)
-        _seen_results.pop(session_key, None)
         entries = _tool_queues.pop(session_key, [])
         _attached_condition.notify_all()
     for entry in entries:

--- a/gateway/tool_channel_state.py
+++ b/gateway/tool_channel_state.py
@@ -1,0 +1,228 @@
+"""In-process state for API-server split-runtime tool requests.
+
+The API server owns the model/agent loop. A local executor client can attach to
+``/v1/runs/{run_id}/events`` and receive ``tool.request`` events for a small
+allowlisted tool surface. This module is the synchronous block/resume registry
+between the tool worker thread and the HTTP/SSE handlers.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import threading
+import time
+from typing import Any, Callable, Dict, Optional
+
+from tools.execution_target import LOCAL_ROUTABLE_TOOLSETS, normalize_routed_toolsets
+
+
+class _ToolRequestEntry:
+    """One pending local-executor tool request."""
+
+    __slots__ = ("event", "request", "result", "created_at")
+
+    def __init__(self, request: dict[str, Any]):
+        self.event = threading.Event()
+        self.request = request
+        self.result: Optional[str] = None
+        self.created_at = time.time()
+
+
+_lock = threading.Lock()
+_tool_queues: dict[str, list[_ToolRequestEntry]] = {}
+_tool_notify: dict[str, Callable[[dict[str, Any]], None]] = {}
+_seen_results: dict[str, set[str]] = {}
+_attached_clients: dict[str, str] = {}
+
+_split_runtime_config: contextvars.ContextVar[Optional[dict[str, Any]]] = contextvars.ContextVar(
+    "split_runtime_config",
+    default=None,
+)
+
+
+def set_current_split_runtime(config: Optional[dict[str, Any]]) -> contextvars.Token:
+    """Bind split-runtime config to the current agent/thread context."""
+
+    if not config or not config.get("enabled"):
+        normalized = None
+    else:
+        normalized = dict(config)
+        normalized["routed_toolsets"] = normalize_routed_toolsets(
+            normalized.get("routed_toolsets", LOCAL_ROUTABLE_TOOLSETS)
+        )
+        try:
+            timeout = float(normalized.get("request_timeout_seconds", 300.0))
+        except (TypeError, ValueError):
+            timeout = 300.0
+        normalized["request_timeout_seconds"] = max(0.1, timeout)
+    return _split_runtime_config.set(normalized)
+
+
+def reset_current_split_runtime(token: contextvars.Token) -> None:
+    """Restore the previous split-runtime context."""
+
+    _split_runtime_config.reset(token)
+
+
+def get_current_split_runtime() -> Optional[dict[str, Any]]:
+    """Return active split-runtime config for this context, if enabled."""
+
+    return _split_runtime_config.get()
+
+
+def register_tool_notify(session_key: str, cb: Callable[[dict[str, Any]], None], client_token: str) -> bool:
+    """Attach one local executor client for a run/session.
+
+    Returns ``False`` if another executor is already attached. A run can have at
+    most one local executor to avoid split-brain writes/results.
+    """
+
+    if not session_key:
+        return False
+    token = client_token or ""
+    with _lock:
+        existing = _attached_clients.get(session_key)
+        if existing is not None:
+            return False
+        _attached_clients[session_key] = token
+        _tool_notify[session_key] = cb
+        _seen_results.setdefault(session_key, set())
+        return True
+
+
+def unregister_tool_notify(session_key: str, client_token: Optional[str] = None) -> bool:
+    """Detach the local executor and release all blocked tool workers.
+
+    When ``client_token`` is provided, only the matching attached executor can
+    detach. This prevents a stale SSE finally block from unregistering a newer
+    executor after reconnect.
+    """
+
+    with _lock:
+        existing = _attached_clients.get(session_key)
+        if client_token is not None and existing not in {None, ""} and existing != client_token:
+            return False
+        _tool_notify.pop(session_key, None)
+        _attached_clients.pop(session_key, None)
+        _seen_results.pop(session_key, None)
+        entries = _tool_queues.pop(session_key, [])
+    for entry in entries:
+        entry.event.set()
+    return True
+
+
+def tool_result_authorized(session_key: str, client_token: Optional[str]) -> bool:
+    """Return True when a tool-result POST may answer this run's executor.
+
+    Empty executor tokens mean the bearer key is the whole trust boundary.
+    Non-empty tokens add a per-attachment guard for clients that want one.
+    """
+
+    with _lock:
+        existing = _attached_clients.get(session_key)
+    return not existing or existing == (client_token or "")
+
+
+def has_attached_client(session_key: str) -> bool:
+    """Return True when a local executor is attached for ``session_key``."""
+
+    with _lock:
+        return session_key in _attached_clients and session_key in _tool_notify
+
+
+def submit_tool_request(session_key: str, request: dict[str, Any]) -> Optional[_ToolRequestEntry]:
+    """Queue a tool request and notify the attached executor.
+
+    Returns the pending entry, or ``None`` when no executor is attached or the
+    notify callback failed synchronously.
+    """
+
+    if not session_key:
+        return None
+    entry = _ToolRequestEntry(dict(request or {}))
+    with _lock:
+        cb = _tool_notify.get(session_key)
+        if cb is None or session_key not in _attached_clients:
+            return None
+        _tool_queues.setdefault(session_key, []).append(entry)
+    try:
+        cb(entry.request)
+    except Exception:
+        cancel_tool_request(session_key, str(entry.request.get("tool_call_id") or ""))
+        return None
+    return entry
+
+
+def cancel_tool_request(session_key: str, tool_call_id: str) -> bool:
+    """Remove a still-pending request after timeout or notify failure."""
+
+    if not session_key or not tool_call_id:
+        return False
+    with _lock:
+        queue = _tool_queues.get(session_key)
+        if not queue:
+            return False
+        for index, entry in enumerate(list(queue)):
+            if str(entry.request.get("tool_call_id") or "") == tool_call_id:
+                queue.pop(index)
+                if not queue:
+                    _tool_queues.pop(session_key, None)
+                entry.event.set()
+                return True
+    return False
+
+
+def resolve_tool_result(session_key: str, tool_call_id: str, result: Any) -> str:
+    """Resolve one pending local-executor request.
+
+    Returns ``resolved``, ``duplicate``, or ``unknown``.
+    """
+
+    if not session_key or not tool_call_id:
+        return "unknown"
+    with _lock:
+        seen = _seen_results.setdefault(session_key, set())
+        if tool_call_id in seen:
+            return "duplicate"
+        queue = _tool_queues.get(session_key)
+        if not queue:
+            return "unknown"
+        target: Optional[_ToolRequestEntry] = None
+        for index, entry in enumerate(list(queue)):
+            if str(entry.request.get("tool_call_id") or "") == tool_call_id:
+                target = entry
+                queue.pop(index)
+                break
+        if target is None:
+            return "unknown"
+        if not queue:
+            _tool_queues.pop(session_key, None)
+        seen.add(tool_call_id)
+
+    if isinstance(result, str):
+        target.result = result
+    else:
+        import json
+
+        target.result = json.dumps(result, ensure_ascii=False)
+    target.event.set()
+    return "resolved"
+
+
+def clear_tool_channel_state(session_key: Optional[str] = None) -> None:
+    """Test/helper cleanup for one session or all split-runtime state."""
+
+    with _lock:
+        if session_key is None:
+            entries = [entry for queue in _tool_queues.values() for entry in queue]
+            _tool_queues.clear()
+            _tool_notify.clear()
+            _seen_results.clear()
+            _attached_clients.clear()
+        else:
+            entries = _tool_queues.pop(session_key, [])
+            _tool_notify.pop(session_key, None)
+            _seen_results.pop(session_key, None)
+            _attached_clients.pop(session_key, None)
+    for entry in entries:
+        entry.event.set()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2962,7 +2962,8 @@ DEFAULT_CONFIG = {
             # Experimental split-runtime support for /v1/runs. When enabled,
             # an attached local executor on the SSE stream can execute a small
             # allowlisted tool surface locally while the agent loop runs on the
-            # API-server host. Default off; PR 1 routes read-only file tools.
+            # API-server host. Default off; the initial protocol routes only
+            # read-only file tools.
             "split_runtime": {
                 "enabled": False,
                 "routed_toolsets": ["file"],

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2959,6 +2959,15 @@ DEFAULT_CONFIG = {
             # bounding CPU / memory / upstream-LLM-quota exhaustion from a
             # request flood. Set to 0 to disable the cap entirely.
             "max_concurrent_runs": 10,
+            # Experimental split-runtime support for /v1/runs. When enabled,
+            # an attached local executor on the SSE stream can execute a small
+            # allowlisted tool surface locally while the agent loop runs on the
+            # API-server host. Default off; PR 1 routes read-only file tools.
+            "split_runtime": {
+                "enabled": False,
+                "routed_toolsets": ["file"],
+                "request_timeout_seconds": 300,
+            },
         },
     },
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -1257,25 +1257,77 @@ def handle_function_call(
         except Exception:
             reset_current_observability_context = None
         try:
-            if function_name == "execute_code":
-                # Prefer the caller-provided list so subagents can't overwrite
-                # the parent's tool set via the process-global.
-                sandbox_enabled = enabled_tools if enabled_tools is not None else _last_resolved_tool_names
-                def _dispatch(next_args: Dict[str, Any]) -> Any:
+            def _route_or_dispatch(
+                next_args: Dict[str, Any],
+                *,
+                sandbox_enabled: Optional[List[str]] = None,
+            ) -> Any:
+                try:
+                    from agent.split_runtime_router import (
+                        _NOT_ROUTED,
+                        _tool_error,
+                        route_tool_locally,
+                        should_route_tool_locally,
+                    )
+
+                    routed = route_tool_locally(
+                        function_name,
+                        next_args if isinstance(next_args, dict) else {},
+                        tool_call_id,
+                        task_id=task_id or "",
+                        session_id=session_id or "",
+                        turn_id=turn_id or "",
+                        api_request_id=api_request_id or "",
+                    )
+                    if routed is not _NOT_ROUTED:
+                        return routed
+                except Exception as _split_err:
+                    logger.debug("split-runtime routing error for %s: %s", function_name, _split_err)
+                    try:
+                        from agent.split_runtime_router import _tool_error, should_route_tool_locally
+
+                        if should_route_tool_locally(function_name):
+                            return _tool_error(
+                                "Split-runtime local routing failed before dispatch; refusing server-side fallback.",
+                                code="split_runtime_router_error",
+                                tool_call_id=tool_call_id,
+                            )
+                    except Exception:
+                        try:
+                            from gateway.tool_channel_state import get_current_split_runtime
+
+                            if get_current_split_runtime():
+                                return json.dumps({
+                                    "error": "Split-runtime router is unavailable; refusing server-side fallback while split runtime is active.",
+                                    "code": "split_runtime_router_unavailable",
+                                    "tool_call_id": tool_call_id or "",
+                                }, ensure_ascii=False)
+                        except Exception:
+                            pass
+
+                if function_name == "execute_code":
                     return registry.dispatch(
                         function_name, next_args,
                         task_id=task_id,
                         session_id=session_id,
                         enabled_tools=sandbox_enabled,
                     )
+                return registry.dispatch(
+                    function_name, next_args,
+                    task_id=task_id,
+                    session_id=session_id,
+                    user_task=user_task,
+                )
+
+            if function_name == "execute_code":
+                # Prefer the caller-provided list so subagents can't overwrite
+                # the parent's tool set via the process-global.
+                sandbox_enabled = enabled_tools if enabled_tools is not None else _last_resolved_tool_names
+                def _dispatch(next_args: Dict[str, Any]) -> Any:
+                    return _route_or_dispatch(next_args, sandbox_enabled=sandbox_enabled)
             else:
                 def _dispatch(next_args: Dict[str, Any]) -> Any:
-                    return registry.dispatch(
-                        function_name, next_args,
-                        task_id=task_id,
-                        session_id=session_id,
-                        user_task=user_task,
-                    )
+                    return _route_or_dispatch(next_args)
             from hermes_cli.middleware import run_tool_execution_middleware
 
             result = run_tool_execution_middleware(

--- a/model_tools.py
+++ b/model_tools.py
@@ -1282,7 +1282,7 @@ def handle_function_call(
                     if routed is not _NOT_ROUTED:
                         return routed
                 except Exception as _split_err:
-                    logger.debug("split-runtime routing error for %s: %s", function_name, _split_err)
+                    logger.warning("split-runtime routing error for %s: %s", function_name, _split_err)
                     try:
                         from agent.split_runtime_router import _tool_error, should_route_tool_locally
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -1265,9 +1265,7 @@ def handle_function_call(
                 try:
                     from agent.split_runtime_router import (
                         _NOT_ROUTED,
-                        _tool_error,
                         route_tool_locally,
-                        should_route_tool_locally,
                     )
 
                     routed = route_tool_locally(

--- a/run_agent.py
+++ b/run_agent.py
@@ -5699,6 +5699,20 @@ class AIAgent:
         New DELEGATE_TASK_SCHEMA fields only need to be added here to reach all
         invocation paths (concurrent, sequential, inline).
         """
+        try:
+            from gateway.tool_channel_state import get_current_split_runtime
+
+            if get_current_split_runtime():
+                return json.dumps({
+                    "error": (
+                        "delegate_task is unavailable during split-runtime runs because "
+                        "child-agent tool routing is not supported by this protocol version."
+                    ),
+                    "code": "split_runtime_delegation_unsupported",
+                }, ensure_ascii=False)
+        except ImportError:
+            pass
+
         from tools.delegate_tool import (
             _strip_model_hidden_task_fields,
             delegate_task as _delegate_task,

--- a/tests/agent/test_split_runtime_router.py
+++ b/tests/agent/test_split_runtime_router.py
@@ -1,0 +1,135 @@
+import json
+import threading
+
+import model_tools
+import agent.split_runtime_router as split_router
+from agent.split_runtime_router import _NOT_ROUTED, route_tool_locally
+from gateway.tool_channel_state import (
+    clear_tool_channel_state,
+    register_tool_notify,
+    reset_current_split_runtime,
+    resolve_tool_result,
+    set_current_split_runtime,
+    unregister_tool_notify,
+)
+from tools.approval import reset_current_session_key, set_current_session_key
+from tools.registry import discover_builtin_tools
+
+
+def setup_module():
+    discover_builtin_tools()
+
+
+def teardown_function():
+    clear_tool_channel_state()
+
+
+def _bind_split(session_key="run_local", *, timeout=1.0):
+    approval_token = set_current_session_key(session_key)
+    split_token = set_current_split_runtime({
+        "enabled": True,
+        "routed_toolsets": ["file"],
+        "request_timeout_seconds": timeout,
+    })
+    return approval_token, split_token
+
+
+def _reset(approval_token, split_token):
+    reset_current_split_runtime(split_token)
+    reset_current_session_key(approval_token)
+
+
+def test_route_tool_locally_returns_sentinel_when_disabled():
+    result = route_tool_locally(
+        "read_file",
+        {"path": "README.md"},
+        "call_disabled",
+        task_id="task",
+        session_id="session",
+    )
+    assert result is _NOT_ROUTED
+
+
+def test_route_tool_locally_returns_sentinel_for_non_routable_tool():
+    approval_token, split_token = _bind_split()
+    try:
+        result = route_tool_locally("write_file", {"path": "x", "content": "y"}, "call_write")
+    finally:
+        _reset(approval_token, split_token)
+    assert result is _NOT_ROUTED
+
+
+def test_route_tool_locally_fails_closed_without_executor():
+    approval_token, split_token = _bind_split()
+    try:
+        result = route_tool_locally("read_file", {"path": "README.md"}, "call_no_executor")
+    finally:
+        _reset(approval_token, split_token)
+    payload = json.loads(result)
+    assert payload["code"] == "split_runtime_no_executor"
+    assert payload["tool_call_id"] == "call_no_executor"
+
+
+def test_route_tool_locally_round_trips_to_attached_executor():
+    session_key = "run_roundtrip"
+    approval_token, split_token = _bind_split(session_key=session_key)
+    saw_request = threading.Event()
+    captured = {}
+
+    def notify(request):
+        captured.update(request)
+        saw_request.set()
+
+    assert register_tool_notify(session_key, notify, "client-a") is True
+
+    def resolver():
+        assert saw_request.wait(timeout=2.0)
+        assert captured["tool_name"] == "read_file"
+        assert captured["arguments"] == {"path": "README.md"}
+        resolve_tool_result(session_key, captured["tool_call_id"], "LOCAL RESULT")
+
+    thread = threading.Thread(target=resolver)
+    thread.start()
+    try:
+        result = route_tool_locally(
+            "read_file",
+            {"path": "README.md"},
+            "call_roundtrip",
+            task_id="task-1",
+            session_id="session-1",
+            turn_id="turn-1",
+            api_request_id="api-1",
+        )
+    finally:
+        thread.join(timeout=2.0)
+        unregister_tool_notify(session_key)
+        _reset(approval_token, split_token)
+
+    assert result == "LOCAL RESULT"
+    assert captured["session_id"] == "session-1"
+    assert captured["task_id"] == "task-1"
+    assert captured["turn_id"] == "turn-1"
+    assert captured["api_request_id"] == "api-1"
+
+
+def test_handle_function_call_fails_closed_when_split_router_crashes(monkeypatch):
+    approval_token, split_token = _bind_split()
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("router exploded")
+
+    monkeypatch.setattr(split_router, "route_tool_locally", boom)
+    try:
+        result = model_tools.handle_function_call(
+            "read_file",
+            {"path": "README.md"},
+            tool_call_id="call_router_crash",
+            skip_pre_tool_call_hook=True,
+            skip_tool_request_middleware=True,
+        )
+    finally:
+        _reset(approval_token, split_token)
+
+    payload = json.loads(result)
+    assert payload["code"] == "split_runtime_router_error"
+    assert payload["tool_call_id"] == "call_router_crash"

--- a/tests/agent/test_split_runtime_router.py
+++ b/tests/agent/test_split_runtime_router.py
@@ -1,5 +1,7 @@
 import json
 import threading
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import model_tools
 import agent.split_runtime_router as split_router
@@ -60,7 +62,7 @@ def test_route_tool_locally_returns_sentinel_for_non_routable_tool():
 
 
 def test_route_tool_locally_fails_closed_without_executor():
-    approval_token, split_token = _bind_split()
+    approval_token, split_token = _bind_split(timeout=0.1)
     try:
         result = route_tool_locally("read_file", {"path": "README.md"}, "call_no_executor")
     finally:
@@ -86,7 +88,7 @@ def test_route_tool_locally_round_trips_to_attached_executor():
         assert saw_request.wait(timeout=2.0)
         assert captured["tool_name"] == "read_file"
         assert captured["arguments"] == {"path": "README.md"}
-        resolve_tool_result(session_key, captured["tool_call_id"], "LOCAL RESULT")
+        resolve_tool_result(session_key, captured["request_id"], "LOCAL RESULT")
 
     thread = threading.Thread(target=resolver)
     thread.start()
@@ -110,6 +112,131 @@ def test_route_tool_locally_round_trips_to_attached_executor():
     assert captured["task_id"] == "task-1"
     assert captured["turn_id"] == "turn-1"
     assert captured["api_request_id"] == "api-1"
+
+
+def test_real_agent_tool_executor_routes_read_file_through_local_channel():
+    from run_agent import AIAgent
+
+    session_key = "run-real-agent"
+    approval_token, split_token = _bind_split(session_key=session_key)
+    captured = {}
+    saw_request = threading.Event()
+
+    def notify(request):
+        captured.update(request)
+        saw_request.set()
+
+    assert register_tool_notify(session_key, notify, "") is True
+
+    def resolve_request():
+        assert saw_request.wait(timeout=2.0)
+        resolve_tool_result(session_key, captured["request_id"], "REAL AGENT LOCAL RESULT")
+
+    resolver = threading.Thread(target=resolve_request)
+    resolver.start()
+    try:
+        with (
+            patch("run_agent.OpenAI"),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+        ):
+            agent = AIAgent(
+                model="test-model",
+                provider="openrouter",
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                enabled_toolsets=["file"],
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        tool_call = SimpleNamespace(
+            id="call_real_agent",
+            function=SimpleNamespace(
+                name="read_file",
+                arguments=json.dumps({"path": "README.md"}),
+            ),
+        )
+        assistant_message = SimpleNamespace(tool_calls=[tool_call])
+        messages = []
+        agent._execute_tool_calls(assistant_message, messages, "task-real-agent")
+    finally:
+        resolver.join(timeout=2.0)
+        unregister_tool_notify(session_key)
+        _reset(approval_token, split_token)
+
+    assert captured["tool_name"] == "read_file"
+    assert len(messages) == 1
+    assert messages[0]["role"] == "tool"
+    assert messages[0]["content"] == "REAL AGENT LOCAL RESULT"
+
+
+def test_route_tool_locally_waits_for_executor_to_attach():
+    session_key = "run_late_attach"
+    approval_token, split_token = _bind_split(session_key=session_key, timeout=1.0)
+    captured = {}
+
+    def attach_and_resolve():
+        def notify(request):
+            captured.update(request)
+            resolve_tool_result(session_key, request["request_id"], "LATE ATTACH RESULT")
+
+        assert register_tool_notify(session_key, notify, "client-late") is True
+
+    timer = threading.Timer(0.02, attach_and_resolve)
+    timer.start()
+    try:
+        result = route_tool_locally(
+            "read_file",
+            {"path": "README.md"},
+            "call_late_attach",
+        )
+    finally:
+        timer.join(timeout=1.0)
+        unregister_tool_notify(session_key)
+        _reset(approval_token, split_token)
+
+    assert result == "LATE ATTACH RESULT"
+    assert captured["tool_call_id"] == "call_late_attach"
+    assert captured["request_id"].startswith("toolreq_")
+
+
+def test_route_tool_locally_times_out_when_executor_never_answers():
+    session_key = "run_timeout"
+    approval_token, split_token = _bind_split(session_key=session_key, timeout=0.1)
+    assert register_tool_notify(session_key, lambda request: None, "client-timeout") is True
+    try:
+        result = route_tool_locally(
+            "read_file",
+            {"path": "README.md"},
+            "call_timeout",
+        )
+    finally:
+        unregister_tool_notify(session_key)
+        _reset(approval_token, split_token)
+
+    assert json.loads(result)["code"] == "split_runtime_tool_timeout"
+
+
+def test_route_tool_locally_reports_executor_disconnect():
+    session_key = "run_disconnect"
+    approval_token, split_token = _bind_split(session_key=session_key, timeout=1.0)
+
+    def disconnect(_request):
+        unregister_tool_notify(session_key, client_token="client-disconnect")
+
+    assert register_tool_notify(session_key, disconnect, "client-disconnect") is True
+    try:
+        result = route_tool_locally(
+            "search_files",
+            {"pattern": "*.py", "target": "files"},
+            "call_disconnect",
+        )
+    finally:
+        unregister_tool_notify(session_key)
+        _reset(approval_token, split_token)
+
+    assert json.loads(result)["code"] == "split_runtime_executor_disconnected"
 
 
 def test_handle_function_call_fails_closed_when_split_router_crashes(monkeypatch):

--- a/tests/agent/test_split_runtime_router.py
+++ b/tests/agent/test_split_runtime_router.py
@@ -118,7 +118,7 @@ def test_real_agent_tool_executor_routes_read_file_through_local_channel():
     from run_agent import AIAgent
 
     session_key = "run-real-agent"
-    approval_token, split_token = _bind_split(session_key=session_key)
+    approval_token, split_token = _bind_split(session_key=session_key, timeout=5.0)
     captured = {}
     saw_request = threading.Event()
 
@@ -129,11 +129,11 @@ def test_real_agent_tool_executor_routes_read_file_through_local_channel():
     assert register_tool_notify(session_key, notify, "") is True
 
     def resolve_request():
-        assert saw_request.wait(timeout=2.0)
+        assert saw_request.wait(timeout=5.0)
         resolve_tool_result(session_key, captured["request_id"], "REAL AGENT LOCAL RESULT")
 
     resolver = threading.Thread(target=resolve_request)
-    resolver.start()
+    resolver_started = False
     try:
         with (
             patch("run_agent.OpenAI"),
@@ -150,6 +150,9 @@ def test_real_agent_tool_executor_routes_read_file_through_local_channel():
                 skip_memory=True,
             )
 
+        resolver.start()
+        resolver_started = True
+
         tool_call = SimpleNamespace(
             id="call_real_agent",
             function=SimpleNamespace(
@@ -161,7 +164,8 @@ def test_real_agent_tool_executor_routes_read_file_through_local_channel():
         messages = []
         agent._execute_tool_calls(assistant_message, messages, "task-real-agent")
     finally:
-        resolver.join(timeout=2.0)
+        if resolver_started:
+            resolver.join(timeout=5.0)
         unregister_tool_notify(session_key)
         _reset(approval_token, split_token)
 
@@ -260,3 +264,20 @@ def test_handle_function_call_fails_closed_when_split_router_crashes(monkeypatch
     payload = json.loads(result)
     assert payload["code"] == "split_runtime_router_error"
     assert payload["tool_call_id"] == "call_router_crash"
+
+
+def test_split_runtime_keeps_server_tool_results_inline_only():
+    from agent.tool_executor import _tool_result_is_local, _tool_result_storage_target
+
+    approval_token, split_token = _bind_split()
+    server_env = object()
+    try:
+        with patch("agent.tool_executor.get_active_env", return_value=server_env):
+            result_env, inline_only = _tool_result_storage_target("terminal", "")
+
+        assert result_env is None
+        assert inline_only is True
+        assert _tool_result_is_local("terminal") is False
+        assert _tool_result_is_local("read_file") is True
+    finally:
+        _reset(approval_token, split_token)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -568,14 +568,25 @@ class TestConcurrencyCap:
         assert resp.headers.get("Retry-After")
 
     def test_cap_counts_both_buckets(self):
-        # /v1/runs (tracked by _run_streams) + chat/responses (inflight)
+        # Active /v1/runs tasks + chat/responses inflight work share the cap.
         adapter = _make_adapter()
         adapter._max_concurrent_runs = 4
         adapter._inflight_agent_runs = 2
-        adapter._run_streams = {"r1": object(), "r2": object()}
+        task_1 = MagicMock()
+        task_1.done.return_value = False
+        task_2 = MagicMock()
+        task_2.done.return_value = False
+        adapter._active_run_tasks = {"r1": task_1, "r2": task_2}
         resp = adapter._concurrency_limited_response()
         assert resp is not None
         assert resp.status == 429
+
+    def test_completed_run_event_buffers_do_not_consume_capacity(self):
+        adapter = _make_adapter()
+        adapter._max_concurrent_runs = 1
+        adapter._run_streams = {"completed": asyncio.Queue()}
+        adapter._active_run_tasks = {}
+        assert adapter._concurrency_limited_response() is None
 
     def test_zero_disables_cap(self):
         adapter = _make_adapter()
@@ -3290,7 +3301,10 @@ class TestCORS:
                 },
             )
             assert resp.status == 200
-            assert "Idempotency-Key" in resp.headers.get("Access-Control-Allow-Headers", "")
+            allowed_headers = resp.headers.get("Access-Control-Allow-Headers", "")
+            assert "Idempotency-Key" in allowed_headers
+            assert "X-Hermes-Tool-Executor" in allowed_headers
+            assert "X-Hermes-Tool-Executor-Token" in allowed_headers
 
     @pytest.mark.asyncio
     async def test_cors_sets_vary_origin_header(self):

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -588,11 +588,130 @@ class TestConcurrencyCap:
         adapter._active_run_tasks = {}
         assert adapter._concurrency_limited_response() is None
 
+    def test_cancelled_wrapper_keeps_capacity_until_worker_thread_finishes(self):
+        import threading
+
+        adapter = _make_adapter()
+        adapter._max_concurrent_runs = 1
+        worker_done = threading.Event()
+        adapter._run_worker_done["run-still-working"] = worker_done
+
+        response = adapter._concurrency_limited_response()
+        assert response is not None
+        assert response.status == 429
+
+        worker_done.set()
+        assert adapter._concurrency_limited_response() is None
+
     def test_zero_disables_cap(self):
         adapter = _make_adapter()
         adapter._max_concurrent_runs = 0
         adapter._inflight_agent_runs = 9999
         assert adapter._concurrency_limited_response() is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "handler_name",
+        ["_handle_chat_completions", "_handle_responses"],
+    )
+    async def test_slow_agent_route_body_reserves_capacity(self, handler_name):
+        adapter = _make_adapter()
+        adapter._max_concurrent_runs = 1
+        body_started = asyncio.Event()
+        release_body = asyncio.Event()
+        first_request = MagicMock()
+        first_request.headers = {}
+
+        async def slow_json():
+            body_started.set()
+            await release_body.wait()
+            return {}
+
+        first_request.json = slow_json
+        handler = getattr(adapter, handler_name)
+        first_task = asyncio.create_task(handler(first_request))
+        await body_started.wait()
+
+        second_request = MagicMock()
+        second_request.headers = {}
+        second_response = await handler(second_request)
+        assert second_response.status == 429
+        assert adapter._pending_agent_admissions == 1
+
+        release_body.set()
+        first_response = await first_task
+        assert first_response.status == 400
+        assert adapter._pending_agent_admissions == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "handler_name",
+        ["_handle_chat_completions", "_handle_responses"],
+    )
+    async def test_agent_route_body_is_rejected_after_drain_starts(self, handler_name):
+        adapter = _make_adapter()
+        body_started = asyncio.Event()
+        release_body = asyncio.Event()
+        request = MagicMock()
+        request.headers = {}
+
+        async def slow_json():
+            body_started.set()
+            await release_body.wait()
+            return {}
+
+        request.json = slow_json
+        task = asyncio.create_task(getattr(adapter, handler_name)(request))
+        await body_started.wait()
+        await adapter.disconnect()
+        adapter._accepting_agent_requests = True  # simulate a quick reconnect
+        release_body.set()
+
+        response = await task
+        assert response.status == 503
+        assert adapter._pending_agent_admissions == 0
+
+    @pytest.mark.asyncio
+    async def test_admission_transfers_to_worker_lifetime_without_double_counting(self):
+        import threading
+
+        adapter = _make_adapter()
+        adapter._max_concurrent_runs = 1
+        started = threading.Event()
+        release = threading.Event()
+        mock_agent = MagicMock()
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        def blocked_run(**_kwargs):
+            started.set()
+            assert release.wait(timeout=10.0)
+            return {"final_response": "done"}
+
+        mock_agent.run_conversation.side_effect = blocked_run
+        first_request = MagicMock()
+        first_request.headers = {}
+        first_request.json = AsyncMock(
+            return_value={"messages": [{"role": "user", "content": "hold"}]}
+        )
+
+        with patch.object(adapter, "_create_agent", return_value=mock_agent):
+            first_task = asyncio.create_task(adapter._handle_chat_completions(first_request))
+            assert await asyncio.to_thread(started.wait, 3.0)
+            assert adapter._pending_agent_admissions == 0
+            assert adapter._inflight_agent_runs == 1
+
+            second_request = MagicMock()
+            second_request.headers = {}
+            second_response = await adapter._handle_chat_completions(second_request)
+            assert second_response.status == 429
+
+            release.set()
+            first_response = await first_task
+            assert first_response.status == 200
+            await asyncio.sleep(0)
+            assert adapter._inflight_agent_runs == 0
 
 
 # ---------------------------------------------------------------------------
@@ -646,6 +765,118 @@ def auth_adapter():
 
 
 class TestAgentExecution:
+    @pytest.mark.asyncio
+    async def test_cancelled_queued_worker_releases_capacity_without_starting(self, adapter):
+        import threading
+
+        adapter._max_concurrent_runs = 1
+        occupied = threading.Event()
+        release = threading.Event()
+
+        def occupy_only_worker():
+            occupied.set()
+            assert release.wait(timeout=10.0)
+
+        blocker = adapter._get_request_executor().submit(occupy_only_worker)
+        assert await asyncio.to_thread(occupied.wait, 3.0)
+
+        with patch.object(adapter, "_create_agent") as create_agent:
+            task = asyncio.create_task(
+                adapter._run_agent(
+                    user_message="never starts",
+                    conversation_history=[],
+                    session_id="queued-cancel",
+                )
+            )
+            for _ in range(100):
+                if adapter._inflight_agent_runs == 1:
+                    break
+                await asyncio.sleep(0.01)
+            assert adapter._inflight_agent_runs == 1
+
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            assert adapter._inflight_agent_runs == 0
+            create_agent.assert_not_called()
+
+        release.set()
+        await asyncio.wrap_future(blocker)
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_interrupts_nonstructured_agent_worker(self, adapter):
+        import threading
+
+        started = threading.Event()
+        release = threading.Event()
+        mock_agent = MagicMock()
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        def blocked_run(**_kwargs):
+            started.set()
+            assert release.wait(timeout=10.0)
+            return {"final_response": "stopped"}
+
+        mock_agent.run_conversation.side_effect = blocked_run
+        mock_agent.interrupt.side_effect = lambda _reason: release.set()
+        with patch.object(adapter, "_create_agent", return_value=mock_agent):
+            task = asyncio.create_task(
+                adapter._run_agent(
+                    user_message="hold",
+                    conversation_history=[],
+                    session_id="disconnect-worker",
+                )
+            )
+            assert await asyncio.to_thread(started.wait, 3.0)
+            await adapter.disconnect()
+            result, _usage = await task
+
+        assert result["final_response"] == "stopped"
+        mock_agent.interrupt.assert_called_once_with("API server disconnecting")
+        assert adapter._inflight_agent_runs == 0
+        assert adapter._active_request_agents == {}
+
+    @pytest.mark.asyncio
+    async def test_cancelled_wrapper_holds_capacity_until_agent_thread_exits(self, adapter):
+        import threading
+
+        started = threading.Event()
+        release = threading.Event()
+        mock_agent = MagicMock()
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        def blocked_run(**_kwargs):
+            started.set()
+            assert release.wait(timeout=10.0)
+            return {"final_response": "done"}
+
+        mock_agent.run_conversation.side_effect = blocked_run
+        with patch.object(adapter, "_create_agent", return_value=mock_agent):
+            task = asyncio.create_task(
+                adapter._run_agent(
+                    user_message="hold",
+                    conversation_history=[],
+                    session_id="cancelled-wrapper",
+                )
+            )
+            assert await asyncio.to_thread(started.wait, 3.0)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            assert adapter._inflight_agent_runs == 1
+
+            release.set()
+            for _ in range(100):
+                if adapter._inflight_agent_runs == 0:
+                    break
+                await asyncio.sleep(0.01)
+            assert adapter._inflight_agent_runs == 0
+
     @pytest.mark.asyncio
     async def test_run_agent_uses_session_id_as_task_id(self, adapter):
         mock_agent = MagicMock()

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -9,6 +9,7 @@ Covers:
 """
 
 import asyncio
+import json
 import threading
 from unittest.mock import MagicMock, patch
 
@@ -23,6 +24,12 @@ from gateway.platforms.api_server import (
     security_headers_middleware,
 )
 from tools import approval as approval_mod
+from gateway.tool_channel_state import (
+    clear_tool_channel_state,
+    register_tool_notify,
+    submit_tool_request,
+    unregister_tool_notify,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -30,12 +37,12 @@ from tools import approval as approval_mod
 # ---------------------------------------------------------------------------
 
 
-def _make_adapter(api_key: str = "") -> APIServerAdapter:
+def _make_adapter(api_key: str = "", extra: dict | None = None) -> APIServerAdapter:
     """Create an adapter with optional API key."""
-    extra = {}
+    cfg_extra = dict(extra or {})
     if api_key:
-        extra["key"] = api_key
-    config = PlatformConfig(enabled=True, extra=extra)
+        cfg_extra["key"] = api_key
+    config = PlatformConfig(enabled=True, extra=cfg_extra)
     adapter = APIServerAdapter(config)
     return adapter
 
@@ -49,6 +56,7 @@ def _create_runs_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_get("/v1/runs/{run_id}", adapter._handle_get_run)
     app.router.add_get("/v1/runs/{run_id}/events", adapter._handle_run_events)
     app.router.add_post("/v1/runs/{run_id}/approval", adapter._handle_run_approval)
+    app.router.add_post("/v1/runs/{run_id}/tool_result", adapter._handle_run_tool_result)
     app.router.add_post("/v1/runs/{run_id}/stop", adapter._handle_stop_run)
     return app
 
@@ -92,6 +100,17 @@ def adapter():
 @pytest.fixture
 def auth_adapter():
     return _make_adapter(api_key="sk-secret")
+
+
+@pytest.fixture
+def split_adapter():
+    return _make_adapter(extra={
+        "split_runtime": {
+            "enabled": True,
+            "routed_toolsets": ["file"],
+            "request_timeout_seconds": 1,
+        }
+    })
 
 
 # ---------------------------------------------------------------------------
@@ -435,11 +454,268 @@ class TestRunEvents:
         assert resp.status == 404
 
     @pytest.mark.asyncio
+    async def test_events_rejects_second_consumer(self, adapter):
+        app = _create_runs_app(adapter)
+        run_id = "run_events_conflict"
+        adapter._run_streams[run_id] = asyncio.Queue()
+        adapter._run_streams_created[run_id] = 1.0
+        adapter._run_event_consumers[run_id] = "events"
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get(f"/v1/runs/{run_id}/events")
+            data = await resp.json()
+        assert resp.status == 409
+        assert data["error"]["code"] == "run_events_consumer_conflict"
+        adapter._run_streams.pop(run_id, None)
+        adapter._run_streams_created.pop(run_id, None)
+        adapter._run_event_consumers.pop(run_id, None)
+
+    @pytest.mark.asyncio
+    async def test_events_tool_executor_disabled_returns_409_and_does_not_leak_consumer(self, adapter):
+        app = _create_runs_app(adapter)
+        run_id = "run_tool_executor_disabled"
+        adapter._run_streams[run_id] = asyncio.Queue()
+        adapter._run_streams_created[run_id] = 1.0
+        adapter._run_tool_sessions[run_id] = "disabled-tool-session"
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get(f"/v1/runs/{run_id}/events?tool_executor=1")
+            data = await resp.json()
+        assert resp.status == 409
+        assert data["error"]["code"] == "split_runtime_disabled"
+        assert run_id not in adapter._run_event_consumers
+        adapter._run_streams.pop(run_id, None)
+        adapter._run_streams_created.pop(run_id, None)
+        adapter._run_tool_sessions.pop(run_id, None)
+
+    @pytest.mark.asyncio
+    async def test_events_tool_executor_round_trips_routed_read_file(self, split_adapter):
+        """A fake local executor can answer a routed read_file over /v1/runs SSE."""
+        app = _create_runs_app(split_adapter)
+        attach_ready = threading.Event()
+
+        class FakeAgent:
+            session_prompt_tokens = 0
+            session_completion_tokens = 0
+            session_total_tokens = 0
+
+            def run_conversation(self, user_message, conversation_history, task_id):
+                import model_tools
+
+                assert attach_ready.wait(timeout=3.0)
+                result = model_tools.handle_function_call(
+                    "read_file",
+                    {"path": "README.md"},
+                    task_id=task_id,
+                    tool_call_id="call_http_e2e",
+                    session_id="session-http-e2e",
+                    skip_pre_tool_call_hook=True,
+                    skip_tool_request_middleware=True,
+                )
+                return {"final_response": f"local executor returned: {result}"}
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(split_adapter, "_create_agent", return_value=FakeAgent()):
+                start_resp = await cli.post("/v1/runs", json={"input": "read local file"})
+                assert start_resp.status == 202
+                run_id = (await start_resp.json())["run_id"]
+
+                events_resp = await cli.get(
+                    f"/v1/runs/{run_id}/events?tool_executor=1",
+                    headers={"X-Hermes-Tool-Executor-Token": "executor-token"},
+                )
+                assert events_resp.status == 200
+                attach_ready.set()
+
+                request_event = None
+                for _ in range(10):
+                    raw = await asyncio.wait_for(events_resp.content.readline(), timeout=3.0)
+                    line = raw.decode().strip()
+                    if line.startswith("data: "):
+                        event = json.loads(line[6:])
+                        if event.get("event") == "tool.request":
+                            request_event = event
+                            break
+                assert request_event is not None
+                assert request_event["tool_call_id"] == "call_http_e2e"
+                assert request_event["tool_name"] == "read_file"
+                assert request_event["arguments"] == {"path": "README.md"}
+
+                result_resp = await cli.post(
+                    f"/v1/runs/{run_id}/tool_result",
+                    json={"tool_call_id": "call_http_e2e", "result": "LOCAL README CONTENT"},
+                    headers={"X-Hermes-Tool-Executor-Token": "executor-token"},
+                )
+                assert result_resp.status == 200
+
+                body = await asyncio.wait_for(events_resp.text(), timeout=3.0)
+                assert "tool.result" in body
+                assert "run.completed" in body
+                assert "LOCAL README CONTENT" in body
+
+    @pytest.mark.asyncio
     async def test_events_requires_auth(self, auth_adapter):
         app = _create_runs_app(auth_adapter)
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.get("/v1/runs/run_any/events")
         assert resp.status == 401
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/runs/{run_id}/tool_result — split-runtime local tool response
+# ---------------------------------------------------------------------------
+
+
+class TestRunToolResult:
+    @pytest.mark.asyncio
+    async def test_tool_result_returns_409_when_split_runtime_disabled(self, adapter):
+        app = _create_runs_app(adapter)
+        run_id = "run_tool_disabled"
+        adapter._run_statuses[run_id] = {"run_id": run_id, "status": "running"}
+        adapter._run_tool_sessions[run_id] = "disabled-session"
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/v1/runs/{run_id}/tool_result",
+                json={"tool_call_id": "call_disabled", "result": "ignored"},
+            )
+            data = await resp.json()
+        assert resp.status == 409
+        assert data["error"]["code"] == "split_runtime_disabled"
+
+    @pytest.mark.asyncio
+    async def test_tool_result_resolves_pending_request_and_emits_event(self, split_adapter):
+        app = _create_runs_app(split_adapter)
+        run_id = "run_tool_result"
+        session_key = "tool-session"
+        q: asyncio.Queue = asyncio.Queue()
+        split_adapter._run_statuses[run_id] = {"run_id": run_id, "status": "waiting_for_tool_result"}
+        split_adapter._run_tool_sessions[run_id] = session_key
+        split_adapter._run_streams[run_id] = q
+        try:
+            assert register_tool_notify(session_key, lambda request: None, "") is True
+            entry = submit_tool_request(session_key, {
+                "v": 1,
+                "tool_call_id": "call_1",
+                "tool_name": "read_file",
+                "arguments": {"path": "README.md"},
+            })
+            assert entry is not None
+
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    f"/v1/runs/{run_id}/tool_result",
+                    json={"tool_call_id": "call_1", "result": "local output"},
+                )
+                assert resp.status == 200
+                data = await resp.json()
+
+            assert data == {
+                "object": "hermes.run.tool_result_response",
+                "run_id": run_id,
+                "tool_call_id": "call_1",
+                "status": "resolved",
+            }
+            assert entry.event.is_set()
+            assert entry.result == "local output"
+            assert split_adapter._run_statuses[run_id]["status"] == "running"
+            event = await asyncio.wait_for(q.get(), timeout=1.0)
+            assert event["event"] == "tool.result"
+            assert event["tool_call_id"] == "call_1"
+        finally:
+            unregister_tool_notify(session_key)
+            clear_tool_channel_state(session_key)
+
+    @pytest.mark.asyncio
+    async def test_tool_result_rejects_mismatched_executor_token(self, split_adapter):
+        app = _create_runs_app(split_adapter)
+        run_id = "run_tool_token_mismatch"
+        session_key = "tool-session-token"
+        split_adapter._run_statuses[run_id] = {"run_id": run_id, "status": "waiting_for_tool_result"}
+        split_adapter._run_tool_sessions[run_id] = session_key
+        try:
+            assert register_tool_notify(session_key, lambda request: None, "client-a") is True
+            entry = submit_tool_request(session_key, {"tool_call_id": "call_token"})
+            assert entry is not None
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    f"/v1/runs/{run_id}/tool_result",
+                    json={"tool_call_id": "call_token", "result": "wrong"},
+                    headers={"X-Hermes-Tool-Executor-Token": "client-b"},
+                )
+                data = await resp.json()
+        finally:
+            unregister_tool_notify(session_key)
+            clear_tool_channel_state(session_key)
+        assert resp.status == 403
+        assert data["error"]["code"] == "tool_result_executor_mismatch"
+        assert entry.result is None
+
+    @pytest.mark.asyncio
+    async def test_tool_result_accepts_matching_executor_token(self, split_adapter):
+        app = _create_runs_app(split_adapter)
+        run_id = "run_tool_token_match"
+        session_key = "tool-session-token-match"
+        split_adapter._run_statuses[run_id] = {"run_id": run_id, "status": "waiting_for_tool_result"}
+        split_adapter._run_tool_sessions[run_id] = session_key
+        try:
+            assert register_tool_notify(session_key, lambda request: None, "client-a") is True
+            entry = submit_tool_request(session_key, {"tool_call_id": "call_token_ok"})
+            assert entry is not None
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    f"/v1/runs/{run_id}/tool_result",
+                    json={"tool_call_id": "call_token_ok", "result": "right"},
+                    headers={"X-Hermes-Tool-Executor-Token": "client-a"},
+                )
+                data = await resp.json()
+        finally:
+            unregister_tool_notify(session_key)
+            clear_tool_channel_state(session_key)
+        assert resp.status == 200
+        assert data["status"] == "resolved"
+        assert entry.result == "right"
+
+    @pytest.mark.asyncio
+    async def test_tool_result_duplicate_is_idempotent(self, split_adapter):
+        app = _create_runs_app(split_adapter)
+        run_id = "run_tool_duplicate"
+        session_key = "tool-session-duplicate"
+        split_adapter._run_statuses[run_id] = {"run_id": run_id, "status": "waiting_for_tool_result"}
+        split_adapter._run_tool_sessions[run_id] = session_key
+        try:
+            assert register_tool_notify(session_key, lambda request: None, "") is True
+            entry = submit_tool_request(session_key, {"tool_call_id": "call_dup"})
+            assert entry is not None
+            async with TestClient(TestServer(app)) as cli:
+                first = await cli.post(
+                    f"/v1/runs/{run_id}/tool_result",
+                    json={"tool_call_id": "call_dup", "result": "one"},
+                )
+                second = await cli.post(
+                    f"/v1/runs/{run_id}/tool_result",
+                    json={"tool_call_id": "call_dup", "result": "two"},
+                )
+                assert first.status == 200
+                assert second.status == 200
+                second_data = await second.json()
+            assert second_data["status"] == "duplicate"
+            assert entry.result == "one"
+        finally:
+            unregister_tool_notify(session_key)
+            clear_tool_channel_state(session_key)
+
+    @pytest.mark.asyncio
+    async def test_tool_result_without_pending_request_returns_409(self, split_adapter):
+        app = _create_runs_app(split_adapter)
+        run_id = "run_tool_missing"
+        split_adapter._run_statuses[run_id] = {"run_id": run_id, "status": "running"}
+        split_adapter._run_tool_sessions[run_id] = "missing-session"
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/v1/runs/{run_id}/tool_result",
+                json={"tool_call_id": "call_missing", "result": "late"},
+            )
+            data = await resp.json()
+        assert resp.status == 409
+        assert data["error"]["code"] == "tool_result_not_pending"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -10,6 +10,8 @@ Covers:
 
 import asyncio
 import json
+import subprocess
+import sys
 import threading
 from unittest.mock import MagicMock, patch
 
@@ -26,8 +28,10 @@ from gateway.platforms.api_server import (
 from tools import approval as approval_mod
 from gateway.tool_channel_state import (
     clear_tool_channel_state,
+    close_tool_channel,
     has_attached_client,
     register_tool_notify,
+    resolve_tool_result,
     submit_tool_request,
     unregister_tool_notify,
 )
@@ -120,6 +124,27 @@ def split_adapter():
 
 
 class TestStartRun:
+    def test_run_executor_workers_do_not_block_process_exit(self):
+        code = """
+import threading
+from gateway.platforms.api_server import _DaemonThreadPoolExecutor
+
+started = threading.Event()
+never = threading.Event()
+executor = _DaemonThreadPoolExecutor(1, "exit-test")
+executor.submit(lambda: (started.set(), never.wait()))
+assert started.wait(2)
+executor.shutdown(wait=False)
+"""
+        completed = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+        assert completed.returncode == 0, completed.stderr
+
     @pytest.mark.asyncio
     async def test_start_returns_202(self, adapter):
         app = _create_runs_app(adapter)
@@ -233,6 +258,211 @@ class TestStartRun:
         assert status["code"] == "split_runtime_incompatible_runtime"
         mock_agent.run_conversation.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_disabled_api_file_toolset_disables_split_runtime_for_run(
+        self,
+        split_adapter,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(
+            "hermes_cli.tools_config._get_platform_tools",
+            lambda config, platform: {"safe"},
+        )
+        app = _create_runs_app(split_adapter)
+        mock_agent = MagicMock()
+        mock_agent.api_mode = "codex_app_server"
+        mock_agent.run_conversation.return_value = {"final_response": "server runtime allowed"}
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(split_adapter, "_create_agent", return_value=mock_agent):
+                resp = await cli.post("/v1/runs", json={"input": "no local tools"})
+                run_id = (await resp.json())["run_id"]
+                status = {}
+                for _ in range(50):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.01)
+
+                executor_resp = await cli.get(f"/v1/runs/{run_id}/events?tool_executor=1")
+
+        assert status["status"] == "completed"
+        assert split_adapter._run_split_runtime_active[run_id] is False
+        assert executor_resp.status == 409
+        mock_agent.run_conversation.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_run_uses_one_toolset_snapshot_for_routing_and_agent(self, split_adapter):
+        app = _create_runs_app(split_adapter)
+        mock_agent = MagicMock()
+        mock_agent.api_mode = "chat_completions"
+        mock_agent.run_conversation.return_value = {"final_response": "done"}
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        with (
+            patch(
+                "hermes_cli.tools_config._get_platform_tools",
+                return_value={"file"},
+            ) as get_tools,
+            patch.object(
+                split_adapter,
+                "_create_agent",
+                return_value=mock_agent,
+            ) as create_agent,
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post("/v1/runs", json={"input": "snapshot tools"})
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+                for _ in range(50):
+                    if split_adapter._run_statuses[run_id]["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.01)
+
+        assert split_adapter._run_split_runtime_active[run_id] is True
+        assert create_agent.call_args.kwargs["enabled_toolsets"] == ["file"]
+        get_tools.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_enabled_split_runtime_rejects_run_when_toolset_resolution_fails(
+        self,
+        split_adapter,
+        monkeypatch,
+    ):
+        def fail_toolset_resolution(*_args, **_kwargs):
+            raise RuntimeError("bad config")
+
+        monkeypatch.setattr(
+            "hermes_cli.tools_config._get_platform_tools",
+            fail_toolset_resolution,
+        )
+        app = _create_runs_app(split_adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/v1/runs", json={"input": "must fail closed"})
+
+        assert resp.status == 500
+        assert split_adapter._active_run_tasks == {}
+
+    @pytest.mark.asyncio
+    async def test_tool_channel_closes_only_after_terminal_status(self, split_adapter):
+        from gateway.tool_channel_state import close_tool_channel
+
+        app = _create_runs_app(split_adapter)
+        mock_agent = MagicMock()
+        mock_agent.api_mode = "chat_completions"
+        mock_agent.run_conversation.return_value = {"final_response": "done"}
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+        closed_statuses = []
+
+        def observed_close(session_key):
+            closed_statuses.append(split_adapter._run_statuses[session_key]["status"])
+            close_tool_channel(session_key)
+
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(split_adapter, "_create_agent", return_value=mock_agent),
+                patch("gateway.tool_channel_state.close_tool_channel", side_effect=observed_close),
+            ):
+                resp = await cli.post("/v1/runs", json={"input": "finish"})
+                run_id = (await resp.json())["run_id"]
+                for _ in range(50):
+                    if run_id not in split_adapter._active_run_tasks:
+                        break
+                    await asyncio.sleep(0.01)
+
+        assert closed_statuses == ["completed"]
+
+    @pytest.mark.asyncio
+    async def test_worker_submission_failure_releases_capacity(self, split_adapter):
+        class BrokenExecutor:
+            def submit(self, *_args, **_kwargs):
+                raise RuntimeError("executor unavailable")
+
+        split_adapter._max_concurrent_runs = 1
+        app = _create_runs_app(split_adapter)
+        mock_agent = MagicMock()
+        mock_agent.api_mode = "chat_completions"
+
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(split_adapter, "_create_agent", return_value=mock_agent),
+                patch.object(split_adapter, "_get_run_executor", return_value=BrokenExecutor()),
+            ):
+                resp = await cli.post("/v1/runs", json={"input": "submission fails"})
+                run_id = (await resp.json())["run_id"]
+                for _ in range(50):
+                    status = split_adapter._run_statuses.get(run_id, {})
+                    if status.get("status") == "failed":
+                        break
+                    await asyncio.sleep(0.01)
+
+        assert split_adapter._run_statuses[run_id]["status"] == "failed"
+        assert split_adapter._run_worker_done[run_id].is_set()
+        assert split_adapter._concurrency_limited_response() is None
+
+    @pytest.mark.asyncio
+    async def test_slow_request_body_reserves_capacity_before_await(self, adapter):
+        adapter._max_concurrent_runs = 1
+        body_started = asyncio.Event()
+        release_body = asyncio.Event()
+        first_request = MagicMock()
+        first_request.headers = {}
+
+        async def slow_json():
+            body_started.set()
+            await release_body.wait()
+            return {}
+
+        first_request.json = slow_json
+        first_task = asyncio.create_task(adapter._handle_runs(first_request))
+        await body_started.wait()
+
+        second_request = MagicMock()
+        second_request.headers = {}
+        second_response = await adapter._handle_runs(second_request)
+
+        assert second_response.status == 429
+        assert adapter._pending_agent_admissions == 1
+
+        release_body.set()
+        first_response = await first_task
+        assert first_response.status == 400
+        assert adapter._pending_agent_admissions == 0
+
+    @pytest.mark.asyncio
+    async def test_draining_server_rejects_body_that_was_already_admitted(self, adapter):
+        body_started = asyncio.Event()
+        release_body = asyncio.Event()
+        request = MagicMock()
+        request.headers = {}
+
+        async def slow_json():
+            body_started.set()
+            await release_body.wait()
+            return {"input": "must not start"}
+
+        request.json = slow_json
+        request_task = asyncio.create_task(adapter._handle_runs(request))
+        await body_started.wait()
+
+        await adapter.disconnect()
+        adapter._accepting_agent_requests = True  # simulate a quick reconnect
+        release_body.set()
+        response = await request_task
+
+        assert response.status == 503
+        assert adapter._active_run_tasks == {}
+        assert adapter._run_worker_futures == {}
+
 
 # ---------------------------------------------------------------------------
 # GET /v1/runs/{run_id} — poll run status
@@ -321,6 +551,34 @@ class TestRunStatus:
 
 class TestRunEvents:
     @pytest.mark.asyncio
+    async def test_late_progress_callback_cannot_overwrite_terminal_status(self, adapter):
+        run_id = "run_late_progress"
+        adapter._run_statuses[run_id] = {"run_id": run_id, "status": "cancelled"}
+        adapter._run_streams[run_id] = asyncio.Queue()
+        callback = adapter._make_run_event_callback(run_id, asyncio.get_running_loop())
+
+        await asyncio.to_thread(callback, "tool.started", tool_name="read_file")
+        await asyncio.sleep(0)
+
+        assert adapter._run_statuses[run_id]["status"] == "cancelled"
+        assert adapter._run_streams[run_id].empty()
+
+    @pytest.mark.asyncio
+    async def test_late_progress_callback_cannot_resurrect_swept_run(self, adapter):
+        run_id = "run_already_swept"
+        adapter._run_statuses[run_id] = {"run_id": run_id, "status": "completed"}
+        adapter._run_streams[run_id] = asyncio.Queue()
+        callback = adapter._make_run_event_callback(run_id, asyncio.get_running_loop())
+
+        adapter._run_statuses.pop(run_id)
+        adapter._run_streams.pop(run_id)
+        await asyncio.to_thread(callback, "tool.completed", tool_name="read_file")
+        await asyncio.sleep(0)
+
+        assert run_id not in adapter._run_statuses
+        assert run_id not in adapter._run_streams
+
+    @pytest.mark.asyncio
     async def test_events_stream_returns_completed(self, adapter):
         """Events stream should receive run.completed when agent finishes."""
         app = _create_runs_app(adapter)
@@ -398,6 +656,24 @@ class TestRunEvents:
             "once",
             resolve_all=False,
         )
+
+    @pytest.mark.asyncio
+    async def test_stopping_run_rejects_approval_without_resolving(self, adapter):
+        app = _create_runs_app(adapter)
+        run_id = "run_stopping_approval"
+        adapter._run_statuses[run_id] = {"run_id": run_id, "status": "stopping"}
+        adapter._run_approval_sessions[run_id] = run_id
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+                approval_resp = await cli.post(
+                    f"/v1/runs/{run_id}/approval",
+                    json={"choice": "once"},
+                )
+
+        assert approval_resp.status == 409
+        mock_resolve.assert_not_called()
+        assert adapter._run_statuses[run_id]["status"] == "stopping"
 
     @pytest.mark.asyncio
     async def test_approval_resolve_all_is_scoped_to_target_run(self, auth_adapter):
@@ -532,7 +808,6 @@ class TestRunEvents:
     async def test_executor_stream_discards_canceled_tool_request_events(self, split_adapter):
         app = _create_runs_app(split_adapter)
         run_id = "run_stale_request_event"
-        session_key = "stale-request-session"
         q = asyncio.Queue()
         q.put_nowait({
             "event": "tool.request",
@@ -544,7 +819,6 @@ class TestRunEvents:
         q.put_nowait(None)
         split_adapter._run_streams[run_id] = q
         split_adapter._run_streams_created[run_id] = 1.0
-        split_adapter._run_tool_sessions[run_id] = session_key
         split_adapter._run_statuses[run_id] = {"run_id": run_id, "status": "completed"}
 
         async with TestClient(TestServer(app)) as cli:
@@ -619,7 +893,7 @@ class TestRunEvents:
 
                 request_event = None
                 for _ in range(10):
-                    raw = await asyncio.wait_for(events_resp.content.readline(), timeout=3.0)
+                    raw = await asyncio.wait_for(events_resp.content.readline(), timeout=10.0)
                     line = raw.decode().strip()
                     if line.startswith("data: "):
                         event = json.loads(line[6:])
@@ -639,7 +913,7 @@ class TestRunEvents:
                 )
                 assert result_resp.status == 200
 
-                body = await asyncio.wait_for(events_resp.text(), timeout=3.0)
+                body = await asyncio.wait_for(events_resp.text(), timeout=10.0)
                 assert "tool.result" in body
                 assert "run.completed" in body
                 assert "LOCAL README CONTENT" in body
@@ -894,6 +1168,33 @@ class TestRunToolResult:
             clear_tool_channel_state(session_key)
 
     @pytest.mark.asyncio
+    async def test_duplicate_tool_result_is_idempotent_after_run_completion(self, split_adapter):
+        app = _create_runs_app(split_adapter)
+        run_id = "run_tool_duplicate_terminal"
+        split_adapter._run_statuses[run_id] = {"run_id": run_id, "status": "running"}
+        split_adapter._run_tool_sessions[run_id] = run_id
+        try:
+            assert register_tool_notify(run_id, lambda request: None, "") is True
+            entry = submit_tool_request(run_id, {"tool_call_id": "call_terminal_dup"})
+            assert entry is not None
+            assert resolve_tool_result(run_id, entry.request["request_id"], "one") == "resolved"
+            close_tool_channel(run_id)
+            split_adapter._run_tool_sessions.pop(run_id, None)
+            split_adapter._run_statuses[run_id]["status"] = "completed"
+
+            async with TestClient(TestServer(app)) as cli:
+                retry = await cli.post(
+                    f"/v1/runs/{run_id}/tool_result",
+                    json={"request_id": entry.request["request_id"], "result": "two"},
+                )
+                retry_data = await retry.json()
+
+            assert retry.status == 200
+            assert retry_data["status"] == "duplicate"
+        finally:
+            clear_tool_channel_state(run_id)
+
+    @pytest.mark.asyncio
     async def test_tool_result_without_pending_request_returns_409(self, split_adapter):
         app = _create_runs_app(split_adapter)
         run_id = "run_tool_missing"
@@ -907,6 +1208,28 @@ class TestRunToolResult:
             data = await resp.json()
         assert resp.status == 409
         assert data["error"]["code"] == "tool_result_not_pending"
+
+    @pytest.mark.asyncio
+    async def test_tool_result_does_not_overwrite_stopping_status(self, split_adapter):
+        app = _create_runs_app(split_adapter)
+        run_id = "run_tool_stopping"
+        split_adapter._run_statuses[run_id] = {"run_id": run_id, "status": "stopping"}
+        split_adapter._run_tool_sessions[run_id] = run_id
+        try:
+            assert register_tool_notify(run_id, lambda request: None, "") is True
+            entry = submit_tool_request(run_id, {"tool_call_id": "call_stopping"})
+            assert entry is not None
+
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    f"/v1/runs/{run_id}/tool_result",
+                    json={"request_id": entry.request["request_id"], "result": "done"},
+                )
+
+            assert resp.status == 200
+            assert split_adapter._run_statuses[run_id]["status"] == "stopping"
+        finally:
+            clear_tool_channel_state(run_id)
 
 
 # ---------------------------------------------------------------------------
@@ -999,11 +1322,334 @@ class TestStopRun:
                 assert asyncio.get_running_loop().time() - started < 1.0
 
     @pytest.mark.asyncio
+    async def test_stop_keeps_capacity_while_uninterruptible_worker_is_running(self):
+        adapter = _make_adapter()
+        adapter._max_concurrent_runs = 1
+        app = _create_runs_app(adapter)
+        ready = threading.Event()
+        release = threading.Event()
+        mock_agent = MagicMock()
+        mock_agent.api_mode = "chat_completions"
+        mock_agent.interrupt = MagicMock()
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        def blocked_run(**kwargs):
+            ready.set()
+            release.wait(timeout=10)
+            return {"final_response": "released"}
+
+        mock_agent.run_conversation.side_effect = blocked_run
+        run_id = ""
+        worker_done = None
+        try:
+            async with TestClient(TestServer(app)) as cli:
+                with patch.object(adapter, "_create_agent", return_value=mock_agent):
+                    start_resp = await cli.post("/v1/runs", json={"input": "block"})
+                    run_id = (await start_resp.json())["run_id"]
+                    assert await asyncio.to_thread(ready.wait, 1.0)
+
+                    stop_resp = await cli.post(f"/v1/runs/{run_id}/stop")
+                    assert stop_resp.status == 200
+
+                    second_resp = await cli.post("/v1/runs", json={"input": "second"})
+                    assert second_resp.status == 429
+        finally:
+            release.set()
+
+        for _ in range(100):
+            worker_done = adapter._run_worker_done.get(run_id)
+            if worker_done is None or worker_done.is_set():
+                break
+            await asyncio.sleep(0.01)
+        assert worker_done is None or worker_done.is_set()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_interrupts_and_drains_running_worker(self):
+        adapter = _make_adapter()
+        app = _create_runs_app(adapter)
+        started = threading.Event()
+        release = threading.Event()
+        mock_agent = MagicMock()
+        mock_agent.api_mode = "chat_completions"
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        def blocked_run(**_kwargs):
+            started.set()
+            assert release.wait(timeout=10.0)
+            return {"final_response": "drained"}
+
+        def interrupt(_reason):
+            release.set()
+
+        mock_agent.run_conversation.side_effect = blocked_run
+        mock_agent.interrupt.side_effect = interrupt
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", return_value=mock_agent):
+                resp = await cli.post("/v1/runs", json={"input": "block"})
+                run_id = (await resp.json())["run_id"]
+                assert await asyncio.to_thread(started.wait, 3.0)
+
+                await adapter.disconnect()
+
+        mock_agent.interrupt.assert_called_once_with("API server disconnecting")
+        assert adapter._run_worker_done[run_id].is_set()
+        assert adapter._run_executor is None
+
+    @pytest.mark.asyncio
+    async def test_disconnect_can_interrupt_worker_after_wrapper_was_cancelled(self):
+        adapter = _make_adapter()
+        app = _create_runs_app(adapter)
+        started = threading.Event()
+        release = threading.Event()
+        mock_agent = MagicMock()
+        mock_agent.api_mode = "chat_completions"
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        def blocked_run(**_kwargs):
+            started.set()
+            assert release.wait(timeout=10.0)
+            return {"final_response": "drained"}
+
+        mock_agent.run_conversation.side_effect = blocked_run
+        mock_agent.interrupt.side_effect = lambda _reason: release.set()
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", return_value=mock_agent):
+                resp = await cli.post("/v1/runs", json={"input": "block"})
+                run_id = (await resp.json())["run_id"]
+                assert await asyncio.to_thread(started.wait, 3.0)
+
+                adapter._active_run_tasks[run_id].cancel()
+                await asyncio.sleep(0.05)
+                assert run_id in adapter._active_run_agents
+                assert not adapter._run_worker_done[run_id].is_set()
+
+                await adapter.disconnect()
+
+        mock_agent.interrupt.assert_called_once_with("API server disconnecting")
+        assert adapter._run_worker_done[run_id].is_set()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_stubborn_worker_leaves_time_for_gateway_cleanup(self):
+        adapter = _make_adapter()
+        app = _create_runs_app(adapter)
+        started = threading.Event()
+        release = threading.Event()
+        mock_agent = MagicMock()
+        mock_agent.api_mode = "chat_completions"
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        def blocked_run(**_kwargs):
+            started.set()
+            assert release.wait(timeout=10.0)
+            return {"final_response": "eventually done"}
+
+        mock_agent.run_conversation.side_effect = blocked_run
+
+        try:
+            async with TestClient(TestServer(app)) as cli:
+                with patch.object(adapter, "_create_agent", return_value=mock_agent):
+                    resp = await cli.post("/v1/runs", json={"input": "block"})
+                    run_id = (await resp.json())["run_id"]
+                    assert await asyncio.to_thread(started.wait, 3.0)
+
+                    before = asyncio.get_running_loop().time()
+                    await asyncio.wait_for(adapter.disconnect(), timeout=4.0)
+                    elapsed = asyncio.get_running_loop().time() - before
+
+                    assert elapsed < 2.0
+                    assert adapter._run_executor is None
+                    assert adapter._accepting_agent_requests is False
+        finally:
+            release.set()
+
+        assert await asyncio.to_thread(adapter._run_worker_done[run_id].wait, 3.0)
+
+    @pytest.mark.asyncio
+    async def test_disconnect_cancels_queued_run_before_worker_starts(self):
+        from concurrent.futures import ThreadPoolExecutor
+
+        adapter = _make_adapter()
+        adapter._max_concurrent_runs = 2
+        adapter._run_executor = ThreadPoolExecutor(max_workers=1)
+        app = _create_runs_app(adapter)
+        first_started = threading.Event()
+        first_release = threading.Event()
+
+        first_agent = MagicMock()
+        first_agent.api_mode = "chat_completions"
+        first_agent.session_prompt_tokens = 0
+        first_agent.session_completion_tokens = 0
+        first_agent.session_total_tokens = 0
+
+        def first_run(**_kwargs):
+            first_started.set()
+            assert first_release.wait(timeout=10.0)
+            return {"final_response": "first drained"}
+
+        first_agent.run_conversation.side_effect = first_run
+        first_agent.interrupt.side_effect = lambda _reason: first_release.set()
+
+        queued_agent = MagicMock()
+        queued_agent.api_mode = "chat_completions"
+        queued_agent.session_prompt_tokens = 0
+        queued_agent.session_completion_tokens = 0
+        queued_agent.session_total_tokens = 0
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                adapter,
+                "_create_agent",
+                side_effect=[first_agent, queued_agent],
+            ):
+                first_resp = await cli.post("/v1/runs", json={"input": "first"})
+                first_run_id = (await first_resp.json())["run_id"]
+                assert await asyncio.to_thread(first_started.wait, 3.0)
+
+                queued_resp = await cli.post("/v1/runs", json={"input": "queued"})
+                queued_run_id = (await queued_resp.json())["run_id"]
+                for _ in range(50):
+                    if queued_run_id in adapter._run_worker_futures:
+                        break
+                    await asyncio.sleep(0.01)
+
+                await adapter.disconnect()
+
+        assert adapter._run_worker_done[first_run_id].is_set()
+        assert adapter._run_worker_done[queued_run_id].is_set()
+        queued_agent.run_conversation.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stop_cancels_queued_run_before_worker_starts(self):
+        from concurrent.futures import ThreadPoolExecutor
+
+        adapter = _make_adapter()
+        adapter._max_concurrent_runs = 2
+        adapter._run_executor = ThreadPoolExecutor(max_workers=1)
+        app = _create_runs_app(adapter)
+        first_started = threading.Event()
+        first_release = threading.Event()
+
+        first_agent = MagicMock()
+        first_agent.api_mode = "chat_completions"
+        first_agent.session_prompt_tokens = 0
+        first_agent.session_completion_tokens = 0
+        first_agent.session_total_tokens = 0
+
+        def first_run(**_kwargs):
+            first_started.set()
+            assert first_release.wait(timeout=10.0)
+            return {"final_response": "first done"}
+
+        first_agent.run_conversation.side_effect = first_run
+        first_agent.interrupt.side_effect = lambda _reason: first_release.set()
+
+        queued_agent = MagicMock()
+        queued_agent.api_mode = "chat_completions"
+        queued_agent.session_prompt_tokens = 0
+        queued_agent.session_completion_tokens = 0
+        queued_agent.session_total_tokens = 0
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                adapter,
+                "_create_agent",
+                side_effect=[first_agent, queued_agent],
+            ):
+                first_resp = await cli.post("/v1/runs", json={"input": "first"})
+                assert await asyncio.to_thread(first_started.wait, 3.0)
+
+                queued_resp = await cli.post("/v1/runs", json={"input": "queued"})
+                queued_run_id = (await queued_resp.json())["run_id"]
+                for _ in range(50):
+                    if queued_run_id in adapter._run_worker_futures:
+                        break
+                    await asyncio.sleep(0.01)
+
+                stop_resp = await cli.post(f"/v1/runs/{queued_run_id}/stop")
+                assert stop_resp.status == 200
+                assert adapter._run_worker_done[queued_run_id].is_set()
+                queued_agent.run_conversation.assert_not_called()
+
+                await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_late_approval_callback_cannot_overwrite_cancelled_status(self):
+        from tools.approval import get_current_session_key
+
+        adapter = _make_adapter()
+        app = _create_runs_app(adapter)
+        redaction_started = threading.Event()
+        release_redaction = threading.Event()
+        mock_agent = MagicMock()
+        mock_agent.api_mode = "chat_completions"
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        def run_conversation(**_kwargs):
+            session_key = get_current_session_key(default="")
+            with approval_mod._lock:
+                callback = approval_mod._gateway_notify_cbs[session_key]
+            callback({"command": "echo harmless"})
+            return {"final_response": "done"}
+
+        def blocked_redaction(command):
+            redaction_started.set()
+            assert release_redaction.wait(timeout=10.0)
+            return command
+
+        mock_agent.run_conversation.side_effect = run_conversation
+
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_create_agent", return_value=mock_agent),
+                patch("gateway.run._redact_approval_command", side_effect=blocked_redaction),
+            ):
+                resp = await cli.post("/v1/runs", json={"input": "approval race"})
+                run_id = (await resp.json())["run_id"]
+                assert await asyncio.to_thread(redaction_started.wait, 3.0)
+
+                stop_task = asyncio.create_task(cli.post(f"/v1/runs/{run_id}/stop"))
+                for _ in range(50):
+                    if adapter._run_statuses[run_id]["status"] in {"stopping", "cancelled"}:
+                        break
+                    await asyncio.sleep(0.01)
+                release_redaction.set()
+                stop_resp = await stop_task
+
+        assert stop_resp.status == 200
+        assert adapter._run_statuses[run_id]["status"] == "cancelled"
+
+    @pytest.mark.asyncio
     async def test_stop_nonexistent_run_returns_404(self, adapter):
         app = _create_runs_app(adapter)
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.post("/v1/runs/run_nonexistent/stop")
         assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_repeated_stop_cannot_reopen_cancelled_run(self, adapter):
+        app = _create_runs_app(adapter)
+        run_id = "run_already_cancelled"
+        adapter._run_statuses[run_id] = {"run_id": run_id, "status": "cancelled"}
+        adapter._active_run_agents[run_id] = MagicMock()
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(f"/v1/runs/{run_id}/stop")
+
+        assert resp.status == 409
+        assert adapter._run_statuses[run_id]["status"] == "cancelled"
+        adapter._active_run_agents[run_id].interrupt.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_stop_requires_auth(self, auth_adapter):
@@ -1110,6 +1756,42 @@ class TestStopRun:
 
 
 class TestRunSweep:
+    @pytest.mark.asyncio
+    async def test_status_sweep_keeps_terminal_fence_until_worker_finishes(self, adapter):
+        run_id = "run_terminal_worker_alive"
+        worker_done = threading.Event()
+        adapter._run_statuses[run_id] = {
+            "run_id": run_id,
+            "status": "cancelled",
+            "updated_at": 0.0,
+        }
+        adapter._run_split_runtime_active[run_id] = True
+        adapter._run_worker_done[run_id] = worker_done
+        adapter._run_streams[run_id] = asyncio.Queue()
+        adapter._run_streams_created[run_id] = 0.0
+        close_tool_channel(run_id)
+
+        sleep_calls = 0
+
+        async def one_sweep(_seconds):
+            nonlocal sleep_calls
+            sleep_calls += 1
+            if sleep_calls > 1:
+                raise asyncio.CancelledError
+
+        with patch("gateway.platforms.api_server.asyncio.sleep", one_sweep), patch(
+            "gateway.platforms.api_server.time.time",
+            return_value=adapter._RUN_STATUS_TTL + 1,
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await adapter._sweep_orphaned_runs()
+
+        assert adapter._run_statuses[run_id]["status"] == "cancelled"
+        assert adapter._run_split_runtime_active[run_id] is True
+        assert adapter._run_worker_done[run_id] is worker_done
+        assert run_id in adapter._run_streams
+        assert register_tool_notify(run_id, lambda request: None, "") is False
+
     @pytest.mark.asyncio
     async def test_sweep_does_not_destroy_active_run_after_stream_ttl(self, adapter):
         run_id = "run_active_past_ttl"

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -26,6 +26,7 @@ from gateway.platforms.api_server import (
 from tools import approval as approval_mod
 from gateway.tool_channel_state import (
     clear_tool_channel_state,
+    has_attached_client,
     register_tool_notify,
     submit_tool_request,
     unregister_tool_notify,
@@ -208,6 +209,29 @@ class TestStartRun:
                     headers={"Authorization": "Bearer sk-secret"},
                 )
                 assert resp.status == 202
+
+    @pytest.mark.asyncio
+    async def test_split_runtime_rejects_codex_app_server_before_conversation(self, split_adapter):
+        app = _create_runs_app(split_adapter)
+        mock_agent = MagicMock()
+        mock_agent.api_mode = "codex_app_server"
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(split_adapter, "_create_agent", return_value=mock_agent):
+                resp = await cli.post("/v1/runs", json={"input": "read local file"})
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+
+                status = {}
+                for _ in range(50):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "failed":
+                        break
+                    await asyncio.sleep(0.01)
+
+        assert status["status"] == "failed"
+        assert status["code"] == "split_runtime_incompatible_runtime"
+        mock_agent.run_conversation.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -454,20 +478,20 @@ class TestRunEvents:
         assert resp.status == 404
 
     @pytest.mark.asyncio
-    async def test_events_rejects_second_consumer(self, adapter):
-        app = _create_runs_app(adapter)
+    async def test_events_rejects_second_consumer_in_split_mode(self, split_adapter):
+        app = _create_runs_app(split_adapter)
         run_id = "run_events_conflict"
-        adapter._run_streams[run_id] = asyncio.Queue()
-        adapter._run_streams_created[run_id] = 1.0
-        adapter._run_event_consumers[run_id] = "events"
+        split_adapter._run_streams[run_id] = asyncio.Queue()
+        split_adapter._run_streams_created[run_id] = 1.0
+        split_adapter._run_event_consumers[run_id] = ("events", "lease-a")
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.get(f"/v1/runs/{run_id}/events")
             data = await resp.json()
         assert resp.status == 409
         assert data["error"]["code"] == "run_events_consumer_conflict"
-        adapter._run_streams.pop(run_id, None)
-        adapter._run_streams_created.pop(run_id, None)
-        adapter._run_event_consumers.pop(run_id, None)
+        split_adapter._run_streams.pop(run_id, None)
+        split_adapter._run_streams_created.pop(run_id, None)
+        split_adapter._run_event_consumers.pop(run_id, None)
 
     @pytest.mark.asyncio
     async def test_events_tool_executor_disabled_returns_409_and_does_not_leak_consumer(self, adapter):
@@ -487,10 +511,78 @@ class TestRunEvents:
         adapter._run_tool_sessions.pop(run_id, None)
 
     @pytest.mark.asyncio
+    async def test_terminal_run_allows_late_executor_stream_to_drain_events(self, split_adapter):
+        app = _create_runs_app(split_adapter)
+        run_id = "run_finished_before_executor_attach"
+        q = asyncio.Queue()
+        q.put_nowait({"event": "run.completed", "run_id": run_id})
+        q.put_nowait(None)
+        split_adapter._run_streams[run_id] = q
+        split_adapter._run_streams_created[run_id] = 1.0
+        split_adapter._run_statuses[run_id] = {"run_id": run_id, "status": "completed"}
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get(f"/v1/runs/{run_id}/events?tool_executor=1")
+            assert resp.status == 200
+            body = await resp.text()
+
+        assert "run.completed" in body
+
+    @pytest.mark.asyncio
+    async def test_executor_stream_discards_canceled_tool_request_events(self, split_adapter):
+        app = _create_runs_app(split_adapter)
+        run_id = "run_stale_request_event"
+        session_key = "stale-request-session"
+        q = asyncio.Queue()
+        q.put_nowait({
+            "event": "tool.request",
+            "run_id": run_id,
+            "request_id": "toolreq_canceled",
+            "tool_call_id": "call_canceled",
+        })
+        q.put_nowait({"event": "run.completed", "run_id": run_id})
+        q.put_nowait(None)
+        split_adapter._run_streams[run_id] = q
+        split_adapter._run_streams_created[run_id] = 1.0
+        split_adapter._run_tool_sessions[run_id] = session_key
+        split_adapter._run_statuses[run_id] = {"run_id": run_id, "status": "completed"}
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get(f"/v1/runs/{run_id}/events?tool_executor=1")
+            assert resp.status == 200
+            body = await resp.text()
+
+        assert "toolreq_canceled" not in body
+        assert "run.completed" in body
+
+    @pytest.mark.asyncio
+    async def test_executor_prepare_failure_releases_attachment_and_lease(self, split_adapter):
+        run_id = "run_prepare_failure"
+        session_key = "prepare-failure-session"
+        split_adapter._run_streams[run_id] = asyncio.Queue()
+        split_adapter._run_streams_created[run_id] = 1.0
+        split_adapter._run_tool_sessions[run_id] = session_key
+        split_adapter._run_statuses[run_id] = {"run_id": run_id, "status": "running"}
+        request = MagicMock()
+        request.match_info = {"run_id": run_id}
+        request.query = {"tool_executor": "1"}
+        request.headers = {"X-Hermes-Tool-Executor-Token": "prepare-client"}
+
+        async def fail_prepare(_response, _request):
+            raise ConnectionResetError("client disconnected during prepare")
+
+        with patch.object(web.StreamResponse, "prepare", fail_prepare):
+            await split_adapter._handle_run_events(request)
+
+        assert has_attached_client(session_key) is False
+        assert run_id not in split_adapter._run_event_consumers
+        assert run_id in split_adapter._run_streams
+
+    @pytest.mark.asyncio
     async def test_events_tool_executor_round_trips_routed_read_file(self, split_adapter):
         """A fake local executor can answer a routed read_file over /v1/runs SSE."""
+        split_adapter._cors_origins = ["https://executor.local"]
         app = _create_runs_app(split_adapter)
-        attach_ready = threading.Event()
 
         class FakeAgent:
             session_prompt_tokens = 0
@@ -500,15 +592,12 @@ class TestRunEvents:
             def run_conversation(self, user_message, conversation_history, task_id):
                 import model_tools
 
-                assert attach_ready.wait(timeout=3.0)
                 result = model_tools.handle_function_call(
                     "read_file",
                     {"path": "README.md"},
                     task_id=task_id,
                     tool_call_id="call_http_e2e",
                     session_id="session-http-e2e",
-                    skip_pre_tool_call_hook=True,
-                    skip_tool_request_middleware=True,
                 )
                 return {"final_response": f"local executor returned: {result}"}
 
@@ -520,10 +609,13 @@ class TestRunEvents:
 
                 events_resp = await cli.get(
                     f"/v1/runs/{run_id}/events?tool_executor=1",
-                    headers={"X-Hermes-Tool-Executor-Token": "executor-token"},
+                    headers={
+                        "X-Hermes-Tool-Executor-Token": "executor-token",
+                        "Origin": "https://executor.local",
+                    },
                 )
                 assert events_resp.status == 200
-                attach_ready.set()
+                assert events_resp.headers["Access-Control-Allow-Origin"] == "https://executor.local"
 
                 request_event = None
                 for _ in range(10):
@@ -535,13 +627,14 @@ class TestRunEvents:
                             request_event = event
                             break
                 assert request_event is not None
+                assert request_event["request_id"].startswith("toolreq_")
                 assert request_event["tool_call_id"] == "call_http_e2e"
                 assert request_event["tool_name"] == "read_file"
                 assert request_event["arguments"] == {"path": "README.md"}
 
                 result_resp = await cli.post(
                     f"/v1/runs/{run_id}/tool_result",
-                    json={"tool_call_id": "call_http_e2e", "result": "LOCAL README CONTENT"},
+                    json={"request_id": request_event["request_id"], "result": "LOCAL README CONTENT"},
                     headers={"X-Hermes-Tool-Executor-Token": "executor-token"},
                 )
                 assert result_resp.status == 200
@@ -550,6 +643,53 @@ class TestRunEvents:
                 assert "tool.result" in body
                 assert "run.completed" in body
                 assert "LOCAL README CONTENT" in body
+
+    @pytest.mark.asyncio
+    async def test_tool_timeout_restores_pollable_running_status(self, split_adapter):
+        split_adapter._split_runtime_request_timeout = 0.05
+        app = _create_runs_app(split_adapter)
+        tool_returned = threading.Event()
+        release_agent = threading.Event()
+
+        class FakeAgent:
+            api_mode = "chat_completions"
+            session_prompt_tokens = 0
+            session_completion_tokens = 0
+            session_total_tokens = 0
+
+            def run_conversation(self, user_message, conversation_history, task_id):
+                import model_tools
+
+                result = model_tools.handle_function_call(
+                    "read_file",
+                    {"path": "README.md"},
+                    task_id=task_id,
+                    tool_call_id="call_timeout_status",
+                )
+                tool_returned.set()
+                release_agent.wait(timeout=1.0)
+                return {"final_response": result}
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(split_adapter, "_create_agent", return_value=FakeAgent()):
+                start_resp = await cli.post("/v1/runs", json={"input": "timeout locally"})
+                run_id = (await start_resp.json())["run_id"]
+                events_resp = await cli.get(f"/v1/runs/{run_id}/events?tool_executor=1")
+                assert events_resp.status == 200
+
+                for _ in range(10):
+                    raw = await asyncio.wait_for(events_resp.content.readline(), timeout=1.0)
+                    if b'"event": "tool.request"' in raw:
+                        break
+                assert await asyncio.to_thread(tool_returned.wait, 1.0)
+
+                status_resp = await cli.get(f"/v1/runs/{run_id}")
+                status = await status_resp.json()
+                assert status["status"] == "running"
+                assert status["last_event"] == "tool.timeout"
+
+                release_agent.set()
+                events_resp.close()
 
     @pytest.mark.asyncio
     async def test_events_requires_auth(self, auth_adapter):
@@ -581,6 +721,23 @@ class TestRunToolResult:
         assert data["error"]["code"] == "split_runtime_disabled"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("body", [None, [], "result", 42])
+    async def test_tool_result_rejects_non_object_json(self, split_adapter, body):
+        app = _create_runs_app(split_adapter)
+        run_id = "run_tool_invalid_shape"
+        split_adapter._run_statuses[run_id] = {"run_id": run_id, "status": "running"}
+        split_adapter._run_tool_sessions[run_id] = "invalid-shape-session"
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/v1/runs/{run_id}/tool_result",
+                data=json.dumps(body),
+                headers={"Content-Type": "application/json"},
+            )
+            data = await resp.json()
+        assert resp.status == 400
+        assert data["error"]["code"] == "invalid_tool_result"
+
+    @pytest.mark.asyncio
     async def test_tool_result_resolves_pending_request_and_emits_event(self, split_adapter):
         app = _create_runs_app(split_adapter)
         run_id = "run_tool_result"
@@ -602,7 +759,7 @@ class TestRunToolResult:
             async with TestClient(TestServer(app)) as cli:
                 resp = await cli.post(
                     f"/v1/runs/{run_id}/tool_result",
-                    json={"tool_call_id": "call_1", "result": "local output"},
+                    json={"request_id": entry.request["request_id"], "result": "local output"},
                 )
                 assert resp.status == 200
                 data = await resp.json()
@@ -610,7 +767,7 @@ class TestRunToolResult:
             assert data == {
                 "object": "hermes.run.tool_result_response",
                 "run_id": run_id,
-                "tool_call_id": "call_1",
+                "request_id": entry.request["request_id"],
                 "status": "resolved",
             }
             assert entry.event.is_set()
@@ -618,7 +775,41 @@ class TestRunToolResult:
             assert split_adapter._run_statuses[run_id]["status"] == "running"
             event = await asyncio.wait_for(q.get(), timeout=1.0)
             assert event["event"] == "tool.result"
-            assert event["tool_call_id"] == "call_1"
+            assert event["request_id"] == entry.request["request_id"]
+        finally:
+            unregister_tool_notify(session_key)
+            clear_tool_channel_state(session_key)
+
+    @pytest.mark.asyncio
+    async def test_tool_result_keeps_waiting_status_until_parallel_requests_finish(self, split_adapter):
+        app = _create_runs_app(split_adapter)
+        run_id = "run_parallel_results"
+        session_key = "parallel-tool-session"
+        split_adapter._run_statuses[run_id] = {
+            "run_id": run_id,
+            "status": "waiting_for_tool_result",
+        }
+        split_adapter._run_tool_sessions[run_id] = session_key
+        try:
+            assert register_tool_notify(session_key, lambda request: None, "") is True
+            first = submit_tool_request(session_key, {"tool_call_id": "call_parallel_1"})
+            second = submit_tool_request(session_key, {"tool_call_id": "call_parallel_2"})
+            assert first is not None and second is not None
+
+            async with TestClient(TestServer(app)) as cli:
+                first_resp = await cli.post(
+                    f"/v1/runs/{run_id}/tool_result",
+                    json={"request_id": first.request["request_id"], "result": "one"},
+                )
+                assert first_resp.status == 200
+                assert split_adapter._run_statuses[run_id]["status"] == "waiting_for_tool_result"
+
+                second_resp = await cli.post(
+                    f"/v1/runs/{run_id}/tool_result",
+                    json={"request_id": second.request["request_id"], "result": "two"},
+                )
+                assert second_resp.status == 200
+                assert split_adapter._run_statuses[run_id]["status"] == "running"
         finally:
             unregister_tool_notify(session_key)
             clear_tool_channel_state(session_key)
@@ -637,7 +828,7 @@ class TestRunToolResult:
             async with TestClient(TestServer(app)) as cli:
                 resp = await cli.post(
                     f"/v1/runs/{run_id}/tool_result",
-                    json={"tool_call_id": "call_token", "result": "wrong"},
+                    json={"request_id": entry.request["request_id"], "result": "wrong"},
                     headers={"X-Hermes-Tool-Executor-Token": "client-b"},
                 )
                 data = await resp.json()
@@ -662,7 +853,7 @@ class TestRunToolResult:
             async with TestClient(TestServer(app)) as cli:
                 resp = await cli.post(
                     f"/v1/runs/{run_id}/tool_result",
-                    json={"tool_call_id": "call_token_ok", "result": "right"},
+                    json={"request_id": entry.request["request_id"], "result": "right"},
                     headers={"X-Hermes-Tool-Executor-Token": "client-a"},
                 )
                 data = await resp.json()
@@ -687,11 +878,11 @@ class TestRunToolResult:
             async with TestClient(TestServer(app)) as cli:
                 first = await cli.post(
                     f"/v1/runs/{run_id}/tool_result",
-                    json={"tool_call_id": "call_dup", "result": "one"},
+                    json={"request_id": entry.request["request_id"], "result": "one"},
                 )
                 second = await cli.post(
                     f"/v1/runs/{run_id}/tool_result",
-                    json={"tool_call_id": "call_dup", "result": "two"},
+                    json={"request_id": entry.request["request_id"], "result": "two"},
                 )
                 assert first.status == 200
                 assert second.status == 200
@@ -711,7 +902,7 @@ class TestRunToolResult:
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.post(
                 f"/v1/runs/{run_id}/tool_result",
-                json={"tool_call_id": "call_missing", "result": "late"},
+                json={"request_id": "toolreq_missing", "result": "late"},
             )
             data = await resp.json()
         assert resp.status == 409
@@ -765,6 +956,47 @@ class TestStopRun:
                 await asyncio.sleep(0.5)
                 assert run_id not in adapter._active_run_agents
                 assert run_id not in adapter._active_run_tasks
+
+    @pytest.mark.asyncio
+    async def test_stop_wakes_split_tool_waiting_for_executor_attachment(self, split_adapter):
+        app = _create_runs_app(split_adapter)
+        agent_started = threading.Event()
+        mock_agent = MagicMock()
+        mock_agent.api_mode = "chat_completions"
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        def run_conversation(user_message, conversation_history, task_id):
+            import model_tools
+
+            agent_started.set()
+            result = model_tools.handle_function_call(
+                "read_file",
+                {"path": "README.md"},
+                task_id=task_id,
+                tool_call_id="call_stop_before_attach",
+            )
+            return {"final_response": result}
+
+        mock_agent.run_conversation.side_effect = run_conversation
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(split_adapter, "_create_agent", return_value=mock_agent):
+                resp = await cli.post("/v1/runs", json={"input": "read before attach"})
+                run_id = (await resp.json())["run_id"]
+                assert agent_started.wait(timeout=1.0)
+
+                started = asyncio.get_running_loop().time()
+                stop_resp = await cli.post(f"/v1/runs/{run_id}/stop")
+                assert stop_resp.status == 200
+                for _ in range(50):
+                    if run_id not in split_adapter._active_run_tasks:
+                        break
+                    await asyncio.sleep(0.01)
+
+                assert run_id not in split_adapter._active_run_tasks
+                assert asyncio.get_running_loop().time() - started < 1.0
 
     @pytest.mark.asyncio
     async def test_stop_nonexistent_run_returns_404(self, adapter):
@@ -875,3 +1107,38 @@ class TestStopRun:
                 body = await events_resp.text()
                 # Stream should have received run.failed and closed
                 assert "run.failed" in body or "stream closed" in body
+
+
+class TestRunSweep:
+    @pytest.mark.asyncio
+    async def test_sweep_does_not_destroy_active_run_after_stream_ttl(self, adapter):
+        run_id = "run_active_past_ttl"
+        task = MagicMock()
+        task.done.return_value = False
+        agent = MagicMock()
+        adapter._run_streams[run_id] = asyncio.Queue()
+        adapter._run_streams_created[run_id] = 0.0
+        adapter._active_run_tasks[run_id] = task
+        adapter._active_run_agents[run_id] = agent
+        adapter._run_approval_sessions[run_id] = run_id
+        adapter._run_tool_sessions[run_id] = run_id
+
+        sleep_calls = 0
+
+        async def one_sweep(_seconds):
+            nonlocal sleep_calls
+            sleep_calls += 1
+            if sleep_calls > 1:
+                raise asyncio.CancelledError
+
+        with patch("gateway.platforms.api_server.asyncio.sleep", one_sweep), patch(
+            "gateway.platforms.api_server.time.time",
+            return_value=adapter._RUN_STREAM_TTL + 1,
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await adapter._sweep_orphaned_runs()
+
+        assert adapter._run_streams[run_id] is not None
+        assert adapter._active_run_tasks[run_id] is task
+        assert adapter._active_run_agents[run_id] is agent
+        assert adapter._run_tool_sessions[run_id] == run_id

--- a/tests/gateway/test_platform_reconnect_fd_leak.py
+++ b/tests/gateway/test_platform_reconnect_fd_leak.py
@@ -21,6 +21,7 @@ this file would have caught the regression and now pins the fix.
 from __future__ import annotations
 
 import asyncio
+import threading
 import time
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -297,6 +298,17 @@ class TestAPIServerDisconnectClosesResponseStore:
         adapter._runner = None
         adapter._app = None
         adapter._response_store = store
+        adapter._agent_admission_generation = 0
+        adapter._active_request_agents = {}
+        adapter._active_request_agents_lock = threading.Lock()
+        adapter._active_run_tasks = {}
+        adapter._run_worker_futures = {}
+        adapter._active_run_agents = {}
+        adapter._run_approval_sessions = {}
+        adapter._run_worker_done = {}
+        adapter._inflight_agent_runs = 0
+        adapter._run_executor = None
+        adapter._request_executor = None
         adapter.platform = Platform.API_SERVER
         return adapter
 

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -67,11 +67,45 @@ async def test_capabilities_advertises_session_control_surface(adapter):
     assert features["admin_config_rw"] is False
     assert features["memory_write_api"] is False
     assert features["skills_api"] is True
+    assert features["run_tool_result"] is False
+    assert features["tool_request_events"] is False
+    assert data["runtime"]["split_runtime"] is False
+    assert data["runtime"]["tool_execution"] == "server"
+    assert data["runtime"]["runs_tool_execution"] == "server"
+    assert data["runtime"]["split_runtime_toolsets"] == []
     assert features["realtime_voice"] is False
     assert data["endpoints"]["sessions"] == {"method": "GET", "path": "/api/sessions"}
     assert data["endpoints"]["session_chat_stream"] == {
         "method": "POST",
         "path": "/api/sessions/{session_id}/chat/stream",
+    }
+
+
+@pytest.mark.asyncio
+async def test_capabilities_advertises_split_runtime_when_enabled(session_db):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={
+        "split_runtime": {
+            "enabled": True,
+            "routed_toolsets": ["file"],
+            "request_timeout_seconds": 1,
+        }
+    }))
+    adapter._session_db = session_db
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.get("/v1/capabilities")
+        assert resp.status == 200
+        data = await resp.json()
+
+    assert data["runtime"]["tool_execution"] == "server"
+    assert data["runtime"]["runs_tool_execution"] == "split"
+    assert data["runtime"]["split_runtime"] is True
+    assert data["runtime"]["split_runtime_toolsets"] == ["file"]
+    assert data["features"]["run_tool_result"] is True
+    assert data["features"]["tool_request_events"] is True
+    assert data["endpoints"]["run_tool_result"] == {
+        "method": "POST",
+        "path": "/v1/runs/{run_id}/tool_result",
     }
 
 

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -73,6 +73,7 @@ async def test_capabilities_advertises_session_control_surface(adapter):
     assert data["runtime"]["tool_execution"] == "server"
     assert data["runtime"]["runs_tool_execution"] == "server"
     assert data["runtime"]["split_runtime_toolsets"] == []
+    assert data["runtime"]["split_runtime_tools"] == []
     assert features["realtime_voice"] is False
     assert data["endpoints"]["sessions"] == {"method": "GET", "path": "/api/sessions"}
     assert data["endpoints"]["session_chat_stream"] == {
@@ -101,12 +102,61 @@ async def test_capabilities_advertises_split_runtime_when_enabled(session_db):
     assert data["runtime"]["runs_tool_execution"] == "split"
     assert data["runtime"]["split_runtime"] is True
     assert data["runtime"]["split_runtime_toolsets"] == ["file"]
+    assert data["runtime"]["split_runtime_tools"] == ["read_file", "search_files"]
+    assert data["runtime"]["split_runtime_protocol"] == {
+        "version": 1,
+        "correlation_key": "request_id",
+        "single_events_consumer": True,
+        "delegation_supported": False,
+        "unsupported_api_modes": ["codex_app_server"],
+    }
     assert data["features"]["run_tool_result"] is True
     assert data["features"]["tool_request_events"] is True
     assert data["endpoints"]["run_tool_result"] == {
         "method": "POST",
         "path": "/v1/runs/{run_id}/tool_result",
     }
+
+
+@pytest.mark.asyncio
+async def test_capabilities_do_not_advertise_unimplemented_split_toolsets(session_db):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={
+        "split_runtime": {
+            "enabled": True,
+            "routed_toolsets": ["terminal", "unknown"],
+        }
+    }))
+    adapter._session_db = session_db
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.get("/v1/capabilities")
+        data = await resp.json()
+
+    assert data["runtime"]["split_runtime"] is False
+    assert data["runtime"]["runs_tool_execution"] == "server"
+    assert data["runtime"]["split_runtime_toolsets"] == []
+    assert data["runtime"]["split_runtime_tools"] == []
+
+
+@pytest.mark.asyncio
+async def test_capabilities_require_file_toolset_on_api_platform(session_db, monkeypatch):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={
+        "split_runtime": {"enabled": True, "routed_toolsets": ["file"]}
+    }))
+    adapter._session_db = session_db
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_platform_tools",
+        lambda config, platform, **kwargs: {"web"},
+    )
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.get("/v1/capabilities")
+        data = await resp.json()
+
+    assert data["runtime"]["split_runtime"] is False
+    assert data["runtime"]["runs_tool_execution"] == "server"
+    assert data["runtime"]["split_runtime_tools"] == []
+    assert data["runtime"]["split_runtime_protocol"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_split_runtime_e2e.py
+++ b/tests/gateway/test_split_runtime_e2e.py
@@ -1,0 +1,214 @@
+"""Production-path integration tests for API-server split runtime."""
+
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp import ClientSession
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+
+
+def _write_config(text: str) -> None:
+    hermes_home = Path(os.environ["HERMES_HOME"])
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "config.yaml").write_text(text, encoding="utf-8")
+
+
+def _point_gateway_at_test_home(monkeypatch) -> None:
+    import gateway.run
+
+    monkeypatch.setattr(gateway.run, "_hermes_home", Path(os.environ["HERMES_HOME"]))
+
+
+def _adapter() -> APIServerAdapter:
+    return APIServerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "host": "127.0.0.1",
+                "port": 0,
+                "key": "split-e2e-server-key",
+            },
+        )
+    )
+
+
+def _chat_response(*, content=None, tool_calls=None, finish_reason="stop"):
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content=content,
+                    tool_calls=tool_calls or [],
+                    reasoning=None,
+                    reasoning_content=None,
+                    refusal=None,
+                ),
+                finish_reason=finish_reason,
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        model="test-model",
+    )
+
+
+def _server_port(adapter: APIServerAdapter) -> int:
+    sockets = adapter._site._server.sockets
+    return int(sockets[0].getsockname()[1])
+
+
+@pytest.mark.asyncio
+async def test_configured_production_routes_drive_real_agent_split_runtime(monkeypatch):
+    _write_config(
+        """
+model:
+  provider: openrouter
+  default: test-model
+platform_toolsets:
+  api_server:
+    - file
+gateway:
+  api_server:
+    split_runtime:
+      enabled: true
+      routed_toolsets:
+        - file
+      request_timeout_seconds: 10
+""".strip()
+        + "\n"
+    )
+    _point_gateway_at_test_home(monkeypatch)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
+
+    server_workspace = Path(os.environ["HERMES_HOME"]) / "server-workspace" / "src"
+    server_workspace.mkdir(parents=True)
+    monkeypatch.setenv("TERMINAL_CWD", str(server_workspace.parent))
+    (server_workspace / "AGENTS.md").write_text(
+        "SERVER_ONLY_SUBDIRECTORY_INSTRUCTIONS",
+        encoding="utf-8",
+    )
+
+    tool_call = SimpleNamespace(
+        id="call_e2e_read",
+        type="function",
+        function=SimpleNamespace(
+            name="read_file",
+            arguments=json.dumps({"path": str(server_workspace / "x.py")}),
+        ),
+        extra_content=None,
+        model_extra={},
+    )
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.side_effect = [
+        _chat_response(content=None, tool_calls=[tool_call], finish_reason="tool_calls"),
+        _chat_response(content="model completed after local read"),
+    ]
+
+    adapter = _adapter()
+    try:
+        with patch("run_agent.OpenAI", return_value=fake_client):
+            assert await adapter.connect() is True
+            assert adapter._split_runtime_enabled is True
+            assert adapter._split_runtime_is_effective() is True
+            base_url = f"http://127.0.0.1:{_server_port(adapter)}"
+            headers = {"Authorization": "Bearer split-e2e-server-key"}
+
+            async with ClientSession(headers=headers) as client:
+                start = await client.post(f"{base_url}/v1/runs", json={"input": "read it"})
+                assert start.status == 202
+                run_id = (await start.json())["run_id"]
+
+                events = await client.get(
+                    f"{base_url}/v1/runs/{run_id}/events?tool_executor=1",
+                    headers={"X-Hermes-Tool-Executor-Token": "e2e-executor"},
+                )
+                assert events.status == 200
+
+                request_event = None
+                for _ in range(20):
+                    raw = await events.content.readline()
+                    line = raw.decode().strip()
+                    if line.startswith("data: "):
+                        event = json.loads(line[6:])
+                        if event.get("event") == "tool.request":
+                            request_event = event
+                            break
+                assert request_event is not None
+                assert request_event["tool_name"] == "read_file"
+
+                result = await client.post(
+                    f"{base_url}/v1/runs/{run_id}/tool_result",
+                    headers={"X-Hermes-Tool-Executor-Token": "e2e-executor"},
+                    json={
+                        "request_id": request_event["request_id"],
+                        "result": "LOCAL E2E CONTENT" + ("x" * 500_000),
+                    },
+                )
+                assert result.status == 200
+
+                stream_body = await events.text()
+                assert "run.completed" in stream_body
+                assert "model completed after local read" in stream_body
+
+            assert fake_client.chat.completions.create.call_count == 2
+            second_messages = fake_client.chat.completions.create.call_args_list[1].kwargs["messages"]
+            tool_message = next(
+                message for message in second_messages if message.get("role") == "tool"
+            )
+            assert "LOCAL E2E CONTENT" in tool_message["content"]
+            assert "Full output could not be saved to sandbox" in tool_message["content"]
+            assert "Full output saved to:" not in tool_message["content"]
+            assert "SERVER_ONLY_SUBDIRECTORY_INSTRUCTIONS" not in tool_message["content"]
+    finally:
+        await adapter.disconnect()
+
+
+def test_split_runtime_is_default_off_from_real_config(monkeypatch):
+    _write_config(
+        """
+model:
+  provider: openrouter
+  default: test-model
+platform_toolsets:
+  api_server:
+    - file
+""".strip()
+        + "\n"
+    )
+
+    _point_gateway_at_test_home(monkeypatch)
+    adapter = _adapter()
+
+    assert adapter._split_runtime_enabled is False
+    assert adapter._split_runtime_is_effective() is False
+
+
+def test_enabled_split_runtime_is_ineffective_without_file_toolset(monkeypatch):
+    _write_config(
+        """
+model:
+  provider: openrouter
+  default: test-model
+platform_toolsets:
+  api_server:
+    - clarify
+gateway:
+  api_server:
+    split_runtime:
+      enabled: true
+      routed_toolsets:
+        - file
+""".strip()
+        + "\n"
+    )
+
+    _point_gateway_at_test_home(monkeypatch)
+    adapter = _adapter()
+
+    assert adapter._split_runtime_enabled is True
+    assert adapter._split_runtime_is_effective() is False

--- a/tests/gateway/test_tool_channel_state.py
+++ b/tests/gateway/test_tool_channel_state.py
@@ -1,0 +1,120 @@
+"""Concurrency contracts for the split-runtime tool broker."""
+
+import threading
+import time
+
+from gateway.tool_channel_state import (
+    cancel_tool_request,
+    clear_tool_channel_state,
+    close_tool_channel,
+    register_tool_notify,
+    resolve_tool_result,
+    submit_tool_request,
+    tool_result_authorized,
+    unregister_tool_notify,
+    wait_for_attached_client,
+)
+
+
+def teardown_function():
+    clear_tool_channel_state()
+
+
+def test_transport_request_ids_are_unique_when_model_call_ids_repeat():
+    session_key = "run-repeated-call-id"
+    assert register_tool_notify(session_key, lambda request: None, "") is True
+
+    first = submit_tool_request(session_key, {"tool_call_id": "call_same"})
+    assert first is not None
+    first_request_id = first.request["request_id"]
+    assert resolve_tool_result(session_key, first_request_id, "first") == "resolved"
+
+    second = submit_tool_request(session_key, {"tool_call_id": "call_same"})
+    assert second is not None
+    second_request_id = second.request["request_id"]
+
+    assert second_request_id != first_request_id
+    assert resolve_tool_result(session_key, second_request_id, "second") == "resolved"
+    assert first.result == "first"
+    assert second.result == "second"
+
+
+def test_late_result_cannot_resolve_retried_model_call_id():
+    session_key = "run-late-result"
+    assert register_tool_notify(session_key, lambda request: None, "") is True
+
+    expired = submit_tool_request(session_key, {"tool_call_id": "call_retry"})
+    assert expired is not None
+    expired_request_id = expired.request["request_id"]
+    assert cancel_tool_request(session_key, expired_request_id) is True
+
+    retry = submit_tool_request(session_key, {"tool_call_id": "call_retry"})
+    assert retry is not None
+    retry_request_id = retry.request["request_id"]
+
+    assert resolve_tool_result(session_key, expired_request_id, "late") == "unknown"
+    assert retry.result is None
+    assert resolve_tool_result(session_key, retry_request_id, "fresh") == "resolved"
+    assert retry.result == "fresh"
+
+
+def test_wait_for_attached_client_observes_late_registration():
+    session_key = "run-attach-wait"
+
+    def attach_later():
+        time.sleep(0.02)
+        register_tool_notify(session_key, lambda request: None, "")
+
+    thread = threading.Thread(target=attach_later)
+    thread.start()
+    try:
+        assert wait_for_attached_client(session_key, timeout=1.0) is True
+    finally:
+        thread.join(timeout=1.0)
+        unregister_tool_notify(session_key)
+
+
+def test_wait_for_attached_client_times_out_without_executor():
+    started = time.monotonic()
+    assert wait_for_attached_client("run-never-attached", timeout=0.02) is False
+    assert time.monotonic() - started < 0.5
+
+
+def test_terminal_close_wakes_pre_attachment_waiter():
+    session_key = "run-close-before-attach"
+    observed = {}
+
+    def wait_for_executor():
+        observed["attached"] = wait_for_attached_client(session_key, timeout=5.0)
+
+    thread = threading.Thread(target=wait_for_executor)
+    thread.start()
+    time.sleep(0.02)
+    close_tool_channel(session_key)
+    thread.join(timeout=0.5)
+
+    assert not thread.is_alive()
+    assert observed == {"attached": False}
+    assert register_tool_notify(session_key, lambda request: None, "") is False
+
+
+def test_completed_request_id_remains_idempotent_across_executor_reconnect():
+    session_key = "run-reconnect-idempotency"
+    assert register_tool_notify(session_key, lambda request: None, "token-a") is True
+    entry = submit_tool_request(session_key, {"tool_call_id": "call_once"})
+    assert entry is not None
+    request_id = entry.request["request_id"]
+    assert resolve_tool_result(session_key, request_id, "done") == "resolved"
+
+    assert unregister_tool_notify(session_key, client_token="token-a") is True
+    assert register_tool_notify(session_key, lambda request: None, "token-b") is True
+    assert resolve_tool_result(session_key, request_id, "retry") == "duplicate"
+
+
+def test_unicode_executor_tokens_compare_without_type_error():
+    session_key = "run-unicode-token"
+    token = "executor-🔐"
+    assert register_tool_notify(session_key, lambda request: None, token) is True
+    assert tool_result_authorized(session_key, token) is True
+    assert tool_result_authorized(session_key, "executor-other") is False
+    assert unregister_tool_notify(session_key, client_token=token) is True

--- a/tests/gateway/test_tool_channel_state.py
+++ b/tests/gateway/test_tool_channel_state.py
@@ -111,6 +111,19 @@ def test_completed_request_id_remains_idempotent_across_executor_reconnect():
     assert resolve_tool_result(session_key, request_id, "retry") == "duplicate"
 
 
+def test_completed_request_id_remains_idempotent_after_terminal_close():
+    session_key = "run-terminal-idempotency"
+    assert register_tool_notify(session_key, lambda request: None, "token-a") is True
+    entry = submit_tool_request(session_key, {"tool_call_id": "call_once"})
+    assert entry is not None
+    request_id = entry.request["request_id"]
+    assert resolve_tool_result(session_key, request_id, "done") == "resolved"
+
+    close_tool_channel(session_key)
+
+    assert resolve_tool_result(session_key, request_id, "retry") == "duplicate"
+
+
 def test_unicode_executor_tokens_compare_without_type_error():
     session_key = "run-unicode-token"
     token = "executor-🔐"

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -510,6 +510,35 @@ def test_dispatch_never_forwards_model_toolsets():
     assert "toolsets" not in captured
 
 
+def test_dispatch_fails_closed_while_split_runtime_is_active():
+    """Child agents must not silently execute routed reads on the server."""
+    import json
+    from unittest.mock import patch
+
+    import run_agent
+    from gateway.tool_channel_state import reset_current_split_runtime, set_current_split_runtime
+
+    class _FakeAgent:
+        _delegate_depth = 0
+
+    token = set_current_split_runtime({
+        "enabled": True,
+        "routed_toolsets": ["file"],
+        "request_timeout_seconds": 1,
+    })
+    try:
+        with patch("tools.delegate_tool.delegate_task") as delegate:
+            result = run_agent.AIAgent._dispatch_delegate_task(
+                _FakeAgent(),
+                {"goal": "read local files"},
+            )
+    finally:
+        reset_current_split_runtime(token)
+
+    assert json.loads(result)["code"] == "split_runtime_delegation_unsupported"
+    delegate.assert_not_called()
+
+
 def test_delegate_task_background_detaches_child_from_parent(monkeypatch):
     """A background child must NOT remain in parent._active_children —
     otherwise parent-turn interrupts / cache evicts / session close would

--- a/tests/tools/test_execution_target.py
+++ b/tests/tools/test_execution_target.py
@@ -1,0 +1,37 @@
+from tools.execution_target import ExecutionTarget, infer_execution_target, normalize_routed_toolsets
+from tools.registry import ToolEntry
+
+
+def _entry(name: str, toolset: str) -> ToolEntry:
+    return ToolEntry(
+        name=name,
+        toolset=toolset,
+        schema={},
+        handler=lambda args: "{}",
+        check_fn=None,
+        requires_env=[],
+        is_async=False,
+        description="",
+        emoji="",
+    )
+
+
+def test_split_runtime_disabled_routes_everything_to_server():
+    assert infer_execution_target(_entry("read_file", "file"), enabled=False) is ExecutionTarget.SERVER
+
+
+def test_read_only_file_tools_route_local_when_enabled():
+    routed = normalize_routed_toolsets(["file"])
+    assert infer_execution_target(_entry("read_file", "file"), enabled=True, routed_toolsets=routed) is ExecutionTarget.LOCAL
+    assert infer_execution_target(_entry("search_files", "file"), enabled=True, routed_toolsets=routed) is ExecutionTarget.LOCAL
+
+
+def test_mutating_file_tools_stay_server_even_when_file_toolset_routed():
+    routed = normalize_routed_toolsets("file")
+    assert infer_execution_target(_entry("write_file", "file"), enabled=True, routed_toolsets=routed) is ExecutionTarget.SERVER
+    assert infer_execution_target(_entry("patch", "file"), enabled=True, routed_toolsets=routed) is ExecutionTarget.SERVER
+
+
+def test_non_file_toolsets_stay_server():
+    routed = normalize_routed_toolsets(["terminal", "file"])
+    assert infer_execution_target(_entry("terminal", "terminal"), enabled=True, routed_toolsets=routed) is ExecutionTarget.SERVER

--- a/tests/tools/test_execution_target.py
+++ b/tests/tools/test_execution_target.py
@@ -34,4 +34,9 @@ def test_mutating_file_tools_stay_server_even_when_file_toolset_routed():
 
 def test_non_file_toolsets_stay_server():
     routed = normalize_routed_toolsets(["terminal", "file"])
+    assert routed == frozenset({"file"})
     assert infer_execution_target(_entry("terminal", "terminal"), enabled=True, routed_toolsets=routed) is ExecutionTarget.SERVER
+
+
+def test_unknown_toolsets_do_not_advertise_effective_routing():
+    assert normalize_routed_toolsets(["terminal", "unknown"]) == frozenset()

--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -519,6 +519,24 @@ class TestEnforceTurnBudget:
         # Should be truncated (no sandbox available)
         assert "Truncated" in msgs[0]["content"] or PERSISTED_OUTPUT_TAG in msgs[0]["content"]
 
+    def test_inline_only_result_never_writes_to_server_environment(self):
+        env = MagicMock()
+        env.execute.return_value = {"output": "", "returncode": 0}
+        msgs = [
+            {"role": "tool", "tool_call_id": "local-call", "content": "x" * 250_000},
+        ]
+
+        enforce_turn_budget(
+            msgs,
+            env=env,
+            config=BudgetConfig(turn_budget=200_000),
+            inline_only_tool_call_ids={"local-call"},
+        )
+
+        env.execute.assert_not_called()
+        assert "Truncated" in msgs[0]["content"]
+        assert PERSISTED_OUTPUT_TAG not in msgs[0]["content"]
+
     def test_returns_same_list(self):
         msgs = [{"role": "tool", "tool_call_id": "t1", "content": "ok"}]
         result = enforce_turn_budget(msgs, env=None, config=BudgetConfig(turn_budget=200_000))

--- a/tests/tools/test_web_tools_truncate.py
+++ b/tests/tools/test_web_tools_truncate.py
@@ -78,6 +78,30 @@ class TestTruncation:
         assert "UNIQUE_MIDDLE_MARKER" in full
         assert "row 2500" in full  # the omitted-middle row is in the stored file
 
+    def test_split_runtime_does_not_emit_server_cache_path(self):
+        from gateway.tool_channel_state import (
+            reset_current_split_runtime,
+            set_current_split_runtime,
+        )
+
+        body = "\n".join(f"line {i} " + "x" * 50 for i in range(2000))
+        token = set_current_split_runtime({"enabled": True, "routed_toolsets": ["file"]})
+        try:
+            with patch("tools.web_tools._store_full_text") as store:
+                out, truncated = wt._truncate_with_footer(
+                    body,
+                    "https://example.com/page",
+                    4000,
+                )
+        finally:
+            reset_current_split_runtime(token)
+
+        assert truncated is True
+        store.assert_not_called()
+        assert "Full text saved to:" not in out
+        assert "read_file path=" not in out
+        assert "Full text could not be stored" in out
+
 
 class TestCharLimitConfig:
     def test_default_when_unset(self):

--- a/tools/execution_target.py
+++ b/tools/execution_target.py
@@ -1,0 +1,63 @@
+"""Tool execution target inference for split-runtime deployments.
+
+This module is deliberately transport-free. It classifies registered tools by
+metadata that already exists in ``tools.registry.ToolEntry`` so API/gateway
+transports can decide where to execute a call without baking routing policy into
+the registry itself.
+"""
+
+from __future__ import annotations
+
+import enum
+from typing import Any, Iterable
+
+
+class ExecutionTarget(enum.Enum):
+    """Where a tool call should execute."""
+
+    SERVER = "server"
+    LOCAL = "local"
+
+
+# PR 1 routes only read-only file tools. The toolset gate keeps the policy
+# broad enough to configure by capability group; the tool-name gate prevents
+# mutating file tools from becoming routable just because they share a toolset.
+LOCAL_ROUTABLE_TOOLSETS: frozenset[str] = frozenset({"file"})
+LOCAL_ROUTABLE_TOOLS: frozenset[str] = frozenset({"read_file", "search_files"})
+
+
+def normalize_routed_toolsets(value: Any) -> frozenset[str]:
+    """Normalize config/env routed-toolset values to a frozenset of names."""
+
+    if value is None:
+        return LOCAL_ROUTABLE_TOOLSETS
+    if isinstance(value, str):
+        items: Iterable[Any] = value.split(",")
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        items = value
+    else:
+        items = [value]
+    return frozenset(str(item).strip() for item in items if str(item).strip())
+
+
+def infer_execution_target(
+    entry: Any,
+    *,
+    enabled: bool = False,
+    routed_toolsets: frozenset[str] | None = None,
+) -> ExecutionTarget:
+    """Return the execution target for a registry ``ToolEntry``.
+
+    Disabled split runtime, missing registry metadata, non-routed toolsets, and
+    mutating file tools all resolve to ``SERVER``. This keeps the default path
+    and every non-PR1 tool unchanged.
+    """
+
+    if not enabled or entry is None:
+        return ExecutionTarget.SERVER
+    routed = routed_toolsets if routed_toolsets is not None else LOCAL_ROUTABLE_TOOLSETS
+    toolset = getattr(entry, "toolset", "") or ""
+    name = getattr(entry, "name", "") or ""
+    if toolset in routed and toolset in LOCAL_ROUTABLE_TOOLSETS and name in LOCAL_ROUTABLE_TOOLS:
+        return ExecutionTarget.LOCAL
+    return ExecutionTarget.SERVER

--- a/tools/execution_target.py
+++ b/tools/execution_target.py
@@ -19,7 +19,7 @@ class ExecutionTarget(enum.Enum):
     LOCAL = "local"
 
 
-# PR 1 routes only read-only file tools. The toolset gate keeps the policy
+# The first protocol version routes only read-only file tools. The toolset gate keeps the policy
 # broad enough to configure by capability group; the tool-name gate prevents
 # mutating file tools from becoming routable just because they share a toolset.
 LOCAL_ROUTABLE_TOOLSETS: frozenset[str] = frozenset({"file"})
@@ -27,7 +27,7 @@ LOCAL_ROUTABLE_TOOLS: frozenset[str] = frozenset({"read_file", "search_files"})
 
 
 def normalize_routed_toolsets(value: Any) -> frozenset[str]:
-    """Normalize config/env routed-toolset values to a frozenset of names."""
+    """Normalize configured toolsets and clamp them to implemented targets."""
 
     if value is None:
         return LOCAL_ROUTABLE_TOOLSETS
@@ -37,7 +37,8 @@ def normalize_routed_toolsets(value: Any) -> frozenset[str]:
         items = value
     else:
         items = [value]
-    return frozenset(str(item).strip() for item in items if str(item).strip())
+    normalized = frozenset(str(item).strip() for item in items if str(item).strip())
+    return normalized & LOCAL_ROUTABLE_TOOLSETS
 
 
 def infer_execution_target(
@@ -50,7 +51,7 @@ def infer_execution_target(
 
     Disabled split runtime, missing registry metadata, non-routed toolsets, and
     mutating file tools all resolve to ``SERVER``. This keeps the default path
-    and every non-PR1 tool unchanged.
+    and every non-routed tool unchanged.
     """
 
     if not enabled or entry is None:

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -28,6 +28,7 @@ import os
 import re
 import shlex
 import uuid
+from typing import Optional
 
 from tools.budget_config import (
     DEFAULT_PREVIEW_SIZE_CHARS,
@@ -204,6 +205,7 @@ def enforce_turn_budget(
     tool_messages: list[dict],
     env=None,
     config: BudgetConfig = DEFAULT_BUDGET,
+    inline_only_tool_call_ids: Optional[set[str]] = None,
 ) -> list[dict]:
     """Layer 3: enforce aggregate budget across all tool results in a turn.
 
@@ -213,6 +215,7 @@ def enforce_turn_budget(
 
     Mutates the list in-place and returns it.
     """
+    inline_only_ids = inline_only_tool_call_ids or set()
     candidates = []
     total_size = 0
     for i, msg in enumerate(tool_messages):
@@ -234,11 +237,12 @@ def enforce_turn_budget(
         content = msg["content"]
         tool_use_id = msg.get("tool_call_id", f"budget_{idx}")
 
+        message_env = None if tool_use_id in inline_only_ids else env
         replacement = maybe_persist_tool_result(
             content=content,
             tool_name=_BUDGET_TOOL_NAME,
             tool_use_id=tool_use_id,
-            env=env,
+            env=message_env,
             config=config,
             threshold=0,
         )

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -544,7 +544,15 @@ def _truncate_with_footer(
         tail = tail[nl + 1:]
 
     total = len(content)
-    stored_path = _store_full_text(url, content)
+    try:
+        from gateway.tool_channel_state import get_current_split_runtime
+
+        split_runtime_active = bool(get_current_split_runtime())
+    except Exception:
+        split_runtime_active = True
+    # read_file is client-routed during split-runtime turns, so a server-side
+    # cache path would be unusable and could expose the wrong workspace.
+    stored_path = None if split_runtime_active else _store_full_text(url, content)
     shown = len(head) + len(tail)
 
     footer_lines = [

--- a/website/docs/developer-guide/programmatic-integration.md
+++ b/website/docs/developer-guide/programmatic-integration.md
@@ -101,7 +101,9 @@ GET  /health, /health/detailed
 
 Setup, headers (`X-Hermes-Session-Id`, `X-Hermes-Session-Key`), and frontend wiring: [API Server](../user-guide/features/api-server).
 
-Split-runtime notes for `/v1/runs`: when `gateway.api_server.split_runtime.enabled` is true, an executor may attach with `GET /v1/runs/{id}/events?tool_executor=1` and answer `tool.request` events through `/tool_result`. PR1 supports one `/events` consumer per run and only routes read-only file tools. Optional executor identity uses the `X-Hermes-Tool-Executor-Token` header on both attach and result requests.
+Split-runtime notes for `/v1/runs`: when `gateway.api_server.split_runtime.enabled` is true, an executor may attach with `GET /v1/runs/{id}/events?tool_executor=1` and answer `tool.request` events through `/tool_result`. The initial protocol supports one `/events` consumer per split run and only routes `read_file` and `search_files`. Each request carries a server-generated `request_id`; echo that value in `POST /tool_result` as `{"request_id": "toolreq_...", "result": ...}`. `tool_call_id` is model metadata and is not the transport correlation key. Optional executor identity uses the `X-Hermes-Tool-Executor-Token` header on both attach and result requests.
+
+The executor may attach after `POST /v1/runs` returns; the first routed tool waits up to `request_timeout_seconds` for attachment. A disconnected executor may reattach while the run remains active, but any request pending at disconnect fails closed. Delegation and the `codex_app_server` runtime are rejected in this protocol version because they cannot yet preserve local-tool routing.
 
 ---
 

--- a/website/docs/developer-guide/programmatic-integration.md
+++ b/website/docs/developer-guide/programmatic-integration.md
@@ -92,6 +92,7 @@ POST /v1/runs                    Start a run, returns run_id (202)
 GET  /v1/runs/{id}               Run status
 GET  /v1/runs/{id}/events        SSE stream of lifecycle events
 POST /v1/runs/{id}/approval      Resolve a pending approval
+POST /v1/runs/{id}/tool_result   Resolve a pending split-runtime local tool request
 POST /v1/runs/{id}/stop          Interrupt the run
 GET  /v1/capabilities            Machine-readable feature flags
 GET  /v1/models                  Lists hermes-agent
@@ -99,6 +100,8 @@ GET  /health, /health/detailed
 ```
 
 Setup, headers (`X-Hermes-Session-Id`, `X-Hermes-Session-Key`), and frontend wiring: [API Server](../user-guide/features/api-server).
+
+Split-runtime notes for `/v1/runs`: when `gateway.api_server.split_runtime.enabled` is true, an executor may attach with `GET /v1/runs/{id}/events?tool_executor=1` and answer `tool.request` events through `/tool_result`. PR1 supports one `/events` consumer per run and only routes read-only file tools. Optional executor identity uses the `X-Hermes-Tool-Executor-Token` header on both attach and result requests.
 
 ---
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -478,9 +478,6 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `API_SERVER_PORT` | Port for the API server (default: `8642`) |
 | `API_SERVER_HOST` | Host/bind address for the API server (default: `127.0.0.1`). `API_SERVER_KEY` is still required on loopback; use a narrow `API_SERVER_CORS_ORIGINS` allowlist for browser access. |
 | `API_SERVER_MODEL_NAME` | Model name advertised on `/v1/models`. Defaults to the profile name (or `hermes-agent` for the default profile). Useful for multi-user setups where frontends like Open WebUI need distinct model names per connection. |
-| `API_SERVER_SPLIT_RUNTIME_ENABLED` | Enable experimental `/v1/runs` split runtime for attached local executors (`true`/`false`). Default: disabled. |
-| `API_SERVER_SPLIT_RUNTIME_TOOLSETS` | Comma-separated toolsets eligible for split runtime. PR 1 only honors `file` and only routes read-only file tools. |
-| `API_SERVER_SPLIT_RUNTIME_TIMEOUT_SECONDS` | Seconds a run waits for an attached local executor to return a tool result before injecting a tool error. Default: `300`. |
 | `GATEWAY_PROXY_URL` | URL of a remote Hermes API server to forward messages to ([proxy mode](/user-guide/messaging/matrix#proxy-mode-e2ee-on-macos)). When set, the gateway handles platform I/O only — all agent work is delegated to the remote server. Also configurable via `gateway.proxy_url` in `config.yaml`. |
 | `GATEWAY_PROXY_KEY` | Bearer token for authenticating with the remote API server in proxy mode. Must match `API_SERVER_KEY` on the remote host. |
 | `MESSAGING_CWD` | Deprecated compatibility fallback for gateway working directory. Prefer `terminal.cwd` in `config.yaml`. |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -478,6 +478,9 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `API_SERVER_PORT` | Port for the API server (default: `8642`) |
 | `API_SERVER_HOST` | Host/bind address for the API server (default: `127.0.0.1`). `API_SERVER_KEY` is still required on loopback; use a narrow `API_SERVER_CORS_ORIGINS` allowlist for browser access. |
 | `API_SERVER_MODEL_NAME` | Model name advertised on `/v1/models`. Defaults to the profile name (or `hermes-agent` for the default profile). Useful for multi-user setups where frontends like Open WebUI need distinct model names per connection. |
+| `API_SERVER_SPLIT_RUNTIME_ENABLED` | Enable experimental `/v1/runs` split runtime for attached local executors (`true`/`false`). Default: disabled. |
+| `API_SERVER_SPLIT_RUNTIME_TOOLSETS` | Comma-separated toolsets eligible for split runtime. PR 1 only honors `file` and only routes read-only file tools. |
+| `API_SERVER_SPLIT_RUNTIME_TIMEOUT_SECONDS` | Seconds a run waits for an attached local executor to return a tool result before injecting a tool error. Default: `300`. |
 | `GATEWAY_PROXY_URL` | URL of a remote Hermes API server to forward messages to ([proxy mode](/user-guide/messaging/matrix#proxy-mode-e2ee-on-macos)). When set, the gateway handles platform I/O only — all agent work is delegated to the remote server. Also configurable via `gateway.proxy_url` in `config.yaml`. |
 | `GATEWAY_PROXY_KEY` | Bearer token for authenticating with the remote API server in proxy mode. Must match `API_SERVER_KEY` on the remote host. |
 | `MESSAGING_CWD` | Deprecated compatibility fallback for gateway working directory. Prefer `terminal.cwd` in `config.yaml`. |

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -208,6 +208,13 @@ Returns a machine-readable description of the API server's stable surface for ex
   "platform": "hermes-agent",
   "model": "hermes-agent",
   "auth": {"type": "bearer", "required": true},
+  "runtime": {
+    "tool_execution": "server",
+    "runs_tool_execution": "server",
+    "split_runtime": false,
+    "split_runtime_tools": [],
+    "split_runtime_protocol": null
+  },
   "features": {
     "chat_completions": true,
     "responses_api": true,
@@ -267,6 +274,44 @@ Statuses are retained briefly after terminal states (`completed`, `failed`, or `
 ### GET /v1/runs/\{run_id\}/events
 
 Server-Sent Events stream of the run's tool-call progress, token deltas, and lifecycle events. Designed for dashboards and thick clients that want to attach/detach without losing state.
+
+#### Experimental split-runtime executor
+
+The `/v1/runs` API can route `read_file` and `search_files` to a trusted local executor while the agent loop remains on the API-server host. This protocol defaults off and is configured only in `config.yaml`:
+
+```yaml
+gateway:
+  api_server:
+    split_runtime:
+      enabled: false
+      routed_toolsets: [file]
+      request_timeout_seconds: 300
+```
+
+After creating a run, attach the executor with `GET /v1/runs/{run_id}/events?tool_executor=1`. The first routed call waits up to `request_timeout_seconds` for this attachment. A `tool.request` event includes a server-generated `request_id`, the model's `tool_call_id` as metadata, the tool name, and arguments:
+
+```json
+{
+  "event": "tool.request",
+  "run_id": "run_abc123",
+  "request_id": "toolreq_abc123",
+  "tool_call_id": "call_provider_id",
+  "tool_name": "read_file",
+  "arguments": {"path": "README.md"}
+}
+```
+
+Return the result through **POST `/v1/runs/{run_id}/tool_result`**:
+
+```json
+{"request_id": "toolreq_abc123", "result": "local file content"}
+```
+
+Use the server-generated `request_id` for transport correlation. Do not correlate results with `tool_call_id`, which providers may reuse. The executor may send `X-Hermes-Tool-Executor-Token` on both the SSE attachment and result POST for an additional per-attachment guard; never put this token in the query string.
+
+Protocol version 1 allows one events consumer per split run. Missing executors, timeouts, disconnects, stale results, and router failures become tool errors and never fall back to server-side execution. Delegated subagents and `codex_app_server` are rejected in split runs because those paths cannot yet preserve the local-routing contract. A fast run that finishes before executor attachment still permits the executor URL to drain terminal lifecycle events as an observer.
+
+The local executor is trusted but must enforce its own workspace/path sandbox and invoke the current local Hermes tool handlers. This version does not ship a packaged executor and does not route write, terminal, browser, GUI, or computer-use tools.
 
 ### POST /v1/runs/\{run_id\}/stop
 

--- a/website/docs/user-guide/messaging/open-webui.md
+++ b/website/docs/user-guide/messaging/open-webui.md
@@ -181,9 +181,9 @@ When you send a message in Open WebUI:
 
 Your agent has access to the same tools and capabilities as that API-server Hermes instance. If the API server is remote, those tools are remote too for `/v1/chat/completions` and `/v1/responses`.
 
-Hermes also exposes an experimental split-runtime path on `/v1/runs`: enable `gateway.api_server.split_runtime.enabled`, open `GET /v1/runs/{run_id}/events?tool_executor=1` from a trusted local executor, then answer `tool.request` events with `POST /v1/runs/{run_id}/tool_result`. PR 1 only routes read-only file tools (`read_file`, `search_files`) and defaults off. The local executor must still sandbox and validate paths; the remote server treats missing or disconnected executors as tool errors, not permission to run those tools remotely.
+Hermes also exposes an experimental split-runtime path on `/v1/runs`: enable `gateway.api_server.split_runtime.enabled`, open `GET /v1/runs/{run_id}/events?tool_executor=1` from a trusted local executor, then answer `tool.request` events with `POST /v1/runs/{run_id}/tool_result`. The initial protocol only routes read-only file tools (`read_file`, `search_files`) and defaults off. The local executor must still sandbox and validate paths; the remote server treats missing or disconnected executors as tool errors, not permission to run those tools remotely.
 
-PR 1 uses one SSE consumer per run. If a local executor attaches to `/events?tool_executor=1`, that stream receives both lifecycle events and `tool.request` events; a second observer stream is rejected with `run_events_consumer_conflict`. Clients that want an extra per-attachment guard can send `X-Hermes-Tool-Executor-Token` on both the executor SSE request and the matching `/tool_result` posts. Do not put executor tokens in the query string.
+Split runs use one SSE consumer. If a local executor attaches to `/events?tool_executor=1`, that stream receives both lifecycle events and `tool.request` events; a second observer stream is rejected with `run_events_consumer_conflict`. Echo the server-generated `request_id` from each `tool.request` in the matching `/tool_result` body; do not use the model's `tool_call_id` for transport correlation. Clients that want an extra per-attachment guard can send `X-Hermes-Tool-Executor-Token` on both the executor SSE request and the matching `/tool_result` posts. Do not put executor tokens in the query string.
 
 :::tip Tool Progress
 With streaming enabled (the default), you'll see brief inline indicators as tools run — the tool emoji and its key argument. These appear in the response stream before the agent's final answer, giving you visibility into what's happening behind the scenes.
@@ -211,7 +211,7 @@ gateway:
       request_timeout_seconds: 300
 ```
 
-Environment overrides are available for embedded deployments: `API_SERVER_SPLIT_RUNTIME_ENABLED`, `API_SERVER_SPLIT_RUNTIME_TOOLSETS`, and `API_SERVER_SPLIT_RUNTIME_TIMEOUT_SECONDS`.
+The first routed call waits for the executor to attach after the run starts. Delegated subagents and the `codex_app_server` runtime are not supported in this protocol version and fail closed rather than reading from the server filesystem.
 
 ### Open WebUI
 

--- a/website/docs/user-guide/messaging/open-webui.md
+++ b/website/docs/user-guide/messaging/open-webui.md
@@ -179,9 +179,11 @@ When you send a message in Open WebUI:
 5. The agent's final text response streams back to Open WebUI
 6. Open WebUI displays the response in its chat interface
 
-Your agent has access to the same tools and capabilities as that API-server Hermes instance. If the API server is remote, those tools are remote too.
+Your agent has access to the same tools and capabilities as that API-server Hermes instance. If the API server is remote, those tools are remote too for `/v1/chat/completions` and `/v1/responses`.
 
-If you need tools to run against your **local** workspace today, run Hermes locally and point it at a pure LLM provider or pure OpenAI-compatible model proxy (for example vLLM, LiteLLM, Ollama, llama.cpp, OpenAI, OpenRouter, etc.). A future split-runtime mode for "remote brain, local hands" is being tracked in [#18715](https://github.com/NousResearch/hermes-agent/issues/18715); it is not the behavior of the current API server.
+Hermes also exposes an experimental split-runtime path on `/v1/runs`: enable `gateway.api_server.split_runtime.enabled`, open `GET /v1/runs/{run_id}/events?tool_executor=1` from a trusted local executor, then answer `tool.request` events with `POST /v1/runs/{run_id}/tool_result`. PR 1 only routes read-only file tools (`read_file`, `search_files`) and defaults off. The local executor must still sandbox and validate paths; the remote server treats missing or disconnected executors as tool errors, not permission to run those tools remotely.
+
+PR 1 uses one SSE consumer per run. If a local executor attaches to `/events?tool_executor=1`, that stream receives both lifecycle events and `tool.request` events; a second observer stream is rejected with `run_events_consumer_conflict`. Clients that want an extra per-attachment guard can send `X-Hermes-Tool-Executor-Token` on both the executor SSE request and the matching `/tool_result` posts. Do not put executor tokens in the query string.
 
 :::tip Tool Progress
 With streaming enabled (the default), you'll see brief inline indicators as tools run — the tool emoji and its key argument. These appear in the response stream before the agent's final answer, giving you visibility into what's happening behind the scenes.
@@ -197,6 +199,19 @@ With streaming enabled (the default), you'll see brief inline indicators as tool
 | `API_SERVER_PORT` | `8642` | HTTP server port |
 | `API_SERVER_HOST` | `127.0.0.1` | Bind address |
 | `API_SERVER_KEY` | _(required)_ | Bearer token for auth. Match `OPENAI_API_KEY`. |
+
+Split-runtime config lives in `config.yaml`:
+
+```yaml
+gateway:
+  api_server:
+    split_runtime:
+      enabled: false
+      routed_toolsets: [file]
+      request_timeout_seconds: 300
+```
+
+Environment overrides are available for embedded deployments: `API_SERVER_SPLIT_RUNTIME_ENABLED`, `API_SERVER_SPLIT_RUNTIME_TOOLSETS`, and `API_SERVER_SPLIT_RUNTIME_TIMEOUT_SECONDS`.
 
 ### Open WebUI
 


### PR DESCRIPTION
## Summary

Adds an experimental, default-off split-runtime channel for `/v1/runs` so a trusted client can execute a narrow read-only tool surface locally while the API-server Hermes retains the model and agent loop.

This is a protocol foundation for #18715, not a complete fix for that issue. It intentionally does not add a packaged desktop/laptop executor or route terminal, browser, GUI, or write tools.

## Scope

- Adds `gateway.api_server.split_runtime` config under `config.yaml`.
- Routes only `read_file` and `search_files` when the `file` toolset is enabled for split execution.
- Emits `tool.request` over the run SSE stream.
- Accepts results through `POST /v1/runs/{run_id}/tool_result`.
- Advertises the effective split-runtime tool surface through `/v1/capabilities`.
- Keeps `/v1/chat/completions`, `/v1/responses`, and default `/v1/runs` behavior unchanged when disabled.

## Protocol

1. The client starts a run with `POST /v1/runs`.
2. The client attaches one trusted executor to `GET /v1/runs/{run_id}/events?tool_executor=1`.
3. A routed tool call waits for that attachment, then emits `tool.request`.
4. Hermes mints a unique `request_id` for each request. The model/provider `tool_call_id` remains metadata only.
5. The executor posts `{ "request_id": "toolreq_...", "result": ... }` to `/tool_result`.
6. Hermes redacts file output before returning it to the agent loop and emits a metadata-only `tool.result` event.

## Security and failure behavior

- Split runtime defaults off.
- Configuration cannot broaden the route beyond `read_file` and `search_files`.
- Missing executors, attach timeouts, result timeouts, disconnects, router failures, duplicate/late results, and incompatible execution paths fail closed instead of falling back to server-side file reads.
- Delegated subagents are rejected during split-runtime runs in this protocol version because child routing is not yet supported.
- `codex_app_server` runs are rejected because Codex would otherwise use server-host file built-ins outside Hermes tool dispatch.
- The API bearer key remains the primary trust boundary. `X-Hermes-Tool-Executor-Token` adds a per-attachment guard and is compared in constant time.
- One split-runtime SSE consumer is allowed per run because the current run stream is a queue, not a broadcast bus.
- The local executor is trusted but still must enforce its own workspace/path sandbox and invoke current local tool handlers. This PR does not ship that executor.

## Adversarial review hardening

Independent reviews by Claude Fable 5, Codex GPT-5.6 Sol Ultra/Max, native Hermes delegates, and the primary agent identified and drove fixes for:

- provider-controlled `tool_call_id` collisions and late-result misbinding;
- timeout/result transition races;
- the unavoidable run-start/executor-attach ordering gap;
- delegated-child and `codex_app_server` routing bypasses;
- SSE preparation leaks, stale-finalizer races, and reconnect cleanup;
- active runs being destroyed by the stream-retention sweep;
- inaccurate status with parallel pending tool requests;
- terminal channel-close and late-attachment interleavings;
- cancelled asyncio wrappers releasing capacity while executor threads still ran;
- non-structured agent workers surviving disconnect without interruption;
- permanently stuck structured workers preventing process exit;
- queued workers executing after `/stop` and live-agent ownership being dropped before production teardown;
- slow request bodies bypassing the configured run cap and racing adapter drain;
- stale admitted requests surviving a fast disconnect/reconnect generation;
- approval responses reopening stopping runs;
- late progress and approval callbacks overwriting terminal status;
- unreachable server artifact paths during mixed local/server tool turns;
- `web_extract` advertising server cache paths that client-routed `read_file` could not access;
- server-side subdirectory context discovery after client-routed file calls;
- stale `tool.request` replay after terminal cleanup;
- queued callbacks recreating run status after the retention sweep;
- effective tool configuration diverging from capability and runtime behavior;
- per-run split activation diverging from the agent's enabled toolset snapshot;
- malformed non-object result payloads;
- CORS omissions for executor headers;
- non-secret environment-variable configuration outside project policy;
- misleading capability labels for unsupported toolsets.

## Validation

Current verified commands and results:

- Focused API/session/router/storage/delegation/E2E selection
  - 571 passed
  - includes real config loading, production HTTP route registration, and a real `AIAgent.run_conversation` loop with only the model transport stubbed
- `scripts/run_tests.sh tests/acp tests/acp_adapter -q`
  - 323 passed after installing the already-pinned `agent-client-protocol==0.9.0` optional dependency
- `scripts/run_tests.sh tests/gateway/ -q`
  - completed all 465 gateway test files: 9,126 passed and 5 failed
  - 2 failures exposed a stale bypass-`__init__` API-server fixture; the fixture was updated and its 7-test file then passed
  - the remaining 3 failures are isolated to unchanged WeCom callback code and reproduce independently because the optional XML parser is unavailable in this environment
- `scripts/run_tests.sh tests/agent/test_compression_concurrent_fork.py -q`
  - 14 passed in isolation
- Ruff on every modified Python file
  - passed
- `py_compile` on every modified Python file
  - passed
- `git diff --check`
  - passed
- Independent closure review
  - Claude Fable, Codex Ultra/Max, native delegates, and a final focused Codex review exercised the security, concurrency, lifecycle, and integration invariants
  - the final review of the queued-cancellation fix returned `PASS — no unresolved P0/P1/P2`

The broad CI-parity run reached 20.3% with 8,224 passing tests. Its only failure was the unrelated timing-sensitive `test_compression_concurrent_fork.py`; that file passed on isolated rerun (14 passed). The broad run was then stopped rather than represented as a full-suite pass.

## Follow-ups intentionally out of scope

- A packaged local executor for desktop/laptop use.
- Real workspace-root negotiation and cross-OS path translation.
- Broadcast event fan-out for an executor plus independent observers.
- `codex_app_server` split routing.
- Backpressure/priority separation for very high-volume run streams.
- Write, terminal, browser, GUI, and computer-use tools.

## Local test plan after review

Use separate remote and local workspaces with conflicting sentinel files. Confirm `read_file` and `search_files` return only local sentinel content, server handlers are never reached, blocked paths remain blocked, disconnects fail the pending request, reattachment permits later requests, and `/stop` still controls a run after the stream-retention TTL.
