### PR TITLE
fix(gateway): anchor Feishu replies to triggering message

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -102,8 +102,8 @@ def _reply_anchor_for_event(event) -> str | None:
         return getattr(event, "message_id", None) or getattr(event, "reply_to_message_id", None)
     if platform == "telegram" and thread_id:
         return None
-    if platform == "feishu" and thread_id and getattr(event, "reply_to_message_id", None):
-        return getattr(event, "reply_to_message_id", None)
+    if platform == "feishu":
+        return getattr(event, "message_id", None) or getattr(event, "reply_to_message_id", None)
     return getattr(event, "message_id", None)
 
 

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -10,6 +10,7 @@ from gateway.platforms.base import (
     BasePlatformAdapter,
     GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE,
     MessageEvent,
+    _reply_anchor_for_event,
     cache_audio_from_bytes,
     cache_image_from_bytes,
     cache_video_from_bytes,
@@ -19,6 +20,8 @@ from gateway.platforms.base import (
     _log_safe_path,
     _prefix_within_utf16_limit,
 )
+from gateway.config import Platform
+from gateway.session import SessionSource
 
 
 class TestInboundMediaSizeCap:
@@ -125,6 +128,52 @@ class TestMessageEventIsCommand:
     def test_slash_only(self):
         event = MessageEvent(text="/")
         assert event.is_command() is True
+
+
+class TestReplyAnchorForEvent:
+    def test_feishu_topic_reply_anchors_to_triggering_user_message(self):
+        event = MessageEvent(
+            text="follow up",
+            message_id="om_user_current",
+            reply_to_message_id="om_bot_parent",
+            source=SessionSource(
+                platform=Platform.FEISHU,
+                chat_id="oc_chat",
+                chat_type="dm",
+                thread_id="om_topic_root",
+            ),
+        )
+
+        assert _reply_anchor_for_event(event) == "om_user_current"
+
+    def test_feishu_topic_reply_falls_back_to_parent_without_current_message_id(self):
+        event = MessageEvent(
+            text="follow up",
+            reply_to_message_id="om_bot_parent",
+            source=SessionSource(
+                platform=Platform.FEISHU,
+                chat_id="oc_chat",
+                chat_type="dm",
+                thread_id="om_topic_root",
+            ),
+        )
+
+        assert _reply_anchor_for_event(event) == "om_bot_parent"
+
+    def test_telegram_private_topic_still_anchors_to_triggering_user_message(self):
+        event = MessageEvent(
+            text="follow up",
+            message_id="tg_user_current",
+            reply_to_message_id="tg_bot_parent",
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id="123",
+                chat_type="dm",
+                thread_id="42",
+            ),
+        )
+
+        assert _reply_anchor_for_event(event) == "tg_user_current"
 
 
 class TestMessageEventGetCommand:


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

N/A — no related issue.

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made


Fix Feishu threaded replies so they anchor to the triggering inbound message,
rather than the parent message of that thread. This preserves the thread while
making the bot visibly reply to the user message that triggered it.


## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_platform_base.py -q`.
2. Confirm the Feishu regression case uses the event's `message_id` rather than
   `reply_to_message_id`.
3. Confirm the Telegram topic-routing regression case still passes.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!macOS>

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

