### PR TITLE
fix: add usedforsecurity=False to hashlib md5/sha1 in skills_hub, skills_sync, web_server

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11137,7 +11137,7 @@ def _mcp_install_action_name(name: str) -> str:
     re-click or a second catalog install doesn't overwrite the first's tracked
     process/log while its git clone is still running."""
     slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")[:48] or "server"
-    digest = hashlib.sha1(name.encode()).hexdigest()[:8]
+    digest = hashlib.sha1(name.encode(), usedforsecurity=False).hexdigest()[:8]
     action = f"mcp-install-{slug}-{digest}"
     _ACTION_LOG_FILES.setdefault(action, f"action-{action}.log")
     return action
@@ -12076,7 +12076,7 @@ def _hub_action_name(verb: str, key: str) -> str:
     (readable) + hash (collision-proof) keys each action to its own row.
     """
     slug = re.sub(r"[^a-z0-9]+", "-", key.lower()).strip("-")[:48] or "skill"
-    digest = hashlib.sha1(key.encode()).hexdigest()[:8]
+    digest = hashlib.sha1(key.encode(), usedforsecurity=False).hexdigest()[:8]
     name = f"skills-{verb}-{slug}-{digest}"
     _ACTION_LOG_FILES.setdefault(name, f"action-{name}.log")
     return name

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -1267,7 +1267,7 @@ class WellKnownSkillSource(SkillSource):
         }
 
     def _parse_index(self, index_url: str) -> Optional[dict]:
-        cache_key = f"well_known_index_{hashlib.md5(index_url.encode()).hexdigest()}"
+        cache_key = f"well_known_index_{hashlib.md5(index_url.encode(), usedforsecurity=False).hexdigest()}"
         cached = _read_index_cache(cache_key)
         if isinstance(cached, dict) and isinstance(cached.get("skills"), list):
             return cached
@@ -1532,7 +1532,7 @@ class SkillsShSource(SkillSource):
             # entries; the sitemap walks the full ~20k+ catalog.
             return self._sitemap_catalog(limit)
 
-        cache_key = f"skills_sh_search_{hashlib.md5(f'{query}|{limit}'.encode()).hexdigest()}"
+        cache_key = f"skills_sh_search_{hashlib.md5(f'{query}|{limit}'.encode(), usedforsecurity=False).hexdigest()}"
         cached = _read_index_cache(cache_key)
         if cached is not None:
             return [SkillMeta(**item) for item in cached][:limit]
@@ -1759,7 +1759,7 @@ class SkillsShSource(SkillSource):
         )
 
     def _fetch_detail_page(self, identifier: str) -> Optional[dict]:
-        cache_key = f"skills_sh_detail_{hashlib.md5(identifier.encode()).hexdigest()}"
+        cache_key = f"skills_sh_detail_{hashlib.md5(identifier.encode(), usedforsecurity=False).hexdigest()}"
         cached = _read_index_cache(cache_key)
         if isinstance(cached, dict):
             return cached
@@ -2253,7 +2253,7 @@ class ClawHubSource(SkillSource):
 
         # Non-empty query catalog miss, or catalog walker failure: fall back to
         # the lightweight listing API for a best-effort response.
-        cache_key = f"clawhub_search_listing_v1_{hashlib.md5(query.encode()).hexdigest()}_{limit}"
+        cache_key = f"clawhub_search_listing_v1_{hashlib.md5(query.encode(), usedforsecurity=False).hexdigest()}_{limit}"
         cached = _read_index_cache(cache_key)
         if cached is not None:
             return self._finalize_search_results(
@@ -2359,7 +2359,7 @@ class ClawHubSource(SkillSource):
         )
 
     def _search_catalog(self, query: str, limit: int = 10) -> List[SkillMeta]:
-        cache_key = f"clawhub_search_catalog_v1_{hashlib.md5(f'{query}|{limit}'.encode()).hexdigest()}"
+        cache_key = f"clawhub_search_catalog_v1_{hashlib.md5(f'{query}|{limit}'.encode(), usedforsecurity=False).hexdigest()}"
         cached = _read_index_cache(cache_key)
         if cached is not None:
             return [SkillMeta(**s) for s in cached][:limit]

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -231,7 +231,7 @@ def _compute_relative_dest(skill_dir: Path, bundled_dir: Path) -> Path:
 
 def _dir_hash(directory: Path) -> str:
     """Compute a hash of all file contents in a directory for change detection."""
-    hasher = hashlib.md5()
+    hasher = hashlib.md5(usedforsecurity=False)
     try:
         for fpath in sorted(directory.rglob("*")):
             if fpath.is_file():


### PR DESCRIPTION
## Summary

`hashlib.md5()` and `hashlib.sha1()` without `usedforsecurity=False` crash on FIPS-enabled systems (RHEL 8/9, Ubuntu FIPS) with `ValueError: EVP_DigestInit_ex disabled for FIPS`.

All affected calls are non-security uses (cache keys, deduplication, file hashing). SHA-256 is FIPS-approved and does not need this parameter.

Prior PRs (#56715, #56716, #56719) fixed the same pattern in `agent/`, `gateway/`, and `tools/` — this PR covers the remaining instances in `tools/skills_*` and `hermes_cli/web_server.py`.

## Changes

| File | Calls fixed | Hash | Purpose |
|------|-------------|------|---------|
| `tools/skills_sync.py` | 1 | md5 | Directory content hash for change detection |
| `tools/skills_hub.py` | 5 | md5 | Cache key generation for search/index/detail |
| `hermes_cli/web_server.py` | 2 | sha1 | Action name slug deduplication |

**Total**: 3 files, 8 calls.

## Test Plan
- [ ] `ruff check` passes
- [ ] No behavioral change — identical hash output, only the FIPS flag differs
