### PR TITLE
fix(desktop): re-pin session context after createBackendSessionForSend to prevent first-prompt bounce

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -1371,7 +1371,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(ok).toBe(true)
     expect(createBackendSessionForSend).toHaveBeenCalledTimes(1)
     expect(requestGateway).toHaveBeenCalledTimes(1)
-    const [method, params] = requestGateway.mock.calls[0]
+    const [method, params] = requestGateway.mock.calls[0] as unknown as [string, Record<string, unknown>]
     expect(method).toBe('prompt.submit')
     expect(params).toMatchObject({ session_id: NEW_RUNTIME })
   })

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -1321,6 +1321,60 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(createBackendSessionForSend).toHaveBeenCalledTimes(1)
     expect(calls).not.toContain('session.resume')
   })
+
+  it('does not bounce the first prompt when createBackendSessionForSend updates the stored session ref (#62600)', async () => {
+    // Regression test: createBackendSessionForSend updates selectedStoredSessionIdRef
+    // and the route token to point at the newly created session. Without re-pinning
+    // the starting snapshots, sessionContextDrifted() false-positives and the prompt
+    // is silently bounced back to the composer.
+    const NEW_STORED = 'stored-new-session-62600'
+    const NEW_RUNTIME = 'rt-new-session-62600'
+
+    // Simulate the real createBackendSessionForSend: it updates the refs.
+    const selectedStoredRef: MutableRefObject<string | null> = { current: null }
+    const activeRef: MutableRefObject<string | null> = { current: null }
+    let routeToken = 'initial-route'
+
+    const createBackendSessionForSend = vi.fn(async () => {
+      // Mimic what the real function does:
+      activeRef.current = NEW_RUNTIME
+      selectedStoredRef.current = NEW_STORED
+      routeToken = 'route-to-new-session'
+
+      return NEW_RUNTIME
+    })
+
+    const requestGateway = vi.fn(async (method: string) => {
+      expect(method).toBe('prompt.submit')
+
+      return { status: 'streaming' } as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={null}
+        activeSessionIdRef={activeRef}
+        selectedStoredSessionIdRef={selectedStoredRef}
+        getRouteToken={() => routeToken}
+        createBackendSessionForSend={createBackendSessionForSend}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        storedSessionId={null}
+      />
+    )
+
+    const ok = await handle!.submitText('first prompt of new chat')
+
+    // The submit must succeed, not be bounced by a false drift detection.
+    expect(ok).toBe(true)
+    expect(createBackendSessionForSend).toHaveBeenCalledTimes(1)
+    expect(requestGateway).toHaveBeenCalledTimes(1)
+    const [method, params] = requestGateway.mock.calls[0]
+    expect(method).toBe('prompt.submit')
+    expect(params).toMatchObject({ session_id: NEW_RUNTIME })
+  })
 })
 
 describe('usePromptActions submit session-context isolation (#54527)', () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -118,9 +118,15 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // Pin the session context for the whole async submit pipeline. Without
       // this, a fast session switch during session.resume / file.attach can
       // redirect the user's text into a different chat (#54527).
-      const startingActiveSessionId = activeSessionIdRef.current
-      const startingStoredSessionId = selectedStoredSessionIdRef.current
-      const startingRouteToken = getRouteToken()
+      //
+      // These are `let` (not `const`) because createBackendSessionForSend
+      // legitimately updates the refs + route when it mints a new session.
+      // Without re-pinning, the drift check would false-positive on the very
+      // call that created the session, bouncing the first prompt of every new
+      // chat back to the composer (#62600).
+      let startingActiveSessionId = activeSessionIdRef.current
+      let startingStoredSessionId = selectedStoredSessionIdRef.current
+      let startingRouteToken = getRouteToken()
 
       const sessionContextDrifted = (): boolean =>
         selectedStoredSessionIdRef.current !== startingStoredSessionId ||
@@ -280,6 +286,16 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
           return false
         }
+
+        // createBackendSessionForSend just minted a new session and updated
+        // activeSessionIdRef / selectedStoredSessionIdRef / the route token
+        // to point at it. Re-pin the starting snapshots so the drift check
+        // below doesn't treat the expected context change as a user-initiated
+        // session switch — otherwise the first prompt of every new chat is
+        // silently bounced back to the composer (#62600).
+        startingActiveSessionId = activeSessionIdRef.current
+        startingStoredSessionId = selectedStoredSessionIdRef.current
+        startingRouteToken = getRouteToken()
 
         if (sessionContextDrifted()) {
           return abortForSessionSwitch(sessionId)


### PR DESCRIPTION
## Problem

When a user clicks **New Session** and immediately submits a prompt, the prompt is silently bounced back to the composer. The session IS created (appears in the sidebar), but the first prompt gets no response. The user must hit Send a second time for the conversation to start.

## Root Cause

`createBackendSessionForSend()` creates the new session and legitimately updates:
- `activeSessionIdRef.current` to the new runtime ID
- `selectedStoredSessionIdRef.current` to the new stored ID
- Route token (via `navigate(sessionRoute(stored))`)

However, `sessionContextDrifted()` in `submit.ts` compares the **current** refs against snapshots taken **before** `createBackendSessionForSend` ran. Since the refs were updated by the session creation itself (not by a user-initiated session switch), the drift check false-positives and calls `abortForSessionSwitch()`, which drops the optimistic message and releases the busy lock — bouncing the prompt.

```
submitPrompt()
  startingStoredSessionId = null  (captured before create)
  createBackendSessionForSend()
    selectedStoredSessionIdRef.current = stored  (updated by create)
  sessionContextDrifted() → null !== stored → TRUE (false positive!)
  abortForSessionSwitch() → prompt bounced
```

## Fix

After `createBackendSessionForSend` returns, re-pin the starting snapshots to the current ref values. This is safe because `createBackendSessionForSend` already has its **own** drift check (lines 189-197 in `use-session-actions/index.ts`) that aborts session creation if the user switched sessions during the async call.

Also changed `starting*` from `const` to `let` to allow re-pinning.

## Test

Added a regression test that simulates `createBackendSessionForSend` updating the refs and verifies `prompt.submit` is called with the new session ID. All 43 existing tests + 1 new test pass.

## Reproduction

1. Open Hermes Desktop
2. Click New Session (or Cmd+N)
3. Immediately type a prompt and hit Send
4. **Before fix**: prompt bounces back to input box, session created but no response
5. **After fix**: prompt submits normally, agent responds