### PR TITLE
feat(devin-acp): Add Devin CLI ACP provider

### DIFF
--- a/agent/acp_client_factory.py
+++ b/agent/acp_client_factory.py
@@ -1,0 +1,35 @@
+"""Factory helpers for ACP subprocess-backed chat clients."""
+
+from __future__ import annotations
+
+from typing import Any
+
+ACP_PROVIDERS = frozenset({"copilot-acp", "devin-acp"})
+
+
+def is_acp_provider(provider: str | None = None, base_url: str | None = None) -> bool:
+    """Return True when *provider* or *base_url* points at an ACP subprocess backend."""
+    p = (provider or "").strip().lower()
+    if p in ACP_PROVIDERS:
+        return True
+    url = (base_url or "").strip().lower()
+    return url.startswith("acp://") or url.startswith("acp+tcp://")
+
+
+def create_acp_client(
+    *,
+    provider: str | None = None,
+    base_url: str | None = None,
+    **kwargs: Any,
+) -> Any:
+    """Instantiate the correct ACP client for *provider* / *base_url*."""
+    p = (provider or "").strip().lower()
+    url = (base_url or kwargs.get("base_url") or "").strip().lower()
+    if p == "devin-acp" or url.startswith("acp://devin"):
+        from agent.devin_acp_client import DevinACPClient
+
+        return DevinACPClient(base_url=base_url, **kwargs)
+
+    from agent.copilot_acp_client import CopilotACPClient
+
+    return CopilotACPClient(base_url=base_url, **kwargs)

--- a/agent/acp_client_factory.py
+++ b/agent/acp_client_factory.py
@@ -16,6 +16,45 @@ def is_acp_provider(provider: str | None = None, base_url: str | None = None) ->
     return url.startswith("acp://") or url.startswith("acp+tcp://")
 
 
+def _fill_missing_acp_invocation(provider: str, kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Fill empty command/args from the external-process credential resolver.
+
+    Call sites sometimes construct an ACP client with only provider/base_url.
+    When that happens, prefer the shared auth resolver (env + PATH) over each
+    client's private defaults — keeps command/args consistent with
+    ``resolve_runtime_provider`` / ``hermes status``.
+    """
+    command = kwargs.get("command") or kwargs.get("acp_command")
+    raw_args = kwargs.get("args")
+    if raw_args is None:
+        raw_args = kwargs.get("acp_args")
+    has_args = isinstance(raw_args, (list, tuple)) and len(raw_args) > 0
+    if command and has_args:
+        return kwargs
+
+    p = (provider or "").strip().lower()
+    if p not in ACP_PROVIDERS:
+        return kwargs
+
+    try:
+        from hermes_cli.auth import resolve_external_process_provider_credentials
+
+        creds = resolve_external_process_provider_credentials(p)
+    except Exception:
+        return kwargs
+
+    filled = dict(kwargs)
+    if not command:
+        resolved = str(creds.get("command") or "").strip()
+        if resolved:
+            filled["command"] = resolved
+    if not has_args:
+        cred_args = list(creds.get("args") or [])
+        if cred_args:
+            filled["args"] = cred_args
+    return filled
+
+
 def create_acp_client(
     *,
     provider: str | None = None,
@@ -25,11 +64,13 @@ def create_acp_client(
     """Instantiate the correct ACP client for *provider* / *base_url*."""
     p = (provider or "").strip().lower()
     url = (base_url or kwargs.get("base_url") or "").strip().lower()
+    client_kwargs = _fill_missing_acp_invocation(p, kwargs)
+
     if p == "devin-acp" or url.startswith("acp://devin"):
         from agent.devin_acp_client import DevinACPClient
 
-        return DevinACPClient(base_url=base_url, **kwargs)
+        return DevinACPClient(base_url=base_url, **client_kwargs)
 
     from agent.copilot_acp_client import CopilotACPClient
 
-    return CopilotACPClient(base_url=base_url, **kwargs)
+    return CopilotACPClient(base_url=base_url, **client_kwargs)

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -487,8 +487,8 @@ def init_agent(
     if (
         api_mode is None
         and agent.api_mode == "chat_completions"
-        and agent.provider != "copilot-acp"
-        and not str(agent.base_url or "").lower().startswith("acp://copilot")
+        and agent.provider not in {"copilot-acp", "devin-acp"}
+        and not str(agent.base_url or "").lower().startswith("acp://")
         and not str(agent.base_url or "").lower().startswith("acp+tcp://")
         and not agent._is_azure_openai_url()
         and (
@@ -912,7 +912,7 @@ def init_agent(
                 client_kwargs = {"api_key": api_key, "base_url": base_url}
             if _provider_timeout is not None:
                 client_kwargs["timeout"] = _provider_timeout
-            if agent.provider == "copilot-acp":
+            if agent.provider in {"copilot-acp", "devin-acp"}:
                 client_kwargs["command"] = agent.acp_command
                 client_kwargs["args"] = agent.acp_args
             effective_base = base_url

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -30,6 +30,7 @@ from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional
 from urllib.parse import urlparse, parse_qs, urlunparse
 
+from agent.acp_client_factory import is_acp_provider
 from agent.context_compressor import ContextCompressor
 from agent.iteration_budget import IterationBudget
 from agent.memory_manager import StreamingContextScrubber
@@ -487,9 +488,7 @@ def init_agent(
     if (
         api_mode is None
         and agent.api_mode == "chat_completions"
-        and agent.provider not in {"copilot-acp", "devin-acp"}
-        and not str(agent.base_url or "").lower().startswith("acp://")
-        and not str(agent.base_url or "").lower().startswith("acp+tcp://")
+        and not is_acp_provider(agent.provider, agent.base_url)
         and not agent._is_azure_openai_url()
         and (
             agent._is_direct_openai_url()
@@ -912,7 +911,7 @@ def init_agent(
                 client_kwargs = {"api_key": api_key, "base_url": base_url}
             if _provider_timeout is not None:
                 client_kwargs["timeout"] = _provider_timeout
-            if agent.provider in {"copilot-acp", "devin-acp"}:
+            if is_acp_provider(agent.provider, base_url):
                 client_kwargs["command"] = agent.acp_command
                 # Prefer None over [] so the ACP client can apply provider
                 # defaults when a call site forgot to forward runtime args.

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -914,7 +914,9 @@ def init_agent(
                 client_kwargs["timeout"] = _provider_timeout
             if agent.provider in {"copilot-acp", "devin-acp"}:
                 client_kwargs["command"] = agent.acp_command
-                client_kwargs["args"] = agent.acp_args
+                # Prefer None over [] so the ACP client can apply provider
+                # defaults when a call site forgot to forward runtime args.
+                client_kwargs["args"] = agent.acp_args or None
             effective_base = base_url
             if base_url_host_matches(effective_base, "openrouter.ai"):
                 from agent.auxiliary_client import build_or_headers

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1661,6 +1661,18 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
 
     if is_acp_provider(agent.provider, client_kwargs.get("base_url")):
         client = create_acp_client(provider=agent.provider, **client_kwargs)
+        # Wire tool_call / tool_call_update → Desktop/TUI activity strip so
+        # long Devin/Copilot ACP turns don't look frozen after the first text.
+        bind = getattr(client, "bind_agent_activity", None)
+        if callable(bind):
+            try:
+                bind(agent)
+            except Exception:
+                _ra().logger.debug(
+                    "ACP bind_agent_activity failed for %s",
+                    agent.provider,
+                    exc_info=True,
+                )
         _ra().logger.info(
             "ACP client created for %s (%s, shared=%s) %s",
             agent.provider,

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1657,12 +1657,13 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     httpx_verify = resolve_httpx_verify(ca_bundle=ssl_ca_cert, ssl_verify=ssl_verify_cfg)
     _validate_proxy_env_urls()
     _validate_base_url(client_kwargs.get("base_url"))
-    if agent.provider == "copilot-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://copilot"):
-        from agent.copilot_acp_client import CopilotACPClient
+    if agent.provider in {"copilot-acp", "devin-acp"} or str(client_kwargs.get("base_url", "")).startswith("acp://"):
+        from agent.acp_client_factory import create_acp_client
 
-        client = CopilotACPClient(**client_kwargs)
+        client = create_acp_client(provider=agent.provider, **client_kwargs)
         _ra().logger.info(
-            "Copilot ACP client created (%s, shared=%s) %s",
+            "ACP client created for %s (%s, shared=%s) %s",
+            agent.provider,
             reason,
             shared,
             agent._client_log_context(),

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1657,9 +1657,9 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     httpx_verify = resolve_httpx_verify(ca_bundle=ssl_ca_cert, ssl_verify=ssl_verify_cfg)
     _validate_proxy_env_urls()
     _validate_base_url(client_kwargs.get("base_url"))
-    if agent.provider in {"copilot-acp", "devin-acp"} or str(client_kwargs.get("base_url", "")).startswith("acp://"):
-        from agent.acp_client_factory import create_acp_client
+    from agent.acp_client_factory import create_acp_client, is_acp_provider
 
+    if is_acp_provider(agent.provider, client_kwargs.get("base_url")):
         client = create_acp_client(provider=agent.provider, **client_kwargs)
         _ra().logger.info(
             "ACP client created for %s (%s, shared=%s) %s",

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4990,7 +4990,9 @@ def resolve_provider_client(
             or _read_main_model(),
             provider,
         )
-        if provider in {"copilot-acp", "devin-acp"}:
+        from agent.acp_client_factory import ACP_PROVIDERS, create_acp_client
+
+        if provider in ACP_PROVIDERS:
             api_key = str(creds.get("api_key", "")).strip()
             base_url = str(creds.get("base_url", "")).strip()
             command = str(creds.get("command", "")).strip() or None
@@ -5009,7 +5011,6 @@ def resolve_provider_client(
                     provider,
                 )
                 return None, None
-            from agent.acp_client_factory import create_acp_client
 
             client = create_acp_client(
                 provider=provider,

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -267,6 +267,9 @@ _PROVIDER_ALIASES = {
     "github-models": "copilot",
     "github-copilot-acp": "copilot-acp",
     "copilot-acp-agent": "copilot-acp",
+    "devin": "devin-acp",
+    "devin-cli": "devin-acp",
+    "cognition-devin": "devin-acp",
     "tencent": "tencent-tokenhub",
     "tokenhub": "tencent-tokenhub",
     "tencent-cloud": "tencent-tokenhub",
@@ -4987,26 +4990,29 @@ def resolve_provider_client(
             or _read_main_model(),
             provider,
         )
-        if provider == "copilot-acp":
+        if provider in {"copilot-acp", "devin-acp"}:
             api_key = str(creds.get("api_key", "")).strip()
             base_url = str(creds.get("base_url", "")).strip()
             command = str(creds.get("command", "")).strip() or None
             args = list(creds.get("args") or [])
             if not final_model:
                 logger.warning(
-                    "resolve_provider_client: copilot-acp requested but no model "
-                    "was provided or configured"
+                    "resolve_provider_client: %s requested but no model "
+                    "was provided or configured",
+                    provider,
                 )
                 return None, None
             if not api_key or not base_url:
                 logger.warning(
-                    "resolve_provider_client: copilot-acp requested but external "
-                    "process credentials are incomplete"
+                    "resolve_provider_client: %s requested but external "
+                    "process credentials are incomplete",
+                    provider,
                 )
                 return None, None
-            from agent.copilot_acp_client import CopilotACPClient
+            from agent.acp_client_factory import create_acp_client
 
-            client = CopilotACPClient(
+            client = create_acp_client(
+                provider=provider,
                 api_key=api_key,
                 base_url=base_url,
                 command=command,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -27,6 +27,7 @@ import time
 import uuid
 from typing import Any, Dict, List, Optional
 
+from agent.acp_client_factory import is_acp_provider
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.conversation_compression import conversation_history_after_compression
 from agent.display import KawaiiSpinner
@@ -1292,11 +1293,7 @@ def run_conversation(
                 # returns a plain SimpleNamespace — not an iterable
                 # stream.  Mirror the ACP exclusion used for Responses
                 # API upgrade (lines ~1083-1085).
-                elif (
-                    agent.provider in {"copilot-acp", "devin-acp"}
-                    or str(agent.base_url or "").lower().startswith("acp://")
-                    or str(agent.base_url or "").lower().startswith("acp+tcp://")
-                ):
+                elif is_acp_provider(agent.provider, agent.base_url):
                     _use_streaming = False
                 # MoA streams only when a display/TTS consumer is present to
                 # receive the deltas. MoAChatCompletions.create() honors

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1293,8 +1293,8 @@ def run_conversation(
                 # stream.  Mirror the ACP exclusion used for Responses
                 # API upgrade (lines ~1083-1085).
                 elif (
-                    agent.provider in {"copilot-acp"}
-                    or str(agent.base_url or "").lower().startswith("acp://copilot")
+                    agent.provider in {"copilot-acp", "devin-acp"}
+                    or str(agent.base_url or "").lower().startswith("acp://")
                     or str(agent.base_url or "").lower().startswith("acp+tcp://")
                 ):
                     _use_streaming = False

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1289,12 +1289,13 @@ def run_conversation(
                 # session instead of re-failing every retry.
                 if getattr(agent, "_disable_streaming", False):
                     _use_streaming = False
-                # CopilotACPClient communicates via subprocess stdio and
-                # returns a plain SimpleNamespace — not an iterable
-                # stream.  Mirror the ACP exclusion used for Responses
-                # API upgrade (lines ~1083-1085).
+                # ACP backends can stream agent_message_chunk frames as
+                # OpenAI-style deltas. Without a display/TTS consumer, keep
+                # the complete-response path (cheaper for quiet/subagent
+                # turns). Process/session reuse still applies either way.
                 elif is_acp_provider(agent.provider, agent.base_url):
-                    _use_streaming = False
+                    if not agent._has_stream_consumers():
+                        _use_streaming = False
                 # MoA streams only when a display/TTS consumer is present to
                 # receive the deltas. MoAChatCompletions.create() honors
                 # stream=True (runs the references, then returns the aggregator's

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -605,6 +605,20 @@ class CopilotACPClient:
         proc = self._active_process
         return proc is not None and proc.poll() is None
 
+    def _normalize_timeout(self, timeout: Any) -> float:
+        if timeout is None:
+            return _DEFAULT_TIMEOUT_SECONDS
+        if isinstance(timeout, (int, float)):
+            return float(timeout)
+        # httpx.Timeout or similar — pick the largest component so the
+        # subprocess has enough wall-clock time for the full response.
+        _candidates = [
+            getattr(timeout, attr, None)
+            for attr in ("read", "write", "connect", "pool", "timeout")
+        ]
+        _numeric = [float(v) for v in _candidates if isinstance(v, (int, float))]
+        return max(_numeric) if _numeric else _DEFAULT_TIMEOUT_SECONDS
+
     def _create_chat_completion(
         self,
         *,
@@ -617,32 +631,34 @@ class CopilotACPClient:
         **_: Any,
     ) -> Any:
         msg_list = [m for m in (messages or []) if isinstance(m, dict)]
-        # Normalise timeout: run_agent.py may pass an httpx.Timeout object
-        # (used natively by the OpenAI SDK) rather than a plain float.
-        if timeout is None:
-            _effective_timeout = _DEFAULT_TIMEOUT_SECONDS
-        elif isinstance(timeout, (int, float)):
-            _effective_timeout = float(timeout)
-        else:
-            # httpx.Timeout or similar — pick the largest component so the
-            # subprocess has enough wall-clock time for the full response.
-            _candidates = [
-                getattr(timeout, attr, None)
-                for attr in ("read", "write", "connect", "pool", "timeout")
-            ]
-            _numeric = [float(v) for v in _candidates if isinstance(v, (int, float))]
-            _effective_timeout = max(_numeric) if _numeric else _DEFAULT_TIMEOUT_SECONDS
+        _effective_timeout = self._normalize_timeout(timeout)
+        model_name = model or self._default_model_name
+
+        if stream:
+            return self._iter_stream_completion(
+                msg_list,
+                model=model_name,
+                tools=tools,
+                tool_choice=tool_choice,
+                timeout_seconds=_effective_timeout,
+            )
 
         response_text, reasoning_text = self._run_conversation_prompt(
             msg_list,
-            model=model,
+            model=model_name,
             tools=tools,
             tool_choice=tool_choice,
             timeout_seconds=_effective_timeout,
         )
+        return self._build_completion(response_text, reasoning_text, model_name)
 
+    def _build_completion(
+        self,
+        response_text: str,
+        reasoning_text: str,
+        model_name: str,
+    ) -> SimpleNamespace:
         tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)
-
         usage = SimpleNamespace(
             prompt_tokens=0,
             completion_tokens=0,
@@ -658,14 +674,104 @@ class CopilotACPClient:
         )
         finish_reason = "tool_calls" if tool_calls else "stop"
         choice = SimpleNamespace(message=assistant_message, finish_reason=finish_reason)
-        completion = SimpleNamespace(
+        return SimpleNamespace(
             choices=[choice],
             usage=usage,
-            model=model or self._default_model_name,
+            model=model_name,
         )
-        if stream:
-            return _completion_to_stream_chunks(completion)
-        return completion
+
+    def _iter_stream_completion(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        model: str,
+        tools: list[dict[str, Any]] | None,
+        tool_choice: Any,
+        timeout_seconds: float,
+    ):
+        """Yield OpenAI-style stream chunks as ACP ``agent_message_chunk`` arrives."""
+        events: queue.Queue[tuple[str, Any]] = queue.Queue()
+
+        def _on_text(chunk: str) -> None:
+            events.put(("text", chunk))
+
+        def _on_reasoning(chunk: str) -> None:
+            events.put(("reasoning", chunk))
+
+        def _worker() -> None:
+            try:
+                text, reasoning = self._run_conversation_prompt(
+                    messages,
+                    model=model,
+                    tools=tools,
+                    tool_choice=tool_choice,
+                    timeout_seconds=timeout_seconds,
+                    on_text_chunk=_on_text,
+                    on_reasoning_chunk=_on_reasoning,
+                )
+                events.put(("done", (text, reasoning)))
+            except Exception as exc:
+                events.put(("error", exc))
+
+        worker = threading.Thread(target=_worker, daemon=True, name="acp-stream-worker")
+        worker.start()
+
+        role_sent = False
+        while True:
+            kind, payload = events.get()
+            if kind == "text":
+                delta = SimpleNamespace(
+                    role="assistant" if not role_sent else None,
+                    content=payload,
+                    tool_calls=None,
+                    reasoning=None,
+                    reasoning_content=None,
+                )
+                role_sent = True
+                yield SimpleNamespace(
+                    choices=[SimpleNamespace(index=0, delta=delta, finish_reason=None)],
+                    model=model,
+                    usage=None,
+                )
+            elif kind == "reasoning":
+                delta = SimpleNamespace(
+                    role=None,
+                    content=None,
+                    tool_calls=None,
+                    reasoning=payload,
+                    reasoning_content=payload,
+                )
+                yield SimpleNamespace(
+                    choices=[SimpleNamespace(index=0, delta=delta, finish_reason=None)],
+                    model=model,
+                    usage=None,
+                )
+            elif kind == "error":
+                worker.join(timeout=2)
+                raise payload
+            elif kind == "done":
+                text, reasoning = payload
+                completion = self._build_completion(text, reasoning or "", model)
+                # Emit terminal tool-call / finish frames (tool calls are only
+                # known after the full ACP text is assembled).
+                for chunk in _completion_to_stream_chunks(completion):
+                    # Skip the bulk content frame if we already streamed tokens
+                    # — only keep tool_call + finish + usage frames.
+                    choice0 = chunk.choices[0] if chunk.choices else None
+                    delta = getattr(choice0, "delta", None) if choice0 else None
+                    content = getattr(delta, "content", None) if delta else None
+                    tool_calls = getattr(delta, "tool_calls", None) if delta else None
+                    finish = getattr(choice0, "finish_reason", None) if choice0 else None
+                    if content and not tool_calls and not finish and role_sent:
+                        continue
+                    if content and role_sent and not tool_calls:
+                        # Strip already-streamed content from the finish frame.
+                        if delta is not None:
+                            delta.content = None
+                    yield chunk
+                break
+
+        worker.join(timeout=5)
 
     def _spawn_process(self) -> subprocess.Popen[str]:
         label = self._acp_display_name
@@ -729,6 +835,8 @@ class CopilotACPClient:
         timeout_seconds: float,
         text_parts: list[str] | None = None,
         reasoning_parts: list[str] | None = None,
+        on_text_chunk: Any = None,
+        on_reasoning_chunk: Any = None,
     ) -> Any:
         """Send one JSON-RPC request on the live transport. Caller holds ``_rpc_lock``."""
         label = self._acp_display_name
@@ -764,6 +872,8 @@ class CopilotACPClient:
                 cwd=self._acp_cwd,
                 text_parts=text_parts,
                 reasoning_parts=reasoning_parts,
+                on_text_chunk=on_text_chunk,
+                on_reasoning_chunk=on_reasoning_chunk,
             ):
                 continue
 
@@ -831,6 +941,8 @@ class CopilotACPClient:
         tools: list[dict[str, Any]] | None,
         tool_choice: Any,
         timeout_seconds: float,
+        on_text_chunk: Any = None,
+        on_reasoning_chunk: Any = None,
     ) -> tuple[str, str]:
         """Run one completion, reusing process and optionally ACP session."""
         label = self._acp_display_name
@@ -862,7 +974,11 @@ class CopilotACPClient:
                     assert session_id is not None
                     try:
                         text, reasoning = self._session_prompt(
-                            session_id, prompt_text, timeout_seconds=timeout_seconds
+                            session_id,
+                            prompt_text,
+                            timeout_seconds=timeout_seconds,
+                            on_text_chunk=on_text_chunk,
+                            on_reasoning_chunk=on_reasoning_chunk,
                         )
                         self._session_continues += 1
                         self._session_history = list(messages)
@@ -894,7 +1010,11 @@ class CopilotACPClient:
                 self._session_count += 1
 
                 text, reasoning = self._session_prompt(
-                    session_id, prompt_text, timeout_seconds=timeout_seconds
+                    session_id,
+                    prompt_text,
+                    timeout_seconds=timeout_seconds,
+                    on_text_chunk=on_text_chunk,
+                    on_reasoning_chunk=on_reasoning_chunk,
                 )
                 self._session_history = list(messages)
                 return text, reasoning
@@ -913,6 +1033,8 @@ class CopilotACPClient:
         prompt_text: str,
         *,
         timeout_seconds: float,
+        on_text_chunk: Any = None,
+        on_reasoning_chunk: Any = None,
     ) -> tuple[str, str]:
         text_parts: list[str] = []
         reasoning_parts: list[str] = []
@@ -930,6 +1052,8 @@ class CopilotACPClient:
             timeout_seconds=timeout_seconds,
             text_parts=text_parts,
             reasoning_parts=reasoning_parts,
+            on_text_chunk=on_text_chunk,
+            on_reasoning_chunk=on_reasoning_chunk,
         )
         return "".join(text_parts), "".join(reasoning_parts)
 
@@ -951,6 +1075,8 @@ class CopilotACPClient:
         cwd: str,
         text_parts: list[str] | None,
         reasoning_parts: list[str] | None,
+        on_text_chunk: Any = None,
+        on_reasoning_chunk: Any = None,
     ) -> bool:
         method = msg.get("method")
         if not isinstance(method, str):
@@ -964,10 +1090,22 @@ class CopilotACPClient:
             chunk_text = ""
             if isinstance(content, dict):
                 chunk_text = str(content.get("text") or "")
-            if kind == "agent_message_chunk" and chunk_text and text_parts is not None:
-                text_parts.append(chunk_text)
-            elif kind == "agent_thought_chunk" and chunk_text and reasoning_parts is not None:
-                reasoning_parts.append(chunk_text)
+            if kind == "agent_message_chunk" and chunk_text:
+                if text_parts is not None:
+                    text_parts.append(chunk_text)
+                if on_text_chunk is not None:
+                    try:
+                        on_text_chunk(chunk_text)
+                    except Exception:
+                        pass
+            elif kind == "agent_thought_chunk" and chunk_text:
+                if reasoning_parts is not None:
+                    reasoning_parts.append(chunk_text)
+                if on_reasoning_chunk is not None:
+                    try:
+                        on_reasoning_chunk(chunk_text)
+                    except Exception:
+                        pass
             return True
 
         if process.stdin is None:

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -393,8 +393,36 @@ class _ACPChatNamespace:
         self.completions = _ACPChatCompletions(client)
 
 
+def _coalesce_acp_args(
+    acp_args: list[str] | None,
+    args: list[str] | None,
+    default_args_fn,
+) -> list[str]:
+    """Resolve ACP CLI args without treating ``[]`` as intentional.
+
+    Call sites sometimes pass ``args=[]`` when runtime wiring forgot to
+    forward the provider defaults (e.g. oneshot). An empty argv is never a
+    valid ACP launch, so fall back to the provider's defaults instead of
+    spawning a bare binary — and never leak a sibling provider's defaults
+    via truthiness fallbacks.
+    """
+    if acp_args is not None and len(acp_args) > 0:
+        return list(acp_args)
+    if args is not None and len(args) > 0:
+        return list(args)
+    return list(default_args_fn())
+
+
 class CopilotACPClient:
     """Minimal OpenAI-client-compatible facade for Copilot ACP."""
+
+    # Subclasses (e.g. DevinACPClient) override these so error messages and
+    # default model labels match the actual backend.
+    _acp_display_name = "Copilot ACP"
+    _default_model_name = "copilot-acp"
+    _install_hint = (
+        "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH."
+    )
 
     def __init__(
         self,
@@ -409,11 +437,11 @@ class CopilotACPClient:
         args: list[str] | None = None,
         **_: Any,
     ):
-        self.api_key = api_key or "copilot-acp"
+        self.api_key = api_key or self._default_model_name
         self.base_url = base_url or ACP_MARKER_BASE_URL
         self._default_headers = dict(default_headers or {})
         self._acp_command = acp_command or command or _resolve_command()
-        self._acp_args = list(acp_args or args or _resolve_args())
+        self._acp_args = _coalesce_acp_args(acp_args, args, _resolve_args)
         self._acp_cwd = str(Path(acp_cwd or os.getcwd()).resolve())
         self.chat = _ACPChatNamespace(self)
         self.is_closed = False
@@ -495,13 +523,14 @@ class CopilotACPClient:
         completion = SimpleNamespace(
             choices=[choice],
             usage=usage,
-            model=model or "copilot-acp",
+            model=model or self._default_model_name,
         )
         if stream:
             return _completion_to_stream_chunks(completion)
         return completion
 
     def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
+        label = self._acp_display_name
         try:
             proc = subprocess.Popen(
                 [self._acp_command] + self._acp_args,
@@ -515,13 +544,13 @@ class CopilotACPClient:
             )
         except FileNotFoundError as exc:
             raise RuntimeError(
-                f"Could not start Copilot ACP command '{self._acp_command}'. "
-                "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH."
+                f"Could not start {label} command '{self._acp_command}'. "
+                f"{self._install_hint}"
             ) from exc
 
         if proc.stdin is None or proc.stdout is None:
             proc.kill()
-            raise RuntimeError("Copilot ACP process did not expose stdin/stdout pipes.")
+            raise RuntimeError(f"{label} process did not expose stdin/stdout pipes.")
 
         self.is_closed = False
         with self._active_process_lock:
@@ -588,7 +617,7 @@ class CopilotACPClient:
                 if "error" in msg:
                     err = msg.get("error") or {}
                     raise RuntimeError(
-                        f"Copilot ACP {method} failed: {err.get('message') or err}"
+                        f"{label} {method} failed: {err.get('message') or err}"
                     )
                 return msg.get("result")
 
@@ -609,8 +638,8 @@ class CopilotACPClient:
                         "directly with a Copilot subscription token) via `hermes setup`.\n\n"
                         f"Original error:\n{stderr_text}"
                     )
-                raise RuntimeError(f"Copilot ACP process exited early: {stderr_text}")
-            raise TimeoutError(f"Timed out waiting for Copilot ACP response to {method}.")
+                raise RuntimeError(f"{label} process exited early: {stderr_text}")
+            raise TimeoutError(f"Timed out waiting for {label} response to {method}.")
 
         try:
             _request(
@@ -639,7 +668,7 @@ class CopilotACPClient:
             ) or {}
             session_id = str(session.get("sessionId") or "").strip()
             if not session_id:
-                raise RuntimeError("Copilot ACP did not return a sessionId.")
+                raise RuntimeError(f"{label} did not return a sessionId.")
 
             text_parts: list[str] = []
             reasoning_parts: list[str] = []

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -159,6 +159,110 @@ def _permission_denied(message_id: Any) -> dict[str, Any]:
     }
 
 
+def _permission_auto_selected(message_id: Any, options: Any) -> dict[str, Any]:
+    """Auto-select an allow option so ACP agent tools can run without a UI.
+
+    Preference: allow_always → allow_once → first option. Falls back to
+    cancelled when no options are present.
+    """
+    opts = options if isinstance(options, list) else []
+    option_id = None
+    for preferred in ("allow_always", "allow_once"):
+        for opt in opts:
+            if not isinstance(opt, dict):
+                continue
+            kind = str(opt.get("kind") or "").strip().lower()
+            if kind == preferred:
+                option_id = opt.get("optionId") or opt.get("option_id")
+                if option_id:
+                    break
+        if option_id:
+            break
+    if not option_id:
+        for opt in opts:
+            if not isinstance(opt, dict):
+                continue
+            kind = str(opt.get("kind") or "").strip().lower()
+            if kind.startswith("allow"):
+                option_id = opt.get("optionId") or opt.get("option_id")
+                if option_id:
+                    break
+    if not option_id and opts and isinstance(opts[0], dict):
+        option_id = opts[0].get("optionId") or opts[0].get("option_id")
+    if not option_id:
+        return _permission_denied(message_id)
+    return {
+        "jsonrpc": "2.0",
+        "id": message_id,
+        "result": {
+            "outcome": {
+                "outcome": "selected",
+                "optionId": str(option_id),
+            }
+        },
+    }
+
+
+def _acp_auto_approve_enabled() -> bool:
+    """Whether ACP permission prompts should be auto-approved.
+
+    Default on: ACP backends (Devin/Copilot) own their tool loop and Hermes
+    has no interactive permission UI in the chat path. Set
+    ``HERMES_ACP_AUTO_APPROVE=0`` to restore deny-all.
+    """
+    raw = os.getenv("HERMES_ACP_AUTO_APPROVE", "1").strip().lower()
+    return raw not in _REUSE_DISABLE_VALUES
+
+
+def _tool_update_text_preview(update: dict[str, Any], *, limit: int = 240) -> str:
+    """Best-effort human preview from an ACP tool_call / tool_call_update."""
+    title = str(update.get("title") or "").strip()
+    chunks: list[str] = []
+    content = update.get("content")
+    if isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            # type: content → nested content.text; or plain text fields
+            inner = block.get("content")
+            if isinstance(inner, dict):
+                text = str(inner.get("text") or "").strip()
+                if text:
+                    chunks.append(text)
+            text = str(block.get("text") or "").strip()
+            if text:
+                chunks.append(text)
+            if block.get("type") == "diff":
+                path = str(block.get("path") or "").strip()
+                if path:
+                    chunks.append(f"diff {path}")
+    elif isinstance(content, dict):
+        text = str(content.get("text") or "").strip()
+        if text:
+            chunks.append(text)
+    raw_in = update.get("rawInput")
+    if isinstance(raw_in, dict) and not chunks:
+        # compact path/command hints
+        for key in ("path", "file", "command", "query", "url", "pattern"):
+            if raw_in.get(key):
+                chunks.append(f"{key}={raw_in.get(key)}")
+                break
+    body = " · ".join(chunks).strip()
+    if title and body:
+        preview = f"{title}: {body}"
+    else:
+        preview = title or body or "ACP tool"
+    if len(preview) > limit:
+        return preview[: limit - 1] + "…"
+    return preview
+
+
+def _tool_kind_name(update: dict[str, Any]) -> str:
+    kind = str(update.get("kind") or "other").strip().lower() or "other"
+    # Prefer a stable synthetic name the Desktop tool strip can show.
+    return f"acp_{kind}"
+
+
 def _message_continuity_key(message: dict[str, Any]) -> tuple[Any, ...]:
     """Stable identity for prefix-matching conversation history."""
     role = str(message.get("role") or "").strip().lower()
@@ -540,6 +644,53 @@ class CopilotACPClient:
         self._session_history: list[dict[str, Any]] = []
         self._session_count = 0  # test/metrics: session/new calls
         self._session_continues = 0  # test/metrics: prompts reusing sessionId
+        # Optional AIAgent (or compatible) for tool_progress / status / activity.
+        # Bound after construction via bind_agent_activity() so create_openai_client
+        # can wire Desktop/TUI progress without coupling constructors.
+        self._activity_agent: Any = None
+        # toolCallId → last title (for completed events that omit title)
+        self._tool_titles: dict[str, str] = {}
+
+    def bind_agent_activity(self, agent: Any) -> None:
+        """Attach an AIAgent so ACP tool/session updates surface in the UI."""
+        self._activity_agent = agent
+
+    def _emit_acp_activity(
+        self,
+        event_type: str,
+        name: str,
+        preview: str,
+        args: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Push tool progress + status so the UI doesn't look frozen mid-turn."""
+        agent = self._activity_agent
+        if agent is None:
+            return
+        label = preview or name or "ACP activity"
+        try:
+            touch = getattr(agent, "_touch_activity", None)
+            if callable(touch):
+                touch(f"{self._acp_display_name}: {label}")
+        except Exception:
+            pass
+        try:
+            cb = getattr(agent, "tool_progress_callback", None)
+            if callable(cb):
+                cb(event_type, name, preview, args or {}, **kwargs)
+        except Exception:
+            pass
+        # Lifecycle line for gateway/desktop status strip (spinner text).
+        if event_type in {"tool.started", "tool.completed"}:
+            try:
+                emit = getattr(agent, "_emit_status", None)
+                if callable(emit):
+                    # ASCII-only markers — Windows CP* consoles choke on
+                    # ellipsis/check glyphs in status paths.
+                    verb = "... " if event_type == "tool.started" else "done "
+                    emit(f"{self._acp_display_name} {verb}{label}")
+            except Exception:
+                pass
 
     def close(self) -> None:
         """Tear down the ACP subprocess and mark the client closed."""
@@ -773,18 +924,55 @@ class CopilotACPClient:
 
         worker.join(timeout=5)
 
+    def _subprocess_env(self) -> dict[str, str]:
+        """Environment for the ACP child process. Subclasses may extend."""
+        return _build_subprocess_env()
+
+    def _spawn_argv(self) -> list[str]:
+        """Argv for the ACP child process. Subclasses may extend."""
+        return [self._acp_command] + list(self._acp_args)
+
+    def _prepare_for_model(self, model: str | None) -> None:
+        """Hook before initialize/prompt so backends can rebind model state.
+
+        Copilot ACP ignores Hermes model ids (no process-level model switch).
+        DevinACPClient overrides this to set DEVIN_MODEL and respawn when needed.
+        """
+        del model
+
+    def _apply_session_model(
+        self,
+        session_id: str,
+        session: dict[str, Any],
+        model: str | None,
+        *,
+        timeout_seconds: float,
+    ) -> None:
+        """Hook after ``session/new`` to bind the Hermes-selected model.
+
+        Default no-op. DevinACPClient uses ``session/set_config_option``.
+        """
+        del session_id, session, model, timeout_seconds
+
     def _spawn_process(self) -> subprocess.Popen[str]:
         label = self._acp_display_name
         try:
+            # Force UTF-8 on the child pipes. On Windows the default console
+            # encoding is often cp950/cp1252; Devin/Copilot ACP logs use UTF-8
+            # (and occasionally raw bytes), so text=True alone raises
+            # UnicodeDecodeError in the stderr reader and can leave the
+            # transport half-dead while the UI shows no tokens.
             proc = subprocess.Popen(
-                [self._acp_command] + self._acp_args,
+                self._spawn_argv(),
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 bufsize=1,
                 cwd=self._acp_cwd,
-                env=_build_subprocess_env(),
+                env=self._subprocess_env(),
             )
         except FileNotFoundError as exc:
             raise RuntimeError(
@@ -948,6 +1136,9 @@ class CopilotACPClient:
         label = self._acp_display_name
         with self._rpc_lock:
             try:
+                # Allow backends (Devin) to rebind process-level model before
+                # initialize — may tear down a warm process when the model changes.
+                self._prepare_for_model(model)
                 self._ensure_initialized(timeout_seconds=timeout_seconds)
 
                 prefix_len = 0
@@ -1008,6 +1199,14 @@ class CopilotACPClient:
                     raise RuntimeError(f"{label} did not return a sessionId.")
                 self._session_id = session_id
                 self._session_count += 1
+                # Subclasses (Devin) bind model via ACP session/set_config_option;
+                # CLI --model is ignored by some ACP agents.
+                self._apply_session_model(
+                    session_id,
+                    session,
+                    model,
+                    timeout_seconds=timeout_seconds,
+                )
 
                 text, reasoning = self._session_prompt(
                     session_id,
@@ -1038,6 +1237,21 @@ class CopilotACPClient:
     ) -> tuple[str, str]:
         text_parts: list[str] = []
         reasoning_parts: list[str] = []
+        # Immediate status so the UI shows activity before the first token/tool.
+        # Devin often spends 10-60s connecting user MCP servers after
+        # session/prompt with zero agent_message_chunk — without this the
+        # chat looks frozen / "no opening reply".
+        try:
+            agent = self._activity_agent
+            emit = getattr(agent, "_emit_status", None) if agent else None
+            touch = getattr(agent, "_touch_activity", None) if agent else None
+            msg = f"{self._acp_display_name} working (may connect MCP tools first)..."
+            if callable(touch):
+                touch(msg)
+            if callable(emit):
+                emit(msg)
+        except Exception:
+            pass
         self._rpc(
             "session/prompt",
             {
@@ -1085,6 +1299,8 @@ class CopilotACPClient:
         if method == "session/update":
             params = msg.get("params") or {}
             update = params.get("update") or {}
+            if not isinstance(update, dict):
+                update = {}
             kind = str(update.get("sessionUpdate") or "").strip()
             content = update.get("content") or {}
             chunk_text = ""
@@ -1106,6 +1322,22 @@ class CopilotACPClient:
                         on_reasoning_chunk(chunk_text)
                     except Exception:
                         pass
+            elif kind in {"tool_call", "tool_call_update"}:
+                self._handle_tool_session_update(kind, update)
+            elif kind in {
+                "available_commands_update",
+                "current_mode_update",
+                "config_option_update",
+                "plan",
+            }:
+                # Heartbeat so long turns still touch activity even without tools.
+                try:
+                    agent = self._activity_agent
+                    touch = getattr(agent, "_touch_activity", None) if agent else None
+                    if callable(touch):
+                        touch(f"{self._acp_display_name}: {kind.replace('_', ' ')}")
+                except Exception:
+                    pass
             return True
 
         if process.stdin is None:
@@ -1115,7 +1347,22 @@ class CopilotACPClient:
         params = msg.get("params") or {}
 
         if method == "session/request_permission":
-            response = _permission_denied(message_id)
+            if _acp_auto_approve_enabled():
+                response = _permission_auto_selected(
+                    message_id, params.get("options")
+                )
+                # Surface the pending tool in the activity strip.
+                tool_call = params.get("toolCall") or params.get("tool_call") or {}
+                if isinstance(tool_call, dict):
+                    preview = _tool_update_text_preview(tool_call)
+                    self._emit_acp_activity(
+                        "tool.started",
+                        _tool_kind_name(tool_call),
+                        preview or "awaiting permission (auto-approved)",
+                        {"toolCallId": tool_call.get("toolCallId")},
+                    )
+            else:
+                response = _permission_denied(message_id)
         elif method == "fs/read_text_file":
             try:
                 path = _ensure_path_within_cwd(str(params.get("path") or ""), cwd)
@@ -1170,3 +1417,63 @@ class CopilotACPClient:
         process.stdin.write(json.dumps(response) + "\n")
         process.stdin.flush()
         return True
+
+    def _handle_tool_session_update(self, kind: str, update: dict[str, Any]) -> None:
+        """Map ACP tool_call / tool_call_update notifications onto Hermes progress."""
+        tool_id = str(update.get("toolCallId") or update.get("tool_call_id") or "").strip()
+        title = str(update.get("title") or "").strip()
+        if title and tool_id:
+            self._tool_titles[tool_id] = title
+        elif tool_id and not title:
+            title = self._tool_titles.get(tool_id, "")
+
+        status = str(update.get("status") or "").strip().lower()
+        preview = _tool_update_text_preview(
+            {**update, "title": title or update.get("title")}
+        )
+        name = _tool_kind_name(update)
+        args: dict[str, Any] = {
+            "toolCallId": tool_id or None,
+            "kind": update.get("kind"),
+            "status": status or None,
+        }
+        locations = update.get("locations")
+        if isinstance(locations, list) and locations:
+            paths = []
+            for loc in locations[:3]:
+                if isinstance(loc, dict) and loc.get("path"):
+                    paths.append(str(loc["path"]))
+            if paths:
+                args["paths"] = paths
+
+        if kind == "tool_call" or status in {"", "pending", "in_progress"}:
+            event = "tool.started"
+            if status == "in_progress" and kind == "tool_call_update":
+                # Keep as started so UIs that only listen for started still refresh
+                # the preview; duration is unknown mid-flight.
+                event = "tool.started"
+            if status in {"completed", "failed"}:
+                event = "tool.completed"
+            self._emit_acp_activity(
+                event,
+                name,
+                preview,
+                args,
+                is_error=(status == "failed"),
+            )
+            return
+
+        if status in {"completed", "failed"}:
+            self._emit_acp_activity(
+                "tool.completed",
+                name,
+                preview,
+                args,
+                is_error=(status == "failed"),
+            )
+            if tool_id:
+                self._tool_titles.pop(tool_id, None)
+            return
+
+        # Unknown status — still heartbeat so the UI doesn't freeze.
+        self._emit_acp_activity("tool.started", name, preview, args)

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -1,9 +1,13 @@
 """OpenAI-compatible shim that forwards Hermes requests to `copilot --acp`.
 
 This adapter lets Hermes treat the GitHub Copilot ACP server as a chat-style
-backend. Each request starts a short-lived ACP session, sends the formatted
-conversation as a single prompt, collects text chunks, and converts the result
-back into the minimal shape Hermes expects from an OpenAI client.
+backend. Hermes keeps the ACP subprocess warm across turns on the same client
+instance (process reuse), opens a fresh ACP session per prompt (Hermes already
+embeds full conversation history), collects text chunks, and converts the
+result into the minimal shape Hermes expects from an OpenAI client.
+
+Disable process reuse with ``HERMES_ACP_PROCESS_REUSE=0`` (falls back to
+spawn-per-request).
 """
 
 from __future__ import annotations
@@ -32,6 +36,12 @@ from tools.environments.local import hermes_subprocess_env
 
 ACP_MARKER_BASE_URL = "acp://copilot"
 _DEFAULT_TIMEOUT_SECONDS = 900.0
+_REUSE_DISABLE_VALUES = frozenset({"0", "false", "no", "off"})
+
+
+def _acp_process_reuse_enabled() -> bool:
+    raw = os.getenv("HERMES_ACP_PROCESS_REUSE", "1").strip().lower()
+    return raw not in _REUSE_DISABLE_VALUES
 
 _TOOL_CALL_BLOCK_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
 _TOOL_CALL_JSON_RE = re.compile(r"\{\s*\"id\"\s*:\s*\"[^\"]+\"\s*,\s*\"type\"\s*:\s*\"function\"\s*,\s*\"function\"\s*:\s*\{.*?\}\s*\}", re.DOTALL)
@@ -445,25 +455,52 @@ class CopilotACPClient:
         self._acp_cwd = str(Path(acp_cwd or os.getcwd()).resolve())
         self.chat = _ACPChatNamespace(self)
         self.is_closed = False
+        self._reuse_enabled = _acp_process_reuse_enabled()
+        # Transport state for process reuse (guarded by _rpc_lock).
         self._active_process: subprocess.Popen[str] | None = None
         self._active_process_lock = threading.Lock()
+        self._rpc_lock = threading.Lock()
+        self._inbox: queue.Queue[dict[str, Any]] | None = None
+        self._stderr_tail: deque[str] | None = None
+        self._next_rpc_id = 0
+        self._initialized = False
+        self._spawn_count = 0  # test/metrics: how many times we Popen'd
 
     def close(self) -> None:
+        """Tear down the ACP subprocess and mark the client closed."""
+        with self._rpc_lock:
+            self._reset_transport(mark_closed=True)
+
+    def _reset_transport(self, *, mark_closed: bool = False) -> None:
+        """Kill any live process and clear reuse state. Caller holds ``_rpc_lock``."""
         proc: subprocess.Popen[str] | None
         with self._active_process_lock:
             proc = self._active_process
             self._active_process = None
-        self.is_closed = True
+        self._inbox = None
+        self._stderr_tail = None
+        self._next_rpc_id = 0
+        self._initialized = False
+        if mark_closed:
+            self.is_closed = True
         if proc is None:
             return
         try:
-            proc.terminate()
-            proc.wait(timeout=2)
+            if proc.poll() is None:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=2)
+                except Exception:
+                    proc.kill()
         except Exception:
             try:
                 proc.kill()
             except Exception:
                 pass
+
+    def _process_alive(self) -> bool:
+        proc = self._active_process
+        return proc is not None and proc.poll() is None
 
     def _create_chat_completion(
         self,
@@ -529,7 +566,7 @@ class CopilotACPClient:
             return _completion_to_stream_chunks(completion)
         return completion
 
-    def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
+    def _spawn_process(self) -> subprocess.Popen[str]:
         label = self._acp_display_name
         try:
             proc = subprocess.Popen(
@@ -558,6 +595,11 @@ class CopilotACPClient:
 
         inbox: queue.Queue[dict[str, Any]] = queue.Queue()
         stderr_tail: deque[str] = deque(maxlen=40)
+        self._inbox = inbox
+        self._stderr_tail = stderr_tail
+        self._next_rpc_id = 0
+        self._initialized = False
+        self._spawn_count += 1
 
         def _stdout_reader() -> None:
             if proc.stdout is None:
@@ -574,121 +616,155 @@ class CopilotACPClient:
             for line in proc.stderr:
                 stderr_tail.append(line.rstrip("\n"))
 
-        out_thread = threading.Thread(target=_stdout_reader, daemon=True)
-        err_thread = threading.Thread(target=_stderr_reader, daemon=True)
-        out_thread.start()
-        err_thread.start()
+        threading.Thread(target=_stdout_reader, daemon=True).start()
+        threading.Thread(target=_stderr_reader, daemon=True).start()
+        return proc
 
-        next_id = 0
+    def _rpc(
+        self,
+        method: str,
+        params: dict[str, Any],
+        *,
+        timeout_seconds: float,
+        text_parts: list[str] | None = None,
+        reasoning_parts: list[str] | None = None,
+    ) -> Any:
+        """Send one JSON-RPC request on the live transport. Caller holds ``_rpc_lock``."""
+        label = self._acp_display_name
+        proc = self._active_process
+        inbox = self._inbox
+        stderr_tail = self._stderr_tail
+        if proc is None or inbox is None or stderr_tail is None or proc.stdin is None:
+            raise RuntimeError(f"{label} transport is not ready.")
 
-        def _request(method: str, params: dict[str, Any], *, text_parts: list[str] | None = None, reasoning_parts: list[str] | None = None) -> Any:
-            nonlocal next_id
-            next_id += 1
-            request_id = next_id
-            payload = {
-                "jsonrpc": "2.0",
-                "id": request_id,
-                "method": method,
-                "params": params,
-            }
-            proc.stdin.write(json.dumps(payload) + "\n")
-            proc.stdin.flush()
+        self._next_rpc_id += 1
+        request_id = self._next_rpc_id
+        payload = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params,
+        }
+        proc.stdin.write(json.dumps(payload) + "\n")
+        proc.stdin.flush()
 
-            deadline = time.monotonic() + timeout_seconds
-            while time.monotonic() < deadline:
-                if proc.poll() is not None:
-                    break
-                try:
-                    msg = inbox.get(timeout=0.1)
-                except queue.Empty:
-                    continue
+        deadline = time.monotonic() + timeout_seconds
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                break
+            try:
+                msg = inbox.get(timeout=0.1)
+            except queue.Empty:
+                continue
 
-                if self._handle_server_message(
-                    msg,
-                    process=proc,
-                    cwd=self._acp_cwd,
-                    text_parts=text_parts,
-                    reasoning_parts=reasoning_parts,
-                ):
-                    continue
-
-                if msg.get("id") != request_id:
-                    continue
-                if "error" in msg:
-                    err = msg.get("error") or {}
-                    raise RuntimeError(
-                        f"{label} {method} failed: {err.get('message') or err}"
-                    )
-                return msg.get("result")
-
-            stderr_text = "\n".join(stderr_tail).strip()
-            if proc.poll() is not None and stderr_text:
-                if _is_gh_copilot_deprecation_message(stderr_text):
-                    raise RuntimeError(
-                        "Hermes ACP mode requires the NEW GitHub Copilot CLI "
-                        "(github.com/github/copilot-cli), but the binary it just "
-                        "spawned is the deprecated `gh copilot` extension.\n\n"
-                        "Install the new CLI:\n"
-                        "  npm install -g @github/copilot\n"
-                        "  # then verify with: copilot --help\n\n"
-                        "If `copilot` already resolves to the new CLI but you still see this,\n"
-                        "point Hermes at it explicitly:\n"
-                        "  export HERMES_COPILOT_ACP_COMMAND=/path/to/new/copilot\n\n"
-                        "Alternative: use the `copilot` provider (no ACP, hits the Copilot API\n"
-                        "directly with a Copilot subscription token) via `hermes setup`.\n\n"
-                        f"Original error:\n{stderr_text}"
-                    )
-                raise RuntimeError(f"{label} process exited early: {stderr_text}")
-            raise TimeoutError(f"Timed out waiting for {label} response to {method}.")
-
-        try:
-            _request(
-                "initialize",
-                {
-                    "protocolVersion": 1,
-                    "clientCapabilities": {
-                        "fs": {
-                            "readTextFile": True,
-                            "writeTextFile": True,
-                        }
-                    },
-                    "clientInfo": {
-                        "name": "hermes-agent",
-                        "title": "Hermes Agent",
-                        "version": "0.0.0",
-                    },
-                },
-            )
-            session = _request(
-                "session/new",
-                {
-                    "cwd": self._acp_cwd,
-                    "mcpServers": [],
-                },
-            ) or {}
-            session_id = str(session.get("sessionId") or "").strip()
-            if not session_id:
-                raise RuntimeError(f"{label} did not return a sessionId.")
-
-            text_parts: list[str] = []
-            reasoning_parts: list[str] = []
-            _request(
-                "session/prompt",
-                {
-                    "sessionId": session_id,
-                    "prompt": [
-                        {
-                            "type": "text",
-                            "text": prompt_text,
-                        }
-                    ],
-                },
+            if self._handle_server_message(
+                msg,
+                process=proc,
+                cwd=self._acp_cwd,
                 text_parts=text_parts,
                 reasoning_parts=reasoning_parts,
-            )
-            return "".join(text_parts), "".join(reasoning_parts)
-        finally:
-            self.close()
+            ):
+                continue
+
+            if msg.get("id") != request_id:
+                continue
+            if "error" in msg:
+                err = msg.get("error") or {}
+                raise RuntimeError(
+                    f"{label} {method} failed: {err.get('message') or err}"
+                )
+            return msg.get("result")
+
+        stderr_text = "\n".join(stderr_tail).strip()
+        if proc.poll() is not None and stderr_text:
+            if _is_gh_copilot_deprecation_message(stderr_text):
+                raise RuntimeError(
+                    "Hermes ACP mode requires the NEW GitHub Copilot CLI "
+                    "(github.com/github/copilot-cli), but the binary it just "
+                    "spawned is the deprecated `gh copilot` extension.\n\n"
+                    "Install the new CLI:\n"
+                    "  npm install -g @github/copilot\n"
+                    "  # then verify with: copilot --help\n\n"
+                    "If `copilot` already resolves to the new CLI but you still see this,\n"
+                    "point Hermes at it explicitly:\n"
+                    "  export HERMES_COPILOT_ACP_COMMAND=/path/to/new/copilot\n\n"
+                    "Alternative: use the `copilot` provider (no ACP, hits the Copilot API\n"
+                    "directly with a Copilot subscription token) via `hermes setup`.\n\n"
+                    f"Original error:\n{stderr_text}"
+                )
+            raise RuntimeError(f"{label} process exited early: {stderr_text}")
+        raise TimeoutError(f"Timed out waiting for {label} response to {method}.")
+
+    def _ensure_initialized(self, *, timeout_seconds: float) -> None:
+        """Spawn (if needed) and run ACP ``initialize`` once per process."""
+        if self._process_alive() and self._initialized:
+            return
+        if not self._process_alive():
+            self._reset_transport(mark_closed=False)
+            self._spawn_process()
+        self._rpc(
+            "initialize",
+            {
+                "protocolVersion": 1,
+                "clientCapabilities": {
+                    "fs": {
+                        "readTextFile": True,
+                        "writeTextFile": True,
+                    }
+                },
+                "clientInfo": {
+                    "name": "hermes-agent",
+                    "title": "Hermes Agent",
+                    "version": "0.0.0",
+                },
+            },
+            timeout_seconds=timeout_seconds,
+        )
+        self._initialized = True
+
+    def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
+        label = self._acp_display_name
+        with self._rpc_lock:
+            try:
+                self._ensure_initialized(timeout_seconds=timeout_seconds)
+                session = self._rpc(
+                    "session/new",
+                    {
+                        "cwd": self._acp_cwd,
+                        "mcpServers": [],
+                    },
+                    timeout_seconds=timeout_seconds,
+                ) or {}
+                session_id = str(session.get("sessionId") or "").strip()
+                if not session_id:
+                    raise RuntimeError(f"{label} did not return a sessionId.")
+
+                text_parts: list[str] = []
+                reasoning_parts: list[str] = []
+                self._rpc(
+                    "session/prompt",
+                    {
+                        "sessionId": session_id,
+                        "prompt": [
+                            {
+                                "type": "text",
+                                "text": prompt_text,
+                            }
+                        ],
+                    },
+                    timeout_seconds=timeout_seconds,
+                    text_parts=text_parts,
+                    reasoning_parts=reasoning_parts,
+                )
+                return "".join(text_parts), "".join(reasoning_parts)
+            except Exception:
+                # Drop a possibly-poisoned transport so the next call gets a
+                # clean process rather than fighting a half-dead inbox.
+                self._reset_transport(mark_closed=False)
+                raise
+            finally:
+                if not self._reuse_enabled:
+                    self._reset_transport(mark_closed=True)
 
     def _handle_server_message(
         self,

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -1,13 +1,18 @@
 """OpenAI-compatible shim that forwards Hermes requests to `copilot --acp`.
 
 This adapter lets Hermes treat the GitHub Copilot ACP server as a chat-style
-backend. Hermes keeps the ACP subprocess warm across turns on the same client
-instance (process reuse), opens a fresh ACP session per prompt (Hermes already
-embeds full conversation history), collects text chunks, and converts the
-result into the minimal shape Hermes expects from an OpenAI client.
+backend.
 
-Disable process reuse with ``HERMES_ACP_PROCESS_REUSE=0`` (falls back to
-spawn-per-request).
+Lifecycle (defaults on):
+- **Process reuse** — keep the ACP subprocess warm across turns.
+- **Session continuity** — when conversation history is a strict extension of
+  the previous request, keep the ACP ``sessionId`` and send only the new
+  messages (smaller prompts; tool-loop friendly).
+
+Disable with env:
+- ``HERMES_ACP_PROCESS_REUSE=0`` — spawn per request
+- ``HERMES_ACP_SESSION_REUSE=0`` — new ``session/new`` every prompt (still
+  reuses the process when process reuse is on)
 """
 
 from __future__ import annotations
@@ -42,6 +47,16 @@ _REUSE_DISABLE_VALUES = frozenset({"0", "false", "no", "off"})
 def _acp_process_reuse_enabled() -> bool:
     raw = os.getenv("HERMES_ACP_PROCESS_REUSE", "1").strip().lower()
     return raw not in _REUSE_DISABLE_VALUES
+
+
+def _acp_session_reuse_enabled() -> bool:
+    """Session continuity defaults to on whenever process reuse is on."""
+    raw = os.getenv("HERMES_ACP_SESSION_REUSE", "").strip().lower()
+    if raw in _REUSE_DISABLE_VALUES:
+        return False
+    if raw in {"1", "true", "yes", "on"}:
+        return True
+    return _acp_process_reuse_enabled()
 
 _TOOL_CALL_BLOCK_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
 _TOOL_CALL_JSON_RE = re.compile(r"\{\s*\"id\"\s*:\s*\"[^\"]+\"\s*,\s*\"type\"\s*:\s*\"function\"\s*,\s*\"function\"\s*:\s*\{.*?\}\s*\}", re.DOTALL)
@@ -144,18 +159,66 @@ def _permission_denied(message_id: Any) -> dict[str, Any]:
     }
 
 
+def _message_continuity_key(message: dict[str, Any]) -> tuple[Any, ...]:
+    """Stable identity for prefix-matching conversation history."""
+    role = str(message.get("role") or "").strip().lower()
+    content = _render_message_content(message.get("content"))
+    tool_sig: tuple[Any, ...] = ()
+    raw_tcs = message.get("tool_calls")
+    if isinstance(raw_tcs, list) and raw_tcs:
+        names: list[str] = []
+        for tc in raw_tcs:
+            if isinstance(tc, dict):
+                fn = tc.get("function") if isinstance(tc.get("function"), dict) else {}
+                names.append(str(fn.get("name") or tc.get("name") or ""))
+            else:
+                fn = getattr(tc, "function", None)
+                name = getattr(fn, "name", None) if fn is not None else getattr(tc, "name", None)
+                names.append(str(name or ""))
+        tool_sig = tuple(names)
+    tool_call_id = str(message.get("tool_call_id") or "")
+    return (role, content, tool_sig, tool_call_id)
+
+
+def _common_message_prefix_len(
+    previous: list[dict[str, Any]] | None,
+    current: list[dict[str, Any]],
+) -> int:
+    if not previous:
+        return 0
+    n = 0
+    for left, right in zip(previous, current):
+        if not isinstance(left, dict) or not isinstance(right, dict):
+            break
+        if _message_continuity_key(left) != _message_continuity_key(right):
+            break
+        n += 1
+    return n
+
+
 def _format_messages_as_prompt(
     messages: list[dict[str, Any]],
     model: str | None = None,
     tools: list[dict[str, Any]] | None = None,
     tool_choice: Any = None,
+    *,
+    continuation: bool = False,
 ) -> str:
-    sections: list[str] = [
-        "You are being used as the active ACP agent backend for Hermes.",
-        "Use ACP capabilities to complete tasks.",
-        "IMPORTANT: If you take an action with a tool, you MUST output tool calls using <tool_call>{...}</tool_call> blocks with JSON exactly in OpenAI function-call shape.",
-        "If no tool is needed, answer normally.",
-    ]
+    sections: list[str] = []
+    if continuation:
+        sections.append(
+            "Continue the same ACP session. The messages below are NEW since "
+            "the previous prompt — do not restate earlier context unless needed."
+        )
+    else:
+        sections.extend(
+            [
+                "You are being used as the active ACP agent backend for Hermes.",
+                "Use ACP capabilities to complete tasks.",
+                "IMPORTANT: If you take an action with a tool, you MUST output tool calls using <tool_call>{...}</tool_call> blocks with JSON exactly in OpenAI function-call shape.",
+                "If no tool is needed, answer normally.",
+            ]
+        )
     if model:
         sections.append(f"Hermes requested model hint: {model}")
 
@@ -200,6 +263,11 @@ def _format_messages_as_prompt(
 
         content = message.get("content")
         rendered = _render_message_content(content)
+        # Keep tool-call-only assistant turns in the transcript for continuity.
+        if not rendered and role == "assistant" and message.get("tool_calls"):
+            rendered = "[tool_calls]"
+        if not rendered and role == "tool":
+            rendered = "[tool result]"
         if not rendered:
             continue
 
@@ -213,7 +281,8 @@ def _format_messages_as_prompt(
         transcript.append(f"{label}:\n{rendered}")
 
     if transcript:
-        sections.append("Conversation transcript:\n\n" + "\n\n".join(transcript))
+        heading = "New messages:\n\n" if continuation else "Conversation transcript:\n\n"
+        sections.append(heading + "\n\n".join(transcript))
 
     sections.append("Continue the conversation from the latest user request.")
     return "\n\n".join(section.strip() for section in sections if section and section.strip())
@@ -456,6 +525,7 @@ class CopilotACPClient:
         self.chat = _ACPChatNamespace(self)
         self.is_closed = False
         self._reuse_enabled = _acp_process_reuse_enabled()
+        self._session_reuse_enabled = _acp_session_reuse_enabled()
         # Transport state for process reuse (guarded by _rpc_lock).
         self._active_process: subprocess.Popen[str] | None = None
         self._active_process_lock = threading.Lock()
@@ -465,11 +535,43 @@ class CopilotACPClient:
         self._next_rpc_id = 0
         self._initialized = False
         self._spawn_count = 0  # test/metrics: how many times we Popen'd
+        # Session continuity state (same lock as transport).
+        self._session_id: str | None = None
+        self._session_history: list[dict[str, Any]] = []
+        self._session_count = 0  # test/metrics: session/new calls
+        self._session_continues = 0  # test/metrics: prompts reusing sessionId
 
     def close(self) -> None:
         """Tear down the ACP subprocess and mark the client closed."""
         with self._rpc_lock:
             self._reset_transport(mark_closed=True)
+
+    def interrupt(self) -> None:
+        """Abort any in-flight ACP RPC by killing the warm subprocess.
+
+        Does **not** wait on ``_rpc_lock`` so a blocked ``_rpc`` can observe
+        ``poll() != None`` and raise. Leaves the client reusable
+        (``is_closed`` stays False); the owning turn resets transport state.
+        """
+        with self._active_process_lock:
+            proc = self._active_process
+        if proc is None or proc.poll() is not None:
+            return
+        try:
+            proc.terminate()
+            try:
+                proc.wait(timeout=1)
+            except Exception:
+                proc.kill()
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+
+    def _reset_session_state(self) -> None:
+        self._session_id = None
+        self._session_history = []
 
     def _reset_transport(self, *, mark_closed: bool = False) -> None:
         """Kill any live process and clear reuse state. Caller holds ``_rpc_lock``."""
@@ -481,6 +583,7 @@ class CopilotACPClient:
         self._stderr_tail = None
         self._next_rpc_id = 0
         self._initialized = False
+        self._reset_session_state()
         if mark_closed:
             self.is_closed = True
         if proc is None:
@@ -513,12 +616,7 @@ class CopilotACPClient:
         stream: bool = False,
         **_: Any,
     ) -> Any:
-        prompt_text = _format_messages_as_prompt(
-            messages or [],
-            model=model,
-            tools=tools,
-            tool_choice=tool_choice,
-        )
+        msg_list = [m for m in (messages or []) if isinstance(m, dict)]
         # Normalise timeout: run_agent.py may pass an httpx.Timeout object
         # (used natively by the OpenAI SDK) rather than a plain float.
         if timeout is None:
@@ -535,8 +633,11 @@ class CopilotACPClient:
             _numeric = [float(v) for v in _candidates if isinstance(v, (int, float))]
             _effective_timeout = max(_numeric) if _numeric else _DEFAULT_TIMEOUT_SECONDS
 
-        response_text, reasoning_text = self._run_prompt(
-            prompt_text,
+        response_text, reasoning_text = self._run_conversation_prompt(
+            msg_list,
+            model=model,
+            tools=tools,
+            tool_choice=tool_choice,
             timeout_seconds=_effective_timeout,
         )
 
@@ -722,11 +823,62 @@ class CopilotACPClient:
         )
         self._initialized = True
 
-    def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
+    def _run_conversation_prompt(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        model: str | None,
+        tools: list[dict[str, Any]] | None,
+        tool_choice: Any,
+        timeout_seconds: float,
+    ) -> tuple[str, str]:
+        """Run one completion, reusing process and optionally ACP session."""
         label = self._acp_display_name
         with self._rpc_lock:
             try:
                 self._ensure_initialized(timeout_seconds=timeout_seconds)
+
+                prefix_len = 0
+                continue_session = False
+                if (
+                    self._session_reuse_enabled
+                    and self._session_id
+                    and self._process_alive()
+                    and self._initialized
+                ):
+                    prefix_len = _common_message_prefix_len(self._session_history, messages)
+                    if 0 < prefix_len < len(messages):
+                        continue_session = True
+
+                if continue_session:
+                    prompt_text = _format_messages_as_prompt(
+                        messages[prefix_len:],
+                        model=model,
+                        tools=tools,
+                        tool_choice=tool_choice,
+                        continuation=True,
+                    )
+                    session_id = self._session_id
+                    assert session_id is not None
+                    try:
+                        text, reasoning = self._session_prompt(
+                            session_id, prompt_text, timeout_seconds=timeout_seconds
+                        )
+                        self._session_continues += 1
+                        self._session_history = list(messages)
+                        return text, reasoning
+                    except Exception:
+                        # Session may have expired — fall through to a fresh
+                        # session/new with the full transcript on the same process.
+                        self._reset_session_state()
+
+                prompt_text = _format_messages_as_prompt(
+                    messages,
+                    model=model,
+                    tools=tools,
+                    tool_choice=tool_choice,
+                    continuation=False,
+                )
                 session = self._rpc(
                     "session/new",
                     {
@@ -738,25 +890,14 @@ class CopilotACPClient:
                 session_id = str(session.get("sessionId") or "").strip()
                 if not session_id:
                     raise RuntimeError(f"{label} did not return a sessionId.")
+                self._session_id = session_id
+                self._session_count += 1
 
-                text_parts: list[str] = []
-                reasoning_parts: list[str] = []
-                self._rpc(
-                    "session/prompt",
-                    {
-                        "sessionId": session_id,
-                        "prompt": [
-                            {
-                                "type": "text",
-                                "text": prompt_text,
-                            }
-                        ],
-                    },
-                    timeout_seconds=timeout_seconds,
-                    text_parts=text_parts,
-                    reasoning_parts=reasoning_parts,
+                text, reasoning = self._session_prompt(
+                    session_id, prompt_text, timeout_seconds=timeout_seconds
                 )
-                return "".join(text_parts), "".join(reasoning_parts)
+                self._session_history = list(messages)
+                return text, reasoning
             except Exception:
                 # Drop a possibly-poisoned transport so the next call gets a
                 # clean process rather than fighting a half-dead inbox.
@@ -765,6 +906,42 @@ class CopilotACPClient:
             finally:
                 if not self._reuse_enabled:
                     self._reset_transport(mark_closed=True)
+
+    def _session_prompt(
+        self,
+        session_id: str,
+        prompt_text: str,
+        *,
+        timeout_seconds: float,
+    ) -> tuple[str, str]:
+        text_parts: list[str] = []
+        reasoning_parts: list[str] = []
+        self._rpc(
+            "session/prompt",
+            {
+                "sessionId": session_id,
+                "prompt": [
+                    {
+                        "type": "text",
+                        "text": prompt_text,
+                    }
+                ],
+            },
+            timeout_seconds=timeout_seconds,
+            text_parts=text_parts,
+            reasoning_parts=reasoning_parts,
+        )
+        return "".join(text_parts), "".join(reasoning_parts)
+
+    def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
+        """Low-level single-blob prompt (tests / callers that skip message lists)."""
+        return self._run_conversation_prompt(
+            [{"role": "user", "content": prompt_text}],
+            model=None,
+            tools=None,
+            tool_choice=None,
+            timeout_seconds=timeout_seconds,
+        )
 
     def _handle_server_message(
         self,

--- a/agent/devin_acp_client.py
+++ b/agent/devin_acp_client.py
@@ -13,7 +13,7 @@ import os
 import shlex
 from typing import Any
 
-from agent.copilot_acp_client import CopilotACPClient
+from agent.copilot_acp_client import CopilotACPClient, _coalesce_acp_args
 
 ACP_MARKER_BASE_URL = "acp://devin"
 
@@ -37,6 +37,13 @@ def _resolve_args() -> list[str]:
 class DevinACPClient(CopilotACPClient):
     """Minimal OpenAI-client-compatible facade for Devin CLI ACP."""
 
+    _acp_display_name = "Devin ACP"
+    _default_model_name = "devin-acp"
+    _install_hint = (
+        "Install Devin CLI (https://docs.devin.ai/cli) and run "
+        "`devin auth login`, or set HERMES_DEVIN_ACP_COMMAND/DEVIN_CLI_PATH."
+    )
+
     def __init__(
         self,
         *,
@@ -50,15 +57,24 @@ class DevinACPClient(CopilotACPClient):
         args: list[str] | None = None,
         **kwargs: Any,
     ):
+        # Resolve against Devin defaults *before* super(), so an empty
+        # ``args=[]`` from incomplete call-site wiring cannot fall through to
+        # CopilotACPClient's module-level ``_resolve_args()`` (``--acp --stdio``).
+        resolved_command = acp_command or command or _resolve_command()
+        resolved_args = _coalesce_acp_args(acp_args, args, _resolve_args)
         super().__init__(
             api_key=api_key or "devin-acp",
             base_url=base_url or ACP_MARKER_BASE_URL,
             default_headers=default_headers,
-            acp_command=acp_command or command or _resolve_command(),
-            acp_args=list(acp_args if acp_args is not None else (args if args is not None else _resolve_args())),
+            acp_command=resolved_command,
+            acp_args=resolved_args,
             acp_cwd=acp_cwd,
             **kwargs,
         )
+        # Parent stores args via its own default_args_fn; re-assert Devin's
+        # resolved argv in case kwargs still carried a stale empty list.
+        self._acp_command = resolved_command
+        self._acp_args = resolved_args
 
     def _create_chat_completion(
         self,
@@ -80,20 +96,3 @@ class DevinACPClient(CopilotACPClient):
             stream=stream,
             **kwargs,
         )
-
-    def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
-        try:
-            return super()._run_prompt(prompt_text, timeout_seconds=timeout_seconds)
-        except RuntimeError as exc:
-            msg = str(exc)
-            if "Could not start Copilot ACP command" in msg:
-                raise RuntimeError(
-                    f"Could not start Devin ACP command '{self._acp_command}'. "
-                    "Install Devin CLI (https://docs.devin.ai/cli) and run "
-                    "`devin auth login`, or set HERMES_DEVIN_ACP_COMMAND/DEVIN_CLI_PATH."
-                ) from exc
-            if "Copilot ACP process did not expose" in msg:
-                raise RuntimeError(
-                    "Devin ACP process did not expose stdin/stdout pipes."
-                ) from exc
-            raise

--- a/agent/devin_acp_client.py
+++ b/agent/devin_acp_client.py
@@ -4,18 +4,46 @@ Mirrors :class:`agent.copilot_acp_client.CopilotACPClient` for Cognition's
 Devin CLI ACP mode (JSON-RPC over stdio). Process reuse and per-prompt
 ``session/new`` follow the shared ACP client lifecycle (see parent module).
 
-Docs: https://docs.devin.ai/cli/acp/jetbrains (``devin acp`` subcommand).
+Model selection (verified against Devin CLI 3000.x on Windows):
+  - CLI root ``devin --model X -p …`` honors ``X`` (non-ACP).
+  - ``devin acp`` **ignores** process-level ``--model`` / ``DEVIN_MODEL`` and
+    starts at config default (often ``swe-1-7``).
+  - The working switch is ACP ``session/set_config_option`` with
+    ``configId="model"`` and an ACP model *value* from
+    ``session/new`` → ``configOptions`` (hyphen ids such as ``swe-1-6-fast``,
+    not the dotted CLI ids from ``devin --model`` help).
+
+Hermes therefore:
+  1. Still passes ``--model`` / ``DEVIN_MODEL`` as a belt-and-suspenders hint.
+  2. After every ``session/new``, maps the Hermes model id onto an ACP option
+     value and calls ``session/set_config_option``.
+  3. Respawns the warm process when the Hermes model id changes.
+
+Docs: https://docs.devin.ai/cli/acp/jetbrains ·
+      https://agentclientprotocol.com/protocol/v1/session-config-options
 """
 
 from __future__ import annotations
 
+import logging
 import os
+import re
 import shlex
 from typing import Any
 
 from agent.copilot_acp_client import CopilotACPClient, _coalesce_acp_args
 
+logger = logging.getLogger(__name__)
+
 ACP_MARKER_BASE_URL = "acp://devin"
+
+# Hermes-side placeholder ids that mean "use Devin's own default model".
+_HERMES_PLACEHOLDER_MODELS = frozenset({
+    "devin-acp",
+    "devin",
+    "devin-cli",
+    "cognition-devin",
+})
 
 
 def _resolve_command() -> str:
@@ -32,6 +60,101 @@ def _resolve_args() -> list[str]:
         # Official JetBrains / Zed ACP config uses a single ``acp`` argument.
         return ["acp"]
     return shlex.split(raw)
+
+
+def _backend_model_id(model: str | None) -> str | None:
+    """Return Hermes model id for binding, or None to leave Devin's default."""
+    m = (model or "").strip()
+    if not m or m.lower() in _HERMES_PLACEHOLDER_MODELS:
+        return None
+    return m
+
+
+def _norm_model_token(value: str) -> str:
+    """Normalize model tokens for fuzzy matching (dots/underscores → hyphens)."""
+    s = (value or "").strip().lower()
+    s = s.replace("_", "-").replace(".", "-")
+    s = re.sub(r"-+", "-", s)
+    return s
+
+
+def resolve_devin_acp_model_value(
+    hermes_model: str | None,
+    config_options: list[dict[str, Any]] | None,
+) -> str | None:
+    """Map a Hermes/CLI model id onto a Devin ACP ``configOptions`` value.
+
+    ACP values look like ``swe-1-6-fast`` / ``claude-sonnet-5-medium`` /
+    ``MODEL_PRIVATE_11`` (Haiku). CLI ``--model`` help uses dotted short names
+    like ``swe-1.6-fast`` / ``claude-haiku-4.5``. Returns None when no mapping
+    is possible (caller should leave the session default).
+    """
+    wanted = _backend_model_id(hermes_model)
+    if not wanted:
+        return None
+
+    options: list[dict[str, str]] = []
+    for opt in config_options or []:
+        if not isinstance(opt, dict):
+            continue
+        if str(opt.get("id") or "") != "model":
+            continue
+        for entry in opt.get("options") or []:
+            if not isinstance(entry, dict):
+                continue
+            value = str(entry.get("value") or "").strip()
+            name = str(entry.get("name") or "").strip()
+            if value:
+                options.append({"value": value, "name": name})
+        break
+
+    if not options:
+        # No catalog — best-effort: convert dots to hyphens (CLI→ACP common case).
+        return _norm_model_token(wanted)
+
+    wanted_n = _norm_model_token(wanted)
+    # 1) Exact value match (already ACP id).
+    for entry in options:
+        if entry["value"] == wanted or _norm_model_token(entry["value"]) == wanted_n:
+            return entry["value"]
+
+    # 2) Value ends with / contains normalized token (e.g. swe-1-6-fast).
+    for entry in options:
+        vn = _norm_model_token(entry["value"])
+        if wanted_n == vn or vn.endswith(wanted_n) or wanted_n.endswith(vn):
+            return entry["value"]
+
+    # 3) Display name match (e.g. "Claude Haiku 4.5" ← claude-haiku-4.5).
+    wanted_words = re.sub(r"[-_.]+", " ", wanted_n).strip()
+    for entry in options:
+        name_n = _norm_model_token(entry["name"]).replace("-", " ")
+        if wanted_words and wanted_words in name_n:
+            return entry["value"]
+        # reverse: name tokens subset of wanted
+        name_compact = name_n.replace(" ", "-")
+        if name_compact and name_compact in wanted_n:
+            return entry["value"]
+
+    # 4) Family alias: opus/sonnet/swe/codex/gemini → first matching option.
+    family = wanted_n.split("-")[0]
+    family_map = {
+        "opus": "claude-opus",
+        "sonnet": "claude-sonnet",
+        "haiku": "haiku",
+        "swe": "swe-",
+        "codex": "codex",
+        "gemini": "gemini",
+        "gpt": "gpt-",
+        "adaptive": "adaptive",
+    }
+    needle = family_map.get(family, wanted_n)
+    for entry in options:
+        vn = _norm_model_token(entry["value"])
+        nn = _norm_model_token(entry["name"])
+        if needle in vn or needle in nn:
+            return entry["value"]
+
+    return None
 
 
 class DevinACPClient(CopilotACPClient):
@@ -75,6 +198,108 @@ class DevinACPClient(CopilotACPClient):
         # resolved argv in case kwargs still carried a stale empty list.
         self._acp_command = resolved_command
         self._acp_args = resolved_args
+        # Process-level model binding (None = leave CLI default alone).
+        self._desired_process_model: str | None = None
+        self._process_bound_model: str | None = None
+        # Last ACP config option value successfully applied (for tests/metrics).
+        self._session_model_value: str | None = None
+
+    def _prepare_for_model(self, model: str | None) -> None:
+        desired = _backend_model_id(model)
+        # Model change requires a new session (and preferably a clean process)
+        # so set_config_option cannot fight a stale warm session.
+        if desired != self._process_bound_model and self._process_alive():
+            self._reset_transport(mark_closed=False)
+        self._desired_process_model = desired
+
+    def _subprocess_env(self) -> dict[str, str]:
+        env = super()._subprocess_env()
+        desired = self._desired_process_model
+        if desired:
+            env["DEVIN_MODEL"] = desired
+        else:
+            # Avoid inheriting a stale host DEVIN_MODEL when Hermes wants default.
+            env.pop("DEVIN_MODEL", None)
+        return env
+
+    def _spawn_argv(self) -> list[str]:
+        # Keep CLI --model as a hint (honored for non-ACP; ignored by acp mode
+        # on current Devin builds — real switch is set_config_option below).
+        desired = self._desired_process_model
+        if desired:
+            return [self._acp_command, "--model", desired, *list(self._acp_args)]
+        return [self._acp_command, *list(self._acp_args)]
+
+    def _spawn_process(self):
+        proc = super()._spawn_process()
+        self._process_bound_model = self._desired_process_model
+        self._session_model_value = None
+        return proc
+
+    def _apply_session_model(
+        self,
+        session_id: str,
+        session: dict[str, Any],
+        model: str | None,
+        *,
+        timeout_seconds: float,
+    ) -> None:
+        desired = _backend_model_id(model) or self._desired_process_model
+        if not desired:
+            return
+
+        config_options = session.get("configOptions")
+        if not isinstance(config_options, list):
+            config_options = []
+
+        acp_value = resolve_devin_acp_model_value(desired, config_options)
+        if not acp_value:
+            logger.warning(
+                "Devin ACP: could not map Hermes model %r onto session configOptions",
+                desired,
+            )
+            return
+
+        # Skip RPC when session already on the requested value.
+        for opt in config_options:
+            if isinstance(opt, dict) and str(opt.get("id") or "") == "model":
+                if str(opt.get("currentValue") or "") == acp_value:
+                    self._session_model_value = acp_value
+                    return
+                break
+
+        try:
+            result = self._rpc(
+                "session/set_config_option",
+                {
+                    "sessionId": session_id,
+                    "configId": "model",
+                    "value": acp_value,
+                },
+                timeout_seconds=timeout_seconds,
+            ) or {}
+        except Exception as exc:
+            logger.warning(
+                "Devin ACP: session/set_config_option(model=%r) failed: %s",
+                acp_value,
+                exc,
+            )
+            return
+
+        # Confirm from response when present.
+        applied = acp_value
+        for opt in result.get("configOptions") or []:
+            if isinstance(opt, dict) and str(opt.get("id") or "") == "model":
+                cur = str(opt.get("currentValue") or "").strip()
+                if cur:
+                    applied = cur
+                break
+        self._session_model_value = applied
+        logger.info(
+            "Devin ACP: session model set hermes=%r → acp=%r",
+            desired,
+            applied,
+        )
 
     def _create_chat_completion(
         self,

--- a/agent/devin_acp_client.py
+++ b/agent/devin_acp_client.py
@@ -1,0 +1,99 @@
+"""OpenAI-compatible shim that forwards Hermes requests to ``devin acp``.
+
+Mirrors :class:`agent.copilot_acp_client.CopilotACPClient` for Cognition's
+Devin CLI ACP mode (JSON-RPC over stdio). Devin is launched as a short-lived
+subprocess per request, the same lifecycle Copilot ACP uses.
+
+Docs: https://docs.devin.ai/cli/acp/jetbrains (``devin acp`` subcommand).
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+from typing import Any
+
+from agent.copilot_acp_client import CopilotACPClient
+
+ACP_MARKER_BASE_URL = "acp://devin"
+
+
+def _resolve_command() -> str:
+    return (
+        os.getenv("HERMES_DEVIN_ACP_COMMAND", "").strip()
+        or os.getenv("DEVIN_CLI_PATH", "").strip()
+        or "devin"
+    )
+
+
+def _resolve_args() -> list[str]:
+    raw = os.getenv("HERMES_DEVIN_ACP_ARGS", "").strip()
+    if not raw:
+        # Official JetBrains / Zed ACP config uses a single ``acp`` argument.
+        return ["acp"]
+    return shlex.split(raw)
+
+
+class DevinACPClient(CopilotACPClient):
+    """Minimal OpenAI-client-compatible facade for Devin CLI ACP."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_headers: dict[str, str] | None = None,
+        acp_command: str | None = None,
+        acp_args: list[str] | None = None,
+        acp_cwd: str | None = None,
+        command: str | None = None,
+        args: list[str] | None = None,
+        **kwargs: Any,
+    ):
+        super().__init__(
+            api_key=api_key or "devin-acp",
+            base_url=base_url or ACP_MARKER_BASE_URL,
+            default_headers=default_headers,
+            acp_command=acp_command or command or _resolve_command(),
+            acp_args=list(acp_args if acp_args is not None else (args if args is not None else _resolve_args())),
+            acp_cwd=acp_cwd,
+            **kwargs,
+        )
+
+    def _create_chat_completion(
+        self,
+        *,
+        model: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        timeout: float | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: Any = None,
+        stream: bool = False,
+        **kwargs: Any,
+    ) -> Any:
+        return super()._create_chat_completion(
+            model=model or "devin-acp",
+            messages=messages,
+            timeout=timeout,
+            tools=tools,
+            tool_choice=tool_choice,
+            stream=stream,
+            **kwargs,
+        )
+
+    def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
+        try:
+            return super()._run_prompt(prompt_text, timeout_seconds=timeout_seconds)
+        except RuntimeError as exc:
+            msg = str(exc)
+            if "Could not start Copilot ACP command" in msg:
+                raise RuntimeError(
+                    f"Could not start Devin ACP command '{self._acp_command}'. "
+                    "Install Devin CLI (https://docs.devin.ai/cli) and run "
+                    "`devin auth login`, or set HERMES_DEVIN_ACP_COMMAND/DEVIN_CLI_PATH."
+                ) from exc
+            if "Copilot ACP process did not expose" in msg:
+                raise RuntimeError(
+                    "Devin ACP process did not expose stdin/stdout pipes."
+                ) from exc
+            raise

--- a/agent/devin_acp_client.py
+++ b/agent/devin_acp_client.py
@@ -1,8 +1,8 @@
 """OpenAI-compatible shim that forwards Hermes requests to ``devin acp``.
 
 Mirrors :class:`agent.copilot_acp_client.CopilotACPClient` for Cognition's
-Devin CLI ACP mode (JSON-RPC over stdio). Devin is launched as a short-lived
-subprocess per request, the same lifecycle Copilot ACP uses.
+Devin CLI ACP mode (JSON-RPC over stdio). Process reuse and per-prompt
+``session/new`` follow the shared ACP client lifecycle (see parent module).
 
 Docs: https://docs.devin.ai/cli/acp/jetbrains (``devin acp`` subcommand).
 """

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -623,6 +623,35 @@ def classify_api_error(
             should_fallback=True,
         )
 
+    # Local ACP subprocess backends (copilot-acp / devin-acp): permanent
+    # setup/config failures must not burn api_max_retries (each attempt
+    # re-spawns a CLI). Match narrow install/argv/pipe messages only.
+    if (
+        "could not start" in error_msg
+        and "acp" in error_msg
+        and ("command" in error_msg or "cli" in error_msg)
+    ) or (
+        "acp" in error_msg
+        and "did not expose stdin/stdout" in error_msg
+    ) or (
+        "unexpected argument" in error_msg
+        and ("--acp" in error_msg or "acp" in error_msg)
+    ):
+        return _result(
+            FailoverReason.format_error,
+            retryable=False,
+            should_fallback=True,
+        )
+    if (
+        "devin auth login" in error_msg
+        or ("acp" in error_msg and "not logged in" in error_msg)
+    ):
+        return _result(
+            FailoverReason.auth_permanent,
+            retryable=False,
+            should_fallback=False,
+        )
+
     # Anthropic thinking block recovery (400).  Two distinct failure modes,
     # same recovery (strip all reasoning_details and retry without thinking
     # blocks — see the thinking_signature handler in conversation_loop.py):

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -46,7 +46,7 @@ def _resolve_requests_verify() -> bool | str:
 # Only these are stripped — Ollama-style "model:tag" colons (e.g. "qwen3.5:27b")
 # are preserved so the full model name reaches cache lookups and server queries.
 _PROVIDER_PREFIXES: frozenset[str] = frozenset({
-    "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
+    "openrouter", "nous", "openai-codex", "copilot", "copilot-acp", "devin-acp",
     "gemini", "ollama-cloud", "zai", "kimi-coding", "kimi-coding-cn", "stepfun", "minimax", "minimax-oauth", "minimax-cn", "anthropic", "deepseek",
     "opencode-zen", "opencode-go", "kilocode", "alibaba", "novita",
     "qwen-oauth",

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -96,6 +96,7 @@ MINIMAX_OAUTH_REFRESH_SKEW_SECONDS = 60
 DEFAULT_QWEN_BASE_URL = "https://portal.qwen.ai/v1"
 DEFAULT_GITHUB_MODELS_BASE_URL = "https://api.githubcopilot.com"
 DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
+DEFAULT_DEVIN_ACP_BASE_URL = "acp://devin"
 DEFAULT_OLLAMA_CLOUD_BASE_URL = "https://ollama.com/v1"
 STEPFUN_STEP_PLAN_INTL_BASE_URL = "https://api.stepfun.ai/step_plan/v1"
 STEPFUN_STEP_PLAN_CN_BASE_URL = "https://api.stepfun.com/step_plan/v1"
@@ -231,6 +232,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="external_process",
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
+    ),
+    "devin-acp": ProviderConfig(
+        id="devin-acp",
+        name="Devin CLI ACP",
+        auth_type="external_process",
+        inference_base_url=DEFAULT_DEVIN_ACP_BASE_URL,
+        base_url_env_var="DEVIN_ACP_BASE_URL",
     ),
     "gemini": ProviderConfig(
         id="gemini",
@@ -1664,6 +1672,7 @@ def resolve_provider(
         "github": "copilot", "github-copilot": "copilot",
         "github-models": "copilot", "github-model": "copilot",
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
+        "devin": "devin-acp", "devin-cli": "devin-acp", "cognition-devin": "devin-acp",
         "opencode": "opencode-zen", "zen": "opencode-zen",
         "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth",
         "hf": "huggingface", "hugging-face": "huggingface", "huggingface-hub": "huggingface",
@@ -6266,19 +6275,63 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     }
 
 
+def _external_process_spec(provider_id: str) -> Dict[str, Any]:
+    """Return command/args defaults for an external-process provider."""
+    specs: Dict[str, Dict[str, Any]] = {
+        "copilot-acp": {
+            "command_env": ("HERMES_COPILOT_ACP_COMMAND", "COPILOT_CLI_PATH"),
+            "default_command": "copilot",
+            "args_env": "HERMES_COPILOT_ACP_ARGS",
+            "default_args": ["--acp", "--stdio"],
+            "api_key": "copilot-acp",
+            "missing_code": "missing_copilot_cli",
+            "missing_msg": (
+                "Could not find the Copilot CLI command '{command}'. "
+                "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH."
+            ),
+        },
+        "devin-acp": {
+            "command_env": ("HERMES_DEVIN_ACP_COMMAND", "DEVIN_CLI_PATH"),
+            "default_command": "devin",
+            "args_env": "HERMES_DEVIN_ACP_ARGS",
+            "default_args": ["acp"],
+            "api_key": "devin-acp",
+            "missing_code": "missing_devin_cli",
+            "missing_msg": (
+                "Could not find the Devin CLI command '{command}'. "
+                "Install Devin CLI (https://docs.devin.ai/cli), run `devin auth login`, "
+                "or set HERMES_DEVIN_ACP_COMMAND/DEVIN_CLI_PATH."
+            ),
+        },
+    }
+    return dict(specs.get(provider_id) or specs["copilot-acp"])
+
+
+def _resolve_external_process_command_args(provider_id: str) -> tuple[str, list[str]]:
+    """Resolve the binary and args for an external-process provider."""
+    spec = _external_process_spec(provider_id)
+    command = ""
+    for env_name in spec.get("command_env") or ():
+        command = os.getenv(str(env_name), "").strip()
+        if command:
+            break
+    if not command:
+        command = str(spec.get("default_command") or "copilot")
+    raw_args = os.getenv(str(spec.get("args_env") or ""), "").strip()
+    if raw_args:
+        args = shlex.split(raw_args)
+    else:
+        args = list(spec.get("default_args") or ["--acp", "--stdio"])
+    return command, args
+
+
 def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     """Status snapshot for providers that run a local subprocess."""
     pconfig = PROVIDER_REGISTRY.get(provider_id)
     if not pconfig or pconfig.auth_type != "external_process":
         return {"configured": False}
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    command, args = _resolve_external_process_command_args(provider_id)
     base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
@@ -6313,7 +6366,10 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_qwen_auth_status()
     if target == "minimax-oauth":
         return get_minimax_oauth_auth_status()
-    if target == "copilot-acp":
+    pconfig_for_status = PROVIDER_REGISTRY.get(target)
+    if target in {"copilot-acp", "devin-acp"} or (
+        pconfig_for_status and pconfig_for_status.auth_type == "external_process"
+    ):
         return get_external_process_provider_status(target)
     if target == "azure-foundry":
         return _get_azure_foundry_auth_status()
@@ -6496,25 +6552,21 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
     if not base_url:
         base_url = pconfig.inference_base_url
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    spec = _external_process_spec(provider_id)
+    command, args = _resolve_external_process_command_args(provider_id)
     resolved_command = shutil.which(command) if command else None
     if not resolved_command and not base_url.startswith("acp+tcp://"):
         raise AuthError(
-            f"Could not find the Copilot CLI command '{command}'. "
-            "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH.",
+            str(spec.get("missing_msg") or "Could not find external process CLI '{command}'.").format(
+                command=command
+            ),
             provider=provider_id,
-            code="missing_copilot_cli",
+            code=str(spec.get("missing_code") or "missing_cli"),
         )
 
     return {
         "provider": provider_id,
-        "api_key": "copilot-acp",
+        "api_key": str(spec.get("api_key") or provider_id),
         "base_url": base_url.rstrip("/"),
         "command": resolved_command or command,
         "args": args,

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -6325,6 +6325,67 @@ def _resolve_external_process_command_args(provider_id: str) -> tuple[str, list[
     return command, args
 
 
+def _devin_local_credentials_present() -> bool:
+    """Best-effort check that Devin CLI has a local credentials file.
+
+    Does **not** validate the token with the network — only that a
+    credentials.toml with a key-shaped field exists in known locations
+    (Windows ``%APPDATA%/devin``, macOS Application Support, XDG config).
+    """
+    from pathlib import Path
+
+    home = Path.home()
+    candidates: list[Path] = []
+    appdata = os.environ.get("APPDATA", "").strip()
+    if appdata:
+        candidates.append(Path(appdata) / "devin" / "credentials.toml")
+    xdg = os.environ.get("XDG_CONFIG_HOME", "").strip()
+    if xdg:
+        candidates.append(Path(xdg) / "devin" / "credentials.toml")
+    candidates.extend(
+        [
+            home / ".config" / "devin" / "credentials.toml",
+            home / "Library" / "Application Support" / "devin" / "credentials.toml",
+            home / ".devin" / "credentials.toml",
+        ]
+    )
+    seen: set[str] = set()
+    for path in candidates:
+        key = str(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        try:
+            if not path.is_file() or path.stat().st_size <= 0:
+                continue
+            # Avoid loading secrets into logs — only look for key *names*.
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        lower = text.lower()
+        if any(
+            marker in lower
+            for marker in (
+                "windsurf_api_key",
+                "api_key",
+                "access_token",
+                "session_token",
+                "refresh_token",
+            )
+        ):
+            return True
+    return False
+
+
+def _external_process_auth_present(provider_id: str) -> Optional[bool]:
+    """Return True/False when local auth can be probed; None if unknown."""
+    if provider_id == "devin-acp":
+        return _devin_local_credentials_present()
+    # Copilot ACP auth is CLI/session specific; PATH presence is the only
+    # cheap signal we have without spawning the binary.
+    return None
+
+
 def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     """Status snapshot for providers that run a local subprocess."""
     pconfig = PROVIDER_REGISTRY.get(provider_id)
@@ -6337,15 +6398,31 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
         base_url = pconfig.inference_base_url
 
     resolved_command = shutil.which(command) if command else None
+    cli_installed = bool(resolved_command or base_url.startswith("acp+tcp://"))
+    auth_present = _external_process_auth_present(provider_id)
+    # Treat a confirmed-missing local auth file as not logged in even when
+    # the CLI binary is on PATH (so doctor/status can nudge `devin auth login`).
+    logged_in = bool(cli_installed and auth_present is not False)
+
+    hint = None
+    if not cli_installed:
+        spec = _external_process_spec(provider_id)
+        hint = str(spec.get("missing_msg") or "CLI not found.").format(command=command)
+    elif auth_present is False and provider_id == "devin-acp":
+        hint = "Devin CLI found but no local credentials — run: devin auth login"
+
     return {
-        "configured": bool(resolved_command or base_url.startswith("acp+tcp://")),
+        "configured": cli_installed,
         "provider": provider_id,
         "name": pconfig.name,
         "command": command,
         "args": args,
         "resolved_command": resolved_command,
         "base_url": base_url,
-        "logged_in": bool(resolved_command or base_url.startswith("acp+tcp://")),
+        "cli_installed": cli_installed,
+        "auth_present": auth_present,
+        "logged_in": logged_in,
+        "hint": hint,
     }
 
 
@@ -6367,7 +6444,11 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
     if target == "minimax-oauth":
         return get_minimax_oauth_auth_status()
     pconfig_for_status = PROVIDER_REGISTRY.get(target)
-    if target in {"copilot-acp", "devin-acp"} or (
+    try:
+        from agent.acp_client_factory import ACP_PROVIDERS as _ACP_PROVIDERS
+    except Exception:
+        _ACP_PROVIDERS = frozenset({"copilot-acp", "devin-acp"})
+    if target in _ACP_PROVIDERS or (
         pconfig_for_status and pconfig_for_status.auth_type == "external_process"
     ):
         return get_external_process_provider_status(target)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -629,6 +629,7 @@ from hermes_cli.model_setup_flows import (
     _model_flow_named_custom,
     _model_flow_copilot,
     _model_flow_copilot_acp,
+    _model_flow_devin_acp,
     _model_flow_kimi,
     _model_flow_stepfun,
     _model_flow_bedrock_api_key,
@@ -3113,6 +3114,8 @@ def select_provider_and_model(args=None):
         _model_flow_minimax_oauth(config, current_model, args=args)
     elif selected_provider == "copilot-acp":
         _model_flow_copilot_acp(config, current_model)
+    elif selected_provider == "devin-acp":
+        _model_flow_devin_acp(config, current_model)
     elif selected_provider == "copilot":
         _model_flow_copilot(config, current_model)
     elif selected_provider == "custom":
@@ -12263,7 +12266,7 @@ def _build_provider_choices() -> list[str]:
     except Exception:
         # Fallback: static list guarantees the CLI always works
         return [
-            "auto", "openrouter", "nous", "openai-codex", "xai-oauth", "copilot-acp", "copilot",
+            "auto", "openrouter", "nous", "openai-codex", "xai-oauth", "copilot-acp", "devin-acp", "copilot",
             "anthropic", "gemini", "vertex", "xai", "bedrock", "azure-foundry",
             "ollama-cloud", "huggingface", "zai", "kimi-coding", "kimi-coding-cn",
             "stepfun", "minimax", "minimax-cn", "kilocode", "novita", "xiaomi", "arcee",

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -1902,7 +1902,7 @@ def _model_flow_devin_acp(config, current_model=""):
     effective_base = status.get("base_url") or pconfig.inference_base_url
 
     print("  Devin CLI ACP delegates Hermes turns to `devin acp`.")
-    print("  Hermes starts a short-lived ACP subprocess for each request.")
+    print("  Hermes keeps the ACP process warm across turns (new session each prompt).")
     print("  Authenticate with: devin auth login")
     print(f"  Command: {resolved_command}")
     print(f"  Backend marker: {effective_base}")

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -1902,7 +1902,7 @@ def _model_flow_devin_acp(config, current_model=""):
     effective_base = status.get("base_url") or pconfig.inference_base_url
 
     print("  Devin CLI ACP delegates Hermes turns to `devin acp`.")
-    print("  Hermes keeps the ACP process warm across turns (new session each prompt).")
+    print("  Hermes keeps the ACP process warm and continues sessions when history grows.")
     print("  Authenticate with: devin auth login")
     print(f"  Command: {resolved_command}")
     print(f"  Backend marker: {effective_base}")

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -1925,10 +1925,20 @@ def _model_flow_devin_acp(config, current_model=""):
         return
 
     effective_base = creds.get("base_url") or effective_base
-    model_list = _PROVIDER_MODELS.get("devin-acp", ["devin-acp"])
+    # Prefer live Devin CLI discovery (invalid --model → Available: …), then
+    # curated snapshot so the CLI `hermes model` flow matches Desktop picker.
+    try:
+        from hermes_cli.models import cached_provider_model_ids
+
+        model_list = cached_provider_model_ids(provider_id) or _PROVIDER_MODELS.get(
+            "devin-acp", ["devin-acp"]
+        )
+    except Exception:
+        model_list = _PROVIDER_MODELS.get("devin-acp", ["devin-acp"])
+    default_pick = current_model or (model_list[0] if model_list else "devin-acp")
     selected = _prompt_model_selection(
         model_list,
-        current_model=current_model or "devin-acp",
+        current_model=default_pick,
         confirm_provider=provider_id,
         confirm_base_url=effective_base,
         confirm_api_key="",

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -1906,6 +1906,12 @@ def _model_flow_devin_acp(config, current_model=""):
     print("  Authenticate with: devin auth login")
     print(f"  Command: {resolved_command}")
     print(f"  Backend marker: {effective_base}")
+    if status.get("auth_present") is True:
+        print("  Local credentials: detected")
+    elif status.get("auth_present") is False:
+        print("  Local credentials: missing")
+    if status.get("hint"):
+        print(f"  ⚠ {status['hint']}")
     print()
 
     try:

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -1877,6 +1877,82 @@ def _model_flow_copilot_acp(config, current_model=""):
 
     print(f"Default model set to: {selected} (via {pconfig.name})")
 
+def _model_flow_devin_acp(config, current_model=""):
+    """Devin CLI ACP flow using the local Devin CLI (`devin acp`)."""
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY,
+        _prompt_model_selection,
+        _save_model_choice,
+        deactivate_provider,
+        get_external_process_provider_status,
+        resolve_external_process_provider_credentials,
+    )
+    from hermes_cli.models import _PROVIDER_MODELS
+    from hermes_cli.config import load_config, save_config
+
+    del config
+
+    provider_id = "devin-acp"
+    pconfig = PROVIDER_REGISTRY[provider_id]
+
+    status = get_external_process_provider_status(provider_id)
+    resolved_command = (
+        status.get("resolved_command") or status.get("command") or "devin"
+    )
+    effective_base = status.get("base_url") or pconfig.inference_base_url
+
+    print("  Devin CLI ACP delegates Hermes turns to `devin acp`.")
+    print("  Hermes starts a short-lived ACP subprocess for each request.")
+    print("  Authenticate with: devin auth login")
+    print(f"  Command: {resolved_command}")
+    print(f"  Backend marker: {effective_base}")
+    print()
+
+    try:
+        creds = resolve_external_process_provider_credentials(provider_id)
+    except Exception as exc:
+        print(f"  ⚠ {exc}")
+        print(
+            "  Install Devin CLI (https://docs.devin.ai/cli) or set "
+            "HERMES_DEVIN_ACP_COMMAND / DEVIN_CLI_PATH."
+        )
+        return
+
+    effective_base = creds.get("base_url") or effective_base
+    model_list = _PROVIDER_MODELS.get("devin-acp", ["devin-acp"])
+    selected = _prompt_model_selection(
+        model_list,
+        current_model=current_model or "devin-acp",
+        confirm_provider=provider_id,
+        confirm_base_url=effective_base,
+        confirm_api_key="",
+    )
+    if not selected:
+        try:
+            selected = input("Model name [devin-acp]: ").strip() or "devin-acp"
+        except (KeyboardInterrupt, EOFError):
+            selected = None
+
+    if not selected:
+        print("No change.")
+        return
+
+    _save_model_choice(selected)
+
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = provider_id
+    model["base_url"] = effective_base
+    model["api_mode"] = "chat_completions"
+    clear_model_endpoint_credentials(model, clear_api_mode=False)
+    save_config(cfg)
+    deactivate_provider()
+
+    print(f"Default model set to: {selected} (via {pconfig.name})")
+
 def _model_flow_kimi(config, current_model=""):
     """Kimi / Moonshot model selection with automatic endpoint routing.
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1812,6 +1812,21 @@ def list_authenticated_providers(
                     has_creds = True
             except Exception as exc:
                 logger.debug("Anthropic external creds check failed: %s", exc)
+        # Local ACP CLIs (copilot-acp / devin-acp): no API key env var — use
+        # the shared external-process status probe (PATH + optional local
+        # credentials file) so Desktop/Accounts + model picker can surface them.
+        if not has_creds and overlay.auth_type == "external_process":
+            try:
+                from hermes_cli.auth import get_external_process_provider_status
+
+                _ext = get_external_process_provider_status(hermes_slug)
+                has_creds = bool(_ext.get("logged_in"))
+            except Exception as exc:
+                logger.debug(
+                    "External process status check failed for %s: %s",
+                    hermes_slug,
+                    exc,
+                )
         if not has_creds:
             continue
 
@@ -1824,6 +1839,11 @@ def list_authenticated_providers(
             # curated list when the live endpoint is unreachable, so this
             # is safe for unauthenticated and offline cases too.
             model_ids = cached_provider_model_ids(hermes_slug)
+        elif overlay.auth_type == "external_process":
+            # ACP backends don't expose a REST /models catalog — use the
+            # curated singleton (e.g. ["devin-acp"]) so the picker has a
+            # selectable row once the local CLI is ready.
+            model_ids = curated.get(hermes_slug, []) or [hermes_slug]
         # For aws_sdk providers (bedrock), use live discovery so the list
         # reflects the active region (eu.*, ap.*) not the static us.* list.
         elif overlay.auth_type == "aws_sdk":

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1830,20 +1830,23 @@ def list_authenticated_providers(
         if not has_creds:
             continue
 
-        if hermes_slug in {"openai-codex", "copilot", "copilot-acp"}:
-            # Use live OAuth-backed discovery so the gateway /model picker
-            # matches what the user's authenticated Codex/Copilot backend
-            # actually serves — including ChatGPT-Pro-only Codex slugs
-            # (e.g. gpt-5.3-codex-spark) that aren't in the static curated
-            # catalog. ``cached_provider_model_ids()`` falls back to the
-            # curated list when the live endpoint is unreachable, so this
-            # is safe for unauthenticated and offline cases too.
+        if hermes_slug in {"openai-codex", "copilot", "copilot-acp", "devin-acp"}:
+            # Use live discovery so the gateway /model picker matches what
+            # the authenticated backend serves. Copilot/Codex hit OAuth
+            # /models; Devin CLI has no REST catalog but exposes an
+            # "Available:" list via a cheap invalid-``--model`` probe
+            # (see ``fetch_devin_cli_models``). ``cached_provider_model_ids``
+            # falls back to curated when live fails.
             model_ids = cached_provider_model_ids(hermes_slug)
         elif overlay.auth_type == "external_process":
-            # ACP backends don't expose a REST /models catalog — use the
-            # curated singleton (e.g. ["devin-acp"]) so the picker has a
-            # selectable row once the local CLI is ready.
-            model_ids = curated.get(hermes_slug, []) or [hermes_slug]
+            # Other external-process backends: try the shared cache path
+            # first (providers can plug live discovery into
+            # provider_model_ids), then curated / slug singleton.
+            model_ids = (
+                cached_provider_model_ids(hermes_slug)
+                or curated.get(hermes_slug, [])
+                or [hermes_slug]
+            )
         # For aws_sdk providers (bedrock), use live discovery so the list
         # reflects the active region (eu.*, ap.*) not the static us.* list.
         elif overlay.auth_type == "aws_sdk":

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -272,6 +272,9 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "devin-acp": [
+        "devin-acp",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -1065,6 +1068,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("nvidia",         "NVIDIA NIM",               "NVIDIA NIM (Nemotron models via build.nvidia.com or local NIM)"),
     ProviderEntry("copilot",        "GitHub Copilot",           "GitHub Copilot (Uses GITHUB_TOKEN or gh auth token)"),
     ProviderEntry("copilot-acp",    "GitHub Copilot ACP",       "GitHub Copilot ACP (Spawns copilot --acp --stdio)"),
+    ProviderEntry("devin-acp",      "Devin CLI ACP",            "Devin CLI ACP (Spawns devin acp)"),
     ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers"),
     ProviderEntry("gemini",         "Google AI Studio",         "Google AI Studio (Native Gemini API)"),
     ProviderEntry("vertex",         "Google Vertex AI",         "Google Vertex AI (Gemini via GCP; OAuth2 service account or ADC, GCP billing/quotas)"),
@@ -1226,6 +1230,9 @@ _PROVIDER_ALIASES = {
     "github-model": "copilot",
     "github-copilot-acp": "copilot-acp",
     "copilot-acp-agent": "copilot-acp",
+    "devin": "devin-acp",
+    "devin-cli": "devin-acp",
+    "cognition-devin": "devin-acp",
     "google": "gemini",
     "google-gemini": "gemini",
     "google-ai-studio": "gemini",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import urllib.parse
 import urllib.request
 import urllib.error
@@ -272,7 +273,50 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    # Snapshot of `devin --model <invalid> -p .` "Available:" list (offline
+    # fallback). Live discovery via fetch_devin_cli_models() preferred when
+    # the Devin CLI is installed. Short family aliases (opus/sonnet/…) are
+    # documented by Cognition and resolve to the latest in-family model.
     "devin-acp": [
+        "adaptive",
+        "swe-1.7",
+        "swe-1.7-lightning",
+        "swe-1.6",
+        "swe-1.6-fast",
+        "swe-1.5",
+        "claude-opus-4.8",
+        "claude-opus-4.7",
+        "claude-opus-4.6",
+        "claude-opus-4.5",
+        "claude-sonnet-5",
+        "claude-sonnet-4.6",
+        "claude-sonnet-4.5",
+        "claude-fable-5",
+        "claude-haiku-4.5",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.3-codex",
+        "gpt-5.2",
+        "gemini-3.5-flash",
+        "gemini-3.1-pro",
+        "gemini-3-flash",
+        "grok-4.5",
+        "deepseek-v4-pro",
+        "kimi-k2.7",
+        "kimi-k2.6",
+        "glm-5.2",
+        "nemotron-3-ultra",
+        # Family aliases (docs: always resolve to latest in family)
+        "opus",
+        "sonnet",
+        "swe",
+        "codex",
+        "gemini",
+        # Hermes placeholder when no specific model is chosen
         "devin-acp",
     ],
     "copilot": [
@@ -2290,6 +2334,97 @@ def _merge_with_models_dev(provider: str, curated: list[str]) -> list[str]:
     return merged
 
 
+# Devin CLI does not expose a REST /models endpoint or `devin models` subcommand.
+# Probing with an invalid --model prints: "Available: a, b, c" on stderr — that
+# is the supported auto-discovery signal (verified against Devin CLI docs + CLI).
+_DEVIN_PROBE_MODEL = "__hermes_devin_probe__"
+_DEVIN_AVAILABLE_RE = re.compile(
+    r"Available:\s*(.+?)(?:\n|$)",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def parse_devin_cli_available_models(text: str) -> list[str]:
+    """Parse model ids from a Devin CLI 'Unknown model' / Available line.
+
+    Returns a de-duplicated list preserving CLI order. Empty when the
+    Available line is missing or unparseable.
+    """
+    if not text:
+        return []
+    match = _DEVIN_AVAILABLE_RE.search(text)
+    if not match:
+        return []
+    raw = match.group(1).strip()
+    # Stop at a second sentence / trailing junk if the CLI wraps.
+    if "\n" in raw:
+        raw = raw.split("\n", 1)[0].strip()
+    seen: set[str] = set()
+    out: list[str] = []
+    for part in raw.split(","):
+        mid = part.strip().strip("'\"")
+        if not mid:
+            continue
+        key = mid.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(mid)
+    return out
+
+
+def fetch_devin_cli_models(
+    *,
+    command: Optional[str] = None,
+    timeout: float = 12.0,
+) -> list[str]:
+    """Discover Devin CLI models by probing ``devin --model <invalid> -p .``.
+
+    Returns [] when the CLI is missing, times out, or does not emit an
+    Available line. Never raises for expected probe failures.
+    """
+    import shutil
+    import subprocess
+
+    cmd = (command or "").strip()
+    if not cmd:
+        try:
+            from hermes_cli.auth import _resolve_external_process_command_args
+
+            cmd, _args = _resolve_external_process_command_args("devin-acp")
+        except Exception:
+            cmd = (
+                os.getenv("HERMES_DEVIN_ACP_COMMAND", "").strip()
+                or os.getenv("DEVIN_CLI_PATH", "").strip()
+                or "devin"
+            )
+    # Resolve bare command names via PATH so Windows/msys work consistently.
+    resolved = shutil.which(cmd) if cmd and os.sep not in cmd and "/" not in cmd else cmd
+    if not resolved:
+        resolved = cmd
+    if not resolved:
+        return []
+
+    try:
+        proc = subprocess.run(
+            [resolved, "--model", _DEVIN_PROBE_MODEL, "-p", "."],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return []
+    except Exception:
+        return []
+
+    blob = "\n".join(
+        part for part in (proc.stderr or "", proc.stdout or "") if part
+    )
+    models = parse_devin_cli_available_models(blob)
+    return models
+
+
 def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) -> list[str]:
     """Return the best known model catalog for a provider.
 
@@ -2329,6 +2464,14 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             pass
         if normalized == "copilot-acp":
             return list(_PROVIDER_MODELS.get("copilot", []))
+    if normalized == "devin-acp":
+        try:
+            live = fetch_devin_cli_models()
+            if live:
+                return live
+        except Exception:
+            pass
+        return list(_PROVIDER_MODELS.get("devin-acp", ["devin-acp"]))
     if normalized == "nous":
         # Try live Nous Portal /models endpoint
         try:
@@ -2612,6 +2755,33 @@ def _credential_fingerprint(provider: str) -> str:
             parts.append(f"{path}@missing")
         except Exception:
             pass
+
+    # Devin CLI: credentials + installed model catalog blobs. CLI updates that
+    # refresh model_configs*.bin should bust the cached Available list.
+    if provider in {"devin-acp", "devin", "devin-cli"}:
+        appdata = _os.environ.get("APPDATA", "").strip()
+        localappdata = _os.environ.get("LOCALAPPDATA", "").strip()
+        xdg = _os.environ.get("XDG_CONFIG_HOME", "").strip()
+        home = _os.path.expanduser("~")
+        devin_paths = [
+            _os.path.join(appdata, "devin", "credentials.toml") if appdata else "",
+            _os.path.join(xdg, "devin", "credentials.toml") if xdg else "",
+            _os.path.join(home, ".config", "devin", "credentials.toml"),
+            _os.path.join(home, "Library", "Application Support", "devin", "credentials.toml"),
+            _os.path.join(localappdata, "devin", "cli", "model_configs_v4.bin") if localappdata else "",
+            _os.path.join(localappdata, "devin", "cli", "model_configs_v2.bin") if localappdata else "",
+            _os.path.join(localappdata, "devin", "cli", "model_configs.bin") if localappdata else "",
+        ]
+        for path in devin_paths:
+            if not path:
+                continue
+            try:
+                mt = _os.stat(path).st_mtime_ns
+                parts.append(f"{path}@{mt}")
+            except FileNotFoundError:
+                parts.append(f"{path}@missing")
+            except Exception:
+                pass
 
     blob = "|".join(parts).encode("utf-8", errors="replace")
     # blake2b for cache-key fingerprinting only — not for credential storage.

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -390,6 +390,11 @@ def _run_agent(
         provider=runtime.get("provider"),
         api_mode=runtime.get("api_mode"),
         model=effective_model,
+        # ACP external-process providers (copilot-acp, devin-acp) need the
+        # resolved CLI command/args; without these, empty agent.acp_args can
+        # fall through to the wrong provider defaults.
+        acp_command=runtime.get("command"),
+        acp_args=runtime.get("args"),
         enabled_toolsets=toolsets_list,
         quiet_mode=True,
         platform="cli",

--- a/hermes_cli/provider_catalog.py
+++ b/hermes_cli/provider_catalog.py
@@ -47,7 +47,7 @@ _ACCOUNTS_AUTH_TYPES: frozenset[str] = frozenset(
         "oauth_device_code",
         "oauth_external",
         "oauth_minimax",
-        "external_process",  # copilot-acp: spawns `copilot --acp --stdio`
+        "external_process",  # copilot-acp / devin-acp: spawn local ACP CLIs
         "copilot",           # GitHub Copilot token / gh auth
     }
 )

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -94,6 +94,13 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="acp://copilot",
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "devin-acp": HermesOverlay(
+        transport="openai_chat",
+        auth_type="external_process",
+        base_url_override="acp://devin",
+        base_url_env_var="DEVIN_ACP_BASE_URL",
+        extra_env_vars=("HERMES_DEVIN_ACP_COMMAND", "DEVIN_CLI_PATH", "HERMES_DEVIN_ACP_ARGS"),
+    ),
     "github-copilot": HermesOverlay(
         transport="openai_chat",
         extra_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN"),
@@ -364,6 +371,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
+    "devin-acp": "Devin CLI ACP",
     "stepfun": "StepFun Step Plan",
     "xiaomi": "Xiaomi MiMo",
     "gmi": "GMI Cloud",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1833,7 +1833,9 @@ def resolve_runtime_provider(
                 "requested_provider": requested_provider,
             }
 
-    if provider in {"copilot-acp", "devin-acp"}:
+    from agent.acp_client_factory import ACP_PROVIDERS
+
+    if provider in ACP_PROVIDERS:
         creds = resolve_external_process_provider_credentials(provider)
         return {
             "provider": provider,

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1833,10 +1833,10 @@ def resolve_runtime_provider(
                 "requested_provider": requested_provider,
             }
 
-    if provider == "copilot-acp":
+    if provider in {"copilot-acp", "devin-acp"}:
         creds = resolve_external_process_provider_credentials(provider)
         return {
-            "provider": "copilot-acp",
+            "provider": provider,
             "api_mode": "chat_completions",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -74,6 +74,9 @@ _DEFAULT_PROVIDER_MODELS = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "devin-acp": [
+        "devin-acp",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -8091,6 +8091,56 @@ def _copilot_acp_status() -> Dict[str, Any]:
     }
 
 
+def _devin_acp_status() -> Dict[str, Any]:
+    """Status for devin-acp — CLI binary + local credentials file probe.
+
+    Unlike copilot-acp, Devin stores a credentials.toml we can detect without
+    spawning the binary or minting network tokens. Never expose secret values.
+    """
+    try:
+        from hermes_cli.auth import get_external_process_provider_status
+
+        raw = get_external_process_provider_status("devin-acp")
+    except Exception as exc:
+        return {
+            "logged_in": False,
+            "source": "devin_cli",
+            "source_label": "Managed by the Devin CLI",
+            "token_preview": None,
+            "expires_at": None,
+            "has_refresh_token": False,
+            "error": str(exc),
+        }
+
+    resolved = raw.get("resolved_command") or raw.get("command") or "devin"
+    parts = ["Managed by the Devin CLI"]
+    if raw.get("resolved_command"):
+        parts.append(str(raw["resolved_command"]))
+    elif raw.get("cli_installed") is False:
+        parts.append("CLI not found on PATH")
+    if raw.get("auth_present") is True:
+        parts.append("local credentials detected")
+    elif raw.get("auth_present") is False and raw.get("cli_installed"):
+        parts.append("not logged in — run: devin auth login")
+    if raw.get("hint"):
+        hint = str(raw["hint"])
+        if hint not in parts[-1]:
+            parts.append(hint)
+
+    return {
+        "logged_in": bool(raw.get("logged_in")),
+        "source": "devin_cli",
+        "source_label": " · ".join(parts),
+        "token_preview": None,
+        "expires_at": None,
+        "has_refresh_token": False,
+        "cli_installed": raw.get("cli_installed"),
+        "auth_present": raw.get("auth_present"),
+        "hint": raw.get("hint"),
+        "resolved_command": resolved,
+    }
+
+
 # Explicit, hand-tuned OAuth/account provider cards. These carry the bits that
 # can't be derived from the unified provider catalog: the OAuth ``flow`` shape,
 # the per-provider ``status_fn``, the ``cli_command`` fallback, and curated
@@ -8160,6 +8210,14 @@ _OAUTH_PROVIDER_CATALOG: tuple[Dict[str, Any], ...] = (
         "cli_command": "copilot /login",
         "docs_url": "https://docs.github.com/en/copilot",
         "status_fn": _copilot_acp_status,
+    },
+    {
+        "id": "devin-acp",
+        "name": "Devin CLI ACP",
+        "flow": "external",
+        "cli_command": "devin auth login",
+        "docs_url": "https://docs.devin.ai/cli",
+        "status_fn": _devin_acp_status,
     },
     # ── Anthropic / Claude entries sit at the bottom: the API-key path
     # first, then the subscription OAuth path (which only works with extra

--- a/plugins/model-providers/devin-acp/__init__.py
+++ b/plugins/model-providers/devin-acp/__init__.py
@@ -1,0 +1,35 @@
+"""Devin CLI ACP provider profile.
+
+devin-acp uses an external ACP subprocess (``devin acp``) — NOT a REST
+chat-completions endpoint. Routing is handled by DevinACPClient, same
+pattern as copilot-acp.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class DevinACPProfile(ProviderProfile):
+    """Devin CLI ACP — external process, no REST models endpoint."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Model listing is handled by the ACP subprocess."""
+        return None
+
+
+devin_acp = DevinACPProfile(
+    name="devin-acp",
+    aliases=("devin", "devin-cli", "cognition-devin"),
+    api_mode="chat_completions",
+    env_vars=(),
+    base_url="acp://devin",
+    auth_type="external_process",
+)
+
+register_provider(devin_acp)

--- a/plugins/model-providers/devin-acp/plugin.yaml
+++ b/plugins/model-providers/devin-acp/plugin.yaml
@@ -1,0 +1,5 @@
+name: devin-acp-provider
+kind: model-provider
+version: 1.0.0
+description: Devin CLI via ACP subprocess (devin acp)
+author: Community

--- a/run_agent.py
+++ b/run_agent.py
@@ -2723,6 +2723,21 @@ class AIAgent:
                 child.interrupt(message)
             except Exception as e:
                 logger.debug("Failed to propagate interrupt to child agent: %s", e)
+        # Warm ACP subprocesses block on stdio RPC — kill them so /stop is
+        # immediate rather than waiting for Devin/Copilot to finish the turn.
+        try:
+            from agent.acp_client_factory import is_acp_provider
+
+            client = getattr(self, "client", None)
+            if client is not None and is_acp_provider(
+                getattr(self, "provider", None), getattr(self, "base_url", None)
+            ):
+                if hasattr(client, "interrupt"):
+                    client.interrupt()
+                elif hasattr(client, "close"):
+                    client.close()
+        except Exception as e:
+            logger.debug("Failed to interrupt ACP client: %s", e)
         if not self.quiet_mode:
             print("\n⚡ Interrupt requested" + (f": '{message[:40]}...'" if message and len(message) > 40 else f": '{message}'" if message else ""))
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -4113,11 +4113,27 @@ class AIAgent:
 
         return copilot_request_headers(is_agent_turn=True, is_vision=is_vision)
 
+    def _uses_shared_request_client(self) -> bool:
+        """True when per-request API calls should reuse ``self.client``.
+
+        MoA is an in-process facade. ACP backends (copilot-acp / devin-acp)
+        keep a warm local subprocess — spawning a fresh client per request
+        would kill process reuse and re-pay CLI cold start every turn.
+        """
+        if self.provider == "moa":
+            return True
+        try:
+            from agent.acp_client_factory import is_acp_provider
+
+            return is_acp_provider(self.provider, getattr(self, "base_url", None))
+        except Exception:
+            return False
+
     def _create_request_openai_client(self, *, reason: str, api_kwargs: Optional[dict] = None) -> Any:
         from unittest.mock import Mock
 
         primary_client = self._ensure_primary_openai_client(reason=reason)
-        if self.provider == "moa":
+        if self._uses_shared_request_client():
             return primary_client
         if isinstance(primary_client, Mock):
             return primary_client
@@ -4142,6 +4158,11 @@ class AIAgent:
         return self._create_openai_client(request_kwargs, reason=reason, shared=False)
 
     def _close_request_openai_client(self, client: Any, *, reason: str) -> None:
+        # Shared primary clients (MoA / ACP) are reused across turns; only
+        # ephemeral request-scoped OpenAI clients should be closed here.
+        primary = getattr(self, "client", None)
+        if client is not None and primary is not None and client is primary:
+            return
         self._close_openai_client(client, reason=reason, shared=False)
 
     def _abort_request_openai_client(self, client: Any, *, reason: str) -> None:
@@ -4159,6 +4180,11 @@ class AIAgent:
         — which is where the FD release belongs.
         """
         if client is None:
+            return
+        primary = getattr(self, "client", None)
+        if primary is not None and client is primary:
+            # ACP subprocess has no TCP pool to half-close; leave it for the
+            # owning turn / agent.close() path.
             return
         try:
             shutdown_count = self._force_close_tcp_sockets(client)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1948,6 +1948,8 @@ AUTHOR_MAP = {
     "i@dex.moe": "dexhunter",  # PR #60339 salvage (skills snapshot manifest speedup)
     "1torhan@protonmail.com": "uzaylisak",  # PR #29988 salvage (detect_local_server_type process-lifetime cache)
     "zhchl@hermes-agent.local": "8294",  # PR #50572 salvage (honor config context_length on banner)
+    # PR #62570 (devin-acp) / #62572 (grok-acp)
+    "zex555.a198719@gmail.com": "shelizi",
 }
 
 

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -31,7 +31,9 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
             "</tool_call>"
         )
 
-        with patch.object(self.client, "_run_prompt", return_value=(tool_response, "")):
+        with patch.object(
+            self.client, "_run_conversation_prompt", return_value=(tool_response, "")
+        ):
             response = self.client._create_chat_completion(
                 model="copilot-acp",
                 messages=[{"role": "user", "content": "read README.md"}],
@@ -57,14 +59,17 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
         self.assertEqual(choice.message.content, "I'll inspect that.")
 
     def test_stream_true_returns_iterable_text_chunks(self) -> None:
-        with patch.object(self.client, "_run_prompt", return_value=("Hello from ACP", "")):
+        # Keep the patch active while the generator is consumed — the stream
+        # worker thread only runs on iteration.
+        with patch.object(
+            self.client, "_run_conversation_prompt", return_value=("Hello from ACP", "")
+        ):
             stream = self.client._create_chat_completion(
                 model="copilot-acp",
                 messages=[{"role": "user", "content": "hello"}],
                 stream=True,
             )
-
-        chunks = list(stream)
+            chunks = list(stream)
         self.assertEqual(len(chunks), 2)
         self.assertEqual(chunks[0].choices[0].delta.content, "Hello from ACP")
         self.assertIsNone(chunks[0].choices[0].delta.tool_calls)
@@ -80,14 +85,15 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
             "</tool_call>"
         )
 
-        with patch.object(self.client, "_run_prompt", return_value=(tool_response, "")):
+        with patch.object(
+            self.client, "_run_conversation_prompt", return_value=(tool_response, "")
+        ):
             stream = self.client._create_chat_completion(
                 model="copilot-acp",
                 messages=[{"role": "user", "content": "read README.md"}],
                 stream=True,
             )
-
-        chunks = list(stream)
+            chunks = list(stream)
         delta = chunks[0].choices[0].delta
         self.assertIsNone(delta.content)
         self.assertEqual(chunks[0].choices[0].finish_reason, "tool_calls")
@@ -105,7 +111,16 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
     def test_timeout_object_is_coerced_for_streaming_requests(self) -> None:
         captured: dict[str, float] = {}
 
-        def fake_run_prompt(prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
+        def fake_run_conversation_prompt(
+            messages,
+            *,
+            model=None,
+            tools=None,
+            tool_choice=None,
+            timeout_seconds: float = 0,
+            on_text_chunk=None,
+            on_reasoning_chunk=None,
+        ) -> tuple[str, str]:
             captured["timeout"] = timeout_seconds
             return "ok", ""
 
@@ -115,7 +130,9 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
             {"read": 12.0, "write": 5.0, "connect": 3.0, "pool": 1.0},
         )()
 
-        with patch.object(self.client, "_run_prompt", side_effect=fake_run_prompt):
+        with patch.object(
+            self.client, "_run_conversation_prompt", side_effect=fake_run_conversation_prompt
+        ):
             list(
                 self.client._create_chat_completion(
                     model="copilot-acp",
@@ -256,9 +273,8 @@ if __name__ == "__main__":
 
 
 # ── HOME env propagation tests (from PR #11285) ─────────────────────
-
-from unittest.mock import patch as _patch
-import pytest
+# pytest is optional at import time so unittest can load the safety class
+# above without a full pytest install in every environment.
 
 
 def _make_home_client(tmp_path):
@@ -280,6 +296,9 @@ def _fake_popen_capture(captured):
 
 
 def test_run_prompt_preserves_real_home_when_profile_home_available(monkeypatch, tmp_path):
+    import pytest
+    from unittest.mock import patch as _patch
+
     hermes_home = tmp_path / "hermes"
     (hermes_home / "home").mkdir(parents=True)
     real_home = tmp_path / "real-home"
@@ -300,6 +319,9 @@ def test_run_prompt_preserves_real_home_when_profile_home_available(monkeypatch,
 
 
 def test_run_prompt_passes_home_when_parent_env_is_clean(monkeypatch, tmp_path):
+    import pytest
+    from unittest.mock import patch as _patch
+
     monkeypatch.delenv("HOME", raising=False)
     monkeypatch.delenv("HERMES_HOME", raising=False)
 

--- a/tests/agent/test_devin_acp_client.py
+++ b/tests/agent/test_devin_acp_client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import unittest
 from unittest.mock import patch
 
-from agent.devin_acp_client import ACP_MARKER_BASE_URL, DevinACPClient, _resolve_args, _resolve_command
+from agent.devin_acp_client import ACP_MARKER_BASE_URL, DevinACPClient, _resolve_args
 from hermes_cli.auth import (
     PROVIDER_REGISTRY,
     get_external_process_provider_status,
@@ -27,9 +27,6 @@ class TestDevinAcpProviderRegistry(unittest.TestCase):
 
 
 class TestDevinAcpResolve(unittest.TestCase):
-    def test_status_detects_local_cli(self, monkeypatch=None):
-        pass
-
     def test_status_and_creds(self):
         with patch("hermes_cli.auth.shutil.which", return_value="/usr/local/bin/devin"):
             with patch.dict("os.environ", {"HERMES_DEVIN_ACP_ARGS": "acp --debug"}, clear=False):
@@ -51,16 +48,40 @@ class TestDevinAcpResolve(unittest.TestCase):
 class TestDevinAcpClientDefaults(unittest.TestCase):
     def test_marker_and_defaults(self):
         assert ACP_MARKER_BASE_URL == "acp://devin"
-        with patch.dict("os.environ", {}, clear=False):
-            # Ensure defaults when env not set — may still pick up user env
-            args = _resolve_args() if not __import__("os").getenv("HERMES_DEVIN_ACP_ARGS") else ["acp"]
-            if not __import__("os").getenv("HERMES_DEVIN_ACP_ARGS"):
-                assert _resolve_args() == ["acp"]
+        with patch.dict("os.environ", {"HERMES_DEVIN_ACP_ARGS": ""}, clear=False):
+            # Force empty env so default path is exercised even if the host
+            # shell exported HERMES_DEVIN_ACP_ARGS.
+            assert _resolve_args() == ["acp"]
         client = DevinACPClient(acp_cwd="/tmp", command="devin", args=["acp"])
         assert client.api_key == "devin-acp"
         assert client.base_url == "acp://devin"
         assert client._acp_command == "devin"
         assert client._acp_args == ["acp"]
+
+    def test_empty_args_does_not_fall_through_to_copilot_defaults(self):
+        """Regression: args=[] used to become ['--acp', '--stdio'] via parent."""
+        with patch.dict(
+            "os.environ",
+            {
+                "HERMES_DEVIN_ACP_ARGS": "",
+                "HERMES_COPILOT_ACP_ARGS": "",
+            },
+            clear=False,
+        ):
+            via_args = DevinACPClient(acp_cwd="/tmp", command="devin", args=[])
+            via_acp_args = DevinACPClient(acp_cwd="/tmp", command="devin", acp_args=[])
+            via_none = DevinACPClient(acp_cwd="/tmp", command="devin")
+
+        for client in (via_args, via_acp_args, via_none):
+            assert client._acp_args == ["acp"], client._acp_args
+            assert "--acp" not in client._acp_args
+            assert "--stdio" not in client._acp_args
+
+    def test_display_name_and_install_hint_are_devin(self):
+        client = DevinACPClient(acp_cwd="/tmp", command="devin", args=["acp"])
+        assert client._acp_display_name == "Devin ACP"
+        assert "Devin CLI" in client._install_hint
+        assert "Copilot" not in client._install_hint
 
 
 class TestAcpClientFactory(unittest.TestCase):
@@ -69,8 +90,79 @@ class TestAcpClientFactory(unittest.TestCase):
 
         assert is_acp_provider("devin-acp") is True
         assert is_acp_provider(base_url="acp://devin") is True
-        client = create_acp_client(provider="devin-acp", command="devin", args=["acp"], acp_cwd="/tmp")
+        client = create_acp_client(
+            provider="devin-acp", command="devin", args=["acp"], acp_cwd="/tmp"
+        )
         assert isinstance(client, DevinACPClient)
+
+    def test_create_devin_empty_args_uses_devin_defaults(self):
+        from agent.acp_client_factory import create_acp_client
+
+        with patch.dict("os.environ", {"HERMES_DEVIN_ACP_ARGS": ""}, clear=False):
+            client = create_acp_client(
+                provider="devin-acp", command="devin", args=[], acp_cwd="/tmp"
+            )
+        assert isinstance(client, DevinACPClient)
+        assert client._acp_args == ["acp"]
+
+
+class TestOneshotAcpWiring(unittest.TestCase):
+    def test_oneshot_forwards_runtime_command_and_args(self):
+        """hermes -z must pass ACP command/args into AIAgent (P0 regression)."""
+        import hermes_cli.oneshot as oneshot_mod
+
+        captured: dict = {}
+
+        class _FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.suppress_status_output = False
+                self.stream_delta_callback = None
+                self.tool_gen_callback = None
+
+            def run_conversation(self, prompt):
+                return {
+                    "final_response": "pong",
+                    "messages": [{"role": "user", "content": prompt}],
+                }
+
+        with (
+            patch.object(
+                oneshot_mod,
+                "resolve_runtime_provider",
+                create=True,
+            ),
+            patch("hermes_cli.oneshot.load_config", create=True),
+            patch("hermes_cli.config.load_config", return_value={"model": {}}),
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value={
+                    "provider": "devin-acp",
+                    "api_mode": "chat_completions",
+                    "base_url": "acp://devin",
+                    "api_key": "devin-acp",
+                    "command": "/usr/bin/devin",
+                    "args": ["acp"],
+                    "credential_pool": None,
+                },
+            ),
+            patch("hermes_cli.oneshot.get_fallback_chain", return_value=None),
+            patch("hermes_cli.oneshot._create_session_db_for_oneshot", return_value=None),
+            patch("hermes_cli.tools_config._get_platform_tools", return_value=set()),
+            patch("run_agent.AIAgent", _FakeAgent),
+        ):
+            response, result = oneshot_mod._run_agent(
+                "ping",
+                model="devin-acp",
+                provider="devin-acp",
+                use_config_toolsets=False,
+            )
+
+        assert response == "pong"
+        assert captured.get("acp_command") == "/usr/bin/devin"
+        assert captured.get("acp_args") == ["acp"]
+        assert captured.get("provider") == "devin-acp"
+        assert captured.get("base_url") == "acp://devin"
 
 
 if __name__ == "__main__":

--- a/tests/agent/test_devin_acp_client.py
+++ b/tests/agent/test_devin_acp_client.py
@@ -1,0 +1,77 @@
+"""Tests for Devin CLI ACP provider wiring."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from agent.devin_acp_client import ACP_MARKER_BASE_URL, DevinACPClient, _resolve_args, _resolve_command
+from hermes_cli.auth import (
+    PROVIDER_REGISTRY,
+    get_external_process_provider_status,
+    resolve_external_process_provider_credentials,
+    resolve_provider,
+)
+
+
+class TestDevinAcpProviderRegistry(unittest.TestCase):
+    def test_registry_entry(self):
+        p = PROVIDER_REGISTRY["devin-acp"]
+        assert p.auth_type == "external_process"
+        assert p.inference_base_url == "acp://devin"
+
+    def test_aliases(self):
+        assert resolve_provider("devin") == "devin-acp"
+        assert resolve_provider("devin-cli") == "devin-acp"
+        assert resolve_provider("cognition-devin") == "devin-acp"
+
+
+class TestDevinAcpResolve(unittest.TestCase):
+    def test_status_detects_local_cli(self, monkeypatch=None):
+        pass
+
+    def test_status_and_creds(self):
+        with patch("hermes_cli.auth.shutil.which", return_value="/usr/local/bin/devin"):
+            with patch.dict("os.environ", {"HERMES_DEVIN_ACP_ARGS": "acp --debug"}, clear=False):
+                status = get_external_process_provider_status("devin-acp")
+                assert status["configured"] is True
+                assert status["command"] == "devin"
+                assert status["resolved_command"] == "/usr/local/bin/devin"
+                assert status["args"] == ["acp", "--debug"]
+                assert status["base_url"] == "acp://devin"
+
+                creds = resolve_external_process_provider_credentials("devin-acp")
+                assert creds["provider"] == "devin-acp"
+                assert creds["api_key"] == "devin-acp"
+                assert creds["base_url"] == "acp://devin"
+                assert creds["command"] == "/usr/local/bin/devin"
+                assert creds["args"] == ["acp", "--debug"]
+
+
+class TestDevinAcpClientDefaults(unittest.TestCase):
+    def test_marker_and_defaults(self):
+        assert ACP_MARKER_BASE_URL == "acp://devin"
+        with patch.dict("os.environ", {}, clear=False):
+            # Ensure defaults when env not set — may still pick up user env
+            args = _resolve_args() if not __import__("os").getenv("HERMES_DEVIN_ACP_ARGS") else ["acp"]
+            if not __import__("os").getenv("HERMES_DEVIN_ACP_ARGS"):
+                assert _resolve_args() == ["acp"]
+        client = DevinACPClient(acp_cwd="/tmp", command="devin", args=["acp"])
+        assert client.api_key == "devin-acp"
+        assert client.base_url == "acp://devin"
+        assert client._acp_command == "devin"
+        assert client._acp_args == ["acp"]
+
+
+class TestAcpClientFactory(unittest.TestCase):
+    def test_create_devin(self):
+        from agent.acp_client_factory import create_acp_client, is_acp_provider
+
+        assert is_acp_provider("devin-acp") is True
+        assert is_acp_provider(base_url="acp://devin") is True
+        client = create_acp_client(provider="devin-acp", command="devin", args=["acp"], acp_cwd="/tmp")
+        assert isinstance(client, DevinACPClient)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agent/test_devin_acp_client.py
+++ b/tests/agent/test_devin_acp_client.py
@@ -231,5 +231,183 @@ class TestOneshotAcpWiring(unittest.TestCase):
         assert captured.get("base_url") == "acp://devin"
 
 
+class _LinePipe:
+    """Thread-safe line pipe used as stdout/stderr stand-in."""
+
+    def __init__(self) -> None:
+        self._lines: list[str] = []
+        self._cond = __import__("threading").Condition()
+        self._closed = False
+
+    def push(self, line: str) -> None:
+        with self._cond:
+            self._lines.append(line)
+            self._cond.notify_all()
+
+    def close(self) -> None:
+        with self._cond:
+            self._closed = True
+            self._cond.notify_all()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self) -> str:
+        with self._cond:
+            while not self._lines and not self._closed:
+                self._cond.wait(timeout=0.05)
+            if self._lines:
+                return self._lines.pop(0)
+            raise StopIteration
+
+
+class _ScriptedAcpProcess:
+    """Minimal Popen stand-in that answers ACP initialize / session RPCs."""
+
+    def __init__(self) -> None:
+        self.stdin = self
+        self.stdout = _LinePipe()
+        self.stderr = _LinePipe()
+        self.returncode = None
+        self.writes: list[dict] = []
+        self.session_seq = 0
+
+    def write(self, data: str) -> int:
+        import json
+
+        line = data.strip()
+        if not line:
+            return 0
+        req = json.loads(line)
+        self.writes.append(req)
+        method = req.get("method")
+        req_id = req.get("id")
+        if method == "initialize":
+            result = {"protocolVersion": 1}
+        elif method == "session/new":
+            self.session_seq += 1
+            result = {"sessionId": f"sess-{self.session_seq}"}
+        elif method == "session/prompt":
+            chunk = {
+                "jsonrpc": "2.0",
+                "method": "session/update",
+                "params": {
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "content": {"type": "text", "text": f"ok-{self.session_seq}"},
+                    }
+                },
+            }
+            self.stdout.push(json.dumps(chunk) + "\n")
+            result = {"stopReason": "end_turn"}
+        else:
+            result = {}
+        resp = {"jsonrpc": "2.0", "id": req_id, "result": result}
+        self.stdout.push(json.dumps(resp) + "\n")
+        return len(data)
+
+    def flush(self) -> None:
+        return None
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.returncode = 0
+        self.stdout.close()
+        self.stderr.close()
+
+    def kill(self) -> None:
+        self.terminate()
+
+    def wait(self, timeout=None) -> int:
+        self.returncode = self.returncode if self.returncode is not None else 0
+        return self.returncode
+
+
+class TestAcpProcessReuse(unittest.TestCase):
+    def test_reuses_process_across_prompts(self):
+        from agent.copilot_acp_client import CopilotACPClient
+
+        procs: list[_ScriptedAcpProcess] = []
+
+        def _popen(*_a, **_k):
+            proc = _ScriptedAcpProcess()
+            procs.append(proc)
+            return proc
+
+        with patch.dict("os.environ", {"HERMES_ACP_PROCESS_REUSE": "1"}, clear=False):
+            with patch("agent.copilot_acp_client.subprocess.Popen", side_effect=_popen):
+                client = CopilotACPClient(
+                    command="fake-acp",
+                    args=["--stdio"],
+                    acp_cwd="/tmp",
+                )
+                r1, _ = client._run_prompt("first", timeout_seconds=5)
+                r2, _ = client._run_prompt("second", timeout_seconds=5)
+                client.close()
+
+        assert r1 == "ok-1"
+        assert r2 == "ok-2"
+        assert client._spawn_count == 1
+        assert len(procs) == 1
+        methods = [w.get("method") for w in procs[0].writes]
+        # initialize once; session/new + session/prompt per turn
+        assert methods.count("initialize") == 1
+        assert methods.count("session/new") == 2
+        assert methods.count("session/prompt") == 2
+
+    def test_reuse_disabled_spawns_each_prompt(self):
+        from agent.copilot_acp_client import CopilotACPClient
+
+        procs: list[_ScriptedAcpProcess] = []
+
+        def _popen(*_a, **_k):
+            proc = _ScriptedAcpProcess()
+            procs.append(proc)
+            return proc
+
+        with patch.dict("os.environ", {"HERMES_ACP_PROCESS_REUSE": "0"}, clear=False):
+            with patch("agent.copilot_acp_client.subprocess.Popen", side_effect=_popen):
+                client = CopilotACPClient(
+                    command="fake-acp",
+                    args=["--stdio"],
+                    acp_cwd="/tmp",
+                )
+                # Re-read flag after env patch (constructor captured it).
+                client._reuse_enabled = False
+                client._run_prompt("first", timeout_seconds=5)
+                client._run_prompt("second", timeout_seconds=5)
+
+        assert client._spawn_count == 2
+        assert len(procs) == 2
+
+    def test_dead_process_respawns_on_next_prompt(self):
+        from agent.copilot_acp_client import CopilotACPClient
+
+        procs: list[_ScriptedAcpProcess] = []
+
+        def _popen(*_a, **_k):
+            proc = _ScriptedAcpProcess()
+            procs.append(proc)
+            return proc
+
+        with patch.dict("os.environ", {"HERMES_ACP_PROCESS_REUSE": "1"}, clear=False):
+            with patch("agent.copilot_acp_client.subprocess.Popen", side_effect=_popen):
+                client = CopilotACPClient(
+                    command="fake-acp",
+                    args=["--stdio"],
+                    acp_cwd="/tmp",
+                )
+                client._run_prompt("first", timeout_seconds=5)
+                # Simulate crash between turns without going through close().
+                procs[0].returncode = 1
+                client._run_prompt("second", timeout_seconds=5)
+                client.close()
+
+        assert client._spawn_count == 2
+        assert len(procs) == 2
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/agent/test_devin_acp_client.py
+++ b/tests/agent/test_devin_acp_client.py
@@ -79,6 +79,126 @@ class TestDevinAcpClientDefaults(unittest.TestCase):
         assert client._acp_command == "devin"
         assert client._acp_args == ["acp"]
 
+    def test_backend_model_id_maps_placeholders_to_none(self):
+        from agent.devin_acp_client import _backend_model_id
+
+        assert _backend_model_id(None) is None
+        assert _backend_model_id("") is None
+        assert _backend_model_id("devin-acp") is None
+        assert _backend_model_id("devin") is None
+        assert _backend_model_id("claude-opus-4.8") == "claude-opus-4.8"
+
+    def test_resolve_devin_acp_model_value_maps_cli_to_acp_ids(self):
+        from agent.devin_acp_client import resolve_devin_acp_model_value
+
+        config_options = [
+            {
+                "id": "model",
+                "currentValue": "swe-1-7",
+                "options": [
+                    {"value": "swe-1-7", "name": "SWE-1.7"},
+                    {"value": "swe-1-6-fast", "name": "SWE-1.6 Fast"},
+                    {"value": "claude-sonnet-5-medium", "name": "Claude Sonnet 5 Medium"},
+                    {"value": "MODEL_PRIVATE_11", "name": "Claude Haiku 4.5"},
+                    {"value": "adaptive", "name": "Adaptive"},
+                ],
+            }
+        ]
+        assert resolve_devin_acp_model_value("swe-1.6-fast", config_options) == "swe-1-6-fast"
+        assert resolve_devin_acp_model_value("swe-1-6-fast", config_options) == "swe-1-6-fast"
+        assert (
+            resolve_devin_acp_model_value("claude-haiku-4.5", config_options)
+            == "MODEL_PRIVATE_11"
+        )
+        assert resolve_devin_acp_model_value("adaptive", config_options) == "adaptive"
+        assert resolve_devin_acp_model_value("devin-acp", config_options) is None
+
+    def test_tool_session_updates_emit_progress(self):
+        from agent.copilot_acp_client import CopilotACPClient
+
+        events: list[tuple] = []
+        statuses: list[str] = []
+
+        class _Agent:
+            def _touch_activity(self, desc):
+                pass
+
+            def _emit_status(self, msg):
+                statuses.append(msg)
+
+            def tool_progress_callback(self, event_type, name=None, preview=None, args=None, **kw):
+                events.append((event_type, name, preview, args, kw))
+
+        client = CopilotACPClient(acp_cwd="/tmp", command="copilot", args=["--acp", "--stdio"])
+        client.bind_agent_activity(_Agent())
+        client._handle_tool_session_update(
+            "tool_call",
+            {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "c1",
+                "title": "Reading config",
+                "kind": "read",
+                "status": "pending",
+            },
+        )
+        client._handle_tool_session_update(
+            "tool_call_update",
+            {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "c1",
+                "status": "completed",
+                "content": [{"type": "content", "content": {"type": "text", "text": "ok"}}],
+            },
+        )
+        assert any(e[0] == "tool.started" for e in events)
+        assert any(e[0] == "tool.completed" for e in events)
+        assert any("Reading config" in (e[2] or "") for e in events)
+        assert any("Devin" in s or "ACP" in s or "Copilot" in s for s in statuses)
+
+    def test_permission_auto_selects_allow(self):
+        from agent.copilot_acp_client import _permission_auto_selected
+
+        resp = _permission_auto_selected(
+            7,
+            [
+                {"optionId": "reject-once", "name": "Reject", "kind": "reject_once"},
+                {"optionId": "allow-once", "name": "Allow", "kind": "allow_once"},
+            ],
+        )
+        assert resp["result"]["outcome"]["outcome"] == "selected"
+        assert resp["result"]["outcome"]["optionId"] == "allow-once"
+
+    def test_spawn_argv_and_env_bind_selected_model(self):
+        client = DevinACPClient(acp_cwd="/tmp", command="devin", args=["acp"])
+        client._prepare_for_model("claude-opus-4.8")
+        assert client._spawn_argv() == [
+            "devin",
+            "--model",
+            "claude-opus-4.8",
+            "acp",
+        ]
+        env = client._subprocess_env()
+        assert env.get("DEVIN_MODEL") == "claude-opus-4.8"
+
+        client._prepare_for_model("devin-acp")
+        assert client._spawn_argv() == ["devin", "acp"]
+        env2 = client._subprocess_env()
+        assert "DEVIN_MODEL" not in env2
+
+    def test_prepare_for_model_respawns_on_change(self):
+        client = DevinACPClient(acp_cwd="/tmp", command="devin", args=["acp"])
+        client._process_bound_model = "swe-1.7"
+        client._active_process = type("P", (), {"poll": lambda self: None})()
+        with patch.object(client, "_reset_transport") as reset:
+            client._prepare_for_model("claude-sonnet-5")
+            reset.assert_called_once_with(mark_closed=False)
+        assert client._desired_process_model == "claude-sonnet-5"
+
+        with patch.object(client, "_reset_transport") as reset2:
+            client._process_bound_model = "claude-sonnet-5"
+            client._prepare_for_model("claude-sonnet-5")
+            reset2.assert_not_called()
+
     def test_empty_args_does_not_fall_through_to_copilot_defaults(self):
         """Regression: args=[] used to become ['--acp', '--stdio'] via parent."""
         with patch.dict(
@@ -342,7 +462,12 @@ class TestDevinDesktopUiSupport(unittest.TestCase):
         slugs = {r.get("slug") for r in rows}
         assert "devin-acp" in slugs
         devin = next(r for r in rows if r.get("slug") == "devin-acp")
-        assert "devin-acp" in (devin.get("models") or [])
+        models = devin.get("models") or []
+        # Live CLI discovery returns real model ids (adaptive, swe-1.7, …);
+        # offline fallback still includes the curated snapshot (+ optional
+        # "devin-acp" placeholder). Either path must yield a non-empty picker list.
+        assert models
+        assert isinstance(models, list)
 
 
 class TestAcpErrorClassification(unittest.TestCase):

--- a/tests/agent/test_devin_acp_client.py
+++ b/tests/agent/test_devin_acp_client.py
@@ -172,6 +172,32 @@ class TestAcpClientFactory(unittest.TestCase):
                     assert _devin_local_credentials_present() is False
 
 
+class TestAcpErrorClassification(unittest.TestCase):
+    def test_missing_cli_is_non_retryable(self):
+        from agent.error_classifier import FailoverReason, classify_api_error
+
+        err = RuntimeError(
+            "Could not start Devin ACP command 'devin'. "
+            "Install Devin CLI and run `devin auth login`."
+        )
+        result = classify_api_error(err, provider="devin-acp")
+        assert result.retryable is False
+        assert result.reason in {
+            FailoverReason.format_error,
+            FailoverReason.auth_permanent,
+        }
+
+    def test_wrong_argv_is_non_retryable(self):
+        from agent.error_classifier import FailoverReason, classify_api_error
+
+        err = RuntimeError(
+            "Devin ACP process exited early: error: unexpected argument '--acp' found"
+        )
+        result = classify_api_error(err, provider="devin-acp")
+        assert result.retryable is False
+        assert result.reason == FailoverReason.format_error
+
+
 class TestOneshotAcpWiring(unittest.TestCase):
     def test_oneshot_forwards_runtime_command_and_args(self):
         """hermes -z must pass ACP command/args into AIAgent (P0 regression)."""
@@ -483,6 +509,38 @@ class TestAcpProcessReuse(unittest.TestCase):
             assert procs[0].poll() is None
             client.interrupt()
             assert procs[0].poll() is not None
+
+    def test_stream_true_yields_iterable_deltas(self):
+        from agent.copilot_acp_client import CopilotACPClient
+
+        def _popen(*_a, **_k):
+            return _ScriptedAcpProcess()
+
+        with patch("agent.copilot_acp_client.subprocess.Popen", side_effect=_popen):
+            client = CopilotACPClient(
+                command="fake-acp",
+                args=["--stdio"],
+                acp_cwd="/tmp",
+            )
+            client._reuse_enabled = True
+            stream = client._create_chat_completion(
+                model="devin-acp",
+                messages=[{"role": "user", "content": "hi"}],
+                stream=True,
+                timeout=5,
+            )
+            assert not hasattr(stream, "choices")  # must be iterable, not final response
+            chunks = list(stream)
+            client.close()
+
+        contents = []
+        for ch in chunks:
+            if not ch.choices:
+                continue
+            delta = ch.choices[0].delta
+            if getattr(delta, "content", None):
+                contents.append(delta.content)
+        assert "".join(contents) == "ok-1" or any(c == "ok-1" for c in contents)
 
 
 if __name__ == "__main__":

--- a/tests/agent/test_devin_acp_client.py
+++ b/tests/agent/test_devin_acp_client.py
@@ -29,20 +29,41 @@ class TestDevinAcpProviderRegistry(unittest.TestCase):
 class TestDevinAcpResolve(unittest.TestCase):
     def test_status_and_creds(self):
         with patch("hermes_cli.auth.shutil.which", return_value="/usr/local/bin/devin"):
-            with patch.dict("os.environ", {"HERMES_DEVIN_ACP_ARGS": "acp --debug"}, clear=False):
-                status = get_external_process_provider_status("devin-acp")
-                assert status["configured"] is True
-                assert status["command"] == "devin"
-                assert status["resolved_command"] == "/usr/local/bin/devin"
-                assert status["args"] == ["acp", "--debug"]
-                assert status["base_url"] == "acp://devin"
+            with patch(
+                "hermes_cli.auth._devin_local_credentials_present",
+                return_value=True,
+            ):
+                with patch.dict("os.environ", {"HERMES_DEVIN_ACP_ARGS": "acp --debug"}, clear=False):
+                    status = get_external_process_provider_status("devin-acp")
+                    assert status["configured"] is True
+                    assert status["cli_installed"] is True
+                    assert status["auth_present"] is True
+                    assert status["logged_in"] is True
+                    assert status["command"] == "devin"
+                    assert status["resolved_command"] == "/usr/local/bin/devin"
+                    assert status["args"] == ["acp", "--debug"]
+                    assert status["base_url"] == "acp://devin"
 
-                creds = resolve_external_process_provider_credentials("devin-acp")
-                assert creds["provider"] == "devin-acp"
-                assert creds["api_key"] == "devin-acp"
-                assert creds["base_url"] == "acp://devin"
-                assert creds["command"] == "/usr/local/bin/devin"
-                assert creds["args"] == ["acp", "--debug"]
+                    creds = resolve_external_process_provider_credentials("devin-acp")
+                    assert creds["provider"] == "devin-acp"
+                    assert creds["api_key"] == "devin-acp"
+                    assert creds["base_url"] == "acp://devin"
+                    assert creds["command"] == "/usr/local/bin/devin"
+                    assert creds["args"] == ["acp", "--debug"]
+
+    def test_status_cli_without_credentials_is_not_logged_in(self):
+        with patch("hermes_cli.auth.shutil.which", return_value="/usr/local/bin/devin"):
+            with patch(
+                "hermes_cli.auth._devin_local_credentials_present",
+                return_value=False,
+            ):
+                status = get_external_process_provider_status("devin-acp")
+        assert status["configured"] is True
+        assert status["cli_installed"] is True
+        assert status["auth_present"] is False
+        assert status["logged_in"] is False
+        assert status.get("hint")
+        assert "devin auth login" in status["hint"]
 
 
 class TestDevinAcpClientDefaults(unittest.TestCase):
@@ -86,8 +107,9 @@ class TestDevinAcpClientDefaults(unittest.TestCase):
 
 class TestAcpClientFactory(unittest.TestCase):
     def test_create_devin(self):
-        from agent.acp_client_factory import create_acp_client, is_acp_provider
+        from agent.acp_client_factory import ACP_PROVIDERS, create_acp_client, is_acp_provider
 
+        assert "devin-acp" in ACP_PROVIDERS
         assert is_acp_provider("devin-acp") is True
         assert is_acp_provider(base_url="acp://devin") is True
         client = create_acp_client(
@@ -104,6 +126,50 @@ class TestAcpClientFactory(unittest.TestCase):
             )
         assert isinstance(client, DevinACPClient)
         assert client._acp_args == ["acp"]
+
+    def test_create_devin_fills_missing_command_from_resolver(self):
+        from agent.acp_client_factory import create_acp_client
+
+        with patch(
+            "hermes_cli.auth.resolve_external_process_provider_credentials",
+            return_value={
+                "command": "/resolved/devin",
+                "args": ["acp", "--from-resolver"],
+            },
+        ):
+            client = create_acp_client(provider="devin-acp", acp_cwd="/tmp")
+        assert isinstance(client, DevinACPClient)
+        assert client._acp_command == "/resolved/devin"
+        assert client._acp_args == ["acp", "--from-resolver"]
+
+    def test_devin_credentials_probe_reads_marker_not_secret(self, tmp_path=None):
+        import tempfile
+        from pathlib import Path
+
+        from hermes_cli.auth import _devin_local_credentials_present
+
+        with tempfile.TemporaryDirectory() as td:
+            cred_dir = Path(td) / "devin"
+            cred_dir.mkdir()
+            cred_file = cred_dir / "credentials.toml"
+            cred_file.write_text(
+                'windsurf_api_key = "devin-session-token$secret-value"\n',
+                encoding="utf-8",
+            )
+            with patch.dict("os.environ", {"APPDATA": td, "XDG_CONFIG_HOME": td}, clear=False):
+                # Point home-based candidates away from the real user home by
+                # still using APPDATA/XDG which our probe checks first.
+                assert _devin_local_credentials_present() is True
+
+            missing = Path(td) / "empty"
+            missing.mkdir()
+            with patch.dict(
+                "os.environ",
+                {"APPDATA": str(missing), "XDG_CONFIG_HOME": str(missing)},
+                clear=False,
+            ):
+                with patch("pathlib.Path.home", return_value=missing):
+                    assert _devin_local_credentials_present() is False
 
 
 class TestOneshotAcpWiring(unittest.TestCase):

--- a/tests/agent/test_devin_acp_client.py
+++ b/tests/agent/test_devin_acp_client.py
@@ -336,13 +336,19 @@ class TestAcpProcessReuse(unittest.TestCase):
             procs.append(proc)
             return proc
 
-        with patch.dict("os.environ", {"HERMES_ACP_PROCESS_REUSE": "1"}, clear=False):
+        with patch.dict(
+            "os.environ",
+            {"HERMES_ACP_PROCESS_REUSE": "1", "HERMES_ACP_SESSION_REUSE": "0"},
+            clear=False,
+        ):
             with patch("agent.copilot_acp_client.subprocess.Popen", side_effect=_popen):
                 client = CopilotACPClient(
                     command="fake-acp",
                     args=["--stdio"],
                     acp_cwd="/tmp",
                 )
+                client._reuse_enabled = True
+                client._session_reuse_enabled = False
                 r1, _ = client._run_prompt("first", timeout_seconds=5)
                 r2, _ = client._run_prompt("second", timeout_seconds=5)
                 client.close()
@@ -352,10 +358,56 @@ class TestAcpProcessReuse(unittest.TestCase):
         assert client._spawn_count == 1
         assert len(procs) == 1
         methods = [w.get("method") for w in procs[0].writes]
-        # initialize once; session/new + session/prompt per turn
+        # initialize once; session/new + session/prompt per turn when session reuse off
         assert methods.count("initialize") == 1
         assert methods.count("session/new") == 2
         assert methods.count("session/prompt") == 2
+
+    def test_session_continuity_sends_only_delta(self):
+        from agent.copilot_acp_client import CopilotACPClient
+
+        procs: list[_ScriptedAcpProcess] = []
+
+        def _popen(*_a, **_k):
+            proc = _ScriptedAcpProcess()
+            procs.append(proc)
+            return proc
+
+        with patch("agent.copilot_acp_client.subprocess.Popen", side_effect=_popen):
+            client = CopilotACPClient(
+                command="fake-acp",
+                args=["--stdio"],
+                acp_cwd="/tmp",
+            )
+            client._reuse_enabled = True
+            client._session_reuse_enabled = True
+            m1 = [{"role": "user", "content": "hello"}]
+            c1 = client._create_chat_completion(model="x", messages=m1, timeout=5)
+            m2 = [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": c1.choices[0].message.content},
+                {"role": "user", "content": "follow up"},
+            ]
+            c2 = client._create_chat_completion(model="x", messages=m2, timeout=5)
+            client.close()
+
+        assert c1.choices[0].message.content == "ok-1"
+        assert c2.choices[0].message.content == "ok-1"  # same session seq (no new session)
+        assert client._spawn_count == 1
+        assert client._session_count == 1
+        assert client._session_continues == 1
+        methods = [w.get("method") for w in procs[0].writes]
+        assert methods.count("session/new") == 1
+        assert methods.count("session/prompt") == 2
+        # Second prompt body should be a continuation delta, not full history.
+        prompt_bodies = [
+            w["params"]["prompt"][0]["text"]
+            for w in procs[0].writes
+            if w.get("method") == "session/prompt"
+        ]
+        assert "New messages:" in prompt_bodies[1]
+        assert "follow up" in prompt_bodies[1]
+        assert "Conversation transcript:" not in prompt_bodies[1]
 
     def test_reuse_disabled_spawns_each_prompt(self):
         from agent.copilot_acp_client import CopilotACPClient
@@ -376,6 +428,7 @@ class TestAcpProcessReuse(unittest.TestCase):
                 )
                 # Re-read flag after env patch (constructor captured it).
                 client._reuse_enabled = False
+                client._session_reuse_enabled = False
                 client._run_prompt("first", timeout_seconds=5)
                 client._run_prompt("second", timeout_seconds=5)
 
@@ -392,21 +445,44 @@ class TestAcpProcessReuse(unittest.TestCase):
             procs.append(proc)
             return proc
 
-        with patch.dict("os.environ", {"HERMES_ACP_PROCESS_REUSE": "1"}, clear=False):
-            with patch("agent.copilot_acp_client.subprocess.Popen", side_effect=_popen):
-                client = CopilotACPClient(
-                    command="fake-acp",
-                    args=["--stdio"],
-                    acp_cwd="/tmp",
-                )
-                client._run_prompt("first", timeout_seconds=5)
-                # Simulate crash between turns without going through close().
-                procs[0].returncode = 1
-                client._run_prompt("second", timeout_seconds=5)
-                client.close()
+        with patch("agent.copilot_acp_client.subprocess.Popen", side_effect=_popen):
+            client = CopilotACPClient(
+                command="fake-acp",
+                args=["--stdio"],
+                acp_cwd="/tmp",
+            )
+            client._reuse_enabled = True
+            client._session_reuse_enabled = True
+            client._run_prompt("first", timeout_seconds=5)
+            # Simulate crash between turns without going through close().
+            procs[0].returncode = 1
+            client._run_prompt("second", timeout_seconds=5)
+            client.close()
 
         assert client._spawn_count == 2
         assert len(procs) == 2
+
+    def test_interrupt_terminates_live_process(self):
+        from agent.copilot_acp_client import CopilotACPClient
+
+        procs: list[_ScriptedAcpProcess] = []
+
+        def _popen(*_a, **_k):
+            proc = _ScriptedAcpProcess()
+            procs.append(proc)
+            return proc
+
+        with patch("agent.copilot_acp_client.subprocess.Popen", side_effect=_popen):
+            client = CopilotACPClient(
+                command="fake-acp",
+                args=["--stdio"],
+                acp_cwd="/tmp",
+            )
+            client._reuse_enabled = True
+            client._run_prompt("first", timeout_seconds=5)
+            assert procs[0].poll() is None
+            client.interrupt()
+            assert procs[0].poll() is not None
 
 
 if __name__ == "__main__":

--- a/tests/agent/test_devin_acp_client.py
+++ b/tests/agent/test_devin_acp_client.py
@@ -293,6 +293,58 @@ class TestAcpToolLoopSession(unittest.TestCase):
         assert methods.count("session/prompt") == 2
 
 
+class TestDevinDesktopUiSupport(unittest.TestCase):
+    def test_oauth_catalog_has_hand_tuned_devin_card(self):
+        from hermes_cli.web_server import _build_oauth_catalog
+
+        cards = {p["id"]: p for p in _build_oauth_catalog()}
+        assert "devin-acp" in cards
+        card = cards["devin-acp"]
+        assert card["flow"] == "external"
+        assert card["cli_command"] == "devin auth login"
+        assert card.get("status_fn") is not None
+        assert "docs.devin.ai" in (card.get("docs_url") or "")
+
+    def test_devin_acp_status_shape(self):
+        from hermes_cli.web_server import _devin_acp_status
+
+        with patch(
+            "hermes_cli.auth.get_external_process_provider_status",
+            return_value={
+                "logged_in": True,
+                "cli_installed": True,
+                "auth_present": True,
+                "resolved_command": "/usr/bin/devin",
+                "command": "devin",
+                "hint": None,
+            },
+        ):
+            st = _devin_acp_status()
+        assert st["logged_in"] is True
+        assert st["source"] == "devin_cli"
+        assert st["token_preview"] is None
+        assert "Devin CLI" in st["source_label"]
+        assert "/usr/bin/devin" in st["source_label"]
+
+    def test_list_authenticated_includes_devin_when_logged_in(self):
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        with patch(
+            "hermes_cli.auth.get_external_process_provider_status",
+            side_effect=lambda pid: {
+                "logged_in": pid == "devin-acp",
+                "cli_installed": pid == "devin-acp",
+                "auth_present": pid == "devin-acp",
+                "configured": pid == "devin-acp",
+            },
+        ):
+            rows = list_authenticated_providers()
+        slugs = {r.get("slug") for r in rows}
+        assert "devin-acp" in slugs
+        devin = next(r for r in rows if r.get("slug") == "devin-acp")
+        assert "devin-acp" in (devin.get("models") or [])
+
+
 class TestAcpErrorClassification(unittest.TestCase):
     def test_missing_cli_is_non_retryable(self):
         from agent.error_classifier import FailoverReason, classify_api_error

--- a/tests/agent/test_devin_acp_client.py
+++ b/tests/agent/test_devin_acp_client.py
@@ -172,6 +172,127 @@ class TestAcpClientFactory(unittest.TestCase):
                     assert _devin_local_credentials_present() is False
 
 
+class TestAcpToolLoopSession(unittest.TestCase):
+    def test_tool_call_then_tool_result_reuses_session(self):
+        """Assistant tool_call → tool result should continue the same ACP session."""
+        from agent.copilot_acp_client import CopilotACPClient
+
+        procs: list[_ScriptedAcpProcess] = []
+
+        class _ToolAwareProcess(_ScriptedAcpProcess):
+            def write(self, data: str) -> int:
+                import json
+
+                line = data.strip()
+                if not line:
+                    return 0
+                req = json.loads(line)
+                self.writes.append(req)
+                method = req.get("method")
+                req_id = req.get("id")
+                if method == "initialize":
+                    result = {"protocolVersion": 1}
+                elif method == "session/new":
+                    self.session_seq += 1
+                    result = {"sessionId": f"sess-{self.session_seq}"}
+                elif method == "session/prompt":
+                    prompt_text = req["params"]["prompt"][0]["text"]
+                    if "Tool:" in prompt_text or "tool result" in prompt_text.lower():
+                        body = "file contents here"
+                    else:
+                        body = (
+                            '<tool_call>{"id":"call_1","type":"function",'
+                            '"function":{"name":"read_file","arguments":"{\\"path\\":\\"a.txt\\"}"}}'
+                            "</tool_call>"
+                        )
+                    chunk = {
+                        "jsonrpc": "2.0",
+                        "method": "session/update",
+                        "params": {
+                            "update": {
+                                "sessionUpdate": "agent_message_chunk",
+                                "content": {"type": "text", "text": body},
+                            }
+                        },
+                    }
+                    self.stdout.push(json.dumps(chunk) + "\n")
+                    result = {"stopReason": "end_turn"}
+                else:
+                    result = {}
+                self.stdout.push(json.dumps({"jsonrpc": "2.0", "id": req_id, "result": result}) + "\n")
+                return len(data)
+
+        def _popen(*_a, **_k):
+            proc = _ToolAwareProcess()
+            procs.append(proc)
+            return proc
+
+        with patch("agent.copilot_acp_client.subprocess.Popen", side_effect=_popen):
+            client = CopilotACPClient(
+                command="fake-acp",
+                args=["--stdio"],
+                acp_cwd="/tmp",
+            )
+            client._reuse_enabled = True
+            client._session_reuse_enabled = True
+
+            tools = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ]
+            r1 = client._create_chat_completion(
+                model="x",
+                messages=[{"role": "user", "content": "read a.txt"}],
+                tools=tools,
+                timeout=5,
+            )
+            assert r1.choices[0].finish_reason == "tool_calls"
+            tc = r1.choices[0].message.tool_calls[0]
+            assert tc.function.name == "read_file"
+
+            r2 = client._create_chat_completion(
+                model="x",
+                messages=[
+                    {"role": "user", "content": "read a.txt"},
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": tc.id,
+                                "type": "function",
+                                "function": {
+                                    "name": "read_file",
+                                    "arguments": tc.function.arguments,
+                                },
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": tc.id,
+                        "content": "hello from file",
+                    },
+                ],
+                tools=tools,
+                timeout=5,
+            )
+            client.close()
+
+        assert "file contents here" in (r2.choices[0].message.content or "")
+        assert client._spawn_count == 1
+        assert client._session_count == 1
+        assert client._session_continues == 1
+        methods = [w.get("method") for w in procs[0].writes]
+        assert methods.count("session/new") == 1
+        assert methods.count("session/prompt") == 2
+
+
 class TestAcpErrorClassification(unittest.TestCase):
     def test_missing_cli_is_non_retryable(self):
         from agent.error_classifier import FailoverReason, classify_api_error

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -30,6 +30,7 @@ class TestProviderRegistry:
 
     @pytest.mark.parametrize("provider_id,name,auth_type", [
         ("copilot-acp", "GitHub Copilot ACP", "external_process"),
+        ("devin-acp", "Devin CLI ACP", "external_process"),
         ("copilot", "GitHub Copilot", "api_key"),
         ("huggingface", "Hugging Face", "api_key"),
         ("zai", "Z.AI / GLM", "api_key"),

--- a/tests/hermes_cli/test_devin_cli_models.py
+++ b/tests/hermes_cli/test_devin_cli_models.py
@@ -1,0 +1,76 @@
+"""Devin CLI model auto-discovery (invalid --model → Available: …)."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from hermes_cli.models import (
+    fetch_devin_cli_models,
+    parse_devin_cli_available_models,
+    provider_model_ids,
+)
+
+
+SAMPLE_ERR = (
+    "Error: Unknown model: '__hermes_devin_probe__'\n"
+    "Available: adaptive, claude-opus-4.8, swe-1.7, gpt-5.5\n"
+)
+
+
+class TestParseDevinAvailable(unittest.TestCase):
+    def test_parses_available_line(self):
+        models = parse_devin_cli_available_models(SAMPLE_ERR)
+        self.assertEqual(models, ["adaptive", "claude-opus-4.8", "swe-1.7", "gpt-5.5"])
+
+    def test_empty_when_missing(self):
+        self.assertEqual(parse_devin_cli_available_models("no available here"), [])
+        self.assertEqual(parse_devin_cli_available_models(""), [])
+
+    def test_dedupes_preserving_order(self):
+        text = "Available: a, b, a, c"
+        self.assertEqual(parse_devin_cli_available_models(text), ["a", "b", "c"])
+
+
+class TestFetchDevinCliModels(unittest.TestCase):
+    def test_fetch_parses_stderr(self):
+        mock_proc = MagicMock()
+        mock_proc.stderr = SAMPLE_ERR
+        mock_proc.stdout = ""
+        with patch("subprocess.run", return_value=mock_proc) as run:
+            with patch("shutil.which", return_value="/bin/devin"):
+                models = fetch_devin_cli_models(command="devin")
+        self.assertEqual(models, ["adaptive", "claude-opus-4.8", "swe-1.7", "gpt-5.5"])
+        argv = run.call_args[0][0]
+        self.assertEqual(argv[0], "/bin/devin")
+        self.assertIn("--model", argv)
+        self.assertIn("-p", argv)
+
+    def test_fetch_returns_empty_on_timeout(self):
+        import subprocess
+
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="devin", timeout=1),
+        ):
+            with patch("shutil.which", return_value="/bin/devin"):
+                self.assertEqual(fetch_devin_cli_models(command="devin"), [])
+
+    def test_provider_model_ids_uses_live(self):
+        with patch(
+            "hermes_cli.models.fetch_devin_cli_models",
+            return_value=["swe-1.7", "claude-opus-4.8"],
+        ):
+            ids = provider_model_ids("devin-acp")
+        self.assertEqual(ids, ["swe-1.7", "claude-opus-4.8"])
+
+    def test_provider_model_ids_falls_back_to_curated(self):
+        with patch("hermes_cli.models.fetch_devin_cli_models", return_value=[]):
+            ids = provider_model_ids("devin-acp")
+        self.assertIn("swe-1.7", ids)
+        self.assertIn("claude-opus-4.8", ids)
+        self.assertIn("devin-acp", ids)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/website/docs/developer-guide/model-provider-plugin.md
+++ b/website/docs/developer-guide/model-provider-plugin.md
@@ -198,7 +198,7 @@ Set `profile.api_mode` to match the default your provider ships — it acts as a
 | `oauth_external` | User signs in elsewhere, tokens land in `auth.json` | Anthropic OAuth, MiniMax OAuth, Qwen Portal, Nous Portal |
 | `copilot` | GitHub Copilot token refresh cycle | `copilot` plugin only |
 | `aws_sdk` | AWS SDK credential chain (IAM role, profile, env) | `bedrock` plugin only |
-| `external_process` | Auth handled by a subprocess the agent spawns | `copilot-acp` plugin only |
+| `external_process` | Auth handled by a subprocess the agent spawns | `copilot-acp`, `devin-acp` |
 
 `auth_type` gates which codepaths treat your provider as a "simple api-key provider" — if it's not `api_key`, the PluginManager still records the manifest but Hermes' CLI-level automation (doctor checks, `--provider` flag, setup wizard delegation) may skip over it.
 

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -208,6 +208,8 @@ model:
 | `COPILOT_GITHUB_TOKEN` | GitHub token for Copilot API (first priority) |
 | `HERMES_COPILOT_ACP_COMMAND` | Override the Copilot CLI binary path (default: `copilot`) |
 | `HERMES_COPILOT_ACP_ARGS` | Override ACP args (default: `--acp --stdio`) |
+| `HERMES_ACP_PROCESS_REUSE` | Keep ACP subprocess warm across turns (default on; `0` disables) |
+| `HERMES_ACP_SESSION_REUSE` | Continue ACP session when history grows (default on with process reuse) |
 
 **`devin-acp` — Devin CLI ACP backend**. Spawns the local Devin CLI as a subprocess (`devin acp`):
 
@@ -228,6 +230,10 @@ model:
 | `HERMES_DEVIN_ACP_COMMAND` / `DEVIN_CLI_PATH` | Override the Devin CLI binary path (default: `devin`) |
 | `HERMES_DEVIN_ACP_ARGS` | Override ACP args (default: `acp`) |
 | `DEVIN_ACP_BASE_URL` | Override marker URL (default: `acp://devin`) |
+| `HERMES_ACP_PROCESS_REUSE` | Keep the ACP CLI process warm across turns (default on; set `0` to disable) |
+| `HERMES_ACP_SESSION_REUSE` | Continue the same ACP session when history extends (default on with process reuse; set `0` for a fresh session each prompt) |
+
+Hermes reuses the local `devin acp` process across multi-turn chat, continues the ACP session when the message list is a strict extension of the previous request (sending only new messages), and streams `agent_message_chunk` frames into the UI when a display consumer is present. Interrupt / `/stop` terminates the warm subprocess immediately.
 
 On Windows, install Devin CLI via PowerShell (`irm https://static.devin.ai/cli/setup.ps1 | iex`), then restart the terminal so `devin` is on `PATH`.
 

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -209,6 +209,28 @@ model:
 | `HERMES_COPILOT_ACP_COMMAND` | Override the Copilot CLI binary path (default: `copilot`) |
 | `HERMES_COPILOT_ACP_ARGS` | Override ACP args (default: `--acp --stdio`) |
 
+**`devin-acp` — Devin CLI ACP backend**. Spawns the local Devin CLI as a subprocess (`devin acp`):
+
+```bash
+hermes chat --provider devin-acp --model devin-acp
+# Requires the Devin CLI in PATH and `devin auth login`
+```
+
+**Permanent config:**
+```yaml
+model:
+  provider: "devin-acp"
+  default: "devin-acp"
+```
+
+| Environment variable | Description |
+|---------------------|-------------|
+| `HERMES_DEVIN_ACP_COMMAND` / `DEVIN_CLI_PATH` | Override the Devin CLI binary path (default: `devin`) |
+| `HERMES_DEVIN_ACP_ARGS` | Override ACP args (default: `acp`) |
+| `DEVIN_ACP_BASE_URL` | Override marker URL (default: `acp://devin`) |
+
+On Windows, install Devin CLI via PowerShell (`irm https://static.devin.ai/cli/setup.ps1 | iex`), then restart the terminal so `devin` is on `PATH`.
+
 ### First-Class API-Key Providers
 
 These providers have built-in support with dedicated provider IDs. Set the API key and use `--provider` to select:
@@ -1472,7 +1494,7 @@ fallback_model:
 
 When activated, the fallback swaps the model and provider mid-session without losing your conversation. The chain is tried entry-by-entry; activation is one-shot per session.
 
-Supported providers: `openrouter`, `nous`, `novita`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `qwen-oauth`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `deepseek`, `nvidia`, `xai`, `xai-oauth`, `ollama-cloud`, `bedrock`, `azure-foundry`, `opencode-zen`, `opencode-go`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `stepfun`, `lmstudio`, `alibaba`, `alibaba-coding-plan`, `tencent-tokenhub`, `custom`.
+Supported providers: `openrouter`, `nous`, `novita`, `openai-codex`, `copilot`, `copilot-acp`, `devin-acp`, `anthropic`, `gemini`, `qwen-oauth`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `deepseek`, `nvidia`, `xai`, `xai-oauth`, `ollama-cloud`, `bedrock`, `azure-foundry`, `opencode-zen`, `opencode-go`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `stepfun`, `lmstudio`, `alibaba`, `alibaba-coding-plan`, `tencent-tokenhub`, `custom`.
 
 :::tip
 Fallback is configured exclusively through `config.yaml` — or interactively via `hermes fallback`. For full details on when it triggers, how the chain advances, and how it interacts with auxiliary tasks and delegation, see [Fallback Providers](/user-guide/features/fallback-providers).

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -235,6 +235,8 @@ model:
 
 Hermes reuses the local `devin acp` process across multi-turn chat, continues the ACP session when the message list is a strict extension of the previous request (sending only new messages), and streams `agent_message_chunk` frames into the UI when a display consumer is present. Interrupt / `/stop` terminates the warm subprocess immediately.
 
+**Desktop / dashboard:** Settings → Accounts shows a **Devin CLI ACP** card (`flow: external`). Authenticate with `devin auth login` in a terminal (same pattern as GitHub Copilot ACP). When the CLI is installed and local credentials are detected, Model Picker lists `devin-acp` so you can set it as the active model without using the CLI wizard.
+
 On Windows, install Devin CLI via PowerShell (`irm https://static.devin.ai/cli/setup.ps1 | iex`), then restart the terminal so `devin` is on `PATH`.
 
 ### First-Class API-Key Providers

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -28,6 +28,10 @@ Hermes reads environment variables from the process environment and, for user-ma
 | `HERMES_COPILOT_ACP_COMMAND` | Override Copilot ACP CLI binary path (default: `copilot`) |
 | `COPILOT_CLI_PATH` | Alias for `HERMES_COPILOT_ACP_COMMAND` |
 | `HERMES_COPILOT_ACP_ARGS` | Override Copilot ACP arguments (default: `--acp --stdio`) |
+| `HERMES_DEVIN_ACP_COMMAND` | Override Devin ACP CLI binary path (default: `devin`) |
+| `DEVIN_CLI_PATH` | Alias for `HERMES_DEVIN_ACP_COMMAND` |
+| `HERMES_DEVIN_ACP_ARGS` | Override Devin ACP arguments (default: `acp`) |
+| `DEVIN_ACP_BASE_URL` | Override Devin ACP marker URL (default: `acp://devin`) |
 | `COPILOT_ACP_BASE_URL` | Override Copilot ACP base URL |
 | `COPILOT_API_BASE_URL` | Override the Copilot API base URL (`copilot` provider) |
 | `GLM_API_KEY` | z.ai / ZhipuAI GLM API key ([z.ai](https://z.ai)) |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -32,6 +32,8 @@ Hermes reads environment variables from the process environment and, for user-ma
 | `DEVIN_CLI_PATH` | Alias for `HERMES_DEVIN_ACP_COMMAND` |
 | `HERMES_DEVIN_ACP_ARGS` | Override Devin ACP arguments (default: `acp`) |
 | `DEVIN_ACP_BASE_URL` | Override Devin ACP marker URL (default: `acp://devin`) |
+| `HERMES_ACP_PROCESS_REUSE` | Keep the ACP subprocess warm across turns (`1`/`true` default; set `0` to spawn per request) |
+| `HERMES_ACP_SESSION_REUSE` | Continue the same ACP `sessionId` when history grows (`1` default when process reuse is on; set `0` for `session/new` every prompt) |
 | `COPILOT_ACP_BASE_URL` | Override Copilot ACP base URL |
 | `COPILOT_API_BASE_URL` | Override the Copilot API base URL (`copilot` provider) |
 | `GLM_API_KEY` | z.ai / ZhipuAI GLM API key ([z.ai](https://z.ai)) |


### PR DESCRIPTION
- feat: add devin-acp provider (Devin CLI ACP backend)
- fix(devin-acp): wire oneshot ACP args and stop empty-list Copilot fallback
- fix(devin-acp): centralize ACP checks and probe local Devin auth
- perf(acp): keep ACP subprocess warm across multi-turn requests
- perf(acp): continue ACP sessions with delta prompts and kill on interrupt
- feat(acp): stream ACP message chunks and fail fast on setup errors
- docs(acp): document process/session reuse env vars and harden tool-loop tests
- feat(devin-acp): surface Devin CLI ACP in Desktop Accounts and model picker
- feat(devin-acp): bind real models, stream tool activity, auto-approve
