### PR TITLE
feat(providers): add native Cline API and ClinePass onboarding

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -693,10 +693,13 @@ class ChatCompletionsTransport(ProviderTransport):
         # so keep them apart in provider_data rather than merging.
         reasoning = getattr(msg, "reasoning", None)
         reasoning_content = getattr(msg, "reasoning_content", None)
-        if reasoning_content is None and hasattr(msg, "model_extra"):
+        if hasattr(msg, "model_extra"):
             model_extra = getattr(msg, "model_extra", None) or {}
-            if isinstance(model_extra, dict) and "reasoning_content" in model_extra:
-                reasoning_content = model_extra["reasoning_content"]
+            if isinstance(model_extra, dict):
+                if reasoning is None and "reasoning" in model_extra:
+                    reasoning = model_extra["reasoning"]
+                if reasoning_content is None and "reasoning_content" in model_extra:
+                    reasoning_content = model_extra["reasoning_content"]
 
         provider_data: Dict[str, Any] = {}
         if reasoning_content is not None:

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -2762,8 +2762,8 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
             else:
                 model_list = mdev_models
             print(f"  Found {len(model_list)} model(s) from models.dev registry")
-        elif curated and len(curated) >= 8:
-            # Curated list is substantial — use it directly, skip live probe
+        elif curated and (len(curated) >= 8 or provider_id in {"cline-api", "cline-pass"}):
+            # Substantial or explicitly no-discovery catalogs use curated data.
             model_list = curated
             print(
                 f'  Showing {len(model_list)} curated models — use "Enter custom model name" for others.'

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1091,6 +1091,8 @@ _canonical_slugs = {p.slug for p in CANONICAL_PROVIDERS}
 try:
     from providers import list_providers as _list_providers_for_canonical
     for _pp in _list_providers_for_canonical():
+        if _pp.fallback_models:
+            _PROVIDER_MODELS.setdefault(_pp.name, list(_pp.fallback_models))
         if _pp.name in _canonical_slugs:
             continue
         if _pp.auth_type in {"oauth_device_code", "oauth_external", "external_process", "aws_sdk", "copilot", "vertex"}:

--- a/plugins/model-providers/cline-api/__init__.py
+++ b/plugins/model-providers/cline-api/__init__.py
@@ -1,0 +1,61 @@
+"""Cline pay-as-you-go API-credit provider.
+
+Cline exposes an OpenAI-compatible chat-completions gateway but does not
+publish a documented model-list endpoint. The curated fallback contains the
+agentic models validated against that gateway and preserves Cline's native
+``provider/model`` identifiers verbatim.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class ClineApiProfile(ProviderProfile):
+    """Cline API wire compatibility and deterministic model catalog."""
+
+    def fetch_models(self, **kwargs: Any) -> list[str] | None:
+        """Return the curated catalog without probing an undocumented endpoint."""
+        return list(self.fallback_models)
+
+    def build_api_kwargs_extras(
+        self, *, reasoning_config: dict | None = None, **context: Any
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        effort = ""
+        if (
+            isinstance(reasoning_config, dict)
+            and reasoning_config.get("enabled") is not False
+        ):
+            effort = str(reasoning_config.get("effort") or "").strip().lower()
+        top_level = (
+            {"reasoning_effort": effort}
+            if effort in {"minimal", "low", "medium", "high", "xhigh"}
+            else {}
+        )
+        return {}, top_level
+
+
+cline_api = ClineApiProfile(
+    name="cline-api",
+    env_vars=("CLINE_API_KEY",),
+    display_name="Cline API",
+    description="Cline API (pay-as-you-go usage credits)",
+    signup_url="https://app.cline.bot/dashboard/account",
+    fallback_models=(
+        "zai/glm-5.2",
+        "moonshotai/kimi-k2.7-code",
+        "moonshotai/kimi-k2.6",
+        "deepseek/deepseek-v4-pro",
+        "deepseek/deepseek-v4-flash",
+    ),
+    base_url="https://api.cline.bot/api/v1",
+    supports_health_check=False,
+    supports_vision=True,
+    default_max_tokens=65536,
+    default_aux_model="deepseek/deepseek-v4-flash",
+)
+
+register_provider(cline_api)

--- a/plugins/model-providers/cline-api/plugin.yaml
+++ b/plugins/model-providers/cline-api/plugin.yaml
@@ -1,0 +1,5 @@
+name: cline-api-provider
+kind: model-provider
+version: 1.0.0
+description: Cline API usage-credit gateway
+author: Nous Research

--- a/plugins/model-providers/cline-pass/__init__.py
+++ b/plugins/model-providers/cline-pass/__init__.py
@@ -1,0 +1,72 @@
+"""ClinePass subscription provider.
+
+ClinePass shares Cline's OpenAI-compatible gateway but has a separate quota,
+credential, and ``cline-pass/*`` model namespace. Its keys do not support model
+discovery, so this profile always returns the curated subscription catalog.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class ClinePassProfile(ProviderProfile):
+    """ClinePass wire compatibility with discovery explicitly disabled."""
+
+    def fetch_models(self, **kwargs: Any) -> list[str] | None:
+        """Never call ``/models``; ClinePass keys receive 404 there."""
+        return list(self.fallback_models)
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        model: str | None = None,
+        **context: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        effort = ""
+        if (
+            isinstance(reasoning_config, dict)
+            and reasoning_config.get("enabled") is not False
+        ):
+            effort = str(reasoning_config.get("effort") or "").strip().lower()
+        if "mimo-v2.5" in (model or "").lower():
+            effort = {"minimal": "low", "xhigh": "high"}.get(effort, effort)
+        top_level = (
+            {"reasoning_effort": effort}
+            if effort in {"minimal", "low", "medium", "high", "xhigh"}
+            else {}
+        )
+        return {}, top_level
+
+
+cline_pass = ClinePassProfile(
+    name="cline-pass",
+    aliases=("clinepass",),
+    env_vars=("CLINEPASS_API_KEY", "CLINE_API_KEY"),
+    display_name="ClinePass",
+    description="ClinePass (monthly subscription quota)",
+    signup_url="https://app.cline.bot/dashboard/subscription?personal=true",
+    fallback_models=(
+        "cline-pass/glm-5.2",
+        "cline-pass/kimi-k2.7-code",
+        "cline-pass/kimi-k2.6",
+        "cline-pass/deepseek-v4-pro",
+        "cline-pass/deepseek-v4-flash",
+        "cline-pass/mimo-v2.5",
+        "cline-pass/mimo-v2.5-pro",
+        "cline-pass/minimax-m3",
+        "cline-pass/qwen3.7-max",
+        "cline-pass/qwen3.7-plus",
+    ),
+    base_url="https://api.cline.bot/api/v1",
+    supports_health_check=False,
+    supports_vision=True,
+    default_max_tokens=65536,
+    default_aux_model="cline-pass/deepseek-v4-flash",
+)
+
+register_provider(cline_pass)

--- a/plugins/model-providers/cline-pass/plugin.yaml
+++ b/plugins/model-providers/cline-pass/plugin.yaml
@@ -1,0 +1,5 @@
+name: cline-pass-provider
+kind: model-provider
+version: 1.0.0
+description: ClinePass subscription gateway
+author: Nous Research

--- a/tests/test_cline_providers.py
+++ b/tests/test_cline_providers.py
@@ -1,0 +1,72 @@
+"""Behavior contracts for the native Cline billing routes."""
+
+from types import SimpleNamespace
+
+from agent.transports.chat_completions import ChatCompletionsTransport
+from hermes_cli.auth import PROVIDER_REGISTRY
+from hermes_cli.models import CANONICAL_PROVIDERS, _PROVIDER_MODELS
+from providers import get_provider_profile
+
+
+def test_cline_providers_should_be_first_class_onboarding_choices():
+    slugs = {provider.slug for provider in CANONICAL_PROVIDERS}
+    assert {"cline-api", "cline-pass"} <= slugs
+    assert PROVIDER_REGISTRY["cline-api"].api_key_env_vars == ("CLINE_API_KEY",)
+    assert PROVIDER_REGISTRY["cline-pass"].api_key_env_vars == (
+        "CLINEPASS_API_KEY",
+        "CLINE_API_KEY",
+    )
+
+
+def test_cline_api_should_preserve_provider_model_wire_ids():
+    profile = get_provider_profile("cline-api")
+    assert profile is not None
+    assert profile.fetch_models() == list(_PROVIDER_MODELS["cline-api"])
+    assert "zai/glm-5.2" in profile.fetch_models()
+    _, top_level = profile.build_api_kwargs_extras(
+        reasoning_config={"enabled": True, "effort": "xhigh"}
+    )
+    assert top_level == {"reasoning_effort": "xhigh"}
+
+
+def test_cline_pass_should_use_static_subscription_catalog_without_discovery():
+    profile = get_provider_profile("cline-pass")
+    assert profile is not None
+    models = profile.fetch_models(api_key="sk-test")
+    assert models == list(_PROVIDER_MODELS["cline-pass"])
+    assert all(model.startswith("cline-pass/") for model in models)
+
+
+def test_cline_pass_should_clamp_mimo_effort_but_preserve_other_xhigh():
+    profile = get_provider_profile("cline-pass")
+    assert profile is not None
+    _, mimo = profile.build_api_kwargs_extras(
+        model="cline-pass/mimo-v2.5",
+        reasoning_config={"enabled": True, "effort": "xhigh"},
+    )
+    _, glm = profile.build_api_kwargs_extras(
+        model="cline-pass/glm-5.2",
+        reasoning_config={"enabled": True, "effort": "xhigh"},
+    )
+    assert mimo == {"reasoning_effort": "high"}
+    assert glm == {"reasoning_effort": "xhigh"}
+
+
+def test_chat_normalization_should_capture_cline_delta_reasoning_from_model_extra():
+    message = SimpleNamespace(
+        content="done",
+        tool_calls=None,
+        reasoning=None,
+        reasoning_content=None,
+        reasoning_details=None,
+        refusal=None,
+        model_extra={"reasoning": "cline thought"},
+    )
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason="stop")],
+        usage=None,
+    )
+    normalized = ChatCompletionsTransport.__new__(
+        ChatCompletionsTransport
+    ).normalize_response(response)
+    assert normalized.reasoning == "cline thought"

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -138,6 +138,8 @@ Good defaults:
 | **Kilo Code** | KiloCode-hosted models | Set `KILOCODE_API_KEY` |
 | **OpenCode Zen** | Pay-as-you-go access to curated models | Set `OPENCODE_ZEN_API_KEY` |
 | **OpenCode Go** | $10/month subscription for open models | Set `OPENCODE_GO_API_KEY` |
+| **Cline API** | Pay-as-you-go access using Cline usage credits | Set `CLINE_API_KEY` |
+| **ClinePass** | Monthly subscription quota for curated open models | Set `CLINEPASS_API_KEY` |
 | **DeepSeek** | Direct DeepSeek API access | Set `DEEPSEEK_API_KEY` |
 | **NVIDIA NIM** | Nemotron models via build.nvidia.com or local NIM | Set `NVIDIA_API_KEY` (optional: `NVIDIA_BASE_URL`) |
 | **GitHub Copilot** | GitHub Copilot subscription (GPT-5.x, Claude, Gemini, etc.) | OAuth via `hermes model`, or `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` |

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -37,6 +37,8 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Tencent TokenHub** | `TOKENHUB_API_KEY` in `~/.hermes/.env` (provider: `tencent-tokenhub`, aliases: `tencent`, `tokenhub`, `tencentmaas`) |
 | **OpenCode Zen** | `OPENCODE_ZEN_API_KEY` in `~/.hermes/.env` (provider: `opencode-zen`) |
 | **OpenCode Go** | `OPENCODE_GO_API_KEY` in `~/.hermes/.env` (provider: `opencode-go`) |
+| **Cline API** | `CLINE_API_KEY` in `~/.hermes/.env` (provider: `cline-api`; pay-as-you-go usage credits) |
+| **ClinePass** | `CLINEPASS_API_KEY` in `~/.hermes/.env` (provider: `cline-pass`, alias: `clinepass`; falls back to `CLINE_API_KEY`) |
 | **DeepSeek** | `DEEPSEEK_API_KEY` in `~/.hermes/.env` (provider: `deepseek`) |
 | **Hugging Face** | `HF_TOKEN` in `~/.hermes/.env` (provider: `huggingface`, aliases: `hf`) |
 | **Google / Gemini** | `GOOGLE_API_KEY` (or `GEMINI_API_KEY`) in `~/.hermes/.env` (provider: `gemini`) |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -74,6 +74,8 @@ Hermes reads environment variables from the process environment and, for user-ma
 | `DASHSCOPE_BASE_URL` | Custom DashScope base URL (default: `https://dashscope-intl.aliyuncs.com/compatible-mode/v1`; use `https://dashscope.aliyuncs.com/compatible-mode/v1` for mainland-China region) |
 | `ALIBABA_CODING_PLAN_API_KEY` | Qwen Coding Plan API key (`alibaba-coding-plan` provider) |
 | `ALIBABA_CODING_PLAN_BASE_URL` | Override the Qwen Coding Plan base URL |
+| `CLINE_API_KEY` | Cline API key for pay-as-you-go usage credits; also a ClinePass compatibility fallback |
+| `CLINEPASS_API_KEY` | ClinePass subscription API key; preferred when both Cline billing routes are configured |
 | `DEEPSEEK_API_KEY` | DeepSeek API key for direct DeepSeek access ([platform.deepseek.com](https://platform.deepseek.com/api_keys)) |
 | `DEEPSEEK_BASE_URL` | Custom DeepSeek API base URL |
 | `NOVITA_API_KEY` | NovitaAI API key — AI-native cloud for Model API, Agent Sandbox, and GPU Cloud ([novita.ai/settings/key-management](https://novita.ai/settings/key-management)) |


### PR DESCRIPTION
## Summary

Adds Cline's two billing routes as separate native Hermes providers and first-class `hermes model` onboarding choices:

- `cline-api` — pay-as-you-go Cline usage credits
- `cline-pass` — monthly ClinePass subscription quota

## Provider behavior

- separate credential identities (`CLINE_API_KEY` and preferred `CLINEPASS_API_KEY`)
- ClinePass retains `CLINE_API_KEY` as a compatibility fallback
- Cline API preserves documented `provider/model` IDs verbatim
- ClinePass uses its required `cline-pass/*` model namespace
- deterministic curated catalogs avoid the unsupported ClinePass `/models` probe
- both routes preserve `minimal` through `xhigh` reasoning effort; MiMo clamps unsupported edge tiers
- chat normalization captures Cline's `delta.reasoning` when the OpenAI SDK stores it in `model_extra`

## Onboarding and docs

Provider profiles auto-register with the canonical model picker and API-key provider registry. The generic setup flow now treats the Cline profiles as explicit no-discovery catalogs. Quickstart, provider, and environment-variable references document both routes.

## Verification

- `pytest -q tests/test_cline_providers.py` — 5 passed
- provider/setup/runtime regression selection — 401 passed
- `ruff check` on all changed Python files — passed

Related: #55815.