### PR TITLE
fix(telegram): render MarkdownV2 on mid-stream edit-transport preview frames

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4000,6 +4000,30 @@ class TelegramAdapter(BasePlatformAdapter):
 
         try:
             if not finalize:
+                # Render streamed preview frames with the same MarkdownV2
+                # conversion the finalize edit applies, so edit-transport
+                # streaming shows formatted output instead of raw ## / ** / |
+                # markdown until the last frame -- parity with send_draft's
+                # per-frame MarkdownV2-then-plain retry.  Only a BadRequest
+                # (malformed mid-stream entities, or MarkdownV2 escapes
+                # inflating the frame past the 4096 limit) falls back to the
+                # plain frame below; flood control and network errors
+                # propagate unchanged to the original handlers.
+                try:
+                    await self._bot.edit_message_text(
+                        chat_id=normalize_telegram_chat_id(chat_id),
+                        message_id=int(message_id),
+                        text=self.format_message(content),
+                        parse_mode=ParseMode.MARKDOWN_V2,
+                    )
+                    if _saturated_preview:
+                        self._last_overflow_preview[_preview_key] = content
+                    return SendResult(success=True, message_id=message_id)
+                except Exception as mdv2_err:
+                    if "not modified" in str(mdv2_err).lower():
+                        return SendResult(success=True, message_id=message_id)
+                    if not self._is_bad_request_error(mdv2_err):
+                        raise
                 await self._bot.edit_message_text(
                     chat_id=normalize_telegram_chat_id(chat_id),
                     message_id=int(message_id),

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -873,19 +873,29 @@ async def test_send_escapes_chunk_indicator_for_markdownv2(adapter):
 
 class TestEditMessageStreamingSafety:
     @pytest.mark.asyncio
-    async def test_non_final_edit_uses_plain_text_without_markdown(self):
+    async def test_non_final_edit_formats_markdownv2_with_plain_fallback(self):
+        """Mid-stream frames render MarkdownV2 like the finalize edit does; a
+        BadRequest from malformed partial entities degrades to a plain frame
+        for that frame only (full matrix in
+        test_telegram_stream_preview_mdv2.py)."""
         adapter = TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
         adapter._bot = MagicMock()
-        adapter._bot.edit_message_text = AsyncMock()
+        bad_request = type("BadRequest", (Exception,), {})
+        adapter._bot.edit_message_text = AsyncMock(
+            side_effect=[bad_request("Bad Request: can't parse entities"), None]
+        )
 
         result = await adapter.edit_message("123", "456", "partial **bold", finalize=False)
 
         assert result.success is True
-        adapter._bot.edit_message_text.assert_awaited_once_with(
-            chat_id=123,
-            message_id=456,
-            text="partial **bold",
-        )
+        first_call = adapter._bot.edit_message_text.await_args_list[0].kwargs
+        second_call = adapter._bot.edit_message_text.await_args_list[1].kwargs
+        assert "parse_mode" in first_call
+        assert second_call == {
+            "chat_id": 123,
+            "message_id": 456,
+            "text": "partial **bold",
+        }
 
     @pytest.mark.asyncio
     async def test_final_edit_uses_markdownv2_with_plain_fallback(self):

--- a/tests/gateway/test_telegram_stream_preview_mdv2.py
+++ b/tests/gateway/test_telegram_stream_preview_mdv2.py
@@ -1,0 +1,157 @@
+"""Streamed edit-transport previews must render MarkdownV2 mid-stream.
+
+Related: #54817
+
+With ``streaming.transport: edit`` (the stable alternative to draft streaming,
+whose per-frame re-render makes the reply bubble collapse/flicker on current
+clients — #54817), ``edit_message`` used to apply MarkdownV2 formatting only on
+the ``finalize=True`` edit: every mid-stream frame was sent as raw text, so
+users watched literal ``##`` / ``**`` / ``|`` markdown until the last frame
+snapped into formatted output.
+
+``send_draft`` already converts every frame with the regular ``format_message``
++ ``ParseMode.MARKDOWN_V2`` pipeline and retries once as plain text when
+Telegram rejects malformed entities.  These tests pin the same per-frame
+contract onto the edit path:
+
+* mid-stream frames are sent formatted (``format_message`` + MarkdownV2);
+* a BadRequest (typically "can't parse entities" from a half-open entity)
+  falls back to the plain frame for that frame only;
+* "message is not modified" is a success no-op;
+* flood control and transient network errors keep their original handling.
+"""
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_telegram_mock():
+    """Install mock telegram modules so TelegramAdapter can be imported."""
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    telegram_mod = MagicMock()
+    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    telegram_mod.constants.ChatType.GROUP = "group"
+    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
+    telegram_mod.constants.ChatType.CHANNEL = "channel"
+    telegram_mod.constants.ChatType.PRIVATE = "private"
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, telegram_mod)
+
+
+_ensure_telegram_mock()
+
+from plugins.platforms.telegram import adapter as telegram_adapter  # noqa: E402
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+
+
+def _run(coro):
+    """Run a coroutine in a fresh event loop for sync-style tests."""
+    return asyncio.run(coro)
+
+
+class _BadRequest(Exception):
+    """Class name is what _is_bad_request_error keys on."""
+
+
+class _FloodError(Exception):
+    def __init__(self, message: str, retry_after: float):
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
+@pytest.fixture
+def adapter():
+    config = PlatformConfig(enabled=True, token="fake-token")
+    a = TelegramAdapter(config)
+    a._bot = MagicMock()
+    return a
+
+
+class TestMidStreamFramesRenderMarkdownV2:
+    def test_mid_stream_edit_is_formatted(self, adapter):
+        """finalize=False frames go out via format_message + MarkdownV2."""
+        adapter._bot.edit_message_text = AsyncMock()
+
+        content = "## Heading\n\n**bold** progress"
+        result = _run(
+            adapter.edit_message("12345", "7", content, finalize=False)
+        )
+
+        assert result.success
+        adapter._bot.edit_message_text.assert_awaited_once()
+        kwargs = adapter._bot.edit_message_text.await_args.kwargs
+        assert kwargs["text"] == adapter.format_message(content)
+        assert kwargs["parse_mode"] is telegram_adapter.ParseMode.MARKDOWN_V2
+
+    def test_bad_entities_fall_back_to_plain_frame(self, adapter):
+        """A rejected formatted frame degrades to plain text for that frame."""
+        calls = []
+
+        async def _edit(**kwargs):
+            calls.append(kwargs)
+            if "parse_mode" in kwargs:
+                raise _BadRequest("Bad Request: can't parse entities")
+
+        adapter._bot.edit_message_text = AsyncMock(side_effect=_edit)
+
+        content = "**unterminated bold"
+        result = _run(
+            adapter.edit_message("12345", "7", content, finalize=False)
+        )
+
+        assert result.success
+        assert len(calls) == 2
+        assert "parse_mode" in calls[0]
+        assert "parse_mode" not in calls[1]
+        assert calls[1]["text"] == content
+
+    def test_not_modified_on_formatted_frame_is_success_noop(self, adapter):
+        """'message is not modified' must not trigger the plain fallback."""
+        adapter._bot.edit_message_text = AsyncMock(
+            side_effect=_BadRequest("Bad Request: message is not modified")
+        )
+
+        result = _run(
+            adapter.edit_message("12345", "7", "same text", finalize=False)
+        )
+
+        assert result.success
+        adapter._bot.edit_message_text.assert_awaited_once()
+
+    def test_flood_control_keeps_original_handling(self, adapter):
+        """Non-BadRequest errors re-raise into the original flood handler."""
+        adapter._bot.edit_message_text = AsyncMock(
+            side_effect=_FloodError("Flood control exceeded. Retry in 30", 30.0)
+        )
+
+        result = _run(
+            adapter.edit_message("12345", "7", "some progress", finalize=False)
+        )
+
+        # Long flood waits surface as the standard retryable flood failure,
+        # exactly as before this change.
+        assert not result.success
+        assert "flood_control" in (result.error or "")
+        assert result.retry_after == 30.0
+
+    def test_finalize_path_unchanged(self, adapter):
+        """finalize=True still sends the formatted final edit."""
+        adapter._bot.edit_message_text = AsyncMock()
+
+        content = "plain final text"
+        result = _run(
+            adapter.edit_message("12345", "7", content, finalize=True)
+        )
+
+        assert result.success
+        kwargs = adapter._bot.edit_message_text.await_args.kwargs
+        assert kwargs["text"] == adapter.format_message(content)


### PR DESCRIPTION
## Problem

With `streaming.transport: edit`, `edit_message` applies MarkdownV2 formatting only on the `finalize=True` edit. Every mid-stream frame is sent as raw text, so the user watches literal `##` / `**` / `|` markdown grow for the whole response, and the bubble snaps into formatted output only at the very end.

This is the main reason to prefer draft streaming — `send_draft` already converts **every** frame with the regular `format_message` + `ParseMode.MARKDOWN_V2` pipeline (its `(True, False)` MarkdownV2-then-plain retry), precisely to avoid "the draft streams as raw text and the final send snaps into formatted output" (quoting the existing comment in `send_draft`). But draft streaming currently causes visible bubble collapse/flicker on Telegram clients (#54817), so users who switch to the edit transport to escape the flicker trade it for raw-markdown previews.

Related: #54817 (this PR does not change the `auto` transport selection — #54883 addresses that; it removes the formatting gap that made the edit transport feel worse than draft).

## Fix

Mirror `send_draft`'s per-frame contract onto the mid-stream (`not finalize`) branch of `edit_message`:

- try the formatted frame first (`format_message` + `ParseMode.MARKDOWN_V2`);
- `"message is not modified"` → success no-op (same treatment as the finalize path);
- BadRequest (typically `can't parse entities` from a half-open entity mid-stream, or MarkdownV2 escapes inflating the frame past the 4096 limit) → fall back to the original plain-text edit **for that frame only**;
- anything else (flood control `RetryAfter`, transient network errors) re-raises so the existing outer handlers keep their retry/split/backoff behavior unchanged.

The finalize path is untouched: `REQUIRES_EDIT_FINALIZE` still forces the final formatted edit, and when the last streamed frame already equals the final text Telegram answers "message is not modified", which both paths already treat as success. Rich finalize (`_try_edit_rich`) is unaffected.

## Tests

- New `tests/gateway/test_telegram_stream_preview_mdv2.py`: formatted mid-stream frame, BadRequest→plain fallback, not-modified no-op, flood control keeps original handling (`flood_control:<wait>` retryable failure), finalize unchanged.
- Updated `tests/gateway/test_telegram_format.py::TestEditMessageStreamingSafety`: the old `test_non_final_edit_uses_plain_text_without_markdown` pinned the raw-text behavior this PR removes; it now asserts the MarkdownV2-with-plain-fallback contract.
- `pytest tests/gateway/test_telegram_format.py tests/gateway/test_telegram_stream_preview_mdv2.py tests/gateway/test_telegram_final_delivery.py tests/gateway/test_telegram_progress_edit_transient.py` → 146 passed.

## Trade-offs

- One extra doomed API call per genuinely unparseable frame (rare — `format_message` escapes most partial shapes), same cost profile as `send_draft`'s retry.
- A malformed frame renders plain and the next frame returns to formatted — the draft path has the same property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)