### PR TITLE
fix(cli): persist the /reload-mcp note instead of silently dropping it

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10820,6 +10820,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 change_parts.append(f"Reconnected servers: {', '.join(sorted(reconnected))}")
             tool_summary = f"{len(new_tools)} MCP tool(s) now available" if new_tools else "No MCP tools available"
             change_detail = ". ".join(change_parts) + ". " if change_parts else ""
+            # Snapshot the already-persisted history BEFORE appending the note so
+            # it can be passed to _persist_session() as ``conversation_history``:
+            # the marker-based flush skips those messages by identity and writes
+            # only the newly-appended note.
+            prior_history = list(self.conversation_history)
             self.conversation_history.append({
                 "role": "user",
                 "content": f"[IMPORTANT: MCP servers have been reloaded. {change_detail}{tool_summary}. The tool list for this conversation has been updated accordingly.]",
@@ -10827,11 +10832,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
             # Persist session immediately so the session log reflects the
             # updated tools list (self.agent.tools was refreshed above).
+            # Pass the PRE-note snapshot as conversation_history. Passing the
+            # post-append list (as this call used to) made history_ids cover the
+            # note itself, so _flush_messages_to_session_db skipped every message
+            # and left the note falsely stamped _DB_PERSISTED_MARKER — the reload
+            # note never reached state.db and no later flush could recover it.
             if self.agent is not None:
                 try:
                     self.agent._persist_session(
                         self.conversation_history,
-                        self.conversation_history,
+                        prior_history,
                     )
                 except Exception:
                     pass  # Best-effort

--- a/tests/cli/test_reload_mcp_persist_note.py
+++ b/tests/cli/test_reload_mcp_persist_note.py
@@ -1,0 +1,124 @@
+"""Regression tests for HermesCLI._reload_mcp session persistence.
+
+`_reload_mcp` appends a "[IMPORTANT: MCP servers have been reloaded ...]" note
+and persists immediately so the session log reflects the new tool list even if
+the user quits right after reloading (see commit 3ead3401e). The call used to
+pass ``self.conversation_history`` as BOTH arguments to ``_persist_session``,
+which made ``_flush_messages_to_session_db`` treat every message — including the
+brand-new note — as already-durable and skip it (stamping a false
+``_DB_PERSISTED_MARKER``). The note therefore never reached state.db and no
+later flush could recover it.
+
+These drive the REAL ``_reload_mcp`` against a REAL ``SessionDB`` with the MCP
+transport calls mocked, asserting the note is actually persisted and that a
+resumed (not-yet-marked) history prefix is not duplicated.
+"""
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _real_agent(db, session_id, session_messages):
+    from run_agent import AIAgent
+
+    agent = object.__new__(AIAgent)
+    agent._session_db = db
+    agent._session_db_created = True
+    agent.session_id = session_id
+    agent.platform = "cli"
+    agent.model = "test-model"
+    agent.tools = []
+    agent._session_messages = session_messages
+    agent._last_flushed_db_idx = 0
+    agent._flushed_db_message_ids = set()
+    agent._flushed_db_message_session_id = None
+    agent._persist_disabled = False
+    agent._cached_system_prompt = None
+    agent._session_init_model_config = None
+    agent._parent_session_id = None
+    agent._session_json_enabled = False
+    agent.quiet_mode = True
+    agent.commit_memory_session = lambda *a, **k: None
+    return agent
+
+
+def _make_cli(agent, conversation_history):
+    import cli as cli_mod
+
+    obj = object.__new__(cli_mod.HermesCLI)
+    obj._command_running = True
+    obj.agent = agent
+    obj.enabled_toolsets = {"all"}  # skip the enabled-override merge branch
+    obj.conversation_history = conversation_history
+    return obj
+
+
+def _drive_reload(cli):
+    """Run _reload_mcp with the MCP transport layer stubbed out."""
+    with patch("tools.mcp_tool.shutdown_mcp_servers"), \
+         patch("tools.mcp_tool.discover_mcp_tools", return_value=["tool_a", "tool_b"]), \
+         patch("tools.mcp_tool.refresh_agent_mcp_tools"), \
+         patch("tools.mcp_tool._servers", {"srv": object()}), \
+         patch("tools.mcp_tool._lock", threading.RLock()):
+        cli._reload_mcp()
+
+
+def _note_rows(db, session_id):
+    rows = db.get_messages_as_conversation(session_id)
+    return [m.get("content") or "" for m in rows]
+
+
+def test_reload_note_persisted_after_a_turn(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "sess-reload-turn"
+    db.create_session(session_id=session_id, source="cli")
+
+    history = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]
+    agent = _real_agent(db, session_id, history)
+    # A prior turn durably persisted the prefix (stamps _DB_PERSISTED_MARKER).
+    agent._persist_session(history)
+
+    cli = _make_cli(agent, history)
+    _drive_reload(cli)
+
+    contents = _note_rows(db, session_id)
+    assert any("MCP servers have been reloaded" in c for c in contents), contents
+    # Prefix not duplicated.
+    assert contents.count("hi") == 1 and contents.count("hello") == 1, contents
+
+
+def test_reload_note_persisted_on_resumed_session_without_duplicating(tmp_path, monkeypatch):
+    """Resumed session, /reload-mcp before any turn: the loaded prefix is durable
+    in the DB but its in-memory dicts carry no marker yet. The note must persist
+    and the prefix must not be re-appended."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "sess-reload-resumed"
+    db.create_session(session_id=session_id, source="cli")
+    for m in [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}]:
+        db.append_message(session_id=session_id, role=m["role"], content=m["content"])
+
+    # Fresh, unmarked dicts, as hydrated by /resume.
+    history = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]
+    agent = _real_agent(db, session_id, history)
+    agent._last_flushed_db_idx = len(history)  # cli resume sets this
+
+    cli = _make_cli(agent, history)
+    _drive_reload(cli)
+
+    contents = _note_rows(db, session_id)
+    assert any("MCP servers have been reloaded" in c for c in contents), contents
+    assert contents.count("hi") == 1 and contents.count("hello") == 1, contents


### PR DESCRIPTION
## What does this PR do?

`HermesCLI._reload_mcp` (the `/reload-mcp` command) appends a note to the
conversation so the model knows the tool list changed, then persists the
session immediately "so the session log reflects the updated tools list … if
the user quit after reloading, the log would have stale tools":

```python
self.conversation_history.append({"role": "user", "content": "[IMPORTANT: MCP servers have been reloaded. …]"})
self.agent._persist_session(
    self.conversation_history,
    self.conversation_history,   # <-- same list passed as conversation_history
)
```

`_flush_messages_to_session_db` skips already-durable messages by identity —
`history_ids = {id(m) for m in conversation_history}` — and stamps each skipped
message with `_DB_PERSISTED_MARKER`. Passing `self.conversation_history` as
**both** arguments makes `history_ids` cover the brand-new note too, so the
flush skips **every** message and marks the note as persisted **without ever
writing it**. The reload note never reaches `state.db`, and because it now
carries a false marker, no later turn flush can recover it — silent data loss,
defeating the immediate-persist this code was added to provide.

The fix snapshots the history **before** appending the note and passes that
snapshot as `conversation_history`, so the flush skips the durable prefix by
identity and writes only the new note. (A bare single-argument call also writes
the note, but would re-append an unmarked, resumed history prefix as duplicate
rows — see the resumed-session test — so the pre-note snapshot is used instead.)

This is the same aliasing failure that was fixed for the TUI gateway's
`finalize` path; this PR closes the equivalent gap on the CLI `/reload-mcp`
path.

## Related Issue

-

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py` — `HermesCLI._reload_mcp`: snapshot `self.conversation_history`
  before appending the reload note and pass that pre-note snapshot as the
  `conversation_history` argument to `_persist_session`, instead of passing the
  post-append list as both arguments.
- `tests/cli/test_reload_mcp_persist_note.py` — new real-`SessionDB` regression
  tests that drive `_reload_mcp` (MCP transport mocked) and assert the reload
  note is persisted, covering both the ran-a-turn and resumed-before-turn cases
  (the latter also asserting the durable prefix is not duplicated).

## How to Test

1. Reproduce the loss on `main`: after `/reload-mcp`, the injected note is
   absent from `state.db`. Equivalent minimal reproduction against a real
   `SessionDB`:

   ```python
   # already-durable prefix + a freshly appended reload note in `ch`
   agent._persist_session(ch, ch)        # current behaviour
   # -> note is NOT written; note dict is left marked _db_persisted
   ```

2. With this PR, the note is written:

   ```python
   prior = list(ch)          # snapshot before appending the note
   ch.append(note)
   agent._persist_session(ch, prior)     # fixed behaviour
   # -> note row lands in state.db; durable prefix is not duplicated
   ```

3. Run the regression tests:

   ```
   pytest tests/cli/test_reload_mcp_persist_note.py -q
   ```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(cli): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: local development environment

### Documentation & Housekeeping

- [x] N/A — internal persistence-argument fix; no README/`docs/`/docstring changes
- [x] N/A — no config keys added/changed
- [x] N/A — no architecture/workflow changes
- [x] Cross-platform impact considered — pure Python list/identity handling, no platform-specific behavior
- [x] N/A — no tool description/schema changes

## Screenshots / Logs

New tests fail on the current code (note dropped) and pass with the fix:

```
# against current code (bug present)
tests/cli/test_reload_mcp_persist_note.py::test_reload_note_persisted_after_a_turn                          FAILED
tests/cli/test_reload_mcp_persist_note.py::test_reload_note_persisted_on_resumed_session_without_duplicating FAILED
E   AssertionError: ['hi', 'hello']        # reload note missing from state.db
2 failed

# with this PR
tests/cli/test_reload_mcp_persist_note.py::test_reload_note_persisted_after_a_turn                          PASSED
tests/cli/test_reload_mcp_persist_note.py::test_reload_note_persisted_on_resumed_session_without_duplicating PASSED
2 passed
```

Regression slice (persistence boundary siblings + reload triggers) stays green:

```
$ pytest tests/cli/test_reload_mcp_persist_note.py tests/tui_gateway/test_finalize_session_persist.py tests/cli/test_cli_mcp_config_watch.py tests/hermes_cli/test_mcp_reload_confirm_gate.py -q
27 passed
```