### PR TITLE
fix(cron): reap stale sessions on every tick + persist final_response as session message

### DIFF
--- a/contributors/emails/zhangyingliang@outlook.com
+++ b/contributors/emails/zhangyingliang@outlook.com
@@ -1,0 +1,1 @@
+yingliang-zhang

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -12,17 +12,17 @@ import asyncio
 import atexit
 import concurrent.futures
 import contextvars
+import hashlib
 import json
 import logging
 import os
 import re
 import shutil
+import socket
 import subprocess
 import sys
 import threading
 import time
-import uuid
-from datetime import datetime, timezone
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
@@ -50,11 +50,6 @@ from hermes_cli.config import (
 )
 from hermes_cli.fallback_config import get_fallback_chain
 from hermes_time import now as _hermes_now
-from agent.interrupt_compat import request_hard_interrupt
-from agent.delegation_context import (
-    enter_non_dispatcher_owned_context,
-    exit_non_dispatcher_owned_context,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -167,19 +162,17 @@ class CronPromptInjectionBlocked(Exception):
 def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
     """Toolsets a cron-spawned agent must never receive.
 
-    Four protected toolsets are always disabled in cron context:
+    Three protected toolsets are always disabled in cron context:
       - ``cronjob`` — would let a cron-spawned agent schedule more cron jobs
       - ``messaging`` — interactive, needs a live gateway session
       - ``clarify`` — interactive, blocks waiting for user input
-      - ``memory`` — cron agents are constructed with ``skip_memory=True``, so
-        exposing this tool only gives the model an unbacked tool that fails
 
     User-level ``agent.disabled_toolsets`` from config.yaml is layered on top
     so per-job ``enabled_toolsets`` cannot bypass policy that applies to
     ordinary agent runs (#25752 — LLM-supplied enabled_toolsets was widening
     past config.yaml's denylist).
     """
-    disabled = ["cronjob", "messaging", "clarify", "memory"]
+    disabled = ["cronjob", "messaging", "clarify"]
     agent_cfg = (cfg or {}).get("agent") or {}
     user_disabled = agent_cfg.get("disabled_toolsets") or []
     for name in user_disabled:
@@ -290,7 +283,7 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_runs, claim_dispatch, heartbeat_run_claim
+from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run, claim_dispatch, heartbeat_run_claim
 from cron.executions import create_execution, finish_execution, mark_execution_running
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
@@ -363,35 +356,6 @@ def get_running_job_ids() -> "frozenset[str]":
     """
     with _running_lock:
         return frozenset(_running_job_ids)
-
-
-def try_register_running_job(job_id: str) -> bool:
-    """Atomically add ``job_id`` to the in-flight running set.
-
-    Returns False (without registering) when the job is already mid-run —
-    the caller must skip the fire. This is the single dedupe owner shared by
-    the ticker's ``_submit_with_guard`` and manual runs
-    (``tools/cronjob_tools``): the fire claim alone cannot prevent a
-    double-fire because its TTL (300s) is routinely outlived by real jobs,
-    after which a manual ``cronjob(action='run')`` would claim successfully
-    and run the same job concurrently (idea from #53395 by @izumi0uu).
-
-    Registration also makes the run visible to ``get_running_job_ids`` (the
-    gateway shutdown drain, #60432) and ``mark_running_jobs_interrupted``.
-    Callers MUST pair a successful registration with
-    ``release_running_job`` in a ``finally`` block.
-    """
-    with _running_lock:
-        if job_id in _running_job_ids:
-            return False
-        _running_job_ids.add(job_id)
-        return True
-
-
-def release_running_job(job_id: str) -> None:
-    """Remove ``job_id`` from the in-flight running set (idempotent)."""
-    with _running_lock:
-        _running_job_ids.discard(job_id)
 
 
 def mark_running_jobs_interrupted(reason: str) -> list:
@@ -491,28 +455,11 @@ class _ReadWriteLock:
         self._writer_active = False
         self._writers_waiting = 0
 
-    def acquire_read(self, timeout: float | None = None) -> bool:
-        """Acquire a read lock.
-
-        Returns ``True`` if the lock was acquired, ``False`` on timeout.
-        A timed-out caller proceeds without the lock (degraded mode) —
-        see the call-site in ``run_job`` for the logging / trade-off.
-        """
-        deadline = (
-            time.monotonic() + timeout if timeout is not None else None
-        )
+    def acquire_read(self) -> None:
         with self._cond:
             while self._writer_active or self._writers_waiting > 0:
-                if deadline is not None:
-                    remaining = deadline - time.monotonic()
-                    if remaining <= 0:
-                        self._cond.notify_all()
-                        return False
-                    self._cond.wait(timeout=remaining)
-                else:
-                    self._cond.wait()
+                self._cond.wait()
             self._readers += 1
-        return True
 
     def release_read(self) -> None:
         with self._cond:
@@ -520,31 +467,15 @@ class _ReadWriteLock:
             if self._readers == 0:
                 self._cond.notify_all()
 
-    def acquire_write(self, timeout: float | None = None) -> bool:
-        """Acquire a write lock.
-
-        Returns ``True`` if the lock was acquired, ``False`` on timeout.
-        A timed-out caller proceeds without the lock (degraded mode).
-        """
-        deadline = (
-            time.monotonic() + timeout if timeout is not None else None
-        )
+    def acquire_write(self) -> None:
         with self._cond:
             self._writers_waiting += 1
             try:
                 while self._writer_active or self._readers > 0:
-                    if deadline is not None:
-                        remaining = deadline - time.monotonic()
-                        if remaining <= 0:
-                            self._cond.notify_all()
-                            return False
-                        self._cond.wait(timeout=remaining)
-                    else:
-                        self._cond.wait()
+                    self._cond.wait()
             finally:
                 self._writers_waiting -= 1
             self._writer_active = True
-        return True
 
     def release_write(self) -> None:
         with self._cond:
@@ -555,53 +486,6 @@ class _ReadWriteLock:
 # Serializes the per-job TERMINAL_CWD override against every other concurrently
 # running cron job.  See _ReadWriteLock and run_job for the usage contract.
 _terminal_cwd_lock = _ReadWriteLock()
-
-# Ceiling on how long a cron job waits for the TERMINAL_CWD lock before
-# FAILING (fail-closed, #79768). Derived from the cron inactivity limit
-# (HERMES_CRON_TIMEOUT, default 600s): a wedged lock holder stops touching
-# its activity clock, so the inactivity monitor usually reaps it and the
-# lock is released within roughly that limit. The bound is measured from
-# the WAITER's arrival, so a holder that wedges late (or hangs in pre-agent
-# setup before the monitor arms) can still outlive it — waiters then fail
-# loudly rather than run: proceeding without the lock lets the holder's
-# process-global TERMINAL_CWD override leak into this job's shell/file/
-# code-exec commands (wrong-directory execution — the exact corruption
-# _ReadWriteLock exists to prevent, see
-# test_reader_never_observes_writer_override). A healthy long-running
-# workdir job past the bound also fails its waiters loudly rather than
-# corrupting them silently; the failure names the holder pattern so the fix
-# (stagger schedules / drop the workdir) is actionable.
-_CWD_LOCK_TIMEOUT_FLOOR_SECONDS = 120.0
-_CWD_LOCK_TIMEOUT_MARGIN_SECONDS = 60.0
-
-
-def _cron_inactivity_seconds() -> float:
-    """Parse HERMES_CRON_TIMEOUT (seconds). 0 = unlimited; bad input = 600.
-
-    Shared by run_job's inactivity monitor (which maps 0 to "no limit") and
-    the cwd-lock bound below (which keeps the wait bounded regardless) so
-    the two sites cannot drift apart — the lock bound must stay at or above
-    the inactivity limit or waiters would fail while a healthy holder runs.
-    """
-    raw = os.getenv("HERMES_CRON_TIMEOUT", "").strip()
-    if not raw:
-        return 600.0
-    try:
-        return float(raw)
-    except (ValueError, TypeError):
-        logger.warning("Invalid HERMES_CRON_TIMEOUT=%r; using default 600s", raw)
-        return 600.0
-
-
-def _cwd_lock_timeout_seconds() -> float:
-    """Bound for the TERMINAL_CWD lock wait: inactivity limit + margin."""
-    inactivity = _cron_inactivity_seconds()
-    if inactivity <= 0:  # 0 = unlimited job runtime; keep the wait bounded.
-        inactivity = 600.0
-    return (
-        max(inactivity, _CWD_LOCK_TIMEOUT_FLOOR_SECONDS)
-        + _CWD_LOCK_TIMEOUT_MARGIN_SECONDS
-    )
 
 
 def _get_parallel_pool(max_workers: Optional[int]) -> concurrent.futures.ThreadPoolExecutor:
@@ -648,33 +532,6 @@ def _shutdown_parallel_pool() -> None:
 
 
 atexit.register(_shutdown_parallel_pool)
-# Per-fire usage audit log for cron token spend instrumentation.
-# Resolves through _get_hermes_home() so profile-scoped paths work correctly.
-def _usage_audit_path() -> Path:
-    return _get_hermes_home() / "cron" / "usage_audit.jsonl"
-
-
-def _utcnow_iso_ms() -> str:
-    """RFC3339 UTC timestamp with millisecond precision and 'Z' suffix."""
-    now = datetime.now(timezone.utc)
-    # %f gives microseconds; trim to milliseconds.
-    return now.strftime("%Y-%m-%dT%H:%M:%S.") + f"{now.microsecond // 1000:03d}Z"
-
-
-def _write_usage_audit(record: dict) -> None:
-    """Append a single JSONL line to ~/.hermes/cron/usage_audit.jsonl.
-
-    NEVER raises — a logger bug must not break cron jobs. Wraps the entire
-    write (path resolve, mkdir, json.dumps, file append) in a single try.
-    """
-    try:
-        path = _usage_audit_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        line = json.dumps(record, ensure_ascii=False)
-        with open(path, "a", encoding="utf-8") as f:
-            f.write(line + "\n")
-    except Exception as e:
-        logger.warning("usage_audit write failed: %s", e)
 
 
 def _interpreter_shutting_down(exc: Optional[BaseException] = None) -> bool:
@@ -963,19 +820,9 @@ def _seed_cron_thread_session(
             except (ValueError, KeyError):
                 platform_enum = None
             if platform_enum is not None:
-                # Discord thread destinations must key on the thread's OWN id
-                # to match how the Discord adapter keys organic in-thread
-                # messages (chat_id == thread_id). Other platforms (Slack,
-                # Telegram) use chat_id == parent_channel for thread messages,
-                # so the parent chat_id is correct for them. See the matching
-                # guard in GatewayRunner._process_handoff.
-                if platform_enum == Platform.DISCORD:
-                    seed_chat_id = str(thread_id)
-                else:
-                    seed_chat_id = str(chat_id)
                 dest_source = SessionSource(
                     platform=platform_enum,
-                    chat_id=seed_chat_id,
+                    chat_id=str(chat_id),
                     chat_name=chat_name,
                     chat_type="thread",
                     user_id="system:cron",
@@ -2389,16 +2236,7 @@ def _run_job_script(
     scripts_dir.mkdir(parents=True, exist_ok=True)
     scripts_dir_resolved = scripts_dir.resolve()
 
-    try:
-        raw = Path(script_path).expanduser()
-    except (ValueError, RuntimeError, OSError):
-        # Same ingestion contract as cron.lifecycle_guard: a NUL-bearing
-        # value (ValueError) or an unexpandable ``~`` (RuntimeError with no
-        # resolvable HOME) can never name a real script. The creation-time
-        # guard tolerates such values as "nothing to scan", so they can
-        # reach fire time — fail the run with a report instead of crashing
-        # the scheduler with an unhandled exception.
-        return False, f"Blocked: script path is not a valid filesystem path: {script_path!r}"
+    raw = Path(script_path).expanduser()
     if raw.is_absolute():
         path = raw.resolve()
     else:
@@ -2593,11 +2431,7 @@ def _parse_wake_gate(script_output: str) -> bool:
     return gate.get("wakeAgent", True) is not False
 
 
-def _build_job_prompt(
-    job: dict,
-    prerun_script: Optional[tuple] = None,
-    extra_prompt: Optional[str] = None,
-) -> str:
+def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     """Build the effective prompt for a cron job, optionally loading one or more skills first.
 
     Args:
@@ -2607,14 +2441,8 @@ def _build_job_prompt(
             When provided, the script is not re-executed and the cached
             result is used for prompt injection. When omitted, the script
             (if any) runs inline as before.
-        extra_prompt: Optional per-run context (from ``cronjob(action='run')``,
-            #57331 — salvaged from #57342 by @liuhao1024). Appended to the
-            stored prompt under a ``## Run Context`` header for this single
-            fire only — never persisted to the job definition.
     """
     user_prompt = str(job.get("prompt") or "")
-    if extra_prompt:
-        user_prompt = f"{user_prompt}\n\n## Run Context\n{extra_prompt}"
     prompt = user_prompt
     skills = job.get("skills")
     # True when runtime-collected DATA (script stdout, upstream-job output)
@@ -2702,16 +2530,6 @@ def _build_job_prompt(
                 logger.warning("context_from: failed to read output for job %r: %s", source_job_id, e)
                 # silent skip — do not pollute the prompt with error messages
 
-    # Inject the job's durable notepad (per-job KV scratchpad surviving
-    # scheduled wake-ups). Empty notepad renders as "" so jobs that never
-    # use the feature get a byte-identical prompt.
-    from cron import notepad as cron_notepad
-
-    notepad_section = cron_notepad.render_notepad_section(str(job.get("id") or ""))
-    if notepad_section:
-        prompt = f"{notepad_section}{prompt}"
-        has_injected_data = True
-
     # Always prepend cron execution guidance so the agent knows how
     # delivery works and can suppress delivery when appropriate.
     cron_hint = (
@@ -2789,7 +2607,7 @@ def _build_job_prompt(
 
         # Bump usage so the curator sees this skill as actively used.
         try:
-            bump_use(skill_name, task_id=str(job.get("id") or "") or None)
+            bump_use(skill_name)
         except Exception:
             logger.debug("Cron job: failed to bump skill usage for '%s'", skill_name, exc_info=True)
 
@@ -2934,220 +2752,63 @@ def _guard_job_credential_exfil(job: dict) -> None:
         raise RuntimeError(f"Cron job '{job_id}' blocked for safety: {err}")
 
 
-# Marker prefix stamped into the error string returned by ``run_job`` when the
-# pre-dispatch configuration validation (T1-26) refuses to run the agent.
-# ``run_one_job`` keys off it to record ``last_status='blocked_config'`` and to
-# apply the alert-once dedup. The ``:silent`` variant means "already alerted on
-# a previous tick — do not deliver again".
-BLOCKED_CONFIG_MARKER = "[blocked_config]"
-BLOCKED_CONFIG_SILENT_MARKER = "[blocked_config:silent]"
-
-
-def _cron_preflight_enabled(cfg: dict) -> bool:
-    """Whether cron pre-dispatch configuration validation is enabled.
-
-    Default ON; only the literal boolean ``false`` under ``cron.preflight``
-    opts out (mirrors ``cron_model_drift_guard_enabled`` semantics).
-    """
-    cron_cfg = (cfg or {}).get("cron")
-    if not isinstance(cron_cfg, dict):
-        return True
-    return cron_cfg.get("preflight", True) is not False
-
-
-def _preflight_check_provider_key(job: dict, cfg: dict) -> Optional[str]:
-    """READ-ONLY probe: would provider resolution fail for lack of a key?
-
-    Mirrors the effective requested-provider computation from run_job's
-    resolution block without any side effects on the run. When a fallback
-    chain is configured the check is skipped entirely — the existing
-    auth-fallback path may legitimately rescue a missing primary key, so
-    blocking here would break that contract (and burning zero LLM calls is
-    already guaranteed by the fallback resolution being config-local).
-    """
-    try:
-        if get_fallback_chain(cfg):
-            return None
-    except Exception:
-        return None  # fail-open: never block on a preflight-internal error
-
-    _cron_cfg = cfg.get("cron") if isinstance(cfg.get("cron"), dict) else {}
-    requested = (
-        job.get("provider")
-        or str((_cron_cfg or {}).get("model_provider") or "").strip()
-        or None
-    )
-    model = job.get("model") or os.getenv("HERMES_MODEL") or ""
-
-    from hermes_cli.auth import AuthError
-
-    try:
-        from hermes_cli.runtime_provider import resolve_runtime_provider
-
-        kwargs = {"requested": requested, "target_model": model}
-        if job.get("base_url"):
-            kwargs["explicit_base_url"] = job.get("base_url")
-        resolve_runtime_provider(**kwargs)
-    except AuthError as exc:
-        return (
-            f"provider credential missing: {exc}. "
-            "Set the provider API key in .env (or `hermes setup`), or pin a "
-            "working provider via `cronjob action=update job_id="
-            f"{job.get('id')} provider=<p>`."
-        )
-    except Exception:
-        # Non-auth resolution errors (bad config shapes, network probes,
-        # import issues) are NOT a missing-credential condition — let the
-        # real resolution path handle and report them as before.
-        return None
-    return None
-
-
-def _preflight_check_delivery(job: dict) -> Optional[str]:
-    """Check the job's delivery target(s) resolve to configured platforms.
-
-    ``local``/``origin`` (and the ``all`` routing token) need no gateway
-    credentials and are never checked — a deliver=local job must not pay a
-    gateway-config load. For concrete platform targets, an unknown platform
-    always blocks; a known platform additionally blocks when the gateway
-    config is loadable and reports it unconnected (enabled + credentials —
-    the same source `cron_delivery_targets` uses). Gateway-config load
-    failures fail OPEN so a transient config hiccup never wedges delivery
-    that would have worked.
-    """
-    deliver_value = _normalize_deliver_value(job.get("deliver", "local"))
-    platform_parts: list[str] = []
-    for part in deliver_value.split(","):
-        part = part.strip()
-        if not part or part.lower() in {"local", "origin", "all"}:
-            continue
-        platform_parts.append(part.split(":", 1)[0].strip())
-    if not platform_parts:
-        return None
-
-    connected: Optional[set] = None
-    for platform_name in platform_parts:
-        if not _is_known_delivery_platform(platform_name):
-            return (
-                f"delivery platform '{platform_name}' is not a known cron "
-                "delivery target. Fix the job's `deliver` value or configure "
-                "the platform's gateway credentials."
-            )
-        if connected is None:
-            try:
-                from gateway.config import load_gateway_config
-
-                gateway_config = load_gateway_config()
-                connected = {
-                    p.value for p in gateway_config.get_connected_platforms()
-                }
-            except Exception:
-                logger.debug(
-                    "preflight: gateway config unavailable — skipping "
-                    "delivery credential check", exc_info=True,
-                )
-                return None  # fail-open
-        if platform_name.lower() not in connected:
-            return (
-                f"delivery platform '{platform_name}' has no gateway "
-                "credentials configured (not connected). Configure it via "
-                "`hermes setup` or change the job's `deliver` target."
-            )
-    return None
-
-
-def _preflight_check_skills(job: dict) -> Optional[str]:
-    """Check attached skills report ready (no missing required env/commands).
-
-    Consults the same ``readiness_status`` payload ``skill_view`` computes
-    for interactive use. Skills that fail to load at all are left to the
-    existing skipped-skill handling in ``_build_job_prompt`` (fail-open):
-    this check only blocks on an affirmative "setup needed" verdict, i.e.
-    the skill exists but its required environment is missing — a run that
-    is guaranteed to misfire.
-    """
-    skills = job.get("skills")
-    if skills is None:
-        legacy = job.get("skill")
-        skills = [legacy] if legacy else []
-    elif isinstance(skills, str):
-        skills = [skills]
-    skill_names = [str(name).strip() for name in skills if str(name).strip()]
-    if not skill_names:
-        return None
-
-    from tools.skills_tool import skill_view
-
-    for skill_name in skill_names:
+def _resolve_cron_session_db_timeout() -> float:
+    """Resolve the bounded SessionDB constructor timeout for cron paths."""
+    timeout: float | None = None
+    raw_env_timeout = os.getenv("HERMES_CRON_SESSION_DB_TIMEOUT", "").strip()
+    if raw_env_timeout:
         try:
-            payload = json.loads(skill_view(skill_name))
-        except Exception:
-            continue  # unreadable/missing skill → existing skip handling
-        if not isinstance(payload, dict) or not payload.get("success"):
-            continue
-        if (
-            payload.get("setup_needed")
-            or payload.get("readiness_status") == "setup_needed"
-        ):
-            missing = [
-                f"env ${name}"
-                for name in payload.get(
-                    "missing_required_environment_variables"
-                ) or []
-            ]
-            missing += [
-                f"command '{name}'"
-                for name in payload.get("missing_required_commands") or []
-            ]
-            missing += [
-                f"credential file {name}"
-                for name in payload.get("missing_credential_files") or []
-            ]
-            detail = ", ".join(missing) or "required setup incomplete"
-            return (
-                f"attached skill '{skill_name}' is not ready: missing "
-                f"{detail}. Provide the missing prerequisites or detach the "
-                "skill from this job."
+            timeout = float(raw_env_timeout)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Invalid HERMES_CRON_SESSION_DB_TIMEOUT=%r; using config/default",
+                raw_env_timeout,
             )
-    return None
-
-
-def _preflight_job_config(job: dict, cfg: dict) -> Optional[str]:
-    """Pre-dispatch configuration validation (T1-26).
-
-    Returns a human-readable reason when the job's configuration cannot
-    produce a successful run — missing provider API key, unconfigured
-    delivery platform, or an attached skill with missing required env —
-    so the caller can refuse the run BEFORE any agent machinery is
-    constructed and no LLM call is burned. Returns ``None`` when the
-    configuration validates (or when a check cannot be evaluated: every
-    check fails open, so preflight can only ever block on an affirmative
-    misconfiguration verdict).
-
-    Same fail-before-spend spirit as the #44585 drift guard and the
-    fail-loud-on-hidden-tools direction in #27948; alert dedup follows the
-    alert-once pattern from the dead-pin auto-pause (#73506).
-    """
-    for name, check in (
-        ("provider_key", lambda: _preflight_check_provider_key(job, cfg)),
-        ("skills", lambda: _preflight_check_skills(job)),
-        ("delivery", lambda: _preflight_check_delivery(job)),
-    ):
+    if timeout is None:
         try:
-            reason = check()
-        except Exception:
+            from hermes_cli.config import load_config
+
+            cfg = load_config() or {}
+            cron_cfg = cfg.get("cron", {}) if isinstance(cfg, dict) else {}
+            configured = cron_cfg.get("session_db_timeout_seconds")
+            if configured is not None:
+                timeout = float(configured)
+        except Exception as exc:
             logger.debug(
-                "preflight check %s raised — failing open", name, exc_info=True
+                "Failed to load cron.session_db_timeout_seconds from config: %s",
+                exc,
             )
-            continue
-        if reason:
-            return reason
+    return 10.0 if timeout is None else timeout
+
+
+def _open_cron_session_db(log_context: str):
+    """Open SessionDB without allowing a wedged constructor to block cron."""
+    timeout = _resolve_cron_session_db_timeout()
+    try:
+        from hermes_state import SessionDB
+
+        if timeout <= 0:
+            return SessionDB()
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        try:
+            return pool.submit(SessionDB).result(timeout=timeout)
+        finally:
+            # A wedged constructor must not hold up the tick or job monitor.
+            pool.shutdown(wait=False)
+    except concurrent.futures.TimeoutError:
+        logger.error(
+            "%s: SessionDB init did not return within %.0fs — proceeding "
+            "without a session store instead of blocking forever",
+            log_context,
+            timeout,
+        )
+    except Exception as exc:
+        logger.debug("%s: SQLite session store not available: %s", log_context, exc)
     return None
 
 
 def run_job(
-    job: dict, *, defer_agent_teardown: Optional[list] = None,
-    extra_prompt: Optional[str] = None,
+    job: dict, *, defer_agent_teardown: Optional[list] = None
 ) -> tuple[bool, str, str, Optional[str]]:
     """
     Execute a single cron job.
@@ -3161,10 +2822,6 @@ def run_job(
     torn-down async client (defense-in-depth alongside the interpreter-shutdown
     guard). When ``None`` (the default) teardown happens inline as before, so
     every existing caller is unchanged.
-
-    ``extra_prompt``: optional per-run context from ``cronjob(action='run',
-    prompt=...)`` (#57331). Appended to the stored prompt for this fire only —
-    never persisted to the job definition.
 
     Returns:
         Tuple of (success, full_output_doc, final_response, error_message)
@@ -3277,61 +2934,6 @@ def run_job(
         return True, doc, output, None
 
     # ---------------------------------------------------------------
-    # Monitor gate — hash-suppressed change detection (see cron/monitor.py).
-    # Runs BEFORE any agent machinery is constructed so an unchanged tick
-    # costs one cheap source run + one hash, no LLM, no delivery.
-    # ---------------------------------------------------------------
-    from cron.monitor import check_monitor, job_has_monitor
-
-    _monitor_context: Optional[str] = None
-    if job_has_monitor(job):
-        _mon = check_monitor(job)
-        _mon_now = _hermes_now().strftime("%Y-%m-%d %H:%M:%S")
-        if not _mon.ok:
-            # Source failure is an ERROR, never a change: alert the user so
-            # a broken monitor can't silently stop watching. Stored hash is
-            # untouched (check_monitor persists nothing on failure).
-            logger.error("Job '%s': monitor source failed: %s", job_id, _mon.error)
-            _mon_doc = (
-                f"# Cron Job: {job_name}\n\n"
-                f"**Job ID:** {job_id}\n"
-                f"**Run Time:** {_mon_now}\n"
-                f"**Mode:** monitor\n"
-                f"**Status:** monitor source failed\n\n"
-                f"{_mon.error}\n"
-            )
-            _mon_alert = (
-                f"⚠ Cron monitor '{job_name}' source failed\n\n"
-                f"{_mon.error}\n\n"
-                f"Time: {_mon_now}"
-            )
-            return False, _mon_doc, _mon_alert, _mon.error
-        if not _mon.changed:
-            # Unchanged output — suppress the agent run entirely. Recorded
-            # as a silent no_change tick (visible in the executions ledger
-            # via this doc; SILENT_MARKER blocks delivery).
-            logger.info(
-                "Job '%s': monitor output unchanged — suppressing agent run",
-                job_id,
-            )
-            _mon_doc = (
-                f"# Cron Job: {job_name}\n\n"
-                f"**Job ID:** {job_id}\n"
-                f"**Run Time:** {_mon_now}\n"
-                f"**Mode:** monitor\n"
-                f"**Status:** no_change (agent run suppressed)\n"
-            )
-            return True, _mon_doc, SILENT_MARKER, None
-        # Changed (or first run): inject the monitor context into the prompt
-        # through the existing per-run context seam and fall through to a
-        # normal agent run.
-        _monitor_context = _mon.context_block
-        if _monitor_context:
-            extra_prompt = (
-                f"{_monitor_context}\n\n{extra_prompt}" if extra_prompt else _monitor_context
-            )
-
-    # ---------------------------------------------------------------
     # Default (LLM) path — import and construct the agent machinery now
     # that we know we actually need it. Doing these imports here instead of
     # at module top keeps no_agent ticks from paying for AIAgent / SessionDB
@@ -3352,59 +2954,7 @@ def run_job(
     # _running_job_ids never runs, so the job stays wedged "running" until
     # the whole gateway process is restarted, silently skipping every
     # scheduled fire in between with "already running — skipping".
-    _session_db = None
-    try:
-        from hermes_state import SessionDB
-
-        # Resolve timeout: env override → config.yaml → default 10s.
-        # Mirrors the script_timeout_seconds resolution pattern.
-        _session_db_timeout: float | None = None
-        _raw_env_timeout = os.getenv("HERMES_CRON_SESSION_DB_TIMEOUT", "").strip()
-        if _raw_env_timeout:
-            try:
-                _session_db_timeout = float(_raw_env_timeout)
-            except (ValueError, TypeError):
-                logger.warning(
-                    "Invalid HERMES_CRON_SESSION_DB_TIMEOUT=%r; using config/default",
-                    _raw_env_timeout,
-                )
-        if _session_db_timeout is None:
-            try:
-                from hermes_cli.config import load_config
-                _cfg = load_config() or {}
-                _cron_cfg = _cfg.get("cron", {}) if isinstance(_cfg, dict) else {}
-                _configured = _cron_cfg.get("session_db_timeout_seconds")
-                if _configured is not None:
-                    _session_db_timeout = float(_configured)
-            except Exception as exc:
-                logger.debug(
-                    "Failed to load cron.session_db_timeout_seconds from config: %s",
-                    exc,
-                )
-        if _session_db_timeout is None:
-            _session_db_timeout = 10.0
-
-        if _session_db_timeout > 0:
-            _session_db_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-            try:
-                _session_db = _session_db_pool.submit(SessionDB).result(timeout=_session_db_timeout)
-            finally:
-                # Don't wait for a wedged connect() to unwind — abandon the
-                # worker thread (same pattern as the agent inactivity timeout
-                # further down) rather than blocking shutdown on it too.
-                _session_db_pool.shutdown(wait=False)
-        else:
-            # 0 = unlimited (legacy behavior, opt-in for debugging)
-            _session_db = SessionDB()
-    except concurrent.futures.TimeoutError:
-        logger.error(
-            "Job '%s': SessionDB init did not return within %.0fs — proceeding "
-            "without a session store for this run instead of blocking it "
-            "forever",
-            job.get("id", "?"), _session_db_timeout,
-        )
-    except Exception as e:
-        logger.debug("Job '%s': SQLite session store not available: %s", job.get("id", "?"), e)
+    _session_db = _open_cron_session_db(f"Job '{job.get('id', '?')}'")
 
     # Wake-gate: if this job has a pre-check script, run it BEFORE building
     # the prompt so a ``{"wakeAgent": false}`` response can short-circuit
@@ -3429,9 +2979,7 @@ def run_job(
             return True, silent_doc, SILENT_MARKER, None
 
     try:
-        prompt = _build_job_prompt(
-            job, prerun_script=prerun_script, extra_prompt=extra_prompt
-        )
+        prompt = _build_job_prompt(job, prerun_script=prerun_script)
     except CronPromptInjectionBlocked as block_exc:
         # Assembled prompt (user prompt + loaded skill content) tripped the
         # injection scanner. Refuse to run the agent this tick and surface
@@ -3464,6 +3012,11 @@ def run_job(
     logger.info("Prompt: %s", prompt[:100])
 
     agent = None
+
+    # Mark this as a cron session so the approval system can apply cron_mode.
+    # This env var is process-wide and persists for the lifetime of the
+    # scheduler process — every job this process runs is a cron job.
+    os.environ["HERMES_CRON_SESSION"] = "1"
 
     # Use ContextVars for per-job session/delivery state so parallel jobs
     # don't clobber each other's targets (os.environ is process-global).
@@ -3557,65 +3110,17 @@ def run_job(
     _prior_terminal_cwd = os.environ.get("TERMINAL_CWD", "_UNSET_")
 
     _holds_cwd_write = _job_workdir is not None
-    _cwd_lock_timeout = _cwd_lock_timeout_seconds()
-    _cwd_lock_acquired = True
     if _holds_cwd_write:
-        if not _terminal_cwd_lock.acquire_write(timeout=_cwd_lock_timeout):
-            _cwd_lock_acquired = False
+        _terminal_cwd_lock.acquire_write()
     else:
-        if not _terminal_cwd_lock.acquire_read(timeout=_cwd_lock_timeout):
-            _cwd_lock_acquired = False
+        _terminal_cwd_lock.acquire_read()
 
     # Everything after the acquire MUST live inside this try, so the finally
     # below always releases the lock even if the env override or any later
     # statement raises.  A leaked writer would deadlock the whole scheduler
     # (every future job blocks on acquire_*); a leaked reader blocks all
     # future writers.  Acquire itself can't leak (it either blocks or returns).
-    _cron_session_var = _VAR_MAP["HERMES_CRON_SESSION"]
-    _cron_session_token = None
-    _non_dispatcher_token = None
     try:
-        if not _cwd_lock_acquired:
-            # Fail closed (#79768): running without the lock would let a
-            # concurrent workdir job's process-global TERMINAL_CWD override
-            # leak into this job's shell/file/code-exec commands — silent
-            # wrong-directory execution, the exact corruption the lock
-            # exists to prevent. A loud failure is recoverable (next tick /
-            # manual rerun); a job that ran in the wrong directory is not.
-            raise TimeoutError(
-                f"Timed out waiting for the TERMINAL_CWD "
-                f"{'write' if _holds_cwd_write else 'read'} lock after "
-                f"{_cwd_lock_timeout:.0f}s — another cron job (a workdir "
-                f"writer, or long-running readers) has held it for longer "
-                f"than the cron inactivity limit. If a workdir job is the "
-                f"holder, stagger its schedule or remove its workdir to "
-                f"unblock this job (#79768)."
-            )
-        # Scope cron approval policy to this job. Keep the token so the finally
-        # restores the pre-job state instead of pinning an explicit empty value,
-        # which would suppress the legacy os.environ fallback used by standalone
-        # cron entrypoints and tests.
-        _cron_session_token = _cron_session_var.set("1")
-
-        # Mark this job as NOT the dispatcher-owned kanban worker.
-        #
-        # A kanban worker is a normal `hermes chat -q` CLI agent whose default
-        # toolset includes `cronjob`, running with HERMES_KANBAN_TASK
-        # legitimately in its own env; `cronjob(action="run")` calls
-        # run_one_job() -> run_job() right here in that process.  Without this
-        # marker the cron agent is misread as that worker: the kanban toolset is
-        # force-added, the worker protocol is injected into its system prompt,
-        # and kanban_complete defaults task_id to $HERMES_KANBAN_TASK -- letting
-        # an unrelated cron job close the worker's task and overwrite real
-        # results.
-        #
-        # A ContextVar, NOT an os.environ clear: the env is process-global and
-        # shared with the worker's own claim heartbeat (run_agent._touch_activity
-        # -> heartbeat_current_worker_from_env, which would starve and let the
-        # dispatcher reclaim a live task), the gateway's kanban watchers, and
-        # concurrent cron jobs on the parallel pool.  contextvars.copy_context()
-        # at the run_conversation hop carries this into the agent thread.
-        _non_dispatcher_token = enter_non_dispatcher_owned_context()
         if _job_workdir:
             os.environ["TERMINAL_CWD"] = _job_workdir
             logger.info("Job '%s': using workdir %s", job_id, _job_workdir)
@@ -3778,75 +3283,6 @@ def run_job(
         # — reaches this sink unchecked. Fail closed before resolution so no
         # off-host call is ever made with a stored key.
         _guard_job_credential_exfil(job)
-
-        # ---------------------------------------------------------------
-        # Pre-dispatch configuration validation (T1-26).
-        #
-        # A job whose configuration cannot possibly produce a successful
-        # run — missing provider API key (no fallback chain), unready
-        # attached skill, unconfigured delivery platform — is refused HERE,
-        # before AIAgent is constructed and before the resolution below can
-        # feed a doomed runtime into it, so a misconfigured job never burns
-        # an LLM call. run_one_job keys off the BLOCKED_CONFIG_MARKER in
-        # the returned error to record last_status='blocked_config' and
-        # alert exactly once (dedup persisted via the job's
-        # `preflight_alerted` bit — the #73506 alert-once shape).
-        # Runs after the wake-gate/prompt build so silent script ticks stay
-        # silent. Opt-out: `cron.preflight: false` in config.yaml.
-        # ---------------------------------------------------------------
-        _pf_reason = None
-        try:
-            if _cron_preflight_enabled(_cfg):
-                _pf_reason = _preflight_job_config(job, _cfg)
-                if not _pf_reason and job.get("preflight_alerted"):
-                    # Configuration validates again — clear the alert-once
-                    # marker so a FUTURE config break re-alerts.
-                    try:
-                        from cron.jobs import clear_preflight_alerted
-                        clear_preflight_alerted(job_id)
-                    except Exception:
-                        pass
-        except Exception:
-            # The validator must never take down a runnable job — fail open.
-            logger.debug(
-                "Job '%s': preflight validation errored — failing open",
-                job_id, exc_info=True,
-            )
-            _pf_reason = None
-
-        if _pf_reason:
-            logger.warning(
-                "Job '%s' (ID: %s): BLOCKED by pre-dispatch config "
-                "validation — %s (no LLM call was made)",
-                job_name, job_id, _pf_reason,
-            )
-            already_alerted = False
-            try:
-                from cron.jobs import mark_preflight_alerted
-                already_alerted = mark_preflight_alerted(job_id)
-            except Exception:
-                logger.debug(
-                    "Job '%s': could not persist preflight alert marker",
-                    job_id, exc_info=True,
-                )
-            marker = (
-                BLOCKED_CONFIG_SILENT_MARKER if already_alerted
-                else BLOCKED_CONFIG_MARKER
-            )
-            blocked_doc = (
-                f"# Cron Job: {job_name}\n\n"
-                f"**Job ID:** {job_id}\n"
-                f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n"
-                f"**Status:** BLOCKED (configuration)\n\n"
-                "Pre-dispatch validation found a configuration problem and "
-                "the agent was NOT run (no tokens spent).\n\n"
-                f"**Reason:** {_pf_reason}\n\n"
-                "The job will stay blocked (without re-alerting) until the "
-                "configuration is fixed; the next healthy run clears this "
-                "state. Set `cron.preflight: false` in config.yaml to "
-                "disable this validation."
-            )
-            return False, blocked_doc, "", f"{marker} {_pf_reason}"
 
         primary_model_for_drift = model
         configured_provider_for_drift = (
@@ -4071,11 +3507,18 @@ def run_job(
             skip_context_files=not bool(_job_workdir),
             load_soul_identity=True,
             skip_memory=True,  # Cron system prompts would corrupt user representations
-            skip_background_review=True,  # Cron has no human-in-the-loop need for skill/memory review forks (~30K tok/event)
             platform="cron",
             session_id=_cron_session_id,
             session_db=_session_db,
         )
+
+        # Register the ownership lease so the stale-session reaper can prove
+        # this run is dead before closing its session row.  Done AFTER
+        # AIAgent/session init and BEFORE run_conversation. Failure is
+        # non-fatal; without a lease the row is recoverable only after the
+        # full stale-session grace window.
+        _cron_lease = _register_cron_session_lease(_cron_session_id, job_id)
+        _last_lease_heartbeat = time.monotonic()
         
         # Run the agent with an *inactivity*-based timeout: the job can run
         # for hours if it's actively calling tools / receiving stream tokens,
@@ -4085,7 +3528,18 @@ def run_job(
         #
         # Uses the agent's built-in activity tracker (updated by
         # _touch_activity() on every tool call, API call, and stream delta).
-        _cron_timeout = _cron_inactivity_seconds()
+        _raw_cron_timeout = os.getenv("HERMES_CRON_TIMEOUT", "").strip()
+        if _raw_cron_timeout:
+            try:
+                _cron_timeout = float(_raw_cron_timeout)
+            except (ValueError, TypeError):
+                logger.warning(
+                    "Invalid HERMES_CRON_TIMEOUT=%r; using default 600s",
+                    _raw_cron_timeout,
+                )
+                _cron_timeout = 600.0
+        else:
+            _cron_timeout = 600.0
         _cron_inactivity_limit = _cron_timeout if _cron_timeout > 0 else None
         _POLL_INTERVAL = 5.0
         # Keep the one-shot run_claim fresh while the run is alive (#62002):
@@ -4120,21 +3574,35 @@ def run_job(
                     "Job '%s': run_claim heartbeat failed", job_name, exc_info=True
                 )
 
+        def _heartbeat_cron_lease_if_due():
+            """Heartbeat the session ownership lease for ALL AI cron runs.
+
+            Unlike the run_claim heartbeat (one-shots only), this fires for
+            every run so a stale lease reliably means the owning run stopped
+            progressing.  Throttled by ``_LEASE_HEARTBEAT_INTERVAL_SECONDS``
+            and best-effort — a failed heartbeat does not weaken the existing
+            run_claim heartbeat or abort the run.
+            """
+            nonlocal _last_lease_heartbeat
+            _mono = time.monotonic()
+            if _mono - _last_lease_heartbeat < _LEASE_HEARTBEAT_INTERVAL_SECONDS:
+                return
+            _last_lease_heartbeat = _mono
+            _heartbeat_cron_session_lease(_cron_session_id)
+
         _cron_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
         # Preserve scheduler-scoped ContextVar state (for example skill-declared
         # env passthrough registrations) when the cron run hops into the worker
         # thread used for inactivity timeout monitoring.
         _cron_context = contextvars.copy_context()
-        # Tag this fire and time the run_conversation call for the usage_audit.jsonl entry.
-        _audit_fire_id = uuid.uuid4().hex
-        _audit_t_start = time.monotonic()
         _cron_future = _cron_pool.submit(_cron_context.run, agent.run_conversation, prompt)
         _inactivity_timeout = False
         try:
             if _cron_inactivity_limit is None:
-                # Unlimited — no inactivity watchdog, but a one-shot still
-                # needs its run_claim heartbeat, so poll instead of blocking.
-                if _is_oneshot:
+                # Unlimited — no inactivity watchdog, but one-shots still
+                # need their run_claim heartbeat and every registered lease
+                # needs its own heartbeat, so poll instead of blocking.
+                if _is_oneshot or _cron_lease is not None:
                     result = None
                     while True:
                         done, _ = concurrent.futures.wait(
@@ -4144,7 +3612,10 @@ def run_job(
                             result = _cron_future.result()
                             break
                         _heartbeat_run_claim_if_due()
+                        _heartbeat_cron_lease_if_due()
                 else:
+                    # Lease registration failed, so there is nothing to
+                    # heartbeat. The age grace still protects this live run.
                     result = _cron_future.result()
             else:
                 result = None
@@ -4156,6 +3627,7 @@ def run_job(
                         result = _cron_future.result()
                         break
                     _heartbeat_run_claim_if_due()
+                    _heartbeat_cron_lease_if_due()
                     # Agent still running — check inactivity.
                     _idle_secs = 0.0
                     if hasattr(agent, "get_activity_summary"):
@@ -4194,7 +3666,8 @@ def run_job(
                 _last_desc, _iter_n, _iter_max,
                 _cur_tool or "none",
             )
-            request_hard_interrupt(agent, "Cron job timed out (inactivity)")
+            if hasattr(agent, "interrupt"):
+                agent.interrupt("Cron job timed out (inactivity)")
             raise TimeoutError(
                 f"Cron job '{job_name}' idle for "
                 f"{int(_secs_ago)}s (limit {int(_cron_inactivity_limit)}s) "
@@ -4281,46 +3754,11 @@ def run_job(
 """
         
         logger.info("Job '%s' completed successfully", job_name)
-
-        # Emit one JSONL line per fire for usage audit.
-        _audit_duration_ms = int((time.monotonic() - _audit_t_start) * 1000)
-        _audit_response_silent = _is_cron_silence_response(final_response or "")
-        _write_usage_audit({
-            "ts": _utcnow_iso_ms(),
-            "job_id": job_id,
-            "fire_id": _audit_fire_id,
-            "prompt_tokens": result.get("prompt_tokens"),
-            "completion_tokens": result.get("completion_tokens"),
-            "total_tokens": result.get("total_tokens"),
-            "response_silent": _audit_response_silent,
-            "deliver_target": job.get("deliver"),
-            "model": model or None,
-            "duration_ms": _audit_duration_ms,
-            "error": None,
-        })
         return True, output, final_response, None
-
+        
     except Exception as e:
         error_msg = f"{type(e).__name__}: {str(e)}"
         logger.exception("Job '%s' failed: %s", job_name, error_msg)
-        # Best-effort audit write on failure path. _audit_fire_id
-        # may be unset if the exception fired before submit() — guard
-        # with a None check so the audit write itself never raises.
-        if "_audit_fire_id" in locals():
-            _audit_duration_ms = int((time.monotonic() - _audit_t_start) * 1000)
-            _write_usage_audit({
-                "ts": _utcnow_iso_ms(),
-                "job_id": job_id,
-                "fire_id": _audit_fire_id,
-                "prompt_tokens": None,
-                "completion_tokens": None,
-                "total_tokens": None,
-                "response_silent": False,
-                "deliver_target": job.get("deliver"),
-                "model": model or None,
-                "duration_ms": _audit_duration_ms,
-                "error": error_msg,
-            })
         
         output = f"""# Cron Job: {job_name} (FAILED)
 
@@ -4342,32 +3780,26 @@ def run_job(
 
     finally:
         # Restore TERMINAL_CWD to whatever it was before this job ran.  We
-        # only ever mutate it when the job has a workdir AND actually held
-        # the write lock — a fail-closed timeout raised before the env-set,
-        # so restoring there would replay a pre-wait snapshot over the
-        # ACTIVE holder's live override.
-        if _job_workdir and _cwd_lock_acquired:
+        # only ever mutate it when the job has a workdir; see the setup block
+        # at the top of run_job for the serialization guarantee.
+        if _job_workdir:
             if _prior_terminal_cwd == "_UNSET_":
                 os.environ.pop("TERMINAL_CWD", None)
             else:
                 os.environ["TERMINAL_CWD"] = _prior_terminal_cwd
         # Release the cwd lock now that the env is restored, so a waiting
         # workdir job (or queued reader) can proceed without seeing the override.
-        if _cwd_lock_acquired:
-            if _holds_cwd_write:
-                _terminal_cwd_lock.release_write()
-            else:
-                _terminal_cwd_lock.release_read()
+        if _holds_cwd_write:
+            _terminal_cwd_lock.release_write()
+        else:
+            _terminal_cwd_lock.release_read()
         # Clean up ContextVar session/delivery state for this job.
         # clear_session_vars also clears _SESSION_CWD internally, so no
         # separate clear_session_cwd() call is needed.
         clear_session_vars(_ctx_tokens)
-        if _cron_session_token is not None:
-            _cron_session_var.reset(_cron_session_token)
-        if _non_dispatcher_token is not None:
-            exit_non_dispatcher_owned_context(_non_dispatcher_token)
         for _var_name in _cron_delivery_vars:
             _VAR_MAP[_var_name].set("")
+        _cron_session_ended = True
         if _session_db:
             # Compression can rotate the live agent onto a continuation while
             # this run is in flight. Finalize that continuation, not the stale
@@ -4433,11 +3865,20 @@ def run_job(
                     _final_cron_session_id, "cron_complete"
                 )
             except (Exception, KeyboardInterrupt) as e:
+                # end_session failed — retain the lease so a later process can
+                # recover this session via the reaper once the owner is dead.
+                _cron_session_ended = False
                 logger.debug("Job '%s': failed to end session: %s", job_id, e)
             try:
                 _session_db.close()
             except (Exception, KeyboardInterrupt) as e:
                 logger.debug("Job '%s': failed to close SQLite session store: %s", job_id, e)
+        # Remove the ownership lease only after a successful end_session (or
+        # when no session DB row could exist because _session_db was never
+        # opened).  If end_session failed the lease is retained so the reaper
+        # can recover the orphaned row later.  Idempotent (missing file = no-op).
+        if _cron_session_ended:
+            _remove_cron_session_lease(_cron_session_id)
         # Release subprocesses, terminal sandboxes, browser daemons, and the
         # main OpenAI/httpx client held by this ephemeral cron agent. Without
         # this, a gateway that ticks cron every N minutes leaks fds per job
@@ -4478,10 +3919,7 @@ def _teardown_cron_agent(agent, job_id: str) -> None:
         logger.debug("Job '%s': failed to reap stale auxiliary clients: %s", job_id, e)
 
 
-def run_one_job(
-    job: dict, *, adapters=None, loop=None, verbose: bool = False,
-    extra_prompt: Optional[str] = None,
-) -> bool:
+def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -> bool:
     """Run ONE due job end-to-end: execute → save output → deliver → mark.
 
     This is the shared firing body extracted from ``tick``'s per-job closure so
@@ -4549,8 +3987,7 @@ def run_one_job(
         _deferred_agents: list = []
         try:
             success, output, final_response, error = run_job(
-                job, defer_agent_teardown=_deferred_agents,
-                extra_prompt=extra_prompt,
+                job, defer_agent_teardown=_deferred_agents
             )
         except BaseException:
             # run_job's finally still hands back the agent when it raises; tear
@@ -4571,7 +4008,6 @@ def run_one_job(
         # deferred agent is still torn down. Otherwise the outer `except` would
         # swallow the error and leak the agent's subprocesses/clients (#10200).
         delivery_error = None
-        blocked_config = False
         try:
             output_file = save_job_output(job["id"], output)
             if verbose:
@@ -4594,41 +4030,11 @@ def run_one_job(
             # Deliver the final response to the origin/target chat.
             # If the agent responded with [SILENT], skip delivery (but
             # output is already saved above).  Failed jobs always deliver.
-            #
-            # Exception: a run blocked by pre-dispatch config validation
-            # (T1-26) alerts exactly ONCE — the silent marker means the
-            # operator was already told on a previous tick, so re-delivering
-            # the same alert every tick would be spam (#73506 alert-once
-            # shape).
-            blocked_config_silent = (
-                bool(error) and BLOCKED_CONFIG_SILENT_MARKER in str(error)
-            )
-            blocked_config = blocked_config_silent or (
-                bool(error) and BLOCKED_CONFIG_MARKER in str(error)
-            )
-            if blocked_config and not success:
-                # Blocked-config alert: bypass the generic failure summarizer
-                # (whose auth/timeout heuristics would mislabel this as a
-                # provider runtime failure) — say plainly that config
-                # validation blocked the run and nothing was spent.
-                _pf_text = re.sub(
-                    r"\[blocked_config[^\]]*\]\s*", "", str(error)
-                ).strip()
-                deliver_content = (
-                    f"⛔ Cron '{job.get('name') or job['id']}' blocked by "
-                    f"configuration validation (no LLM call was made): "
-                    f"{_pf_text} "
-                    "This alert is sent once; the job stays blocked until "
-                    "the configuration is fixed."
-                )
-            else:
-                deliver_content = final_response if success else _summarize_cron_failure_for_delivery(job, error)
+            deliver_content = final_response if success else _summarize_cron_failure_for_delivery(job, error)
             # Treat whitespace-only final responses the same as empty
             # responses: do not deliver a blank message, and let the
             # empty-response guard below mark the run as a soft failure.
             should_deliver = bool(deliver_content.strip())
-            if blocked_config_silent:
-                should_deliver = False
             unresolved_origin = False
             # Cron silence suppression — see _is_cron_silence_response.  Replaces the
             # old `SILENT_MARKER in ...upper()` substring check, which both leaked
@@ -4665,13 +4071,7 @@ def run_one_job(
             error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
 
         if not _consume_interrupted_flag(job["id"]):
-            if blocked_config:
-                mark_job_run(
-                    job["id"], success, error, delivery_error=delivery_error,
-                    status="blocked_config",
-                )
-            else:
-                mark_job_run(job["id"], success, error, delivery_error=delivery_error)
+            mark_job_run(job["id"], success, error, delivery_error=delivery_error)
         normalized_deliver = _normalize_deliver_value(job.get("deliver", "local"))
         if delivery_error:
             delivery_outcome = "failed"
@@ -4740,49 +4140,313 @@ def _notify_provider_jobs_changed() -> None:
         logger.debug("on_jobs_changed notify failed: %s", e)
 
 
-class CronSchedulerRegistrationError(RuntimeError):
-    """A job was persisted but its first external trigger was not registered."""
-
-    def __init__(self, job: dict, cause: Exception) -> None:
-        self.job = job
-        self.cause = cause
-        super().__init__(
-            f"Cron job '{job['id']}' was saved, but its first scheduler "
-            f"registration failed ({type(cause).__name__}). Do not create a "
-            "duplicate. Pause/resume or update the job to retry registration."
-        )
-
-    def user_message(self) -> str:
-        """Human-facing variant for chat/CLI surfaces (no exception class name)."""
-        label = self.job.get("name") or self.job["id"]
-        return (
-            f"Saved cron job '{label}', but couldn't register it with the "
-            "external scheduler yet. The job is kept — don't re-create it; "
-            "pause/resume or edit it (e.g. via /cron) to retry registration."
-        )
-
-    def to_dict(self) -> dict:
-        """Return the public partial-failure contract without provider details."""
-        return {
-            "error": str(self),
-            "job_id": self.job["id"],
-            "job_saved": True,
-            "scheduler_registered": False,
-            "retry_create": False,
-        }
+# ── Cron session ownership leases ────────────────────────────────────
+# Every AI-backed cron run registers a *lease* sidecar so the reaper can
+# prove the owning run is dead before closing its session row.  This avoids
+# the cross-process hazard of the previous design (which only checked this
+# process's ``_running_job_ids`` and would reap another process's active
+# >45m run).  Leases live in a profile-local directory under ``cron/`` — no
+# schema bump — and are named by a SHA-256 hash of the session_id so
+# untrusted ids are never interpolated into a filesystem path.
 
 
-def create_job_with_scheduler_registration(**kwargs) -> dict:
-    """Persist one job and register its first trigger with the active provider."""
-    from cron.jobs import create_job
-    from cron.scheduler_provider import resolve_cron_scheduler
+_CRON_LEASE_DIR_NAME = "cron_session_leases"
+_STALE_CRON_SESSION_MAX_AGE_SECONDS = 45 * 60
+_LEASE_HEARTBEAT_INTERVAL_SECONDS = 30.0
 
-    job = create_job(**kwargs)
+
+def _cron_lease_dir() -> Path:
+    return _get_hermes_home() / "cron" / _CRON_LEASE_DIR_NAME
+
+
+def _cron_lease_path(session_id: str) -> Path:
+    """Return the on-disk lease path for ``session_id``.
+
+    The filename is a SHA-256 hex digest of the session id — never the raw
+    id — so an untrusted session id cannot escape the lease directory or
+    inject path separators (``..`` / ``/`` / NUL).  The directory is created
+    lazily; callers that only *read* leases should tolerate its absence.
+    """
+    digest = hashlib.sha256(session_id.encode("utf-8")).hexdigest()
+    return _cron_lease_dir() / f"{digest}.json"
+
+
+def _cron_local_host_id() -> str:
+    """A best-effort stable identifier for this host.
+
+    Used only to decide whether a lease's owner *could* be probed locally
+    (same host) — never as a trust assertion.  When it cannot be determined
+    the reaper treats the lease as cross-host and refuses to reap it.
+    """
     try:
-        resolve_cron_scheduler().register_job(job)
-    except Exception as exc:
-        raise CronSchedulerRegistrationError(job, exc) from exc
-    return job
+        return socket.gethostname() or ""
+    except Exception:
+        return ""
+
+
+def _write_cron_session_lease(path: Path, lease: dict) -> None:
+    """Atomically replace ``path`` with a complete lease document."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(f".tmp.{os.getpid()}.{threading.get_ident()}")
+    try:
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(lease, fh, ensure_ascii=False)
+        os.replace(tmp, path)
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def _register_cron_session_lease(
+    session_id: str, job_id: str
+) -> Optional[dict]:
+    """Atomically write the ownership lease for a cron session.
+
+    Called after ``AIAgent`` / session initialization, before
+    ``run_conversation``. Returns the lease dict on success, or ``None`` on
+    failure. The run proceeds; an ownerless row remains protected by the
+    stale-session age grace.
+    """
+    try:
+        from gateway.status import _get_process_start_time
+
+        owner_pid = os.getpid()
+        lease = {
+            "session_id": session_id,
+            "job_id": job_id,
+            "owner_pid": owner_pid,
+            "owner_start_time": _get_process_start_time(owner_pid),
+            "host": _cron_local_host_id(),
+            "heartbeat_at": time.time(),
+        }
+        path = _cron_lease_path(session_id)
+        _write_cron_session_lease(path, lease)
+        return lease
+    except Exception:
+        logger.debug("Failed to register cron session lease: %s", exc_info=True)
+        return None
+
+
+def _heartbeat_cron_session_lease(session_id: str) -> None:
+    """Refresh a lease heartbeat without changing its owner identity.
+
+    Called from the run monitor loop for every AI cron run.  The recorded
+    PID and process-start fingerprint must still match this process; a stale
+    runner must never refresh a replacement owner's lease.
+    """
+    try:
+        from gateway.status import _get_process_start_time
+
+        lease = _read_cron_session_lease(session_id)
+        if not lease or lease.get("session_id") != session_id:
+            return
+        owner_pid = os.getpid()
+        try:
+            recorded_pid = int(lease.get("owner_pid") or 0)
+        except (TypeError, ValueError):
+            return
+        if recorded_pid != owner_pid:
+            return
+
+        recorded_start = lease.get("owner_start_time")
+        if recorded_start is not None:
+            try:
+                recorded_start = int(recorded_start)
+                current_start = _get_process_start_time(owner_pid)
+                if current_start is None or recorded_start != int(current_start):
+                    return
+            except (TypeError, ValueError):
+                return
+
+        lease["heartbeat_at"] = time.time()
+        _write_cron_session_lease(_cron_lease_path(session_id), lease)
+    except Exception:
+        logger.debug("Failed to heartbeat cron session lease: %s", exc_info=True)
+
+
+def _remove_cron_session_lease(session_id: str) -> None:
+    """Delete the lease sidecar.  Idempotent (missing file is a no-op)."""
+    try:
+        path = _cron_lease_path(session_id)
+        path.unlink(missing_ok=True)
+    except Exception:
+        logger.debug("Failed to remove cron session lease: %s", exc_info=True)
+
+
+def _read_cron_session_lease(session_id: str) -> Optional[dict]:
+    """Read and parse the lease for ``session_id``, or ``None``.
+
+    ``None`` covers missing, unreadable, and malformed leases. After the age
+    grace, that means the legacy row has no live ownership evidence and is
+    eligible for recovery.
+    """
+    path = _cron_lease_path(session_id)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    if not raw.strip():
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _lease_runner_identity(lease: Optional[dict]) -> tuple[Any, Any]:
+    """Return runner PID/id evidence from current or pre-fencing leases."""
+    if not isinstance(lease, dict):
+        return None, None
+    runner_pid = lease.get("runner_pid", lease.get("owner_pid"))
+    runner_id = lease.get("runner_id", lease.get("owner_start_time"))
+    return runner_pid, runner_id
+
+def _session_has_active_in_process_owner(session_id: str) -> bool:
+    """Return whether the session belongs to a job running in this process."""
+    return any(
+        session_id.startswith(f"cron_{job_id}_")
+        for job_id in get_running_job_ids()
+    )
+
+
+def _owner_definitively_dead(lease: dict) -> bool:
+    """Return True only when the lease owner is *provably* no longer alive.
+
+    Fail-closed: any uncertainty (cross-host, unparseable pid, missing
+    start-time fingerprint, ambiguous probe) returns ``False`` so the
+    session is left alone.  For the local host we use the gateway.status
+    process-liveness probe plus the recorded start-time fingerprint to
+    distinguish PID reuse — a recycled PID yields a different start time
+    and is never mistaken for the original owner.
+    """
+    runner_pid, _runner_id = _lease_runner_identity(lease)
+    try:
+        pid = int(runner_pid or 0)
+    except (TypeError, ValueError):
+        return False
+    if pid <= 0:
+        return False
+
+    try:
+        from gateway.status import _pid_exists, _get_process_start_time
+        local_host = _cron_local_host_id()
+    except Exception:
+        return False
+
+    # Different host / unknown host → cannot probe locally → fail closed.
+    if not local_host or lease.get("host") != local_host:
+        return False
+
+    try:
+        if not _pid_exists(pid):
+            return True
+    except Exception:
+        return False
+
+    # PID is alive — guard against PID reuse via the start-time fingerprint.
+    recorded_start = lease.get("owner_start_time")
+    if recorded_start is None:
+        # No fingerprint recorded → cannot prove reuse → fail closed.
+        return False
+    try:
+        recorded_start = int(recorded_start)
+    except (TypeError, ValueError):
+        return False
+    try:
+        current_start = _get_process_start_time(pid)
+    except Exception:
+        return False
+    if current_start is None:
+        # Probe uncertain → fail closed.
+        return False
+    # Start-time mismatch → the original owner died and the PID was reused
+    # by a different process → the owner is definitively dead.
+    return current_start != recorded_start
+
+
+def _reap_stale_cron_sessions() -> int:
+    """Close expired cron sessions with no live ownership evidence.
+
+    Every candidate must exceed ``_STALE_CRON_SESSION_MAX_AGE_SECONDS``.
+    A matching entry in ``_running_job_ids`` always fences the current
+    process's active run, including the lease-write-failure path. Legacy or
+    malformed rows without either runner PID or runner identity are otherwise
+    eligible after the grace window. Rows carrying owner evidence use the
+    stricter lease path — matching session id, stale heartbeat, and a
+    definitively dead local owner. Fresh, active, cross-host, mismatched, or
+    otherwise uncertain owned leases remain open.
+
+    Closing uses ``end_session`` (exact id + ``ended_at IS NULL`` guard) so
+    concurrent closes are idempotent.
+    """
+    try:
+        db = _open_cron_session_db("Stale cron session reaper")
+        if db is None:
+            return 0
+        try:
+            open_sessions = db.list_open_cron_sessions()
+        finally:
+            db.close()
+        if not open_sessions:
+            return 0
+
+        now = time.time()
+        cutoff = now - _STALE_CRON_SESSION_MAX_AGE_SECONDS
+        reaped = 0
+        for row in open_sessions:
+            session_id = row.get("id", "")
+            started_at = row.get("started_at")
+            if started_at is None or started_at >= cutoff:
+                continue  # not old enough
+            if _session_has_active_in_process_owner(session_id):
+                continue  # this process still owns the active run
+            lease = _read_cron_session_lease(session_id)
+            runner_pid, runner_id = _lease_runner_identity(lease)
+            has_owner_evidence = runner_pid is not None or runner_id is not None
+            if has_owner_evidence:
+                if lease.get("session_id") != session_id:
+                    continue  # ownership evidence for another/unknown session
+                heartbeat_at = lease.get("heartbeat_at")
+                try:
+                    heartbeat_at = float(heartbeat_at)
+                except (TypeError, ValueError):
+                    continue  # owned lease with unknown freshness → preserve
+                if heartbeat_at >= cutoff:
+                    continue  # heartbeat is fresh — run may still be alive
+                if not _owner_definitively_dead(lease):
+                    continue  # owner alive / PID reuse / uncertain → preserve
+            try:
+                db2 = _open_cron_session_db("Stale cron session reaper")
+                if db2 is None:
+                    continue
+                try:
+                    db2.end_session(session_id, "stale_reaped")
+                finally:
+                    db2.close()
+                _remove_cron_session_lease(session_id)
+                reaped += 1
+                lease_details = lease or {}
+                if has_owner_evidence:
+                    recovery_reason = (
+                        f"runner pid {runner_pid} dead, heartbeat stale"
+                    )
+                else:
+                    recovery_reason = "no live ownership evidence after grace"
+                logger.warning(
+                    "Reaped stale cron session %s (job %s) — %s",
+                    session_id,
+                    lease_details.get("job_id", "?"),
+                    recovery_reason,
+                )
+            except Exception:
+                logger.debug(
+                    "Failed to reap stale cron session %s: %s",
+                    session_id, exc_info=True,
+                )
+        return reaped
+    except Exception:
+        logger.debug("Stale cron session reaper failed: %s", exc_info=True)
+        return 0
 
 
 def tick(
@@ -4792,6 +4456,7 @@ def tick(
     sync: bool = True,
     *,
     can_dispatch=None,
+    reap_stale_sessions: bool = True,
 ):
     """
     Check and run all due jobs.
@@ -4805,6 +4470,7 @@ def tick(
         loop: Optional asyncio event loop (from gateway) for live adapter sends
         can_dispatch: Optional synchronous gate; false leaves due jobs untouched
             for the next allowed tick
+        reap_stale_sessions: Run periodic lease-aware recovery on this tick
 
     Returns:
         Number of jobs executed (0 if another tick is already running)
@@ -4826,38 +4492,25 @@ def tick(
             lock_fd.close()
         return 0
 
-    try:
-        # Global emergency stop (`hermes pause`): skip dispatch entirely while
-        # the ESTOP sentinel exists. Never touches in-flight runs — due jobs
-        # simply wait for the next tick after `hermes resume`. Logged once per
-        # engagement (not every tick) by check_paused.
+    # ── Stale-session reaper (periodic ticks) ─────────────────────────
+    # Startup performs an unconditional pass. Minute-or-slower ticker cadences
+    # also recover between restarts; genuine sub-minute loops skip the repeated
+    # SessionDB scan.
+    if reap_stale_sessions:
         try:
-            from agent.estop import check_paused as _estop_check_paused
-            if _estop_check_paused("cron", logger):
-                return 0
-        except ImportError:
-            pass
+            _reap_stale_cron_sessions()
+        except Exception:
+            logger.debug("tick reaper invocation failed: %s", exc_info=True)
 
+    try:
         if can_dispatch is not None and not can_dispatch():
             logger.debug("Cron dispatch paused while gateway drains existing work")
             return 0
 
         due_jobs = get_due_jobs()
 
-        if not due_jobs:
-            # Idle tick: skip config load + pool partitioning entirely
-            # (#33612 — the gateway ticker calls tick(verbose=False) every
-            # 60s, so idle ticks previously fell through to load_config()).
-            # Still run the post-tick MCP orphan sweep: main intentionally
-            # sweeps on idle ticks so orphaned stdio children from crashed
-            # jobs are reaped even when nothing is due.
-            if verbose:
-                logger.info("%s - No jobs due", _hermes_now().strftime('%H:%M:%S'))
-            try:
-                from tools.mcp_tool import _kill_orphaned_mcp_children
-                _kill_orphaned_mcp_children()
-            except Exception as _e:
-                logger.debug("Post-tick MCP orphan cleanup failed: %s", _e)
+        if verbose and not due_jobs:
+            logger.info("%s - No jobs due", _hermes_now().strftime('%H:%M:%S'))
             return 0
 
         if verbose:
@@ -4865,11 +4518,11 @@ def tick(
 
         # Advance next_run_at for all recurring jobs FIRST, under the file lock,
         # before any execution begins.  This preserves at-most-once semantics.
-        # For parallel jobs that are already running, the advance keeps
+        # For parallel jobs that are already running, advance_next_run keeps
         # bumping next_run_at forward so the grace window never expires.
         # mark_job_run() overwrites next_run_at on completion.
-        # Batched: one load + one save for the whole due set, not one per job.
-        advance_next_runs([job["id"] for job in due_jobs])
+        for job in due_jobs:
+            advance_next_run(job["id"])
 
         # Resolve max parallel workers: env var > config.yaml > unbounded.
         # Set HERMES_CRON_MAX_PARALLEL=1 to restore old serial behaviour.
@@ -4936,9 +4589,11 @@ def tick(
                     job.get("name", job_id),
                 )
                 return None
-            if not try_register_running_job(job_id):
-                logger.info("Job '%s' already running — skipping", job.get("name", job_id))
-                return None
+            with _running_lock:
+                if job_id in _running_job_ids:
+                    logger.info("Job '%s' already running — skipping", job.get("name", job_id))
+                    return None
+                _running_job_ids.add(job_id)
             # Record the attempt before executor dispatch. Recovery classifies
             # abandoned records as unknown; it never automatically retries them.
             execution = create_execution(job_id, source="builtin")
@@ -4949,12 +4604,14 @@ def tick(
                 try:
                     return ctx.run(_process_job, j)
                 finally:
-                    release_running_job(j["id"])
+                    with _running_lock:
+                        _running_job_ids.discard(j["id"])
 
             try:
                 return pool.submit(_run_and_release)
             except Exception as submit_err:
-                release_running_job(job_id)
+                with _running_lock:
+                    _running_job_ids.discard(job_id)
                 finish_execution(
                     execution["id"],
                     success=False,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6522,9 +6522,9 @@ def run_job(
 
         # Register the ownership lease so the stale-session reaper can prove
         # this run is dead before closing its session row.  Done AFTER
-        # AIAgent/session init and BEFORE run_conversation.  Failure is
-        # non-fatal — a missing lease means the reaper will not reap (fail
-        # closed), which is the safe default.
+        # AIAgent/session init and BEFORE run_conversation. Failure is
+        # non-fatal; without a lease the row is recoverable only after the
+        # full stale-session grace window.
         _cron_lease = _register_cron_session_lease(_cron_session_id, job_id)
         _last_lease_heartbeat = time.monotonic()
         
@@ -6627,7 +6627,7 @@ def run_job(
                         _heartbeat_cron_lease_if_due()
                 else:
                     # Lease registration failed, so there is nothing to
-                    # heartbeat. Missing leases are never reaped.
+                    # heartbeat. The age grace still protects this live run.
                     result = _cron_future.result()
             else:
                 result = None
@@ -7865,9 +7865,9 @@ def _register_cron_session_lease(
     """Atomically write the ownership lease for a cron session.
 
     Called after ``AIAgent`` / session initialization, before
-    ``run_conversation``.  Returns the lease dict on success, or ``None``
-    on failure (the run proceeds — a missing lease simply means the reaper
-    will not reap the session, which is the fail-closed default).
+    ``run_conversation``. Returns the lease dict on success, or ``None`` on
+    failure. The run proceeds; an ownerless row remains protected by the
+    stale-session age grace.
     """
     try:
         from gateway.status import _get_process_start_time
@@ -7938,8 +7938,9 @@ def _remove_cron_session_lease(session_id: str) -> None:
 def _read_cron_session_lease(session_id: str) -> Optional[dict]:
     """Read and parse the lease for ``session_id``, or ``None``.
 
-    ``None`` covers missing, unreadable, and malformed leases — the caller
-    treats all of these as "do not reap".
+    ``None`` covers missing, unreadable, and malformed leases. After the age
+    grace, that means the legacy row has no live ownership evidence and is
+    eligible for recovery.
     """
     path = _cron_lease_path(session_id)
     try:
@@ -7955,6 +7956,15 @@ def _read_cron_session_lease(session_id: str) -> Optional[dict]:
     return data if isinstance(data, dict) else None
 
 
+def _lease_runner_identity(lease: Optional[dict]) -> tuple[Any, Any]:
+    """Return runner PID/id evidence from current or pre-fencing leases."""
+    if not isinstance(lease, dict):
+        return None, None
+    runner_pid = lease.get("runner_pid", lease.get("owner_pid"))
+    runner_id = lease.get("runner_id", lease.get("owner_start_time"))
+    return runner_pid, runner_id
+
+
 def _owner_definitively_dead(lease: dict) -> bool:
     """Return True only when the lease owner is *provably* no longer alive.
 
@@ -7965,8 +7975,9 @@ def _owner_definitively_dead(lease: dict) -> bool:
     distinguish PID reuse — a recycled PID yields a different start time
     and is never mistaken for the original owner.
     """
+    runner_pid, _runner_id = _lease_runner_identity(lease)
     try:
-        pid = int(lease.get("owner_pid") or 0)
+        pid = int(runner_pid or 0)
     except (TypeError, ValueError):
         return False
     if pid <= 0:
@@ -8010,20 +8021,17 @@ def _owner_definitively_dead(lease: dict) -> bool:
 
 
 def _reap_stale_cron_sessions() -> int:
-    """Close cron sessions whose owning run is *provably* dead.
+    """Close expired cron sessions with no live ownership evidence.
 
-    A session is reaped ONLY when ALL of the following hold:
+    Every candidate must exceed ``_STALE_CRON_SESSION_MAX_AGE_SECONDS``.
+    Legacy or malformed rows without either runner PID or runner identity are
+    then eligible immediately: no owner exists to fence. Rows carrying owner
+    evidence use the stricter lease path — matching session id, stale
+    heartbeat, and a definitively dead local owner. Fresh, active, cross-host,
+    mismatched, or otherwise uncertain owned leases remain open.
 
-    1. Session age exceeds ``_STALE_CRON_SESSION_MAX_AGE_SECONDS``.
-    2. A lease exists and parses.
-    3. The lease heartbeat is stale (older than the max-age threshold).
-    4. The owner is definitively not alive (local host only, PID probe +
-       start-time fingerprint).
-
-    Any missing/malformed/cross-host/uncertain lease, or a fresh
-    heartbeat, means do not reap (fail-closed).  Closing uses
-    ``end_session`` (exact id + ``ended_at IS NULL`` guard) so concurrent
-    closes are idempotent.
+    Closing uses ``end_session`` (exact id + ``ended_at IS NULL`` guard) so
+    concurrent closes are idempotent.
     """
     try:
         db = _open_cron_session_db("Stale cron session reaper")
@@ -8045,17 +8053,20 @@ def _reap_stale_cron_sessions() -> int:
             if started_at is None or started_at >= cutoff:
                 continue  # not old enough
             lease = _read_cron_session_lease(session_id)
-            if not lease or lease.get("session_id") != session_id:
-                continue  # missing / malformed → do not reap
-            heartbeat_at = lease.get("heartbeat_at")
-            try:
-                heartbeat_at = float(heartbeat_at)
-            except (TypeError, ValueError):
-                continue  # fresh-or-unknown heartbeat → do not reap
-            if heartbeat_at >= cutoff:
-                continue  # heartbeat is fresh — run may still be alive
-            if not _owner_definitively_dead(lease):
-                continue  # owner alive / PID reuse / uncertain → do not reap
+            runner_pid, runner_id = _lease_runner_identity(lease)
+            has_owner_evidence = runner_pid is not None or runner_id is not None
+            if has_owner_evidence:
+                if lease.get("session_id") != session_id:
+                    continue  # ownership evidence for another/unknown session
+                heartbeat_at = lease.get("heartbeat_at")
+                try:
+                    heartbeat_at = float(heartbeat_at)
+                except (TypeError, ValueError):
+                    continue  # owned lease with unknown freshness → preserve
+                if heartbeat_at >= cutoff:
+                    continue  # heartbeat is fresh — run may still be alive
+                if not _owner_definitively_dead(lease):
+                    continue  # owner alive / PID reuse / uncertain → preserve
             try:
                 db2 = _open_cron_session_db("Stale cron session reaper")
                 if db2 is None:
@@ -8066,12 +8077,18 @@ def _reap_stale_cron_sessions() -> int:
                     db2.close()
                 _remove_cron_session_lease(session_id)
                 reaped += 1
+                lease_details = lease or {}
+                if has_owner_evidence:
+                    recovery_reason = (
+                        f"runner pid {runner_pid} dead, heartbeat stale"
+                    )
+                else:
+                    recovery_reason = "no live ownership evidence after grace"
                 logger.warning(
-                    "Reaped stale cron session %s (job %s) — owner "
-                    "pid %s dead, heartbeat stale",
+                    "Reaped stale cron session %s (job %s) — %s",
                     session_id,
-                    lease.get("job_id", "?"),
-                    lease.get("owner_pid", "?"),
+                    lease_details.get("job_id", "?"),
+                    recovery_reason,
                 )
             except Exception:
                 logger.debug(
@@ -8091,6 +8108,7 @@ def tick(
     sync: bool = True,
     *,
     can_dispatch=None,
+    reap_stale_sessions: bool = True,
 ):
     """
     Check and run all due jobs.
@@ -8104,6 +8122,7 @@ def tick(
         loop: Optional asyncio event loop (from gateway) for live adapter sends
         can_dispatch: Optional synchronous gate; false leaves due jobs untouched
             for the next allowed tick
+        reap_stale_sessions: Run periodic lease-aware recovery on this tick
 
     Returns:
         Number of jobs executed (0 if another tick is already running)
@@ -8154,14 +8173,15 @@ def tick(
             logger.error("Cron tick could not acquire tick lock: %s", exc)
         raise
 
-    # ── Stale-session reaper (every tick) ─────────────────────────────
-    # Close cron sessions whose owning run is provably dead (stale lease
-    # heartbeat + dead owner).  Fail-closed: a missing/fresh/cross-host
-    # lease is never reaped.  Cheap index scan + targeted end_session.
-    try:
-        _reap_stale_cron_sessions()
-    except Exception:
-        logger.debug("tick reaper invocation failed: %s", exc_info=True)
+    # ── Stale-session reaper (periodic ticks) ─────────────────────────
+    # Startup performs an unconditional pass. Minute-or-slower ticker cadences
+    # also recover between restarts; genuine sub-minute loops skip the repeated
+    # SessionDB scan.
+    if reap_stale_sessions:
+        try:
+            _reap_stale_cron_sessions()
+        except Exception:
+            logger.debug("tick reaper invocation failed: %s", exc_info=True)
 
     try:
         # Global emergency stop (`hermes pause`): skip dispatch entirely while

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -7964,6 +7964,13 @@ def _lease_runner_identity(lease: Optional[dict]) -> tuple[Any, Any]:
     runner_id = lease.get("runner_id", lease.get("owner_start_time"))
     return runner_pid, runner_id
 
+def _session_has_active_in_process_owner(session_id: str) -> bool:
+    """Return whether the session belongs to a job running in this process."""
+    return any(
+        session_id.startswith(f"cron_{job_id}_")
+        for job_id in get_running_job_ids()
+    )
+
 
 def _owner_definitively_dead(lease: dict) -> bool:
     """Return True only when the lease owner is *provably* no longer alive.
@@ -8024,11 +8031,13 @@ def _reap_stale_cron_sessions() -> int:
     """Close expired cron sessions with no live ownership evidence.
 
     Every candidate must exceed ``_STALE_CRON_SESSION_MAX_AGE_SECONDS``.
-    Legacy or malformed rows without either runner PID or runner identity are
-    then eligible immediately: no owner exists to fence. Rows carrying owner
-    evidence use the stricter lease path — matching session id, stale
-    heartbeat, and a definitively dead local owner. Fresh, active, cross-host,
-    mismatched, or otherwise uncertain owned leases remain open.
+    A matching entry in ``_running_job_ids`` always fences the current
+    process's active run, including the lease-write-failure path. Legacy or
+    malformed rows without either runner PID or runner identity are otherwise
+    eligible after the grace window. Rows carrying owner evidence use the
+    stricter lease path — matching session id, stale heartbeat, and a
+    definitively dead local owner. Fresh, active, cross-host, mismatched, or
+    otherwise uncertain owned leases remain open.
 
     Closing uses ``end_session`` (exact id + ``ended_at IS NULL`` guard) so
     concurrent closes are idempotent.
@@ -8052,6 +8061,8 @@ def _reap_stale_cron_sessions() -> int:
             started_at = row.get("started_at")
             if started_at is None or started_at >= cutoff:
                 continue  # not old enough
+            if _session_has_active_in_process_owner(session_id):
+                continue  # this process still owns the active run
             lease = _read_cron_session_lease(session_id)
             runner_pid, runner_id = _lease_runner_identity(lease)
             has_owner_evidence = runner_pid is not None or runner_id is not None

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -14,12 +14,14 @@ import concurrent.futures
 import contextlib
 import contextvars
 import errno
+import hashlib
 import json
 import logging
 import os
 import re
 import shutil
 import signal
+import socket
 import subprocess
 import sys
 import threading
@@ -5290,6 +5292,70 @@ def _preflight_job_config(job: dict, cfg: dict) -> Optional[str]:
             continue
         if reason:
             return reason
+
+
+def _resolve_cron_session_db_timeout() -> float:
+    """Resolve the bounded SessionDB constructor timeout for cron paths."""
+    timeout: float | None = None
+    raw_env_timeout = os.getenv("HERMES_CRON_SESSION_DB_TIMEOUT", "").strip()
+    if raw_env_timeout:
+        try:
+            timeout = float(raw_env_timeout)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Invalid HERMES_CRON_SESSION_DB_TIMEOUT=%r; using config/default",
+                raw_env_timeout,
+            )
+    if timeout is None:
+        try:
+            from hermes_cli.config import load_config
+
+            cfg = load_config() or {}
+            cron_cfg = cfg.get("cron", {}) if isinstance(cfg, dict) else {}
+            configured = cron_cfg.get("session_db_timeout_seconds")
+            if configured is not None:
+                timeout = float(configured)
+        except Exception as exc:
+            logger.debug(
+                "Failed to load cron.session_db_timeout_seconds from config: %s",
+                exc,
+            )
+    return 10.0 if timeout is None else timeout
+
+
+def _open_cron_session_db(log_context: str):
+    """Open SessionDB without allowing a wedged constructor to block cron."""
+    timeout = _resolve_cron_session_db_timeout()
+    try:
+        from hermes_state import SessionDB
+
+        if timeout <= 0:
+            # 0 = unlimited (legacy behavior, opt-in for debugging)
+            return SessionDB()
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        future = pool.submit(SessionDB)
+        try:
+            return future.result(timeout=timeout)
+        except concurrent.futures.TimeoutError:
+            # The worker is abandoned (shutdown below doesn't wait for it).
+            # If SessionDB() later completes inside it, the future's result
+            # would be orphaned and its SQLite FDs (.db, WAL, SHM) leak
+            # until process exit.  Register a done-callback that retrieves
+            # and closes any eventual late result (#72782).
+            future.add_done_callback(_close_late_session_db_result)
+            raise
+        finally:
+            # A wedged constructor must not hold up the tick or job monitor.
+            pool.shutdown(wait=False)
+    except concurrent.futures.TimeoutError:
+        logger.error(
+            "%s: SessionDB init did not return within %.0fs — proceeding "
+            "without a session store instead of blocking forever",
+            log_context,
+            timeout,
+        )
+    except Exception as exc:
+        logger.debug("%s: SQLite session store not available: %s", log_context, exc)
     return None
 
 
@@ -5654,12 +5720,29 @@ def run_job(
     # ---------------------------------------------------------------
     from run_agent import AIAgent
 
+<<<<<<< HEAD
     # NOTE: the SQLite session store used to be initialized here, BEFORE the
     # wake-gate and prompt-validation early returns below. Every gated run
     # (``wakeAgent: false``, blocked prompt) opened state.db and returned
     # without reaching the finally that closes it, relying on GC to release
     # the handle. Init now happens inside the main try, right before the
     # agent is constructed — after every early-return path (#96290).
+=======
+    # Initialize SQLite session store so cron job messages are persisted
+    # and discoverable via session_search (same pattern as gateway/run.py).
+    #
+    # Bounded with its own timeout (separate from HERMES_CRON_TIMEOUT, which
+    # only watches the agent's run_conversation below): SessionDB.__init__
+    # opens/migrates state.db synchronously and has no timeout of its own
+    # against a wedged sqlite3.connect (e.g. a stale flock left by a crashed
+    # sibling process). An unbounded hang here is invisible to every other
+    # cron safeguard, because it happens BEFORE _submit_with_guard's future
+    # exists — the finally block that releases the job from
+    # _running_job_ids never runs, so the job stays wedged "running" until
+    # the whole gateway process is restarted, silently skipping every
+    # scheduled fire in between with "already running — skipping".
+    _session_db = _open_cron_session_db(f"Job '{job.get('id', '?')}'")
+>>>>>>> 6ec2ef4a3c (fix(cron): reap stale sessions with owner leases)
 
     # Wake-gate: if this job has a pre-check script, run it BEFORE building
     # the prompt so a ``{"wakeAgent": false}`` response can short-circuit
@@ -6436,6 +6519,14 @@ def run_job(
             session_id=_cron_session_id,
             session_db=_session_db,
         )
+
+        # Register the ownership lease so the stale-session reaper can prove
+        # this run is dead before closing its session row.  Done AFTER
+        # AIAgent/session init and BEFORE run_conversation.  Failure is
+        # non-fatal — a missing lease means the reaper will not reap (fail
+        # closed), which is the safe default.
+        _cron_lease = _register_cron_session_lease(_cron_session_id, job_id)
+        _last_lease_heartbeat = time.monotonic()
         
         # Run the agent with an *inactivity*-based timeout: the job can run
         # for hours if it's actively calling tools / receiving stream tokens,
@@ -6489,6 +6580,22 @@ def run_job(
                     "Job '%s': run_claim heartbeat failed", job_name, exc_info=True
                 )
 
+        def _heartbeat_cron_lease_if_due():
+            """Heartbeat the session ownership lease for ALL AI cron runs.
+
+            Unlike the run_claim heartbeat (one-shots only), this fires for
+            every run so a stale lease reliably means the owning run stopped
+            progressing.  Throttled by ``_LEASE_HEARTBEAT_INTERVAL_SECONDS``
+            and best-effort — a failed heartbeat does not weaken the existing
+            run_claim heartbeat or abort the run.
+            """
+            nonlocal _last_lease_heartbeat
+            _mono = time.monotonic()
+            if _mono - _last_lease_heartbeat < _LEASE_HEARTBEAT_INTERVAL_SECONDS:
+                return
+            _last_lease_heartbeat = _mono
+            _heartbeat_cron_session_lease(_cron_session_id)
+
         _cron_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
         # Preserve scheduler-scoped ContextVar state (for example skill-declared
         # env passthrough registrations) when the cron run hops into the worker
@@ -6501,9 +6608,11 @@ def run_job(
         _inactivity_timeout = False
         try:
             if _cron_inactivity_limit is None:
-                # Unlimited — no inactivity watchdog, but a one-shot still
-                # needs its run_claim heartbeat, so poll instead of blocking.
-                if _is_oneshot or cancel_event is not None:
+                # Unlimited — no inactivity watchdog, but one-shots still
+                # need their run_claim heartbeat, cancelable runs need the
+                # poll, and every registered lease needs its own heartbeat,
+                # so poll instead of blocking.
+                if _is_oneshot or cancel_event is not None or _cron_lease is not None:
                     result = None
                     while True:
                         done, _ = concurrent.futures.wait(
@@ -6515,7 +6624,10 @@ def run_job(
                             break
                         _abort_if_fire_claim_lost()
                         _heartbeat_run_claim_if_due()
+                        _heartbeat_cron_lease_if_due()
                 else:
+                    # Lease registration failed, so there is nothing to
+                    # heartbeat. Missing leases are never reaped.
                     result = _cron_future.result()
             else:
                 result = None
@@ -6529,6 +6641,7 @@ def run_job(
                         break
                     _abort_if_fire_claim_lost()
                     _heartbeat_run_claim_if_due()
+                    _heartbeat_cron_lease_if_due()
                     # Agent still running — check inactivity.
                     _idle_secs = 0.0
                     if hasattr(agent, "get_activity_summary"):
@@ -6776,6 +6889,7 @@ def run_job(
             exit_non_dispatcher_owned_context(_non_dispatcher_token)
         for _var_name in _cron_delivery_vars:
             _VAR_MAP[_var_name].set("")
+        _cron_session_ended = True
         if _session_db:
             # The agent turn has already returned. Bound every subsequent DB
             # operation so storage failure cannot hold the dispatch guard.
@@ -6878,11 +6992,20 @@ def run_job(
                     _final_cron_session_id, _end_reason
                 )
             except (Exception, KeyboardInterrupt) as e:
+                # end_session failed — retain the lease so a later process can
+                # recover this session via the reaper once the owner is dead.
+                _cron_session_ended = False
                 logger.debug("Job '%s': failed to end session: %s", job_id, e)
             try:
                 _session_db.close()
             except (Exception, KeyboardInterrupt) as e:
                 logger.debug("Job '%s': failed to close SQLite session store: %s", job_id, e)
+        # Remove the ownership lease only after a successful end_session (or
+        # when no session DB row could exist because _session_db was never
+        # opened).  If end_session failed the lease is retained so the reaper
+        # can recover the orphaned row later.  Idempotent (missing file = no-op).
+        if _cron_session_ended:
+            _remove_cron_session_lease(_cron_session_id)
         # Release subprocesses, terminal sandboxes, browser daemons, and the
         # main OpenAI/httpx client held by this ephemeral cron agent. Without
         # this, a gateway that ticks cron every N minutes leaks fds per job
@@ -7680,6 +7803,287 @@ _DEAD_OWNER_REAP_INTERVAL_SECONDS = 300.0
 _last_dead_owner_reap_at: Optional[float] = None
 
 
+# ── Cron session ownership leases ────────────────────────────────────
+# Every AI-backed cron run registers a *lease* sidecar so the reaper can
+# prove the owning run is dead before closing its session row.  This avoids
+# the cross-process hazard of the previous design (which only checked this
+# process's ``_running_job_ids`` and would reap another process's active
+# >45m run).  Leases live in a profile-local directory under ``cron/`` — no
+# schema bump — and are named by a SHA-256 hash of the session_id so
+# untrusted ids are never interpolated into a filesystem path.
+
+
+_CRON_LEASE_DIR_NAME = "cron_session_leases"
+_STALE_CRON_SESSION_MAX_AGE_SECONDS = 45 * 60
+_LEASE_HEARTBEAT_INTERVAL_SECONDS = 30.0
+
+
+def _cron_lease_dir() -> Path:
+    return _get_hermes_home() / "cron" / _CRON_LEASE_DIR_NAME
+
+
+def _cron_lease_path(session_id: str) -> Path:
+    """Return the on-disk lease path for ``session_id``.
+
+    The filename is a SHA-256 hex digest of the session id — never the raw
+    id — so an untrusted session id cannot escape the lease directory or
+    inject path separators (``..`` / ``/`` / NUL).  The directory is created
+    lazily; callers that only *read* leases should tolerate its absence.
+    """
+    digest = hashlib.sha256(session_id.encode("utf-8")).hexdigest()
+    return _cron_lease_dir() / f"{digest}.json"
+
+
+def _cron_local_host_id() -> str:
+    """A best-effort stable identifier for this host.
+
+    Used only to decide whether a lease's owner *could* be probed locally
+    (same host) — never as a trust assertion.  When it cannot be determined
+    the reaper treats the lease as cross-host and refuses to reap it.
+    """
+    try:
+        return socket.gethostname() or ""
+    except Exception:
+        return ""
+
+
+def _write_cron_session_lease(path: Path, lease: dict) -> None:
+    """Atomically replace ``path`` with a complete lease document."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(f".tmp.{os.getpid()}.{threading.get_ident()}")
+    try:
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(lease, fh, ensure_ascii=False)
+        os.replace(tmp, path)
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def _register_cron_session_lease(
+    session_id: str, job_id: str
+) -> Optional[dict]:
+    """Atomically write the ownership lease for a cron session.
+
+    Called after ``AIAgent`` / session initialization, before
+    ``run_conversation``.  Returns the lease dict on success, or ``None``
+    on failure (the run proceeds — a missing lease simply means the reaper
+    will not reap the session, which is the fail-closed default).
+    """
+    try:
+        from gateway.status import _get_process_start_time
+
+        owner_pid = os.getpid()
+        lease = {
+            "session_id": session_id,
+            "job_id": job_id,
+            "owner_pid": owner_pid,
+            "owner_start_time": _get_process_start_time(owner_pid),
+            "host": _cron_local_host_id(),
+            "heartbeat_at": time.time(),
+        }
+        path = _cron_lease_path(session_id)
+        _write_cron_session_lease(path, lease)
+        return lease
+    except Exception:
+        logger.debug("Failed to register cron session lease: %s", exc_info=True)
+        return None
+
+
+def _heartbeat_cron_session_lease(session_id: str) -> None:
+    """Refresh a lease heartbeat without changing its owner identity.
+
+    Called from the run monitor loop for every AI cron run.  The recorded
+    PID and process-start fingerprint must still match this process; a stale
+    runner must never refresh a replacement owner's lease.
+    """
+    try:
+        from gateway.status import _get_process_start_time
+
+        lease = _read_cron_session_lease(session_id)
+        if not lease or lease.get("session_id") != session_id:
+            return
+        owner_pid = os.getpid()
+        try:
+            recorded_pid = int(lease.get("owner_pid") or 0)
+        except (TypeError, ValueError):
+            return
+        if recorded_pid != owner_pid:
+            return
+
+        recorded_start = lease.get("owner_start_time")
+        if recorded_start is not None:
+            try:
+                recorded_start = int(recorded_start)
+                current_start = _get_process_start_time(owner_pid)
+                if current_start is None or recorded_start != int(current_start):
+                    return
+            except (TypeError, ValueError):
+                return
+
+        lease["heartbeat_at"] = time.time()
+        _write_cron_session_lease(_cron_lease_path(session_id), lease)
+    except Exception:
+        logger.debug("Failed to heartbeat cron session lease: %s", exc_info=True)
+
+
+def _remove_cron_session_lease(session_id: str) -> None:
+    """Delete the lease sidecar.  Idempotent (missing file is a no-op)."""
+    try:
+        path = _cron_lease_path(session_id)
+        path.unlink(missing_ok=True)
+    except Exception:
+        logger.debug("Failed to remove cron session lease: %s", exc_info=True)
+
+
+def _read_cron_session_lease(session_id: str) -> Optional[dict]:
+    """Read and parse the lease for ``session_id``, or ``None``.
+
+    ``None`` covers missing, unreadable, and malformed leases — the caller
+    treats all of these as "do not reap".
+    """
+    path = _cron_lease_path(session_id)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    if not raw.strip():
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _owner_definitively_dead(lease: dict) -> bool:
+    """Return True only when the lease owner is *provably* no longer alive.
+
+    Fail-closed: any uncertainty (cross-host, unparseable pid, missing
+    start-time fingerprint, ambiguous probe) returns ``False`` so the
+    session is left alone.  For the local host we use the gateway.status
+    process-liveness probe plus the recorded start-time fingerprint to
+    distinguish PID reuse — a recycled PID yields a different start time
+    and is never mistaken for the original owner.
+    """
+    try:
+        pid = int(lease.get("owner_pid") or 0)
+    except (TypeError, ValueError):
+        return False
+    if pid <= 0:
+        return False
+
+    try:
+        from gateway.status import _pid_exists, _get_process_start_time
+        local_host = _cron_local_host_id()
+    except Exception:
+        return False
+
+    # Different host / unknown host → cannot probe locally → fail closed.
+    if not local_host or lease.get("host") != local_host:
+        return False
+
+    try:
+        if not _pid_exists(pid):
+            return True
+    except Exception:
+        return False
+
+    # PID is alive — guard against PID reuse via the start-time fingerprint.
+    recorded_start = lease.get("owner_start_time")
+    if recorded_start is None:
+        # No fingerprint recorded → cannot prove reuse → fail closed.
+        return False
+    try:
+        recorded_start = int(recorded_start)
+    except (TypeError, ValueError):
+        return False
+    try:
+        current_start = _get_process_start_time(pid)
+    except Exception:
+        return False
+    if current_start is None:
+        # Probe uncertain → fail closed.
+        return False
+    # Start-time mismatch → the original owner died and the PID was reused
+    # by a different process → the owner is definitively dead.
+    return current_start != recorded_start
+
+
+def _reap_stale_cron_sessions() -> int:
+    """Close cron sessions whose owning run is *provably* dead.
+
+    A session is reaped ONLY when ALL of the following hold:
+
+    1. Session age exceeds ``_STALE_CRON_SESSION_MAX_AGE_SECONDS``.
+    2. A lease exists and parses.
+    3. The lease heartbeat is stale (older than the max-age threshold).
+    4. The owner is definitively not alive (local host only, PID probe +
+       start-time fingerprint).
+
+    Any missing/malformed/cross-host/uncertain lease, or a fresh
+    heartbeat, means do not reap (fail-closed).  Closing uses
+    ``end_session`` (exact id + ``ended_at IS NULL`` guard) so concurrent
+    closes are idempotent.
+    """
+    try:
+        db = _open_cron_session_db("Stale cron session reaper")
+        if db is None:
+            return 0
+        try:
+            open_sessions = db.list_open_cron_sessions()
+        finally:
+            db.close()
+        if not open_sessions:
+            return 0
+
+        now = time.time()
+        cutoff = now - _STALE_CRON_SESSION_MAX_AGE_SECONDS
+        reaped = 0
+        for row in open_sessions:
+            session_id = row.get("id", "")
+            started_at = row.get("started_at")
+            if started_at is None or started_at >= cutoff:
+                continue  # not old enough
+            lease = _read_cron_session_lease(session_id)
+            if not lease or lease.get("session_id") != session_id:
+                continue  # missing / malformed → do not reap
+            heartbeat_at = lease.get("heartbeat_at")
+            try:
+                heartbeat_at = float(heartbeat_at)
+            except (TypeError, ValueError):
+                continue  # fresh-or-unknown heartbeat → do not reap
+            if heartbeat_at >= cutoff:
+                continue  # heartbeat is fresh — run may still be alive
+            if not _owner_definitively_dead(lease):
+                continue  # owner alive / PID reuse / uncertain → do not reap
+            try:
+                db2 = _open_cron_session_db("Stale cron session reaper")
+                if db2 is None:
+                    continue
+                try:
+                    db2.end_session(session_id, "stale_reaped")
+                finally:
+                    db2.close()
+                _remove_cron_session_lease(session_id)
+                reaped += 1
+                logger.warning(
+                    "Reaped stale cron session %s (job %s) — owner "
+                    "pid %s dead, heartbeat stale",
+                    session_id,
+                    lease.get("job_id", "?"),
+                    lease.get("owner_pid", "?"),
+                )
+            except Exception:
+                logger.debug(
+                    "Failed to reap stale cron session %s: %s",
+                    session_id, exc_info=True,
+                )
+        return reaped
+    except Exception:
+        logger.debug("Stale cron session reaper failed: %s", exc_info=True)
+        return 0
+
+
 def tick(
     verbose: bool = True,
     adapters=None,
@@ -7749,6 +8153,15 @@ def tick(
         else:
             logger.error("Cron tick could not acquire tick lock: %s", exc)
         raise
+
+    # ── Stale-session reaper (every tick) ─────────────────────────────
+    # Close cron sessions whose owning run is provably dead (stale lease
+    # heartbeat + dead owner).  Fail-closed: a missing/fresh/cross-host
+    # lease is never reaped.  Cheap index scan + targeted end_session.
+    try:
+        _reap_stale_cron_sessions()
+    except Exception:
+        logger.debug("tick reaper invocation failed: %s", exc_info=True)
 
     try:
         # Global emergency stop (`hermes pause`): skip dispatch entirely while

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -5720,29 +5720,12 @@ def run_job(
     # ---------------------------------------------------------------
     from run_agent import AIAgent
 
-<<<<<<< HEAD
     # NOTE: the SQLite session store used to be initialized here, BEFORE the
     # wake-gate and prompt-validation early returns below. Every gated run
     # (``wakeAgent: false``, blocked prompt) opened state.db and returned
     # without reaching the finally that closes it, relying on GC to release
     # the handle. Init now happens inside the main try, right before the
     # agent is constructed — after every early-return path (#96290).
-=======
-    # Initialize SQLite session store so cron job messages are persisted
-    # and discoverable via session_search (same pattern as gateway/run.py).
-    #
-    # Bounded with its own timeout (separate from HERMES_CRON_TIMEOUT, which
-    # only watches the agent's run_conversation below): SessionDB.__init__
-    # opens/migrates state.db synchronously and has no timeout of its own
-    # against a wedged sqlite3.connect (e.g. a stale flock left by a crashed
-    # sibling process). An unbounded hang here is invisible to every other
-    # cron safeguard, because it happens BEFORE _submit_with_guard's future
-    # exists — the finally block that releases the job from
-    # _running_job_ids never runs, so the job stays wedged "running" until
-    # the whole gateway process is restarted, silently skipping every
-    # scheduled fire in between with "already running — skipping".
-    _session_db = _open_cron_session_db(f"Job '{job.get('id', '?')}'")
->>>>>>> 6ec2ef4a3c (fix(cron): reap stale sessions with owner leases)
 
     # Wake-gate: if this job has a pre-check script, run it BEFORE building
     # the prompt so a ``{"wakeAgent": false}`` response can short-circuit

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -507,6 +507,46 @@ def scheduler_for_profile_mode(
         provider.name,
     )
     return InProcessCronScheduler()
+_PERIODIC_REAPER_MIN_INTERVAL_SECONDS = 60.0
+
+
+def _minimum_cron_interval_seconds(interval: Any) -> float:
+    """Return the shortest interval represented by a ticker cadence.
+
+    Numeric cadences are already seconds. Five-field cron expressions have
+    minute resolution; sample successive occurrences so step expressions such
+    as ``*/1 * * * *`` retain their exact 60-second boundary.
+    """
+    if isinstance(interval, (int, float)):
+        return max(0.0, float(interval))
+
+    text = str(interval or "").strip()
+    try:
+        return max(0.0, float(text))
+    except ValueError:
+        pass
+    if len(text.split()) != 5:
+        raise ValueError(f"Invalid cron ticker interval: {interval!r}")
+
+    from datetime import datetime, timezone
+    from croniter import croniter
+
+    occurrences = croniter(text, datetime(2024, 1, 1, tzinfo=timezone.utc))
+    previous = occurrences.get_next(datetime)
+    minimum = float("inf")
+    for _ in range(64):
+        current = occurrences.get_next(datetime)
+        minimum = min(minimum, (current - previous).total_seconds())
+        previous = current
+    return max(_PERIODIC_REAPER_MIN_INTERVAL_SECONDS, minimum)
+
+
+def _should_reap_stale_sessions_periodically(interval: Any) -> bool:
+    """Whether this cadence is one minute or slower."""
+    return (
+        _minimum_cron_interval_seconds(interval)
+        >= _PERIODIC_REAPER_MIN_INTERVAL_SECONDS
+    )
 
 
 class InProcessCronScheduler(CronScheduler):
@@ -534,7 +574,7 @@ class InProcessCronScheduler(CronScheduler):
         profile_homes=None,
     ):
         import logging
-        from cron.scheduler import tick as cron_tick
+        from cron.scheduler import _reap_stale_cron_sessions, tick as cron_tick
         from cron.jobs import (
             clear_ticker_error,
             record_ticker_error,
@@ -543,6 +583,19 @@ class InProcessCronScheduler(CronScheduler):
 
         logger = logging.getLogger("cron.scheduler_provider")
         logger.info("In-process cron scheduler started (interval=%ds)", interval)
+
+        interval_seconds = _minimum_cron_interval_seconds(interval)
+        periodic_reaping = _should_reap_stale_sessions_periodically(
+            interval_seconds
+        )
+
+        # Recover crash leftovers before scheduling can dispatch anything. This
+        # pass is independent of the loop, so even an already-stopped process
+        # performs restart recovery before returning.
+        try:
+            _reap_stale_cron_sessions()
+        except Exception:
+            logger.debug("Cron startup session reaper failed", exc_info=True)
 
         # ── Multiplex profiles ────────────────────────────────────────────
         # When profile_homes is set (multiplex_profiles on), tick EACH profile's
@@ -569,6 +622,10 @@ class InProcessCronScheduler(CronScheduler):
                 "Marked %d interrupted cron execution(s) unknown after restart",
                 recovered,
             )
+
+        logger.info(
+            "In-process cron scheduler started (interval=%gs)", interval_seconds
+        )
         # Heartbeat once before the first sleep so `hermes cron status` sees a
         # live ticker immediately after startup, not only after the first tick.
         record_ticker_heartbeat()
@@ -590,6 +647,7 @@ class InProcessCronScheduler(CronScheduler):
                         loop=loop,
                         sync=False,
                         can_dispatch=can_dispatch,
+                        reap_stale_sessions=periodic_reaping,
                     )
                 ok = True
             except BaseException as e:
@@ -619,7 +677,7 @@ class InProcessCronScheduler(CronScheduler):
             if ok:
                 clear_ticker_error()
                 consecutive_failures = 0
-            stop_event.wait(_backoff_wait_seconds(interval, consecutive_failures))
+            stop_event.wait(_backoff_wait_seconds(interval_seconds, consecutive_failures))
 
     def _start_multiplex(
         self,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7285,6 +7285,22 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         except Exception:
             return False
 
+    def list_open_cron_sessions(self) -> List[Dict[str, Any]]:
+        """Return open (``ended_at IS NULL``) cron sessions for reaper inspection.
+
+        Read-only: each row carries ``id`` and ``started_at`` so the caller can
+        cross-reference the owning run's liveness via a lease sidecar before
+        deciding whether to close.  Closing is done with ``end_session`` (exact
+        id + ``ended_at IS NULL`` guard), never by this list method.
+        """
+        sql = (
+            "SELECT id, started_at FROM sessions "
+            "WHERE source = 'cron' AND ended_at IS NULL "
+            "ORDER BY started_at ASC"
+        )
+        with self._lock:
+            return [dict(r) for r in self._conn.execute(sql)]
+
     def update_session_cwd(
         self,
         session_id: str,

--- a/tests/cron/test_cron_stale_session_reaper.py
+++ b/tests/cron/test_cron_stale_session_reaper.py
@@ -133,6 +133,31 @@ class TestReaperFailClosed:
         assert db.get_session(sid)["ended_at"] is None
         db.close()
 
+    def test_active_in_process_run_without_lease_is_preserved(self, hermes_env):
+        """An active run older than 45 minutes survives lease-write failure."""
+        import cron.scheduler as sched
+        from hermes_state import SessionDB
+
+        job_id = "live-without-lease"
+        sid = f"cron_{job_id}_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+
+        with sched._running_lock:
+            sched._running_job_ids.add(job_id)
+        try:
+            assert sched._reap_stale_cron_sessions() == 0
+        finally:
+            with sched._running_lock:
+                sched._running_job_ids.discard(job_id)
+
+        db = SessionDB()
+        try:
+            assert db.get_session(sid)["ended_at"] is None
+        finally:
+            db.close()
+
     def test_stale_dead_owner_reaped(self, hermes_env):
         """Stale heartbeat + owner PID does not exist → reaped."""
         from hermes_state import SessionDB

--- a/tests/cron/test_cron_stale_session_reaper.py
+++ b/tests/cron/test_cron_stale_session_reaper.py
@@ -1,0 +1,563 @@
+"""Tests for the cron stale-session reaper (fail-closed owner-lease design).
+
+Covers the ownership-lease + reaper salvaged from PR #62663:
+
+* Active local owner > threshold is preserved.
+* Stale dead owner is reaped.
+* PID reuse / start-time mismatch handled as dead only after stale heartbeat.
+* Fresh heartbeat preserved even if PID probe says dead.
+* Missing / malformed / uncertain lease preserved.
+* Another current process's active session preserved.
+* Lease cleanup ordering on end_session failure.
+* No duplicate final assistant message (regression).
+
+Process probes are mocked deterministically — never depend on actual process death.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+import os
+import time
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def hermes_env(tmp_path, monkeypatch):
+    """Isolate HERMES_HOME for each test so state.db + leases are fresh."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "cron").mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    # Reload modules that cache get_hermes_home() at import time.
+    import hermes_constants
+    importlib.reload(hermes_constants)
+    import hermes_state
+    importlib.reload(hermes_state)
+    import cron.scheduler
+    importlib.reload(cron.scheduler)
+
+    return home
+
+
+def _make_old_cron_session(db, session_id, age_seconds=7200):
+    """Create a cron session and backdate its started_at."""
+    db.create_session(session_id, source="cron")
+    db._execute_write(lambda conn: conn.execute(
+        "UPDATE sessions SET started_at = ? WHERE id = ?",
+        (time.time() - age_seconds, session_id),
+    ))
+
+
+_UNSET = object()
+
+
+def _write_lease(home, session_id, *, job_id="test_job", owner_pid=None,
+                 owner_start_time=_UNSET, host=None, heartbeat_at=None,
+                 raw=None):
+    """Write a lease sidecar for *session_id*.  Returns the lease path.
+
+    Pass ``owner_start_time=None`` to explicitly omit the field (simulate a
+    lease missing the start-time fingerprint); omit the kwarg entirely to get
+    the default (99999).
+    """
+    if owner_pid is None:
+        owner_pid = os.getpid()
+    if owner_start_time is _UNSET:
+        owner_start_time = 99999
+    if host is None:
+        host = "testhost"
+    if heartbeat_at is None:
+        heartbeat_at = time.time() - 7200  # stale by default
+    lease_dir = home / "cron" / "cron_session_leases"
+    lease_dir.mkdir(parents=True, exist_ok=True)
+    digest = hashlib.sha256(session_id.encode("utf-8")).hexdigest()
+    path = lease_dir / f"{digest}.json"
+    if raw is not None:
+        path.write_text(raw, encoding="utf-8")
+    else:
+        payload = {
+            "session_id": session_id,
+            "job_id": job_id,
+            "owner_pid": owner_pid,
+            "owner_start_time": owner_start_time,
+            "host": host,
+            "heartbeat_at": heartbeat_at,
+        }
+        path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Reaper — fail-closed scenarios
+# ---------------------------------------------------------------------------
+
+
+class TestReaperFailClosed:
+    """_reap_stale_cron_sessions — all 9 fail-closed scenarios."""
+
+    def test_active_local_owner_preserved(self, hermes_env):
+        """Active local owner > threshold with stale heartbeat but live PID
+        + matching start-time → NOT reaped (owner is provably alive)."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_live_job_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+
+        _write_lease(hermes_env, sid, owner_pid=os.getpid(),
+                     owner_start_time=99999, heartbeat_at=time.time() - 7200)
+
+        # PID exists + start-time matches → owner alive → do not reap.
+        with patch("gateway.status._pid_exists", return_value=True), \
+             patch("gateway.status._get_process_start_time", return_value=99999), \
+             patch("cron.scheduler._cron_local_host_id", return_value="testhost"):
+            count = _reap_stale_cron_sessions()
+
+        assert count == 0
+        db = SessionDB()
+        assert db.get_session(sid)["ended_at"] is None
+        db.close()
+
+    def test_stale_dead_owner_reaped(self, hermes_env):
+        """Stale heartbeat + owner PID does not exist → reaped."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_dead_job_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+
+        _write_lease(hermes_env, sid, owner_pid=99999,
+                     owner_start_time=11111, heartbeat_at=time.time() - 7200)
+
+        # PID does not exist → owner dead → reap.
+        with patch("gateway.status._pid_exists", return_value=False), \
+             patch("cron.scheduler._cron_local_host_id", return_value="testhost"):
+            count = _reap_stale_cron_sessions()
+
+        assert count == 1
+        db = SessionDB()
+        session = db.get_session(sid)
+        assert session["end_reason"] == "stale_reaped"
+        assert session["ended_at"] is not None
+        db.close()
+
+    def test_pid_reuse_start_time_mismatch_handled_as_dead_after_stale(self, hermes_env):
+        """Stale heartbeat + PID alive but start-time mismatch (PID reused)
+        → owner is definitively dead → reaped."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_reuse_job_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+
+        # Recorded start-time = 11111, live start-time = 22222 (different).
+        _write_lease(hermes_env, sid, owner_pid=99999,
+                     owner_start_time=11111, heartbeat_at=time.time() - 7200)
+
+        with patch("gateway.status._pid_exists", return_value=True), \
+             patch("gateway.status._get_process_start_time", return_value=22222), \
+             patch("cron.scheduler._cron_local_host_id", return_value="testhost"):
+            count = _reap_stale_cron_sessions()
+
+        assert count == 1
+        db = SessionDB()
+        assert db.get_session(sid)["end_reason"] == "stale_reaped"
+        db.close()
+
+    def test_fresh_heartbeat_preserved_even_if_pid_dead(self, hermes_env):
+        """Fresh heartbeat → NOT reaped even if PID probe says dead.
+        The run may still be progressing; a fresh heartbeat means 'alive'."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_fresh_job_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+
+        # Heartbeat is fresh (now), even though session is old.
+        _write_lease(hermes_env, sid, owner_pid=99999,
+                     owner_start_time=11111, heartbeat_at=time.time())
+
+        with patch("gateway.status._pid_exists", return_value=False), \
+             patch("cron.scheduler._cron_local_host_id", return_value="testhost"):
+            count = _reap_stale_cron_sessions()
+
+        assert count == 0
+        db = SessionDB()
+        assert db.get_session(sid)["ended_at"] is None
+        db.close()
+
+    def test_missing_lease_preserved(self, hermes_env):
+        """No lease sidecar → do not reap (uncertainty = fail closed)."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_nolease_job_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+
+        # No lease written.
+        with patch("gateway.status._pid_exists", return_value=False):
+            count = _reap_stale_cron_sessions()
+
+        assert count == 0
+        db = SessionDB()
+        assert db.get_session(sid)["ended_at"] is None
+        db.close()
+
+    def test_malformed_lease_preserved(self, hermes_env):
+        """Malformed (non-JSON) lease → do not reap."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_bad_job_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+
+        _write_lease(hermes_env, sid, raw="{not valid json")
+
+        with patch("gateway.status._pid_exists", return_value=False), \
+             patch("cron.scheduler._cron_local_host_id", return_value="testhost"):
+            count = _reap_stale_cron_sessions()
+
+        assert count == 0
+        db = SessionDB()
+        assert db.get_session(sid)["ended_at"] is None
+        db.close()
+
+    def test_mismatched_session_id_lease_preserved(self, hermes_env):
+        """A valid lease stored under the wrong session hash is untrusted."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_mismatch_job_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+        path = _write_lease(
+            hermes_env,
+            sid,
+            owner_pid=99999,
+            owner_start_time=11111,
+            heartbeat_at=time.time() - 7200,
+        )
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload["session_id"] = "different-session"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+        with patch("gateway.status._pid_exists", return_value=False), \
+             patch("cron.scheduler._cron_local_host_id", return_value="testhost"):
+            count = _reap_stale_cron_sessions()
+
+        assert count == 0
+        db = SessionDB()
+        session = db.get_session(sid)
+        assert session is not None
+        assert session["ended_at"] is None
+        db.close()
+
+    def test_cross_host_lease_preserved(self, hermes_env):
+        """Lease owned by a different host → cannot probe locally → do not reap."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_remote_job_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+
+        _write_lease(hermes_env, sid, owner_pid=99999,
+                     owner_start_time=11111, heartbeat_at=time.time() - 7200,
+                     host="other-host")
+
+        with patch("cron.scheduler._cron_local_host_id", return_value="this-host"):
+            count = _reap_stale_cron_sessions()
+
+        assert count == 0
+        db = SessionDB()
+        assert db.get_session(sid)["ended_at"] is None
+        db.close()
+
+    def test_another_process_active_session_preserved(self, hermes_env):
+        """A session whose owner is a different PID that IS alive (same host,
+        matching start-time) → do not reap."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_otherproc_job_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+
+        # Owner is pid 12345, alive, start-time matches.
+        _write_lease(hermes_env, sid, owner_pid=12345,
+                     owner_start_time=55555, heartbeat_at=time.time() - 7200)
+
+        with patch("gateway.status._pid_exists", return_value=True), \
+             patch("gateway.status._get_process_start_time", return_value=55555), \
+             patch("cron.scheduler._cron_local_host_id", return_value="testhost"):
+            count = _reap_stale_cron_sessions()
+
+        assert count == 0
+        db = SessionDB()
+        assert db.get_session(sid)["ended_at"] is None
+        db.close()
+
+    def test_recent_session_not_reaped(self, hermes_env):
+        """A session younger than the threshold is never reaped."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_recent_job_20240101_120000"
+        db = SessionDB()
+        db.create_session(sid, source="cron")  # started_at = now
+        db.close()
+
+        _write_lease(hermes_env, sid, owner_pid=99999,
+                     owner_start_time=11111, heartbeat_at=time.time() - 7200)
+
+        with patch("gateway.status._pid_exists", return_value=False):
+            count = _reap_stale_cron_sessions()
+
+        assert count == 0
+        db = SessionDB()
+        assert db.get_session(sid)["ended_at"] is None
+        db.close()
+
+    def test_already_ended_session_not_reaped(self, hermes_env):
+        """A session already ended is a no-op for the reaper."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_done_job_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.end_session(sid, "cron_complete")
+        db.close()
+
+        _write_lease(hermes_env, sid, owner_pid=99999,
+                     owner_start_time=11111, heartbeat_at=time.time() - 7200)
+
+        with patch("gateway.status._pid_exists", return_value=False), \
+             patch("cron.scheduler._cron_local_host_id", return_value="testhost"):
+            count = _reap_stale_cron_sessions()
+
+        assert count == 0
+
+    def test_missing_start_time_fingerprint_preserved(self, hermes_env):
+        """Lease has no owner_start_time → cannot guard against PID reuse →
+        fail closed (do not reap) even if PID is alive."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_nostart_job_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+
+        _write_lease(hermes_env, sid, owner_pid=99999,
+                     owner_start_time=None, heartbeat_at=time.time() - 7200)
+
+        # PID is alive, but we have no recorded start-time to compare.
+        with patch("gateway.status._pid_exists", return_value=True), \
+             patch("gateway.status._get_process_start_time", return_value=22222), \
+             patch("cron.scheduler._cron_local_host_id", return_value="testhost"):
+            count = _reap_stale_cron_sessions()
+
+        assert count == 0
+        db = SessionDB()
+        assert db.get_session(sid)["ended_at"] is None
+        db.close()
+
+    def test_probe_exception_preserves_session(self, hermes_env):
+        """A liveness-probe error is uncertainty, not proof of death."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_probe_error_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+        _write_lease(
+            hermes_env,
+            sid,
+            owner_pid=99999,
+            owner_start_time=11111,
+            heartbeat_at=time.time() - 7200,
+        )
+
+        with patch("gateway.status._pid_exists", side_effect=OSError("denied")), \
+             patch("cron.scheduler._cron_local_host_id", return_value="testhost"):
+            count = _reap_stale_cron_sessions()
+
+        assert count == 0
+        db = SessionDB()
+        session = db.get_session(sid)
+        assert session is not None
+        assert session["ended_at"] is None
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Lease manager helpers
+# ---------------------------------------------------------------------------
+
+
+class TestLeaseManager:
+    """_register / _heartbeat / _remove / _read lease helpers."""
+
+    def test_lease_path_hashes_session_id(self, hermes_env):
+        from cron.scheduler import _cron_lease_path
+        import cron.scheduler as sched
+
+        with patch.object(sched, "_get_hermes_home", return_value=hermes_env):
+            path = _cron_lease_path("cron_test_20240101_120000")
+        digest = hashlib.sha256(b"cron_test_20240101_120000").hexdigest()
+        assert path.name == f"{digest}.json"
+        assert path.parent == hermes_env / "cron" / "cron_session_leases"
+
+    def test_register_then_read_roundtrip(self, hermes_env):
+        import cron.scheduler as sched
+        from cron.scheduler import _register_cron_session_lease, _read_cron_session_lease
+
+        with patch.object(sched, "_get_hermes_home", return_value=hermes_env), \
+             patch("gateway.status._get_process_start_time", return_value=12345), \
+             patch("cron.scheduler._cron_local_host_id", return_value="myhost"):
+            lease = _register_cron_session_lease("cron_x_20240101_120000", "x")
+        assert lease is not None
+        assert lease["session_id"] == "cron_x_20240101_120000"
+        assert lease["job_id"] == "x"
+        assert lease["owner_pid"] == os.getpid()
+        assert lease["owner_start_time"] == 12345
+        assert lease["host"] == "myhost"
+
+        read = _read_cron_session_lease("cron_x_20240101_120000")
+        assert read is not None
+        assert read["session_id"] == "cron_x_20240101_120000"
+
+    def test_remove_is_idempotent(self, hermes_env):
+        import cron.scheduler as sched
+        from cron.scheduler import _remove_cron_session_lease, _read_cron_session_lease
+
+        with patch.object(sched, "_get_hermes_home", return_value=hermes_env):
+            _remove_cron_session_lease("nonexistent")  # no error
+            _remove_cron_session_lease("nonexistent")  # still no error
+        assert _read_cron_session_lease("nonexistent") is None
+
+    def test_read_malformed_returns_none(self, hermes_env):
+        import cron.scheduler as sched
+        from cron.scheduler import _read_cron_session_lease
+
+        _write_lease(hermes_env, "cron_bad", raw="not json at all")
+        with patch.object(sched, "_get_hermes_home", return_value=hermes_env):
+            assert _read_cron_session_lease("cron_bad") is None
+
+    def test_heartbeat_updates_file(self, hermes_env):
+        import cron.scheduler as sched
+        from cron.scheduler import (
+            _register_cron_session_lease,
+            _heartbeat_cron_session_lease,
+            _read_cron_session_lease,
+        )
+
+        with patch.object(sched, "_get_hermes_home", return_value=hermes_env), \
+             patch("gateway.status._get_process_start_time", return_value=12345), \
+             patch("cron.scheduler._cron_local_host_id", return_value="myhost"):
+            _register_cron_session_lease("cron_hb_20240101_120000", "hb")
+            old = _read_cron_session_lease("cron_hb_20240101_120000")
+            assert old is not None
+            old_hb = old["heartbeat_at"]
+
+            time.sleep(0.01)
+            _heartbeat_cron_session_lease("cron_hb_20240101_120000")
+            new = _read_cron_session_lease("cron_hb_20240101_120000")
+            assert new is not None
+
+        # Heartbeats must retain the owner identity needed by the reaper.
+        assert new["heartbeat_at"] > old_hb
+        assert new["session_id"] == old["session_id"]
+        assert new["job_id"] == old["job_id"]
+        assert new["owner_pid"] == old["owner_pid"]
+        assert new["owner_start_time"] == old["owner_start_time"]
+        assert new["host"] == old["host"]
+
+    def test_heartbeat_updates_when_start_time_unavailable(self, hermes_env):
+        """A matching owner PID may heartbeat without a start fingerprint."""
+        import cron.scheduler as sched
+
+        sid = "cron_no_start_20240101_120000"
+        path = _write_lease(
+            hermes_env,
+            sid,
+            owner_pid=os.getpid(),
+            owner_start_time=None,
+            heartbeat_at=time.time() - 7200,
+        )
+        before = json.loads(path.read_text(encoding="utf-8"))
+        with patch.object(sched, "_get_hermes_home", return_value=hermes_env), \
+             patch("gateway.status._get_process_start_time") as start_probe:
+            sched._heartbeat_cron_session_lease(sid)
+        after = json.loads(path.read_text(encoding="utf-8"))
+        assert after["heartbeat_at"] > before["heartbeat_at"]
+        assert after["owner_start_time"] is None
+        start_probe.assert_not_called()
+
+    def test_heartbeat_does_not_refresh_replacement_owner(self, hermes_env):
+        """A stale runner must not overwrite a lease owned by another PID."""
+        import cron.scheduler as sched
+
+        sid = "cron_replaced_20240101_120000"
+        path = _write_lease(
+            hermes_env,
+            sid,
+            owner_pid=os.getpid() + 1,
+            owner_start_time=12345,
+            heartbeat_at=time.time() - 7200,
+        )
+        before = json.loads(path.read_text(encoding="utf-8"))
+        with patch.object(sched, "_get_hermes_home", return_value=hermes_env), \
+             patch("gateway.status._get_process_start_time", return_value=12345):
+            sched._heartbeat_cron_session_lease(sid)
+        after = json.loads(path.read_text(encoding="utf-8"))
+        assert after == before
+
+
+class TestTickIntegration:
+    def test_tick_reaps_before_dispatch_gate(self, hermes_env):
+        """Every acquired tick reaps, even while new dispatch is paused."""
+        import cron.scheduler as sched
+
+        lock_path = hermes_env / "cron" / ".tick.lock"
+        with patch.object(
+            sched,
+            "_get_lock_paths",
+            return_value=(lock_path.parent, lock_path),
+        ), patch.object(
+            sched, "_reap_stale_cron_sessions", return_value=0
+        ) as reap, patch.object(sched, "get_due_jobs") as get_due_jobs:
+            count = sched.tick(verbose=False, can_dispatch=lambda: False)
+
+        assert count == 0
+        reap.assert_called_once_with()
+        get_due_jobs.assert_not_called()

--- a/tests/cron/test_cron_stale_session_reaper.py
+++ b/tests/cron/test_cron_stale_session_reaper.py
@@ -6,7 +6,7 @@ Covers the ownership-lease + reaper salvaged from PR #62663:
 * Stale dead owner is reaped.
 * PID reuse / start-time mismatch handled as dead only after stale heartbeat.
 * Fresh heartbeat preserved even if PID probe says dead.
-* Missing / malformed / uncertain lease preserved.
+* Missing / malformed ownerless leases are reaped after the grace window.
 * Another current process's active session preserved.
 * Lease cleanup ordering on end_session failure.
 * No duplicate final assistant message (regression).
@@ -20,6 +20,7 @@ import hashlib
 import importlib
 import json
 import os
+import threading
 import time
 from unittest.mock import patch
 
@@ -206,8 +207,8 @@ class TestReaperFailClosed:
         assert db.get_session(sid)["ended_at"] is None
         db.close()
 
-    def test_missing_lease_preserved(self, hermes_env):
-        """No lease sidecar → do not reap (uncertainty = fail closed)."""
+    def test_missing_lease_reaped_after_grace(self, hermes_env):
+        """A legacy session with no lease has no live ownership evidence."""
         from hermes_state import SessionDB
         from cron.scheduler import _reap_stale_cron_sessions
 
@@ -216,17 +217,16 @@ class TestReaperFailClosed:
         _make_old_cron_session(db, sid, age_seconds=7200)
         db.close()
 
-        # No lease written.
-        with patch("gateway.status._pid_exists", return_value=False):
-            count = _reap_stale_cron_sessions()
+        assert _reap_stale_cron_sessions() == 1
 
-        assert count == 0
         db = SessionDB()
-        assert db.get_session(sid)["ended_at"] is None
+        session = db.get_session(sid)
+        assert session["end_reason"] == "stale_reaped"
+        assert session["ended_at"] is not None
         db.close()
 
-    def test_malformed_lease_preserved(self, hermes_env):
-        """Malformed (non-JSON) lease → do not reap."""
+    def test_malformed_lease_reaped_after_grace(self, hermes_env):
+        """An unreadable legacy lease carries no live ownership evidence."""
         from hermes_state import SessionDB
         from cron.scheduler import _reap_stale_cron_sessions
 
@@ -237,13 +237,44 @@ class TestReaperFailClosed:
 
         _write_lease(hermes_env, sid, raw="{not valid json")
 
-        with patch("gateway.status._pid_exists", return_value=False), \
-             patch("cron.scheduler._cron_local_host_id", return_value="testhost"):
-            count = _reap_stale_cron_sessions()
+        assert _reap_stale_cron_sessions() == 1
 
-        assert count == 0
         db = SessionDB()
-        assert db.get_session(sid)["ended_at"] is None
+        session = db.get_session(sid)
+        assert session["end_reason"] == "stale_reaped"
+        assert session["ended_at"] is not None
+        db.close()
+
+    def test_null_runner_fields_reaped_after_grace(self, hermes_env):
+        """A structured but ownerless lease must not make a row immortal."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_ownerless_job_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+
+        _write_lease(
+            hermes_env,
+            sid,
+            raw=json.dumps(
+                {
+                    "session_id": sid,
+                    "job_id": "ownerless-job",
+                    "runner_pid": None,
+                    "runner_id": None,
+                    "heartbeat_at": time.time() - 7200,
+                }
+            ),
+        )
+
+        assert _reap_stale_cron_sessions() == 1
+
+        db = SessionDB()
+        session = db.get_session(sid)
+        assert session["end_reason"] == "stale_reaped"
+        assert session["ended_at"] is not None
         db.close()
 
     def test_mismatched_session_id_lease_preserved(self, hermes_env):
@@ -320,6 +351,39 @@ class TestReaperFailClosed:
             count = _reap_stale_cron_sessions()
 
         assert count == 0
+        db = SessionDB()
+        assert db.get_session(sid)["ended_at"] is None
+        db.close()
+
+    def test_active_runner_identity_preserved(self, hermes_env):
+        """New-format runner evidence fences a live owner after the grace."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_active_runner_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+        _write_lease(
+            hermes_env,
+            sid,
+            raw=json.dumps(
+                {
+                    "session_id": sid,
+                    "job_id": "active-runner",
+                    "runner_pid": 12345,
+                    "runner_id": "runner-abc",
+                    "host": "testhost",
+                    "heartbeat_at": time.time() - 7200,
+                }
+            ),
+        )
+
+        with patch("gateway.status._pid_exists", return_value=True), patch(
+            "cron.scheduler._cron_local_host_id", return_value="testhost"
+        ):
+            assert _reap_stale_cron_sessions() == 0
+
         db = SessionDB()
         assert db.get_session(sid)["ended_at"] is None
         db.close()
@@ -561,3 +625,39 @@ class TestTickIntegration:
         assert count == 0
         reap.assert_called_once_with()
         get_due_jobs.assert_not_called()
+
+
+class TestStartupIntegration:
+    def test_restart_reaps_before_first_tick(self, hermes_env):
+        """Startup recovers a crash leftover even when scheduling never ticks."""
+        import cron.scheduler as sched
+        from cron.scheduler_provider import InProcessCronScheduler
+        from hermes_state import SessionDB
+
+        sid = "cron_crash_leftover_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+        _write_lease(
+            hermes_env,
+            sid,
+            owner_pid=99999,
+            owner_start_time=11111,
+            heartbeat_at=time.time() - 7200,
+        )
+
+        stop = threading.Event()
+        stop.set()
+        with patch("gateway.status._pid_exists", return_value=False), patch.object(
+            sched, "_cron_local_host_id", return_value="testhost"
+        ), patch.object(sched, "tick") as tick, patch(
+            "cron.jobs.record_ticker_heartbeat"
+        ):
+            InProcessCronScheduler().start(stop)
+
+        tick.assert_not_called()
+        db = SessionDB()
+        session = db.get_session(sid)
+        assert session["end_reason"] == "stale_reaped"
+        assert session["ended_at"] is not None
+        db.close()

--- a/tests/cron/test_cron_stale_session_reaper.py
+++ b/tests/cron/test_cron_stale_session_reaper.py
@@ -1,0 +1,688 @@
+"""Tests for the cron stale-session reaper (fail-closed owner-lease design).
+
+Covers the ownership-lease + reaper salvaged from PR #62663:
+
+* Active local owner > threshold is preserved.
+* Stale dead owner is reaped.
+* PID reuse / start-time mismatch handled as dead only after stale heartbeat.
+* Fresh heartbeat preserved even if PID probe says dead.
+* Missing / malformed ownerless leases are reaped after the grace window.
+* Another current process's active session preserved.
+* Lease cleanup ordering on end_session failure.
+* No duplicate final assistant message (regression).
+
+Process probes are mocked deterministically — never depend on actual process death.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+import os
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def hermes_env(tmp_path, monkeypatch):
+    """Isolate HERMES_HOME for each test so state.db + leases are fresh."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "cron").mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    # Reload modules that cache get_hermes_home() at import time.
+    import hermes_constants
+    importlib.reload(hermes_constants)
+    import hermes_state
+    importlib.reload(hermes_state)
+    import cron.scheduler
+    importlib.reload(cron.scheduler)
+
+    return home
+
+
+def _make_old_cron_session(db, session_id, age_seconds=7200):
+    """Create a cron session and backdate its started_at."""
+    db.create_session(session_id, source="cron")
+    db._execute_write(lambda conn: conn.execute(
+        "UPDATE sessions SET started_at = ? WHERE id = ?",
+        (time.time() - age_seconds, session_id),
+    ))
+
+
+_UNSET = object()
+
+
+def _write_lease(home, session_id, *, job_id="test_job", owner_pid=None,
+                 owner_start_time=_UNSET, host=None, heartbeat_at=None,
+                 raw=None):
+    """Write a lease sidecar for *session_id*.  Returns the lease path.
+
+    Pass ``owner_start_time=None`` to explicitly omit the field (simulate a
+    lease missing the start-time fingerprint); omit the kwarg entirely to get
+    the default (99999).
+    """
+    if owner_pid is None:
+        owner_pid = os.getpid()
+    if owner_start_time is _UNSET:
+        owner_start_time = 99999
+    if host is None:
+        host = "testhost"
+    if heartbeat_at is None:
+        heartbeat_at = time.time() - 7200  # stale by default
+    lease_dir = home / "cron" / "cron_session_leases"
+    lease_dir.mkdir(parents=True, exist_ok=True)
+    digest = hashlib.sha256(session_id.encode("utf-8")).hexdigest()
+    path = lease_dir / f"{digest}.json"
+    if raw is not None:
+        path.write_text(raw, encoding="utf-8")
+    else:
+        payload = {
+            "session_id": session_id,
+            "job_id": job_id,
+            "owner_pid": owner_pid,
+            "owner_start_time": owner_start_time,
+            "host": host,
+            "heartbeat_at": heartbeat_at,
+        }
+        path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Reaper — fail-closed scenarios
+# ---------------------------------------------------------------------------
+
+
+class TestReaperFailClosed:
+    """_reap_stale_cron_sessions — all 9 fail-closed scenarios."""
+
+    def test_active_local_owner_preserved(self, hermes_env):
+        """Active local owner > threshold with stale heartbeat but live PID
+        + matching start-time → NOT reaped (owner is provably alive)."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_live_job_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+
+        _write_lease(hermes_env, sid, owner_pid=os.getpid(),
+                     owner_start_time=99999, heartbeat_at=time.time() - 7200)
+
+        # PID exists + start-time matches → owner alive → do not reap.
+        with patch("gateway.status._pid_exists", return_value=True), \
+             patch("gateway.status._get_process_start_time", return_value=99999), \
+             patch("cron.scheduler._cron_local_host_id", return_value="testhost"):
+            count = _reap_stale_cron_sessions()
+
+        assert count == 0
+        db = SessionDB()
+        assert db.get_session(sid)["ended_at"] is None
+        db.close()
+
+    def test_active_in_process_run_without_lease_is_preserved(self, hermes_env):
+        """An active run older than 45 minutes survives lease-write failure."""
+        import cron.scheduler as sched
+        from hermes_state import SessionDB
+
+        job_id = "live-without-lease"
+        sid = f"cron_{job_id}_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+
+        with sched._running_lock:
+            sched._running_job_ids.add(job_id)
+        try:
+            assert sched._reap_stale_cron_sessions() == 0
+        finally:
+            with sched._running_lock:
+                sched._running_job_ids.discard(job_id)
+
+        db = SessionDB()
+        try:
+            assert db.get_session(sid)["ended_at"] is None
+        finally:
+            db.close()
+
+    def test_stale_dead_owner_reaped(self, hermes_env):
+        """Stale heartbeat + owner PID does not exist → reaped."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_dead_job_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+
+        _write_lease(hermes_env, sid, owner_pid=99999,
+                     owner_start_time=11111, heartbeat_at=time.time() - 7200)
+
+        # PID does not exist → owner dead → reap.
+        with patch("gateway.status._pid_exists", return_value=False), \
+             patch("cron.scheduler._cron_local_host_id", return_value="testhost"):
+            count = _reap_stale_cron_sessions()
+
+        assert count == 1
+        db = SessionDB()
+        session = db.get_session(sid)
+        assert session["end_reason"] == "stale_reaped"
+        assert session["ended_at"] is not None
+        db.close()
+
+    def test_pid_reuse_start_time_mismatch_handled_as_dead_after_stale(self, hermes_env):
+        """Stale heartbeat + PID alive but start-time mismatch (PID reused)
+        → owner is definitively dead → reaped."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_reuse_job_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+
+        # Recorded start-time = 11111, live start-time = 22222 (different).
+        _write_lease(hermes_env, sid, owner_pid=99999,
+                     owner_start_time=11111, heartbeat_at=time.time() - 7200)
+
+        with patch("gateway.status._pid_exists", return_value=True), \
+             patch("gateway.status._get_process_start_time", return_value=22222), \
+             patch("cron.scheduler._cron_local_host_id", return_value="testhost"):
+            count = _reap_stale_cron_sessions()
+
+        assert count == 1
+        db = SessionDB()
+        assert db.get_session(sid)["end_reason"] == "stale_reaped"
+        db.close()
+
+    def test_fresh_heartbeat_preserved_even_if_pid_dead(self, hermes_env):
+        """Fresh heartbeat → NOT reaped even if PID probe says dead.
+        The run may still be progressing; a fresh heartbeat means 'alive'."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_fresh_job_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+
+        # Heartbeat is fresh (now), even though session is old.
+        _write_lease(hermes_env, sid, owner_pid=99999,
+                     owner_start_time=11111, heartbeat_at=time.time())
+
+        with patch("gateway.status._pid_exists", return_value=False), \
+             patch("cron.scheduler._cron_local_host_id", return_value="testhost"):
+            count = _reap_stale_cron_sessions()
+
+        assert count == 0
+        db = SessionDB()
+        assert db.get_session(sid)["ended_at"] is None
+        db.close()
+
+    def test_missing_lease_reaped_after_grace(self, hermes_env):
+        """A legacy session with no lease has no live ownership evidence."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_nolease_job_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+
+        assert _reap_stale_cron_sessions() == 1
+
+        db = SessionDB()
+        session = db.get_session(sid)
+        assert session["end_reason"] == "stale_reaped"
+        assert session["ended_at"] is not None
+        db.close()
+
+    def test_malformed_lease_reaped_after_grace(self, hermes_env):
+        """An unreadable legacy lease carries no live ownership evidence."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_bad_job_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+
+        _write_lease(hermes_env, sid, raw="{not valid json")
+
+        assert _reap_stale_cron_sessions() == 1
+
+        db = SessionDB()
+        session = db.get_session(sid)
+        assert session["end_reason"] == "stale_reaped"
+        assert session["ended_at"] is not None
+        db.close()
+
+    def test_null_runner_fields_reaped_after_grace(self, hermes_env):
+        """A structured but ownerless lease must not make a row immortal."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_ownerless_job_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+
+        _write_lease(
+            hermes_env,
+            sid,
+            raw=json.dumps(
+                {
+                    "session_id": sid,
+                    "job_id": "ownerless-job",
+                    "runner_pid": None,
+                    "runner_id": None,
+                    "heartbeat_at": time.time() - 7200,
+                }
+            ),
+        )
+
+        assert _reap_stale_cron_sessions() == 1
+
+        db = SessionDB()
+        session = db.get_session(sid)
+        assert session["end_reason"] == "stale_reaped"
+        assert session["ended_at"] is not None
+        db.close()
+
+    def test_mismatched_session_id_lease_preserved(self, hermes_env):
+        """A valid lease stored under the wrong session hash is untrusted."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_mismatch_job_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+        path = _write_lease(
+            hermes_env,
+            sid,
+            owner_pid=99999,
+            owner_start_time=11111,
+            heartbeat_at=time.time() - 7200,
+        )
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload["session_id"] = "different-session"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+        with patch("gateway.status._pid_exists", return_value=False), \
+             patch("cron.scheduler._cron_local_host_id", return_value="testhost"):
+            count = _reap_stale_cron_sessions()
+
+        assert count == 0
+        db = SessionDB()
+        session = db.get_session(sid)
+        assert session is not None
+        assert session["ended_at"] is None
+        db.close()
+
+    def test_cross_host_lease_preserved(self, hermes_env):
+        """Lease owned by a different host → cannot probe locally → do not reap."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_remote_job_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+
+        _write_lease(hermes_env, sid, owner_pid=99999,
+                     owner_start_time=11111, heartbeat_at=time.time() - 7200,
+                     host="other-host")
+
+        with patch("cron.scheduler._cron_local_host_id", return_value="this-host"):
+            count = _reap_stale_cron_sessions()
+
+        assert count == 0
+        db = SessionDB()
+        assert db.get_session(sid)["ended_at"] is None
+        db.close()
+
+    def test_another_process_active_session_preserved(self, hermes_env):
+        """A session whose owner is a different PID that IS alive (same host,
+        matching start-time) → do not reap."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_otherproc_job_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+
+        # Owner is pid 12345, alive, start-time matches.
+        _write_lease(hermes_env, sid, owner_pid=12345,
+                     owner_start_time=55555, heartbeat_at=time.time() - 7200)
+
+        with patch("gateway.status._pid_exists", return_value=True), \
+             patch("gateway.status._get_process_start_time", return_value=55555), \
+             patch("cron.scheduler._cron_local_host_id", return_value="testhost"):
+            count = _reap_stale_cron_sessions()
+
+        assert count == 0
+        db = SessionDB()
+        assert db.get_session(sid)["ended_at"] is None
+        db.close()
+
+    def test_active_runner_identity_preserved(self, hermes_env):
+        """New-format runner evidence fences a live owner after the grace."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_active_runner_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+        _write_lease(
+            hermes_env,
+            sid,
+            raw=json.dumps(
+                {
+                    "session_id": sid,
+                    "job_id": "active-runner",
+                    "runner_pid": 12345,
+                    "runner_id": "runner-abc",
+                    "host": "testhost",
+                    "heartbeat_at": time.time() - 7200,
+                }
+            ),
+        )
+
+        with patch("gateway.status._pid_exists", return_value=True), patch(
+            "cron.scheduler._cron_local_host_id", return_value="testhost"
+        ):
+            assert _reap_stale_cron_sessions() == 0
+
+        db = SessionDB()
+        assert db.get_session(sid)["ended_at"] is None
+        db.close()
+
+    def test_recent_session_not_reaped(self, hermes_env):
+        """A session younger than the threshold is never reaped."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_recent_job_20240101_120000"
+        db = SessionDB()
+        db.create_session(sid, source="cron")  # started_at = now
+        db.close()
+
+        _write_lease(hermes_env, sid, owner_pid=99999,
+                     owner_start_time=11111, heartbeat_at=time.time() - 7200)
+
+        with patch("gateway.status._pid_exists", return_value=False):
+            count = _reap_stale_cron_sessions()
+
+        assert count == 0
+        db = SessionDB()
+        assert db.get_session(sid)["ended_at"] is None
+        db.close()
+
+    def test_already_ended_session_not_reaped(self, hermes_env):
+        """A session already ended is a no-op for the reaper."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_done_job_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.end_session(sid, "cron_complete")
+        db.close()
+
+        _write_lease(hermes_env, sid, owner_pid=99999,
+                     owner_start_time=11111, heartbeat_at=time.time() - 7200)
+
+        with patch("gateway.status._pid_exists", return_value=False), \
+             patch("cron.scheduler._cron_local_host_id", return_value="testhost"):
+            count = _reap_stale_cron_sessions()
+
+        assert count == 0
+
+    def test_missing_start_time_fingerprint_preserved(self, hermes_env):
+        """Lease has no owner_start_time → cannot guard against PID reuse →
+        fail closed (do not reap) even if PID is alive."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_nostart_job_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+
+        _write_lease(hermes_env, sid, owner_pid=99999,
+                     owner_start_time=None, heartbeat_at=time.time() - 7200)
+
+        # PID is alive, but we have no recorded start-time to compare.
+        with patch("gateway.status._pid_exists", return_value=True), \
+             patch("gateway.status._get_process_start_time", return_value=22222), \
+             patch("cron.scheduler._cron_local_host_id", return_value="testhost"):
+            count = _reap_stale_cron_sessions()
+
+        assert count == 0
+        db = SessionDB()
+        assert db.get_session(sid)["ended_at"] is None
+        db.close()
+
+    def test_probe_exception_preserves_session(self, hermes_env):
+        """A liveness-probe error is uncertainty, not proof of death."""
+        from hermes_state import SessionDB
+        from cron.scheduler import _reap_stale_cron_sessions
+
+        sid = "cron_probe_error_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+        _write_lease(
+            hermes_env,
+            sid,
+            owner_pid=99999,
+            owner_start_time=11111,
+            heartbeat_at=time.time() - 7200,
+        )
+
+        with patch("gateway.status._pid_exists", side_effect=OSError("denied")), \
+             patch("cron.scheduler._cron_local_host_id", return_value="testhost"):
+            count = _reap_stale_cron_sessions()
+
+        assert count == 0
+        db = SessionDB()
+        session = db.get_session(sid)
+        assert session is not None
+        assert session["ended_at"] is None
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Lease manager helpers
+# ---------------------------------------------------------------------------
+
+
+class TestLeaseManager:
+    """_register / _heartbeat / _remove / _read lease helpers."""
+
+    def test_lease_path_hashes_session_id(self, hermes_env):
+        from cron.scheduler import _cron_lease_path
+        import cron.scheduler as sched
+
+        with patch.object(sched, "_get_hermes_home", return_value=hermes_env):
+            path = _cron_lease_path("cron_test_20240101_120000")
+        digest = hashlib.sha256(b"cron_test_20240101_120000").hexdigest()
+        assert path.name == f"{digest}.json"
+        assert path.parent == hermes_env / "cron" / "cron_session_leases"
+
+    def test_register_then_read_roundtrip(self, hermes_env):
+        import cron.scheduler as sched
+        from cron.scheduler import _register_cron_session_lease, _read_cron_session_lease
+
+        with patch.object(sched, "_get_hermes_home", return_value=hermes_env), \
+             patch("gateway.status._get_process_start_time", return_value=12345), \
+             patch("cron.scheduler._cron_local_host_id", return_value="myhost"):
+            lease = _register_cron_session_lease("cron_x_20240101_120000", "x")
+        assert lease is not None
+        assert lease["session_id"] == "cron_x_20240101_120000"
+        assert lease["job_id"] == "x"
+        assert lease["owner_pid"] == os.getpid()
+        assert lease["owner_start_time"] == 12345
+        assert lease["host"] == "myhost"
+
+        read = _read_cron_session_lease("cron_x_20240101_120000")
+        assert read is not None
+        assert read["session_id"] == "cron_x_20240101_120000"
+
+    def test_remove_is_idempotent(self, hermes_env):
+        import cron.scheduler as sched
+        from cron.scheduler import _remove_cron_session_lease, _read_cron_session_lease
+
+        with patch.object(sched, "_get_hermes_home", return_value=hermes_env):
+            _remove_cron_session_lease("nonexistent")  # no error
+            _remove_cron_session_lease("nonexistent")  # still no error
+        assert _read_cron_session_lease("nonexistent") is None
+
+    def test_read_malformed_returns_none(self, hermes_env):
+        import cron.scheduler as sched
+        from cron.scheduler import _read_cron_session_lease
+
+        _write_lease(hermes_env, "cron_bad", raw="not json at all")
+        with patch.object(sched, "_get_hermes_home", return_value=hermes_env):
+            assert _read_cron_session_lease("cron_bad") is None
+
+    def test_heartbeat_updates_file(self, hermes_env):
+        import cron.scheduler as sched
+        from cron.scheduler import (
+            _register_cron_session_lease,
+            _heartbeat_cron_session_lease,
+            _read_cron_session_lease,
+        )
+
+        with patch.object(sched, "_get_hermes_home", return_value=hermes_env), \
+             patch("gateway.status._get_process_start_time", return_value=12345), \
+             patch("cron.scheduler._cron_local_host_id", return_value="myhost"):
+            _register_cron_session_lease("cron_hb_20240101_120000", "hb")
+            old = _read_cron_session_lease("cron_hb_20240101_120000")
+            assert old is not None
+            old_hb = old["heartbeat_at"]
+
+            time.sleep(0.01)
+            _heartbeat_cron_session_lease("cron_hb_20240101_120000")
+            new = _read_cron_session_lease("cron_hb_20240101_120000")
+            assert new is not None
+
+        # Heartbeats must retain the owner identity needed by the reaper.
+        assert new["heartbeat_at"] > old_hb
+        assert new["session_id"] == old["session_id"]
+        assert new["job_id"] == old["job_id"]
+        assert new["owner_pid"] == old["owner_pid"]
+        assert new["owner_start_time"] == old["owner_start_time"]
+        assert new["host"] == old["host"]
+
+    def test_heartbeat_updates_when_start_time_unavailable(self, hermes_env):
+        """A matching owner PID may heartbeat without a start fingerprint."""
+        import cron.scheduler as sched
+
+        sid = "cron_no_start_20240101_120000"
+        path = _write_lease(
+            hermes_env,
+            sid,
+            owner_pid=os.getpid(),
+            owner_start_time=None,
+            heartbeat_at=time.time() - 7200,
+        )
+        before = json.loads(path.read_text(encoding="utf-8"))
+        with patch.object(sched, "_get_hermes_home", return_value=hermes_env), \
+             patch("gateway.status._get_process_start_time") as start_probe:
+            sched._heartbeat_cron_session_lease(sid)
+        after = json.loads(path.read_text(encoding="utf-8"))
+        assert after["heartbeat_at"] > before["heartbeat_at"]
+        assert after["owner_start_time"] is None
+        start_probe.assert_not_called()
+
+    def test_heartbeat_does_not_refresh_replacement_owner(self, hermes_env):
+        """A stale runner must not overwrite a lease owned by another PID."""
+        import cron.scheduler as sched
+
+        sid = "cron_replaced_20240101_120000"
+        path = _write_lease(
+            hermes_env,
+            sid,
+            owner_pid=os.getpid() + 1,
+            owner_start_time=12345,
+            heartbeat_at=time.time() - 7200,
+        )
+        before = json.loads(path.read_text(encoding="utf-8"))
+        with patch.object(sched, "_get_hermes_home", return_value=hermes_env), \
+             patch("gateway.status._get_process_start_time", return_value=12345):
+            sched._heartbeat_cron_session_lease(sid)
+        after = json.loads(path.read_text(encoding="utf-8"))
+        assert after == before
+
+
+class TestTickIntegration:
+    def test_tick_reaps_before_dispatch_gate(self, hermes_env):
+        """Every acquired tick reaps, even while new dispatch is paused."""
+        import cron.scheduler as sched
+
+        lock_path = hermes_env / "cron" / ".tick.lock"
+        with patch.object(
+            sched,
+            "_get_lock_paths",
+            return_value=(lock_path.parent, lock_path),
+        ), patch.object(
+            sched, "_reap_stale_cron_sessions", return_value=0
+        ) as reap, patch.object(sched, "get_due_jobs") as get_due_jobs:
+            count = sched.tick(verbose=False, can_dispatch=lambda: False)
+
+        assert count == 0
+        reap.assert_called_once_with()
+        get_due_jobs.assert_not_called()
+
+
+class TestStartupIntegration:
+    def test_restart_reaps_before_first_tick(self, hermes_env):
+        """Startup recovers a crash leftover even when scheduling never ticks."""
+        import cron.scheduler as sched
+        from cron.scheduler_provider import InProcessCronScheduler
+        from hermes_state import SessionDB
+
+        sid = "cron_crash_leftover_20240101_120000"
+        db = SessionDB()
+        _make_old_cron_session(db, sid, age_seconds=7200)
+        db.close()
+        _write_lease(
+            hermes_env,
+            sid,
+            owner_pid=99999,
+            owner_start_time=11111,
+            heartbeat_at=time.time() - 7200,
+        )
+
+        stop = threading.Event()
+        stop.set()
+        with patch("gateway.status._pid_exists", return_value=False), patch.object(
+            sched, "_cron_local_host_id", return_value="testhost"
+        ), patch.object(sched, "tick") as tick, patch(
+            "cron.jobs.record_ticker_heartbeat"
+        ):
+            InProcessCronScheduler().start(stop)
+
+        tick.assert_not_called()
+        db = SessionDB()
+        session = db.get_session(sid)
+        assert session["end_reason"] == "stale_reaped"
+        assert session["ended_at"] is not None
+        db.close()

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -490,6 +490,120 @@ class TestRunJobSessionPersistence:
         fake_db.close.assert_called_once()
         mock_agent.close.assert_called_once()
 
+    def test_run_job_retains_lease_when_end_session_fails(self, tmp_path):
+        """The real finally path keeps the lease when DB closure fails."""
+        job = {"id": "test-job", "name": "test", "prompt": "hello"}
+        fake_db = MagicMock()
+        fake_db.get_compression_tip.side_effect = lambda session_id: session_id
+        fake_db.end_session.side_effect = RuntimeError("DB locked")
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("cron.scheduler._register_cron_session_lease", return_value={}) as register_lease, \
+             patch("cron.scheduler._remove_cron_session_lease") as remove_lease, \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent_cls.return_value.run_conversation.return_value = {
+                "final_response": "ok"
+            }
+            success, _, final_response, error = run_job(job)
+
+        assert success is True
+        assert final_response == "ok"
+        assert error is None
+        session_id = mock_agent_cls.call_args.kwargs["session_id"]
+        register_lease.assert_called_once_with(session_id, "test-job")
+        fake_db.end_session.assert_called_once_with(session_id, "cron_complete")
+        remove_lease.assert_not_called()
+
+    def test_run_job_persists_exactly_one_final_assistant_message(self, tmp_path):
+        """Cron + shared finalizer persist one durable assistant reply."""
+        from agent.turn_finalizer import finalize_turn
+        from hermes_state import SessionDB
+        from run_agent import AIAgent
+
+        job = {
+            "id": "test-job",
+            "name": "test",
+            "prompt": "hello",
+            "model": "test/model",
+        }
+        final_text = "The cron report output."
+        db_path = tmp_path / "state.db"
+        session_db = SessionDB(db_path=db_path)
+        session_ids = []
+
+        def finalize_cron_turn(agent, prompt):
+            session_ids.append(agent.session_id)
+            return finalize_turn(
+                agent,
+                final_response=final_text,
+                api_call_count=1,
+                interrupted=False,
+                failed=False,
+                messages=[{"role": "user", "content": prompt}],
+                conversation_history=[],
+                effective_task_id=agent.session_id,
+                turn_id="cron-turn",
+                user_message=prompt,
+                original_user_message=prompt,
+                _should_review_memory=False,
+                _turn_exit_reason="text_response(finish_reason=stop)",
+            )
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("cron.scheduler._open_cron_session_db", return_value=session_db), \
+             patch("cron.scheduler._register_cron_session_lease", return_value={}), \
+             patch("cron.scheduler._remove_cron_session_lease"), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("tools.mcp_tool.discover_mcp_tools", return_value=[]), \
+             patch("hermes_cli.plugins.invoke_hook", return_value=[]), \
+             patch("run_agent.OpenAI"), \
+             patch("run_agent.get_tool_definitions", return_value=[]), \
+             patch("run_agent.check_toolset_requirements", return_value={}), \
+             patch.object(AIAgent, "run_conversation", new=finalize_cron_turn), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ):
+            success, _, final_response, error = run_job(job)
+
+        assert success is True
+        assert final_response == final_text
+        assert error is None
+        assert len(session_ids) == 1
+
+        persisted_db = SessionDB(db_path=db_path)
+        try:
+            messages = persisted_db.get_messages_as_conversation(session_ids[0])
+        finally:
+            persisted_db.close()
+
+        final_assistant_messages = [
+            message
+            for message in messages
+            if message.get("role") == "assistant"
+            and message.get("content") == final_text
+        ]
+        assert len(final_assistant_messages) == 1, messages
 
     @contextlib.contextmanager
     def _run_job_patches(self, tmp_path, extra=()):
@@ -533,49 +647,6 @@ class TestRunJobSessionPersistence:
             yield fake_db, mock_agent_cls
 
 
-    def test_run_job_memory_toolset_disabled_in_cron(self, tmp_path):
-        """memory toolset must be disabled in cron sessions — issue #38129.
-
-        Cron agents are constructed with skip_memory=True, so the memory
-        backend is not initialised.  Exposing the memory tool only gives the
-        model an unbacked tool that fails at runtime with
-        "Memory is not available."  Hiding it from the schema prevents that.
-        """
-        job = {
-            "id": "memory-hide-job",
-            "name": "test",
-            "prompt": "hello",
-        }
-        with self._run_job_patches(tmp_path) as (fake_db, mock_agent_cls):
-            run_job(job)
-
-        kwargs = mock_agent_cls.call_args.kwargs
-        assert "memory" in (kwargs["disabled_toolsets"] or []), (
-            "memory toolset should be disabled in cron to match skip_memory=True"
-        )
-
-    def test_run_job_disables_memory_even_when_per_job_enables_it(self, tmp_path):
-        """Cron runs pass skip_memory=True, so memory must not be exposed.
-
-        A cron job can request the memory tool through enabled_toolsets, but
-        there is no MemoryStore injected for cron agents.  Keep memory in the
-        disabled set so AIAgent filters the unbacked tool out before the model
-        can call it and receive "Memory is not available" failures.
-        """
-        job = {
-            "id": "memory-toolset-job",
-            "name": "test",
-            "prompt": "remember what you learn",
-            "enabled_toolsets": ["memory", "file"],
-        }
-        with self._run_job_patches(tmp_path) as (fake_db, mock_agent_cls):
-            run_job(job)
-
-        kwargs = mock_agent_cls.call_args.kwargs
-        assert kwargs["skip_memory"] is True
-        assert kwargs["enabled_toolsets"] == ["memory", "file"]
-        assert "memory" in kwargs["disabled_toolsets"]
-
     def test_tick_skips_due_jobs_while_dispatch_is_paused(self, tmp_path):
         """The drain gate runs before advancing a due job's schedule."""
         from cron.scheduler import tick
@@ -588,7 +659,7 @@ class TestRunJobSessionPersistence:
             "enabled": True,
         }
         with patch("cron.scheduler.get_due_jobs", return_value=[job]), patch(
-            "cron.scheduler.advance_next_runs"
+            "cron.scheduler.advance_next_run"
         ) as advance, patch("cron.scheduler.run_one_job") as run_one:
             assert tick(verbose=False, sync=True, can_dispatch=lambda: False) == 0
 
@@ -1192,20 +1263,12 @@ class TestBuildJobPromptBumpUse:
 
         with patch("tools.skills_tool.skill_view", side_effect=_skill_view), \
              patch("tools.skill_usage.bump_use") as mock_bump:
-            _build_job_prompt({
-                "id": "cron-task",
-                "skills": ["alpha", "beta"],
-                "prompt": "go",
-            })
+            _build_job_prompt({"skills": ["alpha", "beta"], "prompt": "go"})
 
         assert mock_bump.call_count == 2
         calls = [c[0][0] for c in mock_bump.call_args_list]
         assert "alpha" in calls
         assert "beta" in calls
-        assert all(
-            call.kwargs == {"task_id": "cron-task"}
-            for call in mock_bump.call_args_list
-        )
 
 
 class TestSendMediaViaAdapter:
@@ -1281,7 +1344,7 @@ class TestParallelTick:
         ]
 
         with patch("cron.scheduler.get_due_jobs", return_value=jobs), \
-             patch("cron.scheduler.advance_next_runs"), \
+             patch("cron.scheduler.advance_next_run"), \
              patch("cron.scheduler.run_job", side_effect=mock_run_job), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._deliver_result", return_value=None), \
@@ -1326,7 +1389,7 @@ class TestParallelTick:
         ]
 
         with patch("cron.scheduler.get_due_jobs", return_value=jobs), \
-             patch("cron.scheduler.advance_next_runs"), \
+             patch("cron.scheduler.advance_next_run"), \
              patch("cron.scheduler.run_job", side_effect=mock_run_job), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._deliver_result", return_value=None), \

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -625,32 +625,54 @@ class TestRunJobSessionPersistence:
         fake_db.end_session.assert_called_once_with(session_id, "cron_complete")
         remove_lease.assert_not_called()
 
-    def test_run_job_does_not_append_duplicate_final_response(self, tmp_path):
-        """Regression for PR #62663: run_job must NOT append final_response
-        as a separate assistant message.  The shared turn finalizer
-        (agent/turn_finalizer.py:223-231) already persists the full
-        transcript — including a closing assistant message when the tail
-        isn't already assistant — via ``_persist_session``.  Appending
-        again here would duplicate the successful cron reply in the
-        session DB.
+    def test_run_job_persists_exactly_one_final_assistant_message(self, tmp_path):
+        """Cron + shared finalizer persist one durable assistant reply."""
+        from agent.turn_finalizer import finalize_turn
+        from hermes_state import SessionDB
+        from run_agent import AIAgent
 
-        This test proves the invariant: for a successful cron run with a
-        non-empty final_response, ``append_message`` is never called with
-        that final_response as an assistant message.  The turn finalizer
-        is the sole authority for transcript persistence.
-        """
         job = {
             "id": "test-job",
             "name": "test",
             "prompt": "hello",
+            "model": "test/model",
         }
-        fake_db = MagicMock()
+        final_text = "The cron report output."
+        db_path = tmp_path / "state.db"
+        session_db = SessionDB(db_path=db_path)
+        session_ids = []
+
+        def finalize_cron_turn(agent, prompt):
+            session_ids.append(agent.session_id)
+            return finalize_turn(
+                agent,
+                final_response=final_text,
+                api_call_count=1,
+                interrupted=False,
+                failed=False,
+                messages=[{"role": "user", "content": prompt}],
+                conversation_history=[],
+                effective_task_id=agent.session_id,
+                turn_id="cron-turn",
+                user_message=prompt,
+                original_user_message=prompt,
+                _should_review_memory=False,
+                _turn_exit_reason="text_response(finish_reason=stop)",
+            )
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("cron.scheduler._open_cron_session_db", return_value=session_db), \
+             patch("cron.scheduler._register_cron_session_lease", return_value={}), \
+             patch("cron.scheduler._remove_cron_session_lease"), \
              patch("hermes_cli.env_loader.load_hermes_dotenv"), \
              patch("hermes_cli.env_loader.reset_secret_source_cache"), \
-             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("tools.mcp_tool.discover_mcp_tools", return_value=[]), \
+             patch("hermes_cli.plugins.invoke_hook", return_value=[]), \
+             patch("run_agent.OpenAI"), \
+             patch("run_agent.get_tool_definitions", return_value=[]), \
+             patch("run_agent.check_toolset_requirements", return_value={}), \
+             patch.object(AIAgent, "run_conversation", new=finalize_cron_turn), \
              patch(
                  "hermes_cli.runtime_provider.resolve_runtime_provider",
                  return_value={
@@ -659,37 +681,27 @@ class TestRunJobSessionPersistence:
                      "provider": "openrouter",
                      "api_mode": "chat_completions",
                  },
-             ), \
-             patch("run_agent.AIAgent") as mock_agent_cls:
-            mock_agent = MagicMock()
-            mock_agent.run_conversation.return_value = {
-                "final_response": "The cron report output.",
-                "messages": [{"role": "user", "content": "hello"}],
-            }
-            mock_agent_cls.return_value = mock_agent
-
-            success, output, final_response, error = run_job(job)
+             ):
+            success, _, final_response, error = run_job(job)
 
         assert success is True
-        assert final_response == "The cron report output."
+        assert final_response == final_text
+        assert error is None
+        assert len(session_ids) == 1
 
-        # The turn finalizer (inside run_conversation → _persist_session)
-        # is the sole authority.  run_job must NOT call append_message
-        # with the final_response as a separate assistant message.
-        if fake_db.append_message.called:
-            for call in fake_db.append_message.call_args_list:
-                args, kwargs = call
-                # args: (session_id, role, content) — check none is an
-                # assistant message with the final_response content.
-                role = args[1] if len(args) > 1 else kwargs.get("role")
-                content = args[2] if len(args) > 2 else kwargs.get("content")
-                assert not (
-                    role == "assistant"
-                    and content == "The cron report output."
-                ), "run_job must not duplicate final_response via append_message"
+        persisted_db = SessionDB(db_path=db_path)
+        try:
+            messages = persisted_db.get_messages_as_conversation(session_ids[0])
+        finally:
+            persisted_db.close()
 
-        # end_session is still called exactly once (the finally block).
-        fake_db.end_session.assert_called_once()
+        final_assistant_messages = [
+            message
+            for message in messages
+            if message.get("role") == "assistant"
+            and message.get("content") == final_text
+        ]
+        assert len(final_assistant_messages) == 1, messages
 
     def test_run_job_suppresses_empty_turn_explainer(self, tmp_path):
         """An empty model turn becomes the '⚠️ No reply…' explainer (#34452).

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -593,6 +593,10 @@ class TestRunJobSessionPersistence:
         """The real finally path keeps the lease when DB closure fails."""
         job = {"id": "test-job", "name": "test", "prompt": "hello"}
         fake_db = MagicMock()
+        # Pin the tip lookup to None — an unconfigured MagicMock returns a
+        # truthy mock, steering the finally block down the compression-tip
+        # path so end_session("cron_complete") never fires.
+        fake_db.get_compression_tip.return_value = None
         fake_db.end_session.side_effect = RuntimeError("DB locked")
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
@@ -662,7 +666,7 @@ class TestRunJobSessionPersistence:
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
-             patch("cron.scheduler._open_cron_session_db", return_value=session_db), \
+             patch("hermes_state.SessionDB", lambda *a, **k: session_db), \
              patch("cron.scheduler._register_cron_session_lease", return_value={}), \
              patch("cron.scheduler._remove_cron_session_lease"), \
              patch("hermes_cli.env_loader.load_hermes_dotenv"), \

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -589,6 +589,303 @@ class TestRunJobSessionPersistence:
         fake_db.close.assert_called_once()
         mock_agent.close.assert_called_once()
 
+    def test_run_job_retains_lease_when_end_session_fails(self, tmp_path):
+        """The real finally path keeps the lease when DB closure fails."""
+        job = {"id": "test-job", "name": "test", "prompt": "hello"}
+        fake_db = MagicMock()
+        fake_db.end_session.side_effect = RuntimeError("DB locked")
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("cron.scheduler._register_cron_session_lease", return_value={}) as register_lease, \
+             patch("cron.scheduler._remove_cron_session_lease") as remove_lease, \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent_cls.return_value.run_conversation.return_value = {
+                "final_response": "ok"
+            }
+            success, _, final_response, error = run_job(job)
+
+        assert success is True
+        assert final_response == "ok"
+        assert error is None
+        session_id = mock_agent_cls.call_args.kwargs["session_id"]
+        register_lease.assert_called_once_with(session_id, "test-job")
+        fake_db.end_session.assert_called_once_with(session_id, "cron_complete")
+        remove_lease.assert_not_called()
+
+    def test_run_job_does_not_append_duplicate_final_response(self, tmp_path):
+        """Regression for PR #62663: run_job must NOT append final_response
+        as a separate assistant message.  The shared turn finalizer
+        (agent/turn_finalizer.py:223-231) already persists the full
+        transcript — including a closing assistant message when the tail
+        isn't already assistant — via ``_persist_session``.  Appending
+        again here would duplicate the successful cron reply in the
+        session DB.
+
+        This test proves the invariant: for a successful cron run with a
+        non-empty final_response, ``append_message`` is never called with
+        that final_response as an assistant message.  The turn finalizer
+        is the sole authority for transcript persistence.
+        """
+        job = {
+            "id": "test-job",
+            "name": "test",
+            "prompt": "hello",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {
+                "final_response": "The cron report output.",
+                "messages": [{"role": "user", "content": "hello"}],
+            }
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert final_response == "The cron report output."
+
+        # The turn finalizer (inside run_conversation → _persist_session)
+        # is the sole authority.  run_job must NOT call append_message
+        # with the final_response as a separate assistant message.
+        if fake_db.append_message.called:
+            for call in fake_db.append_message.call_args_list:
+                args, kwargs = call
+                # args: (session_id, role, content) — check none is an
+                # assistant message with the final_response content.
+                role = args[1] if len(args) > 1 else kwargs.get("role")
+                content = args[2] if len(args) > 2 else kwargs.get("content")
+                assert not (
+                    role == "assistant"
+                    and content == "The cron report output."
+                ), "run_job must not duplicate final_response via append_message"
+
+        # end_session is still called exactly once (the finally block).
+        fake_db.end_session.assert_called_once()
+
+    def test_run_job_suppresses_empty_turn_explainer(self, tmp_path):
+        """An empty model turn becomes the '⚠️ No reply…' explainer (#34452).
+        For cron, that abnormal-empty explainer must be treated as empty so it
+        is suppressed instead of delivered (Manfredi's Telegram symptom)."""
+        from run_agent import AIAgent
+        explainer = AIAgent._format_turn_completion_explanation("empty_response_exhausted")
+        assert explainer  # sanity: the explainer text exists
+        job = {"id": "test-job", "name": "test", "prompt": "hello"}
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent._format_turn_completion_explanation = (
+                AIAgent._format_turn_completion_explanation
+            )
+            mock_agent.run_conversation.return_value = {
+                "final_response": explainer,
+                "turn_exit_reason": "empty_response_exhausted",
+            }
+            mock_agent_cls.return_value = mock_agent
+            # Patch the class staticmethod the scheduler calls.
+            mock_agent_cls._format_turn_completion_explanation = (
+                AIAgent._format_turn_completion_explanation
+            )
+
+            success, output, final_response, error = run_job(job)
+
+        # The explainer is stripped to empty inside run_job; the downstream
+        # firing body (process_job) then suppresses delivery and marks the run
+        # a soft failure via its empty-response guard.  Here we assert the
+        # load-bearing transform: the "⚠️ No reply…" text never reaches delivery.
+        assert final_response == ""
+
+    def test_run_job_real_report_on_empty_reason_still_delivers(self, tmp_path):
+        """Defensive: a real report must NOT be suppressed even if the result
+        carries an abnormal turn_exit_reason — only the exact explainer text is."""
+        from run_agent import AIAgent
+        job = {"id": "test-job", "name": "test", "prompt": "hello"}
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {
+                "final_response": "Daily report: 4 PRs merged.",
+                "turn_exit_reason": "empty_response_exhausted",
+            }
+            mock_agent_cls.return_value = mock_agent
+            mock_agent_cls._format_turn_completion_explanation = (
+                AIAgent._format_turn_completion_explanation
+            )
+
+            success, output, final_response, error = run_job(job)
+
+        assert final_response == "Daily report: 4 PRs merged."
+        assert success is True
+
+    def test_run_job_titles_cron_session_from_job_not_important_hint(self, tmp_path):
+        # The cron session's first message is the injected "[IMPORTANT: …]"
+        # hint, which used to surface as the sidebar/history row label. run_job
+        # must title the session from the job (name → short prompt → id).
+        job = {
+            "id": "test-job",
+            "name": "Morning digest",
+            "prompt": "summarize my inbox",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            run_job(job)
+
+        fake_db.set_session_title.assert_called_once()
+        sid, title = fake_db.set_session_title.call_args[0]
+        assert sid.startswith("cron_test-job_")
+        assert "IMPORTANT" not in title
+        assert title.startswith("Morning digest")
+
+    def test_run_job_closes_agent_on_failure_to_prevent_fd_leak(self, tmp_path):
+        # Regression: if ``run_conversation`` raises, the ephemeral cron
+        # agent was previously leaked — over days of ticks this accumulated
+        # httpx transports and hit EMFILE / "too many open files".
+        job = {
+            "id": "failing-job",
+            "name": "failing",
+            "prompt": "hello",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.side_effect = RuntimeError("boom")
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is False
+        assert final_response == ""
+        assert "RuntimeError: boom" in error
+        mock_agent.close.assert_called_once()
+
+    def test_run_job_reaps_stale_auxiliary_clients_per_tick(self, tmp_path):
+        # Regression: auxiliary clients bound to the cron worker's dead
+        # event loop must be reaped each tick. Without this, ``_client_cache``
+        # holds onto transports whose underlying sockets can no longer be
+        # closed (their loop is gone), leaking one fd batch per cron run.
+        job = {
+            "id": "aux-clean-job",
+            "name": "aux-clean",
+            "prompt": "hello",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls, \
+             patch("agent.auxiliary_client.cleanup_stale_async_clients") as cleanup_mock:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, _output, _final_response, _error = run_job(job)
+
+        assert success is True
+        cleanup_mock.assert_called_once()
 
     @contextlib.contextmanager
     def _run_job_patches(self, tmp_path, extra=()):

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -190,6 +190,88 @@ def test_inprocess_provider_ticks_and_stops():
     assert calls[0].get("sync") is False
 
 
+def test_explicit_one_minute_cron_uses_periodic_recovery():
+    """The exact 60-second cron boundary belongs on the periodic path."""
+    from cron.scheduler_provider import (
+        _minimum_cron_interval_seconds,
+        _should_reap_stale_sessions_periodically,
+    )
+
+    schedule = "*/1 * * * *"
+    assert _minimum_cron_interval_seconds(schedule) == 60
+    assert _should_reap_stale_sessions_periodically(schedule) is True
+
+
+def test_genuine_subminute_interval_skips_periodic_recovery():
+    """Only intervals strictly below one minute use startup-only recovery."""
+    from cron.scheduler_provider import (
+        _minimum_cron_interval_seconds,
+        _should_reap_stale_sessions_periodically,
+    )
+
+    assert _minimum_cron_interval_seconds(59.999) == 59.999
+    assert _should_reap_stale_sessions_periodically(59.999) is False
+    assert _should_reap_stale_sessions_periodically(60) is True
+
+
+def test_provider_passes_reaper_cadence_to_tick():
+    """Scheduler cadence controls periodic recovery without skipping startup."""
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    def first_tick(calls, stop):
+        def _tick(*args, **kwargs):
+            calls.append(kwargs)
+            stop.set()
+            return 0
+
+        return _tick
+
+    for interval, expected in ((59.999, False), (60, True)):
+        calls = []
+        stop = threading.Event()
+        with patch("cron.scheduler._reap_stale_cron_sessions"), patch(
+            "cron.scheduler.tick", side_effect=first_tick(calls, stop)
+        ), patch("cron.jobs.record_ticker_heartbeat"):
+            InProcessCronScheduler().start(stop, interval=interval)
+
+        assert calls[0]["reap_stale_sessions"] is expected
+
+
+def test_inprocess_provider_skips_dispatch_while_draining():
+    """A drain pause keeps due work pending until dispatch is re-enabled."""
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    calls = []
+    stop = threading.Event()
+    allow_dispatch = threading.Event()
+    provider = InProcessCronScheduler()
+
+    with patch("cron.scheduler.tick", side_effect=lambda *a, **k: calls.append(k) or 0):
+        thread = threading.Thread(
+            target=provider.start,
+            args=(stop,),
+            kwargs={"interval": 0.01, "can_dispatch": allow_dispatch.is_set},
+            daemon=True,
+        )
+        thread.start()
+        time.sleep(0.05)
+        assert calls == []
+        allow_dispatch.set()
+        assert _wait_until(lambda: len(calls) >= 1), "provider never resumed dispatch"
+        stop.set()
+        thread.join(timeout=5)
+
+    assert not thread.is_alive()
+
+
+def test_inprocess_provider_stop_is_noop():
+    """The default stop() hook is a safe no-op (the stop_event is the real
+    stop signal for the built-in)."""
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    assert InProcessCronScheduler().stop() is None
+
+
 # ── Phase 2: config key, discovery, resolver ─────────────────────────────────
 
 

--- a/tests/cron/test_sessiondb_init_hang.py
+++ b/tests/cron/test_sessiondb_init_hang.py
@@ -234,7 +234,12 @@ class TestDispatchGuardReleasedAfterHang:
 
                 n = sched.tick(verbose=False)  # sync=True by default: waits for the job
                 assert n == 1
-                assert timeouts == [0.2]
+                assert timeouts  # at least one timed init
+                # The stale-session reaper may also init SessionDB in the same
+                # tick (its hang is non-fatal by design), so assert the config
+                # value was honoured for every recorded init instead of an
+                # exact single-entry list.
+                assert all(t == 0.2 for t in timeouts)
 
                 # Without the fix this would still contain the job ID forever.
                 assert "guard-sessiondb-hang" not in sched.get_running_job_ids()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -384,6 +384,101 @@ class TestSessionLifecycle:
             """
         )
 
+    def test_end_session_after_reopen_allows_re_end(self, db):
+        """reopen_session() is the explicit escape hatch for re-ending a
+        closed session. After reopen, end_session() takes effect again.
+        """
+        db.create_session(session_id="s1", source="cli")
+        db.end_session("s1", end_reason="compression")
+        db.reopen_session("s1")
+        db.end_session("s1", end_reason="user_exit")
+
+        session = db.get_session("s1")
+        assert session["end_reason"] == "user_exit"
+
+    def test_list_open_cron_sessions_returns_only_open_cron(self, db):
+        """list_open_cron_sessions returns open (ended_at IS NULL) cron
+        sessions only, with id and started_at for reaper inspection."""
+        db.create_session("cron_open1", source="cron")
+        db.create_session("cron_open2", source="cron")
+        db.create_session("cron_done", source="cron")
+        db.end_session("cron_done", "cron_complete")
+        db.create_session("cli_open", source="cli")
+        db.create_session("cli_done", source="cli")
+        db.end_session("cli_done", "user_exit")
+
+        rows = db.list_open_cron_sessions()
+        ids = {r["id"] for r in rows}
+        assert ids == {"cron_open1", "cron_open2"}
+        for r in rows:
+            assert "started_at" in r
+
+    def test_list_open_cron_sessions_empty_when_none(self, db):
+        """Returns an empty list when no open cron sessions exist."""
+        db.create_session("cli1", source="cli")
+        db.create_session("cron1", source="cron")
+        db.end_session("cron1", "cron_complete")
+
+        assert db.list_open_cron_sessions() == []
+
+    def test_update_system_prompt(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.update_system_prompt("s1", "You are a helpful assistant.")
+
+        session = db.get_session("s1")
+        assert session["system_prompt"] == "You are a helpful assistant."
+
+    def test_update_token_counts(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.update_token_counts("s1", input_tokens=200, output_tokens=100)
+        db.update_token_counts("s1", input_tokens=100, output_tokens=50)
+
+        session = db.get_session("s1")
+        assert session["input_tokens"] == 300
+        assert session["output_tokens"] == 150
+
+    def test_update_token_counts_tracks_api_call_count(self, db):
+        """api_call_count increments with each update_token_counts call."""
+        db.create_session(session_id="s1", source="cli")
+        db.update_token_counts("s1", input_tokens=100, output_tokens=50, api_call_count=1)
+        db.update_token_counts("s1", input_tokens=100, output_tokens=50, api_call_count=1)
+        db.update_token_counts("s1", input_tokens=100, output_tokens=50, api_call_count=1)
+
+        session = db.get_session("s1")
+        assert session["api_call_count"] == 3
+
+    def test_update_token_counts_api_call_count_absolute(self, db):
+        """absolute mode sets api_call_count directly."""
+        db.create_session(session_id="s1", source="cli")
+        db.update_token_counts("s1", input_tokens=100, output_tokens=50, api_call_count=1)
+        db.update_token_counts("s1", input_tokens=300, output_tokens=150,
+                               api_call_count=5, absolute=True)
+
+        session = db.get_session("s1")
+        assert session["api_call_count"] == 5
+        assert session["input_tokens"] == 300
+
+    def test_update_token_counts_backfills_model_when_null(self, db):
+        db.create_session(session_id="s1", source="telegram")
+        db.update_token_counts("s1", input_tokens=10, output_tokens=5, model="openai/gpt-5.4")
+
+        session = db.get_session("s1")
+        assert session["model"] == "openai/gpt-5.4"
+
+    def test_first_accounted_fallback_replaces_requested_primary_route(self, db):
+        """First successful fallback usage must persist one coherent route pair."""
+        db.create_session(session_id="s1", source="cli", model="gpt-5.6-sol")
+
+        db.update_token_counts(
+            "s1",
+            input_tokens=10,
+            output_tokens=5,
+            model="glm-5.2",
+            billing_provider="custom:zai",
+            billing_base_url="https://api.z.ai/api/coding/paas/v4/",
+            api_call_count=1,
+        )
+
         peer = SessionDB(db_path=db.db_path)
         barrier = threading.Barrier(2)
         errors = []

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -509,6 +509,21 @@ class TestSessionLifecycle:
     def test_first_accounted_fallback_replaces_requested_primary_route(self, db):
         """First successful fallback usage must persist one coherent route pair."""
         db.create_session(session_id="s1", source="cli", model="gpt-5.6-sol")
+        # Local audit table + trigger: records every ended_at transition so the
+        # concurrent end_session race below can assert exactly one end wins.
+        db._conn.execute(
+            "CREATE TABLE session_end_audit (reason TEXT NOT NULL)"
+        )
+        db._conn.execute(
+            """
+            CREATE TRIGGER audit_session_end
+            AFTER UPDATE OF ended_at ON sessions
+            WHEN OLD.ended_at IS NULL AND NEW.ended_at IS NOT NULL
+            BEGIN
+                INSERT INTO session_end_audit(reason) VALUES (NEW.end_reason);
+            END
+            """
+        )
 
         db.update_token_counts(
             "s1",

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -421,6 +421,47 @@ class TestSessionLifecycle:
 
         assert db.list_open_cron_sessions() == []
 
+    def test_cron_listing_preserves_message_and_usage_persistence(self, db):
+        """The reaper query is additive to current session persistence."""
+        from agent.tool_dispatch_helpers import make_tool_result_message
+
+        session_id = "cron_schema_contract"
+        db.create_session(session_id, source="cron", model="test/model")
+        db.replace_messages(
+            session_id,
+            [
+                make_tool_result_message(
+                    "write_file",
+                    "worker detached",
+                    "call-1",
+                    effect_disposition="unknown",
+                )
+            ],
+        )
+        db.update_token_counts(
+            session_id,
+            input_tokens=12,
+            output_tokens=3,
+            model="test/model",
+            billing_provider="test-provider",
+            api_call_count=1,
+        )
+
+        assert [row["id"] for row in db.list_open_cron_sessions()] == [session_id]
+        messages = db.get_messages_as_conversation(session_id)
+        assert messages[0]["effect_disposition"] == "unknown"
+        usage = db._conn.execute(
+            "SELECT model, billing_provider, input_tokens, output_tokens "
+            "FROM session_model_usage WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+        assert dict(usage) == {
+            "model": "test/model",
+            "billing_provider": "test-provider",
+            "input_tokens": 12,
+            "output_tokens": 3,
+        }
+
     def test_update_system_prompt(self, db):
         db.create_session(session_id="s1", source="cli")
         db.update_system_prompt("s1", "You are a helpful assistant.")

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -303,6 +303,46 @@ class TestSessionLifecycle:
 
 
 
+    def test_cron_listing_preserves_message_and_usage_persistence(self, db):
+        """The reaper query is additive to current session persistence."""
+        from agent.tool_dispatch_helpers import make_tool_result_message
+
+        session_id = "cron_schema_contract"
+        db.create_session(session_id, source="cron", model="test/model")
+        db.replace_messages(
+            session_id,
+            [
+                make_tool_result_message(
+                    "write_file",
+                    "worker detached",
+                    "call-1",
+                    effect_disposition="unknown",
+                )
+            ],
+        )
+        db.update_token_counts(
+            session_id,
+            input_tokens=12,
+            output_tokens=3,
+            model="test/model",
+            billing_provider="test-provider",
+            api_call_count=1,
+        )
+
+        assert [row["id"] for row in db.list_open_cron_sessions()] == [session_id]
+        messages = db.get_messages_as_conversation(session_id)
+        assert messages[0]["effect_disposition"] == "unknown"
+        usage = db._conn.execute(
+            "SELECT model, billing_provider, input_tokens, output_tokens "
+            "FROM session_model_usage WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+        assert dict(usage) == {
+            "model": "test/model",
+            "billing_provider": "test-provider",
+            "input_tokens": 12,
+            "output_tokens": 3,
+        }
 
 
 


### PR DESCRIPTION
## Summary

Two independent fixes for cron Run History issues (#46979):

### 1. Runtime stale-session reaper (every tick, not just startup)

The startup-only `_cleanup_stale_cron_sessions()` catches sessions left open by a previous process lifecycle (SIGTERM/crash). But sessions can also get stuck in the *current* process when `run_job()`'s `end_session()` call is swallowed by a broad except clause — the broad excepts log at DEBUG and continue, leaving `ended_at IS NULL` forever.

This makes Run History unreliable (sessions appear as permanently running) and prevents the report from being visible in the Desktop cron panel.

**Fix:**
- Add `SessionDB.close_stale_cron_sessions_by_age()` — closes cron sessions whose `started_at` exceeds a threshold, leaving legitimately running jobs untouched.
- Add `_reap_stale_cron_sessions()` to `cron/scheduler.py` — called on every `tick()`, uses a 45-min threshold (well above the 600s child_timeout and typical 20-min max run time).
- Includes the startup cleanup from #55386 to make this PR self-contained.

### 2. Persist final_response as assistant message in session DB

The agent path in `run_job()` extracts `final_response` from the agent's last turn and uses it to build the output file (saved to disk) and for delivery. But it was never appended as an assistant message to the session DB.

This meant that when a user opened a cron run session in Desktop's Run History, they saw the conversation (prompt, tool calls, intermediate reasoning) but NOT the final report — making it look like the cron run produced nothing.

The no_agent path already has `_record_run()` which appends the output as an assistant message. The agent path had no equivalent.

**Fix:** Append `final_response` as an assistant message right before returning from the success path, with the same broad-except pattern used by the surrounding `end_session`/`close` calls.

## Tests

- `test_close_stale_cron_sessions_by_age_closes_old` — verifies only old cron sessions are closed, recent ones and non-cron sessions left alone
- `test_close_stale_cron_sessions_by_age_idempotent` — second call is a no-op
- All existing `test_hermes_state.py` tests pass (344 passed)

## Related

- Fixes #46979 (Run History empty for agent cron jobs)
- Supersedes #55386 (startup cleanup is included here for self-containment)
