### PR TITLE
fix(gateway): respect params.profile in session.* WebSocket RPC dispatch

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5298,7 +5298,7 @@ def _(rid, params: dict) -> dict:
                 "branch": _git_branch_for_cwd(_sessions[sid]["cwd"]),
                 "lazy": True,
                 "desktop_contract": DESKTOP_BACKEND_CONTRACT,
-                "profile_name": _current_profile_name(),
+                "profile_name": profile or _current_profile_name(),
             },
         },
     )
@@ -5306,7 +5306,16 @@ def _(rid, params: dict) -> dict:
 
 @method("session.list")
 def _(rid, params: dict) -> dict:
-    db = _get_db()
+    # ``profile`` (app-global remote mode): list sessions from another local
+    # profile's state.db. None/own profile → the launch profile (unchanged).
+    profile = (params.get("profile") or "").strip() or None
+    profile_home = _profile_home(profile)
+    if profile_home is not None:
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=profile_home / "state.db")
+    else:
+        db = _get_db()
     if db is None:
         return _db_unavailable_error(rid, code=5006)
     try:
@@ -5365,7 +5374,16 @@ def _(rid, params: dict) -> dict:
     null-result shape (and logged) so callers don't have to special-
     case JSON-RPC error envelopes for what is a normal "no answer".
     """
-    db = _get_db()
+    # ``profile`` (app-global remote mode): read from another local profile's
+    # state.db. None/own profile → the launch profile (unchanged).
+    profile = (params.get("profile") or "").strip() or None
+    profile_home = _profile_home(profile)
+    if profile_home is not None:
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=profile_home / "state.db")
+    else:
+        db = _get_db()
     if db is None:
         return _ok(rid, {"session_id": None})
     try:
@@ -5436,7 +5454,7 @@ def _(rid, params: dict) -> dict:
         return _ok(rid, {"verification": {"status": "unknown", "evidence": None}})
 
 
-def _lazy_resume_info(cwd: str, *, model: str = "", provider: str = "") -> dict:
+def _lazy_resume_info(cwd: str, *, model: str = "", provider: str = "", profile: str = "") -> dict:
     """session.info for a not-yet-built session (the shape session.create
     returns). tools/skills land later when the deferred build emits session.info."""
     info = {
@@ -5447,7 +5465,7 @@ def _lazy_resume_info(cwd: str, *, model: str = "", provider: str = "") -> dict:
         "skills": {},
         "lazy": True,
         "desktop_contract": DESKTOP_BACKEND_CONTRACT,
-        "profile_name": _current_profile_name(),
+        "profile_name": profile or _current_profile_name(),
     }
     if provider:
         info["provider"] = provider
@@ -5682,7 +5700,7 @@ def _(rid, params: dict) -> dict:
                 "resumed": target,
                 "message_count": len(messages),
                 "messages": messages,
-                "info": _lazy_resume_info(cwd),
+                "info": _lazy_resume_info(cwd, profile=profile or ""),
                 "inflight": None,
                 "running": child_running,
                 "session_key": target,
@@ -5765,6 +5783,7 @@ def _(rid, params: dict) -> dict:
                     cwd,
                     model=model_override.get("model") or "",
                     provider=overrides.get("provider_override") or "",
+                    profile=profile or "",
                 ),
                 "inflight": None,
                 "running": False,
@@ -7767,7 +7786,14 @@ def _(rid, params: dict) -> dict:
     key = session.get("session_key") or params.get("session_id") or ""
     agent = session.get("agent")
     meta = {}
-    db = _get_db()
+    profile_home = session.get("profile_home")
+    if profile_home:
+        from pathlib import Path
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=Path(profile_home) / "state.db")
+    else:
+        db = _get_db()
     if db and key:
         try:
             meta = db.get_session(key) or {}
@@ -7819,7 +7845,14 @@ def _(rid, params: dict) -> dict:
     if err:
         return err
     history = list(session.get("history", []))
-    db = _get_db()
+    profile_home = session.get("profile_home")
+    if profile_home:
+        from pathlib import Path
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=Path(profile_home) / "state.db")
+    else:
+        db = _get_db()
     if db is not None and session.get("session_key"):
         try:
             history = db.get_messages_as_conversation(


### PR DESCRIPTION
## Description

`session.list`, `session.most_recent`, `session.create`, `session.status`, and `session.history` all used `_get_db()` (launch profile) and/or `_current_profile_name()` regardless of `params.profile`. In app-global remote mode where one backend serves multiple profiles, this caused:

- `session.list` returning the launch profile's session list
- `session.most_recent` returning the launch profile's latest session
- `session.create` returning `profile_name='default'` regardless of the requested profile
- `session.status` / `session.history` reading from the wrong `state.db`

### Fix

Use profile-scoped `SessionDB` instances (following the `session.resume` pattern) and return the requested profile name in responses.

### Methods fixed

| Method | Before | After |
|--------|--------|-------|
| `session.list` | Always launch profile DB | Profile-scoped DB |
| `session.most_recent` | Always launch profile DB | Profile-scoped DB |
| `session.create` | Always `_current_profile_name()` | `profile or _current_profile_name()` |
| `session.status` | Always launch profile DB | Session's profile DB |
| `session.history` | Always launch profile DB | Session's profile DB |
| `_lazy_resume_info` | Always `_current_profile_name()` | Accepts `profile` param |

Fixes #62503