### PR TITLE
fix(cli): shut down memory provider in oneshot mode to prevent SIGABRT

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -416,12 +416,23 @@ def _run_agent(
     agent.stream_delta_callback = None
     agent.tool_gen_callback = None
 
-    result = agent.run_conversation(prompt)
-    # Shut down memory provider to prevent SIGABRT on interpreter shutdown (#60616)
     try:
-        agent.shutdown_memory_provider()
-    except Exception:
-        pass
+        result = agent.run_conversation(prompt)
+    finally:
+        # Shut down memory provider to prevent SIGABRT on interpreter shutdown (#60616)
+        # Forward the agent's own transcript so memory providers' on_session_end hooks
+        # see the real conversation instead of an empty list (a59a98b).
+        # _session_messages is set on AIAgent.__init__ and refreshed every turn via
+        # _persist_session. Fall back to no-arg on test stubs / partially-initialised
+        # agents where the attribute is missing.
+        try:
+            _session_msgs = getattr(agent, "_session_messages", None)
+            if isinstance(_session_msgs, list):
+                agent.shutdown_memory_provider(_session_msgs)
+            else:
+                agent.shutdown_memory_provider()
+        except Exception:
+            pass
     return (result.get("final_response") or "", result)
 
 

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -417,6 +417,11 @@ def _run_agent(
     agent.tool_gen_callback = None
 
     result = agent.run_conversation(prompt)
+    # Shut down memory provider to prevent SIGABRT on interpreter shutdown (#60616)
+    try:
+        agent.shutdown_memory_provider()
+    except Exception:
+        pass
     return (result.get("final_response") or "", result)
 
 

--- a/tests/hermes_cli/test_oneshot_memory_cleanup.py
+++ b/tests/hermes_cli/test_oneshot_memory_cleanup.py
@@ -1,0 +1,185 @@
+"""Tests for hermes -z memory provider cleanup (#60616)."""
+
+import sys
+import types
+import pytest
+
+
+def test_oneshot_shutdown_memory_provider_on_return(monkeypatch):
+    """Shutdown should be called even when run_conversation returns normally."""
+    from hermes_cli.oneshot import _run_agent
+
+    cleanup_calls = []
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            self._session_messages = [{"role": "user", "content": "test"}]
+
+        def run_conversation(self, prompt, **_kwargs):
+            return {"final_response": "ok", "failed": False, "partial": False}
+
+        def shutdown_memory_provider(self, messages=None):
+            cleanup_calls.append(messages)
+
+    def mod(name, **attrs):
+        module = types.ModuleType(name)
+        for key, value in attrs.items():
+            setattr(module, key, value)
+        return module
+
+    monkeypatch.setitem(sys.modules, "run_agent", mod("run_agent", AIAgent=FakeAgent))
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        mod("hermes_cli.config", load_config=lambda: {"model": {"default": "m"}}),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.models",
+        mod("hermes_cli.models", detect_provider_for_model=lambda *_args, **_kwargs: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.runtime_provider",
+        mod(
+            "hermes_cli.runtime_provider",
+            resolve_runtime_provider=lambda **_kwargs: {
+                "api_key": "k",
+                "base_url": "u",
+                "provider": "p",
+                "api_mode": "chat_completions",
+                "credential_pool": None,
+            },
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        mod("hermes_cli.tools_config", _get_platform_tools=lambda *_args, **_kwargs: set()),
+    )
+
+    text, result = _run_agent("hello")
+    assert text == "ok"
+    assert len(cleanup_calls) == 1
+    assert cleanup_calls[0] == [{"role": "user", "content": "test"}]
+
+
+def test_oneshot_shutdown_memory_provider_on_exception(monkeypatch):
+    """Shutdown should be called even when run_conversation raises an exception."""
+    from hermes_cli.oneshot import _run_agent
+
+    cleanup_calls = []
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            self._session_messages = [{"role": "user", "content": "test"}]
+
+        def run_conversation(self, prompt, **_kwargs):
+            raise ValueError("boom")
+
+        def shutdown_memory_provider(self, messages=None):
+            cleanup_calls.append(messages)
+
+    def mod(name, **attrs):
+        module = types.ModuleType(name)
+        for key, value in attrs.items():
+            setattr(module, key, value)
+        return module
+
+    monkeypatch.setitem(sys.modules, "run_agent", mod("run_agent", AIAgent=FakeAgent))
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        mod("hermes_cli.config", load_config=lambda: {"model": {"default": "m"}}),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.models",
+        mod("hermes_cli.models", detect_provider_for_model=lambda *_args, **_kwargs: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.runtime_provider",
+        mod(
+            "hermes_cli.runtime_provider",
+            resolve_runtime_provider=lambda **_kwargs: {
+                "api_key": "k",
+                "base_url": "u",
+                "provider": "p",
+                "api_mode": "chat_completions",
+                "credential_pool": None,
+            },
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        mod("hermes_cli.tools_config", _get_platform_tools=lambda *_args, **_kwargs: set()),
+    )
+
+    with pytest.raises(ValueError, match="boom"):
+        _run_agent("hello")
+
+    assert len(cleanup_calls) == 1
+    assert cleanup_calls[0] == [{"role": "user", "content": "test"}]
+
+
+def test_oneshot_shutdown_memory_provider_fallback_when_no_session_messages(monkeypatch):
+    """Fallback to no-arg shutdown when _session_messages is missing or not a list."""
+    from hermes_cli.oneshot import _run_agent
+
+    cleanup_calls = []
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            # Don't set _session_messages at all
+            pass
+
+        def run_conversation(self, prompt, **_kwargs):
+            return {"final_response": "ok", "failed": False, "partial": False}
+
+        def shutdown_memory_provider(self, messages=None):
+            cleanup_calls.append(messages)
+
+    def mod(name, **attrs):
+        module = types.ModuleType(name)
+        for key, value in attrs.items():
+            setattr(module, key, value)
+        return module
+
+    monkeypatch.setitem(sys.modules, "run_agent", mod("run_agent", AIAgent=FakeAgent))
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        mod("hermes_cli.config", load_config=lambda: {"model": {"default": "m"}}),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.models",
+        mod("hermes_cli.models", detect_provider_for_model=lambda *_args, **_kwargs: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.runtime_provider",
+        mod(
+            "hermes_cli.runtime_provider",
+            resolve_runtime_provider=lambda **_kwargs: {
+                "api_key": "k",
+                "base_url": "u",
+                "provider": "p",
+                "api_mode": "chat_completions",
+                "credential_pool": None,
+            },
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        mod("hermes_cli.tools_config", _get_platform_tools=lambda *_args, **_kwargs: set()),
+    )
+
+    text, result = _run_agent("hello")
+    assert text == "ok"
+    assert len(cleanup_calls) == 1
+    # When _session_messages is missing, fallback to no-arg call
+    assert cleanup_calls[0] is None


### PR DESCRIPTION
## What does this PR do?

Fixes SIGABRT crash in `hermes -z` (oneshot mode) when using async memory providers (e.g. Honcho with `writeFrequency: async`). Oneshot mode bypasses `cli.py`'s cleanup path and never calls `agent.shutdown_memory_provider()`, leaving background async threads (e.g. httpx clients) running during interpreter shutdown, which causes the process to abort. This change ensures memory providers are properly shut down before process exit.

## Related Issue

Fixes #60616

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/oneshot.py`: Added `agent.shutdown_memory_provider()` call in `_run_agent()` after `run_conversation()` completes to safely flush and close memory providers before process exit. Wrapped in try/except to ensure cleanup failures don't mask the actual conversation result.

## How to Test

1. Configure Honcho memory provider with async writes:
   ```yaml
   memory:
     provider: honcho
     honcho:
       writeFrequency: async
   ```
2. Run oneshot with Honcho backend running:
   ```bash
   hermes -z "say ok"
   ```
3. **Expected**: Clean exit (exit code 0) with no SIGABRT or core dump
4. **Observed result**: Before fix, `hermes -z` exits with SIGABRT (exit 134) after printing response. After fix, clean exit with code 0.

Alternative repro using strace (shows network calls in working mode vs crash mode):
```bash
strace -f -e trace=%network hermes -z "any prompt"
```
- Before fix: Network call to Honcho backend followed by SIGABRT
- After fix: Network call followed by clean exit

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A