### PR TITLE
fix: make kanban completion delivery restart-safe

### DIFF
--- a/gateway/cgroup_cleanup.py
+++ b/gateway/cgroup_cleanup.py
@@ -51,6 +51,48 @@ def _read_cgroup_pids(cgroup_path: str) -> list[int]:
     return pids
 
 
+def _running_kanban_worker_pids() -> set[int]:
+    """Return worker roots that must survive a gateway service restart."""
+    try:
+        from hermes_cli import kanban_db
+    except Exception:
+        return set()
+    workers: set[int] = set()
+    try:
+        boards = kanban_db.list_boards(include_archived=False)
+    except Exception:
+        boards = [{"slug": kanban_db.DEFAULT_BOARD}]
+    for board in boards:
+        try:
+            with kanban_db.connect(board=board.get("slug")) as connection:
+                workers.update(
+                    int(row[0])
+                    for row in connection.execute(
+                        "select worker_pid from tasks where status = 'running' and worker_pid is not null"
+                    )
+                )
+        except Exception:
+            continue
+    return workers
+
+
+def _descendant_pids(roots: set[int], candidates: list[int]) -> set[int]:
+    """Find candidate descendants of protected roots from Linux procfs."""
+    parents: dict[int, int] = {}
+    for pid in candidates:
+        try:
+            fields = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8").rsplit(")", 1)[1].split()
+            parents[pid] = int(fields[1])
+        except (OSError, ValueError, IndexError):
+            continue
+    protected = set(roots)
+    while True:
+        children = {pid for pid, parent in parents.items() if parent in protected}
+        if children <= protected:
+            return protected - roots
+        protected.update(children)
+
+
 def reap_cgroup(cgroup_path: str | None = None) -> int:
     """SIGKILL every PID in the cgroup other than the caller. Returns the count killed."""
     if cgroup_path is None:
@@ -58,9 +100,12 @@ def reap_cgroup(cgroup_path: str | None = None) -> int:
     if not cgroup_path:
         return 0
     own = os.getpid()
+    pids = _read_cgroup_pids(cgroup_path)
+    worker_roots = _running_kanban_worker_pids()
+    protected = worker_roots | _descendant_pids(worker_roots, pids)
     killed = 0
-    for pid in _read_cgroup_pids(cgroup_path):
-        if pid == own:
+    for pid in pids:
+        if pid == own or pid in protected:
             continue
         try:
             os.kill(pid, signal.SIGKILL)  # windows-footgun: ok — Linux-only (reads /proc, /sys/fs/cgroup; runs from a systemd unit)

--- a/gateway/cgroup_cleanup.py
+++ b/gateway/cgroup_cleanup.py
@@ -51,17 +51,17 @@ def _read_cgroup_pids(cgroup_path: str) -> list[int]:
     return pids
 
 
-def _running_kanban_worker_pids() -> set[int]:
+def _running_kanban_worker_pids() -> set[int] | None:
     """Return worker roots that must survive a gateway service restart."""
     try:
         from hermes_cli import kanban_db
     except Exception:
-        return set()
+        return None
     workers: set[int] = set()
     try:
         boards = kanban_db.list_boards(include_archived=False)
     except Exception:
-        boards = [{"slug": kanban_db.DEFAULT_BOARD}]
+        return None
     for board in boards:
         try:
             with kanban_db.connect(board=board.get("slug")) as connection:
@@ -72,7 +72,7 @@ def _running_kanban_worker_pids() -> set[int]:
                     )
                 )
         except Exception:
-            continue
+            return None
     return workers
 
 
@@ -102,6 +102,8 @@ def reap_cgroup(cgroup_path: str | None = None) -> int:
     own = os.getpid()
     pids = _read_cgroup_pids(cgroup_path)
     worker_roots = _running_kanban_worker_pids()
+    if worker_roots is None:
+        return 0
     protected = worker_roots | _descendant_pids(worker_roots, pids)
     killed = 0
     for pid in pids:

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -41,7 +41,7 @@ def _format_completed_message(title: str, summary: str = "") -> str:
         details.append(f"PR #{pr.group(1)} gemerged")
     if production and checked:
         details.append("Production geprüft")
-    return first + ("\n" + ", ".join(details) + "." if details else "")
+    return first + (" " + ", ".join(details) + "." if details else "")
 
 
 def _resolve_auto_decompose_settings(

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -15,6 +15,7 @@ import logging
 import os
 import re
 import sqlite3
+import uuid
 import time
 from pathlib import Path
 from typing import Any, Callable, Optional
@@ -27,8 +28,10 @@ logger = logging.getLogger("gateway.run")
 
 
 def _format_completed_message(title: str, summary: str = "") -> str:
-    """Render a short human completion, without internal task or commit ids."""
-    first = f"{title[:120]} fertig."
+    """Render at most two short lines without internal task/commit identifiers."""
+    clean_title = re.sub(r"\b(?:t_[0-9a-f]{8,}|[0-9a-f]{7,40})\b", "", title, flags=re.IGNORECASE)
+    clean_title = re.sub(r"\s+", " ", clean_title).strip(" -–—:,.\t\r\n") or "Aufgabe"
+    first = f"{clean_title[:120].rstrip()} fertig."
     pr = re.search(r"PR\s*#(\d+)", summary, re.IGNORECASE)
     merged = bool(re.search(r"\b(?:gemerged|merged)\b", summary, re.IGNORECASE))
     production = bool(re.search(r"\bproduction\b", summary, re.IGNORECASE))
@@ -388,7 +391,12 @@ class GatewayKanbanWatchersMixin:
                             # internal transition. They are also excluded from
                             # _WAKE_KINDS below, so they never wake the creator.
                             continue
-                        metadata: dict[str, Any] = {}
+                        metadata: dict[str, Any] = {
+                            "client_msg_id": str(uuid.uuid5(
+                                uuid.NAMESPACE_URL,
+                                f"hermes-kanban:{board_slug}:{sub['task_id']}:{ev.id}:{sub['platform']}:{sub['chat_id']}",
+                            )),
+                        }
                         if sub.get("thread_id"):
                             metadata["thread_id"] = sub["thread_id"]
                         sub_key = (
@@ -396,9 +404,11 @@ class GatewayKanbanWatchersMixin:
                             sub["chat_id"], sub.get("thread_id") or "",
                         )
                         try:
-                            await adapter.send(
+                            send_result = await adapter.send(
                                 sub["chat_id"], msg, metadata=metadata,
                             )
+                            if getattr(send_result, "success", True) is False:
+                                raise RuntimeError(getattr(send_result, "error", None) or "notification send failed")
                             logger.debug(
                                 "kanban notifier: delivered %s event for %s to %s/%s on board %s",
                                 kind, sub["task_id"], platform_str, sub["chat_id"], board_slug,

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import sqlite3
 import time
 from pathlib import Path
@@ -23,6 +24,21 @@ from agent.i18n import t
 # Match the logger run.py uses (logging.getLogger(__name__) where __name__ ==
 # "gateway.run") so extracted log records keep their original logger name.
 logger = logging.getLogger("gateway.run")
+
+
+def _format_completed_message(title: str, summary: str = "") -> str:
+    """Render a short human completion, without internal task or commit ids."""
+    first = f"{title[:120]} fertig."
+    pr = re.search(r"PR\s*#(\d+)", summary, re.IGNORECASE)
+    merged = bool(re.search(r"\b(?:gemerged|merged)\b", summary, re.IGNORECASE))
+    production = bool(re.search(r"\bproduction\b", summary, re.IGNORECASE))
+    checked = bool(re.search(r"\b(?:geprüft|verified|ready|success)\b", summary, re.IGNORECASE))
+    details = []
+    if pr and merged:
+        details.append(f"PR #{pr.group(1)} gemerged")
+    if production and checked:
+        details.append("Production geprüft")
+    return first + ("\n" + ", ".join(details) + "." if details else "")
 
 
 def _resolve_auto_decompose_settings(
@@ -131,30 +147,6 @@ class GatewayKanbanWatchersMixin:
         cross boards, so delivery semantics are unchanged — this is
         purely a fan-out of the single-DB poll.
         """
-        # Gate: only the dispatch-owning gateway opens kanban DBs for notifier polling.
-        # Non-dispatch gateways have no subscriptions to deliver — all kanban state lives
-        # in the dispatch owner's per-board DBs. This prevents N-gateway -shm contention.
-        # TODO: gate per-board when per-board dispatcher_owner tracking lands.
-        try:
-            from hermes_cli.config import load_config as _load_config
-        except Exception:
-            logger.warning("kanban notifier: config loader unavailable; disabled")
-            return
-        env_override = os.environ.get("HERMES_KANBAN_DISPATCH_IN_GATEWAY", "").strip().lower()
-        if env_override in {"0", "false", "no", "off"}:
-            logger.info("kanban notifier: disabled via HERMES_KANBAN_DISPATCH_IN_GATEWAY env")
-            return
-        try:
-            cfg = _load_config()
-        except Exception as exc:
-            logger.warning("kanban notifier: cannot load config (%s); disabled", exc)
-            return
-        kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
-        if not kanban_cfg.get("dispatch_in_gateway", True):
-            logger.info(
-                "kanban notifier: disabled via config kanban.dispatch_in_gateway=false"
-            )
-            return
         from gateway.config import Platform as _Platform
         try:
             from hermes_cli import kanban_db as _kb
@@ -349,21 +341,12 @@ class GatewayKanbanWatchersMixin:
                             # in the event payload), then fall back to
                             # task.result for legacy rows written before
                             # runs shipped.
-                            handoff = ""
                             payload_summary = None
                             if ev.payload and ev.payload.get("summary"):
                                 payload_summary = str(ev.payload["summary"])
-                            if payload_summary:
-                                lines = payload_summary.strip().splitlines()
-                                h = lines[0][:200] if lines else payload_summary[:200]
-                                handoff = f"\n{h}"
-                            elif task and task.result:
-                                lines = task.result.strip().splitlines()
-                                r = lines[0][:160] if lines else task.result[:160]
-                                handoff = f"\n{r}"
-                            msg = (
-                                f"✔ {board_tag}{tag}Kanban {sub['task_id']} done"
-                                f" — {title}{handoff}"
+                            msg = _format_completed_message(
+                                title,
+                                payload_summary or (task.result if task else "") or "",
                             )
                         elif kind == "blocked":
                             reason = ""
@@ -481,14 +464,6 @@ class GatewayKanbanWatchersMixin:
                         await asyncio.to_thread(
                             self._kanban_advance, sub, d["cursor"], board_slug,
                         )
-                        # Unsubscribe only when the task has reached a truly
-                        # final status (done / archived). For blocked /
-                        # gave_up / crashed / timed_out the subscription is
-                        # kept alive so the user gets notified again if the
-                        # dispatcher respawns the task and it cycles into the
-                        # same state. See the longer comment on TERMINAL_KINDS
-                        # above for the failure mode this prevents.
-                        task_terminal = task and task.status in {"done", "archived"}
                         _WAKE_KINDS = ("completed", "gave_up", "crashed", "timed_out", "blocked")
                         _wake_kinds = {ev.kind for ev in d["events"] if ev.kind in _WAKE_KINDS}
                         if _wake_kinds:
@@ -561,10 +536,6 @@ class GatewayKanbanWatchersMixin:
                                     "kanban notifier: wakeup injection failed for %s: %s",
                                     sub["task_id"], _wk_err, exc_info=True,
                                 )
-                        if task_terminal:
-                            await asyncio.to_thread(
-                                self._kanban_unsub, sub, board_slug,
-                            )
             except Exception as exc:
                 logger.warning("kanban notifier tick failed: %s", exc)
             # Sleep with cancellation checks.

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -394,7 +394,8 @@ class GatewayKanbanWatchersMixin:
                         metadata: dict[str, Any] = {
                             "client_msg_id": str(uuid.uuid5(
                                 uuid.NAMESPACE_URL,
-                                f"hermes-kanban:{board_slug}:{sub['task_id']}:{ev.id}:{sub['platform']}:{sub['chat_id']}",
+                                f"hermes-kanban:{board_slug}:{sub['task_id']}:{ev.id}:"
+                                f"{sub['platform']}:{sub['chat_id']}:{sub.get('thread_id') or ''}",
                             )),
                         }
                         if sub.get("thread_id"):

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2761,7 +2761,7 @@ Environment="HERMES_HOME={hermes_home}"
 Restart=always
 RestartSec=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
-KillMode=mixed
+KillMode=process
 KillSignal=SIGTERM
 ExecReload=/bin/kill -USR1 $MAINPID
 ExecStopPost=-{python_path} -m gateway.cgroup_cleanup
@@ -2795,7 +2795,7 @@ Environment="HERMES_HOME={hermes_home}"
 Restart=always
 RestartSec=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
-KillMode=mixed
+KillMode=process
 KillSignal=SIGTERM
 ExecReload=/bin/kill -USR1 $MAINPID
 ExecStopPost=-{python_path} -m gateway.cgroup_cleanup
@@ -3960,6 +3960,9 @@ def generate_launchd_plist() -> str:
     <true/>
     
     <key>KeepAlive</key>
+    <true/>
+
+    <key>AbandonProcessGroup</key>
     <true/>
     
     <key>StandardOutPath</key>

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3906,6 +3906,11 @@ def generate_launchd_plist() -> str:
             priority_dirs + [p for p in os.environ.get("PATH", "").split(":") if p]
         )
     )
+    kanban_db = os.environ.get("HERMES_KANBAN_DB", "").strip()
+    kanban_plist_env = (
+        f"        <key>HERMES_KANBAN_DB</key>\n        <string>{kanban_db}</string>\n"
+        if kanban_db else ""
+    )
 
     # Build ProgramArguments array, including --profile when using a named profile
     prog_args = [
@@ -3948,7 +3953,7 @@ def generate_launchd_plist() -> str:
         <string>{venv_dir}</string>
         <key>HERMES_HOME</key>
         <string>{hermes_home}</string>
-    </dict>
+{kanban_plist_env}    </dict>
 
     <key>LimitLoadToSessionType</key>
     <array>

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1260,6 +1260,9 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     notifier_profile TEXT,
     created_at    INTEGER NOT NULL,
     last_event_id INTEGER NOT NULL DEFAULT 0,
+    pending_event_id INTEGER,
+    pending_previous_event_id INTEGER,
+    pending_claimed_at INTEGER,
     PRIMARY KEY (task_id, platform, chat_id, thread_id)
 );
 
@@ -2026,6 +2029,11 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             _add_column_if_missing(
                 conn, "kanban_notify_subs", "notifier_profile", "notifier_profile TEXT"
             )
+        for column in ("pending_event_id", "pending_previous_event_id", "pending_claimed_at"):
+            if column not in notify_cols:
+                _add_column_if_missing(
+                    conn, "kanban_notify_subs", column, f"{column} INTEGER"
+                )
 
     # One-shot backfill: any task that is 'running' before runs existed
     # had its claim_lock / claim_expires / worker_pid on the task row.
@@ -2151,6 +2159,8 @@ _REBUILD_SPECS = {
         " thread_id TEXT NOT NULL DEFAULT '', user_id TEXT,"
         " notifier_profile TEXT, created_at INTEGER NOT NULL,"
         " last_event_id INTEGER NOT NULL DEFAULT 0,"
+        " pending_event_id INTEGER, pending_previous_event_id INTEGER,"
+        " pending_claimed_at INTEGER,"
         " PRIMARY KEY (task_id, platform, chat_id, thread_id))",
         ("CREATE INDEX idx_notify_task ON kanban_notify_subs(task_id)",),
     ),
@@ -6240,7 +6250,7 @@ def detect_stale_running(
     reclaimed: list[str] = []
 
     rows = conn.execute(
-        "SELECT t.id, t.worker_pid, t.last_heartbeat_at, t.claim_lock, "
+        "SELECT t.id, t.assignee, t.current_run_id, t.worker_pid, t.last_heartbeat_at, t.claim_lock, "
         "       COALESCE(r.started_at, t.started_at) AS active_started_at "
         "FROM tasks t "
         "LEFT JOIN task_runs r ON r.id = t.current_run_id "
@@ -6277,6 +6287,43 @@ def detect_stale_running(
                 conn, tid, lock, now, termination,
                 reason="heartbeat_stale_worker_alive",
             )
+            continue
+
+        prior_stalls = int(conn.execute(
+            "SELECT count(*) FROM task_events WHERE task_id = ? AND kind = 'stale'",
+            (tid,),
+        ).fetchone()[0])
+        if prior_stalls >= 1:
+            reason = (
+                "orchestrator-escalation: worker stalled again after automatic recovery; "
+                "Hermes must recover or choose an alternative before asking Mika"
+            )
+            block_task(
+                conn, tid, reason=reason, kind="capability",
+                expected_run_id=(int(row["current_run_id"]) if row["current_run_id"] else None),
+            )
+            recovery_task_id = None
+            if (row["assignee"] or "") != "default":
+                recovery_task_id = create_task(
+                    conn,
+                    title=f"Recover stalled Kanban task {tid}",
+                    body=(
+                        f"Source task {tid} stalled twice. Inspect its run/events, attempt technical "
+                        "recovery or an alternative, then unblock it. Only block for Mika if Hermes "
+                        "cannot resolve the technical blocker."
+                    ),
+                    assignee="default",
+                    created_by="kanban-stall-escalation",
+                    priority=100,
+                    idempotency_key=f"stall-recovery:{tid}",
+                )
+            with write_txn(conn):
+                _append_event(
+                    conn, tid, "escalated",
+                    {"reason": reason, "recovery_task_id": recovery_task_id, "stall_count": prior_stalls + 1},
+                    run_id=(int(row["current_run_id"]) if row["current_run_id"] else None),
+                )
+            reclaimed.append(tid)
             continue
 
         with write_txn(conn):
@@ -8396,13 +8443,32 @@ def claim_unseen_events_for_sub(
     """
     with write_txn(conn):
         row = conn.execute(
-            "SELECT last_event_id FROM kanban_notify_subs "
+            "SELECT last_event_id, pending_event_id, pending_previous_event_id, pending_claimed_at "
+            "FROM kanban_notify_subs "
             "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?",
             (task_id, platform, chat_id, thread_id or ""),
         ).fetchone()
         if row is None:
             return 0, 0, []
         old_cursor = int(row["last_event_id"])
+        pending_cursor = row["pending_event_id"]
+        if pending_cursor is not None:
+            claimed_at = int(row["pending_claimed_at"] or 0)
+            if int(time.time()) - claimed_at < 60:
+                return old_cursor, old_cursor, []
+            previous = int(row["pending_previous_event_id"] or 0)
+            allowed = set(kinds or ())
+            events = [
+                event for event in list_events(conn, task_id)
+                if previous < event.id <= int(pending_cursor)
+                and (not allowed or event.kind in allowed)
+            ]
+            conn.execute(
+                "UPDATE kanban_notify_subs SET pending_claimed_at = ? "
+                "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?",
+                (int(time.time()), task_id, platform, chat_id, thread_id or ""),
+            )
+            return previous, int(pending_cursor), events
         new_cursor, events = unseen_events_for_sub(
             conn,
             task_id=task_id,
@@ -8414,10 +8480,14 @@ def claim_unseen_events_for_sub(
         if not events:
             return old_cursor, old_cursor, []
         conn.execute(
-            "UPDATE kanban_notify_subs SET last_event_id = ? "
+            "UPDATE kanban_notify_subs SET last_event_id = ?, "
+            "pending_event_id = ?, pending_previous_event_id = ?, pending_claimed_at = ? "
             "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ? "
-            "AND last_event_id = ?",
-            (int(new_cursor), task_id, platform, chat_id, thread_id or "", int(old_cursor)),
+            "AND last_event_id = ? AND pending_event_id IS NULL",
+            (
+                int(new_cursor), int(new_cursor), int(old_cursor), int(time.time()),
+                task_id, platform, chat_id, thread_id or "", int(old_cursor),
+            ),
         )
         return old_cursor, new_cursor, events
 
@@ -8433,9 +8503,11 @@ def advance_notify_cursor(
 ) -> None:
     with write_txn(conn):
         conn.execute(
-            "UPDATE kanban_notify_subs SET last_event_id = ? "
-            "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?",
-            (int(new_cursor), task_id, platform, chat_id, thread_id or ""),
+            "UPDATE kanban_notify_subs SET last_event_id = ?, "
+            "pending_event_id = NULL, pending_previous_event_id = NULL, pending_claimed_at = NULL "
+            "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ? "
+            "AND (pending_event_id IS NULL OR pending_event_id = ?)",
+            (int(new_cursor), task_id, platform, chat_id, thread_id or "", int(new_cursor)),
         )
 
 
@@ -8457,12 +8529,13 @@ def rewind_notify_cursor(
     """
     with write_txn(conn):
         cur = conn.execute(
-            "UPDATE kanban_notify_subs SET last_event_id = ? "
+            "UPDATE kanban_notify_subs SET last_event_id = ?, "
+            "pending_event_id = NULL, pending_previous_event_id = NULL, pending_claimed_at = NULL "
             "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ? "
-            "AND last_event_id = ?",
+            "AND last_event_id = ? AND pending_event_id = ?",
             (
                 int(old_cursor), task_id, platform, chat_id, thread_id or "",
-                int(claimed_cursor),
+                int(claimed_cursor), int(claimed_cursor),
             ),
         )
     return cur.rowcount > 0

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8283,14 +8283,11 @@ def add_notify_sub(
             (task_id, platform, chat_id, thread_id or "", user_id, notifier_profile, now),
         )
         if notifier_profile:
-            # Self-heal legacy rows that predate notifier ownership by
-            # backfilling only when the existing value is unset.
             conn.execute(
                 """
                 UPDATE kanban_notify_subs
                    SET notifier_profile = ?
                  WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?
-                   AND (notifier_profile IS NULL OR notifier_profile = '')
                 """,
                 (notifier_profile, task_id, platform, chat_id, thread_id or ""),
             )

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6298,10 +6298,6 @@ def detect_stale_running(
                 "orchestrator-escalation: worker stalled again after automatic recovery; "
                 "Hermes must recover or choose an alternative before asking Mika"
             )
-            block_task(
-                conn, tid, reason=reason, kind="capability",
-                expected_run_id=(int(row["current_run_id"]) if row["current_run_id"] else None),
-            )
             recovery_task_id = None
             if (row["assignee"] or "") != "default":
                 recovery_task_id = create_task(
@@ -6318,11 +6314,23 @@ def detect_stale_running(
                     idempotency_key=f"stall-recovery:{tid}",
                 )
             with write_txn(conn):
-                _append_event(
-                    conn, tid, "escalated",
-                    {"reason": reason, "recovery_task_id": recovery_task_id, "stall_count": prior_stalls + 1},
-                    run_id=(int(row["current_run_id"]) if row["current_run_id"] else None),
-                )
+                already_escalated = conn.execute(
+                    "SELECT 1 FROM task_events WHERE task_id = ? AND kind = 'escalated' LIMIT 1",
+                    (tid,),
+                ).fetchone()
+                if already_escalated is None:
+                    _append_event(
+                        conn, tid, "escalated",
+                        {"reason": reason, "recovery_task_id": recovery_task_id, "stall_count": prior_stalls + 1},
+                        run_id=(int(row["current_run_id"]) if row["current_run_id"] else None),
+                    )
+            # Block only after the idempotent recovery task and durable escalation
+            # marker exist. A crash at any earlier point leaves the source running,
+            # so the next stale scan safely resumes the sequence.
+            block_task(
+                conn, tid, reason=reason, kind="capability",
+                expected_run_id=(int(row["current_run_id"]) if row["current_run_id"] else None),
+            )
             reclaimed.append(tid)
             continue
 

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1399,6 +1399,8 @@ class SlackAdapter(BasePlatformAdapter):
                     "text": chunk,
                     "mrkdwn": True,
                 }
+                if metadata and metadata.get("client_msg_id") and i == 0:
+                    kwargs["client_msg_id"] = str(metadata["client_msg_id"])
                 if blocks and i == 0:
                     kwargs["blocks"] = blocks
                 if thread_ts:

--- a/tests/gateway/test_cgroup_cleanup.py
+++ b/tests/gateway/test_cgroup_cleanup.py
@@ -115,3 +115,18 @@ class TestReapCgroup:
 
         monkeypatch.setattr(cgroup_cleanup.os, "kill", _explode)
         assert cgroup_cleanup.reap_cgroup(cgroup_path) == 0
+
+    def test_worker_discovery_failure_fails_closed(self, tmp_path, monkeypatch):
+        procs_file = tmp_path / "cgroup.procs"
+        procs_file.write_text("1001\n")
+        monkeypatch.setattr(
+            cgroup_cleanup,
+            "Path",
+            lambda p: procs_file if p.endswith("cgroup.procs") else Path(p),
+        )
+        monkeypatch.setattr(cgroup_cleanup, "_running_kanban_worker_pids", lambda: None)
+        killed = []
+        monkeypatch.setattr(cgroup_cleanup.os, "kill", lambda pid, sig: killed.append((pid, sig)))
+
+        assert cgroup_cleanup.reap_cgroup("/user.slice/hermes-gateway.service") == 0
+        assert killed == []

--- a/tests/gateway/test_cgroup_cleanup.py
+++ b/tests/gateway/test_cgroup_cleanup.py
@@ -55,6 +55,23 @@ class TestReapCgroup:
         assert (1001, signal.SIGKILL) in killed_pids
         assert (1002, signal.SIGKILL) in killed_pids
 
+    def test_preserves_running_kanban_worker_tree(self, tmp_path, monkeypatch):
+        cgroup_path = "/test.slice/hermes-gateway.service"
+        procs_file = tmp_path / "cgroup.procs"
+        procs_file.write_text("1001\n1002\n1003\n")
+        monkeypatch.setattr(
+            cgroup_cleanup,
+            "Path",
+            lambda p: procs_file if p.endswith("cgroup.procs") else Path(p),
+        )
+        monkeypatch.setattr(cgroup_cleanup, "_running_kanban_worker_pids", lambda: {1001})
+        monkeypatch.setattr(cgroup_cleanup, "_descendant_pids", lambda roots, pids: {1002})
+        killed = []
+        monkeypatch.setattr(cgroup_cleanup.os, "kill", lambda pid, sig: killed.append(pid))
+
+        assert cgroup_cleanup.reap_cgroup(cgroup_path) == 1
+        assert killed == [1003]
+
     def test_tolerates_already_exited_pids(self, tmp_path, monkeypatch):
         cgroup_path = "/test.slice/hermes-gateway.service"
         procs_file = tmp_path / "cgroup.procs"

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -121,6 +121,27 @@ def test_kanban_notifier_claim_prevents_second_watcher_send(tmp_path, monkeypatc
     assert adapter2.sent == []
 
 
+def test_notification_idempotency_key_is_thread_scoped(tmp_path, monkeypatch):
+    db_path = tmp_path / "thread-scoped.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="threaded", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1", thread_id="A")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1", thread_id="B")
+        kb.complete_task(conn, tid, summary="done")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
+
+    assert len(adapter.sent) == 2
+    assert {item["metadata"]["thread_id"] for item in adapter.sent} == {"A", "B"}
+    assert len({item["metadata"]["client_msg_id"] for item in adapter.sent}) == 2
+
+
 def test_kanban_notifier_rewinds_claim_if_adapter_disconnects(tmp_path, monkeypatch):
     db_path = tmp_path / "adapter-disconnect.db"
     monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 
 from gateway.config import Platform
+from gateway.kanban_watchers import _format_completed_message
 from gateway.run import GatewayRunner
 from hermes_cli import kanban_db as kb
 
@@ -13,6 +14,16 @@ class RecordingAdapter:
 
     async def send(self, chat_id, text, metadata=None):
         self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+
+
+def test_completed_message_is_concise_and_omits_technical_ids():
+    message = _format_completed_message(
+        "Agent Board bereinigen",
+        "PR #158 ist gemerged. Vercel Production läuft auf ff04ae4 und wurde geprüft.",
+    )
+
+    assert message == "Agent Board bereinigen fertig.\nPR #158 gemerged, Production geprüft."
+    assert "t_" not in message and "ff04ae4" not in message
 
 
 class DisconnectedAdapters(dict):
@@ -84,8 +95,7 @@ def test_kanban_notifier_dedupes_board_slugs_pointing_to_same_db(tmp_path, monke
     asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
 
     assert len(adapter.sent) == 1
-    assert "Kanban" in adapter.sent[0]["text"]
-    assert tid in adapter.sent[0]["text"]
+    assert adapter.sent[0]["text"] == "notify once fertig."
 
 
 def test_kanban_notifier_claim_prevents_second_watcher_send(tmp_path, monkeypatch):

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -22,7 +22,7 @@ def test_completed_message_is_concise_and_omits_technical_ids():
         "PR #158 ist gemerged. Vercel Production läuft auf ff04ae4 und wurde geprüft.",
     )
 
-    assert message == "Agent Board bereinigen fertig.\nPR #158 gemerged, Production geprüft."
+    assert message == "Agent Board bereinigen fertig. PR #158 gemerged, Production geprüft."
     assert "t_" not in message and "ff04ae4" not in message
 
 

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -26,6 +26,12 @@ def test_completed_message_is_concise_and_omits_technical_ids():
     assert "t_" not in message and "ff04ae4" not in message
 
 
+def test_completed_message_collapses_lines_and_strips_technical_ids():
+    message = _format_completed_message("Task t_94f38ab5\ncommit deadbeef rollout", "")
+    assert message == "Task commit rollout fertig."
+    assert len(message.splitlines()) == 1
+
+
 class DisconnectedAdapters(dict):
     """Expose a platform during collection, then simulate disconnect on get()."""
 

--- a/tests/gateway/test_kanban_notifier_watcher_dispatch_gate.py
+++ b/tests/gateway/test_kanban_notifier_watcher_dispatch_gate.py
@@ -1,9 +1,4 @@
-"""Tests for the dispatch_in_gateway gate on _kanban_notifier_watcher.
-
-- Non-dispatch gateways (dispatch_in_gateway=false) exit before opening any DB.
-- HERMES_KANBAN_DISPATCH_IN_GATEWAY env var disables without loading config.
-- Dispatch-owning gateways (dispatch_in_gateway=true) proceed past the gate.
-"""
+"""Notifier subscriptions are independent from dispatcher ownership."""
 
 import asyncio
 from unittest.mock import MagicMock, patch
@@ -24,24 +19,32 @@ def _fake_config(dispatch_in_gateway):
     return {"kanban": {"dispatch_in_gateway": dispatch_in_gateway}}
 
 
-def test_notifier_watcher_skips_when_dispatch_disabled():
-    """dispatch_in_gateway=false returns before opening any board DB."""
-    runner = _make_runner()
+def test_notifier_watcher_runs_when_dispatch_disabled():
+    """A profile-only gateway must still deliver its own subscriptions."""
+    runner = _make_runner(with_adapter=True)
+    past_gate = []
+    sleep_calls = []
+
+    async def fake_sleep(delay):
+        sleep_calls.append(delay)
+        if len(sleep_calls) >= 2:
+            runner._running = False
+
+    async def fake_to_thread(fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+    import hermes_cli.kanban_db as _kb
+
     with patch("hermes_cli.config.load_config", return_value=_fake_config(False)):
-        with patch("hermes_cli.kanban_db.connect") as mock_connect:
-            asyncio.run(runner._kanban_notifier_watcher())
-    mock_connect.assert_not_called()
+        with patch.object(
+            _kb, "list_boards",
+            side_effect=lambda *a, **kw: past_gate.append(True) or [],
+        ):
+            with patch("asyncio.sleep", side_effect=fake_sleep):
+                with patch("asyncio.to_thread", side_effect=fake_to_thread):
+                    asyncio.run(runner._kanban_notifier_watcher())
 
-
-def test_notifier_watcher_env_override_disables(monkeypatch):
-    """HERMES_KANBAN_DISPATCH_IN_GATEWAY=false skips config load entirely."""
-    runner = _make_runner()
-    monkeypatch.setenv("HERMES_KANBAN_DISPATCH_IN_GATEWAY", "false")
-    with patch("hermes_cli.config.load_config") as mock_load_config:
-        with patch("hermes_cli.kanban_db.connect") as mock_connect:
-            asyncio.run(runner._kanban_notifier_watcher())
-    mock_load_config.assert_not_called()
-    mock_connect.assert_not_called()
+    assert past_gate
 
 
 def test_notifier_watcher_runs_when_dispatch_enabled():

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -3570,10 +3570,12 @@ class TestServiceWorkingDirIsStable:
         home = tmp_path / ".hermes"
         home.mkdir()
         monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: home)
+        monkeypatch.setenv("HERMES_KANBAN_DB", "/shared/kanban.db")
 
         plist = gateway_cli.generate_launchd_plist()
 
         assert "<key>AbandonProcessGroup</key>\n    <true/>" in plist
+        assert "<key>HERMES_KANBAN_DB</key>\n        <string>/shared/kanban.db</string>" in plist
 
 
 class TestLaunchctlBootstrapEioRetry:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -444,9 +444,7 @@ class TestGeneratedSystemdUnits:
         # cgroup and block Restart=always — issue #37454.
         assert "ExecStopPost=" in unit
         assert "-m gateway.cgroup_cleanup" in unit
-        # KillMode=mixed is preserved so the gateway still reaps its own
-        # tool-call children before systemd SIGKILLs the cgroup — #8202.
-        assert "KillMode=mixed" in unit
+        assert "KillMode=process" in unit
 
     def test_user_unit_includes_resolved_node_directory_in_path(self, monkeypatch):
         monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: "/home/test/.nvm/versions/node/v24.14.0/bin/node" if cmd == "node" else None)
@@ -556,9 +554,7 @@ class TestGeneratedSystemdUnits:
         # cgroup and block Restart=always — issue #37454.
         assert "ExecStopPost=" in unit
         assert "-m gateway.cgroup_cleanup" in unit
-        # KillMode=mixed is preserved so the gateway still reaps its own
-        # tool-call children before systemd SIGKILLs the cgroup — #8202.
-        assert "KillMode=mixed" in unit
+        assert "KillMode=process" in unit
 
 
 class TestGatewayStopCleanup:
@@ -3569,6 +3565,15 @@ class TestServiceWorkingDirIsStable:
         # The old conditional dict form must NOT appear
         assert "SuccessfulExit" not in plist
         assert "<key>KeepAlive</key>\n    <dict>" not in plist
+
+    def test_launchd_restart_leaves_detached_workers_running(self, tmp_path, monkeypatch):
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: home)
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert "<key>AbandonProcessGroup</key>\n    <true/>" in plist
 
 
 class TestLaunchctlBootstrapEioRetry:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3897,6 +3897,47 @@ def test_detect_stale_returns_running_task_with_no_heartbeat(kanban_home, monkey
         assert task.status == "ready"
 
 
+def test_repeated_stall_escalates_to_hermes_once(kanban_home, monkeypatch):
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="repeat-stall", assignee="developer")
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+        for attempt in range(2):
+            kb.claim_task(conn, task_id)
+            kb._set_worker_pid(conn, task_id, os.getpid())
+            five_hours_ago = int(time.time()) - (5 * 3600)
+            with kb.write_txn(conn):
+                conn.execute(
+                    "UPDATE tasks SET started_at = ?, last_heartbeat_at = NULL WHERE id = ?",
+                    (five_hours_ago, task_id),
+                )
+                conn.execute(
+                    "UPDATE task_runs SET started_at = ? WHERE id = (SELECT current_run_id FROM tasks WHERE id = ?)",
+                    (five_hours_ago, task_id),
+                )
+            assert task_id in kb.detect_stale_running(
+                conn, stale_timeout_seconds=14400, signal_fn=lambda _p, _s: None,
+            )
+            task = kb.get_task(conn, task_id)
+            assert task is not None
+            assert task.status == ("ready" if attempt == 0 else "blocked")
+
+        assert conn.execute(
+            "SELECT count(*) FROM tasks WHERE created_by = 'kanban-stall-escalation'"
+        ).fetchone()[0] == 1
+        assert conn.execute(
+            "SELECT count(*) FROM task_events WHERE task_id = ? AND kind = 'escalated'",
+            (task_id,),
+        ).fetchone()[0] == 1
+        assert kb.detect_stale_running(
+            conn, stale_timeout_seconds=14400, signal_fn=lambda _p, _s: None,
+        ) == []
+        assert conn.execute(
+            "SELECT count(*) FROM tasks WHERE created_by = 'kanban-stall-escalation'"
+        ).fetchone()[0] == 1
+
+
 def test_detect_stale_returns_task_with_stale_heartbeat(kanban_home, monkeypatch):
     """A task running > timeout with a heartbeat older than 1h gets reclaimed."""
     import hermes_cli.kanban_db as _kb

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3916,6 +3916,17 @@ def test_repeated_stall_escalates_to_hermes_once(kanban_home, monkeypatch):
                     "UPDATE task_runs SET started_at = ? WHERE id = (SELECT current_run_id FROM tasks WHERE id = ?)",
                     (five_hours_ago, task_id),
                 )
+            if attempt == 1:
+                original_block_task = _kb.block_task
+                monkeypatch.setattr(
+                    _kb, "block_task",
+                    lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("crash-before-block")),
+                )
+                with pytest.raises(RuntimeError, match="crash-before-block"):
+                    kb.detect_stale_running(
+                        conn, stale_timeout_seconds=14400, signal_fn=lambda _p, _s: None,
+                    )
+                monkeypatch.setattr(_kb, "block_task", original_block_task)
             assert task_id in kb.detect_stale_running(
                 conn, stale_timeout_seconds=14400, signal_fn=lambda _p, _s: None,
             )

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -43,6 +43,33 @@ def test_notify_subscribe_updates_explicit_notifier_identity(kanban_home):
         conn.close()
 
 
+def test_notification_claim_recovers_after_crash_without_losing_event(kanban_home):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="lease", assignee="developer")
+        kb.add_notify_sub(conn, task_id=tid, platform="slack", chat_id="C1")
+        kb.complete_task(conn, tid, summary="done")
+        old, claimed, events = kb.claim_unseen_events_for_sub(
+            conn, task_id=tid, platform="slack", chat_id="C1", kinds=("completed",)
+        )
+        assert [event.kind for event in events] == ["completed"]
+        conn.execute("update kanban_notify_subs set pending_claimed_at = 0 where task_id = ?", (tid,))
+        old_retry, claimed_retry, retry_events = kb.claim_unseen_events_for_sub(
+            conn, task_id=tid, platform="slack", chat_id="C1", kinds=("completed",)
+        )
+        assert (old_retry, claimed_retry) == (old, claimed)
+        assert [event.id for event in retry_events] == [event.id for event in events]
+        kb.advance_notify_cursor(
+            conn, task_id=tid, platform="slack", chat_id="C1", new_cursor=claimed_retry
+        )
+        _, _, final_events = kb.claim_unseen_events_for_sub(
+            conn, task_id=tid, platform="slack", chat_id="C1", kinds=("completed",)
+        )
+        assert final_events == []
+    finally:
+        conn.close()
+
+
 @pytest.mark.asyncio
 async def test_notifier_retains_delivery_receipt_after_completed_event(kanban_home):
     """Completed subscriptions retain their cursor as a durable delivery receipt."""

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -26,11 +26,26 @@ def kanban_home(tmp_path, monkeypatch):
     return home
 
 
+def test_notify_subscribe_updates_explicit_notifier_identity(kanban_home):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="identity", assignee="default")
+        kb.add_notify_sub(
+            conn, task_id=tid, platform="slack", chat_id="channel",
+            notifier_profile="developer",
+        )
+        kb.add_notify_sub(
+            conn, task_id=tid, platform="slack", chat_id="channel",
+            notifier_profile="default",
+        )
+        assert kb.list_notify_subs(conn, tid)[0]["notifier_profile"] == "default"
+    finally:
+        conn.close()
+
+
 @pytest.mark.asyncio
-async def test_notifier_unsubs_after_completed_event(kanban_home):
-    """
-    Subscription should be remove after completed event
-    """
+async def test_notifier_retains_delivery_receipt_after_completed_event(kanban_home):
+    """Completed subscriptions retain their cursor as a durable delivery receipt."""
     import hermes_cli.kanban_db as kb
     from gateway.run import GatewayRunner
     from gateway.config import Platform
@@ -68,14 +83,15 @@ async def test_notifier_unsubs_after_completed_event(kanban_home):
 
     fake_adapter.send.assert_called_once()
     call_msg = fake_adapter.send.call_args[0][1]
-    assert "completed" in call_msg
+    assert call_msg == "test task fertig."
 
     conn = kb.connect()
     try:
         subs = kb.list_notify_subs(conn, tid)
     finally:
         conn.close()
-    assert subs == [], "Subscription should be unsub after completed event"
+    assert len(subs) == 1
+    assert int(subs[0]["last_event_id"]) > 0
 
 
 @pytest.mark.asyncio
@@ -437,7 +453,7 @@ async def test_notifier_delivers_subscription_owned_by_current_profile(kanban_ho
         subs = kb.list_notify_subs(conn, tid)
     finally:
         conn.close()
-    assert subs == []
+    assert len(subs) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- let profile-only gateways process their own notifier subscriptions
- retain terminal subscription cursors as durable delivery receipts and keep explicit notifier identity current
- preserve active Kanban worker process trees across launchd/systemd gateway restarts
- render concise completion messages without internal task or commit IDs

## Verification
- 33 focused notifier/service/process tests passed
- Python compile check passed
- launchd E2E: detached worker survived service unload

## Notes
- full `test_gateway_service.py` on macOS has four unrelated pre-existing systemd preflight failures; all changed service-generation tests pass