### PR TITLE
fix(gateway): exempt Weixin from open-policy startup gate (transport-bound adapter)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2915,6 +2915,17 @@ class BasePlatformAdapter(ABC):
     # property) so the stream consumer knows not to short-circuit.
     REQUIRES_EDIT_FINALIZE: bool = False
 
+    # Whether dm_policy/group_policy: "open" exposes this adapter to peers
+    # the transport has NOT already authenticated or bound at provisioning.
+    # True (default) for public-reachable platforms where anyone can message
+    # the bot handle (Telegram, WhatsApp, Signal, etc.) — "open" = open to
+    # the world, and the startup gate is correct to require allow-all opt-in.
+    # False for transport-bound adapters where the bot is cryptographically
+    # fused to a single peer at provisioning: on these platforms "open" admits
+    # exactly the one already-authenticated bound user, so there is no external
+    # surface for the gate to protect (issue #62553).
+    open_admits_unbound_peers: bool = True
+
     async def create_handoff_thread(
         self,
         parent_chat_id: str,

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1147,6 +1147,15 @@ class WeixinAdapter(BasePlatformAdapter):
     # fallback "send-final-only" path so the cursor (▉) is never left visible.
     SUPPORTS_MESSAGE_EDITING = False
 
+    # iLink ClawBot (bot_type=3) is cryptographically bound at provisioning to
+    # the single WeChat user who scanned the QR code.  The issued bot_token
+    # embeds that user's ilink_user_id; from_user_id is always the scanner and
+    # the bot cannot be discovered, added, or messaged by any second user.
+    # dm_policy: "open" therefore admits exactly the one already-authenticated
+    # bound user — there is no external surface, and the startup open-policy
+    # gate is a false positive on this platform (issue #62553).
+    open_admits_unbound_peers = False
+
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.WEIXIN)
         extra = config.extra or {}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1742,9 +1742,24 @@ from gateway.whatsapp_identity import (
 logger = logging.getLogger(__name__)
 
 
+# Platforms where dm_policy/group_policy: "open" exposes the gateway to
+# unauthenticated peers (i.e. anyone can message the bot handle/number).
+# These are the platforms where an open policy without allow-all opt-in is a
+# genuine security risk and the startup gate should refuse to boot.
+#
+# Platforms where the transport itself binds the bot to a single authenticated
+# peer at provisioning (e.g. Weixin iLink ClawBot: bot_token is fused to one
+# ilink_user_id, no second user can ever reach the bot) are deliberately
+# excluded here -- on those platforms open_admits_unbound_peers=False on the
+# adapter class, and "open" admits exactly the one already-authenticated bound
+# user.  The gate would be a false positive and would break upgrades for users
+# who ran open legitimately under v0.17 (issue #62553).
 _OWN_POLICY_OPEN_ENV = {
     Platform.WECOM: ("WECOM_DM_POLICY", "WECOM_GROUP_POLICY", "WECOM_ALLOW_ALL_USERS"),
-    Platform.WEIXIN: ("WEIXIN_DM_POLICY", "WEIXIN_GROUP_POLICY", "WEIXIN_ALLOW_ALL_USERS"),
+    # Platform.WEIXIN is intentionally absent: iLink ClawBot (bot_type=3) is
+    # transport-bound to the single user who scanned the QR at provisioning.
+    # open_admits_unbound_peers=False on WeixinAdapter; the gate is a
+    # false positive here.  See gateway/platforms/weixin.py and issue #62553.
     Platform.YUANBAO: ("YUANBAO_DM_POLICY", "YUANBAO_GROUP_POLICY", "YUANBAO_ALLOW_ALL_USERS"),
     Platform.QQBOT: (None, None, "QQ_ALLOW_ALL_USERS"),
     Platform.WHATSAPP: ("WHATSAPP_DM_POLICY", "WHATSAPP_GROUP_POLICY", "WHATSAPP_ALLOW_ALL_USERS"),


### PR DESCRIPTION
## Problem

The v0.18 open-policy startup gate correctly protects public-reachable platforms where dm_policy: open means anyone can message the bot. It is a false positive for Weixin iLink ClawBot (bot_type=3): the bot_token is cryptographically fused at provisioning to the single user who scanned the QR -- no second user can ever reach the bot. dm_policy: open there admits exactly the one already-authenticated bound user, so there is no external surface to protect (issue #62553). This broke any Weixin deployment running open under v0.17 after upgrading.

## Fix

Implements the adapter-trait design suggested in the issue: (1) BasePlatformAdapter gets open_admits_unbound_peers: bool = True (safe default for public platforms), (2) WeixinAdapter overrides to False with a docstring explaining the iLink provisioning model, (3) Platform.WEIXIN removed from _OWN_POLICY_OPEN_ENV with a comment. WECOM, YUANBAO, QQBOT, and WHATSAPP remain gated.

Fixes #62553