### PR TITLE
fix(feishu): tolerate legacy websocket client kwargs

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -52,6 +52,7 @@ import collections
 import concurrent.futures
 import hashlib
 import hmac
+import inspect
 import itertools
 import json
 import logging
@@ -215,6 +216,19 @@ _FEISHU_WEBHOOK_BODY_TIMEOUT_SECONDS = 30          # max seconds to read request
 _FEISHU_WEBHOOK_ANOMALY_THRESHOLD = 25             # consecutive error responses before WARNING log
 _FEISHU_WEBHOOK_ANOMALY_TTL_SECONDS = 6 * 60 * 60  # anomaly tracker TTL (6 hours) — matches openclaw
 _FEISHU_CARD_ACTION_DEDUP_TTL_SECONDS = 15 * 60    # card action token dedup window (15 min)
+
+
+def _supports_keyword_argument(callable_obj: Any, keyword: str) -> bool:
+    try:
+        signature = inspect.signature(callable_obj)
+    except (TypeError, ValueError):
+        return False
+    for parameter in signature.parameters.values():
+        if parameter.kind == inspect.Parameter.VAR_KEYWORD:
+            return True
+        if parameter.name == keyword:
+            return True
+    return False
 
 _APPROVAL_CHOICE_MAP: Dict[str, str] = {
     "approve_once": "once",
@@ -4724,19 +4738,25 @@ class FeishuAdapter(BasePlatformAdapter):
         if loop is None or loop.is_closed():
             raise RuntimeError("adapter loop is not ready")
         await self._hydrate_bot_identity()
-        self._ws_client = FeishuWSClient(
-            app_id=self._app_id,
-            app_secret=self._app_secret,
-            log_level=lark.LogLevel.INFO,
-            event_handler=self._event_handler,
-            domain=domain,
-            # Channel SDK signaling tag: without this UA tag the Feishu
-            # server does not push group @mention events over the WebSocket
-            # transport.  The tag tells the server to use the Channel protocol
-            # which enables group-message routing in addition to P2P DM.
-            # See https://github.com/NousResearch/hermes-agent/issues/50656
-            extra_ua_tags=["channel"],
-        )
+        ws_client_kwargs = {
+            "app_id": self._app_id,
+            "app_secret": self._app_secret,
+            "log_level": lark.LogLevel.INFO,
+            "event_handler": self._event_handler,
+            "domain": domain,
+        }
+        # Channel SDK signaling tag: without this UA tag the Feishu server may
+        # not push group @mention events over the WebSocket transport.  Older
+        # lark_oapi builds do not accept this kwarg, so keep the gateway alive
+        # and let newer SDKs opt into the tag when available.
+        if _supports_keyword_argument(FeishuWSClient, "extra_ua_tags"):
+            ws_client_kwargs["extra_ua_tags"] = ["channel"]
+        else:
+            logger.warning(
+                "[Feishu] lark_oapi.ws.Client does not support extra_ua_tags; "
+                "connecting without Channel UA tag"
+            )
+        self._ws_client = FeishuWSClient(**ws_client_kwargs)
         self._ws_future = loop.run_in_executor(
             None,
             _run_official_feishu_ws_client,

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -174,14 +174,13 @@ class TestFeishuMessageNormalization(unittest.TestCase):
 
 class TestFeishuAdapterMessaging(unittest.TestCase):
     @unittest.skipUnless(_HAS_LARK_OAPI, "lark-oapi not installed")
-    def test_websocket_sdk_accepts_channel_ua_tag(self):
-        """The shipped SDK must support the Channel signaling argument."""
-        import inspect
+    def test_websocket_sdk_channel_ua_tag_capability_is_detectable(self):
+        """The adapter must tolerate SDKs with or without the Channel argument."""
 
         from lark_oapi.ws import Client as FeishuWSClient
+        from plugins.platforms.feishu.adapter import _supports_keyword_argument
 
-        signature = inspect.signature(FeishuWSClient)
-        self.assertIn("extra_ua_tags", signature.parameters)
+        self.assertIsInstance(_supports_keyword_argument(FeishuWSClient, "extra_ua_tags"), bool)
 
     @patch.dict(os.environ, {
         "FEISHU_APP_ID": "cli_app",
@@ -482,6 +481,66 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
                       "FeishuWSClient must receive extra_ua_tags for group @mention delivery")
         self.assertEqual(call_kwargs["extra_ua_tags"], ["channel"],
                          "extra_ua_tags must be ['channel'] to enable group event routing")
+
+    @patch.dict(os.environ, {
+        "FEISHU_APP_ID": "cli_app",
+        "FEISHU_APP_SECRET": "secret_app",
+    }, clear=True)
+    def test_connect_websocket_omits_channel_ua_tag_for_legacy_sdk(self):
+        """Older lark_oapi.ws.Client builds reject extra_ua_tags."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured_kwargs = {}
+
+        class LegacyFeishuWSClient:
+            def __init__(self, *, app_id, app_secret, log_level, event_handler, domain):
+                captured_kwargs.update(
+                    {
+                        "app_id": app_id,
+                        "app_secret": app_secret,
+                        "log_level": log_level,
+                        "event_handler": event_handler,
+                        "domain": domain,
+                    }
+                )
+
+        with (
+            patch("plugins.platforms.feishu.adapter.FEISHU_AVAILABLE", True),
+            patch("plugins.platforms.feishu.adapter.FEISHU_WEBSOCKET_AVAILABLE", True),
+            patch("plugins.platforms.feishu.adapter.lark",
+                  SimpleNamespace(LogLevel=SimpleNamespace(INFO="INFO", WARNING="WARNING"))),
+            patch("plugins.platforms.feishu.adapter.EventDispatcherHandler") as mock_handler_class,
+            patch("plugins.platforms.feishu.adapter.FeishuWSClient", LegacyFeishuWSClient),
+            patch("plugins.platforms.feishu.adapter._run_official_feishu_ws_client"),
+            patch("plugins.platforms.feishu.adapter.acquire_scoped_lock", return_value=(True, None)),
+            patch("plugins.platforms.feishu.adapter.release_scoped_lock"),
+            patch.object(adapter, "_hydrate_bot_identity", new=AsyncMock()),
+            patch.object(adapter, "_build_lark_client", return_value=SimpleNamespace()),
+        ):
+            _mock_event_dispatcher_builder(mock_handler_class)
+
+            loop = asyncio.new_event_loop()
+            future = loop.create_future()
+            future.set_result(None)
+
+            class _Loop:
+                def run_in_executor(self, *_args, **_kwargs):
+                    return future
+                def is_closed(self):
+                    return False
+
+            try:
+                with patch("plugins.platforms.feishu.adapter.asyncio.get_running_loop",
+                           return_value=_Loop()):
+                    connected = asyncio.run(adapter.connect())
+            finally:
+                loop.close()
+
+        self.assertTrue(connected)
+        self.assertNotIn("extra_ua_tags", captured_kwargs)
+        self.assertEqual(captured_kwargs["app_id"], "cli_app")
 
     @patch.dict(os.environ, {}, clear=True)
     def test_edit_message_updates_existing_feishu_message(self):


### PR DESCRIPTION
## Summary
- detect whether the installed `lark_oapi.ws.Client` accepts `extra_ua_tags` before passing it
- keep the Channel UA tag path for newer SDKs while allowing older SDKs to connect
- update Feishu gateway tests to cover both SDK shapes

## Root Cause
The live Hermes runtime had an older Feishu/Lark websocket SDK whose `Client.__init__` signature rejects `extra_ua_tags`. The adapter always passed that keyword, so Feishu startup repeatedly failed with `TypeError` and the gateway stayed in retrying state.

## Validation
- `PYTHONPATH=/private/tmp/hermes-feishu-ws-client-compat-20260711 /Users/minim4/.hermes/hermes-agent/.venv/bin/python -m pytest tests/gateway/test_feishu.py -q`
- live gateway restart verified Feishu returned to `connected` after the local equivalent patch.