### PR TITLE
fix(compressor): unwrap web_extract dict URLs in tool-result summaries

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -652,7 +652,16 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
 
     if tool_name == "web_extract":
         urls = args.get("urls", [])
-        url_desc = urls[0] if isinstance(urls, list) and urls else "?"
+        first = urls[0] if isinstance(urls, list) and urls else "?"
+        # web_search results are dicts ({"url"/"href": ...}) and models often
+        # forward them straight into web_extract. Unwrap to the URL string so
+        # the summary stays readable and the ``+=`` below never hits the
+        # ``dict + str`` TypeError that would abort pre-compression pruning.
+        if isinstance(first, dict):
+            first = first.get("url") or first.get("href") or "?"
+        elif not isinstance(first, str):
+            first = "?"
+        url_desc = first
         if isinstance(urls, list) and len(urls) > 1:
             url_desc += f" (+{len(urls) - 1} more)"
         return f"[web_extract] {url_desc} ({content_len:,} chars)"

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1,5 +1,6 @@
 """Tests for agent/context_compressor.py — compression logic, thresholds, truncation fallback."""
 
+import json
 import pytest
 import time
 from unittest.mock import patch, MagicMock
@@ -9,6 +10,7 @@ from agent.context_compressor import (
     HISTORICAL_TASK_HEADING,
     SUMMARY_PREFIX,
     COMPRESSED_SUMMARY_METADATA_KEY,
+    _summarize_tool_result,
 )
 from hermes_state import SessionDB
 
@@ -25,6 +27,49 @@ def compressor():
             quiet_mode=True,
         )
         return c
+
+
+class TestSummarizeToolResultWebExtract:
+    """Pre-compression pruning must survive web_extract calls whose ``urls`` are
+    web_search result dicts ({"url"/"href": ...}), which models routinely forward
+    straight into web_extract.
+    """
+
+    CONTENT = "x" * 500  # >200 chars so the pruning pass actually summarizes
+
+    def test_multiple_dict_urls_do_not_crash(self):
+        # Two dict URLs previously hit ``dict + str`` -> TypeError, aborting
+        # _prune_old_tool_results() (and thus compress()).
+        args = json.dumps({
+            "urls": [
+                {"url": "https://example.com/a", "title": "A"},
+                {"url": "https://example.org/b", "title": "B"},
+            ]
+        })
+        summary = _summarize_tool_result("web_extract", args, self.CONTENT)
+        assert summary == "[web_extract] https://example.com/a (+1 more) (500 chars)"
+
+    def test_single_dict_url_is_unwrapped_not_stringified(self):
+        args = json.dumps({"urls": [{"url": "https://example.com/a", "title": "A"}]})
+        summary = _summarize_tool_result("web_extract", args, self.CONTENT)
+        assert summary == "[web_extract] https://example.com/a (500 chars)"
+        assert "{" not in summary  # no raw dict repr leaked into the summary
+
+    def test_href_key_is_unwrapped(self):
+        args = json.dumps({"urls": [{"href": "https://example.com/h"}]})
+        summary = _summarize_tool_result("web_extract", args, self.CONTENT)
+        assert summary == "[web_extract] https://example.com/h (500 chars)"
+
+    def test_malformed_dict_falls_back_to_placeholder(self):
+        args = json.dumps({"urls": [{"title": "no url here"}, {"title": "still none"}]})
+        summary = _summarize_tool_result("web_extract", args, self.CONTENT)
+        assert summary == "[web_extract] ? (+1 more) (500 chars)"
+
+    def test_plain_string_urls_unchanged(self):
+        # Regression guard: the normal (already-working) string path is intact.
+        args = json.dumps({"urls": ["https://example.com/a", "https://example.org/b"]})
+        summary = _summarize_tool_result("web_extract", args, self.CONTENT)
+        assert summary == "[web_extract] https://example.com/a (+1 more) (500 chars)"
 
 
 class TestShouldCompress:


### PR DESCRIPTION
## What does this PR do?

`_summarize_tool_result()` in `agent/context_compressor.py` builds a one-line
summary of each tool call during the pre-compression pruning pass. Its
`web_extract` branch read the first `urls` entry directly:

```python
url_desc = urls[0] if isinstance(urls, list) and urls else "?"
if isinstance(urls, list) and len(urls) > 1:
    url_desc += f" (+{len(urls) - 1} more)"
```

When `web_search` results are forwarded straight into `web_extract` — a common
chain, and the exact case already handled in `agent/display.py`,
`tools/web_tools.py` and `acp_adapter/tools.py` — each `urls` entry is a dict
like `{"url": "...", "title": "..."}`, not a URL string. Then:

- **2+ URLs → crash.** `url_desc` is a dict, so `url_desc += " (+N more)"` raises
  `TypeError: unsupported operand type(s) for +=: 'dict' and 'str'`. This aborts
  `_prune_old_tool_results()` and therefore `compress()`. The caller in
  `agent/conversation_compression.py` catches `TypeError` but treats it as a
  *plugin context-engine signature mismatch*, retries `compress()` once (which
  crashes again), then re-raises — so a normal search→extract chain can break
  context compression for the session.
- **1 URL → corrupted summary.** No crash, but the raw dict repr leaks into the
  summary text: `[web_extract] {'url': 'https://…', 'title': '…'} (500 chars)`.

The fix unwraps the URL from dict entries before use (coercing any non-string to
`"?"`), mirroring the established pattern in the sibling surfaces
(`_display_url`, `_web_extract_url`, `build_tool_title`), so `url_desc` is always
a string and the concatenation is always `str + str`.

## Related Issue

Related to #61693 (the "web_search result dicts forwarded to web_extract" class).
That issue's fixes patched the display, tool-processing and ACP surfaces;
`agent/context_compressor.py` was the remaining path with the same root cause.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/context_compressor.py` — `_summarize_tool_result()` web_extract branch
  now unwraps `{"url"/"href": ...}` dict entries (and coerces any non-string to
  `"?"`) before building the summary, so the `+=` concatenation is always
  `str + str`.
- `tests/agent/test_context_compressor.py` — added
  `TestSummarizeToolResultWebExtract` (5 tests): multiple dict URLs (no crash),
  single dict URL (no dict repr), the `href` key, malformed-dict fallback, and a
  plain-string regression guard.

## How to Test

1. Reproduce the crash on `main` (raises
   `TypeError: unsupported operand type(s) for +=: 'dict' and 'str'`):

   ```python
   import json
   from agent.context_compressor import _summarize_tool_result

   args = json.dumps({"urls": [
       {"url": "https://example.com/a", "title": "A"},
       {"url": "https://example.org/b", "title": "B"},
   ]})
   print(_summarize_tool_result("web_extract", args, "x" * 500))
   ```

2. With this PR applied, the same call returns a clean string instead of
   crashing:

   ```
   [web_extract] https://example.com/a (+1 more) (500 chars)
   ```

3. Run the test suite for the affected module:

   ```
   pytest tests/agent/test_context_compressor.py -q
   ```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(compressor): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: local development environment

### Documentation & Housekeeping

- [x] N/A — internal summary-formatting fix; no README/`docs/`/docstring changes
- [x] N/A — no config keys added/changed
- [x] N/A — no architecture/workflow changes
- [x] Cross-platform impact considered — pure-Python string handling, no platform-specific behavior
- [x] N/A — no tool description/schema changes

## Screenshots / Logs

```
$ pytest tests/agent/test_context_compressor.py::TestSummarizeToolResultWebExtract -v
test_multiple_dict_urls_do_not_crash .................. PASSED
test_single_dict_url_is_unwrapped_not_stringified ..... PASSED
test_href_key_is_unwrapped ............................ PASSED
test_malformed_dict_falls_back_to_placeholder ......... PASSED
test_plain_string_urls_unchanged ...................... PASSED
5 passed

$ pytest tests/agent/test_context_compressor.py -q
156 passed

$ pytest tests/tools/test_web_tools_dict_urls.py tests/acp/test_tools.py tests/agent/test_display.py -q
132 passed
```****