### PR TITLE
fix: add encoding="utf-8" to write_text() with ensure_ascii=False in skills_hub

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -1052,7 +1052,7 @@ class GitHubSource(SkillSource):
         index_cache_dir.mkdir(parents=True, exist_ok=True)
         cache_file = index_cache_dir / f"{key}.json"
         try:
-            cache_file.write_text(json.dumps(data, ensure_ascii=False))
+            cache_file.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
         except OSError as e:
             logger.debug("Could not write cache: %s", e)
 
@@ -3251,7 +3251,7 @@ def _write_index_cache(key: str, data: Any) -> None:
             pass
     cache_file = index_cache_dir / f"{key}.json"
     try:
-        cache_file.write_text(json.dumps(data, ensure_ascii=False, default=str))
+        cache_file.write_text(json.dumps(data, ensure_ascii=False, default=str), encoding="utf-8")
     except OSError as e:
         logger.debug("Could not write cache: %s", e)
 


### PR DESCRIPTION
## Summary

`Path.write_text()` without `encoding=` defaults to the platform encoding — `cp1252` on Windows, `utf-8` on Linux/macOS. Two call sites in `skills_hub.py` pass `ensure_ascii=False` to `json.dumps()` (allowing non-ASCII characters through) but omit `encoding="utf-8"` on the subsequent `write_text()`. On Windows, this silently corrupts non-ASCII skill names, descriptions, and metadata into mojibake, which then fails to parse on read.

All other `write_text()` calls in the codebase already specify `encoding="utf-8"` (checked: `curator.py`, `curator_backup.py`, `skill_bundles.py`, `agent_init.py`, `skills_sync.py`, `checkpoint_manager.py`).

## Changes

| Line | Before | After |
|------|--------|-------|
| 1055 | `write_text(json.dumps(data, ensure_ascii=False))` | `..., encoding="utf-8")` |
| 3254 | `write_text(json.dumps(data, ensure_ascii=False, default=str))` | `..., encoding="utf-8")` |

## Test Plan
- [ ] `ruff check tools/skills_hub.py` passes
- [ ] Cache files with non-ASCII content survive a round-trip on Windows
