### PR TITLE
fix(desktop): force rebuild when packaged app is missing node-pty native binary (closes #62462)

### DIFF
--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -126,6 +126,36 @@ export function stageNodePty({ platform = process.platform, arch = process.arch 
     )
   }
 
+  // Verify the staged payload actually contains a native binary. Either
+  // build/Release/ (compiled from source) or prebuilds/<platform>-<arch>/
+  // (downloaded prebuild) must hold at least one *.node file. Without this
+  // guard, a build with no matching prebuild AND no compiled output would
+  // produce a "successful" pack that crashes Electron on first launch with
+  // "Cannot find module pty.node" (see issue #62462). Fail loudly here so
+  // the user gets a clear remediation path instead of a runtime crash.
+  const buildReleaseDir = join(destRoot, 'build', 'Release')
+  const prebuildArchDir = join(destRoot, 'prebuilds', `${platform}-${arch}`)
+  const hasNativeBinary = (dir) => {
+    if (!existsSync(dir)) return false
+    try {
+      return readdirSync(dir).some(
+        (name) => name.endsWith('.node') || name === 'spawn-helper'
+      )
+    } catch {
+      return false
+    }
+  }
+  if (!hasNativeBinary(buildReleaseDir) && !hasNativeBinary(prebuildArchDir)) {
+    throw new Error(
+      `[stage-native-deps] no node-pty native binary staged for ${platform}-${arch}. ` +
+        `Looked in build/Release/ and prebuilds/${platform}-${arch}/. ` +
+        `Either node-pty has no published prebuild for this target, or ` +
+        `@electron/rebuild was not run. Run ` +
+        `"npx @electron/rebuild -w node-pty --platform ${platform} --arch ${arch}" ` +
+        `or install a matching prebuild before repacking.`
+    )
+  }
+
   console.log(`[stage-native-deps] staged node-pty (${platform}-${arch}) -> ${destRoot}`)
   return destRoot
 }

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5064,12 +5064,139 @@ def _desktop_stamp_path() -> Path:
     return get_hermes_home() / "desktop-build-stamp.json"
 
 
+def _desktop_native_deps_present(desktop_dir: Path, *, source_mode: bool) -> bool:
+    """Return True when the desktop build artifact ships the runtime
+    native deps needed by Electron (currently: ``node-pty``'s ``pty.node``).
+
+    Used as a second gate alongside the content-hash stamp. The stamp only
+    proves the source tree is unchanged; it does NOT prove the packaged
+    artifact actually carries a usable native binary. Without this check,
+    a previously-built (but broken) artifact can satisfy the stamp forever
+    and crash Electron at launch with "Cannot find module pty.node"
+    (see issue #62462).
+
+    Source mode looks at ``dist/node_modules/node-pty/``; packaged mode
+    looks at the ``app.asar.unpacked`` mirror electron-builder writes
+    alongside the packaged executable. Both follow the same layout that
+    ``scripts/stage-native-deps.mjs`` produces.
+    """
+    if source_mode:
+        node_pty_root = desktop_dir / "dist" / "node_modules" / "node-pty"
+        rel_arch = _native_arch_suffix(sys.platform, machine_suffix=True)
+    else:
+        unpacked_root = _desktop_unpacked_resources_root(desktop_dir)
+        if unpacked_root is None:
+            return False
+        node_pty_root = unpacked_root / "dist" / "node_modules" / "node-pty"
+        rel_arch = _native_arch_suffix(sys.platform, machine_suffix=False)
+
+    if not node_pty_root.is_dir():
+        return False
+
+    # The renderer's integrated terminal needs node-pty; the loader looks in
+    # build/Release/ and prebuilds/<platform>-<arch>/. Either is acceptable
+    # (prebuild-install OR @electron/rebuild). Also require lib/index.js so
+    # a future layout change doesn't silently regress.
+    lib_index = node_pty_root / "lib" / "index.js"
+    if not lib_index.is_file():
+        return False
+
+    def _dir_has_native(d: Path) -> bool:
+        if not d.is_dir():
+            return False
+        try:
+            for entry in d.iterdir():
+                if entry.name.endswith(".node"):
+                    return True
+                if entry.name == "spawn-helper":
+                    return True
+        except OSError:
+            return False
+        return False
+
+    build_release = node_pty_root / "build" / "Release"
+    prebuilds = node_pty_root / "prebuilds" / rel_arch if rel_arch else None
+    return _dir_has_native(build_release) or (
+        prebuilds is not None and _dir_has_native(prebuilds)
+    )
+
+
+def _native_arch_suffix(platform_name: str, *, machine_suffix: bool) -> Optional[str]:
+    """Return the ``<platform>-<arch>`` directory name node-pty uses for
+    prebuilds, e.g. ``linux-x64`` / ``darwin-arm64`` / ``win32-x64``.
+
+    ``machine_suffix=False`` returns ``None`` when the host arch can't be
+    determined cheaply (e.g. exotic arches); the caller should fall back
+    to checking ``build/Release/`` only.
+    """
+    if platform_name.startswith("linux"):
+        arch = "x64"
+        try:
+            import platform as _platform
+            m = _platform.machine().lower()
+            if m in ("aarch64", "arm64"):
+                arch = "arm64"
+            elif m.startswith("arm"):
+                arch = "armv7l"
+        except Exception:
+            pass
+        return f"linux-{arch}"
+    if platform_name == "darwin":
+        arch = "arm64"
+        try:
+            import platform as _platform
+            if _platform.machine().lower() in ("x86_64",):
+                arch = "x64"
+        except Exception:
+            pass
+        return f"darwin-{arch}"
+    if platform_name == "win32":
+        return "win32-x64"
+    return None
+
+
+def _desktop_unpacked_resources_root(desktop_dir: Path) -> Optional[Path]:
+    """Locate the packaged app's ``resources/`` directory (next to the
+    unpacked Electron binary). Returns ``None`` when the unpacked tree
+    isn't present.
+
+    Centralized here so native-deps verification stays in sync with
+    ``_desktop_packaged_executable``'s idea of what counts as a packaged
+    build.
+    """
+    release_dir = desktop_dir / "release"
+    if sys.platform == "darwin":
+        # macOS: .../mac/Hermes.app/Contents/Resources/
+        bundles = list(release_dir.glob("mac*/Hermes.app"))
+        if not bundles:
+            return None
+        return max(bundles, key=lambda p: p.stat().st_mtime) / "Contents" / "Resources"
+    if sys.platform == "win32":
+        for name in ("win-unpacked", "win-ia32-unpacked", "win-arm64-unpacked"):
+            p = release_dir / name / "resources"
+            if p.is_dir():
+                return p
+        return None
+    # Linux: release/<arch>-unpacked/resources/
+    for name in (
+        "linux-unpacked",
+        "linux-arm64-unpacked",
+        "linux-x64-unpacked",
+    ):
+        p = release_dir / name / "resources"
+        if p.is_dir():
+            return p
+    return None
+
+
 def _desktop_build_needed(desktop_dir: Path, project_root: Path, *, source_mode: bool) -> bool:
     """Return True when the desktop build output is stale or missing.
 
     Compares the current content hash against the saved stamp. Also returns
     True if the expected build artifact doesn't exist (e.g. first run after
-    ``hermes update`` that pulled new source but hasn't built yet).
+    ``hermes update`` that pulled new source but hasn't built yet), or if
+    a previously-built artifact is missing the runtime native deps that
+    Electron needs to launch (node-pty's ``pty.node`` — see issue #62462).
     """
     # If there's no build output at all, we definitely need to build
     if source_mode:
@@ -5078,6 +5205,14 @@ def _desktop_build_needed(desktop_dir: Path, project_root: Path, *, source_mode:
     else:
         if _desktop_packaged_executable(desktop_dir) is None:
             return True
+
+    # A previously-built artifact that looks complete on disk but is missing
+    # the native modules Electron loads on startup is worse than no artifact
+    # at all: it passes the stamp check, gets launched, and crashes with
+    # "Cannot find module pty.node" inside the main process. Detect and
+    # force a rebuild.
+    if not _desktop_native_deps_present(desktop_dir, source_mode=source_mode):
+        return True
 
     stamp_file = _desktop_stamp_path()
     if not stamp_file.is_file():

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -36,18 +36,46 @@ def _make_desktop_tree(tmp_path: Path) -> Path:
     return root
 
 
-def _make_packaged_executable(root: Path, monkeypatch, platform: str = "darwin") -> Path:
+def _make_packaged_executable(
+    root: Path,
+    monkeypatch,
+    platform: str = "darwin",
+    with_native_deps: bool = True,
+) -> Path:
     monkeypatch.setattr(cli_main.sys, "platform", platform)
     desktop_dir = root / "apps" / "desktop"
     if platform == "darwin":
         exe = desktop_dir / "release" / "mac-arm64" / "Hermes.app" / "Contents" / "MacOS" / "Hermes"
+        unpacked_resources = (
+            desktop_dir / "release" / "mac-arm64" / "Hermes.app" / "Contents" / "Resources"
+        )
     elif platform == "win32":
         exe = desktop_dir / "release" / "win-unpacked" / "Hermes.exe"
+        unpacked_resources = desktop_dir / "release" / "win-unpacked" / "resources"
     else:
         exe = desktop_dir / "release" / "linux-unpacked" / "hermes"
+        unpacked_resources = desktop_dir / "release" / "linux-unpacked" / "resources"
     exe.parent.mkdir(parents=True)
     exe.write_text("", encoding="utf-8")
+    if with_native_deps:
+        _stage_node_pty_in(unpacked_resources)
     return exe
+
+
+def _stage_node_pty_in(unpacked_resources: Path) -> None:
+    """Create a realistic node-pty payload inside ``unpacked_resources`` so
+    ``_desktop_native_deps_present`` returns True. Mirrors the layout
+    ``scripts/stage-native-deps.mjs`` writes: ``dist/node_modules/node-pty/``
+    with ``lib/index.js`` and a ``build/Release/pty.node`` binary.
+    """
+    node_pty = unpacked_resources / "dist" / "node_modules" / "node-pty"
+    (node_pty / "lib").mkdir(parents=True, exist_ok=True)
+    (node_pty / "lib" / "index.js").write_text(
+        "// stubbed node-pty entry", encoding="utf-8"
+    )
+    build_release = node_pty / "build" / "Release"
+    build_release.mkdir(parents=True, exist_ok=True)
+    (build_release / "pty.node").write_bytes(b"")
 
 
 def test_gui_installs_packages_and_launches_desktop_app(tmp_path, monkeypatch):
@@ -400,6 +428,87 @@ def test_desktop_build_stamp_round_trip(tmp_path, monkeypatch):
     assert cli_main._desktop_build_needed(
         root / "apps" / "desktop", root, source_mode=False
     ) is False
+
+
+def test_desktop_build_needed_when_native_deps_missing(tmp_path, monkeypatch):
+    """Issue #62462: a packaged artifact that is missing pty.node must force
+    a rebuild even when the content stamp is fresh. Otherwise ``hermes desktop``
+    silently launches an Electron that crashes on startup with
+    ``Cannot find module pty.node``.
+    """
+    root = _make_desktop_tree(tmp_path)
+    (root / "package.json").write_text("{}", encoding="utf-8")
+    (root / "package-lock.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    # Create the packaged executable but DELIBERATELY skip the native deps
+    # layout — simulates a broken build that left the unpacked tree without
+    # node-pty's native binary.
+    _make_packaged_executable(root, monkeypatch, with_native_deps=False)
+    # Stamp says up-to-date
+    cli_main._write_desktop_build_stamp(root, source_mode=False)
+    assert cli_main._desktop_build_needed(
+        root / "apps" / "desktop", root, source_mode=False
+    ) is True, "missing pty.node must force rebuild even when stamp is fresh"
+
+
+def test_desktop_native_deps_present_accepts_prebuild_layout(tmp_path, monkeypatch):
+    """A node-pty layout that only ships a ``prebuilds/<platform>-<arch>/``
+    payload (no ``build/Release/``) is still valid — that's how prebuild-install
+    delivers the binary when @electron/rebuild isn't run.
+    """
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    unpacked = desktop_dir / "release" / "linux-unpacked" / "resources"
+    node_pty = unpacked / "dist" / "node_modules" / "node-pty"
+    (node_pty / "lib").mkdir(parents=True)
+    (node_pty / "lib" / "index.js").write_text("", encoding="utf-8")
+    prebuilds = node_pty / "prebuilds" / "linux-x64"
+    prebuilds.mkdir(parents=True)
+    (prebuilds / "pty.node").write_bytes(b"")
+    assert (
+        cli_main._desktop_native_deps_present(desktop_dir, source_mode=False)
+        is True
+    )
+
+
+def test_desktop_native_deps_present_rejects_empty_lib(tmp_path, monkeypatch):
+    """Defensive: native binary present but ``lib/index.js`` missing must NOT
+    pass the gate. Guards against a future layout change that silently drops
+    the JS half of node-pty.
+    """
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    unpacked = desktop_dir / "release" / "linux-unpacked" / "resources"
+    node_pty = unpacked / "dist" / "node_modules" / "node-pty"
+    build_release = node_pty / "build" / "Release"
+    build_release.mkdir(parents=True)
+    (build_release / "pty.node").write_bytes(b"")
+    # No lib/index.js — should fail
+    assert (
+        cli_main._desktop_native_deps_present(desktop_dir, source_mode=False)
+        is False
+    )
+
+
+def test_native_arch_suffix_matches_node_pty_layout():
+    """The arch suffix we hand to ``prebuilds/<dir>`` must match what
+    node-pty publishes (linux-x64, linux-arm64, darwin-x64, darwin-arm64,
+    win32-x64). ``linux-armv7l`` is included for completeness even though
+    we no longer ship armv7l builds — guards a future regression where a
+    rename silently misroutes prebuild lookups.
+    """
+    assert cli_main._native_arch_suffix("linux", machine_suffix=False) in (
+        "linux-x64",
+        "linux-arm64",
+        "linux-armv7l",
+    )
+    assert cli_main._native_arch_suffix("darwin", machine_suffix=False) in (
+        "darwin-x64",
+        "darwin-arm64",
+    )
+    assert cli_main._native_arch_suffix("win32", machine_suffix=False) == "win32-x64"
+    # Anything exotic returns None — caller falls back to build/Release only.
+    assert cli_main._native_arch_suffix("freebsd", machine_suffix=False) is None
 
 
 def test_compute_desktop_content_hash_works_without_gitignore(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

`hermes desktop` on Linux could silently launch a packaged Electron app whose `pty.node` was missing, then crash in the main process with `Cannot find module pty.node`. The content-hash stamp only proved the source tree was unchanged — it did NOT verify the packaged artifact actually carried a usable native binary, so a previously-built (but broken) artifact could satisfy the stamp forever.

This adds two layers of defense at build-time so the failure surfaces as a loud rebuild, not a runtime crash.

## Root cause

The user's reported behavior matches exactly what happens when both:
- `prebuilds/linux-x64/` is empty (no matching prebuild for Electron's Node ABI), AND
- `build/Release/` is empty (`@electron/rebuild` was never run)

…because both paths fall through, `node-pty` ships into the package with its JS surface intact but no `.node` binary, and Electron dies loading `unixTerminal.js` at startup.

The existing stamp check in `_desktop_build_needed()` would happily mark the broken package "up to date (content stamp matches)" because the source tree hadn't changed since the broken build was produced.

## Changes

**`apps/desktop/scripts/stage-native-deps.mjs`** — fail loud, not silent
- New validation step that throws when both `build/Release/` and `prebuilds/<platform>-<arch>/` lack a `*.node` binary or `spawn-helper`.
- Error message points to the exact remediation: `npx @electron/rebuild -w node-pty --platform <p> --arch <a>`.

**`hermes_cli/main.py`** — native-deps gate alongside content stamp
- New `_desktop_native_deps_present()` checks the same paths node-pty's loader checks (build/Release/, prebuilds/<platform>-<arch>/) plus `lib/index.js` for defensive coverage.
- New `_native_arch_suffix()` returns the canonical `<platform>-<arch>` dir name (linux-x64, linux-arm64, darwin-arm64, win32-x64, …) without duplicating the lookup logic in 5 places.
- New `_desktop_unpacked_resources_root()` centralizes how we locate `app.asar.unpacked/.../resources/dist/node_modules/node-pty` — stays in sync with `_desktop_packaged_executable`.
- `_desktop_build_needed()` now returns `True` when native deps are missing, forcing a rebuild.

**`tests/hermes_cli/test_gui_command.py`** — coverage
- `_make_packaged_executable` helper updated to stage realistic node-pty payload (lib/index.js + build/Release/pty.node) by default; `with_native_deps=False` opt-out for the missing-deps test.
- 4 new tests: missing native binary forces rebuild even with fresh stamp; prebuild-only layout is accepted; lib/index.js regression is caught; arch-suffix mapping covers linux/darwin/win32.

## Verification

```
$ ./venv/bin/python -m pytest tests/hermes_cli/test_gui_command.py -v
============================== 65 passed in 1.13s ==============================
```

End-to-end smoke test of the mjs change confirmed the new validation throws with the expected error message when both build/Release/ and prebuilds/linux-x64/ are empty.

## Notes

- Sir's machine has the binary at the correct path (`apps/desktop/release/linux-unpacked/resources/app.asar.unpacked/dist/node_modules/node-pty/build/Release/pty.node`) — this only affects installs where the staging step produced an incomplete payload.
- The fix is conservative: it does NOT modify electron-builder config, asarUnpack, or before-pack.mjs. Those would be a larger change touching every platform's packaging flow. This PR isolates the change to: (1) fail loud during staging, and (2) detect + rebuild at the CLI gate.

Closes #62462