### PR TITLE
security(node): reject zip-slip and symlink members before extracting the Node heal archive

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -394,6 +394,32 @@ def _heal_managed_node_windows() -> bool:
             extract_dir = tmp_path / "extract"
             extract_dir.mkdir()
             with zipfile.ZipFile(zip_path) as archive:
+                # Validate member paths to prevent zip-slip (path traversal)
+                # AND reject symlink members before extracting.  The zip is
+                # fetched over the network from a nodejs.org mirror without a
+                # pinned checksum, so an attacker who can MITM the connection
+                # or compromise the mirror could otherwise plant files outside
+                # ``extract_dir`` (e.g. into %HERMES_HOME% or a startup dir) and
+                # gain code execution on the next launch.  This mirrors the
+                # guard already applied on the self-update path in
+                # ``hermes_cli/main.py``.
+                extract_dir_real = os.path.realpath(extract_dir)
+                for member in archive.infolist():
+                    member_path = os.path.realpath(os.path.join(extract_dir, member.filename))
+                    if (
+                        not member_path.startswith(extract_dir_real + os.sep)
+                        and member_path != extract_dir_real
+                    ):
+                        raise ValueError(
+                            f"Zip-slip detected: {member.filename} escapes extraction directory"
+                        )
+                    # Unix mode lives in the upper 16 bits of external_attr;
+                    # mask to the file-type bits.
+                    mode = (member.external_attr >> 16) & 0o170000
+                    if stat.S_ISLNK(mode):
+                        raise ValueError(
+                            f"ZIP contains unsupported symlink member: {member.filename}"
+                        )
                 archive.extractall(extract_dir)
             extracted = next(extract_dir.glob("node-v*"), None)
             if extracted is None or not extracted.is_dir():
@@ -402,6 +428,11 @@ def _heal_managed_node_windows() -> bool:
             if target.exists():
                 shutil.rmtree(target)
             shutil.move(str(extracted), str(target))
+    except ValueError as exc:
+        # A malicious archive (zip-slip / symlink member) — fail closed: abort
+        # the heal instead of extracting, and never crash Node resolution.
+        print(f"hermes: refusing unsafe Node archive: {exc}", file=sys.stderr)
+        return False
     except OSError:
         return False
 

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -209,6 +209,114 @@ class TestHermesManagedNode:
         assert parts[-1] == "system-node"
 
 
+class TestHealManagedNodeWindowsZipSlip:
+    """_heal_managed_node_windows must reject malicious Node archives.
+
+    The portable Node zip is fetched over the network from a nodejs.org
+    mirror with no pinned checksum, then extracted with ``extractall``.  An
+    attacker who can MITM or compromise the mirror could otherwise ship a
+    zip-slip member (``..`` traversal) or a symlink member that escapes the
+    extraction directory and plants files under %HERMES_HOME%.  These tests
+    lock in the pre-extraction validation and its fail-closed behavior.
+    """
+
+    @staticmethod
+    def _major():
+        return hermes_constants._HERMES_NODE_TARGET_MAJOR
+
+    def _dir_name(self):
+        return f"node-v{self._major()}.0.0-win-x64"
+
+    def _zip_name(self):
+        return f"{self._dir_name()}.zip"
+
+    def _fake_urlopen(self, zip_bytes):
+        """Return a urlopen stub: 1st call = index HTML, 2nd = zip bytes."""
+        import io
+
+        index_html = (
+            f'<a href="{self._zip_name()}">{self._zip_name()}</a>'
+        ).encode("utf-8")
+
+        class _FakeResp(io.BytesIO):
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+        responses = iter([_FakeResp(index_html), _FakeResp(zip_bytes)])
+
+        def _urlopen(url, *args, **kwargs):
+            return next(responses)
+
+        return _urlopen
+
+    def _run_with_zip(self, monkeypatch, tmp_path, zip_bytes):
+        from unittest.mock import patch
+
+        monkeypatch.delenv("PROCESSOR_ARCHITEW6432", raising=False)
+        monkeypatch.setenv("PROCESSOR_ARCHITECTURE", "AMD64")
+        home = tmp_path / "hermes_home"
+        home.mkdir()
+        monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: home)
+
+        with patch("urllib.request.urlopen", side_effect=self._fake_urlopen(zip_bytes)):
+            result = hermes_constants._heal_managed_node_windows()
+        return result, home
+
+    def test_rejects_symlink_member(self, tmp_path, monkeypatch, capsys):
+        import io
+        import stat
+        import zipfile
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            info = zipfile.ZipInfo(f"{self._dir_name()}/evil-link")
+            info.external_attr = (stat.S_IFLNK | 0o777) << 16
+            zf.writestr(info, "/etc/passwd")
+
+        result, home = self._run_with_zip(monkeypatch, tmp_path, buf.getvalue())
+
+        assert result is False
+        assert "refusing unsafe Node archive" in capsys.readouterr().err
+        assert not (home / "node").exists(), "malicious archive must not be extracted"
+
+    def test_rejects_zip_slip_member(self, tmp_path, monkeypatch, capsys):
+        import io
+        import zipfile
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr(f"{self._dir_name()}/ok.txt", "ok")
+            zf.writestr("../escapes.txt", "pwned")
+
+        result, home = self._run_with_zip(monkeypatch, tmp_path, buf.getvalue())
+
+        assert result is False
+        assert "refusing unsafe Node archive" in capsys.readouterr().err
+        assert not (home / "node").exists()
+
+    def test_accepts_normal_archive(self, tmp_path, monkeypatch, capsys):
+        import io
+        import zipfile
+        from unittest.mock import patch
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr(f"{self._dir_name()}/node.exe", "fake-binary")
+            zf.writestr(f"{self._dir_name()}/README.md", "ok")
+
+        # A clean archive must pass validation and extract; stub the final
+        # runnable probe so the happy path returns True without a real node.exe.
+        with patch.object(hermes_constants, "node_tool_runnable", return_value=True):
+            result, home = self._run_with_zip(monkeypatch, tmp_path, buf.getvalue())
+
+        assert result is True
+        assert (home / "node").is_dir(), "clean archive should extract into %HERMES_HOME%/node"
+        assert "refusing unsafe Node archive" not in capsys.readouterr().err
+
+
 @pytest.mark.skipif(os.name == "nt", reason="POSIX shell stubs; Windows uses .cmd shims")
 class TestNodeToolRunnable:
     """node_tool_runnable() rejects broken Hermes-managed npm/node wrappers."""


### PR DESCRIPTION
## What

`_heal_managed_node_windows` (`hermes_constants.py`) downloads the portable Node zip from a `nodejs.org` mirror and calls `extractall` **with no member validation**:

```python
with zipfile.ZipFile(zip_path) as archive:
    archive.extractall(extract_dir)   # no zip-slip / symlink guard
```

The archive is fetched over the network with **no pinned checksum**, so an attacker who can MITM the connection or compromise the mirror can serve a member with `..\` traversal (or a symlink member whose target escapes the tempdir). `extractall` then writes **outside** `extract_dir` — e.g. into `%HERMES_HOME%` or a startup directory — yielding arbitrary file plant → code execution on the next launch.

## Why this is a real gap, not theoretical

The self-update path already treats this exact threat as real. `hermes_cli/main.py` guards its own `extractall` with a per-member zip-slip realpath check **and** a symlink-mode rejection, with a comment spelling out the "compromise the update mirror" scenario. The Node heal path is the **un-hardened twin** of that same pattern.

## Fix

- Reuse the same validation loop before `extractall`: reject any member whose `realpath` escapes `extract_dir`, and reject symlink members (`S_IFLNK` type bits in `external_attr >> 16`).
- **Fail closed:** a malicious archive aborts the heal (warn on stderr, return `False`) instead of crashing Node resolution — the surrounding `except OSError` would not have caught the guard's `ValueError`.

## Tests

Added `TestHealManagedNodeWindowsZipSlip` in `tests/test_hermes_constants.py`:
- symlink member → rejected, nothing extracted;
- `..` traversal member → rejected, nothing extracted;
- clean archive → passes validation and extracts (happy-path regression).

`python -m pytest tests/test_hermes_constants.py` — new tests pass; the one unrelated pre-existing failure (`TestGetDefaultHermesRoot::test_no_hermes_home_returns_native`, environment-specific) is present on `main` too. `check-windows-footguns.py` clean.