### PR TITLE
fix(desktop): wheel-scroll dead zones in the sessions sidebar

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -147,17 +147,28 @@ const SIDEBAR_NAV: SidebarNavItem[] = [
   { id: 'artifacts', label: '', icon: props => <Codicon name="files" {...props} />, route: ARTIFACTS_ROUTE }
 ]
 
-// Two modes via the `compact` height variant (styles.css):
-//   tall    → each section is shrink-0, capped, its own scroller; Sessions is flex-1.
-//   compact → COMPACT_FLAT drops the caps so the whole stack scrolls as one.
-// Sections stay shrink-0 so none can be squeezed below its content and bleed onto
-// the next — the flexbox `min-height: auto` overlap trap that caused the bug.
+// Scroll architecture: ONE shared scroll container (the SCROLL_Y div below)
+// owns all session-stack scrolling in both height modes. Sections are
+// shrink-0 (never flex-squeezed below content — the `min-height: auto`
+// overlap trap). In tall mode, pinned/messaging bodies are max-h capped with
+// their own small chainable scrollers (GROUP_BODY); in compact mode
+// COMPACT_FLAT drops those caps so the whole stack is one flat scroll.
 const COMPACT_FLAT = 'compact:max-h-none compact:overflow-visible'
 
-// Vertical scroll only — never a horizontal bar from glow bleed, long titles, etc.
-const SCROLL_Y = 'overflow-y-auto overflow-x-hidden overscroll-contain'
+// Vertical scroll only — never a horizontal bar from glow bleed, long titles,
+// etc. Deliberately NO overscroll-contain here or on anything nested inside:
+// Chromium latches a wheel gesture to the nearest scroll container under the
+// cursor, and overscroll-contain stops the scroll chain there EVEN WHEN that
+// container cannot scroll — nested (often unscrollable) containers with
+// contain made wheel input dead over session rows while the scrollbar track
+// still worked. scrollbar-gutter keeps the width stable as the scrollbar
+// comes and goes.
+const SCROLL_Y = 'overflow-y-auto overflow-x-hidden [scrollbar-gutter:stable]'
 
-// A non-session group's scroll body: own scroller when tall, flattened when compact.
+// A capped group body (pinned, messaging): max-h capped with its OWN small
+// scroller so rows beyond the cap stay reachable. No overscroll-contain (see
+// SCROLL_Y): at its scroll edges the wheel chains outward to the shared
+// sidebar scroller instead of dying here. Compact mode drops the cap.
 const GROUP_BODY = cn(SCROLL_Y, COMPACT_FLAT)
 
 // Section-header action icons stay hidden until the whole header row is hovered
@@ -285,6 +296,11 @@ export function ChatSidebar({
   // Per-platform count of rows currently revealed (starts at NON_SESSION_INITIAL_ROWS).
   const [messagingVisible, setMessagingVisible] = useState<Record<string, number>>({})
   const searchInputRef = useRef<HTMLInputElement>(null)
+  // The single scroll container for the whole session stack (search results,
+  // pinned, recents). Also handed to the virtualizer via getScrollElement so
+  // virtualized recents scroll in the same surface instead of nesting a
+  // second scroller inside this one.
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
   const trimmedQuery = searchQuery.trim()
 
   // Hotkey (session.focusSearch) → focus the field once it's mounted.
@@ -975,6 +991,9 @@ export function ChatSidebar({
   const recentsVirtualizes =
     !displayAgentGroups?.length && !agentProjectTree?.length && displayAgentSessions.length >= VIRTUALIZE_THRESHOLD
 
+  // The one scroll element shared by every section (and the virtualizer).
+  const getScrollElement = useCallback(() => scrollContainerRef.current, [])
+
   // Keep the persisted parent + worktree orders reconciled with what's on screen:
   // freshly-seen repos/worktrees surface at the top, vanished ones drop out of
   // the saved order.
@@ -1123,11 +1142,16 @@ export function ChatSidebar({
         )}
 
         {contentVisible && showSessionSections && (
-          <div className={cn('flex min-h-0 flex-1 flex-col pb-1.75', SCROLL_Y)}>
+          <div className={cn('flex min-h-0 flex-1 flex-col pb-1.75', SCROLL_Y)} ref={scrollContainerRef}>
             {trimmedQuery && (
               <SidebarSessionsSection
                 activeSessionId={activeSidebarSessionId}
-                contentClassName={cn('flex min-h-0 flex-1 flex-col gap-px pb-1.75', SCROLL_Y)}
+                // No nested scroller here: the outer container is the only
+                // scroller; long result lists virtualize into it via
+                // getScrollElement. The root must be shrink-0 and NOT
+                // overflow-hidden, or the flexbox squeezes the section to its
+                // min-height and clips results out of reach.
+                contentClassName="flex flex-col gap-px pb-1.75"
                 emptyState={
                   searchPending ? (
                     <SidebarSessionSkeletons />
@@ -1137,6 +1161,7 @@ export function ChatSidebar({
                     </div>
                   )
                 }
+                getScrollElement={getScrollElement}
                 label={s.results}
                 labelMeta={String(searchResults.length)}
                 onArchiveSession={onArchiveSession}
@@ -1147,7 +1172,7 @@ export function ChatSidebar({
                 onTogglePin={pinSession}
                 open
                 pinned={false}
-                rootClassName="min-h-32 flex-1 overflow-hidden p-0"
+                rootClassName="min-h-32 shrink-0 p-0"
                 sessions={searchResults}
                 workingSessionIdSet={workingSessionIdSet}
               />
@@ -1181,15 +1206,15 @@ export function ChatSidebar({
                 activeProjectId={activeProjectId}
                 activeSessionId={activeSidebarSessionId}
                 collapsible={!inProject}
+                // No own scroller and no COMPACT_FLAT needed: this section
+                // carries no overflow or max-height in either height mode —
+                // the shared outer container scrolls, and virtualized recents
+                // scroll in it too (getScrollElement below).
                 contentClassName={cn(
-                  'flex min-h-0 flex-1 flex-col pb-1.75',
-                  SCROLL_Y,
+                  'flex flex-col pb-1.75',
                   // Separate profile sections clearly in the ALL view; rows inside
                   // each group keep their own tight gap-px rhythm.
-                  showAllProfiles ? 'gap-3' : 'gap-px',
-                  // Flatten into the single scroll when compact — unless this is the
-                  // virtualized long list, which must keep its own scroller.
-                  !recentsVirtualizes && COMPACT_FLAT
+                  showAllProfiles ? 'gap-3' : 'gap-px'
                 )}
                 dndSensors={dndSensors}
                 emptyState={
@@ -1217,6 +1242,7 @@ export function ChatSidebar({
                   ) : null
                 }
                 forceEmptyState={showSessionSkeletons}
+                getScrollElement={recentsVirtualizes ? getScrollElement : undefined}
                 groups={displayAgentGroups}
                 headerAction={
                   inProject && enteredProject ? (
@@ -1321,10 +1347,11 @@ export function ChatSidebar({
                 projectRepoWorktrees={inProject ? scopedRepoWorktrees : undefined}
                 projectsLoading={worktreeGroupingActive ? projectTreeLoading : false}
                 removedSessionIds={inProject ? removedSessionIds : undefined}
-                rootClassName={cn(
-                  'min-h-32 flex-1 overflow-hidden p-0',
-                  !recentsVirtualizes && 'compact:min-h-0 compact:flex-none compact:overflow-visible'
-                )}
+                // shrink-0: sections in the shared scroller must never be
+                // flex-squeezed below their content — the outer container
+                // scrolls; sections take their natural height. compact keeps
+                // its tighter minimum.
+                rootClassName="min-h-32 shrink-0 p-0 compact:min-h-0"
                 sessions={displayAgentSessions}
                 sortable={!showAllProfiles && agentSessions.length > 1}
                 workingSessionIdSet={workingSessionIdSet}

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -8,7 +8,6 @@ import { SidebarGroup, SidebarGroupContent } from '@/components/ui/sidebar'
 import type { HermesGitWorktree } from '@/global'
 import type { SessionInfo } from '@/hermes'
 import { flattenSessionsWithBranches } from '@/lib/session-branch-tree'
-import { cn } from '@/lib/utils'
 import { sessionPinId } from '@/store/session'
 
 import { SidebarCount } from './chrome'
@@ -127,6 +126,11 @@ interface SidebarSessionsSectionProps {
   // When false the section header is static (no caret/toggle) and always open.
   collapsible?: boolean
   sortable?: boolean
+  /** When provided, the virtualized flat list scrolls in this external
+   *  element (the sidebar's shared scroll container) instead of owning its
+   *  own nested scroller. Virtualization only activates in this mode — see
+   *  the `flatVirtualized` predicate. */
+  getScrollElement?: () => HTMLElement | null
   // The flat session list is the only hand-reorderable surface (grouped/project
   // views sort deterministically), so it owns the one ReorderableList.
   onReorderSessions?: (ids: string[]) => void
@@ -171,6 +175,7 @@ export function SidebarSessionsSection({
   labelIcon,
   collapsible = true,
   sortable = false,
+  getScrollElement,
   onReorderSessions,
   onReorderProjects,
   projectBackRow,
@@ -217,12 +222,20 @@ export function SidebarSessionsSection({
   const renderRows = (items: SessionInfo[]) =>
     flattenSessionsWithBranches(items).map(({ branchStem, session }) => renderRow(session, false, branchStem))
 
+  // Virtualize ONLY in shared-scroll mode (caller provides the scroll
+  // element). Without one, the virtual list would nest its OWN scroll
+  // container inside the sidebar's scroller; a nested scroller that grows to
+  // its content height can never scroll, yet Chromium still latches wheel
+  // events to it, and overscroll-contain then stops the scroll chain — wheel
+  // goes dead over the rows and only the outer scrollbar track works. A long
+  // list without a scroll element simply renders flat.
   const flatVirtualized =
     !showEmptyState &&
     !groups?.length &&
     !projectOverview?.length &&
     !projectContent &&
-    sessions.length >= VIRTUALIZE_THRESHOLD
+    sessions.length >= VIRTUALIZE_THRESHOLD &&
+    Boolean(getScrollElement)
 
   // First paint into the grouped view (e.g. the app restoring the Projects tab)
   // has flat recents in `sessions` but no tree yet. Show skeletons rather than
@@ -305,6 +318,7 @@ export function SidebarSessionsSection({
         activeSessionId={activeSessionId}
         className={contentClassName}
         entries={displayEntries}
+        getScrollElement={getScrollElement}
         onArchiveSession={onArchiveSession}
         onBranchSession={onBranchSession}
         onDeleteSession={onDeleteSession}
@@ -334,9 +348,12 @@ export function SidebarSessionsSection({
     inner = displayEntries.map(({ branchStem, session }) => renderRow(session, false, branchStem))
   }
 
-  // The virtualizer owns its own scroller, so suppress the wrapper's overflow
-  // to avoid a double scroll container.
-  const resolvedContentClassName = cn(contentClassName, flatVirtualized && 'overflow-y-visible')
+  // flatVirtualized implies shared-scroll mode (see the predicate above): the
+  // virtualizer never owns a scroller here, so the wrapper needs no overflow
+  // suppression. Do not add per-axis overflow classes to this wrapper — a
+  // single-axis overflow forces the other axis from `visible` to `auto` and
+  // silently recreates a nested scroll container.
+  const resolvedContentClassName = contentClassName
 
   return (
     <SidebarGroup className={rootClassName}>

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -1,7 +1,7 @@
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { type FC, useCallback, useRef } from 'react'
+import { type FC, useCallback, useLayoutEffect, useRef, useState } from 'react'
 
 import type { SessionInfo } from '@/hermes'
 import { type SidebarSessionEntry } from '@/lib/session-branch-tree'
@@ -27,6 +27,10 @@ interface VirtualSessionListProps {
   activeSessionId: null | string
   className?: string
   entries: SidebarSessionEntry[]
+  /** When provided, the virtualizer scrolls in this external element instead
+   *  of owning its own overflow container (shared-scroll mode). Use it to
+   *  unify scrolling with sibling sections in a single scroll container. */
+  getScrollElement?: () => HTMLElement | null
   onArchiveSession: (sessionId: string) => void
   onBranchSession?: (sessionId: string, profile?: string) => void
   onDeleteSession: (sessionId: string) => void
@@ -39,11 +43,16 @@ interface VirtualSessionListProps {
 
 const ROW_ESTIMATE_PX = 28
 const OVERSCAN_ROWS = 12
+// The row grid renders with `gap-px`; the virtualizer must be told about it or
+// every row's computed start drifts 1px further from reality (N-1 px of error
+// across the list), which reads as rows popping in late / blank tail space.
+const ROW_GAP_PX = 1
 
 export const VirtualSessionList: FC<VirtualSessionListProps> = ({
   activeSessionId,
   className,
   entries,
+  getScrollElement: getScrollElementProp,
   onArchiveSession,
   onBranchSession,
   onDeleteSession,
@@ -53,22 +62,96 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
   sortable,
   workingSessionIdSet
 }) => {
-  const scrollerRef = useRef<HTMLDivElement | null>(null)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  // When an external scroll element is provided (shared-scroll mode), use it
+  // instead of owning our own overflow container, so this list scrolls
+  // together with the sibling sections around it.
+  const sharedScroll = Boolean(getScrollElementProp)
+  const resolvedGetScrollElement = getScrollElementProp ?? (() => containerRef.current)
+
+  // Shared-scroll offset (TanStack `scrollMargin`): in shared mode this list
+  // does NOT start at the scroll element's top — other sections render above
+  // it in the same scroller. The virtualizer maps scrollTop → visible rows,
+  // so it must know that offset or the visible window is computed against the
+  // wrong origin and rows unmount while still on screen.
+  //
+  // Re-measured after every commit (no dep array). Invariant: everything that
+  // changes the height of the content above must flow through a render of the
+  // sidebar tree containing this list, or the origin goes stale until the
+  // next render. The setState is guarded to >=1px change, so this cannot
+  // render-loop.
+  const [sharedScrollMargin, setSharedScrollMargin] = useState(0)
+  // One-shot retry for same-commit mounts: when the scroll container and this
+  // list mount in the SAME commit, descendant layout effects run before the
+  // ancestor ref attaches, so the first measure sees null.
+  const [measureRetry, setMeasureRetry] = useState(0)
+  const retriedRef = useRef(false)
+
+  // Intentionally no dep array: the offset depends on SIBLING layout, not on
+  // any prop or state of this component, so it must re-measure after every
+  // commit. The >=1px setState guard prevents an update loop.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useLayoutEffect(() => {
+    if (!sharedScroll) {
+      return
+    }
+
+    const el = containerRef.current
+    const scrollEl = getScrollElementProp?.()
+
+    if (!el || !scrollEl) {
+      // Ancestor ref not attached yet (same-commit mount). Force ONE
+      // post-frame re-render so both this measure and the virtualizer's
+      // getScrollElement bind; without it the list shows only the initialRect
+      // window until unrelated state churn re-renders the sidebar.
+      if (!retriedRef.current) {
+        retriedRef.current = true
+        requestAnimationFrame(() => setMeasureRetry(n => n + 1))
+      }
+
+      return
+    }
+
+    const margin = Math.round(
+      el.getBoundingClientRect().top - scrollEl.getBoundingClientRect().top + scrollEl.scrollTop
+    )
+
+    setSharedScrollMargin(prev => (Math.abs(prev - margin) < 1 ? prev : margin))
+  })
+
+  const scrollMargin = sharedScroll ? sharedScrollMargin : 0
 
   const virtualizer = useVirtualizer({
     count: entries.length,
     estimateSize: () => ROW_ESTIMATE_PX,
+    gap: ROW_GAP_PX,
     getItemKey: index => entries[index]?.session.id ?? index,
-    getScrollElement: () => scrollerRef.current,
+    getScrollElement: resolvedGetScrollElement,
+    // On scroll-element attach, virtual-core calls scrollToOffset with the
+    // current offset, which defaults to initialOffset = 0 — in shared-scroll
+    // mode that would yank the WHOLE shared container to the top every time
+    // this list (re)mounts while scrolled (section reopen, list crossing the
+    // virtualization threshold). Seeding from the live scrollTop makes the
+    // attach a no-op. (Same trick useWindowVirtualizer uses with scrollY.)
+    initialOffset: () => resolvedGetScrollElement()?.scrollTop ?? 0,
     // jsdom-friendly default; the real rect takes over on first observe.
     initialRect: { height: 600, width: 240 },
-    overscan: OVERSCAN_ROWS
+    overscan: OVERSCAN_ROWS,
+    scrollMargin
   })
+
+  // Consume the retry counter so the forced re-render sticks.
+  void measureRetry
 
   const virtualItems = virtualizer.getVirtualItems()
   const totalSize = virtualizer.getTotalSize()
-  const paddingTop = virtualItems[0]?.start ?? 0
-  const paddingBottom = Math.max(0, totalSize - (virtualItems[virtualItems.length - 1]?.end ?? 0))
+  // Item `start`/`end` values include scrollMargin; getTotalSize() does not.
+  // Convert to list-local space before deriving the spacer paddings.
+  const firstStart = (virtualItems[0]?.start ?? scrollMargin) - scrollMargin
+  const lastEnd = (virtualItems[virtualItems.length - 1]?.end ?? scrollMargin) - scrollMargin
+  const paddingTop = Math.max(0, firstStart)
+  const paddingBottom = Math.max(0, totalSize - lastEnd)
 
   const rows = virtualItems.map(virtualItem => {
     const entry = entries[virtualItem.index]
@@ -115,10 +198,25 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
   // When sortable, the caller wraps this in a ReorderableList that owns the
   // DndContext + SortableContext (keyed on the same ids); the virtualized rows
   // just consume that context via useSortable.
+  const ownsScroll = !sharedScroll
+
   return (
     <div
-      className={cn('relative min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain', className)}
-      ref={scrollerRef}
+      className={cn(
+        'relative min-h-0',
+        // In shared-scroll mode this wrapper must carry NO overflow property
+        // at all — not even overflow-x-hidden. Setting overflow on one axis
+        // computes the other axis from `visible` to `auto` (CSS Overflow 3),
+        // which silently turns the wrapper back into a scroll container.
+        // A nested scroll container is what causes wheel-scroll dead zones:
+        // Chromium latches wheel events to the nearest scroll container under
+        // the cursor, and with overscroll-contain the chain stops there even
+        // when that container has nothing to scroll. The outer scroller
+        // already clips X for everyone.
+        ownsScroll && 'flex-1 overflow-x-hidden overflow-y-auto overscroll-contain',
+        className
+      )}
+      ref={containerRef}
     >
       <div className="grid gap-px" style={{ paddingBottom: `${paddingBottom}px`, paddingTop: `${paddingTop}px` }}>
         {rows}


### PR DESCRIPTION
## Problem

Mouse-wheel scrolling in the sessions sidebar can go completely dead while the cursor is over session rows — the panel only scrolls when the cursor is on the scrollbar track (or by dragging the thumb). When the virtualized recents list is scrollable, the wheel also gets "stuck" at its edges instead of continuing to scroll the rest of the sidebar.

## Root cause

Nested scroll containers with `overscroll-contain`. Chromium latches a wheel gesture to the nearest scroll container under the cursor, and `overscroll-behavior: contain` stops the scroll chain there **even when that container cannot scroll**. The sidebar nested several such containers inside the outer `SCROLL_Y` scroller:

- the search-results section body (its own `SCROLL_Y`),
- the recents section body (`SCROLL_Y` again),
- `VirtualSessionList`, which always owned its own `overflow-y-auto overscroll-contain` scroller.

A subtle contributor: an element with overflow set on **one** axis gets the other axis computed from `visible` to `auto` (CSS Overflow 3), so even a wrapper with just `overflow-x-hidden` silently becomes a vertical scroll container that can latch wheel events.

## Fix

One shared scroll container owns all session-stack scrolling:

- **`VirtualSessionList`** gains a shared-scroll mode: it takes an external `getScrollElement` and feeds TanStack Virtual a per-commit-measured `scrollMargin`, so sections rendered above it in the same scroller no longer break the visible-window math. Also passes `gap: 1` to match the row grid's `gap-px` (row positions previously drifted N-1 px across the list) and seeds `initialOffset` from the live `scrollTop` (virtual-core calls `scrollToOffset(initialOffset=0)` on scroll-element attach, which would yank the whole shared container to the top whenever the list (re)mounts while scrolled). In shared mode the wrapper carries no overflow classes at all.
- **`SidebarSessionsSection`** only virtualizes when the caller provides the shared scroll element, so an owned nested scroller can no longer appear inside the sidebar.
- **`index.tsx`** drops `overscroll-contain` from `SCROLL_Y` (the capped pinned/messaging bodies keep real scrollers that now chain outward at their edges), adds `scrollbar-gutter: stable`, removes the search section's nested scroller and its `overflow-hidden` clipping (which could make results unreachable), and marks sections `shrink-0` so flexbox cannot squeeze them below their content.

## Testing

- `tsc -p . --noEmit` clean
- `eslint` clean on the three touched files
- all 51 existing sidebar vitest tests pass
- verified in a packaged Windows build: wheel scrolling works everywhere over the sidebar (rows, headers, empty space), virtualized recents scroll correctly with content above them, no scroll-position jumps on section expand/collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)