### PR TITLE
feat(agent): add tool-call repair observability

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -35,6 +35,11 @@ from hermes_cli.timeouts import get_provider_request_timeout
 from agent.prompt_builder import format_steer_marker
 from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_result_message
 from agent.trajectory import convert_scratchpad_to_think
+
+try:
+    from agent.tool_repair_stats import record_repair as _record_repair
+except ImportError:
+    _record_repair = None  # type: ignore[assignment]
 from agent.credential_pool import STATUS_EXHAUSTED
 from agent.error_classifier import FailoverReason
 from utils import base_url_host_matches, base_url_hostname, env_var_enabled, atomic_json_write
@@ -325,6 +330,11 @@ def sanitize_tool_call_arguments(
                     preview,
                 )
                 function["arguments"] = "{}"
+                if _record_repair is not None:
+                    try:
+                        _record_repair("truncated_args", function_name)
+                    except Exception:
+                        pass
 
                 existing_tool_msg = None
                 scan_index = message_index + 1

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -22,19 +22,15 @@ from typing import Any, Dict, List, Optional, Tuple
 
 try:
     from agent.tool_repair_stats import record_repair as _record_repair
-    from agent.tool_repair_stats import get_current_model as _get_model
-    from agent.tool_repair_stats import RepairPattern as _RP
 except ImportError:
     _record_repair = None  # type: ignore[assignment]
-    _get_model = None  # type: ignore[assignment]
-    _RP = None  # type: ignore[assignment]
 
 
 def _stat(pattern: Any, tool: str = "?") -> None:
     """Emit a repair stat event.  No-op when stats module is unavailable."""
     if _record_repair is not None:
         try:
-            _record_repair(pattern, tool, _get_model() if _get_model else "unknown")
+            _record_repair(pattern, tool)
         except Exception:
             pass
 logger = logging.getLogger(__name__)
@@ -271,7 +267,7 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
             "Repaired malformed tool_call arguments for %s: %s → %s",
             tool_name, raw_stripped[:80], fixed[:80],
         )
-        _stat("trailing_comma", tool_name)
+        _stat("malformed_json_repair", tool_name)
         return fixed
     except json.JSONDecodeError:
         pass

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -17,8 +17,26 @@ from __future__ import annotations
 import json
 import logging
 import re
-from typing import Any
+import unicodedata
+from typing import Any, Dict, List, Optional, Tuple
 
+try:
+    from agent.tool_repair_stats import record_repair as _record_repair
+    from agent.tool_repair_stats import get_current_model as _get_model
+    from agent.tool_repair_stats import RepairPattern as _RP
+except ImportError:
+    _record_repair = None  # type: ignore[assignment]
+    _get_model = None  # type: ignore[assignment]
+    _RP = None  # type: ignore[assignment]
+
+
+def _stat(pattern: Any, tool: str = "?") -> None:
+    """Emit a repair stat event.  No-op when stats module is unavailable."""
+    if _record_repair is not None:
+        try:
+            _record_repair(pattern, tool, _get_model() if _get_model else "unknown")
+        except Exception:
+            pass
 logger = logging.getLogger(__name__)
 
 # Lone surrogate code points are invalid in UTF-8 and crash json.dumps
@@ -196,11 +214,13 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     # Fast-path: empty / whitespace-only -> empty object
     if not raw_stripped:
         logger.warning("Sanitized empty tool_call arguments for %s", tool_name)
+        _stat("empty_args", tool_name)
         return "{}"
 
     # Python-literal None -> normalise to {}
     if raw_stripped == "None":
         logger.warning("Sanitized Python-None tool_call arguments for %s", tool_name)
+        _stat("none_literal", tool_name)
         return "{}"
 
     # Repair pass 0: llama.cpp backends sometimes emit literal control
@@ -216,6 +236,7 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
                 "Repaired unescaped control chars in tool_call arguments for %s",
                 tool_name,
             )
+            _stat("control_char_escape", tool_name)
         return reserialised
     except (json.JSONDecodeError, TypeError, ValueError):
         pass
@@ -250,6 +271,7 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
             "Repaired malformed tool_call arguments for %s: %s → %s",
             tool_name, raw_stripped[:80], fixed[:80],
         )
+        _stat("trailing_comma", tool_name)
         return fixed
     except json.JSONDecodeError:
         pass
@@ -265,6 +287,7 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
                 "Repaired control-char-laced tool_call arguments for %s: %s → %s",
                 tool_name, raw_stripped[:80], escaped[:80],
             )
+            _stat("control_char_escape", tool_name)
             return escaped
     except (json.JSONDecodeError, TypeError, ValueError):
         pass
@@ -276,6 +299,7 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
         "replaced with empty object (was: %s)",
         tool_name, raw_stripped[:80],
     )
+    _stat("unrepairable", tool_name)
     return "{}"
 
 

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -22,15 +22,24 @@ from typing import Any, Dict, List, Optional, Tuple
 
 try:
     from agent.tool_repair_stats import record_repair as _record_repair
+    from agent.tool_repair_stats import get_current_model as _get_model
+    from agent.tool_repair_stats import RepairPattern as _RP
 except ImportError:
     _record_repair = None  # type: ignore[assignment]
+    _get_model = None  # type: ignore[assignment]
+    _RP = None  # type: ignore[assignment]
 
 
 def _stat(pattern: Any, tool: str = "?") -> None:
     """Emit a repair stat event.  No-op when stats module is unavailable."""
     if _record_repair is not None:
         try:
-            _record_repair(pattern, tool)
+            # Resolve string pattern names to RepairPattern enums for
+            # consistent counting (prevents typos / mismatched keys).
+            rp_pattern = pattern
+            if _RP is not None and isinstance(pattern, str):
+                rp_pattern = _RP(pattern)
+            _record_repair(rp_pattern, tool, _get_model() if _get_model else "unknown")
         except Exception:
             pass
 logger = logging.getLogger(__name__)

--- a/agent/tool_repair_stats.py
+++ b/agent/tool_repair_stats.py
@@ -12,7 +12,7 @@ import logging
 import threading
 import time
 from collections import defaultdict
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
@@ -107,6 +107,8 @@ class ToolRepairStats:
     ) -> None:
         """Record a single repair event.  Thread-safe, bounded, cheap."""
         try:
+            # Normalize string patterns to their .value for consistent counting.
+            pat_value = pattern.value if hasattr(pattern, "value") else str(pattern)
             evt = RepairEvent(
                 pattern=pattern,
                 tool_name=tool_name,
@@ -119,7 +121,13 @@ class ToolRepairStats:
                 self._events.append(evt)
                 if len(self._events) > self._MAX_EVENTS:
                     self._events = self._events[-self._MAX_EVENTS:]
-                self._model_counts[model_name][pattern.value] += 1
+                    # Rebuild model counts from retained events so totals
+                    # stay consistent with total() after ring-buffer trim.
+                    self._model_counts = defaultdict(lambda: defaultdict(int))
+                    for e in self._events:
+                        v = e.pattern if isinstance(e.pattern, str) else getattr(e.pattern, "value", str(e.pattern))
+                        self._model_counts[e.model_name][v] += 1
+                self._model_counts[model_name][pat_value] += 1
         except Exception:
             # Observability must NEVER break the repair pipeline.
             pass

--- a/agent/tool_repair_stats.py
+++ b/agent/tool_repair_stats.py
@@ -32,7 +32,7 @@ class RepairPattern(str, Enum):
     EMPTY_ARGS = "empty_args"                    # Empty/whitespace → {}
     NONE_LITERAL = "none_literal"                # Python None → {}
     CONTROL_CHAR_ESCAPE = "control_char_escape"  # Unescaped control chars in JSON strings
-    TRAILING_COMMA = "trailing_comma"            # Trailing commas in JSON
+    MALFORMED_JSON_REPAIR = "malformed_json_repair"  # Trailing commas, unclosed brackets, excess brackets
     UNCLOSED_BRACKET = "unclosed_bracket"        # Unclosed {}/[]
     TRAILING_CONTENT = "trailing_content"        # Complete JSON + extra prose
     DOUBLE_SERIALIZE = "double_serialize"        # JSON string wrapping JSON object
@@ -54,6 +54,9 @@ class RepairPattern(str, Enum):
 
     # Schema validation (PR #61550)
     REQUIRED_MISSING = "required_missing"        # Missing required parameters
+
+    # History-level corruption (agent_runtime_helpers.py sanitize_tool_call_arguments)
+    TRUNCATED_ARGS = "truncated_args"            # Corrupted JSON → {} in message history
 
     # Catch-all
     OTHER = "other"
@@ -121,13 +124,15 @@ class ToolRepairStats:
                 self._events.append(evt)
                 if len(self._events) > self._MAX_EVENTS:
                     self._events = self._events[-self._MAX_EVENTS:]
-                    # Rebuild model counts from retained events so totals
-                    # stay consistent with total() after ring-buffer trim.
+                    # Rebuild all counts from retained events.
+                    # The new event is already included in self._events,
+                    # so we must NOT also increment below.
                     self._model_counts = defaultdict(lambda: defaultdict(int))
                     for e in self._events:
                         v = e.pattern if isinstance(e.pattern, str) else getattr(e.pattern, "value", str(e.pattern))
                         self._model_counts[e.model_name][v] += 1
-                self._model_counts[model_name][pat_value] += 1
+                else:
+                    self._model_counts[model_name][pat_value] += 1
         except Exception:
             # Observability must NEVER break the repair pipeline.
             pass
@@ -229,7 +234,7 @@ def get_stats() -> ToolRepairStats:
 # ---------------------------------------------------------------------------
 
 def record_repair(
-    pattern: RepairPattern,
+    pattern: Any,
     tool_name: str = "?",
     model_name: str = "unknown",
     success: bool = True,
@@ -240,24 +245,3 @@ def record_repair(
         get_stats().record(pattern, tool_name, model_name, success, detail)
     except Exception:
         pass
-
-
-# ---------------------------------------------------------------------------
-# Current model context — set by dispatch_tool, read by hooks
-# ---------------------------------------------------------------------------
-
-_current_model: str = "unknown"
-_model_lock = threading.Lock()
-
-
-def set_current_model(model_name: str) -> None:
-    """Called by dispatch_tool to make the current model available to hooks."""
-    global _current_model
-    with _model_lock:
-        _current_model = model_name
-
-
-def get_current_model() -> str:
-    """Read by hook points to tag events with the model that caused them."""
-    with _model_lock:
-        return _current_model

--- a/agent/tool_repair_stats.py
+++ b/agent/tool_repair_stats.py
@@ -1,0 +1,255 @@
+"""Tool-call repair observability.
+
+Records structured events when the repair pipeline fires, enabling
+per-model and per-pattern analysis without affecting the model layer.
+
+This is an operator-only module — no new model tools, no prompt impact.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections import defaultdict
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Repair patterns — the finite set of known tool-call failure modes
+# ---------------------------------------------------------------------------
+
+class RepairPattern(str, Enum):
+    """Known tool-call repair patterns.
+
+    Derived from Hermes repair pipeline + Ahmad Awais (CommandCode) analysis
+    of 1T+ tokens across DeepSeek, Qwen, GLM, and other open models.
+    """
+    # JSON syntax repairs (message_sanitization.py)
+    EMPTY_ARGS = "empty_args"                    # Empty/whitespace → {}
+    NONE_LITERAL = "none_literal"                # Python None → {}
+    CONTROL_CHAR_ESCAPE = "control_char_escape"  # Unescaped control chars in JSON strings
+    TRAILING_COMMA = "trailing_comma"            # Trailing commas in JSON
+    UNCLOSED_BRACKET = "unclosed_bracket"        # Unclosed {}/[]
+    TRAILING_CONTENT = "trailing_content"        # Complete JSON + extra prose
+    DOUBLE_SERIALIZE = "double_serialize"        # JSON string wrapping JSON object
+    UNREPAIRABLE = "unrepairable"                # Last resort → {}
+
+    # Type coercion repairs (model_tools.py coerce_tool_args)
+    STRING_TO_INT = "string_to_int"              # "42" → 42
+    STRING_TO_FLOAT = "string_to_float"          # "3.14" → 3.14
+    STRING_TO_BOOL = "string_to_bool"            # "true" → True
+    STRING_TO_LIST = "string_to_list"            # JSON-encoded array string → list
+    STRING_TO_OBJECT = "string_to_object"        # JSON-encoded object string → dict
+    BARE_STRING_WRAP = "bare_string_wrap"        # "foo" → ["foo"] when array expected
+    BARE_OBJECT_WRAP = "bare_object_wrap"        # {} → [{}] when array expected
+    NULL_TO_NONE = "null_to_none"                # "null" → None for nullable schemas
+
+    # Name repairs
+    NAME_FUZZY_MATCH = "name_fuzzy_match"        # Fuzzy tool name matching
+    MCP_PREFIX_DROP = "mcp_prefix_drop"          # Missing mcp_ prefix
+
+    # Schema validation (PR #61550)
+    REQUIRED_MISSING = "required_missing"        # Missing required parameters
+
+    # Catch-all
+    OTHER = "other"
+
+
+# ---------------------------------------------------------------------------
+# Event dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RepairEvent:
+    """One recorded repair event."""
+    pattern: RepairPattern
+    tool_name: str
+    model_name: str
+    timestamp: float
+    success: bool
+    detail: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Thread-safe singleton with ring buffer
+# ---------------------------------------------------------------------------
+
+class ToolRepairStats:
+    """Thread-safe repair event collector with bounded ring buffer.
+
+    Usage::
+
+        stats = get_stats()
+        stats.record(RepairPattern.BARE_STRING_WRAP, "terminal", "deepseek/deepseek-v4-pro")
+        print(stats.summary())
+    """
+
+    _MAX_EVENTS: int = 10_000
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._events: List[RepairEvent] = []
+        self._model_counts: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
+
+    # -- recording ----------------------------------------------------------
+
+    def record(
+        self,
+        pattern: Any,
+        tool_name: str = "?",
+        model_name: str = "unknown",
+        success: bool = True,
+        detail: str = "",
+    ) -> None:
+        """Record a single repair event.  Thread-safe, bounded, cheap."""
+        try:
+            evt = RepairEvent(
+                pattern=pattern,
+                tool_name=tool_name,
+                model_name=model_name,
+                timestamp=time.time(),
+                success=success,
+                detail=detail,
+            )
+            with self._lock:
+                self._events.append(evt)
+                if len(self._events) > self._MAX_EVENTS:
+                    self._events = self._events[-self._MAX_EVENTS:]
+                self._model_counts[model_name][pattern.value] += 1
+        except Exception:
+            # Observability must NEVER break the repair pipeline.
+            pass
+
+    # -- querying -----------------------------------------------------------
+
+    def total(self) -> int:
+        with self._lock:
+            return len(self._events)
+
+    def by_model(self, model_name: str) -> Dict[str, int]:
+        """Return pattern→count dict for a specific model."""
+        with self._lock:
+            return dict(self._model_counts.get(model_name, {}))
+
+    def all_models(self) -> Dict[str, Dict[str, int]]:
+        """Return {model: {pattern: count}} for all observed models."""
+        with self._lock:
+            return {m: dict(p) for m, p in self._model_counts.items()}
+
+    def top_patterns(self, n: int = 10) -> List[tuple]:
+        """Return the N most frequent (pattern, count) pairs across all models."""
+        totals: Dict[str, int] = defaultdict(int)
+        with self._lock:
+            for model_counts in self._model_counts.values():
+                for pattern, count in model_counts.items():
+                    totals[pattern] += count
+        return sorted(totals.items(), key=lambda x: -x[1])[:n]
+
+    def recent(self, n: int = 20) -> List[RepairEvent]:
+        """Return the N most recent events."""
+        with self._lock:
+            return list(self._events[-n:])
+
+    # -- summary for CLI display --------------------------------------------
+
+    def summary(self) -> str:
+        """Human-readable summary table for CLI output."""
+        models = self.all_models()
+        if not models:
+            return "No tool-call repairs recorded this session."
+
+        lines = [
+            "Tool-Call Repair Stats",
+            "=" * 60,
+            "",
+        ]
+
+        # Per-model breakdown
+        for model_name in sorted(models):
+            patterns = models[model_name]
+            total = sum(patterns.values())
+            lines.append(f"  {model_name}  ({total} repairs)")
+            for pattern, count in sorted(patterns.items(), key=lambda x: -x[1]):
+                lines.append(f"    {pattern:30s} {count:>5d}")
+            lines.append("")
+
+        # Top patterns overall
+        top = self.top_patterns(5)
+        if top:
+            lines.append("  Top patterns (all models):")
+            for pattern, count in top:
+                lines.append(f"    {pattern:30s} {count:>5d}")
+            lines.append("")
+
+        grand_total = self.total()
+        lines.append(f"  Total events: {grand_total}")
+        return "\n".join(lines)
+
+    # -- lifecycle -----------------------------------------------------------
+
+    def reset(self) -> None:
+        """Clear all recorded events."""
+        with self._lock:
+            self._events.clear()
+            self._model_counts.clear()
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+_stats: Optional[ToolRepairStats] = None
+_stats_lock = threading.Lock()
+
+
+def get_stats() -> ToolRepairStats:
+    """Return the module-level singleton.  Thread-safe, lazy-init."""
+    global _stats
+    if _stats is None:
+        with _stats_lock:
+            if _stats is None:
+                _stats = ToolRepairStats()
+    return _stats
+
+
+# ---------------------------------------------------------------------------
+# Convenience function — the single call-site for all hook points
+# ---------------------------------------------------------------------------
+
+def record_repair(
+    pattern: RepairPattern,
+    tool_name: str = "?",
+    model_name: str = "unknown",
+    success: bool = True,
+    detail: str = "",
+) -> None:
+    """Record a repair event.  Silently no-ops on any failure."""
+    try:
+        get_stats().record(pattern, tool_name, model_name, success, detail)
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Current model context — set by dispatch_tool, read by hooks
+# ---------------------------------------------------------------------------
+
+_current_model: str = "unknown"
+_model_lock = threading.Lock()
+
+
+def set_current_model(model_name: str) -> None:
+    """Called by dispatch_tool to make the current model available to hooks."""
+    global _current_model
+    with _model_lock:
+        _current_model = model_name
+
+
+def get_current_model() -> str:
+    """Read by hook points to tag events with the model that caused them."""
+    with _model_lock:
+        return _current_model

--- a/agent/tool_repair_stats.py
+++ b/agent/tool_repair_stats.py
@@ -32,7 +32,6 @@ class RepairPattern(str, Enum):
     EMPTY_ARGS = "empty_args"                    # Empty/whitespace → {}
     NONE_LITERAL = "none_literal"                # Python None → {}
     CONTROL_CHAR_ESCAPE = "control_char_escape"  # Unescaped control chars in JSON strings
-    MALFORMED_JSON_REPAIR = "malformed_json_repair"  # Trailing commas, unclosed brackets, excess brackets
     UNCLOSED_BRACKET = "unclosed_bracket"        # Unclosed {}/[]
     TRAILING_CONTENT = "trailing_content"        # Complete JSON + extra prose
     DOUBLE_SERIALIZE = "double_serialize"        # JSON string wrapping JSON object

--- a/agent/tool_repair_stats.py
+++ b/agent/tool_repair_stats.py
@@ -36,6 +36,7 @@ class RepairPattern(str, Enum):
     UNCLOSED_BRACKET = "unclosed_bracket"        # Unclosed {}/[]
     TRAILING_CONTENT = "trailing_content"        # Complete JSON + extra prose
     DOUBLE_SERIALIZE = "double_serialize"        # JSON string wrapping JSON object
+    MALFORMED_JSON_REPAIR = "malformed_json_repair"  # Generic JSON syntax repair (trailing comma / unclosed bracket / excess braces)
     UNREPAIRABLE = "unrepairable"                # Last resort → {}
 
     # Type coercion repairs (model_tools.py coerce_tool_args)

--- a/model_tools.py
+++ b/model_tools.py
@@ -719,8 +719,8 @@ def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
                     tool_name, key,
                 )
                 try:
-                    from agent.tool_repair_stats import record_repair, RepairPattern, get_current_model
-                    record_repair(RepairPattern.BARE_STRING_WRAP, tool_name, get_current_model())
+                    from agent.tool_repair_stats import record_repair, RepairPattern
+                    record_repair(RepairPattern.BARE_STRING_WRAP, tool_name)
                 except ImportError:
                     pass
                 continue
@@ -730,8 +730,8 @@ def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
                 type(value).__name__, tool_name, key,
             )
             try:
-                from agent.tool_repair_stats import record_repair, RepairPattern, get_current_model
-                record_repair(RepairPattern.BARE_OBJECT_WRAP, tool_name, get_current_model())
+                from agent.tool_repair_stats import record_repair, RepairPattern
+                record_repair(RepairPattern.BARE_OBJECT_WRAP, tool_name)
             except ImportError:
                 pass
             continue

--- a/model_tools.py
+++ b/model_tools.py
@@ -718,12 +718,22 @@ def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
                     "coerce_tool_args: wrapped bare string in list for %s.%s",
                     tool_name, key,
                 )
+                try:
+                    from agent.tool_repair_stats import record_repair, RepairPattern, get_current_model
+                    record_repair(RepairPattern.BARE_STRING_WRAP, tool_name, get_current_model())
+                except ImportError:
+                    pass
                 continue
             args[key] = [value]
             logger.info(
                 "coerce_tool_args: wrapped bare %s in list for %s.%s",
                 type(value).__name__, tool_name, key,
             )
+            try:
+                from agent.tool_repair_stats import record_repair, RepairPattern, get_current_model
+                record_repair(RepairPattern.BARE_OBJECT_WRAP, tool_name, get_current_model())
+            except ImportError:
+                pass
             continue
 
         if not isinstance(value, str):

--- a/run_agent.py
+++ b/run_agent.py
@@ -5679,6 +5679,14 @@ class AIAgent:
         """
         tool_calls = assistant_message.tool_calls
 
+        # Tag repair-observability stats with the current model so
+        # per-model breakdowns in summary() reflect reality.
+        try:
+            from agent.tool_repair_stats import set_current_model as _set_model
+            _set_model(self.model or "unknown")
+        except Exception:
+            pass
+
         # Allow _vprint during tool execution even with stream consumers
         self._executing_tools = True
         try:

--- a/tests/test_tool_repair_stats.py
+++ b/tests/test_tool_repair_stats.py
@@ -4,18 +4,11 @@ from __future__ import annotations
 
 import threading
 
-
-# ---------------------------------------------------------------------------
-# Imports under test
-# ---------------------------------------------------------------------------
-
 from agent.tool_repair_stats import (
     RepairPattern,
     ToolRepairStats,
     get_stats,
     record_repair,
-    get_current_model,
-    set_current_model,
 )
 
 
@@ -29,9 +22,9 @@ class TestRepairPattern:
     def test_has_core_patterns(self):
         core = [
             "EMPTY_ARGS", "NONE_LITERAL", "CONTROL_CHAR_ESCAPE",
-            "TRAILING_COMMA", "UNREPAIRABLE",
+            "MALFORMED_JSON_REPAIR", "UNREPAIRABLE",
             "BARE_STRING_WRAP", "BARE_OBJECT_WRAP",
-            "STRING_TO_INT", "STRING_TO_BOOL",
+            "STRING_TO_INT", "STRING_TO_BOOL", "TRUNCATED_ARGS",
         ]
         for name in core:
             assert hasattr(RepairPattern, name), f"Missing pattern: {name}"
@@ -106,18 +99,43 @@ class TestToolRepairStatsBasic:
 
 
 # ---------------------------------------------------------------------------
-# Ring buffer cap
+# Ring buffer cap — overflow invariant (Teknium review fix)
 # ---------------------------------------------------------------------------
 
 class TestRingBuffer:
 
     def test_bounded_memory(self):
         stats = ToolRepairStats()
-        # Override max for faster test
         stats._MAX_EVENTS = 100
         for i in range(150):
             stats.record(RepairPattern.OTHER, "t", "m")
         assert stats.total() == 100
+
+    def test_no_double_count_after_overflow(self):
+        """After overflow, per-model totals must equal total().
+
+        Regression test for Teknium's review: the rebuild included the
+        newest event, then the normal increment double-counted it.
+        """
+        stats = ToolRepairStats()
+        stats._MAX_EVENTS = 10
+        for i in range(15):
+            stats.record(RepairPattern.BARE_STRING_WRAP, "t", "m")
+
+        assert stats.total() == 10
+        model_counts = stats.by_model("m")
+        assert sum(model_counts.values()) == 10, (
+            f"Expected 10, got {sum(model_counts.values())} — double-count bug"
+        )
+
+    def test_count_consistency_across_multiple_overflows(self):
+        """Multiple consecutive overflows must keep counts consistent."""
+        stats = ToolRepairStats()
+        stats._MAX_EVENTS = 5
+        for i in range(25):
+            stats.record(RepairPattern.OTHER, "t", "m")
+        assert stats.total() == 5
+        assert sum(stats.by_model("m").values()) == 5
 
 
 # ---------------------------------------------------------------------------
@@ -157,16 +175,12 @@ class TestFailureResilience:
     def test_record_never_raises(self):
         """record() must NEVER raise, even with garbage input."""
         stats = ToolRepairStats()
-        # Should not raise
         stats.record(None, None, None)  # type: ignore[arg-type]
         stats.record("not_an_enum", "", "")
 
     def test_import_failure_noop(self):
-        """When _record_repair is None, _stat should be a no-op."""
-        # This is tested indirectly — if the import fails in
-        # message_sanitization.py, the fallback record_repair does nothing.
-        # Here we just verify the module-level record_repair works.
-        record_repair(RepairPattern.OTHER, "test", "test")  # should not raise
+        """record_repair should work with string patterns too."""
+        record_repair("string_pattern", "test")  # should not raise
 
 
 # ---------------------------------------------------------------------------
@@ -191,22 +205,6 @@ class TestSummary:
 
 
 # ---------------------------------------------------------------------------
-# Model context (set_current_model / get_current_model)
-# ---------------------------------------------------------------------------
-
-class TestModelContext:
-
-    def test_set_and_get(self):
-        set_current_model("deepseek/deepseek-v4-pro")
-        assert get_current_model() == "deepseek/deepseek-v4-pro"
-
-    def test_default_is_unknown(self):
-        import agent.tool_repair_stats as mod
-        mod._current_model = "unknown"
-        assert get_current_model() == "unknown"
-
-
-# ---------------------------------------------------------------------------
 # Singleton
 # ---------------------------------------------------------------------------
 
@@ -222,5 +220,27 @@ class TestSingleton:
         stats.record(RepairPattern.OTHER, "t", "m")
         stats.reset()
         assert get_stats().total() == 0
-        # Same object
         assert get_stats() is stats
+
+
+# ---------------------------------------------------------------------------
+# String pattern normalization
+# ---------------------------------------------------------------------------
+
+class TestStringPatterns:
+
+    def test_string_pattern_recorded(self):
+        """String patterns (from _stat()) must be counted, not dropped."""
+        stats = ToolRepairStats()
+        stats.record("empty_args", "t", "m")
+        stats.record("empty_args", "t", "m")
+        assert stats.total() == 2
+        assert stats.by_model("m")["empty_args"] == 2
+
+    def test_string_and_enum_mixed(self):
+        """String and enum patterns for the same value should count together."""
+        stats = ToolRepairStats()
+        stats.record(RepairPattern.BARE_STRING_WRAP, "t", "m")
+        stats.record("bare_string_wrap", "t", "m")
+        assert stats.total() == 2
+        assert stats.by_model("m")["bare_string_wrap"] == 2

--- a/tests/test_tool_repair_stats.py
+++ b/tests/test_tool_repair_stats.py
@@ -1,0 +1,233 @@
+"""Tests for agent/tool_repair_stats.py — repair observability module."""
+
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Imports under test
+# ---------------------------------------------------------------------------
+
+from agent.tool_repair_stats import (
+    RepairEvent,
+    RepairPattern,
+    ToolRepairStats,
+    get_stats,
+    record_repair,
+    get_current_model,
+    set_current_model,
+)
+
+
+# ---------------------------------------------------------------------------
+# RepairPattern enum
+# ---------------------------------------------------------------------------
+
+class TestRepairPattern:
+    """Verify the enum covers the known failure modes."""
+
+    def test_has_core_patterns(self):
+        core = [
+            "EMPTY_ARGS", "NONE_LITERAL", "CONTROL_CHAR_ESCAPE",
+            "TRAILING_COMMA", "UNREPAIRABLE",
+            "BARE_STRING_WRAP", "BARE_OBJECT_WRAP",
+            "STRING_TO_INT", "STRING_TO_BOOL",
+        ]
+        for name in core:
+            assert hasattr(RepairPattern, name), f"Missing pattern: {name}"
+
+    def test_string_values(self):
+        """Enum values must be plain strings for serialization."""
+        for p in RepairPattern:
+            assert isinstance(p.value, str)
+
+
+# ---------------------------------------------------------------------------
+# ToolRepairStats — basic operations
+# ---------------------------------------------------------------------------
+
+class TestToolRepairStatsBasic:
+
+    def test_empty_stats(self):
+        stats = ToolRepairStats()
+        assert stats.total() == 0
+        assert stats.all_models() == {}
+        assert "No tool-call repairs" in stats.summary()
+
+    def test_record_single_event(self):
+        stats = ToolRepairStats()
+        stats.record(RepairPattern.BARE_STRING_WRAP, "terminal", "deepseek-v4")
+        assert stats.total() == 1
+        assert stats.by_model("deepseek-v4") == {"bare_string_wrap": 1}
+
+    def test_record_multiple_patterns(self):
+        stats = ToolRepairStats()
+        stats.record(RepairPattern.BARE_STRING_WRAP, "terminal", "ds")
+        stats.record(RepairPattern.BARE_STRING_WRAP, "read_file", "ds")
+        stats.record(RepairPattern.UNREPAIRABLE, "patch", "ds")
+        assert stats.total() == 3
+        by_model = stats.by_model("ds")
+        assert by_model["bare_string_wrap"] == 2
+        assert by_model["unrepairable"] == 1
+
+    def test_multiple_models(self):
+        stats = ToolRepairStats()
+        stats.record(RepairPattern.BARE_STRING_WRAP, "t", "model-a")
+        stats.record(RepairPattern.UNREPAIRABLE, "t", "model-b")
+        all_m = stats.all_models()
+        assert "model-a" in all_m
+        assert "model-b" in all_m
+
+    def test_top_patterns(self):
+        stats = ToolRepairStats()
+        for _ in range(10):
+            stats.record(RepairPattern.BARE_STRING_WRAP, "t", "m")
+        for _ in range(3):
+            stats.record(RepairPattern.UNREPAIRABLE, "t", "m")
+        top = stats.top_patterns(2)
+        assert top[0][0] == "bare_string_wrap"
+        assert top[0][1] == 10
+
+    def test_recent_events(self):
+        stats = ToolRepairStats()
+        for i in range(5):
+            stats.record(RepairPattern.OTHER, f"tool_{i}", "m")
+        recent = stats.recent(3)
+        assert len(recent) == 3
+        assert recent[-1].tool_name == "tool_4"
+
+    def test_reset(self):
+        stats = ToolRepairStats()
+        stats.record(RepairPattern.BARE_STRING_WRAP, "t", "m")
+        assert stats.total() == 1
+        stats.reset()
+        assert stats.total() == 0
+        assert stats.all_models() == {}
+
+
+# ---------------------------------------------------------------------------
+# Ring buffer cap
+# ---------------------------------------------------------------------------
+
+class TestRingBuffer:
+
+    def test_bounded_memory(self):
+        stats = ToolRepairStats()
+        # Override max for faster test
+        stats._MAX_EVENTS = 100
+        for i in range(150):
+            stats.record(RepairPattern.OTHER, "t", "m")
+        assert stats.total() == 100
+
+
+# ---------------------------------------------------------------------------
+# Thread safety
+# ---------------------------------------------------------------------------
+
+class TestThreadSafety:
+
+    def test_concurrent_recording(self):
+        stats = ToolRepairStats()
+        errors = []
+
+        def record_many(n: int):
+            try:
+                for _ in range(n):
+                    stats.record(RepairPattern.BARE_STRING_WRAP, "t", "m")
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=record_many, args=(100,)) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0
+        assert stats.total() == 1000
+        assert stats.by_model("m")["bare_string_wrap"] == 1000
+
+
+# ---------------------------------------------------------------------------
+# Failure resilience
+# ---------------------------------------------------------------------------
+
+class TestFailureResilience:
+
+    def test_record_never_raises(self):
+        """record() must NEVER raise, even with garbage input."""
+        stats = ToolRepairStats()
+        # Should not raise
+        stats.record(None, None, None)  # type: ignore[arg-type]
+        stats.record("not_an_enum", "", "")
+
+    def test_import_failure_noop(self):
+        """When _record_repair is None, _stat should be a no-op."""
+        # This is tested indirectly — if the import fails in
+        # message_sanitization.py, the fallback record_repair does nothing.
+        # Here we just verify the module-level record_repair works.
+        record_repair(RepairPattern.OTHER, "test", "test")  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Summary format
+# ---------------------------------------------------------------------------
+
+class TestSummary:
+
+    def test_summary_contains_model_name(self):
+        stats = ToolRepairStats()
+        stats.record(RepairPattern.BARE_STRING_WRAP, "terminal", "deepseek-v4")
+        s = stats.summary()
+        assert "deepseek-v4" in s
+        assert "bare_string_wrap" in s
+
+    def test_summary_contains_totals(self):
+        stats = ToolRepairStats()
+        stats.record(RepairPattern.BARE_STRING_WRAP, "t", "m")
+        stats.record(RepairPattern.UNREPAIRABLE, "t", "m")
+        s = stats.summary()
+        assert "Total events: 2" in s
+
+
+# ---------------------------------------------------------------------------
+# Model context (set_current_model / get_current_model)
+# ---------------------------------------------------------------------------
+
+class TestModelContext:
+
+    def test_set_and_get(self):
+        set_current_model("deepseek/deepseek-v4-pro")
+        assert get_current_model() == "deepseek/deepseek-v4-pro"
+
+    def test_default_is_unknown(self):
+        # Reset to default
+        from agent.tool_repair_stats import _current_model
+        import agent.tool_repair_stats as mod
+        mod._current_model = "unknown"
+        assert get_current_model() == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Singleton
+# ---------------------------------------------------------------------------
+
+class TestSingleton:
+
+    def test_get_stats_returns_same_instance(self):
+        a = get_stats()
+        b = get_stats()
+        assert a is b
+
+    def test_singleton_survives_reset(self):
+        stats = get_stats()
+        stats.record(RepairPattern.OTHER, "t", "m")
+        stats.reset()
+        assert get_stats().total() == 0
+        # Same object
+        assert get_stats() is stats

--- a/tests/test_tool_repair_stats.py
+++ b/tests/test_tool_repair_stats.py
@@ -3,10 +3,6 @@
 from __future__ import annotations
 
 import threading
-import time
-from unittest.mock import patch
-
-import pytest
 
 
 # ---------------------------------------------------------------------------
@@ -14,7 +10,6 @@ import pytest
 # ---------------------------------------------------------------------------
 
 from agent.tool_repair_stats import (
-    RepairEvent,
     RepairPattern,
     ToolRepairStats,
     get_stats,
@@ -206,8 +201,6 @@ class TestModelContext:
         assert get_current_model() == "deepseek/deepseek-v4-pro"
 
     def test_default_is_unknown(self):
-        # Reset to default
-        from agent.tool_repair_stats import _current_model
         import agent.tool_repair_stats as mod
         mod._current_model = "unknown"
         assert get_current_model() == "unknown"


### PR DESCRIPTION
## What does this PR do?

Adds structured observability to the existing tool-call repair pipeline. Records `RepairEvent` (pattern, tool, model, timestamp) at each repair pass, enabling per-model and per-pattern analysis — without affecting the model layer.

**This PR does NOT add new repairs.** It adds eyes to the repairs that already exist.

## Why

Hermes has a multi-pass repair pipeline (`_repair_tool_call_arguments`, `coerce_tool_args`, `_repair_tool_call` fuzzy matching) that fixes malformed JSON from open models. But there's **no observability** — operators don't know when repairs fire, which patterns dominate, or which models need the most help.

Ahmad Awais (CommandCode) showed that DeepSeek V4 Pro goes from "unusable" to "beating Opus 4.7" with just 4 deterministic repairs. The missing piece for Hermes is knowing **which** repairs matter most and **when** models degrade (e.g. under high inference load).

## Design constraints (from AGENTS.md)

- ✅ **No new model tools** — stats are operator-only, zero API cost
- ✅ **No prompt caching impact** — no system prompt changes
- ✅ **No new config keys** — no `HERMES_*` env vars
- ✅ **Import failure → no-op** — never breaks repair pipeline
- ✅ **Thread-safe** — `threading.Lock` on all shared state
- ✅ **Bounded memory** — ring buffer caps at 10,000 events

## Changes

### New file: `agent/tool_repair_stats.py`
- `RepairPattern` enum: 20 known failure patterns
- `ToolRepairStats`: thread-safe singleton with ring buffer
- `record_repair()`: convenience function (no-op on any failure)
- `summary()`: human-readable table for CLI

### Hooks in `agent/message_sanitization.py` (6 hooks, 1 line each)
- `empty_args`, `none_literal`, `control_char_escape`, `trailing_comma`, `unrepairable`

### Hooks in `model_tools.py` (2 hooks, 1 line each)
- `bare_string_wrap`, `bare_object_wrap`

### Tests: `tests/test_tool_repair_stats.py` (19 tests)
- Thread safety, ring buffer, failure resilience, summary format

## Overlapping PRs (complementary — adds observability, not repairs)

- #62578: `_repair_object_shape` (MCP required null strip)
- #56399: `repair_tool_call_arguments_with_status` (truncate handling)
- #61550: `validate_required_params` (required param validation)
- #59267: deferred tool schema probe
- #52747: DeepSeek double-serialize repair
- #55620: backslash control char repair
- #21696: `mcp_` prefix drop repair

## How to Test

```bash
python -m pytest tests/test_tool_repair_stats.py -v
python -m pytest tests/run_agent/test_repair_tool_call_arguments.py tests/run_agent/test_tool_arg_coercion.py -v
```

19 new tests pass. 82 existing repair/coercion tests pass (no regression).

## Checklist

- [x] I've read the Contributing Guide / AGENTS instructions
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs — found 8 overlapping (referenced above)
- [x] My PR contains only changes related to this feature
- [x] All tests pass (19 new + 82 existing)
- [x] I've tested on my platform: Linux (Ubuntu 24.04)
