### PR TITLE
fix(desktop): prevent composer draft leak on new session

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.test.tsx
@@ -1,0 +1,98 @@
+import { act } from '@testing-library/react'
+import { type RefObject, useRef } from 'react'
+import { flushSync } from 'react-dom'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $composerAttachments, clearSessionDraft, stashSessionDraft, takeSessionDraft } from '@/store/composer'
+
+import type { QueueEditState } from '../composer-utils'
+
+import { useComposerDraft } from './use-composer-draft'
+
+const composer = vi.hoisted(() => {
+  let text = ''
+  const listeners = new Set<() => void>()
+
+  return {
+    getText: () => text,
+    reset: () => {
+      text = ''
+      listeners.clear()
+    },
+    runtime: {
+      getState: () => ({ text }),
+      subscribe: (listener: () => void) => {
+        listeners.add(listener)
+
+        return () => listeners.delete(listener)
+      }
+    },
+    setText: (next: string) => {
+      text = next
+      listeners.forEach(listener => listener())
+    }
+  }
+})
+
+vi.mock('@assistant-ui/react', () => ({
+  useAui: () => ({ composer: () => ({ setText: composer.setText }) }),
+  useAuiState: (selector: (state: { composer: { text: string } }) => unknown) =>
+    selector({ composer: { text: composer.getText() } }),
+  useComposerRuntime: () => composer.runtime
+}))
+
+function Harness({ scope }: { scope: string | null }) {
+  const queueEditRef = useRef<QueueEditState | null>(null)
+  const draft = useComposerDraft({
+    activeQueueSessionKey: scope,
+    focusKey: scope,
+    inputDisabled: false,
+    queueEditRef: queueEditRef as RefObject<QueueEditState | null>,
+    sessionId: scope
+  })
+
+  return <div data-testid="editor" ref={draft.editorRef} />
+}
+
+describe('useComposerDraft session swap', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    composer.reset()
+    $composerAttachments.set([])
+    clearSessionDraft('session-a')
+    clearSessionDraft(null)
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+
+    composer.reset()
+    $composerAttachments.set([])
+    clearSessionDraft('session-a')
+    clearSessionDraft(null)
+    vi.restoreAllMocks()
+  })
+
+  it('loads the new-session draft before paint when leaving an existing session', () => {
+    stashSessionDraft('session-a', 'previous draft', [])
+
+    act(() => root.render(<Harness scope="session-a" />))
+
+    const editor = container.querySelector('[data-testid="editor"]')
+    expect(editor?.textContent).toBe('previous draft')
+
+    flushSync(() => root.render(<Harness scope={null} />))
+
+    expect(editor?.textContent).toBe('')
+    expect(takeSessionDraft('session-a').text.trim()).toBe('previous draft')
+    expect(takeSessionDraft(null).text).toBe('')
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.test.tsx
@@ -1,5 +1,5 @@
 import { act } from '@testing-library/react'
-import { type RefObject, useRef } from 'react'
+import { type RefObject, useLayoutEffect, useRef } from 'react'
 import { flushSync } from 'react-dom'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -42,7 +42,12 @@ vi.mock('@assistant-ui/react', () => ({
   useComposerRuntime: () => composer.runtime
 }))
 
-function Harness({ scope }: { scope: string | null }) {
+interface HarnessProps {
+  onLayoutRead?: (text: string | null) => void
+  scope: string | null
+}
+
+function Harness({ onLayoutRead, scope }: HarnessProps) {
   const queueEditRef = useRef<QueueEditState | null>(null)
   const draft = useComposerDraft({
     activeQueueSessionKey: scope,
@@ -50,6 +55,10 @@ function Harness({ scope }: { scope: string | null }) {
     inputDisabled: false,
     queueEditRef: queueEditRef as RefObject<QueueEditState | null>,
     sessionId: scope
+  })
+
+  useLayoutEffect(() => {
+    onLayoutRead?.(draft.editorRef.current?.textContent ?? null)
   })
 
   return <div data-testid="editor" ref={draft.editorRef} />
@@ -82,15 +91,18 @@ describe('useComposerDraft session swap', () => {
   })
 
   it('loads the new-session draft before paint when leaving an existing session', () => {
+    const layoutReads: Array<string | null> = []
     stashSessionDraft('session-a', 'previous draft', [])
 
-    act(() => root.render(<Harness scope="session-a" />))
+    act(() => root.render(<Harness onLayoutRead={text => layoutReads.push(text)} scope="session-a" />))
 
     const editor = container.querySelector('[data-testid="editor"]')
     expect(editor?.textContent).toBe('previous draft')
+    expect(layoutReads[layoutReads.length - 1]).toBe('previous draft')
 
-    flushSync(() => root.render(<Harness scope={null} />))
+    flushSync(() => root.render(<Harness onLayoutRead={text => layoutReads.push(text)} scope={null} />))
 
+    expect(layoutReads[layoutReads.length - 1]).toBe('')
     expect(editor?.textContent).toBe('')
     expect(takeSessionDraft('session-a').text.trim()).toBe('previous draft')
     expect(takeSessionDraft(null).text).toBe('')

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
@@ -1,5 +1,5 @@
 import { useAui, useAuiState, useComposerRuntime } from '@assistant-ui/react'
-import { type RefObject, useCallback, useEffect, useRef, useState } from 'react'
+import { type RefObject, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 
 import { SLASH_COMMAND_RE } from '@/lib/chat-runtime'
 import { $composerAttachments, type ComposerAttachment, stashSessionDraft, takeSessionDraft } from '@/store/composer'
@@ -305,8 +305,10 @@ export function useComposerDraft({
 
   // Per-thread draft swap — the composer's only session coupling. Lifecycle
   // never clears composer state; this effect alone stashes on leave, restores
-  // on enter. Keyed writes are idempotent, so no skip-sentinel.
-  useEffect(() => {
+  // on enter. This must run before paint so a new session never renders the
+  // previous session's contentEditable draft for one frame. Keyed writes are
+  // idempotent, so no skip-sentinel.
+  useLayoutEffect(() => {
     // A pending debounce timer from the outgoing session is now stale — its
     // scope was correct when scheduled, but the authoritative stash below
     // (and the cleanup on the way out) already covers that text. Letting it


### PR DESCRIPTION
## What does this PR do?

Fixes a Desktop composer regression where a draft from the previously opened session could briefly appear in a newly created session.

The composer draft swap was running in a passive `useEffect`, so React could paint the new-session view before the composer restored the `__new__` draft. This allowed the previous session's contentEditable text to appear in the new session for a frame and could make the first Enter feel ignored while the composer state was still catching up.

This PR moves the per-session draft swap to `useLayoutEffect`, which stashes the outgoing draft and loads the incoming draft before paint.

## Related Issue

Fixes #62490

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts`
  - Changed the per-thread composer draft swap from `useEffect` to `useLayoutEffect`.
  - Added a comment explaining why the swap must happen before paint.
- Added `apps/desktop/src/app/chat/composer/hooks/use-composer-draft.test.tsx`
  - Covers switching from an existing session draft to the new-session scope.
  - Verifies the new-session editor is blank and the previous draft remains scoped to the original session.

## How to Test

1. Open an existing Desktop session.
2. Type text into the composer without sending it.
3. Create a new session.
4. Verify the new session composer is empty and does not show the previous session's draft.
5. Type a new message and press Enter; it should submit on the first press.

Automated checks run:

```bash
npm --workspace apps/desktop run test:ui -- src/app/chat/composer/hooks/use-composer-draft.test.tsx src/app/chat/composer/composer-utils.test.ts --reporter=dot
npm --workspace apps/desktop run test:ui -- src/app/chat/composer/enter-submit-dom-race.test.tsx --reporter=dot
npm --workspace apps/desktop run typecheck
git diff --check