### PR TITLE
fix(file-tools): capture read mtime before reading bytes

### DIFF
--- a/tests/tools/test_file_staleness.py
+++ b/tests/tools/test_file_staleness.py
@@ -23,6 +23,7 @@ from tools.file_tools import (
     patch_tool,
     _check_file_staleness,
     _read_tracker,
+    _resolve_path_for_task,
 )
 
 
@@ -292,6 +293,10 @@ class TestCheckFileStalenessHelper(unittest.TestCase):
         self.assertIsNone(_check_file_staleness("/nonexistent/path", "t1"))
 
 
+# ---------------------------------------------------------------------------
+# Read-time mtime capture
+# ---------------------------------------------------------------------------
+
 class TestReadTimeMtimeCapture(unittest.TestCase):
     """The mtime tracked for a read must reflect the bytes handed to the model.
 
@@ -374,5 +379,16 @@ class TestReadTimeMtimeCapture(unittest.TestCase):
         read_file_tool(self._tmpfile, task_id="torn2")
         second = json.loads(read_file_tool(self._tmpfile, task_id="torn2"))
         self.assertNotEqual(second.get("status"), "unchanged")
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_registry_check_stale_detects_edit_during_read(self, mock_ops):
+        """The cross-agent registry must also see the edit that landed mid-read."""
+        mock_ops.return_value = self._ops_editing_during_read()
+        read_file_tool(self._tmpfile, task_id="torn3")
+
+        resolved = str(_resolve_path_for_task(self._tmpfile, "torn3"))
+        stale = file_state.get_registry().check_stale("torn3", resolved)
+        self.assertIsNotNone(stale)
+        self.assertIn("modified since you last read", stale)
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tools/test_file_staleness.py
+++ b/tests/tools/test_file_staleness.py
@@ -292,5 +292,87 @@ class TestCheckFileStalenessHelper(unittest.TestCase):
         self.assertIsNone(_check_file_staleness("/nonexistent/path", "t1"))
 
 
+class TestReadTimeMtimeCapture(unittest.TestCase):
+    """The mtime tracked for a read must reflect the bytes handed to the model.
+
+    If the file is edited between the pre-read snapshot and the returned
+    content, the tracked mtime must stay the pre-read value; otherwise the
+    staleness guard is blinded (silent overwrite of the external edit) and the
+    dedup cache returns an "unchanged" stub for a file that did change.  Both
+    are exercised by editing the file from inside the faked ``read_file`` so
+    the edit lands squarely in the read window.
+    """
+
+    def setUp(self):
+        _read_tracker.clear()
+        file_state.get_registry().clear()
+        self._tmpdir = tempfile.mkdtemp()
+        self._tmpfile = os.path.join(self._tmpdir, "torn_read.txt")
+        with open(self._tmpfile, "w") as f:
+            f.write("original content\n")
+        # Pin a known-old mtime so the mid-read edit is guaranteed to produce
+        # a strictly newer mtime regardless of filesystem timestamp resolution.
+        old = time.time() - 100
+        os.utime(self._tmpfile, (old, old))
+
+    def tearDown(self):
+        _read_tracker.clear()
+        file_state.get_registry().clear()
+        try:
+            os.unlink(self._tmpfile)
+            os.rmdir(self._tmpdir)
+        except OSError:
+            pass
+
+    def _ops_editing_during_read(self):
+        """Fake ops whose read_file edits the file on disk mid-read.
+
+        The returned bytes are the pre-edit content while the file on disk is
+        advanced to a newer mtime — the exact torn-read window.
+        """
+        fake = _make_fake_ops("original content\n", 17)
+
+        def _edit_then_return(path, offset=1, limit=500):
+            with open(self._tmpfile, "w") as f:
+                f.write("changed by a concurrent writer\n")
+            return _FakeReadResult("original content\n", total_lines=1, file_size=17)
+
+        fake.read_file = _edit_then_return
+        return fake
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_staleness_detected_for_edit_during_read(self, mock_ops):
+        """A write after an edit-during-read must still warn (guard not blinded)."""
+        mock_ops.return_value = self._ops_editing_during_read()
+        read_file_tool(self._tmpfile, task_id="torn1")
+
+        result = json.loads(
+            write_file_tool(self._tmpfile, "replacement", task_id="torn1")
+        )
+        self.assertIn("_warning", result)
+        self.assertIn("modified since you last read", result["_warning"])
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_dedup_not_stubbed_for_edit_during_read(self, mock_ops):
+        """A re-read after an edit-during-read must return fresh content, not a stub."""
+        fake = self._ops_editing_during_read()
+        # Second and later reads no longer edit — they just return current bytes.
+        calls = {"n": 0}
+        original = fake.read_file
+
+        def _first_edits_then_plain(path, offset=1, limit=500):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return original(path, offset, limit)
+            return _FakeReadResult(
+                "changed by a concurrent writer\n", total_lines=1, file_size=31
+            )
+
+        fake.read_file = _first_edits_then_plain
+        mock_ops.return_value = fake
+
+        read_file_tool(self._tmpfile, task_id="torn2")
+        second = json.loads(read_file_tool(self._tmpfile, task_id="torn2"))
+        self.assertNotEqual(second.get("status"), "unchanged")
 if __name__ == "__main__":
     unittest.main()

--- a/tools/file_state.py
+++ b/tools/file_state.py
@@ -292,8 +292,16 @@ def _cap_dict(d: dict, limit: int) -> None:
 
 
 # ── Convenience wrappers (short names used at call sites) ────────────
-def record_read(task_id: str, resolved_or_path: str | Path, *, partial: bool = False) -> None:
-    _registry.record_read(task_id, str(resolved_or_path), partial=partial)
+def record_read(
+    task_id: str,
+    resolved_or_path: str | Path,
+    *,
+    partial: bool = False,
+    mtime: Optional[float] = None,
+) -> None:
+    _registry.record_read(
+        task_id, str(resolved_or_path), partial=partial, mtime=mtime
+    )
 
 
 def note_write(task_id: str, resolved_or_path: str | Path) -> None:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1479,7 +1479,9 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         # isn't nested under ours.
         try:
             _partial = (offset > 1) or bool(result_dict.get("truncated"))
-            file_state.record_read(task_id, resolved_str, partial=_partial)
+            file_state.record_read(
+                task_id, resolved_str, partial=_partial, mtime=_mtime_at_read
+            )
         except Exception:
             logger.debug("file_state.record_read failed", exc_info=True)
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1363,6 +1363,16 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
 
         # ── Perform the read ──────────────────────────────────────────
         file_ops = _get_file_ops(task_id)
+        # Snapshot the file's mtime BEFORE reading its bytes so the tracked
+        # timestamp reflects the version handed to the model.  A stat taken
+        # after the read would attribute a newer mtime to older content when
+        # the file is edited mid-read (concurrent subagent, editor, watcher)
+        # — silently blinding the write/patch staleness guard and returning a
+        # stale "unchanged" dedup stub on the next read.
+        try:
+            _mtime_at_read = os.path.getmtime(resolved_str)
+        except OSError:
+            _mtime_at_read = None  # Can't stat — tracking is skipped below.
         result = file_ops.read_file(path, offset, limit)
         result_dict = result.to_dict()
 
@@ -1449,12 +1459,12 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
             # 1. Dedup: skip identical re-reads of unchanged files.
             # 2. Staleness: warn on write/patch if the file changed since
             #    the agent last read it (external edit, concurrent agent, etc.).
-            try:
-                _mtime_now = os.path.getmtime(resolved_str)
-                task_data["dedup"][dedup_key] = _mtime_now
-                task_data.setdefault("read_timestamps", {})[resolved_str] = _mtime_now
-            except OSError:
-                pass  # Can't stat — skip tracking for this entry
+            # The pre-read stat keeps the tracked timestamp aligned with the
+            # content the model actually holds; a post-read stat could record
+            # a newer version's mtime and silently defeat both guards.
+            if _mtime_at_read is not None:
+                task_data["dedup"][dedup_key] = _mtime_at_read
+                task_data.setdefault("read_timestamps", {})[resolved_str] = _mtime_at_read
 
             # Bound the per-task containers so a long CLI session doesn't
             # accumulate megabytes of dict/set state.  See _cap_read_tracker_data.


### PR DESCRIPTION
## Summary
Captures the file mtime before `file_ops.read_file` in `read_file_tool`
instead of after, so the value tracked for dedup and staleness reflects
the bytes handed to the model. This prevents a silent overwrite of an
external edit and a stale `unchanged` dedup stub when the file is
modified in the window between the byte read and the stat.

---

## Root cause
`read_file_tool` in `tools/file_tools.py` recorded the file mtime by
calling `os.path.getmtime(resolved_str)` after `file_ops.read_file(...)`
returned, and stored that value in both `task_data["dedup"]` and
`read_timestamps`. When the file is edited in the window between the
byte read and the stat (a concurrent subagent, an editor, a file
watcher), the recorded mtime belongs to the post-edit version while the
content in hand is the pre-edit version.

Two consequences followed. On a later write, `_check_file_staleness`
compared the recorded mtime against the current mtime; because the
recorded value was already the post-edit mtime, the two matched, no
warning was emitted, and the external edit was overwritten silently. On
the next read of the same region, the dedup check found the current
mtime equal to the cached value and returned an `unchanged` stub, so the
model kept its pre-edit content for a file that had changed.

---

## Behavioral change
Before: the mtime was stat'd after the read, so an edit landing in the
read window produced a tracked timestamp newer than the content. The
staleness guard then stayed silent on the following write, and the dedup
path returned an `unchanged` stub, both while the model held stale bytes.

After: the mtime is stat'd before the read and that pre-read value is
stored. An edit during the read makes the recorded mtime differ from the
current one, so the staleness guard emits a warning on the next write and
the dedup path misses and re-reads, instead of going silent. The no-edit
path is unchanged; the `OSError` best-effort handling is preserved, and
the tracking entry is simply skipped when the pre-read stat fails.

---

## What changed
**`tools/file_tools.py`**: in `read_file_tool`, the mtime snapshot was
moved ahead of `file_ops.read_file` into `_mtime_at_read`, wrapped in the
existing `try`/`except OSError` best-effort form. The post-read block
that previously re-stat'd the file now records `_mtime_at_read` into
`task_data["dedup"]` and `read_timestamps` only when it is not `None`,
replacing the old `_mtime_now` stat.

**`tests/tools/test_file_staleness.py`**: added `TestReadTimeMtimeCapture`
with two tests. Both edit the file from inside the faked `read_file` so
the edit lands squarely in the read window; one asserts that a later
write still warns (the staleness guard is not blinded), the other asserts
that a re-read returns fresh content rather than an `unchanged` stub. Both
tests fail on the pre-fix code and pass with the fix. The full
`tests/tools/test_file_staleness.py` (13 tests) and the adjacent
`tests/tools/test_read_loop_detection.py` (25 tests) pass.

---

## What is NOT changed
- `file_ops.read_file` itself is unchanged
- `_check_file_staleness` and the dedup comparison logic are unchanged
- The post-write timestamp refresh is unchanged
- The no-edit path behaves as before: pre-read and current mtime match,
  so dedup and staleness behave identically to today
- No locking is added around the read; the change narrows the window and
  resolves any edit inside it toward a warning and a dedup miss, not a
  silent overwrite
