### PR TITLE
fix(desktop): separate Projects and Sessions sidebar sections

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.test.tsx
@@ -1,0 +1,98 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SidebarProvider } from '@/components/ui/sidebar'
+import type { SessionInfo } from '@/hermes'
+import { I18nProvider } from '@/i18n'
+import { $sidebarProjectsOpen, $sidebarRecentsOpen } from '@/store/layout'
+import { $profiles } from '@/store/profile'
+import { $projects, $projectTree } from '@/store/projects'
+import { $gatewayState, $messagingSessions, $sessions, $sessionsLoading, $sessionsTotal } from '@/store/session'
+
+import { ChatSidebar } from './index'
+
+const session: SessionInfo = {
+  ended_at: null,
+  id: 'session-1',
+  input_tokens: 0,
+  is_active: false,
+  last_active: 1,
+  message_count: 1,
+  model: null,
+  output_tokens: 0,
+  preview: 'A desktop session',
+  source: 'desktop',
+  started_at: 1,
+  title: 'A desktop session',
+  tool_call_count: 0
+}
+
+function renderSidebar() {
+  return render(
+    <MemoryRouter>
+      <I18nProvider configClient={null}>
+        <SidebarProvider>
+          <ChatSidebar
+            currentView="chat"
+            onArchiveSession={vi.fn()}
+            onBranchSession={vi.fn()}
+            onDeleteSession={vi.fn()}
+            onLoadMoreSessions={vi.fn()}
+            onManageCronJob={vi.fn()}
+            onNavigate={vi.fn()}
+            onNewSessionInWorkspace={vi.fn()}
+            onResumeSession={vi.fn()}
+            onTriggerCronJob={vi.fn()}
+          />
+        </SidebarProvider>
+      </I18nProvider>
+    </MemoryRouter>
+  )
+}
+
+describe('ChatSidebar primary sections', () => {
+  beforeEach(() => {
+    $gatewayState.set('idle')
+    $profiles.set([])
+    $projects.set([])
+    $projectTree.set([])
+    $sessions.set([session])
+    $messagingSessions.set([])
+    $sessionsLoading.set(false)
+    $sessionsTotal.set(1)
+    $sidebarProjectsOpen.set(false)
+    $sidebarRecentsOpen.set(true)
+  })
+
+  afterEach(() => {
+    cleanup()
+    $sessions.set([])
+    $messagingSessions.set([])
+  })
+
+  it('keeps Projects and Sessions as independent sections when Projects is expanded', () => {
+    renderSidebar()
+
+    expect(screen.getByRole('button', { name: 'Projects' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /^Sessions/ })).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Projects' }))
+
+    expect(screen.getByText('No projects yet — create one with +')).toBeTruthy()
+    expect(screen.getByRole('button', { name: /^Sessions/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'A desktop session' })).toBeTruthy()
+  })
+
+  it('keeps the primary sections visible when only messaging sessions exist', () => {
+    $sessions.set([])
+    $sessionsTotal.set(0)
+    $messagingSessions.set([{ ...session, id: 'telegram-1', source: 'telegram' }])
+
+    renderSidebar()
+
+    expect(screen.getByRole('button', { name: 'Projects' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /^Sessions/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /^Telegram/ })).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -31,7 +31,7 @@ import {
   $dismissedAutoProjectIds,
   $panesFlipped,
   $pinnedSessionIds,
-  $sidebarAgentsGrouped,
+  $sidebarProjectsOpen,
   $sidebarCronOpen,
   $sidebarMessagingOpenIds,
   $sidebarOpen,
@@ -46,7 +46,7 @@ import {
   pinSession,
   SESSION_SEARCH_FOCUS_EVENT,
   setPinnedSessionOrder,
-  setSidebarAgentsGrouped,
+  setSidebarProjectsOpen,
   setSidebarCronOpen,
   setSidebarPinsOpen,
   setSidebarProjectOrderIds,
@@ -234,7 +234,9 @@ export function ChatSidebar({
   const overlayMounted = useStore($sidebarOverlayMounted)
   const contentVisible = sidebarOpen || overlayMounted
   const panesFlipped = useStore($panesFlipped)
-  const agentsGrouped = useStore($sidebarAgentsGrouped)
+  // Keep the persisted key for backward compatibility, but this now controls
+  // the independent Projects section instead of replacing the Sessions list.
+  const projectsOpen = useStore($sidebarProjectsOpen)
   const pinnedSessionIds = useStore($pinnedSessionIds)
   const pinsOpen = useStore($sidebarPinsOpen)
   const agentsOpen = useStore($sidebarRecentsOpen)
@@ -475,10 +477,10 @@ export function ChatSidebar({
   // own slice ($messagingSessions) and rendered in self-managed per-platform
   // sections below, so there is no source-grouping magic to untangle here.
   //
-  // Workspace grouping is a `project -> repo -> lane -> sessions` tree computed
-  // authoritatively on the backend (projects.tree). Parents reorder via
-  // workspaceParentOrderIds; worktrees within a parent via workspaceOrderIds.
-  const worktreeGroupingActive = agentsGrouped && !showAllProfiles
+  // Projects are a `project -> repo -> lane -> sessions` tree computed
+  // authoritatively on the backend. It is a section beside Sessions, not an
+  // alternate rendering mode for that list.
+  const projectsSectionActive = projectsOpen && !showAllProfiles
   const gatewayReady = gatewayState === 'open'
 
   // The backend project tree is a structural snapshot, NOT a per-message feed.
@@ -489,7 +491,7 @@ export function ChatSidebar({
   // completing does NOT re-run the heavy list_sessions_rich scan. Project
   // mutations refresh the tree from their own store actions.
   useEffect(() => {
-    if (worktreeGroupingActive && gatewayReady) {
+    if (projectsSectionActive && gatewayReady) {
       void refreshProjects()
       // Paint the list from the fast tree fetch (explicit projects + repos from
       // existing sessions / the backend cache) FIRST, then kick off the heavy
@@ -497,7 +499,7 @@ export function ChatSidebar({
       // of the crawl blocking the first render.
       void refreshProjectTree().finally(() => void scanAndRecordRepos())
     }
-  }, [worktreeGroupingActive, profileScope, gatewayReady])
+  }, [projectsSectionActive, profileScope, gatewayReady])
 
   // Out-of-band repo changes (a `git init` / `rm -rf` in another terminal) emit
   // no git events, so — like every git GUI — re-pull on window focus / tab
@@ -506,7 +508,7 @@ export function ChatSidebar({
   // session regrouping); the heavy disk crawl that surfaces brand-new repos is
   // throttled. Agent-driven changes already refresh via $workspaceChangeTick.
   useEffect(() => {
-    if (!worktreeGroupingActive || !gatewayReady) {
+    if (!projectsSectionActive || !gatewayReady) {
       return
     }
 
@@ -536,7 +538,7 @@ export function ChatSidebar({
       window.removeEventListener('focus', onActive)
       document.removeEventListener('visibilitychange', onActive)
     }
-  }, [worktreeGroupingActive, gatewayReady])
+  }, [projectsSectionActive, gatewayReady])
 
   // Apply the persisted repo + worktree orders to a project's repo subtrees.
   const orderRepos = useCallback(
@@ -572,21 +574,15 @@ export function ChatSidebar({
     return orderByIds(sorted, project => project.id, projectOrderIds)
   }, [showAllProfiles, projectTree, dismissedAutoProjects, orderRepos, activeProjectId, projectOrderIds])
 
-  // The overview only renders in grouped mode; the model stays live regardless
-  // so scoping is consistent across views.
-  const agentProjectTree = worktreeGroupingActive ? projectModel : undefined
-
   // ── Project switcher (drill-in) ────────────────────────────────────────────
-  // Grouped, single-profile view is a project switcher: ALL_PROJECTS shows the
+  // The single-profile Projects section is a switcher: ALL_PROJECTS shows the
   // overview (a list you click into); a concrete scope means you've "entered" a
-  // project, so the Sessions list shows ONLY that project's worktrees/sessions.
-  const projectsActive = Boolean(agentProjectTree?.length)
+  // project, so this section shows that project's worktrees/sessions.
+  const projectsActive = projectModel.length > 0
 
   // The overview node for the entered project (structure + counts, empty lanes).
   const overviewEnteredProject =
-    projectsActive && projectScope !== ALL_PROJECTS
-      ? agentProjectTree?.find(node => node.id === projectScope)
-      : undefined
+    projectsActive && projectScope !== ALL_PROJECTS ? projectModel.find(node => node.id === projectScope) : undefined
 
   const inProject = Boolean(overviewEnteredProject)
   const enteredProjectId = overviewEnteredProject?.id
@@ -725,7 +721,7 @@ export function ChatSidebar({
   }, [projectScope, projectsActive, enteredProject])
 
   // The project overview (drill-in list) vs. the entered project's content.
-  const projectOverview = projectsActive && !inProject ? agentProjectTree : undefined
+  const projectOverview = projectsActive && !inProject ? projectModel : undefined
 
   // Preview rows come from the backend tree (each project carries its
   // most-recent sessions), overlaid with live $sessions so a just-created
@@ -749,16 +745,12 @@ export function ChatSidebar({
     [projectModel, syncProjectCwd]
   )
 
-  // The Sessions section is a project switcher in grouped mode: its label reads
-  // "Sessions" when flat, "Projects" at the overview, and the project's name
-  // once you've entered one.
-  const sessionsLabel =
-    inProject && enteredProject ? enteredProject.label : worktreeGroupingActive ? s.projects.sectionLabel : s.sessions
+  const projectsLabel = inProject && enteredProject ? enteredProject.label : s.projects.sectionLabel
 
   // Mirror the section's skeleton gate (projectsLoading + nothing to show yet):
   // while the skeleton is up there's no point also spinning the header count.
   const projectsSkeletonVisible =
-    worktreeGroupingActive &&
+    projectsSectionActive &&
     projectTreeLoading &&
     !projectOverview?.length &&
     !(inProject && (enteredProject?.sessionCount ?? 0) > 0)
@@ -968,12 +960,11 @@ export function ChatSidebar({
   // single source for reconciling repo/worktree order, whether repos hang off
   // the bare tree or are nested under projects.
   const activeRepoTrees = useMemo<SidebarWorkspaceTree[]>(
-    () => (agentProjectTree ? agentProjectTree.flatMap(project => project.repos) : []),
-    [agentProjectTree]
+    () => projectModel.flatMap(project => project.repos),
+    [projectModel]
   )
 
-  const recentsVirtualizes =
-    !displayAgentGroups?.length && !agentProjectTree?.length && displayAgentSessions.length >= VIRTUALIZE_THRESHOLD
+  const recentsVirtualizes = !displayAgentGroups?.length && displayAgentSessions.length >= VIRTUALIZE_THRESHOLD
 
   // Keep the persisted parent + worktree orders reconciled with what's on screen:
   // freshly-seen repos/worktrees surface at the top, vanished ones drop out of
@@ -1004,7 +995,12 @@ export function ChatSidebar({
 
   const showSessionSkeletons = sessionsLoading && sortedSessions.length === 0
 
-  const showSessionSections = showSessionSkeletons || sortedSessions.length > 0 || projectModel.length > 0
+  const showSessionSections =
+    showSessionSkeletons ||
+    sortedSessions.length > 0 ||
+    projectModel.length > 0 ||
+    messagingGroups.length > 0 ||
+    cronJobs.length > 0
 
   // Each reorderable list reports its OWN new id order; persisting is a direct,
   // typed write — no id-prefix sniffing to figure out which level moved.
@@ -1176,48 +1172,17 @@ export function ChatSidebar({
               />
             )}
 
-            {!trimmedQuery && (
+            {!trimmedQuery && !showAllProfiles && (
               <SidebarSessionsSection
                 activeProjectId={activeProjectId}
                 activeSessionId={activeSidebarSessionId}
-                collapsible={!inProject}
-                contentClassName={cn(
-                  'flex min-h-0 flex-1 flex-col pb-1.75',
-                  SCROLL_Y,
-                  // Separate profile sections clearly in the ALL view; rows inside
-                  // each group keep their own tight gap-px rhythm.
-                  showAllProfiles ? 'gap-3' : 'gap-px',
-                  // Flatten into the single scroll when compact — unless this is the
-                  // virtualized long list, which must keep its own scroller.
-                  !recentsVirtualizes && COMPACT_FLAT
-                )}
+                contentClassName={cn('flex max-h-72 flex-col gap-px pb-1.75', GROUP_BODY)}
                 dndSensors={dndSensors}
                 emptyState={
-                  showSessionSkeletons ? (
-                    <SidebarSessionSkeletons />
-                  ) : (
-                    <div className="grid min-h-16 place-items-center rounded-lg px-2 text-center text-xs text-(--ui-text-tertiary)">
-                      {inProject ? s.projectEmpty : pinnedSessions.length > 0 ? s.allPinned : s.noSessions}
-                    </div>
-                  )
+                  <div className="grid min-h-16 place-items-center rounded-lg px-2 text-center text-xs text-(--ui-text-tertiary)">
+                    {inProject ? s.projectEmpty : s.projects.empty}
+                  </div>
                 }
-                footer={
-                  // Hide "load more" only when workspace-grouped (those groups page
-                  // themselves). ALL-profiles now pages per-profile from each profile
-                  // header; the global footer only applies to non-ALL views.
-                  !showAllProfiles && !agentsGrouped && !showSessionSkeletons && hasMoreSessions ? (
-                    <SidebarLoadMoreRow
-                      loading={sessionsLoading || recentsLoadMorePending}
-                      onClick={() => void onLoadMoreRecents()}
-                      // Recents are post-filtered to non-project sessions, so a
-                      // backend page size (50) is not a truthful "rows you'll
-                      // see" count. Use the generic label instead of a fake N.
-                      step={0}
-                    />
-                  ) : null
-                }
-                forceEmptyState={showSessionSkeletons}
-                groups={displayAgentGroups}
                 headerAction={
                   inProject && enteredProject ? (
                     <div className="group/workspace flex shrink-0 items-center gap-0.5">
@@ -1247,70 +1212,38 @@ export function ChatSidebar({
                     </div>
                   ) : (
                     <div className="flex shrink-0 items-center gap-0.5">
-                      {!showAllProfiles ? (
-                        <Button
-                          aria-label={agentsGrouped ? s.projects.newButton : s.nav['new-session']}
-                          className={HEADER_ACTION_BTN}
-                          onClick={event => {
-                            event.stopPropagation()
-
-                            if (agentsGrouped) {
-                              openProjectCreate()
-                            } else {
-                              onNewSessionInWorkspace(null)
-                            }
-                          }}
-                          size="icon-xs"
-                          variant="ghost"
-                        >
-                          <Codicon name="add" size="0.75rem" />
-                        </Button>
-                      ) : null}
-                      <div className="grid size-6 place-items-center">
-                        {!showAllProfiles && agentSessions.length > 0 ? (
-                          <Button
-                            aria-label={agentsGrouped ? s.showSessions : s.showProjects}
-                            className={cn(
-                              HEADER_NAV_BTN,
-                              agentsGrouped && 'bg-(--ui-control-active-background) text-foreground opacity-100'
-                            )}
-                            onClick={event => {
-                              event.stopPropagation()
-                              setSidebarRecentsOpen(true)
-                              setSidebarAgentsGrouped(!agentsGrouped)
-                            }}
-                            size="icon-xs"
-                            variant="ghost"
-                          >
-                            <Codicon name={agentsGrouped ? 'list-unordered' : 'root-folder'} size="0.75rem" />
-                          </Button>
-                        ) : null}
-                      </div>
+                      <Button
+                        aria-label={s.projects.newButton}
+                        className={HEADER_ACTION_BTN}
+                        onClick={event => {
+                          event.stopPropagation()
+                          openProjectCreate()
+                        }}
+                        size="icon-xs"
+                        variant="ghost"
+                      >
+                        <Codicon name="add" size="0.75rem" />
+                      </Button>
                     </div>
                   )
                 }
-                label={sessionsLabel}
+                label={projectsLabel}
                 labelMeta={
-                  worktreeGroupingActive ? (
-                    reposScanning && !projectsSkeletonVisible ? (
-                      <GlyphSpinner ariaLabel={s.loading} className="text-[0.6875rem] text-(--ui-text-quaternary)" />
-                    ) : undefined
-                  ) : (
-                    recentsMeta
-                  )
+                  projectsSectionActive && reposScanning && !projectsSkeletonVisible ? (
+                    <GlyphSpinner ariaLabel={s.loading} className="text-[0.6875rem] text-(--ui-text-quaternary)" />
+                  ) : undefined
                 }
                 liveSessions={inProject ? agentSessions : undefined}
                 onArchiveSession={onArchiveSession}
                 onBranchSession={onBranchSession}
                 onDeleteSession={onDeleteSession}
                 onEnterProject={onEnterProject}
-                onNewSessionInWorkspace={showAllProfiles ? undefined : onNewSessionInWorkspace}
-                onReorderProjects={showAllProfiles ? undefined : reorderProjects}
-                onReorderSessions={showAllProfiles ? undefined : reorderSessions}
+                onNewSessionInWorkspace={onNewSessionInWorkspace}
+                onReorderProjects={reorderProjects}
                 onResumeSession={onResumeSession}
-                onToggle={() => setSidebarRecentsOpen(!agentsOpen)}
+                onToggle={() => setSidebarProjectsOpen(!projectsOpen)}
                 onTogglePin={pinSession}
-                open={agentsOpen}
+                open={projectsOpen}
                 pinned={false}
                 projectBackRow={
                   inProject ? <ProjectBackRow label={s.projects.back} onClick={exitProjectScope} /> : undefined
@@ -1319,8 +1252,71 @@ export function ChatSidebar({
                 projectOverview={projectOverview}
                 projectOverviewPreviews={overviewPreviews}
                 projectRepoWorktrees={inProject ? scopedRepoWorktrees : undefined}
-                projectsLoading={worktreeGroupingActive ? projectTreeLoading : false}
+                projectsLoading={projectsSectionActive ? projectTreeLoading : false}
                 removedSessionIds={inProject ? removedSessionIds : undefined}
+                rootClassName="shrink-0 p-0 pb-1"
+                sessions={[]}
+                workingSessionIdSet={workingSessionIdSet}
+              />
+            )}
+
+            {!trimmedQuery && (
+              <SidebarSessionsSection
+                activeSessionId={activeSidebarSessionId}
+                contentClassName={cn(
+                  'flex min-h-0 flex-1 flex-col pb-1.75',
+                  SCROLL_Y,
+                  showAllProfiles ? 'gap-3' : 'gap-px',
+                  !recentsVirtualizes && COMPACT_FLAT
+                )}
+                dndSensors={dndSensors}
+                emptyState={
+                  showSessionSkeletons ? (
+                    <SidebarSessionSkeletons />
+                  ) : (
+                    <div className="grid min-h-16 place-items-center rounded-lg px-2 text-center text-xs text-(--ui-text-tertiary)">
+                      {pinnedSessions.length > 0 ? s.allPinned : s.noSessions}
+                    </div>
+                  )
+                }
+                footer={
+                  !showAllProfiles && !showSessionSkeletons && hasMoreSessions ? (
+                    <SidebarLoadMoreRow
+                      loading={sessionsLoading || recentsLoadMorePending}
+                      onClick={() => void onLoadMoreRecents()}
+                      step={0}
+                    />
+                  ) : null
+                }
+                forceEmptyState={showSessionSkeletons}
+                groups={displayAgentGroups}
+                headerAction={
+                  !showAllProfiles ? (
+                    <Button
+                      aria-label={s.nav['new-session']}
+                      className={HEADER_ACTION_BTN}
+                      onClick={event => {
+                        event.stopPropagation()
+                        onNewSessionInWorkspace(null)
+                      }}
+                      size="icon-xs"
+                      variant="ghost"
+                    >
+                      <Codicon name="add" size="0.75rem" />
+                    </Button>
+                  ) : null
+                }
+                label={s.sessions}
+                labelMeta={recentsMeta}
+                onArchiveSession={onArchiveSession}
+                onBranchSession={onBranchSession}
+                onDeleteSession={onDeleteSession}
+                onReorderSessions={showAllProfiles ? undefined : reorderSessions}
+                onResumeSession={onResumeSession}
+                onToggle={() => setSidebarRecentsOpen(!agentsOpen)}
+                onTogglePin={pinSession}
+                open={agentsOpen}
+                pinned={false}
                 rootClassName={cn(
                   'min-h-32 flex-1 overflow-hidden p-0',
                   !recentsVirtualizes && 'compact:min-h-0 compact:flex-none compact:overflow-visible'
@@ -1332,7 +1328,6 @@ export function ChatSidebar({
             )}
 
             {!trimmedQuery &&
-              !worktreeGroupingActive &&
               messagingGroups.map(group => {
                 const visible = messagingVisible[group.sourceId] ?? NON_SESSION_INITIAL_ROWS
                 const shownSessions = group.sessions.slice(0, visible)
@@ -1378,7 +1373,7 @@ export function ChatSidebar({
                 )
               })}
 
-            {!trimmedQuery && !worktreeGroupingActive && cronJobs.length > 0 && (
+            {!trimmedQuery && cronJobs.length > 0 && (
               <SidebarCronJobsSection
                 jobs={cronJobs}
                 label={s.cronJobs}

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1539,6 +1539,7 @@ export const en: Translations = {
     noSessions: 'No sessions yet',
     projects: {
       sectionLabel: 'Projects',
+      empty: 'No projects yet — create one with +',
       newButton: 'New project',
       createTitle: 'New project',
       createDesc: 'Name a workspace and add one or more folders.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1484,6 +1484,7 @@ export const ja = defineLocale({
     noSessions: 'セッションはまだありません',
     projects: {
       sectionLabel: 'プロジェクト',
+      empty: 'プロジェクトはまだありません — + で作成',
       newButton: '新規プロジェクト',
       createTitle: '新規プロジェクト',
       createDesc: 'ワークスペースに名前を付け、1つ以上のフォルダを追加します。',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1268,6 +1268,7 @@ export interface Translations {
     noSessions: string
     projects: {
       sectionLabel: string
+      empty: string
       newButton: string
       createTitle: string
       createDesc: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1437,6 +1437,7 @@ export const zhHant = defineLocale({
     noSessions: '尚無工作階段',
     projects: {
       sectionLabel: '專案',
+      empty: '尚無專案 — 點選 + 建立',
       newButton: '新增專案',
       createTitle: '新增專案',
       createDesc: '為工作區命名並新增一個或多個資料夾。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1716,6 +1716,7 @@ export const zh: Translations = {
     noSessions: '暂无会话',
     projects: {
       sectionLabel: '项目',
+      empty: '暂无项目 — 点击 + 创建',
       newButton: '新建项目',
       createTitle: '新建项目',
       createDesc: '为工作区命名并添加一个或多个文件夹。',

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -17,7 +17,9 @@ export const FILE_BROWSER_MAX_WIDTH = '20rem'
 export const SIDEBAR_SESSIONS_PAGE_SIZE = 50
 
 const SIDEBAR_PINNED_STORAGE_KEY = 'hermes.desktop.pinnedSessions'
-const SIDEBAR_AGENTS_GROUPED_STORAGE_KEY = 'hermes.desktop.agentsGroupedByWorkspace'
+// Keep the existing storage key so the former Projects-view preference migrates
+// naturally into the independent Projects section's open state.
+const SIDEBAR_PROJECTS_OPEN_STORAGE_KEY = 'hermes.desktop.agentsGroupedByWorkspace'
 const SIDEBAR_CRON_OPEN_STORAGE_KEY = 'hermes.desktop.sidebarCronOpen'
 const SIDEBAR_MESSAGING_OPEN_STORAGE_KEY = 'hermes.desktop.sidebarMessagingOpen'
 const SIDEBAR_SESSION_ORDER_STORAGE_KEY = 'hermes.desktop.sessionOrder'
@@ -136,7 +138,7 @@ export const $sidebarMessagingOpenIds = persistentAtom(
   [] as string[],
   Codecs.stringArray
 )
-export const $sidebarAgentsGrouped = persistentAtom(SIDEBAR_AGENTS_GROUPED_STORAGE_KEY, false, Codecs.bool)
+export const $sidebarProjectsOpen = persistentAtom(SIDEBAR_PROJECTS_OPEN_STORAGE_KEY, false, Codecs.bool)
 // When true, the sessions sidebar moves to the right and the file browser +
 // preview rail move to the left — a mirror of the default layout.
 export const $panesFlipped = persistentAtom(PANES_FLIPPED_STORAGE_KEY, false, Codecs.bool)
@@ -253,8 +255,8 @@ export function toggleSidebarMessagingOpen(sourceId: string) {
   )
 }
 
-export function setSidebarAgentsGrouped(grouped: boolean) {
-  $sidebarAgentsGrouped.set(grouped)
+export function setSidebarProjectsOpen(open: boolean) {
+  $sidebarProjectsOpen.set(open)
 }
 
 export function setSidebarSessionOrderIds(ids: string[]) {

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { $sidebarAgentsGrouped } from '@/store/layout'
+import { $sidebarProjectsOpen } from '@/store/layout'
 
 import {
   $activeProjectId,
@@ -126,7 +126,7 @@ describe('pickProjectFolder', () => {
 describe('createProject', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    $sidebarAgentsGrouped.set(false)
+    $sidebarProjectsOpen.set(false)
     $activeProjectId.set(null)
     $projectsRpcAvailable.set(null)
   })
@@ -150,7 +150,7 @@ describe('createProject', () => {
 
     expect(result).toEqual(created)
     expect(request).toHaveBeenCalledWith('projects.create', expect.objectContaining({ name: 'Demo' }))
-    expect($sidebarAgentsGrouped.get()).toBe(true)
+    expect($sidebarProjectsOpen.get()).toBe(true)
     expect($activeProjectId.get()).toBe('p_new')
   })
 

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -8,7 +8,7 @@ import { desktopGit } from '@/lib/desktop-git'
 import { isMissingRpcMethod } from '@/lib/gateway-rpc'
 import { persistentAtom } from '@/lib/persisted'
 import { activeGateway, ensureActiveGatewayOpen } from '@/store/gateway'
-import { setSidebarAgentsGrouped } from '@/store/layout'
+import { setSidebarProjectsOpen } from '@/store/layout'
 import { notify } from '@/store/notifications'
 import { requestFreshSession } from '@/store/profile'
 import { $selectedStoredSessionId, $sessions, workspaceCwdForNewSession } from '@/store/session'
@@ -199,10 +199,9 @@ export async function followActiveSessionCwd(cwd: string): Promise<void> {
   const projectId = projectIdForCwd(target)
 
   if (projectId) {
-    // The Projects tree only renders in grouped mode, so flip the sidebar into
-    // it — otherwise following from the flat Sessions list would change scope
-    // invisibly. Then drill into the thread's project.
-    setSidebarAgentsGrouped(true)
+    // Ensure the independent Projects section is visible before drilling into
+    // the thread's project, so the scope change is never hidden.
+    setSidebarProjectsOpen(true)
 
     if (projectId !== $projectScope.get()) {
       enterProject(projectId)
@@ -488,7 +487,7 @@ export async function createProject(input: CreateProjectInput): Promise<ProjectI
       $activeProjectId.set(created.id)
     }
 
-    setSidebarAgentsGrouped(true)
+    setSidebarProjectsOpen(true)
   }
 
   reconcileProjects()


### PR DESCRIPTION
Fixes #62537

## Summary
- render Projects and Sessions as independent, collapsible sidebar sections instead of mutually exclusive views
- keep messaging-source and cron sections visible while Projects is expanded, including messaging-only histories
- add a localized empty-project state and preserve the existing Projects preference storage key
- keep project creation and active-session project following opening the Projects section

## Validation
- `npx vitest run --environment jsdom src/app/chat/sidebar/index.test.tsx src/store/projects.test.ts` (15 passed)
- `npm run typecheck --workspace apps/desktop`
- `npm run lint --workspace apps/desktop`

## Test-suite note
- `npm run test:ui --workspace apps/desktop` currently also collects Node `node:test` suites under Vitest/jsdom and has unrelated existing failures; the changed sidebar/project tests pass when run directly.