### PR TITLE
feat(gateway): relay auth prompts (clarify/approval/secret/sudo) to operator WhatsApp

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8713,6 +8713,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             self._toggle_verbose()
         elif canonical == "footer":
             self._handle_footer_command(cmd_original)
+        elif canonical == "auth-relay":
+            self._handle_auth_relay_command(cmd_original)
         elif canonical == "yolo":
             self._toggle_yolo()
         elif canonical == "reasoning":

--- a/gateway/auth_relay.py
+++ b/gateway/auth_relay.py
@@ -186,6 +186,69 @@ def is_enabled() -> bool:
     return _LIVE_CFG.active
 
 
+def set_enabled(enabled: bool, cfg: Optional[AuthRelayConfig] = None) -> bool:
+    """Live on/off switch for the relay — no gateway restart required.
+
+    When ``cfg`` is provided it fully replaces the live config (e.g. after a
+    config.yaml edit).  When omitted, the current live config is reused with
+    only ``enabled`` flipped, so a single toggle call can't accidentally wipe
+    the operator_chat / per-kind settings the operator already has.
+
+    Returns True if the relay ended up active (enabled + operator resolvable +
+    callbacks installed), False if it ended up inactive (either because it was
+    turned off, or because it couldn't be enabled — e.g. no operator target).
+    """
+    global _LIVE_CFG
+    if cfg is None:
+        cfg = AuthRelayConfig(
+            enabled=enabled,
+            operator_chat=_LIVE_CFG.operator_chat,
+            clarify=_LIVE_CFG.clarify,
+            approval=_LIVE_CFG.approval,
+            secret=_LIVE_CFG.secret,
+            sudo=_LIVE_CFG.sudo,
+            require_confirm=_LIVE_CFG.require_confirm,
+            timeout=_LIVE_CFG.timeout,
+        )
+    else:
+        cfg = AuthRelayConfig(
+            enabled=enabled if enabled else cfg.enabled,
+            operator_chat=cfg.operator_chat or _LIVE_CFG.operator_chat,
+            clarify=cfg.clarify,
+            approval=cfg.approval,
+            secret=cfg.secret,
+            sudo=cfg.sudo,
+            require_confirm=cfg.require_confirm,
+            timeout=cfg.timeout,
+        )
+    # configure() derives operator_chat from the local WhatsApp config when
+    # empty, and forces inactive when enabled-but-unresolvable.
+    configure(cfg)
+    if _LIVE_CFG.active:
+        # Best-effort: install the gateway callbacks now.  A failure (e.g. no
+        # WhatsApp adapter connected in this process, or gateway not fully up)
+        # does NOT make the feature inactive — the operator target is valid and
+        # the callbacks will be (re)installed when the gateway connects at
+        # startup / on the next connect.  This matches the startup wiring, which
+        # logs and continues on install failure rather than disabling the relay.
+        if install_gateway_callbacks():
+            return True
+        logger.warning(
+            "auth_relay: enabled + operator resolved, but callback install failed "
+            "now (no WhatsApp adapter connected?); relay stays active and will "
+            "install callbacks when the gateway connects."
+        )
+        return True
+    # Turned off (or could not be enabled): tear down callbacks if present.
+    uninstall_gateway_callbacks()
+    return False
+
+
+def toggle() -> bool:
+    """Flip the relay's enabled state and return the new active state."""
+    return set_enabled(not _LIVE_CFG.enabled)
+
+
 def kind_enabled(kind: str) -> bool:
     if not _LIVE_CFG.active:
         return False

--- a/gateway/auth_relay.py
+++ b/gateway/auth_relay.py
@@ -1,0 +1,618 @@
+"""WhatsApp auth-relay for gateway authentication prompts.
+
+Problem this solves
+-------------------
+Several Hermes authentication paths block the agent thread waiting for a
+human response, but only work when the *originating* session is itself a
+rich messaging platform:
+
+* ``clarify`` / ``approval`` prompts deliver to WhatsApp **only** when the
+  session that triggered them is a WhatsApp chat (they use the originating
+  session's ``_status_adapter``).  For non-WhatsApp sessions (CLI
+  background tasks, cron jobs, Telegram, ...) they time out silently.
+* ``sudo`` password prompts (``tools/terminal_tool._prompt_for_sudo_password``)
+  have a hard 45s timeout and **no gateway callback** — in messaging/cron
+  mode they fail closed with no notification to anyone.
+* ``secret`` capture (``tools/skills_tool``) **deliberately short-circuits**
+  on messaging platforms, so a skill that needs an API key set up while the
+  agent runs unattended never gets it.
+
+The auth-relay routes **all** of these prompts to the operator's WhatsApp
+number (configured explicitly via ``gateway.auth_relay.operator_chat``),
+regardless of which session triggered them, and relays the operator's reply
+back to the waiting agent thread.
+
+Security model
+--------------
+* Opt-in. Nothing changes unless ``gateway.auth_relay.enabled`` is true AND a
+  WhatsApp adapter is connected.
+* The operator is identified by an explicit WhatsApp ID (``operator_chat``),
+  cross-checked against the adapter's existing DM allowlist.  Relayed
+  secrets / sudo passwords are ONLY accepted from that sender — an arbitrary
+  inbound WhatsApp message can never resolve a relayed prompt.
+* Secrets are persisted through the **same** trusted writer the CLI uses
+  (``hermes_cli.config.save_env_value_secure`` → ``~/.hermes/.env`` with
+  atomic replace + mode preservation).  They are never returned to the model
+  as text and never logged.
+* Approval command text is redacted before it is shown to the operator
+  (reusing ``_redact_approval_command`` semantics — see
+  ``tools/approval._redact_approval_command``).
+* A timeout (configurable, default 120s) returns a safe sentinel so the
+  agent thread unblocks and adapts instead of hanging forever.
+
+Pluggability / footprint
+------------------------
+This is a *gateway* feature (notification/relay), not a new core tool, so it
+adds zero permanent schema surface.  It is enabled entirely through
+``config.yaml`` and the already-connected WhatsApp adapter.
+
+Session routing
+---------------
+For clarify/approval the relay reuses the adapter's existing interactive-reply
+maps (``_clarify_state`` / ``_exec_approval_state`` map
+``clarify_id``/``approval_id`` → *originating* session key).  When a prompt is
+sent to WhatsApp on behalf of a non-WhatsApp session, the operator's tap on
+the WhatsApp button resolves the originating session's pending entry via the
+existing ``resolve_gateway_clarify`` / ``resolve_gateway_approval`` callers —
+no new resolution plumbing is needed for those two kinds.
+
+For sudo/secret there is no pre-existing WhatsApp resolution path, so this
+module owns a small per-token pending map and the WhatsApp adapter's
+``_dispatch_auth_relay_reply`` handler routes the operator's reply back.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# =========================================================================
+# Config
+# =========================================================================
+
+# Default timeout (seconds) for a relayed sudo/secret prompt.  Long enough
+# for the operator to notice + type on a phone, short enough that an
+# abandoned prompt unblocks the agent thread reasonably soon.
+DEFAULT_RELAY_TIMEOUT = 120
+
+
+@dataclass
+class AuthRelayConfig:
+    """Parsed ``gateway.auth_relay`` configuration."""
+
+    enabled: bool = False
+    operator_chat: str = ""          # WhatsApp ID (wa_id) of the operator
+    # Per-kind toggles (all default on once the feature is enabled).
+    clarify: bool = True
+    approval: bool = True
+    secret: bool = True
+    sudo: bool = True
+    # Require the operator to reply "yes"/"skip" to a confirm prompt BEFORE a
+    # sensitive value (secret/sudo) is actually relayed, as an anti-misdelivery
+    # guard.  clarify/approval are informational so they don't need it.
+    require_confirm: bool = True
+    timeout: int = DEFAULT_RELAY_TIMEOUT
+
+    @property
+    def active(self) -> bool:
+        """Feature is live only with an operator target (explicit or derived)."""
+        return self.enabled and bool(self.operator_chat)
+
+
+def _default_operator_chat() -> str:
+    """Best-effort operator WhatsApp ID from the locally-stored agent config.
+
+    Used when ``gateway.auth_relay.operator_chat`` is not set.  Prefers the
+    Baileys self-chat owner (``WHATSAPP_ALLOWED_USERS``), then the Cloud API
+    business phone (``WHATSAPP_CLOUD_PHONE`` / ``WHATSAPP_CLOUD_BUSINESS_PHONE``).
+    Returns the normalized numeric identifier (no ``+``), or \"\".
+    """
+    try:
+        from gateway.whatsapp_identity import normalize_whatsapp_identifier
+    except Exception:
+        normalize_whatsapp_identifier = lambda v: str(v or "").strip().lstrip("+")
+    for env_var in (
+        "WHATSAPP_ALLOWED_USERS",
+        "WHATSAPP_CLOUD_PHONE",
+        "WHATSAPP_CLOUD_BUSINESS_PHONE",
+        "WHATSAPP_CLOUD_OWNER_WA_ID",
+    ):
+        raw = os.getenv(env_var, "").strip()
+        if not raw:
+            continue
+        # WHATSAPP_ALLOWED_USERS is a comma-separated list.
+        first = raw.split(",")[0].strip()
+        norm = normalize_whatsapp_identifier(first)
+        if norm:
+            return norm
+    return ""
+
+
+# Module-level live config, set by the gateway at startup.  Kept simple and
+# process-global because the gateway is a single long-lived process.
+_LIVE_CFG: AuthRelayConfig = AuthRelayConfig()
+
+
+def configure(cfg: AuthRelayConfig) -> None:
+    """Install the live relay config.  Called once at gateway startup.
+
+    When ``operator_chat`` is empty but the feature is enabled, fall back to
+    the locally-stored WhatsApp owner number (Baileys ``WHATSAPP_ALLOWED_USERS``
+    or the Cloud business phone) so the operator doesn't have to repeat a number
+    already known to the agent.  If nothing can be derived, the feature stays
+    inert (active == False) rather than failing closed on every auth request.
+    """
+    global _LIVE_CFG
+    cfg = cfg or AuthRelayConfig()
+    if cfg.enabled and not cfg.operator_chat:
+        derived = _default_operator_chat()
+        if derived:
+            cfg = AuthRelayConfig(
+                enabled=cfg.enabled,
+                operator_chat=derived,
+                clarify=cfg.clarify,
+                approval=cfg.approval,
+                secret=cfg.secret,
+                sudo=cfg.sudo,
+                require_confirm=cfg.require_confirm,
+                timeout=cfg.timeout,
+            )
+            logger.info(
+                "auth_relay: operator_chat not set; derived from local WhatsApp "
+                "config -> %s",
+                derived,
+            )
+        else:
+            logger.warning(
+                "auth_relay: enabled but no operator_chat and none derivable from "
+                "local WhatsApp config; relay inactive."
+            )
+    _LIVE_CFG = cfg
+
+
+def get_config() -> AuthRelayConfig:
+    return _LIVE_CFG
+
+
+def is_enabled() -> bool:
+    return _LIVE_CFG.active
+
+
+def kind_enabled(kind: str) -> bool:
+    if not _LIVE_CFG.active:
+        return False
+    return bool(getattr(_LIVE_CFG, kind, False))
+
+
+# =========================================================================
+# Pending sudo/secret entries (operator-relayed credentials)
+# =========================================================================
+
+@dataclass
+class _RelayEntry:
+    """One pending sudo/secret prompt awaiting the operator's WhatsApp reply."""
+
+    relay_id: str
+    kind: str                   # "sudo" | "secret"
+    event: threading.Event = field(default_factory=threading.Event)
+    result: Optional[str] = None
+    # For secret: the env var name we will persist the value under.
+    var_name: Optional[str] = None
+    prompt: Optional[str] = None
+    metadata: Optional[dict] = None
+
+
+_lock = threading.RLock()
+# relay_id → _RelayEntry
+_entries: Dict[str, _RelayEntry] = {}
+
+
+def _register(kind: str, var_name: Optional[str], prompt: Optional[str],
+              metadata: Optional[dict]) -> _RelayEntry:
+    entry = _RelayEntry(
+        relay_id=uuid.uuid4().hex[:16],
+        kind=kind,
+        var_name=var_name,
+        prompt=prompt,
+        metadata=metadata,
+    )
+    with _lock:
+        _entries[entry.relay_id] = entry
+    return entry
+
+
+def _resolve(relay_id: str, value: str) -> bool:
+    """Resolve a pending relay entry.  Returns True if found + resolved.
+
+    Does NOT pop the entry — ``wait_for_response`` consumes it after the
+    waiter wakes.  This avoids a race where an inbound reply arrives (and
+    resolves) before the blocked waiter calls ``wait_for_response``, which
+    would otherwise see the entry already gone and return None.
+    """
+    with _lock:
+        entry = _entries.get(relay_id)
+        if entry is None:
+            return False
+        entry.result = value
+        entry.event.set()
+        return True
+
+
+def _cancel(relay_id: str) -> None:
+    """Cancel a pending relay entry (skip/timeout).  Sets result=None + event."""
+    with _lock:
+        entry = _entries.get(relay_id)
+        if entry is None:
+            return
+        entry.result = None
+        entry.event.set()
+
+
+def clear_all() -> None:
+    """Cancel every pending relay entry (gateway shutdown / interrupt)."""
+    with _lock:
+        pending = list(_entries.values())
+        _entries.clear()
+    for entry in pending:
+        entry.result = None
+        entry.event.set()
+
+
+def wait_for_response(relay_id: str, timeout: float) -> Optional[str]:
+    """Block on the entry's event until resolved or timeout fires.
+
+    Mirrors ``tools.clarify_gateway.wait_for_response`` — polls in 1s slices
+    and touches the gateway's inactivity watchdog so a long wait doesn't get
+    the agent killed while the operator is typing.
+    """
+    with _lock:
+        entry = _entries.get(relay_id)
+    if entry is None:
+        return None
+    try:
+        from tools.environments.base import touch_activity_if_due
+    except Exception:  # pragma: no cover
+        touch_activity_if_due = None
+    deadline = time.monotonic() + max(timeout, 0.0)
+    activity_state = {"last_touch": time.monotonic(), "start": time.monotonic()}
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            # Timed out — drop the entry so a late reply can't resolve a dead
+            # waiter (which would leak into a future unrelated prompt).
+            _cancel(relay_id)
+            return None
+        if entry.event.wait(timeout=min(1.0, remaining)):
+            with _lock:
+                _entries.pop(relay_id, None)
+            return entry.result
+        if touch_activity_if_due is not None:
+            touch_activity_if_due(activity_state, "waiting for operator auth reply")
+
+
+# =========================================================================
+# Gateway-wide callbacks (registered at startup when relay is active)
+# =========================================================================
+
+# These replace the no-op default callbacks on messaging/cron surfaces.  They
+# send a WhatsApp message to the operator, then block on the relay entry's
+# Event.  The WhatsApp adapter's inbound handler resolves the entry.
+
+def _whatsapp_operator_adapter():
+    """Best-effort lookup of a connected WhatsApp adapter.
+
+    Imported lazily to avoid a hard dependency on the gateway runner at
+    module import time.  Returns the adapter instance or None.
+    """
+    try:
+        from gateway.run import _get_whatsapp_operator_adapter
+        return _get_whatsapp_operator_adapter()
+    except Exception:
+        return None
+
+
+def _send_to_operator(text: str) -> bool:
+    """Deliver a relay prompt to the operator's WhatsApp chat.
+
+    Returns True if the send was accepted by the adapter.
+    """
+    adapter = _whatsapp_operator_adapter()
+    if adapter is None:
+        return False
+    op = _LIVE_CFG.operator_chat
+    if not op:
+        return False
+    try:
+        from gateway.run import safe_schedule_threadsafe
+        loop = _get_gateway_loop()
+        if loop is None:
+            return False
+
+        async def _do_send():
+            return await adapter.send(op, text)
+
+        fut = safe_schedule_threadsafe(_do_send(), loop, logger=logger,
+                                        log_message="auth_relay send failed")
+        if fut is None:
+            return False
+        result = fut.result(timeout=15)
+        return bool(getattr(result, "success", False))
+    except Exception as exc:
+        logger.warning("auth_relay: failed to send prompt to operator: %s", exc)
+        return False
+
+
+def _get_gateway_loop():
+    try:
+        from gateway.run import _get_gateway_event_loop
+        return _get_gateway_event_loop()
+    except Exception:
+        return None
+
+
+def _secret_capture_callback(var_name: str, prompt: str, metadata=None) -> dict:
+    """Gateway-wide secret capture callback → operator WhatsApp relay.
+
+    Sends the operator a prompt, waits for the relayed value, persists it via
+    the trusted CLI writer, and returns the same shape the CLI callback does.
+    """
+    if not kind_enabled("secret"):
+        return {
+            "success": False,
+            "stored_as": var_name,
+            "validated": False,
+            "skipped": True,
+            "message": "Auth relay secret capture is disabled.",
+        }
+
+    # Confirmation gate (anti-misdelivery): the operator must first ack the
+    # prompt before we surface a field asking them to type the secret.
+    # Skipped when require_confirm is disabled in config.
+    require_confirm = bool(getattr(_LIVE_CFG, "require_confirm", True))
+    if require_confirm:
+        entry = _register("secret", var_name, prompt, metadata)
+        rid = entry.relay_id
+        confirm_msg = (
+            f"🔐 *Secret required* for skill setup\n\n"
+            f"Variable: `{var_name}`\n"
+            f"{prompt or ''}\n\n"
+            f"Reply *yes* to receive a secure input prompt, or *skip* to skip."
+        )
+        if not _send_to_operator(confirm_msg):
+            _cancel(rid)
+            return {
+                "success": True,
+                "reason": "relay_failed",
+                "stored_as": var_name,
+                "validated": False,
+                "skipped": True,
+                "message": "Could not reach operator over WhatsApp; secret setup skipped.",
+            }
+
+        # Wait for the operator's confirm reply.
+        confirm = wait_for_response(rid, timeout=_LIVE_CFG.timeout)
+        if confirm is None:
+            return {
+                "success": True,
+                "reason": "timeout",
+                "stored_as": var_name,
+                "validated": False,
+                "skipped": True,
+                "message": "Secret setup timed out (operator did not confirm).",
+            }
+        if confirm.strip().lower() not in {"yes", "y"}:
+            return {
+                "success": True,
+                "reason": "cancelled",
+                "stored_as": var_name,
+                "validated": False,
+                "skipped": True,
+                "message": "Secret setup skipped by operator.",
+            }
+
+    # Register for the actual value (new relay id so a stale reply can't
+    # cross wires).  When confirmation was skipped this is the first prompt.
+    entry2 = _register("secret", var_name, prompt, metadata)
+    rid2 = entry2.relay_id
+    value_msg = (
+        f"🔐 *Enter secret for* `{var_name}`\n\n"
+        f"Reply with the value (it will be stored securely in "
+        f"`~/.hermes/.env` and never shown to the agent). "
+        f"Reply *skip* to cancel."
+    )
+    if not _send_to_operator(value_msg):
+        _cancel(rid2)
+        return {
+            "success": True,
+            "reason": "relay_failed",
+            "stored_as": var_name,
+            "validated": False,
+            "skipped": True,
+            "message": "Could not reach operator over WhatsApp; secret setup skipped.",
+        }
+
+    value = wait_for_response(rid2, timeout=_LIVE_CFG.timeout)
+    if value is None:
+        return {
+            "success": True,
+            "reason": "timeout",
+            "stored_as": var_name,
+            "validated": False,
+            "skipped": True,
+            "message": "Secret entry timed out.",
+        }
+    if not value:
+        return {
+            "success": True,
+            "reason": "cancelled",
+            "stored_as": var_name,
+            "validated": False,
+            "skipped": True,
+            "message": "Secret setup skipped.",
+        }
+
+    # Persist through the identical trusted writer the CLI uses.  Never
+    # returns the value to the model; the skill reads it from the env/secret
+    # scope later.
+    try:
+        from hermes_cli.config import save_env_value_secure
+        stored = save_env_value_secure(var_name, value)
+    except Exception as exc:  # pragma: no cover - storage failure
+        logger.error("auth_relay: failed to persist secret %s: %s", var_name, exc)
+        return {
+            "success": False,
+            "stored_as": var_name,
+            "validated": False,
+            "skipped": False,
+            "message": f"Failed to store secret: {exc}",
+        }
+    return {
+        **stored,
+        "skipped": False,
+        "message": "Secret stored securely via operator relay. The value was not exposed to the agent.",
+    }
+
+
+def _sudo_password_callback() -> str:
+    """Gateway-wide sudo password callback → operator WhatsApp relay.
+
+    Returns the password string (or "" on timeout/skip).  The terminal tool
+    caches it for the session like the CLI path does.
+    """
+    if not kind_enabled("sudo"):
+        return ""
+
+    entry = _register("sudo", None, "sudo password required", None)
+    rid = entry.relay_id
+
+    msg = (
+        "🔑 *Sudo password required*\n\n"
+        "An agent task needs sudo privileges. Reply with the sudo password, "
+        "or *skip* to continue without sudo."
+    )
+    if not _send_to_operator(msg):
+        _cancel(rid)
+        return ""
+
+    value = wait_for_response(rid, timeout=_LIVE_CFG.timeout)
+    if value is None or not value:
+        # Timeout / skip → continue without sudo (matches CLI fail-closed).
+        return ""
+    return value
+
+
+def install_gateway_callbacks() -> bool:
+    """Register the relay callbacks when the feature is active.
+
+    Returns True if callbacks were installed.  Idempotent per process.
+    """
+    if not is_enabled():
+        return False
+    # Sanity: a WhatsApp adapter must be reachable.
+    if _whatsapp_operator_adapter() is None:
+        logger.warning(
+            "auth_relay: enabled but no WhatsApp adapter connected; "
+            "not installing sudo/secret relay callbacks."
+        )
+        return False
+    try:
+        from tools.skills_tool import set_secret_capture_callback
+        from tools.terminal_tool import set_sudo_password_callback
+        set_secret_capture_callback(_secret_capture_callback)
+        set_sudo_password_callback(_sudo_password_callback)
+    except Exception as exc:
+        logger.error("auth_relay: failed to install callbacks: %s", exc)
+        return False
+    logger.info(
+        "auth_relay: installed sudo/secret relay callbacks → operator %s",
+        _LIVE_CFG.operator_chat,
+    )
+    return True
+
+
+def uninstall_gateway_callbacks() -> None:
+    """Clear the relay callbacks (gateway shutdown / feature disabled)."""
+    try:
+        from tools.skills_tool import set_secret_capture_callback
+        from tools.terminal_tool import set_sudo_password_callback
+        set_secret_capture_callback(None)
+        set_sudo_password_callback(None)
+    except Exception:
+        pass
+    clear_all()
+
+
+# ---------------------------------------------------------------------------
+# Inbound (operator → relay) resolution API.  The WhatsApp adapter calls these
+# from its inbound message handler to deliver a relayed secret/sudo value back
+# to the blocked agent thread.  Operator-only upstream; the adapter already
+# enforces that the sender is the configured operator_chat.
+# ---------------------------------------------------------------------------
+def resolve_secret_relay(relay_id: str, value: Optional[str]) -> bool:
+    """Resolve a pending secret relay entry with the operator's value.
+
+    ``value`` None means skip/cancel.  Returns True if an entry was resolved.
+    """
+    with _lock:
+        exists = relay_id in _entries
+    if value is None:
+        if not exists:
+            return False
+        _cancel(relay_id)
+        return True
+    return _resolve(relay_id, value)
+
+
+def resolve_sudo_relay(relay_id: str, value: Optional[str]) -> bool:
+    """Resolve a pending sudo relay entry with the operator's password.
+
+    ``value`` None means skip/cancel (continue without sudo).  Returns True if
+    an entry was resolved.
+    """
+    with _lock:
+        exists = relay_id in _entries
+    if value is None:
+        if not exists:
+            return False
+        _cancel(relay_id)
+        return True
+    return _resolve(relay_id, value)
+
+
+def pending_secret_for(operator_id: str) -> Optional[str]:
+    """Return the active secret relay id awaiting ``operator_id``'s reply.
+
+    Returns None when there is no pending secret prompt.  The operator_id
+    match is enforced when an explicit ``operator_chat`` is configured; in
+    auto/self-chat mode (operator_chat derived or empty) the adapter itself
+    gates the caller (e.g. Baileys only invokes this for ``fromOwner``
+    messages), so the match check is relaxed.
+    """
+    explicit = _LIVE_CFG.operator_chat
+    if explicit and operator_id != explicit:
+        return None
+    with _lock:
+        for rid, entry in _entries.items():
+            if entry.kind == "secret":
+                return rid
+    return None
+
+
+def pending_sudo_for(operator_id: str) -> Optional[str]:
+    """Return the active sudo relay id awaiting ``operator_id``'s reply."""
+    explicit = _LIVE_CFG.operator_chat
+    if explicit and operator_id != explicit:
+        return None
+    with _lock:
+        for rid, entry in _entries.items():
+            if entry.kind == "sudo":
+                return rid
+    return None

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -19,6 +19,7 @@ from enum import Enum
 from hermes_cli.config import get_hermes_home
 from agent.secret_scope import current_secret_scope, get_secret as _get_secret
 from utils import is_truthy_value
+from gateway.auth_relay import AuthRelayConfig
 
 logger = logging.getLogger(__name__)
 
@@ -142,6 +143,53 @@ def _normalize_unauthorized_dm_behavior(value: Any, default: str = "pair") -> st
         if normalized in {"pair", "ignore"}:
             return normalized
     return default
+
+
+def _parse_auth_relay(data: Any) -> "AuthRelayConfig":
+    """Build an ``AuthRelayConfig`` from the ``gateway.auth_relay`` mapping.
+
+    Missing/empty data → disabled config (the safe default).  Per-kind toggles
+    default to True when the feature is enabled so flipping ``enabled: true``
+    turns on the whole relay; individual kinds can be opted out.
+    """
+    if not isinstance(data, dict):
+        return AuthRelayConfig()
+    enabled = _coerce_bool(data.get("enabled"), False)
+    operator_chat = str(data.get("operator_chat") or "").strip()
+    # The operator target is mandatory for the feature to be live.  Without a
+    # destination WhatsApp ID the relay can never deliver a prompt.  Try to
+    # derive it from the locally-stored WhatsApp owner number first; only if
+    # that also fails do we force the feature disabled (so it can't silently
+    # no-op on every auth request).
+    if enabled and not operator_chat:
+        try:
+            from gateway.auth_relay import _default_operator_chat
+            operator_chat = _default_operator_chat()
+        except Exception:
+            operator_chat = ""
+        if not operator_chat:
+            logger.warning(
+                "gateway.auth_relay.enabled=true but no operator_chat set and "
+                "none derivable from local WhatsApp config; relay will stay inactive."
+            )
+            enabled = False
+    require_confirm = _coerce_bool(data.get("require_confirm"), True)
+    try:
+        timeout = int(data.get("timeout", AuthRelayConfig().timeout))
+    except (TypeError, ValueError):
+        timeout = AuthRelayConfig().timeout
+    if timeout <= 0:
+        timeout = AuthRelayConfig().timeout
+    return AuthRelayConfig(
+        enabled=enabled,
+        operator_chat=operator_chat,
+        clarify=_coerce_bool(data.get("clarify"), True),
+        approval=_coerce_bool(data.get("approval"), True),
+        secret=_coerce_bool(data.get("secret"), True),
+        sudo=_coerce_bool(data.get("sudo"), True),
+        require_confirm=require_confirm,
+        timeout=timeout,
+    )
 
 
 def _normalize_notice_delivery(value: Any, default: str = "public") -> str:
@@ -721,6 +769,12 @@ class GatewayConfig:
     # fresh session exactly as if the reset policy had fired.  0 = disabled.
     session_store_max_age_days: int = 90
 
+    # Auth-relay: route agent authentication prompts (clarify / approval /
+    # secret / sudo) from ANY session to the operator's WhatsApp for remote
+    # approval / credential entry.  Opt-in; see gateway/auth_relay.py.  Parsed
+    # into ``AuthRelayConfig`` at startup.
+    auth_relay: "AuthRelayConfig" = field(default_factory=lambda: AuthRelayConfig())
+
     def get_connected_platforms(self) -> List[Platform]:
         """Return list of platforms that are enabled and configured."""
         connected = []
@@ -827,6 +881,16 @@ class GatewayConfig:
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
             "session_store_max_age_days": self.session_store_max_age_days,
+            "auth_relay": {
+                "enabled": self.auth_relay.enabled,
+                "operator_chat": self.auth_relay.operator_chat,
+                "clarify": self.auth_relay.clarify,
+                "approval": self.auth_relay.approval,
+                "secret": self.auth_relay.secret,
+                "sudo": self.auth_relay.sudo,
+                "require_confirm": self.auth_relay.require_confirm,
+                "timeout": self.auth_relay.timeout,
+            },
         }
     
     @classmethod
@@ -919,6 +983,17 @@ class GatewayConfig:
         except (TypeError, ValueError):
             session_store_max_age_days = 90
 
+        # Auth-relay: parse gateway.auth_relay into AuthRelayConfig.
+        auth_relay_data = data.get("auth_relay")
+        if not isinstance(auth_relay_data, dict):
+            # Also accept the nested gateway.auth_relay form.
+            auth_relay_data = (
+                nested_gateway.get("auth_relay")
+                if isinstance(nested_gateway, dict)
+                else None
+            )
+        auth_relay = _parse_auth_relay(auth_relay_data)
+
         return cls(
             platforms=platforms,
             default_reset_policy=default_policy,
@@ -941,6 +1016,7 @@ class GatewayConfig:
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
             session_store_max_age_days=session_store_max_age_days,
+            auth_relay=auth_relay,
         )
 
     def get_unauthorized_dm_behavior(self, platform: Optional[Platform] = None) -> str:

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -1606,6 +1606,68 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                             status.get("id"),
                         )
 
+    async def _try_resolve_auth_relay(
+        self, sender_wa_id: str, text: str, raw_message: Dict[str, Any]
+    ) -> bool:
+        """Intercept an operator's reply to a pending secret/sudo relay prompt.
+
+        Called from ``_build_message_event_from_cloud`` before a text message
+        is turned into a chat turn.  Only the configured operator WhatsApp ID
+        is honored; any other sender falls through to normal chat (returns
+        False).  The relay module owns the pending entries and their
+        ``threading.Event``; we just hand the value (or a skip signal) to it.
+
+        Returns True if the message was consumed by the relay (caller must
+        drop the webhook entry and NOT start a conversation turn).
+        """
+        try:
+            from gateway.auth_relay import (
+                is_enabled,
+                get_config,
+                resolve_secret_relay,
+                resolve_sudo_relay,
+                pending_secret_for,
+                pending_sudo_for,
+            )
+        except Exception:
+            return False
+        if not is_enabled():
+            return False
+        operator = get_config().operator_chat
+        if not operator:
+            return False
+        # Normalize the operator id the same way the relay compares it.
+        # The relay stores operator_chat as the raw WhatsApp ID (digits); the
+        # webhook ``from`` is also the raw digits — compare directly.
+        if sender_wa_id != operator:
+            return False
+        lowered = text.strip().lower()
+        # Secret relay: pending token is a "sec:"-prefixed id.
+        sec_token = pending_secret_for(operator)
+        if sec_token is not None:
+            if lowered in ("skip", "cancel", "abort"):
+                resolve_secret_relay(sec_token, None)
+            else:
+                resolve_secret_relay(sec_token, text.strip())
+            try:
+                await self.send(operator, "🔐 Secret captured — thank you.")
+            except Exception:
+                pass
+            return True
+        # Sudo relay: pending token is a "sudo:"-prefixed id.
+        sudo_token = pending_sudo_for(operator)
+        if sudo_token is not None:
+            if lowered in ("skip", "cancel", "abort"):
+                resolve_sudo_relay(sudo_token, None)
+            else:
+                resolve_sudo_relay(sudo_token, text.strip())
+            try:
+                await self.send(operator, "🔑 Sudo password captured — thank you.")
+            except Exception:
+                pass
+            return True
+        return False
+
     async def _dispatch_interactive_reply(
         self,
         raw_message: Dict[str, Any],
@@ -1842,6 +1904,24 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             )
             if handled:
                 return None
+
+        # Auth-relay: a text reply from the operator to a pending secret/sudo
+        # prompt.  This must be intercepted BEFORE the message is turned into a
+        # normal chat turn — the value is sensitive and not a conversation
+        # input.  Operator-only; non-operator text falls through to chat.
+        if msg_type_str == "text":
+            sender_wa_id = str(
+                (raw_message.get("from") or contacts_by_waid.get("*") or "")
+            ).strip()
+            _text_body = str(
+                (raw_message.get("text") or {}).get("body") or ""
+            ).strip()
+            if _text_body:
+                consumed = await self._try_resolve_auth_relay(
+                    sender_wa_id, _text_body, raw_message
+                )
+                if consumed:
+                    return None
 
         body = ""
         if msg_type_str == "text":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9982,6 +9982,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if canonical == "footer":
             return await self._handle_footer_command(event)
 
+        if canonical == "auth-relay":
+            return await self._handle_auth_relay_command(event)
+
         if canonical == "yolo":
             return await self._handle_yolo_command(event)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7402,9 +7402,190 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # engages drain on the first tick.
         asyncio.create_task(self._drain_control_watcher())
 
+        # ------------------------------------------------------------------
+        # Auth-relay: install the operator-WhatsApp sudo/secret callbacks.
+        # Must run after adapters are connected (so a WhatsApp adapter is
+        # available) and after self.adapters is populated.  Idempotent + safe
+        # no-op when the feature is disabled or no WhatsApp adapter exists.
+        # ------------------------------------------------------------------
+        try:
+            from gateway.auth_relay import (
+                configure as _auth_relay_configure,
+                install_gateway_callbacks as _auth_relay_install,
+            )
+            _auth_relay_configure(self.config.auth_relay)
+            if _auth_relay_install():
+                logger.info("auth_relay: operator WhatsApp relay active")
+        except Exception as _ar_exc:
+            logger.warning("auth_relay: startup wiring failed: %s", _ar_exc)
+
         logger.info("Press Ctrl+C to stop")
         
         return True
+
+    # ------------------------------------------------------------------
+    # Auth-relay helpers (exposed so gateway/auth_relay.py can reach the
+    # running gateway's WhatsApp adapter + event loop without a hard import
+    # cycle).  Module-level functions keep the helper surface small and test
+    # friendly.
+    # ------------------------------------------------------------------
+    def _get_whatsapp_operator_adapter(self):
+        """Return the connected WhatsApp adapter (operator relay target).
+
+        Prefers the ``whatsapp`` platform (the configured ``WHATSAPP``
+        adapter in this user's config), falling back to ``whatsapp_cloud``.
+        Returns None when no WhatsApp adapter is connected.
+        """
+        from gateway.config import Platform
+        for plat in (Platform.WHATSAPP, Platform.WHATSAPP_CLOUD):
+            adapter = self.adapters.get(plat)
+            if adapter is not None:
+                return adapter
+        return None
+
+    def _get_gateway_event_loop(self):
+        """Return the running asyncio event loop (for sync→async bridging)."""
+        return getattr(self, "_gateway_loop", None)
+
+    # ------------------------------------------------------------------
+    # Auth-relay delivery (clarify / approval).  These reuse the operator
+    # WhatsApp adapter's EXISTING button-rendering + interactive-reply
+    # resolution, so the operator's tap unblocks the originating (possibly
+    # non-WhatsApp) agent thread via the already-wired resolve_* callers.
+    # ------------------------------------------------------------------
+    def _auth_relay_target_for(self, kind: str, status_adapter):
+        """Return the operator WhatsApp adapter to relay a prompt to, or None.
+
+        Returns the adapter only when:
+          * the auth-relay feature is enabled for ``kind``,
+          * a WhatsApp adapter is connected,
+          * the originating session's own adapter is NOT already WhatsApp
+            (otherwise the prompt is already delivered there — relaying again
+            would double-prompt the operator for no benefit).
+        """
+        try:
+            from gateway.auth_relay import kind_enabled, is_enabled, get_config
+        except Exception:
+            return None
+        if not is_enabled() or not kind_enabled(kind):
+            return None
+        wa = self._get_whatsapp_operator_adapter()
+        if wa is None:
+            return None
+        # Don't relay if the prompt is already going to WhatsApp natively.
+        from gateway.config import Platform
+        if status_adapter is not None and getattr(status_adapter, "platform", None) in (
+            Platform.WHATSAPP,
+            Platform.WHATSAPP_CLOUD,
+        ):
+            return None
+        # Operator gating: the adapter must consider the configured operator
+        # chat an allowed DM, or the relayed prompt can't be delivered there.
+        op = get_config().operator_chat
+        if not op:
+            return None
+        try:
+            if not wa._is_dm_allowed(op):
+                logger.warning(
+                    "auth_relay: operator_chat %s not in WhatsApp allowlist; "
+                    "skipping relay for %s",
+                    op, kind,
+                )
+                return None
+        except Exception:
+            return None
+        return wa
+
+    def _auth_relay_send_clarify(
+        self, adapter, clarify_id: str, question: str, choices, session_key: str
+    ) -> str:
+        """Deliver a clarify prompt to the operator's WhatsApp and block.
+
+        Mirrors the native _clarify_callback_sync path but targets the
+        operator adapter.  Returns the resolved response string (or a timeout
+        sentinel) — the same contract the clarify tool expects.
+        """
+        from tools import clarify_gateway as _clarify_mod
+        from gateway.auth_relay import wait_for_response as _relay_wait, get_config
+
+        op = get_config().operator_chat
+        try:
+            adapter.pause_typing_for_chat(op)
+        except Exception:
+            pass
+
+        send_ok = False
+        loop = self._get_gateway_event_loop()
+        try:
+            fut = safe_schedule_threadsafe(
+                adapter.send_clarify(
+                    chat_id=op,
+                    question=question,
+                    choices=list(choices) if choices else None,
+                    clarify_id=clarify_id,
+                    session_key=session_key,
+                    metadata=None,
+                ),
+                loop,
+                logger=logger,
+                log_message="auth_relay clarify send failed",
+            )
+            if fut is not None:
+                result = fut.result(timeout=15)
+                send_ok = bool(getattr(result, "success", False))
+        except Exception as exc:
+            logger.warning("auth_relay clarify send failed: %s", exc)
+            send_ok = False
+
+        if not send_ok:
+            _clarify_mod.clear_session(session_key)
+            return "[clarify prompt could not be delivered to operator]"
+
+        timeout = _clarify_mod.get_clarify_timeout()
+        response = _relay_wait(clarify_id, timeout=float(timeout))
+        if response is None or response == "":
+            return f"[user did not respond within {int(timeout / 60)}m]"
+        return response
+
+    def _auth_relay_send_approval(
+        self, adapter, approval_id: str, command: str, description: str, session_key: str
+    ) -> None:
+        """Deliver a dangerous-command approval prompt to the operator's WhatsApp.
+
+        Notify-style (mirrors the native ``_approval_notify_sync`` contract:
+        deliver the prompt and return).  The agent thread is blocked in
+        ``tools.approval``'s gateway queue; the operator's WhatsApp button tap
+        calls ``resolve_gateway_approval(session_key, choice)`` which unblocks
+        the originating thread.
+        """
+        from gateway.auth_relay import get_config as _ar_get_config
+
+        op = _ar_get_config().operator_chat
+        # Redact credentials from the command before showing the operator.
+        try:
+            from tools.approval import _redact_approval_command
+            cmd = _redact_approval_command(command)
+        except Exception:
+            cmd = command
+
+        loop = self._get_gateway_event_loop()
+        try:
+            fut = safe_schedule_threadsafe(
+                adapter.send_exec_approval(
+                    chat_id=op,
+                    command=cmd,
+                    session_key=session_key,
+                    description=description,
+                    metadata=None,
+                ),
+                loop,
+                logger=logger,
+                log_message="auth_relay approval send failed",
+            )
+            if fut is not None:
+                fut.result(timeout=15)
+        except Exception as exc:
+            logger.warning("auth_relay approval send failed: %s", exc)
 
     async def _handoff_watcher(self, interval: float = 2.0) -> None:
         """Background task that processes pending CLI→gateway session handoffs.
@@ -18408,6 +18589,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     choices=list(choices) if choices else None,
                 )
 
+                # Auth-relay: when the originating session is NOT a WhatsApp
+                # chat (CLI background task, cron, Telegram, ...) and the relay
+                # is enabled for clarify, deliver the prompt to the operator's
+                # WhatsApp instead of (or in addition to) the originating
+                # adapter.  The operator's tap on the WhatsApp button resolves
+                # this same clarify_id via the adapter's existing interactive
+                # reply handler — which unblocks THIS (originating) thread.
+                _relay_adapter = _auth_relay_target_for("clarify", _status_adapter)
+                if _relay_adapter is not None:
+                    return _auth_relay_send_clarify(
+                        _relay_adapter, clarify_id, question, choices, session_key or "",
+                    )
+
                 # Pause typing — like approval, we don't want a "thinking..."
                 # status to obscure the prompt or block the user from typing
                 # an "Other" response on platforms that disable input while
@@ -18538,6 +18732,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 UX.  Otherwise fall back to a plain text message with
                 ``/approve`` instructions.
                 """
+                # Auth-relay: when the originating session is NOT a WhatsApp
+                # chat and the relay is enabled for approval, deliver the
+                # prompt to the operator's WhatsApp instead.  The operator's
+                # button tap calls resolve_gateway_approval, unblocking the
+                # originating thread exactly like the native path.
+                _relay_adapter = _auth_relay_target_for("approval", _status_adapter)
+                if _relay_adapter is not None:
+                    _auth_relay_send_approval(
+                        _relay_adapter,
+                        _uuid.uuid4().hex[:12],
+                        approval_data.get("command", ""),
+                        approval_data.get("description", "dangerous command"),
+                        _approval_session_key,
+                    )
+                    return
+
                 # Pause the typing indicator while the agent waits for
                 # user approval.  Critical for Slack's Assistant API where
                 # assistant_threads_setStatus disables the compose box — the

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3080,6 +3080,116 @@ class GatewaySlashCommandsMixin:
                 example = t("gateway.footer.example_line", preview=preview)
         return t("gateway.footer.saved", state=state, example=example)
 
+    async def _handle_auth_relay_command(self, event: MessageEvent) -> str:
+        """Handle /auth-relay — toggle / inspect the operator WhatsApp auth-relay.
+
+        Usage:
+            /auth-relay            → toggle on/off
+            /auth-relay on         → enable (live, no restart) + persist
+            /auth-relay off        → disable (live) + persist
+            /auth-relay status     → show current state + operator target
+
+        The relay routes clarify/approval/secret/sudo prompts to the
+        operator's WhatsApp. When enabled it is applied immediately by
+        re-installing the gateway callbacks; when disabled the callbacks are
+        torn down. The setting is persisted to ``gateway.auth_relay.enabled``
+        so it survives a gateway restart.
+        """
+        from gateway.run import _hermes_home, _load_gateway_config
+        from gateway.auth_relay import (
+            AuthRelayConfig,
+            get_config,
+            is_enabled,
+            set_enabled,
+        )
+
+        config_path = _hermes_home / "config.yaml"
+
+        # --- parse argument -------------------------------------------------
+        arg = ""
+        try:
+            text = (getattr(event, "message", None) or "").strip()
+            if text.startswith("/"):
+                parts = text.split(None, 1)
+                if len(parts) > 1:
+                    arg = parts[1].strip().lower()
+        except Exception:
+            arg = ""
+
+        live = get_config()
+        currently_active = is_enabled()
+
+        if arg in {"status", "?"}:
+            op = live.operator_chat or "(derived from local WhatsApp config)"
+            kinds = [
+                k for k, on in (
+                    ("clarify", live.clarify),
+                    ("approval", live.approval),
+                    ("secret", live.secret),
+                    ("sudo", live.sudo),
+                ) if on
+            ]
+            state = "ON" if currently_active else "OFF"
+            return (
+                f"🔐 Auth-relay: *{state}*\n"
+                f"Operator: `{op}`\n"
+                f"Relayed prompts: {', '.join(kinds) or '(none)'}\n"
+                f"require_confirm: {live.require_confirm}  timeout: {live.timeout}s"
+            )
+
+        if arg in {"on", "enable", "true", "1"}:
+            new_state = True
+        elif arg in {"off", "disable", "false", "0"}:
+            new_state = False
+        elif arg == "":
+            new_state = not currently_active
+        else:
+            return (
+                "Usage: /auth-relay [on|off|status]\n"
+                "Routes clarify/approval/secret/sudo prompts to your WhatsApp."
+            )
+
+        # --- persist to config.yaml ----------------------------------------
+        try:
+            user_config: dict = _load_gateway_config()
+            if not isinstance(user_config.get("gateway"), dict):
+                user_config["gateway"] = {}
+            gw = user_config["gateway"]
+            if not isinstance(gw.get("auth_relay"), dict):
+                gw["auth_relay"] = {}
+            gw["auth_relay"]["enabled"] = new_state
+            atomic_config_write(config_path, user_config)
+        except Exception as e:
+            logger.warning("auth_relay: failed to persist enabled=%s: %s", new_state, e)
+            return f"⚠️ Could not save setting to config.yaml: {e}"
+
+        # --- apply live (re-install / tear down callbacks) ------------------
+        # Build a config that keeps the operator_chat + per-kind settings from
+        # the live config, flipping only enabled. set_enabled() derives the
+        # operator target from the local WhatsApp config when empty.
+        active = set_enabled(
+            new_state,
+            AuthRelayConfig(
+                enabled=new_state,
+                operator_chat=live.operator_chat,
+                clarify=live.clarify,
+                approval=live.approval,
+                secret=live.secret,
+                sudo=live.sudo,
+                require_confirm=live.require_confirm,
+                timeout=live.timeout,
+            ),
+        )
+        if new_state and not active:
+            return (
+                "⚠️ Auth-relay enabled but could not activate: no operator WhatsApp "
+                "target resolved (set gateway.auth_relay.operator_chat or ensure "
+                "WHATSAPP_ALLOWED_USERS is configured). Setting saved; restart the "
+                "gateway after fixing."
+            )
+        state = "ON" if active else "OFF"
+        return f"🔐 Auth-relay is now *{state}* (applied live; saved to config.yaml)."
+
     async def _handle_compress_command(self, event: MessageEvent) -> str:
         """Handle /compress command -- manually compress conversation context.
 

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2416,6 +2416,111 @@ class CLICommandsMixin:
         else:
             _cprint("  Failed to save runtime_footer setting to config.yaml")
 
+    def _handle_auth_relay_command(self, cmd_original: str) -> None:
+        """Toggle or inspect the operator WhatsApp auth-relay from the CLI.
+
+        Usage:
+            /auth-relay           → toggle on/off
+            /auth-relay on|off    → explicit
+            /auth-relay status    → show current state
+
+        Persists ``gateway.auth_relay.enabled`` to config.yaml and, when the
+        gateway runtime is importable in this process, applies the change live
+        (re-installing / tearing down the relay callbacks). In a pure CLI
+        process the relay only activates once the gateway is running, so the
+        saved state takes effect on the next gateway start.
+        """
+        from cli import _cprint, save_config_value
+        from hermes_cli.colors import Colors as _Colors
+
+        arg = ""
+        try:
+            parts = (cmd_original or "").strip().split(None, 1)
+            if len(parts) > 1:
+                arg = parts[1].strip().lower()
+        except Exception:
+            arg = ""
+
+        # Current live state (best-effort — gateway module may not be loaded
+        # in a bare CLI process).
+        current = False
+        try:
+            from gateway.auth_relay import get_config, is_enabled
+            current = is_enabled()
+        except Exception:
+            pass
+
+        if arg in {"status", "?"}:
+            op = ""
+            try:
+                from gateway.auth_relay import get_config
+                op = get_config().operator_chat or "(derived from local WhatsApp config)"
+            except Exception:
+                op = "(unknown — gateway not loaded)"
+            state = "ON" if current else "OFF"
+            _cprint(
+                f"  {_Colors.BOLD}Auth-relay:{_Colors.RESET} {state}\n"
+                f"  Operator: {op}\n"
+                f"  (saved to gateway.auth_relay.enabled in config.yaml)"
+            )
+            return
+
+        if arg in {"on", "enable", "true", "1"}:
+            new_state = True
+        elif arg in {"off", "disable", "false", "0"}:
+            new_state = False
+        elif arg == "":
+            new_state = not current
+        else:
+            _cprint("  Usage: /auth-relay [on|off|status]")
+            return
+
+        if not save_config_value("gateway.auth_relay.enabled", new_state):
+            _cprint("  Failed to save auth-relay setting to config.yaml")
+            return
+
+        # Apply live if the gateway runtime is available in this process.
+        applied = None
+        try:
+            from gateway.auth_relay import AuthRelayConfig, get_config, set_enabled
+            live = get_config()
+            applied = set_enabled(
+                new_state,
+                AuthRelayConfig(
+                    enabled=new_state,
+                    operator_chat=live.operator_chat,
+                    clarify=live.clarify,
+                    approval=live.approval,
+                    secret=live.secret,
+                    sudo=live.sudo,
+                    require_confirm=live.require_confirm,
+                    timeout=live.timeout,
+                ),
+            )
+        except Exception as exc:
+            applied = None
+            import logging as _logging
+            _logging.getLogger(__name__).debug(
+                "auth_relay live toggle unavailable in CLI process: %s", exc
+            )
+
+        state = (
+            f"{_Colors.GREEN}ON{_Colors.RESET}" if new_state
+            else f"{_Colors.DIM}OFF{_Colors.RESET}"
+        )
+        if applied is True:
+            _cprint(f"  Auth-relay: {state} (applied live; saved to config.yaml)")
+        elif applied is False and new_state:
+            _cprint(
+                f"  Auth-relay: setting saved but could not activate live (no operator "
+                f"WhatsApp target). It will activate on the next gateway start once "
+                f"operator_chat / WHATSAPP_ALLOWED_USERS is configured."
+            )
+        else:
+            _cprint(
+                f"  Auth-relay: {state} (saved to config.yaml; applies on next gateway start)"
+            )
+
     def _handle_timestamps_command(self, cmd_original: str) -> None:
         """Toggle or inspect ``display.timestamps`` from the CLI.
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -150,6 +150,10 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("footer", "Toggle gateway runtime-metadata footer on final replies",
                "Configuration", args_hint="[on|off|status]",
                subcommands=("on", "off", "status")),
+    CommandDef("auth-relay", "Toggle / inspect the operator WhatsApp auth-relay (relays clarify/approval/secret/sudo prompts to your WhatsApp)",
+               "Configuration", aliases=("authrelay", "auth_relay"),
+               args_hint="[on|off|status]",
+               subcommands=("on", "off", "status")),
     CommandDef("yolo", "Toggle YOLO mode (skip all dangerous command approvals)",
                "Configuration"),
     CommandDef("reasoning", "Manage reasoning effort and display", "Configuration",
@@ -1163,7 +1167,14 @@ _SLACK_PRIORITY_ALIASES = ("btw", "bg")
 #   - moa: high-cost slash mode, available through /hermes moa to avoid
 #     displacing existing native Slack slash commands at the 50-command cap.
 #   - debug: the log/report upload surface; reached via /hermes debug on Slack.
-_SLACK_VIA_HERMES_ONLY = frozenset({"credits", "billing", "moa", "debug"})
+#   - auth_relay: operator WhatsApp auth-relay toggle (a config power-user
+#     command); reached via /hermes auth-relay on Slack so it doesn't spend a
+#     scarce native slash. Works natively on Telegram/Discord/CLI/gateway.
+#     The canonical sanitized Slack name is "auth-relay" (hyphen preserved by
+#     _sanitize_slack_name), so that is what must be excluded here.
+_SLACK_VIA_HERMES_ONLY = frozenset(
+    {"credits", "billing", "moa", "debug", "auth-relay", "authrelay"}
+)
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1333,6 +1333,21 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             if not self._should_process_message(data):
                 return None
 
+            # Auth-relay: intercept the owner's text reply to a pending
+            # secret/sudo prompt BEFORE it becomes a chat turn.  The value is
+            # sensitive and must not be fed to the agent as conversation input.
+            if str(data.get("body") or "").strip() and (
+                data.get("fromOwner") or data.get("fromMe")
+            ):
+                try:
+                    if await self._try_resolve_auth_relay(data):
+                        return None
+                except Exception as _relay_exc:
+                    print(
+                        f"[{self.name}] auth_relay intercept error: {_relay_exc}",
+                        flush=True,
+                    )
+
             # Determine message type
             msg_type = MessageType.TEXT
             media_type = str(data.get("mediaType", "") or "")
@@ -1519,6 +1534,60 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         except Exception as e:
             print(f"[{self.name}] Error building event: {e}")
             return None
+
+    async def _try_resolve_auth_relay(self, data: Dict[str, Any]) -> bool:
+        """Intercept the owner's reply to a pending secret/sudo relay prompt.
+
+        For the Baileys self-chat bridge the operator is the account owner, so
+        we gate on the bridge's ``fromOwner`` / ``fromMe`` markers rather than
+        an explicit chat id (the relay module already relaxed the operator_id
+        match in auto/self-chat mode).  Returns True if the message was
+        consumed by the relay (caller must drop the event — NOT start a chat
+        turn with the secret/sudo value).
+        """
+        try:
+            from gateway.auth_relay import (
+                is_enabled,
+                resolve_secret_relay,
+                resolve_sudo_relay,
+                pending_secret_for,
+                pending_sudo_for,
+            )
+        except Exception:
+            return False
+        if not is_enabled():
+            return False
+        # Only the owner may answer relay prompts.  In self-chat the bridge
+        # tags owner-typed inbound with fromOwner (and fromMe for own sends).
+        if not (data.get("fromOwner") or data.get("fromMe")):
+            return False
+        body = str(data.get("body") or "").strip()
+        if not body:
+            return False
+        lowered = body.lower()
+        sec_token = pending_secret_for("")
+        if sec_token is not None:
+            if lowered in ("skip", "cancel", "abort"):
+                resolve_secret_relay(sec_token, None)
+            else:
+                resolve_secret_relay(sec_token, body)
+            try:
+                await self.send(str(data.get("chatId") or ""), "🔐 Secret captured — thank you.")
+            except Exception:
+                pass
+            return True
+        sudo_token = pending_sudo_for("")
+        if sudo_token is not None:
+            if lowered in ("skip", "cancel", "abort"):
+                resolve_sudo_relay(sudo_token, None)
+            else:
+                resolve_sudo_relay(sudo_token, body)
+            try:
+                await self.send(str(data.get("chatId") or ""), "🔑 Sudo password captured — thank you.")
+            except Exception:
+                pass
+            return True
+        return False
 
 
 # ──────────────────────────────────────────────────────────────────────────

--- a/tests/gateway/test_auth_relay.py
+++ b/tests/gateway/test_auth_relay.py
@@ -1,0 +1,354 @@
+"""Tests for the gateway auth-relay subsystem (operator WhatsApp relay).
+
+These exercise the real relay mechanics in gateway/auth_relay.py:
+  * config parsing / enable gating
+  * secret capture round-trip (persisted via hermes_cli.config.save_env_value_secure)
+  * sudo password round-trip
+  * timeout safety (no hang, returns sentinel)
+  * operator-only pending-query resolution
+  * inbound resolve_* functions unblock the waiting thread
+
+No network: the WhatsApp send is monkeypatched, so the callbacks run
+synchronously and deterministically.  HERMES_HOME is redirected to a temp dir
+by the conftest autouse fixture.
+"""
+
+import os
+import sys
+import time
+import threading
+import tempfile
+import importlib
+
+import pytest
+
+# Make the repo importable regardless of CWD.
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+def _import_relay():
+    import gateway.auth_relay as relay
+    importlib.reload(relay)
+    return relay
+
+
+@pytest.fixture
+def relay_module():
+    """Fresh relay module + cleared state per test."""
+    relay = _import_relay()
+    relay.clear_all()
+    # Default: feature off.
+    relay.configure(
+        relay.AuthRelayConfig(
+            enabled=False, operator_chat="", timeout=10
+        )
+    )
+    yield relay
+    relay.clear_all()
+    relay.configure(relay.AuthRelayConfig(enabled=False, operator_chat="", timeout=10))
+
+
+class TestConfig:
+    def test_disabled_by_default(self, relay_module):
+        assert relay_module.is_enabled() is False
+
+    def test_enable_requires_operator(self, relay_module):
+        # enabled but no operator → still inert.
+        relay_module.configure(
+            relay_module.AuthRelayConfig(enabled=True, operator_chat="", timeout=10)
+        )
+        assert relay_module.is_enabled() is False
+
+    def test_enable_with_operator(self, relay_module):
+        relay_module.configure(
+            relay_module.AuthRelayConfig(
+                enabled=True, operator_chat="85251234567", timeout=10
+            )
+        )
+        assert relay_module.is_enabled() is True
+        assert relay_module.kind_enabled("secret") is True
+        assert relay_module.kind_enabled("sudo") is True
+
+    def test_per_kind_opt_out(self, relay_module):
+        relay_module.configure(
+            relay_module.AuthRelayConfig(
+                enabled=True,
+                operator_chat="85251234567",
+                secret=False,
+                sudo=True,
+                timeout=10,
+            )
+        )
+        assert relay_module.kind_enabled("secret") is False
+        assert relay_module.kind_enabled("sudo") is True
+
+
+class TestSecretRelay:
+    def _drive_two_step(self, relay_module, monkeypatch, confirm_word, value):
+        """fake_send that answers BOTH the confirm and value prompts."""
+        relay_module._whatsapp_operator_adapter = lambda: object()
+        sent = []
+
+        def fake_send(text):
+            sent.append(text)
+            op = "85251234567"
+            # First prompt is the confirm; second is the value.
+            rid = relay_module.pending_secret_for(op)
+            if rid is None:
+                return True
+            # Decide what to reply based on which prompt this is.
+            if "Reply *yes*" in text or "reply *yes*" in text.lower():
+                reply = confirm_word
+            else:
+                reply = value
+            threading.Thread(
+                target=lambda: relay_module.resolve_secret_relay(rid, reply),
+                daemon=True,
+            ).start()
+            return True
+
+        monkeypatch.setattr(relay_module, "_send_to_operator", fake_send)
+        return sent
+
+    def test_secret_round_trip_persists(self, relay_module, tmp_path, monkeypatch):
+        import hermes_cli.config as hc
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        relay_module.configure(
+            relay_module.AuthRelayConfig(
+                enabled=True,
+                operator_chat="85251234567",
+                timeout=15,
+                require_confirm=False,
+            )
+        )
+        sent = []
+
+        def fake_send(text):
+            sent.append(text)
+            rid = relay_module.pending_secret_for("85251234567")
+            if rid:
+                threading.Thread(
+                    target=lambda: relay_module.resolve_secret_relay(
+                        rid, "s3cr3t-value"
+                    ),
+                    daemon=True,
+                ).start()
+            return True
+
+        monkeypatch.setattr(relay_module, "_send_to_operator", fake_send)
+
+        result = relay_module._secret_capture_callback(
+            "MY_API_KEY", "Enter your API key", None
+        )
+        assert result["success"] is True
+        assert result["stored_as"] == "MY_API_KEY"
+        assert "MY_API_KEY" in sent[0]
+        dotenv = tmp_path / ".env"
+        assert dotenv.exists()
+        content = dotenv.read_text()
+        assert "MY_API_KEY" in content
+        assert "s3cr3t-value" in content
+
+    def test_secret_confirm_flow_persists(self, relay_module, tmp_path, monkeypatch):
+        import hermes_cli.config as hc
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        relay_module.configure(
+            relay_module.AuthRelayConfig(
+                enabled=True,
+                operator_chat="85251234567",
+                timeout=15,
+                require_confirm=True,
+            )
+        )
+        sent = self._drive_two_step(relay_module, monkeypatch, "yes", "tok-en-123")
+
+        result = relay_module._secret_capture_callback(
+            "MY_TOKEN", "Enter token", None
+        )
+        assert result["success"] is True
+        assert result["stored_as"] == "MY_TOKEN"
+        # Two messages were sent: confirm + value.
+        assert len(sent) == 2
+        dotenv = tmp_path / ".env"
+        content = dotenv.read_text()
+        assert "MY_TOKEN" in content
+        assert "tok-en-123" in content
+
+    def test_secret_skip_at_confirm(self, relay_module, monkeypatch):
+        relay_module.configure(
+            relay_module.AuthRelayConfig(
+                enabled=True,
+                operator_chat="85251234567",
+                timeout=5,
+                require_confirm=True,
+            )
+        )
+        relay_module._whatsapp_operator_adapter = lambda: object()
+
+        def fake_send(text):
+            rid = relay_module.pending_secret_for("85251234567")
+            if rid:
+                threading.Thread(
+                    target=lambda: relay_module.resolve_secret_relay(rid, "no"),
+                    daemon=True,
+                ).start()
+            return True
+
+        monkeypatch.setattr(relay_module, "_send_to_operator", fake_send)
+        result = relay_module._secret_capture_callback("X", "p", None)
+        assert result["success"] is True
+        assert result["skipped"] is True
+
+
+class TestSudoRelay:
+    def test_sudo_round_trip(self, relay_module, monkeypatch):
+        relay_module.configure(
+            relay_module.AuthRelayConfig(
+                enabled=True, operator_chat="85251234567", timeout=15
+            )
+        )
+        relay_module._whatsapp_operator_adapter = lambda: object()
+
+        def fake_send(text):
+            rid = relay_module.pending_sudo_for("85251234567")
+            if rid:
+                threading.Thread(
+                    target=lambda: relay_module.resolve_sudo_relay(rid, "p@ssw0rd"),
+                    daemon=True,
+                ).start()
+            return True
+
+        monkeypatch.setattr(relay_module, "_send_to_operator", fake_send)
+        pw = relay_module._sudo_password_callback()
+        assert pw == "p@ssw0rd"
+
+    def test_sudo_skip_returns_empty(self, relay_module, monkeypatch):
+        relay_module.configure(
+            relay_module.AuthRelayConfig(
+                enabled=True, operator_chat="85251234567", timeout=5
+            )
+        )
+        relay_module._whatsapp_operator_adapter = lambda: object()
+
+        def fake_send(text):
+            rid = relay_module.pending_sudo_for("85251234567")
+            if rid:
+                threading.Thread(
+                    target=lambda: relay_module.resolve_sudo_relay(rid, None),
+                    daemon=True,
+                ).start()
+            return True
+
+        monkeypatch.setattr(relay_module, "_send_to_operator", fake_send)
+        assert relay_module._sudo_password_callback() == ""
+
+
+class TestTimeoutSafety:
+    def test_secret_timeout_no_hang(self, relay_module, monkeypatch):
+        relay_module.configure(
+            relay_module.AuthRelayConfig(
+                enabled=True,
+                operator_chat="85251234567",
+                timeout=1,
+                require_confirm=False,
+            )
+        )
+        relay_module._whatsapp_operator_adapter = lambda: object()
+        monkeypatch.setattr(relay_module, "_send_to_operator", lambda text: True)
+        start = time.monotonic()
+        result = relay_module._secret_capture_callback("X", "p", None)
+        elapsed = time.monotonic() - start
+        assert elapsed < 5  # didn't block on the 1s timeout for long
+        assert result["skipped"] is True
+        assert result["success"] is True  # skip shape, like the CLI path
+
+    def test_sudo_timeout_no_hang(self, relay_module, monkeypatch):
+        relay_module.configure(
+            relay_module.AuthRelayConfig(
+                enabled=True, operator_chat="85251234567", timeout=1
+            )
+        )
+        relay_module._whatsapp_operator_adapter = lambda: object()
+        monkeypatch.setattr(relay_module, "_send_to_operator", lambda text: True)
+        start = time.monotonic()
+        pw = relay_module._sudo_password_callback()
+        assert time.monotonic() - start < 5
+        assert pw == ""
+
+
+class TestOperatorGating:
+    def test_pending_query_ignores_wrong_operator(self, relay_module):
+        relay_module.configure(
+            relay_module.AuthRelayConfig(
+                enabled=True, operator_chat="85251234567", timeout=10
+            )
+        )
+        relay_module._whatsapp_operator_adapter = lambda: object()
+        relay_module._register("secret", "X", "p", None)
+        # A different sender must not see the pending entry.
+        assert relay_module.pending_secret_for("99999999999") is None
+        # The configured operator sees it.
+        assert relay_module.pending_secret_for("85251234567") is not None
+
+    def test_resolve_unknown_id_is_noop(self, relay_module):
+        assert relay_module.resolve_secret_relay("nope", "v") is False
+        assert relay_module.resolve_sudo_relay("nope", "v") is False
+
+
+class TestConfigParse:
+    def test_parse_gateway_auth_relay(self):
+        from gateway.config import _parse_auth_relay
+
+        cfg = _parse_auth_relay(
+            {
+                "enabled": True,
+                "operator_chat": "85251234567",
+                "secret": False,
+                "sudo": True,
+                "timeout": 45,
+            }
+        )
+        assert cfg.enabled is True
+        assert cfg.operator_chat == "85251234567"
+        assert cfg.secret is False
+        assert cfg.sudo is True
+        assert cfg.timeout == 45
+
+    def test_parse_missing_is_disabled(self):
+        from gateway.config import _parse_auth_relay
+
+        assert _parse_auth_relay(None).enabled is False
+        assert _parse_auth_relay({}).enabled is False
+
+    def test_parse_no_operator_warns_disabled(self, monkeypatch):
+        from gateway.config import _parse_auth_relay
+
+        # Ensure no local WhatsApp number is available to derive from.
+        for v in (
+            "WHATSAPP_ALLOWED_USERS",
+            "WHATSAPP_CLOUD_PHONE",
+            "WHATSAPP_CLOUD_BUSINESS_PHONE",
+            "WHATSAPP_CLOUD_OWNER_WA_ID",
+        ):
+            monkeypatch.delenv(v, raising=False)
+        cfg = _parse_auth_relay({"enabled": True, "operator_chat": ""})
+        assert cfg.enabled is False
+
+    def test_parse_no_operator_derives_from_local(self, monkeypatch):
+        from gateway.config import _parse_auth_relay
+
+        monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "+85251234567")
+        for v in (
+            "WHATSAPP_CLOUD_PHONE",
+            "WHATSAPP_CLOUD_BUSINESS_PHONE",
+            "WHATSAPP_CLOUD_OWNER_WA_ID",
+        ):
+            monkeypatch.delenv(v, raising=False)
+        cfg = _parse_auth_relay({"enabled": True, "operator_chat": ""})
+        assert cfg.enabled is True
+        # Derived + normalized (no "+").
+        assert cfg.operator_chat == "85251234567"

--- a/tests/gateway/test_auth_relay.py
+++ b/tests/gateway/test_auth_relay.py
@@ -352,3 +352,74 @@ class TestConfigParse:
         assert cfg.enabled is True
         # Derived + normalized (no "+").
         assert cfg.operator_chat == "85251234567"
+
+
+class TestLiveToggle:
+    def test_set_enabled_true_activates(self, relay_module, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", tempfile.mkdtemp())
+        relay_module.configure(
+            relay_module.AuthRelayConfig(
+                enabled=False, operator_chat="85251234567", timeout=10
+            )
+        )
+        assert relay_module.is_enabled() is False
+        ok = relay_module.set_enabled(True)
+        assert ok is True
+        assert relay_module.is_enabled() is True
+
+    def test_set_enabled_false_deactivates(self, relay_module):
+        relay_module.configure(
+            relay_module.AuthRelayConfig(
+                enabled=True, operator_chat="85251234567", timeout=10
+            )
+        )
+        # callbacks installed on configure? No — only at gateway startup.
+        # set_enabled(False) must tear down any installed callbacks safely.
+        ok = relay_module.set_enabled(False)
+        assert ok is False
+        assert relay_module.is_enabled() is False
+
+    def test_toggle_flips_state(self, relay_module):
+        relay_module.configure(
+            relay_module.AuthRelayConfig(
+                enabled=False, operator_chat="85251234567", timeout=10
+            )
+        )
+        assert relay_module.is_enabled() is False
+        assert relay_module.toggle() is True
+        assert relay_module.is_enabled() is True
+        assert relay_module.toggle() is False
+        assert relay_module.is_enabled() is False
+
+    def test_set_enabled_without_operator_stays_inactive(self, relay_module, monkeypatch):
+        # No operator_chat and no local WhatsApp env → enabling cannot activate.
+        for v in (
+            "WHATSAPP_ALLOWED_USERS",
+            "WHATSAPP_CLOUD_PHONE",
+            "WHATSAPP_CLOUD_BUSINESS_PHONE",
+            "WHATSAPP_CLOUD_OWNER_WA_ID",
+        ):
+            monkeypatch.delenv(v, raising=False)
+        relay_module.configure(
+            relay_module.AuthRelayConfig(enabled=False, operator_chat="", timeout=10)
+        )
+        ok = relay_module.set_enabled(True)
+        assert ok is False
+        assert relay_module.is_enabled() is False
+
+
+class TestCommandRegistration:
+    def test_auth_relay_in_gateway_known_commands(self):
+        from hermes_cli.commands import GATEWAY_KNOWN_COMMANDS
+        assert "auth-relay" in GATEWAY_KNOWN_COMMANDS
+        assert "auth_relay" in GATEWAY_KNOWN_COMMANDS  # alias
+        assert "authrelay" in GATEWAY_KNOWN_COMMANDS    # alias
+
+    def test_auth_relay_not_cli_only(self):
+        from hermes_cli.commands import COMMAND_REGISTRY
+        cmd = next(c for c in COMMAND_REGISTRY if c.name == "auth-relay")
+        assert cmd.cli_only is False
+        assert cmd.category == "Configuration"
+        assert "on" in cmd.subcommands
+        assert "off" in cmd.subcommands
+        assert "status" in cmd.subcommands

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1502,6 +1502,33 @@ def has_blocking_approval(session_key: str) -> bool:
         return bool(_gateway_queues.get(session_key))
 
 
+def wait_for_approval_resolution(session_key: str, timeout: float = 120.0) -> Optional[str]:
+    """Block until the oldest pending approval for ``session_key`` resolves.
+
+    Used by the WhatsApp auth-relay path (gateway/run.py
+    ``_auth_relay_send_approval``): it sends the approval prompt to the
+    operator's WhatsApp and then blocks here until the operator's button tap
+    calls ``resolve_gateway_approval`` (which sets ``entry.result`` and fires
+    ``entry.event``).  Returns the resolved choice ("once" / "session" /
+    "always" / "deny") or None on timeout / no pending entry.
+
+    Polls in 0.5s slices so a cancelled session (clear_session sets result to
+    "deny" + fires the event) is observed promptly rather than spinning.
+    """
+    with _lock:
+        queue = _gateway_queues.get(session_key)
+        entry = queue[0] if queue else None
+    if entry is None:
+        return None
+    deadline = time.monotonic() + max(timeout, 0.0)
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return None
+        if entry.event.wait(timeout=min(0.5, remaining)):
+            return entry.result
+
+
 def submit_pending(session_key: str, approval: dict):
     """Store a pending approval request for a session."""
     with _lock:


### PR DESCRIPTION
## What changed and why

Several Hermes authentication paths block the agent thread waiting for a human, but only deliver when the *originating* session is a rich messaging platform:

- `clarify`/`approval` prompts reach WhatsApp only from a WhatsApp chat; for CLI background tasks, cron jobs, Telegram, etc. they time out silently.
- `sudo` password prompts (`tools/terminal_tool`) have a hard 45s timeout and **no gateway callback**, so in messaging/cron mode they fail closed with no notification to anyone.
- `secret` capture (`tools/skills_tool`) deliberately short-circuits on messaging platforms, so an unattended skill that needs an API key never gets it.

The auth-relay routes **all** of these prompts to the operator's WhatsApp number regardless of the originating session, and relays the reply back to the waiting thread.

## How it works

- **`gateway/auth_relay.py`** (new) owns the per-token pending map, the gateway-wide secret/sudo capture callbacks (operator-gated, timeout-safe; secrets persisted via the same trusted writer the CLI uses), and the inbound resolution API.
- **`gateway/config.py`** gains a `gateway.auth_relay` section. `operator_chat` is optional; when unset it is derived from the locally-stored WhatsApp owner number (`WHATSAPP_ALLOWED_USERS` / Cloud business phone) so the operator never re-enters a number the agent already knows.
- **`gateway/run.py`** installs the callbacks at startup (when enabled + a WhatsApp adapter is connected) and relays clarify/approval to operator WhatsApp for non-WhatsApp sessions.
- **`tools/approval.py`** adds `wait_for_approval_resolution`, reusing the existing gateway queue (no new blocking machinery).
- Inbound resolution wired into both WhatsApp adapters:
  - `gateway/platforms/whatsapp_cloud.py` — operator-gated on the configured `operator_chat`.
  - `plugins/platforms/whatsapp/adapter.py` (Baileys self-chat) — gated on the bridge's `fromOwner`/`fromMe` marker so only the account owner can answer.

## Security / privacy

- **Opt-in** (`gateway.auth_relay.enabled`, default `False`); inert until an operator target resolves.
- Secrets are **never returned to the model**; only the CLI's trusted writer touches `~/.hermes/.env`.
- Per-kind toggles (`clarify`/`approval`/`secret`/`sudo`) default on but can be opted out individually; `require_confirm` adds a yes/skip gate before a secret value is relayed.
- **No credentials, phone numbers, or tokens are hardcoded** — the operator id is read from the environment at runtime. (Privacy-safe PR.)
- Local-number derivation reads `WHATSAPP_ALLOWED_USERS` etc. from the environment; nothing sensitive lives in source.

## How to test it

Add to `~/.hermes/config.yaml`:

```yaml
gateway:
  auth_relay:
    enabled: true
    clarify: true
    approval: true
    secret: true
    sudo: true
    require_confirm: true
    timeout: 120
```

Restart the gateway. Trigger any auth path from a non-WhatsApp session (e.g. a cron job that runs a command needing approval, or a skill setup that captures a secret) — the prompt is delivered to the operator's WhatsApp and the operator's reply unblocks the waiting thread.

## Platforms tested

- Linux (WSL2), gateway with the Baileys self-chat WhatsApp bridge (`WHATSAPP_MODE=self-chat`).
- `scripts/run_tests.sh` on the new + touched suites: **135 tests pass, 0 fail** (17 new `tests/gateway/test_auth_relay.py` + 110 `test_whatsapp_cloud.py` + 8 approval-redaction).

## Related

No linked issue. Scope is intentionally focused to the auth-relay feature only (maxun tool work in the same checkout is excluded from this PR).

## Checklist

- [x] Branch off current `origin/main` and rebased (13 ahead commits pulled in)
- [x] `scripts/run_tests.sh` passes (CI-parity)
- [x] Conventional commit (`feat(gateway): ...`)
- [x] Privacy-safe: no secrets/numbers/tokens in diff