### PR TITLE
security(cli): strip credentials on cross-host redirects in Nous Portal calls

### DIFF
--- a/hermes_cli/dashboard_register.py
+++ b/hermes_cli/dashboard_register.py
@@ -32,6 +32,8 @@ import urllib.error
 import urllib.request
 from typing import Optional
 
+from hermes_cli.urllib_security import open_credentialed_url
+
 
 # Docker-style name generator. Same vibe as Docker's adjective_surname, but
 # adjective_noun with a space-free underscore join so it drops cleanly into a
@@ -138,7 +140,7 @@ def _register_self_hosted_client(
     )
 
     try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        with open_credentialed_url(req, timeout=timeout) as resp:
             payload = json.loads(resp.read().decode())
     except urllib.error.HTTPError as exc:
         # The endpoint returns structured JSON errors ({error, error_description}).

--- a/hermes_cli/gateway_enroll.py
+++ b/hermes_cli/gateway_enroll.py
@@ -39,6 +39,8 @@ import urllib.parse
 import urllib.request
 from typing import Optional
 
+from hermes_cli.urllib_security import open_credentialed_url
+
 
 def _default_gateway_id() -> str:
     """A stable-ish default gateway instance id: ``<hostname>-<pid-free slug>``.
@@ -127,7 +129,7 @@ def _post_enroll(
         },
     )
     try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        with open_credentialed_url(req, timeout=timeout) as resp:
             payload = json.loads(resp.read().decode())
     except urllib.error.HTTPError as exc:
         detail = ""

--- a/hermes_cli/nous_account.py
+++ b/hermes_cli/nous_account.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Literal, Optional
 
+from hermes_cli.urllib_security import open_credentialed_url
+
 
 NousAccountInfoSource = Literal["jwt", "account_api", "inference_key", "none", "error"]
 
@@ -592,7 +594,7 @@ def _fetch_nous_account_info(
         "Accept": "application/json",
     }
     req = urllib.request.Request(url, headers=headers)
-    with urllib.request.urlopen(req, timeout=8) as resp:
+    with open_credentialed_url(req, timeout=8) as resp:
         payload = json.loads(resp.read().decode())
     return payload if isinstance(payload, dict) else {}
 

--- a/hermes_cli/nous_billing.py
+++ b/hermes_cli/nous_billing.py
@@ -32,6 +32,8 @@ import urllib.parse
 import urllib.request
 from typing import Any, Optional
 
+from hermes_cli.urllib_security import open_credentialed_url
+
 DEFAULT_PORTAL_BASE_URL = "https://portal.nousresearch.com"
 
 # Default HTTP timeout (seconds). Charge/poll calls are quick; keep this tight so
@@ -410,7 +412,7 @@ def _request(
     req = urllib.request.Request(url, data=data, headers=headers, method=method)
 
     try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        with open_credentialed_url(req, timeout=timeout) as resp:
             raw = resp.read().decode("utf-8")
             if not raw.strip():
                 return {}

--- a/tests/hermes_cli/test_dashboard_register.py
+++ b/tests/hermes_cli/test_dashboard_register.py
@@ -116,7 +116,7 @@ class TestHappyPath:
         ), patch(
             "hermes_cli.config.save_env_value", side_effect=fake_save
         ), patch.object(
-            dr.urllib.request, "urlopen", side_effect=fake_urlopen
+            dr, "open_credentialed_url", side_effect=fake_urlopen
         ):
             dr.cmd_dashboard_register(args)
         return saved
@@ -243,7 +243,7 @@ class TestCustomPortalPersistence:
         ), patch(
             "hermes_cli.config.save_env_value", side_effect=fake_save
         ), patch.object(
-            dr.urllib.request, "urlopen", return_value=_fake_http_ok(response)
+            dr, "open_credentialed_url", return_value=_fake_http_ok(response)
         ):
             # The ambient process env may carry HERMES_DASHBOARD_PORTAL_URL
             # (e.g. staging dev shells); drop it so `custom_portal_supplied`
@@ -315,7 +315,7 @@ class TestPublicUrlPersistence:
         ), patch(
             "hermes_cli.config.save_env_value", side_effect=fake_save
         ), patch.object(
-            dr.urllib.request, "urlopen", return_value=_fake_http_ok(response)
+            dr, "open_credentialed_url", return_value=_fake_http_ok(response)
         ):
             dr.os.environ.pop("HERMES_DASHBOARD_PORTAL_URL", None)
             dr.cmd_dashboard_register(args)
@@ -367,7 +367,7 @@ class TestPublicUrlPersistence:
         ), patch(
             "hermes_cli.config.save_env_value", side_effect=fake_save
         ), patch.object(
-            dr.urllib.request, "urlopen", return_value=_fake_http_ok(response)
+            dr, "open_credentialed_url", return_value=_fake_http_ok(response)
         ):
             dr.os.environ.pop("HERMES_DASHBOARD_PORTAL_URL", None)
             dr.cmd_dashboard_register(
@@ -412,7 +412,7 @@ class TestPortalErrors:
             "hermes_cli.auth.resolve_nous_access_token", return_value="tok"
         ), patch("hermes_cli.config.is_managed", return_value=False), patch.object(
             dr, "_resolve_portal_base_url", return_value="https://portal.nousresearch.com"
-        ), patch.object(dr.urllib.request, "urlopen", side_effect=err):
+        ), patch.object(dr, "open_credentialed_url", side_effect=err):
             with pytest.raises(SystemExit) as exc:
                 dr.cmd_dashboard_register(_ns())
         return exc.value.code

--- a/tests/hermes_cli/test_gateway_enroll.py
+++ b/tests/hermes_cli/test_gateway_enroll.py
@@ -1,0 +1,51 @@
+"""Regression test: gateway_enroll._post_enroll() must route its credentialed
+HTTP call through hermes_cli.urllib_security.open_credentialed_url, not raw
+urllib.request.urlopen, so a Bearer token cannot follow a cross-host redirect
+to a malicious relay connector.
+
+Sibling of the security(providers)/fix(security) sweep that migrated
+providers/base.py, hermes_cli/models.py, hermes_cli/azure_detect.py, and
+plugins/model-providers/anthropic/__init__.py to the same shared helper —
+this call site read a caller-supplied ``connector_base_url`` but was not
+one of them.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import hermes_cli.gateway_enroll as ge
+
+
+def _fake_http_ok(payload: dict):
+    cm = MagicMock()
+    cm.__enter__.return_value.read.return_value = json.dumps(payload).encode()
+    return cm
+
+
+def test_post_enroll_uses_open_credentialed_url_not_raw_urlopen():
+    """Patching ``open_credentialed_url`` on pre-fix code (where it isn't
+    imported into this module) raises AttributeError, so this test fails
+    closed against the vulnerable code and only passes once the call site
+    is migrated.
+    """
+    response = {"secret": "s3cr3t", "deliveryKey": "dk", "tenant": "t1", "gatewayId": "gw1"}
+    with patch.object(
+        ge, "open_credentialed_url", return_value=_fake_http_ok(response)
+    ) as mock_open, patch.object(
+        ge.urllib.request, "urlopen"
+    ) as mock_urlopen:
+        result = ge._post_enroll(
+            connector_base_url="https://connector.example.com",
+            access_token="tok_abc",
+            enrollment_token="enroll_tok",
+            gateway_id="gw1",
+        )
+
+    assert result == response
+    mock_open.assert_called_once()
+    mock_urlopen.assert_not_called()
+    req = mock_open.call_args.args[0]
+    assert req.get_header("Authorization") == "Bearer tok_abc"
+    assert req.full_url == "https://connector.example.com/relay/enroll"

--- a/tests/hermes_cli/test_nous_account.py
+++ b/tests/hermes_cli/test_nous_account.py
@@ -6,15 +6,16 @@ import base64
 import json
 import time
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+import hermes_cli.nous_account as na
 from hermes_cli.nous_account import (
     NousPaidServiceAccessInfo,
     NousPortalAccountInfo,
     format_nous_portal_entitlement_message,
     get_nous_portal_account_info,
-    nous_portal_topup_url,
     reset_nous_portal_account_info_cache,
 )
 
@@ -340,3 +341,36 @@ def test_member_spend_cap_exceeded_without_amounts(monkeypatch):
 
 
 
+def _fake_http_ok(payload: dict):
+    cm = MagicMock()
+    cm.__enter__.return_value.read.return_value = json.dumps(payload).encode()
+    return cm
+
+
+def test_fetch_nous_account_info_uses_open_credentialed_url_not_raw_urlopen():
+    """_fetch_nous_account_info must route through the safe wrapper.
+
+    Sibling of the security(providers)/fix(security) sweep that migrated
+    providers/base.py, hermes_cli/models.py, hermes_cli/azure_detect.py, and
+    plugins/model-providers/anthropic/__init__.py to
+    hermes_cli.urllib_security.open_credentialed_url — this call site read a
+    caller-supplied ``portal_base_url`` but was not one of them. Patching
+    ``open_credentialed_url`` on pre-fix code (where it isn't imported into
+    this module) raises AttributeError, so this test fails closed against
+    the vulnerable code and only passes once the call site is migrated.
+    """
+    with patch.object(
+        na, "open_credentialed_url", return_value=_fake_http_ok({"id": "acct-1"})
+    ) as mock_open, patch.object(
+        na.urllib.request, "urlopen"
+    ) as mock_urlopen:
+        result = na._fetch_nous_account_info(
+            "tok_abc", portal_base_url="https://portal.example.test"
+        )
+
+    assert result == {"id": "acct-1"}
+    mock_open.assert_called_once()
+    mock_urlopen.assert_not_called()
+    req = mock_open.call_args.args[0]
+    assert req.get_header("Authorization") == "Bearer tok_abc"
+    assert req.full_url == "https://portal.example.test/api/oauth/account"

--- a/tests/hermes_cli/test_nous_billing.py
+++ b/tests/hermes_cli/test_nous_billing.py
@@ -1,0 +1,47 @@
+"""Regression test: nous_billing._request() must route its credentialed HTTP
+call through hermes_cli.urllib_security.open_credentialed_url, not raw
+urllib.request.urlopen, so a Bearer token cannot follow a cross-host redirect.
+
+Sibling of the security(providers)/fix(security) sweep that migrated
+providers/base.py, hermes_cli/models.py, hermes_cli/azure_detect.py, and
+plugins/model-providers/anthropic/__init__.py to the same shared helper —
+this call site read the exact same "portal_base_url" style configurable
+base URL but was not one of them.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import hermes_cli.nous_billing as nb
+
+
+def _fake_http_ok(payload: dict):
+    cm = MagicMock()
+    cm.__enter__.return_value.read.return_value = json.dumps(payload).encode()
+    return cm
+
+
+def test_request_uses_open_credentialed_url_not_raw_urlopen():
+    """The billing request must go through the safe wrapper.
+
+    Patching ``open_credentialed_url`` on pre-fix code (where it isn't
+    imported into this module) raises AttributeError, so this test fails
+    closed against the vulnerable code and only passes once the call site
+    is migrated.
+    """
+    with patch.object(
+        nb, "_resolve_token_and_base", return_value=("tok_abc", "https://portal.nousresearch.com")
+    ), patch.object(
+        nb, "open_credentialed_url", return_value=_fake_http_ok({"ok": True})
+    ) as mock_open, patch.object(
+        nb.urllib.request, "urlopen"
+    ) as mock_urlopen:
+        result = nb._request("GET", "/api/billing/status")
+
+    assert result == {"ok": True}
+    mock_open.assert_called_once()
+    mock_urlopen.assert_not_called()
+    req = mock_open.call_args.args[0]
+    assert req.get_header("Authorization") == "Bearer tok_abc"

--- a/tests/hermes_cli/test_nous_billing_request.py
+++ b/tests/hermes_cli/test_nous_billing_request.py
@@ -46,7 +46,10 @@ def _http_error(status: int, body: bytes | dict[str, object] = b"{}", headers=No
 
 
 def _sequence(monkeypatch, *outcomes, resolver=None):
-    """Stub urlopen with ordered outcomes and record each Request."""
+    """Stub the credential-safe opener with ordered outcomes and record each
+    Request. _request() routes through open_credentialed_url (not raw
+    urlopen) so its cross-host redirects strip the bearer token — patch that
+    seam, not urllib.request.urlopen directly, or these fakes are bypassed."""
     seen: list[dict[str, object]] = []
     monkeypatch.setattr(nb, "_token_cache", None, raising=False)
     monkeypatch.setattr(
@@ -55,7 +58,7 @@ def _sequence(monkeypatch, *outcomes, resolver=None):
         resolver or (lambda **kw: ("tok", "https://portal.example")),
     )
 
-    def _fake_urlopen(req, timeout=None):
+    def _fake_open_credentialed_url(req, *, timeout=None, opener_factory=None):
         seen.append(
             {
                 "method": req.get_method(),
@@ -69,7 +72,7 @@ def _sequence(monkeypatch, *outcomes, resolver=None):
             raise outcome
         return outcome
 
-    monkeypatch.setattr(nb.urllib.request, "urlopen", _fake_urlopen)
+    monkeypatch.setattr(nb, "open_credentialed_url", _fake_open_credentialed_url)
     return seen
 
 


### PR DESCRIPTION
## What does this PR do?
`hermes_cli/nous_billing.py`, `hermes_cli/dashboard_register.py`, `hermes_cli/gateway_enroll.py`, and `hermes_cli/nous_account.py` each send a live `Authorization: Bearer <access_token>` header via `urllib.request.urlopen()` to a configurable base URL (`portal_base_url` / `connector_base_url` — resolved from env vars, stored OAuth state, or a CLI flag). Python's stdlib redirect handling forwards **every** request header, including `Authorization`, when following a 3xx to a **different host**. A compromised or misconfigured portal/connector endpoint answering with a redirect therefore receives the user's Nous access token on the redirected origin.

This is the same vulnerability class as today's security sweep that migrated `providers/base.py`, `hermes_cli/models.py`, and `plugins/model-providers/anthropic/__init__.py` to the shared `hermes_cli.urllib_security.open_credentialed_url()` helper (strips `Authorization`/`x-api-key`/`api-key`/`x-goog-api-key`/`Cookie` on cross-host redirects, keeps them on same-host redirects) — these four files read the exact same class of configurable, credentialed Nous Portal / relay-connector base URL but weren't among the migrated call sites. (`#62321`'s own description explicitly scopes it to "the separate CLI model catalog / picker / setup probe paths in `hermes_cli/models.py`" — not a claim of full coverage.)

## Related Issue
N/A — found via a sibling-site sweep after today's `open_credentialed_url` migration (`providers/base.py`, `hermes_cli/models.py`, `plugins/model-providers/anthropic/__init__.py`). `grep -rln "urllib.request.urlopen(" hermes_cli/ | xargs grep -l "Authorization"` turned up these four additional, unmigrated call sites.

## Type of Change
- [x] 🔒 Security fix

## Changes Made
- `hermes_cli/nous_billing.py`, `hermes_cli/dashboard_register.py`, `hermes_cli/gateway_enroll.py`, `hermes_cli/nous_account.py`: route the credentialed `urlopen()` call through `open_credentialed_url()`.
- `tests/hermes_cli/test_dashboard_register.py`: existing tests mocked `urllib.request.urlopen` directly; since `open_credentialed_url` builds its own opener internally rather than calling `urlopen()`, those mocks are retargeted to patch `open_credentialed_url` — mirroring the identical fix already applied to `hermes_cli/azure_detect.py`'s tests in today's sweep (`d83cd6f7c`).
- `tests/hermes_cli/test_nous_account.py`: add a regression test (this call site had no direct HTTP-layer coverage before).
- `tests/hermes_cli/test_nous_billing.py`, `tests/hermes_cli/test_gateway_enroll.py` (new files): same, for the two modules with no prior test file.

## How to Test
```
pytest tests/hermes_cli/test_nous_billing.py tests/hermes_cli/test_gateway_enroll.py tests/hermes_cli/test_nous_account.py tests/hermes_cli/test_dashboard_register.py -v
```
113 tests pass (including neighboring `test_billing_portal_url.py`, `test_billing_scope_stepup.py`, `test_azure_detect.py`, `test_urllib_security.py`). Mutation-verified: stashing the four production-file changes reproduces failures in all 4 new/retargeted test files — `test_nous_billing.py`/`test_gateway_enroll.py`/`test_nous_account.py`'s new tests raise `AttributeError` (module has no `open_credentialed_url` attribute pre-fix), and all 34 affected `test_dashboard_register.py` tests fail the same way.

## Checklist
- [x] Read the Contributing Guide
- [x] Conventional Commits format
- [x] No duplicate PR
- [x] Single logical change
- [x] Tests added
- [x] Cross-platform: N/A (pure Python urllib)