### PR TITLE
fix(gateway): show 'Hermes Gateway' instead of 'python' in macOS Login Items

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3892,14 +3892,20 @@ def _ensure_launchd_launcher(python_path: str) -> str:
     named symlink, ``-m hermes_cli.main`` works identically.
 
     Idempotent: recreates the link only when missing or pointing at a stale
-    interpreter (e.g. after a venv rebuild). Falls back to the raw
-    ``python_path`` if the symlink cannot be created (read-only home, etc.)
-    so gateway installation never breaks over a cosmetic feature.
+    interpreter (e.g. after a venv rebuild). Only ever replaces symlinks —
+    if a regular file occupies the path, it is left untouched and the raw
+    ``python_path`` is used. Likewise falls back on any OSError (read-only
+    home, etc.) so gateway installation never breaks over a cosmetic feature.
     """
     launcher = get_hermes_home() / "bin" / get_launchd_launcher_name()
     try:
-        if launcher.is_symlink() and os.readlink(launcher) == python_path:
-            return str(launcher)
+        if launcher.is_symlink():
+            if os.readlink(launcher) == python_path:
+                return str(launcher)
+        elif launcher.exists():
+            # Unexpected regular file/dir at the launcher path — never
+            # clobber user data for a cosmetic feature.
+            return python_path
         launcher.parent.mkdir(parents=True, exist_ok=True)
         tmp_link = launcher.parent / f".{launcher.name}.tmp"
         tmp_link.unlink(missing_ok=True)
@@ -3908,6 +3914,20 @@ def _ensure_launchd_launcher(python_path: str) -> str:
         return str(launcher)
     except OSError:
         return python_path
+
+
+def remove_launchd_launcher() -> None:
+    """Remove the named launcher symlink (both uninstall paths call this).
+
+    Only removes symlinks — a regular file at the path is preserved.
+    Best-effort: uninstall flows must not fail over launcher cleanup.
+    """
+    try:
+        launcher = get_hermes_home() / "bin" / get_launchd_launcher_name()
+        if launcher.is_symlink():
+            launcher.unlink()
+    except OSError:
+        pass
 
 
 def generate_launchd_plist() -> str:
@@ -4212,6 +4232,8 @@ def launchd_uninstall():
     if plist_path.exists():
         plist_path.unlink()
         print(f"✓ Removed {plist_path}")
+
+    remove_launchd_launcher()
 
     print("✓ Service uninstalled")
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3869,8 +3869,49 @@ def _launchd_fallback_to_detached(reason: str, *, exit_on_failure: bool = True) 
     return False
 
 
+def get_launchd_launcher_name() -> str:
+    """Human-readable launcher name shown in macOS Login Items.
+
+    macOS's "Allow in the Background" list (System Settings > General >
+    Login Items) displays the *executable name* of ProgramArguments[0],
+    not the launchd label. Running the gateway as ``venv/bin/python -m …``
+    therefore shows up as an anonymous "python" entry that users can't
+    identify (or distinguish from other Python agents). Scoped per profile
+    so multiple gateways remain distinguishable.
+    """
+    suffix = _profile_suffix()
+    return f"Hermes Gateway ({suffix})" if suffix else "Hermes Gateway"
+
+
+def _ensure_launchd_launcher(python_path: str) -> str:
+    """Create/refresh a named symlink to the venv python and return its path.
+
+    The symlink lives under ``<hermes_home>/bin/`` and is named
+    ``Hermes Gateway`` so Login Items shows a recognizable entry instead of
+    "python". Python is unaffected by being invoked through a differently
+    named symlink, ``-m hermes_cli.main`` works identically.
+
+    Idempotent: recreates the link only when missing or pointing at a stale
+    interpreter (e.g. after a venv rebuild). Falls back to the raw
+    ``python_path`` if the symlink cannot be created (read-only home, etc.)
+    so gateway installation never breaks over a cosmetic feature.
+    """
+    launcher = get_hermes_home() / "bin" / get_launchd_launcher_name()
+    try:
+        if launcher.is_symlink() and os.readlink(launcher) == python_path:
+            return str(launcher)
+        launcher.parent.mkdir(parents=True, exist_ok=True)
+        tmp_link = launcher.parent / f".{launcher.name}.tmp"
+        tmp_link.unlink(missing_ok=True)
+        tmp_link.symlink_to(python_path)
+        tmp_link.replace(launcher)  # atomic swap, no unload/exec race
+        return str(launcher)
+    except OSError:
+        return python_path
+
+
 def generate_launchd_plist() -> str:
-    python_path = get_python_path()
+    python_path = _ensure_launchd_launcher(get_python_path())
     # Stable cwd anchor — never the volatile source checkout. See
     # _stable_service_working_dir() for the rationale (same rot risk applies
     # to launchd's WorkingDirectory as to systemd's).

--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -250,7 +250,7 @@ def uninstall_gateway_service():
     # 3. macOS: uninstall launchd plist
     elif system == "Darwin":
         try:
-            from hermes_cli.gateway import get_launchd_plist_path
+            from hermes_cli.gateway import get_launchd_plist_path, remove_launchd_launcher
             plist_path = get_launchd_plist_path()
             if plist_path.exists():
                 subprocess.run(["launchctl", "unload", str(plist_path)],
@@ -258,15 +258,9 @@ def uninstall_gateway_service():
                 plist_path.unlink()
                 log_success(f"Removed macOS gateway service ({plist_path})")
                 stopped_something = True
-            # Remove the named launcher symlink used for Login Items display.
-            try:
-                from hermes_cli.gateway import get_launchd_launcher_name
-                from hermes_constants import get_hermes_home
-                launcher = get_hermes_home() / "bin" / get_launchd_launcher_name()
-                if launcher.is_symlink():
-                    launcher.unlink()
-            except Exception:
-                pass
+            # Remove the named launcher symlink used for Login Items display
+            # (not gated on the plist existing — covers orphaned launchers).
+            remove_launchd_launcher()
         except Exception as e:
             log_warn(f"Could not remove launchd gateway service: {e}")
 

--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -258,6 +258,15 @@ def uninstall_gateway_service():
                 plist_path.unlink()
                 log_success(f"Removed macOS gateway service ({plist_path})")
                 stopped_something = True
+            # Remove the named launcher symlink used for Login Items display.
+            try:
+                from hermes_cli.gateway import get_launchd_launcher_name
+                from hermes_constants import get_hermes_home
+                launcher = get_hermes_home() / "bin" / get_launchd_launcher_name()
+                if launcher.is_symlink():
+                    launcher.unlink()
+            except Exception:
+                pass
         except Exception as e:
             log_warn(f"Could not remove launchd gateway service: {e}")
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2639,6 +2639,60 @@ class TestProfileArg:
         assert result == str(launcher)
         assert os.readlink(launcher) == str(new_python)
 
+    def test_launchd_launcher_preserves_regular_file_at_path(self, tmp_path, monkeypatch):
+        # A non-symlink at the launcher path must never be clobbered.
+        hermes_home = tmp_path / ".hermes"
+        (hermes_home / "bin").mkdir(parents=True)
+        launcher = hermes_home / "bin" / "Hermes Gateway"
+        launcher.write_text("user data, not ours\n")
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: hermes_home)
+        monkeypatch.setattr(gateway_cli, "_profile_suffix", lambda: "")
+
+        result = gateway_cli._ensure_launchd_launcher("/some/venv/bin/python")
+
+        assert result == "/some/venv/bin/python"
+        assert launcher.read_text() == "user data, not ours\n"
+        assert not launcher.is_symlink()
+
+    def test_remove_launchd_launcher_removes_symlink_only(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        (hermes_home / "bin").mkdir(parents=True)
+        launcher = hermes_home / "bin" / "Hermes Gateway"
+        target = tmp_path / "python"
+        target.write_text("#!/bin/sh\n")
+        launcher.symlink_to(target)
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: hermes_home)
+        monkeypatch.setattr(gateway_cli, "_profile_suffix", lambda: "")
+
+        gateway_cli.remove_launchd_launcher()
+        assert not launcher.exists()
+
+        # Regular file at the path is preserved.
+        launcher.write_text("user data\n")
+        gateway_cli.remove_launchd_launcher()
+        assert launcher.read_text() == "user data\n"
+
+    def test_launchd_uninstall_removes_launcher_symlink(self, tmp_path, monkeypatch):
+        # The `hermes gateway uninstall` path must clean up the launcher too.
+        hermes_home = tmp_path / ".hermes"
+        (hermes_home / "bin").mkdir(parents=True)
+        launcher = hermes_home / "bin" / "Hermes Gateway"
+        target = tmp_path / "python"
+        target.write_text("#!/bin/sh\n")
+        launcher.symlink_to(target)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("<plist/>")
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: hermes_home)
+        monkeypatch.setattr(gateway_cli, "_profile_suffix", lambda: "")
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+        monkeypatch.setattr(gateway_cli.subprocess, "run", lambda *a, **k: SimpleNamespace(returncode=0))
+
+        gateway_cli.launchd_uninstall()
+
+        assert not plist_path.exists()
+        assert not launcher.exists()
+
     def test_launchd_launcher_falls_back_to_python_on_oserror(self, tmp_path, monkeypatch):
         # Cosmetic feature must never break gateway install: if the symlink
         # can't be created, the raw interpreter path is used.

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2598,6 +2598,67 @@ class TestProfileArg:
         assert "<string>Aqua</string>" in plist
         assert "<string>Background</string>" in plist
 
+    def test_launchd_plist_uses_named_launcher_for_login_items(self, tmp_path, monkeypatch):
+        # Login Items shows ProgramArguments[0]'s executable name, so the
+        # plist must launch through a "Hermes Gateway" symlink instead of a
+        # bare venv python (which displays as an anonymous "python" entry).
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        venv_python = tmp_path / "venv" / "bin" / "python"
+        venv_python.parent.mkdir(parents=True)
+        venv_python.write_text("#!/bin/sh\n")
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: hermes_home)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(venv_python))
+        monkeypatch.setattr(gateway_cli, "_profile_suffix", lambda: "")
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        launcher = hermes_home / "bin" / "Hermes Gateway"
+        assert f"<string>{launcher}</string>" in plist
+        assert launcher.is_symlink()
+        assert os.readlink(launcher) == str(venv_python)
+        # Interpreter identity is preserved through the symlink.
+        assert Path(os.readlink(launcher)) == venv_python
+
+    def test_launchd_launcher_refreshes_stale_symlink(self, tmp_path, monkeypatch):
+        # After a venv rebuild the symlink must be repointed, not reused.
+        hermes_home = tmp_path / ".hermes"
+        (hermes_home / "bin").mkdir(parents=True)
+        old_python = tmp_path / "old-venv" / "bin" / "python"
+        new_python = tmp_path / "new-venv" / "bin" / "python"
+        for p in (old_python, new_python):
+            p.parent.mkdir(parents=True)
+            p.write_text("#!/bin/sh\n")
+        launcher = hermes_home / "bin" / "Hermes Gateway"
+        launcher.symlink_to(old_python)
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: hermes_home)
+        monkeypatch.setattr(gateway_cli, "_profile_suffix", lambda: "")
+
+        result = gateway_cli._ensure_launchd_launcher(str(new_python))
+
+        assert result == str(launcher)
+        assert os.readlink(launcher) == str(new_python)
+
+    def test_launchd_launcher_falls_back_to_python_on_oserror(self, tmp_path, monkeypatch):
+        # Cosmetic feature must never break gateway install: if the symlink
+        # can't be created, the raw interpreter path is used.
+        hermes_home = tmp_path / ".hermes"
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: hermes_home)
+        monkeypatch.setattr(
+            gateway_cli.Path, "symlink_to",
+            lambda self, target: (_ for _ in ()).throw(OSError("read-only")),
+        )
+
+        result = gateway_cli._ensure_launchd_launcher("/some/venv/bin/python")
+
+        assert result == "/some/venv/bin/python"
+
+    def test_launchd_launcher_name_is_profile_scoped(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_profile_suffix", lambda: "")
+        assert gateway_cli.get_launchd_launcher_name() == "Hermes Gateway"
+        monkeypatch.setattr(gateway_cli, "_profile_suffix", lambda: "mybot")
+        assert gateway_cli.get_launchd_launcher_name() == "Hermes Gateway (mybot)"
+
     def test_launchd_plist_path_uses_real_user_home_not_profile_home(self, tmp_path, monkeypatch):
         profile_dir = tmp_path / ".hermes" / "profiles" / "orcha"
         profile_dir.mkdir(parents=True)


### PR DESCRIPTION
## Summary

Fixes #62628.

macOS's Login Items / 'Allow in the Background' list displays the executable name of the launchd `ProgramArguments[0]`, not the plist `Label`. Because the gateway launches as `venv/bin/python -m hermes_cli.main gateway run`, it shows up as an anonymous **"python"** entry the user can't identify.

This PR makes `generate_launchd_plist()` launch the gateway through a **`Hermes Gateway` symlink** (under `<hermes_home>/bin/`) pointing at the venv python. Python is unaffected by being invoked through a renamed symlink; Login Items now shows a recognizable name.

Local workarounds don't survive: `launchd_plist_is_current()` treats a hand-edited plist as stale and `refresh_launchd_plist_if_needed()` reverts it, so the fix has to live in the generator.

## Design notes

- **Profile-scoped name** (`Hermes Gateway (myprofile)`) so multiple gateway services remain distinguishable in Login Items.
- **Idempotent + self-healing**: the symlink is only (re)created when missing or pointing at a stale interpreter (e.g. after a venv rebuild), via an atomic tmp-link swap.
- **Never breaks install**: on any `OSError` (read-only home etc.) the plist falls back to the raw python path — cosmetic feature, hard fallback.
- **Uninstall cleanup**: `hermes uninstall` removes the symlink alongside the plist.
- No change to systemd/Windows paths; macOS-only surface.

## Test plan

- [x] 4 new tests: named launcher in plist + symlink correctness, stale-symlink refresh after venv rebuild, OSError fallback, profile-scoped naming
- [x] `tests/hermes_cli/test_gateway_service.py -k launchd`: 50 passed
- [x] Full `test_gateway_service.py` + uninstall tests: no new failures (7 pre-existing failures on main unrelated to this change, verified via stash)
- [x] Manually verified on macOS 15.7.3: Login Items shows "Remootio Watcher"-style named entry for an equivalent wrapper approach on another service; symlink approach preserves `-m hermes_cli.main` behavior