### PR TITLE
fix: persist and emit agent response during verification stop loop

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -417,17 +417,15 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
 
     Repairs applied:
       0. Consecutive ``assistant`` messages with no intervening
-         ``tool``/``user`` turn — merged into a single assistant turn
-         (union of ``tool_calls``, concatenated ``content``). Strict
-         OpenAI-compatible providers (DeepSeek v4, Moonshot/Kimi) reject
-         a history where an ``assistant`` message carrying ``tool_calls``
-         is immediately followed by another ``assistant`` message instead
-         of its ``tool`` results — HTTP 400 "An assistant message with
-         'tool_calls' must be followed by tool messages…". The split
-         shape is produced by recovery/continuation paths that append an
-         interim assistant turn (thinking-prefill, codex
-         incomplete-continuation) or by host-fed / legacy-persisted /
-         resumed histories. Refs #29148, #49147.
+         ``tool``/``user`` turn — provisional verification candidates are
+         replaced by the later assistant row for model replay; all other pairs
+         are merged into a single assistant turn (union of ``tool_calls``,
+         concatenated ``content``). Strict OpenAI-compatible providers
+         (DeepSeek v4, Moonshot/Kimi) reject a history where an ``assistant``
+         message carrying ``tool_calls`` is immediately followed by another
+         ``assistant`` message instead of its ``tool`` results — HTTP 400.
+         Recovery/continuation paths and resumed histories can produce this
+         split shape. Refs #29148, #49147, #62676.
       1. Stray ``tool`` messages whose ``tool_call_id`` doesn't match
          any preceding assistant tool_call — dropped.
       2. Consecutive ``user`` messages — merged with newline separator
@@ -468,6 +466,12 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
             or m.get("finish_reason") == "incomplete"
         )
 
+    def _is_verification_candidate(m: Dict) -> bool:
+        return m.get("finish_reason") in {
+            "verification_required",
+            "verify_hook_continue",
+        }
+
     collapsed: List[Dict] = []
     for msg in messages:
         if (
@@ -480,6 +484,15 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
             and not _is_codex_interim(collapsed[-1])
         ):
             prev = collapsed[-1]
+            # Verification candidates are durable user-visible reports, but a
+            # later assistant row supersedes them for model replay. Keeping all
+            # candidate rows in state.db preserves the transcript/event order;
+            # replacing the adjacent provisional row here prevents replay from
+            # merging stale claims into the verified final answer or correction.
+            if _is_verification_candidate(prev):
+                collapsed[-1] = msg
+                repairs += 1
+                continue
             # Union tool_calls (preserve order, both may carry them).
             prev_calls = list(prev.get("tool_calls") or [])
             new_calls = list(msg.get("tool_calls") or [])

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5486,12 +5486,12 @@ def run_conversation(
                     # post-verification response, never the full answer.
                     #
                     # The nudge stays synthetic (internal instruction, not for
-                    # display) and uses ``role="system"`` so it does not create
-                    # a durable user→assistant pair. The resulting
-                    # assistant→assistant gap in the persisted transcript
-                    # (nudge is stripped by ``_is_ephemeral_scaffolding``) is
-                    # repaired at API-call time by ``repair_message_sequence``
-                    # (Pass 0: consecutive-assistant merge). (#55733, #62657)
+                    # display) but remains a protocol-valid user continuation
+                    # for the one request that consumes it. The finalizer drops
+                    # it from live history after the turn, while persistence
+                    # skips it at every flush. Superseded candidate rows remain
+                    # durable/displayable and replay repair discards them from
+                    # model context once a later assistant response exists.
                     messages.append(final_msg)
                     agent._emit_interim_assistant_message(
                         final_msg, force_display=True
@@ -5506,7 +5506,7 @@ def run_conversation(
                             exc_info=True,
                         )
                     messages.append({
-                        "role": "system",
+                        "role": "user",
                         "content": _verify_nudge,
                         "_verification_stop_synthetic": True,
                     })
@@ -5558,9 +5558,8 @@ def run_conversation(
                 if _verify_nudge2:
                     agent._pre_verify_nudges = _attempt + 1
                     final_msg["finish_reason"] = "verify_hook_continue"
-                    # Same persist-and-surface contract as verify-on-stop
-                    # above: the attempted answer is persisted and emitted to
-                    # the UI, while only the nudge stays synthetic. (#62657)
+                    # Same one-request continuation contract as verify-on-stop:
+                    # publish the candidate, then use an ephemeral user nudge.
                     messages.append(final_msg)
                     agent._emit_interim_assistant_message(
                         final_msg, force_display=True
@@ -5575,7 +5574,7 @@ def run_conversation(
                             exc_info=True,
                         )
                     messages.append({
-                        "role": "system",
+                        "role": "user",
                         "content": _verify_nudge2,
                         "_pre_verify_synthetic": True,
                     })

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5493,7 +5493,9 @@ def run_conversation(
                     # repaired at API-call time by ``repair_message_sequence``
                     # (Pass 0: consecutive-assistant merge). (#55733, #62657)
                     messages.append(final_msg)
-                    agent._emit_interim_assistant_message(final_msg)
+                    agent._emit_interim_assistant_message(
+                        final_msg, force_display=True
+                    )
                     try:
                         agent._flush_messages_to_session_db(
                             messages, conversation_history
@@ -5560,7 +5562,9 @@ def run_conversation(
                     # above: the attempted answer is persisted and emitted to
                     # the UI, while only the nudge stays synthetic. (#62657)
                     messages.append(final_msg)
-                    agent._emit_interim_assistant_message(final_msg)
+                    agent._emit_interim_assistant_message(
+                        final_msg, force_display=True
+                    )
                     try:
                         agent._flush_messages_to_session_db(
                             messages, conversation_history

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5478,28 +5478,41 @@ def run_conversation(
                         getattr(agent, "_verification_stop_nudges", 0) + 1
                     )
                     final_msg["finish_reason"] = "verification_required"
-                    final_msg["_verification_stop_synthetic"] = True
+                    # Persist and surface the attempted answer so the user can
+                    # see it while the verification loop runs. Previously both
+                    # the answer and the nudge were flagged
+                    # ``_verification_stop_synthetic`` and suppressed from the
+                    # durable transcript — the user only saw the brief
+                    # post-verification response, never the full answer.
+                    #
+                    # The nudge stays synthetic (internal instruction, not for
+                    # display) and uses ``role="system"`` so it does not create
+                    # a durable user→assistant pair. The resulting
+                    # assistant→assistant gap in the persisted transcript
+                    # (nudge is stripped by ``_is_ephemeral_scaffolding``) is
+                    # repaired at API-call time by ``repair_message_sequence``
+                    # (Pass 0: consecutive-assistant merge). (#55733, #62657)
                     messages.append(final_msg)
-                    # Keep the attempted final answer in model history so the
-                    # synthetic user nudge preserves role alternation, but do
-                    # not surface it to the user as an interim answer. The
-                    # whole point of this guard is to prevent premature
-                    # "done" claims before checks run. Both the attempted
-                    # answer and the nudge are flagged synthetic so neither
-                    # persists — otherwise the resumed transcript keeps a
-                    # premature "done" with the nudge stripped, producing an
-                    # assistant→assistant adjacency. (#55733)
+                    agent._emit_interim_assistant_message(final_msg)
+                    try:
+                        agent._flush_messages_to_session_db(
+                            messages, conversation_history
+                        )
+                    except Exception:
+                        logger.debug(
+                            "verification-stop interim flush failed",
+                            exc_info=True,
+                        )
                     messages.append({
-                        "role": "user",
+                        "role": "system",
                         "content": _verify_nudge,
                         "_verification_stop_synthetic": True,
                     })
                     agent._session_messages = messages
-                    # Run the verification-stop loop silently — the nudge is an
-                    # internal turn that should not add noise to the user's
-                    # terminal. Keep a debug breadcrumb in agent.log for tracing.
-                    logger.debug("verification stop-loop nudge issued (attempt %d)",
-                                 agent._verification_stop_nudges)
+                    logger.debug(
+                        "verification stop-loop nudge issued (attempt %d)",
+                        agent._verification_stop_nudges,
+                    )
                     # Keep the attempted answer only as an explicit fallback for
                     # continuation-budget exhaustion.  ``final_response`` itself
                     # must be cleared so the finalizer can distinguish this gate
@@ -5543,20 +5556,30 @@ def run_conversation(
                 if _verify_nudge2:
                     agent._pre_verify_nudges = _attempt + 1
                     final_msg["finish_reason"] = "verify_hook_continue"
-                    final_msg["_pre_verify_synthetic"] = True
-                    # Same alternation contract as verify-on-stop: keep the
-                    # attempted answer in history, follow it with a synthetic
-                    # user nudge, and don't surface the premature answer. Both
-                    # are flagged synthetic so neither persists. (#55733)
+                    # Same persist-and-surface contract as verify-on-stop
+                    # above: the attempted answer is persisted and emitted to
+                    # the UI, while only the nudge stays synthetic. (#62657)
                     messages.append(final_msg)
+                    agent._emit_interim_assistant_message(final_msg)
+                    try:
+                        agent._flush_messages_to_session_db(
+                            messages, conversation_history
+                        )
+                    except Exception:
+                        logger.debug(
+                            "pre_verify interim flush failed",
+                            exc_info=True,
+                        )
                     messages.append({
-                        "role": "user",
+                        "role": "system",
                         "content": _verify_nudge2,
                         "_pre_verify_synthetic": True,
                     })
                     agent._session_messages = messages
-                    logger.debug("pre_verify nudge issued (attempt %d)",
-                                 agent._pre_verify_nudges)
+                    logger.debug(
+                        "pre_verify nudge issued (attempt %d)",
+                        agent._pre_verify_nudges,
+                    )
                     _pending_verification_response = final_response
                     final_response = None
                     continue

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -42,6 +42,24 @@ def _is_pure_tool_call_tail(msg: dict) -> bool:
     return not flatten_message_text(msg.get("content")).strip()
 
 
+_VERIFICATION_CONTINUATION_FLAGS = (
+    "_verification_stop_synthetic",
+    "_pre_verify_synthetic",
+)
+
+
+def _drop_verification_continuation_scaffolding(messages) -> None:
+    """Drop one-request verification nudges from returned/live history."""
+    messages[:] = [
+        message
+        for message in messages
+        if not (
+            isinstance(message, dict)
+            and any(message.get(flag) for flag in _VERIFICATION_CONTINUATION_FLAGS)
+        )
+    ]
+
+
 def finalize_turn(
     agent,
     *,
@@ -184,6 +202,12 @@ def finalize_turn(
     # killing the turn.
     _cleanup_errors = []
 
+    # Verification nudges are protocol-valid user turns only for the immediate
+    # retry request. Candidate assistant rows have already been flushed, so the
+    # nudges can now be removed without losing any user-visible content. This
+    # also exposes the actual assistant tail for exact-content dedup below.
+    _drop_verification_continuation_scaffolding(messages)
+
     # Save trajectory if enabled.  ``user_message`` may be a multimodal
     # list of parts; the trajectory format wants a plain string.
     try:
@@ -225,23 +249,29 @@ def finalize_turn(
             close_interrupted_tool_sequence(messages, final_response)
 
         # Some recovery/fallback paths return a real final_response without
-        # adding a closing assistant message to the transcript (e.g. the
-        # partial-stream and prior-turn-content recovery ``break`` sites in
-        # ``conversation_loop``). If persisted as-is, the durable session can
-        # end at a tool/user message even though the caller — and the gateway
-        # platform — already saw a completed assistant response. The next turn
-        # then replays a user-only backlog and the model re-answers every
-        # "unanswered" message. Close the durable turn at the source, at the
-        # single chokepoint every recovery ``break`` flows through, so the
-        # invariant "delivered final_response ⇒ assistant row in transcript"
-        # holds regardless of which path produced it. (#43849 / #44100)
+        # adding a matching closing assistant message to the transcript (e.g.
+        # the partial-stream and prior-turn-content recovery ``break`` sites in
+        # ``conversation_loop``). Compare content, not only role: verification
+        # may already have published a provisional assistant candidate. Reusing
+        # the same candidate at budget exhaustion must not duplicate it, while a
+        # different terminal correction (for example ``[Verification failed]``)
+        # must be persisted once so the transcript matches what the caller sends.
         if final_response and not interrupted:
             try:
                 _tail = messages[-1] if messages else None
             except Exception:
                 _tail = None
-            _tail_role = _tail.get("role") if isinstance(_tail, dict) else None
-            if _tail_role != "assistant":
+            _tail_matches_final = (
+                isinstance(_tail, dict)
+                and _tail.get("role") == "assistant"
+                and _tail.get("content") == final_response
+            )
+            _tail_is_tool_call = (
+                isinstance(_tail, dict)
+                and _tail.get("role") == "assistant"
+                and bool(_tail.get("tool_calls"))
+            )
+            if not _tail_matches_final and not _tail_is_tool_call:
                 messages.append({"role": "assistant", "content": final_response})
             elif isinstance(_tail, dict) and _is_pure_tool_call_tail(_tail):
                 # The tail IS an assistant row, but a *pure tool-call turn*:

--- a/run_agent.py
+++ b/run_agent.py
@@ -4865,8 +4865,18 @@ class AIAgent:
         except Exception:
             logger.debug("interim_assistant_callback error", exc_info=True)
 
-    def _emit_interim_assistant_message(self, assistant_msg: Dict[str, Any]) -> None:
-        """Surface a real mid-turn assistant commentary message to the UI layer."""
+    def _emit_interim_assistant_message(
+        self, assistant_msg: Dict[str, Any], *, force_display: bool = False
+    ) -> None:
+        """Surface a real mid-turn assistant commentary message to the UI layer.
+
+        When ``force_display`` is True the message is sent as a standalone
+        commentary bubble even if the text was already streamed via
+        ``stream_delta_callback``.  This is needed for the verify-on-stop
+        path: the streamed text lives in the streaming buffer and is
+        overwritten by subsequent verification messages, so without a
+        forced commentary bubble the user never sees the full answer.
+        """
         cb = getattr(self, "interim_assistant_callback", None)
         if cb is None or not isinstance(assistant_msg, dict):
             return
@@ -4894,7 +4904,10 @@ class AIAgent:
             or self._interim_text_was_delivered(visible)
         ):
             return
-        already_streamed = self._interim_content_was_streamed(visible)
+        already_streamed = (
+            False if force_display
+            else self._interim_content_was_streamed(visible)
+        )
         try:
             cb(visible, already_streamed=already_streamed)
             if undelivered_parts:

--- a/tests/agent/test_turn_finalizer_iteration_limit_exit.py
+++ b/tests/agent/test_turn_finalizer_iteration_limit_exit.py
@@ -148,6 +148,103 @@ def test_pending_pre_verify_response_is_preserved_on_budget_exhaustion(monkeypat
     assert result["turn_exit_reason"] == "max_iterations_reached(60/60)"
     assert agent._handle_max_iterations_called is False
 
+def test_published_pending_candidate_is_not_duplicated_by_finalizer(monkeypatch):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = _LimitAgent()
+    candidate = {
+        "role": "assistant",
+        "content": "already published candidate",
+        "finish_reason": "verification_required",
+    }
+    messages = [
+        {"role": "user", "content": "task"},
+        candidate,
+        {
+            "role": "user",
+            "content": "verify it",
+            "_verification_stop_synthetic": True,
+        },
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response=None,
+        api_call_count=60,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="task",
+        original_user_message="task",
+        _should_review_memory=False,
+        _turn_exit_reason="unknown",
+        _pending_verification_response=candidate["content"],
+    )
+
+    assert result["final_response"] == candidate["content"]
+    assert [
+        message["content"]
+        for message in result["messages"]
+        if message["role"] == "assistant"
+    ] == [candidate["content"]]
+    assert result["messages"] == [
+        {"role": "user", "content": "task"},
+        candidate,
+    ]
+    assert agent.persisted_messages == result["messages"]
+
+
+def test_terminal_verification_failure_is_persisted_as_one_correction(monkeypatch):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = _LimitAgent(budget_remaining=58)
+    candidate = {
+        "role": "assistant",
+        "content": "published before verifier failed",
+        "finish_reason": "verification_required",
+    }
+    correction = "[Verification failed]"
+    messages = [
+        {"role": "user", "content": "task"},
+        candidate,
+        {
+            "role": "user",
+            "content": "verify it",
+            "_verification_stop_synthetic": True,
+        },
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response=correction,
+        api_call_count=2,
+        interrupted=False,
+        failed=True,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="task",
+        original_user_message="task",
+        _should_review_memory=False,
+        _turn_exit_reason="verification_failed",
+        _pending_verification_response=candidate["content"],
+    )
+
+    assert result["final_response"] == correction
+    assert result["failed"] is True
+    assert [
+        message["content"]
+        for message in result["messages"]
+        if message["role"] == "assistant"
+    ] == [candidate["content"], correction]
+    assert not any(
+        message.get("_verification_stop_synthetic")
+        for message in result["messages"]
+    )
+    assert agent.persisted_messages == result["messages"]
+
 
 def test_empty_pending_verification_response_uses_summary_fallback(monkeypatch):
     monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])

--- a/tests/agent/test_verification_stop_caching.py
+++ b/tests/agent/test_verification_stop_caching.py
@@ -71,8 +71,10 @@ def test_db_flush_drops_verification_scaffolding(tmp_path, monkeypatch):
 
     messages = [
         {"role": "user", "content": "hi"},
-        {"role": "assistant", "content": "premature done", "_verification_stop_synthetic": True},
-        {"role": "user", "content": "[System: run tests]", "_verification_stop_synthetic": True},
+        # The assistant response is NOT flagged synthetic — it persists.
+        {"role": "assistant", "content": "premature done"},
+        # Only the nudge is synthetic — it gets dropped.
+        {"role": "system", "content": "[System: run tests]", "_verification_stop_synthetic": True},
         {"role": "assistant", "content": "verified and clean"},
     ]
 
@@ -83,8 +85,8 @@ def test_db_flush_drops_verification_scaffolding(tmp_path, monkeypatch):
         for _args, kwargs in agent._session_db.append_message.call_args_list
     ]
     assert "hi" in persisted
+    assert "premature done" in persisted
     assert "verified and clean" in persisted
-    assert "premature done" not in persisted
     assert "[System: run tests]" not in persisted
 
 
@@ -95,8 +97,10 @@ def test_json_log_drops_verification_scaffolding(tmp_path, monkeypatch):
 
     messages = [
         {"role": "user", "content": "hi"},
-        {"role": "assistant", "content": "premature done", "_pre_verify_synthetic": True},
-        {"role": "user", "content": "[System: run tests]", "_pre_verify_synthetic": True},
+        # The assistant response is NOT flagged synthetic — it persists.
+        {"role": "assistant", "content": "premature done"},
+        # Only the nudge is synthetic — it gets dropped.
+        {"role": "system", "content": "[System: run tests]", "_pre_verify_synthetic": True},
         {"role": "assistant", "content": "verified and clean"},
     ]
 
@@ -106,5 +110,5 @@ def test_json_log_drops_verification_scaffolding(tmp_path, monkeypatch):
     assert log_file.exists()
     data = json.loads(log_file.read_text(encoding="utf-8"))
     contents = [m.get("content") for m in data["messages"]]
-    assert contents == ["hi", "verified and clean"]
+    assert contents == ["hi", "premature done", "verified and clean"]
     assert all(not m.get("_pre_verify_synthetic") for m in data["messages"])

--- a/tests/agent/test_verification_stop_caching.py
+++ b/tests/agent/test_verification_stop_caching.py
@@ -1,9 +1,9 @@
 """Verification-loop synthetic scaffolding must never reach durable session state.
 
-verify_on_stop / pre_verify append a synthetic assistant "done" plus a synthetic
+verify_on_stop / pre_verify append a real assistant candidate plus a synthetic
 user nudge to keep the agent going one more turn before it can claim completion.
-These messages exist only to drive the loop; persisting them poisons the resumed
-transcript and breaks prompt-prefix cache reuse on later turns (#55733).
+Candidates are durable; nudges exist only to drive one retry request. Persisting
+the nudges poisons resumed history and breaks prompt-prefix reuse (#55733).
 
 Both persistence sinks (SQLite flush + JSON snapshot) route through the single
 ``_is_ephemeral_scaffolding`` chokepoint, which is driven by
@@ -74,7 +74,11 @@ def test_db_flush_drops_verification_scaffolding(tmp_path, monkeypatch):
         # The assistant response is NOT flagged synthetic — it persists.
         {"role": "assistant", "content": "premature done"},
         # Only the nudge is synthetic — it gets dropped.
-        {"role": "system", "content": "[System: run tests]", "_verification_stop_synthetic": True},
+        {
+            "role": "user",
+            "content": "[System: run tests]",
+            "_verification_stop_synthetic": True,
+        },
         {"role": "assistant", "content": "verified and clean"},
     ]
 
@@ -100,7 +104,11 @@ def test_json_log_drops_verification_scaffolding(tmp_path, monkeypatch):
         # The assistant response is NOT flagged synthetic — it persists.
         {"role": "assistant", "content": "premature done"},
         # Only the nudge is synthetic — it gets dropped.
-        {"role": "system", "content": "[System: run tests]", "_pre_verify_synthetic": True},
+        {
+            "role": "user",
+            "content": "[System: run tests]",
+            "_pre_verify_synthetic": True,
+        },
         {"role": "assistant", "content": "verified and clean"},
     ]
 

--- a/tests/run_agent/test_verification_continuation_budget.py
+++ b/tests/run_agent/test_verification_continuation_budget.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from hermes_state import SessionDB
 from run_agent import AIAgent
 
 
@@ -46,6 +47,22 @@ def agent(tmp_path, monkeypatch):
     return instance
 
 
+def _attach_real_db(agent, tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(agent.session_id, source="test", model=agent.model)
+    agent._session_db = db
+    agent._session_db_created = True
+    return db
+
+
+def _assistant_contents(db, session_id):
+    return [
+        row["content"]
+        for row in db.get_messages(session_id)
+        if row["role"] == "assistant"
+    ]
+
+
 def _assert_pending_response_survives(agent, result):
     assert result["final_response"] == "composed report"
     assert result["turn_exit_reason"] == "max_iterations_reached(1/1)"
@@ -53,8 +70,6 @@ def _assert_pending_response_survives(agent, result):
     assert agent._handle_max_iterations.call_count == 0
     assert [message["role"] for message in result["messages"]] == [
         "user",
-        "assistant",
-        "system",
         "assistant",
     ]
 
@@ -75,12 +90,11 @@ def test_verify_on_stop_preserves_composed_report_at_budget_limit(agent, monkeyp
         result = agent.run_conversation("edit changed.py")
 
     _assert_pending_response_survives(agent, result)
-    # The assistant response (messages[1]) is no longer flagged synthetic —
-    # it persists to the DB and is emitted to the UI so the user sees the
-    # full answer while verification runs. Only the nudge (messages[2])
-    # remains synthetic. (#62657)
+    # The published candidate is durable and becomes the budget fallback.
+    # Its one-request continuation nudge is removed before finalization, so the
+    # same assistant content is not appended a second time.
     assert "_verification_stop_synthetic" not in result["messages"][1]
-    assert result["messages"][2]["_verification_stop_synthetic"] is True
+    assert result["messages"][1]["content"] == "composed report"
 
 
 def test_pre_verify_preserves_composed_report_at_budget_limit(agent, monkeypatch):
@@ -104,9 +118,9 @@ def test_pre_verify_preserves_composed_report_at_budget_limit(agent, monkeypatch
         result = agent.run_conversation("edit changed.py")
 
     _assert_pending_response_survives(agent, result)
-    # Same as verify-on-stop: only the nudge is synthetic. (#62657)
+    # The pre-verify path has the same exact-once finalizer contract.
     assert "_pre_verify_synthetic" not in result["messages"][1]
-    assert result["messages"][2]["_pre_verify_synthetic"] is True
+    assert result["messages"][1]["content"] == "composed report"
 
 
 def test_intermediate_ack_uses_summary_instead_of_premature_text(agent, monkeypatch):
@@ -149,6 +163,128 @@ def test_later_verified_response_supersedes_pending_report(agent, monkeypatch):
     assert result["turn_exit_reason"] == "text_response(finish_reason=stop)"
     assert result["completed"] is True
     agent._handle_max_iterations.assert_not_called()
+
+
+def test_multiple_verification_retries_publish_each_candidate_once_in_order(
+    agent, monkeypatch, tmp_path
+):
+    """Every retry candidate is one durable row and one commentary event.
+
+    The terminal answer remains the normal final response; it is persisted once
+    by the finalizer and is not re-emitted as interim commentary.
+    """
+    db = _attach_real_db(agent, tmp_path)
+    agent.max_iterations = 3
+    agent.iteration_budget.max_total = 3
+    answers = iter(
+        [
+            _response("candidate one"),
+            _response("candidate two"),
+            _response("verified final report"),
+        ]
+    )
+    request_roles = []
+
+    def model_call(api_kwargs):
+        agent._turn_file_mutation_paths = {"changed.py"}
+        request_roles.append([message["role"] for message in api_kwargs["messages"]])
+        return next(answers)
+
+    emitted = []
+    agent._interruptible_api_call = model_call
+    agent.interim_assistant_callback = (
+        lambda text, **_kwargs: emitted.append(text)
+    )
+    monkeypatch.setenv("HERMES_VERIFY_ON_STOP", "1")
+
+    with (
+        patch(
+            "agent.verification_stop.build_verify_on_stop_nudge",
+            side_effect=["verify once", "verify again", None],
+        ),
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+    ):
+        result = agent.run_conversation("edit changed.py")
+
+    assert result["final_response"] == "verified final report"
+    assert result["completed"] is True
+    assert emitted == ["candidate one", "candidate two"]
+    assert _assistant_contents(db, agent.session_id) == [
+        "candidate one",
+        "candidate two",
+        "verified final report",
+    ]
+    assert request_roles == [
+        ["system", "user"],
+        ["system", "user", "assistant", "user"],
+        ["system", "user", "assistant", "user", "assistant", "user"],
+    ]
+    assert not any(
+        message.get("_verification_stop_synthetic")
+        or message.get("_pre_verify_synthetic")
+        for message in result["messages"]
+    )
+
+    # Resume/replay keeps all three durable rows distinct, while protocol
+    # repair removes superseded provisional candidates from the model history.
+    replay = db.get_messages_as_conversation(agent.session_id)
+    agent._repair_message_sequence(replay)
+    assert [
+        message["content"]
+        for message in replay
+        if message["role"] == "assistant"
+    ] == ["verified final report"]
+    assert _assistant_contents(db, agent.session_id) == [
+        "candidate one",
+        "candidate two",
+        "verified final report",
+    ]
+    db.close()
+
+
+@pytest.mark.parametrize("verification_outcome", [False, RuntimeError("verifier crashed")])
+def test_verification_false_or_exception_finalizes_candidate_once(
+    agent, monkeypatch, tmp_path, verification_outcome
+):
+    """A failed verifier decision happens before interim publication.
+
+    False and exceptions both fail open: the candidate becomes the one terminal
+    response, so the return value and durable transcript cannot disagree.
+    """
+    db = _attach_real_db(agent, tmp_path)
+    emitted = []
+
+    def model_call(_api_kwargs):
+        agent._turn_file_mutation_paths = {"changed.py"}
+        return _response("candidate after verifier failure")
+
+    agent._interruptible_api_call = model_call
+    agent.interim_assistant_callback = (
+        lambda text, **_kwargs: emitted.append(text)
+    )
+    monkeypatch.setenv("HERMES_VERIFY_ON_STOP", "1")
+    verifier = (
+        patch(
+            "agent.verification_stop.build_verify_on_stop_nudge",
+            side_effect=verification_outcome,
+        )
+        if isinstance(verification_outcome, Exception)
+        else patch(
+            "agent.verification_stop.build_verify_on_stop_nudge",
+            return_value=verification_outcome,
+        )
+    )
+
+    with verifier, patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+        result = agent.run_conversation("edit changed.py")
+
+    assert result["final_response"] == "candidate after verifier failure"
+    assert result["completed"] is True
+    assert emitted == []
+    assert _assistant_contents(db, agent.session_id) == [
+        "candidate after verifier failure"
+    ]
+    db.close()
 
 
 def test_verify_on_stop_emits_interim_response_to_ui(agent, monkeypatch):

--- a/tests/run_agent/test_verification_continuation_budget.py
+++ b/tests/run_agent/test_verification_continuation_budget.py
@@ -54,7 +54,7 @@ def _assert_pending_response_survives(agent, result):
     assert [message["role"] for message in result["messages"]] == [
         "user",
         "assistant",
-        "user",
+        "system",
         "assistant",
     ]
 
@@ -75,7 +75,11 @@ def test_verify_on_stop_preserves_composed_report_at_budget_limit(agent, monkeyp
         result = agent.run_conversation("edit changed.py")
 
     _assert_pending_response_survives(agent, result)
-    assert result["messages"][1]["_verification_stop_synthetic"] is True
+    # The assistant response (messages[1]) is no longer flagged synthetic —
+    # it persists to the DB and is emitted to the UI so the user sees the
+    # full answer while verification runs. Only the nudge (messages[2])
+    # remains synthetic. (#62657)
+    assert "_verification_stop_synthetic" not in result["messages"][1]
     assert result["messages"][2]["_verification_stop_synthetic"] is True
 
 
@@ -100,7 +104,8 @@ def test_pre_verify_preserves_composed_report_at_budget_limit(agent, monkeypatch
         result = agent.run_conversation("edit changed.py")
 
     _assert_pending_response_survives(agent, result)
-    assert result["messages"][1]["_pre_verify_synthetic"] is True
+    # Same as verify-on-stop: only the nudge is synthetic. (#62657)
+    assert "_pre_verify_synthetic" not in result["messages"][1]
     assert result["messages"][2]["_pre_verify_synthetic"] is True
 
 
@@ -144,3 +149,38 @@ def test_later_verified_response_supersedes_pending_report(agent, monkeypatch):
     assert result["turn_exit_reason"] == "text_response(finish_reason=stop)"
     assert result["completed"] is True
     agent._handle_max_iterations.assert_not_called()
+
+
+def test_verify_on_stop_emits_interim_response_to_ui(agent, monkeypatch):
+    """The full assistant response must reach the UI when verification stop
+    triggers — not just the terse post-verification reply. (#62657)
+    """
+    emitted = []
+    agent.interim_assistant_callback = lambda text, **kw: emitted.append(text)
+
+    def model_call(_api_kwargs):
+        agent._turn_file_mutation_paths = {"changed.py"}
+        return _response("full detailed report with tables and analysis")
+
+    agent._interruptible_api_call = model_call
+    agent._handle_max_iterations = MagicMock(return_value="replacement summary")
+    monkeypatch.setenv("HERMES_VERIFY_ON_STOP", "1")
+
+    with (
+        patch("agent.verification_stop.build_verify_on_stop_nudge", return_value="verify it"),
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+    ):
+        result = agent.run_conversation("edit changed.py")
+
+    # The full response was emitted to the UI callback.
+    assert any("full detailed report" in e for e in emitted), (
+        f"expected full response in emitted messages, got: {emitted}"
+    )
+    # The response was also persisted to the in-memory message list without
+    # the synthetic flag.
+    assistant_msgs = [m for m in result["messages"] if m["role"] == "assistant"]
+    assert any(
+        "full detailed report" in (m.get("content") or "")
+        and "_verification_stop_synthetic" not in m
+        for m in assistant_msgs
+    )

--- a/tests/run_agent/test_verification_continuation_budget.py
+++ b/tests/run_agent/test_verification_continuation_budget.py
@@ -154,9 +154,18 @@ def test_later_verified_response_supersedes_pending_report(agent, monkeypatch):
 def test_verify_on_stop_emits_interim_response_to_ui(agent, monkeypatch):
     """The full assistant response must reach the UI when verification stop
     triggers — not just the terse post-verification reply. (#62657)
+
+    When the response was already streamed (Desktop gateway), the callback
+    must still send it as a standalone commentary bubble (force_display=True)
+    so it survives the subsequent verification messages.
     """
     emitted = []
-    agent.interim_assistant_callback = lambda text, **kw: emitted.append(text)
+    call_kwargs = []
+    def _capture(text, **kw):
+        emitted.append(text)
+        call_kwargs.append(kw)
+
+    agent.interim_assistant_callback = _capture
 
     def model_call(_api_kwargs):
         agent._turn_file_mutation_paths = {"changed.py"}
@@ -175,6 +184,12 @@ def test_verify_on_stop_emits_interim_response_to_ui(agent, monkeypatch):
     # The full response was emitted to the UI callback.
     assert any("full detailed report" in e for e in emitted), (
         f"expected full response in emitted messages, got: {emitted}"
+    )
+    # force_display=True → already_streamed=False so the gateway calls
+    # on_commentary() (standalone bubble), not on_segment_break() (which
+    # just finalizes the streaming buffer and gets overwritten).
+    assert any(kw.get("already_streamed") is False for kw in call_kwargs), (
+        f"expected already_streamed=False in at least one call, got: {call_kwargs}"
     )
     # The response was also persisted to the in-memory message list without
     # the synthetic flag.


### PR DESCRIPTION
## Problem

When `verify-on-stop` or `pre_verify` triggers, the agent produces a complete response (e.g., a detailed summary with tables and analysis), but that response is suppressed from both the durable transcript (state.db) and the UI. The user only sees the terse post-verification reply — never the full answer.

This is the bug behind repeated user reports of "系统消息冲走了回复" (system messages flushed the response). PR #62657 attempted to fix this by removing the synthetic flag from `final_msg`, but only addressed DB persistence — the response was still not emitted to the UI.

## Root Cause (Three Layers)

### Layer 1: DB persistence (fixed by #62657)
`final_msg["_verification_stop_synthetic"] = True` → `_is_ephemeral_scaffolding()` returns True → `_flush_messages_to_session_db()` skips it → **not persisted**

### Layer 2: UI emission (fixed by initial #62676)
No call to `_emit_interim_assistant_message()` → **not displayed**

### Layer 3: Streaming buffer overwrite (fixed by this update)
Even with `_emit_interim_assistant_message()` called, the Desktop gateway streams the response via `stream_delta_callback`. `_interim_content_was_streamed()` detects `already_streamed=True`, so the callback only calls `on_segment_break()` (paragraph break) instead of `on_commentary()` (standalone message bubble). The streamed text lives in the streaming buffer and gets **overwritten by subsequent verification messages**.

## Fix

**`run_agent.py`** — `_emit_interim_assistant_message()` gains `force_display` parameter:
- When `True`, `already_streamed` is forced to `False`
- The gateway callback calls `on_commentary(text)` → standalone permanent message bubble
- The full answer survives the verification loop

**`agent/conversation_loop.py`** — both verify-on-stop and pre_verify paths:
1. **Remove** synthetic flag from `final_msg` → persists to DB
2. **Call** `_emit_interim_assistant_message(final_msg, force_display=True)` → standalone UI bubble
3. **Call** `_flush_messages_to_session_db()` → persist before verification loop
4. **Change** nudge from `role="user"` to `role="system"` → internal instruction, not durable user message

## Tests

| File | Changes |
|------|---------|
| `test_verification_continuation_budget.py` | Role sequence updated; `final_msg` no longer synthetic; new test asserts `already_streamed=False` (force_display) |
| `test_verification_stop_caching.py` | Assistant response now persists (not dropped); nudge still dropped |

**Results:** 5/5 pass (test_verification_continuation_budget.py), 50/50 pass (test_verification_stop.py)

## Supersedes #62657

PR #62657 only fixed DB persistence. This PR is a complete fix: DB persistence + UI emission + streaming buffer survival.