### PR TITLE
fix(agent): add return_exceptions to asyncio.gather in context ref expansion

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -167,9 +167,14 @@ async def preprocess_context_references_async(
                 allowed_root=allowed_root_path,
             )
             for ref in refs
-        )
+        ),
+        return_exceptions=True,
     )
-    for warning, block in expanded:
+    for result in expanded:
+        if isinstance(result, BaseException):
+            warnings.append(f"context expansion failed: {result}")
+            continue
+        warning, block = result
         if warning:
             warnings.append(warning)
         if block:


### PR DESCRIPTION
## Summary

Add `return_exceptions=True` to `asyncio.gather()` in `preprocess_context_references_async()`.

## Problem

When multiple `@ref` context references appear in a message, they are expanded concurrently via `asyncio.gather()`. Without `return_exceptions=True`, a single failed reference (e.g. a bad URL that raises, network timeout, or malformed path) crashes the entire gather, causing **ALL** context references in that message to be dropped instead of gracefully skipping just the broken one.

## Fix

Added `return_exceptions=True` to the gather call and handle each exception in the iteration loop by appending a warning, matching the pattern used elsewhere in the codebase (e.g. `agent/lsp/manager.py:575`, `gateway/platforms/yuanbao.py:2873`).

## Testing
- Syntax check passed (py_compile)
- Behavior verified