### PR TITLE
Fix hidden skill bundles and TUI execution

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -24,6 +24,7 @@ from agent.skill_utils import (
     extract_skill_description,
     get_all_skills_dirs,
     get_disabled_skill_names,
+    get_hidden_skill_names,
     iter_skill_index_files,
     parse_frontmatter,
     skill_matches_environment,
@@ -1477,7 +1478,10 @@ def build_skills_system_prompt(
     # Include the resolved platform so per-platform disabled-skill lists
     # produce distinct cache entries (gateway serves multiple platforms).
     _platform_hint = _current_session_platform_hint()
-    disabled = get_disabled_skill_names(_platform_hint or None)
+    disabled = (
+        get_disabled_skill_names(_platform_hint or None)
+        | get_hidden_skill_names(_platform_hint or None)
+    )
     cache_key = (
         str(skills_dir),
         tuple(str(d) for d in external_dirs),

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -328,8 +328,8 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     _skill_commands = {}
     try:
         from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
-        from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
-        disabled = _get_disabled_skill_names()
+        from agent.skill_utils import get_external_skills_dirs, get_hidden_skill_names, iter_skill_index_files
+        disabled = _get_disabled_skill_names() | get_hidden_skill_names()
         seen_names: set = set()
 
         # Scan local dir first, then external dirs

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -308,7 +308,7 @@ def skill_matches_environment(frontmatter: Dict[str, Any]) -> bool:
     return False
 
 
-# ── Disabled skills ───────────────────────────────────────────────────────
+# ── Skill visibility ──────────────────────────────────────────────────────
 
 
 _RAW_CONFIG_CACHE: Dict[Tuple[str, int, int], Dict[str, Any]] = {}
@@ -354,19 +354,15 @@ def _load_raw_config() -> Dict[str, Any]:
     return parsed
 
 
-def get_disabled_skill_names(platform: str | None = None) -> Set[str]:
-    """Read disabled skill names from config.yaml.
+def _get_configured_skill_names(key: str, platform: str | None = None) -> Set[str]:
+    """Read one global/per-platform skill-name set from config.yaml.
 
-    Args:
-        platform: Explicit platform name (e.g. ``"telegram"``).  When
-            *None*, resolves from ``HERMES_PLATFORM`` or
-            ``HERMES_SESSION_PLATFORM`` env vars.  Returns the global
-            disabled list, unioned with the platform-specific list when a
-            platform is resolved (a globally-disabled skill stays disabled
-            on every platform).
+    ``key=hidden`` removes skills from offer surfaces while keeping explicit
+    ``skill_view`` and bundle loads available. ``key=disabled`` blocks both.
 
-    Reads the config file directly (no CLI config imports) to stay
-    lightweight.
+    Global values are unioned with the platform-specific list when a platform
+    is resolved, so a globally hidden or disabled skill stays that way on
+    every platform. The config is read through the shared lightweight cache.
     """
     parsed = _load_raw_config()
     if not parsed:
@@ -382,14 +378,24 @@ def get_disabled_skill_names(platform: str | None = None) -> Set[str]:
         or os.getenv("HERMES_PLATFORM")
         or get_session_env("HERMES_SESSION_PLATFORM")
     )
-    global_disabled = _normalize_string_set(skills_cfg.get("disabled"))
+    global_values = _normalize_string_set(skills_cfg.get(key))
     if resolved_platform:
-        platform_disabled = (skills_cfg.get("platform_disabled") or {}).get(
+        platform_values = (skills_cfg.get(f"platform_{key}") or {}).get(
             resolved_platform
         )
-        if platform_disabled is not None:
-            return global_disabled | _normalize_string_set(platform_disabled)
-    return global_disabled
+        if platform_values is not None:
+            return global_values | _normalize_string_set(platform_values)
+    return global_values
+
+
+def get_disabled_skill_names(platform: str | None = None) -> Set[str]:
+    """Return skills blocked from both discovery and explicit loading."""
+    return _get_configured_skill_names("disabled", platform)
+
+
+def get_hidden_skill_names(platform: str | None = None) -> Set[str]:
+    """Return skills hidden from discovery but available to explicit loading."""
+    return _get_configured_skill_names("hidden", platform)
 
 
 def _normalize_string_set(values) -> Set[str]:

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -34,7 +34,6 @@ from agent.prompt_builder import (
     KANBAN_GUIDANCE,
     MEMORY_GUIDANCE,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
-    PARALLEL_TOOL_CALL_GUIDANCE,
     PLATFORM_HINTS,
     SESSION_SEARCH_GUIDANCE,
     SKILLS_GUIDANCE,
@@ -44,6 +43,14 @@ from agent.prompt_builder import (
     TOOL_USE_ENFORCEMENT_MODELS,
     drain_truncation_warnings,
 )
+
+# A running CLI can update its checkout before this lazily imported module is
+# loaded.  Keep old in-memory prompt_builder modules compatible with new code.
+try:
+    from agent.prompt_builder import PARALLEL_TOOL_CALL_GUIDANCE
+except ImportError:
+    PARALLEL_TOOL_CALL_GUIDANCE = ""
+
 from agent.runtime_cwd import resolve_context_cwd
 from utils import is_truthy_value
 

--- a/tests/agent/test_skill_bundles.py
+++ b/tests/agent/test_skill_bundles.py
@@ -184,6 +184,26 @@ class TestResolveBundleCommandKey:
 
 
 class TestBuildBundleInvocationMessage:
+    def test_hidden_skill_is_bundle_only_but_loadable(self, bundles_env, monkeypatch, tmp_path):
+        bundles_dir, skills_dir = bundles_env
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("skills:\n  hidden: [manual]\n")
+        _make_skill(skills_dir, "manual", body="Manual workflow body.")
+        _make_bundle_yaml(bundles_dir, "manual", ["manual/SKILL"])
+        scan_bundles()
+
+        from agent.prompt_builder import build_skills_system_prompt
+        from agent.skill_commands import scan_skill_commands
+
+        assert "/manual" not in scan_skill_commands()
+        assert "manual" not in build_skills_system_prompt()
+        result = build_bundle_invocation_message("/manual")
+        assert result is not None
+        message, loaded, missing = result
+        assert "Manual workflow body." in message
+        assert loaded == ["manual"]
+        assert missing == []
+
     def test_loads_all_skills(self, bundles_env):
         bundles_dir, skills_dir = bundles_env
         _make_skill(skills_dir, "skill-a", body="Skill A content.")

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -6,6 +6,24 @@ from unittest.mock import patch
 from agent.system_prompt import build_system_prompt_parts
 
 
+def test_import_survives_stale_prompt_builder_without_parallel_guidance():
+    """A live CLI may retain prompt_builder while an update replaces system_prompt."""
+    import subprocess
+    import sys
+
+    script = """
+import sys
+import agent.prompt_builder as prompt_builder
+
+del prompt_builder.PARALLEL_TOOL_CALL_GUIDANCE
+sys.modules.pop('agent.system_prompt', None)
+import agent.system_prompt as system_prompt
+
+assert system_prompt.PARALLEL_TOOL_CALL_GUIDANCE == ''
+"""
+    subprocess.run([sys.executable, "-c", script], check=True)
+
+
 def _make_agent(**overrides):
     base = dict(
         load_soul_identity=False,

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4551,6 +4551,57 @@ def test_skills_reload_runs_in_gateway_process(monkeypatch):
     assert "42 skill(s) available" in resp["result"]["output"]
 
 
+def test_slash_exec_routes_skill_bundle_payload_to_live_agent(monkeypatch):
+    import agent.skill_bundles as skill_bundles
+    import agent.skill_commands as skill_commands
+
+    monkeypatch.setattr(
+        skill_commands,
+        "get_skill_commands",
+        lambda: {"/taskfinish": {"name": "colliding-visible-skill"}},
+    )
+    monkeypatch.setattr(
+        skill_bundles,
+        "resolve_bundle_command_key",
+        lambda command: "/taskfinish" if command == "taskfinish" else None,
+    )
+    monkeypatch.setattr(
+        skill_bundles,
+        "build_bundle_invocation_message",
+        lambda *args, **kwargs: ("taskfinish bundle payload", ["taskfinish"], []),
+    )
+    monkeypatch.setattr(
+        skill_bundles,
+        "get_skill_bundles",
+        lambda: {"/taskfinish": {"name": "taskfinish"}},
+    )
+    monkeypatch.setattr(
+        server,
+        "_SlashWorker",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("bundle must not enter slash worker")
+        ),
+    )
+    server._sessions["sid"] = _session()
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "slash.exec",
+                "params": {"command": "/taskfinish", "session_id": "sid"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert resp is not None
+    assert resp["result"] == {
+        "type": "send",
+        "notice": "⚡ Loading bundle: taskfinish (1 skills)",
+        "message": "taskfinish bundle payload",
+    }
+
+
 def test_snapshot_restore_is_blocked_from_tui_worker():
     server._sessions["sid"] = _session()
     try:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11867,6 +11867,31 @@ def _(rid, params: dict) -> dict:
         pass
 
     try:
+        from agent.skill_bundles import (
+            build_bundle_invocation_message,
+            get_skill_bundles,
+            resolve_bundle_command_key,
+        )
+
+        bundle_key = resolve_bundle_command_key(name)
+        if bundle_key is not None:
+            bundle_result = build_bundle_invocation_message(
+                bundle_key,
+                arg,
+                task_id=session.get("session_key", "") if session else "",
+            )
+            if bundle_result:
+                msg, loaded, missing = bundle_result
+                bundle = get_skill_bundles().get(bundle_key, {})
+                bundle_name = bundle.get("name") or bundle_key.lstrip("/")
+                notice = f"⚡ Loading bundle: {bundle_name} ({len(loaded)} skills)"
+                if missing:
+                    notice += f"\nSkipped missing skills: {', '.join(missing)}"
+                return _ok(rid, {"type": "send", "notice": notice, "message": msg})
+    except Exception:
+        pass
+
+    try:
         from agent.skill_commands import (
             scan_skill_commands,
             build_skill_invocation_message,
@@ -13099,6 +13124,21 @@ def _(rid, params: dict) -> dict:
                 4018,
                 "snapshot restore mutates live config/state; use command.dispatch for /snapshot restore",
             )
+
+    try:
+        from agent.skill_bundles import resolve_bundle_command_key
+
+        if resolve_bundle_command_key(_cmd_base) is not None:
+            return _methods["command.dispatch"](
+                rid,
+                {
+                    "name": _cmd_base,
+                    "arg": _cmd_arg,
+                    "session_id": params.get("session_id", ""),
+                },
+            )
+    except Exception:
+        pass
 
     try:
         from agent.skill_commands import get_skill_commands


### PR DESCRIPTION
## Summary

- separate `skills.hidden` from hard-disabled skills so explicitly invoked local bundles can load hidden owners without exposing them in automatic discovery
- keep prompt assembly compatible with a stale in-memory `prompt_builder` during a live checkout update
- route TUI bundle commands through `command.dispatch` as `type=send` instead of losing the payload in the slash worker's private `_pending_input`
- preserve bundle priority over a colliding visible skill such as `/design`

## Verification

- canonical runner: 359 tests passed, 0 failed across bundle, prompt, and TUI gateway suites
- fresh TUI RPC probe: all seven curated bundles returned non-empty `type=send` payloads
