### PR TITLE
feat(compression): proactive tool-result pruning for large-window models

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1552,6 +1552,8 @@ def init_agent(
     compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in {"true", "1", "yes"}
     compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
     compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))
+    compression_proactive_prune_tokens = int(_compression_cfg.get("proactive_prune_tokens", 0))
+    compression_proactive_prune_min_chars = int(_compression_cfg.get("proactive_prune_min_result_chars", 8000))
     # protect_first_n is the number of non-system messages to protect at
     # the head, in addition to the system prompt (which is always
     # implicitly protected by the compressor).  Floor at 0 — a value of
@@ -1827,6 +1829,8 @@ def init_agent(
             api_mode=agent.api_mode,
             abort_on_summary_failure=compression_abort_on_summary_failure,
             max_tokens=agent.max_tokens,
+            proactive_prune_tokens=compression_proactive_prune_tokens,
+            proactive_prune_min_result_chars=compression_proactive_prune_min_chars,
         )
     _bind_session_state = getattr(agent.context_compressor, "bind_session_state", None)
     if callable(_bind_session_state):

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1044,6 +1044,8 @@ class ContextCompressor(ContextEngine):
         api_mode: str = "",
         abort_on_summary_failure: bool = False,
         max_tokens: int | None = None,
+        proactive_prune_tokens: int = 0,
+        proactive_prune_min_result_chars: int = 8000,
     ):
         self.model = model
         self.base_url = base_url
@@ -1053,6 +1055,19 @@ class ContextCompressor(ContextEngine):
         self.threshold_percent = threshold_percent
         self.protect_first_n = protect_first_n
         self.protect_last_n = protect_last_n
+        # Proactive tool-result pruning (cost-oriented; runs INDEPENDENTLY of the
+        # full-compression trigger, via prune_tool_results_only()). 0 = disabled.
+        self.proactive_prune_tokens = int(proactive_prune_tokens or 0)
+        # Floor the summarize threshold at 200 chars (matching
+        # _prune_old_tool_results' dedup floor). Below ~200 a generated summary
+        # can be longer than the floor it replaces, so Pass 2 would re-summarize
+        # its own output every turn (corrupting it and never converging); a
+        # negative value would strip every non-tail tool result outright. A
+        # configured 0 keeps the 8000 default via `or`. Keep the floor well above
+        # typical summary length (default 8000) to stay idempotent.
+        self.proactive_prune_min_result_chars = max(
+            200, int(proactive_prune_min_result_chars or 8000)
+        )
         self.summary_target_ratio = max(0.10, min(summary_target_ratio, 0.80))
         self.quiet_mode = quiet_mode
         # Output-token reservation: the provider carves max_tokens out of the
@@ -1269,6 +1284,7 @@ class ContextCompressor(ContextEngine):
     def _prune_old_tool_results(
         self, messages: List[Dict[str, Any]], protect_tail_count: int,
         protect_tail_tokens: int | None = None,
+        min_prune_chars: int = 200,
     ) -> tuple[List[Dict[str, Any]], int]:
         """Replace old tool result contents with informative 1-line summaries.
 
@@ -1392,8 +1408,9 @@ class ContextCompressor(ContextEngine):
             # Skip already-deduplicated or previously-summarized results
             if content.startswith("[Duplicate tool output"):
                 continue
-            # Only prune if the content is substantial (>200 chars)
-            if len(content) > 200:
+            # Only prune if the content is substantial (default >200 chars; the
+            # proactive path raises this floor via min_prune_chars).
+            if len(content) > min_prune_chars:
                 call_id = msg.get("tool_call_id", "")
                 tool_name, tool_args = call_id_to_tool.get(call_id, ("unknown", ""))
                 summary = _summarize_tool_result(tool_name, tool_args, content)
@@ -1427,6 +1444,51 @@ class ContextCompressor(ContextEngine):
                 result[i] = {**msg, "tool_calls": new_tcs}
 
         return result, pruned
+
+    def prune_tool_results_only(
+        self, messages: List[Dict[str, Any]], current_tokens: int | None = None,
+    ) -> tuple[List[Dict[str, Any]], int]:
+        """Deterministic, no-LLM tool-result prune for the cost-oriented path.
+
+        Runs the Phase-1 prune (``_prune_old_tool_results``) WITHOUT the
+        compression summary phase, gated on ``proactive_prune_tokens`` rather
+        than the (much higher) full-compression threshold. On large-window
+        models ``should_compress()`` (≈50% of the window) rarely fires, so old
+        tool outputs otherwise ride in history and are re-sent verbatim on every
+        subsequent turn; this reclaims them early with no quality-risky LLM
+        summarization.
+
+        Protects the recent tail by message COUNT (``protect_last_n``), never by
+        ``tail_token_budget`` — the latter is derived from the 50% compression
+        threshold (≈100K tokens on a 1M window) and would protect the entire
+        session, pruning nothing.
+
+        ``_prune_old_tool_results`` runs all three deterministic passes:
+        (1) dedup byte-identical tool results — keeps the newest full copy and
+        back-references older exact duplicates ANYWHERE in the list (including
+        the protected tail), so no unique content is ever lost; (2) summarize
+        non-tail tool results larger than ``min_prune_chars``; (3) truncate
+        oversized tool_call arguments on non-tail assistant messages. Only
+        pass (2)'s floor is raised by ``proactive_prune_min_result_chars``;
+        passes (1) and (3) keep their own fixed floors. The recent-tail
+        protection applies to passes (2) and (3); pass (1) is tail-agnostic by
+        design because dedup is lossless.
+
+        Returns ``(messages, 0)`` unchanged when disabled or below the trigger.
+        """
+        if self.proactive_prune_tokens <= 0:
+            return messages, 0
+        if current_tokens is not None and current_tokens < self.proactive_prune_tokens:
+            return messages, 0
+        # Nothing to reclaim until there are messages outside the protected tail.
+        if len(messages) <= self.protect_last_n + self._protect_head_size(messages) + 1:
+            return messages, 0
+        return self._prune_old_tool_results(
+            messages,
+            protect_tail_count=self.protect_last_n,
+            protect_tail_tokens=None,
+            min_prune_chars=self.proactive_prune_min_result_chars,
+        )
 
     # ------------------------------------------------------------------
     # Summarization

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -105,6 +105,27 @@ class ContextEngine(ABC):
                 don't support it may simply ignore this argument.
         """
 
+    # -- Optional: proactive tool-result prune -----------------------------
+
+    def prune_tool_results_only(
+        self,
+        messages: List[Dict[str, Any]],
+        current_tokens: int | None = None,
+    ) -> tuple[List[Dict[str, Any]], int]:
+        """Deterministically trim old tool-result payloads without an LLM call.
+
+        Runs on a low, cost-oriented trigger independent of ``should_compress``
+        so large-window engines can reclaim re-sent tool output long before full
+        compaction would fire. Returns ``(messages, n_pruned)``.
+
+        Default is a safe no-op: the list is returned unchanged with ``0``
+        pruned. Engines that don't implement a cheap prune — and any engine that
+        predates this hook — inherit this default, so the agent loop's
+        post-tool-call prune path never raises ``AttributeError`` on them. The
+        built-in ContextCompressor overrides this with the real implementation.
+        """
+        return messages, 0
+
     # -- Optional: pre-flight check ----------------------------------------
 
     def should_compress_preflight(self, messages: List[Dict[str, Any]]) -> bool:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4791,6 +4791,31 @@ def run_conversation(
                     conversation_history = conversation_history_after_compression(
                         agent, messages
                     )
+                elif agent.compression_enabled:
+                    # Proactive tool-result prune: reclaim re-sent history on
+                    # large-window models long before should_compress() (≈50% of
+                    # the window) would ever fire. Deterministic, no LLM call;
+                    # protects the recent tail. No-op unless proactive_prune_tokens
+                    # is configured and _real_tokens is above it. See
+                    # ContextCompressor.prune_tool_results_only.
+                    _pruned_msgs, _pruned_n = _compressor.prune_tool_results_only(
+                        messages, current_tokens=_real_tokens
+                    )
+                    if _pruned_n:
+                        # Do NOT rebuild conversation_history here. Unlike the
+                        # compression branch, the prune neither rotates the session
+                        # nor calls archive_and_compact(), so there is no new
+                        # persistence baseline to establish. _prune_old_tool_results
+                        # returns per-message copies that preserve the
+                        # _DB_PERSISTED_MARKER, so the marker-based flush dedup (see
+                        # _flush_messages_to_session_db) already prevents both
+                        # duplicate writes and dropped rows. Calling
+                        # conversation_history_after_compression (a compaction-only
+                        # helper keyed on the _last_compaction_in_place flag) would be
+                        # a no-op at best, and on a stale in-place flag could seed
+                        # this turn's fresh, not-yet-persisted rows into history_ids
+                        # and skip writing them.
+                        messages = _pruned_msgs
                 
                 # Save session log incrementally (so progress is visible even if interrupted)
                 agent._session_messages = messages

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1418,6 +1418,19 @@ DEFAULT_CONFIG = {
                                       # set this above 0.75 to override the floor.
         "target_ratio": 0.20,         # fraction of threshold to preserve as recent tail
         "protect_last_n": 20,         # minimum recent messages to keep uncompressed
+        "proactive_prune_tokens": 0,  # opt-in trigger (tokens) for the deterministic,
+                                      # no-LLM tool-result prune, run independently of
+                                      # `threshold` above. On large-window models
+                                      # `threshold` (≈50% of the window) rarely fires,
+                                      # so old tool output otherwise rides in history
+                                      # and is re-sent every turn; a low value like
+                                      # 48000 reclaims it early. 0 = off. Recent tail
+                                      # protected by `protect_last_n`. Built-in
+                                      # compressor only (other engines inherit a no-op).
+        "proactive_prune_min_result_chars": 8000,  # the prune's summarize pass only
+                                      # touches tool results larger than this (chars);
+                                      # clamped to >= 200 so a generated summary can't
+                                      # itself be re-summarized.
         "hygiene_hard_message_limit": 5000,  # gateway session-hygiene force-compress threshold by message count
         "protect_first_n": 3,         # non-system head messages always preserved
                                       # verbatim, in ADDITION to the system prompt

--- a/tests/agent/test_context_engine.py
+++ b/tests/agent/test_context_engine.py
@@ -181,6 +181,21 @@ class TestStubEngine:
         assert engine.last_prompt_tokens == 1000
         assert engine.last_completion_tokens == 200
 
+    def test_prune_tool_results_only_defaults_to_safe_noop(self):
+        # An engine implementing only the required interface (no prune override)
+        # must inherit the base no-op instead of raising AttributeError: the
+        # agent loop calls prune_tool_results_only() on the active engine after a
+        # tool call whenever full compression does not fire, so every pluggable
+        # ContextEngine reaches this path (see conversation_loop proactive-prune).
+        engine = StubEngine()
+        msgs = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        result, pruned = engine.prune_tool_results_only(msgs, current_tokens=10_000_000)
+        assert pruned == 0
+        assert result is msgs
+
 
 # ---------------------------------------------------------------------------
 # ContextCompressor session reset via ABC

--- a/tests/agent/test_proactive_tool_result_pruning.py
+++ b/tests/agent/test_proactive_tool_result_pruning.py
@@ -1,0 +1,164 @@
+"""Tests for proactive tool-result pruning.
+
+``ContextCompressor.prune_tool_results_only`` runs the cheap, deterministic
+Phase-1 prune (summarize old tool outputs, dedup repeats) on a cost-oriented
+trigger that is INDEPENDENT of the full-compression threshold. On large-window
+models ``should_compress()`` (~50% of the window) rarely fires, so without this
+the old tool outputs ride in history and are re-sent verbatim every turn.
+
+Mirrors the construction/patching conventions in test_context_compressor.py.
+"""
+
+from unittest.mock import patch
+
+from agent.context_compressor import ContextCompressor, _PRUNED_TOOL_PLACEHOLDER
+
+LARGE_WINDOW = 1_000_000
+
+
+def _compressor(**kw):
+    defaults = dict(
+        model="test",
+        quiet_mode=True,
+        threshold_percent=0.50,
+        protect_first_n=2,
+        protect_last_n=4,
+    )
+    defaults.update(kw)
+    with patch(
+        "agent.context_compressor.get_model_context_length",
+        return_value=LARGE_WINDOW,
+    ):
+        return ContextCompressor(**defaults)
+
+
+def _assistant_call(cid, name="terminal", args='{"cmd":"ls"}'):
+    return {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {"id": cid, "type": "function",
+             "function": {"name": name, "arguments": args}}
+        ],
+    }
+
+
+def _tool_msg(cid, content):
+    return {"role": "tool", "tool_call_id": cid, "content": content}
+
+
+def _build(n_pairs, big_indices, big_chars=9000, small="ok"):
+    """system + n_pairs of (assistant tool_call, tool result).
+
+    Tool results whose pair index is in ``big_indices`` get a distinct payload
+    of ``big_chars`` characters; the rest get a tiny payload.
+    """
+    msgs = [{"role": "system", "content": "sys"}]
+    for i in range(n_pairs):
+        cid = f"call_{i}"
+        msgs.append(_assistant_call(cid))
+        if i in big_indices:
+            msgs.append(_tool_msg(cid, chr(65 + (i % 26)) * big_chars))
+        else:
+            msgs.append(_tool_msg(cid, small))
+    return msgs
+
+
+def _tool_by_id(msgs, cid):
+    return [m for m in msgs if m.get("role") == "tool" and m.get("tool_call_id") == cid][0]
+
+
+def test_prunes_below_compression_threshold():
+    """The whole point: prune fires at 120k tokens, far below the ~500k
+    (50% of 1M) full-compression trigger that would otherwise never run."""
+    c = _compressor(proactive_prune_tokens=48_000, proactive_prune_min_result_chars=8_000)
+    assert c.should_compress(prompt_tokens=120_000) is False  # compression would NOT run
+    msgs = _build(8, big_indices={0, 1, 2})
+    result, pruned = c.prune_tool_results_only(msgs, current_tokens=120_000)
+    assert pruned >= 3
+    assert len(result) == len(msgs)
+    for cid in ("call_0", "call_1", "call_2"):
+        m = _tool_by_id(result, cid)
+        assert len(m["content"]) < 9000                       # summarized
+        assert m["content"] != _PRUNED_TOOL_PLACEHOLDER       # informative, not a blank placeholder
+
+
+def test_disabled_by_default_is_noop():
+    c = _compressor()  # proactive_prune_tokens defaults to 0
+    assert c.proactive_prune_tokens == 0
+    msgs = _build(8, big_indices={0, 1, 2})
+    result, pruned = c.prune_tool_results_only(msgs, current_tokens=500_000)
+    assert pruned == 0
+    assert [m.get("content") for m in result] == [m.get("content") for m in msgs]
+
+
+def test_below_trigger_is_noop():
+    c = _compressor(proactive_prune_tokens=48_000)
+    msgs = _build(8, big_indices={0, 1, 2})
+    result, pruned = c.prune_tool_results_only(msgs, current_tokens=10_000)
+    assert pruned == 0
+
+
+def test_recent_tail_is_protected():
+    c = _compressor(proactive_prune_tokens=48_000, proactive_prune_min_result_chars=8_000)
+    # pair 0 tool is old (index 2); pair 7 tool is in the last-4 protected tail (index 16)
+    msgs = _build(8, big_indices={0, 7})
+    result, pruned = c.prune_tool_results_only(msgs, current_tokens=120_000)
+    assert len(_tool_by_id(result, "call_7")["content"]) == 9000   # protected, untouched
+    assert len(_tool_by_id(result, "call_0")["content"]) < 9000    # old, summarized
+
+
+def test_size_floor_spares_small_results():
+    c = _compressor(proactive_prune_tokens=48_000, proactive_prune_min_result_chars=8_000)
+    msgs = _build(8, big_indices={1}, big_chars=9000)
+    for m in msgs:                      # make pair 0's tool 5000 chars (< 8000 floor), still old
+        if m.get("tool_call_id") == "call_0":
+            m["content"] = "Z" * 5000
+    result, pruned = c.prune_tool_results_only(msgs, current_tokens=120_000)
+    assert len(_tool_by_id(result, "call_0")["content"]) == 5000   # under floor -> untouched
+    assert len(_tool_by_id(result, "call_1")["content"]) < 9000    # over floor -> summarized
+
+
+def test_structure_preserved():
+    c = _compressor(proactive_prune_tokens=48_000, proactive_prune_min_result_chars=8_000)
+    msgs = _build(8, big_indices={0, 1, 2})
+    roles_before = [m["role"] for m in msgs]
+    ids_before = [m.get("tool_call_id") for m in msgs]
+    result, _ = c.prune_tool_results_only(msgs, current_tokens=120_000)
+    assert len(result) == len(msgs)
+    assert [m["role"] for m in result] == roles_before
+    assert [m.get("tool_call_id") for m in result] == ids_before
+
+
+def test_idempotent():
+    c = _compressor(proactive_prune_tokens=48_000, proactive_prune_min_result_chars=8_000)
+    msgs = _build(8, big_indices={0, 1, 2})
+    first, n1 = c.prune_tool_results_only(msgs, current_tokens=120_000)
+    assert n1 >= 3
+    second, n2 = c.prune_tool_results_only(first, current_tokens=120_000)
+    assert n2 == 0
+    assert [m.get("content") for m in second] == [m.get("content") for m in first]
+
+
+def test_prune_old_tool_results_default_floor_unchanged():
+    """Backward-compat: without min_prune_chars, _prune_old_tool_results still
+    prunes >200-char results (the compression Phase-1 caller's behavior)."""
+    c = _compressor()
+    msgs = _build(8, big_indices=set())
+    for m in msgs:                      # a 300-char old tool result
+        if m.get("tool_call_id") == "call_0":
+            m["content"] = "Q" * 300
+    result, pruned = c._prune_old_tool_results(msgs, protect_tail_count=4)
+    assert len(_tool_by_id(result, "call_0")["content"]) < 300
+    assert pruned >= 1
+
+
+def test_min_result_chars_floor_is_clamped():
+    """Config-robustness: a floor below 200 (or negative) is clamped up to 200,
+    while a configured 0 falls back to the 8000 default via ``or``. Without the
+    clamp, a tiny floor lets Pass 2 re-summarize its own (short) summary every
+    turn, and a negative floor strips every non-tail tool result."""
+    assert _compressor(proactive_prune_min_result_chars=0).proactive_prune_min_result_chars == 8000
+    assert _compressor(proactive_prune_min_result_chars=50).proactive_prune_min_result_chars == 200
+    assert _compressor(proactive_prune_min_result_chars=-1).proactive_prune_min_result_chars == 200
+    assert _compressor(proactive_prune_min_result_chars=8000).proactive_prune_min_result_chars == 8000

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -742,6 +742,8 @@ compression:
   protect_last_n: 20                                # Min recent messages to keep uncompressed
   protect_first_n: 3                                # Non-system head messages pinned across compactions (0 = pin nothing)
   hygiene_hard_message_limit: 5000                  # Gateway safety valve — see below
+  proactive_prune_tokens: 0                         # Opt-in tokens trigger for the no-LLM tool-result prune (0 = off; see below)
+  proactive_prune_min_result_chars: 8000            # Prune's summarize pass only touches tool results larger than this (clamped >= 200)
 
 # The summarization model/provider is configured under auxiliary:
 auxiliary:
@@ -758,6 +760,8 @@ Older configs with `compression.summary_model`, `compression.summary_provider`, 
 `hygiene_hard_message_limit` is a gateway-only **pre-compression safety valve**. It exists to break a death spiral: when API calls keep disconnecting on an oversized session, the gateway never receives token-usage data, so the token-based threshold can't fire, so the transcript keeps growing and disconnects get worse. This count-based floor fires on message count alone (always known, regardless of API failures) to force compression and recover the session. Default `5000` — far above any normal session, including large-context (1M+) models doing thousands of short turns, which compress on the token threshold long before this. Raise it further for unusual platforms, lower it to force more aggressive compression. Editing this value on a running gateway takes effect on the next message (see below).
 
 `protect_first_n` controls how many **non-system** head messages are pinned across every compaction. Default `3` — the opening user/assistant exchange survives every summarizer pass so the original goal stays visible. On long-running rolling-compaction sessions where the opening turn is no longer relevant, set `protect_first_n: 0` to pin nothing but the system prompt + summary + tail. The system prompt itself is always preserved regardless of this setting.
+
+`proactive_prune_tokens` enables a deterministic, no-LLM prune of old tool-result payloads that runs independently of `threshold`. On large-window models the `threshold` compaction (≈50% of the window) rarely fires, so bulky tool outputs (terminal dumps, file reads, web extracts) ride along in history and get re-sent on every subsequent turn. When re-sent history exceeds `proactive_prune_tokens` (default `0` = off; try `48000` to enable), the prune dedupes identical results, summarizes older oversized ones, and truncates large tool-call arguments — protecting the most recent `protect_last_n` messages and never calling the model. Full outputs stay recoverable from the session store. `proactive_prune_min_result_chars` (default `8000`, clamped to ≥ 200) sets the size below which a tool result is left untouched. This runs only under the built-in `compressor` engine; other context engines inherit a no-op.
 
 :::tip Gateway hot-reload of compression and context length
 As of recent releases, editing `model.context_length` or any `compression.*` key in `config.yaml` on a running gateway takes effect on the next message — no gateway restart, no `/reset`, no session rotation required. The cached-agent signature includes these keys, so the gateway transparently rebuilds the agent when it sees a change. API keys and tool/skill config still require the usual reload paths.


### PR DESCRIPTION
## Summary

An opt-in pass that trims old tool-result payloads out of the re-sent history on a low token trigger, separate from the full-compression trigger. It makes no LLM call and is off by default, so nothing changes unless you turn it on.

## Problem

Every turn re-sends the whole message list, so a single large tool output (a `terminal` dump, a `read_file`, a `web_extract`) keeps getting re-billed on every turn after it lands. Profiling real sessions, re-sent history was over 70% of input tokens, almost all of it old tool output that never gets trimmed.

The compressor already has a cheap, deterministic pass for exactly this: `_prune_old_tool_results` dedups identical results, summarizes old ones, and truncates oversized tool-call args. The catch is that it only runs as phase 1 of `compress()`, which fires at roughly 50% of the context window. On a 1M-token window that's ~500K, and real sessions rarely come close, so the prune sits there and never runs.

## Change

Run that same phase-1 prune on its own low trigger, `proactive_prune_tokens`, decoupled from compression:

- `ContextCompressor.prune_tool_results_only()` runs the prune without the LLM summary phase.
- It's wired into the loop as an `elif` on the compression branch, so the two never both fire in a turn. When `should_compress()` is False (the usual case on a large window), the cheap prune gets its shot.
- The recent tail is protected by message count (`protect_last_n`), not by a token budget. A token-budget tail on a 1M window would cover the whole session and prune nothing.
- The method is declared on the `ContextEngine` base class as a no-op default, so a pluggable context engine that doesn't implement it inherits the no-op instead of raising `AttributeError` on the post-tool-call path. The built-in compressor supplies the real implementation.

## Configuration

Opt-in, under the top-level `compression:` block (same place as `threshold`, `protect_last_n`, etc.):

```yaml
compression:
  proactive_prune_tokens: 48000           # run the tool-result prune once re-sent history
                                          # reaches this many tokens. 0 (default) = off.
  proactive_prune_min_result_chars: 8000  # only summarize tool results larger than this. Clamped to >= 200.
```

Both keys are registered in the config defaults and documented in the configuration guide. `compression.*` keys hot-reload on a running gateway, so tuning the trigger takes effect on the next message.

## Safety and behavior

- It never calls the model, so there's no summary-quality risk; it only dedups, writes one-line summaries, and truncates big tool-call args.
- The last `protect_last_n` messages are never touched by the summarize or truncate passes. Dedup keeps the newest full copy and only back-references byte-identical older ones, so nothing unique is lost.
- Persistence is untouched. Pruned messages are copies that keep the internal persisted marker, so the session DB isn't double-written or stripped, and the full output is still on disk for reload.
- It's idempotent. The `proactive_prune_min_result_chars` floor is clamped to 200 so a generated summary can't itself be re-summarized into garbage.
- Pluggable context engines are unaffected: they inherit the base no-op and never see this behavior unless they implement it.
- If compression backs off (its anti-thrash guard), the prune still reclaims tokens.

## Performance

On real large sessions this reclaimed 18–30% of snapshot input tokens with no quality change I could see, and `should_compress()` stayed False throughout, so the prune did the work rather than compaction.

## Testing

New `tests/agent/test_proactive_tool_result_pruning.py` (9 tests) plus a regression test in `tests/agent/test_context_engine.py` that a minimal engine implementing only the required interface inherits the base no-op without raising.

```
pytest tests/agent/test_proactive_tool_result_pruning.py tests/agent/test_context_compressor.py tests/agent/test_context_engine.py -q
# 188 passed
```

## Backward compatibility

Off by default (`proactive_prune_tokens: 0`). `_prune_old_tool_results` gets a new `min_prune_chars` argument defaulting to the old hard-coded 200, so the existing compression path is byte-for-byte identical. The new `ContextEngine.prune_tool_results_only` is a no-op default, so existing engines keep their current behavior.
