### PR TITLE
fix(desktop): guard soft gateway-switch against concurrent invocation

### DIFF
--- a/apps/desktop/electron/connection-apply.test.ts
+++ b/apps/desktop/electron/connection-apply.test.ts
@@ -64,6 +64,61 @@ describe('applyConnectionChange', () => {
     })
     expect(events).toEqual(['cancel:worker', 'ssh:worker', 'pool:worker'])
   })
+
+  it('dedupes two concurrent primary-scope calls into one teardown + apply', async () => {
+    // Reproduces the Settings "Apply" button and the cloud-agent "Connect"
+    // button firing back-to-back: each is an independent UI trigger with its
+    // own pending-state guard, so nothing stops both calling
+    // applyConnectionChange for the primary scope close together. Without
+    // dedup, a second call starts its own teardownPrimary() while the first
+    // is still waiting on the real process exit.
+    const gate = deferred()
+    const teardownPrimary = vi.fn(async () => {
+      await gate.promise
+    })
+    const sendApplied = vi.fn()
+
+    const first = applyConnectionChange({
+      cancelAndWait: vi.fn(async () => undefined),
+      isPrimary: true,
+      scope: '',
+      sendApplied,
+      stopPool: vi.fn(),
+      teardownPrimary,
+      teardownSsh: vi.fn(async () => undefined)
+    })
+
+    // Flush enough microtasks for `first` to reach the in-flight teardown
+    // and suspend on the still-open gate, without resolving it.
+    for (let i = 0; i < 10; i++) {
+      await Promise.resolve()
+    }
+    expect(teardownPrimary).toHaveBeenCalledOnce()
+
+    const second = applyConnectionChange({
+      cancelAndWait: vi.fn(async () => undefined),
+      isPrimary: true,
+      scope: '',
+      sendApplied,
+      stopPool: vi.fn(),
+      teardownPrimary,
+      teardownSsh: vi.fn(async () => undefined)
+    })
+
+    for (let i = 0; i < 10; i++) {
+      await Promise.resolve()
+    }
+    // The second call joined the first's in-flight re-home instead of
+    // starting its own teardown.
+    expect(teardownPrimary).toHaveBeenCalledOnce()
+    expect(sendApplied).not.toHaveBeenCalled()
+
+    gate.resolve()
+    await Promise.all([first, second])
+
+    expect(teardownPrimary).toHaveBeenCalledOnce()
+    expect(sendApplied).toHaveBeenCalledOnce()
+  })
 })
 
 describe('resolveTerminalConnection', () => {

--- a/apps/desktop/electron/connection-apply.ts
+++ b/apps/desktop/electron/connection-apply.ts
@@ -1,3 +1,15 @@
+// The in-flight soft re-home promise, if any. Two connection-config:apply
+// calls for the global/primary scope can arrive back-to-back (e.g. the
+// Settings "Apply" button and the cloud-agent "Connect" button are two
+// independent UI triggers with independent pending-state guards, so nothing
+// stops both firing close together). Without this, a second call would start
+// its own teardownPrimary() while the first is still waiting on the real
+// process exit, race the "backend stopped" toast suppression back off early
+// (surfacing a spurious crash toast for the first's still-pending teardown),
+// and fire a second hermes:connection:applied the renderer has no guard
+// against. Concurrent callers instead await the one in-flight re-home.
+let primaryRehomeInFlight = null
+
 async function applyConnectionChange({
   cancelAndWait,
   isPrimary,
@@ -23,8 +35,20 @@ async function applyConnectionChange({
     return
   }
 
-  await teardownPrimary()
-  sendApplied()
+  // A second call arriving while one is already in flight awaits the same
+  // re-home instead of racing its own teardown + notify.
+  if (!primaryRehomeInFlight) {
+    primaryRehomeInFlight = (async () => {
+      try {
+        await teardownPrimary()
+        sendApplied()
+      } finally {
+        primaryRehomeInFlight = null
+      }
+    })()
+  }
+
+  await primaryRehomeInFlight
 }
 
 function commitConnectionFailure(current, starting, commit) {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -250,6 +250,32 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect($gatewayState.get()).toBe('open')
   })
 
+  it('two hermes:connection:applied events firing back-to-back only run softSwitch once', async () => {
+    // Reproduces main's connection-config:apply race: the Settings "Apply"
+    // button and the cloud-agent "Connect" button are two independent UI
+    // triggers with independent pending-state guards, so nothing stops both
+    // firing close together — main can (pre-fix) emit
+    // hermes:connection:applied twice for one user action. Without a
+    // reentrancy guard in softSwitch(), each event independently wipes the
+    // session lists and re-dials — beforeConnectionSwitch() is called once
+    // per real softSwitch body execution, right after the guard, so its call
+    // count is the signal a guard vs. no-guard implementation disagrees on.
+    const beforeConnectionSwitch = vi.fn()
+    render(<Harness beforeConnectionSwitch={beforeConnectionSwitch} />)
+    await flushAsync()
+    expect(connectionApplied).not.toBeNull()
+    expect(beforeConnectionSwitch).not.toHaveBeenCalled()
+
+    act(() => {
+      connectionApplied?.()
+      connectionApplied?.()
+    })
+    await flushAsync()
+
+    expect(beforeConnectionSwitch).toHaveBeenCalledTimes(1)
+    expect($gatewayState.get()).toBe('open')
+  })
+
   it('a remote that drops post-boot keeps looping with NO boot.error (the dead-end CONNECTING combo)', async () => {
     render(<Harness />)
     await flushAsync()

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -291,7 +291,12 @@ export function useGatewayBoot({
     // Soft gateway-mode apply: main tore down the primary without reloading.
     // Wipe session lists so skeletons retrigger, then re-dial in place.
     const softSwitch = async () => {
-      if (cancelled) {
+      // Reentrancy guard: main dedupes concurrent connection-config:apply
+      // calls (see primaryRehomeInFlight in connection-apply.ts) so this
+      // should only ever fire once per soft re-home, but guard here too — a
+      // second overlapping in-flight switch must not wipe the session lists
+      // / re-dial a second time out from under the first.
+      if (cancelled || $gatewaySwitching.get()) {
         return
       }
 


### PR DESCRIPTION
## What does this PR do?
`ipcMain.handle('hermes:connection-config:apply', ...)`'s global/primary branch (`apps/desktop/electron/main.ts`) tears down the window backend via `teardownPrimaryBackendAndWait({ soft: true })` and notifies the renderer via `sendConnectionApplied()`, which drives `softSwitch()` in `useGatewayBoot` (`apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts`).

Two independent UI triggers can call `window.hermesDesktop.applyConnectionConfig(...)` close together — the Settings "Apply" button (guarded by its own `saving` state) and the cloud-agent "Connect" button (guarded by its own `cloudConnectingId` state). Neither guard knows about the other, so both can fire back-to-back for the same global/primary scope.

Without protection, tracing the race:
- The second `teardownPrimaryBackendAndWait({ soft: true })` starts while the first is still awaiting the real child-process exit (up to 5s). Both toggle the shared `softRehomeInProgress` flag; the second's `finally` can flip it back to `false` *before* the first's real process actually exits, so that exit's `sendBackendExit()` is no longer suppressed — an intentional teardown surfaces as a spurious "backend stopped" error toast.
- Both calls call `sendConnectionApplied()`, so the renderer's `hermes:connection:applied` handler fires twice. `softSwitch()` had no guard against running twice concurrently — each invocation independently wipes the session lists and re-dials, racing each other through `getConnection()` / `adoptPrimaryProfile()` / `completeDesktopBoot()`.
- Notably, `previewGatewaySwitch()` — `softSwitch()`'s own dev-preview twin in `apps/desktop/src/store/gateway-switch.ts`, added in the same feature (#61916) — already has exactly this reentrancy guard (`if ($gatewaySwitching.get()) return`). The production path was missing its sibling's protection.

## Related Issue
No existing issue — found while auditing the soft gateway-switch feature (#61916/#61912) for sibling gaps after a `#of N sites` review pass.

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- `apps/desktop/electron/main.ts`: dedupe concurrent `connection-config:apply` calls for the global/primary scope through a single `primaryRehomeInFlight` promise — a second caller awaits the first's in-flight re-home instead of starting its own `teardownPrimaryBackendAndWait()` + `sendConnectionApplied()`.
- `apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts`: `softSwitch()` gets the same `$gatewaySwitching` reentrancy check its dev-preview twin `previewGatewaySwitch()` already has, as defense in depth against any other path that could fire `hermes:connection:applied` twice.
- `apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx` (new test): simulates main firing `hermes:connection:applied` twice back-to-back and asserts `softSwitch()`'s body (`desktop.getConnection()`) only runs once. (`gateway.connect()` has its own `'connecting'`-state dedup, so a duplicate literal WebSocket was never the observable symptom — a duplicate `getConnection()`/session-wipe pass was.)

## How to Test
```
cd apps/desktop
npx vitest run src/app/gateway/hooks/use-gateway-boot.test.tsx --environment jsdom
```
Mutation-verified: temporarily reverting just the `softSwitch()` guard makes the new test fail (`expected 2 to be 1`) while the other 4 tests in the file still pass; restoring the guard passes all 5. Also ran the neighboring `gateway-switch.test.ts` and `gateway-connecting-overlay.test.tsx` suites (7 + 4 tests) — all green. `tsc --noEmit` (both renderer and electron configs) and `eslint` on both changed source files are clean (0 errors; pre-existing unrelated style warnings elsewhere in `main.ts` are untouched).

The `main.ts` half of the fix (`primaryRehomeInFlight`) has no automated regression test — `main.ts` is a non-modular Electron entry script with zero exports and no existing test seam for its internal IPC-handler logic anywhere in this codebase (every `electron/*.test.ts` file tests a separate, exported helper module instead). Verified by tracing the promise-dedup logic by hand instead.

## Checklist
- [x] Contributing Guide read | Conventional Commits | No duplicate PR found (searched by function/variable name, "desktop gateway switch", "connection-config apply"; noted #62308 touches nearby `main.ts` code — different bug, generation-tagged stale-process ownership — but doesn't touch the `connection-config:apply` handler or add apply-call dedup)
- [x] Single logical fix (guard soft gateway-switch against concurrent invocation, main + renderer) | Tests added where a seam exists (mutation-verified) | Platform: macOS
- [x] Docs — N/A | Cross-platform — N/A (pure JS control flow, no OS dependency)