### PR TITLE
feat(api): stream subagent progress through Runs SSE

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4767,7 +4767,10 @@ class APIServerAdapter(BasePlatformAdapter):
                     "run_id": run_id,
                     "timestamp": ts,
                     "tool": tool_name or "",
-                    "preview": preview or tool_name or "",
+                    "preview": redact_sensitive_text(
+                        str(preview or tool_name or ""),
+                        force=True,
+                    ),
                 }
                 for field in (
                     "subagent_id",

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4761,6 +4761,26 @@ class APIServerAdapter(BasePlatformAdapter):
                     "duration": round(kwargs.get("duration", 0), 3),
                     "error": kwargs.get("is_error", False),
                 })
+            elif event_type == "subagent.tool":
+                event = {
+                    "event": "subagent.progress",
+                    "run_id": run_id,
+                    "timestamp": ts,
+                    "tool": tool_name or "",
+                    "preview": preview or tool_name or "",
+                }
+                for field in (
+                    "subagent_id",
+                    "parent_id",
+                    "depth",
+                    "task_index",
+                    "task_count",
+                    "child_session_id",
+                    "tool_count",
+                ):
+                    if kwargs.get(field) is not None:
+                        event[field] = kwargs[field]
+                _push(event)
             elif event_type == "reasoning.available":
                 _push({
                     "event": "reasoning.available",

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -684,6 +684,56 @@ def auth_adapter():
     return _make_adapter(api_key="sk-secret")
 
 
+class TestMakeRunEventCallback:
+    """Structured progress events emitted by long-running API runs."""
+
+    @staticmethod
+    def _make_callback(run_id="run_test"):
+        adapter = _make_adapter()
+        captured = []
+        fake_queue = MagicMock()
+        fake_queue.put_nowait.side_effect = captured.append
+        adapter._run_streams = {run_id: fake_queue}
+
+        fake_loop = MagicMock()
+        fake_loop.call_soon_threadsafe.side_effect = lambda fn, arg: fn(arg)
+        return adapter._make_run_event_callback(run_id, fake_loop), captured
+
+    def test_subagent_tool_is_forwarded_as_structured_progress(self):
+        callback, events = self._make_callback()
+
+        callback(
+            "subagent.tool",
+            tool_name="read_file",
+            preview="reading gateway/run.py",
+            args={"api_key": "must-not-stream"},
+            subagent_id="subagent-1",
+            parent_id="parent-1",
+            depth=1,
+            task_index=0,
+            task_count=2,
+            child_session_id="session-child",
+            tool_count=3,
+        )
+
+        assert len(events) == 1
+        event = events[0]
+        assert event["timestamp"] > 0
+        assert {key: value for key, value in event.items() if key != "timestamp"} == {
+            "event": "subagent.progress",
+            "run_id": "run_test",
+            "tool": "read_file",
+            "preview": "reading gateway/run.py",
+            "subagent_id": "subagent-1",
+            "parent_id": "parent-1",
+            "depth": 1,
+            "task_index": 0,
+            "task_count": 2,
+            "child_session_id": "session-child",
+            "tool_count": 3,
+        }
+
+
 # ---------------------------------------------------------------------------
 # Adapter internals
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -328,9 +328,8 @@ class TestRunEvents:
                 assert "Hello!" in body
 
     @pytest.mark.asyncio
-    async def test_events_stream_serializes_subagent_progress(self, adapter):
-        """Clients should receive structured child tool progress over SSE."""
-        run_id = "run_subagent_progress"
+    async def test_events_stream_relays_subagent_progress_without_raw_args(self, adapter):
+        """The Runs endpoint exposes relayed child progress without raw args."""
         secret = "sk-test-SSE-SECRET-0000000000000000"
         args = {
             "command": (
@@ -340,31 +339,42 @@ class TestRunEvents:
         }
         preview = build_tool_preview("terminal", args, max_len=0)
         assert preview is not None
-        adapter._run_streams[run_id] = asyncio.Queue()
-        callback = adapter._make_run_event_callback(
-            run_id,
-            asyncio.get_running_loop(),
-        )
-
-        callback(
-            "subagent.tool",
-            tool_name="terminal",
-            preview=preview,
-            args=args,
-            subagent_id="subagent-1",
-            parent_id="parent-1",
-            depth=1,
-            task_index=0,
-            task_count=2,
-            child_session_id="session-child",
-            tool_count=3,
-        )
-        await asyncio.sleep(0)
-        adapter._run_streams[run_id].put_nowait(None)
 
         app = _create_runs_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            response = await cli.get(f"/v1/runs/{run_id}/events")
+            callback_holder = {}
+            mock_agent = MagicMock()
+            mock_agent.session_prompt_tokens = 0
+            mock_agent.session_completion_tokens = 0
+            mock_agent.session_total_tokens = 0
+
+            def _create_agent(**kwargs):
+                callback_holder["callback"] = kwargs["tool_progress_callback"]
+                return mock_agent
+
+            def _run_conversation(**kwargs):
+                callback_holder["callback"](
+                    "subagent.tool",
+                    tool_name="terminal",
+                    preview=preview,
+                    args=args,
+                    subagent_id="subagent-1",
+                    parent_id="parent-1",
+                    depth=1,
+                    task_index=0,
+                    task_count=2,
+                    child_session_id="session-child",
+                    tool_count=3,
+                )
+                return {"final_response": "done"}
+
+            mock_agent.run_conversation.side_effect = _run_conversation
+            with patch.object(adapter, "_create_agent", side_effect=_create_agent):
+                start_response = await cli.post("/v1/runs", json={"input": "hello"})
+                assert start_response.status == 202
+                run_id = (await start_response.json())["run_id"]
+
+                response = await cli.get(f"/v1/runs/{run_id}/events")
             assert response.status == 200
             assert response.content_type == "text/event-stream"
             body = await response.text()
@@ -374,8 +384,9 @@ class TestRunEvents:
             for line in body.splitlines()
             if line.startswith("data: ")
         ]
-        assert len(payloads) == 1
-        event = payloads[0]
+        events = [payload for payload in payloads if payload.get("event") == "subagent.progress"]
+        assert len(events) == 1
+        event = events[0]
         assert event.pop("timestamp") > 0
         event_preview = event.pop("preview")
         assert event == {
@@ -391,6 +402,8 @@ class TestRunEvents:
             "tool_count": 3,
         }
         assert event_preview.startswith("curl -H")
+        assert event_preview != preview
+        assert "args" not in events[0]
         assert secret not in body
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -9,6 +9,7 @@ Covers:
 """
 
 import asyncio
+import json
 import threading
 import time
 from unittest.mock import MagicMock, patch
@@ -17,6 +18,7 @@ import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
+from agent.display import build_tool_preview
 from gateway.config import PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
@@ -325,7 +327,71 @@ class TestRunEvents:
                 assert "run.completed" in body
                 assert "Hello!" in body
 
+    @pytest.mark.asyncio
+    async def test_events_stream_serializes_subagent_progress(self, adapter):
+        """Clients should receive structured child tool progress over SSE."""
+        run_id = "run_subagent_progress"
+        secret = "sk-test-SSE-SECRET-0000000000000000"
+        args = {
+            "command": (
+                "curl -H 'Authorization: Bearer "
+                f"{secret}' https://example.test"
+            ),
+        }
+        preview = build_tool_preview("terminal", args, max_len=0)
+        assert preview is not None
+        adapter._run_streams[run_id] = asyncio.Queue()
+        callback = adapter._make_run_event_callback(
+            run_id,
+            asyncio.get_running_loop(),
+        )
 
+        callback(
+            "subagent.tool",
+            tool_name="terminal",
+            preview=preview,
+            args=args,
+            subagent_id="subagent-1",
+            parent_id="parent-1",
+            depth=1,
+            task_index=0,
+            task_count=2,
+            child_session_id="session-child",
+            tool_count=3,
+        )
+        await asyncio.sleep(0)
+        adapter._run_streams[run_id].put_nowait(None)
+
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.get(f"/v1/runs/{run_id}/events")
+            assert response.status == 200
+            assert response.content_type == "text/event-stream"
+            body = await response.text()
+
+        payloads = [
+            json.loads(line.removeprefix("data: "))
+            for line in body.splitlines()
+            if line.startswith("data: ")
+        ]
+        assert len(payloads) == 1
+        event = payloads[0]
+        assert event.pop("timestamp") > 0
+        event_preview = event.pop("preview")
+        assert event == {
+            "event": "subagent.progress",
+            "run_id": run_id,
+            "tool": "terminal",
+            "subagent_id": "subagent-1",
+            "parent_id": "parent-1",
+            "depth": 1,
+            "task_index": 0,
+            "task_count": 2,
+            "child_session_id": "session-child",
+            "tool_count": 3,
+        }
+        assert event_preview.startswith("curl -H")
+        assert secret not in body
 
     @pytest.mark.asyncio
     async def test_approval_response_without_pending_returns_409(self, adapter):

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -274,7 +274,31 @@ Statuses are retained briefly after terminal states (`completed`, `failed`, or `
 
 ### GET /v1/runs/\{run_id\}/events
 
-Server-Sent Events stream of the run's tool-call progress, token deltas, and lifecycle events. Designed for dashboards and thick clients that want to attach/detach without losing state.
+Server-Sent Events stream of the run's tool-call progress, subagent activity,
+token deltas, and lifecycle events. Designed for dashboards and thick clients
+that want to attach/detach without losing state.
+
+Subagent tool calls are emitted immediately as structured
+`subagent.progress` events. The event preserves stable delegation identifiers
+when available, while deliberately omitting raw tool arguments and internal
+thinking:
+
+```json
+{
+  "event": "subagent.progress",
+  "run_id": "run_abc123",
+  "timestamp": 1770000000.0,
+  "tool": "read_file",
+  "preview": "reading gateway/run.py",
+  "subagent_id": "subagent-1",
+  "parent_id": "parent-1",
+  "depth": 1,
+  "task_index": 0,
+  "task_count": 2,
+  "child_session_id": "session-child",
+  "tool_count": 3
+}
+```
 
 Unconsumed event buffers expire after five minutes so a detached client cannot
 grow memory indefinitely. This expires transport state only: a run that is

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -280,8 +280,8 @@ that want to attach/detach without losing state.
 
 Subagent tool calls are emitted immediately as structured
 `subagent.progress` events. The event preserves stable delegation identifiers
-when available, while deliberately omitting raw tool arguments and internal
-thinking:
+when available. Raw tool arguments and internal thinking are omitted, and
+previews are redacted at this API boundary before they enter the SSE stream:
 
 ```json
 {


### PR DESCRIPTION
## What does this PR do?

Long-running clients of `GET /v1/runs/{run_id}/events` currently see parent tool activity but go silent while a delegated child is working. Current `main` already emits an immediate, machine-readable `subagent.tool` callback for every child tool call; the Runs API callback simply drops it.

This change maps those callbacks to structured `subagent.progress` SSE events. It preserves stable delegation identifiers when available, while deliberately excluding raw tool arguments and internal thinking.

This is a conflict-resolved salvage of #5839. I cannot push to the original contributor branch (the dry-run is rejected with HTTP 403), so the replacement keeps Pradeep as the commit author and adapts the original contribution to the richer subagent event schema now present on `main`.

This complements rather than replaces #51642: that PR forwards low-volume `subagent.start` / `subagent.complete` lifecycle boundaries, while this one exposes per-tool progress to clients that explicitly subscribe to the Runs SSE stream. The implementation is positioned separately so either PR can be rebased after the other without duplicating lifecycle behavior.

## Related Issue

Supersedes #5839. Complements #51642. Related to #53836.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/api_server.py`
  - Forward current-main `subagent.tool` callbacks as immediate `subagent.progress` SSE events.
  - Preserve `subagent_id`, `parent_id`, depth, task coordinates, child session ID, and tool count when present.
  - Do not stream raw tool arguments, hidden thinking, or duplicate batched summaries.
- `tests/gateway/test_api_server.py`
  - Add a focused contract test for the structured event, including zero-valued task indexes and argument redaction.
- `website/docs/user-guide/features/api-server.md`
  - Document the event and its wire shape.

## How to Test

1. Start a run through `POST /v1/runs` whose agent delegates a task.
2. Subscribe to `GET /v1/runs/{run_id}/events`.
3. Observe one `subagent.progress` event for each direct child tool call, without raw tool arguments or internal thinking.

Automated verification:

- `scripts/run_tests.sh tests/gateway/test_api_server.py tests/agent/test_subagent_progress.py -- -q -o addopts=` — 215 passed
- `python -m py_compile gateway/platforms/api_server.py tests/gateway/test_api_server.py` — passed
- `python scripts/check-windows-footguns.py gateway/platforms/api_server.py tests/gateway/test_api_server.py` — passed
- `git diff --check` — passed
- `git merge-tree --write-tree origin/pr/51642 HEAD` — clean merge simulation with the complementary lifecycle-event PR
- `scripts/run_tests.sh tests/gateway -- -q -o addopts=` — broad run completed; four test failures plus two parallel-runner/collection failures were isolated
- Serial rerun of all six affected files — four recovered; two unrelated macOS failures remained
- The same two remaining failures reproduced unchanged in a clean `origin/main` worktree at `3b2ef789d`:
  - `test_media_files_routed_by_type` (`/var` vs `/private/var` path canonicalization)
  - `test_spawns_subprocess_and_writes_output` (diagnostic subprocess returned no PID)

The focused changed-file coverage is green. The full gateway suite is not claimed green because of those verified baseline failures; Linux CI on this PR is the final broad gate.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs and am explicitly salvaging #5839 rather than silently duplicating it
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on macOS 27.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` — N/A, no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture or workflow change
- [x] I've considered cross-platform impact; the change is pure Python event mapping and passes the Windows footgun scan
- [x] Tool descriptions/schemas — N/A, no model tool behavior changed

## Screenshots / Logs

The focused regression test first failed on current `main` with `assert 0 == 1` because `subagent.tool` was dropped. It passes after the mapping is added.
