### PR TITLE
feat(browser): add Helium browser support on Linux

### DIFF
--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -41,6 +41,10 @@ _WINDOWS_INSTALL_PARTS = tuple(parts for _, group in _WINDOWS_BROWSER_GROUPS for
 
 _LINUX_BROWSER_GROUPS = (
     (
+        ("helium-browser",),
+        ("/usr/bin/helium-browser",),
+    ),
+    (
         ("google-chrome", "google-chrome-stable"),
         ("/opt/google/chrome/chrome", "/usr/bin/google-chrome", "/usr/bin/google-chrome-stable"),
     ),
@@ -129,13 +133,15 @@ def chrome_debug_data_dir() -> str:
     return str(get_hermes_home() / "chrome-debug")
 
 
-def _chrome_debug_args(port: int) -> list[str]:
-    return [
+def _chrome_debug_args(port: int, data_dir: str | None = None) -> list[str]:
+    args = [
         f"--remote-debugging-port={port}",
-        f"--user-data-dir={chrome_debug_data_dir()}",
         "--no-first-run",
         "--no-default-browser-check",
     ]
+    if data_dir is not None:
+        args.append(f"--user-data-dir={data_dir}")
+    return args
 
 
 def is_browser_debug_ready(url: str, timeout: float = 1.0) -> bool:
@@ -179,7 +185,8 @@ def manual_chrome_debug_command(port: int = DEFAULT_BROWSER_CDP_PORT, system: st
     candidates = get_chrome_debug_candidates(system)
 
     if candidates:
-        argv = [candidates[0], *_chrome_debug_args(port)]
+        data_dir = None if "helium" in os.path.basename(candidates[0]).lower() else chrome_debug_data_dir()
+        argv = [candidates[0], *_chrome_debug_args(port, data_dir)]
         return subprocess.list2cmdline(argv) if system == "Windows" else shlex.join(argv)
 
     if system == "Darwin":
@@ -306,9 +313,10 @@ def launch_chrome_debug(
 
     for candidate in candidates:
         try:
+            data_dir = None if "helium" in os.path.basename(candidate).lower() else chrome_debug_data_dir()
             with open(stderr_path, "wb") as stderr_file:
                 proc = subprocess.Popen(
-                    [candidate, *_chrome_debug_args(port)],
+                    [candidate, *_chrome_debug_args(port, data_dir)],
                     stdout=subprocess.DEVNULL,
                     stderr=stderr_file,
                     **_detach_kwargs(system),

--- a/tests/cli/test_cli_browser_connect.py
+++ b/tests/cli/test_cli_browser_connect.py
@@ -111,6 +111,51 @@ class TestChromeDebugLaunch:
         assert command is not None
         assert command.startswith("/usr/bin/chromium --remote-debugging-port=9222")
 
+    def test_linux_candidates_prefer_helium_browser_when_present(self):
+        helium = "/usr/bin/helium-browser"
+        chrome = "/usr/bin/google-chrome"
+
+        with patch("hermes_cli.browser_connect.shutil.which", side_effect=lambda name: helium if name == "helium-browser" else None), \
+             patch("hermes_cli.browser_connect.os.path.isfile", side_effect=lambda path: path in {helium, chrome}):
+            candidates = get_chrome_debug_candidates("Linux")
+
+        assert candidates[0] == helium
+
+    def test_helium_manual_command_retains_cdp_and_first_run_flags_omits_user_data_dir(self):
+        helium = "/usr/bin/helium-browser"
+
+        with patch("hermes_cli.browser_connect.shutil.which", side_effect=lambda name: helium if name == "helium-browser" else None), \
+             patch("hermes_cli.browser_connect.os.path.isfile", side_effect=lambda path: path == helium):
+            command = manual_chrome_debug_command(9222, "Linux")
+
+        assert command is not None
+        assert command.startswith(f"{helium} --remote-debugging-port=9222")
+        assert "--no-first-run" in command
+        assert "--no-default-browser-check" in command
+        assert "--user-data-dir" not in command
+
+    def test_helium_popen_launch_retains_cdp_and_first_run_flags_omits_user_data_dir(self):
+        helium = "/usr/bin/helium-browser"
+        captured = {}
+
+        def fake_popen(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+            return object()
+
+        with patch("hermes_cli.browser_connect.shutil.which", side_effect=lambda name: helium if name == "helium-browser" else None), \
+             patch("hermes_cli.browser_connect.os.path.isfile", side_effect=lambda path: path == helium), \
+             patch("hermes_cli.browser_connect._wait_for_browser_debug_ready_or_exit", return_value="ready"), \
+             patch("subprocess.Popen", side_effect=fake_popen):
+            assert HermesCLI._try_launch_chrome_debug(9222, "Linux") is True
+
+        cmd = captured["cmd"]
+        assert cmd[0] == helium
+        assert "--remote-debugging-port=9222" in cmd
+        assert "--no-first-run" in cmd
+        assert "--no-default-browser-check" in cmd
+        assert not any(arg.startswith("--user-data-dir") for arg in cmd)
+
     def test_linux_candidates_prefer_chrome_before_brave_when_both_exist(self):
         chrome = "/usr/bin/google-chrome"
         brave = "/usr/bin/brave-browser"


### PR DESCRIPTION
Helium crashes when launched with --user-data-dir. This adds Helium as the first candidate in the Linux browser list and makes --user-data-dir conditional — skipped for Helium, preserved for other browsers.