### PR TITLE
fix(tools): reap headless Chromium orphaned from a dead agent-browser daemon

### DIFF
--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -537,3 +537,151 @@ class TestEmergencyCleanupRunsReaper:
         assert reaper_called, (
             "Reaper must run on exit even with no active sessions"
         )
+
+
+class _FakeChromeProc:
+    """Minimal stand-in for a psutil.Process yielded by process_iter(attrs=...)."""
+
+    def __init__(self, pid, name, ppid, cmdline, running=True):
+        self.pid = pid
+        self.info = {"pid": pid, "name": name, "ppid": ppid, "cmdline": cmdline}
+        self._running = running
+
+    def is_running(self):
+        return self._running
+
+
+def _make_profile_dir(tmpdir, uuid="ffb99f0d-4ba2-429a-9c64-0c19bd826018"):
+    """Create a fake agent-browser Chromium profile dir and return its path."""
+    d = tmpdir / f"agent-browser-chrome-{uuid}"
+    d.mkdir()
+    return d
+
+
+class TestReapOrphanedChromiumProfiles:
+    """Tests for _reap_orphaned_chromium_profiles() — the daemon-independent
+    sweep that catches headless Chromium reparented to init after its
+    agent-browser daemon died uncleanly (gateway --replace / SIGKILL / crash).
+
+    These browsers have no socket dir, no live daemon, and no _active_sessions
+    entry, so the socket-dir reaper structurally cannot see them.  The sweep
+    keys on the Chromium --user-data-dir instead.
+    """
+
+    def test_no_profile_dirs_is_noop(self, fake_tmpdir):
+        from tools.browser_tool import _reap_orphaned_chromium_profiles
+        _reap_orphaned_chromium_profiles()  # should not raise
+
+    def test_orphaned_chromium_is_reaped_and_dir_removed(self, fake_tmpdir):
+        """Chromium reparented to init (PPID 1) bound to the profile is reaped,
+        and its now-unreferenced profile dir is removed."""
+        from tools.browser_tool import _reap_orphaned_chromium_profiles
+
+        d = _make_profile_dir(fake_tmpdir)
+        proc = _FakeChromeProc(
+            pid=4242, name="chrome", ppid=1,
+            cmdline=["/snap/chromium/chrome", "--headless=new",
+                     f"--user-data-dir={d}"],
+        )
+
+        killed = []
+        with patch("psutil.process_iter", return_value=[proc]), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=lambda pid: killed.append(pid)):
+            _reap_orphaned_chromium_profiles()
+
+        assert killed == [4242]
+        assert not d.exists()
+
+    def test_live_daemon_owned_browser_is_spared(self, fake_tmpdir):
+        """A browser whose daemon is still alive keeps that daemon as parent
+        (PPID != 1) and must NOT be touched; its profile dir is retained."""
+        from tools.browser_tool import _reap_orphaned_chromium_profiles
+
+        d = _make_profile_dir(fake_tmpdir)
+        proc = _FakeChromeProc(
+            pid=4242, name="chrome", ppid=9999,  # live daemon parent
+            cmdline=["/snap/chromium/chrome", f"--user-data-dir={d}"],
+        )
+
+        killed = []
+        with patch("psutil.process_iter", return_value=[proc]), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=lambda pid: killed.append(pid)):
+            _reap_orphaned_chromium_profiles()
+
+        assert killed == []
+        assert d.exists()
+
+    def test_non_chromium_proc_referencing_dir_is_spared(self, fake_tmpdir):
+        """Fail-closed: a non-Chromium process that references the exact profile
+        dir (e.g. a planted cmdline) is not killed and keeps the dir alive."""
+        from tools.browser_tool import _reap_orphaned_chromium_profiles
+
+        d = _make_profile_dir(fake_tmpdir)
+        proc = _FakeChromeProc(
+            pid=4242, name="python3", ppid=1,
+            cmdline=["python3", "server.py", f"--user-data-dir={d}"],
+        )
+
+        killed = []
+        with patch("psutil.process_iter", return_value=[proc]), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=lambda pid: killed.append(pid)):
+            _reap_orphaned_chromium_profiles()
+
+        assert killed == []
+        assert d.exists()
+
+    def test_stale_profile_dir_with_no_procs_is_removed(self, fake_tmpdir):
+        """A profile dir referenced by no live process is cleaned up as stale."""
+        from tools.browser_tool import _reap_orphaned_chromium_profiles
+
+        d = _make_profile_dir(fake_tmpdir)
+        with patch("psutil.process_iter", return_value=[]), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=lambda pid: None):
+            _reap_orphaned_chromium_profiles()
+        assert not d.exists()
+
+    def test_only_exact_user_data_dir_matches(self, fake_tmpdir):
+        """A Chromium bound to a *different* profile dir must not cause us to
+        reap for, or remove, this profile."""
+        from tools.browser_tool import _reap_orphaned_chromium_profiles
+
+        d = _make_profile_dir(fake_tmpdir, uuid="aaaaaaaa-0000-0000-0000-000000000000")
+        other = _FakeChromeProc(
+            pid=4242, name="chrome", ppid=1,
+            cmdline=["chrome", "--user-data-dir=/tmp/agent-browser-chrome-OTHER"],
+        )
+
+        killed = []
+        with patch("psutil.process_iter", return_value=[other]), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=lambda pid: killed.append(pid)):
+            _reap_orphaned_chromium_profiles()
+
+        assert killed == []          # the other browser is not ours
+        assert not d.exists()        # our dir had no referencing proc → stale
+
+    def test_reaper_runs_profile_sweep_even_with_no_socket_dirs(self, fake_tmpdir):
+        """Regression: the leak scenario has ZERO socket dirs (daemon already
+        gone), so _reap_orphaned_browser_sessions must still invoke the profile
+        sweep rather than early-returning."""
+        import tools.browser_tool as bt
+
+        called = []
+        monkeypatch_target = "_reap_orphaned_chromium_profiles"
+        orig = getattr(bt, monkeypatch_target)
+
+        def _spy():
+            called.append(True)
+            orig()
+
+        with patch.object(bt, monkeypatch_target, _spy):
+            # No socket dirs and no profile dirs in fake_tmpdir.
+            bt._reap_orphaned_browser_sessions()
+
+        assert called, (
+            "profile sweep must run even when there are no daemon socket dirs"
+        )

--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -564,3 +564,151 @@ class TestPeriodicOrphanReap:
         expected = len([c for c in range(cycles_to_run) if c % every == 0])
         assert len(reap_calls) == expected
         assert len(reap_calls) > 1, "startup-only reap would give exactly 1"
+
+
+class _FakeChromeProc:
+    """Minimal stand-in for a psutil.Process yielded by process_iter(attrs=...)."""
+
+    def __init__(self, pid, name, ppid, cmdline, running=True):
+        self.pid = pid
+        self.info = {"pid": pid, "name": name, "ppid": ppid, "cmdline": cmdline}
+        self._running = running
+
+    def is_running(self):
+        return self._running
+
+
+def _make_profile_dir(tmpdir, uuid="ffb99f0d-4ba2-429a-9c64-0c19bd826018"):
+    """Create a fake agent-browser Chromium profile dir and return its path."""
+    d = tmpdir / f"agent-browser-chrome-{uuid}"
+    d.mkdir()
+    return d
+
+
+class TestReapOrphanedChromiumProfiles:
+    """Tests for _reap_orphaned_chromium_profiles() — the daemon-independent
+    sweep that catches headless Chromium reparented to init after its
+    agent-browser daemon died uncleanly (gateway --replace / SIGKILL / crash).
+
+    These browsers have no socket dir, no live daemon, and no _active_sessions
+    entry, so the socket-dir reaper structurally cannot see them.  The sweep
+    keys on the Chromium --user-data-dir instead.
+    """
+
+    def test_no_profile_dirs_is_noop(self, fake_tmpdir):
+        from tools.browser_tool import _reap_orphaned_chromium_profiles
+        _reap_orphaned_chromium_profiles()  # should not raise
+
+    def test_orphaned_chromium_is_reaped_and_dir_removed(self, fake_tmpdir):
+        """Chromium reparented to init (PPID 1) bound to the profile is reaped,
+        and its now-unreferenced profile dir is removed."""
+        from tools.browser_tool import _reap_orphaned_chromium_profiles
+
+        d = _make_profile_dir(fake_tmpdir)
+        proc = _FakeChromeProc(
+            pid=4242, name="chrome", ppid=1,
+            cmdline=["/snap/chromium/chrome", "--headless=new",
+                     f"--user-data-dir={d}"],
+        )
+
+        killed = []
+        with patch("psutil.process_iter", return_value=[proc]), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=lambda pid: killed.append(pid)):
+            _reap_orphaned_chromium_profiles()
+
+        assert killed == [4242]
+        assert not d.exists()
+
+    def test_live_daemon_owned_browser_is_spared(self, fake_tmpdir):
+        """A browser whose daemon is still alive keeps that daemon as parent
+        (PPID != 1) and must NOT be touched; its profile dir is retained."""
+        from tools.browser_tool import _reap_orphaned_chromium_profiles
+
+        d = _make_profile_dir(fake_tmpdir)
+        proc = _FakeChromeProc(
+            pid=4242, name="chrome", ppid=9999,  # live daemon parent
+            cmdline=["/snap/chromium/chrome", f"--user-data-dir={d}"],
+        )
+
+        killed = []
+        with patch("psutil.process_iter", return_value=[proc]), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=lambda pid: killed.append(pid)):
+            _reap_orphaned_chromium_profiles()
+
+        assert killed == []
+        assert d.exists()
+
+    def test_non_chromium_proc_referencing_dir_is_spared(self, fake_tmpdir):
+        """Fail-closed: a non-Chromium process that references the exact profile
+        dir (e.g. a planted cmdline) is not killed and keeps the dir alive."""
+        from tools.browser_tool import _reap_orphaned_chromium_profiles
+
+        d = _make_profile_dir(fake_tmpdir)
+        proc = _FakeChromeProc(
+            pid=4242, name="python3", ppid=1,
+            cmdline=["python3", "server.py", f"--user-data-dir={d}"],
+        )
+
+        killed = []
+        with patch("psutil.process_iter", return_value=[proc]), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=lambda pid: killed.append(pid)):
+            _reap_orphaned_chromium_profiles()
+
+        assert killed == []
+        assert d.exists()
+
+    def test_stale_profile_dir_with_no_procs_is_removed(self, fake_tmpdir):
+        """A profile dir referenced by no live process is cleaned up as stale."""
+        from tools.browser_tool import _reap_orphaned_chromium_profiles
+
+        d = _make_profile_dir(fake_tmpdir)
+        with patch("psutil.process_iter", return_value=[]), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=lambda pid: None):
+            _reap_orphaned_chromium_profiles()
+        assert not d.exists()
+
+    def test_only_exact_user_data_dir_matches(self, fake_tmpdir):
+        """A Chromium bound to a *different* profile dir must not cause us to
+        reap for, or remove, this profile."""
+        from tools.browser_tool import _reap_orphaned_chromium_profiles
+
+        d = _make_profile_dir(fake_tmpdir, uuid="aaaaaaaa-0000-0000-0000-000000000000")
+        other = _FakeChromeProc(
+            pid=4242, name="chrome", ppid=1,
+            cmdline=["chrome", "--user-data-dir=/tmp/agent-browser-chrome-OTHER"],
+        )
+
+        killed = []
+        with patch("psutil.process_iter", return_value=[other]), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=lambda pid: killed.append(pid)):
+            _reap_orphaned_chromium_profiles()
+
+        assert killed == []          # the other browser is not ours
+        assert not d.exists()        # our dir had no referencing proc → stale
+
+    def test_reaper_runs_profile_sweep_even_with_no_socket_dirs(self, fake_tmpdir):
+        """Regression: the leak scenario has ZERO socket dirs (daemon already
+        gone), so _reap_orphaned_browser_sessions must still invoke the profile
+        sweep rather than early-returning."""
+        import tools.browser_tool as bt
+
+        called = []
+        monkeypatch_target = "_reap_orphaned_chromium_profiles"
+        orig = getattr(bt, monkeypatch_target)
+
+        def _spy():
+            called.append(True)
+            orig()
+
+        with patch.object(bt, monkeypatch_target, _spy):
+            # No socket dirs and no profile dirs in fake_tmpdir.
+            bt._reap_orphaned_browser_sessions()
+
+        assert called, (
+            "profile sweep must run even when there are no daemon socket dirs"
+        )

--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -569,12 +569,16 @@ class TestPeriodicOrphanReap:
 class _FakeChromeProc:
     """Minimal stand-in for a psutil.Process yielded by process_iter(attrs=...)."""
 
-    def __init__(self, pid, name, ppid, cmdline, running=True):
+    def __init__(self, pid, name, ppid, cmdline, running=True,
+                 running_error=None):
         self.pid = pid
         self.info = {"pid": pid, "name": name, "ppid": ppid, "cmdline": cmdline}
         self._running = running
+        self._running_error = running_error
 
     def is_running(self):
+        if self._running_error is not None:
+            raise self._running_error
         return self._running
 
 
@@ -690,6 +694,52 @@ class TestReapOrphanedChromiumProfiles:
 
         assert killed == []          # the other browser is not ours
         assert not d.exists()        # our dir had no referencing proc → stale
+
+    @pytest.mark.parametrize("cmdline", [None, "not-a-command-line"])
+    def test_unreadable_or_unusable_cmdline_retains_profiles(
+        self, fake_tmpdir, cmdline
+    ):
+        """A process hidden by an incomplete psutil snapshot may reference any
+        profile, so stale-dir deletion must fail closed for the whole scan."""
+        from tools.browser_tool import _reap_orphaned_chromium_profiles
+
+        d = _make_profile_dir(fake_tmpdir)
+        ambiguous = _FakeChromeProc(
+            pid=4242, name=None, ppid=None, cmdline=cmdline
+        )
+
+        with patch("psutil.process_iter", return_value=[ambiguous]), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid") \
+                as terminate:
+            _reap_orphaned_chromium_profiles()
+
+        terminate.assert_not_called()
+        assert d.exists(), "ambiguous process inspection must retain the profile"
+
+    def test_access_denied_for_matched_process_retains_profile(
+        self, fake_tmpdir
+    ):
+        """If liveness becomes unreadable after matching the exact profile,
+        that process must still count as a possible live reference."""
+        import psutil
+        from tools.browser_tool import _reap_orphaned_chromium_profiles
+
+        d = _make_profile_dir(fake_tmpdir)
+        proc = _FakeChromeProc(
+            pid=4242,
+            name="chrome",
+            ppid=1,
+            cmdline=["chrome", f"--user-data-dir={d}"],
+            running_error=psutil.AccessDenied(pid=4242),
+        )
+
+        with patch("psutil.process_iter", return_value=[proc]), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid") \
+                as terminate:
+            _reap_orphaned_chromium_profiles()
+
+        terminate.assert_not_called()
+        assert d.exists(), "an unreadable matched process may still be live"
 
     def test_reaper_runs_profile_sweep_even_with_no_socket_dirs(self, fake_tmpdir):
         """Regression: the leak scenario has ZERO socket dirs (daemon already

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1659,6 +1659,16 @@ def _reap_orphaned_browser_sessions():
     # Also pick up cloud-provider sessions (browser-use/browserbase/firecrawl)
     socket_dirs += glob.glob(os.path.join(tmpdir, "agent-browser-hermes_*"))
 
+    # Daemon-independent sweep for Chromium that outlived its daemon.  This MUST
+    # run before the early return below: the whole leak scenario is that the
+    # daemon (and its socket dir) is already gone, so ``socket_dirs`` is often
+    # empty precisely when orphaned browsers are piling up.  The socket-dir loop
+    # can only ever see browsers whose daemon is still alive.
+    try:
+        _reap_orphaned_chromium_profiles()
+    except Exception as e:  # never let the profile sweep break daemon reaping
+        logger.warning("Chromium profile reap error: %s", e)
+
     if not socket_dirs:
         return
 
@@ -1749,6 +1759,101 @@ def _reap_orphaned_browser_sessions():
 
     if reaped:
         logger.info("Reaped %d orphaned browser session(s) from previous run(s)", reaped)
+
+
+def _reap_orphaned_chromium_profiles():
+    """Reap headless Chromium orphaned from a dead ``agent-browser`` daemon.
+
+    The daemon-centric reaper (:func:`_reap_orphaned_browser_sessions`) finds
+    work by globbing daemon *socket* dirs (``agent-browser-{h_,cdp_,hermes_}*``)
+    and tree-killing the daemon, which cascades to its Chromium children *while
+    the daemon is alive*.  But ``agent-browser`` launches Chromium as a
+    **detached grandchild** with its own
+    ``--user-data-dir=<tmp>/agent-browser-chrome-<uuid>``.  When the daemon dies
+    uncleanly — gateway ``run --replace``, SIGKILL, or a crash, where neither the
+    ``atexit`` handler nor a signal handler runs (SIGTERM/SIGINT handlers were
+    deliberately removed) — that Chromium **reparents to init (PPID 1)** and its
+    socket dir is gone.  The survivor then has no socket dir, no live daemon, and
+    no ``_active_sessions`` entry, so the socket-dir sweep can never see it.
+    Across many restarts these accumulate and exhaust host memory (observed in
+    production: ~20 instances / ~200 procs / ~4.5 GB before an external
+    ``pkill``).
+
+    This sweep closes the gap by keying on the Chromium *profile dir* instead of
+    the daemon socket dir: for each ``agent-browser-chrome-*`` profile it finds
+    the live processes launched against it (via ``--user-data-dir``) and reaps
+    the ones reparented to init — i.e. whose launching daemon is gone.  A profile
+    dir referenced by no live process is removed as stale.
+
+    Safety mirrors :func:`_verify_reapable_browser_daemon`.  ``/tmp`` is
+    world-writable and the profile names are predictable, so we fail closed and
+    only reap a PID that (1) is a Chromium-family executable by name, (2) carries
+    this exact ``--user-data-dir=<profile>`` on its command line, and (3) has
+    been reparented to init (its real parent already exited).  A browser still
+    owned by a live daemon keeps that daemon as its parent (PPID != 1) and is
+    never touched, so an in-use session is safe.  Idempotent; safe to call from
+    any context (cleanup-thread startup, atexit, on demand).
+    """
+    import glob
+    try:
+        import psutil
+    except ImportError:  # psutil is a hard dep; defensive only
+        return
+
+    tmpdir = _socket_safe_tmpdir()
+    profile_dirs = glob.glob(os.path.join(tmpdir, "agent-browser-chrome-*"))
+    if not profile_dirs:
+        return
+
+    # Index profiles by normalized path, then make a single pass over the
+    # process table, matching each proc to a profile via its --user-data-dir.
+    wanted = {os.path.normpath(d): d for d in profile_dirs}
+    procs_by_profile: dict[str, list] = {d: [] for d in profile_dirs}
+    flag = "--user-data-dir="
+    for proc in psutil.process_iter(["pid", "name", "ppid", "cmdline"]):
+        for arg in (proc.info.get("cmdline") or []):
+            if not arg.startswith(flag):
+                continue
+            orig = wanted.get(os.path.normpath(arg[len(flag):]))
+            if orig is not None:
+                procs_by_profile[orig].append(proc)
+            break
+
+    reaped = 0
+    for profile_dir, procs in procs_by_profile.items():
+        remaining_live = 0
+        for proc in procs:
+            try:
+                if not proc.is_running():
+                    continue
+                name = (proc.info.get("name") or "").lower()
+                ppid = proc.info.get("ppid")
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+            # Fail closed unless this is clearly an ORPHANED Chromium: a
+            # chromium-family executable reparented to init.  Anything else that
+            # still references the profile keeps the dir alive for a later sweep.
+            if "chrom" not in name or ppid != 1:
+                remaining_live += 1
+                continue
+            try:
+                from tools.process_registry import ProcessRegistry
+                ProcessRegistry._terminate_host_pid(proc.pid)
+                logger.info("Reaped orphaned Chromium PID %s (profile %s)",
+                            proc.pid, os.path.basename(profile_dir))
+                reaped += 1
+            except (ProcessLookupError, PermissionError, OSError):
+                remaining_live += 1  # couldn't signal it — retry next sweep
+
+        # Remove the profile dir only when nothing live still references it
+        # (it was already dead, or we just reaped every referencing proc).
+        if remaining_live == 0:
+            shutil.rmtree(profile_dir, ignore_errors=True)
+
+    if reaped:
+        logger.info(
+            "Reaped %d orphaned Chromium process(es) from previous run(s)",
+            reaped)
 
 
 def _browser_cleanup_thread_worker():

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2121,8 +2121,11 @@ def _reap_orphaned_chromium_profiles():
     this exact ``--user-data-dir=<profile>`` on its command line, and (3) has
     been reparented to init (its real parent already exited).  A browser still
     owned by a live daemon keeps that daemon as its parent (PPID != 1) and is
-    never touched, so an in-use session is safe.  Idempotent; safe to call from
-    any context (cleanup-thread startup, atexit, on demand).
+    never touched, so an in-use session is safe.  Profile deletion additionally
+    requires a complete process-table scan: if any command line is unreadable,
+    no profile can be proven unreferenced and all are retained for a later
+    sweep.  Idempotent; safe to call from any context (cleanup-thread startup,
+    atexit, on demand).
     """
     import glob
     try:
@@ -2140,14 +2143,45 @@ def _reap_orphaned_chromium_profiles():
     wanted = {os.path.normpath(d): d for d in profile_dirs}
     procs_by_profile: dict[str, list] = {d: [] for d in profile_dirs}
     flag = "--user-data-dir="
-    for proc in psutil.process_iter(["pid", "name", "ppid", "cmdline"]):
-        for arg in (proc.info.get("cmdline") or []):
-            if not arg.startswith(flag):
+    inspection_ambiguous = False
+    try:
+        for proc in psutil.process_iter(["pid", "name", "ppid", "cmdline"]):
+            try:
+                cmdline = proc.info.get("cmdline")
+            except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
+                # A vanished process cannot still reference a profile.  Any
+                # other read failure could conceal an exact --user-data-dir.
+                try:
+                    if not proc.is_running():
+                        continue
+                except psutil.NoSuchProcess:
+                    continue
+                except (psutil.AccessDenied, OSError):
+                    pass
+                inspection_ambiguous = True
                 continue
-            orig = wanted.get(os.path.normpath(arg[len(flag):]))
-            if orig is not None:
-                procs_by_profile[orig].append(proc)
-            break
+
+            # psutil uses None for attributes it could not read.  An empty
+            # list, by contrast, is a successfully-read command line with no
+            # arguments and cannot contain a profile reference.
+            if cmdline is None or not isinstance(cmdline, (list, tuple)) or \
+                    any(not isinstance(arg, str) for arg in cmdline):
+                inspection_ambiguous = True
+                continue
+
+            for arg in cmdline:
+                if not arg.startswith(flag):
+                    continue
+                orig = wanted.get(os.path.normpath(arg[len(flag):]))
+                if orig is not None:
+                    procs_by_profile[orig].append(proc)
+                break
+    except (psutil.Error, OSError) as exc:
+        # The iterator itself failed, so this was not a complete snapshot.
+        inspection_ambiguous = True
+        logger.warning(
+            "Retaining Chromium profile dirs: process scan incomplete (%s)",
+            exc)
 
     reaped = 0
     for profile_dir, procs in procs_by_profile.items():
@@ -2158,7 +2192,10 @@ def _reap_orphaned_chromium_profiles():
                     continue
                 name = (proc.info.get("name") or "").lower()
                 ppid = proc.info.get("ppid")
-            except (psutil.NoSuchProcess, psutil.AccessDenied):
+            except psutil.NoSuchProcess:
+                continue
+            except (psutil.AccessDenied, OSError):
+                remaining_live += 1
                 continue
             # Fail closed unless this is clearly an ORPHANED Chromium: a
             # chromium-family executable reparented to init.  Anything else that
@@ -2177,8 +2214,14 @@ def _reap_orphaned_chromium_profiles():
 
         # Remove the profile dir only when nothing live still references it
         # (it was already dead, or we just reaped every referencing proc).
-        if remaining_live == 0:
+        if remaining_live == 0 and not inspection_ambiguous:
             shutil.rmtree(profile_dir, ignore_errors=True)
+
+    if inspection_ambiguous:
+        logger.warning(
+            "Retained %d Chromium profile dir(s): one or more process "
+            "command lines could not be inspected safely",
+            len(profile_dirs))
 
     if reaped:
         logger.info(

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1965,6 +1965,16 @@ def _reap_orphaned_browser_sessions():
     # Also pick up cloud-provider sessions (browser-use/browserbase/firecrawl)
     socket_dirs += glob.glob(os.path.join(tmpdir, "agent-browser-hermes_*"))
 
+    # Daemon-independent sweep for Chromium that outlived its daemon.  This MUST
+    # run before the early return below: the whole leak scenario is that the
+    # daemon (and its socket dir) is already gone, so ``socket_dirs`` is often
+    # empty precisely when orphaned browsers are piling up.  The socket-dir loop
+    # can only ever see browsers whose daemon is still alive.
+    try:
+        _reap_orphaned_chromium_profiles()
+    except Exception as e:  # never let the profile sweep break daemon reaping
+        logger.warning("Chromium profile reap error: %s", e)
+
     if not socket_dirs:
         return
 
@@ -2079,6 +2089,101 @@ def _reap_orphaned_browser_sessions():
 
     if reaped:
         logger.info("Reaped %d orphaned browser session(s) from previous run(s)", reaped)
+
+
+def _reap_orphaned_chromium_profiles():
+    """Reap headless Chromium orphaned from a dead ``agent-browser`` daemon.
+
+    The daemon-centric reaper (:func:`_reap_orphaned_browser_sessions`) finds
+    work by globbing daemon *socket* dirs (``agent-browser-{h_,cdp_,hermes_}*``)
+    and tree-killing the daemon, which cascades to its Chromium children *while
+    the daemon is alive*.  But ``agent-browser`` launches Chromium as a
+    **detached grandchild** with its own
+    ``--user-data-dir=<tmp>/agent-browser-chrome-<uuid>``.  When the daemon dies
+    uncleanly — gateway ``run --replace``, SIGKILL, or a crash, where neither the
+    ``atexit`` handler nor a signal handler runs (SIGTERM/SIGINT handlers were
+    deliberately removed) — that Chromium **reparents to init (PPID 1)** and its
+    socket dir is gone.  The survivor then has no socket dir, no live daemon, and
+    no ``_active_sessions`` entry, so the socket-dir sweep can never see it.
+    Across many restarts these accumulate and exhaust host memory (observed in
+    production: ~20 instances / ~200 procs / ~4.5 GB before an external
+    ``pkill``).
+
+    This sweep closes the gap by keying on the Chromium *profile dir* instead of
+    the daemon socket dir: for each ``agent-browser-chrome-*`` profile it finds
+    the live processes launched against it (via ``--user-data-dir``) and reaps
+    the ones reparented to init — i.e. whose launching daemon is gone.  A profile
+    dir referenced by no live process is removed as stale.
+
+    Safety mirrors :func:`_verify_reapable_browser_daemon`.  ``/tmp`` is
+    world-writable and the profile names are predictable, so we fail closed and
+    only reap a PID that (1) is a Chromium-family executable by name, (2) carries
+    this exact ``--user-data-dir=<profile>`` on its command line, and (3) has
+    been reparented to init (its real parent already exited).  A browser still
+    owned by a live daemon keeps that daemon as its parent (PPID != 1) and is
+    never touched, so an in-use session is safe.  Idempotent; safe to call from
+    any context (cleanup-thread startup, atexit, on demand).
+    """
+    import glob
+    try:
+        import psutil
+    except ImportError:  # psutil is a hard dep; defensive only
+        return
+
+    tmpdir = _socket_safe_tmpdir()
+    profile_dirs = glob.glob(os.path.join(tmpdir, "agent-browser-chrome-*"))
+    if not profile_dirs:
+        return
+
+    # Index profiles by normalized path, then make a single pass over the
+    # process table, matching each proc to a profile via its --user-data-dir.
+    wanted = {os.path.normpath(d): d for d in profile_dirs}
+    procs_by_profile: dict[str, list] = {d: [] for d in profile_dirs}
+    flag = "--user-data-dir="
+    for proc in psutil.process_iter(["pid", "name", "ppid", "cmdline"]):
+        for arg in (proc.info.get("cmdline") or []):
+            if not arg.startswith(flag):
+                continue
+            orig = wanted.get(os.path.normpath(arg[len(flag):]))
+            if orig is not None:
+                procs_by_profile[orig].append(proc)
+            break
+
+    reaped = 0
+    for profile_dir, procs in procs_by_profile.items():
+        remaining_live = 0
+        for proc in procs:
+            try:
+                if not proc.is_running():
+                    continue
+                name = (proc.info.get("name") or "").lower()
+                ppid = proc.info.get("ppid")
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+            # Fail closed unless this is clearly an ORPHANED Chromium: a
+            # chromium-family executable reparented to init.  Anything else that
+            # still references the profile keeps the dir alive for a later sweep.
+            if "chrom" not in name or ppid != 1:
+                remaining_live += 1
+                continue
+            try:
+                from tools.process_registry import ProcessRegistry
+                ProcessRegistry._terminate_host_pid(proc.pid)
+                logger.info("Reaped orphaned Chromium PID %s (profile %s)",
+                            proc.pid, os.path.basename(profile_dir))
+                reaped += 1
+            except (ProcessLookupError, PermissionError, OSError):
+                remaining_live += 1  # couldn't signal it — retry next sweep
+
+        # Remove the profile dir only when nothing live still references it
+        # (it was already dead, or we just reaped every referencing proc).
+        if remaining_live == 0:
+            shutil.rmtree(profile_dir, ignore_errors=True)
+
+    if reaped:
+        logger.info(
+            "Reaped %d orphaned Chromium process(es) from previous run(s)",
+            reaped)
 
 
 def _browser_cleanup_thread_worker():


### PR DESCRIPTION
# Reap headless Chromium orphaned from a dead agent-browser daemon

## Problem

On a long-running gateway (`hermes … gateway run --replace`) headless Chromium
instances accumulate until the host runs out of memory. Observed in production:
~20 orphaned browser instances (~200 chromium processes, ~4.5 GB RSS) built up
over ~6 days on a 7.6 GiB box (133 MiB free, no swap — one alloc from the OOM
killer). `/tmp` was full of empty `agent-browser-chrome-<uuid>` profile dirs with
no matching daemon socket dirs.

## Root cause

`agent-browser` launches Chromium as a **detached grandchild** with its own
`--user-data-dir=<tmp>/agent-browser-chrome-<uuid>`. The existing orphan reaper,
`_reap_orphaned_browser_sessions()`, discovers work by globbing daemon **socket**
dirs (`agent-browser-{h_,cdp_,hermes_}*`) and tree-killing the daemon — which
only reaches Chromium *while the daemon is alive*.

When the daemon dies uncleanly — `gateway run --replace`, SIGKILL, or a crash,
where neither the `atexit` handler nor a signal handler runs (SIGTERM/SIGINT
handlers were deliberately removed) — the Chromium child **reparents to init
(PPID 1)** and its socket dir is gone. The survivor now has:

- no socket dir (so the glob can't find it),
- no live daemon (nothing to tree-kill),
- no `_active_sessions` entry (wiped on restart).

It is **structurally undiscoverable** by the daemon-centric sweep. The
`chrome-<uuid>` profile namespace and the `h_/cdp_/hermes_` socket namespace
can't be correlated, so the reaper never even globs `chrome-*`. Every unclean
restart strands another batch.

## Fix

Add `_reap_orphaned_chromium_profiles()`, a **daemon-independent** sweep keyed on
the Chromium profile dir instead of the daemon socket dir:

1. Glob `<tmpdir>/agent-browser-chrome-*`.
2. In one pass over the process table, match each process to a profile via its
   exact `--user-data-dir=` argv token.
3. Reap only processes that are **(a)** a Chromium-family executable by name,
   **(b)** bound to that exact profile dir, and **(c)** reparented to init
   (PPID 1 — their launching daemon is gone).
4. Remove a profile dir only once nothing live still references it.

It is wired into `_reap_orphaned_browser_sessions()` **before** the
`if not socket_dirs: return` early-out — the leak scenario is precisely that no
socket dirs remain, so the sweep has to run even then. That means it fires
everywhere the existing reaper already does: cleanup-thread startup (every
gateway boot) and the atexit emergency cleanup.

## Safety

Mirrors the existing `_verify_reapable_browser_daemon` posture. `/tmp` is
world-writable and profile names are predictable, so the sweep **fails closed**:
a browser still owned by a live daemon keeps that daemon as its parent
(PPID != 1) and is never touched, and any non-Chromium process referencing a
profile dir keeps the dir alive rather than being killed. Termination goes
through the existing `ProcessRegistry._terminate_host_pid` tree-kill.

> Note on the PPID-1 signal: orphans reparent to init on this deployment (Linux,
> no child-subreaper). Under a registered subreaper they'd reparent elsewhere and
> this sweep would simply not reap them — a safe no-op, never an over-kill.

## Follow-ups (not in this PR)

- Make `gateway … --replace` send SIGTERM + drain so the daemon's own teardown
  runs before it's replaced (fixes the root trigger, not just the symptom).
- Reconsider removing the SIGTERM/SIGINT cleanup handlers that made `atexit` the
  only cleanup path.

## Testing

`tests/tools/test_browser_orphan_reaper.py` gains a
`TestReapOrphanedChromiumProfiles` class covering: orphan reaped + dir removed,
live daemon-owned browser spared, non-Chromium referrer spared (fail-closed),
stale dir removed, exact-`--user-data-dir` matching, and the regression that the
profile sweep runs even with zero socket dirs.

All scenarios were executed against the real patched function using the
project's own venv (psutil present; pytest is not installed in the venv, so they
were also driven directly via `unittest.mock`) — 11/11 checks pass. `py_compile`
clean on both files.
