### PR TITLE
fix: classify streaming render errors (no status_code) as format_error for failover

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -741,6 +741,28 @@ def classify_api_error(
             should_fallback=True,
         )
 
+    # ── 1b. Streaming render/format errors (no status code) ────────
+    # OpenAI-compatible providers (LM Studio, llama.cpp) can raise a
+    # bare ``APIError`` with no ``status_code`` when a chat-template
+    # Jinja render fails during streaming.  These are deterministic —
+    # the provider cannot serve the request regardless of retries.
+    # Classify as ``format_error`` so the fallback chain fires instead
+    # of retrying on the same backend until max_retries.  See #62662.
+    if status_code is None and any(
+        p in error_msg
+        for p in (
+            "error rendering",
+            "rendering prompt",
+            "jinja template",
+            "jinja render",
+        )
+    ):
+        return _result(
+            FailoverReason.format_error,
+            retryable=False,
+            should_fallback=True,
+        )
+
     # ── 2. HTTP status code classification ──────────────────────────
 
     if status_code is not None:


### PR DESCRIPTION
## Summary

When an OpenAI-compatible provider (LM Studio, llama.cpp) rejects a request **during streaming** — e.g. a chat-template Jinja render exception — the OpenAI SDK raises a bare `APIError` with **no `status_code`**. The error classifier only dispatches to `_classify_400` when `status_code == 400`, so these errors fall through to generic retry-then-abandon on the same provider. The configured `fallback_providers` are never tried, and the user gets no response.

**Root cause**: streaming render errors carry `status_code=None`, bypassing the status-code dispatch entirely. They don't match any message-pattern list either (no "connection lost", "network error", etc.), so they land in the `unknown` bucket — `retryable=True`, same provider, 3 retries, then silent abandon.

**Fix**: Add a check before the status-code dispatch. When `status_code is None` and the error message contains render/template keywords (`"error rendering"`, `"rendering prompt"`, `"jinja template"`, `"jinja render"`), classify as `format_error(retryable=False, should_fallback=True)` so the fallback chain fires.

## Changes

`agent/error_classifier.py` — 22 lines added between step 1 (provider-specific patterns) and step 2 (HTTP status code classification).

## Test Plan
- [ ] `ruff check agent/error_classifier.py` passes
- [ ] A bare `APIError("Error rendering prompt with jinja template: ...")` with no `status_code` is classified as `format_error` with `should_fallback=True`

Fixes #62662
