### PR TITLE
fix(cli): add Piper to TTS setup menu

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -933,7 +933,7 @@ def _run_xai_oauth_login_from_setup() -> bool:
 
 
 def _setup_tts_provider(config: dict):
-    """Interactive TTS provider selection with install flow for NeuTTS."""
+    """Interactive TTS provider selection with install flows for local providers."""
     tts_config = config.get("tts", {})
     current_provider = tts_config.get("provider", "edge")
     subscription_features = get_nous_subscription_features(config)
@@ -948,6 +948,7 @@ def _setup_tts_provider(config: dict):
         "gemini": "Google Gemini TTS",
         "neutts": "NeuTTS",
         "kittentts": "KittenTTS",
+        "piper": "Piper",
     }
     current_label = provider_labels.get(current_provider, current_provider)
 
@@ -972,9 +973,10 @@ def _setup_tts_provider(config: dict):
             "Google Gemini TTS (30 prebuilt voices, prompt-controllable, needs API key)",
             "NeuTTS (local on-device, free, ~300MB model download)",
             "KittenTTS (local on-device, free, lightweight ~25-80MB ONNX)",
+            "Piper (local on-device, free, 44 languages, voices ~20-90MB)",
         ]
     )
-    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts"])
+    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts", "piper"])
     choices.append(f"Keep current ({current_label})")
     keep_current_idx = len(choices) - 1
     idx = prompt_choice("Select TTS provider:", choices, keep_current_idx)
@@ -1159,6 +1161,29 @@ def _setup_tts_provider(config: dict):
             else:
                 print_info("Skipping install. Set tts.provider to 'kittentts' after installing manually.")
                 selected = "edge"
+
+    elif selected == "piper":
+        try:
+            already_installed = importlib.util.find_spec("piper") is not None
+        except Exception:
+            already_installed = False
+
+        if already_installed:
+            print_success("Piper is already installed")
+        elif prompt_yes_no("Install Piper dependencies now?", True):
+            from hermes_cli.tools_config import _run_post_setup
+
+            _run_post_setup("piper")
+            try:
+                already_installed = importlib.util.find_spec("piper") is not None
+            except Exception:
+                already_installed = False
+            if not already_installed:
+                print_warning("Piper installation incomplete. Falling back to Edge TTS.")
+                selected = "edge"
+        else:
+            print_info("Skipping install. Set tts.provider to 'piper' after installing manually.")
+            selected = "edge"
 
     # Save the selection
     if "tts" not in config:

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -544,6 +544,15 @@ def _print_setup_summary(config: dict, hermes_home):
             tool_status.append(("Text-to-Speech (KittenTTS local)", True, None))
         else:
             tool_status.append(("Text-to-Speech (KittenTTS — not installed)", False, "run 'hermes setup tts'"))
+    elif tts_provider == "piper":
+        try:
+            piper_ok = importlib.util.find_spec("piper") is not None
+        except Exception:
+            piper_ok = False
+        if piper_ok:
+            tool_status.append(("Text-to-Speech (Piper local)", True, None))
+        else:
+            tool_status.append(("Text-to-Speech (Piper - not installed)", False, "run 'hermes setup tts'"))
     else:
         tool_status.append(("Text-to-Speech (Edge TTS)", True, None))
 

--- a/hermes_cli/setup_summary.py
+++ b/hermes_cli/setup_summary.py
@@ -15,7 +15,8 @@ _TTS_SUMMARY_ROWS = {
     "minimax": ("MiniMax", ("MINIMAX_API_KEY",)), "mistral": ("Mistral Voxtral", ("MISTRAL_API_KEY",)),
     "gemini": ("Google Gemini", ("GEMINI_API_KEY", "GOOGLE_API_KEY")),
     "neutts": ("NeuTTS", "neutts", "run 'hermes setup tts'"),
-    "kittentts": ("KittenTTS", "kittentts", "run 'hermes setup tts'")}
+    "kittentts": ("KittenTTS", "kittentts", "run 'hermes setup tts'"),
+    "piper": ("Piper", "piper", "run 'hermes setup tts'")}
 _TTS_SUMMARY_DEFAULT = ("Edge TTS", ())
 _STT_SUMMARY_ROWS = {
     "openai": ("OpenAI", ("VOICE_TOOLS_OPENAI_KEY", "OPENAI_API_KEY")), "groq": ("Groq Whisper", ("GROQ_API_KEY",)),

--- a/hermes_cli/setup_tts.py
+++ b/hermes_cli/setup_tts.py
@@ -70,6 +70,14 @@ def _install_kittentts_deps() -> bool:
         "kittentts", ["-U", wheel_url, "soundfile", "--quiet"], f"uv pip install -U '{wheel_url}' soundfile")
 
 
+def _install_piper_deps() -> bool:
+    """Reuse the Piper installer already exposed by ``hermes tools``."""
+    from hermes_cli.tools_config import _run_post_setup
+
+    _run_post_setup("piper")
+    return _setup._module_installed("piper")
+
+
 def _xai_oauth_logged_in_for_setup() -> bool:
     """True iff xAI Grok OAuth credentials are stored locally, so TTS/STT setup can skip the
     API-key prompt for users who logged in via ``hermes model`` -> xAI Grok OAuth."""
@@ -115,7 +123,8 @@ _TTS_PROVIDER_CHOICES = [
     ("mistral", "Mistral Voxtral TTS (multilingual, native Opus, needs API key)"),
     ("gemini", "Google Gemini TTS (30 prebuilt voices, prompt-controllable, needs API key)"),
     ("neutts", "NeuTTS (local on-device, free, ~300MB model download)"),
-    ("kittentts", "KittenTTS (local on-device, free, lightweight ~25-80MB ONNX)")]
+    ("kittentts", "KittenTTS (local on-device, free, lightweight ~25-80MB ONNX)"),
+    ("piper", "Piper (local on-device, free, 44 languages, voices ~20-90MB)")]
 # Short label = menu label minus its parenthetical ("Edge TTS", "Mistral Voxtral TTS", ...).
 _TTS_PROVIDER_LABELS = {key: label.split(" (")[0] for key, label in _TTS_PROVIDER_CHOICES}
 # provider -> (env vars that satisfy it, env var to save, prompt, success line, pre-prompt hint)
@@ -140,7 +149,11 @@ _TTS_LOCAL_PROVIDERS = {
     "kittentts": ("kittentts", "KittenTTS",
                   ("KittenTTS is lightweight (~25-80MB, CPU-only, no API key required).",
                    "Voices: Jasper, Bella, Luna, Bruno, Rosie, Hugo, Kiki, Leo"),
-                  "Install KittenTTS now?", _install_kittentts_deps)}
+                  "Install KittenTTS now?", _install_kittentts_deps),
+    "piper": ("piper", "Piper",
+              ("Piper is local, free, and supports 44 languages.",
+               "Voices are downloaded on first use (about 20-90MB)."),
+              "Install Piper dependencies now?", _install_piper_deps)}
 
 
 def _tts_api_key_step(selected: str) -> str:

--- a/tests/hermes_cli/test_setup_tts.py
+++ b/tests/hermes_cli/test_setup_tts.py
@@ -1,3 +1,7 @@
+from types import SimpleNamespace
+
+import pytest
+
 from hermes_cli import setup
 
 
@@ -33,3 +37,34 @@ def test_setup_tts_uses_existing_piper_post_setup(monkeypatch):
 
     assert post_setup_calls == ["piper"]
     assert config["tts"]["provider"] == "piper"
+
+
+@pytest.mark.parametrize(
+    ("installed", "expected"),
+    [
+        (True, "Text-to-Speech (Piper local)"),
+        (False, "Text-to-Speech (Piper - not installed)"),
+    ],
+)
+def test_setup_summary_reports_piper_availability(
+    installed, expected, tmp_path, monkeypatch, capsys
+):
+    unavailable = SimpleNamespace(managed_by_nous=False, available=False, current_provider=None)
+    features = SimpleNamespace(
+        web=unavailable,
+        browser=unavailable,
+        image_gen=unavailable,
+        video_gen=unavailable,
+        tts=unavailable,
+        modal=SimpleNamespace(managed_by_nous=False, direct_override=False),
+        nous_auth_present=False,
+    )
+    monkeypatch.setattr(setup, "get_nous_subscription_features", lambda config: features)
+    monkeypatch.setattr(setup, "managed_nous_tools_enabled", lambda: False)
+    monkeypatch.setattr(setup.importlib.util, "find_spec", lambda name: object() if name == "piper" and installed else None)
+
+    setup._print_setup_summary({"tts": {"provider": "piper"}}, tmp_path)
+
+    output = capsys.readouterr().out
+    assert expected in output
+    assert "Text-to-Speech (Edge TTS)" not in output

--- a/tests/hermes_cli/test_setup_tts.py
+++ b/tests/hermes_cli/test_setup_tts.py
@@ -1,0 +1,35 @@
+from hermes_cli import setup
+
+
+def _select_piper(question, choices, default=0):
+    assert question == "Select TTS provider:"
+    return next(i for i, choice in enumerate(choices) if choice.startswith("Piper "))
+
+
+def test_setup_tts_lists_and_selects_installed_piper(monkeypatch):
+    config = {}
+    monkeypatch.setattr(setup, "managed_nous_tools_enabled", lambda: False)
+    monkeypatch.setattr(setup, "prompt_choice", _select_piper)
+    monkeypatch.setattr(setup.importlib.util, "find_spec", lambda name: object() if name == "piper" else None)
+    monkeypatch.setattr(setup, "save_config", lambda value: None)
+
+    setup._setup_tts_provider(config)
+
+    assert config["tts"]["provider"] == "piper"
+
+
+def test_setup_tts_uses_existing_piper_post_setup(monkeypatch):
+    config = {}
+    probes = iter([None, object()])
+    post_setup_calls = []
+    monkeypatch.setattr(setup, "managed_nous_tools_enabled", lambda: False)
+    monkeypatch.setattr(setup, "prompt_choice", _select_piper)
+    monkeypatch.setattr(setup, "prompt_yes_no", lambda *args: True)
+    monkeypatch.setattr(setup.importlib.util, "find_spec", lambda name: next(probes) if name == "piper" else None)
+    monkeypatch.setattr(setup, "save_config", lambda value: None)
+    monkeypatch.setattr("hermes_cli.tools_config._run_post_setup", post_setup_calls.append)
+
+    setup._setup_tts_provider(config)
+
+    assert post_setup_calls == ["piper"]
+    assert config["tts"]["provider"] == "piper"

--- a/tests/hermes_cli/test_setup_tts.py
+++ b/tests/hermes_cli/test_setup_tts.py
@@ -1,0 +1,52 @@
+import pytest
+
+from hermes_cli import setup, setup_summary
+
+
+def _select_piper(question, choices, default=0):
+    assert question == "Select TTS provider:"
+    return next(i for i, choice in enumerate(choices) if choice.startswith("Piper "))
+
+
+def test_setup_tts_lists_and_selects_installed_piper(monkeypatch):
+    config = {}
+    monkeypatch.setattr("hermes_cli.setup_tts.tool_backend_helpers.managed_nous_tools_enabled", lambda: False)
+    monkeypatch.setattr(setup, "prompt_choice", _select_piper)
+    monkeypatch.setattr(setup.importlib.util, "find_spec", lambda name: object() if name == "piper" else None)
+    monkeypatch.setattr(setup, "save_config", lambda value: None)
+
+    setup.setup_tts(config)
+
+    assert config["tts"]["provider"] == "piper"
+
+
+def test_setup_tts_uses_existing_piper_post_setup(monkeypatch):
+    config = {}
+    probes = iter([None, object()])
+    post_setup_calls = []
+    monkeypatch.setattr("hermes_cli.setup_tts.tool_backend_helpers.managed_nous_tools_enabled", lambda: False)
+    monkeypatch.setattr(setup, "prompt_choice", _select_piper)
+    monkeypatch.setattr(setup, "prompt_yes_no", lambda *args: True)
+    monkeypatch.setattr(setup.importlib.util, "find_spec", lambda name: next(probes) if name == "piper" else None)
+    monkeypatch.setattr(setup, "save_config", lambda value: None)
+    monkeypatch.setattr("hermes_cli.tools_config._run_post_setup", post_setup_calls.append)
+
+    setup.setup_tts(config)
+
+    assert post_setup_calls == ["piper"]
+    assert config["tts"]["provider"] == "piper"
+
+
+@pytest.mark.parametrize(
+    ("installed", "available"),
+    [(True, True), (False, False)],
+)
+def test_setup_summary_reports_piper_availability(installed, available, monkeypatch):
+    monkeypatch.setattr(setup, "_module_installed", lambda name: name == "piper" and installed)
+
+    status = setup_summary._voice_provider_status(
+        "Text-to-Speech", "piper", setup_summary._TTS_SUMMARY_ROWS, setup_summary._TTS_SUMMARY_DEFAULT)
+
+    assert "Piper" in status[0]
+    assert status[1] is available
+    assert ("not installed" in status[0]) is not available


### PR DESCRIPTION
## What

Add Piper to `hermes setup tts`, reuse the existing Piper installer from `hermes tools`, and report whether Piper is installed in the setup summary.

## Why

Piper already works as a TTS provider and is available through `hermes tools`, but it is missing from the dedicated TTS setup menu.

This addresses only the Piper setup path from #35439. MiniMax and NeuTTS picker parity remain outside this PR.

## Tests

- `tests/hermes_cli/test_setup_tts.py`: 4 passed
- Focused setup and TTS registry suite: 29 passed
- `git diff --check upstream/main...HEAD` passed

Tested on macOS.
