### PR TITLE
fix(acp): don't let a malformed tool argument abort the tool-call render

### DIFF
--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import uuid
 from typing import Any, Dict, List, Optional
 
@@ -13,6 +14,8 @@ from acp.schema import (
     ToolCallProgress,
     ToolKind,
 )
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Map hermes tool names -> ACP ToolKind
@@ -1026,7 +1029,37 @@ def build_tool_start(
     *,
     edit_diff: Any = None,
 ) -> ToolCallStart:
-    """Create a ToolCallStart event for the given hermes tool invocation."""
+    """Create a ToolCallStart event for the given hermes tool invocation.
+
+    A malformed tool argument (e.g. a non-string ``command``/``path`` from a
+    model that ignores the schema) must never abort the ACP tool-call render —
+    ``build_tool_start`` runs on the live tool-progress callback and during
+    session history replay. On any failure in the title/content/location
+    builders, fall back to a minimal, valid start event. Mirrors
+    ``get_cute_tool_message`` in ``agent/display.py``, wrapped for the same
+    reason on the CLI side.
+    """
+    try:
+        return _build_tool_start(
+            tool_call_id, tool_name, arguments, edit_diff=edit_diff
+        )
+    except Exception as exc:  # noqa: BLE001 — a tool-call render must never abort the turn
+        logger.debug("ACP tool-start render failed for %r: %s", tool_name, exc)
+        safe_name = tool_name if isinstance(tool_name, str) and tool_name else "tool"
+        return acp.start_tool_call(
+            tool_call_id, safe_name, kind=get_tool_kind(safe_name),
+            content=None, locations=[], raw_input=None,
+        )
+
+
+def _build_tool_start(
+    tool_call_id: str,
+    tool_name: str,
+    arguments: Dict[str, Any],
+    *,
+    edit_diff: Any = None,
+) -> ToolCallStart:
+    """Build the ToolCallStart event (unguarded; see ``build_tool_start``)."""
     kind = get_tool_kind(tool_name)
     title = build_tool_title(tool_name, arguments)
     locations = extract_locations(arguments)

--- a/tests/acp/test_tools.py
+++ b/tests/acp/test_tools.py
@@ -227,6 +227,26 @@ class TestBuildToolStart:
         assert result.content is None
         assert result.raw_input is None
 
+    def test_build_tool_start_survives_non_string_command(self):
+        """A malformed (non-string) terminal command previously raised
+        TypeError in build_tool_title (len(None)) and aborted the render."""
+        result = build_tool_start("tc-bad-cmd", "terminal", {"command": None})
+        assert isinstance(result, ToolCallStart)
+        assert result.kind == "execute"  # tool identity preserved in the fallback
+
+    def test_build_tool_start_survives_non_string_path(self):
+        """A non-string read_file path previously raised a ToolCallLocation
+        pydantic ValidationError in extract_locations and aborted the render."""
+        result = build_tool_start("tc-bad-path", "read_file", {"path": {"p": "x"}})
+        assert isinstance(result, ToolCallStart)
+        assert result.kind == "read"
+
+    def test_build_tool_start_survives_non_string_goal(self):
+        """A non-string delegate_task goal previously raised TypeError
+        (len(123)) in build_tool_title and aborted the render."""
+        result = build_tool_start("tc-bad-goal", "delegate_task", {"goal": 123})
+        assert isinstance(result, ToolCallStart)
+
     def test_build_tool_start_for_web_extract_is_compact(self):
         """web_extract start should stay compact; title identifies URLs."""
         args = {"urls": ["https://example.com/docs"]}


### PR DESCRIPTION
## What does this PR do?

`build_tool_start` in `acp_adapter/tools.py` renders every ACP (Zed) tool call.
It calls `build_tool_title` and `extract_locations` directly:

```python
kind = get_tool_kind(tool_name)
title = build_tool_title(tool_name, arguments)      # len()/indexing on args
locations = extract_locations(arguments)            # ToolCallLocation(path=...)
```

Neither is guarded against a model that ignores the tool schema and emits a
malformed argument, so the render crashes:

- `terminal` `command` as `null`/a number → `TypeError: object of type
  'NoneType' has no len()` (in `build_tool_title`)
- `delegate_task` `goal` as a number → `TypeError` (same `len()` path)
- `read_file` `path` as a non-string → pydantic `ValidationError` building a
  `ToolCallLocation`

`build_tool_start` is called **without** a try/except from both the live
tool-progress callback (`acp_adapter/events.py`) and the session history-replay
loop (`acp_adapter/server.py`). So a malformed tool call crashes the live
tool-call render — and, once persisted, crashes history replay on every
subsequent resume of that session.

The sibling CLI label builder `get_cute_tool_message` was already wrapped for
exactly this reason ("display must never abort a turn"). This applies the same
guard to `build_tool_start`: the implementation is moved to `_build_tool_start`,
and `build_tool_start` wraps it — on any builder failure it falls back to a
minimal, valid start event (the tool name as title, the resolved kind). The
happy path is unchanged.

## Related Issue

---
## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `acp_adapter/tools.py` — renamed `build_tool_start` to `_build_tool_start` and
  added a `build_tool_start` wrapper that catches any exception from the
  title/content/location builders and returns a minimal valid `ToolCallStart`
  (tool name as title, resolved kind). Added a module logger.
- `tests/acp/test_tools.py` — added three `TestBuildToolStart` cases: a
  non-string `command`, a non-string `path`, and a non-string `goal`.

## How to Test

1. On `main`, a malformed argument crashes the render:

   ```python
   from acp_adapter.tools import build_tool_start
   build_tool_start("tc", "terminal", {"command": None})     # TypeError: len()
   build_tool_start("tc", "read_file", {"path": {"p": "x"}})  # pydantic ValidationError
   ```

2. With this PR both return a valid `ToolCallStart` (falling back to a minimal
   start event) instead of raising.

3. Run the tests:

   ```
   pytest tests/acp/test_tools.py -q
   ```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(acp): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the tests for the affected area (`pytest tests/acp/test_tools.py -q`) and they pass
- [x] I've added tests for my changes

### Documentation & Housekeeping

- [x] N/A — internal ACP render-hardening; no README/`docs/`/docstring changes
- [x] N/A — no config keys added/changed
- [x] N/A — no architecture/workflow changes
- [x] Cross-platform impact considered — pure Python control flow, no platform-specific behavior
- [x] N/A — no tool description/schema changes

## Screenshots / Logs

New tests fail on the current code (the crashes) and pass with the fix:

```
# against current code (bug present)
tests/acp/test_tools.py::TestBuildToolStart::test_build_tool_start_survives_non_string_command  FAILED
tests/acp/test_tools.py::TestBuildToolStart::test_build_tool_start_survives_non_string_path      FAILED
tests/acp/test_tools.py::TestBuildToolStart::test_build_tool_start_survives_non_string_goal      FAILED
E   TypeError: object of type 'int' has no len()          # build_tool_title
E   ValidationError: ... ToolCallLocation.path            # extract_locations
3 failed

# with this PR
tests/acp/test_tools.py  ...........................................................  75 passed
```