### PR TITLE
fix(mcp_oauth): preserve refresh_token when token refresh response omits it

### DIFF
--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -351,6 +351,15 @@ class HermesTokenStorage:
 
     async def set_tokens(self, tokens: "OAuthToken") -> None:
         payload = tokens.model_dump(mode="json", exclude_none=True)
+        # Per RFC 6749 §6, a token refresh response MAY omit the
+        # ``refresh_token`` field.  If the new token doesn't include one,
+        # carry forward the existing stored refresh_token so the client can
+        # continue refreshing indefinitely instead of losing the token at
+        # the next expiry (issue #62333).
+        if "refresh_token" not in payload:
+            old_data = _read_json(self._tokens_path())
+            if old_data and "refresh_token" in old_data:
+                payload["refresh_token"] = old_data["refresh_token"]
         # Persist an absolute ``expires_at`` so a process restart can
         # reconstruct the correct remaining TTL. Without this the MCP SDK's
         # ``_initialize`` reloads a relative ``expires_in`` which has no


### PR DESCRIPTION
Fixes #62333

**Problem:** `HermesTokenStorage.set_tokens()` calls `tokens.model_dump(mode="json", exclude_none=True)` before writing the token file. Per RFC 6749 §6, a token refresh response MAY omit the `refresh_token` field. When this happens, `exclude_none=True` silently drops the `refresh_token` from the stored payload. After the next access-token expiry, `can_refresh_token()` returns `False` because no `refresh_token` is stored, and the MCP server dies until a full re-OAuth authorization.

**Fix:** After serializing the new token, check if `refresh_token` is missing from the payload. If so, read the existing token file and carry forward the old `refresh_token`.