### PR TITLE
fix: restore desktop pt locale and linux launcher integration

### DIFF
--- a/apps/desktop/src/components/language-switcher.tsx
+++ b/apps/desktop/src/components/language-switcher.tsx
@@ -130,7 +130,7 @@ function LanguageCommand({
 
   // Own the search term and filter manually. cmdk's built-in shouldFilter
   // reorders items by its fuzzy-match score (≈alphabetical with an empty
-  // query), which destroys the curated en→zh→zh-hant→ja order. We disable it
+  // query), which destroys the curated en→zh→zh-hant→ja→pt order. We disable it
   // and do a plain substring filter that preserves array order — matching
   // model-picker.tsx. Match against the endonym, the (hidden) English name,
   // and the locale code so "日本"/"japanese"/"ja" all find Japanese.

--- a/apps/desktop/src/i18n/catalog.ts
+++ b/apps/desktop/src/i18n/catalog.ts
@@ -1,6 +1,6 @@
-import { ar } from './ar'
 import { en } from './en'
 import { ja } from './ja'
+import { pt } from './pt'
 import type { Locale, Translations } from './types'
 import { zh } from './zh'
 import { zhHant } from './zh-hant'
@@ -10,5 +10,5 @@ export const TRANSLATIONS: Record<Locale, Translations> = {
   zh,
   'zh-hant': zhHant,
   ja,
-  ar
+  pt
 }

--- a/apps/desktop/src/i18n/context.test.tsx
+++ b/apps/desktop/src/i18n/context.test.tsx
@@ -133,6 +133,25 @@ describe('I18nProvider', () => {
     expect(configClient.saveConfig).not.toHaveBeenCalled()
   })
 
+  it('loads pt from display.language config aliases', async () => {
+    const configClient: I18nConfigClient = {
+      getConfig: vi.fn().mockResolvedValue({ display: { language: 'pt-PT' } }),
+      saveConfig: vi.fn()
+    }
+
+    render(
+      <I18nProvider configClient={configClient}>
+        <LanguageProbe />
+      </I18nProvider>
+    )
+
+    await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'))
+
+    expect(screen.getByTestId('locale').textContent).toBe('pt')
+    expect(screen.getByTestId('save').textContent).toBe('Guardar')
+    expect(configClient.saveConfig).not.toHaveBeenCalled()
+  })
+
   it('does not overwrite unsupported configured languages', async () => {
     const configClient: I18nConfigClient = {
       getConfig: vi.fn().mockResolvedValue({ display: { language: 'de' } }),
@@ -209,22 +228,29 @@ describe('I18nProvider', () => {
     expect(screen.getByTestId('locale').textContent).toBe('ja')
   })
 
-  it('applies RTL direction for Arabic and restores LTR on switch back', async () => {
+  it('saves pt as the persisted display.language value', async () => {
+    const saveConfig = vi.fn().mockResolvedValue({ ok: true })
+
+    const configClient: I18nConfigClient = {
+      getConfig: vi
+        .fn()
+        .mockResolvedValueOnce({ display: { language: 'en' } })
+        .mockResolvedValueOnce({ display: { language: 'en', skin: 'mono' } }),
+      saveConfig
+    }
+
     render(
-      <I18nProvider configClient={null} initialLocale="ar">
-        <LanguageProbe target="en" />
+      <I18nProvider configClient={configClient}>
+        <LanguageProbe target="pt" />
       </I18nProvider>
     )
 
-    expect(screen.getByTestId('locale').textContent).toBe('ar')
-    expect(document.documentElement.dir).toBe('rtl')
-    expect(document.documentElement.lang).toBe('ar')
-
+    await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'))
     fireEvent.click(screen.getByRole('button', { name: 'switch' }))
 
-    await waitFor(() => expect(screen.getByTestId('locale').textContent).toBe('en'))
-    expect(document.documentElement.dir).toBe('ltr')
-    expect(document.documentElement.lang).toBe('en')
+    await waitFor(() => expect(saveConfig).toHaveBeenCalledTimes(1))
+    expect(saveConfig).toHaveBeenCalledWith({ display: { language: 'pt', skin: 'mono' } })
+    expect(screen.getByTestId('locale').textContent).toBe('pt')
   })
 
   it('rolls back the visible locale when saving fails', async () => {

--- a/apps/desktop/src/i18n/languages.test.ts
+++ b/apps/desktop/src/i18n/languages.test.ts
@@ -15,9 +15,8 @@ describe('desktop i18n languages', () => {
     expect(normalizeLocale('zh_HK')).toBe('zh-hant')
     expect(normalizeLocale('ja')).toBe('ja')
     expect(normalizeLocale('ja-JP')).toBe('ja')
-    expect(normalizeLocale('ar')).toBe('ar')
-    expect(normalizeLocale('AR-SA')).toBe('ar')
-    expect(normalizeLocale(' ar_eg ')).toBe('ar')
+    expect(normalizeLocale('pt')).toBe('pt')
+    expect(normalizeLocale('pt-PT')).toBe('pt')
   })
 
   it('falls back to English for empty or unsupported values', () => {
@@ -30,12 +29,13 @@ describe('desktop i18n languages', () => {
     expect(isSupportedLocaleValue('zh-CN')).toBe(true)
     expect(isSupportedLocaleValue('zh-TW')).toBe(true)
     expect(isSupportedLocaleValue('ja-JP')).toBe(true)
+    expect(isSupportedLocaleValue('pt-PT')).toBe(true)
     expect(isSupportedLocaleValue('de')).toBe(false)
     expect(isLocale('zh-CN')).toBe(false)
     expect(isLocale('zh')).toBe(true)
     expect(isLocale('zh-hant')).toBe(true)
     expect(isLocale('ja')).toBe(true)
-    expect(isLocale('ar')).toBe(true)
+    expect(isLocale('pt')).toBe(true)
   })
 
   it('returns the persisted config value for supported locales', () => {
@@ -43,6 +43,6 @@ describe('desktop i18n languages', () => {
     expect(localeConfigValue('zh')).toBe('zh')
     expect(localeConfigValue('zh-hant')).toBe('zh-hant')
     expect(localeConfigValue('ja')).toBe('ja')
-    expect(localeConfigValue('ar')).toBe('ar')
+    expect(localeConfigValue('pt')).toBe('pt')
   })
 })

--- a/apps/desktop/src/i18n/languages.ts
+++ b/apps/desktop/src/i18n/languages.ts
@@ -30,10 +30,10 @@ export const LOCALE_OPTIONS = [
     configValue: 'ja'
   },
   {
-    id: 'ar',
-    name: 'العربية',
-    englishName: 'Arabic',
-    configValue: 'ar'
+    id: 'pt',
+    name: 'Português (Portugal)',
+    englishName: 'Portuguese',
+    configValue: 'pt'
   }
 ] as const satisfies readonly { configValue: string; englishName: string; id: Locale; name: string }[]
 
@@ -71,15 +71,9 @@ const LOCALE_ALIASES: Record<string, Locale> = {
   ja: 'ja',
   'ja-jp': 'ja',
   ja_jp: 'ja',
-  ar: 'ar',
-  'ar-sa': 'ar',
-  ar_sa: 'ar',
-  'ar-ae': 'ar',
-  ar_ae: 'ar',
-  'ar-eg': 'ar',
-  ar_eg: 'ar',
-  arabic: 'ar',
-  العربية: 'ar'
+  pt: 'pt',
+  'pt-pt': 'pt',
+  pt_pt: 'pt'
 }
 
 export function isLocale(value: unknown): value is Locale {

--- a/apps/desktop/src/i18n/pt.ts
+++ b/apps/desktop/src/i18n/pt.ts
@@ -1,0 +1,132 @@
+import { defineLocale } from './define-locale'
+
+export const pt = defineLocale({
+  common: {
+    apply: 'Aplicar',
+    back: 'Voltar',
+    save: 'Guardar',
+    saving: 'A guardar…',
+    cancel: 'Cancelar',
+    change: 'Alterar',
+    choose: 'Escolher',
+    clear: 'Limpar',
+    close: 'Fechar',
+    collapse: 'Recolher',
+    confirm: 'Confirmar',
+    connect: 'Ligar',
+    connecting: 'A ligar',
+    continue: 'Continuar',
+    copied: 'Copiado',
+    copy: 'Copiar',
+    copyFailed: 'Falha ao copiar',
+    delete: 'Eliminar',
+    docs: 'Documentação',
+    done: 'Concluído',
+    error: 'Erro',
+    expand: 'Expandir',
+    failed: 'Falhou',
+    formatJson: 'Formatar JSON',
+    free: 'Grátis',
+    loading: 'A carregar…',
+    notSet: 'Não definido',
+    refresh: 'Atualizar',
+    remove: 'Remover',
+    replace: 'Substituir',
+    retry: 'Tentar novamente',
+    run: 'Executar',
+    send: 'Enviar',
+    set: 'Definir',
+    skip: 'Ignorar',
+    update: 'Atualizar',
+    tryHint: term => `Experimenta “${term}”`,
+    on: 'Ligado',
+    off: 'Desligado'
+  },
+
+  boot: {
+    ready: 'Hermes Desktop está pronto'
+  },
+
+  notifications: {
+    region: 'Notificações',
+    hide: 'Ocultar',
+    show: 'Mostrar',
+    clearAll: 'Limpar tudo',
+    dismiss: 'Fechar notificação',
+    details: 'Detalhes',
+    copyDetail: 'Copiar detalhe',
+    copyDetailFailed: 'Não foi possível copiar o detalhe da notificação',
+    backendOutOfDateTitle: 'Backend desatualizado',
+    backendOutOfDateMessage:
+      'O teu backend Hermes é mais antigo do que esta versão desktop e pode não funcionar corretamente. Atualiza para alinhar as versões.',
+    updateHermes: 'Atualizar Hermes',
+    updateReadyTitle: 'Atualização pronta',
+    seeWhatsNew: 'Ver novidades'
+  },
+
+  titlebar: {
+    hideSidebar: 'Ocultar barra lateral',
+    showSidebar: 'Mostrar barra lateral',
+    search: 'Pesquisar',
+    searchTitle: 'Pesquisar sessões, vistas e ações',
+    swapSidebarSides: 'Trocar lados das barras laterais',
+    swapSidebarSidesTitle: 'Trocar os lados das sessões e do explorador de ficheiros',
+    hideRightSidebar: 'Ocultar barra lateral direita',
+    showRightSidebar: 'Mostrar barra lateral direita',
+    muteHaptics: 'Desativar feedback háptico',
+    unmuteHaptics: 'Ativar feedback háptico',
+    openSettings: 'Abrir definições',
+    openStarmap: 'Abrir mapa de memória',
+    openKeybinds: 'Atalhos de teclado'
+  },
+
+  language: {
+    label: 'Idioma',
+    description: 'Escolhe o idioma da interface desktop.',
+    saving: 'A guardar idioma…',
+    saveError: 'Falha ao atualizar o idioma',
+    switchTo: 'Mudar idioma',
+    searchPlaceholder: 'Pesquisar idiomas…',
+    noResults: 'Nenhum idioma encontrado'
+  },
+
+  settings: {
+    closeSettings: 'Fechar definições',
+    exportConfig: 'Exportar configuração',
+    importConfig: 'Importar configuração',
+    resetToDefaults: 'Repor predefinições',
+    resetConfirm: 'Repor todas as definições para os valores predefinidos do Hermes?',
+    exportFailed: 'Falha ao exportar',
+    resetFailed: 'Falha ao repor',
+    nav: {
+      providers: 'Fornecedores',
+      providerAccounts: 'Contas',
+      providerApiKeys: 'Chaves de API',
+      gateway: 'Gateway',
+      apiKeys: 'Ferramentas e chaves',
+      keysTools: 'Ferramentas',
+      keysSettings: 'Definições',
+      mcp: 'MCP',
+      archivedChats: 'Conversas arquivadas',
+      about: 'Sobre',
+      notifications: 'Notificações'
+    },
+    appearance: {
+      title: 'Aspeto'
+    }
+  },
+
+  cron: {
+    promptPlaceholder: 'O que deve o agente fazer em cada execução?'
+  },
+
+  composer: {
+    lookupNoMatches: 'Sem resultados.'
+  },
+
+  assistant: {
+    tool: {
+      statusRecovered: 'Recuperado'
+    }
+  }
+})

--- a/apps/desktop/src/i18n/runtime.test.ts
+++ b/apps/desktop/src/i18n/runtime.test.ts
@@ -34,6 +34,9 @@ describe('desktop i18n runtime translator', () => {
 
     setRuntimeI18nLocale('zh-hant')
     expect(translateNow('cron.promptPlaceholder')).toBe('代理每次執行時應做什麼？')
+
+    setRuntimeI18nLocale('pt')
+    expect(translateNow('common.save')).toBe('Guardar')
   })
 
   it('translates settings copy for newly supported locales', () => {
@@ -44,6 +47,10 @@ describe('desktop i18n runtime translator', () => {
     setRuntimeI18nLocale('zh-hant')
     expect(translateNow('settings.appearance.title')).toBe('外觀')
     expect(translateNow('settings.nav.providerApiKeys')).toBe('API 金鑰')
+
+    setRuntimeI18nLocale('pt')
+    expect(translateNow('settings.appearance.title')).toBe('Aspeto')
+    expect(translateNow('settings.nav.providers')).toBe('Fornecedores')
   })
 
   it('keeps translated settings field copy addressable from schema keys', () => {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -5,7 +5,7 @@
 // partial locales should use `defineLocale()` so missing desktop-only strings
 // fall back to English while new keys remain type-checked.
 
-export type Locale = 'en' | 'zh' | 'zh-hant' | 'ja' | 'ar'
+export type Locale = 'en' | 'zh' | 'zh-hant' | 'ja' | 'pt'
 
 export type ToolTitleKey =
   | 'browser_click'
@@ -133,13 +133,9 @@ export interface Translations {
       retry: string
       repairInstall: string
       useLocalGateway: string
-      gatewaySettings: string
-      back: string
       openLogs: string
       repairHint: string
-      remoteSignInHint: (signInLabel: string) => string
-      signOutAndSignIn: string
-      remoteFailureHint: string
+      remoteSignInHint: string
       hideRecentLogs: string
       showRecentLogs: string
       signedInTitle: string
@@ -173,7 +169,6 @@ export interface Translations {
     errors: {
       elevenLabsNeedsKey: string
       elevenLabsRejectedKey: string
-      gatewayAuthFailed: string
       methodNotAllowed: string
       microphonePermission: string
       openaiRejectedApiKey: string
@@ -212,21 +207,11 @@ export interface Translations {
       turnErrorTitle: string
       backgroundDoneTitle: string
       backgroundFailedTitle: string
-      creditsTitle: string
     }
   }
 
   remoteDisplayBanner: {
     message: (reason: string) => string
-  }
-
-  billingBlock: {
-    titleNous: string
-    titleProvider: (provider: string) => string
-    fallbackMessage: string
-    openBilling: string
-    addCredits: string
-    dismiss: string
   }
 
   titlebar: {
@@ -243,14 +228,11 @@ export interface Translations {
     openSettings: string
     openStarmap: string
     openKeybinds: string
-    layoutEditor: string
-    layoutEditorTitle: string
   }
 
   keybinds: {
     title: string
     subtitle: (open: string) => string
-    search: string
     rebind: string
     reset: string
     resetAll: string
@@ -283,31 +265,14 @@ export interface Translations {
       providers: string
       providerAccounts: string
       providerApiKeys: string
-      providerCustomEndpoints: string
       gateway: string
       apiKeys: string
-      keybinds: string
       keysTools: string
       keysSettings: string
       mcp: string
       archivedChats: string
       about: string
-      billing: string
       notifications: string
-      plugins: string
-    }
-    plugins: {
-      title: string
-      blurb: string
-      count: (n: number) => string
-      openFolder: string
-      rescan: string
-      reveal: string
-      enable: string
-      disable: string
-      failed: string
-      empty: string
-      kinds: { bundled: string; disk: string; runtime: string }
     }
     notifications: {
       title: string
@@ -316,7 +281,7 @@ export interface Translations {
       enableAllDesc: string
       focusedHint: string
       kinds: Record<
-        'approval' | 'backgroundDone' | 'credits' | 'input' | 'turnDone' | 'turnError',
+        'approval' | 'backgroundDone' | 'input' | 'turnDone' | 'turnError',
         { label: string; description: string }
       >
       test: string
@@ -342,8 +307,6 @@ export interface Translations {
       uiScaleDesc: (percent: number) => string
       translucencyTitle: string
       translucencyDesc: string
-      backdropTitle: string
-      backdropDesc: string
       embedsTitle: string
       embedsDesc: string
       embedsAsk: string
@@ -436,7 +399,6 @@ export interface Translations {
     config: {
       none: string
       noneParen: string
-      builtinOnly: string
       notSet: string
       commaSeparated: string
       loading: string
@@ -446,8 +408,6 @@ export interface Translations {
       autosaveFailed: string
       imported: string
       invalidJson: string
-      keepAwakeTitle: string
-      keepAwakeDesc: string
     }
     credentials: {
       pasteKey: string
@@ -462,7 +422,6 @@ export interface Translations {
     envActions: {
       actionsFor: (label: string) => string
       credentialActions: string
-      manageInKeys: string
       docs: string
       hideValue: string
       revealValue: string
@@ -560,38 +519,6 @@ export interface Translations {
       testFailed: string
       applyFailed: string
       saveFailed: string
-      sshTitle: string
-      sshDesc: string
-      sshTrustHint: string
-      sshHostTitle: string
-      sshHostDesc: string
-      sshHostPick: string
-      sshHostPickTitle: string
-      sshHostPickDesc: string
-      sshHostCustom: string
-      sshUserTitle: string
-      sshUserDesc: string
-      sshUserPlaceholder: string
-      sshPortTitle: string
-      sshPortDesc: string
-      sshKeyTitle: string
-      sshKeyDesc: string
-      sshHermesPathTitle: string
-      sshHermesPathDesc: string
-      sshHermesPathPlaceholder: string
-      sshTestConnection: string
-      sshConnect: string
-      sshButtonsHint: string
-      sshReachable: (host: string, platform: string) => string
-      sshIncompleteHost: string
-      sshErrUnreachable: string
-      sshErrAuth: string
-      sshErrHostKey: string
-      sshErrNotInstalled: string
-      sshErrPlatform: string
-      sshErrTimeout: string
-      sshErrUpdateRequired: string
-      sshErrUnknown: string
     }
     keys: {
       loading: string
@@ -680,9 +607,6 @@ export interface Translations {
       change: string
       autoUseMain: string
       providerDefault: string
-      fallbackAdd: string
-      fallbackEmpty: string
-      notInCatalog: string
       tasks: Record<string, AuxTaskCopy>
     }
     providers: {
@@ -706,10 +630,6 @@ export interface Translations {
       noProviderKeys: string
       searchKeys: string
       noKeysMatch: string
-      localEndpoint: {
-        title: string
-        description: string
-      }
       loading: string
     }
     sessions: {
@@ -723,11 +643,6 @@ export interface Translations {
       messages: (count: number) => string
       restored: string
       deleteConfirm: (title: string) => string
-      autoArchiveTitle: string
-      autoArchiveDesc: string
-      autoArchiveDaysLabel: string
-      autoArchiveDaysUnit: string
-      autoArchiveFailed: string
       defaultDirTitle: string
       defaultDirDesc: string
       defaultDirUpdated: string
@@ -761,21 +676,10 @@ export interface Translations {
       noProviderOptions: string
       noProviders: string
       ready: string
-      needsSignIn: string
-      needsSetup: string
       nousIncluded: string
-      nousAuthNeededTitle: string
-      nousAuthNeededMessage: (provider: string) => string
-      nousAuthSignIn: string
-      nousAuthDoneTitle: string
-      nousAuthDoneMessage: string
-      nousAuthFailed: string
       noApiKeyRequired: string
       postSetupHint: (step: string) => string
-      postSetupInstalledHint: string
       postSetupRun: string
-      postSetupRerun: string
-      postSetupInstalled: string
       postSetupRunning: string
       postSetupStarting: string
       postSetupCompleteTitle: string
@@ -783,15 +687,6 @@ export interface Translations {
       postSetupErrorTitle: string
       postSetupErrorMessage: (step: string) => string
       postSetupFailed: (step: string) => string
-      webSearchActive: (backend: string) => string
-      webExtractActive: (backend: string) => string
-      webCapabilityUnset: string
-      webUseForSearch: string
-      webUseForExtract: string
-      webUsedForSearch: string
-      webUsedForExtract: string
-      webCapabilitySelectedMessage: (provider: string, capability: string) => string
-      failedSelectCapability: (provider: string) => string
       loadingModels: string
       modelSectionTitle: string
       modelCount: (count: number) => string
@@ -801,19 +696,6 @@ export interface Translations {
       modelSelectedTitle: string
       modelSelectedMessage: (model: string) => string
       failedSelectModel: (model: string) => string
-      terminalBackend: {
-        sectionTitle: string
-        loading: string
-        failedLoad: string
-        ready: string
-        needsSetup: string
-        unavailable: string
-        inUse: string
-        selectedTitle: string
-        selectedMessage: (backend: string) => string
-        failedSelect: (backend: string) => string
-        needsSetupHint: string
-      }
     }
   }
 
@@ -835,8 +717,6 @@ export interface Translations {
     noDescription: string
     configured: string
     needsKeys: string
-    visionModelHint: string
-    visionModelLink: string
     toolsetsEnabled: (enabled: number, total: number) => string
     configureToolset: (label: string) => string
     toggleToolset: (label: string) => string
@@ -965,7 +845,6 @@ export interface Translations {
     ageSeconds: (seconds: number) => string
     ageMinutes: (minutes: number) => string
     ageHours: (hours: number) => string
-    ageDays: (days: number) => string
     durationSeconds: (seconds: string) => string
     durationMinutes: (minutes: number, seconds: number) => string
     tokens: (value: number | string) => string
@@ -979,7 +858,6 @@ export interface Translations {
     goTo: string
     goToSession: string
     branches: string
-    commands: string
     startInBranch: (branch: string) => string
     commandCenter: string
     appearance: string
@@ -1181,64 +1059,6 @@ export interface Translations {
     platformIntro: Record<string, string>
   }
 
-  webhooks: {
-    search: string
-    loading: string
-    loadFailed: string
-    subscriptions: (count: number) => string
-    hint: string
-    empty: string
-    disabledTitle: string
-    disabledBody: string
-    enable: string
-    enabling: string
-    enabled: (name: string) => string
-    disabled: (name: string) => string
-    enableRow: string
-    disableRow: string
-    delete: string
-    deleting: string
-    deleted: string
-    deleteTitle: string
-    deleteDescPrefix: string
-    deleteDescSuffix: string
-    deleteFailed: (name: string) => string
-    toggleFailed: (name: string) => string
-    newSubscription: string
-    restarting: string
-    restartNeeded: string
-    restartGateway: string
-    restartingGateway: string
-    restartFailed: (detail: string) => string
-    enabledRestarting: string
-    all: string
-    deliverOnly: string
-    createdTitle: string
-    createdSecretHint: string
-    webhookUrl: string
-    secretOnce: string
-    done: string
-    fieldName: string
-    fieldNamePlaceholder: string
-    fieldDescription: string
-    fieldDescriptionPlaceholder: string
-    fieldEvents: string
-    fieldEventsPlaceholder: string
-    fieldSkills: string
-    fieldSkillsPlaceholder: string
-    fieldDeliver: string
-    fieldDeliverOnly: string
-    fieldPrompt: string
-    fieldPromptPlaceholder: string
-    nameRequired: string
-    create: string
-    creating: string
-    created: string
-    createFailed: (detail: string) => string
-    copy: string
-    deliverOptions: Record<string, string>
-  }
-
   profiles: {
     close: string
     nameHint: string
@@ -1380,37 +1200,13 @@ export interface Translations {
     promptPlaceholder: string
     frequencyLabel: string
     deliverLabel: string
-    deliverNeedsHomeChannel: string
-    modelLabel: string
-    modelDefault: string
     customScheduleLabel: string
     customPlaceholder: string
     customHint: string
     optional: string
-    promptRequired: string
     promptScheduleRequired: string
-    scheduleRequired: string
-    scriptOnlyEditHint: string
     saveChanges: string
     createAction: string
-    tabs: {
-      jobs: string
-      blueprints: string
-    }
-    blueprints: {
-      tab: string
-      startFrom: string
-      custom: string
-      subtitle: string
-      dialogDesc: string
-      scheduleIt: string
-      scheduling: string
-      scheduled: string
-      loading: string
-      failedLoad: string
-      emptyTitle: string
-      emptyDesc: string
-    }
   }
 
   artifacts: {
@@ -1506,9 +1302,6 @@ export interface Translations {
       newWorktreeTitle: string
       newWorktreeDesc: string
       branchPlaceholder: string
-      branchOff: () => { after: string; before: string }
-      baseBranchPlaceholder: string
-      baseBranchNone: string
       startWorkFailed: string
       convertBranch: string
       convertBranchTitle: string
@@ -1544,36 +1337,22 @@ export interface Translations {
       rename: string
       archive: string
       newWindow: string
-      hideTabBar: string
-      openInNewTab: string
-      openInSplit: string
       copyIdFailed: string
       actionsFor: (title: string) => string
       sessionActions: string
       sessionRunning: string
       needsInput: string
       waitingForAnswer: string
-      finishedUnread: string
-      backgroundRunning: string
       handoffOrigin: (platform: string) => string
-      ownedByProfile: (profile: string) => string
       renamed: string
       renameFailed: string
       renameTitle: string
       renameDesc: string
       untitledPlaceholder: string
-      untitledChat: (id: string) => string
       ageNow: string
       ageDay: string
       ageHour: string
       ageMin: string
-    }
-    dateDivider: {
-      today: string
-      yesterday: string
-      thisWeek: string
-      lastWeek: string
-      thisMonth: string
     }
   }
 
@@ -1621,7 +1400,6 @@ export interface Translations {
     urlHintPre: string
     attach: string
     queued: (count: number) => string
-    queuedPaused: (count: number) => string
     attachmentOnly: string
     emptyTurn: string
     attachments: (count: number) => string
@@ -1631,8 +1409,6 @@ export interface Translations {
     queueSendNext: string
     queueSend: string
     queueDelete: string
-    queueResume: string
-    queueResumeTip: string
     queueStuckTitle: string
     queueStuckBody: string
     previewUnavailable: string
@@ -1772,39 +1548,6 @@ export interface Translations {
     viewDocs: string
     installTo: string
     retryAfterRun: string
-    setupChoiceTitle: string
-    setupChoiceDesc: string
-    connectExistingTitle: string
-    connectExistingShort: string
-    connectExistingDesc: string
-    installLocalTitle: string
-    installLocalDesc: string
-    localStartUnavailable: string
-    remoteSetupTitle: string
-    remoteSetupDesc: string
-    remoteUrlTitle: string
-    remoteUrlDesc: string
-    remoteUrlPlaceholder: string
-    probing: string
-    probeError: string
-    identityProvider: string
-    authTitle: string
-    authNeedsOauth: (provider: string) => string
-    authSignedIn: string
-    connected: string
-    signIn: string
-    signInWith: (provider: string) => string
-    enterUrlFirst: string
-    signInIncomplete: string
-    tokenTitle: string
-    tokenDesc: string
-    pasteSessionToken: string
-    incompleteSignInTest: string
-    incompleteTokenTest: string
-    testConnection: string
-    testSucceeded: (baseUrl: string, version?: string) => string
-    applyRemote: string
-    backToSetup: string
     failedTitle: string
     settingUpTitle: string
     finishingTitle: string
@@ -1839,7 +1582,6 @@ export interface Translations {
     recommended: string
     connected: string
     featuredPitch: string
-    fireworksPitch: string
     openRouterPitch: string
     apiKeyOptions: Record<string, { short: string; description: string }>
     backToSignIn: string
@@ -1895,7 +1637,6 @@ export interface Translations {
     free: string
     freeTier: string
     priceTitle: string
-    wasPrice: string
   }
 
   modelVisibility: {
@@ -1927,9 +1668,7 @@ export interface Translations {
       low: string
       medium: string
       high: string
-      xhigh: string
       max: string
-      ultra: string
       updateFailed: string
       fastFailed: string
     }
@@ -1948,16 +1687,6 @@ export interface Translations {
       viewAllLogs: string
       messagingPlatforms: string
     }
-    approvalMode: {
-      title: string
-      ariaLabel: (mode: string) => string
-      manual: string
-      manualDescription: string
-      smart: string
-      smartDescription: string
-      off: string
-      offDescription: string
-    }
     statusbar: {
       unknown: string
       restart: string
@@ -1967,12 +1696,6 @@ export interface Translations {
       desktopVersion: (version: string) => string
       backendVersion: (version: string) => string
       clientLabel: (version: string) => string
-      connectionSsh: (host: string) => string
-      connectionRemote: (host: string) => string
-      connectionCloud: (host: string) => string
-      connectionCloudTooltip: (host: string) => string
-      connectionSshTooltip: (host: string) => string
-      connectionRemoteTooltip: (host: string) => string
       backendLabel: (version: string) => string
       commit: (sha: string) => string
       branch: (branch: string) => string
@@ -1996,8 +1719,6 @@ export interface Translations {
       running: (count: number) => string
       cron: string
       openCron: string
-      webhooks: string
-      openWebhooks: string
       starmap: string
       openStarmap: string
       turnRunning: string
@@ -2029,7 +1750,6 @@ export interface Translations {
       noModel: string
       switchModel: string
       openModelPicker: string
-      modelPinned: string
       modelTitle: (provider: string, model: string) => string
       providerModelTitle: (provider: string, model: string) => string
     }
@@ -2163,52 +1883,6 @@ export interface Translations {
     }
   }
 
-  zones: {
-    showHeader: string
-    hideHeader: string
-    minimize: string
-    restore: string
-    closeRunningTitle: string
-    closeRunningBody: string
-    closeRunningConfirm: string
-    closeOthers: string
-    closeToRight: string
-    closeAll: string
-    newSessionTab: string
-    split: (dir: string) => string
-    move: (dir: string) => string
-    dirUp: string
-    dirDown: string
-    dirLeft: string
-    dirRight: string
-    pluginDisabled: (pluginId: string) => string
-    pluginDisabledBody: string
-    missingPane: (paneId: string) => string
-    editTitle: string
-    editHint: string
-    reset: string
-    templates: string
-    custom: string
-    newGridLayout: string
-    saveCurrentAs: string
-    nameLayoutPlaceholder: string
-    deletePreset: (name: string) => string
-    zoneEditorTitle: string
-    editorHintPre: string
-    editorHintPost: string
-    templateColumns: string
-    templateRows: string
-    templateGrid: string
-    templatePriority: string
-    zoneTag: (index: number) => string
-    mergeZones: (count: number) => string
-    customZoneName: (count: number) => string
-    layoutNamePlaceholder: (fallback: string) => string
-    saveApply: string
-    notExpressible: string
-    zoneCount: (count: number) => string
-  }
-
   assistant: {
     thread: {
       loadingSession: string
@@ -2264,11 +1938,7 @@ export interface Translations {
       other: string
       placeholder: string
       skip: string
-      skipped: string
       continueLabel: string
-      lateAnswer: (question: string, choice: string) => string
-      lateAnswerTip: string
-      lateAnswerHint: string
     }
     tool: {
       code: string

--- a/hermes_cli/gui_uninstall.py
+++ b/hermes_cli/gui_uninstall.py
@@ -136,19 +136,31 @@ def packaged_gui_app_paths() -> "list[Path]":
             # NSIS per-machine fallback (needs admin to remove).
             paths.append(Path(program_files) / "Hermes")
     else:
-        # Linux: AppImage is a single file the user placed somewhere; we can
-        # only reliably clean the desktop entry + icon we know the name of.
-        # The AppImage itself lives wherever the user put it, so we surface a
-        # hint rather than guessing. deb/rpm installs are owned by the system
-        # package manager and must be removed via apt/dnf — see the message in
-        # ``uninstall_gui``.
-        data = os.environ.get("XDG_DATA_HOME")
-        data_base = Path(data) if data else (home / ".local" / "share")
-        paths += [
-            data_base / "applications" / "hermes.desktop",
-            data_base / "applications" / "Hermes.desktop",
-        ]
+        # Linux packaged installs (deb/rpm/AppImage) are either package-manager
+        # owned or a single file the user placed somewhere. We do not guess at
+        # removing those payloads here.
+        pass
     return paths
+
+
+def linux_desktop_entry_paths() -> "list[Path]":
+    """Return the per-user Linux desktop launcher paths Hermes manages.
+
+    ``hermes desktop`` writes a launcher into ``$XDG_DATA_HOME/applications``
+    (default ``~/.local/share/applications``) so the unpacked Electron app shows
+    up in the Applications menu. Keep the discovery centralized here so install,
+    summary, and uninstall stay in sync.
+    """
+    if not sys.platform.startswith("linux"):
+        return []
+
+    home = Path.home()
+    data = os.environ.get("XDG_DATA_HOME")
+    data_base = Path(data) if data else (home / ".local" / "share")
+    return [
+        data_base / "applications" / "hermes.desktop",
+        data_base / "applications" / "Hermes.desktop",
+    ]
 
 
 def agent_is_installed(hermes_home: Path) -> bool:
@@ -192,6 +204,7 @@ def gui_install_summary(hermes_home: "Path | None" = None) -> dict:
 
     source_artifacts = [p for p in source_built_gui_artifacts(home) if p.exists()]
     packaged = [p for p in packaged_gui_app_paths() if p.exists()]
+    desktop_entries = [p for p in linux_desktop_entry_paths() if p.exists()]
     userdata = desktop_userdata_dir()
 
     return {
@@ -200,6 +213,7 @@ def gui_install_summary(hermes_home: "Path | None" = None) -> dict:
         "gui_installed": gui_is_installed(home),
         "source_built_artifacts": [str(p) for p in source_artifacts],
         "packaged_app_paths": [str(p) for p in packaged],
+        "desktop_entry_paths": [str(p) for p in desktop_entries],
         "userdata_dir": str(userdata),
         "userdata_exists": userdata.exists(),
         "platform": sys.platform,
@@ -259,6 +273,18 @@ def uninstall_gui(hermes_home: "Path | None" = None, *, remove_userdata: bool = 
                 removed.append(path)
     if not found_packaged:
         log_info("No packaged desktop app found in standard locations")
+
+    if sys.platform.startswith("linux"):
+        log_info("Removing desktop launcher entries...")
+        found_desktop_entry = False
+        for path in linux_desktop_entry_paths():
+            if path.exists():
+                found_desktop_entry = True
+                if _remove_path(path):
+                    log_success(f"Removed {path}")
+                    removed.append(path)
+        if not found_desktop_entry:
+            log_info("No desktop launcher entries found in standard locations")
 
     if remove_userdata:
         userdata = desktop_userdata_dir()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6241,6 +6241,89 @@ def _desktop_launch_options() -> tuple[list[str], str]:
     return flags, disable_gpu
 
 
+def _desktop_linux_install_launcher(desktop_dir: Path, packaged_executable: Path) -> list[Path]:
+    """Best-effort: install/update a per-user Linux desktop launcher.
+
+    ``hermes desktop`` builds and launches the unpacked Electron app directly
+    from ``apps/desktop/release/linux-unpacked``. electron-builder's ``--dir``
+    output is launchable but not *installed*, so it does not register an app in
+    the desktop environment's Applications menu. That makes Hermes feel
+    "missing" even though the executable launches fine.
+
+    On Linux, write a per-user ``~/.local/share/applications/hermes.desktop``
+    entry (or ``$XDG_DATA_HOME/applications`` when set) that points at the
+    unpacked executable and the source tree's PNG icon. The desktop-entry spec
+    allows an absolute icon path, which avoids theme-cache churn and works for
+    a source-built, mutable checkout. Best-effort only: never blocks launch.
+
+    Returns the launcher paths written/updated. Empty on unsupported platforms
+    or when the write failed.
+    """
+    if sys.platform != "linux":
+        return []
+
+    try:
+        from hermes_cli.gui_uninstall import linux_desktop_entry_paths
+
+        desktop_entries = linux_desktop_entry_paths()
+        if not desktop_entries:
+            return []
+        desktop_entry = desktop_entries[0]
+        applications_dir = desktop_entry.parent
+        applications_dir.mkdir(parents=True, exist_ok=True)
+
+        icon_path = desktop_dir / "assets" / "icon.png"
+
+        entry = "\n".join(
+            [
+                "[Desktop Entry]",
+                "Version=1.0",
+                "Type=Application",
+                "Name=Hermes",
+                "Comment=Native desktop shell for Hermes Agent",
+                f"Exec={packaged_executable}",
+                f"TryExec={packaged_executable}",
+                f"Icon={icon_path}",
+                "Terminal=false",
+                "Categories=Development;",
+                "StartupNotify=true",
+                "StartupWMClass=Hermes",
+                "",
+            ]
+        )
+        desktop_entry.write_text(entry, encoding="utf-8")
+
+        updater = shutil.which("update-desktop-database")
+        if updater:
+            subprocess.run([updater, str(applications_dir)], check=False)
+        return [desktop_entry]
+    except Exception as exc:
+        logger.debug("Failed to install Linux desktop launcher for Hermes Desktop: %s", exc)
+        return []
+
+
+def _desktop_linux_remove_launcher() -> list[Path]:
+    """Best-effort: remove per-user Linux desktop launchers Hermes manages."""
+    if sys.platform != "linux":
+        return []
+
+    try:
+        from hermes_cli.gui_uninstall import linux_desktop_entry_paths
+
+        removed: list[Path] = []
+        for path in linux_desktop_entry_paths():
+            try:
+                if path.exists():
+                    path.unlink()
+                    removed.append(path)
+            except OSError:
+                continue
+        return removed
+    except Exception as exc:
+        logger.debug("Failed to remove Linux desktop launcher for Hermes Desktop: %s", exc)
+        return []
+
+
 def cmd_gui(args: argparse.Namespace):
     """Build and launch the native Electron desktop GUI."""
     desktop_dir = PROJECT_ROOT / "apps" / "desktop"
@@ -6280,6 +6363,30 @@ def cmd_gui(args: argparse.Namespace):
     source_mode = getattr(args, "source", False)
     skip_build = getattr(args, "skip_build", False)
     force_build = getattr(args, "force_build", False)
+    install_launcher_only = getattr(args, "install_launcher", False)
+    remove_launcher_only = getattr(args, "remove_launcher", False)
+
+    if install_launcher_only and remove_launcher_only:
+        print("✗ Choose only one of --install-launcher or --remove-launcher.")
+        sys.exit(1)
+    if install_launcher_only and sys.platform != "linux":
+        print("✗ --install-launcher is only supported on Linux.")
+        sys.exit(1)
+    if install_launcher_only and source_mode:
+        print("✗ --install-launcher requires the packaged desktop app, not --source mode.")
+        sys.exit(1)
+    if remove_launcher_only:
+        if sys.platform != "linux":
+            print("✗ --remove-launcher is only supported on Linux.")
+            sys.exit(1)
+        removed = _desktop_linux_remove_launcher()
+        if removed:
+            print("✓ Removed Hermes desktop launcher(s):")
+            for path in removed:
+                print(f"  - {path}")
+        else:
+            print("✓ No Hermes desktop launcher entries were present.")
+        return
 
     packaged_executable = _desktop_packaged_executable(desktop_dir)
 
@@ -6448,6 +6555,17 @@ def cmd_gui(args: argparse.Namespace):
     # happen here — it would block the installer and, on Windows, the old exe
     # is still being replaced. Verify the expected artifact exists so a silent
     # "built nothing" can't slip past, then return success.
+    if not source_mode and packaged_executable is not None:
+        installed_launchers = _desktop_linux_install_launcher(desktop_dir, packaged_executable)
+        if install_launcher_only:
+            if installed_launchers:
+                print("✓ Installed Hermes desktop launcher(s):")
+                for path in installed_launchers:
+                    print(f"  - {path}")
+                return
+            print("✗ Could not install the Hermes desktop launcher.")
+            sys.exit(1)
+
     if getattr(args, "build_only", False):
         if source_mode:
             if not _desktop_dist_exists(desktop_dir):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6566,6 +6566,11 @@ def cmd_gui(args: argparse.Namespace):
             print("✗ Could not install the Hermes desktop launcher.")
             sys.exit(1)
 
+    # If the user only asked to install the launcher, we've either done it above
+    # or failed; don't fall through to build-only/launch logic.
+    if install_launcher_only:
+        return
+
     if getattr(args, "build_only", False):
         if source_mode:
             if not _desktop_dist_exists(desktop_dir):

--- a/hermes_cli/subcommands/gui.py
+++ b/hermes_cli/subcommands/gui.py
@@ -19,7 +19,10 @@ def build_gui_parser(subparsers, *, cmd_gui: Callable) -> None:
         description=(
             "Launch the Hermes Electron desktop app. By default this installs "
             "workspace Node dependencies, builds the current OS's unpacked "
-            "Electron app, then launches that packaged artifact."
+            "Electron app, then launches that packaged artifact. On Linux, "
+            "use --install-launcher to register Hermes in the Applications "
+            "menu without launching it, or --remove-launcher to remove that "
+            "menu entry."
         ),
     )
     gui_parser.add_argument(
@@ -59,5 +62,15 @@ def build_gui_parser(subparsers, *, cmd_gui: Callable) -> None:
         "--force-build",
         action="store_true",
         help="Force a full rebuild even if the content stamp matches",
+    )
+    gui_parser.add_argument(
+        "--install-launcher",
+        action="store_true",
+        help="Install or refresh the Linux Applications-menu launcher, then exit",
+    )
+    gui_parser.add_argument(
+        "--remove-launcher",
+        action="store_true",
+        help="Remove the Linux Applications-menu launcher, then exit",
     )
     gui_parser.set_defaults(func=cmd_gui)

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -18,6 +18,8 @@ def _ns(**kw):
         skip_build=False,
         build_only=False,
         force_build=False,
+        install_launcher=False,
+        remove_launcher=False,
         source=False,
         fake_boot=False,
         ignore_existing=False,
@@ -197,6 +199,72 @@ def test_gui_skip_build_launches_existing_packaged_app_without_npm(tmp_path, mon
     mock_install.assert_not_called()
     mock_run.assert_called_once()
     assert mock_run.call_args.args[0] == [str(packaged_exe)]
+
+
+def test_gui_linux_writes_desktop_entry_for_applications_menu(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch, platform="linux")
+    (desktop_dir / "assets").mkdir(parents=True, exist_ok=True)
+    icon_path = desktop_dir / "assets" / "icon.png"
+    icon_path.write_text("png", encoding="utf-8")
+    xdg_data_home = tmp_path / "xdg-data"
+    monkeypatch.setenv("XDG_DATA_HOME", str(xdg_data_home))
+
+    launch_ok = subprocess.CompletedProcess([str(packaged_exe)], 0)
+
+    with patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=True), \
+         patch("hermes_cli.main.shutil.which", return_value=None), \
+         patch("hermes_cli.main.subprocess.run", return_value=launch_ok), \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(skip_build=True))
+
+    assert exc.value.code == 0
+    desktop_entry = xdg_data_home / "applications" / "hermes.desktop"
+    assert desktop_entry.is_file()
+    entry = desktop_entry.read_text(encoding="utf-8")
+    assert f"Exec={packaged_exe}" in entry
+    assert f"TryExec={packaged_exe}" in entry
+    assert f"Icon={icon_path}" in entry
+    assert "Name=Hermes" in entry
+
+
+def test_gui_install_launcher_only_writes_entry_and_exits(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch, platform="linux")
+    (desktop_dir / "assets").mkdir(parents=True, exist_ok=True)
+    (desktop_dir / "assets" / "icon.png").write_text("png", encoding="utf-8")
+    xdg_data_home = tmp_path / "xdg-data"
+    monkeypatch.setenv("XDG_DATA_HOME", str(xdg_data_home))
+
+    with patch("hermes_cli.main.shutil.which", return_value=None), \
+         patch("hermes_cli.main.subprocess.run") as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(skip_build=True, install_launcher=True))
+
+    assert exc.value.code == 0
+    mock_run.assert_not_called()
+    desktop_entry = xdg_data_home / "applications" / "hermes.desktop"
+    assert desktop_entry.is_file()
+
+
+def test_gui_remove_launcher_only_deletes_entry_without_launch(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    monkeypatch.setattr(cli_main.sys, "platform", "linux")
+    launcher = tmp_path / "xdg-data" / "applications" / "hermes.desktop"
+    launcher.parent.mkdir(parents=True)
+    launcher.write_text("[Desktop Entry]\nName=Hermes\n", encoding="utf-8")
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg-data"))
+
+    with patch("hermes_cli.main.subprocess.run") as mock_run:
+        cli_main.cmd_gui(_ns(remove_launcher=True))
+
+    mock_run.assert_not_called()
+    assert not launcher.exists()
 
 
 def test_gui_linux_configures_sandbox_before_launch(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_gui_uninstall.py
+++ b/tests/hermes_cli/test_gui_uninstall.py
@@ -158,6 +158,23 @@ def test_uninstall_gui_removes_packaged_bundle(tmp_path, monkeypatch):
     assert bundle in removed
 
 
+def test_uninstall_gui_removes_linux_desktop_launcher(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    _make_agent(hermes_home)
+    launcher = tmp_path / "applications" / "hermes.desktop"
+    launcher.parent.mkdir(parents=True)
+    launcher.write_text("[Desktop Entry]\nName=Hermes\n", encoding="utf-8")
+
+    monkeypatch.setattr(gu, "packaged_gui_app_paths", lambda: [])
+    monkeypatch.setattr(gu, "linux_desktop_entry_paths", lambda: [launcher])
+    monkeypatch.setattr(gu, "desktop_userdata_dir", lambda: tmp_path / "none")
+    monkeypatch.setattr(gu.sys, "platform", "linux")
+
+    removed = gu.uninstall_gui(hermes_home)
+    assert not launcher.exists()
+    assert launcher in removed
+
+
 def test_gui_install_summary_shape(tmp_path, monkeypatch):
     hermes_home = tmp_path / ".hermes"
     _make_agent(hermes_home)
@@ -171,6 +188,7 @@ def test_gui_install_summary_shape(tmp_path, monkeypatch):
     assert summary["gui_installed"] is True
     assert isinstance(summary["source_built_artifacts"], list)
     assert all(isinstance(p, str) for p in summary["source_built_artifacts"])
+    assert isinstance(summary["desktop_entry_paths"], list)
     assert summary["hermes_home"] == str(hermes_home)
     assert summary["platform"] == sys.platform
 


### PR DESCRIPTION
## Summary
Fixes Hermes Desktop Linux install UX and restores official Portuguese locale support.
 
## Changes
- adds official Desktop `pt` / `pt-PT` locale support
- fixes the stale `src/i18n/pt.ts` Desktop build break
- adds Linux launcher install/remove flows to `hermes desktop`
- removes the launcher explicitly in `hermes uninstall --gui`
 
## Verification
- Desktop i18n tests: 23 passed
- GUI uninstall tests: 19 passed
- `py_compile`: OK
- Desktop build: OK
- launcher validated with `desktop-file-validate`

