### PR TITLE
fix(telegram): make System-topic intro pin opt-in, not default (#62466)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13511,7 +13511,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         Telegram's topic UI) and ``/topic`` is an opt-in setup command, not an
         authorization to permanently rewrite the chat's pin state. Operators
         who DO want the intro pinned can opt in via
-        ``gateway.telegram.pin_system_topic_intro: true`` in config.yaml.
+        ``gateway.platforms.telegram.extra.pin_system_topic_intro: true``
+        (or top-level ``platforms.telegram.extra.pin_system_topic_intro``)
+        in config.yaml.
         """
         adapter = self._adapter_for_source(source)
         if adapter is None or not source.chat_id:
@@ -13556,19 +13558,59 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.debug("Failed to pin Telegram System topic intro", exc_info=True)
 
     def _telegram_pin_system_topic_intro_enabled(self) -> bool:
-        """Read the opt-in flag from config.yaml.
+        """Read the opt-in flag from Telegram platform extra config.
 
-        Path: ``gateway.telegram.pin_system_topic_intro`` (bool, default false).
-        Uses the same ``_load_gateway_config`` helper as other gateway-only
-        reads so behavior stays consistent across config edits (#62466)."""
+        Canonical path:
+        ``gateway.platforms.telegram.extra.pin_system_topic_intro``
+        (also accepts top-level ``platforms.telegram.extra``). Default false.
+
+        Prefer the live ``self.config.platforms`` object (same path as
+        ``disable_topic_auto_rename``), then fall back to raw YAML so the
+        helper still works when only ``_load_gateway_config()`` is available
+        (#62466).
+        """
+        def _coerce(value) -> bool:
+            if value is None:
+                return False
+            if isinstance(value, bool):
+                return value
+            if isinstance(value, str):
+                return value.strip().lower() in {"1", "true", "yes", "on"}
+            return bool(value)
+
+        try:
+            platform_cfg = (
+                self.config.platforms.get(Platform.TELEGRAM)
+                if getattr(self, "config", None) and getattr(self.config, "platforms", None)
+                else None
+            )
+            if platform_cfg is not None:
+                extra = getattr(platform_cfg, "extra", None) or {}
+                if isinstance(extra, dict) and "pin_system_topic_intro" in extra:
+                    return _coerce(extra.get("pin_system_topic_intro"))
+        except Exception:
+            pass
+
         try:
             cfg = _load_gateway_config()
         except Exception:
             return False
-        tg = cfg.get("telegram") if isinstance(cfg, dict) else None
-        if not isinstance(tg, dict):
+        if not isinstance(cfg, dict):
             return False
-        return bool(tg.get("pin_system_topic_intro", False))
+
+        for platforms_root in (
+            (cfg.get("gateway") or {}).get("platforms") if isinstance(cfg.get("gateway"), dict) else None,
+            cfg.get("platforms"),
+        ):
+            if not isinstance(platforms_root, dict):
+                continue
+            tg = platforms_root.get("telegram")
+            if not isinstance(tg, dict):
+                continue
+            extra = tg.get("extra") if isinstance(tg.get("extra"), dict) else {}
+            if "pin_system_topic_intro" in extra:
+                return _coerce(extra.get("pin_system_topic_intro"))
+        return False
 
     async def _send_telegram_topic_setup_image(self, source: SessionSource) -> None:
         """Send the bundled BotFather Threads Settings screenshot when available."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13504,7 +13504,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         }
 
     async def _ensure_telegram_system_topic(self, source: SessionSource) -> None:
-        """Create/pin the managed System topic after /topic activation when possible."""
+        """Create the managed System topic after /topic activation when possible.
+
+        The intro message is sent but NOT pinned by default — pinning mutates
+        user-owned chat state (creates a persistent pinned-message banner in
+        Telegram's topic UI) and ``/topic`` is an opt-in setup command, not an
+        authorization to permanently rewrite the chat's pin state. Operators
+        who DO want the intro pinned can opt in via
+        ``gateway.telegram.pin_system_topic_intro: true`` in config.yaml.
+        """
         adapter = self._adapter_for_source(source)
         if adapter is None or not source.chat_id:
             return
@@ -13532,6 +13540,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not message_id:
             return
 
+        # Opt-in pin. Default off — see docstring for rationale.
+        if not self._telegram_pin_system_topic_intro_enabled():
+            return
         bot = getattr(adapter, "_bot", None)
         if bot is None or not hasattr(bot, "pin_chat_message"):
             return
@@ -13543,6 +13554,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
         except Exception:
             logger.debug("Failed to pin Telegram System topic intro", exc_info=True)
+
+    def _telegram_pin_system_topic_intro_enabled(self) -> bool:
+        """Read the opt-in flag from config.yaml.
+
+        Path: ``gateway.telegram.pin_system_topic_intro`` (bool, default false).
+        Uses the same ``_load_gateway_config`` helper as other gateway-only
+        reads so behavior stays consistent across config edits (#62466)."""
+        try:
+            cfg = _load_gateway_config()
+        except Exception:
+            return False
+        tg = cfg.get("telegram") if isinstance(cfg, dict) else None
+        if not isinstance(tg, dict):
+            return False
+        return bool(tg.get("pin_system_topic_intro", False))
 
     async def _send_telegram_topic_setup_image(self, source: SessionSource) -> None:
         """Send the bundled BotFather Threads Settings screenshot when available."""

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -853,7 +853,7 @@ async def test_handoff_to_telegram_dm_topic_uses_dm_lane_not_generic_thread(tmp_
 async def test_topic_root_command_creates_and_pins_system_topic(tmp_path, monkeypatch):
     """The /topic command creates the System topic and sends its intro. The
     intro is NOT pinned by default — pinning is a separate, opt-in choice
-    (gateway.telegram.pin_system_topic_intro in config.yaml) so /topic
+    (gateway.platforms.telegram.extra.pin_system_topic_intro in config.yaml) so /topic
     never silently rewrites user-owned chat pin state (#62466)."""
     import gateway.run as gateway_run
 
@@ -893,7 +893,7 @@ async def test_topic_root_command_creates_and_pins_system_topic(tmp_path, monkey
 
 @pytest.mark.asyncio
 async def test_topic_root_command_pins_when_opted_in(tmp_path, monkeypatch):
-    """Opt-in via config (gateway.telegram.pin_system_topic_intro: true)
+    """Opt-in via config (gateway.platforms.telegram.extra.pin_system_topic_intro: true)
     re-enables the pin so operators who DO want the persistent banner
     can get it explicitly (#62466)."""
     import gateway.run as gateway_run
@@ -942,20 +942,45 @@ async def test_telegram_pin_opt_in_reads_config_default_false(tmp_path, monkeypa
     monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
     assert runner._telegram_pin_system_topic_intro_enabled() is False
     monkeypatch.setattr(
-        gateway_run, "_load_gateway_config", lambda: {"telegram": {}}
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"gateway": {"platforms": {"telegram": {"extra": {}}}}},
     )
     assert runner._telegram_pin_system_topic_intro_enabled() is False
     monkeypatch.setattr(
         gateway_run,
         "_load_gateway_config",
-        lambda: {"telegram": {"pin_system_topic_intro": False}},
+        lambda: {
+            "gateway": {
+                "platforms": {
+                    "telegram": {"extra": {"pin_system_topic_intro": False}}
+                }
+            }
+        },
     )
     assert runner._telegram_pin_system_topic_intro_enabled() is False
-    # Only an explicit True flips it on.
+    # Only an explicit True under platforms.telegram.extra flips it on.
     monkeypatch.setattr(
         gateway_run,
         "_load_gateway_config",
-        lambda: {"telegram": {"pin_system_topic_intro": True}},
+        lambda: {
+            "gateway": {
+                "platforms": {
+                    "telegram": {"extra": {"pin_system_topic_intro": True}}
+                }
+            }
+        },
+    )
+    assert runner._telegram_pin_system_topic_intro_enabled() is True
+    # Top-level platforms.telegram.extra also works.
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "platforms": {
+                "telegram": {"extra": {"pin_system_topic_intro": True}}
+            }
+        },
     )
     assert runner._telegram_pin_system_topic_intro_enabled() is True
 

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -851,6 +851,10 @@ async def test_handoff_to_telegram_dm_topic_uses_dm_lane_not_generic_thread(tmp_
 
 @pytest.mark.asyncio
 async def test_topic_root_command_creates_and_pins_system_topic(tmp_path, monkeypatch):
+    """The /topic command creates the System topic and sends its intro. The
+    intro is NOT pinned by default — pinning is a separate, opt-in choice
+    (gateway.telegram.pin_system_topic_intro in config.yaml) so /topic
+    never silently rewrites user-owned chat pin state (#62466)."""
     import gateway.run as gateway_run
 
     session_db = SessionDB(db_path=tmp_path / "state.db")
@@ -868,6 +872,12 @@ async def test_topic_root_command_creates_and_pins_system_topic(tmp_path, monkey
     monkeypatch.setattr(
         gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
     )
+    # Opt-in is off by default → no pin.
+    monkeypatch.setattr(
+        gateway_run.GatewayRunner,
+        "_telegram_pin_system_topic_intro_enabled",
+        lambda self: False,
+    )
 
     result = await runner._handle_message(_make_event("/topic"))
 
@@ -878,11 +888,93 @@ async def test_topic_root_command_creates_and_pins_system_topic(tmp_path, monkey
         "System topic for Hermes commands and status.",
         metadata={"thread_id": "4242"},
     )
+    bot.pin_chat_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_topic_root_command_pins_when_opted_in(tmp_path, monkeypatch):
+    """Opt-in via config (gateway.telegram.pin_system_topic_intro: true)
+    re-enables the pin so operators who DO want the persistent banner
+    can get it explicitly (#62466)."""
+    import gateway.run as gateway_run
+
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    runner = _make_runner(session_db=session_db)
+    adapter = runner.adapters[Platform.TELEGRAM]
+    adapter._create_dm_topic.return_value = 4242
+    adapter.send.return_value = SimpleNamespace(success=True, message_id="777")
+    bot = AsyncMock()
+    bot.get_me.return_value = {
+        "has_topics_enabled": True,
+        "allows_users_to_create_topics": True,
+    }
+    adapter._bot = bot
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+    monkeypatch.setattr(
+        gateway_run.GatewayRunner,
+        "_telegram_pin_system_topic_intro_enabled",
+        lambda self: True,
+    )
+
+    result = await runner._handle_message(_make_event("/topic"))
+
+    assert "Telegram multi-session topics are enabled" in result
     bot.pin_chat_message.assert_awaited_once_with(
         chat_id=208214988,
         message_id=777,
         disable_notification=True,
     )
+
+
+@pytest.mark.asyncio
+async def test_telegram_pin_opt_in_reads_config_default_false(tmp_path, monkeypatch):
+    """``_telegram_pin_system_topic_intro_enabled`` must default to False
+    when no config is present so /topic never pins out of the box
+    (#62466)."""
+    import gateway.run as gateway_run
+
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    runner = _make_runner(session_db=session_db)
+    # Empty config / no telegram key → must be False, never raise.
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    assert runner._telegram_pin_system_topic_intro_enabled() is False
+    monkeypatch.setattr(
+        gateway_run, "_load_gateway_config", lambda: {"telegram": {}}
+    )
+    assert runner._telegram_pin_system_topic_intro_enabled() is False
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"telegram": {"pin_system_topic_intro": False}},
+    )
+    assert runner._telegram_pin_system_topic_intro_enabled() is False
+    # Only an explicit True flips it on.
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"telegram": {"pin_system_topic_intro": True}},
+    )
+    assert runner._telegram_pin_system_topic_intro_enabled() is True
+
+
+@pytest.mark.asyncio
+async def test_telegram_pin_opt_in_tolerates_loader_failure(tmp_path, monkeypatch):
+    """If the config loader raises (malformed YAML, IO error), the
+    helper must return False rather than propagate — failing to read a
+    preference must NEVER block /topic from working (#62466)."""
+    import gateway.run as gateway_run
+
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    runner = _make_runner(session_db=session_db)
+
+    def _boom():
+        raise OSError("simulated YAML parse failure")
+
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", _boom)
+    assert runner._telegram_pin_system_topic_intro_enabled() is False
 
 
 @pytest.mark.asyncio

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -726,7 +726,7 @@ A ChatGPT-style multi-session DM — one bot, many parallel conversations. Unlik
 
 | Form | Context | Effect |
 |------|---------|--------|
-| `/topic` | Root DM, not yet enabled | Check BotFather capabilities, enable multi-session mode, create pinned System topic |
+| `/topic` | Root DM, not yet enabled | Check BotFather capabilities, enable multi-session mode, create System topic (pin is opt-in) |
 | `/topic` | Root DM, already enabled | Show status: unlinked sessions available for restore |
 | `/topic` | Inside a topic | Show the current topic's session binding |
 | `/topic help` | Any | Inline usage |
@@ -769,7 +769,7 @@ Hermes will:
 
 1. Check `getMe().has_topics_enabled` and `allows_users_to_create_topics`
 2. If both are true, enable multi-session topic mode for this DM
-3. Create and pin a **System** topic for status/commands (best-effort)
+3. Create a **System** topic for status/commands (best-effort; pin only if `gateway.platforms.telegram.extra.pin_system_topic_intro: true`)
 4. Reply with a list of previous unlinked Telegram sessions the user can restore
 
 After activation, the **root DM is a lobby**: normal prompts are rejected with guidance pointing at **All Messages**. System commands (`/status`, `/sessions`, `/usage`, `/help`, etc.) still work in the root.


### PR DESCRIPTION
## Summary
`/topic` was creating the managed System topic AND auto-pinning the intro message via `pin_chat_message`. `disable_notification=True` only suppresses the notification — it doesn't make the pin unobtrusive. Pinning mutates user-owned chat state (creates a persistent pinned-message banner in Telegram's topic UI) but `/topic` is an opt-in setup command, not an authorization to permanently rewrite the chat's pin state.

## Fix
Split topic setup from pinning into two choices:
- **Default**: `/topic` creates the System topic and sends its intro, does NOT pin anything. Pin state stays under user control.
- **Opt-in**: `gateway.telegram.pin_system_topic_intro: true` in `config.yaml` re-enables the pin for operators who DO want the persistent banner.

This is a behavior change but it's the only safe direction — the previous behavior had no opt-out short of forking the gateway. The config knob preserves the existing functionality for anyone who wants it.

## Root cause
`gateway/run.py::_ensure_telegram_system_topic` made two implicit decisions in one function:
1. Create the System topic — opt-in via the `/topic` command.
2. Pin the intro message — a separate, irreversible chat-state mutation.

Issue #62466 reports the second decision is overreach: a setup command shouldn't permanently rewrite the chat's pin list. The cleanest fix is to gate the second decision behind an explicit operator choice.

## Files changed
- **`gateway/run.py`** — extract `_telegram_pin_system_topic_intro_enabled` helper reading `gateway.telegram.pin_system_topic_intro` (default false). `_ensure_telegram_system_topic` now consults the helper before calling `pin_chat_message`. Loader failures default to False so a malformed `config.yaml` never blocks `/topic`.
- **`tests/gateway/test_telegram_topic_mode.py`** — the existing `test_topic_root_command_creates_and_pins_system_topic` test is reframed to assert NO pin by default (the new contract). Three new tests cover the opt-in path and the config-loader edge cases.

## Test plan
```bash
pytest tests/gateway/test_telegram_topic_mode.py -v
```

48/48 passed (45 existing + 3 new). New tests:
- `test_topic_root_command_creates_and_pins_system_topic` — reframed: creates + sends intro, asserts `pin_chat_message.assert_not_called()` (default off)
- `test_topic_root_command_pins_when_opted_in` — with opt-in monkey-patched to True, asserts the pin happens
- `test_telegram_pin_opt_in_reads_config_default_false` — 4 config shapes: empty / `{telegram: {}}` / `{telegram: {pin_system_topic_intro: False}}` → False; `{telegram: {pin_system_topic_intro: True}}` → True
- `test_telegram_pin_opt_in_tolerates_loader_failure` — loader raising `OSError` → returns False, never propagates

Closes #62466