### PR TITLE
fix(desktop): discard draft on explicit new session

### DIFF
--- a/apps/desktop/src/app/chat/composer/focus.ts
+++ b/apps/desktop/src/app/chat/composer/focus.ts
@@ -32,6 +32,7 @@ interface InsertRefsDetail {
 }
 
 const FOCUS_EVENT = 'hermes:composer-focus'
+const CLEAR_EVENT = 'hermes:composer-clear'
 const INSERT_EVENT = 'hermes:composer-insert'
 const INSERT_REFS_EVENT = 'hermes:composer-insert-refs'
 const SUBMIT_EVENT = 'hermes:composer-submit'
@@ -94,6 +95,12 @@ export const requestComposerInsert = (
 
 export const onComposerFocusRequest = (handler: (target: ComposerTarget) => void) =>
   subscribe<FocusDetail>(FOCUS_EVENT, ({ target }) => handler(target))
+
+/** Clear an explicitly discarded new-session draft after its route/state swap. */
+export const requestComposerClear = (target: ComposerTarget = 'main') => dispatch<FocusDetail>(CLEAR_EVENT, { target })
+
+export const onComposerClearRequest = (handler: (target: ComposerTarget) => void) =>
+  subscribe<FocusDetail>(CLEAR_EVENT, ({ target }) => handler(target))
 
 export const onComposerInsertRequest = (handler: (detail: InsertDetail) => void) =>
   subscribe<InsertDetail>(INSERT_EVENT, handler)

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
@@ -2,7 +2,13 @@ import { useAui, useAuiState, useComposerRuntime } from '@assistant-ui/react'
 import { type RefObject, useCallback, useEffect, useRef, useState } from 'react'
 
 import { SLASH_COMMAND_RE } from '@/lib/chat-runtime'
-import { $composerAttachments, type ComposerAttachment, stashSessionDraft, takeSessionDraft } from '@/store/composer'
+import {
+  $composerAttachments,
+  clearSessionDraft,
+  type ComposerAttachment,
+  stashSessionDraft,
+  takeSessionDraft
+} from '@/store/composer'
 import { isBrowsingHistory } from '@/store/composer-input-history'
 
 import {
@@ -15,6 +21,7 @@ import {
   type ComposerInsertMode,
   focusComposerInput,
   markActiveComposer,
+  onComposerClearRequest,
   onComposerFocusRequest,
   onComposerInsertRefsRequest,
   onComposerInsertRequest
@@ -144,6 +151,15 @@ export function useComposerDraft({
     [paintDraft]
   )
 
+  const clearDraft = useCallback(() => {
+    setComposerText('')
+    draftRef.current = ''
+
+    if (editorRef.current) {
+      editorRef.current.replaceChildren()
+    }
+  }, [setComposerText])
+
   useEffect(() => {
     if (!inputDisabled) {
       focusInput()
@@ -167,11 +183,23 @@ export function useComposerDraft({
       }
     })
 
+    const offClear = onComposerClearRequest(target => {
+      // This event is dispatched after New Session's route/state updates. Only
+      // touch the `__new__` scratch scope: if a delayed React commit has not
+      // reached it yet, retain the active session's recoverable draft instead.
+      if (target === 'main' && activeQueueSessionKeyRef.current === null) {
+        clearDraft()
+        $composerAttachments.set([])
+        clearSessionDraft(null)
+      }
+    })
+
     return () => {
       offFocus()
       offInsert()
+      offClear()
     }
-  }, [appendExternalText, inputDisabled])
+  }, [appendExternalText, clearDraft, inputDisabled])
 
   const stashAt = (scope: string | null, text = draftRef.current, attachments = $composerAttachments.get()) =>
     stashSessionDraft(scope, text, attachments)
@@ -180,15 +208,6 @@ export function useComposerDraft({
     $composerAttachments.set(cloneAttachments(attachments))
     paintDraft(text, false)
   }
-
-  const clearDraft = useCallback(() => {
-    setComposerText('')
-    draftRef.current = ''
-
-    if (editorRef.current) {
-      editorRef.current.replaceChildren()
-    }
-  }, [setComposerText])
 
   // Read the editor's current plain text into draftRef + composer state. This
   // closes the "queued rAF flush hasn't run yet" window so scope-swap/pagehide

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -631,7 +631,7 @@ export function DesktopController() {
   // Single global listener for every rebindable hotkey (incl. profile switching)
   // plus the on-screen keybind editor's capture mode.
   useKeybinds({
-    startFreshSession: startFreshSessionDraft,
+    startFreshSession: () => startFreshSessionDraft(false, true),
     toggleCommandCenter,
     toggleSelectedPin
   })
@@ -647,7 +647,7 @@ export function DesktopController() {
     }
 
     lastFreshRef.current = freshSessionRequest
-    startFreshSessionDraft()
+    startFreshSessionDraft(false, true)
   }, [freshSessionRequest, startFreshSessionDraft])
 
   // Swapping the live gateway to another profile must re-pull that profile's
@@ -735,7 +735,7 @@ export function DesktopController() {
 
   const startSessionInWorkspace = useCallback(
     (path: null | string) => {
-      startFreshSessionDraft()
+      startFreshSessionDraft(false, true)
 
       // A worktree lane carries its own path; the trunk "+" can be path-less (the
       // main checkout is implicit), so fall back to the active project's root

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -165,7 +165,7 @@ interface PromptActionsOptions {
   requestGateway: <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<T>
   resumeStoredSession: (storedSessionId: string) => Promise<void> | void
   selectedStoredSessionIdRef: MutableRefObject<string | null>
-  startFreshSessionDraft: () => void
+  startFreshSessionDraft: (replaceRoute?: boolean, clearNewDraft?: boolean) => void
   sttEnabled: boolean
   updateSessionState: (
     sessionId: string,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -58,7 +58,7 @@ interface SlashCommandDeps {
   refreshSessions: () => Promise<void>
   requestGateway: GatewayRequest
   resumeStoredSession: (storedSessionId: string) => Promise<void> | void
-  startFreshSessionDraft: () => void
+  startFreshSessionDraft: (replaceRoute?: boolean, clearNewDraft?: boolean) => void
   submitPromptText: (
     rawText: string,
     options?: { attachments?: ComposerAttachment[]; fromQueue?: boolean }
@@ -229,7 +229,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
       // new branch in a dispatch ladder.
       const actionHandlers: Record<DesktopActionId, (ctx: SlashActionCtx) => Promise<void>> = {
         new: async () => {
-          startFreshSessionDraft()
+          startFreshSessionDraft(false, true)
         },
         branch: async () => {
           await branchCurrentSession()

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -3,6 +3,7 @@ import type { MutableRefObject } from 'react'
 import { useEffect } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { onComposerClearRequest } from '@/app/chat/composer/focus'
 import { getSessionMessages, type SessionInfo } from '@/hermes'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { $activeGatewayProfile, $newChatProfile } from '@/store/profile'
@@ -160,6 +161,63 @@ describe('createBackendSessionForSend profile routing', () => {
     })
 
     expect(params).toMatchObject({ cwd: '/remote/worktree' })
+  })
+})
+
+function FreshDraftHarness({
+  onReady
+}: {
+  onReady: (start: (replaceRoute?: boolean, clearNewDraft?: boolean) => void) => void
+}) {
+  const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
+
+  const actions = useSessionActions({
+    activeSessionId: null,
+    activeSessionIdRef: ref<string | null>(null),
+    busyRef: ref(false),
+    creatingSessionRef: ref(false),
+    ensureSessionState: () => ({}) as ClientSessionState,
+    getRouteToken: () => 'token',
+    navigate: vi.fn() as never,
+    requestGateway: vi.fn(async () => ({}) as never),
+    runtimeIdByStoredSessionIdRef: ref(new Map<string, string>()),
+    selectedStoredSessionId: null,
+    selectedStoredSessionIdRef: ref<string | null>(null),
+    sessionStateByRuntimeIdRef: ref(new Map<string, ClientSessionState>()),
+    syncSessionStateToView: vi.fn(),
+    updateSessionState: () => ({}) as ClientSessionState
+  })
+
+  useEffect(() => {
+    onReady(actions.startFreshSessionDraft)
+  }, [actions.startFreshSessionDraft, onReady])
+
+  return null
+}
+
+describe('startFreshSessionDraft scratch reset', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('asks the composer to discard the old scratch only for an explicit New Session', async () => {
+    const cleared = vi.fn()
+    const offClear = onComposerClearRequest(cleared)
+    let start: ((replaceRoute?: boolean, clearNewDraft?: boolean) => void) | null = null
+
+    render(<FreshDraftHarness onReady={callback => (start = callback)} />)
+    await waitFor(() => expect(start).not.toBeNull())
+
+    start!(true)
+    await new Promise(resolve => window.setTimeout(resolve, 0))
+    expect(cleared).not.toHaveBeenCalled()
+
+    start!(false, true)
+    await new Promise(resolve => window.setTimeout(resolve, 0))
+    expect(cleared).toHaveBeenCalledWith('main')
+
+    offClear()
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -2,6 +2,7 @@ import type { MutableRefObject } from 'react'
 import { useCallback, useRef } from 'react'
 import type { NavigateFunction } from 'react-router-dom'
 
+import { requestComposerClear } from '@/app/chat/composer/focus'
 import { deleteSession, getSessionMessages, setSessionArchived } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
@@ -105,7 +106,7 @@ export function useSessionActions({
   const resumeRequestRef = useRef(0)
 
   const startFreshSessionDraft = useCallback(
-    (replaceRoute = false) => {
+    (replaceRoute = false, clearNewDraft = false) => {
       busyRef.current = false
       setBusy(false)
       setAwaitingResponse(false)
@@ -138,7 +139,15 @@ export function useSessionActions({
       // whatever linked worktree the last session drifted into.
       setCurrentCwd(resolveNewSessionCwd())
       setCurrentBranch('')
-      // Never clear the composer here — ChatBar's per-thread draft swap owns it.
+      // Recovering a route preserves its unsent new-chat draft. An explicit user
+      // New Session instead discards the `__new__` scratch prompt, otherwise the
+      // next chat can silently submit the previous topic. The composer owns its
+      // live DOM, so clear it through its deferred scoped event after this swap.
+
+      if (clearNewDraft) {
+        requestComposerClear('main')
+      }
+
       setFreshDraftReady(true)
     },
     [activeSessionIdRef, busyRef, navigate, selectedStoredSessionIdRef]
@@ -251,7 +260,7 @@ export function useSessionActions({
   const selectSidebarItem = useCallback(
     (item: SidebarNavItem) => {
       if (item.action === 'new-session') {
-        startFreshSessionDraft()
+        startFreshSessionDraft(false, true)
 
         return
       }

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15678,6 +15678,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ("compression", "codex_app_server_auto"),
         ("compression", "target_ratio"),
         ("compression", "protect_last_n"),
+        # This controls whether compaction rotates to a child session or keeps
+        # the durable session id. The agent reads it only at construction, so a
+        # config toggle must rebuild a cached agent before its next turn.
+        ("compression", "in_place"),
         ("agent", "disabled_toolsets"),
         ("memory", "provider"),
     )

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -169,6 +169,21 @@ class TestAgentConfigSignature:
         )
         assert sig_on != sig_off
 
+    def test_compression_in_place_toggle_busts_cache(self):
+        """Changing session-identity compaction mode must rebuild the agent."""
+        from gateway.run import GatewayRunner
+
+        runtime = {"api_key": "k", "base_url": "u", "provider": "p"}
+        sig_rotating = GatewayRunner._agent_config_signature(
+            "m", runtime, [], "",
+            cache_keys={"compression.in_place": False},
+        )
+        sig_in_place = GatewayRunner._agent_config_signature(
+            "m", runtime, [], "",
+            cache_keys={"compression.in_place": True},
+        )
+        assert sig_rotating != sig_in_place
+
     def test_cache_keys_key_order_does_not_matter(self):
         """Signature must be stable regardless of dict key insertion order."""
         from gateway.run import GatewayRunner
@@ -231,6 +246,7 @@ class TestExtractCacheBustingConfig:
                     "codex_gpt55_autoraise": False,
                     "target_ratio": 0.3,
                     "protect_last_n": 25,
+                    "in_place": True,
                     "codex_app_server_auto": "hermes",
                     "some_other_key": "ignored",
                 }
@@ -241,6 +257,7 @@ class TestExtractCacheBustingConfig:
         assert out["compression.codex_gpt55_autoraise"] is False
         assert out["compression.target_ratio"] == 0.3
         assert out["compression.protect_last_n"] == 25
+        assert out["compression.in_place"] is True
         assert out["compression.codex_app_server_auto"] == "hermes"
 
     def test_missing_keys_yield_none(self):


### PR DESCRIPTION
## Summary
- Clear the shared `__new__` composer draft only for explicit Desktop New Session actions, preventing a prior unsent prompt from appearing or being submitted in a nominally fresh chat.
- Preserve drafts during automatic route recovery/resume and ordinary thread changes.
- Include `compression.in_place` in the gateway agent-cache signature so changing durable-ID compaction mode reconstructs cached agents.

## Details
The composer owns both its live contenteditable state and the persisted scratch scope. New Session now dispatches a deferred, scoped clear after session/route state changes, and the listener only clears while the composer is in the null/new-chat scope. Explicit entry points covered: sidebar New Session, global keybind, `/new`, profile-driven new sessions, and workspace/project lanes.

## Validation
- `npm run test:ui -- src/app/session/hooks/use-session-actions.test.tsx src/store/composer.test.ts` — 24 passed
- `npm run typecheck`
- `uv run pytest tests/gateway/test_agent_cache.py -q -o 'addopts='` — 79 passed
- `python3 -m py_compile gateway/run.py`
- `git diff --check`

## Risk / rollback
The clear is opt-in per explicit New Session path; automatic recovery preserves unsent drafts. Reverting commit `f0b728ce3` restores the prior behavior.
