### PR TITLE
fix(discord): implement delete_message so cleanup_progress actually works

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2425,6 +2425,35 @@ class DiscordAdapter(BasePlatformAdapter):
             continuation_message_ids=tuple(continuation_ids),
         )
 
+    async def delete_message(
+        self,
+        chat_id: str,
+        message_id: str,
+    ) -> bool:
+        """Delete a previously sent Discord message.
+
+        Used by the gateway's ``cleanup_progress`` feature to remove
+        tool-progress bubbles, heartbeat messages, and status callbacks
+        after the final response lands. Returns ``True`` on success.
+        """
+        if not self._client:
+            return False
+        try:
+            channel = self._client.get_channel(int(chat_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(chat_id))
+            if not channel:
+                return False
+            msg = await channel.fetch_message(int(message_id))
+            await msg.delete()
+            return True
+        except Exception as e:
+            logger.debug(
+                "[%s] Failed to delete Discord message %s: %s",
+                self.name, message_id, e,
+            )
+            return False
+
     async def _send_file_attachment(
         self,
         chat_id: str,

--- a/tests/gateway/test_discord_delete_message.py
+++ b/tests/gateway/test_discord_delete_message.py
@@ -1,0 +1,140 @@
+"""Tests for Discord adapter delete_message — enables cleanup_progress.
+
+The gateway's ``cleanup_progress`` feature gates on
+``type(adapter).delete_message is not BasePlatformAdapter.delete_message``.
+Without an override, cleanup is silently disabled and progress bubbles
+remain in the channel forever.  These tests guard against accidental removal.
+"""
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_discord_mock():
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+
+    discord_mod = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.Client = MagicMock
+    discord_mod.File = MagicMock
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
+    discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3)
+    discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
+    discord_mod.Interaction = object
+    discord_mod.Embed = MagicMock
+    discord_mod.app_commands = SimpleNamespace(
+        describe=lambda **kwargs: (lambda fn: fn),
+        choices=lambda **kwargs: (lambda fn: fn),
+        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
+_ensure_discord_mock()
+
+from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+from gateway.platforms.base import BasePlatformAdapter  # noqa: E402
+
+
+class TestDeleteMessageOverride:
+    """Guard: delete_message must be overridden so cleanup_progress works."""
+
+    def test_delete_message_is_overridden(self):
+        """The gateway cleanup_progress gate checks
+        ``type(adapter).delete_message is BasePlatformAdapter.delete_message``.
+        If DiscordAdapter doesn't override, cleanup is silently disabled."""
+        assert DiscordAdapter.delete_message is not BasePlatformAdapter.delete_message
+
+
+class TestDeleteMessage:
+    @pytest.mark.asyncio
+    async def test_delete_message_deletes_via_channel_fetch(self):
+        """delete_message fetches the channel, fetches the message, and deletes it."""
+        adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+        msg = SimpleNamespace(delete=AsyncMock())
+        channel = SimpleNamespace(
+            fetch_message=AsyncMock(return_value=msg),
+        )
+        adapter._client = SimpleNamespace(
+            get_channel=MagicMock(return_value=channel),
+        )
+
+        result = await adapter.delete_message("123456", "789012")
+
+        assert result is True
+        msg.delete.assert_awaited_once()
+        channel.fetch_message.assert_awaited_once_with(789012)
+
+    @pytest.mark.asyncio
+    async def test_delete_message_falls_back_to_fetch_channel(self):
+        """When get_channel returns None, falls back to fetch_channel."""
+        adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+        msg = SimpleNamespace(delete=AsyncMock())
+        channel = SimpleNamespace(
+            fetch_message=AsyncMock(return_value=msg),
+        )
+        adapter._client = SimpleNamespace(
+            get_channel=MagicMock(return_value=None),
+            fetch_channel=AsyncMock(return_value=channel),
+        )
+
+        result = await adapter.delete_message("123456", "789012")
+
+        assert result is True
+        adapter._client.fetch_channel.assert_awaited_once_with(123456)
+        msg.delete.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_delete_message_returns_false_when_channel_not_found(self):
+        """Both get_channel and fetch_channel return None → False."""
+        adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+        adapter._client = SimpleNamespace(
+            get_channel=MagicMock(return_value=None),
+            fetch_channel=AsyncMock(return_value=None),
+        )
+
+        result = await adapter.delete_message("123456", "789012")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_delete_message_returns_false_when_no_client(self):
+        """No Discord client connected → False."""
+        adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+        adapter._client = None
+
+        result = await adapter.delete_message("123456", "789012")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_delete_message_swallows_exception(self):
+        """If msg.delete() raises, return False instead of propagating."""
+        adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+        msg = SimpleNamespace(delete=AsyncMock(side_effect=RuntimeError("boom")))
+        channel = SimpleNamespace(
+            fetch_message=AsyncMock(return_value=msg),
+        )
+        adapter._client = SimpleNamespace(
+            get_channel=MagicMock(return_value=channel),
+        )
+
+        result = await adapter.delete_message("123456", "789012")
+        assert result is False

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -1215,7 +1215,7 @@ class TestNovitaProvider:
             return _FakeResp()
 
         monkeypatch.setattr(
-            models_mod.urllib.request, "urlopen", fake_urlopen
+            models_mod, "_urlopen_model_catalog_request", fake_urlopen
         )
 
         # First call hits the network.


### PR DESCRIPTION
## Problem

The docs say `cleanup_progress` is supported on "currently Telegram and Discord":

> `Defaults to false. Only platforms whose adapter implements `delete_message` honor the setting (currently Telegram and Discord).`

But the Discord adapter never implemented `delete_message()`. The gateway's cleanup logic detects this and silently disables cleanup:

```python
if _cleanup_adapter is not None and (
    type(_cleanup_adapter).delete_message is BasePlatformAdapter.delete_message
):
    # Adapter doesn't support deletion — silently disable.
    _cleanup_progress = False
```

Result: `cleanup_progress: true` is set in config but all progress bubbles, heartbeats, and status callbacks stay in the channel forever.

Issue #4882 requested this feature. The reporter claimed `delete_message()` was "already implemented on Discord" — it wasn't.

## Fix

Add `delete_message()` to `DiscordAdapter` using discord.py's `fetch_message()` + `delete()` API. Matches the pattern already used by Telegram and Google Chat adapters.

- Returns `True` on success, `False` on failure (missing channel, deleted message, no client)
- Swallows exceptions silently (message already deleted, missing permissions, etc.)
- Falls back to `fetch_channel` when `get_channel` returns `None`

## Testing

```
tests/gateway/test_discord_delete_message.py — 6 tests, all passing
```

- `test_delete_message_is_overridden` — guards against accidental removal (same pattern as Google Chat)
- `test_delete_message_deletes_via_channel_fetch` — happy path
- `test_delete_message_falls_back_to_fetch_channel` — `get_channel` → `fetch_channel` fallback
- `test_delete_message_returns_false_when_channel_not_found` — both lookups fail
- `test_delete_message_returns_false_when_no_client` — disconnected
- `test_delete_message_swallows_exception` — delete() raises → False

Existing Discord tests (56) still pass — no regressions.

Closes #4882