### PR TITLE
fix(openviking): read recall settings from config.yaml first, env vars as fallback

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -2585,45 +2585,46 @@ class OpenVikingMemoryProvider(MemoryProvider):
         return max(minimum, min(maximum, value))
 
     def _recall_config(self) -> Dict[str, Any]:
+        # Read from config.yaml → memory.openviking as primary source, env vars
+        # as override. Behavioural settings belong in config.yaml (AGENTS.md).
+        provider_config = _load_hermes_openviking_config()
+        cfg = provider_config
+
         return {
             "limit": self._env_int(
                 "OPENVIKING_RECALL_LIMIT",
-                _DEFAULT_RECALL_LIMIT,
-                minimum=1,
-                maximum=100,
+                cfg.get("recall_limit", _DEFAULT_RECALL_LIMIT),
+                minimum=1, maximum=100,
             ),
             "score_threshold": self._env_float(
                 "OPENVIKING_RECALL_SCORE_THRESHOLD",
-                _DEFAULT_RECALL_SCORE_THRESHOLD,
-                minimum=0.0,
-                maximum=1.0,
+                cfg.get("recall_score_threshold", _DEFAULT_RECALL_SCORE_THRESHOLD),
+                minimum=0.0, maximum=1.0,
             ),
             "max_injected_chars": self._env_int(
                 "OPENVIKING_RECALL_MAX_INJECTED_CHARS",
-                _DEFAULT_RECALL_MAX_INJECTED_CHARS,
-                minimum=100,
-                maximum=50000,
+                cfg.get("recall_max_injected_chars", _DEFAULT_RECALL_MAX_INJECTED_CHARS),
+                minimum=100, maximum=50000,
             ),
             "timeout_seconds": self._env_float(
                 "OPENVIKING_RECALL_TIMEOUT_SECONDS",
-                _DEFAULT_RECALL_TIMEOUT_SECONDS,
-                minimum=0.25,
-                maximum=60.0,
+                cfg.get("recall_timeout_seconds", _DEFAULT_RECALL_TIMEOUT_SECONDS),
+                minimum=0.25, maximum=60.0,
             ),
             "request_timeout_seconds": self._env_float(
                 "OPENVIKING_RECALL_REQUEST_TIMEOUT_SECONDS",
-                _DEFAULT_RECALL_REQUEST_TIMEOUT_SECONDS,
-                minimum=0.25,
-                maximum=60.0,
+                cfg.get("recall_request_timeout_seconds", _DEFAULT_RECALL_REQUEST_TIMEOUT_SECONDS),
+                minimum=0.25, maximum=60.0,
             ),
             "full_read_limit": self._env_int(
                 "OPENVIKING_RECALL_FULL_READ_LIMIT",
-                _DEFAULT_RECALL_FULL_READ_LIMIT,
-                minimum=0,
-                maximum=100,
+                cfg.get("recall_full_read_limit", _DEFAULT_RECALL_FULL_READ_LIMIT),
+                minimum=0, maximum=100,
             ),
-            "prefer_abstract": self._env_bool("OPENVIKING_RECALL_PREFER_ABSTRACT", False),
-            "resources": self._env_bool("OPENVIKING_RECALL_RESOURCES", False),
+            "prefer_abstract": self._env_bool("OPENVIKING_RECALL_PREFER_ABSTRACT",
+                cfg.get("recall_prefer_abstract", False)),
+            "resources": self._env_bool("OPENVIKING_RECALL_RESOURCES",
+                cfg.get("recall_resources", False)),
         }
 
     @staticmethod

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -1,6 +1,7 @@
 """Tests for plugins/memory/openviking/__init__.py — URI normalization and payload handling."""
 
 import json
+import os
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any, cast
@@ -365,6 +366,93 @@ class TestOpenVikingConfigSchema:
             "prefer_abstract": False,
             "resources": False,
         }
+
+    def test_recall_config_reads_from_config_yaml(self, monkeypatch, tmp_path):
+        """_recall_config() reads memory.openviking values from config.yaml when
+        the corresponding OPENVIKING_RECALL_* env vars are not set."""
+        # Populate config.yaml in the temp HERMES_HOME
+        hermes_home = tmp_path / "hermes_test"
+        hermes_home.mkdir(exist_ok=True)
+        config_yaml = hermes_home / "config.yaml"
+        config_yaml.write_text("""\
+memory:
+  provider: openviking
+  openviking:
+    recall_limit: 12
+    recall_score_threshold: 0.42
+    recall_max_injected_chars: 8000
+    recall_timeout_seconds: 2.0
+    recall_request_timeout_seconds: 1.5
+    recall_full_read_limit: 5
+    recall_prefer_abstract: true
+    recall_resources: true
+""")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        # Clear any OPENVIKING_RECALL_* env vars so config.yaml prevails
+        for key in list(os.environ):
+            if key.startswith("OPENVIKING_RECALL_"):
+                monkeypatch.delenv(key, raising=False)
+
+        provider = OpenVikingMemoryProvider()
+        cfg = provider._recall_config()
+
+        assert cfg["limit"] == 12
+        assert cfg["score_threshold"] == 0.42
+        assert cfg["max_injected_chars"] == 8000
+        assert cfg["timeout_seconds"] == 2.0
+        assert cfg["request_timeout_seconds"] == 1.5
+        assert cfg["full_read_limit"] == 5
+        assert cfg["prefer_abstract"] is True
+        assert cfg["resources"] is True
+
+    def test_recall_config_env_overrides_config_yaml(self, monkeypatch, tmp_path):
+        """Env vars OPENVIKING_RECALL_* take precedence over config.yaml values
+        when both are present."""
+        hermes_home = tmp_path / "hermes_test"
+        hermes_home.mkdir(exist_ok=True)
+        config_yaml = hermes_home / "config.yaml"
+        config_yaml.write_text("""\
+memory:
+  provider: openviking
+  openviking:
+    recall_limit: 12
+    recall_resources: true
+""")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        # Override config.yaml via env
+        monkeypatch.setenv("OPENVIKING_RECALL_LIMIT", "6")
+        monkeypatch.setenv("OPENVIKING_RECALL_RESOURCES", "false")
+
+        provider = OpenVikingMemoryProvider()
+        cfg = provider._recall_config()
+
+        assert cfg["limit"] == 6, "env var should override config.yaml"
+        assert cfg["resources"] is False, "env var false should override config.yaml true"
+
+    def test_recall_config_partial_config_yaml(self, monkeypatch, tmp_path):
+        """Partially populated config.yaml falls back to defaults for omitted keys
+        and env vars can override individual fields."""
+        hermes_home = tmp_path / "hermes_test"
+        hermes_home.mkdir(exist_ok=True)
+        config_yaml = hermes_home / "config.yaml"
+        config_yaml.write_text("""\
+memory:
+  provider: openviking
+  openviking:
+    recall_limit: 3
+    # No recall_resources set — should use default (False)
+""")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        for key in list(os.environ):
+            if key.startswith("OPENVIKING_RECALL_"):
+                monkeypatch.delenv(key, raising=False)
+
+        provider = OpenVikingMemoryProvider()
+        cfg = provider._recall_config()
+
+        assert cfg["limit"] == 3, "config.yaml value should be picked up"
+        assert cfg["resources"] is False, "omitted key should use default"
+        assert cfg["timeout_seconds"] == 4.0, "omitted key should use built-in default"
 
 
 class TestOpenVikingTurnConversion:


### PR DESCRIPTION
## Summary

`OpenVikingMemoryProvider._recall_config()` previously read all recall settings (`recall_limit`, `score_threshold`, `recall_resources`, etc.) exclusively from environment variables. This forced users to store behavioural configuration in `.env`, violating the Hermes convention that `.env` is for secrets only.

## Root Cause

The infrastructure to load `config.yaml → memory.openviking` was already in place via `_load_hermes_openviking_config()`, and was used by `_resolve_connection_settings()` for connection parameters. But `_recall_config()` never called it — it only read env vars.

## Fix

`_recall_config()` now calls `_load_hermes_openviking_config()` and passes config.yaml values as the `default` parameter to the existing `_env_int`/`_env_float`/`_env_bool` helpers. Env vars still override config.yaml values, preserving backward compatibility.

## Priority

config.yaml → env var → built-in default. This matches how `_resolve_connection_settings()` already uses config.yaml for connection parameters.

## Closes

Closes #62540