### PR TITLE
fix(cli): resolve --model <alias> through model_aliases in interactive chat (#62491)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4353,7 +4353,28 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         _model_config = CLI_CONFIG.get("model", {})
         _config_model = (_model_config.get("default") or _model_config.get("model") or "") if isinstance(_model_config, dict) else (_model_config or "")
         _DEFAULT_CONFIG_MODEL = ""
-        self.model = model or _config_model or _DEFAULT_CONFIG_MODEL
+
+        # Resolve a `--model <alias>` against config.yaml ``model_aliases:``
+        # (e.g. a local server behind a custom base_url) BEFORE the default
+        # provider is attached. Without this, the alias string is sent verbatim
+        # to the configured default provider (OpenRouter) and 400s. The GUI
+        # picker already reads these aliases; the CLI path must too. See #62491.
+        # ponytail: reuse model_switch.DIRECT_ALIASES rather than re-parse config.
+        _model_alias_target = None
+        if model:
+            try:
+                from hermes_cli import model_switch as _ms
+                _ms._ensure_direct_aliases()
+                _model_alias_target = _ms.DIRECT_ALIASES.get(model.strip().lower())
+            except Exception:
+                _model_alias_target = None
+
+        self.model = (
+            _model_alias_target.model
+            if _model_alias_target is not None
+            else (model or _config_model or _DEFAULT_CONFIG_MODEL)
+        )
+
         # A ``moa:<preset>`` model string selects the MoA virtual provider in
         # one shot (parity with interactive ``/moa`` and the model picker). Do
         # this before provider resolution so ``-Q -m moa:<preset>`` routes
@@ -4391,12 +4412,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         )
 
         self._explicit_api_key = api_key
-        self._explicit_base_url = base_url
+        self._explicit_base_url = (
+            _model_alias_target.base_url.rstrip("/")
+            if _model_alias_target is not None and _model_alias_target.base_url
+            else base_url
+        )
 
         # Provider selection is resolved lazily at use-time via _ensure_runtime_credentials().
         self.requested_provider = (
             _moa_provider_override
             or provider
+            or (_model_alias_target.provider if _model_alias_target is not None else None)
             or CLI_CONFIG["model"].get("provider")
             or os.getenv("HERMES_INFERENCE_PROVIDER")
             or "auto"
@@ -4407,7 +4433,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self.acp_command: Optional[str] = None
         self.acp_args: list[str] = []
         self.base_url = (
-            base_url
+            self._explicit_base_url
             or CLI_CONFIG["model"].get("base_url", "")
             or os.getenv("OPENROUTER_BASE_URL", "")
         ) or None

--- a/cli.py
+++ b/cli.py
@@ -4412,10 +4412,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         )
 
         self._explicit_api_key = api_key
+        # ponytail: explicit --base-url must win over the alias's base_url
+        # (#62534). Only fall back to the alias URL when no explicit one given.
         self._explicit_base_url = (
-            _model_alias_target.base_url.rstrip("/")
-            if _model_alias_target is not None and _model_alias_target.base_url
-            else base_url
+            base_url
+            if base_url
+            else (_model_alias_target.base_url.rstrip("/")
+                  if _model_alias_target is not None and _model_alias_target.base_url
+                  else None)
         )
 
         # Provider selection is resolved lazily at use-time via _ensure_runtime_credentials().

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -628,3 +628,32 @@ def test_cli_model_alias_resolves_to_target_provider_and_base_url(monkeypatch):
     shell3 = cli.HermesCLI(model="anthropic/claude-3.5", compact=True, max_turns=1)
     assert shell3.model == "anthropic/claude-3.5"
     assert shell3.requested_provider == "openrouter"
+
+
+def test_cli_explicit_base_url_wins_over_alias(monkeypatch):
+    """#62534: an explicit --base-url must override the alias's base_url.
+
+    Regression for the alias-resolution clobbering caller-supplied endpoints.
+    """
+    cli = _import_cli()
+
+    _config = load_config()
+    _config["model_aliases"] = {
+        "gemma": {
+            "base_url": "http://localhost:1234/v1",
+            "model": "gemma-4-31B-it-qat-bf16",
+            "provider": "custom",
+        },
+    }
+    _config["model"] = {"provider": "openrouter", "default": "tencent/hy3:free"}
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: _config)
+    monkeypatch.setattr(cli, "CLI_CONFIG", _config)
+
+    shell = cli.HermesCLI(
+        model="gemma", base_url="https://explicit.example/v1", compact=True, max_turns=1
+    )
+    # model + provider still come from the alias...
+    assert shell.model == "gemma-4-31B-it-qat-bf16"
+    assert shell.requested_provider == "custom"
+    # ...but the explicit base_url wins over the alias's localhost URL.
+    assert shell.base_url == "https://explicit.example/v1"

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -8,6 +8,7 @@ import pytest
 
 from hermes_cli.auth import AuthError
 from hermes_cli import main as hermes_main
+from hermes_cli.config import load_config
 
 
 # ---------------------------------------------------------------------------
@@ -575,8 +576,6 @@ def test_save_custom_provider_references_the_key_instead_of_inlining_it(monkeypa
     assert "sk-secret" not in yaml.safe_dump(saved)
 
 
-
-
 def test_custom_endpoint_key_env_is_a_valid_posix_name_for_ip_endpoints():
     """Every IP-based local endpoint slugs to a digit-leading name.
 
@@ -593,3 +592,39 @@ def test_custom_endpoint_key_env_is_a_valid_posix_name_for_ip_endpoints():
         assert _ENV_VAR_NAME_RE.match(custom_endpoint_key_env(identity)), identity
 
 
+def test_cli_model_alias_resolves_to_target_provider_and_base_url(monkeypatch):
+    """#62491: `hermes chat --model <alias>` must resolve model_aliases.
+
+    Without this, the alias string is sent verbatim to the configured default
+    provider (OpenRouter) and 400s. The CLI path must behave like the GUI
+    picker: expand the alias into (model, provider, base_url).
+    """
+    cli = _import_cli()
+
+    _config = load_config()
+    _config["model_aliases"] = {
+        "gemma": {
+            "base_url": "http://localhost:1234/v1",
+            "model": "gemma-4-31B-it-qat-bf16",
+            "provider": "custom",
+        },
+    }
+    _config["model"] = {"provider": "openrouter", "default": "tencent/hy3:free"}
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: _config)
+    # CLI_CONFIG is read for the default provider + display.
+    monkeypatch.setattr(cli, "CLI_CONFIG", _config)
+
+    shell = cli.HermesCLI(model="gemma", compact=True, max_turns=1)
+    assert shell.model == "gemma-4-31B-it-qat-bf16"
+    assert shell.requested_provider == "custom"
+    assert shell.base_url == "http://localhost:1234/v1"
+
+    # Explicit --provider custom alongside the alias should not break either.
+    shell2 = cli.HermesCLI(model="gemma", provider="custom", compact=True, max_turns=1)
+    assert shell2.model == "gemma-4-31B-it-qat-bf16"
+    assert shell2.requested_provider == "custom"
+
+    # A non-alias model is untouched (no fallback to default provider).
+    shell3 = cli.HermesCLI(model="anthropic/claude-3.5", compact=True, max_turns=1)
+    assert shell3.model == "anthropic/claude-3.5"
+    assert shell3.requested_provider == "openrouter"


### PR DESCRIPTION
## Summary

Fixes #62491 — `hermes chat --model <alias>` ignores `model_aliases`, sending the alias verbatim to the configured default provider (OpenRouter) → HTTP 400. The GUI picker reads these aliases; the CLI chat path did not.

**Root cause** (`cli.py`, `HermesCLI.__init__`)
`self.model = model or _config_model` and `self.requested_provider` were set from the raw `--model` / `--provider` args with no consultation of `model_aliases`. The alias-resolution logic existed only in `hermes_cli/oneshot.py` (the `hermes -z` path) — not in the interactive-chat path, which flows through `HermesCLI.__init__` → `_ensure_runtime_credentials`. So an alias with `provider: custom` + `base_url: http://localhost:...` was turned into `openrouter` + model=`gemma`, and `--provider custom` alongside it was also bypassed.

**Fix** (single choke point, root cause not symptom)
In `HermesCLI.__init__`, resolve the `--model` arg against `model_switch.DIRECT_ALIASES` (the same loaded aliases the GUI/oneshot use — no re-parsing, no new abstraction) before the default provider is attached:
- `self.model` ← alias target model
- `self.requested_provider` ← alias provider (only when `--provider` not explicitly given)
- `self._explicit_base_url` / `self.base_url` ← alias `base_url` (when present)

Explicit `--provider custom` still wins; a non-alias model is untouched (falls through to configured defaults as before). Both reporter cases now route correctly.

## Test plan

`tests/cli/test_cli_provider_resolution.py` (added `test_cli_model_alias_resolves_to_target_provider_and_base_url`, full file 24 passed):
- `hermes chat --model gemma` → `model=gemma-4-31B-it-qat-bf16`, `requested_provider=custom`, `base_url=http://localhost:1234/v1`
- `--model gemma --provider custom` → still resolves to the alias target (no break)
- non-alias model (`anthropic/claude-3.5`) → unchanged, `requested_provider=openrouter`

## Verification

```
# end-to-end repro against reporter config:
.venv/bin/python /tmp/repro62491.py  -> RESOLVED provider=custom base_url=http://localhost:1234/v1
.venv/bin/python -m pytest tests/cli/test_cli_provider_resolution.py -q  # 24 passed
```

## Risk

`cli.py` only; adds one alias lookup at the existing model-init site, reusing `model_switch.DIRECT_ALIASES`. No change to oneshot behavior or the GUI picker. repowise `risk`: 2nd percentile (low).
