### PR TITLE
fix(installer): validate SSH clone produced files before proceeding to HTTPS fallback

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1274,7 +1274,22 @@ clone_repo() {
         log_info "Trying SSH clone..."
         if GIT_SSH_COMMAND="ssh -o BatchMode=yes -o ConnectTimeout=5" \
            git clone --depth 1 --branch "$BRANCH" "$REPO_URL_SSH" "$INSTALL_DIR" 2>/dev/null; then
-            log_success "Cloned via SSH"
+            # Validate the clone actually produced files — in some environments
+            # (notably Lightning.ai studios) SSH can exit 0 without a valid
+            # clone, producing an empty directory.  Trusting only the exit code
+            # skips the HTTPS fallback and the install fails downstream.
+            if [ -d "$INSTALL_DIR/.git" ] && [ -n "$(ls -A "$INSTALL_DIR" 2>/dev/null)" ]; then
+                log_success "Cloned via SSH"
+            else
+                rm -rf "$INSTALL_DIR" 2>/dev/null
+                log_info "SSH clone incomplete (empty directory), trying HTTPS..."
+                if git clone --depth 1 --branch "$BRANCH" "$REPO_URL_HTTPS" "$INSTALL_DIR"; then
+                    log_success "Cloned via HTTPS"
+                else
+                    log_error "Failed to clone repository"
+                    exit 1
+                fi
+            fi
         else
             rm -rf "$INSTALL_DIR" 2>/dev/null  # Clean up partial SSH clone
             log_info "SSH failed, trying HTTPS..."


### PR DESCRIPTION
## Description

In some environments (notably Lightning.ai studios), `git clone` via SSH exits with code 0 but doesn't actually produce a valid clone — the directory is empty and lacks a `.git` directory. The installer trusted only the exit code, so it skipped the HTTPS fallback and the install failed downstream when trying to `cd` into the empty directory.

### Fix

After a successful SSH clone, verify that `/.git` exists and the directory is non-empty. If validation fails, clean up and fall through to the HTTPS clone path, matching the same error handling the SSH failure branch already has.

### Testing

The fix is minimal and self-contained — the only behavioral change is adding a content-validity check between the SSH clone success and the `log_success` path.

Fixes #62132