### PR TITLE
fix(dashboard): allow configured public URL websocket origin

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -456,6 +456,36 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     return host_only == bound_lc
 
 
+def _origin_matches_dashboard_public_url(origin: str) -> bool:
+    """True when a browser Origin matches dashboard.public_url exactly.
+
+    This is intentionally narrow and only used by WebSocket origin checks for
+    loopback-bound dashboards that are reached through a trusted reverse proxy
+    or Cloudflare Tunnel.  HTTP Host validation still rejects arbitrary hosts;
+    this helper only prevents the WS guard from rejecting the configured public
+    frontend origin (for example https://jarvis.sw-dev.uk) when the backend is
+    safely bound to 127.0.0.1.
+    """
+    public_url = (cfg_get(load_config(), "dashboard", "public_url", default="") or "").strip()
+    if not public_url or not origin:
+        return False
+
+    try:
+        origin_parts = urllib.parse.urlparse(origin)
+        public_parts = urllib.parse.urlparse(public_url)
+    except Exception:
+        return False
+
+    if origin_parts.scheme not in {"http", "https"}:
+        return False
+    if public_parts.scheme not in {"http", "https"}:
+        return False
+    return (
+        origin_parts.scheme == public_parts.scheme
+        and origin_parts.netloc.lower() == public_parts.netloc.lower()
+    )
+
+
 @app.middleware("http")
 async def host_header_middleware(request: Request, call_next):
     """Reject requests whose Host header doesn't match the bound interface.
@@ -14383,6 +14413,11 @@ def _ws_host_origin_reason(ws: "WebSocket") -> Optional[str]:
         return f"origin_mismatch origin={origin} bound={bound_host}"
 
     if not _is_accepted_host(parsed.netloc, bound_host):
+        if (
+            bound_host.lower() in _LOOPBACK_HOST_VALUES
+            and _origin_matches_dashboard_public_url(origin)
+        ):
+            return None
         return f"origin_mismatch origin={origin} bound={bound_host}"
     return None
 

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -215,3 +215,29 @@ class TestWebSocketHostOriginGuard:
             },
         ):
             pass
+
+    def test_loopback_websocket_accepts_configured_public_url_origin(self, monkeypatch):
+        """Cloudflare/SSH-tunnel dashboards keep the backend bound to 127.0.0.1
+        while the browser's WebSocket Origin is the configured public URL."""
+        from fastapi.testclient import TestClient
+
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws.app.state, "bound_host", "127.0.0.1", raising=False)
+        monkeypatch.setattr(ws, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
+        monkeypatch.setattr(
+            ws,
+            "load_config",
+            lambda: {"dashboard": {"public_url": "https://jarvis.sw-dev.uk"}},
+        )
+
+        client = TestClient(ws.app)
+        url = f"/api/events?token={ws._SESSION_TOKEN}&channel=security-test"
+        with client.websocket_connect(
+            url,
+            headers={
+                "Host": "localhost:9119",
+                "Origin": "https://jarvis.sw-dev.uk",
+            },
+        ):
+            pass


### PR DESCRIPTION
## Summary
- Allow a loopback-bound dashboard to accept the configured `dashboard.public_url` as a WebSocket `Origin`.
- Keeps the existing Host header and loopback DNS-rebinding guards intact.
- Fixes Cloudflare Tunnel / reverse-proxy deployments where the page loads via the public URL but `/api/pty` closes with `origin_mismatch` because the backend is bound to `127.0.0.1`.

## Test Plan
- `python3 -m py_compile hermes_cli/web_server.py`
- `scripts/run_tests.sh tests/hermes_cli/test_web_server_host_header.py -q`

## Notes
Observed failure pattern:

```text
pty refused: origin_mismatch origin=https://jarvis.sw-dev.uk bound=127.0.0.1 peer=127.0.0.1
```
