### PR TITLE
fix(gateway): set end_reason='session_reset' on expiry finalization to prevent recovery loop

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1472,6 +1472,27 @@ class SessionStore:
                         "Session DB expiry_finalized write failed for %s: %s",
                         entry.session_id, exc,
                     )
+            # After finalization, set end_reason='session_reset' so the
+            # recovery query in find_latest_gateway_session_for_peer does
+            # NOT match this session (it only matches ended_at IS NULL OR
+            # end_reason='agent_close').  Without this, the agent cleanup
+            # path may later end the session with 'agent_close', which the
+            # recovery query treats as recoverable — causing the session to
+            # be silently resurrected with full history instead of starting
+            # a fresh session (GH #61220, #54878).
+            #
+            # reopen_session() first: if agent cleanup already ended the
+            # session with 'agent_close', end_session() would no-op
+            # (first end_reason wins). Reopening clears that, then we
+            # re-end with the correct unrecoverable reason.
+            try:
+                self._db.reopen_session(entry.session_id)
+                self._db.end_session(entry.session_id, "session_reset")
+            except Exception as exc:
+                logger.debug(
+                    "Session DB end_session write failed for %s: %s",
+                    entry.session_id, exc,
+                )
     
     def _is_session_expired(self, entry: SessionEntry) -> bool:
         """Check if a session has expired based on its reset policy.


### PR DESCRIPTION
## Problem

`set_expiry_finalized()` in `gateway/session.py` marks sessions as finalized via the `expiry_finalized` flag, but does **not** set `end_reason='session_reset'` in state.db.

The session expiry watcher triggers this. Later, when the agent is cleaned up, `run_agent.py` calls `end_session(session_id, "agent_close")`. The recovery query in `find_latest_gateway_session_for_peer` treats `agent_close` as recoverable (`ended_at IS NULL OR end_reason = 'agent_close'`).

Result: the next inbound message after a daily/idle reset triggers the #54878 stale-routing self-heal, which **reopens the expired session** with full history instead of starting a fresh session. The `_should_reset` check is bypassed during recovery, so the session lives forever (Groundhog Day loop).

## Fix

After setting `expiry_finalized`, also call `reopen_session()` + `end_session(session_id, "session_reset")` so the recovery query does **not** match the session.

`reopen_session()` is needed first because the agent cleanup may have already ended the session with `agent_close`, and `end_session()` no-ops when `ended_at IS NOT NULL` (first `end_reason` wins).

## Related

- Closes #61220
- Root cause of the stale-routing recovery loop described in #54878, #60609, #61993

## Verification

The session expiry watcher flow:
1. Expiry watcher → `set_expiry_finalized()` → now sets `end_reason='session_reset'` ✅
2. `find_latest_gateway_session_for_peer` → does NOT match (requires `agent_close` or NULL) ✅
3. Next inbound message → `_is_session_ended_in_db` → True → recovery skipped → falls through to `_should_reset` ✅
4. `_should_reset` → returns None (session already ended with `session_reset`) → fresh session created ✅