### PR TITLE
fix(email): set splits_long_messages on EmailAdapter to prevent cron output truncation

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -422,6 +422,11 @@ def _extract_attachments(
 class EmailAdapter(BasePlatformAdapter):
     """Email gateway adapter using IMAP (receive) and SMTP (send)."""
 
+    # Email bodies have no practical per-message length limit at the ~4000-char
+    # threshold where MAX_PLATFORM_OUTPUT would otherwise truncate.  SMTP can
+    # handle messages well beyond the adapter's own MAX_MESSAGE_LENGTH (50K).
+    splits_long_messages = True  # send() accepts the full payload without truncation
+
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.EMAIL)
 


### PR DESCRIPTION
## Description

The `EmailAdapter` did not declare `splits_long_messages = True`, so the delivery path truncated cron output at `MAX_PLATFORM_OUTPUT` (4000 chars) with a footer pointing to the saved audit file. SMTP has no practical per-message length limit at 4K, and the adapter already defines `MAX_MESSAGE_LENGTH = 50_000`.

Adding `splits_long_messages = True` tells `delivery.py` to pass the full payload to `send()` instead of truncating, matching the behavior of all other platform adapters (Telegram, Discord, Slack, Teams, etc.).

Fixes #61990