### PR TITLE
Fix: display web extract preview dict url

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -546,6 +546,12 @@ def build_tool_preview(tool_name: str, args: dict, max_len: int | None = None) -
     value = args[key]
     if isinstance(value, list):
         value = value[0] if value else ""
+    # web_search results forwarded into web_extract arrive as dict objects
+    # ({"url"/"href": ...}); coerce to the URL string so the preview shows the
+    # target instead of a raw dict repr (mirrors _display_url used by
+    # get_cute_tool_message for the same argument).
+    if isinstance(value, dict):
+        value = _display_url(value)
 
     preview = _oneline(str(value))
     if not preview:

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -90,6 +90,24 @@ class TestBuildToolPreview:
         assert result is not None
         assert "hello world" in result
 
+    def test_web_extract_preview_plain_string_url(self):
+        result = build_tool_preview("web_extract", {"urls": ["https://example.com/a"]})
+        assert result == "https://example.com/a"
+
+    def test_web_extract_preview_unwraps_search_result_object(self):
+        # web_search results forwarded into web_extract are dicts; the preview
+        # must show the URL, not the raw dict repr ("{'url': ...}").
+        result = build_tool_preview(
+            "web_extract",
+            {"urls": [{"url": "https://example.com/a", "title": "A"}, {"url": "https://example.org/b"}]},
+        )
+        assert result == "https://example.com/a"
+        assert "{" not in result
+
+    def test_web_extract_preview_unwraps_bare_dict(self):
+        result = build_tool_preview("web_extract", {"urls": {"href": "https://example.org/b"}})
+        assert result == "https://example.org/b"
+
     def test_read_file_preview(self):
         result = build_tool_preview("read_file", {"path": "/tmp/test.py", "offset": 1})
         assert result is not None


### PR DESCRIPTION
## What does this PR do?

`build_tool_preview` in `agent/display.py` builds the short tool-progress label
shown while a tool runs. For most tools the primary argument is a scalar, so the
generic tail just stringifies it:

```python
value = args[key]
if isinstance(value, list):
    value = value[0] if value else ""
preview = _oneline(str(value))
```

`web_extract`'s primary argument is `urls`. When `web_search` results are
forwarded into `web_extract` — the common chain where each entry is an object
like `{"url": "…", "title": "…"}` — `value` (or `value[0]`) is a **dict**, so
`str(value)` renders the raw dict repr into the preview:

```
{'url': 'https://example.com/a', 'title': 'A'}
```

That garbage string is shown by the tool-progress callback (CLI/TUI) and by the
gateway platform label (`gateway/platforms/api_server.py`). The sibling
`get_cute_tool_message` already coerces the same argument through `_display_url`
(added in the recent display-boundary hardening); `build_tool_preview` was the
remaining display surface that did not.

The fix coerces a dict `value` through the existing `_display_url` helper, so the
preview shows the URL target. It handles the list-of-objects, bare-object, and
plain-string forms.

## Related Issue

-

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/display.py` — `build_tool_preview` now coerces a dict primary value via
  `_display_url` before stringifying, so a `web_extract` `urls` object renders as
  its URL instead of a dict repr.
- `tests/agent/test_display.py` — added three `TestBuildToolPreview` cases:
  plain-string url, list of result objects, and a bare result object.

## How to Test

1. On `main`, the tool-progress preview leaks the dict repr:

   ```python
   from agent.display import build_tool_preview
   build_tool_preview("web_extract", {"urls": [{"url": "https://example.com/a", "title": "A"}]})
   # -> "{'url': 'https://example.com/a', 'title': 'A'}"
   ```

2. With this PR it shows the URL:

   ```
   https://example.com/a
   ```

3. Run the tests:

   ```
   pytest tests/agent/test_display.py -q
   ```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(display): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the tests for the affected area (`pytest tests/agent/test_display.py -q`) and they pass
- [x] I've added tests for my changes

### Documentation & Housekeeping

- [x] N/A — internal display-label fix; no README/`docs/`/docstring changes
- [x] N/A — no config keys added/changed
- [x] N/A — no architecture/workflow changes
- [x] Cross-platform impact considered — pure Python value handling, no platform-specific behavior
- [x] N/A — no tool description/schema changes

## Screenshots / Logs

New tests fail on the current code (dict repr leaked) and pass with the fix:

```
# against current code (bug present)
tests/agent/test_display.py::TestBuildToolPreview::test_web_extract_preview_unwraps_search_result_object  FAILED
tests/agent/test_display.py::TestBuildToolPreview::test_web_extract_preview_unwraps_bare_dict             FAILED
E   AssertionError: assert '{...}' ...      # - https://example.org/b  + {'href': 'https://example.org/b'}

# with this PR
tests/agent/test_display.py  ............................................................  60 passed
```