### PR TITLE
fix(telegram): truncate media captions by UTF-16 units, not code points

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -296,6 +296,7 @@ from gateway.platforms.base import (
     SUPPORTED_IMAGE_DOCUMENT_TYPES,
     _TEXT_INJECT_EXTENSIONS,
     utf16_len,
+    _prefix_within_utf16_limit,
 )
 from plugins.platforms.telegram.telegram_ids import (
     normalize_telegram_chat_id,
@@ -6994,7 +6995,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         "[%s] voice caption MarkdownV2 formatting failed; "
                         "sending plain caption", self.name, exc_info=True,
                     )
-                _caption_variants.append((caption[:1024], None))
+                _caption_variants.append((_prefix_within_utf16_limit(caption, 1024), None))
             else:
                 _caption_variants.append((None, None))
 
@@ -7071,7 +7072,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         {
                             "chat_id": normalize_telegram_chat_id(chat_id),
                             "audio": audio_file,
-                            "caption": caption[:1024] if caption else None,
+                            "caption": _prefix_within_utf16_limit(caption, 1024) if caption else None,
                             "reply_to_message_id": reply_to_id,
                             "duration": _duration_secs,
                             "read_timeout": _MEDIA_SEND_READ_TIMEOUT,
@@ -7169,7 +7170,7 @@ class TelegramAdapter(BasePlatformAdapter):
             opened_files: List[Any] = []
             try:
                 for image_url, alt_text in chunk:
-                    caption = alt_text[:1024] if alt_text else None
+                    caption = _prefix_within_utf16_limit(alt_text, 1024) if alt_text else None
                     if image_url.startswith("file://"):
                         local_path = _unquote(image_url[7:])
                         if not os.path.exists(local_path):
@@ -7271,7 +7272,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     {
                         "chat_id": normalize_telegram_chat_id(chat_id),
                         "photo": image_file,
-                        "caption": caption[:1024] if caption else None,
+                        "caption": _prefix_within_utf16_limit(caption, 1024) if caption else None,
                         "reply_to_message_id": reply_to_id,
                         "read_timeout": _MEDIA_SEND_READ_TIMEOUT,
                         **thread_kwargs,
@@ -7369,7 +7370,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         "chat_id": normalize_telegram_chat_id(chat_id),
                         "document": f,
                         "filename": display_name,
-                        "caption": caption[:1024] if caption else None,
+                        "caption": _prefix_within_utf16_limit(caption, 1024) if caption else None,
                         "reply_to_message_id": reply_to_id,
                         "read_timeout": _MEDIA_SEND_READ_TIMEOUT,
                         **thread_kwargs,
@@ -7420,7 +7421,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     {
                         "chat_id": normalize_telegram_chat_id(chat_id),
                         "video": f,
-                        "caption": caption[:1024] if caption else None,
+                        "caption": _prefix_within_utf16_limit(caption, 1024) if caption else None,
                         "reply_to_message_id": reply_to_id,
                         "read_timeout": _MEDIA_SEND_READ_TIMEOUT,
                         **thread_kwargs,
@@ -7476,7 +7477,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 {
                     "chat_id": normalize_telegram_chat_id(chat_id),
                     "photo": image_url,
-                    "caption": caption[:1024] if caption else None,
+                    "caption": _prefix_within_utf16_limit(caption, 1024) if caption else None,
                     "reply_to_message_id": reply_to_id,
                     "read_timeout": _MEDIA_SEND_READ_TIMEOUT,
                     **photo_thread_kwargs,
@@ -7519,7 +7520,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     {
                         "chat_id": normalize_telegram_chat_id(chat_id),
                         "photo": image_data,
-                        "caption": caption[:1024] if caption else None,
+                        "caption": _prefix_within_utf16_limit(caption, 1024) if caption else None,
                         "reply_to_message_id": reply_to_id,
                         "read_timeout": _MEDIA_SEND_READ_TIMEOUT,
                         **upload_thread_kwargs,
@@ -7567,7 +7568,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 {
                     "chat_id": normalize_telegram_chat_id(chat_id),
                     "animation": animation_url,
-                    "caption": caption[:1024] if caption else None,
+                    "caption": _prefix_within_utf16_limit(caption, 1024) if caption else None,
                     "reply_to_message_id": reply_to_id,
                     "read_timeout": _MEDIA_SEND_READ_TIMEOUT,
                     **animation_thread_kwargs,

--- a/tests/gateway/test_telegram_caption_utf16_truncation.py
+++ b/tests/gateway/test_telegram_caption_utf16_truncation.py
@@ -1,0 +1,95 @@
+"""Telegram media captions must be truncated by UTF-16 code units, not code points.
+
+Telegram's caption cap (1024) is measured in UTF-16 code units, the same as
+the message-length cap (see ``gateway.platforms.base.utf16_len``). Characters
+outside the Basic Multilingual Plane (emoji, rare CJK) are surrogate pairs and
+consume two UTF-16 code units each even though Python's ``len()``/``[:n]``
+count them as one. A plain ``caption[:1024]`` can therefore pass a caption
+whose true UTF-16 length is up to 2048 straight to the Bot API, which Telegram
+rejects outright — the media never sends.
+"""
+import os
+import sys
+import tempfile
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    mod = MagicMock()
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+from gateway.config import PlatformConfig  # noqa: E402
+from gateway.platforms.base import utf16_len  # noqa: E402
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+
+# U+1F600 (astral plane) — one Python code point, two UTF-16 code units.
+_ASTRAL_EMOJI = "\U0001F600"
+
+
+def _make_adapter() -> TelegramAdapter:
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._bot = MagicMock()
+    return adapter
+
+
+@pytest.fixture
+def tmp_file(tmp_path):
+    path = tmp_path / "payload.bin"
+    path.write_bytes(b"data")
+    return str(path)
+
+
+@pytest.mark.asyncio
+async def test_send_document_caption_truncated_by_utf16_units(tmp_file):
+    """1024 astral-plane code points (2048 UTF-16 units) must be cut to <=1024
+    UTF-16 units, not passed through unchanged because len() sees only 1024."""
+    adapter = _make_adapter()
+    adapter._bot.send_document = AsyncMock(return_value=MagicMock(message_id=1))
+    caption = _ASTRAL_EMOJI * 1024  # code-point len == 1024, UTF-16 len == 2048
+
+    await adapter.send_document("123", tmp_file, caption=caption)
+
+    sent_caption = adapter._bot.send_document.call_args.kwargs["caption"]
+    assert utf16_len(sent_caption) <= 1024
+    # Must not split a surrogate pair: re-encoding must round-trip cleanly.
+    sent_caption.encode("utf-16-le").decode("utf-16-le")
+
+
+@pytest.mark.asyncio
+async def test_send_document_short_caption_untouched(tmp_file):
+    """A caption well under the limit is passed through unchanged."""
+    adapter = _make_adapter()
+    adapter._bot.send_document = AsyncMock(return_value=MagicMock(message_id=1))
+
+    await adapter.send_document("123", tmp_file, caption="short caption")
+
+    sent_caption = adapter._bot.send_document.call_args.kwargs["caption"]
+    assert sent_caption == "short caption"
+
+
+@pytest.mark.asyncio
+async def test_send_image_file_caption_truncated_by_utf16_units(tmp_path):
+    """send_image_file shares the same caption cap and must be equally safe."""
+    img_path = tmp_path / "pic.png"
+    img_path.write_bytes(b"\x89PNG\r\n\x1a\n")
+    adapter = _make_adapter()
+    adapter._bot.send_photo = AsyncMock(return_value=MagicMock(message_id=1))
+    caption = _ASTRAL_EMOJI * 1024
+
+    await adapter.send_image_file("123", str(img_path), caption=caption)
+
+    sent_caption = adapter._bot.send_photo.call_args.kwargs["caption"]
+    assert utf16_len(sent_caption) <= 1024
+    sent_caption.encode("utf-16-le").decode("utf-16-le")


### PR DESCRIPTION
## What does this PR do?
`TelegramAdapter.send_voice/send_multiple_images/send_image_file/send_document/send_video/send_image/send_animation` (`plugins/platforms/telegram/adapter.py`) cap the outgoing `caption` with `caption[:1024]` / `alt_text[:1024]` — a Python code-point slice.

Telegram's 1024-character caption limit is measured in **UTF-16 code units**, the same unit the 4096-character message-length limit uses — which this same file already handles correctly via `utf16_len()` / `_prefix_within_utf16_limit()` at 7 message-text call sites. Characters outside the Basic Multilingual Plane (emoji, rare CJK extensions) are surrogate pairs and cost two UTF-16 units each but only one Python code point, so a caption whose code-point length is `<=1024` can still have a true UTF-16 length of up to 2048. The Bot API then rejects the send outright and the media never reaches the chat.

Fix: route all 9 caption-truncation sites through the existing `_prefix_within_utf16_limit()` helper (already imported/used in this file for message-text truncation), instead of the raw `[:1024]` slice.

## Related Issue
No existing issue — found via a systematic UTF-16-truncation sweep after fixing the same bug class for Discord auto-thread names (#60252).

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- `plugins/platforms/telegram/adapter.py`: import `_prefix_within_utf16_limit` from `gateway.platforms.base` (already used for message-text truncation in the same file); replace all 9 `caption[:1024]` / `alt_text[:1024]` sites (`send_voice` x2, `send_multiple_images`, `send_image_file`, `send_document`, `send_video`, `send_image` x2, `send_animation`) with `_prefix_within_utf16_limit(caption, 1024)`.
- `tests/gateway/test_telegram_caption_utf16_truncation.py` (new): regression tests — a caption of 1024 astral-plane emoji (code-point length 1024, UTF-16 length 2048) must come out `<=1024` UTF-16 units without splitting a surrogate pair; a short caption is passed through unchanged.

## How to Test
```
pytest tests/gateway/test_telegram_caption_utf16_truncation.py -v
```
Mutation-verified: the new tests fail against the pre-fix code (`AssertionError: assert 2048 <= 1024`) and pass after the fix. Also ran the full neighboring Telegram caption/send suites (`test_telegram_caption_merge.py`, `test_telegram_send_path_health.py`, `test_telegram_send_draft_format.py`, `test_telegram_documents.py`, `test_telegram_photo_interrupts.py`, `test_telegram_voice_v0_regressions.py`, `test_telegram_rich_messages.py`, `test_telegram_overflow_partial.py`, `tests/tools/test_telegram_send_message_caption.py`) — 151 tests, all pass.

## Checklist
- [x] Contributing Guide read | Conventional Commits | No duplicate PR found (searched by function name, "telegram caption", "caption utf16")
- [x] Single logical fix | Tests added (mutation-verified) | Platform: macOS
- [x] Docs — N/A | Cross-platform — N/A (pure string handling, no OS dependency)