### PR TITLE
fix: replace assert with runtime guards in 7 production files (15 sites)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4765,7 +4765,6 @@ class APIServerAdapter(BasePlatformAdapter):
         try:
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
             self._app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
-            assert self._app is not None
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)
             self._app.router.add_get("/v1/health", self._handle_health)

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -221,13 +221,15 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         return text
 
     async def _api_get(self, path: str) -> Dict[str, Any]:
-        assert self.client is not None
+        if self.client is None:
+            raise RuntimeError("HTTP client not initialised")
         res = await self.client.get(self._api_url(path))
         res.raise_for_status()
         return res.json()
 
     async def _api_post(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
-        assert self.client is not None
+        if self.client is None:
+            raise RuntimeError("HTTP client not initialised")
         res = await self.client.post(self._api_url(path), json=payload)
         res.raise_for_status()
         return res.json()

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1335,7 +1335,8 @@ class WeixinAdapter(BasePlatformAdapter):
         logger.info("[%s] Disconnected", self.name)
 
     async def _poll_loop(self) -> None:
-        assert self._poll_session is not None
+        if self._poll_session is None:
+            raise RuntimeError("poll_session not initialised")
         sync_buf = _load_sync_buf(self._hermes_home, self._account_id)
         timeout_ms = LONG_POLL_TIMEOUT_MS
         consecutive_failures = 0
@@ -1401,7 +1402,8 @@ class WeixinAdapter(BasePlatformAdapter):
             logger.error("[%s] unhandled inbound error from=%s: %s", self.name, _safe_id(message.get("from_user_id")), exc, exc_info=True)
 
     async def _process_message(self, message: Dict[str, Any]) -> None:
-        assert self._poll_session is not None
+        if self._poll_session is None:
+            raise RuntimeError("poll_session not initialised")
         sender_id = str(message.get("from_user_id") or "").strip()
         if not sender_id:
             return
@@ -1833,7 +1835,8 @@ class WeixinAdapter(BasePlatformAdapter):
                 )
                 if wait > 0:
                     await asyncio.sleep(wait)
-        assert last_error is not None
+        if last_error is None:
+            raise RuntimeError("retry loop completed without capturing error")
         raise last_error
 
     async def send(
@@ -2088,7 +2091,8 @@ class WeixinAdapter(BasePlatformAdapter):
         if not is_safe_url(url):
             raise ValueError(f"Blocked unsafe URL (SSRF protection): {url}")
 
-        assert self._send_session is not None
+        if self._send_session is None:
+            raise RuntimeError("send_session not initialised")
         # Use asyncio.wait_for() instead of aiohttp ClientTimeout to avoid
         # "Timeout context manager should be used inside a task" errors.
         async def _do_fetch():
@@ -2108,7 +2112,8 @@ class WeixinAdapter(BasePlatformAdapter):
         caption: str,
         force_file_attachment: bool = False,
     ) -> str:
-        assert self._send_session is not None and self._token is not None
+        if self._send_session is None or self._token is None:
+            raise RuntimeError("send_session or token not initialised")
         plaintext = Path(path).read_bytes()
         media_type, item_builder = self._outbound_media_builder(path, force_file_attachment=force_file_attachment)
         filekey = secrets.token_hex(16)

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -557,7 +557,8 @@ class WebSocketRelayTransport:
         await self._ws.send(json.dumps(frame) + "\n")
 
     async def _read_loop(self) -> None:
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("WebSocket not connected")
         buf = ""
         try:
             async for chunk in self._ws:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4691,7 +4691,8 @@ def _run_with_idle_timeout(
 
     def _reader() -> None:
         nonlocal last_output_ts
-        assert proc.stdout is not None
+        if proc.stdout is None:
+            return
         for line in proc.stdout:
             try:
                 print(f"{indent}{line.rstrip()}", flush=True)

--- a/hermes_cli/mcp_picker.py
+++ b/hermes_cli/mcp_picker.py
@@ -219,7 +219,8 @@ def _handle_row(row: _Row) -> None:
                 print(color(f"  '{row.name}' was not installed", Colors.DIM))
     elif choice == 3:
         try:
-            assert row.entry is not None
+            if row.entry is None:
+                raise CatalogError("Catalog entry is missing for the selected server")
             install_entry(row.entry, enable=True)
         except CatalogError as exc:
             print(color(f"  ✗ reinstall failed: {exc}", Colors.RED))

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -945,7 +945,8 @@ def _patch_skill(
         target, err = _resolve_skill_target(skill_dir, file_path)
         if err:
             return {"success": False, "error": err}
-        assert target is not None
+        if target is None:
+            return {"success": False, "error": "Failed to resolve skill target path"}
     else:
         # Patching SKILL.md
         target = skill_dir / "SKILL.md"
@@ -1163,7 +1164,8 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     target, err = _resolve_skill_target(existing["path"], file_path)
     if err:
         return {"success": False, "error": err}
-    assert target is not None
+    if target is None:
+        return {"success": False, "error": "Failed to resolve skill target path"}
     if target.exists():
         read_guard = _background_review_read_before_write_guard(
             name, target, "write_file", file_path
@@ -1209,7 +1211,8 @@ def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
     target, err = _resolve_skill_target(skill_dir, file_path)
     if err:
         return {"success": False, "error": err}
-    assert target is not None
+    if target is None:
+        return {"success": False, "error": "Failed to resolve skill target path"}
     if not target.exists():
         # List what's actually there for the model to see
         available = []


### PR DESCRIPTION
## Summary

`assert` statements in production code are stripped by `python -O`, silently removing invariant checks. This PR replaces 15 `assert` sites across 7 files with explicit `if`/`raise` (or `if`/`return`) guards that survive optimised builds.

Prior PRs (#56866, #61983, #62001) covered `agent/transports/`, `gateway/session.py`, `tools/docker.py`, `tools/browser_supervisor.py`, `tools/browser_cdp_tool.py`, and `hermes_cli/mcp_catalog.py`. This PR covers the remaining uncovered files.

## Changes

| File | Asserts | Replacement |
|------|---------|-------------|
| `tools/skill_manager_tool.py` | 3 | `return {"success": False, "error": ...}` |
| `hermes_cli/mcp_picker.py` | 1 | `raise CatalogError(...)` |
| `hermes_cli/main.py` | 1 | early `return` |
| `gateway/platforms/api_server.py` | 1 | removed (redundant — just assigned) |
| `gateway/platforms/weixin.py` | 5 | `raise RuntimeError(...)` |
| `gateway/platforms/bluebubbles.py` | 2 | `raise RuntimeError(...)` |
| `gateway/relay/ws_transport.py` | 1 | `raise RuntimeError(...)` |

**Total**: 7 files, 15 assert sites.

## Test Plan
- [ ] `ruff check` passes on all modified files
- [ ] No behavioural change in normal execution — guards only fire on genuinely broken state
