### PR TITLE
fix: normalize path separators in skills content hash for Windows parity (#62310)

### DIFF
--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -776,7 +776,13 @@ def content_hash(skill_path: Path) -> str:
     """
     h = hashlib.sha256()
     if skill_path.is_dir():
-        for f in sorted(skill_path.rglob("*")):
+        # Sort by normalized posix path to ensure identical hash on
+        # Windows and POSIX — Path sorting is case-insensitive on
+        # Windows but case-sensitive on Linux (#62310).
+        for f in sorted(
+            skill_path.rglob("*"),
+            key=lambda p: p.relative_to(skill_path).as_posix(),
+        ):
             if f.is_file():
                 try:
                     rel = f.relative_to(skill_path).as_posix()

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3573,10 +3573,13 @@ def uninstall_skill(skill_name: str) -> Tuple[bool, str]:
 def bundle_content_hash(bundle: SkillBundle) -> str:
     """Compute a deterministic hash for an in-memory skill bundle."""
     h = hashlib.sha256()
-    for rel_path in sorted(bundle.files):
+    # Normalize backslash separators to forward slash before sorting
+    # so the hash is identical on Windows and POSIX (#62310).
+    for rel_path in sorted(bundle.files, key=lambda p: p.replace("\\", "/")):
+        normalized = rel_path.replace("\\", "/")
         # Include the path so swapping file contents between two paths
         # changes the hash (avoids filename-swap evading update detection).
-        h.update(rel_path.encode("utf-8"))
+        h.update(normalized.encode("utf-8"))
         h.update(b"\x00")
         content = bundle.files[rel_path]
         if isinstance(content, bytes):


### PR DESCRIPTION
## What

Normalize path separators in `bundle_content_hash` (skills_hub.py) and `content_hash` (skills_guard.py) so they produce identical digests on Windows and POSIX.

## Why

The two hash functions "MUST stay symmetric" but diverge on Windows:

- `bundle_content_hash`: `sorted(bundle.files)` uses backslash keys on Windows, case-sensitive sort
- `content_hash`: `sorted(Path.rglob)` uses case-insensitive Path sort on Windows, forward-slash via `as_posix()`

For any skill with subdirectory files, the two digests can never match on Windows, causing permanent false-positive `update_available` on `hermes skills check`.

## Fix

- `bundle_content_hash`: normalize `\` to `/` before sorting and hashing
- `content_hash`: sort by `as_posix()` string (case-sensitive, forward slash) instead of by Path object

Fixes #62310