### PR TITLE
fix(desktop): send first message in new sessions

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -79,7 +79,7 @@ function Harness({
   selectedStoredSessionIdRef?: MutableRefObject<string | null>
   storedSessionId?: null | string
   activeSessionId?: null | string
-  createBackendSessionForSend?: () => Promise<null | string>
+  createBackendSessionForSend?: (preview?: string | null) => Promise<null | string>
 }) {
   const activeSessionIdRef: MutableRefObject<string | null> = activeSessionIdRefProp ?? {
     current: activeSessionId === undefined ? RUNTIME_SESSION_ID : activeSessionId
@@ -1293,12 +1293,29 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(calls[1]?.params).toMatchObject({ session_id: RECOVERED_SESSION_ID })
   })
 
-  it('still creates a new session for a genuine new-chat draft (no stored session selected)', async () => {
-    const createBackendSessionForSend = vi.fn(async () => RUNTIME_SESSION_ID)
-    const calls: string[] = []
+  it('creates a new session and submits its first message through the intentional route transition (#62501)', async () => {
+    const STORED_SESSION_ID = 'stored-new-chat'
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
+    let routeToken = 'new-chat'
 
-    const requestGateway = vi.fn(async (method: string) => {
-      calls.push(method)
+    // Mirror the real session creator: session.create selects the persisted
+    // row and replaces /chat/new with its routed URL before returning. The
+    // submit pipeline must adopt that intentional transition, not mistake it
+    // for a user switching conversations and stop before prompt.submit.
+    const createBackendSessionForSend = vi.fn(async (preview?: string | null) => {
+      expect(preview).toBe('first message of a new chat')
+      activeSessionIdRef.current = RUNTIME_SESSION_ID
+      selectedStoredSessionIdRef.current = STORED_SESSION_ID
+      routeToken = `session:${STORED_SESSION_ID}`
+
+      return RUNTIME_SESSION_ID
+    })
+
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
 
       return {} as never
     })
@@ -1307,10 +1324,13 @@ describe('usePromptActions sleep/wake session recovery', () => {
     render(
       <Harness
         activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
         createBackendSessionForSend={createBackendSessionForSend}
+        getRouteToken={() => routeToken}
         onReady={h => (handle = h)}
         refreshSessions={async () => undefined}
         requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
         storedSessionId={null}
       />
     )
@@ -1319,7 +1339,12 @@ describe('usePromptActions sleep/wake session recovery', () => {
 
     expect(ok).toBe(true)
     expect(createBackendSessionForSend).toHaveBeenCalledTimes(1)
-    expect(calls).not.toContain('session.resume')
+    expect(calls).toEqual([
+      {
+        method: 'prompt.submit',
+        params: { session_id: RUNTIME_SESSION_ID, text: 'first message of a new chat' }
+      }
+    ])
   })
 })
 
@@ -1390,6 +1415,7 @@ describe('usePromptActions submit session-context isolation (#54527)', () => {
   it('aborts recovery submit when the user switches sessions during timeout resume', async () => {
     const calls: { method: string; params?: Record<string, unknown> }[] = []
     let submitAttempts = 0
+
     let releaseResume: () => void = () => {}
 
     const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: STORED_SESSION_A }

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -1052,6 +1052,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
   afterEach(() => {
     cleanup()
     vi.restoreAllMocks()
+    $connection.set(null)
   })
 
   it('resumes the stored session and retries once when prompt.submit reports "session not found"', async () => {
@@ -1307,7 +1308,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
       expect(preview).toBe('first message of a new chat')
       activeSessionIdRef.current = RUNTIME_SESSION_ID
       selectedStoredSessionIdRef.current = STORED_SESSION_ID
-      routeToken = `session:${STORED_SESSION_ID}`
+      routeToken = `/${STORED_SESSION_ID}::`
 
       return RUNTIME_SESSION_ID
     })
@@ -1345,6 +1346,86 @@ describe('usePromptActions sleep/wake session recovery', () => {
         params: { session_id: RUNTIME_SESSION_ID, text: 'first message of a new chat' }
       }
     ])
+  })
+
+  it('aborts a new-session submit when sidebar navigation changes the route before its selected ref', async () => {
+    const STORED_NEW_SESSION_ID = 'stored-new-chat'
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
+    let routeToken = 'new-chat'
+
+    let releaseAttach: () => void = () => {}
+
+    $connection.set({ mode: 'remote' } as never)
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { readFileDataUrl: vi.fn(async () => 'data:text/plain;base64,aGVsbG8=') }
+    })
+
+    const createBackendSessionForSend = vi.fn(async () => {
+      activeSessionIdRef.current = RUNTIME_SESSION_ID
+      selectedStoredSessionIdRef.current = STORED_NEW_SESSION_ID
+      routeToken = `/${STORED_NEW_SESSION_ID}::`
+
+      return RUNTIME_SESSION_ID
+    })
+
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'file.attach') {
+        await new Promise<void>(resolve => {
+          releaseAttach = resolve
+        })
+
+        return {
+          attached: true,
+          path: '/remote/work/report.txt',
+          ref_text: '@file:report.txt',
+          uploaded: true
+        } as never
+      }
+
+      return {} as never
+    })
+
+    const attachment: ComposerAttachment = {
+      id: 'file:report.txt',
+      kind: 'file',
+      label: 'report.txt',
+      path: '/Users/alice/report.txt',
+      refText: '@file:`/Users/alice/report.txt`'
+    }
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        createBackendSessionForSend={createBackendSessionForSend}
+        getRouteToken={() => routeToken}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={null}
+      />
+    )
+
+    const submitting = handle!.submitText('first message', { attachments: [attachment] })
+    await waitFor(() => expect(calls.some(call => call.method === 'file.attach')).toBe(true))
+
+    // selectSidebarItem calls navigate() first. The routed effect has not yet
+    // entered resumeSession(), so the selected-session ref still points at the
+    // just-created session when attachment sync settles.
+    routeToken = '/sidebar-target::'
+    releaseAttach()
+
+    expect(await submitting).toBe(false)
+    expect(selectedStoredSessionIdRef.current).toBe(STORED_NEW_SESSION_ID)
+    expect(calls.some(call => call.method === 'prompt.submit')).toBe(false)
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -119,16 +119,17 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // this, a fast session switch during session.resume / file.attach can
       // redirect the user's text into a different chat (#54527).
       const startingActiveSessionId = activeSessionIdRef.current
-      const startingStoredSessionId = selectedStoredSessionIdRef.current
+      let targetStoredSessionId = selectedStoredSessionIdRef.current
       const startingRouteToken = getRouteToken()
+      let routePinned = true
 
       const sessionContextDrifted = (): boolean =>
-        selectedStoredSessionIdRef.current !== startingStoredSessionId ||
-        getRouteToken() !== startingRouteToken
+        selectedStoredSessionIdRef.current !== targetStoredSessionId ||
+        (routePinned && getRouteToken() !== startingRouteToken)
 
       // One submit in flight per session — drop any concurrent re-fire so a
       // stalled turn can't stack the same prompt into multiple real turns.
-      const submitLockKey = startingStoredSessionId || startingActiveSessionId || '__pending_new__'
+      const submitLockKey = targetStoredSessionId || startingActiveSessionId || '__pending_new__'
 
       if (_submitInFlight.has(submitLockKey)) {
         return false
@@ -179,7 +180,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             // (what made drained-after-interrupt sends go silent).
             interrupted: false
           }),
-          startingStoredSessionId
+          targetStoredSessionId
         )
 
       // After sync rewrites refs, refresh the optimistic message in place so the
@@ -191,7 +192,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             ...state,
             messages: state.messages.map(message => (message.id === optimisticId ? buildUserMessage() : message))
           }),
-          startingStoredSessionId
+          targetStoredSessionId
         )
 
       const dropOptimistic = (sid: null | string) => {
@@ -210,7 +211,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             awaitingResponse: false,
             pendingBranchGroup: null
           }),
-          startingStoredSessionId
+          targetStoredSessionId
         )
       }
 
@@ -234,7 +235,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         setMessages(current => [...current, buildUserMessage()])
       }
 
-      if (!sessionId && startingStoredSessionId) {
+      if (!sessionId && targetStoredSessionId) {
         // A stored session is SELECTED but its runtime binding is gone (the
         // live session was orphan-reaped, or a timeout/reconnect cleared
         // activeSessionId). Continuing the selected conversation must mean
@@ -244,7 +245,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         // new-chat draft).
         try {
           const resumed = await requestGateway<{ session_id: string }>('session.resume', {
-            session_id: startingStoredSessionId
+            session_id: targetStoredSessionId
           })
 
           if (sessionContextDrifted()) {
@@ -281,16 +282,31 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           return false
         }
 
-        if (sessionContextDrifted()) {
-          return abortForSessionSwitch(sessionId)
-        }
-
+        // Creating a new chat intentionally changes both the selected stored
+        // session and the route. Treat that transition as the submit's new
+        // pinned target, but only while the runtime returned by the creator is
+        // still active. A real user navigation during creation changes the
+        // active ref (or clears it), so it must still abort instead of sending
+        // this prompt into whichever conversation won the race (#54527).
         if (!sessionId) {
           dropOptimistic(null)
           releaseBusy()
           notify({ kind: 'error', title: copy.sessionUnavailable, message: copy.createSessionFailed })
 
           return false
+        }
+
+        if (activeSessionIdRef.current !== sessionId) {
+          return abortForSessionSwitch(sessionId)
+        }
+
+        targetStoredSessionId = selectedStoredSessionIdRef.current
+
+        if (targetStoredSessionId) {
+          // The selected stored id is now the durable pin. React may commit the
+          // matching route replacement before or after this continuation, so
+          // the old new-chat route token is no longer a valid drift signal.
+          routePinned = false
         }
 
         seedOptimistic(sessionId)
@@ -324,7 +340,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         } catch (firstErr) {
           if (
             (isSessionNotFoundError(firstErr) || isGatewayTimeoutError(firstErr)) &&
-            startingStoredSessionId
+            targetStoredSessionId
           ) {
             // Re-register the session in the gateway and get a fresh live ID.
             // Timeouts recover the same way as "session not found": a starved
@@ -332,7 +348,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             // the stored session is fine — resume + retry instead of erroring
             // out and losing the session binding.
             const resumed = await requestGateway<{ session_id: string }>('session.resume', {
-              session_id: startingStoredSessionId,
+              session_id: targetStoredSessionId,
               source: 'desktop'
             })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -15,6 +15,7 @@ import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { requestDesktopOnboarding } from '@/store/onboarding'
 import { setAwaitingResponse, setBusy, setMessages } from '@/store/session'
 
+import { sessionRoute } from '../../../routes'
 import type { ClientSessionState } from '../../../types'
 
 import {
@@ -120,12 +121,24 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // redirect the user's text into a different chat (#54527).
       const startingActiveSessionId = activeSessionIdRef.current
       let targetStoredSessionId = selectedStoredSessionIdRef.current
-      const startingRouteToken = getRouteToken()
-      let routePinned = true
+      let expectedRouteToken = getRouteToken()
+      let transitionalRouteToken: null | string = null
 
-      const sessionContextDrifted = (): boolean =>
-        selectedStoredSessionIdRef.current !== targetStoredSessionId ||
-        (routePinned && getRouteToken() !== startingRouteToken)
+      const sessionContextDrifted = (): boolean => {
+        if (selectedStoredSessionIdRef.current !== targetStoredSessionId) {
+          return true
+        }
+
+        const currentRouteToken = getRouteToken()
+
+        if (currentRouteToken === expectedRouteToken) {
+          transitionalRouteToken = null
+
+          return false
+        }
+
+        return currentRouteToken !== transitionalRouteToken
+      }
 
       // One submit in flight per session — drop any concurrent re-fire so a
       // stalled turn can't stack the same prompt into multiple real turns.
@@ -303,10 +316,14 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         targetStoredSessionId = selectedStoredSessionIdRef.current
 
         if (targetStoredSessionId) {
-          // The selected stored id is now the durable pin. React may commit the
-          // matching route replacement before or after this continuation, so
-          // the old new-chat route token is no longer a valid drift signal.
-          routePinned = false
+          // The creator intentionally replaces the new-chat route with the
+          // persisted session route. Rebase the route pin to that destination,
+          // while briefly accepting the previous token in case React has not
+          // committed the replacement yet. Sidebar navigation uses a third
+          // token before resumeSession updates the selected-session ref, so it
+          // still aborts this submit while a later await is in flight.
+          transitionalRouteToken = expectedRouteToken
+          expectedRouteToken = `${sessionRoute(targetStoredSessionId)}::`
         }
 
         seedOptimistic(sessionId)
@@ -338,10 +355,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             requestGateway('prompt.submit', { session_id: sessionId, text }, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)
           )
         } catch (firstErr) {
-          if (
-            (isSessionNotFoundError(firstErr) || isGatewayTimeoutError(firstErr)) &&
-            targetStoredSessionId
-          ) {
+          if ((isSessionNotFoundError(firstErr) || isGatewayTimeoutError(firstErr)) && targetStoredSessionId) {
             // Re-register the session in the gateway and get a fresh live ID.
             // Timeouts recover the same way as "session not found": a starved
             // backend loop (#55578 symptom d) rejects the submit even though


### PR DESCRIPTION
## Summary

- adopt the session identity created by a first-message submit as the submit pipeline's new pinned target
- distinguish the expected `/chat/new` route replacement from a real concurrent conversation switch
- keep the existing session-switch isolation and timeout recovery behavior intact
- strengthen the new-session regression test to require the first Enter to reach `prompt.submit`

## Root cause

The session-context guard added for #54527 snapshots the selected stored session and route before `session.create`. A successful new-session create intentionally changes both values before returning, so the guard treated its own transition as user navigation and aborted before `prompt.submit`. The sidebar preview made the first message look like it had only become the title.

## Tests

- `vitest run --environment jsdom src/app/session/hooks/use-prompt-actions/index.test.tsx src/app/session/hooks/use-session-actions.test.tsx` (57 passed)
- `tsc -p apps/desktop --noEmit`
- targeted ESLint on the changed files

Closes #62501