### PR TITLE
Show in-progress indicator while /compress runs

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3231,6 +3231,12 @@ class GatewaySlashCommandsMixin:
                     return t("gateway.compress.nothing_to_do")
 
                 loop = asyncio.get_running_loop()
+                # Surface an in-progress indicator so the user sees compression
+                # is running (it's a blocking LLM summary call) instead of the
+                # command appearing to "do nothing" until it returns.
+                tmp_agent._emit_status(
+                    f"📦 Compressing context (~{approx_tokens:,} tokens)…"
+                )
                 compressed, _ = await loop.run_in_executor(
                     None,
                     lambda: tmp_agent._compress_context(head, "", approx_tokens=approx_tokens, focus_topic=focus_topic, force=True)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3209,6 +3209,41 @@ class GatewaySlashCommandsMixin:
                 session_id=session_entry.session_id,
                 session_db=getattr(self._session_db, "_db", self._session_db),
             )
+            # Bridge status → platform adapter so the in-progress "Compressing
+            # context…" indicator actually reaches the gateway user. The temp
+            # agent has no status_callback by default (unlike the live agent in
+            # gateway/run.py:18238), so _emit_status would otherwise go nowhere.
+            # Mirrors gateway/run.py's _status_callback_sync bridge.
+            try:
+                from agent.async_utils import safe_schedule_threadsafe
+                from gateway.run import (
+                    _prepare_gateway_status_message,
+                    _send_or_update_status_coro,
+                )
+
+                _status_adapter = self._adapter_for_source(source)
+                _status_chat_id = source.chat_id
+                _status_loop = asyncio.get_running_loop()
+
+                def _status_cb(event_type: str, message: str) -> None:
+                    if not _status_adapter:
+                        return
+                    _prepared = _prepare_gateway_status_message(
+                        source.platform, event_type, message
+                    )
+                    if _prepared is None:
+                        return
+                    safe_schedule_threadsafe(
+                        _send_or_update_status_coro(
+                            _status_adapter, _status_chat_id, event_type, _prepared, None
+                        ),
+                        _status_loop,
+                        logger=logger,
+                    )
+
+                tmp_agent.status_callback = _status_cb
+            except Exception:
+                pass
             try:
                 tmp_agent._print_fn = lambda *a, **kw: None
                 # Prevent close() from ending the newly rotated session —

--- a/tests/gateway/test_compress_command.py
+++ b/tests/gateway/test_compress_command.py
@@ -531,3 +531,42 @@ async def test_compress_command_passes_tool_messages_to_compressor():
     # Assistant tool_calls stubs (content=None) must survive too, or the
     # tool message would dangle without its call.
     assert any(m.get("tool_calls") for m in passed), "assistant tool_calls stub dropped"
+
+
+@pytest.mark.asyncio
+async def test_compress_command_emits_in_progress_status():
+    """/compress must surface an in-progress status BEFORE the blocking
+    summary LLM call, so the user sees compression is running instead of the
+    command appearing to 'do nothing' until it returns.
+
+    Regression guard: previously the gateway /compress path went straight into
+    ``run_in_executor(_compress_context)`` with no status, so on a slow
+    summariser the user got silence for the whole call.
+    """
+    history = _make_history()
+    runner = _make_runner(history)
+    agent_instance = MagicMock()
+    agent_instance.shutdown_memory_provider = MagicMock()
+    agent_instance.close = MagicMock()
+    agent_instance._cached_system_prompt = ""
+    agent_instance.tools = None
+    agent_instance.context_compressor.has_content_to_compress.return_value = True
+    agent_instance.session_id = "sess-1"
+    agent_instance._compress_context.return_value = (list(history), "")
+
+    with (
+        patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}),
+        patch("gateway.run._resolve_gateway_model", return_value="test-model"),
+        patch("run_agent.AIAgent", return_value=agent_instance),
+        patch("agent.model_metadata.estimate_request_tokens_rough", return_value=100),
+    ):
+        await runner._handle_compress_command(_make_event())
+
+    # A "Compressing context" status was emitted before the summary call ran.
+    assert agent_instance._emit_status.called
+    _status_texts = [c.args[0] for c in agent_instance._emit_status.call_args_list]
+    assert any("Compressing context" in t for t in _status_texts), (
+        f"expected an in-progress 'Compressing context' status, got: {_status_texts}"
+    )
+    # The compression call itself still happened.
+    agent_instance._compress_context.assert_called_once()

--- a/tests/gateway/test_compress_command.py
+++ b/tests/gateway/test_compress_command.py
@@ -545,6 +545,11 @@ async def test_compress_command_emits_in_progress_status():
     """
     history = _make_history()
     runner = _make_runner(history)
+    # The handler bridges tmp_agent.status_callback -> platform adapter via
+    # _send_or_update_status_coro; give it a fake adapter so the delivery path
+    # actually fires (otherwise _adapter_for_source returns None and the
+    # bridge early-returns).
+    runner._adapter_for_source = lambda *a, **kw: _adapter
     agent_instance = MagicMock()
     agent_instance.shutdown_memory_provider = MagicMock()
     agent_instance.close = MagicMock()
@@ -553,20 +558,44 @@ async def test_compress_command_emits_in_progress_status():
     agent_instance.context_compressor.has_content_to_compress.return_value = True
     agent_instance.session_id = "sess-1"
     agent_instance._compress_context.return_value = (list(history), "")
+    # Mirror the real AIAgent._emit_status: it forwards to status_callback,
+    # which the handler bridges to the platform adapter. Without this the
+    # MagicMock would swallow the callback and we'd only be proving invocation,
+    # not adapter-visible delivery.
+    def _emit_status(message: str) -> None:
+        cb = agent_instance.status_callback
+        if cb:
+            cb("lifecycle", message)
+
+    agent_instance._emit_status = _emit_status
+    # The handler bridges tmp_agent.status_callback -> platform adapter via
+    # _send_or_update_status_coro. Assert the indicator reaches that delivery
+    # call (adapter-visible), not just that _emit_status was invoked on the
+    # agent and dropped.
+    _adapter = MagicMock()
+
+    def _fake_send(adapter, chat_id, status_key, content, metadata):
+        # Mirror the real coroutine's adapter.send delivery so we can assert
+        # the in-progress text actually reaches the platform adapter.
+        adapter.send(chat_id, content)
 
     with (
         patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}),
         patch("gateway.run._resolve_gateway_model", return_value="test-model"),
         patch("run_agent.AIAgent", return_value=agent_instance),
         patch("agent.model_metadata.estimate_request_tokens_rough", return_value=100),
+        patch("gateway.run._send_or_update_status_coro", _fake_send),
+        patch("agent.async_utils.safe_schedule_threadsafe", lambda *a, **kw: None),
     ):
         await runner._handle_compress_command(_make_event())
 
-    # A "Compressing context" status was emitted before the summary call ran.
-    assert agent_instance._emit_status.called
-    _status_texts = [c.args[0] for c in agent_instance._emit_status.call_args_list]
-    assert any("Compressing context" in t for t in _status_texts), (
-        f"expected an in-progress 'Compressing context' status, got: {_status_texts}"
-    )
+    # A "Compressing context" status was delivered to the platform adapter
+    # BEFORE the summary call ran (adapter-visible, not just invoked on the
+    # agent and dropped).
+    assert _adapter.send.called
+    _delivered = [c.args[1] for c in _adapter.send.call_args_list]
+    assert any(
+        "Compressing context" in (t or "") for t in _delivered
+    ), f"expected an in-progress 'Compressing context' delivery via adapter, got: {_delivered}"
     # The compression call itself still happened.
     agent_instance._compress_context.assert_called_once()

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4029,6 +4029,55 @@ def test_session_compress_uses_compress_helper(monkeypatch):
     emit.assert_any_call("status.update", "sid", {"kind": "status", "text": "ready"})
 
 
+def test_slash_exec_compress_emits_progress(monkeypatch):
+    """Regression guard: the /compress side-effect mirror (the path
+    `slash.exec` actually takes for /compress) must surface an in-progress
+    'compressing' status BEFORE _compress_session_history runs, and clear it
+    (ready) afterwards.
+
+    This is the live route the sweeper review flagged after routing moved away
+    from the stale slash.exec-compress branch; without this test the indicator
+    could silently regress.
+    """
+    import types
+
+    session = _session(running=False)
+    session["agent"] = types.SimpleNamespace(model="x")
+    session["history"] = [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+        {"role": "user", "content": "c"},
+        {"role": "assistant", "content": "d"},
+    ]
+
+    _order = []
+
+    def _fake_status_update(sid, kind, text=None):
+        _order.append(("status_update", kind, text))
+
+    def _fake_compress(session, focus_topic=None, **_kw):
+        _order.append(("compress", None, None))
+        return (1, {"total": 10})
+
+    monkeypatch.setattr(server, "_status_update", _fake_status_update)
+    monkeypatch.setattr(server, "_compress_session_history", _fake_compress)
+    monkeypatch.setattr(server, "_sync_session_key_after_compress", lambda *a, **kw: None)
+
+    warning = server._mirror_slash_side_effects("sid", session, "/compress")
+
+    # No busy warning, and the in-progress status fired before compression.
+    assert "session busy" not in warning
+    assert any(
+        k == "compressing" and "compressing" in (t or "")
+        for (_s, k, t) in _order
+    ), f"expected an in-progress 'compressing' status, got: {_order}"
+    assert ("compress", None, None) in _order
+    assert any(k == "ready" for (_s, k, t) in _order), f"expected 'ready' clear, got: {_order}"
+    # compressing must come BEFORE the compress call, ready AFTER.
+    assert _order.index(next(o for o in _order if o[1] == "compressing")) < _order.index(("compress", None, None))
+    assert _order.index(("compress", None, None)) < _order.index(next(o for o in _order if o[1] == "ready"))
+
+
 def test_session_compress_syncs_session_key_after_rotation(monkeypatch):
     """When AIAgent._compress_context rotates session_id (compression split),
     the gateway session_key must follow so subsequent approval routing,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12224,13 +12224,26 @@ def _(rid, params: dict) -> dict:
                 if before_count
                 else 0
             )
-            removed, usage = _compress_session_history(
-                session,
-                arg.strip() or None,
-                approx_tokens=before_tokens,
-                before_messages=before_messages,
-                history_version=history_version,
-            )
+            if before_count >= 4:
+                _status_update(
+                    sid,
+                    "compressing",
+                    f"⠋ compressing {before_count} messages "
+                    f"(~{before_tokens:,} tok)…",
+                )
+            try:
+                removed, usage = _compress_session_history(
+                    session,
+                    arg.strip() or None,
+                    approx_tokens=before_tokens,
+                    before_messages=before_messages,
+                    history_version=history_version,
+                )
+            finally:
+                # Always clear the pinned compressing status so the bar
+                # reverts to neutral whether compaction succeeded, was a
+                # no-op, or raised — mirrors the session.compress RPC.
+                _status_update(sid, "ready")
             with session["history_lock"]:
                 after_messages = list(session.get("history", []))
             after_count = len(after_messages)
@@ -13006,7 +13019,20 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
                 else 0
             )
 
-            _compress_session_history(session, arg)
+            if _before_count >= 4:
+                _status_update(
+                    sid,
+                    "compressing",
+                    f"⠋ compressing {_before_count} messages "
+                    f"(~{_before_tokens:,} tok)…",
+                )
+            try:
+                _compress_session_history(session, arg)
+            finally:
+                # Always clear the pinned compressing status so the bar
+                # reverts to neutral whether compaction succeeded, was a
+                # no-op, or raised — mirrors the session.compress RPC.
+                _status_update(sid, "ready")
             _sync_session_key_after_compress(sid, session)
 
             with session["history_lock"]:


### PR DESCRIPTION
## Problem

Manual `/compress` gave **no feedback** while the blocking summary LLM call
ran. On a slow summariser the command appeared to "do nothing" until it
returned, so users thought it was broken (the conversation just sat there with
no status, no spinner, no countdown).

Note: the desktop **"compress" button** (via the `session.compress` RPC)
already showed a live `compressing` indicator — only the `/compress` *slash*
paths were silent.

Related issue: #62708. Companion PR for the silent-overflow warning: #62625.

## Fix

- `tui_gateway/server.py`: the `/compress` `slash.exec` path
  (`session.slash`) and the gateway live-agent mirror
  (`_mirror_slash_side_effects`) now emit
  `_status_update(sid, "compressing", "⠋ compressing N messages (~X tok)…")`
  **before** `_compress_session_history`, and clear it with
  `_status_update(sid, "ready")` in a `finally` block — mirroring the existing
  `session.compress` RPC. The desktop app already renders the `compressing`
  status kind as a live indicator.
- `gateway/slash_commands.py`: `_handle_compress_command` emits
  `📦 Compressing context (~N tokens)…` via `_emit_status` before the blocking
  `run_in_executor` call, so Telegram/gateway users see progress too.

## Tests

- `tests/gateway/test_compress_command.py`: new
  `test_compress_command_emits_in_progress_status` asserts `_emit_status` is
  called with a "Compressing context" message before the summary LLM call, and
  that the compression call still happens.

## Verification

- `tests/gateway/test_compress_command.py`: 11 passed (incl. new).
- `tests/test_tui_gateway_server.py -k "compress or slash"`: 19 passed.

Fixes #62708