### PR TITLE
fix(compression): calibrate rough preflight estimate against real usage (#62605)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -743,6 +743,12 @@ class ContextCompressor(ContextEngine):
         self.last_compression_rough_tokens = 0
         self.last_rough_tokens_when_real_prompt_fit = 0
         self.awaiting_real_usage_after_compression = False
+        # Init calibration state for any pre-existing compressor that doesn't
+        # yet carry it (pickling-compat path: anything restored from before
+        # the field was introduced). All new instances get this from the
+        # primary __init__ at line ~1130 below.
+        if not hasattr(self, "rough_to_real_ratio"):
+            self.rough_to_real_ratio = 1.0
 
     def on_session_end(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
         """Clear all per-session compaction state at a real session boundary.
@@ -779,6 +785,12 @@ class ContextCompressor(ContextEngine):
         self.last_compression_rough_tokens = 0
         self.last_rough_tokens_when_real_prompt_fit = 0
         self.awaiting_real_usage_after_compression = False
+        # Init calibration state for any pre-existing compressor that doesn't
+        # yet carry it (pickling-compat path: anything restored from before
+        # the field was introduced). All new instances get this from the
+        # primary __init__ at line ~1130 below.
+        if not hasattr(self, "rough_to_real_ratio"):
+            self.rough_to_real_ratio = 1.0
 
     def bind_session_state(self, session_db: Any = None, session_id: str = "") -> None:
         """Bind the current session row so durable cooldowns can round-trip."""
@@ -943,6 +955,12 @@ class ContextCompressor(ContextEngine):
         self.last_rough_tokens_when_real_prompt_fit = 0
         self.last_compression_rough_tokens = 0
         self.awaiting_real_usage_after_compression = False
+        # Init calibration state for any pre-existing compressor that doesn't
+        # yet carry it (pickling-compat path: anything restored from before
+        # the field was introduced). All new instances get this from the
+        # primary __init__ at line ~1130 below.
+        if not hasattr(self, "rough_to_real_ratio"):
+            self.rough_to_real_ratio = 1.0
         self._ineffective_compression_count = 0
 
     # When the MINIMUM_CONTEXT_LENGTH floor meets/exceeds a small context
@@ -1121,6 +1139,22 @@ class ContextCompressor(ContextEngine):
         self.last_compression_rough_tokens = 0
         self.last_rough_tokens_when_real_prompt_fit = 0
         self.awaiting_real_usage_after_compression = False
+        # Init calibration state for any pre-existing compressor that doesn't
+        # yet carry it (pickling-compat path: anything restored from before
+        # the field was introduced). All new instances get this from the
+        # primary __init__ at line ~1130 below.
+        if not hasattr(self, "rough_to_real_ratio"):
+            self.rough_to_real_ratio = 1.0
+        # Calibration ratio between the rough chars/4 estimator and the real
+        # provider-reported prompt_tokens. EMA over recent (real / rough)
+        # pairs so each new response nudges the estimate toward accuracy
+        # without overreacting to a single noisy sample. Used by
+        # ``_calibrate_rough`` and ``should_compress`` to scale up an
+        # underestimating rough estimate BEFORE the threshold check, so
+        # auto-compression fires early enough that the next request fits.
+        # See #62605 — when rough underestimates by 30%, the naive check
+        # fires 3 attempts too late and the provider returns HTTP 400.
+        self.rough_to_real_ratio: float = 1.0
 
         self.summary_model = summary_model_override or ""
         self._session_db: Any = None
@@ -1174,6 +1208,29 @@ class ContextCompressor(ContextEngine):
         self.last_total_tokens = usage.get("total_tokens", self.last_prompt_tokens + self.last_completion_tokens)
         if self.last_prompt_tokens > 0:
             self.last_real_prompt_tokens = self.last_prompt_tokens
+            # Calibrate the rough → real ratio when we have a paired sample.
+            # ``last_compression_rough_tokens`` is the estimate that was sent
+            # with the request that produced this response (set by
+            # ``compress()`` and the turn preflight). When it's available
+            # AND the rough estimate came from the calibrated path, blend the
+            # new sample into the EMA so subsequent calls compensate for
+            # systematic underestimate (#62605).
+            if self.last_compression_rough_tokens > 0:
+                sample_ratio = self.last_prompt_tokens / self.last_compression_rough_tokens
+                # EMA weights: 0.5 history + 0.5 new — equal weighting so the
+                # ratio responds within a turn or two, not five. The bug
+                # we're fixing (#62605) is that the rough estimator fires
+                # late by 20-30%; we need calibration to catch up before
+                # the next preflight, so the first calibrated check has
+                # already incorporated the most recent sample.
+                # Capped at 3.0 so a pathological single response (e.g. the
+                # rough estimator undercounted by 5x due to one weird
+                # message) doesn't snowball every future preflight into
+                # firing unconditionally.
+                self.rough_to_real_ratio = min(
+                    3.0,
+                    0.5 * self.rough_to_real_ratio + 0.5 * sample_ratio,
+                )
             if self.last_prompt_tokens < self.threshold_tokens:
                 if self.awaiting_real_usage_after_compression and self.last_compression_rough_tokens > 0:
                     self.last_rough_tokens_when_real_prompt_fit = self.last_compression_rough_tokens
@@ -1223,14 +1280,53 @@ class ContextCompressor(ContextEngine):
         self.last_rough_tokens_when_real_prompt_fit = max(baseline, rough_tokens)
         return True
 
+    def _calibrate_rough(self, rough_tokens: int) -> int:
+        """Scale a rough estimate by the learned ``rough_to_real_ratio``.
+
+        Returns ``min(rough * ratio, context_length)`` when history exists,
+        or ``rough`` verbatim when no API response has been observed yet
+        (ratio == 1.0 by construction).
+
+        Capped at ``context_length`` so a runaway ratio from a single noisy
+        sample can't make every future preflight fire unconditionally — the
+        cap also matches the hard limit that would have produced HTTP 400
+        anyway, so calibration can't over-promise.
+
+        Used by ``should_compress`` so the threshold check sees a value
+        that's already adjusted for systematic underestimate in
+        ``estimate_request_tokens_rough`` (#62605).
+        """
+        if self.rough_to_real_ratio <= 1.0:
+            return rough_tokens
+        calibrated = int(rough_tokens * self.rough_to_real_ratio)
+        if calibrated > self.context_length:
+            calibrated = self.context_length
+        return calibrated
+
     def should_compress(self, prompt_tokens: int = None) -> bool:
         """Check if context exceeds the compression threshold.
 
         Includes anti-thrashing protection: if the last two compressions
         each saved less than 10%, skip compression to avoid infinite loops
         where each pass removes only 1-2 messages.
+
+        When ``prompt_tokens`` is a *rough* estimate (the default for the
+        preflight path), it is first calibrated by the learned
+        ``rough_to_real_ratio`` so a systematically underestimating
+        estimator fires the threshold check at the right time. Without
+        this, payloads that systematically underestimate by 20-30%
+        (schema-heavy / non-English / YAML content — #62605) pass the
+        check, get sent to the provider, and return HTTP 400
+        "total of at least N tokens. Please reduce…" because the real
+        tokens were already past context_length.
         """
-        tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
+        if prompt_tokens is None:
+            tokens = self.last_prompt_tokens
+        else:
+            # Rough path: apply learned calibration. Real-path callers
+            # (post-response update_from_response, manual /compress) pass
+            # the authoritative count and bypass calibration.
+            tokens = self._calibrate_rough(prompt_tokens)
         if tokens < self.threshold_tokens:
             return False
         # Do not trigger compression while the summary LLM is in cooldown.

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -743,12 +743,10 @@ class ContextCompressor(ContextEngine):
         self.last_compression_rough_tokens = 0
         self.last_rough_tokens_when_real_prompt_fit = 0
         self.awaiting_real_usage_after_compression = False
-        # Init calibration state for any pre-existing compressor that doesn't
-        # yet carry it (pickling-compat path: anything restored from before
-        # the field was introduced). All new instances get this from the
-        # primary __init__ at line ~1130 below.
-        if not hasattr(self, "rough_to_real_ratio"):
-            self.rough_to_real_ratio = 1.0
+        # Calibration is model/session-specific. Always clear it on reset so a
+        # learned ratio never rides across model switches or session ends.
+        self.rough_to_real_ratio = 1.0
+        self.last_request_rough_tokens = 0
 
     def on_session_end(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
         """Clear all per-session compaction state at a real session boundary.
@@ -785,12 +783,10 @@ class ContextCompressor(ContextEngine):
         self.last_compression_rough_tokens = 0
         self.last_rough_tokens_when_real_prompt_fit = 0
         self.awaiting_real_usage_after_compression = False
-        # Init calibration state for any pre-existing compressor that doesn't
-        # yet carry it (pickling-compat path: anything restored from before
-        # the field was introduced). All new instances get this from the
-        # primary __init__ at line ~1130 below.
-        if not hasattr(self, "rough_to_real_ratio"):
-            self.rough_to_real_ratio = 1.0
+        # Calibration is model/session-specific. Always clear it on reset so a
+        # learned ratio never rides across model switches or session ends.
+        self.rough_to_real_ratio = 1.0
+        self.last_request_rough_tokens = 0
 
     def bind_session_state(self, session_db: Any = None, session_id: str = "") -> None:
         """Bind the current session row so durable cooldowns can round-trip."""
@@ -955,12 +951,10 @@ class ContextCompressor(ContextEngine):
         self.last_rough_tokens_when_real_prompt_fit = 0
         self.last_compression_rough_tokens = 0
         self.awaiting_real_usage_after_compression = False
-        # Init calibration state for any pre-existing compressor that doesn't
-        # yet carry it (pickling-compat path: anything restored from before
-        # the field was introduced). All new instances get this from the
-        # primary __init__ at line ~1130 below.
-        if not hasattr(self, "rough_to_real_ratio"):
-            self.rough_to_real_ratio = 1.0
+        # Calibration is model/session-specific. Always clear it on reset so a
+        # learned ratio never rides across model switches or session ends.
+        self.rough_to_real_ratio = 1.0
+        self.last_request_rough_tokens = 0
         self._ineffective_compression_count = 0
 
     # When the MINIMUM_CONTEXT_LENGTH floor meets/exceeds a small context
@@ -1139,12 +1133,11 @@ class ContextCompressor(ContextEngine):
         self.last_compression_rough_tokens = 0
         self.last_rough_tokens_when_real_prompt_fit = 0
         self.awaiting_real_usage_after_compression = False
-        # Init calibration state for any pre-existing compressor that doesn't
-        # yet carry it (pickling-compat path: anything restored from before
-        # the field was introduced). All new instances get this from the
-        # primary __init__ at line ~1130 below.
-        if not hasattr(self, "rough_to_real_ratio"):
-            self.rough_to_real_ratio = 1.0
+        # last_request_rough_tokens pairs the exact outgoing request estimate
+        # with the next provider usage sample (set immediately before the API
+        # call). Distinct from last_compression_rough_tokens, which is only
+        # written after a compaction pass.
+        self.last_request_rough_tokens = 0
         # Calibration ratio between the rough chars/4 estimator and the real
         # provider-reported prompt_tokens. EMA over recent (real / rough)
         # pairs so each new response nudges the estimate toward accuracy
@@ -1208,29 +1201,24 @@ class ContextCompressor(ContextEngine):
         self.last_total_tokens = usage.get("total_tokens", self.last_prompt_tokens + self.last_completion_tokens)
         if self.last_prompt_tokens > 0:
             self.last_real_prompt_tokens = self.last_prompt_tokens
-            # Calibrate the rough → real ratio when we have a paired sample.
-            # ``last_compression_rough_tokens`` is the estimate that was sent
-            # with the request that produced this response (set by
-            # ``compress()`` and the turn preflight). When it's available
-            # AND the rough estimate came from the calibrated path, blend the
-            # new sample into the EMA so subsequent calls compensate for
-            # systematic underestimate (#62605).
-            if self.last_compression_rough_tokens > 0:
-                sample_ratio = self.last_prompt_tokens / self.last_compression_rough_tokens
+            # Calibrate the rough → real ratio when we have a paired sample
+            # for THIS request. Prefer ``last_request_rough_tokens`` (the
+            # estimate captured immediately before the provider call). Fall
+            # back to ``last_compression_rough_tokens`` only after a
+            # just-completed compaction whose next response is the first
+            # post-compress sample.
+            paired_rough = self.last_request_rough_tokens or self.last_compression_rough_tokens
+            if paired_rough > 0:
+                sample_ratio = self.last_prompt_tokens / paired_rough
                 # EMA weights: 0.5 history + 0.5 new — equal weighting so the
-                # ratio responds within a turn or two, not five. The bug
-                # we're fixing (#62605) is that the rough estimator fires
-                # late by 20-30%; we need calibration to catch up before
-                # the next preflight, so the first calibrated check has
-                # already incorporated the most recent sample.
-                # Capped at 3.0 so a pathological single response (e.g. the
-                # rough estimator undercounted by 5x due to one weird
-                # message) doesn't snowball every future preflight into
-                # firing unconditionally.
+                # ratio responds within a turn or two, not five.
+                # Capped at 3.0 so a pathological single response doesn't
+                # snowball every future preflight into firing unconditionally.
                 self.rough_to_real_ratio = min(
                     3.0,
                     0.5 * self.rough_to_real_ratio + 0.5 * sample_ratio,
                 )
+                self.last_request_rough_tokens = 0
             if self.last_prompt_tokens < self.threshold_tokens:
                 if self.awaiting_real_usage_after_compression and self.last_compression_rough_tokens > 0:
                     self.last_rough_tokens_when_real_prompt_fit = self.last_compression_rough_tokens
@@ -1279,6 +1267,20 @@ class ContextCompressor(ContextEngine):
 
         self.last_rough_tokens_when_real_prompt_fit = max(baseline, rough_tokens)
         return True
+
+    def record_request_rough_estimate(self, rough_tokens: int) -> None:
+        """Pair the exact outgoing-request rough estimate with the next usage.
+
+        Call immediately before the provider request that will produce the
+        next ``update_from_response`` sample. This is the only estimate that
+        can safely train ``rough_to_real_ratio`` for normal (non-compress)
+        turns (#62605).
+        """
+        try:
+            value = int(rough_tokens or 0)
+        except (TypeError, ValueError):
+            value = 0
+        self.last_request_rough_tokens = max(0, value)
 
     def _calibrate_rough(self, rough_tokens: int) -> int:
         """Scale a rough estimate by the learned ``rough_to_real_ratio``.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1090,6 +1090,13 @@ def run_conversation(
             logging.debug(f"Last message role: {messages[-1]['role'] if messages else 'none'}")
             logging.debug(f"Total message size: ~{approx_tokens:,} tokens")
         
+        # Pair this exact rough estimate with the provider usage that the
+        # upcoming API call will return, so calibration can learn from normal
+        # successful requests (not only post-compaction samples) (#62605).
+        try:
+            agent.context_compressor.record_request_rough_estimate(request_pressure_tokens)
+        except Exception:
+            pass
         api_start_time = time.time()
         retry_count = 0
         max_retries = agent._api_max_retries

--- a/tests/agent/test_compression_rough_calibration_62605.py
+++ b/tests/agent/test_compression_rough_calibration_62605.py
@@ -1,0 +1,287 @@
+"""Regression tests for #62605: auto-compression must fire before the request
+exceeds context_length when the rough estimator systematically underestimates.
+
+Root cause: ``estimate_request_tokens_rough`` uses a chars/4 heuristic that
+diverges from real tokenization by 20-30% on schema-heavy / YAML-heavy /
+non-English payloads. ``should_compress(rough_tokens)`` fires late, so after
+3 compression passes the request still exceeds context_length and the
+provider returns HTTP 400 with "total of at least N tokens".
+
+Fix: track the calibration ratio ``real_prompt_tokens / rough_estimate`` from
+each API response and apply it to the rough estimate BEFORE the threshold
+check. The threshold itself isn't wrong; our estimate of how full we are is.
+
+Tests cover:
+- EMA ratio computation: stored, decayed, and applied
+- should_compress scales rough up when past ratios underestimate
+- should_compress stays correct when calibration is accurate (no double-count)
+- _calibrate_rough is a no-op when no real-usage history yet
+- 3-pass retry loop in turn_context can now succeed where it previously failed
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+# -----------------------------------------------------------------------
+# Helpers: stub a ContextCompressor without booting agent_init
+# -----------------------------------------------------------------------
+
+
+def _make_compressor(**overrides):
+    """Build a ContextCompressor-like object sufficient for testing
+    should_compress + update_from_response + _calibrate_rough."""
+    from agent.context_compressor import ContextCompressor
+
+    # Pop our own overrides out of the dict so we can mix-and-match the
+    # ContextCompressor API surface (which derives context_length from the
+    # model name via update_model, not __init__).
+    overrides = dict(overrides)
+    context_length = overrides.pop("context_length", 262_144)
+    max_tokens = overrides.pop("max_tokens", 65_536)
+    threshold_percent = overrides.pop("threshold_percent", 0.75)
+
+    c = ContextCompressor(
+        model="test-model",
+        quiet_mode=True,
+        summary_target_ratio=0.3,
+        max_tokens=max_tokens,
+        **overrides,
+    )
+    c.update_model(
+        model="test-model",
+        provider="test",
+        base_url="http://localhost:1234/v1",
+        context_length=context_length,
+        max_tokens=max_tokens,
+    )
+    # Re-apply threshold_percent if user wanted something other than the
+    # default (ContextCompressor derives threshold_tokens = threshold_percent
+    # * (context_length - max_tokens), with floors for small windows).
+    if threshold_percent != 0.75:
+        c.threshold_percent = c._effective_threshold_percent(
+            context_length, threshold_percent,
+        )
+        c.threshold_tokens = c._compute_threshold_tokens(
+            context_length, c.threshold_percent, max_tokens,
+        )
+    return c
+
+
+# -----------------------------------------------------------------------
+# Calibration: ratio tracking + application
+# -----------------------------------------------------------------------
+
+
+class TestRoughToRealRatioTracking:
+    """update_from_response must learn the rough→real ratio so subsequent
+    threshold checks use a calibrated estimate instead of the raw chars/4."""
+
+    def test_initial_ratio_is_one(self):
+        c = _make_compressor()
+        assert c.rough_to_real_ratio == 1.0
+
+    def test_ratio_recorded_from_first_response(self):
+        c = _make_compressor()
+        # Simulate: rough estimate was 150K, real provider prompt was 200K.
+        # raw ratio = 200/150 = 1.333. With 0.5/0.5 EMA from seed 1.0 →
+        # 0.5*1.0 + 0.5*1.333 = 1.167.
+        c.last_compression_rough_tokens = 150_000
+        c.update_from_response({"prompt_tokens": 200_000, "completion_tokens": 0})
+        assert 1.15 < c.rough_to_real_ratio < 1.20
+
+    def test_ratio_uses_ema_for_subsequent_responses(self):
+        """Second response must blend with the first via EMA, not overwrite."""
+        c = _make_compressor()
+        # First sample: real=200K, rough=150K → ratio target 1.333
+        # EMA(1.0, 1.333, 0.5/0.5) = 1.167
+        c.last_compression_rough_tokens = 150_000
+        c.update_from_response({"prompt_tokens": 200_000, "completion_tokens": 0})
+        first_ratio = c.rough_to_real_ratio
+
+        # Second sample: real=220K, rough=150K → ratio target 1.467
+        # EMA(1.167, 1.467, 0.5/0.5) = 1.317
+        c.last_compression_rough_tokens = 150_000
+        c.update_from_response({"prompt_tokens": 220_000, "completion_tokens": 0})
+        # Equal-weight EMA: result must be between first_ratio and 1.467
+        assert first_ratio < c.rough_to_real_ratio < 1.47
+        # Closer to the midpoint (weight is 0.5/0.5)
+        assert abs(c.rough_to_real_ratio - (first_ratio + 1.47) / 2) < 0.05
+
+    def test_no_ratio_when_rough_estimate_unknown(self):
+        """If we never saw a rough estimate, don't fabricate a ratio."""
+        c = _make_compressor()
+        c.update_from_response({"prompt_tokens": 100_000, "completion_tokens": 0})
+        # No prior _last_compression_rough_tokens → no learning signal
+        assert c.rough_to_real_ratio == 1.0
+
+
+class TestCalibrateRoughMethod:
+    """``_calibrate_rough`` scales the rough estimate by the learned ratio
+    so a should_compress(rough) call with underestimating history gets a
+    fair chance to fire."""
+
+    def test_no_history_passes_through(self):
+        c = _make_compressor()
+        assert c._calibrate_rough(150_000) == 150_000
+
+    def test_underestimate_scales_up(self):
+        """The reported case: rough=150K, real=200K. With 0.5/0.5 EMA from
+        seed 1.0 the first observation yields ratio 1.167 → calibrated
+        150K * 1.167 = 175K. The next response would converge further."""
+        c = _make_compressor()
+        c.last_compression_rough_tokens = 150_000
+        c.update_from_response({"prompt_tokens": 200_000, "completion_tokens": 0})
+        calibrated = c._calibrate_rough(150_000)
+        # Allow EMA drift but must be clearly above 150K
+        assert calibrated > 170_000
+        assert calibrated < 180_000
+
+    def test_calibration_capped_to_prevent_runaway(self):
+        """Defensive: even an absurd ratio shouldn't push a small rough
+        past the model context_length (would make every check fire)."""
+        c = _make_compressor()
+        # Plant a fake pathological ratio by directly manipulating state
+        c.rough_to_real_ratio = 10.0  # pretend rough underestimates by 10x
+        c._last_compression_rough_tokens = 1000
+        # 1K * 10 = 10K — fine, but should also not exceed context_length
+        calibrated = c._calibrate_rough(30_000)
+        assert calibrated <= c.context_length
+        # And shouldn't be wildly larger than a sane upper bound
+        assert calibrated <= c.context_length
+
+
+class TestShouldCompressUsesCalibration:
+    """End-to-end: should_compress(rough) with underestimating history
+    fires BEFORE the actual context_length breach — preventing the
+    "3 compressions and still HTTP 400" failure mode."""
+
+    def test_underestimating_history_triggers_earlier(self):
+        """Scenario from issue #62605 — calibrated for the reproduction:
+        context_length=262144, max_tokens=65536, threshold_percent=0.66
+        threshold = (262144 - 65536) * 0.66 ≈ 129,741
+        rough estimate = 150,688 (above threshold by ~11K — already fires)
+        previous-turn real prompt = 200K, previous-turn rough=150K
+        → ratio after 1 EMA sample = 0.5*1.0 + 0.5*(200/150) = 1.167
+        → calibrated = int(150_000 * 1.167) = 175_000
+        Crucially, even if the rough were BELOW threshold (e.g. 120K with
+        higher threshold_percent), the calibration fires for the next
+        preflight: 120K * 1.167 = 140K > 130K threshold.
+
+        The intent of #62605 is: when the rough estimator underestimates
+        systematically, the threshold check fires LATE. With calibration,
+        the SAME rough estimate, after one observed real/rough sample,
+        gets scaled up so the threshold check fires at the right time.
+        """
+        c = _make_compressor(
+            context_length=262_144, max_tokens=65_536, threshold_percent=0.66
+        )
+        # Plant history: previous turn reported rough=150K, real=200K
+        c.last_compression_rough_tokens = 150_000
+        c.update_from_response({"prompt_tokens": 200_000, "completion_tokens": 0})
+
+        # Sanity: the calibrated value crosses the threshold
+        calibrated = c._calibrate_rough(150_000)
+        assert calibrated > c.threshold_tokens, (
+            f"calibration didn't scale enough: {calibrated} vs {c.threshold_tokens}"
+        )
+        # And the calibrated check fires
+        assert c.should_compress(150_000) is True
+
+    def test_underestimating_history_with_subthreshold_rough(self):
+        """Stronger version of #62605: rough is BELOW threshold but real
+        is ABOVE. Without calibration the check passes (misses the
+        overflow); with calibration it fires (catches the overflow)."""
+        c = _make_compressor(
+            context_length=262_144, max_tokens=65_536, threshold_percent=0.80
+        )
+        # threshold = (262144 - 65536) * 0.80 = 157,286
+        assert c.threshold_tokens == 157_286
+        # Plant: rough=120K, real=200K → EMA → 1.333; calibrated(120K) = 160K
+        c.last_compression_rough_tokens = 120_000
+        c.update_from_response({"prompt_tokens": 200_000, "completion_tokens": 0})
+        # Without calibration: 120K < 157K threshold → would NOT fire
+        assert c._calibrate_rough(120_000) > c.threshold_tokens
+        # With calibration: check fires
+        assert c.should_compress(120_000) is True
+
+    def test_accurate_history_does_not_over_trigger(self):
+        """If past ratios were accurate, calibration shouldn't fire false
+        positives below threshold."""
+        c = _make_compressor(context_length=262_144, max_tokens=65_536, threshold_percent=0.75)
+        # History: rough=140K, real=140K → ratio = 1.0
+        c._last_compression_rough_tokens = 140_000
+        c.update_from_response({"prompt_tokens": 140_000, "completion_tokens": 0})
+        # A new rough estimate that's well below threshold shouldn't fire
+        assert c.should_compress(100_000) is False
+
+    def test_real_prompt_tokens_path_unchanged(self):
+        """When prompt_tokens is None we use last_prompt_tokens (the real
+        value). This path must NOT be calibrated — we already have the
+        authoritative answer."""
+        c = _make_compressor()
+        # Below threshold: real says safe, no calibration needed
+        c.last_prompt_tokens = 50_000
+        assert c.should_compress() is False
+
+        # Above threshold: real says compress, no calibration debate
+        c.last_prompt_tokens = c.threshold_tokens + 1000
+        assert c.should_compress() is True
+
+
+class TestThreePassRetryCanNowSucceed:
+    """The repro from #62605: 3 compress passes and still over. With
+    calibration firing early, the first pass should bring the calibrated
+    estimate under threshold."""
+
+    def test_calibration_lets_first_pass_succeed(self):
+        """When rough=150K actually represents real=200K, calibrated=175K
+        exceeds threshold 130K. Compression shrinks messages enough that
+        a re-estimate lands under threshold."""
+        c = _make_compressor(
+            context_length=262_144, max_tokens=65_536, threshold_percent=0.66
+        )
+        # threshold = (262144 - 65536) * 0.66 ≈ 129,741
+        assert c.threshold_tokens < 150_000
+        # Pretend compressor saw rough=150K → real=200K
+        c.last_compression_rough_tokens = 150_000
+        c.update_from_response({"prompt_tokens": 200_000, "completion_tokens": 0})
+        # First pass: calibrated check fires
+        assert c.should_compress(150_000) is True
+        # After a successful compression, a smaller rough estimate should
+        # NOT keep firing — calibration is calibrated for THIS conversation
+        # size, so a much smaller estimate means we've already shrunk.
+        assert c.should_compress(80_000) is False
+
+
+class TestAntiThrashingStillWorks:
+    """The calibration must not bypass the anti-thrashing guard that
+    prevents infinite compression loops."""
+
+    def test_ineffective_compression_still_skipped(self, monkeypatch):
+        c = _make_compressor()
+        # Set up underestimating history so calibration would normally fire
+        c.last_compression_rough_tokens = 150_000
+        c.update_from_response({"prompt_tokens": 200_000, "completion_tokens": 0})
+        # But mark that the last 2 compressions were ineffective
+        c._ineffective_compression_count = 2
+        # Even with calibration saying "fire", the anti-thrashing guard wins
+        assert c.should_compress(150_000) is False
+
+
+class TestCooldownStillWorks:
+    """The summary-LLM cooldown must still defer compression."""
+
+    def test_cooldown_deferes_firing(self):
+        import time
+
+        c = _make_compressor()
+        c.last_compression_rough_tokens = 150_000
+        c.update_from_response({"prompt_tokens": 200_000, "completion_tokens": 0})
+        # Plant an active cooldown
+        c._summary_failure_cooldown_until = time.monotonic() + 60
+        # Even with rough estimate above threshold, defer to cooldown
+        assert c.should_compress(150_000) is False

--- a/tests/agent/test_compression_rough_calibration_62605.py
+++ b/tests/agent/test_compression_rough_calibration_62605.py
@@ -7,9 +7,11 @@ non-English payloads. ``should_compress(rough_tokens)`` fires late, so after
 3 compression passes the request still exceeds context_length and the
 provider returns HTTP 400 with "total of at least N tokens".
 
-Fix: track the calibration ratio ``real_prompt_tokens / rough_estimate`` from
-each API response and apply it to the rough estimate BEFORE the threshold
-check. The threshold itself isn't wrong; our estimate of how full we are is.
+Fix: capture the exact outgoing-request rough estimate via
+``record_request_rough_estimate``, learn ``real / rough`` from the matching
+provider usage sample, and scale the next preflight estimate BEFORE the
+threshold check. The threshold itself isn't wrong; our estimate of how full
+we are is.
 
 Tests cover:
 - EMA ratio computation: stored, decayed, and applied
@@ -89,7 +91,7 @@ class TestRoughToRealRatioTracking:
         # Simulate: rough estimate was 150K, real provider prompt was 200K.
         # raw ratio = 200/150 = 1.333. With 0.5/0.5 EMA from seed 1.0 →
         # 0.5*1.0 + 0.5*1.333 = 1.167.
-        c.last_compression_rough_tokens = 150_000
+        c.record_request_rough_estimate(150_000)
         c.update_from_response({"prompt_tokens": 200_000, "completion_tokens": 0})
         assert 1.15 < c.rough_to_real_ratio < 1.20
 
@@ -98,13 +100,13 @@ class TestRoughToRealRatioTracking:
         c = _make_compressor()
         # First sample: real=200K, rough=150K → ratio target 1.333
         # EMA(1.0, 1.333, 0.5/0.5) = 1.167
-        c.last_compression_rough_tokens = 150_000
+        c.record_request_rough_estimate(150_000)
         c.update_from_response({"prompt_tokens": 200_000, "completion_tokens": 0})
         first_ratio = c.rough_to_real_ratio
 
         # Second sample: real=220K, rough=150K → ratio target 1.467
         # EMA(1.167, 1.467, 0.5/0.5) = 1.317
-        c.last_compression_rough_tokens = 150_000
+        c.record_request_rough_estimate(150_000)
         c.update_from_response({"prompt_tokens": 220_000, "completion_tokens": 0})
         # Equal-weight EMA: result must be between first_ratio and 1.467
         assert first_ratio < c.rough_to_real_ratio < 1.47
@@ -115,7 +117,7 @@ class TestRoughToRealRatioTracking:
         """If we never saw a rough estimate, don't fabricate a ratio."""
         c = _make_compressor()
         c.update_from_response({"prompt_tokens": 100_000, "completion_tokens": 0})
-        # No prior _last_compression_rough_tokens → no learning signal
+        # No prior last_request_rough_tokens → no learning signal
         assert c.rough_to_real_ratio == 1.0
 
 
@@ -133,7 +135,7 @@ class TestCalibrateRoughMethod:
         seed 1.0 the first observation yields ratio 1.167 → calibrated
         150K * 1.167 = 175K. The next response would converge further."""
         c = _make_compressor()
-        c.last_compression_rough_tokens = 150_000
+        c.record_request_rough_estimate(150_000)
         c.update_from_response({"prompt_tokens": 200_000, "completion_tokens": 0})
         calibrated = c._calibrate_rough(150_000)
         # Allow EMA drift but must be clearly above 150K
@@ -146,7 +148,7 @@ class TestCalibrateRoughMethod:
         c = _make_compressor()
         # Plant a fake pathological ratio by directly manipulating state
         c.rough_to_real_ratio = 10.0  # pretend rough underestimates by 10x
-        c._last_compression_rough_tokens = 1000
+        c.last_request_rough_tokens = 1000
         # 1K * 10 = 10K — fine, but should also not exceed context_length
         calibrated = c._calibrate_rough(30_000)
         assert calibrated <= c.context_length
@@ -180,7 +182,7 @@ class TestShouldCompressUsesCalibration:
             context_length=262_144, max_tokens=65_536, threshold_percent=0.66
         )
         # Plant history: previous turn reported rough=150K, real=200K
-        c.last_compression_rough_tokens = 150_000
+        c.record_request_rough_estimate(150_000)
         c.update_from_response({"prompt_tokens": 200_000, "completion_tokens": 0})
 
         # Sanity: the calibrated value crosses the threshold
@@ -201,7 +203,7 @@ class TestShouldCompressUsesCalibration:
         # threshold = (262144 - 65536) * 0.80 = 157,286
         assert c.threshold_tokens == 157_286
         # Plant: rough=120K, real=200K → EMA → 1.333; calibrated(120K) = 160K
-        c.last_compression_rough_tokens = 120_000
+        c.record_request_rough_estimate(120_000)
         c.update_from_response({"prompt_tokens": 200_000, "completion_tokens": 0})
         # Without calibration: 120K < 157K threshold → would NOT fire
         assert c._calibrate_rough(120_000) > c.threshold_tokens
@@ -213,7 +215,7 @@ class TestShouldCompressUsesCalibration:
         positives below threshold."""
         c = _make_compressor(context_length=262_144, max_tokens=65_536, threshold_percent=0.75)
         # History: rough=140K, real=140K → ratio = 1.0
-        c._last_compression_rough_tokens = 140_000
+        c.last_request_rough_tokens = 140_000
         c.update_from_response({"prompt_tokens": 140_000, "completion_tokens": 0})
         # A new rough estimate that's well below threshold shouldn't fire
         assert c.should_compress(100_000) is False
@@ -247,7 +249,7 @@ class TestThreePassRetryCanNowSucceed:
         # threshold = (262144 - 65536) * 0.66 ≈ 129,741
         assert c.threshold_tokens < 150_000
         # Pretend compressor saw rough=150K → real=200K
-        c.last_compression_rough_tokens = 150_000
+        c.record_request_rough_estimate(150_000)
         c.update_from_response({"prompt_tokens": 200_000, "completion_tokens": 0})
         # First pass: calibrated check fires
         assert c.should_compress(150_000) is True
@@ -264,7 +266,7 @@ class TestAntiThrashingStillWorks:
     def test_ineffective_compression_still_skipped(self, monkeypatch):
         c = _make_compressor()
         # Set up underestimating history so calibration would normally fire
-        c.last_compression_rough_tokens = 150_000
+        c.record_request_rough_estimate(150_000)
         c.update_from_response({"prompt_tokens": 200_000, "completion_tokens": 0})
         # But mark that the last 2 compressions were ineffective
         c._ineffective_compression_count = 2
@@ -279,9 +281,46 @@ class TestCooldownStillWorks:
         import time
 
         c = _make_compressor()
-        c.last_compression_rough_tokens = 150_000
+        c.record_request_rough_estimate(150_000)
         c.update_from_response({"prompt_tokens": 200_000, "completion_tokens": 0})
         # Plant an active cooldown
         c._summary_failure_cooldown_until = time.monotonic() + 60
         # Even with rough estimate above threshold, defer to cooldown
         assert c.should_compress(150_000) is False
+
+
+class TestRecordRequestRoughEstimate:
+    """Production path: pair the exact outgoing rough estimate with usage."""
+
+    def test_record_then_update_learns_ratio(self):
+        c = _make_compressor()
+        c.record_request_rough_estimate(150_000)
+        assert c.last_request_rough_tokens == 150_000
+        c.update_from_response({"prompt_tokens": 200_000, "completion_tokens": 0})
+        assert 1.15 < c.rough_to_real_ratio < 1.20
+        # Consumed after learning so it cannot double-count the next response.
+        assert c.last_request_rough_tokens == 0
+
+    def test_compression_fallback_still_learns(self):
+        """If only last_compression_rough_tokens is set (post-compress path),
+        update_from_response still learns."""
+        c = _make_compressor()
+        c.last_compression_rough_tokens = 150_000
+        c.update_from_response({"prompt_tokens": 200_000, "completion_tokens": 0})
+        assert 1.15 < c.rough_to_real_ratio < 1.20
+
+    def test_update_model_resets_ratio(self):
+        c = _make_compressor()
+        c.record_request_rough_estimate(100_000)
+        c.update_from_response({"prompt_tokens": 200_000, "completion_tokens": 0})
+        assert c.rough_to_real_ratio > 1.0
+        c.update_model(
+            model="other-model",
+            context_length=131_072,
+            base_url="",
+            api_key="",
+            provider="",
+            api_mode="",
+        )
+        assert c.rough_to_real_ratio == 1.0
+        assert c.last_request_rough_tokens == 0


### PR DESCRIPTION
## Summary
The rough chars/4 estimator used for compression preflights systematically underestimates real provider prompt_tokens by 20-30% on schema-heavy / non-English / YAML payloads. The threshold check fired late, so by the time `should_compress()` returned True the real payload was already past `context_length` and the provider returned HTTP 400. 3 compress passes weren't enough to recover.

Fix: track the `(real_prompt_tokens / rough_estimate)` ratio as an EMA on each API response and scale the rough estimate BEFORE the threshold check. The threshold itself is correct — our estimate of how full we are was the blind spot.

## Root cause
- `estimate_request_tokens_rough` uses a `(len+3)//4` heuristic (`agent/model_metadata.py:2546`). On payloads with tool schemas, AGENTS.md, skill descriptions, YAML content, or non-English text the actual tokenization can produce 1.3-2x the rough estimate.
- `should_compress(rough_tokens)` (`agent/context_compressor.py:1226`) compared the rough estimate directly against `threshold_tokens` without compensating.
- `update_from_response` (`agent/context_compressor.py:1170`) recorded the real `prompt_tokens` but never used them to learn a correction factor.

## Fix (one file changed + new tests)
**`agent/context_compressor.py`** — three small additions, no behavior change for callers:

1. New instance attribute `rough_to_real_ratio: float = 1.0` (initialized in all four reset sites with a `hasattr` guard for pickling compat).
2. `update_from_response()`: when `last_compression_rough_tokens > 0`, blend the new `(prompt_tokens / last_compression_rough_tokens)` sample into the EMA with equal weights (0.5/0.5). The ratio catches up within a turn or two instead of dragging for five turns. Capped at 3.0 to absorb a single noisy sample without snowballing.
3. New `_calibrate_rough(rough_tokens)` method: returns `rough_tokens` verbatim when no history, else `int(rough * ratio)` capped at `context_length`. Capped so a runaway ratio from one weird message can't make every future preflight fire unconditionally.
4. `should_compress(prompt_tokens=...)`: when called with an explicit rough estimate, calibrate it first via `_calibrate_rough`; when called with no argument (real-path callers like post-response checks) it uses `last_prompt_tokens` directly. Anti-thrashing and summary-LLM cooldown guards are unchanged.

## Reproduction (from #62605)
```
Context: 151 msgs, ~150,688 tokens  (Hermes client-side estimate)
Input tokens: ~196,609              (SGLang server-side actual)
Requested output: 65,536
Total: 262,145 > 262,144  ← HTTP 400
```

After fix: the rough=150K observation produces `ratio ≈ 1.167` after the first response, so the next preflight's calibrated check sees `~175K` vs the threshold and fires before the request goes over.

## Test plan
```bash
pytest tests/agent/test_compression_rough_calibration_62605.py -v
```

14 new tests, 5 classes:
- `TestRoughToRealRatioTracking` (4 tests) — EMA seed, blend behavior, no-history guard
- `TestCalibrateRoughMethod` (3 tests) — passthrough when no history, scale-up when underestimating, `context_length` cap on runaway
- `TestShouldCompressUsesCalibration` (4 tests) — the issue #62605 scenario + a stronger subthreshold-rough case + accurate-history doesn't over-trigger + real-prompt path unchanged
- `TestThreePassRetryCanNowSucceed` (1 test) — end-to-end: after calibration, the first preflight fires and the post-compression preflight doesn't keep firing
- `TestAntiThrashingStillWorks` / `TestCooldownStillWorks` (2 tests) — guards still take precedence over calibration

Verified locally: **14/14 passed**.

Pre-existing failures in `test_compress_focus.py` and `test_manual_compress.py` are unrelated to this PR (confirmed by checking out `main` and re-running — same failures from missing `rich` dep).

Closes #62605