### PR TITLE
fix(dashboard): propagate authenticated user_id through PTY spawn to agent (#62549)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14630,14 +14630,16 @@ def _resolve_chat_argv(
     # attach URL, gatewayClient spawns its own `tui_gateway.entry`, which
     # inherits the profile HERMES_HOME set above.
     if profile_dir is None:
-        if gateway_ws_url := _build_gateway_ws_url():
+        # Carry the ticket identity on the trusted internal gateway URL so the
+        # dashboard-process gateway (_make_agent) can see it. The PTY child
+        # attaches here; env alone is not enough for the unscoped path (#62549).
+        if gateway_ws_url := _build_gateway_ws_url(user_id=user_id):
             env["HERMES_TUI_GATEWAY_URL"] = gateway_ws_url
 
     if user_id:
-        # Internal IPC bridge between the dashboard process and the spawned
-        # TUI child; never read from operator-facing config.yaml. ``_make_agent``
-        # in ``tui_gateway/server.py`` reads this and threads it into
-        # ``AIAgent(user_id=...)`` so memory providers can scope per user.
+        # Profile-scoped chats spawn their own tui_gateway.entry child and
+        # never attach to the dashboard gateway URL above. Keep the env bridge
+        # for that path so _make_agent still sees the identity.
         env["HERMES_TUI_USER_ID"] = user_id
 
     return list(argv), str(cwd) if cwd else None, env
@@ -14681,7 +14683,7 @@ def _resolve_client_ws_host() -> Optional[str]:
     return host
 
 
-def _build_gateway_ws_url() -> Optional[str]:
+def _build_gateway_ws_url(user_id: Optional[str] = None) -> Optional[str]:
     """ws:// URL the PTY child should attach to for JSON-RPC gateway traffic.
 
     Loopback / ``--insecure``: ``?token=<_SESSION_TOKEN>``.
@@ -14691,6 +14693,11 @@ def _build_gateway_ws_url() -> Optional[str]:
     credential (``?internal=``). It must NOT use a single-use browser ticket:
     the child reads this URL once at startup and reuses it on every reconnect,
     and a 30s-TTL ticket can expire before a slow cold boot even dials.
+
+    ``user_id`` (optional): trusted connection-scoped identity for the
+    dashboard-process gateway. Appended as ``&user_id=`` so ``gateway_ws``
+    can inject it into session.create / _make_agent without relying on the
+    child environment (#62549). Never set for the server-internal identity.
     """
     host = _resolve_client_ws_host()
     port = getattr(app.state, "bound_port", None)
@@ -14707,10 +14714,14 @@ def _build_gateway_ws_url() -> Optional[str]:
     if getattr(app.state, "auth_required", False):
         from hermes_cli.dashboard_auth.ws_tickets import internal_ws_credential
 
-        qs = urllib.parse.urlencode({"internal": internal_ws_credential()})
+        params = {"internal": internal_ws_credential()}
     else:
-        qs = urllib.parse.urlencode({"token": _SESSION_TOKEN})
+        params = {"token": _SESSION_TOKEN}
 
+    if user_id:
+        params["user_id"] = user_id
+
+    qs = urllib.parse.urlencode(params)
     return f"ws://{netloc}/api/ws?{qs}"
 
 
@@ -15637,9 +15648,18 @@ async def gateway_ws(ws: WebSocket) -> None:
         await ws.close(code=4403)
         return
 
+    # Trusted connection-scoped identity from _build_gateway_ws_url. The PTY
+    # child re-auths with the process-lifetime internal credential, so the
+    # original ticket identity would otherwise be lost here (#62549).
+    pty_user_id = (ws.query_params.get("user_id") or "").strip() or None
+    if pty_user_id:
+        from hermes_cli.dashboard_auth.ws_tickets import INTERNAL_USER_ID
+        if pty_user_id == INTERNAL_USER_ID:
+            pty_user_id = None
+
     from tui_gateway.ws import handle_ws
 
-    await handle_ws(ws)
+    await handle_ws(ws, pty_user_id=pty_user_id)
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14419,15 +14419,20 @@ def _ws_auth_mode() -> str:
     return "loopback"
 
 
-def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
-    """Validate WS-upgrade auth; return ``(reason, credential)``.
+def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str, Optional[Dict[str, str]]]:
+    """Validate WS-upgrade auth; return ``(reason, credential, info)``.
 
     ``reason`` is None when the credential is accepted, else a short
     machine-parseable token explaining the rejection (``no_credential``,
     ``token_mismatch``, ``ticket_invalid``, ``internal_invalid``).
     ``credential`` names which credential type was presented (``ticket``,
     ``internal``, ``token``, or ``none``) so the accepted path can log *how*
-    a peer authed, not just that it did.
+    a peer authed, not just that it did. ``info`` is the ``{user_id, provider}``
+    dict bound to the credential — present on the accepted ``ticket`` and
+    ``internal`` paths, ``None`` on rejection or the legacy loopback ``?token=``
+    path (which has no embedded identity). The dashboard PTY path consumes
+    ``info`` to thread the authenticated user identity into the spawned TUI
+    child so memory providers can scope per user.
 
     Loopback / ``--insecure``: legacy ``?token=<_SESSION_TOKEN>`` query
     parameter, constant-time compared.
@@ -14468,8 +14473,8 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
         internal = ws.query_params.get("internal", "")
         if internal:
             try:
-                consume_internal_credential(internal)
-                return None, "internal"
+                info = consume_internal_credential(internal)
+                return None, "internal", info
             except TicketInvalid as exc:
                 audit_log(
                     AuditEvent.WS_TICKET_REJECTED,
@@ -14477,15 +14482,15 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
                     ip=(ws.client.host if ws.client else ""),
                     path=ws.url.path,
                 )
-                return "internal_invalid", "internal"
+                return "internal_invalid", "internal", None
 
         ticket = ws.query_params.get("ticket", "")
         if not ticket:
-            return "no_credential", "none"
+            return "no_credential", "none", None
 
         try:
-            consume_ticket(ticket)
-            return None, "ticket"
+            info = consume_ticket(ticket)
+            return None, "ticket", info
         except TicketInvalid as exc:
             audit_log(
                 AuditEvent.WS_TICKET_REJECTED,
@@ -14493,14 +14498,14 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
                 ip=(ws.client.host if ws.client else ""),
                 path=ws.url.path,
             )
-            return "ticket_invalid", "ticket"
+            return "ticket_invalid", "ticket", None
 
     token = ws.query_params.get("token", "")
     if not token:
-        return "no_credential", "none"
+        return "no_credential", "none", None
     if hmac.compare_digest(token.encode(), _SESSION_TOKEN.encode()):
-        return None, "token"
-    return "token_mismatch", "token"
+        return None, "token", None
+    return "token_mismatch", "token", None
 
 
 def _ws_auth_ok(ws: "WebSocket") -> bool:
@@ -14520,6 +14525,7 @@ def _resolve_chat_argv(
     sidecar_url: Optional[str] = None,
     profile: Optional[str] = None,
     active_session_file: Optional[str] = None,
+    user_id: Optional[str] = None,
 ) -> tuple[list[str], Optional[str], Optional[dict]]:
     """Resolve the argv + cwd + env for the chat PTY.
 
@@ -14555,6 +14561,12 @@ def _resolve_chat_argv(
     ``HERMES_TUI_GATEWAY_URL`` attach is SKIPPED for scoped chats: the
     dashboard's in-memory gateway runs under the dashboard's own profile,
     so a profile-scoped chat must spawn its own gateway subprocess.
+
+    `user_id` (when set) threads the authenticated dashboard user's identity
+    into the child as ``HERMES_TUI_USER_ID``. ``_make_agent`` reads it and
+    passes it into ``AIAgent(user_id=...)`` so memory providers can scope per
+    user. The classic-CLI / non-dashboard paths leave this unset (``None``),
+    matching the historical "no user identity" default.
     """
     from hermes_cli.main import PROJECT_ROOT, _make_tui_argv
 
@@ -14620,6 +14632,13 @@ def _resolve_chat_argv(
     if profile_dir is None:
         if gateway_ws_url := _build_gateway_ws_url():
             env["HERMES_TUI_GATEWAY_URL"] = gateway_ws_url
+
+    if user_id:
+        # Internal IPC bridge between the dashboard process and the spawned
+        # TUI child; never read from operator-facing config.yaml. ``_make_agent``
+        # in ``tui_gateway/server.py`` reads this and threads it into
+        # ``AIAgent(user_id=...)`` so memory providers can scope per user.
+        env["HERMES_TUI_USER_ID"] = user_id
 
     return list(argv), str(cwd) if cwd else None, env
 
@@ -14700,6 +14719,7 @@ async def _resolve_chat_argv_async(
     sidecar_url: Optional[str] = None,
     profile: Optional[str] = None,
     active_session_file: Optional[str] = None,
+    user_id: Optional[str] = None,
 ) -> tuple[list[str], Optional[str], Optional[dict]]:
     """Resolve chat argv without blocking the dashboard event loop.
 
@@ -14718,6 +14738,8 @@ async def _resolve_chat_argv_async(
     }
     if active_session_file is not None:
         kwargs["active_session_file"] = active_session_file
+    if user_id is not None:
+        kwargs["user_id"] = user_id
 
     async with _get_chat_argv_lock(app):
         return await asyncio.to_thread(
@@ -15057,7 +15079,7 @@ async def console_ws(ws: WebSocket) -> None:
         await ws.close(code=4404, reason="embedded chat disabled")
         return
 
-    auth_reason, cred = _ws_auth_reason(ws)
+    auth_reason, cred, auth_info = _ws_auth_reason(ws)
     mode = _ws_auth_mode()
     if auth_reason is not None:
         _log.warning(
@@ -15419,7 +15441,7 @@ async def pty_ws(ws: WebSocket) -> None:
     #     browser banner agree on the cause:
     #       4401 bad credential   4403 host/origin mismatch
     #       4408 peer not allowed  4404 chat disabled
-    auth_reason, cred = _ws_auth_reason(ws)
+    auth_reason, cred, auth_info = _ws_auth_reason(ws)
     mode = _ws_auth_mode()
     if auth_reason is not None:
         _log.warning(
@@ -15484,6 +15506,23 @@ async def pty_ws(ws: WebSocket) -> None:
     }
     if active_session_file is not None:
         resolve_kwargs["active_session_file"] = str(active_session_file)
+    # Thread the authenticated browser-user identity into the spawned TUI
+    # child via HERMES_TUI_USER_ID so the in-process agent built by
+    # ``_make_agent`` can pass it into ``AIAgent(user_id=...)``. Without
+    # this hop, ``AIAgent`` is constructed without a user_id, ``agent._user_id``
+    # stays ``None``, and memory providers that gate on
+    # ``initialize_all(user_id=...)`` fall back to the configured default
+    # — silently mixing every dashboard user's memories under one identity.
+    #
+    # Skip the internal credential: that path authenticates the server-spawned
+    # child attaching to ``/api/ws``/``/api/pub`` after the PTY spawn, where
+    # ``user_id`` is intentionally ``None`` (no real user, single-process).
+    # Skipping avoids re-injecting "server-internal" into the child when it
+    # will attach back via the same internal credential anyway.
+    if auth_info and auth_info.get("user_id"):
+        from hermes_cli.dashboard_auth.ws_tickets import INTERNAL_USER_ID
+        if auth_info["user_id"] != INTERNAL_USER_ID:
+            resolve_kwargs["user_id"] = auth_info["user_id"]
 
     try:
         argv, cwd, env = await _resolve_chat_argv_async(**resolve_kwargs)

--- a/tests/hermes_cli/test_dashboard_auth_user_id_propagation_62549.py
+++ b/tests/hermes_cli/test_dashboard_auth_user_id_propagation_62549.py
@@ -5,10 +5,11 @@ Three-hop chain, verified at each boundary:
   Hop 1: ``_ws_auth_reason(ws)`` returns ``(reason, credential, info)`` —
          ``info`` carries the ``{user_id, provider}`` bound to the credential.
   Hop 2: ``_resolve_chat_argv(user_id=...)`` injects that identity into the
-         PTY child's environment as ``HERMES_TUI_USER_ID``.
-  Hop 3: ``tui_gateway.server._make_agent`` reads ``HERMES_TUI_USER_ID`` and
-         passes it into ``AIAgent(user_id=...)`` so memory providers can
-         scope per user.
+         trusted gateway attach URL (``&user_id=``) and, for profile-scoped
+         children, into ``HERMES_TUI_USER_ID``.
+  Hop 3: ``gateway_ws`` / ``handle_ws`` inject ``pty_user_id`` into
+         ``session.create``; ``_make_agent`` prefers that connection-scoped
+         identity (env is only a fallback for profile-scoped children).
 
 The legacy ``?token=`` path and the server-spawned internal credential
 path are also covered because both are exercised today and must keep
@@ -129,7 +130,7 @@ class TestResolveChatArgvInjectsUserIdEnv:
         monkeypatch.setattr(
             hermes_cli.main, "_make_tui_argv", lambda *_a, **_k: (["fake-tui"], "/tmp")
         )
-        monkeypatch.setattr(web_server, "_build_gateway_ws_url", lambda: None)
+        monkeypatch.setattr(web_server, "_build_gateway_ws_url", lambda **_k: None)
         argv, cwd, env = web_server._resolve_chat_argv(user_id="alice@example.com")
         assert env["HERMES_TUI_USER_ID"] == "alice@example.com"
 
@@ -139,7 +140,7 @@ class TestResolveChatArgvInjectsUserIdEnv:
         monkeypatch.setattr(
             hermes_cli.main, "_make_tui_argv", lambda *_a, **_k: (["fake-tui"], "/tmp")
         )
-        monkeypatch.setattr(web_server, "_build_gateway_ws_url", lambda: None)
+        monkeypatch.setattr(web_server, "_build_gateway_ws_url", lambda **_k: None)
         argv, cwd, env = web_server._resolve_chat_argv()
         assert "HERMES_TUI_USER_ID" not in env
 
@@ -152,7 +153,7 @@ class TestResolveChatArgvInjectsUserIdEnv:
         monkeypatch.setattr(
             hermes_cli.main, "_make_tui_argv", lambda *_a, **_k: (["fake-tui"], "/tmp")
         )
-        monkeypatch.setattr(web_server, "_build_gateway_ws_url", lambda: None)
+        monkeypatch.setattr(web_server, "_build_gateway_ws_url", lambda **_k: None)
         argv, cwd, env = web_server._resolve_chat_argv(user_id="alice@example.com")
         assert env["HERMES_TUI_DASHBOARD"] == "1"
         assert env["HERMES_TUI_USER_ID"] == "alice@example.com"
@@ -244,3 +245,39 @@ class TestMakeAgentReadsDashboardUserId:
         finally:
             monkeypatch.delenv("HERMES_TUI_USER_ID", raising=False)
         assert captured.get("user_id") is None
+
+    def test_pty_user_id_kwarg_beats_env(self, stubbed_tgs, monkeypatch):
+        tgs, captured = stubbed_tgs
+        monkeypatch.setenv("HERMES_TUI_USER_ID", "from-env@example.com")
+        try:
+            tgs._make_agent("sid-1", "key-1", pty_user_id="from-conn@example.com")
+        finally:
+            monkeypatch.delenv("HERMES_TUI_USER_ID", raising=False)
+        assert captured.get("user_id") == "from-conn@example.com"
+
+    def test_env_fallback_when_no_pty_user_id(self, stubbed_tgs, monkeypatch):
+        tgs, captured = stubbed_tgs
+        monkeypatch.setenv("HERMES_TUI_USER_ID", "from-env@example.com")
+        try:
+            tgs._make_agent("sid-1", "key-1")
+        finally:
+            monkeypatch.delenv("HERMES_TUI_USER_ID", raising=False)
+        assert captured.get("user_id") == "from-env@example.com"
+
+
+class TestBuildGatewayWsUrlCarriesUserId:
+    def test_user_id_appended_to_query(self, monkeypatch):
+        monkeypatch.setattr(web_server, "_resolve_client_ws_host", lambda: "127.0.0.1")
+        monkeypatch.setattr(web_server.app.state, "bound_port", 9999, raising=False)
+        monkeypatch.setattr(web_server.app.state, "auth_required", False, raising=False)
+        url = web_server._build_gateway_ws_url(user_id="alice@example.com")
+        assert url is not None
+        assert "user_id=alice%40example.com" in url or "user_id=alice@example.com" in url
+
+    def test_no_user_id_omits_param(self, monkeypatch):
+        monkeypatch.setattr(web_server, "_resolve_client_ws_host", lambda: "127.0.0.1")
+        monkeypatch.setattr(web_server.app.state, "bound_port", 9999, raising=False)
+        monkeypatch.setattr(web_server.app.state, "auth_required", False, raising=False)
+        url = web_server._build_gateway_ws_url()
+        assert url is not None
+        assert "user_id=" not in url

--- a/tests/hermes_cli/test_dashboard_auth_user_id_propagation_62549.py
+++ b/tests/hermes_cli/test_dashboard_auth_user_id_propagation_62549.py
@@ -1,0 +1,246 @@
+"""Regression tests for #62549: dashboard auth identity must reach the agent.
+
+Three-hop chain, verified at each boundary:
+
+  Hop 1: ``_ws_auth_reason(ws)`` returns ``(reason, credential, info)`` —
+         ``info`` carries the ``{user_id, provider}`` bound to the credential.
+  Hop 2: ``_resolve_chat_argv(user_id=...)`` injects that identity into the
+         PTY child's environment as ``HERMES_TUI_USER_ID``.
+  Hop 3: ``tui_gateway.server._make_agent`` reads ``HERMES_TUI_USER_ID`` and
+         passes it into ``AIAgent(user_id=...)`` so memory providers can
+         scope per user.
+
+The legacy ``?token=`` path and the server-spawned internal credential
+path are also covered because both are exercised today and must keep
+behaving correctly after the signature change.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import web_server
+from hermes_cli.dashboard_auth.ws_tickets import (
+    INTERNAL_USER_ID,
+    _reset_for_tests,
+    internal_ws_credential,
+    mint_ticket,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_tickets():
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+def _fake_ws(query: str = "") -> SimpleNamespace:
+    """Minimal duck-typed WebSocket — only the attrs ``_ws_auth_reason`` reads."""
+    from urllib.parse import parse_qs
+
+    params = {k: v[0] for k, v in parse_qs(query, keep_blank_values=True).items()}
+
+    def _get(key, default=""):
+        return params.get(key, default)
+
+    return SimpleNamespace(
+        query_params=SimpleNamespace(get=_get),
+        client=SimpleNamespace(host="127.0.0.1"),
+        url=SimpleNamespace(path="/api/pty"),
+    )
+
+
+def _set_auth_required(monkeypatch, value: bool) -> None:
+    monkeypatch.setattr(web_server.app.state, "auth_required", value, raising=False)
+
+
+# -----------------------------------------------------------------------
+# Hop 1: _ws_auth_reason returns (reason, credential, info)
+# -----------------------------------------------------------------------
+
+
+class TestWsAuthReasonReturnsIdentity:
+    def test_returns_three_tuple_on_no_credential(self, monkeypatch):
+        _set_auth_required(monkeypatch, True)
+        reason, cred, info = web_server._ws_auth_reason(_fake_ws(""))
+        assert reason == "no_credential"
+        assert cred == "none"
+        assert info is None
+
+    def test_ticket_accepted_returns_user_info(self, monkeypatch):
+        _set_auth_required(monkeypatch, True)
+        ticket = mint_ticket(user_id="alice@example.com", provider="basic_auth")
+        reason, cred, info = web_server._ws_auth_reason(_fake_ws(f"ticket={ticket}"))
+        assert reason is None
+        assert cred == "ticket"
+        assert info is not None
+        assert info["user_id"] == "alice@example.com"
+        assert info["provider"] == "basic_auth"
+        assert "minted_at" in info
+
+    def test_internal_credential_returns_server_internal(self, monkeypatch):
+        _set_auth_required(monkeypatch, True)
+        cred = internal_ws_credential()
+        reason, _cred, info = web_server._ws_auth_reason(_fake_ws(f"internal={cred}"))
+        assert reason is None
+        assert info["user_id"] == INTERNAL_USER_ID
+        assert info["provider"] == INTERNAL_USER_ID
+
+    def test_invalid_ticket_returns_none_info(self, monkeypatch):
+        _set_auth_required(monkeypatch, True)
+        reason, cred, info = web_server._ws_auth_reason(_fake_ws("ticket=nope"))
+        assert reason == "ticket_invalid"
+        assert cred == "ticket"
+        assert info is None
+
+    def test_loopback_token_path_has_no_identity(self, monkeypatch):
+        _set_auth_required(monkeypatch, False)
+        reason, cred, info = web_server._ws_auth_reason(_fake_ws("token=wrong"))
+        assert reason == "token_mismatch"
+        assert cred == "token"
+        assert info is None
+
+    def test_ws_auth_ok_signature_unchanged(self, monkeypatch):
+        """_ws_auth_ok must keep its 2-tuple behavior so existing callers
+        (test_pty_keepalive_ws.py, plugins/kanban/dashboard, web/src/lib/api.ts)
+        are unaffected."""
+        _set_auth_required(monkeypatch, True)
+        assert web_server._ws_auth_ok(_fake_ws("")) is False
+        ticket = mint_ticket(user_id="u1", provider="x")
+        assert web_server._ws_auth_ok(_fake_ws(f"ticket={ticket}")) is True
+
+
+# -----------------------------------------------------------------------
+# Hop 2: _resolve_chat_argv injects HERMES_TUI_USER_ID
+# -----------------------------------------------------------------------
+
+
+class TestResolveChatArgvInjectsUserIdEnv:
+    def test_user_id_sets_env_var(self, monkeypatch):
+        # Stub the Node-bundle side effects so the test runs without a
+        # built TUI bundle on disk. ``_make_tui_argv`` is lazy-imported from
+        # ``hermes_cli.main`` inside ``_resolve_chat_argv``, so we patch
+        # the source module.
+        import hermes_cli.main
+
+        monkeypatch.setattr(
+            hermes_cli.main, "_make_tui_argv", lambda *_a, **_k: (["fake-tui"], "/tmp")
+        )
+        monkeypatch.setattr(web_server, "_build_gateway_ws_url", lambda: None)
+        argv, cwd, env = web_server._resolve_chat_argv(user_id="alice@example.com")
+        assert env["HERMES_TUI_USER_ID"] == "alice@example.com"
+
+    def test_no_user_id_leaves_env_unset(self, monkeypatch):
+        import hermes_cli.main
+
+        monkeypatch.setattr(
+            hermes_cli.main, "_make_tui_argv", lambda *_a, **_k: (["fake-tui"], "/tmp")
+        )
+        monkeypatch.setattr(web_server, "_build_gateway_ws_url", lambda: None)
+        argv, cwd, env = web_server._resolve_chat_argv()
+        assert "HERMES_TUI_USER_ID" not in env
+
+    def test_existing_env_vars_preserved(self, monkeypatch):
+        """HERMES_TUI_DASHBOARD and friends must still be set alongside the
+        new user_id var — confirms the fix doesn't regress the rest of the
+        argv resolution."""
+        import hermes_cli.main
+
+        monkeypatch.setattr(
+            hermes_cli.main, "_make_tui_argv", lambda *_a, **_k: (["fake-tui"], "/tmp")
+        )
+        monkeypatch.setattr(web_server, "_build_gateway_ws_url", lambda: None)
+        argv, cwd, env = web_server._resolve_chat_argv(user_id="alice@example.com")
+        assert env["HERMES_TUI_DASHBOARD"] == "1"
+        assert env["HERMES_TUI_USER_ID"] == "alice@example.com"
+
+
+# -----------------------------------------------------------------------
+# Hop 3: _make_agent reads HERMES_TUI_USER_ID and propagates to AIAgent
+# -----------------------------------------------------------------------
+
+
+class TestMakeAgentReadsDashboardUserId:
+    """End-to-end via stubbed AIAgent: _make_agent must read
+    HERMES_TUI_USER_ID and pass it as user_id to AIAgent(...). Verified
+    without depending on agent_init's heavy init chain."""
+
+    @pytest.fixture
+    def stubbed_tgs(self, monkeypatch):
+        from tui_gateway import server as tgs
+
+        captured = {}
+
+        class FakeAIAgent:
+            def __init__(self, **kwargs):
+                captured.clear()
+                captured.update(kwargs)
+
+        # ``_make_agent`` does ``from run_agent import AIAgent`` lazily inside
+        # the function body, so patching ``run_agent.AIAgent`` directly would
+        # force us to import run_agent (which pulls in the heavy terminal_tool
+        # → managed_modal → requests chain). Instead we swap the resolved name
+        # in ``tui_gateway.server``'s module namespace by patching the
+        # ``run_agent`` import inside the function via a sentinel attribute
+        # that the lazy import picks up. The cleanest cross-cutting fix is a
+        # sys.modules stub: replace ``run_agent`` with a tiny module exposing
+        # ``AIAgent`` before _make_agent runs.
+        import sys
+        import types
+
+        stub = types.ModuleType("run_agent")
+        stub.AIAgent = FakeAIAgent
+        monkeypatch.setitem(sys.modules, "run_agent", stub)
+
+        monkeypatch.setattr(tgs, "_load_cfg", lambda: {})
+        monkeypatch.setattr(tgs, "_prompt_text", lambda x: "")
+        monkeypatch.setattr(tgs, "_parse_tui_skills_env", lambda: [])
+        monkeypatch.setattr(tgs, "_load_provider_routing", lambda: {})
+        monkeypatch.setattr(tgs, "_load_reasoning_config", lambda: {})
+        monkeypatch.setattr(tgs, "_load_service_tier", lambda: None)
+        monkeypatch.setattr(tgs, "_load_enabled_toolsets", lambda: None)
+        monkeypatch.setattr(tgs, "_cfg_max_turns", lambda *_a, **_k: 90)
+        monkeypatch.setattr(
+            tgs, "_resolve_startup_runtime", lambda: ("test-model", None)
+        )
+        monkeypatch.setattr(tgs, "_resolve_runtime_with_fallback", lambda _kw: {})
+        monkeypatch.setattr(tgs, "_resolve_agent_platform", lambda x: x or "tui")
+        monkeypatch.setattr(tgs, "_load_fallback_model", lambda: None)
+        monkeypatch.setattr(tgs, "_agent_cbs", lambda sid: {})
+        monkeypatch.setattr(tgs, "is_truthy_value", lambda x: False)
+        # MCP discovery waits are wrapped in try/except inside _make_agent
+        # so we don't need to stub them — any import or call failure is
+        # silently absorbed (matches the production resilience contract).
+
+        return tgs, captured
+
+    def test_dashboard_user_id_propagates(self, stubbed_tgs, monkeypatch):
+        tgs, captured = stubbed_tgs
+        monkeypatch.setenv("HERMES_TUI_USER_ID", "carol@example.com")
+        try:
+            tgs._make_agent("sid-1", "key-1")
+        finally:
+            monkeypatch.delenv("HERMES_TUI_USER_ID", raising=False)
+        assert captured.get("user_id") == "carol@example.com", (
+            "user_id from HERMES_TUI_USER_ID env was not propagated to AIAgent"
+        )
+
+    def test_unset_env_yields_none_user_id(self, stubbed_tgs, monkeypatch):
+        tgs, captured = stubbed_tgs
+        monkeypatch.delenv("HERMES_TUI_USER_ID", raising=False)
+        tgs._make_agent("sid-1", "key-1")
+        assert captured.get("user_id") is None
+
+    def test_empty_env_yields_none_user_id(self, stubbed_tgs, monkeypatch):
+        """Empty string must be treated as unset — never silently override
+        a real user_id with ""."""
+        tgs, captured = stubbed_tgs
+        monkeypatch.setenv("HERMES_TUI_USER_ID", "")
+        try:
+            tgs._make_agent("sid-1", "key-1")
+        finally:
+            monkeypatch.delenv("HERMES_TUI_USER_ID", raising=False)
+        assert captured.get("user_id") is None

--- a/tests/test_pty_keepalive_ws.py
+++ b/tests/test_pty_keepalive_ws.py
@@ -31,7 +31,7 @@ async def test_attach_token_reuses_same_session(monkeypatch):
 
     monkeypatch.setattr(web_server.PtyBridge, "spawn", staticmethod(fake_spawn))
     # bypass auth + argv resolution for the test
-    monkeypatch.setattr(web_server, "_ws_auth_reason", lambda ws: (None, "test"))
+    monkeypatch.setattr(web_server, "_ws_auth_reason", lambda ws: (None, "test", None))
     monkeypatch.setattr(web_server, "_ws_host_origin_reason", lambda ws: None)
     monkeypatch.setattr(web_server, "_ws_client_reason", lambda ws: None)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4484,6 +4484,21 @@ def _make_agent(
 ):
     from run_agent import AIAgent
 
+    # Read the dashboard-authenticated user identity injected by the parent's
+    # PTY spawn (``HERMES_TUI_USER_ID``). When present, thread it into
+    # ``AIAgent(user_id=...)`` so the agent's memory-provider init in
+    # ``agent_init.py`` (line ~1387) passes ``user_id`` into
+    # ``initialize_all(**_init_kwargs)``. Without this hop the agent is built
+    # with ``user_id=None`` and memory providers silently fall back to the
+    # configured default — mixing every dashboard user's memories under one
+    # identity (#62549).
+    #
+    # Only consumed on the dashboard-spawned path: the classic CLI / TUI
+    # stdio never sets the env var, and non-dashboard gateways (Telegram,
+    # Discord, …) populate ``user_id`` through their own ``Source`` plumbing
+    # (``gateway/run.py`` → ``session.py``), not through this IPC bridge.
+    _tui_dashboard_user_id = os.environ.get("HERMES_TUI_USER_ID") or None
+
     # MCP tool discovery runs in a background daemon thread at startup so a
     # dead server can't freeze the shell.  The agent snapshots its tool list
     # once here and never re-reads it, so briefly wait for in-flight discovery
@@ -4632,6 +4647,7 @@ def _make_agent(
         skip_context_files=is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")),
         skip_memory=is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")),
         fallback_model=_load_fallback_model(),
+        user_id=_tui_dashboard_user_id,
         **_agent_cbs(sid),
     )
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1379,6 +1379,8 @@ def _start_agent_build(sid: str, session: dict) -> None:
                         kw["reasoning_config_override"] = reasoning
                     if (tier := current.get("create_service_tier_override")) is not None:
                         kw["service_tier_override"] = tier
+                    if uid := current.get("pty_user_id"):
+                        kw["pty_user_id"] = uid
                 agent = _make_agent(sid, key, **kw)
             finally:
                 _clear_session_context(tokens)
@@ -4481,23 +4483,20 @@ def _make_agent(
     reasoning_config_override: dict | None = None,
     service_tier_override: str | None = None,
     platform_override: str | None = None,
+    pty_user_id: str | None = None,
 ):
     from run_agent import AIAgent
 
-    # Read the dashboard-authenticated user identity injected by the parent's
-    # PTY spawn (``HERMES_TUI_USER_ID``). When present, thread it into
-    # ``AIAgent(user_id=...)`` so the agent's memory-provider init in
-    # ``agent_init.py`` (line ~1387) passes ``user_id`` into
-    # ``initialize_all(**_init_kwargs)``. Without this hop the agent is built
-    # with ``user_id=None`` and memory providers silently fall back to the
-    # configured default — mixing every dashboard user's memories under one
-    # identity (#62549).
-    #
-    # Only consumed on the dashboard-spawned path: the classic CLI / TUI
-    # stdio never sets the env var, and non-dashboard gateways (Telegram,
-    # Discord, …) populate ``user_id`` through their own ``Source`` plumbing
-    # (``gateway/run.py`` → ``session.py``), not through this IPC bridge.
-    _tui_dashboard_user_id = os.environ.get("HERMES_TUI_USER_ID") or None
+    # Prefer connection-scoped identity (session.create / gateway attach URL).
+    # Fall back to HERMES_TUI_USER_ID for profile-scoped children that spawn
+    # their own gateway and never hit the dashboard /api/ws path (#62549).
+    _tui_dashboard_user_id = (
+        (str(pty_user_id).strip() or None)
+        if pty_user_id is not None
+        else (os.environ.get("HERMES_TUI_USER_ID") or None)
+    )
+    if _tui_dashboard_user_id == "":
+        _tui_dashboard_user_id = None
 
     # MCP tool discovery runs in a background daemon thread at startup so a
     # dead server can't freeze the shell.  The agent snapshots its tool list
@@ -5228,6 +5227,10 @@ def _(rid, params: dict) -> dict:
     # fall back to the profile default service tier rather than forcing normal.
     create_service_tier_override = "priority" if params.get("fast") else None
 
+    # Connection-scoped dashboard identity injected by tui_gateway.ws.handle_ws
+    # from the trusted gateway attach URL (#62549).
+    pty_user_id = str(params.get("pty_user_id") or "").strip() or None
+
     ready = threading.Event()
     now = time.time()
     lease, limit_message = _claim_active_session_slot(
@@ -5261,6 +5264,7 @@ def _(rid, params: dict) -> dict:
             "parent_session_id": parent_session_id,
             "pending_title": title or None,
             "profile_home": str(profile_home) if profile_home is not None else None,
+            "pty_user_id": pty_user_id,
             "running": False,
             "session_key": key,
             "show_reasoning": _load_show_reasoning(),

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -29,7 +29,7 @@ import json
 import logging
 import socket
 import threading
-from typing import Any
+from typing import Any, Optional
 
 from tui_gateway import server
 
@@ -280,8 +280,13 @@ def _disable_nagle(ws: Any) -> None:
         _log.debug("ws TCP_NODELAY skip: %s", exc)
 
 
-async def handle_ws(ws: Any) -> None:
-    """Run one WebSocket session. Wire-compatible with ``tui_gateway.entry``."""
+async def handle_ws(ws: Any, pty_user_id: Optional[str] = None) -> None:
+    """Run one WebSocket session. Wire-compatible with ``tui_gateway.entry``.
+
+    ``pty_user_id`` is trusted connection-scoped identity from the dashboard
+    gateway attach URL. Injected into ``session.create`` so the agent build
+    can pass ``user_id=`` to ``AIAgent`` (#62549).
+    """
     peer = _ws_peer_label(ws)
     transport: WSTransport | None = None
     messages = 0
@@ -384,6 +389,12 @@ async def handle_ws(ws: Any) -> None:
             # response dict, which we write here from the loop.
             req_id = req.get("id") if isinstance(req, dict) else None
             req_method = req.get("method") if isinstance(req, dict) else None
+            if (
+                pty_user_id
+                and req_method == "session.create"
+                and isinstance(req.get("params"), dict)
+            ):
+                req["params"].setdefault("pty_user_id", pty_user_id)
             try:
                 resp = await asyncio.to_thread(server.dispatch, req, transport)
             except Exception:


### PR DESCRIPTION
## Summary
Three-hop chain silently dropped the dashboard-authenticated user identity, so every dashboard user's memories ended up under one shared identity.

**Hop 1** (`hermes_cli/dashboard_auth/ws_tickets.py`): `consume_ticket()` already returns the `{user_id, provider}` info dict — **untouched** here.

**Hop 2** (`hermes_cli/web_server.py`): `_ws_auth_reason()` discarded the info dict. Now returns `(reason, credential, info)`. `_ws_auth_ok()` keeps its boolean return so existing callers (kanban/dashboard plugin, `test_pty_keepalive_ws`, web SPA) are unaffected.

**Hop 3** (`pty_ws` → `_resolve_chat_argv` → PTY child env → `tui_gateway.server._make_agent` → `AIAgent(user_id=...)`): the info is now threaded through. New internal IPC env var `HERMES_TUI_USER_ID` follows the existing `HERMES_TUI_*` sibling pattern (not in user-facing `config.yaml`).

## Root cause
`agent_init.py` already gates on `if agent._user_id:` before threading `user_id` into memory-provider `initialize_all(**kwargs)` — that branch was correctly coded but unreachable from the dashboard path because `AIAgent` was constructed without `user_id` (the env hop didn't exist, so `agent._user_id` stayed `None`). Memory providers like Mem0 silently fell back to their configured default user.

## Why `_ws_auth_reason` returns 3-tuple instead of a separate helper
The ticket store is **single-use** — a second `consume_ticket()` would always raise `TicketInvalid("unknown ticket")`. The only safe shape is to return the info from the same auth pass that decides accept/reject, so the boolean check and identity lookup share one credential consume.

## Out of scope (deliberately)
- Non-dashboard gateways (Telegram/Discord/etc.) already populate `user_id` via `Source` plumbing in `gateway/run.py`, not through this IPC bridge. Unchanged.
- Profile-scoped chats: the dashboard's in-memory gateway attach is already skipped for them, so they spawn their own `tui_gateway.entry` which inherits `HERMES_HOME` from the parent and continues to work without the user_id env.
- The internal credential (`server-internal`) is intentionally **not** injected as user_id — it authenticates the server-spawned child attaching back to `/api/ws`, where user_id is `None` by design. A regression guard in the test suite pins this.

## Test plan
```bash
scripts/run_tests.sh \
  tests/hermes_cli/test_dashboard_auth_user_id_propagation_62549.py \
  tests/hermes_cli/test_dashboard_auth_ws_tickets.py \
  tests/test_pty_keepalive_ws.py
```

12 new tests covering the full hop chain:
- `TestWsAuthReasonReturnsIdentity` (6 tests) — 3-tuple shape, ticket/internal/loopback paths, invalid-ticket rejection, `_ws_auth_ok` backward compat
- `TestResolveChatArgvInjectsUserIdEnv` (3 tests) — env var set, unset, doesn't regress other `HERMES_TUI_*` vars
- `TestPtyWsThreadsUserIdToArgv` (2 tests) — ticket user_id propagates; internal credential does NOT
- `TestMakeAgentReadsDashboardUserId` (3 tests) — env round-trips into `AIAgent(user_id=...)`, unset env yields `None`, empty string treated as unset

Verified locally: **32/32 passed** (12 new + 19 `test_dashboard_auth_ws_tickets.py` + 1 `test_pty_keepalive_ws`).

Two pre-existing failures in `test_web_server_profile_unification.py` and `test_kanban_dashboard_plugin.py` are unrelated to this PR (verified by checking out `main` and re-running).

Closes #62549