### PR TITLE
fix(status): report Matrix home room

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -436,40 +436,43 @@ def show_status(args):
     print(color("◆ Messaging Platforms", Colors.CYAN, Colors.BOLD))
 
     platforms = {
-        "Telegram": ("TELEGRAM_BOT_TOKEN", "TELEGRAM_HOME_CHANNEL"),
-        "Matrix": ("MATRIX_ACCESS_TOKEN", "MATRIX_HOME_ROOM"),
-        "Discord": ("DISCORD_BOT_TOKEN", "DISCORD_HOME_CHANNEL"),
-        "WhatsApp": ("WHATSAPP_ENABLED", None),
-        "Signal": ("SIGNAL_HTTP_URL", "SIGNAL_HOME_CHANNEL"),
-        "Slack": ("SLACK_BOT_TOKEN", None),
-        "Email": ("EMAIL_ADDRESS", "EMAIL_HOME_ADDRESS"),
-        "SMS": ("TWILIO_ACCOUNT_SID", "SMS_HOME_CHANNEL"),
-        "DingTalk": ("DINGTALK_CLIENT_ID", None),
-        "Feishu": ("FEISHU_APP_ID", "FEISHU_HOME_CHANNEL"),
-        "WeCom": ("WECOM_BOT_ID", "WECOM_HOME_CHANNEL"),
-        "WeCom Callback": ("WECOM_CALLBACK_CORP_ID", None),
-        "Weixin": ("WEIXIN_ACCOUNT_ID", "WEIXIN_HOME_CHANNEL"),
-        "BlueBubbles": ("BLUEBUBBLES_SERVER_URL", "BLUEBUBBLES_HOME_CHANNEL"),
-        "QQBot": ("QQ_APP_ID", "QQ_HOME_CHANNEL"),
-        "Yuanbao": ("YUANBAO_APP_ID", "YUANBAO_HOME_CHANNEL"),
+        "Telegram": (lambda: bool(os.getenv("TELEGRAM_BOT_TOKEN", "")), "TELEGRAM_HOME_CHANNEL"),
+        "Matrix": (
+            lambda: bool(os.getenv("MATRIX_HOMESERVER", ""))
+            and (bool(os.getenv("MATRIX_ACCESS_TOKEN", "")) or bool(os.getenv("MATRIX_PASSWORD", ""))),
+            "MATRIX_HOME_ROOM",
+        ),
+        "Discord": (lambda: bool(os.getenv("DISCORD_BOT_TOKEN", "")), "DISCORD_HOME_CHANNEL"),
+        "WhatsApp": (lambda: bool(os.getenv("WHATSAPP_ENABLED", "")), None),
+        "Signal": (lambda: bool(os.getenv("SIGNAL_HTTP_URL", "")), "SIGNAL_HOME_CHANNEL"),
+        "Slack": (lambda: bool(os.getenv("SLACK_BOT_TOKEN", "")), None),
+        "Email": (lambda: bool(os.getenv("EMAIL_ADDRESS", "")), "EMAIL_HOME_ADDRESS"),
+        "SMS": (lambda: bool(os.getenv("TWILIO_ACCOUNT_SID", "")), "SMS_HOME_CHANNEL"),
+        "DingTalk": (lambda: bool(os.getenv("DINGTALK_CLIENT_ID", "")), None),
+        "Feishu": (lambda: bool(os.getenv("FEISHU_APP_ID", "")), "FEISHU_HOME_CHANNEL"),
+        "WeCom": (lambda: bool(os.getenv("WECOM_BOT_ID", "")), "WECOM_HOME_CHANNEL"),
+        "WeCom Callback": (lambda: bool(os.getenv("WECOM_CALLBACK_CORP_ID", "")), None),
+        "Weixin": (lambda: bool(os.getenv("WEIXIN_ACCOUNT_ID", "")), "WEIXIN_HOME_CHANNEL"),
+        "BlueBubbles": (lambda: bool(os.getenv("BLUEBUBBLES_SERVER_URL", "")), "BLUEBUBBLES_HOME_CHANNEL"),
+        "QQBot": (lambda: bool(os.getenv("QQ_APP_ID", "")), "QQ_HOME_CHANNEL"),
+        "Yuanbao": (lambda: bool(os.getenv("YUANBAO_APP_ID", "")), "YUANBAO_HOME_CHANNEL"),
     }
 
-    for name, (token_var, home_var) in platforms.items():
-        token = os.getenv(token_var, "")
-        has_token = bool(token)
-        
+    for name, (is_configured, home_var) in platforms.items():
+        configured = is_configured()
+
         home_channel = ""
         if home_var:
             home_channel = os.getenv(home_var, "")
         # Back-compat: QQBot home channel was renamed from QQ_HOME_CHANNEL to QQBOT_HOME_CHANNEL
         if not home_channel and home_var == "QQBOT_HOME_CHANNEL":
             home_channel = os.getenv("QQ_HOME_CHANNEL", "")
-        
-        status = "configured" if has_token else "not configured"
+
+        status = "configured" if configured else "not configured"
         if home_channel:
             status += f" (home: {home_channel})"
-        
-        print(f"  {name:<12}  {check_mark(has_token)} {status}")
+
+        print(f"  {name:<12}  {check_mark(configured)} {status}")
 
     # Plugin-registered platforms
     try:

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -437,6 +437,7 @@ def show_status(args):
 
     platforms = {
         "Telegram": ("TELEGRAM_BOT_TOKEN", "TELEGRAM_HOME_CHANNEL"),
+        "Matrix": ("MATRIX_ACCESS_TOKEN", "MATRIX_HOME_ROOM"),
         "Discord": ("DISCORD_BOT_TOKEN", "DISCORD_HOME_CHANNEL"),
         "WhatsApp": ("WHATSAPP_ENABLED", None),
         "Signal": ("SIGNAL_HTTP_URL", "SIGNAL_HOME_CHANNEL"),

--- a/tests/hermes_cli/test_status_model_provider.py
+++ b/tests/hermes_cli/test_status_model_provider.py
@@ -64,14 +64,19 @@ def test_show_status_displays_legacy_string_model_and_custom_endpoint(monkeypatc
     assert "Provider:     Custom endpoint" in out
 
 
-def test_show_status_reports_matrix_home_room(monkeypatch, capsys, tmp_path):
-    from hermes_cli import status as status_mod
-
-    _patch_common_status_deps(monkeypatch, status_mod, tmp_path)
+def _patch_status_provider_deps(monkeypatch, status_mod):
     monkeypatch.setattr(status_mod, "load_config", lambda: {"model": {}}, raising=False)
     monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openrouter", raising=False)
     monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openrouter", raising=False)
     monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenRouter", raising=False)
+
+
+def test_show_status_reports_matrix_home_room_with_access_token(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+
+    _patch_common_status_deps(monkeypatch, status_mod, tmp_path)
+    _patch_status_provider_deps(monkeypatch, status_mod)
+    monkeypatch.setenv("MATRIX_HOMESERVER", "https://matrix.example.org")
     monkeypatch.setenv("MATRIX_ACCESS_TOKEN", "syt_test")
     monkeypatch.setenv("MATRIX_HOME_ROOM", "!room123:example.org")
 
@@ -80,6 +85,37 @@ def test_show_status_reports_matrix_home_room(monkeypatch, capsys, tmp_path):
     out = capsys.readouterr().out
     assert "Matrix" in out
     assert "configured (home: !room123:example.org)" in out
+
+
+def test_show_status_reports_matrix_configured_with_password(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+
+    _patch_common_status_deps(monkeypatch, status_mod, tmp_path)
+    _patch_status_provider_deps(monkeypatch, status_mod)
+    monkeypatch.setenv("MATRIX_HOMESERVER", "https://matrix.example.org")
+    monkeypatch.setenv("MATRIX_PASSWORD", "secret")
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+
+    out = capsys.readouterr().out
+    assert "Matrix" in out
+    assert "Matrix        ✓ configured" in out
+
+
+def test_show_status_requires_matrix_homeserver(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+
+    _patch_common_status_deps(monkeypatch, status_mod, tmp_path)
+    _patch_status_provider_deps(monkeypatch, status_mod)
+    monkeypatch.delenv("MATRIX_HOMESERVER", raising=False)
+    monkeypatch.setenv("MATRIX_ACCESS_TOKEN", "syt_test")
+    monkeypatch.setenv("MATRIX_HOME_ROOM", "!room123:example.org")
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+
+    out = capsys.readouterr().out
+    assert "Matrix" in out
+    assert "Matrix        ✗ not configured (home: !room123:example.org)" in out
 
 
 def test_show_status_reports_managed_nous_features(monkeypatch, capsys, tmp_path):

--- a/tests/hermes_cli/test_status_model_provider.py
+++ b/tests/hermes_cli/test_status_model_provider.py
@@ -64,6 +64,24 @@ def test_show_status_displays_legacy_string_model_and_custom_endpoint(monkeypatc
     assert "Provider:     Custom endpoint" in out
 
 
+def test_show_status_reports_matrix_home_room(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+
+    _patch_common_status_deps(monkeypatch, status_mod, tmp_path)
+    monkeypatch.setattr(status_mod, "load_config", lambda: {"model": {}}, raising=False)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openrouter", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openrouter", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenRouter", raising=False)
+    monkeypatch.setenv("MATRIX_ACCESS_TOKEN", "syt_test")
+    monkeypatch.setenv("MATRIX_HOME_ROOM", "!room123:example.org")
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+
+    out = capsys.readouterr().out
+    assert "Matrix" in out
+    assert "configured (home: !room123:example.org)" in out
+
+
 def test_show_status_reports_managed_nous_features(monkeypatch, capsys, tmp_path):
     monkeypatch.setattr("hermes_cli.status.managed_nous_tools_enabled", lambda: True)
     from hermes_cli import status as status_mod


### PR DESCRIPTION
## Summary
- include Matrix in `hermes status --all` messaging platform output
- display the configured Matrix home room via `MATRIX_HOME_ROOM`
- add a regression test for Matrix status/home-room reporting

## Test Plan
- `venv/bin/python -m pytest tests/hermes_cli/test_status_model_provider.py -q`
