### PR TITLE
fix(acp): deliver background completion notifications

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1074,6 +1074,30 @@ class HermesACPAgent(acp.Agent):
         except Exception:
             logger.debug("Could not send ACP session info update for %s", session_id, exc_info=True)
 
+    def _schedule_session_info_update_from_thread(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        session_id: str,
+    ) -> None:
+        """Schedule a title/provenance update without creating an orphan coroutine.
+
+        Auto-title callbacks run on a worker thread. Constructing the coroutine
+        before ``call_soon_threadsafe`` leaks it when the owning ACP event loop
+        has already closed. Defer construction until the callback executes on
+        that loop instead.
+        """
+
+        def _schedule_on_loop() -> None:
+            asyncio.create_task(self._send_session_info_update(session_id))
+
+        try:
+            loop.call_soon_threadsafe(_schedule_on_loop)
+        except RuntimeError:
+            logger.debug(
+                "ACP event loop closed before title update for %s",
+                session_id,
+            )
+
     def _schedule_usage_update(self, state: SessionState) -> None:
         """Schedule native context indicator refresh after ACP responses."""
         if not self._conn:
@@ -2025,10 +2049,7 @@ class HermesACPAgent(acp.Agent):
 
                 def _notify_title_update(_title: str) -> None:
                     if conn:
-                        loop.call_soon_threadsafe(
-                            asyncio.create_task,
-                            self._send_session_info_update(session_id),
-                        )
+                        self._schedule_session_info_update_from_thread(loop, session_id)
 
                 # Snapshot the runtime identity; the validator lets the
                 # background titler skip its LLM call if the session's model

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -82,6 +82,7 @@ from tools.approval import (
     reset_hermes_interactive_context,
     set_hermes_interactive_context,
 )
+from tools.process_registry import process_registry
 
 logger = logging.getLogger(__name__)
 
@@ -637,14 +638,128 @@ class HermesACPAgent(acp.Agent):
         super().__init__()
         self.session_manager = session_manager or SessionManager()
         self._conn: Optional[acp.Client] = None
+        self._connected_session_ids: set[str] = set()
+        self._background_notification_task: asyncio.Task | None = None
 
     # ---- Connection lifecycle -----------------------------------------------
 
     def on_connect(self, conn: acp.Client) -> None:
         """Store the client connection for sending session updates."""
+        if self._background_notification_task is not None:
+            self._background_notification_task.cancel()
+        self._background_notification_task = None
+        # Session ownership belongs to one transport connection. A replacement
+        # client must attach or load its own sessions before receiving events.
+        self._connected_session_ids.clear()
         self._conn = conn
         logger.info("ACP client connected")
+        self._ensure_background_notification_task()
 
+    def _ensure_background_notification_task(self) -> None:
+        """Ensure async process notifications have a live dispatcher on this loop."""
+        conn = self._conn
+        task = self._background_notification_task
+        if conn is None or (task is not None and not task.done()):
+            return
+        try:
+            loop = asyncio.get_running_loop()
+            coroutine = self._background_notification_loop(conn)
+            created = loop.create_task(coroutine)
+            if not asyncio.isfuture(created):
+                coroutine.close()
+                self._background_notification_task = None
+                return
+            self._background_notification_task = created
+            logger.info("ACP background notification dispatcher started")
+        except RuntimeError:
+            self._background_notification_task = None
+            logger.debug("ACP connection has no running loop for background notifications")
+
+    async def _dispatch_background_notifications_once(self) -> int:
+        """Deliver pending process events owned by sessions on this ACP connection."""
+        conn = self._conn
+        if conn is None or not self._connected_session_ids:
+            return 0
+        pending = process_registry.drain_notifications(
+            owns_event=lambda event: str(event.get("session_key") or "")
+            in self._connected_session_ids,
+            # ACP, like gateway/TUI, must still deliver an autonomous result
+            # after the agent only polled the process status inline.
+            skip_poll_observed=False,
+        )
+        delivered = 0
+
+        def requeue_from(start_index: int) -> None:
+            for queued_event, _ in pending[start_index:]:
+                process_registry.completion_queue.put(queued_event)
+
+        for index, (event, text) in enumerate(pending):
+            session_id = str(event.get("session_key") or "")
+            try:
+                event_type = str(event.get("type") or "completion")
+                process_status = "running"
+                if event_type == "completion":
+                    process_status = "completed" if event.get("exit_code") == 0 else "failed"
+                process_meta = {
+                    "id": str(event.get("session_id") or ""),
+                    "event": event_type,
+                    "status": process_status,
+                }
+                if event.get("exit_code") is not None:
+                    process_meta["exitCode"] = event.get("exit_code")
+                await conn.session_update(
+                    session_id=session_id,
+                    update=AgentMessageChunk(
+                        session_update="agent_message_chunk",
+                        content=TextContentBlock(type="text", text=text),
+                        field_meta={
+                            "hermes": {
+                                "backgroundNotification": True,
+                                "process": process_meta,
+                            }
+                        },
+                    ),
+                )
+                delivered += 1
+                logger.info(
+                    "ACP background notification delivered session=%s process=%s status=%s",
+                    session_id,
+                    process_meta["id"],
+                    process_meta["status"],
+                )
+            except asyncio.CancelledError:
+                # A replacement connection cancels this task while a drained
+                # event may be in flight. Restore the undelivered suffix before
+                # propagating cancellation to the connection-bound loop.
+                requeue_from(index)
+                raise
+            except Exception:
+                # Preserve this event and every not-yet-attempted owned event.
+                # The transport is no longer usable, so do not repeatedly drain
+                # and retry the same queue entries on this connection.
+                requeue_from(index)
+                if self._conn is conn:
+                    self._conn = None
+                logger.debug(
+                    "Failed to deliver ACP background notification for %s",
+                    session_id,
+                    exc_info=True,
+                )
+                break
+        return delivered
+
+    async def _background_notification_loop(self, conn: acp.Client) -> None:
+        """Poll the shared completion queue while this ACP connection is active."""
+        try:
+            while self._conn is conn:
+                await self._dispatch_background_notifications_once()
+                if self._conn is not conn:
+                    break
+                await asyncio.sleep(0.25)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("ACP background notification loop stopped", exc_info=True)
 
     def _session_modes(self, state: SessionState) -> SessionModeState:
         """Return ACP session modes while preserving Zed's separate model picker.
@@ -1342,6 +1457,7 @@ class HermesACPAgent(acp.Agent):
         **kwargs: Any,
     ) -> NewSessionResponse:
         state = self.session_manager.create_session(cwd=cwd)
+        self._connected_session_ids.add(state.session_id)
         await self._register_session_mcp_servers(state, mcp_servers)
         logger.info("New session %s (cwd=%s)", state.session_id, cwd)
         self._schedule_available_commands_update(state.session_id)
@@ -1366,6 +1482,7 @@ class HermesACPAgent(acp.Agent):
         if state is None:
             logger.warning("load_session: session %s not found", session_id)
             return None
+        self._connected_session_ids.add(state.session_id)
         await self._register_session_mcp_servers(state, mcp_servers)
         logger.info("Loaded session %s", session_id)
         # Per ACP spec, `session/load` must stream the prior conversation back
@@ -1413,6 +1530,7 @@ class HermesACPAgent(acp.Agent):
         if state is None:
             logger.warning("resume_session: session %s not found, creating new", session_id)
             state = self.session_manager.create_session(cwd=cwd)
+        self._connected_session_ids.add(state.session_id)
         await self._register_session_mcp_servers(state, mcp_servers)
         logger.info("Resumed session %s", state.session_id)
         # See `load_session` above for the spec rationale — replay must
@@ -1468,6 +1586,7 @@ class HermesACPAgent(acp.Agent):
         state = self.session_manager.fork_session(session_id, cwd=cwd)
         new_id = state.session_id if state else ""
         if state is not None:
+            self._connected_session_ids.add(state.session_id)
             await self._register_session_mcp_servers(state, mcp_servers)
         logger.info("Forked session %s -> %s", session_id, new_id)
         if new_id:
@@ -1538,11 +1657,13 @@ class HermesACPAgent(acp.Agent):
         **kwargs: Any,
     ) -> PromptResponse:
         """Run Hermes on the user's prompt and stream events back to the editor."""
+        self._ensure_background_notification_task()
         state = self.session_manager.get_session(session_id)
         if state is None:
             logger.error("prompt: session %s not found", session_id)
             return PromptResponse(stop_reason="refusal")
 
+        self._connected_session_ids.add(state.session_id)
         user_text = _extract_text(prompt).strip()
         user_content = _content_blocks_to_openai_user_content(prompt)
         text_only_prompt = all(isinstance(block, TextContentBlock) for block in prompt)

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -242,6 +242,141 @@ class TestSessionOps:
         assert state.cwd == "/home/user/project"
 
     @pytest.mark.asyncio
+    async def test_dispatches_only_background_notifications_owned_by_connected_sessions(
+        self, agent, monkeypatch
+    ):
+        from tools.process_registry import ProcessRegistry
+
+        registry = ProcessRegistry()
+        conn = MagicMock()
+        conn.session_update = AsyncMock()
+        agent._conn = conn
+        agent._connected_session_ids.add("acp-owned")
+        monkeypatch.setattr("acp_adapter.server.process_registry", registry)
+
+        registry.completion_queue.put({
+            "type": "completion",
+            "session_id": "proc_owned",
+            "session_key": "acp-owned",
+            "command": "printf done",
+            "exit_code": 0,
+            "output": "done",
+        })
+        registry.completion_queue.put({
+            "type": "completion",
+            "session_id": "proc_foreign",
+            "session_key": "acp-foreign",
+            "command": "printf secret",
+            "exit_code": 0,
+            "output": "secret",
+        })
+        # ACP is an autonomous surface: an inline status poll must not suppress
+        # the later completion turn as it does for the synchronous CLI path.
+        registry._poll_observed.add("proc_owned")
+
+        delivered = await agent._dispatch_background_notifications_once()
+
+        assert delivered == 1
+        conn.session_update.assert_awaited_once()
+        assert conn.session_update.await_args.kwargs["session_id"] == "acp-owned"
+        update = conn.session_update.await_args.kwargs["update"]
+        assert update.session_update == "agent_message_chunk"
+        assert update.field_meta == {
+            "hermes": {
+                "backgroundNotification": True,
+                "process": {
+                    "id": "proc_owned",
+                    "event": "completion",
+                    "status": "completed",
+                    "exitCode": 0,
+                },
+            }
+        }
+        assert "proc_owned completed normally" in update.content.text
+        assert registry.completion_queue.get_nowait()["session_id"] == "proc_foreign"
+
+    @pytest.mark.asyncio
+    async def test_background_notification_loop_stops_after_transport_failure(
+        self, agent, monkeypatch
+    ):
+        from tools.process_registry import ProcessRegistry
+
+        registry = ProcessRegistry()
+        conn = MagicMock()
+        conn.session_update = AsyncMock(side_effect=ConnectionError("disconnected"))
+        agent._conn = conn
+        agent._connected_session_ids.add("acp-owned")
+        monkeypatch.setattr("acp_adapter.server.process_registry", registry)
+
+        registry.completion_queue.put({
+            "type": "completion",
+            "session_id": "proc_owned",
+            "session_key": "acp-owned",
+            "command": "printf done",
+            "exit_code": 0,
+            "output": "done",
+        })
+
+        await asyncio.wait_for(agent._background_notification_loop(conn), timeout=0.05)
+
+        assert agent._conn is None
+        conn.session_update.assert_awaited_once()
+        assert registry.completion_queue.get_nowait()["session_id"] == "proc_owned"
+
+    @pytest.mark.asyncio
+    async def test_connection_replacement_requeues_cancelled_delivery_suffix(
+        self, agent, monkeypatch
+    ):
+        from tools.process_registry import ProcessRegistry
+
+        registry = ProcessRegistry()
+        old_conn = MagicMock()
+        new_conn = MagicMock()
+        delivery_started = asyncio.Event()
+        block_delivery = asyncio.Event()
+
+        async def blocked_session_update(**_kwargs):
+            delivery_started.set()
+            await block_delivery.wait()
+
+        old_conn.session_update = AsyncMock(side_effect=blocked_session_update)
+        new_conn.session_update = AsyncMock()
+        agent._conn = old_conn
+        agent._connected_session_ids.add("acp-owned")
+        monkeypatch.setattr("acp_adapter.server.process_registry", registry)
+
+        for process_id in ("proc_first", "proc_second"):
+            registry.completion_queue.put({
+                "type": "completion",
+                "session_id": process_id,
+                "session_key": "acp-owned",
+                "command": "printf done",
+                "exit_code": 0,
+                "output": "done",
+            })
+
+        old_task = asyncio.create_task(agent._background_notification_loop(old_conn))
+        agent._background_notification_task = old_task
+        await asyncio.wait_for(delivery_started.wait(), timeout=0.1)
+
+        agent.on_connect(new_conn)
+        new_task = agent._background_notification_task
+        try:
+            with pytest.raises(asyncio.CancelledError):
+                await old_task
+            queued_ids = [
+                registry.completion_queue.get_nowait()["session_id"],
+                registry.completion_queue.get_nowait()["session_id"],
+            ]
+            assert queued_ids == ["proc_first", "proc_second"]
+            assert registry.completion_queue.empty()
+        finally:
+            if new_task is not None:
+                new_task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await new_task
+
+    @pytest.mark.asyncio
     async def test_new_session_returns_authenticated_cross_provider_model_state(self):
         manager = SessionManager(
             agent_factory=lambda: SimpleNamespace(
@@ -1396,6 +1531,27 @@ class TestPrompt:
         assert state.history == expected_history
 
     @pytest.mark.asyncio
+    async def test_prompt_binds_acp_session_key_for_tools(self, agent):
+        """Terminal/process tools must inherit the stable ACP session UUID."""
+        from tools.approval import get_current_session_key
+
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        observed = []
+
+        def run_conversation(**_kwargs):
+            observed.append(get_current_session_key(default=""))
+            return {"final_response": "done", "messages": []}
+
+        state.agent.run_conversation = run_conversation
+        await agent.prompt(
+            prompt=[TextContentBlock(type="text", text="start background work")],
+            session_id=new_resp.session_id,
+        )
+
+        assert observed == [new_resp.session_id]
+
+    @pytest.mark.asyncio
     async def test_prompt_sends_final_message_update(self, agent):
         """The final response should be sent as an AgentMessageChunk."""
         new_resp = await agent.new_session(cwd=".")
@@ -1824,6 +1980,17 @@ class TestOnConnect:
         mock_conn = MagicMock(spec=acp.Client)
         agent.on_connect(mock_conn)
         assert agent._conn is mock_conn
+
+    def test_on_connect_replaces_connection_session_ownership(self, agent):
+        old_conn = MagicMock(spec=acp.Client)
+        new_conn = MagicMock(spec=acp.Client)
+        agent._conn = old_conn
+        agent._connected_session_ids.add("old-session")
+
+        agent.on_connect(new_conn)
+
+        assert agent._conn is new_conn
+        assert agent._connected_session_ids == set()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1916,6 +1916,20 @@ class TestPrompt:
         assert info_updates[0].session_update == "session_info_update"
         assert info_updates[0].title == "Fix Zed titles"
 
+    def test_title_update_does_not_create_coroutine_after_loop_closes(self, agent):
+        class ClosedLoop:
+            def call_soon_threadsafe(self, _callback):
+                raise RuntimeError("event loop is closed")
+
+        agent._send_session_info_update = MagicMock()
+
+        agent._schedule_session_info_update_from_thread(
+            ClosedLoop(),
+            "closed-session",
+        )
+
+        agent._send_session_info_update.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_prompt_populates_usage_from_top_level_run_conversation_fields(self, agent):
         """ACP should map top-level token fields into PromptResponse.usage."""

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -2508,3 +2508,18 @@ class TestReaderLoopOrphanedPipe:
         for i in range(1, 6):
             assert f"line-{i}" in s.output_buffer
         assert "tail-after-sleep" in s.output_buffer
+
+
+class TestAtomicCompletionNotification:
+    def test_fast_process_keeps_spawn_time_notification_intent(self, registry, tmp_path):
+        session = registry.spawn_local(
+            "printf fast-done",
+            cwd=str(tmp_path),
+            session_key="acp-session",
+            notify_on_complete=True,
+        )
+        assert session._completion_event.wait(timeout=5)
+        event = registry.completion_queue.get(timeout=1)
+        assert event["session_id"] == session.id
+        assert event["session_key"] == "acp-session"
+        assert event["exit_code"] == 0

--- a/tests/tools/test_terminal_task_cwd.py
+++ b/tests/tools/test_terminal_task_cwd.py
@@ -164,6 +164,7 @@ def test_background_command_prefers_recorded_session_cwd_over_init_time_cwd(monk
         "session_key": task_id,
         "env_vars": {},
         "use_pty": False,
+        "notify_on_complete": False,
     }]
 
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -694,6 +694,7 @@ class ProcessRegistry:
         session_key: str = "",
         env_vars: dict = None,
         use_pty: bool = False,
+        notify_on_complete: bool = False,
     ) -> ProcessSession:
         """
         Spawn a background process locally.
@@ -721,6 +722,7 @@ class ProcessRegistry:
             session_key=session_key,
             cwd=_resolve_safe_cwd(cwd or os.getcwd()),
             started_at=time.time(),
+            notify_on_complete=notify_on_complete,
         )
 
         if use_pty:
@@ -842,6 +844,7 @@ class ProcessRegistry:
         task_id: str = "",
         session_key: str = "",
         timeout: int = 10,
+        notify_on_complete: bool = False,
     ) -> ProcessSession:
         """
         Spawn a background process through a non-local environment backend.
@@ -863,6 +866,7 @@ class ProcessRegistry:
             started_at=time.time(),
             env_ref=env,
             pid_scope="sandbox",
+            notify_on_complete=notify_on_complete,
         )
 
         # Run the command in the sandbox with output capture
@@ -1267,6 +1271,7 @@ class ProcessRegistry:
         retain that legacy behavior even when a filter is provided. When a
         filter is provided, ownerless async-delegation events remain
         fail-closed and require positive proof.
+
         """
         results: "list[tuple[dict, str]]" = []
         requeue: "list[dict]" = []

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2473,6 +2473,7 @@ def terminal_tool(
                         session_key=session_key,
                         env_vars=env.env if hasattr(env, 'env') else None,
                         use_pty=effective_pty,
+                        notify_on_complete=bool(notify_on_complete),
                     )
                 else:
                     proc_session = process_registry.spawn_via_env(
@@ -2481,6 +2482,7 @@ def terminal_tool(
                         cwd=effective_cwd,
                         task_id=effective_task_id,
                         session_key=session_key,
+                        notify_on_complete=bool(notify_on_complete),
                     )
 
                 result_data = {


### PR DESCRIPTION
## Summary
- drain process/delegation notifications through the ACP adapter after `session/prompt` returns
- route events only to ACP sessions attached to the current connection
- mark delayed chunks with ACP `_meta.hermes.backgroundNotification`
- preserve foreign events in the shared queue and existing duplicate-suppression semantics
- capture `notify_on_complete` atomically when local or remote background processes are spawned

Fixes #62548

Client counterpart: https://github.com/joaompfp/hermes-vscode/pull/24

## Review-remediation contract
- replacement ACP connections clear connection-local session ownership
- transport failure requeues the failed and unattempted suffix, detaches the stale connection, and stops its poller
- cancellation during connection replacement restores the complete drained-but-undelivered suffix exactly once
- current-main ownership filtering and process-reader behavior remain preserved

## Current integration
- head: `00ed2e6d79aeefa1f906785f82d9244762483102`
- base integrated: `760112adb6458417da8614d2269e5325f0739ed5`
- the merge conflicts were limited to concurrent test additions in `tests/acp/test_server.py` and `tests/tools/test_process_registry.py`; both feature and current-main regressions were retained

## Verification
- `scripts/run_tests.sh tests/acp/test_server.py tests/tools/test_process_registry.py tests/tools/test_async_delegation.py tests/gateway/test_background_process_notifications.py -q` — **282 passed**
- `scripts/run_tests.sh tests/agent/test_context_compressor.py -q` — **214 passed** on the exact final tree
- `python3 -m py_compile ...` — passed for the touched Python source/tests
- Ruff on the six feature files — passed
- `git diff --check origin/main` and exact merge-tree conflict probe — passed/clean
- added-line secret/dangerous-pattern scan — clean
- independent exact-head fail-closed review — **PASS**, no security or logic blockers
- comprehensive runner: 29 failures in 18 unrelated files; the same 18 files and 29 failures reproduced on clean base `760112adb`. One full-run resource/collection anomaly for `test_context_compressor.py` did not reproduce: the exact final-tree rerun passed 214/214, and clean base also passed that file 214/214.

GitHub currently reports no checks for this head. Collaborator review/clearance remains reviewer-controlled.
