### PR TITLE
fix(compression): distinguish lock contention from concurrency

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -588,21 +588,42 @@ def compress_context(
                 existing = _lock_db.get_compression_lock_holder(_lock_sid)
             except Exception:
                 existing = None
-            logger.warning(
-                "compression skipped: another path is compressing session=%s "
-                "(holder=%s) — returning messages unchanged to avoid session fork",
-                _lock_sid, existing,
-            )
+            if existing is not None:
+                logger.warning(
+                    "compression skipped: another path is compressing session=%s "
+                    "(holder=%s) — returning messages unchanged to avoid session fork",
+                    _lock_sid, existing,
+                )
+                warning_attr = "_last_compression_lock_warning_sid"
+                warning_text = (
+                    "⚠ Skipping concurrent compression — another path "
+                    "is already compressing this session. Will retry "
+                    "after it finishes."
+                )
+            else:
+                # try_acquire_compression_lock() also returns False when its
+                # SQLite transaction fails.  With no diagnostic holder, no
+                # same-session compressor has been confirmed: fail closed, but
+                # describe the state-store contention truthfully instead of
+                # reporting a phantom concurrent path.
+                logger.warning(
+                    "compression deferred: session lock unavailable for session=%s "
+                    "(holder=None) — returning messages unchanged; no concurrent "
+                    "compressor confirmed",
+                    _lock_sid,
+                )
+                warning_attr = "_last_compression_lock_unavailable_warning_sid"
+                warning_text = (
+                    "⚠ Compression deferred — the session lock was temporarily "
+                    "unavailable, likely because state storage was busy. "
+                    "No concurrent compressor was confirmed. Compression will retry later."
+                )
             _lock_holder = None  # don't release a lock we don't own
-            # Surface to the user once — quiet for downstream auto-compress loops
-            if getattr(agent, "_last_compression_lock_warning_sid", None) != _lock_sid:
-                agent._last_compression_lock_warning_sid = _lock_sid
+            # Surface to the user once — quiet for downstream auto-compress loops.
+            if getattr(agent, warning_attr, None) != _lock_sid:
+                setattr(agent, warning_attr, _lock_sid)
                 try:
-                    agent._emit_warning(
-                        "⚠ Skipping concurrent compression — another path "
-                        "is already compressing this session. Will retry "
-                        "after it finishes."
-                    )
+                    agent._emit_warning(warning_text)
                 except Exception:
                     pass
             _existing_sp = getattr(agent, "_cached_system_prompt", None)

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -191,6 +191,7 @@ def test_skipped_compression_returns_messages_unchanged(tmp_path: Path) -> None:
     assert held is True
 
     agent = _build_agent_with_db(db, parent_sid)
+    agent._emit_warning = MagicMock()
     messages = [{"role": "user", "content": "m1"}, {"role": "user", "content": "m2"}]
 
     compressed, _sp = agent._compress_context(messages, "sys", approx_tokens=120_000)
@@ -200,6 +201,44 @@ def test_skipped_compression_returns_messages_unchanged(tmp_path: Path) -> None:
     assert agent.session_id == parent_sid
     # Compressor was never called (the skip happens before .compress())
     agent.context_compressor.compress.assert_not_called()
+    assert "another path" in agent._emit_warning.call_args.args[0]
+
+
+def test_lock_backend_contention_does_not_claim_concurrent_compressor(
+    tmp_path: Path,
+) -> None:
+    """A failed lock write without a holder is storage contention, not a race.
+
+    ``try_acquire_compression_lock`` returns ``False`` both when another
+    compressor owns the per-session row and when its SQLite transaction fails.
+    If the diagnostic holder lookup then returns ``None``, Hermes has not
+    confirmed a concurrent same-session compressor and must not tell the user
+    that it has. Compression still fails closed and retries later.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_sid = "LOCK_BACKEND_BUSY"
+    db.create_session(parent_sid, source="telegram")
+
+    db.try_acquire_compression_lock = MagicMock(return_value=False)
+    db.get_compression_lock_holder = MagicMock(return_value=None)
+
+    agent = _build_agent_with_db(db, parent_sid)
+    agent._emit_warning = MagicMock()
+    messages = [
+        {"role": "user", "content": "m1"},
+        {"role": "assistant", "content": "m2"},
+    ]
+
+    compressed, _sp = agent._compress_context(
+        messages, "sys", approx_tokens=120_000
+    )
+
+    assert compressed is messages or compressed == messages
+    assert getattr(agent, "session_id", None) == parent_sid
+    getattr(agent, "context_compressor").compress.assert_not_called()
+    warning = agent._emit_warning.call_args.args[0]
+    assert "No concurrent compressor was confirmed" in warning
+    assert "another path" not in warning
 
 
 def test_compression_restores_user_turn_when_compressor_drops_all_users(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- distinguish a confirmed per-session compression-lock holder from a failed SQLite lock transaction
- keep compression fail-closed in both cases while avoiding the false claim that another compressor is running
- preserve the existing concurrent-path warning when a real holder is present
- add regression coverage for both classifications

## Root cause

`SessionDB.try_acquire_compression_lock()` returns `False` for two different outcomes: a real `INSERT OR IGNORE` loss to an existing holder, and a caught SQLite transaction failure. `compress_context()` previously described both outcomes as “another path is already compressing this session,” even when `get_compression_lock_holder()` returned `None`.

The new no-holder branch says the session lock was temporarily unavailable and that no concurrent compressor was confirmed. It still returns the original messages unchanged, so the anti-fork safety behavior is unchanged.

## Verification

- `27 passed` — concurrent compression and compression-lock suites
- `1 passed, 338 deselected` — compression-lock tests in `test_hermes_state.py`
- `ruff check` passed
- Python compilation and `git diff --check` passed
