### PR TITLE
fix: persist [System:] markers with role=system, demote at API call time

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -39,6 +39,7 @@ from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_res
 from agent.trajectory import convert_scratchpad_to_think
 from agent.credential_pool import STATUS_EXHAUSTED, credential_pool_matches_provider
 from agent.error_classifier import FailoverReason
+from agent.message_sanitization import HERMES_INTERNAL_SYSTEM_MARKER_KEY
 from agent.turn_context import drop_stale_api_content
 from utils import base_url_host_matches, base_url_hostname, env_var_enabled, atomic_json_write
 
@@ -3300,6 +3301,33 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     # Done first so a substituted turn participates normally in the tool-pair
     # and dedup passes below.
     messages = repair_empty_non_final_messages(messages)
+
+    # --- Demote tagged Hermes system markers for strict providers (#48338) ---
+    # Hermes pivot/nudge records remain role="system" in memory and persistence
+    # so transcript consumers render them correctly. Strict OpenAI-compatible
+    # providers (vLLM, Qwen) reject those records mid-conversation, so demote
+    # only explicitly tagged Hermes markers on this per-call copy. Ordinary
+    # system-role prefills are provider input and must retain their configured
+    # role. Strip the private tag from every outbound message either way.
+    _demoted = 0
+    for _idx, _msg in enumerate(messages):
+        if not isinstance(_msg, dict) or HERMES_INTERNAL_SYSTEM_MARKER_KEY not in _msg:
+            continue
+        _is_internal_marker = _msg.get(HERMES_INTERNAL_SYSTEM_MARKER_KEY) is True
+        _wire_msg = {
+            _key: _value
+            for _key, _value in _msg.items()
+            if _key != HERMES_INTERNAL_SYSTEM_MARKER_KEY
+        }
+        if _idx > 0 and _is_internal_marker and _msg.get("role") == "system":
+            _wire_msg["role"] = "user"
+            _demoted += 1
+        messages[_idx] = _wire_msg
+    if _demoted:
+        _ra().logger.debug(
+            "Pre-call sanitizer: demoted %d tagged Hermes system marker(s) to user role",
+            _demoted,
+        )
 
     # --- Drop empty / malformed tool_calls arrays on assistant messages ---
     # An assistant message carrying ``tool_calls: []`` (an empty array) — or a

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -47,6 +47,7 @@ from agent.turn_context import (
 from agent.turn_retry_state import TurnRetryState
 from agent.runtime_cwd import resolve_agent_cwd
 from agent.message_sanitization import (
+    make_internal_system_marker,
     close_interrupted_tool_sequence,
     _repair_tool_call_arguments,
     _sanitize_messages_non_ascii,
@@ -3402,11 +3403,9 @@ def run_conversation(
                                 _continue_content = _get_continuation_prompt(
                                     _is_partial_stream_stub, _dropped_tools
                                 )
-                                continue_msg = {
-                                    "role": "user",
-                                    "content": _continue_content,
-                                    "_length_continuation_nudge": True,
-                                }
+                                continue_msg = make_internal_system_marker(
+                                    _continue_content, _length_continuation_nudge=True
+                                )
                                 messages.append(continue_msg)
                                 agent._session_messages = messages
                                 _retry.restart_with_length_continuation = True
@@ -7342,10 +7341,9 @@ def run_conversation(
                     messages.append(interim_msg)
                     agent._emit_interim_assistant_message(interim_msg)
 
-                    continue_msg = {
-                        "role": "user",
-                        "content": _CODEX_ACK_CONTINUATION_NUDGE,
-                    }
+                    continue_msg = make_internal_system_marker(
+                        _CODEX_ACK_CONTINUATION_NUDGE
+                    )
                     messages.append(continue_msg)
                     agent._session_messages = messages
                     # An acknowledgment is explicitly non-final. Do not let its
@@ -7475,11 +7473,10 @@ def run_conversation(
                         agent._flush_messages_to_session_db(messages, conversation_history)
                     except Exception:
                         logger.debug("verify-on-stop interim flush failed", exc_info=True)
-                    messages.append({
-                        "role": "user",
-                        "content": _verify_nudge,
-                        "_verification_stop_synthetic": True,
-                    })
+                    messages.append(make_internal_system_marker(
+                        _verify_nudge,
+                        _verification_stop_synthetic=True,
+                    ))
                     agent._session_messages = messages
                     # Run the verification-stop loop silently — the nudge is an
                     # internal turn that should not add noise to the user's
@@ -7547,11 +7544,10 @@ def run_conversation(
                         agent._flush_messages_to_session_db(messages, conversation_history)
                     except Exception:
                         logger.debug("pre_verify interim flush failed", exc_info=True)
-                    messages.append({
-                        "role": "user",
-                        "content": _verify_nudge2,
-                        "_pre_verify_synthetic": True,
-                    })
+                    messages.append(make_internal_system_marker(
+                        _verify_nudge2,
+                        _pre_verify_synthetic=True,
+                    ))
                     agent._session_messages = messages
                     logger.debug("pre_verify nudge issued (attempt %d)",
                                  agent._pre_verify_nudges)

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -26,7 +26,18 @@ logger = logging.getLogger(__name__)
 # inside the OpenAI SDK.  Used by every surrogate-sanitization helper
 # below as well as by run_agent and the CLI for paste-from-clipboard
 # scrubbing.
-_SURROGATE_RE = re.compile(r'[\ud800-\udfff]')
+_SURROGATE_RE = re.compile(r"[\ud800-\udfff]")
+HERMES_INTERNAL_SYSTEM_MARKER_KEY = "_hermes_internal_system_marker"
+
+
+def make_internal_system_marker(content: str, **fields: Any) -> dict[str, Any]:
+    """Build a tagged Hermes-only system record for transcript history."""
+    return {
+        **fields,
+        "role": "system",
+        "content": content,
+        HERMES_INTERNAL_SYSTEM_MARKER_KEY: True,
+    }
 
 
 def _sanitize_surrogates(text: str) -> str:

--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -13,6 +13,7 @@ import json
 import logging
 from datetime import datetime
 from typing import Optional
+from agent.message_sanitization import HERMES_INTERNAL_SYSTEM_MARKER_KEY
 
 from hermes_cli.config import get_hermes_home
 
@@ -198,6 +199,9 @@ def _append_to_sqlite(session_id: str, message: dict) -> None:
             session_id=session_id,
             role=message.get("role", "assistant"),
             content=message.get("content"),
+            internal_system_marker=bool(
+                message.get(HERMES_INTERNAL_SYSTEM_MARKER_KEY)
+            ),
         )
     except Exception as e:
         logger.debug("Mirror SQLite write failed: %s", e)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from datetime import datetime, timedelta
 from dataclasses import dataclass, field, replace
 from typing import Dict, List, Optional, Any
+from agent.message_sanitization import HERMES_INTERNAL_SYSTEM_MARKER_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -3668,6 +3669,9 @@ class SessionStore:
             codex_message_items=message.get("codex_message_items") if message.get("role") == "assistant" else None,
             platform_message_id=(message.get("platform_message_id") or message.get("message_id")),
             observed=bool(message.get("observed")),
+            internal_system_marker=bool(
+                message.get(HERMES_INTERNAL_SYSTEM_MARKER_KEY)
+            ),
             timestamp=message.get("timestamp"),
             # api_content sidecar: the exact bytes sent to the API for
             # this message (prompt-cache-stable replay). Must survive

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from typing import Any, Optional, Union
 
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
+from agent.message_sanitization import HERMES_INTERNAL_SYSTEM_MARKER_KEY
 from agent.i18n import t
 from agent.turn_context import extract_api_content_sidecar
 from gateway.config import HomeChannel, Platform, PlatformConfig, persist_home_channel
@@ -4858,6 +4859,9 @@ class GatewaySlashCommandsMixin:
                         # prompt cache) instead of a full cold prefill.
                         "api_content": extract_api_content_sidecar(msg),
                         "timestamp": msg.get("timestamp"),
+                        "internal_system_marker": bool(
+                            msg.get(HERMES_INTERNAL_SYSTEM_MARKER_KEY)
+                        ),
                     }
                     for msg in history
                 ],

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -27,6 +27,7 @@ from rich import box as rich_box
 from rich.markup import escape as _escape
 from rich.panel import Panel
 
+from agent.message_sanitization import HERMES_INTERNAL_SYSTEM_MARKER_KEY
 from hermes_constants import display_hermes_home, is_termux as _is_termux_environment
 from agent.turn_context import extract_api_content_sidecar
 from hermes_cli.browser_connect import (
@@ -1271,6 +1272,9 @@ class CLICommandsMixin:
                         # prompt cache) instead of a full cold prefill.
                         "api_content": extract_api_content_sidecar(msg),
                         "timestamp": msg.get("timestamp"),
+                        "internal_system_marker": bool(
+                            msg.get(HERMES_INTERNAL_SYSTEM_MARKER_KEY)
+                        ),
                     }
                     for msg in self.conversation_history
                 ],

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -34,7 +34,10 @@ from pathlib import Path
 
 from agent.memory_manager import sanitize_context
 from agent.session_activity import ActivityProvenance
-from agent.message_sanitization import _sanitize_surrogates
+from agent.message_sanitization import (
+    HERMES_INTERNAL_SYSTEM_MARKER_KEY,
+    _sanitize_surrogates,
+)
 from agent.skill_commands import (
     SKILL_EXCERPT_JOINT,
     SKILL_SCAFFOLD_SQL_LIKE,
@@ -1885,6 +1888,7 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
             db_path, report["backup_path"],
         )
     return report
+
 
 
 # ── CJK-bigram FTS index (replaces the trigram index when available) ────
@@ -7658,6 +7662,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         platform_message_id: str = None,
         observed: bool = False,
         effect_disposition: Optional[str] = None,
+        internal_system_marker: bool = False,
         timestamp: Any = None,
         api_content: Optional[str] = None,
         display_kind: Optional[str] = None,
@@ -7727,8 +7732,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed, active, api_content, display_kind, display_metadata)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, observed, internal_system_marker,
+                   active, api_content, display_kind, display_metadata)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -7747,6 +7753,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     codex_message_items_json,
                     platform_message_id,
                     1 if observed else 0,
+                    1 if internal_system_marker else 0,
                     1,
                     _scrub_surrogates(api_content) if isinstance(api_content, str) else None,
                     _scrub_surrogates(display_kind) if isinstance(display_kind, str) else None,
@@ -8150,8 +8157,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed, active, api_content, display_kind, display_metadata)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, observed, internal_system_marker,
+                   active, api_content, display_kind, display_metadata)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -8170,6 +8178,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     codex_message_items_json,
                     platform_msg_id,
                     1 if msg.get("observed") else 0,
+                    1
+                    if (
+                        msg.get(HERMES_INTERNAL_SYSTEM_MARKER_KEY)
+                        or msg.get("internal_system_marker")
+                    )
+                    else 0,
                     1,
                     _scrub_surrogates(api_content) if isinstance(api_content, str) else None,
                     _scrub_surrogates(msg.get("display_kind")) if isinstance(msg.get("display_kind"), str) else None,
@@ -8714,8 +8728,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     _CONVERSATION_ROW_COLUMNS = (
         "id, role, content, tool_call_id, tool_calls, tool_name, effect_disposition, "
         "finish_reason, reasoning, reasoning_content, reasoning_details, "
-        "codex_reasoning_items, codex_message_items, platform_message_id, observed, timestamp, "
-        "api_content, display_kind, display_metadata"
+"codex_reasoning_items, codex_message_items, platform_message_id, observed, "
+        "internal_system_marker, timestamp, api_content, display_kind, display_metadata"
     )
 
     def _rows_to_conversation(
@@ -8756,6 +8770,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # re-introduce the divergence it exists to remove.
             if row["api_content"]:
                 msg["api_content"] = row["api_content"]
+            if row["internal_system_marker"]:
+                msg[HERMES_INTERNAL_SYSTEM_MARKER_KEY] = True
             if row["display_kind"]:
                 msg["display_kind"] = row["display_kind"]
             if row["display_metadata"]:

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -282,6 +282,7 @@ CREATE TABLE IF NOT EXISTS messages (
     codex_message_items TEXT,
     platform_message_id TEXT,
     observed INTEGER DEFAULT 0,
+    internal_system_marker INTEGER NOT NULL DEFAULT 0,
     active INTEGER NOT NULL DEFAULT 1,
     compacted INTEGER NOT NULL DEFAULT 0,
     api_content TEXT,

--- a/run_agent.py
+++ b/run_agent.py
@@ -175,6 +175,7 @@ from agent.prompt_builder import (  # noqa: F401  # re-exported via _ra() / mock
 from agent.process_bootstrap import _get_proxy_from_env  # noqa: F401
 from agent.message_sanitization import (  # noqa: F401
     _SURROGATE_RE,
+    HERMES_INTERNAL_SYSTEM_MARKER_KEY,
     _sanitize_surrogates,
     _sanitize_structure_surrogates,
     _sanitize_messages_surrogates,
@@ -497,7 +498,6 @@ class AIAgent:
         skip_context_files: bool = False,
         load_soul_identity: bool = False,
         skip_memory: bool = False,
-        skip_background_review: bool = False,
         session_db=None,
         parent_session_id: str = None,
         iteration_budget: "IterationBudget" = None,
@@ -584,7 +584,6 @@ class AIAgent:
             skip_context_files=skip_context_files,
             load_soul_identity=load_soul_identity,
             skip_memory=skip_memory,
-            skip_background_review=skip_background_review,
             session_db=session_db,
             parent_session_id=parent_session_id,
             iteration_budget=iteration_budget,
@@ -617,9 +616,6 @@ class AIAgent:
             from hermes_state import SessionDB
 
             self._session_db = SessionDB()
-            # We opened it here, so nothing else holds a reference — this agent
-            # is its only owner and close() must release it.
-            self._owns_session_db = True
             return self._session_db
         except Exception:
             logger.debug("SessionDB unavailable for recall", exc_info=True)
@@ -2249,26 +2245,13 @@ class AIAgent:
                     "codex_message_items": msg.get("codex_message_items"),
                     "timestamp": _row_timestamp,
                     "api_content": _row_api_content,
-                    # Standalone reference handoffs are always hidden, even
-                    # when the summarized transcript contained a user turn —
-                    # otherwise they occupy the active user slot in
-                    # retry/undo/session dispatch (#80622). Merge-into-tail
-                    # carriers keep prior visibility rules so preserved tail
-                    # content stays readable.
+                    "internal_system_marker": bool(
+                        msg.get(HERMES_INTERNAL_SYSTEM_MARKER_KEY)
+                    ),
                     "display_kind": (
                         "hidden"
-                        if (
-                            msg.get(COMPRESSED_SUMMARY_METADATA_KEY)
-                            and (
-                                ContextCompressor.classify_summary_content(
-                                    msg.get("content")
-                                )
-                                == "standalone"
-                                or not msg.get(
-                                    "_compressed_summary_has_user_turn"
-                                )
-                            )
-                        )
+                        if msg.get(COMPRESSED_SUMMARY_METADATA_KEY)
+                        and not msg.get("_compressed_summary_has_user_turn")
                         else msg.get("display_kind")
                     ),
                     "display_metadata": msg.get("display_metadata"),
@@ -4414,30 +4397,12 @@ class AIAgent:
         # must leave it open). end_session() is first-reason-wins and no-ops on
         # an already-ended row, so this never clobbers a 'compression' /
         # 'cron_complete' / 'cli_close' reason set by an earlier terminal path.
-        session_db = getattr(self, "_session_db", None)
         try:
             if getattr(self, "_end_session_on_close", True):
+                session_db = getattr(self, "_session_db", None)
                 session_id = getattr(self, "session_id", None)
                 if session_db and session_id:
                     session_db.end_session(session_id, "agent_close")
-        except Exception:
-            pass
-
-        # 9. Close the SQLite handle itself, but ONLY when this agent owns it.
-        # end_session() above finalizes the session ROW; it does not release the
-        # connection. For the shared launch handle that is correct — it outlives
-        # every agent — so _owns_session_db defaults False and this is a no-op.
-        # A DEDICATED handle (the gateway's per-profile state.db opens, and the
-        # lazy self-open in _get_session_db_for_recall) has no other owner: left
-        # unclosed it keeps its db/-wal/-shm fds and its background token-writer
-        # thread, and once that writer has started the instance pins ITSELF via
-        # atexit.register(_drain_token_queue_at_exit) — which only close()
-        # unregisters — so it survives for the life of the process.
-        # Cleared first so the documented idempotency of close() holds.
-        try:
-            if getattr(self, "_owns_session_db", False) and session_db is not None:
-                self._owns_session_db = False
-                session_db.close()
         except Exception:
             pass
 

--- a/tests/agent/test_verification_stop_caching.py
+++ b/tests/agent/test_verification_stop_caching.py
@@ -1,16 +1,18 @@
 """Verification-loop synthetic scaffolding must never reach durable session state.
 
-verify_on_stop / pre_verify inject a synthetic user nudge to keep the agent
+verify_on_stop / pre_verify inject a synthetic system nudge to keep the agent
 going one more turn before it can claim completion. The assistant response is
 real content that persists and is emitted to the UI as an interim message.
-Only the nudge (the synthetic user message) is flagged, so only the nudge
-gets stripped from the durable transcript. This test file verifies:
+Only the tagged nudge is flagged, so only the nudge gets stripped from the
+durable transcript. This test file verifies:
 
   - The verification-loop flags remain registered in
     ``_EPHEMERAL_SCAFFOLDING_FLAGS`` (so nudges are stripped).
   - The DB flush drops only the nudge, keeping the assistant candidate.
   - The JSON log drops only the nudge, keeping the assistant candidate.
 """
+
+from datetime import datetime
 
 import json
 import sys
@@ -36,10 +38,10 @@ def test_verification_flags_registered_as_ephemeral(tmp_path, monkeypatch):
 
     # The nudge messages ARE scaffolding (they carry the synthetic flag).
     assert ra._is_ephemeral_scaffolding(
-        {"role": "user", "content": "[System: run tests]", "_pre_verify_synthetic": True}
+        {"role": "system", "content": "[System: run tests]", "_pre_verify_synthetic": True}
     )
     assert ra._is_ephemeral_scaffolding(
-        {"role": "user", "content": "[System: run tests]", "_verification_stop_synthetic": True}
+        {"role": "system", "content": "[System: run tests]", "_verification_stop_synthetic": True}
     )
     # Real messages (including the assistant candidate) are not.
     assert not ra._is_ephemeral_scaffolding({"role": "user", "content": "hi"})
@@ -47,19 +49,21 @@ def test_verification_flags_registered_as_ephemeral(tmp_path, monkeypatch):
 
 
 def _make_agent(ra, session_id, tmp_path):
-    agent = ra.AIAgent(
-        session_id=session_id,
-        api_key="test-key",
-        base_url="http://127.0.0.1:8000/v1",
-        provider="openai-compat",
-        model="test-model",
-        quiet_mode=True,
-        skip_context_files=True,
-        skip_memory=True,
-    )
+    """Build only the attributes exercised by persistence methods."""
+    agent = ra.AIAgent.__new__(ra.AIAgent)
+    agent.session_id = session_id
+    agent.model = "test-model"
+    agent.base_url = "http://127.0.0.1:8000/v1"
+    agent.platform = "test"
+    agent.session_start = datetime.now()
+    agent._cached_system_prompt = None
+    agent.tools = []
     agent._session_db = MagicMock()
     agent._session_db_created = True
     agent._session_json_enabled = True
+    agent._last_flushed_db_idx = 0
+    agent._flushed_db_message_ids = set()
+    agent._flushed_db_message_session_id = None
     agent.logs_dir = tmp_path / "logs"
     agent.logs_dir.mkdir(parents=True, exist_ok=True)
     return agent
@@ -77,7 +81,7 @@ def test_db_flush_drops_only_nudge_keeps_candidate(tmp_path, monkeypatch):
         # Assistant candidate — NOT flagged synthetic, persists.
         {"role": "assistant", "content": "premature done"},
         # Nudge — flagged synthetic, gets dropped.
-        {"role": "user", "content": "[System: run tests]", "_verification_stop_synthetic": True},
+        {"role": "system", "content": "[System: run tests]", "_verification_stop_synthetic": True},
         {"role": "assistant", "content": "verified and clean"},
     ]
 
@@ -108,7 +112,7 @@ def test_json_log_drops_only_nudge_keeps_candidate(tmp_path, monkeypatch):
         # Assistant candidate — NOT flagged synthetic, persists.
         {"role": "assistant", "content": "premature done"},
         # Nudge — flagged synthetic, gets dropped.
-        {"role": "user", "content": "[System: run tests]", "_pre_verify_synthetic": True},
+        {"role": "system", "content": "[System: run tests]", "_pre_verify_synthetic": True},
         {"role": "assistant", "content": "verified and clean"},
     ]
 

--- a/tests/run_agent/test_agent_guardrails.py
+++ b/tests/run_agent/test_agent_guardrails.py
@@ -106,6 +106,50 @@ class TestSanitizeApiMessages:
     def test_empty_list_is_safe(self):
         assert AIAgent._sanitize_api_messages([]) == []
 
+    def test_only_internal_system_markers_are_demoted(self):
+        """Only tagged Hermes markers are demoted for strict providers."""
+        marker_key = "_hermes_internal_system_marker"
+        marker = {
+            "role": "system",
+            "content": "[System: model changed]",
+            marker_key: True,
+        }
+        msgs = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "system", "content": "[System: configured prefill.]"},
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+            {"role": "user", "content": "[System: quoted user text]"},
+            marker,
+        ]
+
+        out = AIAgent._sanitize_api_messages(msgs)
+
+        assert out[0]["role"] == "system"
+        assert out[1]["role"] == "system"
+        assert out[4] == {"role": "user", "content": "[System: quoted user text]"}
+        assert out[5]["role"] == "user"
+        assert out[5]["content"] == "[System: model changed]"
+        assert all(marker_key not in msg for msg in out)
+        assert marker["role"] == "system"
+        assert marker[marker_key] is True
+
+    def test_first_system_message_preserved(self):
+        """A single system message at position 0 is NOT demoted."""
+        msgs = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "hi"},
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert out[0]["role"] == "system"
+
+    def test_no_tool_messages(self):
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert out == msgs
 
     def test_sdk_object_tool_calls(self):
         tc_obj = types.SimpleNamespace(id="c6", function=types.SimpleNamespace(

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -10,6 +10,7 @@ recovery every turn.
 """
 
 from run_agent import AIAgent
+from agent.message_sanitization import make_internal_system_marker
 
 
 def _bare_agent():
@@ -249,7 +250,35 @@ def test_flush_guard_clamps_overshooting_cursor():
     assert agent._last_flushed_db_idx == 2
 
 
+def test_flush_persists_internal_system_marker_metadata():
+    class _DB:
+        def __init__(self):
+            self.rows = []
+
+        def append_message(self, **kwargs):
+            self.rows.append(kwargs)
+
+        def append_messages_batch(self, session_id, messages, **kwargs):
+            for m in messages:
+                self.rows.append(dict(m, session_id=session_id))
+            return list(range(1, len(messages) + 1))
+
+    agent = _bare_agent()
+    agent._session_db = _DB()
+    agent._session_db_created = True
+    agent.session_id = "s1"
+    agent._persist_user_message_override = None
+    agent._last_flushed_db_idx = 0
+    marker = make_internal_system_marker("[System: model changed]")
+
+    AIAgent._flush_messages_to_session_db(agent, [marker], conversation_history=[])
+
+    assert agent._session_db.rows[0]["role"] == "system"
+    assert agent._session_db.rows[0]["internal_system_marker"] is True
+
+
 # ── Pass 0: merge consecutive assistant messages (issue #29148, #49147) ─────
+
 
 
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2887,6 +2887,48 @@ class TestRunConversation:
             (hook_events[0]["api_request_id"], "success")
         ]
 
+    def test_api_payload_preserves_system_prefill_and_demotes_internal_marker(
+        self, agent
+    ):
+        self._setup_agent(agent)
+        marker_key = "_hermes_internal_system_marker"
+        agent.prefill_messages = [
+            {"role": "system", "content": "Configured system prefill."}
+        ]
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Final answer", finish_reason="stop"
+        )
+        history = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+            {
+                "role": "system",
+                "content": "[System: model changed]",
+                marker_key: True,
+            },
+        ]
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("continue", conversation_history=history)
+
+        assert result["completed"] is True
+        sent = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        prefill = next(
+            msg for msg in sent if msg.get("content") == "Configured system prefill."
+        )
+        marker = next(
+            msg
+            for msg in sent
+            if "[System: model changed]" in (msg.get("content") or "")
+        )
+        assert prefill["role"] == "system"
+        assert marker["role"] == "user"
+        assert all(marker_key not in msg for msg in sent)
+
     def test_ollama_small_runtime_context_fails_before_api_call(self, agent, caplog):
         self._setup_agent(agent)
         agent.model = "qwen3.5:9b"

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1748,7 +1748,6 @@ def test_codex_commentary_emits_before_tool_and_withholds_final_answer(monkeypat
 
 
 
-
 def test_dump_api_request_debug_uses_responses_url(monkeypatch, tmp_path):
     """Debug dumps should show /responses URL when in codex_responses mode."""
     import json

--- a/tests/run_agent/test_verification_continuation_budget.py
+++ b/tests/run_agent/test_verification_continuation_budget.py
@@ -57,6 +57,7 @@ def _assert_pending_response_survives(agent, result):
     assert [message["role"] for message in result["messages"]] == [
         "user",
         "assistant",
+
     ]
 
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -492,6 +492,25 @@ class TestMessageStorage:
 
 
 
+    def test_internal_system_marker_survives_persistence_rewrites(self, db):
+        marker_key = "_hermes_internal_system_marker"
+        db.create_session(session_id="marker-session", source="tui")
+        db.append_message(
+            "marker-session",
+            role="system",
+            content="[System: model changed]",
+            internal_system_marker=True,
+        )
+        assert db.get_messages("marker-session")[0]["internal_system_marker"] == 1
+
+        loaded = db.get_messages_as_conversation("marker-session")
+        assert loaded[0]["role"] == "system"
+        assert loaded[0][marker_key] is True
+
+        db.replace_messages("marker-session", loaded)
+        reloaded = db.get_messages_as_conversation("marker-session")
+        assert reloaded[0]["role"] == "system"
+        assert reloaded[0][marker_key] is True
 
     def test_get_messages_as_conversation_strips_leaked_memory_context(self, db):
         db.create_session(session_id="s1", source="cli")

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7323,9 +7323,16 @@ def test_config_set_model_switches_agent_without_touching_env(monkeypatch):
         def update_system_prompt(self, _session_id, system_prompt):
             self.system_prompt = system_prompt
 
-        def append_message(self, session_id, role, content=None, **_kwargs):
+        def append_message(self, session_id, role, content=None, **kwargs):
             self.messages.append(
-                {"session_id": session_id, "role": role, "content": content}
+                {
+                    "session_id": session_id,
+                    "role": role,
+                    "content": content,
+                    "internal_system_marker": bool(
+                        kwargs.get("internal_system_marker")
+                    ),
+                }
             )
 
     agent = Agent()
@@ -7380,12 +7387,14 @@ def test_config_set_model_switches_agent_without_touching_env(monkeypatch):
             "Model: anthropic/claude-sonnet-4.6\nProvider: anthropic"
         )
         assert agent._cached_system_prompt == db.system_prompt
-        assert session["history"][-1]["role"] == "user"
+        assert session["history"][-1]["role"] == "system"
         assert "changed to anthropic/claude-sonnet-4.6" in session["history"][-1]["content"]
+        assert session["history"][-1]["_hermes_internal_system_marker"] is True
         assert db.messages[-1] == {
             "session_id": "session-key",
-            "role": "user",
+            "role": "system",
             "content": session["history"][-1]["content"],
+            "internal_system_marker": True,
         }
         # ...and the shared process env was NOT touched.
         assert os.environ["HERMES_TUI_PROVIDER"] == "openai-codex"
@@ -7627,9 +7636,10 @@ def test_config_set_personality_preserves_history_and_returns_info(monkeypatch):
     # History is preserved with a pivot marker appended
     assert len(session["history"]) == 2
     assert session["history"][0] == {"role": "user", "text": "hi"}
-    assert session["history"][1]["role"] == "user"
+    assert session["history"][1]["role"] == "system"
     assert "personality" in session["history"][1]["content"].lower()
     assert "You are helpful." in session["history"][1]["content"]
+    assert session["history"][1]["_hermes_internal_system_marker"] is True
     assert session["history_version"] == 5
     # Agent's system prompt was updated in-place; cached prompt untouched
     assert agent.ephemeral_system_prompt == "You are helpful."
@@ -16932,7 +16942,8 @@ def test_personality_marker_does_not_shift_truncate_ordinal(monkeypatch):
         )
 
         marker = session["history"][-1]
-        assert marker["role"] == "user", "provider compatibility: pivot rides as a user turn"
+        assert marker["role"] == "system", "pivot rides as a tagged system marker"
+        assert marker.get("display_kind") == "personality_switch"
 
         # Two more real turns land after the personality change.
         session["history"].extend(

--- a/tests/tui_gateway/test_model_switch_marker_role.py
+++ b/tests/tui_gateway/test_model_switch_marker_role.py
@@ -1,10 +1,9 @@
-"""Tests for _append_model_switch_marker role fix (issue #48338).
+"""Tests for _append_model_switch_marker role semantics (issue #48338).
 
-The model switch marker must NOT use role="system" because strict providers
-(vLLM, Qwen) reject system messages that appear mid-conversation. Using
-role="user" is safe — the system prompt is prepended to the API message list,
-so a user-role marker can appear at any later position, and the gateway's
-sanitize/merge pass already coalesces consecutive user messages.
+The model switch marker is tagged and uses role="system" for correct transcript
+semantics. The pre-call sanitizer demotes only tagged Hermes system markers to
+role="user" for strict-provider compatibility; persisted transcript and Desktop
+rendering keep the system role.
 """
 
 from __future__ import annotations
@@ -17,18 +16,20 @@ from tui_gateway.server import _append_model_switch_marker
 
 
 class TestAppendModelSwitchMarkerRole:
-    """Verify the marker uses role='user', not role='system'."""
+    """Verify the marker uses role='system' (demoted to 'user' at API call time)."""
 
-    def test_marker_uses_user_role(self) -> None:
-        """The history entry must be role='user', not role='system'."""
+    def test_marker_uses_system_role(self) -> None:
+        """The history entry must be role='system' for correct semantics."""
         session: dict = {"session_key": "test-session", "history": []}
         _append_model_switch_marker(session, model="gpt-4o", provider="openai")
         assert len(session["history"]) == 1
         entry = session["history"][0]
-        assert entry["role"] == "user", (
-            f"Expected role='user' but got role='{entry['role']}'. "
-            "Strict providers (vLLM, Qwen) reject mid-conversation system messages."
+        assert entry["role"] == "system", (
+            f"Expected role='system' but got role='{entry['role']}'. "
+            "The sanitizer demotes to 'user' at API call time (#48338)."
         )
+        assert entry["_hermes_internal_system_marker"] is True
+
 
 
     def test_no_marker_for_none_session(self) -> None:
@@ -105,6 +106,32 @@ class TestModelSwitchMarkerDedup:
         _append_model_switch_marker(session, model="model-a", provider="p")
         _append_model_switch_marker(session, model="model-b", provider="p")
         assert session["history_version"] == 2  # one increment per switch
+
+    def test_marker_role_after_turns(self) -> None:
+        """Persist tagged model-switch markers with the system role."""
+        db = MagicMock()
+        session: dict = {
+            "session_key": "sess-1",
+            "history": [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi"},
+            ],
+            "history_version": 7,
+            "agent": SimpleNamespace(_session_db=db),
+        }
+        _append_model_switch_marker(
+            session, model="qwen3.6-35b", provider="vllm"
+        )
+        marker = session["history"][-1]
+        assert marker["role"] == "system"
+        assert marker["_hermes_internal_system_marker"] is True
+        assert session["history_version"] == 8
+        db.append_message.assert_called_once_with(
+            session_id="sess-1",
+            role="system",
+            content=marker["content"],
+            internal_system_marker=True,
+        )
 
 
 def _make_marker_entry(model: str) -> dict:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -37,6 +37,10 @@ from tools.environments.local import hermes_subprocess_env
 from agent.replay_cleanup import sanitize_replay_history
 from agent.skill_commands import describe_skill_invocation
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
+from agent.message_sanitization import (
+    HERMES_INTERNAL_SYSTEM_MARKER_KEY,
+    make_internal_system_marker,
+)
 from tui_gateway import git_probe
 from tui_gateway.turn_marker import (
     clear_turn_marker,
@@ -2905,6 +2909,9 @@ def _persist_branch_seed(session: dict) -> None:
                         # append_message would otherwise stamp time.time() and the
                         # branch's copied history would all appear authored "now".
                         "timestamp": msg.get("timestamp"),
+                        "internal_system_marker": bool(
+                            msg.get(HERMES_INTERNAL_SYSTEM_MARKER_KEY)
+                        ),
                     }
                     for msg in seed
                 ],
@@ -3989,11 +3996,11 @@ def _append_model_switch_marker(session: dict | None, *, model: str, provider: s
         f"{model}{provider_part}. From this point forward, use this runtime "
         "metadata when answering questions about what model/provider is active.]"
     )
-    # Persist as a user message, not a system message.  The gateway appends
-    # this marker after prior conversation turns, and strict OpenAI-compatible
-    # providers (vLLM, Qwen) reject system messages that are not at the
-    # beginning of the API message list (#48338).
-    entry = {"role": "user", "content": marker, "display_kind": "model_switch"}
+    # Persist as a tagged system message for correct transcript semantics.
+    # The pre-call sanitizer demotes only this explicit marker on the provider
+    # copy, preserving strict-provider compatibility without rewriting ordinary
+    # system prefills.
+    entry = make_internal_system_marker(marker)
 
     def _replace_markers() -> None:
         history = session.setdefault("history", [])
@@ -4015,9 +4022,9 @@ def _append_model_switch_marker(session: dict | None, *, model: str, provider: s
         if db is not None:
             db.append_message(
                 session_id=session_key,
-                role="user",
+                role="system",
                 content=marker,
-                display_kind="model_switch",
+                internal_system_marker=True,
             )
             return
 
@@ -4026,9 +4033,9 @@ def _append_model_switch_marker(session: dict | None, *, model: str, provider: s
             if scoped_db is not None:
                 scoped_db.append_message(
                     session_id=session_key,
-                    role="user",
+                    role="system",
                     content=marker,
-                    display_kind="model_switch",
+                    internal_system_marker=True,
                 )
     except Exception:
         logger.debug("failed to persist model switch marker", exc_info=True)
@@ -6083,7 +6090,7 @@ def _apply_personality_to_session(
         # hard-deletes the difference (#82756).
         with session["history_lock"]:
             session["history"].append(
-                {"role": "user", "content": marker, "display_kind": "personality_switch"}
+                make_internal_system_marker(marker, display_kind="personality_switch")
             )
             session["history_version"] = int(session.get("history_version", 0)) + 1
         info = _session_info(agent)
@@ -8823,6 +8830,7 @@ def _serialize_subscription_preview(p) -> dict:
         "amount_due_now_cents": p.amount_due_now_cents,
         "effective_at": p.effective_at,
     }
+
 
 
 # ── Delegation: subagent tree observability + controls ───────────────


### PR DESCRIPTION
## Problem

`[System:]` messages (model-switch markers, personality pivots, verification nudges, continuation prompts) are persisted as `role=user` to avoid HTTP 400 on strict OpenAI-compatible providers (#48338). This causes the Desktop to render them as prominent right-aligned user message bubbles, visually pushing assistant responses out of view — users report their "response was washed away by a system message."

## Root Cause

PR #54210 (fixing #48338) changed model-switch markers from `role=system` to `role=user` to avoid strict providers rejecting mid-array system messages. This conflated the **API compatibility layer** with the **persistence/representation layer**: the wire-format constraint was pushed into the DB, where the Desktop reads it as a real user message.

The same `role=user` pattern was then copied to all 7 `[System:]` injection points across `tui_gateway/server.py` and `agent/conversation_loop.py`.

## Fix

Separate the concerns: persist with the correct `role=system`, demote to `role=user` only at API call time.

### 1. Persistence layer — use `role=system` (4 files, 7 injection points)

| File | Injection point | Change |
|------|----------------|--------|
| `tui_gateway/server.py:~2440` | Model-switch marker (history + DB) | `user` → `system` |
| `tui_gateway/server.py:~2448` | Model-switch marker (agent DB) | `user` → `system` |
| `tui_gateway/server.py:~2454` | Model-switch marker (scoped DB) | `user` → `system` |
| `tui_gateway/server.py:~4098` | Personality change marker | `user` → `system` |
| `agent/conversation_loop.py:~1942` | Continuation prompt (timeout/truncation) | `user` → `system` |
| `agent/conversation_loop.py:~5111` | "Continue now" tool-call nudge | `user` → `system` |
| `agent/conversation_loop.py:~5184` | Verification-stop nudge | `user` → `system` |
| `agent/conversation_loop.py:~5242` | Pre-verify nudge | `user` → `system` |

### 2. API compatibility layer — demote in `sanitize_api_messages` (1 file)

Added a new step in `sanitize_api_messages` (`agent/agent_runtime_helpers.py`) that demotes any `system` message at position > 0 to `role=user` on the **per-call copy**. The stored transcript and Desktop rendering keep the correct `system` role; only the wire payload is adjusted.

This is the same chokepoint already used for empty tool_calls cleanup and orphaned tool repair — it runs on every API call and only mutates the per-call copy, never the persisted trajectory.

### 3. Desktop rendering — zero changes needed

The Desktop already has a `SystemMessage` component (`apps/desktop/src/components/assistant-ui/thread/system-message.tsx`) that renders `role=system` messages as small, centered, gray text. The `toRuntimeMessage` function (`chat-runtime.ts:355`) already maps `role=system` to this component. No frontend changes required.

## Related

- Closes #48356 (alternative approach using `session_meta` rows — this PR is simpler)
- Supersedes the `role=user` workaround from #54210 / #48338
- Addresses the verification-nudge persistence leak (#55733) — leaked nudges now render as small system messages instead of large user bubbles

## Test

- 358 tests passed, 0 failed across `test_tui_gateway_server.py` (316), `test_agent_guardrails.py` (39), `test_verification_stop_caching.py` (3)
- 2 new tests for sanitize_api_messages demotion logic
- 3 existing tests updated to assert `role=system`