### PR TITLE
feat: add Wanxiang V2 (万相) image generation provider via DashScope API

### DIFF
--- a/plugins/image_gen/qwen/__init__.py
+++ b/plugins/image_gen/qwen/__init__.py
@@ -1,0 +1,339 @@
+"""
+Wanxiang (万相) V2 -- Alibaba DashScope text-to-image backend.
+
+Supports wan2.6-t2i (sync), wan2.5/wan2.2 (async) via the DashScope API.
+Models: wan2.6-t2i, wan2.5-t2i-preview, wan2.2-t2i-flash, wan2.2-t2i-plus
+
+API reference:
+  https://help.aliyun.com/zh/model-studio/text-to-image-v2-api-reference
+
+Authentication:
+  DASHSCOPE_API_KEY environment variable, or
+  config.yaml: image_gen.providers.qwen.api_key
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import time
+import urllib.request
+import urllib.error
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from agent.image_gen_provider import (
+    DEFAULT_ASPECT_RATIO,
+    ImageGenProvider,
+    resolve_aspect_ratio,
+)
+
+logger = logging.getLogger(__name__)
+
+# Default public endpoint.
+_DEFAULT_BASE_URL = "https://dashscope.aliyuncs.com/api/v1"
+
+MODELS: Dict[str, Dict[str, Any]] = {
+    "wan2.6-t2i": {
+        "display": "Wan 2.6",
+        "speed": "~10s",
+        "strengths": "Latest model, HTTP sync, free size [1280*1280~1440*1440] px",
+        "price": "paid",
+        "sync": True,
+    },
+    "wan2.5-t2i-preview": {
+        "display": "Wan 2.5 Preview",
+        "speed": "~30s async",
+        "strengths": "Free size, ratio [1:4~4:1]",
+        "price": "paid",
+        "sync": False,
+    },
+    "wan2.2-t2i-flash": {
+        "display": "Wan 2.2 Flash",
+        "speed": "~15s async",
+        "strengths": "50% faster than 2.1",
+        "price": "paid",
+        "sync": False,
+    },
+    "wan2.2-t2i-plus": {
+        "display": "Wan 2.2 Plus",
+        "speed": "~30s async",
+        "strengths": "Higher stability and success rate",
+        "price": "paid",
+        "sync": False,
+    },
+}
+DEFAULT_MODEL = "wan2.6-t2i"
+
+_FREE_SIZES: Dict[str, str] = {
+    "landscape": "1696*960",
+    "square": "1280*1280",
+    "portrait": "960*1696",
+}
+_FIXED_SIZES: Dict[str, str] = {
+    "landscape": "1408*800",
+    "square": "1024*1024",
+    "portrait": "800*1408",
+}
+
+_MAX_PROMPT_CHARS = 2100
+_MAX_NEGATIVE_PROMPT_CHARS = 500
+_ASYNC_POLL_INTERVAL = 2
+_ASYNC_POLL_MAX_ATTEMPTS = 60
+_CIRCUIT_BREAKER_THRESHOLD = 5
+_CIRCUIT_BREAKER_COOLDOWN = 120
+
+
+def _resolve_api_key() -> Optional[str]:
+    key = os.environ.get("DASHSCOPE_API_KEY", "").strip()
+    if key:
+        return key
+    try:
+        from hermes_cli.config import cfg_get
+        key = (cfg_get("image_gen.providers.qwen.api_key") or "").strip()
+        return key or None
+    except Exception:
+        return None
+
+
+def _resolve_base_url() -> str:
+    return os.environ.get("QWEN_IMAGE_BASE_URL", _DEFAULT_BASE_URL).rstrip("/")
+
+
+def _resolve_model(model_id: Optional[str] = None) -> Tuple[str, Dict[str, Any]]:
+    if model_id and model_id in MODELS:
+        return model_id, MODELS[model_id]
+    try:
+        from hermes_cli.config import cfg_get
+        configured = cfg_get("image_gen.model")
+        if configured and configured in MODELS:
+            return configured, MODELS[configured]
+    except Exception:
+        pass
+    return DEFAULT_MODEL, MODELS[DEFAULT_MODEL]
+
+
+def _resolve_size(aspect_ratio: str, sync: bool) -> str:
+    sizes = _FREE_SIZES if sync else _FIXED_SIZES
+    return sizes.get(aspect_ratio, "1280*1280" if sync else "1024*1024")
+
+
+def _download_to_cache(image_url: str, cache_dir: Path) -> Optional[Path]:
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = int(time.time() * 1000)
+    url_hash = hashlib.md5(image_url.encode()).hexdigest()[:8]
+    output_path = cache_dir / f"wanx_{timestamp}_{url_hash}.png"
+    try:
+        urllib.request.urlretrieve(image_url, str(output_path))
+        if output_path.stat().st_size > 0:
+            return output_path
+    except Exception:
+        logger.debug("Failed to download image from %s", image_url)
+    return None
+
+
+class QwenImageProvider(ImageGenProvider):
+    """Wanxiang V2 text-to-image via Alibaba DashScope."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._consecutive_failures: int = 0
+        self._breaker_open_until: float = 0.0
+
+    @property
+    def name(self) -> str:
+        return "qwen"
+
+    @property
+    def display_name(self) -> str:
+        return "Wanxiang V2 (万相)"
+
+    def is_available(self) -> bool:
+        return bool(_resolve_api_key())
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [
+            {"id": mid, "display": meta["display"],
+             "speed": meta.get("speed", ""),
+             "strengths": meta.get("strengths", ""),
+             "price": meta.get("price", "")}
+            for mid, meta in MODELS.items()
+        ]
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_MODEL
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Wanxiang V2 (万相)",
+            "badge": "paid",
+            "tag": "Alibaba Bailian - wan2.6-t2i, wan2.5, wan2.2",
+            "env_vars": [{"key": "DASHSCOPE_API_KEY",
+                          "prompt": "Alibaba Bailian API Key",
+                          "url": "https://help.aliyun.com/zh/model-studio/get-api-key"}],
+        }
+
+    def capabilities(self) -> Dict[str, Any]:
+        return {"modalities": ["text"], "max_reference_images": 0}
+
+    def generate(self, prompt, aspect_ratio=DEFAULT_ASPECT_RATIO, *,
+                 image_url=None, reference_image_urls=None, **kwargs):
+        api_key = _resolve_api_key()
+        if not api_key:
+            return self._error("DASHSCOPE_API_KEY not set", "auth")
+        if self._breaker_tripped():
+            return self._error("Temporarily unavailable after repeated failures",
+                               "circuit_breaker")
+
+        model_id, meta = _resolve_model()
+        aspect = resolve_aspect_ratio(aspect_ratio)
+        size = _resolve_size(aspect, meta.get("sync", True))
+        n = self._clamp_n(kwargs.get("n", 1))
+
+        safe_prompt = prompt[:_MAX_PROMPT_CHARS]
+        body = {"model": model_id,
+                "input": {"messages": [{"role": "user",
+                          "content": [{"text": safe_prompt}]}]},
+                "parameters": {"size": size, "watermark": False,
+                               "prompt_extend": True, "n": n}}
+        if kwargs.get("seed") is not None:
+            body["parameters"]["seed"] = int(kwargs["seed"])
+        if kwargs.get("negative_prompt"):
+            body["parameters"]["negative_prompt"] = str(
+                kwargs["negative_prompt"])[:_MAX_NEGATIVE_PROMPT_CHARS]
+
+        base_url = _resolve_base_url()
+        try:
+            if meta.get("sync"):
+                response = self._sync_generate(api_key, base_url, body)
+            else:
+                response = self._async_generate(api_key, base_url, body)
+            self._record_success()
+        except Exception as exc:
+            self._record_failure()
+            return self._error(f"Generation failed: {exc}", type(exc).__name__)
+
+        if not isinstance(response, dict):
+            return self._error("Unexpected API response", "provider_contract")
+
+        # API-level error: pass the error code through as error_type
+        if response.get("code"):
+            return self._error(
+                f"{response.get('code')}: {response.get('message', '')}",
+                response.get("code", "api_error"),
+            )
+
+        image_url = self._extract_image_url(response)
+        if not image_url:
+            return self._error("No image in response", "empty_response")
+
+        from hermes_constants import get_hermes_home
+        cache_dir = get_hermes_home() / "image_cache"
+        local = _download_to_cache(image_url, cache_dir)
+        result = str(local) if local else image_url
+
+        return {"success": True, "image": result, "model": model_id,
+                "prompt": prompt, "aspect_ratio": aspect,
+                "modality": "text", "provider": self.name}
+
+    def _sync_generate(self, api_key, base_url, body):
+        url = f"{base_url}/services/aigc/multimodal-generation/generation"
+        return self._post(api_key, url, body, 120)
+
+    def _async_generate(self, api_key, base_url, body):
+        submit_url = f"{base_url}/services/aigc/text2image/image-synthesis"
+        h = {"X-DashScope-Async": "enable"}
+        resp = self._post(api_key, submit_url, body, 30, h)
+        if resp.get("code"):
+            return resp
+        tid = (resp.get("output") or {}).get("task_id") or resp.get("task_id")
+        if not tid:
+            return {"code": "parse_error", "message": "No task_id"}
+
+        poll_url = f"{base_url}/tasks/{tid}"
+        delay = _ASYNC_POLL_INTERVAL
+        for attempt in range(1, _ASYNC_POLL_MAX_ATTEMPTS + 1):
+            time.sleep(delay)
+            delay = min(delay * 1.2, 10.0)
+            try:
+                s = self._get(api_key, poll_url, 10)
+            except Exception:
+                continue
+            st = (s.get("output") or {}).get("task_status") or s.get("task_status", "")
+            if st == "SUCCEEDED":
+                return s
+            if st in ("FAILED", "ERROR", "CANCELED"):
+                return {"code": "api_error",
+                        "message": f"Task {st}: {(s.get('output') or {}).get('message', '')}"}
+        return {"code": "timeout", "message": "Async task timed out"}
+
+    @staticmethod
+    def _post(api_key, url, body, timeout, extra_headers=None):
+        h = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+        if extra_headers:
+            h.update(extra_headers)
+        req = urllib.request.Request(url, data=json.dumps(body).encode(),
+                                      headers=h, method="POST")
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as r:
+                return json.loads(r.read().decode())
+        except urllib.error.HTTPError as e:
+            try:
+                return json.loads(e.read().decode())
+            except Exception:
+                return {"code": str(e.code), "message": str(e)}
+
+    @staticmethod
+    def _get(api_key, url, timeout):
+        req = urllib.request.Request(url, headers={"Authorization": f"Bearer {api_key}"})
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return json.loads(r.read().decode())
+
+    @staticmethod
+    def _extract_image_url(data):
+        output = data.get("output") or {}
+        choices = output.get("choices") or []
+        if choices:
+            parts = choices[0].get("message", {}).get("content") or []
+            for p in parts:
+                if isinstance(p, dict) and p.get("image"):
+                    return str(p["image"])
+        results = output.get("results") or []
+        if results and isinstance(results[0], dict) and results[0].get("url"):
+            return str(results[0]["url"])
+        return None
+
+    def _breaker_tripped(self):
+        if self._consecutive_failures < _CIRCUIT_BREAKER_THRESHOLD:
+            return False
+        if time.monotonic() >= self._breaker_open_until:
+            self._consecutive_failures = 0
+            return False
+        return True
+
+    def _record_success(self):
+        self._consecutive_failures = 0
+
+    def _record_failure(self):
+        self._consecutive_failures += 1
+        if self._consecutive_failures >= _CIRCUIT_BREAKER_THRESHOLD:
+            self._breaker_open_until = time.monotonic() + _CIRCUIT_BREAKER_COOLDOWN
+
+    @staticmethod
+    def _error(msg, typ="unknown"):
+        return {"success": False, "image": None, "error": msg,
+                "error_type": typ, "provider": "qwen"}
+
+    @staticmethod
+    def _clamp_n(n):
+        try:
+            v = int(n)
+        except (TypeError, ValueError):
+            return 1
+        return max(1, min(v, 4))
+
+
+def register(ctx):
+    ctx.register_image_gen_provider(QwenImageProvider())

--- a/plugins/image_gen/qwen/plugin.yaml
+++ b/plugins/image_gen/qwen/plugin.yaml
@@ -1,0 +1,7 @@
+name: qwen
+version: 1.0.0
+description: "Wanxiang V2 (万相) text-to-image via Alibaba DashScope — wan2.6-t2i, wan2.5, wan2.2"
+author: Agent
+kind: backend
+requires_env:
+  - DASHSCOPE_API_KEY

--- a/tests/plugins/image_gen/test_qwen_provider.py
+++ b/tests/plugins/image_gen/test_qwen_provider.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Tests for the Wanxiang V2 (Qwen Image) provider plugin."""
+
+from __future__ import annotations
+
+import io, json
+from unittest.mock import MagicMock, patch
+import pytest
+import urllib.error
+
+
+@pytest.fixture(autouse=True)
+def _fake_api_key(monkeypatch, tmp_path):
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "sk-test-key-12345")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+
+class TestQwenImageGenProviderSurface:
+    def test_name(self):
+        from plugins.image_gen.qwen import QwenImageProvider
+        assert QwenImageProvider().name == "qwen"
+
+    def test_display_name(self):
+        from plugins.image_gen.qwen import QwenImageProvider
+        assert "Wanxiang" in QwenImageProvider().display_name
+
+    def test_is_available_with_key(self, monkeypatch):
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "sk-xxx")
+        from plugins.image_gen.qwen import QwenImageProvider
+        assert QwenImageProvider().is_available() is True
+
+    def test_is_available_without_key(self, monkeypatch):
+        monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+        from plugins.image_gen.qwen import QwenImageProvider
+        assert QwenImageProvider().is_available() is False
+
+    def test_list_models_returns_all_models(self):
+        from plugins.image_gen.qwen import QwenImageProvider, MODELS
+        ids = {m["id"] for m in QwenImageProvider().list_models()}
+        assert ids == set(MODELS.keys())
+
+    def test_default_model(self):
+        from plugins.image_gen.qwen import QwenImageProvider
+        assert QwenImageProvider().default_model() == "wan2.6-t2i"
+
+    def test_capabilities_text_only(self):
+        from plugins.image_gen.qwen import QwenImageProvider
+        caps = QwenImageProvider().capabilities()
+        assert caps["modalities"] == ["text"]
+
+    def test_get_setup_schema(self):
+        from plugins.image_gen.qwen import QwenImageProvider
+        s = QwenImageProvider().get_setup_schema()
+        assert "Wanxiang" in s["name"]
+        assert s["badge"] == "paid"
+
+
+class TestConfigHelpers:
+    def test_resolve_model_default(self):
+        from plugins.image_gen.qwen import _resolve_model
+        mid, meta = _resolve_model()
+        assert mid == "wan2.6-t2i"
+        assert meta["sync"] is True
+
+    def test_resolve_model_async(self):
+        from plugins.image_gen.qwen import _resolve_model
+        mid, meta = _resolve_model("wan2.5-t2i-preview")
+        assert mid == "wan2.5-t2i-preview"
+        assert meta["sync"] is False
+
+    def test_resolve_model_invalid_fallback(self):
+        from plugins.image_gen.qwen import _resolve_model
+        mid, _ = _resolve_model("bogus")
+        assert mid == "wan2.6-t2i"
+
+    def test_resolve_size(self):
+        from plugins.image_gen.qwen import _resolve_size
+        assert _resolve_size("landscape", True) == "1696*960"
+        assert _resolve_size("square", True) == "1280*1280"
+        assert _resolve_size("square", False) == "1024*1024"
+
+    def test_clamp_n(self):
+        from plugins.image_gen.qwen import QwenImageProvider
+        c = QwenImageProvider._clamp_n
+        assert c(1) == 1
+        assert c(5) == 4
+        assert c(None) == 1
+
+
+def _mock_sync_resp(image_url="https://oss.example.com/img.png"):
+    m = MagicMock()
+    m.__enter__ = MagicMock(return_value=m)
+    m.__exit__ = MagicMock(return_value=False)
+    m.read.return_value = json.dumps({
+        "output": {"choices": [{"message": {"content": [{"image": image_url}]}}]}
+    }).encode()
+    return m
+
+
+def _mock_async_submit(task_id="task-abc"):
+    m = MagicMock()
+    m.__enter__ = MagicMock(return_value=m)
+    m.__exit__ = MagicMock(return_value=False)
+    m.read.return_value = json.dumps({"output": {"task_id": task_id}}).encode()
+    return m
+
+
+def _mock_async_poll(status="SUCCEEDED", url="https://oss.example.com/img.png"):
+    m = MagicMock()
+    m.__enter__ = MagicMock(return_value=m)
+    m.__exit__ = MagicMock(return_value=False)
+    m.read.return_value = json.dumps({
+        "output": {"task_status": status, "results": [{"url": url}]}
+    }).encode()
+    return m
+
+
+class TestGenerate:
+    def test_missing_api_key(self, monkeypatch):
+        monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+        from plugins.image_gen.qwen import QwenImageProvider
+        r = QwenImageProvider().generate(prompt="test")
+        assert r["success"] is False
+        assert "DASHSCOPE_API_KEY" in r["error"]
+
+    def test_sync_success(self):
+        from plugins.image_gen.qwen import QwenImageProvider
+        with patch("urllib.request.urlopen", return_value=_mock_sync_resp()):
+            with patch("urllib.request.urlretrieve"):
+                r = QwenImageProvider().generate(prompt="cat", aspect_ratio="square")
+        assert r["success"] is True
+        assert r["provider"] == "qwen"
+        assert r["model"] == "wan2.6-t2i"
+
+    def test_sync_api_error(self):
+        from plugins.image_gen.qwen import QwenImageProvider
+        err = urllib.error.HTTPError("url", 400, "Bad", {},
+            io.BytesIO(json.dumps({"code": "BadParam", "message": "bad size"}).encode()))
+        with patch("urllib.request.urlopen", side_effect=err):
+            r = QwenImageProvider().generate(prompt="test")
+        assert r["success"] is False
+        assert r["error_type"] in ("api_error", "BadParam")
+
+    def test_sync_empty_response(self):
+        from plugins.image_gen.qwen import QwenImageProvider
+        with patch("urllib.request.urlopen", return_value=_mock_sync_resp("")):
+            r = QwenImageProvider().generate(prompt="test")
+        assert r["success"] is False
+
+    def test_async_success(self, monkeypatch):
+        monkeypatch.setattr(
+            "plugins.image_gen.qwen._resolve_model",
+            lambda mid=None: ("wan2.5-t2i-preview", {"sync": False, "display": "", "speed": "", "strengths": "", "price": ""})
+        )
+        from plugins.image_gen.qwen import QwenImageProvider
+        calls = [0]
+        def seq(req, timeout=None):
+            calls[0] += 1
+            if calls[0] == 1:
+                return _mock_async_submit()
+            return _mock_async_poll()
+        with patch("urllib.request.urlopen", side_effect=seq):
+            with patch("urllib.request.urlretrieve"):
+                r = QwenImageProvider().generate(prompt="cat")
+        assert r["success"] is True
+
+    def test_async_timeout(self, monkeypatch):
+        monkeypatch.setattr(
+            "plugins.image_gen.qwen._resolve_model",
+            lambda mid=None: ("wan2.5-t2i-preview", {"sync": False, "display": "", "speed": "", "strengths": "", "price": ""})
+        )
+        from plugins.image_gen.qwen import QwenImageProvider
+        calls = [0]
+        def seq(req, timeout=None):
+            calls[0] += 1
+            if calls[0] == 1:
+                return _mock_async_submit()
+            return _mock_async_poll(status="PENDING")
+        with patch("urllib.request.urlopen", side_effect=seq):
+            with patch("plugins.image_gen.qwen._ASYNC_POLL_MAX_ATTEMPTS", 3):
+                with patch("plugins.image_gen.qwen._ASYNC_POLL_INTERVAL", 0.01):
+                    r = QwenImageProvider().generate(prompt="cat")
+        assert r["success"] is False
+        assert r["error_type"] == "timeout"
+
+    def test_seed_and_n_passthrough(self):
+        from plugins.image_gen.qwen import QwenImageProvider
+        body = {}
+        def cap(req, timeout=None):
+            nonlocal body
+            body = json.loads(req.data.decode())
+            return _mock_sync_resp()
+        with patch("urllib.request.urlopen", side_effect=cap):
+            with patch("urllib.request.urlretrieve"):
+                QwenImageProvider().generate(prompt="x", seed=42, n=3)
+        assert body["parameters"]["seed"] == 42
+        assert body["parameters"]["n"] == 3
+
+
+class TestExtractImageUrl:
+    def test_sync_shape(self):
+        from plugins.image_gen.qwen import QwenImageProvider
+        u = QwenImageProvider._extract_image_url({
+            "output": {"choices": [{"message": {"content": [{"image": "https://a.png"}]}}]}
+        })
+        assert u == "https://a.png"
+
+    def test_async_shape(self):
+        from plugins.image_gen.qwen import QwenImageProvider
+        u = QwenImageProvider._extract_image_url({
+            "output": {"results": [{"url": "https://b.png"}]}
+        })
+        assert u == "https://b.png"
+
+    def test_empty(self):
+        from plugins.image_gen.qwen import QwenImageProvider
+        assert QwenImageProvider._extract_image_url({}) is None
+
+
+class TestCircuitBreaker:
+    def test_initially_closed(self):
+        from plugins.image_gen.qwen import QwenImageProvider
+        assert QwenImageProvider()._breaker_tripped() is False
+
+    def test_trips_after_threshold(self):
+        from plugins.image_gen.qwen import QwenImageProvider, _CIRCUIT_BREAKER_THRESHOLD
+        p = QwenImageProvider()
+        for _ in range(_CIRCUIT_BREAKER_THRESHOLD):
+            p._record_failure()
+        assert p._breaker_tripped() is True
+
+    def test_resets_on_success(self):
+        from plugins.image_gen.qwen import QwenImageProvider, _CIRCUIT_BREAKER_THRESHOLD
+        p = QwenImageProvider()
+        for _ in range(_CIRCUIT_BREAKER_THRESHOLD):
+            p._record_failure()
+        p._record_success()
+        assert p._breaker_tripped() is False
+
+
+class TestRegistration:
+    def test_register(self):
+        from plugins.image_gen.qwen import QwenImageProvider, register
+        ctx = MagicMock()
+        register(ctx)
+        ctx.register_image_gen_provider.assert_called_once()
+        assert isinstance(ctx.register_image_gen_provider.call_args[0][0], QwenImageProvider)


### PR DESCRIPTION
    Adds Wanxiang V2 (万相) text-to-image backend via Alibaba DashScope API.

    Supported models
    - wan2.6-t2i — HTTP sync (recommended)
    - wan2.5-t2i-preview — async with polling
    - wan2.2-t2i-flash — async, 50% faster
    - wan2.2-t2i-plus — async, higher stability

    Features
    - Zero external dependencies (stdlib only)
    - Circuit breaker (5 failures → 120s cooldown)
    - Exponential backoff for async polling
    - Prompt truncation to API limits
    - Image caching (OSS URLs expire after 24h)
    - Parameters: n (1-4 images), seed, negative_prompt

    Tests
    27 tests covering provider surface, config helpers, sync/async generation, error handling, circuit breaker, and registration. All passing.

    API
    - Auth: DASHSCOPE_API_KEY in .env or image_gen.providers.qwen.api_key in config
    - Docs: https://help.aliyun.com/zh/model-studio/text-to-image-v2-api-reference