### PR TITLE
fix(memory): update Hindsight client to 0.8.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,7 +156,7 @@ fal = ["fal-client==0.13.1"]
 edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
-hindsight = ["hindsight-client==0.6.1"]
+hindsight = ["hindsight-client==0.8.4"]
 dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "mcp==1.26.0", "starlette==1.0.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==81.0.0"]  # starlette: CVE-2026-48710; setuptools: latest <82 (torch >=2.11 caps setuptools<82)
 messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.14.1", "brotlicffi==1.2.0.1", "slack-bolt==1.27.0", "slack-sdk==3.40.1", "qrcode==7.4.2"]  # aiohttp 3.14.1: CVE-2026-34513/34518/34519/34520/34525 + 34993(RCE)/47265
 cron = []  # croniter is now a core dependency; this extra kept for back-compat

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -140,7 +140,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
 
     # ─── Memory providers ──────────────────────────────────────────────────
     "memory.honcho": ("honcho-ai==2.0.1",),
-    "memory.hindsight": ("hindsight-client==0.6.1",),
+    "memory.hindsight": ("hindsight-client==0.8.4",),
     # supermemory + mem0 are opt-in cloud memory providers with their own
     # SDKs. On the published Docker image the agent venv is sealed
     # (HERMES_DISABLE_LAZY_INSTALLS=1) and lazy installs are redirected to the

--- a/uv.lock
+++ b/uv.lock
@@ -1790,7 +1790,7 @@ requires-dist = [
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'termux-all'" },
     { name = "hermes-agent", extras = ["youtube"], marker = "extra == 'all'" },
-    { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = "==0.6.1" },
+    { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = "==0.8.4" },
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = "==2.0.1" },
     { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
     { name = "jinja2", specifier = "==3.1.6" },
@@ -1881,7 +1881,7 @@ wheels = [
 
 [[package]]
 name = "hindsight-client"
-version = "0.6.1"
+version = "0.8.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1891,9 +1891,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/26/8b8efa4be21fc3ba12ade3b1353d87f9837ec0d3ec2607e8adbf85bc9c63/hindsight_client-0.6.1.tar.gz", hash = "sha256:314d0bb9e13622e15586ba1586a799726d405b27bc20d78872474b5d6d96cd51", size = 99833, upload-time = "2026-05-08T13:01:23.537Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/e6/1fe61c4fb97afa1dcd9579b8b0f7cb8de24d567a6e8ed5a84192a57a5db5/hindsight_client-0.8.4.tar.gz", hash = "sha256:7291f1aa0e6bb226cd585d1f216e91078cce0af5aca60c24b90e1a54750f3a76", size = 117909, upload-time = "2026-07-01T11:43:58.987Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/4f/a1d0bc33ef933ecc52e76dc1514163594d25836a5d303c256a61bb61445d/hindsight_client-0.6.1-py3-none-any.whl", hash = "sha256:9fdda176ab50f7cec8d7339c6608c148f0cd9ad7e65d9d76192f2db730bc330a", size = 249379, upload-time = "2026-05-08T13:01:22.035Z" },
+    { url = "https://files.pythonhosted.org/packages/19/b1/4abd57a52d3126e0a3554b558442c7d0972be2f3c5b879b9c215d35d5d7e/hindsight_client-0.8.4-py3-none-any.whl", hash = "sha256:8e352bd90d5c43cccb1bee5023ac8c17fb578398c8220d9b85dd6175e7c40c52", size = 290269, upload-time = "2026-07-01T11:43:57.519Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- bump the `hindsight` extra from `hindsight-client==0.6.1` to `0.8.4`
- keep the lazy dependency installer on the same client version
- refresh `uv.lock` to the current PyPI release

## Why

The current Hermes pin installs Hindsight client 0.6.1 even when a newer Hindsight 0.8.4 server is deployed. This also downgrades a manually upgraded client whenever Hermes is reinstalled or the lazy dependency path runs.

Hindsight 0.8.4 is the current PyPI release for both `hindsight-client` and `hindsight-all`, so aligning the client pin avoids that downgrade and keeps the supported client/server release pair in sync.

## Verification

- `uv lock --upgrade-package hindsight-client`
- installed Hermes with `.[hindsight,dev]`
- verified `importlib.metadata.version("hindsight-client") == "0.8.4"`
- verified a live Hindsight 0.8.4 server returned `healthy` with the 0.8.4 client
- targeted gateway/config suite: 236 passed
