### PR TITLE
fix(dashboard): pass --output to backup command

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11672,7 +11672,7 @@ async def run_backup(body: BackupRequest):
     args = ["backup"]
     archive: Optional[Path] = None
     if body.output:
-        args.append(body.output.strip())
+        args.extend(["--output", body.output.strip()])
     else:
         archive = _new_dashboard_backup_path()
         try:
@@ -11682,7 +11682,7 @@ async def run_backup(body: BackupRequest):
                 status_code=500,
                 detail=f"Could not create backup directory: {exc}",
             )
-        args.append(str(archive))
+        args.extend(["--output", str(archive)])
     try:
         proc = _spawn_hermes_action(args, "backup")
     except Exception as exc:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2230,7 +2230,7 @@ class TestWebServerEndpoints:
 
         assert data["name"] == "backup"
         assert captured["name"] == "backup"
-        assert captured["args"] == ["backup", str(archive)]
+        assert captured["args"] == ["backup", "--output", str(archive)]
         assert archive.parent == get_hermes_home() / "backups"
         assert archive.name.startswith("hermes-backup-")
         assert archive.suffix == ".zip"
@@ -2257,8 +2257,35 @@ class TestWebServerEndpoints:
         archive = Path(resp.json()["archive"])
 
         assert archive.parent == hosted_home / "backups"
-        assert captured["args"] == ["backup", str(archive)]
+        assert captured["args"] == ["backup", "--output", str(archive)]
         assert archive.parent.is_dir()
+
+    def test_ops_backup_passes_requested_archive_as_output_option(self, monkeypatch):
+        import hermes_cli.web_server as ws
+
+        captured = {}
+
+        def fake_spawn(subcommand, name):
+            captured["args"] = subcommand
+            captured["name"] = name
+            from types import SimpleNamespace as NS
+            return NS(pid=12345)
+
+        monkeypatch.setattr(ws, "_spawn_hermes_action", fake_spawn)
+
+        resp = self.client.post(
+            "/api/ops/backup",
+            json={"output": "/tmp/requested-backup.zip"},
+        )
+
+        assert resp.status_code == 200
+        assert captured["name"] == "backup"
+        assert captured["args"] == [
+            "backup",
+            "--output",
+            "/tmp/requested-backup.zip",
+        ]
+        assert "archive" not in resp.json()
 
     def test_ops_backup_download_streams_dashboard_backup(self, tmp_path):
         import hermes_cli.web_server as ws


### PR DESCRIPTION
## What does this PR do?

Fixes desktop and dashboard backup creation by passing generated and user-requested archive paths through the `hermes backup --output <path>` option.

The `/api/ops/backup` endpoint previously passed the archive path as a positional argument. The backup CLI parser only accepts an output path through `-o` / `--output`, so desktop maintenance backups failed with `unrecognized arguments: <archive>`. Keeping the existing endpoint flow and adding the required option is the narrowest fix and preserves the downloadable dashboard archive behavior.

## Related Issue

Fixes #62489

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `hermes_cli/web_server.py` to invoke backup actions with `--output` for both generated and explicitly requested archive paths.
- Updated the existing dashboard backup assertions to cover the CLI argument contract.
- Added regression coverage for an explicitly requested output path.

## How to Test

1. Open Desktop Settings → Maintenance and select **Create backup**.
2. Confirm the backup action completes and creates a ZIP archive instead of reporting an unrecognized positional argument.
3. Run the focused regression suites:

   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_web_server.py -k ops_backup -q
   scripts/run_tests.sh tests/hermes_cli/test_backup.py tests/hermes_cli/test_subcommands_batch.py -q
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no user-facing contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — argument-list construction is platform-neutral and the Windows footgun scan passes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Validation

- Focused backup API tests: 4 passed.
- Backup and subcommand parser suites: 175 passed.
- Ruff, Python compilation, `git diff --check`, and `scripts/check-windows-footguns.py`: passed.
- Manual smoke test with an isolated `HERMES_HOME`: `hermes backup --output <temp-path>` created a valid ZIP archive.
- A full-suite run was attempted after installing the missing dev test dependency. It reached more than 1,000 passing tests but encountered unrelated failures in LSP process cleanup and Anthropic credential-state tests; neither failing test file imports or exercises the changed backup endpoint.

## Screenshots / Logs

Not applicable; this fixes the command invocation behind the existing maintenance action.
