### PR TITLE
fix(pets): honor terminal render mode off in TUI

### DIFF
--- a/tests/tui_gateway/test_pet_surface_render_mode.py
+++ b/tests/tui_gateway/test_pet_surface_render_mode.py
@@ -1,0 +1,52 @@
+"""Cross-surface pet rendering contracts for the TUI gateway."""
+
+import pytest
+
+pytest.importorskip("PIL")
+from PIL import Image  # noqa: E402
+
+from tui_gateway import server  # noqa: E402
+
+
+def test_render_mode_off_hides_terminal_pet_but_keeps_desktop_enabled(monkeypatch):
+    import hermes_cli.config as cli_config
+    from agent.pet import constants, store
+
+    sheet = Image.new(
+        "RGBA",
+        (constants.FRAME_W * 8, constants.FRAME_H * 9),
+        (80, 120, 220, 255),
+    )
+    pet = store.register_local_pet(
+        sheet,
+        slug="desktop-only",
+        display_name="Desktop Only",
+    )
+    monkeypatch.setattr(
+        cli_config,
+        "load_config",
+        lambda: {
+            "display": {
+                "pet": {
+                    "enabled": True,
+                    "slug": pet.slug,
+                    "render_mode": "off",
+                    "scale": 0.33,
+                }
+            }
+        },
+    )
+
+    for graphics in (False, True):
+        cells = server._methods["pet.cells"](
+            f"cells-{graphics}",
+            {"graphics": graphics, "state": "idle"},
+        )["result"]
+        assert cells == {"enabled": False}
+
+    info = server._methods["pet.info"]("info", {})["result"]
+    meta = server._methods["pet.info.meta"]("meta", {})["result"]
+    assert info["enabled"] is True
+    assert info["slug"] == pet.slug
+    assert meta["enabled"] is True
+    assert meta["slug"] == pet.slug

--- a/tests/tui_gateway/test_pet_surface_render_mode.py
+++ b/tests/tui_gateway/test_pet_surface_render_mode.py
@@ -1,0 +1,52 @@
+"""Cross-surface pet rendering contracts for the TUI gateway."""
+
+import pytest
+
+pytest.importorskip("PIL")
+from PIL import Image  # noqa: E402
+
+from tui_gateway import server  # noqa: E402
+
+
+@pytest.mark.parametrize("graphics", [False, True])
+def test_render_mode_off_hides_terminal_pet_but_keeps_desktop_enabled(monkeypatch, graphics):
+    import hermes_cli.config as cli_config
+    from agent.pet import constants, store
+
+    sheet = Image.new(
+        "RGBA",
+        (constants.FRAME_W * 8, constants.FRAME_H * 9),
+        (80, 120, 220, 255),
+    )
+    pet = store.register_local_pet(
+        sheet,
+        slug="desktop-only",
+        display_name="Desktop Only",
+    )
+    monkeypatch.setattr(
+        cli_config,
+        "load_config",
+        lambda: {
+            "display": {
+                "pet": {
+                    "enabled": True,
+                    "slug": pet.slug,
+                    "render_mode": "off",
+                    "scale": 0.33,
+                }
+            }
+        },
+    )
+
+    cells = server._methods["pet.cells"](
+        f"cells-{graphics}",
+        {"graphics": graphics, "state": "idle"},
+    )["result"]
+    assert cells == {"enabled": False}
+
+    info = server._methods["pet.info"]("info", {})["result"]
+    meta = server._methods["pet.info.meta"]("meta", {})["result"]
+    assert info["enabled"] is True
+    assert info["slug"] == pet.slug
+    assert meta["enabled"] is True
+    assert meta["slug"] == pet.slug

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -1400,6 +1400,12 @@ def _(rid, params: dict) -> dict:
         if not bool(pet_cfg.get("enabled")):
             return _ok(rid, {"enabled": False})
 
+        # render_mode is terminal-scoped. Keep pet.info / pet.info.meta enabled
+        # for Desktop, but do not build Unicode or graphics frames for the TUI.
+        configured = str(pet_cfg.get("render_mode", "auto") or "auto").strip().lower()
+        if configured == "off":
+            return _ok(rid, {"enabled": False})
+
         pet = store.resolve_active_pet(str(pet_cfg.get("slug", "") or ""))
         if pet is None or not pet.exists:
             return _ok(rid, {"enabled": False})
@@ -1416,7 +1422,6 @@ def _(rid, params: dict) -> dict:
         # such env, so it falls through to half-blocks automatically. Only
         # kitty is grid-safe in Ink — iTerm/sixel stay on the fallback.
         if params.get("graphics"):
-            configured = str(pet_cfg.get("render_mode", "auto") or "auto").lower()
             gmode = render.detect_terminal_graphics() if configured in ("", "auto") else configured
             if gmode == "kitty":
                 image_id = render.kitty_image_id(pet.slug)

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -1221,6 +1221,9 @@ def _(rid, params: dict) -> dict:
     from agent.pet import constants, store
     from agent.pet.render import PetRenderer
     pet_cfg = _pet_display_cfg()
+    # Terminal rendering can be disabled independently of the Desktop pet.
+    if str(pet_cfg.get("render_mode", "auto") or "auto").lower() == "off":
+        return _ok(rid, {"enabled": False})
     pet = None
     if is_truthy_value(pet_cfg.get("enabled"), default=False):
         pet = store.resolve_active_pet(str(pet_cfg.get("slug", "") or ""))


### PR DESCRIPTION
## Summary

Honor `display.pet.render_mode: off` in the TUI `pet.cells` RPC while keeping Desktop `pet.info` and `pet.info.meta` enabled.

The terminal-only setting currently falls through to Unicode frames even when graphics are requested. Return `{enabled: false}` before resolving or decoding the active pet. Preserve upstream's `is_truthy_value` handling and refactored pet helpers; no Desktop behavior changes.

## Relationship to upstream work

- #63499 superseded the original config-set special case. This diff contains no config coercion changes.
- Metadata-first polling from #70311 landed through #86754. This fix addresses the remaining server-side terminal rendering contract, not polling optimization. Desktop metadata remains globally enabled; optimizing repeated terminal-disabled cell requests is outside this PR.

## Verification

Rebased semantically onto freshly fetched main `22c5684b983eac6a81ee015ae80296c4b3dbf5bb`.

- RED: `scripts/run_tests.sh tests/tui_gateway/test_pet_surface_render_mode.py` — both graphics=False/True cases fail on main because cells remain enabled with Unicode frames.
- GREEN: same command — 2 passed. Uses a real registered spritesheet and the RPC handlers; asserts cells are disabled while both Desktop RPCs retain the active pet.
- `scripts/run_tests.sh tests/tui_gateway/ tests/agent/test_pet_engine.py tests/agent/test_pet_generate.py tests/cli/test_cli_pet_pane.py tests/hermes_cli/test_pet_toggle.py` — 1071 passed, 17 skipped; two unrelated files passed on runner retry (`test_hosted_room_service.py`, `test_slash_worker_mcp_discovery.py`). Initial environment lacked pytest-asyncio; rerun used an isolated test venv with that plugin installed.
- `uv tool run --from ruff==0.12.1 ruff check tui_gateway/methods_session.py tests/tui_gateway/test_pet_surface_render_mode.py` — passed.
- `git diff --check` — passed.
