### PR TITLE
fix(redact): narrow ElevenLabs key pattern to prevent sk_ filename false positives

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -96,7 +96,7 @@ _PREFIX_PATTERNS = [
     r"dop_v1_[A-Za-z0-9]{10,}",         # DigitalOcean PAT
     r"doo_v1_[A-Za-z0-9]{10,}",         # DigitalOcean OAuth
     r"am_[A-Za-z0-9_-]{10,}",           # AgentMail API key
-    r"sk_[A-Za-z0-9_]{10,}",            # ElevenLabs TTS key (sk_ underscore, not sk- dash)
+    r"sk_[A-Za-z0-9]{10,}",             # ElevenLabs TTS key (sk_ prefix, body is alpha+numeric only)
     r"tvly-[A-Za-z0-9]{10,}",           # Tavily search API key
     r"exa_[A-Za-z0-9]{10,}",            # Exa search API key
     r"gsk_[A-Za-z0-9]{10,}",            # Groq Cloud API key


### PR DESCRIPTION
Fixes #61876

**Problem:** The ElevenLabs API key pattern `sk_[A-Za-z0-9_]{10,}` in `agent/redact.py` matched filenames starting with `sk_` followed by snake_case components (e.g. `sk_hynix_*`, `sk_telecom_*`), because the body character class allowed underscores. This caused MEDIA delivery to fail with "Skipping unsafe MEDIA directive path" since the model saw a redacted (nonexistent) path.

**Fix:** Removed underscore from the body character class. ElevenLabs keys use only alphanumeric characters after the `sk_` prefix, so `sk_[A-Za-z0-9]{10,}` is correct. This prevents false matches on snake_case filenames while continuing to match real ElevenLabs keys.

**Testing:** Existing redaction tests continue to pass.