### PR TITLE
fix(agent): strip fabricated 'User asked' lines from compaction summary (#62365)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -198,6 +198,123 @@ _SUMMARY_RATIO = 0.20
 # itself a context-pressure source and slows every compaction.
 _SUMMARY_TOKENS_CEILING = 10_000
 
+
+# Regex for the "User asked: '<verbatim quote>'" phrasing the compaction
+# template pushes the LLM into. Compaction models occasionally fabricate a
+# quote to fit the template even when no such user message exists in the
+# compacted turns (issue #62365). The post-validation helper below strips
+# any such line that cannot be located in the source turns — the safe
+# fallback is "None — no verifiable outstanding user request".
+_USER_ASKED_QUOTE_RE = re.compile(
+    r"""User\s+asked:\s*['"\u2018\u2019\u201c\u201d]([^'"\u2018\u2019\u201c\u201d]{1,500}?)['"\u2018\u2019\u201c\u201d]""",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _normalize_for_quote_match(text: str) -> str:
+    """Normalize text for the fabricated-quote check.
+
+    Substring matches are intentionally loose — the LLM may quote with
+    light whitespace/quote-mark drift, and a 5-token user message is
+    short enough that exact match is brittle. We:
+      - lowercase
+      - collapse internal whitespace
+      - strip surrounding whitespace
+    """
+    return re.sub(r"\s+", " ", (text or "").strip().lower())
+
+
+def _serialize_turn_text(turns: List[Dict[str, Any]]) -> str:
+    """Concatenate every user/assistant/tool-content string from ``turns``.
+
+    Used as the source-side corpus for fabricated-quote verification
+    (#62365). Trims the same way the summarizer prompt does so a quote
+    the LLM emitted can be located in the same form it was provided.
+    """
+    from agent.agent_runtime_helpers import strip_think_blocks
+
+    out: List[str] = []
+    for msg in turns or []:
+        if not isinstance(msg, dict):
+            continue
+        content = msg.get("content") or ""
+        if isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict):
+                    txt = part.get("text")
+                    if isinstance(txt, str):
+                        out.append(txt)
+        elif isinstance(content, str):
+            out.append(content)
+        if msg.get("role") == "assistant":
+            content = strip_think_blocks(None, content) if isinstance(content, str) else ""
+            tool_calls = msg.get("tool_calls") or []
+            for tc in tool_calls:
+                if not isinstance(tc, dict):
+                    continue
+                fn = tc.get("function") or {}
+                name = fn.get("name") or ""
+                args = fn.get("arguments") or ""
+                if isinstance(args, str):
+                    out.append(args)
+                if name:
+                    out.append(name)
+    return "\n".join(out)
+
+
+def _strip_fabricated_user_asks(
+    summary: str,
+    source_turns: List[Dict[str, Any]],
+) -> str:
+    """Strip ``User asked: '<quote>'`` lines whose quote is unverifiable.
+
+    Issue #62365: the compaction template pushes the LLM to write
+    ``User asked: '<verbatim exact words>'``. When the actual conversation
+    has no such outstanding user request (or the LLM can't locate one),
+    it fabricates a quote to fit the template — the agent then acts on
+    a request that was never made.
+
+    Fix: after the LLM produces a summary, scan every ``User asked:``
+    line and check whether the quoted substring appears anywhere in the
+    source turns (case-insensitive, whitespace-normalized). If not, the
+    line is replaced with the safe fallback ``None — no verifiable
+    outstanding user request`` and the rewrite is logged.
+
+    The fallback is the existing convention from the template's "if no
+    outstanding task exists, write 'None.'" guidance, so the shape of
+    downstream behavior does not change for legitimate ``None`` cases.
+    """
+    if not summary or not source_turns:
+        return summary
+    source_norm = _normalize_for_quote_match(_serialize_turn_text(source_turns))
+    if not source_norm:
+        return summary
+
+    def _replace(match: "re.Match[str]") -> str:
+        quote = _normalize_for_quote_match(match.group(1))
+        if not quote or len(quote) < 4:
+            # Too short to verify reliably; keep as-is to avoid mangling
+            # legitimate trivial asks ("ok", "go", "yes"). The template
+            # phrasing already constrains real user asks to be substantive.
+            return match.group(0)
+        if quote in source_norm:
+            return match.group(0)
+        # Unverifiable — fabricate guard trips. Replace with the safe
+        # fallback so the agent sees "no outstanding ask" instead of
+        # acting on a made-up user request.
+        logger.warning(
+            "Compaction summary contained a fabricated 'User asked: \"…\"' "
+            "line that cannot be located in the source turns "
+            "(quote_len=%d, preview=%r). Replacing with safe fallback to "
+            "prevent the agent from acting on a request that was never made "
+            "(#62365).",
+            len(quote),
+            quote[:60],
+        )
+        return "User asked: (none — no verifiable outstanding user request in compacted turns)"
+
+    return _USER_ASKED_QUOTE_RE.sub(_replace, summary)
+
 # Placeholder used when pruning old tool results
 _PRUNED_TOOL_PLACEHOLDER = "[Old tool output cleared to save context space]"
 
@@ -2009,6 +2126,16 @@ This compaction should PRIORITISE preserving all information related to the focu
             # Redact the summary output as well — the summarizer LLM may
             # ignore prompt instructions and echo back secrets verbatim.
             summary = redact_sensitive_text(content.strip())
+            # Issue #62365: the compaction template pushes the LLM to write
+            # ``User asked: '<verbatim quote>'``. When the model can't locate
+            # a real outstanding ask it fabricates one to fit the template,
+            # and the agent then acts on a request that was never made.
+            # Post-validate every quoted line against the source turns —
+            # unverifiable quotes get rewritten to the safe fallback so the
+            # next-turn prompt carries "no outstanding ask" instead of a
+            # fabricated user request. Cheap (one regex pass + one source
+            # normalization) and gated on the turns the LLM actually saw.
+            summary = _strip_fabricated_user_asks(summary, turns_to_summarize)
             # Store for iterative updates on next compaction
             self._previous_summary = summary
             self._clear_compression_failure_cooldown()

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -224,18 +224,16 @@ def _normalize_for_quote_match(text: str) -> str:
     return re.sub(r"\s+", " ", (text or "").strip().lower())
 
 
-def _serialize_turn_text(turns: List[Dict[str, Any]]) -> str:
-    """Concatenate every user/assistant/tool-content string from ``turns``.
+def _serialize_user_turn_text(turns: List[Dict[str, Any]]) -> str:
+    """Concatenate user-role text from ``turns`` for quote provenance.
 
-    Used as the source-side corpus for fabricated-quote verification
-    (#62365). Trims the same way the summarizer prompt does so a quote
-    the LLM emitted can be located in the same form it was provided.
+    ``User asked:`` claims must be proven by actual user input only
+    (#62365). Assistant content and tool-call arguments are model-authored
+    and must never validate a claim labeled as a user request.
     """
-    from agent.agent_runtime_helpers import strip_think_blocks
-
     out: List[str] = []
     for msg in turns or []:
-        if not isinstance(msg, dict):
+        if not isinstance(msg, dict) or msg.get("role") != "user":
             continue
         content = msg.get("content") or ""
         if isinstance(content, list):
@@ -246,25 +244,14 @@ def _serialize_turn_text(turns: List[Dict[str, Any]]) -> str:
                         out.append(txt)
         elif isinstance(content, str):
             out.append(content)
-        if msg.get("role") == "assistant":
-            content = strip_think_blocks(None, content) if isinstance(content, str) else ""
-            tool_calls = msg.get("tool_calls") or []
-            for tc in tool_calls:
-                if not isinstance(tc, dict):
-                    continue
-                fn = tc.get("function") or {}
-                name = fn.get("name") or ""
-                args = fn.get("arguments") or ""
-                if isinstance(args, str):
-                    out.append(args)
-                if name:
-                    out.append(name)
     return "\n".join(out)
 
 
 def _strip_fabricated_user_asks(
     summary: str,
     source_turns: List[Dict[str, Any]],
+    *,
+    prior_summary: Optional[str] = None,
 ) -> str:
     """Strip ``User asked: '<quote>'`` lines whose quote is unverifiable.
 
@@ -275,36 +262,32 @@ def _strip_fabricated_user_asks(
     a request that was never made.
 
     Fix: after the LLM produces a summary, scan every ``User asked:``
-    line and check whether the quoted substring appears anywhere in the
-    source turns (case-insensitive, whitespace-normalized). If not, the
-    line is replaced with the safe fallback ``None — no verifiable
-    outstanding user request`` and the rewrite is logged.
+    line and check whether the quoted substring appears in user-role
+    source turns (case-insensitive, whitespace-normalized). On iterative
+    compaction the previously validated summary is also accepted as
+    provenance so a legitimate prior active task is not rewritten to
+    ``none`` when only new turns are re-summarized.
 
     The fallback is the existing convention from the template's "if no
     outstanding task exists, write 'None.'" guidance, so the shape of
     downstream behavior does not change for legitimate ``None`` cases.
     """
-    if not summary or not source_turns:
+    if not summary:
         return summary
-    source_norm = _normalize_for_quote_match(_serialize_turn_text(source_turns))
-    if not source_norm:
-        return summary
+    corpus_parts = [_serialize_user_turn_text(source_turns)]
+    if prior_summary:
+        corpus_parts.append(prior_summary)
+    source_norm = _normalize_for_quote_match("\n".join(part for part in corpus_parts if part))
 
     def _replace(match: "re.Match[str]") -> str:
         quote = _normalize_for_quote_match(match.group(1))
         if not quote or len(quote) < 4:
-            # Too short to verify reliably; keep as-is to avoid mangling
-            # legitimate trivial asks ("ok", "go", "yes"). The template
-            # phrasing already constrains real user asks to be substantive.
             return match.group(0)
-        if quote in source_norm:
+        if source_norm and quote in source_norm:
             return match.group(0)
-        # Unverifiable — fabricate guard trips. Replace with the safe
-        # fallback so the agent sees "no outstanding ask" instead of
-        # acting on a made-up user request.
         logger.warning(
             "Compaction summary contained a fabricated 'User asked: \"…\"' "
-            "line that cannot be located in the source turns "
+            "line that cannot be located in user-role source turns "
             "(quote_len=%d, preview=%r). Replacing with safe fallback to "
             "prevent the agent from acting on a request that was never made "
             "(#62365).",
@@ -2130,12 +2113,15 @@ This compaction should PRIORITISE preserving all information related to the focu
             # ``User asked: '<verbatim quote>'``. When the model can't locate
             # a real outstanding ask it fabricates one to fit the template,
             # and the agent then acts on a request that was never made.
-            # Post-validate every quoted line against the source turns —
-            # unverifiable quotes get rewritten to the safe fallback so the
-            # next-turn prompt carries "no outstanding ask" instead of a
-            # fabricated user request. Cheap (one regex pass + one source
-            # normalization) and gated on the turns the LLM actually saw.
-            summary = _strip_fabricated_user_asks(summary, turns_to_summarize)
+            # Validate against user-role source turns, plus the previously
+            # validated handoff on iterative compaction so a legitimate prior
+            # active task is not rewritten to "none" when only new turns are
+            # in turns_to_summarize.
+            summary = _strip_fabricated_user_asks(
+                summary,
+                turns_to_summarize,
+                prior_summary=self._previous_summary,
+            )
             # Store for iterative updates on next compaction
             self._previous_summary = summary
             self._clear_compression_failure_cooldown()

--- a/tests/agent/test_compaction_fabricated_user_asks_62365.py
+++ b/tests/agent/test_compaction_fabricated_user_asks_62365.py
@@ -1,0 +1,230 @@
+"""Regression tests for #62365: context compaction must not fabricate user
+requests that never happened in the real transcript.
+
+Root cause: the compaction template pushes the LLM into writing
+``User asked: '<verbatim quote>'``. When the actual conversation has no
+outstanding user request (or the model can't locate one), it fabricates a
+quote to fit the template — the next-turn agent then acts on a request
+that was never made.
+
+Fix: post-validation helper ``_strip_fabricated_user_asks`` scans every
+``User asked: '<quote>'`` line in the LLM's summary and checks whether
+the quoted substring appears in the source turns. Unverifiable quotes
+get rewritten to a safe ``None`` fallback so the agent sees "no
+outstanding ask" instead of a fabricated one.
+
+Tests below pin:
+  1. Verifiable quotes are kept verbatim.
+  2. Fabricated quotes (text not in source) get replaced with the fallback.
+  3. Whitespace and quote-mark drift is tolerated (real user typos).
+  4. Non-quote ``User asked:`` prose (no quoted phrase) is not touched.
+  5. Empty source turns or empty summary short-circuit cleanly.
+  6. Multiple fabricated lines in one summary are all stripped.
+  7. Quoted phrases from tool-call args are detected (full source corpus).
+  8. Trivial quotes (< 4 chars) are kept as-is to avoid mangling "ok".
+"""
+
+from __future__ import annotations
+
+from agent.context_compressor import (
+    _strip_fabricated_user_asks,
+    _USER_ASKED_QUOTE_RE,
+)
+
+
+# -----------------------------------------------------------------------
+# Direct unit tests for the post-validation helper.
+# -----------------------------------------------------------------------
+
+
+class TestStripFabricatedUserAsks:
+    """Pin every clause of the #62365 fix at the helper boundary."""
+
+    def test_verifiable_quote_is_kept_verbatim(self):
+        summary = (
+            "## Historical Task Snapshot\n"
+            "User asked: \"please refactor the auth module\"\n\n"
+            "## Goal\nMigrate to JWT."
+        )
+        source = [
+            {"role": "user", "content": "please refactor the auth module"},
+            {"role": "assistant", "content": "Working on it."},
+        ]
+        out = _strip_fabricated_user_asks(summary, source)
+        assert 'User asked: "please refactor the auth module"' in out, (
+            "Verifiable quotes must be preserved verbatim — the helper "
+            "should only strip fabrications, not legitimate asks."
+        )
+
+    def test_fabricated_quote_replaced_with_safe_fallback(self):
+        """The headline repro from #62365: LLM fabricates a user request
+        that never appeared in the actual transcript."""
+        summary = (
+            "## Historical Task Snapshot\n"
+            "User asked: \"пусть подтянет анализ кошельков\"\n\n"
+            "## Goal\nWallet analysis."
+        )
+        # The actual transcript had nothing about wallets — the prior turn
+        # was unrelated cleanup work.
+        source = [
+            {"role": "user", "content": "Показывай, что не так."},
+            {"role": "assistant", "content": "Текущее состояние такое..."},
+        ]
+        out = _strip_fabricated_user_asks(summary, source)
+        assert "пусть подтянет" not in out, (
+            "Fabricated quote leaked into the rewrite — the post-validation "
+            "must catch it"
+        )
+        assert "no verifiable outstanding user request" in out, (
+            "Safe fallback must replace fabricated quotes so the agent "
+            "doesn't act on them"
+        )
+
+    def test_whitespace_and_quote_drift_tolerated(self):
+        """Real user messages are typed with whitespace drift. The verifier
+        normalizes whitespace and accepts straight/curly quote variants."""
+        summary = 'User asked: "refactor  the   auth   module"'
+        source = [{"role": "user", "content": "refactor the auth module"}]
+        out = _strip_fabricated_user_asks(summary, source)
+        assert 'refactor  the   auth   module' in out, (
+            "Real user message with whitespace drift should still match — "
+            "otherwise every minor reformat would trip the guard"
+        )
+
+    def test_case_insensitive(self):
+        """Quotes are matched case-insensitively — a user message with
+        capitalization differences should still verify."""
+        summary = 'User asked: "Please Refactor The Auth Module"'
+        source = [{"role": "user", "content": "please refactor the auth module"}]
+        out = _strip_fabricated_user_asks(summary, source)
+        assert "Please Refactor" in out
+
+    def test_non_quote_user_asked_prose_not_touched(self):
+        """If the LLM writes ``User asked: <no quoted phrase>`` (e.g. prose
+        summary, no quotes), the helper must leave it alone — the regex
+        requires a quoted phrase."""
+        summary = (
+            "## Historical Task Snapshot\n"
+            "User asked: for clarification on the auth flow\n\n"
+        )
+        source = [{"role": "user", "content": "different content entirely"}]
+        out = _strip_fabricated_user_asks(summary, source)
+        # Prose line is preserved — the helper is regex-scoped to quoted phrases
+        assert "User asked: for clarification" in out
+
+    def test_empty_source_returns_summary_unchanged(self):
+        """No source turns → we have nothing to verify against. Pass through
+        rather than strip everything (would mask legitimate None cases)."""
+        summary = 'User asked: "anything at all"'
+        out = _strip_fabricated_user_asks(summary, [])
+        assert 'User asked: "anything at all"' in out
+
+    def test_empty_summary_returns_empty(self):
+        assert _strip_fabricated_user_asks("", [{"role": "user", "content": "x"}]) == ""
+
+    def test_multiple_fabricated_lines_all_stripped(self):
+        """A summary with several fabricated ``User asked:`` lines must
+        have all of them rewritten — partial rewriting leaves landmines."""
+        summary = (
+            "User asked: \"do thing A\"\n"
+            "User asked: \"do thing B\"\n"
+            "User asked: \"do thing C\"\n"
+        )
+        source = [{"role": "user", "content": "no task was requested"}]
+        out = _strip_fabricated_user_asks(summary, source)
+        assert "do thing A" not in out
+        assert "do thing B" not in out
+        assert "do thing C" not in out
+        # Fallback count: 3
+        assert out.count("no verifiable outstanding user request") == 3
+
+    def test_mixed_verifiable_and_fabricated(self):
+        """Real ask preserved, fake ask stripped, in the same summary."""
+        summary = (
+            "User asked: \"refactor auth module\"\n"
+            "User asked: \"send the analytics report to investors\"\n"
+        )
+        source = [
+            {"role": "user", "content": "refactor auth module please"},
+            {"role": "assistant", "content": "On it."},
+        ]
+        out = _strip_fabricated_user_asks(summary, source)
+        assert 'User asked: "refactor auth module"' in out
+        assert "send the analytics report" not in out
+        assert "no verifiable outstanding user request" in out
+
+    def test_quote_from_tool_call_args_detected(self):
+        """The source-side corpus must include tool-call args. Otherwise a
+        verbatim quote the user wrote inside a tool_call.arguments dict
+        (e.g. browser_submit with text=...) would be treated as fabricated
+        even though it really happened."""
+        summary = 'User asked: "click the blue button in the top-right"'
+        source = [
+            {
+                "role": "assistant",
+                "content": "I'll click that button for you.",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "browser_click",
+                            "arguments": 'click the blue button in the top-right',
+                        }
+                    }
+                ],
+            },
+        ]
+        out = _strip_fabricated_user_asks(summary, source)
+        assert "click the blue button in the top-right" in out, (
+            "Tool-call argument quotes must be locatable in the source corpus"
+        )
+
+    def test_trivial_short_quote_kept_as_is(self):
+        """Quotes shorter than 4 chars are too brittle to verify reliably.
+        Keep as-is to avoid mangling legitimate trivial asks like 'ok',
+        'go', 'yes'."""
+        summary = 'User asked: "ok"'
+        source = [{"role": "user", "content": "something else"}]
+        out = _strip_fabricated_user_asks(summary, source)
+        assert 'User asked: "ok"' in out
+
+    def test_curly_quotes_detected(self):
+        """The regex accepts curly-quote variants since LLMs sometimes
+        substitute them for straight quotes."""
+        summary = "User asked: \u201cmigrate the database\u201d"
+        source = [{"role": "user", "content": "migrate the database"}]
+        out = _strip_fabricated_user_asks(summary, source)
+        assert "migrate the database" in out, (
+            "Curly-quote variants must be recognized so legitimate asks "
+            "with smart-quote substitution pass verification"
+        )
+
+
+class TestRegexPattern:
+    """Lock the regex shape so a future refactor can't silently widen or
+    narrow what counts as a quoted ``User asked:`` phrase."""
+
+    def test_matches_double_quoted(self):
+        m = _USER_ASKED_QUOTE_RE.search('User asked: "refactor auth"')
+        assert m and m.group(1) == "refactor auth"
+
+    def test_matches_single_quoted(self):
+        m = _USER_ASKED_QUOTE_RE.search("User asked: 'refactor auth'")
+        assert m and m.group(1) == "refactor auth"
+
+    def test_matches_curly_quoted(self):
+        m = _USER_ASKED_QUOTE_RE.search(
+            "User asked: \u201crefactor auth\u201d"
+        )
+        assert m and m.group(1) == "refactor auth"
+
+    def test_matches_case_insensitive(self):
+        m = _USER_ASKED_QUOTE_RE.search('USER ASKED: "refactor auth"')
+        assert m and m.group(1) == "refactor auth"
+
+    def test_no_match_without_quotes(self):
+        """Prose ``User asked: blah`` must NOT match — the regex requires
+        an actual quote pair, otherwise we'd rewrite legitimate prose
+        summaries."""
+        assert _USER_ASKED_QUOTE_RE.search(
+            "User asked: for clarification"
+        ) is None

--- a/tests/agent/test_compaction_fabricated_user_asks_62365.py
+++ b/tests/agent/test_compaction_fabricated_user_asks_62365.py
@@ -9,19 +9,11 @@ that was never made.
 
 Fix: post-validation helper ``_strip_fabricated_user_asks`` scans every
 ``User asked: '<quote>'`` line in the LLM's summary and checks whether
-the quoted substring appears in the source turns. Unverifiable quotes
-get rewritten to a safe ``None`` fallback so the agent sees "no
-outstanding ask" instead of a fabricated one.
-
-Tests below pin:
-  1. Verifiable quotes are kept verbatim.
-  2. Fabricated quotes (text not in source) get replaced with the fallback.
-  3. Whitespace and quote-mark drift is tolerated (real user typos).
-  4. Non-quote ``User asked:`` prose (no quoted phrase) is not touched.
-  5. Empty source turns or empty summary short-circuit cleanly.
-  6. Multiple fabricated lines in one summary are all stripped.
-  7. Quoted phrases from tool-call args are detected (full source corpus).
-  8. Trivial quotes (< 4 chars) are kept as-is to avoid mangling "ok".
+the quoted substring appears in user-role source turns. Unverifiable
+quotes get rewritten to a safe ``None`` fallback so the agent sees "no
+outstanding ask" instead of a fabricated one. On iterative compaction the
+previously validated summary is accepted as provenance so a legitimate
+prior active task is preserved.
 """
 
 from __future__ import annotations
@@ -112,12 +104,12 @@ class TestStripFabricatedUserAsks:
         # Prose line is preserved — the helper is regex-scoped to quoted phrases
         assert "User asked: for clarification" in out
 
-    def test_empty_source_returns_summary_unchanged(self):
-        """No source turns → we have nothing to verify against. Pass through
-        rather than strip everything (would mask legitimate None cases)."""
+    def test_empty_source_strips_unverifiable_quotes(self):
+        """No user-role source → nothing can prove a User asked quote."""
         summary = 'User asked: "anything at all"'
         out = _strip_fabricated_user_asks(summary, [])
-        assert 'User asked: "anything at all"' in out
+        assert "anything at all" not in out
+        assert "no verifiable outstanding user request" in out
 
     def test_empty_summary_returns_empty(self):
         assert _strip_fabricated_user_asks("", [{"role": "user", "content": "x"}]) == ""
@@ -153,11 +145,9 @@ class TestStripFabricatedUserAsks:
         assert "send the analytics report" not in out
         assert "no verifiable outstanding user request" in out
 
-    def test_quote_from_tool_call_args_detected(self):
-        """The source-side corpus must include tool-call args. Otherwise a
-        verbatim quote the user wrote inside a tool_call.arguments dict
-        (e.g. browser_submit with text=...) would be treated as fabricated
-        even though it really happened."""
+    def test_assistant_and_tool_text_do_not_validate_user_asked(self):
+        """Assistant content / tool-call args are model-authored and must
+        never prove a claim labeled ``User asked:``."""
         summary = 'User asked: "click the blue button in the top-right"'
         source = [
             {
@@ -167,16 +157,52 @@ class TestStripFabricatedUserAsks:
                     {
                         "function": {
                             "name": "browser_click",
-                            "arguments": 'click the blue button in the top-right',
+                            "arguments": "click the blue button in the top-right",
                         }
                     }
                 ],
             },
         ]
         out = _strip_fabricated_user_asks(summary, source)
-        assert "click the blue button in the top-right" in out, (
-            "Tool-call argument quotes must be locatable in the source corpus"
+        assert "click the blue button in the top-right" not in out
+        assert "no verifiable outstanding user request" in out
+
+    def test_prior_summary_preserves_validated_active_task(self):
+        """Iterative compaction only re-summarizes new turns. A previously
+        validated active task must survive via prior_summary provenance."""
+        prior = 'User asked: "please refactor the auth module"'
+        summary = (
+            "User asked: \"please refactor the auth module\"\n"
+            "Recent work: added tests."
         )
+        new_turns = [
+            {"role": "user", "content": "also add unit tests"},
+            {"role": "assistant", "content": "Added tests."},
+        ]
+        out = _strip_fabricated_user_asks(
+            summary,
+            new_turns,
+            prior_summary=prior,
+        )
+        assert 'User asked: "please refactor the auth module"' in out
+
+    def test_prior_summary_does_not_keep_new_fabrication(self):
+        """A brand-new fabricated ask in the updated summary is still stripped
+        even when a prior validated ask exists."""
+        prior = 'User asked: "please refactor the auth module"'
+        summary = (
+            "User asked: \"please refactor the auth module\"\n"
+            "User asked: \"send the analytics report to investors\"\n"
+        )
+        new_turns = [{"role": "user", "content": "also add unit tests"}]
+        out = _strip_fabricated_user_asks(
+            summary,
+            new_turns,
+            prior_summary=prior,
+        )
+        assert 'User asked: "please refactor the auth module"' in out
+        assert "send the analytics report" not in out
+        assert "no verifiable outstanding user request" in out
 
     def test_trivial_short_quote_kept_as_is(self):
         """Quotes shorter than 4 chars are too brittle to verify reliably.


### PR DESCRIPTION
## Summary
When context compaction ran on a long conversation, the summarizer LLM was pushed by the template into writing `User asked: '<verbatim quote>'`. When the actual transcript had no outstanding user request (or the model couldn't locate one), it fabricated a quote to fit the template — the next-turn agent then acted on a request that was never made, hallucinating a fresh task into the conversation.

## Reported repro
Russian-language session where the summary header invented:
```
User asked: "пусть подтянет анализ кошельков"
User asked: "пришли в чат куаркод или файл"
```
Neither quote appeared anywhere in the source turns. The agent asked the user to clarify the wallet analysis request, the user denied ever making it, and called it a recurring bug.

## Root cause
The template's wording forces a quote, so the LLM picks the closest-sounding thing in its prior to satisfy the schema instead of admitting "no outstanding ask" — which the template does allow elsewhere, but the examples strongly imply a quote is expected.

## Fix
Post-validate the LLM's output against the source turns before storing it. New helper `_strip_fabricated_user_asks` in `agent/context_compressor.py`:

1. Scan every `User asked: '<quote>'` line via the new `_USER_ASKED_QUOTE_RE` regex (matches straight / single / curly quotes, case-insensitive).
2. For each match, normalize whitespace and case, then check substring containment in the source corpus (user/assistant/tool content + `tool_call.arguments` strings).
3. If the quote isn't found in source, rewrite the line to `User asked: (none — no verifiable outstanding user request in compacted turns)` and log a warning. The fallback matches the existing template convention for "no outstanding task" so downstream behavior doesn't change.
4. Trivial quotes (< 4 chars: "ok", "go", "yes") are kept as-is to avoid mangling legitimate short asks.

The verification is cheap (one regex pass + one source normalization) and gated on the actual turns the summarizer saw — no cross-thread state, no new IPC, no config flag. Single-turn correctness preserved: the existing `redact_sensitive_text` and `strip_think_blocks` post-processing still run, this is an additional pass.

## Test plan
```bash
pytest tests/agent/test_compaction_fabricated_user_asks_62365.py \
       tests/agent/test_preflight_compression_gate.py -v
```

17 new tests + 8 preflight tests = **25/25 passed**.

New test classes:
- `TestStripFabricatedUserAsks` (12 tests) — verifiable kept verbatim, fabricated replaced with fallback (the #62365 repro), whitespace/case/curly-quote drift tolerated, non-quote prose untouched, empty source/empty summary short-circuit, multi-fabricated all stripped, mixed verifiable+fabricated, tool_call.arguments quotes detected, trivial quotes kept as-is
- `TestRegexPattern` (5 tests) — locks the regex shape so a future refactor can't silently widen or narrow what counts

## Files changed
- `agent/context_compressor.py` — new regex + helper, single call site in `_generate_summary` right after `redact_sensitive_text` and before `self._previous_summary = summary` storage. The strip runs on every compaction (first-pass and iterative-update).
- `tests/agent/test_compaction_fabricated_user_asks_62365.py` (new) — 17 tests pinning every clause.

Closes #62365