### PR TITLE
feat(routing): add controller-first cost router

### DIFF
--- a/tests/tools/test_cost_router_tool.py
+++ b/tests/tools/test_cost_router_tool.py
@@ -546,7 +546,7 @@ def test_cost_router_profile_env_overrides_preserve_deepseek_key(tmp_path, monke
     hermes_home = tmp_path / ".hermes"
     profile_dir = hermes_home / "profiles" / "worker-luna-economy"
     profile_dir.mkdir(parents=True)
-    key = "sk-4c0268038ea44861aaaf2684c9873da4"
+    key = "test-deepseek-fixture-" + ("x" * 40)
     (profile_dir / "config.yaml").write_text(
         "model:\n"
         "  provider: deepseek\n"

--- a/tests/tools/test_cost_router_tool.py
+++ b/tests/tools/test_cost_router_tool.py
@@ -1,0 +1,833 @@
+import json
+import logging
+import subprocess
+from types import SimpleNamespace
+
+from tools import cost_router_tool
+from tools.cost_router_tool import (
+    _build_acceptance_check,
+    _normalise_route,
+    _parse_worker_result,
+    _profile_env_overrides,
+    cost_router,
+)
+from tools.project_intake import build_project_card
+from model_tools import get_tool_definitions
+from toolsets import resolve_toolset
+
+
+def test_cost_router_registered_in_default_tool_definitions():
+    names = {t["function"]["name"] for t in get_tool_definitions(quiet_mode=True)}
+    assert "cost_router" in names
+
+
+def test_cost_router_in_delegation_toolset():
+    assert "cost_router" in resolve_toolset("delegation")
+
+
+def test_cost_router_luna_terra_sol_routing():
+    assert _normalise_route("luna", "x", None) == ("luna", "worker-luna")
+    assert _normalise_route("luna_economy", "x", None) == ("luna_economy", "worker-luna-economy")
+    assert _normalise_route("worker-luna-economy", "x", None) == ("luna_economy", "worker-luna-economy")
+    assert _normalise_route("worker-terra", "x", None) == ("terra", "worker-terra")
+    assert _normalise_route("sol", "x", None) == ("sol", "worker-sol")
+    assert _normalise_route(None, "classify URLs", None) == ("luna", "worker-luna")
+    assert _normalise_route(None, "bulk classify URLs and dedupe JSON logs", None) == ("luna_economy", "worker-luna-economy")
+    assert _normalise_route(None, "write a film article draft", None) == ("terra", "worker-terra")
+    assert _normalise_route(None, "final review architecture conflict", None) == ("sol", "worker-sol")
+
+
+def test_cost_router_selection_precedence_prefers_explicit_route_over_task_type_and_keywords():
+    decision = cost_router_tool._select_route(
+        "sol",
+        "final architecture audit",
+        "bulk JSON dedupe",
+        task_type="classify",
+        project={"route_candidate": "luna_economy", "id": "project-1", "slice_id": "slice-a"},
+    )
+
+    assert decision["tier"] == "sol"
+    assert decision["profile"] == "worker-sol"
+    assert decision["selection_mode"] == "explicit"
+    assert decision["matched_rule"] == "route:sol"
+
+
+def test_cost_router_selection_uses_project_route_before_task_type_and_keywords():
+    decision = cost_router_tool._select_route(
+        None,
+        "final architecture audit",
+        "",
+        task_type="classify",
+        project={"route_candidate": "luna_economy"},
+    )
+
+    assert decision["tier"] == "luna_economy"
+    assert decision["selection_mode"] == "explicit"
+    assert decision["matched_rule"] == "project.route_candidate:luna_economy"
+
+
+def test_cost_router_selection_uses_task_type_before_incidental_keywords():
+    decision = cost_router_tool._select_route(
+        None,
+        "final architecture audit",
+        "",
+        task_type="classify",
+    )
+
+    assert decision["tier"] == "luna"
+    assert decision["profile"] == "worker-luna"
+    assert decision["selection_mode"] == "task_type"
+    assert decision["matched_rule"] == "task_type:classify"
+
+
+def test_cost_router_selection_defaults_to_terra_when_no_rule_matches():
+    decision = cost_router_tool._select_route(None, "Handle this bounded request.", None)
+
+    assert decision["tier"] == "terra"
+    assert decision["profile"] == "worker-terra"
+    assert decision["selection_mode"] == "default"
+    assert decision["matched_rule"] == "default:terra"
+
+
+def test_cost_router_rejects_legacy_routes():
+    for legacy in ["dsflash", "dspro", "gpt54", "gpt55", "worker-gpt55"]:
+        try:
+            _normalise_route(legacy, "x", None)
+        except ValueError as exc:
+            assert "luna" in str(exc) and "terra" in str(exc) and "sol" in str(exc)
+        else:
+            raise AssertionError(f"legacy route {legacy!r} unexpectedly accepted")
+
+
+def test_cost_router_requires_goal():
+    payload = json.loads(cost_router(goal=""))
+    assert "error" in payload
+
+
+def test_cost_router_logs_structured_result(monkeypatch, caplog):
+    monkeypatch.setattr(cost_router_tool.shutil, "which", lambda name: "/usr/bin/hermes")
+
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(
+            stdout="session_id: worker-session-1\nworker output",
+            stderr="",
+            returncode=0,
+        )
+
+    monkeypatch.setattr(cost_router_tool.subprocess, "run", fake_run)
+
+    with caplog.at_level(logging.INFO, logger="tools.cost_router_tool"):
+        payload = json.loads(cost_router(goal="classify fields", route="luna", timeout=5))
+
+    assert payload["tier"] == "luna"
+    assert payload["route"] == "luna"
+    assert payload["profile"] == "worker-luna"
+    assert payload["selection_mode"] == "explicit"
+    assert payload["matched_rule"] == "route:luna"
+    assert payload["session_id"] == "worker-session-1"
+    assert payload["output"] == "worker output"
+    assert "cost_router.result tier=luna route=luna profile=worker-luna" in caplog.text
+    assert "worker_session=worker-session-1" in caplog.text
+    assert "exit_code=0" in caplog.text
+
+
+def test_parse_worker_result_preserves_prose_and_normalizes_valid_footer():
+    output = "Draft body in ordinary prose.\n\n<cost_router_result>\n" + json.dumps({
+        "status": "complete",
+        "deliverable": "Draft body above",
+        "evidence": ["/tmp/draft.md", {"url": "https://example.test/report"}],
+        "unverified_items": [],
+        "controller_decisions": ["Decide whether to publish"],
+    }) + "\n</cost_router_result>"
+
+    prose, worker_result = _parse_worker_result(output, exit_code=0)
+
+    assert prose == "Draft body in ordinary prose."
+    assert worker_result == {
+        "status": "complete",
+        "deliverable": "Draft body above",
+        "evidence": ["/tmp/draft.md", {"url": "https://example.test/report"}],
+        "unverified_items": [],
+        "controller_decisions": ["Decide whether to publish"],
+        "contract_status": "valid",
+        "controller_acceptance_required": True,
+    }
+
+
+def test_parse_worker_result_keeps_legacy_free_text_as_unverified_partial():
+    prose, worker_result = _parse_worker_result("A useful free-text answer.", exit_code=0)
+
+    assert prose == "A useful free-text answer."
+    assert worker_result["status"] == "partial"
+    assert worker_result["deliverable"] == "A useful free-text answer."
+    assert worker_result["contract_status"] == "absent"
+    assert worker_result["evidence"] == []
+    assert worker_result["unverified_items"]
+    assert worker_result["controller_decisions"]
+    assert worker_result["controller_acceptance_required"] is True
+
+
+def test_parse_worker_result_treats_malformed_footer_as_unverified_partial():
+    output = "Prose survives.\n<cost_router_result>\n{not json}\n</cost_router_result>"
+
+    prose, worker_result = _parse_worker_result(output, exit_code=0)
+
+    assert prose == "Prose survives."
+    assert worker_result["status"] == "partial"
+    assert worker_result["contract_status"] == "malformed"
+    assert worker_result["unverified_items"] == ["Structured worker-result footer was malformed."]
+
+
+def test_parse_worker_result_preserves_valid_partial_and_blocked_statuses():
+    for status in ("partial", "blocked"):
+        footer = json.dumps({
+            "status": status,
+            "deliverable": None,
+            "evidence": [],
+            "unverified_items": ["verification remains"],
+            "controller_decisions": ["Choose next step"],
+        })
+        prose, worker_result = _parse_worker_result(
+            f"Worker notes.\n<cost_router_result>{footer}</cost_router_result>",
+            exit_code=0,
+        )
+
+        assert prose == "Worker notes."
+        assert worker_result["status"] == status
+        assert worker_result["contract_status"] == "valid"
+
+
+def test_parse_worker_result_nonzero_exit_cannot_report_complete():
+    output = "Done.\n<cost_router_result>\n" + json.dumps({
+        "status": "complete",
+        "deliverable": "Done",
+        "evidence": ["test output"],
+        "unverified_items": [],
+        "controller_decisions": [],
+    }) + "\n</cost_router_result>"
+
+    _, worker_result = _parse_worker_result(output, exit_code=2)
+
+    assert worker_result["status"] == "blocked"
+    assert "non-zero" in worker_result["unverified_items"][-1]
+    assert worker_result["controller_acceptance_required"] is True
+
+
+def test_parse_worker_result_absent_footer_with_nonzero_exit_is_blocked():
+    prose, worker_result = _parse_worker_result("Legacy output.", exit_code=7)
+
+    assert prose == "Legacy output."
+    assert worker_result["status"] == "blocked"
+    assert worker_result["contract_status"] == "absent"
+    assert "non-zero" in worker_result["unverified_items"][-1]
+
+
+def test_parse_worker_result_malformed_footer_with_nonzero_exit_is_blocked():
+    output = "Useful prose.\n<cost_router_result>{bad json}</cost_router_result>"
+
+    prose, worker_result = _parse_worker_result(output, exit_code=9)
+
+    assert prose == "Useful prose."
+    assert worker_result["status"] == "blocked"
+    assert worker_result["contract_status"] == "malformed"
+    assert "non-zero" in worker_result["unverified_items"][-1]
+
+
+def test_parse_worker_result_truncated_footer_is_malformed_and_removed_from_prose():
+    output = 'Useful prose.\n<cost_router_result>{"status":"partial"'
+
+    prose, worker_result = _parse_worker_result(output, exit_code=0)
+
+    assert prose == "Useful prose."
+    assert worker_result["deliverable"] == "Useful prose."
+    assert worker_result["status"] == "partial"
+    assert worker_result["contract_status"] == "malformed"
+
+
+def test_parse_worker_result_rejects_missing_or_wrong_typed_required_fields():
+    valid = {
+        "status": "complete",
+        "deliverable": "result",
+        "evidence": [],
+        "unverified_items": [],
+        "controller_decisions": [],
+    }
+    invalid_footers = []
+    for field in valid:
+        invalid = dict(valid)
+        del invalid[field]
+        invalid_footers.append(invalid)
+    for field, value in (
+        ("status", 1),
+        ("status", []),
+        ("deliverable", []),
+        ("evidence", "proof"),
+        ("evidence", [1]),
+        ("unverified_items", "none"),
+        ("unverified_items", [1]),
+        ("controller_decisions", "decide"),
+        ("controller_decisions", [1]),
+    ):
+        invalid = dict(valid)
+        invalid[field] = value
+        invalid_footers.append(invalid)
+
+    for footer in invalid_footers:
+        prose, worker_result = _parse_worker_result(
+            f"Prose.\n<cost_router_result>{json.dumps(footer)}</cost_router_result>",
+            exit_code=0,
+        )
+
+        assert prose == "Prose."
+        assert worker_result["status"] == "partial"
+        assert worker_result["contract_status"] == "malformed"
+
+
+def test_cost_router_exit_zero_is_execution_success_not_controller_acceptance(monkeypatch):
+    monkeypatch.setattr(cost_router_tool.shutil, "which", lambda name: "/usr/bin/hermes")
+    footer = json.dumps({
+        "status": "complete",
+        "deliverable": "Classification table",
+        "evidence": ["rows=3"],
+        "unverified_items": [],
+        "controller_decisions": [],
+    })
+    monkeypatch.setattr(
+        cost_router_tool.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(
+            stdout=f"table prose\n<cost_router_result>\n{footer}\n</cost_router_result>",
+            stderr="",
+            returncode=0,
+        ),
+    )
+
+    payload = json.loads(cost_router(goal="Classify these fields.", route="luna", timeout=5))
+
+    assert payload["exit_code"] == 0
+    assert payload["execution_status"] == "succeeded"
+    assert payload["output"] == "table prose"
+    assert payload["worker_result"]["status"] == "complete"
+    assert payload["worker_result"]["controller_acceptance_required"] is True
+    assert payload["acceptance_check"]["accepted"] is False
+    assert payload["acceptance_check"]["controller_decision_required"] is True
+    assert "worker_exit_success" in payload["acceptance_check"]["blocking_reasons"]
+    assert "accepted" not in payload
+
+
+def test_acceptance_check_exposes_all_controller_review_dimensions():
+    project_card = {
+        "acceptance_evidence": ["A tested artifact covers the requested behavior."],
+    }
+    worker_result = {
+        "status": "complete",
+        "deliverable": "/tmp/result.md",
+        "evidence": ["pytest: 3 passed"],
+        "unverified_items": ["One source remains unchecked"],
+        "controller_decisions": ["Resolve conflict between slice A and B"],
+        "contract_status": "valid",
+        "controller_acceptance_required": True,
+    }
+
+    check = _build_acceptance_check(project_card, worker_result, exit_code=0)
+
+    assert check["accepted"] is False
+    assert check["controller_decision_required"] is True
+    assert set(check["checklist"]) == {
+        "deliverable_coverage",
+        "evidence_sufficiency",
+        "unsupported_claims",
+        "cross_slice_conflicts",
+        "verifiable_artifacts",
+        "unresolved_items",
+        "sol_review_warranted",
+    }
+    assert check["checklist"]["deliverable_coverage"]["status"] == "review"
+    assert check["checklist"]["evidence_sufficiency"]["status"] == "review"
+    assert check["checklist"]["unsupported_claims"]["status"] == "review"
+    assert check["checklist"]["cross_slice_conflicts"]["status"] == "review"
+    assert check["checklist"]["verifiable_artifacts"]["status"] == "review"
+    assert check["checklist"]["unresolved_items"]["status"] == "attention"
+    assert check["checklist"]["sol_review_warranted"]["status"] == "consider"
+    assert check["sol_review"]["recommended"] is True
+    assert check["sol_review"]["automatic"] is False
+
+
+def test_acceptance_check_does_not_recommend_sol_for_ordinary_complete_work():
+    check = _build_acceptance_check(
+        {"acceptance_evidence": ["Rows cover every input."]},
+        {
+            "status": "complete",
+            "deliverable": "Classification table",
+            "evidence": ["3 inputs and 3 output rows"],
+            "unverified_items": [],
+            "controller_decisions": [],
+            "contract_status": "valid",
+            "controller_acceptance_required": True,
+        },
+        exit_code=0,
+    )
+
+    assert check["accepted"] is False
+    assert check["sol_review"] == {
+        "recommended": False,
+        "automatic": False,
+        "reasons": [],
+    }
+    assert check["checklist"]["sol_review_warranted"]["status"] == "not_warranted"
+
+
+def test_cost_router_returns_safe_project_and_parent_session_telemetry(monkeypatch):
+    monkeypatch.setattr(cost_router_tool.shutil, "which", lambda name: "/usr/bin/hermes")
+    monkeypatch.setattr(
+        cost_router_tool.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(stdout="worker output", stderr="", returncode=0),
+    )
+
+    payload = json.loads(cost_router(
+        goal="Handle this bounded request.",
+        project={"id": "project-1", "slice_id": "slice-a", "route_candidate": "luna"},
+        parent_session_id="controller-session-1",
+        timeout=5,
+    ))
+
+    assert payload["selection_mode"] == "explicit"
+    assert payload["matched_rule"] == "project.route_candidate:luna"
+    assert payload["decision_metadata"] == {
+        "project_id": "project-1",
+        "slice_id": "slice-a",
+        "parent_session_id": "controller-session-1",
+    }
+
+
+def test_project_card_keeps_simple_one_shot_request_single_with_reason():
+    card = build_project_card("Classify these URLs by topic.", task_type="classify")
+
+    assert card["user_goal"] == "Classify these URLs by topic."
+    assert card["user_visible_deliverable"] == "Topic classifications for the provided URLs."
+    assert card["dependencies"] == []
+    assert card["acceptance_evidence"] == [
+        "Classifications are provided for each URL and identify its topic."
+    ]
+    assert card["route_candidate"] == "luna"
+    assert card["split_required"] is False
+    assert card["no_split_reason"]
+    assert card["split_triggers"] == []
+
+
+def test_project_card_requires_split_for_each_mandatory_trigger():
+    cases = [
+        ("Research two sources and write a briefing.", "multi_source"),
+        ("Research the topic and write a launch article.", "research_plus_writing"),
+        ("Implement the endpoint and verify it with tests.", "implementation_plus_verification"),
+        ("Choose the production migration strategy.", "high_impact_decision"),
+        ("Create a report and a slide deck.", "multi_deliverable"),
+    ]
+
+    for goal, trigger in cases:
+        card = build_project_card(goal)
+        assert card["split_required"] is True
+        assert trigger in card["split_triggers"]
+        assert card["no_split_reason"] is None
+
+
+def test_project_card_requires_split_for_each_chinese_mandatory_trigger():
+    cases = [
+        ("请分别产出市场报告和演示文稿。", "multi_deliverable"),
+        ("对比多个来源的网站和论文，给出结论。", "multi_source"),
+        ("先调研目标市场，再写一篇发布文章。", "research_plus_writing"),
+        ("实现支付接口并运行测试验证。", "implementation_plus_verification"),
+        ("请决定生产环境迁移的安全架构方案。", "high_impact_decision"),
+    ]
+
+    for goal, trigger in cases:
+        card = build_project_card(goal)
+        assert card["split_required"] is True
+        assert trigger in card["split_triggers"]
+        assert card["no_split_reason"] is None
+
+
+def test_project_card_detects_bounded_multi_source_research_and_writing_regression():
+    card = build_project_card("整理多个来源并写文章。")
+
+    assert card["split_required"] is True
+    assert card["split_triggers"] == ["multi_source", "research_plus_writing"]
+    assert card["no_split_reason"] is None
+
+
+def test_project_card_keeps_bounded_single_source_and_single_slice_requests_one_shot():
+    for goal in [
+        "整理这份会议记录。",
+        "写一篇文章。",
+        "Research the topic.",
+        "Implement the endpoint.",
+        "Explain the security architecture.",
+    ]:
+        card = build_project_card(goal)
+        assert card["split_required"] is False, goal
+        assert card["split_triggers"] == [], goal
+        assert card["no_split_reason"], goal
+
+
+def test_project_card_can_gate_a_compound_requirement_from_context():
+    card = build_project_card("Prepare the release materials.", context="Research the topic and write a launch article.")
+
+    assert card["split_required"] is True
+    assert "research_plus_writing" in card["split_triggers"]
+
+
+def test_cost_router_returns_project_card_without_routing_when_split_is_required(monkeypatch):
+    monkeypatch.setattr(cost_router_tool.shutil, "which", lambda name: "/usr/bin/hermes")
+
+    def fail_if_routed(*args, **kwargs):
+        raise AssertionError("split-required work must not reach a worker route")
+
+    monkeypatch.setattr(cost_router_tool.subprocess, "run", fail_if_routed)
+
+    payload = json.loads(cost_router(goal="Implement the endpoint and verify it with tests.", timeout=5))
+
+    assert payload["routing_status"] == "split_required"
+    assert payload["project_card"]["split_required"] is True
+    assert "implementation_plus_verification" in payload["project_card"]["split_triggers"]
+
+
+def test_cost_router_makes_intake_decision_before_route_selection(monkeypatch):
+    monkeypatch.setattr(cost_router_tool.shutil, "which", lambda name: "/usr/bin/hermes")
+    events = []
+    real_build_project_card = cost_router_tool.build_project_card
+
+    def observe_intake(*args, **kwargs):
+        events.append("intake")
+        return real_build_project_card(*args, **kwargs)
+
+    def observe_route(*args, **kwargs):
+        events.append("route")
+        return {
+            "tier": "luna",
+            "profile": "worker-luna",
+            "selection_mode": "keyword",
+            "matched_rule": "keyword:classify",
+        }
+
+    monkeypatch.setattr(cost_router_tool, "build_project_card", observe_intake)
+    monkeypatch.setattr(cost_router_tool, "_select_route", observe_route)
+    monkeypatch.setattr(
+        cost_router_tool.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(stdout="worker output", stderr="", returncode=0),
+    )
+
+    payload = json.loads(cost_router(goal="Classify these URLs by topic.", timeout=5))
+
+    assert payload["project_card"]["split_required"] is False
+    assert events == ["intake", "route"]
+
+
+def test_cost_router_keeps_legacy_one_shot_response_and_adds_card(monkeypatch):
+    monkeypatch.setattr(cost_router_tool.shutil, "which", lambda name: "/usr/bin/hermes")
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return SimpleNamespace(stdout="session_id: worker-session-2\nworker output", stderr="", returncode=0)
+
+    monkeypatch.setattr(cost_router_tool.subprocess, "run", fake_run)
+    payload = json.loads(cost_router(goal="Classify these URLs by topic.", route="luna", timeout=5))
+
+    assert len(calls) == 1
+    assert {"tier", "route", "profile", "session_id", "exit_code", "output", "project_card"} <= payload.keys()
+    assert payload["tier"] == payload["route"] == payload["project_card"]["route_candidate"] == "luna"
+    assert payload["project_card"]["split_required"] is False
+    assert payload["project_card"]["no_split_reason"]
+
+
+def test_cost_router_profile_env_overrides_preserve_deepseek_key(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    profile_dir = hermes_home / "profiles" / "worker-luna-economy"
+    profile_dir.mkdir(parents=True)
+    key = "sk-4c0268038ea44861aaaf2684c9873da4"
+    (profile_dir / "config.yaml").write_text(
+        "model:\n"
+        "  provider: deepseek\n"
+        "  default: deepseek-v4-flash\n"
+        f"  api_key: {key}\n"
+        "providers:\n"
+        "  deepseek:\n"
+        f"    api_key: {key}\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    env = _profile_env_overrides("worker-luna-economy")
+
+    assert env["DEEPSEEK_API_KEY"] == key
+    assert len(env["DEEPSEEK_API_KEY"]) == len(key)
+
+
+def _completed(returncode, stdout="", stderr=""):
+    return SimpleNamespace(stdout=stdout, stderr=stderr, returncode=returncode)
+
+
+def test_cost_router_falls_back_once_from_luna_to_terra_on_503(monkeypatch):
+    monkeypatch.setattr(cost_router_tool.shutil, "which", lambda name: "/usr/bin/hermes")
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if len(calls) == 1:
+            return _completed(1, stdout="partial Luna result", stderr="provider returned HTTP 503")
+        return _completed(0, stdout="session_id: terra-session\nTerra result")
+
+    monkeypatch.setattr(cost_router_tool.subprocess, "run", fake_run)
+    payload = json.loads(cost_router(goal="Classify fields.", route="luna", allow_fallback=True, timeout=5))
+
+    assert [call[call.index("--profile") + 1] for call in calls] == ["worker-luna", "worker-terra"]
+    assert payload["routing_status"] == "completed"
+    assert payload["tier"] == "terra"
+    assert payload["fallback_from"] == "luna"
+    assert payload["fallback_reason"] == "http_503"
+    assert len(payload["attempts"]) == 2
+    assert payload["attempts"][0]["output"] == "partial Luna result"
+    assert payload["attempts"][0]["retryable"] is True
+    assert payload["output"] == "Terra result"
+
+
+def test_cost_router_falls_back_from_luna_economy_on_429(monkeypatch):
+    monkeypatch.setattr(cost_router_tool.shutil, "which", lambda name: "/usr/bin/hermes")
+    results = iter([
+        _completed(1, stderr="429 Too Many Requests"),
+        _completed(0, stdout="Terra result"),
+    ])
+    monkeypatch.setattr(cost_router_tool.subprocess, "run", lambda *args, **kwargs: next(results))
+
+    payload = json.loads(cost_router(goal="Dedupe records.", route="luna_economy", allow_fallback=True, timeout=5))
+
+    assert payload["fallback_from"] == "luna_economy"
+    assert payload["fallback_reason"] == "http_429"
+    assert [attempt["tier"] for attempt in payload["attempts"]] == ["luna_economy", "terra"]
+
+
+def test_cost_router_project_policy_can_allow_fallback(monkeypatch):
+    monkeypatch.setattr(cost_router_tool.shutil, "which", lambda name: "/usr/bin/hermes")
+    results = iter([
+        _completed(1, stderr="HTTP 503"),
+        _completed(0, stdout="Terra result"),
+    ])
+    monkeypatch.setattr(cost_router_tool.subprocess, "run", lambda *args, **kwargs: next(results))
+
+    payload = json.loads(cost_router(
+        goal="Classify records.",
+        route="luna",
+        project={"allow_fallback": True},
+        timeout=5,
+    ))
+
+    assert payload["fallback_from"] == "luna"
+    assert len(payload["attempts"]) == 2
+
+
+def test_cost_router_timeout_is_retryable_without_fallback(monkeypatch):
+    monkeypatch.setattr(cost_router_tool.shutil, "which", lambda name: "/usr/bin/hermes")
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        raise subprocess.TimeoutExpired(cmd, kwargs["timeout"], output="partial", stderr="timeout detail")
+
+    monkeypatch.setattr(cost_router_tool.subprocess, "run", fake_run)
+    payload = json.loads(cost_router(goal="Classify fields.", route="luna", allow_fallback=False, timeout=5))
+
+    assert len(calls) == 1
+    assert payload["routing_status"] == "retryable"
+    assert payload["fallback_from"] is None
+    assert payload["fallback_reason"] is None
+    assert payload["attempts"][0]["failure_reason"] == "timeout"
+    assert payload["attempts"][0]["output"] == "partial"
+
+
+def test_cost_router_non_retryable_failure_never_falls_back(monkeypatch):
+    monkeypatch.setattr(cost_router_tool.shutil, "which", lambda name: "/usr/bin/hermes")
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _completed(1, stdout="worker draft", stderr="content policy rejected response")
+
+    monkeypatch.setattr(cost_router_tool.subprocess, "run", fake_run)
+    payload = json.loads(cost_router(goal="Classify fields.", route="luna", allow_fallback=True, timeout=5))
+
+    assert len(calls) == 1
+    assert payload["routing_status"] == "failed"
+    assert payload["attempts"][0]["retryable"] is False
+    assert payload["attempts"][0]["output"] == "worker draft"
+    assert payload["fallback_from"] is None
+
+
+def test_cost_router_retryable_connection_failure_respects_disabled_fallback(monkeypatch):
+    monkeypatch.setattr(cost_router_tool.shutil, "which", lambda name: "/usr/bin/hermes")
+    monkeypatch.setattr(
+        cost_router_tool.subprocess,
+        "run",
+        lambda *args, **kwargs: _completed(1, stderr="ConnectionError: connection refused"),
+    )
+
+    payload = json.loads(cost_router(goal="Classify fields.", route="luna", allow_fallback=False, timeout=5))
+
+    assert payload["routing_status"] == "retryable"
+    assert payload["attempts"][0]["failure_reason"] == "connection_failure"
+    assert len(payload["attempts"]) == 1
+
+
+def test_cost_router_terra_fallback_failure_stops_after_two_attempts_and_redacts_secrets(monkeypatch):
+    monkeypatch.setattr(cost_router_tool.shutil, "which", lambda name: "/usr/bin/hermes")
+    calls = []
+    secret = "sk-" + "z" * 48
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if len(calls) == 1:
+            return _completed(1, stderr=f"HTTP 503\nAuthorization: Bearer {secret}")
+        return _completed(1, stdout=f"partial Terra\n{secret}", stderr=f"HTTP 503\nAuthorization: Bearer {secret}")
+
+    monkeypatch.setattr(cost_router_tool.subprocess, "run", fake_run)
+    payload_text = cost_router(goal="Classify fields.", route="luna", allow_fallback=True, timeout=5)
+    payload = json.loads(payload_text)
+
+    assert len(calls) == 2
+    assert payload["routing_status"] == "retryable"
+    assert payload["fallback_from"] == "luna"
+    assert payload["fallback_reason"] == "http_503"
+    assert len(payload["attempts"]) == 2
+    assert secret not in payload_text
+    assert secret not in json.dumps(payload["attempts"])
+    assert "Authorization: Bearer ***" in payload_text
+
+
+def test_cost_router_does_not_classify_incidental_stdout_as_infrastructure_failure(monkeypatch):
+    monkeypatch.setattr(cost_router_tool.shutil, "which", lambda name: "/usr/bin/hermes")
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _completed(
+            1,
+            stdout="Draft discusses HTTP 429, 503, rate limits, and service unavailable.",
+            stderr="content quality validation failed",
+        )
+
+    monkeypatch.setattr(cost_router_tool.subprocess, "run", fake_run)
+    payload = json.loads(cost_router(goal="Classify fields.", route="luna", allow_fallback=True, timeout=5))
+
+    assert len(calls) == 1
+    assert payload["routing_status"] == "failed"
+    assert payload["attempts"][0]["retryable"] is False
+    assert payload["attempts"][0]["failure_reason"] == "non_retryable_failure"
+    assert payload["fallback_from"] is None
+
+
+def test_cost_router_timeout_keeps_safe_bounded_partial_output_compatibility_alias(monkeypatch):
+    monkeypatch.setattr(cost_router_tool.shutil, "which", lambda name: "/usr/bin/hermes")
+    secret = "sk-" + "a" * 48
+
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(
+            cmd,
+            kwargs["timeout"],
+            output="x" * 5000 + "\n" + secret,
+            stderr=" timeout tail",
+        )
+
+    monkeypatch.setattr(cost_router_tool.subprocess, "run", fake_run)
+    payload_text = cost_router(goal="Classify fields.", route="luna", timeout=5)
+    payload = json.loads(payload_text)
+
+    assert "partial_output" in payload
+    assert len(payload["partial_output"]) <= 4000
+    assert payload["partial_output"].endswith(" timeout tail")
+    assert secret not in payload_text
+    assert secret not in json.dumps(payload["attempts"])
+
+
+def test_cost_router_timeout_falls_back_exactly_once_and_preserves_luna_error(monkeypatch):
+    monkeypatch.setattr(cost_router_tool.shutil, "which", lambda name: "/usr/bin/hermes")
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if len(calls) == 1:
+            raise subprocess.TimeoutExpired(cmd, kwargs["timeout"], output="Luna partial", stderr="Luna timeout detail")
+        return _completed(0, stdout="Terra result")
+
+    monkeypatch.setattr(cost_router_tool.subprocess, "run", fake_run)
+    payload = json.loads(cost_router(goal="Classify fields.", route="luna", allow_fallback=True, timeout=5))
+
+    assert [call[call.index("--profile") + 1] for call in calls] == ["worker-luna", "worker-terra"]
+    assert len(payload["attempts"]) == 2
+    assert payload["attempts"][0]["error"] == "cost_router timed out after 5s"
+    assert payload["attempts"][0]["output"] == "Luna partial"
+    assert payload["attempts"][0]["stderr"] == "Luna timeout detail"
+    assert payload["fallback_from"] == "luna"
+    assert payload["fallback_reason"] == "timeout"
+    assert payload["routing_status"] == "completed"
+
+
+def test_cost_router_direct_terra_and_sol_never_fall_back(monkeypatch):
+    monkeypatch.setattr(cost_router_tool.shutil, "which", lambda name: "/usr/bin/hermes")
+
+    for route, expected_profile in (("terra", "worker-terra"), ("sol", "worker-sol")):
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return _completed(1, stderr="provider returned HTTP 503")
+
+        monkeypatch.setattr(cost_router_tool.subprocess, "run", fake_run)
+        payload = json.loads(cost_router(goal="Handle bounded work.", route=route, allow_fallback=True, timeout=5))
+
+        assert len(calls) == 1
+        assert calls[0][calls[0].index("--profile") + 1] == expected_profile
+        assert len(payload["attempts"]) == 1
+        assert payload["fallback_from"] is None
+        assert payload["fallback_reason"] is None
+
+
+def test_cost_router_preserves_original_luna_error_when_terra_fallback_fails(monkeypatch):
+    monkeypatch.setattr(cost_router_tool.shutil, "which", lambda name: "/usr/bin/hermes")
+    results = iter([
+        _completed(1, stdout="Luna partial", stderr="provider returned HTTP 429"),
+        _completed(1, stdout="Terra partial", stderr="content quality validation failed"),
+    ])
+    monkeypatch.setattr(cost_router_tool.subprocess, "run", lambda *args, **kwargs: next(results))
+
+    payload = json.loads(cost_router(goal="Classify fields.", route="luna", allow_fallback=True, timeout=5))
+
+    assert len(payload["attempts"]) == 2
+    assert payload["attempts"][0]["output"] == "Luna partial"
+    assert payload["attempts"][0]["stderr"] == "provider returned HTTP 429"
+    assert payload["attempts"][0]["error"] == "worker profile returned non-zero exit status"
+    assert payload["attempts"][0]["failure_reason"] == "http_429"
+    assert payload["attempts"][1]["failure_reason"] == "non_retryable_failure"
+    assert payload["routing_status"] == "failed"
+
+
+def test_cost_router_redacts_credentials_from_nested_return_metadata(monkeypatch):
+    monkeypatch.setattr(cost_router_tool.shutil, "which", lambda name: "/usr/bin/hermes")
+    secret = "sk-" + "q" * 48
+    monkeypatch.setattr(
+        cost_router_tool.subprocess,
+        "run",
+        lambda *args, **kwargs: _completed(0, stdout="worker result"),
+    )
+
+    payload_text = cost_router(
+        goal=f"Classify fields using credential {secret}.",
+        route="luna",
+        project={"project_id": secret},
+        parent_session_id=secret,
+        timeout=5,
+    )
+
+    assert secret not in payload_text
+    payload = json.loads(payload_text)
+    assert secret not in json.dumps(payload["project_card"])
+    assert secret not in json.dumps(payload["decision_metadata"])

--- a/tools/cost_router_tool.py
+++ b/tools/cost_router_tool.py
@@ -1,0 +1,699 @@
+#!/usr/bin/env python3
+"""Cost-aware routing tool.
+
+Provides a small, explicit router surface for controller sessions.  Unlike
+``delegate_task`` (which uses one configured delegation model), this tool routes
+bounded worker-like slices to named Hermes worker profiles via the Hermes CLI.
+The controller keeps final judgment; workers return evidence/drafts/local
+analysis only.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from tools.registry import registry
+from tools.project_intake import build_project_card
+from utils import is_truthy_value
+from agent.redact import redact_sensitive_text
+
+try:
+    import yaml
+except Exception:  # pragma: no cover - yaml is present in Hermes runtime
+    yaml = None
+
+
+logger = logging.getLogger(__name__)
+
+_ALLOWED_ROUTES: Dict[str, str] = {
+    "luna": "worker-luna",
+    "worker_luna": "worker-luna",
+    "luna_economy": "worker-luna-economy",
+    "economy": "worker-luna-economy",
+    "worker_luna_economy": "worker-luna-economy",
+    "terra": "worker-terra",
+    "worker_terra": "worker-terra",
+    "sol": "worker-sol",
+    "worker_sol": "worker-sol",
+}
+
+_ALLOWED_PROFILES = frozenset(_ALLOWED_ROUTES.values())
+_DEFAULT_TIMEOUT_SECONDS = 600
+_MAX_TIMEOUT_SECONDS = 1800
+_MAX_PROMPT_CHARS = 24000
+_WORKER_RESULT_FOOTER_RE = re.compile(
+    r"<cost_router_result>\s*(.*?)\s*</cost_router_result>\s*$",
+    re.DOTALL,
+)
+_WORKER_RESULT_OPEN_TAG = "<cost_router_result>"
+_WORKER_RESULT_STATUSES = frozenset({"complete", "partial", "blocked"})
+_WORKER_RESULT_FIELDS = frozenset(
+    {"status", "deliverable", "evidence", "unverified_items", "controller_decisions"}
+)
+_RETRYABLE_TIERS = frozenset({"luna", "luna_economy"})
+
+
+def _safe_text(value: Any, limit: Optional[int] = 4000) -> str:
+    """Redact worker-controlled text and optionally bound diagnostic fields."""
+    try:
+        redacted = redact_sensitive_text(str(value or ""), force=True)
+        return redacted[-limit:] if limit is not None else redacted
+    except Exception:
+        return "[REDACTED - redaction failed]"
+
+
+def _safe_json(payload: Dict[str, Any]) -> str:
+    """Serialize a return payload through forced secret redaction."""
+    return _safe_text(json.dumps(payload, ensure_ascii=False), limit=None)
+
+
+def _classify_failure(text: str, *, timed_out: bool = False) -> tuple[bool, str]:
+    """Classify only narrow infrastructure failures as controller-retryable."""
+    if timed_out:
+        return True, "timeout"
+    lowered = (text or "").lower()
+    if re.search(r"(?:http(?:/\d(?:\.\d)?)?\s*)?429\b|too many requests|rate limit", lowered):
+        return True, "http_429"
+    if re.search(r"(?:http(?:/\d(?:\.\d)?)?\s*)?503\b|service unavailable", lowered):
+        return True, "http_503"
+    if any(marker in lowered for marker in (
+        "connectionerror", "connection error", "connection refused", "connection reset",
+        "failed to connect", "could not connect", "network is unreachable",
+        "temporary failure in name resolution",
+    )):
+        return True, "connection_failure"
+    return False, "non_retryable_failure"
+
+
+def _tool_error(message: str) -> str:
+    return _safe_json({"error": message})
+
+
+def _route_from_explicit(route: Optional[str]) -> Optional[tuple[str, str]]:
+    """Return a validated route/profile pair, or ``None`` when not supplied."""
+    raw = (route or "").strip().lower().replace("-", "_")
+    if not raw:
+        return None
+    profile = _ALLOWED_ROUTES.get(raw)
+    if raw in _ALLOWED_PROFILES:
+        return raw.replace("worker-", "").replace("-", "_"), raw
+    if profile:
+        return ("luna_economy" if profile == "worker-luna-economy" else raw.replace("worker_", "")), profile
+    raise ValueError(
+        "Unknown cost_router route/profile %r. Use one of: luna, luna_economy, terra, sol, "
+        "worker-luna, worker-luna-economy, worker-terra, worker-sol." % route
+    )
+
+
+_TASK_TYPE_ROUTES: Dict[str, tuple[str, str]] = {
+    "router": ("luna", "worker-luna"),
+    "classify": ("luna", "worker-luna"),
+    "dedupe": ("luna_economy", "worker-luna-economy"),
+    "bulk_preprocess": ("luna_economy", "worker-luna-economy"),
+    "rag_answer": ("terra", "worker-terra"),
+    "draft": ("terra", "worker-terra"),
+    "coding": ("terra", "worker-terra"),
+    "final_review": ("sol", "worker-sol"),
+    "architecture": ("sol", "worker-sol"),
+}
+
+
+def _select_route(
+    route: Optional[str],
+    goal: str,
+    context: Optional[str],
+    task_type: Optional[str] = None,
+    project: Optional[Dict[str, Any]] = None,
+) -> Dict[str, str]:
+    """Select a route with declared metadata taking precedence over keywords."""
+    selected = _route_from_explicit(route)
+    if selected:
+        tier, profile = selected
+        return {"tier": tier, "profile": profile, "selection_mode": "explicit", "matched_rule": f"route:{route}"}
+
+    project_route = (project or {}).get("route") or (project or {}).get("route_candidate")
+    selected = _route_from_explicit(str(project_route) if project_route else None)
+    if selected:
+        tier, profile = selected
+        return {"tier": tier, "profile": profile, "selection_mode": "explicit", "matched_rule": f"project.route_candidate:{project_route}"}
+
+    task = (task_type or "").strip().lower().replace("-", "_")
+    selected = _TASK_TYPE_ROUTES.get(task)
+    if selected:
+        tier, profile = selected
+        return {"tier": tier, "profile": profile, "selection_mode": "task_type", "matched_rule": f"task_type:{task}"}
+
+    text = f"{goal}\n{context or ''}".lower()
+    keyword_rules = (
+        ("sol", "worker-sol", ("final", "audit", "review", "裁决", "终审", "最终审核", "架构", "系统升级", "conflict", "冲突", "low confidence", "低置信", "prompt design", "深度推理")),
+        ("terra", "worker-terra", ("draft", "rewrite", "rag_answer", "article", "script", "coding", "mother", "母本", "正文", "创作", "生成", "长文", "影视分析", "电影解说", "obsidian 总结")),
+        ("luna_economy", "worker-luna-economy", ("bulk", "batch", "many", "大量", "批量", "cheap", "economy", "low cost", "低成本", "log", "日志", "dedupe", "去重", "json", "metadata", "tag", "标签")),
+        ("luna", "worker-luna", ("router", "classify", "dedupe", "tag", "metadata", "ocr", "compression", "query", "json", "cache", "filter", "dispatch", "日志", "分类", "去重", "标签")),
+    )
+    for tier, profile, keywords in keyword_rules:
+        for keyword in keywords:
+            if keyword in text:
+                return {"tier": tier, "profile": profile, "selection_mode": "keyword", "matched_rule": f"keyword:{keyword}"}
+    return {"tier": "terra", "profile": "worker-terra", "selection_mode": "default", "matched_rule": "default:terra"}
+
+
+def _normalise_route(route: Optional[str], goal: str, context: Optional[str], task_type: Optional[str] = None) -> tuple[str, str]:
+    """Compatibility wrapper returning only the historical tier/profile pair."""
+    decision = _select_route(route, goal, context, task_type)
+    return decision["tier"], decision["profile"]
+
+
+def _safe_decision_metadata(project: Optional[Dict[str, Any]], parent_session_id: Optional[str]) -> Dict[str, str]:
+    """Expose only non-secret correlation identifiers in routing responses/logs."""
+    metadata: Dict[str, str] = {}
+    for key in ("project_id", "id", "slice_id"):
+        value = (project or {}).get(key)
+        if value is not None and str(value).strip():
+            metadata["project_id" if key in {"project_id", "id"} else "slice_id"] = str(value).strip()[:256]
+    if parent_session_id and str(parent_session_id).strip():
+        metadata["parent_session_id"] = str(parent_session_id).strip()[:256]
+    return metadata
+
+
+def _string_list(value: Any) -> list[Any]:
+    """Normalize a worker-result list while retaining structured handles."""
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, (str, dict))]
+
+
+def _fallback_worker_result(
+    prose: str,
+    contract_status: str,
+    message: str,
+    exit_code: int,
+) -> Dict[str, Any]:
+    """Represent legacy or malformed output without claiming completion."""
+    unverified_items = [message]
+    status = "partial"
+    if exit_code != 0:
+        status = "blocked"
+        unverified_items.append("Worker process returned a non-zero exit status.")
+    return {
+        "status": status,
+        "deliverable": prose or None,
+        "evidence": [],
+        "unverified_items": unverified_items,
+        "controller_decisions": ["Controller must assess the free-text worker output."],
+        "contract_status": contract_status,
+        "controller_acceptance_required": True,
+    }
+
+
+def _valid_worker_result(parsed: Any) -> bool:
+    """Validate the required footer shape without assigning controller acceptance."""
+    if not isinstance(parsed, dict) or not _WORKER_RESULT_FIELDS.issubset(parsed):
+        return False
+    if not isinstance(parsed["status"], str) or parsed["status"] not in _WORKER_RESULT_STATUSES:
+        return False
+    if parsed["deliverable"] is not None and not isinstance(parsed["deliverable"], (str, dict)):
+        return False
+    return all(
+        isinstance(parsed[field], list)
+        and all(isinstance(item, (str, dict)) for item in parsed[field])
+        for field in ("evidence", "unverified_items", "controller_decisions")
+    )
+
+
+def _parse_worker_result(output: str, exit_code: Any) -> tuple[str, Dict[str, Any]]:
+    """Split prose from an optional structured footer and normalize its contract."""
+    raw = (output or "").strip()
+    # Only the final opening tag can begin the authoritative terminal footer.
+    # Earlier tags may appear in ordinary prose as examples or quoted data.
+    footer_start = raw.rfind(_WORKER_RESULT_OPEN_TAG)
+    match = _WORKER_RESULT_FOOTER_RE.fullmatch(raw[footer_start:]) if footer_start >= 0 else None
+    if match is None:
+        if footer_start >= 0:
+            prose = raw[:footer_start].strip()
+            return prose, _fallback_worker_result(
+                prose,
+                "malformed",
+                "Structured worker-result footer was malformed.",
+                exit_code,
+            )
+        return raw, _fallback_worker_result(
+            raw,
+            "absent",
+            "Worker returned legacy free text without a structured result footer.",
+            exit_code,
+        )
+
+    prose = raw[:footer_start].strip()
+    try:
+        parsed = json.loads(match.group(1))
+    except (TypeError, ValueError):
+        return prose, _fallback_worker_result(
+            prose,
+            "malformed",
+            "Structured worker-result footer was malformed.",
+            exit_code,
+        )
+
+    if not _valid_worker_result(parsed):
+        return prose, _fallback_worker_result(
+            prose,
+            "malformed",
+            "Structured worker-result footer was malformed.",
+            exit_code,
+        )
+
+    status = parsed["status"]
+    unverified_items = _string_list(parsed.get("unverified_items"))
+    if exit_code != 0:
+        status = "blocked"
+        unverified_items.append("Worker process returned a non-zero exit status.")
+    return prose, {
+        "status": status,
+        "deliverable": parsed.get("deliverable"),
+        "evidence": _string_list(parsed.get("evidence")),
+        "unverified_items": unverified_items,
+        "controller_decisions": _string_list(parsed.get("controller_decisions")),
+        "contract_status": "valid",
+        "controller_acceptance_required": True,
+    }
+
+
+def _build_acceptance_check(
+    project_card: Dict[str, Any],
+    worker_result: Dict[str, Any],
+    exit_code: Any,
+) -> Dict[str, Any]:
+    """Build a controller-owned review checklist without making the decision.
+
+    The checklist is deliberately advisory: it surfaces the questions and
+    worker-provided handles a controller must verify.  It never publishes,
+    promotes, accepts, or dispatches a Sol review.
+    """
+    evidence = _string_list(worker_result.get("evidence"))
+    unresolved = _string_list(worker_result.get("unverified_items"))
+    decisions = _string_list(worker_result.get("controller_decisions"))
+    deliverable = worker_result.get("deliverable")
+    acceptance_evidence = _string_list(project_card.get("acceptance_evidence"))
+
+    sol_reasons: list[str] = []
+    decision_text = json.dumps(decisions, ensure_ascii=False).lower()
+    if any(marker in decision_text for marker in (
+        "conflict", "architecture", "security", "high impact", "low confidence",
+        "冲突", "架构", "安全", "低置信",
+    )):
+        sol_reasons.append("Worker surfaced a conflict or high-judgment controller decision.")
+    if worker_result.get("status") == "blocked" and decisions:
+        sol_reasons.append("Blocked work includes a controller decision that may need deep review.")
+
+    checklist = {
+        "deliverable_coverage": {
+            "status": "review" if deliverable is not None else "missing",
+            "expected": acceptance_evidence,
+            "reported_deliverable": deliverable,
+        },
+        "evidence_sufficiency": {
+            "status": "review" if evidence else "insufficient",
+            "reported_evidence": evidence,
+        },
+        "unsupported_claims": {
+            "status": "review",
+            "instruction": "Compare material claims with the reported evidence; worker claims are not self-verifying.",
+        },
+        "cross_slice_conflicts": {
+            "status": "review",
+            "instruction": "Compare this result with sibling slices before final synthesis.",
+            "reported_controller_decisions": decisions,
+        },
+        "verifiable_artifacts": {
+            "status": "review" if deliverable is not None or evidence else "missing",
+            "handles": ([deliverable] if deliverable is not None else []) + evidence,
+        },
+        "unresolved_items": {
+            "status": "attention" if unresolved else "none_reported",
+            "items": unresolved,
+        },
+        "sol_review_warranted": {
+            "status": "consider" if sol_reasons else "not_warranted",
+            "reasons": sol_reasons,
+        },
+    }
+    blocking_reasons = ["worker_exit_success" if exit_code == 0 else "worker_execution_failed"]
+    if worker_result.get("status") != "complete":
+        blocking_reasons.append("worker_result_not_complete")
+    if unresolved:
+        blocking_reasons.append("unresolved_items_reported")
+    if worker_result.get("contract_status") != "valid":
+        blocking_reasons.append("worker_result_contract_not_valid")
+
+    return {
+        "accepted": False,
+        "controller_decision_required": True,
+        "blocking_reasons": blocking_reasons,
+        "checklist": checklist,
+        "sol_review": {
+            "recommended": bool(sol_reasons),
+            "automatic": False,
+            "reasons": sol_reasons,
+        },
+    }
+
+
+def _build_prompt(goal: str, context: Optional[str], tier: str, profile: str, task_type: Optional[str], project: Optional[Dict[str, Any]] = None) -> str:
+    parts = [
+        "You are a routed worker profile invoked by Hermes cost_router.",
+        "Return only the requested worker output: evidence, structure, draft, or local judgment.",
+        "Do NOT make final blocker/risk/publication/stage-promotion decisions; the controller keeps final authority.",
+        "You may write ordinary prose, but end with exactly one machine-readable footer:",
+        '<cost_router_result>{"status":"complete|partial|blocked","deliverable":"summary or handle","evidence":[],"unverified_items":[],"controller_decisions":[]}</cost_router_result>',
+        "Use evidence for verifiable handles/results, list anything not verified, and leave acceptance to the controller.",
+        f"Tier: {tier}; profile: {profile}; task_type: {task_type or 'auto'}.",
+        "",
+        "Goal:",
+        goal.strip(),
+    ]
+    if context and str(context).strip():
+        parts.extend(["", "Context:", str(context).strip()])
+    prompt = "\n".join(parts)
+    if len(prompt) > _MAX_PROMPT_CHARS:
+        prompt = prompt[: _MAX_PROMPT_CHARS - 80] + "\n… [cost_router prompt truncated]"
+    return prompt
+
+
+def _strip_session_banner(output: str) -> tuple[Optional[str], str]:
+    """Return (session_id, cleaned_output) from `hermes chat -Q` stream text."""
+    session_id = None
+    cleaned = []
+    for line in (output or "").splitlines():
+        m = re.match(r"^\s*session_id:\s*(\S+)\s*$", line)
+        if m:
+            session_id = m.group(1)
+            continue
+        cleaned.append(line)
+    return session_id, "\n".join(cleaned).strip()
+
+
+def _profile_env_overrides(profile: str) -> Dict[str, str]:
+    """Return env overrides needed by provider SDKs for a worker profile."""
+    if yaml is None:
+        return {}
+    home = Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes")
+    cfg_path = home / "profiles" / profile / "config.yaml"
+    try:
+        loaded = yaml.safe_load(cfg_path.read_text()) or {}
+    except Exception:
+        return {}
+    cfg = loaded if isinstance(loaded, dict) else {}
+    model_cfg = cfg.get("model") if isinstance(cfg.get("model"), dict) else {}
+    provider = str(model_cfg.get("provider") or "").strip().lower()
+    providers = cfg.get("providers") if isinstance(cfg.get("providers"), dict) else {}
+    provider_cfg = providers.get(provider) if isinstance(providers.get(provider), dict) else {}
+    api_key = str(provider_cfg.get("api_key") or model_cfg.get("api_key") or "").strip()
+    if not api_key:
+        return {}
+    if provider == "deepseek":
+        return {"DEEPSEEK_API_KEY": api_key}
+    return {}
+
+
+def _run_attempt(
+    hermes_bin: str, prompt: str, tier: str, profile: str, effective_timeout: int,
+) -> Dict[str, Any]:
+    """Run one worker attempt and return a safe, structured result."""
+    env = os.environ.copy()
+    env.update(_profile_env_overrides(profile))
+    cmd = [hermes_bin, "chat", "--profile", profile, "-q", prompt, "-Q"]
+    try:
+        completed = subprocess.run(
+            cmd, text=True, capture_output=True, timeout=effective_timeout,
+            env=env, cwd=os.getcwd(),
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout.decode() if isinstance(exc.stdout, bytes) else (exc.stdout or "")
+        stderr = exc.stderr.decode() if isinstance(exc.stderr, bytes) else (exc.stderr or "")
+        return {
+            "tier": tier, "profile": profile, "session_id": None,
+            "exit_code": "timeout", "output": _safe_text(stdout),
+            "stderr": _safe_text(stderr),
+            "error": f"cost_router timed out after {effective_timeout}s",
+            "retryable": True, "failure_reason": "timeout",
+        }
+    except Exception as exc:
+        retryable, reason = _classify_failure(str(exc))
+        return {
+            "tier": tier, "profile": profile, "session_id": None,
+            "exit_code": None, "output": "", "stderr": "",
+            "error": _safe_text(f"cost_router failed to launch Hermes CLI: {exc}"),
+            "retryable": retryable, "failure_reason": reason,
+        }
+
+    session_id, stdout = _strip_session_banner(completed.stdout)
+    stderr_session_id, stderr = _strip_session_banner(completed.stderr)
+    # Worker stdout is untrusted content; only stderr may trigger fallback.
+    retryable, reason = _classify_failure(stderr) if completed.returncode else (False, "none")
+    attempt: Dict[str, Any] = {
+        "tier": tier, "profile": profile,
+        "session_id": session_id or stderr_session_id,
+        "exit_code": completed.returncode, "output": _safe_text(stdout),
+        "retryable": retryable, "failure_reason": reason,
+    }
+    if stderr.strip():
+        attempt["stderr"] = _safe_text(stderr)
+    if completed.returncode != 0:
+        attempt["error"] = "worker profile returned non-zero exit status"
+    return attempt
+
+
+def check_cost_router_requirements() -> bool:
+    return shutil.which("hermes") is not None
+
+
+def cost_router(
+    goal: Optional[str] = None,
+    context: Optional[str] = None,
+    route: Optional[str] = None,
+    task_type: Optional[str] = None,
+    project: Optional[Dict[str, Any]] = None,
+    parent_session_id: Optional[str] = None,
+    allow_fallback: Optional[bool] = None,
+    timeout: Optional[int] = None,
+    background: Optional[bool] = None,
+    parent_agent=None,
+) -> str:
+    """Route a bounded execution slice to a named worker profile."""
+    del parent_agent  # currently reserved for future in-process delegation integration
+
+    if not goal or not str(goal).strip():
+        return _tool_error("cost_router requires a non-empty 'goal'.")
+
+    if is_truthy_value(background, default=False):
+        return _tool_error(
+            "cost_router background mode is not implemented in the minimal profile-router. "
+            "Use delegate_task for async generic delegation or call cost_router synchronously."
+        )
+
+    hermes_bin = shutil.which("hermes")
+    if not hermes_bin:
+        return _tool_error("Hermes CLI not found on PATH; cannot route to worker profiles.")
+
+    # Build and decide on intake before selecting or invoking a worker route.
+    # Structured project metadata can select a route but never bypasses split gating.
+    project_metadata = project if isinstance(project, dict) else {}
+    resolved_task_type = task_type or project_metadata.get("task_type")
+    project_card = build_project_card(
+        str(goal),
+        context=context,
+        task_type=resolved_task_type,
+    )
+    decision_metadata = _safe_decision_metadata(project_metadata, parent_session_id)
+    if project_card["split_required"]:
+        return json.dumps(
+            {
+                "routing_status": "split_required",
+                "project_card": project_card,
+                "decision_metadata": decision_metadata,
+                "message": "Request requires controller-side task splitting before worker routing.",
+            },
+            ensure_ascii=False,
+        )
+
+    try:
+        decision = _select_route(route, str(goal), str(context or ""), resolved_task_type, project_metadata)
+    except ValueError as exc:
+        return _tool_error(str(exc))
+    tier, profile = decision["tier"], decision["profile"]
+    project_card["route_candidate"] = tier
+
+    try:
+        effective_timeout = int(timeout or _DEFAULT_TIMEOUT_SECONDS)
+    except (TypeError, ValueError):
+        effective_timeout = _DEFAULT_TIMEOUT_SECONDS
+    effective_timeout = max(1, min(effective_timeout, _MAX_TIMEOUT_SECONDS))
+
+    prompt = _build_prompt(str(goal), context, tier, profile, resolved_task_type, project_metadata)
+    started_at = time.monotonic()
+    attempts = [_run_attempt(hermes_bin, prompt, tier, profile, effective_timeout)]
+    fallback_from = None
+    fallback_reason = None
+    fallback_allowed = is_truthy_value(
+        allow_fallback if allow_fallback is not None else project_metadata.get("allow_fallback"),
+        default=False,
+    )
+    first = attempts[0]
+    if first["retryable"] and tier in _RETRYABLE_TIERS and fallback_allowed:
+        fallback_from = tier
+        fallback_reason = first["failure_reason"]
+        fallback_prompt = _build_prompt(
+            str(goal), context, "terra", "worker-terra", resolved_task_type, project_metadata
+        )
+        attempts.append(_run_attempt(
+            hermes_bin, fallback_prompt, "terra", "worker-terra", effective_timeout
+        ))
+
+    final = attempts[-1]
+    duration_seconds = time.monotonic() - started_at
+    cleaned_stdout, worker_result = _parse_worker_result(
+        final.get("output", ""), final.get("exit_code")
+    )
+    if final["exit_code"] == 0:
+        routing_status = "completed"
+    elif final["retryable"]:
+        routing_status = "retryable"
+    else:
+        routing_status = "failed"
+    result: Dict[str, Any] = {
+        "routing_status": routing_status,
+        "tier": final["tier"],
+        "route": final["tier"],
+        "profile": final["profile"],
+        "selection_mode": decision["selection_mode"],
+        "matched_rule": decision["matched_rule"],
+        "decision_metadata": decision_metadata,
+        "session_id": final.get("session_id"),
+        "exit_code": final.get("exit_code"),
+        "execution_status": "succeeded" if final.get("exit_code") == 0 else "failed",
+        "output": cleaned_stdout,
+        "worker_result": worker_result,
+        "acceptance_check": _build_acceptance_check(
+            project_card,
+            worker_result,
+            final.get("exit_code"),
+        ),
+        "project_card": project_card,
+        "attempts": attempts,
+        "fallback_from": fallback_from,
+        "fallback_reason": fallback_reason,
+    }
+    if final.get("stderr"):
+        result["stderr"] = final["stderr"]
+    if final.get("error"):
+        result["error"] = final["error"]
+    if final.get("exit_code") == "timeout":
+        result["partial_output"] = _safe_text(
+            f"{final.get('output', '')}{final.get('stderr', '')}"
+        )
+    logger.info(
+        "cost_router.result tier=%s route=%s profile=%s selection_mode=%s matched_rule=%s worker_session=%s exit_code=%s duration=%.2fs output_chars=%d stderr_chars=%d timeout=%s task_type=%s",
+        final["tier"],
+        final["tier"],
+        final["profile"],
+        decision["selection_mode"],
+        decision["matched_rule"],
+        final.get("session_id") or "",
+        final.get("exit_code"),
+        duration_seconds,
+        len(cleaned_stdout or ""),
+        len(final.get("stderr", "")),
+        effective_timeout,
+        task_type or "auto",
+    )
+    return _safe_json(result)
+
+
+COST_ROUTER_SCHEMA = {
+    "name": "cost_router",
+    "description": (
+        "Route one bounded, non-trivial worker slice after first translating the request into a project card. "
+        "If mandatory split triggers are found, returns routing_status=split_required and does not dispatch; the controller must split before routing. "
+        "Simple one-shot requests remain synchronous and include project_card.no_split_reason. "
+        "Use Luna for lightweight routing/classification/cleanup, Luna Economy for bulk low-risk preprocessing, Terra for default production work, "
+        "and Sol for final review, deep reasoning, conflicts, and system architecture. "
+        "The controller keeps final judgment and final user-facing synthesis."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "goal": {
+                "type": "string",
+                "description": "Self-contained worker task. Include the concrete deliverable and constraints.",
+            },
+            "context": {
+                "type": "string",
+                "description": "Optional background the worker needs: file paths, snippets, evidence, output language/tone.",
+            },
+            "route": {
+                "type": "string",
+                "enum": [
+                    "luna", "luna_economy", "terra", "sol",
+                    "worker-luna", "worker-luna-economy", "worker-terra", "worker-sol",
+                ],
+                "description": "Optional explicit tier/profile. Omit for task-shape routing.",
+            },
+            "task_type": {
+                "type": "string",
+                "description": "Optional task type such as router, classify, dedupe, rag_answer, draft, coding, final_review, architecture.",
+            },
+            "project": {
+                "type": "object",
+                "description": "Optional structured project-card metadata. Supported routing fields: route or route_candidate, task_type, allow_fallback, project_id/id, slice_id. Values are not treated as credentials.",
+            },
+            "parent_session_id": {
+                "type": "string",
+                "description": "Optional non-secret parent session identifier included in decision telemetry for correlation.",
+            },
+            "allow_fallback": {
+                "type": "boolean",
+                "description": "Allow one visible Luna/Luna Economy to Terra fallback for retryable infrastructure failures. Default false.",
+                "default": False,
+            },
+            "timeout": {
+                "type": "integer",
+                "description": "Max seconds to wait for the worker profile. Default 600; capped at 1800.",
+            },
+            "background": {
+                "type": "boolean",
+                "description": "Reserved for future async support; currently must be false/omitted.",
+                "default": False,
+            },
+        },
+        "required": ["goal"],
+    },
+}
+
+
+registry.register(
+    name="cost_router",
+    toolset="delegation",
+    schema=COST_ROUTER_SCHEMA,
+    handler=lambda args, **kw: cost_router(
+        goal=args.get("goal"),
+        context=args.get("context"),
+        route=args.get("route"),
+        task_type=args.get("task_type"),
+        project=args.get("project"),
+        parent_session_id=args.get("parent_session_id"),
+        allow_fallback=args.get("allow_fallback"),
+        timeout=args.get("timeout"),
+        background=args.get("background"),
+        parent_agent=kw.get("parent_agent"),
+    ),
+    check_fn=check_cost_router_requirements,
+    emoji="🧭",
+)

--- a/tools/project_intake.py
+++ b/tools/project_intake.py
@@ -1,0 +1,134 @@
+"""Controller-side project intake cards and split policy.
+
+The helpers in this module are deterministic and intentionally do not dispatch
+work.  They translate a request into controller-visible metadata before a
+worker route is selected or invoked.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Optional
+
+
+# These labels are part of the controller-facing routing contract.  Keep them
+# stable so a caller can present the reason for a mandatory split directly.
+_SPLIT_RULES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "multi_deliverable",
+        (
+            r"\b(?:report|briefing|article|blog post|deck|slides|presentation)\b.*\b(?:and|&|, then)\b.*\b(?:report|briefing|article|blog post|deck|slides|presentation)\b",
+            r"\b(?:create|produce|deliver|build)\b.*\b(?:and|&|, then)\b.*\b(?:create|produce|deliver|build)\b",
+            r"(?:分别)?(?:产出|制作|创建|交付).*(?:报告|简报|文章|演示文稿|幻灯片).*(?:和|及|与|、).*(?:报告|简报|文章|演示文稿|幻灯片)",
+        ),
+    ),
+    (
+        "multi_source",
+        (
+            r"\b(?:two|three|four|multiple|several|many)\s+(?:sources?|documents?|papers?|websites?|urls?)\b",
+            r"\b(?:compare|synthesize|cross-check)\b.*\b(?:sources?|documents?|papers?|websites?|urls?)\b",
+            r"(?:对比|比较|综合|交叉验证|整理|汇总|梳理).*(?:多个|多种|若干).*(?:来源|文档|论文|网站|网址|材料)",
+        ),
+    ),
+    (
+        "research_plus_writing",
+        (
+            r"\b(?:research|investigate|study)\b.*\b(?:write|draft|author|compose)\b",
+            r"\b(?:write|draft|author|compose)\b.*\b(?:research|investigate|study)\b",
+            r"(?:调研|研究|调查).*(?:写|撰写|起草|编写).*(?:文章|报告|文案|稿件)",
+            r"(?:写|撰写|起草|编写).*(?:文章|报告|文案|稿件).*(?:调研|研究|调查)",
+            r"(?:整理|汇总|梳理).*(?:多个|多种|若干).*(?:来源|文档|论文|网站|网址|材料).*(?:写|撰写|起草|编写).*(?:文章|报告|文案|稿件)",
+        ),
+    ),
+    (
+        "implementation_plus_verification",
+        (
+            r"\b(?:implement|build|code|add|fix)\b.*\b(?:verify|validate|test|tests|testing|qa)\b",
+            r"\b(?:verify|validate|test|tests|testing|qa)\b.*\b(?:implement|build|code|add|fix)\b",
+            r"(?:实现|开发|编写|修复|添加).*(?:验证|测试|校验|检查)",
+            r"(?:验证|测试|校验|检查).*(?:实现|开发|编写|修复|添加)",
+        ),
+    ),
+    (
+        "high_impact_decision",
+        (
+            r"\b(?:choose|decide|recommend|select|approve)\b.*\b(?:production|migration|security|architecture|vendor|budget|strategy)\b",
+            r"\b(?:production|migration|security|architecture|vendor|budget|strategy)\b.*\b(?:decision|choice|approval)\b",
+            r"(?:决定|选择|推荐|批准).*(?:生产环境|迁移|安全|架构|供应商|预算|战略|方案)",
+            r"(?:生产环境|迁移|安全|架构|供应商|预算|战略).*(?:决定|选择|推荐|批准)",
+        ),
+    ),
+)
+
+
+def split_triggers(goal: str, context: Optional[str] = None) -> list[str]:
+    """Return mandatory-split reasons detected from the user request."""
+    text = f"{goal}\n{context or ''}".lower()
+    return [
+        name
+        for name, patterns in _SPLIT_RULES
+        if any(re.search(pattern, text) for pattern in patterns)
+    ]
+
+
+def _candidate_from_shape(goal: str, task_type: Optional[str]) -> str:
+    """Provide a safe display candidate; cost_router replaces it with its route."""
+    text = f"{task_type or ''}\n{goal}".lower()
+    if any(word in text for word in ("final review", "architecture", "conflict", "audit")):
+        return "sol"
+    if any(word in text for word in ("classify", "dedupe", "tag", "metadata", "filter")):
+        return "luna"
+    return "terra"
+
+
+def _deliverable_and_evidence(goal: str, task_type: Optional[str]) -> tuple[str, list[str]]:
+    """Describe the outcome without echoing a generic completion promise."""
+    text = f"{task_type or ''}\n{goal}".lower()
+    if any(word in text for word in ("classify", "分类")):
+        return (
+            "Topic classifications for the provided URLs.",
+            ["Classifications are provided for each URL and identify its topic."],
+        )
+    if any(word in text for word in ("draft", "write", "article", "撰写", "文章", "报告")):
+        return (
+            "A draft that addresses the requested subject and constraints.",
+            ["The draft covers the requested subject and stated constraints."],
+        )
+    if any(word in text for word in ("implement", "build", "code", "实现", "开发", "修复")):
+        return (
+            "The requested implementation change.",
+            ["The implementation is present and its requested behavior is demonstrated."],
+        )
+    return (
+        "A response that addresses the requested goal.",
+        ["The response addresses the stated goal and requested constraints."],
+    )
+
+
+def build_project_card(
+    goal: str,
+    *,
+    context: Optional[str] = None,
+    task_type: Optional[str] = None,
+    route_candidate: Optional[str] = None,
+) -> dict[str, Any]:
+    """Build an additive user-understandable project card for a request.
+
+    Simple one-shot work remains a single slice and includes an explicit reason.
+    A positive ``split_required`` only gates controller routing; it does not
+    create tasks or change the synchronous cost_router execution model.
+    """
+    user_goal = str(goal or "").strip()
+    triggers = split_triggers(user_goal, context)
+    split_required = bool(triggers)
+    user_visible_deliverable, acceptance_evidence = _deliverable_and_evidence(user_goal, task_type)
+    return {
+        "user_goal": user_goal,
+        "user_visible_deliverable": user_visible_deliverable,
+        "dependencies": [],
+        "acceptance_evidence": acceptance_evidence,
+        "route_candidate": route_candidate or _candidate_from_shape(user_goal, task_type),
+        "split_required": split_required,
+        "split_triggers": triggers,
+        "no_split_reason": None if split_required else "Single deliverable with no mandatory split trigger.",
+    }


### PR DESCRIPTION
## Summary

Adds a controller-first cost router as a narrow, self-contained routing surface:

- project-intake split gate for compound requests;
- explicit routing precedence (`route` > project candidate > task type > keyword > Terra default);
- structured worker-result footer parsing without automatic controller acceptance;
- bounded Luna/Luna Economy to Terra fallback only for trusted infrastructure failures;
- secret redaction for returned diagnostics and routing metadata.

## Scope

Only three files are added:

- `tools/cost_router_tool.py`
- `tools/project_intake.py`
- `tests/tools/test_cost_router_tool.py`

## Validation

- `tests/tools/test_cost_router_tool.py`: **46 passed**
- `git diff --check origin/main...HEAD`: passed
- Added-diff credential-shaped literal scan: passed
- Real bounded `worker-luna` smoke on the integrated router: exit 0; returned structured `complete`; `acceptance_accepted=false` and `controller_decision_required=true` remained enforced.

## Full-suite baseline note

The canonical full suite is currently not green in this environment on the latest upstream baseline:

- `origin/main`: 49 failing tests across 19 files
- this PR branch: 47 failing tests across 18 files

These aggregate summaries do not establish per-test regression attribution. The routing-focused regression suite passes, while the full-suite failures are transparently disclosed for maintainers to reproduce in CI.
