### PR TITLE
fix(cli): list sessions from all sources in /sessions and /resume

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6806,11 +6806,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         try:
             from hermes_cli.session_listing import query_session_listing
 
+            # Show sessions from ALL sources (cli + desktop + gateway), not just
+            # "cli". Profiles where the user only used the desktop app would
+            # otherwise show an empty list in /sessions and /resume even though
+            # the sessions exist in state.db. Tool-generated sessions stay
+            # excluded via exclude_sources below.
             return query_session_listing(
                 self._session_db,
-                source="cli",
+                source=None,
                 current_session_id=self.session_id,
-                include_all_sources=False,
+                include_all_sources=True,
                 include_unnamed=True,
                 limit=limit,
                 exclude_sources=["tool"],

--- a/tests/cli/test_cli_resume_command.py
+++ b/tests/cli/test_cli_resume_command.py
@@ -351,3 +351,46 @@ class TestResumeFlushesBeforeEndSession:
             [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "hi"}]
         )
         cli_obj._session_db.end_session.assert_called_once()
+
+
+class TestListRecentSessionsSourceScope:
+    """_list_recent_sessions must surface sessions from every source, not just
+    'cli'. A profile used only via the desktop app stores sessions with
+    source='desktop'; the old source='cli' filter hid them from /sessions and
+    /resume (reported as 'No previous sessions yet'). See fix in cli.py
+    _list_recent_sessions."""
+
+    def test_list_recent_sessions_queries_all_sources(self):
+        from unittest.mock import patch
+
+        from hermes_cli.session_listing import query_session_listing
+
+        cli_obj = _make_cli()
+        captured = {}
+
+        def fake_query(db, *, source, current_session_id, include_all_sources,
+                       include_unnamed, limit, exclude_sources):
+            captured.update(
+                source=source, include_all_sources=include_all_sources,
+                exclude_sources=exclude_sources,
+            )
+            return [{"id": "desktop_sess", "source": "desktop", "title": "Coding"}]
+
+        with patch(
+            "hermes_cli.session_listing.query_session_listing", side_effect=fake_query
+        ):
+            rows = cli_obj._list_recent_sessions(limit=10)
+
+        # The real method must now query across ALL sources (desktop included).
+        assert captured["source"] is None
+        assert captured["include_all_sources"] is True
+        assert captured["exclude_sources"] == ["tool"]
+        assert rows and rows[0]["source"] == "desktop"
+
+        # And document that the *old* filter would have dropped it.
+        old_rows = query_session_listing(
+            cli_obj._session_db, source="cli",
+            current_session_id=cli_obj.session_id, include_all_sources=False,
+            include_unnamed=True, limit=10, exclude_sources=["tool"],
+        )
+        assert old_rows == []


### PR DESCRIPTION
## Summary
`HermesCLI._list_recent_sessions` (the data source behind the in-chat `/sessions` and `/resume` pickers) hardcoded `source="cli"` when calling `query_session_listing`. Any profile whose sessions were created only via the **desktop app** (stored with `source="desktop"`) therefore showed an empty list — `/sessions` printed `(._.) No previous sessions yet.` even though the sessions exist in `state.db`.

This was inconsistent with the standalone `hermes sessions list` command, which uses `source=None` and correctly shows all sources.

## Fix
- `cli.py` `_list_recent_sessions`: pass `source=None, include_all_sources=True` (tool-generated sessions stay excluded via `exclude_sources=["tool"]`).
- This also fixes `/resume <number>` / `<title>` for desktop-created sessions, since they share the same `_list_recent_sessions` path.

## Verification
- New regression test `TestListRecentSessionsSourceScope::test_list_recent_sessions_queries_all_sources` pins the delegation to `source=None` / `include_all_sources=True` and documents that the old `source="cli"` filter returned `[]`.
- Full `tests/cli/test_cli_resume_command.py`: 19 passed. `ruff check` clean.

## Repro
1. `hermes profile create desktoponly` then chat in the desktop app.
2. `hermes -p desktoponly` → type `/sessions`.
3. Before: `(._.) No previous sessions yet.` After: the desktop session is listed.

🤖 Generated with [Hermes Agent](https://hermes-agent.nousresearch.com)