### PR TITLE
fix: persist agent response during verification stop loop

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5170,17 +5170,18 @@ def run_conversation(
                         getattr(agent, "_verification_stop_nudges", 0) + 1
                     )
                     final_msg["finish_reason"] = "verification_required"
-                    final_msg["_verification_stop_synthetic"] = True
+                    # Persist the attempted answer so the user can see it
+                    # while the verification loop runs. Previously both the
+                    # answer and the nudge were flagged
+                    # ``_verification_stop_synthetic`` and suppressed from
+                    # the durable transcript — the user only saw the brief
+                    # post-verification response, never the full answer.
+                    # The nudge stays synthetic (internal instruction, not
+                    # for display). The resulting assistant→assistant gap
+                    # in the persisted transcript (nudge is stripped) is
+                    # repaired at API-call time by ``repair_message_sequence``
+                    # (Pass 0: consecutive-assistant merge). (#55733)
                     messages.append(final_msg)
-                    # Keep the attempted final answer in model history so the
-                    # synthetic user nudge preserves role alternation, but do
-                    # not surface it to the user as an interim answer. The
-                    # whole point of this guard is to prevent premature
-                    # "done" claims before checks run. Both the attempted
-                    # answer and the nudge are flagged synthetic so neither
-                    # persists — otherwise the resumed transcript keeps a
-                    # premature "done" with the nudge stripped, producing an
-                    # assistant→assistant adjacency. (#55733)
                     messages.append({
                         "role": "user",
                         "content": _verify_nudge,

--- a/tests/run_agent/test_verification_continuation_budget.py
+++ b/tests/run_agent/test_verification_continuation_budget.py
@@ -75,7 +75,11 @@ def test_verify_on_stop_preserves_composed_report_at_budget_limit(agent, monkeyp
         result = agent.run_conversation("edit changed.py")
 
     _assert_pending_response_survives(agent, result)
-    assert result["messages"][1]["_verification_stop_synthetic"] is True
+    # The agent's attempted response must NOT be flagged synthetic — it
+    # should persist so the user can see it while verification runs.
+    # Only the nudge message stays synthetic. (verification-stop response
+    # suppression fix)
+    assert "_verification_stop_synthetic" not in result["messages"][1]
     assert result["messages"][2]["_verification_stop_synthetic"] is True
 
 
@@ -144,3 +148,33 @@ def test_later_verified_response_supersedes_pending_report(agent, monkeypatch):
     assert result["turn_exit_reason"] == "text_response(finish_reason=stop)"
     assert result["completed"] is True
     agent._handle_max_iterations.assert_not_called()
+
+
+def test_verify_on_stop_response_is_not_ephemeral(agent, monkeypatch):
+    """The agent's attempted response must survive persistence (not be
+    flagged _verification_stop_synthetic) so the user sees the full answer
+    while the verification loop runs. Only the nudge stays ephemeral."""
+    from run_agent import _is_ephemeral_scaffolding
+
+    def model_call(_api_kwargs):
+        agent._turn_file_mutation_paths = {"changed.py"}
+        return _response()
+
+    agent._interruptible_api_call = model_call
+    agent._handle_max_iterations = MagicMock(return_value="replacement summary")
+    monkeypatch.setenv("HERMES_VERIFY_ON_STOP", "1")
+
+    with (
+        patch("agent.verification_stop.build_verify_on_stop_nudge", return_value="verify it"),
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+    ):
+        result = agent.run_conversation("edit changed.py")
+
+    # messages[1] is the agent's response — must NOT be ephemeral
+    assert result["messages"][1]["role"] == "assistant"
+    assert result["messages"][1]["content"] == "composed report"
+    assert not _is_ephemeral_scaffolding(result["messages"][1])
+
+    # messages[2] is the nudge — MUST be ephemeral
+    assert result["messages"][2]["role"] == "user"
+    assert _is_ephemeral_scaffolding(result["messages"][2])


### PR DESCRIPTION
## Problem

When `verify_on_stop` triggers (agent edited code, then tried to end the turn), the agent's **complete response was silently suppressed** from the durable transcript. The user only saw the brief post-verification response — their full reply appeared to be "washed away" by the verification nudge.

## Root Cause

In `agent/conversation_loop.py`, when the verification stop loop triggers:

1. The agent's response (`final_msg`) is flagged `_verification_stop_synthetic = True`
2. This flag is registered in `_EPHEMERAL_SCAFFOLDING_FLAGS` (`run_agent.py:233`)
3. `_is_ephemeral_scaffolding()` filters the message from **both** persistence sinks (SQLite flush + JSON snapshot)
4. `final_response` is set to `None` (for finalizer logic)
5. The loop continues — the agent runs tests and generates a new, briefer response

Result: the user never sees the full response. Only the brief post-verification summary is persisted.

## Fix

Remove the `_verification_stop_synthetic` flag from the agent's response (`final_msg`). The response persists normally as a durable assistant message. The nudge message keeps the flag (internal instruction, not for display).

The resulting assistant→assistant gap in the persisted transcript (nudge is stripped by the ephemeral filter) is repaired at API-call time by `repair_message_sequence` (Pass 0: consecutive-assistant merge, `agent_runtime_helpers.py:408`).

## Changes

| File | Change |
|------|--------|
| `agent/conversation_loop.py` | Remove `_verification_stop_synthetic` flag from `final_msg`; update comment |
| `tests/run_agent/test_verification_continuation_budget.py` | Update assertion: response no longer synthetic; add new test verifying response survives `_is_ephemeral_scaffolding()` |

## Verification

```
scripts/run_tests.sh tests/run_agent/test_verification_continuation_budget.py -q
→ 5 tests passed, 0 failed
```

The 2 pre-existing failures in `tests/agent/test_verification_stop_caching.py` are unrelated (MINIMUM_CONTEXT_LENGTH model validation, fails on origin/main too).

## Relationship to #62598

Complementary but independent:
- **#62598** fixes `[System:]` marker **role** persistence (`role=user` → `role=system`)
- **This PR** fixes verification stop **response** suppression (response flagged synthetic → not persisted)

Different code paths, no file conflicts.