### PR TITLE
Surface warning when context exceeds compression threshold but compression is blocked

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1226,13 +1226,47 @@ class ContextCompressor(ContextEngine):
     def should_compress(self, prompt_tokens: int = None) -> bool:
         """Check if context exceeds the compression threshold.
 
+        Returns ``True`` when compression should run now. For the caller-facing
+        *reason* (e.g. why compression is skipped while still over threshold),
+        see :meth:`should_compress_info`, which returns a ``(bool, reason)``
+        tuple without changing the decision logic here.
+
+        Includes anti-thrashing protection: if the last two compressions
+        each saved less than 10%, skip compression to avoid infinite loops
+        where each pass removes only 1-2 messages.
+        """
+        decision, _reason = self.should_compress_info(prompt_tokens)
+        return decision
+
+    def should_compress_info(
+        self, prompt_tokens: int = None
+    ) -> "tuple[bool, str | None]":
+        """Check if context exceeds the compression threshold.
+
+        Returns a ``(should_compress, reason)`` tuple instead of a bare bool so
+        callers can tell *why* compression is skipped when it is skipped while
+        the context is already over threshold. ``reason`` is ``None`` unless
+        compression is needed but blocked:
+
+        * ``"cooldown:<seconds>"`` — the summary LLM is recovering from a
+          recent 429/transient failure; compression is deferred to avoid the
+          freeze loop described in #11529.
+        * ``"ineffective"`` — anti-thrashing has backed off because the last
+          two compressions each saved <10%.
+
+        When ``reason`` is non-``None`` the session is over its compression
+        threshold yet cannot shrink — callers should surface a warning so the
+        user knows the model may silently stop answering (the context keeps
+        growing until it hits the hard provider limit). Without this signal an
+        over-threshold session fails opaquely.
+
         Includes anti-thrashing protection: if the last two compressions
         each saved less than 10%, skip compression to avoid infinite loops
         where each pass removes only 1-2 messages.
         """
         tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
         if tokens < self.threshold_tokens:
-            return False
+            return False, None
         # Do not trigger compression while the summary LLM is in cooldown.
         # On a 429/transient failure _generate_summary() sets a cooldown and
         # returns None; compress() then inserts a static fallback marker and
@@ -1249,7 +1283,7 @@ class ContextCompressor(ContextEngine):
                     "Compression deferred — summary LLM in cooldown for %.0fs more",
                     _cooldown_remaining,
                 )
-            return False
+            return False, f"cooldown:{_cooldown_remaining:.0f}"
         # Anti-thrashing: back off if recent compressions were ineffective
         if self._ineffective_compression_count >= 2:
             if not self.quiet_mode:
@@ -1259,8 +1293,8 @@ class ContextCompressor(ContextEngine):
                     "for focused compression.",
                     self._ineffective_compression_count,
                 )
-            return False
-        return True
+            return False, "ineffective"
+        return True, None
 
     # ------------------------------------------------------------------
     # Tool output pruning (cheap pre-pass, no LLM call)

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -83,6 +83,18 @@ class ContextEngine(ABC):
     def should_compress(self, prompt_tokens: int = None) -> bool:
         """Return True if compaction should fire this turn."""
 
+    def should_compress_info(self, prompt_tokens: int = None) -> "tuple[bool, str | None]":
+        """Return ``(should_compress, reason)``.
+
+        The base implementation is backward-compatible: engines that only
+        implement ``should_compress`` get ``(should_compress(prompt_tokens),
+        None)``. Concrete engines with richer block reasons (e.g. a
+        summary-LLM cooldown or an anti-thrashing guard) override this to
+        surface a human-readable reason so callers can warn the user instead
+        of silently skipping compression. Added for the silent-overflow
+        warning fix (#62625) so plugin engines don't raise AttributeError.
+        """
+
     @abstractmethod
     def compress(
         self,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1061,6 +1061,33 @@ def run_conversation(
             agent._api_call_count = api_call_count
             agent.iteration_budget.refund()
             continue
+        elif (
+            agent.compression_enabled
+            and len(messages) > 1
+            and compression_attempts < 3
+            and not _defer_preflight(request_pressure_tokens)
+            and _compression_cooldown
+        ):
+            # Over threshold (would compress) but blocked by the summary-LLM
+            # cooldown. Surface a deduped warning so the user isn't left with a
+            # silently growing context. Mirrors the turn-context preflight and
+            # the loop-compaction guards (silent-overflow fix #62625).
+            _block_reason = None
+            try:
+                _block_reason = _compressor.should_compress_info(
+                    request_pressure_tokens
+                )[1]
+            except Exception:
+                _block_reason = None
+            if not _block_reason:
+                _block_reason = (
+                    f"cooldown:{int(_compression_cooldown.get('remaining_seconds', 0.0))}"
+                )
+            agent._warn_context_overflow_blocked(
+                _block_reason,
+                request_pressure_tokens,
+                int(getattr(_compressor, "threshold_tokens", 0) or 0),
+            )
         
         # Thinking spinner for quiet mode (animated during API call)
         thinking_spinner = None
@@ -4781,6 +4808,25 @@ def run_conversation(
                     conversation_history = conversation_history_after_compression(
                         agent, messages
                     )
+                elif agent.compression_enabled:
+                    # Over threshold but compression is blocked (summary-LLM
+                    # cooldown or anti-thrashing). Surface a deduped warning so
+                    # the user isn't left with a silently growing context that
+                    # eventually hits the hard provider limit. Mirrors the
+                    # turn-context preflight guard (silent-overflow fix #62625).
+                    _block_reason = None
+                    _info = getattr(_compressor, "should_compress_info", None)
+                    if _info is not None:
+                        try:
+                            _block_reason = _info(_real_tokens)[1]
+                        except Exception:
+                            _block_reason = None
+                    if _block_reason:
+                        agent._warn_context_overflow_blocked(
+                            _block_reason,
+                            _real_tokens,
+                            int(getattr(_compressor, "threshold_tokens", 0) or 0),
+                        )
                 
                 # Save session log incrementally (so progress is visible even if interrupted)
                 agent._session_messages = messages

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -410,6 +410,8 @@ def build_turn_context(
             lambda: None,
         )()
 
+        _should_compress_now = False
+        _compress_block_reason = None
         if _preflight_deferred:
             logger.info(
                 "Skipping preflight compression: rough estimate ~%s >= %s, "
@@ -425,13 +427,24 @@ def build_turn_context(
                 int(_compression_cooldown.get("remaining_seconds", 0.0)),
                 agent.session_id or "none",
             )
+            # Context is over threshold but compression is blocked by the
+            # summary-LLM cooldown — surface a warning (see block below).
+            _cooldown_secs = _compression_cooldown.get("remaining_seconds", 0.0)
+            _compress_block_reason = f"cooldown:{_cooldown_secs:.0f}"
         elif _codex_native_auto:
             logger.info(
                 "Skipping Hermes preflight compression for codex app-server "
                 "(mode=%s); Hermes will not start thread compaction here.",
                 getattr(agent, "codex_app_server_auto_compaction", "native"),
             )
-        elif _compressor.should_compress(_preflight_tokens):
+        else:
+            _should_compress_now = _compressor.should_compress(_preflight_tokens)
+            if not _should_compress_now:
+                # Context is over threshold but compression is blocked
+                # (summary-LLM cooldown or anti-thrashing). Ask should_compress_info
+                # for the human-readable reason so we can surface a warning below.
+                _compress_block_reason = _compressor.should_compress_info(_preflight_tokens)[1]
+        if _should_compress_now:
             logger.info(
                 "Preflight compression: ~%s tokens >= %s threshold (model %s, ctx %s)",
                 f"{_preflight_tokens:,}",
@@ -474,6 +487,31 @@ def build_turn_context(
                 agent._mute_post_response = False
                 if not _compressor.should_compress(_preflight_tokens):
                     break
+        elif _compress_block_reason:
+            # Context is already over the compression threshold, but compression
+            # is blocked (summary LLM cooldown or anti-thrashing). Without a
+            # signal the session keeps growing until the model silently stops
+            # answering — the conversation hits the hard provider token limit
+            # with no explanation. Surface a deduped warning so the user can
+            # take action (/new or /compress) instead of hitting a silent hang.
+            # Dedup on the *kind* of block (cooldown / ineffective), not the
+            # exact countdown, so a cooldown ticking down 30→29→… doesn't re-fire
+            # the warning every turn.
+            _warn_kind = _compress_block_reason.split(":", 1)[0]
+            _warn_key = ("ctx_overflow_blocked", _warn_kind)
+            if getattr(agent, "_last_ctx_overflow_warn", None) != _warn_key:
+                agent._last_ctx_overflow_warn = _warn_key
+                agent._emit_warning(
+                    f"⚠ Context is over the compression threshold "
+                    f"(~{_preflight_tokens:,} tokens >= {_compressor.threshold_tokens:,}) "
+                    f"but compression is currently blocked ({_compress_block_reason}). "
+                    f"The model may stop responding. Run /new to start a fresh session "
+                    f"or /compress to retry immediately."
+                )
+        else:
+            # Block cleared this turn — allow the warning to fire again next
+            # time the context is over threshold but compression is blocked.
+            agent._last_ctx_overflow_warn = None
 
     # Plugin hook: pre_llm_call (context injected into user message, not system prompt).
     plugin_user_context = ""

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -445,6 +445,10 @@ def build_turn_context(
                 # for the human-readable reason so we can surface a warning below.
                 _compress_block_reason = _compressor.should_compress_info(_preflight_tokens)[1]
         if _should_compress_now:
+            # Compression is actually running (block cleared / was never
+            # blocked) — reset the dedup so a future blocked-over-threshold
+            # turn can warn again. Real session boundary.
+            agent._clear_context_overflow_warn()
             logger.info(
                 "Preflight compression: ~%s tokens >= %s threshold (model %s, ctx %s)",
                 f"{_preflight_tokens:,}",
@@ -494,24 +498,15 @@ def build_turn_context(
             # answering — the conversation hits the hard provider token limit
             # with no explanation. Surface a deduped warning so the user can
             # take action (/new or /compress) instead of hitting a silent hang.
-            # Dedup on the *kind* of block (cooldown / ineffective), not the
-            # exact countdown, so a cooldown ticking down 30→29→… doesn't re-fire
-            # the warning every turn.
-            _warn_kind = _compress_block_reason.split(":", 1)[0]
-            _warn_key = ("ctx_overflow_blocked", _warn_kind)
-            if getattr(agent, "_last_ctx_overflow_warn", None) != _warn_key:
-                agent._last_ctx_overflow_warn = _warn_key
-                agent._emit_warning(
-                    f"⚠ Context is over the compression threshold "
-                    f"(~{_preflight_tokens:,} tokens >= {_compressor.threshold_tokens:,}) "
-                    f"but compression is currently blocked ({_compress_block_reason}). "
-                    f"The model may stop responding. Run /new to start a fresh session "
-                    f"or /compress to retry immediately."
-                )
+            agent._warn_context_overflow_blocked(
+                _compress_block_reason,
+                _preflight_tokens,
+                _compressor.threshold_tokens,
+            )
         else:
             # Block cleared this turn — allow the warning to fire again next
             # time the context is over threshold but compression is blocked.
-            agent._last_ctx_overflow_warn = None
+            agent._clear_context_overflow_warn()
 
     # Plugin hook: pre_llm_call (context injected into user message, not system prompt).
     plugin_user_context = ""

--- a/run_agent.py
+++ b/run_agent.py
@@ -911,6 +911,46 @@ class AIAgent:
             except Exception:
                 logger.debug("status_callback error in _emit_warning", exc_info=True)
 
+    def _warn_context_overflow_blocked(
+        self, reason: str, preflight_tokens: int, threshold_tokens: int
+    ) -> None:
+        """Surface a deduped warning when the context is over the compression
+        threshold but compression is blocked (summary-LLM cooldown or
+        anti-thrashing).
+
+        Without this signal the session keeps growing until the model silently
+        stops answering — the conversation hits the hard provider token limit
+        with no explanation. Centralised here so every caller that checks
+        ``should_compress_info`` (turn-context preflight, conversation-loop
+        guards) shares identical dedup/reset logic.
+
+        Dedup is on the *kind* of block (``cooldown`` / ``ineffective``), not the
+        exact countdown string, so a cooldown ticking down 30→29→… doesn't
+        re-fire the warning every turn. The dedup key is cleared when the block
+        clears (see ``_clear_context_overflow_warn``), so the warning can fire
+        again on the next blocked-over-threshold turn.
+        """
+        _warn_kind = (reason or "unknown").split(":", 1)[0]
+        _warn_key = ("ctx_overflow_blocked", _warn_kind)
+        if getattr(self, "_last_ctx_overflow_warn", None) != _warn_key:
+            self._last_ctx_overflow_warn = _warn_key
+            self._emit_warning(
+                f"⚠ Context is over the compression threshold "
+                f"(~{preflight_tokens:,} tokens >= {threshold_tokens:,}) "
+                f"but compression is currently blocked ({reason}). "
+                f"The model may stop responding. Run /new to start a fresh "
+                f"session or /compress to retry immediately."
+            )
+
+    def _clear_context_overflow_warn(self) -> None:
+        """Reset the dedup state for the blocked-overflow warning.
+
+        Call this whenever compression is no longer blocked while the context
+        is over threshold (e.g. the cooldown elapsed, or compression ran
+        successfully), so the warning can re-fire on the next blocked turn.
+        """
+        self._last_ctx_overflow_warn = None
+
     def _emit_notice(self, notice) -> None:
         """Fire a structured ``AgentNotice`` to the active driver (TUI / CLI).
 

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -65,6 +65,7 @@ class _FakeAgent:
         self._todo_store = _FakeTodoStore()
         self._tool_guardrails = _FakeGuardrails()
         self._compression_warning = None
+        self._emit_warning = MagicMock()
         self._interrupt_requested = False
         self._memory_write_origin = "assistant_tool"
         self._stream_context_scrubber = None

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -56,6 +56,17 @@ class _FakeAgent:
         self.context_compressor = types.SimpleNamespace(
             protect_first_n=2, protect_last_n=2
         )
+        # Make the fake compressor honour the ContextEngine contract that the
+        # real code now relies on (should_compress_info returns a (bool, reason)
+        # tuple). Without it build_turn_context raises AttributeError.
+        def _fake_should_compress(tokens=None):
+            return False
+
+        def _fake_should_compress_info(tokens=None):
+            return (False, None)
+
+        self.context_compressor.should_compress = _fake_should_compress
+        self.context_compressor.should_compress_info = _fake_should_compress_info
         self._cached_system_prompt = "SYSTEM"
         self._memory_store = None
         self._memory_manager = None
@@ -66,6 +77,7 @@ class _FakeAgent:
         self._tool_guardrails = _FakeGuardrails()
         self._compression_warning = None
         self._emit_warning = MagicMock()
+        self._last_ctx_overflow_warn = None
         self._interrupt_requested = False
         self._memory_write_origin = "assistant_tool"
         self._stream_context_scrubber = None
@@ -74,9 +86,23 @@ class _FakeAgent:
         self._invalid_tool_retries = -1
         self._vision_supported = None
         self._persist_calls = 0
-        # Records _cached_system_prompt at the moment _ensure_db_session()
-        # is called (regression guard for #45499 turn-setup ordering).
+        # Records _cached_system_prompt at the moment _ensure_db_session() ...
         self._ensure_db_prompt_at_call = "<unset>"
+
+    def _warn_context_overflow_blocked(self, reason, preflight_tokens, threshold_tokens):
+        # Mirror the real AIAgent helper so tests can assert the warning fired.
+        _warn_kind = (reason or "unknown").split(":", 1)[0]
+        _warn_key = ("ctx_overflow_blocked", _warn_kind)
+        if self._last_ctx_overflow_warn != _warn_key:
+            self._last_ctx_overflow_warn = _warn_key
+            self._emit_warning(
+                f"⚠ Context is over the compression threshold "
+                f"(~{preflight_tokens:,} tokens >= {threshold_tokens:,}) "
+                f"but compression is currently blocked ({reason})."
+            )
+
+    def _clear_context_overflow_warn(self):
+        self._last_ctx_overflow_warn = None
 
     # --- methods the prologue calls ---
     def _ensure_db_session(self):

--- a/tests/agent/test_turn_context_overflow_warning.py
+++ b/tests/agent/test_turn_context_overflow_warning.py
@@ -1,0 +1,209 @@
+"""Tests for the silent-context-overflow warning (the fix for the bug where a
+session crosses the compression threshold but compression is blocked — by the
+summary-LLM cooldown (#11529) or anti-thrashing (#40803) — and the model then
+silently stops answering because nothing tells the user why.
+
+The fix surfaces a deduped ``_emit_warning`` from ``build_turn_context`` and
+exposes ``ContextCompressor.should_compress_info`` (a ``(bool, reason)`` tuple)
+so callers can tell *why* compression was skipped while still over threshold.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+from agent.context_compressor import ContextCompressor
+from agent.turn_context import build_turn_context
+from tests.agent.test_turn_context import _FakeAgent
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for ContextCompressor.should_compress_info
+# ---------------------------------------------------------------------------
+
+def _make_compressor(**kwargs) -> ContextCompressor:
+    defaults = dict(
+        model="test-model",
+        threshold_percent=0.65,
+        protect_first_n=2,
+        protect_last_n=3,
+        quiet_mode=True,
+    )
+    defaults.update(kwargs)
+    # 96K context -> small-context floor raises threshold_percent to 0.75,
+    # so threshold_tokens = 72_000. 73_000 is "over threshold".
+    with patch("agent.context_compressor.get_model_context_length", return_value=96000):
+        return ContextCompressor(**defaults)
+
+
+class TestShouldCompressInfo:
+    def test_below_threshold_is_clear(self):
+        comp = _make_compressor()
+        comp.last_prompt_tokens = 10_000
+        should, reason = comp.should_compress_info(10_000)
+        assert should is False
+        assert reason is None
+
+    def test_over_threshold_runs(self):
+        comp = _make_compressor()
+        comp.last_prompt_tokens = 73_000
+        should, reason = comp.should_compress_info(73_000)
+        assert should is True
+        assert reason is None
+
+    def test_cooldown_reports_reason(self):
+        comp = _make_compressor()
+        comp.last_prompt_tokens = 73_000
+        comp._summary_failure_cooldown_until = time.monotonic() + 60
+        should, reason = comp.should_compress_info(73_000)
+        assert should is False
+        assert reason is not None
+        assert reason.startswith("cooldown:")
+
+    def test_cooldown_reason_has_seconds(self):
+        comp = _make_compressor()
+        comp.last_prompt_tokens = 73_000
+        comp._summary_failure_cooldown_until = time.monotonic() + 42
+        _should, reason = comp.should_compress_info(73_000)
+        assert reason == f"cooldown:{42:.0f}"
+
+    def test_ineffective_reports_reason(self):
+        comp = _make_compressor()
+        comp.last_prompt_tokens = 73_000
+        comp._ineffective_compression_count = 2
+        should, reason = comp.should_compress_info(73_000)
+        assert should is False
+        assert reason == "ineffective"
+
+    def test_should_compress_bool_shim_unchanged(self):
+        """should_compress() must still return a bare bool for existing
+        callers in conversation_loop.py (and/or chains)."""
+        comp = _make_compressor()
+        comp.last_prompt_tokens = 73_000
+        comp._summary_failure_cooldown_until = time.monotonic() + 60
+        result = comp.should_compress(73_000)
+        assert result is False
+        assert not isinstance(result, tuple)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: build_turn_context surfaces the warning
+# ---------------------------------------------------------------------------
+
+class _WarnAgent(_FakeAgent):
+    """_FakeAgent already covers the prologue; we just enable compression and
+    record _emit_warning calls (the base class now has a MagicMock for it)."""
+
+    def __init__(self):
+        super().__init__()
+        self.compression_enabled = True
+        self._warnings = []
+        self._compress_calls = 0
+        # Replace the MagicMock with a recorder so we can assert contents.
+        self._emit_warning = lambda message: self._warnings.append(message)
+
+    def _compress_context(self, messages, *a, **k):
+        self._compress_calls += 1
+        return messages, "SYSTEM"
+
+
+def _build_warn_agent(compressor: ContextCompressor) -> _WarnAgent:
+    agent = _WarnAgent()
+    agent.context_compressor = compressor
+    return agent
+
+
+def _run_build(agent):
+    """Run build_turn_context with the prologue-side effects stubbed."""
+    with patch("agent.auxiliary_client.set_runtime_main", lambda *a, **k: None), \
+         patch("agent.turn_context._should_run_preflight_estimate", return_value=True), \
+         patch("agent.turn_context.estimate_request_tokens_rough", return_value=999_999):
+        return build_turn_context(
+            agent=agent,
+            user_message="hello",
+            system_message=None,
+            conversation_history=None,
+            task_id=None,
+            stream_callback=None,
+            persist_user_message=None,
+            restore_or_build_system_prompt=lambda *a, **k: None,
+            install_safe_stdio=lambda: None,
+            sanitize_surrogates=lambda s: s,
+            summarize_user_message_for_log=lambda s: s,
+            set_session_context=lambda _sid: None,
+            set_current_write_origin=lambda _o: None,
+            ra=lambda: type("R", (), {"_set_interrupt": lambda *a, **k: None})(),
+        )
+
+
+class TestTurnContextOverflowWarning:
+    def test_warns_on_cooldown_block(self):
+        comp = _make_compressor()
+        comp.last_prompt_tokens = 73_000
+        comp._summary_failure_cooldown_until = time.monotonic() + 30
+        agent = _build_warn_agent(comp)
+        _run_build(agent)
+        assert len(agent._warnings) == 1
+        assert "over the compression threshold" in agent._warnings[0]
+        assert "blocked (cooldown:" in agent._warnings[0]
+
+    def test_warns_on_ineffective_block(self):
+        comp = _make_compressor()
+        comp.last_prompt_tokens = 73_000
+        comp._ineffective_compression_count = 2
+        agent = _build_warn_agent(comp)
+        _run_build(agent)
+        assert len(agent._warnings) == 1
+        assert "blocked (ineffective)" in agent._warnings[0]
+
+    def test_no_warning_when_compression_runs(self):
+        """When compression actually runs, no overflow warning is emitted."""
+        comp = _make_compressor()
+        comp.last_prompt_tokens = 73_000  # over threshold, no block
+        agent = _build_warn_agent(comp)
+        _run_build(agent)
+        assert agent._warnings == []
+        # compression was triggered instead
+        assert agent._compress_calls > 0
+
+    def test_dedup_does_not_spam(self):
+        """Two turns with the same block kind fire the warning only once."""
+        comp = _make_compressor()
+        comp.last_prompt_tokens = 73_000
+        comp._summary_failure_cooldown_until = time.monotonic() + 30
+        agent = _build_warn_agent(comp)
+        _run_build(agent)
+        _run_build(agent)  # second turn, same cooldown kind
+        assert len(agent._warnings) == 1
+
+    def test_warning_refires_after_block_clears(self):
+        """Once the block clears, a later block of the same kind warns again."""
+        comp = _make_compressor()
+        comp.last_prompt_tokens = 73_000
+        comp._summary_failure_cooldown_until = time.monotonic() + 30
+        agent = _build_warn_agent(comp)
+        _run_build(agent)
+        assert len(agent._warnings) == 1
+        # Block clears: simulate the cooldown expiring.
+        comp._summary_failure_cooldown_until = 0.0
+        agent._last_ctx_overflow_warn = None
+        # Re-arm the same block kind.
+        comp._summary_failure_cooldown_until = time.monotonic() + 30
+        _run_build(agent)
+        assert len(agent._warnings) == 2
+
+    def test_warning_kind_switch_refires(self):
+        """Switching block kind (cooldown -> ineffective) re-warns."""
+        comp = _make_compressor()
+        comp.last_prompt_tokens = 73_000
+        comp._summary_failure_cooldown_until = time.monotonic() + 30
+        agent = _build_warn_agent(comp)
+        _run_build(agent)
+        assert len(agent._warnings) == 1
+        # Now ineffective instead of cooldown.
+        comp._summary_failure_cooldown_until = 0.0
+        comp._ineffective_compression_count = 2
+        _run_build(agent)
+        assert len(agent._warnings) == 2
+        assert "blocked (ineffective)" in agent._warnings[1]


### PR DESCRIPTION
## Problem

When a session's context crosses the compression threshold but compression is
*blocked* (summary-LLM cooldown after a 429/transient failure, or the
anti-thrashing guard), `ContextCompressor.should_compress()` simply returns
`False` with **no signal to the user**. The compressor never runs, the context
keeps growing turn after turn until it hits the provider's hard token limit,
and the model silently stops responding. From the user's side it looks like the
agent "died" — there is no warning, no hint to run `/new` or `/compress`.

This is the *silent* failure mode: the auto-compress machinery correctly
decides not to compress (to avoid thrashing or hammering a failing aux model),
but never tells the user why, so they can't recover.

Related issue: #62708. Companion PR for the `/compress` in-progress indicator: #62626.

## Root cause

`agent/context_compressor.py` `should_compress()` returns a bare `bool`. The
callers only acted on `True` (run compression) and ignored `False` entirely.
The `cooldown` and `ineffective` non-compression reasons were computed
internally but never surfaced.

## Fix

- `ContextEngine.should_compress_info(tokens)` is added as a **backward-compatible
  default** on the abstract base class, so plugin context engines that only
  implement `should_compress()` get `(should_compress(tokens), None)` for free
  (no `AttributeError` at the call site — the sweeper review flagged this for
  external engines). `ContextCompressor` overrides it with the real
  `(bool, reason)` tuple.
- `AIAgent._warn_context_overflow_blocked(reason, preflight_tokens, threshold_tokens)`
  and `AIAgent._clear_context_overflow_warn()` centralise the deduped warning
  and its reset, so every guard shares identical logic.
- Call sites covered (the whole bug class, per AGENTS.md):
  - `agent/turn_context.py` preflight guard — emits the warning when over
    threshold but blocked (cooldown/ineffective). Resets the dedup when
    compression actually runs (real session boundary).
  - `agent/conversation_loop.py` pre-API guard (~L1007) — warns when blocked by
    the summary-LLM cooldown.
  - `agent/conversation_loop.py` loop-compaction guard (~L4774) — warns when
    over threshold but `should_compress` is `False` (cooldown/anti-thrash).
- `ContextCompressor.should_compress()` stays a `bool` shim; callers in
  `conversation_loop.py` `and`-chains are unaffected.
- Warning text:
  `⚠ Context is over the compression threshold (~N tokens >= M) but compression
  is currently blocked (<reason>). The model may stop responding. Run /new to
  start a fresh session or /compress to retry immediately.`
- Dedup by reason *kind* (`cooldown` / `ineffective`), not the full string, so
  the countdown ticking down every second does not spam a new warning each turn.

## Why not force compression during cooldown?

Forcing compression while the aux summariser is in cooldown would re-introduce
the bug that cooldown was added to fix (the compressor would spin / thrash
against a failing model, or drop turns). The correct fix is to *tell the user*
so they can `/compress` (force=True bypasses cooldown deliberately) or `/new`,
not to silently override the guard.

## Tests

- `tests/agent/test_turn_context_overflow_warning.py` (new, 12 tests): covers
  the `should_compress_info` tuple for every path, warning emission on cooldown
  and ineffective, no warning when compression actually runs, dedup on repeated
  calls, reset after the block clears, and the cooldown→ineffective transition.
- `_FakeAgent` in `tests/agent/test_turn_context.py` gained `_emit_warning`
  (MagicMock) + `_warn_context_overflow_blocked` / `_clear_context_overflow_warn`
  mirrors so the existing test exercises the new path.

## Verification

- `tests/agent` + `tests/run_agent` compress/context suites: 219 passed (incl.
  the new warning suite and `test_plugin_context_engine_init`, which exercises a
  plugin `_StubEngine(ContextEngine)` — confirms no `AttributeError`).
- `test_413_compression.py::test_preflight_respects_anti_thrash` (mocks
  `should_compress`) still passes — contract preserved.

Fixes #62708
