### PR TITLE
fix(mcp): strip non-list required values in _repair_object_shape

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -438,6 +438,61 @@ class TestSchemaConversion:
 
         assert schema["properties"]["items"]["items"]["properties"] == {}
 
+    def test_required_null_is_stripped(self):
+        """MCP servers that emit required: null must not leak into output."""
+        from tools.mcp_tool import _normalize_mcp_input_schema
+
+        schema = _normalize_mcp_input_schema({
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+            "required": None,
+        })
+
+        assert "required" not in schema
+
+    def test_required_non_list_string_is_stripped(self):
+        """MCP servers that emit required as a bare string must not leak."""
+        from tools.mcp_tool import _normalize_mcp_input_schema
+
+        schema = _normalize_mcp_input_schema({
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+            "required": "q",
+        })
+
+        assert "required" not in schema
+
+    def test_required_non_list_integer_is_stripped(self):
+        """MCP servers that emit required as an integer must not leak."""
+        from tools.mcp_tool import _normalize_mcp_input_schema
+
+        schema = _normalize_mcp_input_schema({
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+            "required": 42,
+        })
+
+        assert "required" not in schema
+
+    def test_required_null_in_nested_object_is_stripped(self):
+        """Nested objects with required: null should also be cleaned."""
+        from tools.mcp_tool import _normalize_mcp_input_schema
+
+        schema = _normalize_mcp_input_schema({
+            "type": "object",
+            "properties": {
+                "opts": {
+                    "type": "object",
+                    "properties": {"x": {"type": "integer"}},
+                    "required": None,
+                },
+            },
+            "required": ["opts"],
+        })
+
+        assert schema["required"] == ["opts"]
+        assert "required" not in schema["properties"]["opts"]
+
     def test_optional_nullable_field_is_collapsed_to_non_null_schema(self):
         """Anthropic rejects MCP/Pydantic anyOf-null optional parameter schemas."""
         from tools.mcp_tool import _normalize_mcp_input_schema

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4148,7 +4148,9 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
                 if not isinstance(repaired.get("properties"), dict):
                     repaired["properties"] = {}
 
-            # Prune required to only include names that exist in properties
+            # Prune required to only include names that exist in properties.
+            # Also strip non-list values (null, string, int, …) that would
+            # cause strict OpenAI-compatible backends to return HTTP 400.
             required = repaired.get("required")
             if isinstance(required, list):
                 props = repaired.get("properties") or {}
@@ -4158,6 +4160,8 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
                         repaired["required"] = valid
                     else:
                         repaired.pop("required", None)
+            elif "required" in repaired:
+                repaired.pop("required", None)
 
         return repaired
 


### PR DESCRIPTION
## Summary

MCP servers that emit `required: null`, `required: "string"`, or other non-list values in their `inputSchema` cause strict OpenAI-compatible backends (vLLM, SGLang, etc.) to reject tool calls with **HTTP 400**.

The `_repair_object_shape` helper in `tools/mcp_tool.py` already prunes dangling names from valid `required` arrays but silently skips any non-list value, leaving the malformed key in the output schema.

## Root Cause

```python
# Before (line 4152-4160):
required = repaired.get("required")
if isinstance(required, list):
    # ... prune logic ...
# ← non-list values (null, string, int) silently pass through
```

## Fix

Add an `elif` branch that strips `required` whenever it is present but not a list:

```python
elif "required" in repaired:
    repaired.pop("required", None)
```

This matches the defensive pattern already applied in `schema_sanitizer.py` (lines 346-355).

## Test Plan

4 new tests added to `tests/tools/test_mcp_tool.py::TestSchemaConversion`:

| Test | Input | Expected |
|------|-------|----------|
| `test_required_null_is_stripped` | `required: null` | `required` absent |
| `test_required_non_list_string_is_stripped` | `required: "q"` | `required` absent |
| `test_required_non_list_integer_is_stripped` | `required: 42` | `required` absent |
| `test_required_null_in_nested_object_is_stripped` | nested `required: null` | nested `required` absent |

Full test suite: **207/207 passed**.
