### PR TITLE
fix(desktop): make boot failure overlay dismissible

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -470,6 +470,10 @@ export function DesktopController() {
     navigate(`${SETTINGS_ROUTE}?tab=providers`)
   }, [navigate])
 
+  const openGatewaySettings = useCallback(() => {
+    navigate(`${SETTINGS_ROUTE}?tab=gateway`)
+  }, [navigate])
+
   const modelMenuContent = useMemo(
     () =>
       gatewayState === 'open' ? (
@@ -1064,7 +1068,7 @@ export function DesktopController() {
       <ModelVisibilityOverlay gateway={gatewayRef.current || undefined} onOpenProviders={openProviderSettings} />
       <UpdatesOverlay />
       <GatewayConnectingOverlay />
-      <BootFailureOverlay />
+      <BootFailureOverlay onOpenGatewaySettings={openGatewaySettings} />
       <CommandPalette />
       <PetGenerateOverlay />
       <SessionSwitcher />

--- a/apps/desktop/src/components/boot-failure-overlay.tsx
+++ b/apps/desktop/src/components/boot-failure-overlay.tsx
@@ -6,7 +6,7 @@ import { ErrorIcon } from '@/components/ui/error-state'
 import { LogView } from '@/components/ui/log-view'
 import type { DesktopConnectionConfig } from '@/global'
 import { useI18n } from '@/i18n'
-import { FileText, Loader2, LogIn, RefreshCw, Wrench } from '@/lib/icons'
+import { FileText, Loader2, LogIn, RefreshCw, Settings, Wrench, X } from '@/lib/icons'
 import { $desktopBoot } from '@/store/boot'
 import { notify, notifyError } from '@/store/notifications'
 import { $desktopOnboarding } from '@/store/onboarding'
@@ -27,7 +27,11 @@ type BusyAction = 'local' | 'repair' | 'retry' | 'signin' | null
 // exited during startup, bootstrap latched, …). Without this the app shell
 // renders dead — "gateway offline", no composer, only a toast — with no way
 // to retry, repair the install, switch the gateway, or find the logs.
-export function BootFailureOverlay() {
+interface BootFailureOverlayProps {
+  onOpenGatewaySettings?: () => void
+}
+
+export function BootFailureOverlay({ onOpenGatewaySettings }: BootFailureOverlayProps) {
   const boot = useStore($desktopBoot)
   const onboarding = useStore($desktopOnboarding)
   const { t } = useI18n()
@@ -35,12 +39,19 @@ export function BootFailureOverlay() {
   const [logs, setLogs] = useState<string[]>([])
   const [showLogs, setShowLogs] = useState(false)
   const [remoteReauth, setRemoteReauth] = useState<RemoteReauth | null>(null)
+  const [dismissedError, setDismissedError] = useState<string | null>(null)
 
-  const visible = Boolean(boot.error) && !boot.running
+  const visible = Boolean(boot.error) && boot.error !== dismissedError && !boot.running
   // While first-run onboarding owns the picker/flow we let it surface its own
   // progress; the recovery overlay is for hard failures, which it covers via a
   // higher z-index regardless of onboarding state.
   const suppressed = onboarding.flow.status !== 'idle' && onboarding.flow.status !== 'error'
+
+  useEffect(() => {
+    if (!boot.error || boot.running) {
+      setDismissedError(null)
+    }
+  }, [boot.error, boot.running])
 
   useEffect(() => {
     if (!visible) {
@@ -164,6 +175,11 @@ export function BootFailureOverlay() {
   }
 
   const openLogs = () => void window.hermesDesktop?.revealLogs().catch(() => undefined)
+  const dismiss = () => setDismissedError(boot.error)
+  const openSettings = () => {
+    dismiss()
+    onOpenGatewaySettings?.()
+  }
   const copy = t.boot.failure
 
   const label = signInLabel(remoteReauth, {
@@ -174,8 +190,17 @@ export function BootFailureOverlay() {
 
   return (
     <div className="fixed inset-0 z-[1400] flex items-center justify-center bg-(--ui-chat-surface-background) p-6">
-      <div className="w-full max-w-[40rem] overflow-hidden rounded-xl border border-(--stroke-nous) bg-(--ui-chat-bubble-background) shadow-nous">
-        <div className="flex items-start gap-3 px-5 py-4">
+      <div className="relative w-full max-w-[40rem] overflow-hidden rounded-xl border border-(--stroke-nous) bg-(--ui-chat-bubble-background) shadow-nous">
+        <Button
+          aria-label={t.common.close}
+          className="absolute right-3 top-3"
+          onClick={dismiss}
+          size="icon-sm"
+          variant="ghost"
+        >
+          <X />
+        </Button>
+        <div className="flex items-start gap-3 px-5 py-4 pr-14">
           <ErrorIcon className="mt-0.5" size="1.25rem" />
           <div>
             <h2 className="text-[0.9375rem] font-semibold tracking-tight">
@@ -215,6 +240,12 @@ export function BootFailureOverlay() {
                 {busy === 'local' ? <Loader2 className="animate-spin" /> : null}
                 {copy.useLocalGateway}
               </Button>
+              {onOpenGatewaySettings ? (
+                <Button disabled={Boolean(busy)} onClick={openSettings} variant="secondary">
+                  <Settings />
+                  {copy.openSettings}
+                </Button>
+              ) : null}
               <Button onClick={openLogs} variant="ghost">
                 <FileText />
                 {copy.openLogs}

--- a/apps/desktop/src/components/gateway-connecting-overlay.test.tsx
+++ b/apps/desktop/src/components/gateway-connecting-overlay.test.tsx
@@ -1,5 +1,5 @@
-import { cleanup, render, screen } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $desktopBoot } from '@/store/boot'
 import { $gatewaySwitching } from '@/store/gateway-switch'
@@ -81,6 +81,51 @@ describe('connecting overlay vs recovery surface', () => {
     expect(isRecoveryShown()).toBe(true)
     // Connecting overlay bows out when boot.error is set.
     expect(isConnectingShown()).toBe(false)
+  })
+
+  it('lets the user dismiss a hard boot failure and open settings', () => {
+    $desktopBoot.set({
+      ...$desktopBoot.get(),
+      error: 'Hermes backend did not become ready',
+      running: false,
+      visible: true
+    })
+    setGatewayState('error')
+    const openSettings = vi.fn()
+
+    render(<BootFailureOverlay onOpenGatewaySettings={openSettings} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /open settings/i }))
+
+    expect(openSettings).toHaveBeenCalledOnce()
+    expect(isRecoveryShown()).toBe(false)
+  })
+
+  it('can be closed without choosing a recovery action', () => {
+    $desktopBoot.set({
+      ...$desktopBoot.get(),
+      error: 'Hermes backend did not become ready',
+      running: false,
+      visible: true
+    })
+    setGatewayState('error')
+
+    const { rerender } = render(<BootFailureOverlay />)
+
+    fireEvent.click(screen.getByRole('button', { name: /^close$/i }))
+    expect(isRecoveryShown()).toBe(false)
+
+    $desktopBoot.set({ ...$desktopBoot.get(), error: 'A different startup failure' })
+    rerender(<BootFailureOverlay />)
+
+    expect(isRecoveryShown()).toBe(true)
+
+    $desktopBoot.set({ ...$desktopBoot.get(), error: null })
+    rerender(<BootFailureOverlay />)
+    $desktopBoot.set({ ...$desktopBoot.get(), error: 'Hermes backend did not become ready' })
+    rerender(<BootFailureOverlay />)
+
+    expect(isRecoveryShown()).toBe(true)
   })
 
   it('post-boot socket drops do not re-cover the app with the initial CONNECTING overlay', () => {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -90,6 +90,7 @@ export const en: Translations = {
       retry: 'Retry',
       repairInstall: 'Repair install',
       useLocalGateway: 'Use local gateway',
+      openSettings: 'Open settings',
       openLogs: 'Open logs',
       repairHint: 'Repair re-runs the installer and can take a few minutes on a fresh machine.',
       remoteSignInHint: 'Opens the gateway login window. Use local gateway to switch to the bundled backend instead.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -90,6 +90,7 @@ export const ja = defineLocale({
       retry: '再試行',
       repairInstall: 'インストールを修復',
       useLocalGateway: 'ローカルゲートウェイを使用',
+      openSettings: '設定を開く',
       openLogs: 'ログを開く',
       repairHint: '修復はインストーラーを再実行します。新しいマシンでは数分かかる場合があります。',
       remoteSignInHint:

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -133,6 +133,7 @@ export interface Translations {
       retry: string
       repairInstall: string
       useLocalGateway: string
+      openSettings: string
       openLogs: string
       repairHint: string
       remoteSignInHint: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -88,6 +88,7 @@ export const zhHant = defineLocale({
       retry: '重試',
       repairInstall: '修復安裝',
       useLocalGateway: '使用本機閘道',
+      openSettings: '開啟設定',
       openLogs: '開啟記錄',
       repairHint: '修復會重新執行安裝程式，在新機器上可能需要幾分鐘。',
       remoteSignInHint: '開啟閘道登入視窗。使用本機閘道可切換至內建後端。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -88,6 +88,7 @@ export const zh: Translations = {
       retry: '重试',
       repairInstall: '修复安装',
       useLocalGateway: '使用本地网关',
+      openSettings: '打开设置',
       openLogs: '打开日志',
       repairHint: '修复会重新运行安装器，在新机器上可能需要几分钟。',
       remoteSignInHint: '打开网关登录窗口。也可以使用本地网关切换到随应用提供的后端。',


### PR DESCRIPTION
Fixes #62533.

## Summary

- make the desktop boot-failure recovery overlay dismissible
- add an **Open settings** action that deep-links to Settings → Gateway
- reset dismissal after the boot error clears so future failures are still surfaced
- localize the new action in all desktop locales

## Tests

- `npm run test:ui --workspace apps/desktop -- src/components/gateway-connecting-overlay.test.tsx src/components/boot-failure-reauth.test.ts`
- `npm run typecheck --workspace apps/desktop`
- ESLint on all changed desktop files
