### PR TITLE
fix(discord): bound approval reason embed fields

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -133,6 +133,21 @@ def _truncate_discord_component_text(text: str, limit: int) -> str:
     return _prefix_within_utf16_limit(str(text or ""), max(0, limit))
 
 
+def _truncate_discord_text(
+    text: str,
+    limit: int,
+    *,
+    suffix: str = "... [truncated]",
+) -> str:
+    """Return text within a Discord UTF-16 field budget, preserving a marker."""
+    value = str(text or "")
+    if utf16_len(value) <= limit:
+        return value
+    suffix = _prefix_within_utf16_limit(suffix, max(0, limit))
+    prefix_budget = max(0, limit - utf16_len(suffix))
+    return _prefix_within_utf16_limit(value, prefix_budget) + suffix
+
+
 async def _wait_for_ready_or_bot_exit(
     ready_event: asyncio.Event,
     bot_task: asyncio.Task,
@@ -5596,10 +5611,11 @@ class DiscordAdapter(BasePlatformAdapter):
             # component row on some clients (notably web/mobile), so the actual
             # command and reason must be visible in the same content block as
             # the approval buttons.
-            reason_budget = 300
-            reason_display = str(description or "dangerous command")
-            if len(reason_display) > reason_budget:
-                reason_display = reason_display[: reason_budget - 15] + "... [truncated]"
+            reason_display = _truncate_discord_text(
+                str(description or "dangerous command"),
+                1024,
+                suffix="... [truncated]",
+            )
 
             prompt_prefix = (
                 "⚠️ **Command Approval Required**\n\n"

--- a/tests/gateway/test_discord_exec_approval_content.py
+++ b/tests/gateway/test_discord_exec_approval_content.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from gateway.config import PlatformConfig
+from gateway.platforms.base import utf16_len
 from plugins.platforms.discord.adapter import DiscordAdapter
 
 
@@ -66,3 +67,23 @@ async def test_exec_approval_prompt_truncates_long_command_in_content():
     assert "... [truncated]" in sent["content"]
     assert "long generated shell command" in sent["content"]
     assert len(sent["embed"].description) > len(sent["content"])
+
+
+@pytest.mark.asyncio
+async def test_exec_approval_prompt_bounds_long_reason_to_discord_field_limit():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    sent = _capture_channel(adapter)
+
+    long_reason = "security finding 🚨 " * 200
+    result = await adapter.send_exec_approval(
+        chat_id="555",
+        command="curl http://sparky.local:8000/metrics",
+        session_key="discord:555",
+        description=long_reason,
+    )
+
+    assert result.success is True
+    reason = sent["embed"].fields[0]["value"]
+    assert utf16_len(reason) <= 1024
+    assert reason.endswith("... [truncated]")
+    assert reason in sent["content"]


### PR DESCRIPTION
## Summary
- bound Discord approval `Reason` embed fields to the platform's 1,024 UTF-16-unit limit
- preserve an explicit truncation marker and the same reason in visible message content
- add regression coverage using emoji to exercise Discord's UTF-16 counting semantics

## Incident
The Discord gateway fell back to plain text when Tirith emitted long security findings:

```text
400 Bad Request (error code: 50035): Invalid Form Body
In embeds.0.fields.0.value: Must be 1024 or fewer in length.
```

## Tests
```text
scripts/run_tests.sh tests/gateway/test_discord_exec_approval_content.py tests/gateway/test_discord_approval_mentions.py -v --tb=short
6 passed, 0 failed
```