### PR TITLE
feat: formalize delegate handoff results

### DIFF
--- a/tests/tools/test_delegate_handoff_result.py
+++ b/tests/tools/test_delegate_handoff_result.py
@@ -1,0 +1,120 @@
+import json
+
+from tools.delegate_tool import HandoffResult, _handoff_error, _run_single_child
+
+
+class FakeParent:
+    _current_task_id = "parent-task"
+    _active_children = []
+    _active_children_lock = None
+
+    def _touch_activity(self, desc):
+        self.last_activity = desc
+
+
+class FakeChild:
+    _delegate_role = "leaf"
+    _delegate_depth = 1
+    _parent_subagent_id = None
+    _delegate_saved_tool_names = []
+    model = "test-model"
+    session_prompt_tokens = 11
+    session_completion_tokens = 7
+    session_estimated_cost_usd = 0.0123
+    session_reasoning_tokens = 0
+    session_id = "child-session"
+    tool_progress_callback = None
+
+    def __init__(self, result):
+        self.result = result
+        self.closed = False
+
+    def run_conversation(self, **kwargs):
+        return self.result
+
+    def get_activity_summary(self):
+        return {
+            "current_tool": None,
+            "api_call_count": 1,
+            "max_iterations": 3,
+            "last_activity_desc": "testing",
+        }
+
+    def close(self):
+        self.closed = True
+
+
+def test_handoff_result_serializes_typed_frame_with_legacy_keys():
+    frame = HandoffResult.from_child_run(
+        task_index=2,
+        status="completed",
+        summary="done",
+        exit_reason="completed",
+        api_calls="3",
+        duration_seconds="1.5",
+        model="m",
+        tokens={"input": 1, "output": 2},
+        tool_trace=[{"tool": "read_file"}],
+        child_role="leaf",
+        child_cost_usd="0.25",
+    ).to_dict()
+
+    assert frame["type"] == "handoff_result"
+    assert frame["handoff_schema"] == "delegate.handoff_result.v1"
+    assert frame["task_index"] == 2
+    assert frame["status"] == "completed"
+    assert frame["summary"] == "done"
+    assert frame["api_calls"] == 3
+    assert frame["duration_seconds"] == 1.5
+    assert frame["tokens"] == {"input": 1, "output": 2}
+    assert frame["tool_trace"] == [{"tool": "read_file"}]
+    assert frame["_child_role"] == "leaf"
+    assert frame["_child_cost_usd"] == 0.25
+    json.dumps(frame)
+
+
+def test_handoff_error_uses_formal_schema_and_exit_reason():
+    frame = _handoff_error(
+        task_index=0,
+        status="timeout",
+        error="stuck",
+        exit_reason="timeout",
+        duration_seconds=9,
+        child_role="orchestrator",
+        diagnostic_path="/tmp/diag.txt",
+    )
+
+    assert frame["type"] == "handoff_result"
+    assert frame["handoff_schema"] == "delegate.handoff_result.v1"
+    assert frame["summary"] is None
+    assert frame["error"] == "stuck"
+    assert frame["exit_reason"] == "timeout"
+    assert frame["diagnostic_path"] == "/tmp/diag.txt"
+    assert frame["_child_role"] == "orchestrator"
+
+
+def test_run_single_child_returns_formal_handoff_result():
+    child = FakeChild(
+        {
+            "final_response": "implemented",
+            "completed": True,
+            "interrupted": False,
+            "api_calls": 1,
+            "messages": [],
+        }
+    )
+
+    frame = _run_single_child(0, "do work", child=child, parent_agent=FakeParent())
+
+    assert frame["type"] == "handoff_result"
+    assert frame["handoff_schema"] == "delegate.handoff_result.v1"
+    assert frame["task_index"] == 0
+    assert frame["status"] == "completed"
+    assert frame["summary"] == "implemented"
+    assert frame["exit_reason"] == "completed"
+    assert frame["api_calls"] == 1
+    assert frame["model"] == "test-model"
+    assert frame["tokens"] == {"input": 11, "output": 7}
+    assert frame["_child_role"] == "leaf"
+    assert frame["_child_cost_usd"] == 0.0123
+    assert child.closed is True

--- a/tests/tools/test_delegate_handoff_result.py
+++ b/tests/tools/test_delegate_handoff_result.py
@@ -73,6 +73,20 @@ def test_handoff_result_serializes_typed_frame_with_legacy_keys():
     json.dumps(frame)
 
 
+def test_handoff_result_preserves_legacy_empty_public_keys():
+    frame = HandoffResult.from_child_run(
+        task_index=1,
+        status="failed",
+        summary=None,
+        exit_reason="max_iterations",
+    ).to_dict()
+
+    assert frame["model"] is None
+    assert frame["tokens"] == {}
+    assert frame["tool_trace"] == []
+    assert frame["diagnostic_path"] is None
+
+
 def test_handoff_error_uses_formal_schema_and_exit_reason():
     frame = _handoff_error(
         task_index=0,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -973,17 +973,15 @@ class HandoffResult:
             "api_calls": self.api_calls,
             "duration_seconds": self.duration_seconds,
             "exit_reason": self.exit_reason,
+            # Keep the pre-HandoffResult public result shape stable: callers
+            # already expect these keys to exist with null/empty semantics.
+            "model": self.model,
+            "tokens": self.tokens,
+            "tool_trace": self.tool_trace,
+            "diagnostic_path": self.diagnostic_path,
         }
         if self.error is not None:
             payload["error"] = self.error
-        if self.model is not None:
-            payload["model"] = self.model
-        if self.tokens:
-            payload["tokens"] = self.tokens
-        if self.tool_trace:
-            payload["tool_trace"] = self.tool_trace
-        if self.diagnostic_path:
-            payload["diagnostic_path"] = self.diagnostic_path
         if self.stale_paths:
             payload["stale_paths"] = self.stale_paths
         if self.summary_truncated:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -30,6 +30,7 @@ import time
 from concurrent.futures import (
     TimeoutError as FuturesTimeoutError,
 )
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlsplit, urlunsplit
 
@@ -879,6 +880,147 @@ class DelegateEvent(str, enum.Enum):
     TASK_THINKING = "delegate.task_thinking"
     TASK_TOOL_STARTED = "delegate.tool_started"
     TASK_TOOL_COMPLETED = "delegate.tool_completed"
+
+
+@dataclass
+class HandoffResult:
+    """Typed handoff frame returned from a child agent to its parent.
+
+    ``delegate_task`` has historically returned plain dictionaries.  This
+    dataclass makes the parent/child boundary explicit while preserving the
+    public JSON shape: ``to_dict()`` emits the existing keys plus typed framing
+    metadata so downstream consumers can distinguish formal handoffs from
+    ad-hoc result dicts.
+    """
+
+    task_index: int
+    status: str
+    summary: Optional[str]
+    exit_reason: str
+    api_calls: int = 0
+    duration_seconds: float = 0.0
+    error: Optional[str] = None
+    model: Optional[str] = None
+    tokens: Dict[str, Any] = field(default_factory=dict)
+    tool_trace: List[Dict[str, Any]] = field(default_factory=list)
+    diagnostic_path: Optional[str] = None
+    stale_paths: List[str] = field(default_factory=list)
+    summary_truncated: bool = False
+    summary_full_path: Optional[str] = None
+    child_role: Optional[str] = None
+    child_cost_usd: float = 0.0
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_child_run(
+        cls,
+        *,
+        task_index: int,
+        status: str,
+        summary: Optional[str],
+        exit_reason: str,
+        api_calls: Any = 0,
+        duration_seconds: Any = 0.0,
+        error: Optional[str] = None,
+        model: Optional[str] = None,
+        tokens: Optional[Dict[str, Any]] = None,
+        tool_trace: Optional[List[Dict[str, Any]]] = None,
+        diagnostic_path: Optional[str] = None,
+        stale_paths: Optional[List[str]] = None,
+        child_role: Optional[str] = None,
+        child_cost_usd: Any = 0.0,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> "HandoffResult":
+        """Build a validated handoff frame from raw child-agent values."""
+        try:
+            api_calls_i = int(api_calls or 0)
+        except (TypeError, ValueError):
+            api_calls_i = 0
+        try:
+            duration_f = float(duration_seconds or 0.0)
+        except (TypeError, ValueError):
+            duration_f = 0.0
+        try:
+            cost_f = float(child_cost_usd or 0.0)
+        except (TypeError, ValueError):
+            cost_f = 0.0
+        return cls(
+            task_index=int(task_index),
+            status=str(status),
+            summary=summary if summary is None or isinstance(summary, str) else str(summary),
+            exit_reason=str(exit_reason),
+            api_calls=api_calls_i,
+            duration_seconds=duration_f,
+            error=error if error is None or isinstance(error, str) else str(error),
+            model=model if isinstance(model, str) else None,
+            tokens=tokens or {},
+            tool_trace=tool_trace or [],
+            diagnostic_path=diagnostic_path,
+            stale_paths=stale_paths or [],
+            child_role=child_role,
+            child_cost_usd=cost_f,
+            metadata=metadata or {},
+        )
+
+    def to_dict(self, *, include_private: bool = True) -> Dict[str, Any]:
+        """Return the JSON-compatible parent-facing handoff payload."""
+        payload: Dict[str, Any] = {
+            "type": "handoff_result",
+            "handoff_schema": "delegate.handoff_result.v1",
+            "task_index": self.task_index,
+            "status": self.status,
+            "summary": self.summary,
+            "api_calls": self.api_calls,
+            "duration_seconds": self.duration_seconds,
+            "exit_reason": self.exit_reason,
+        }
+        if self.error is not None:
+            payload["error"] = self.error
+        if self.model is not None:
+            payload["model"] = self.model
+        if self.tokens:
+            payload["tokens"] = self.tokens
+        if self.tool_trace:
+            payload["tool_trace"] = self.tool_trace
+        if self.diagnostic_path:
+            payload["diagnostic_path"] = self.diagnostic_path
+        if self.stale_paths:
+            payload["stale_paths"] = self.stale_paths
+        if self.summary_truncated:
+            payload["summary_truncated"] = True
+        if self.summary_full_path:
+            payload["summary_full_path"] = self.summary_full_path
+        if self.metadata:
+            payload["metadata"] = self.metadata
+        if include_private:
+            payload["_child_role"] = self.child_role
+            payload["_child_cost_usd"] = self.child_cost_usd
+        return payload
+
+
+def _handoff_error(
+    *,
+    task_index: int,
+    status: str,
+    error: str,
+    exit_reason: str,
+    duration_seconds: Any = 0.0,
+    api_calls: Any = 0,
+    child_role: Optional[str] = None,
+    diagnostic_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Create a typed error/timeout/interrupted handoff dict."""
+    return HandoffResult.from_child_run(
+        task_index=task_index,
+        status=status,
+        summary=None,
+        error=error,
+        exit_reason=exit_reason,
+        duration_seconds=duration_seconds,
+        api_calls=api_calls,
+        child_role=child_role,
+        diagnostic_path=diagnostic_path,
+    ).to_dict()
 
 
 # Legacy event strings → DelegateEvent mapping.
@@ -2428,24 +2570,27 @@ def _run_single_child(
             else:
                 _err = str(_timeout_exc)
 
-            _error_entry = {
-                "task_index": task_index,
-                "status": "timeout" if is_timeout else "error",
-                "summary": None,
-                "error": _err,
-                "exit_reason": "timeout" if is_timeout else "error",
-                "api_calls": child_api_calls,
-                "duration_seconds": duration,
-                "timeout_seconds": child_timeout if is_timeout else None,
-                "timed_out_after_seconds": duration if is_timeout else None,
-                "timeout_phase": (
-                    "before_first_llm_call" if is_timeout and child_api_calls == 0
-                    else "after_llm_calls" if is_timeout
-                    else None
-                ),
-                "_child_role": getattr(child, "_delegate_role", None),
-                "diagnostic_path": diagnostic_path,
-            }
+            _error_entry = _handoff_error(
+                task_index=task_index,
+                status="timeout" if is_timeout else "error",
+                error=_err,
+                exit_reason="timeout" if is_timeout else "error",
+                api_calls=child_api_calls,
+                duration_seconds=duration,
+                child_role=getattr(child, "_delegate_role", None),
+                diagnostic_path=diagnostic_path,
+            )
+            _error_entry.update(
+                {
+                    "timeout_seconds": child_timeout if is_timeout else None,
+                    "timed_out_after_seconds": duration if is_timeout else None,
+                    "timeout_phase": (
+                        "before_first_llm_call" if is_timeout and child_api_calls == 0
+                        else "after_llm_calls" if is_timeout
+                        else None
+                    ),
+                }
+            )
             if _late_pending_steer:
                 _error_entry["missed_steer"] = _late_pending_steer
                 _error_entry["error"] += (
@@ -2616,15 +2761,15 @@ def _run_single_child(
         _output_tokens = getattr(child, "session_completion_tokens", 0)
         _model = getattr(child, "model", None)
 
-        entry: Dict[str, Any] = {
-            "task_index": task_index,
-            "status": status,
-            "summary": summary,
-            "api_calls": api_calls,
-            "duration_seconds": duration,
-            "model": _model if isinstance(_model, str) else None,
-            "exit_reason": exit_reason,
-            "tokens": {
+        entry = HandoffResult.from_child_run(
+            task_index=task_index,
+            status=status,
+            summary=summary,
+            api_calls=api_calls,
+            duration_seconds=duration,
+            model=_model if isinstance(_model, str) else None,
+            exit_reason=exit_reason,
+            tokens={
                 "input": (
                     _input_tokens if isinstance(_input_tokens, (int, float)) else 0
                 ),
@@ -2632,17 +2777,9 @@ def _run_single_child(
                     _output_tokens if isinstance(_output_tokens, (int, float)) else 0
                 ),
             },
-            "tool_trace": tool_trace,
-            # Captured before the finally block calls child.close() so the
-            # parent thread can fire subagent_stop with the correct role.
-            # Stripped before the dict is serialised back to the model.
-            "_child_role": getattr(child, "_delegate_role", None),
-            # Captured before child.close() so the parent aggregator can fold
-            # the child's total spend into the parent's session cost.  Port of
-            # Kilo-Org/kilocode#9448 — previously the footer only reflected the
-            # parent's direct API calls and under-counted subagent-heavy runs.
-            # Stripped before the dict is serialised back to the model.
-            "_child_cost_usd": (
+            tool_trace=tool_trace,
+            child_role=getattr(child, "_delegate_role", None),
+            child_cost_usd=(
                 float(getattr(child, "session_estimated_cost_usd", 0.0) or 0.0)
                 if isinstance(
                     getattr(child, "session_estimated_cost_usd", 0.0),
@@ -2650,7 +2787,7 @@ def _run_single_child(
                 )
                 else 0.0
             ),
-        }
+        ).to_dict()
         # Per-delegation spend, serialized back to the model alongside
         # tokens/api_calls so the parent can see what each delegation cost.
         # Mirrors _child_cost_usd (which is stripped pre-serialization and
@@ -2802,15 +2939,14 @@ def _run_single_child(
                 )
             except Exception as e:
                 logger.debug("Progress callback failure relay failed: %s", e)
-        _error_entry = {
-            "task_index": task_index,
-            "status": "error",
-            "summary": None,
-            "error": str(exc),
-            "api_calls": 0,
-            "duration_seconds": duration,
-            "_child_role": getattr(child, "_delegate_role", None),
-        }
+        _error_entry = _handoff_error(
+            task_index=task_index,
+            status="error",
+            error=str(exc),
+            exit_reason="error",
+            duration_seconds=duration,
+            child_role=getattr(child, "_delegate_role", None),
+        )
         if _late_pending_steer:
             _error_entry["missed_steer"] = _late_pending_steer
             _error_entry["error"] += (
@@ -3447,29 +3583,25 @@ def delegate_task(
                                 try:
                                     entry = f.result()
                                 except Exception as exc:
-                                    entry = {
-                                        "task_index": idx,
-                                        "status": "error",
-                                        "summary": None,
-                                        "error": str(exc),
-                                        "api_calls": 0,
-                                        "duration_seconds": 0,
-                                        "_child_role": getattr(
+                                    entry = _handoff_error(
+                                        task_index=idx,
+                                        status="error",
+                                        error=str(exc),
+                                        exit_reason="error",
+                                        child_role=getattr(
                                             _child_by_index.get(idx), "_delegate_role", None
                                         ),
-                                    }
+                                    )
                             else:
-                                entry = {
-                                    "task_index": idx,
-                                    "status": "interrupted",
-                                    "summary": None,
-                                    "error": "Parent agent interrupted — child did not finish in time",
-                                    "api_calls": 0,
-                                    "duration_seconds": 0,
-                                    "_child_role": getattr(
+                                entry = _handoff_error(
+                                    task_index=idx,
+                                    status="interrupted",
+                                    error="Parent agent interrupted — child did not finish in time",
+                                    exit_reason="interrupted",
+                                    child_role=getattr(
                                         _child_by_index.get(idx), "_delegate_role", None
                                     ),
-                                }
+                                )
                             results.append(entry)
                             completed_count += 1
                         break
@@ -3484,17 +3616,15 @@ def delegate_task(
                             entry = future.result()
                         except Exception as exc:
                             idx = futures[future]
-                            entry = {
-                                "task_index": idx,
-                                "status": "error",
-                                "summary": None,
-                                "error": str(exc),
-                                "api_calls": 0,
-                                "duration_seconds": 0,
-                                "_child_role": getattr(
+                            entry = _handoff_error(
+                                task_index=idx,
+                                status="error",
+                                error=str(exc),
+                                exit_reason="error",
+                                child_role=getattr(
                                     _child_by_index.get(idx), "_delegate_role", None
                                 ),
-                            }
+                            )
                         results.append(entry)
                         completed_count += 1
 


### PR DESCRIPTION
## Thinking Path
Paperclip COM-40 asks for a formal parent/child agent handoff protocol in `tools/delegate_tool.py`. I kept the existing delegate result shape intact and added typed handoff framing around it so parent aggregation and hooks remain backward-compatible.

## What Changed
- Added a structured `HandoffResult` dataclass with typed frame metadata: `type=handoff_result` and `handoff_schema=delegate.handoff_result.v1`.
- Routed successful child completions, timeout/error branches, and interrupted batch fallback entries through formal handoff framing while preserving legacy result keys.
- Added focused regression coverage for serialization, error framing, and `_run_single_child` output.

## Verification
- `python3 -m py_compile tools/delegate_tool.py`
- `python3 -m pytest tests/tools/test_delegate_handoff_result.py -q -o 'addopts='` → 3 passed

## Risks
Low. The framed result preserves the legacy top-level fields that existing aggregation/hooks consume.

## Model Used
Coder-Platform / OpenAI Codex via Hermes Agent.

## Checklist
- [x] Targeted tests added
- [x] Targeted tests pass
- [x] Backward-compatible result keys preserved
