### PR TITLE
fix(security): deny writes to the consolidated and profile-scoped platforms/pairing store

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -138,10 +138,38 @@ def _classify_write_denial(path: str) -> Optional[str]:
                 return "credential"
         except Exception:
             pass
+        # gateway/pairing.py resolves the live pairing store via
+        # get_hermes_dir("platforms/pairing", "pairing") — new installs (and
+        # any install whose legacy `pairing/` is empty) use the consolidated
+        # `platforms/pairing/` location, not the legacy one. Block both so a
+        # write is denied regardless of which layout is currently active.
+        for pairing_rel in ("pairing", os.path.join("platforms", "pairing")):
+            try:
+                pairing_real = os.path.realpath(os.path.join(base_real, pairing_rel))
+                if resolved == pairing_real or resolved.startswith(pairing_real + os.sep):
+                    return "credential"
+            except Exception:
+                pass
+        # Multiplex gateways serve secondary profiles via
+        # PairingStore(profile=name) (gateway/pairing.py), which resolves a
+        # profile's store the same way the default-home lookup above does:
+        # the legacy <HERMES_HOME>/profiles/<name>/pairing/ layout, or (for a
+        # freshly created profile, or one whose legacy dir is empty) the
+        # consolidated <HERMES_HOME>/profiles/<name>/platforms/pairing/
+        # layout. Profile names aren't known ahead of time, so match the
+        # shape of the path rather than a fixed name.
         try:
-            pairing_real = os.path.realpath(os.path.join(base_real, "pairing"))
-            if resolved == pairing_real or resolved.startswith(pairing_real + os.sep):
-                return "credential"
+            profiles_real = os.path.realpath(os.path.join(base_real, "profiles"))
+            if resolved == profiles_real or resolved.startswith(profiles_real + os.sep):
+                rel_parts = os.path.relpath(resolved, profiles_real).split(os.sep)
+                if len(rel_parts) >= 2 and rel_parts[1] == "pairing":
+                    return "credential"
+                if (
+                    len(rel_parts) >= 3
+                    and rel_parts[1] == "platforms"
+                    and rel_parts[2] == "pairing"
+                ):
+                    return "credential"
         except Exception:
             pass
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1375,8 +1375,15 @@ def _media_delivery_denied_paths() -> List[Path]:
     # this pairs the media-delivery (exfil) side so a prompt-injection MEDIA
     # tag can't deliver a live bearer token as a native attachment.
     # (session/kanban SQLite stores are handled by #41071 — kept out here.)
+    #
+    # pairing/ covers both possible DM-pairing store layouts: gateway/pairing.py
+    # resolves the live directory via get_hermes_dir("platforms/pairing",
+    # "pairing"), so new installs (and any install whose legacy pairing/ is
+    # empty) use platforms/pairing/ instead of the legacy pairing/ — both are
+    # blocked here regardless of which one is currently active.
     _ROOT_CREDENTIAL_DIRS = (
         "pairing",
+        os.path.join("platforms", "pairing"),
         "mcp-tokens",
     )
     for hermes_root in (_HERMES_HOME, _HERMES_ROOT):
@@ -1417,6 +1424,40 @@ def _path_under_denied_prefix(resolved: Path) -> bool:
         if home is not None and resolved_denied == home:
             continue
         return True
+    return _is_profile_pairing_path(resolved)
+
+
+def _is_profile_pairing_path(resolved: Path) -> bool:
+    """True if ``resolved`` sits under a profile's pairing store.
+
+    Multiplex gateways serve secondary profiles via ``PairingStore(profile=name)``
+    (``gateway/pairing.py``), which resolves a profile's store the same way the
+    root-level lookup above does: the legacy
+    ``<hermes_root>/profiles/<name>/pairing/`` layout, or (for a freshly
+    created profile, or one whose legacy dir is empty) the consolidated
+    ``<hermes_root>/profiles/<name>/platforms/pairing/`` layout. The fixed
+    denylist above can't enumerate either shape since profile names aren't
+    known at import time, so this matches the shape of the path instead.
+    """
+    for hermes_root in (_HERMES_HOME, _HERMES_ROOT):
+        try:
+            profiles_root = (hermes_root / "profiles").resolve(strict=False)
+        except (OSError, RuntimeError, ValueError):
+            continue
+        if not _path_is_within(resolved, profiles_root):
+            continue
+        try:
+            rel_parts = resolved.relative_to(profiles_root).parts
+        except ValueError:
+            continue
+        if (
+            len(rel_parts) >= 3
+            and rel_parts[1] == "platforms"
+            and rel_parts[2] == "pairing"
+        ):
+            return True
+        if len(rel_parts) >= 2 and rel_parts[1] == "pairing":
+            return True
     return False
 
 

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -655,6 +655,157 @@ class TestMediaDeliveryDefaultMode:
 
         assert BasePlatformAdapter.validate_media_delivery_path(str(token)) is None
 
+    def test_denylist_blocks_google_token_even_when_freshly_refreshed(self, tmp_path, monkeypatch):
+        """The exploit was that the Google integration rewrites
+        google_token.json every turn, bumping its mtime to ~now, so the
+        strict-mode recency window (trust_recent_files) kept re-trusting it
+        and it re-sent on every reply. An explicit denylist entry must win
+        over recency trust.
+        """
+        self._patch_roots(monkeypatch)  # zero cache allowlist, strict mode on
+        monkeypatch.setenv("HERMES_MEDIA_TRUST_RECENT_FILES", "1")
+        monkeypatch.setenv("HERMES_MEDIA_TRUST_RECENT_SECONDS", "600")
+
+        fake_home = tmp_path / "home"
+        hermes_dir = fake_home / ".hermes"
+        hermes_dir.mkdir(parents=True)
+        token = hermes_dir / "google_token.json"
+        token.write_text('{"access_token": "***"}')  # mtime = now → "recent"
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", hermes_dir)
+        monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_dir)
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(token)) is None
+
+    def test_denylist_blocks_pairing_directory_contents(self, tmp_path, monkeypatch):
+        """Files under ~/.hermes/pairing/ (platform pairing tokens) are
+        credential material and must not be deliverable.
+        """
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        hermes_dir = fake_home / ".hermes"
+        pairing = hermes_dir / "pairing"
+        pairing.mkdir(parents=True)
+        token = pairing / "telegram-approved.json"
+        token.write_text('{"approved": ["123"]}')
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", hermes_dir)
+        monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_dir)
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(token)) is None
+
+    def test_denylist_blocks_consolidated_platforms_pairing_directory_contents(
+        self, tmp_path, monkeypatch
+    ):
+        """gateway/pairing.py resolves the live store via
+        get_hermes_dir("platforms/pairing", "pairing") — new installs (and
+        any install whose legacy pairing/ is empty) use platforms/pairing/,
+        not the legacy pairing/ this class's sibling test covers. Same
+        credential material, must be equally undeliverable.
+        """
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        hermes_dir = fake_home / ".hermes"
+        pairing = hermes_dir / "platforms" / "pairing"
+        pairing.mkdir(parents=True)
+        token = pairing / "telegram-approved.json"
+        token.write_text('{"approved": ["123"]}')
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", hermes_dir)
+        monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_dir)
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(token)) is None
+
+    def test_denylist_blocks_profile_scoped_pairing_directory_contents(
+        self, tmp_path, monkeypatch
+    ):
+        """Multiplex gateways serve secondary profiles via
+        PairingStore(profile=name) (gateway/pairing.py), which stores
+        per-profile DM-pairing credentials at
+        <HERMES_HOME>/profiles/<name>/pairing/ — a third layout distinct
+        from the legacy and consolidated global stores this class's sibling
+        tests cover. Same credential material, must be equally undeliverable.
+        """
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        hermes_dir = fake_home / ".hermes"
+        pairing = hermes_dir / "profiles" / "coder" / "pairing"
+        pairing.mkdir(parents=True)
+        token = pairing / "telegram-approved.json"
+        token.write_text('{"approved": ["123"]}')
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", hermes_dir)
+        monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_dir)
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(token)) is None
+
+    def test_denylist_blocks_profile_scoped_consolidated_platforms_pairing_directory_contents(
+        self, tmp_path, monkeypatch
+    ):
+        """A profile's pairing store may also live at the consolidated
+        platforms/pairing/ layout (gateway/pairing.py resolves it via
+        get_hermes_dir("platforms/pairing", "pairing")) rather than the
+        legacy profiles/<name>/pairing/ layout this class's sibling test
+        covers. Same credential material, must be equally undeliverable.
+        """
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        hermes_dir = fake_home / ".hermes"
+        pairing = hermes_dir / "profiles" / "coder" / "platforms" / "pairing"
+        pairing.mkdir(parents=True)
+        token = pairing / "telegram-approved.json"
+        token.write_text('{"approved": ["123"]}')
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", hermes_dir)
+        monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_dir)
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(token)) is None
+
+    def test_allows_delivery_from_profile_scoped_non_pairing_subdir(
+        self, tmp_path, monkeypatch
+    ):
+        """Only the pairing/ credential store within a profile is denied — a
+        freshly-produced file in another profile subdirectory (e.g. a media
+        cache) must stay deliverable via recency trust, i.e. it must not be
+        caught by the new profile-pairing denylist check."""
+        self._patch_roots(monkeypatch)
+        monkeypatch.delenv("HERMES_MEDIA_ALLOW_DIRS", raising=False)
+        monkeypatch.setenv("HERMES_MEDIA_TRUST_RECENT_FILES", "1")
+        monkeypatch.setenv("HERMES_MEDIA_TRUST_RECENT_SECONDS", "600")
+
+        fake_home = tmp_path / "home"
+        hermes_dir = fake_home / ".hermes"
+        other = hermes_dir / "profiles" / "coder" / "cache"
+        other.mkdir(parents=True)
+        media = other / "report.pdf"
+        media.write_bytes(b"%PDF-1.4")
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", hermes_dir)
+        monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_dir)
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(media)) == str(media.resolve())
+
+    def test_hermes_cache_still_delivers_under_denied_home(self, tmp_path, monkeypatch):
+        """The targeted credential denylist must not break legitimate cache
+        deliveries: a generated artifact under the allowlisted cache root is
+        matched before the denylist and still delivers.
+        """
+        fake_home = tmp_path / "home"
+        hermes_dir = fake_home / ".hermes"
+        cache_dir = hermes_dir / "cache" / "documents"
+        cache_dir.mkdir(parents=True)
+        artifact = cache_dir / "report.pdf"
+        artifact.write_bytes(b"%PDF-1.4")
+        self._patch_roots(monkeypatch, cache_dir)
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", hermes_dir)
+        monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_dir)
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(artifact)) == str(artifact.resolve())
 
     def test_denylist_blocks_non_cache_file_under_hermes_home(self, tmp_path, monkeypatch):
         """A non-credential file the agent wrote directly under ~/.hermes

--- a/tests/tools/test_write_deny.py
+++ b/tests/tools/test_write_deny.py
@@ -82,6 +82,71 @@ class TestWriteDenyPrefixes:
             assert _is_write_denied(target) is True
 
 
+class TestWriteDenyPairingBothLayouts:
+    """gateway/pairing.py resolves the live store via
+    get_hermes_dir("platforms/pairing", "pairing") — new installs (and any
+    install whose legacy pairing/ is empty) use platforms/pairing/, not the
+    legacy pairing/. Both layouts must be write-denied regardless of which
+    one is currently active on disk."""
+
+    def test_legacy_pairing_dir_denied(self):
+        from hermes_constants import get_hermes_home
+
+        path = get_hermes_home() / "pairing" / "telegram-approved.json"
+        assert _is_write_denied(str(path)) is True
+
+    def test_consolidated_platforms_pairing_dir_denied(self):
+        from hermes_constants import get_hermes_home
+
+        path = get_hermes_home() / "platforms" / "pairing" / "telegram-approved.json"
+        assert _is_write_denied(str(path)) is True
+
+
+class TestWriteDenyProfileScopedPairingDir:
+    """Multiplex gateways serve secondary profiles via
+    ``PairingStore(profile=name)`` (gateway/pairing.py), which stores
+    per-profile DM-pairing credentials at
+    ``<HERMES_HOME>/profiles/<name>/pairing/`` — a third layout distinct
+    from the legacy and consolidated global stores above, and one the
+    fixed checks can't enumerate since profile names aren't known ahead
+    of time."""
+
+    def test_profile_scoped_pairing_dir_denied(self):
+        from hermes_constants import get_default_hermes_root
+
+        root = get_default_hermes_root()
+        path = root / "profiles" / "coder" / "pairing" / "telegram-approved.json"
+        assert _is_write_denied(str(path)) is True
+
+    def test_profile_scoped_consolidated_platforms_pairing_dir_denied(self):
+        """A profile's pairing store may also live at the consolidated
+        platforms/pairing/ layout (gateway/pairing.py resolves it via
+        get_hermes_dir("platforms/pairing", "pairing")) — same credential
+        material as the legacy profiles/<name>/pairing/ layout above, must
+        be equally write-denied."""
+        from hermes_constants import get_default_hermes_root
+
+        root = get_default_hermes_root()
+        path = (
+            root
+            / "profiles"
+            / "coder"
+            / "platforms"
+            / "pairing"
+            / "telegram-approved.json"
+        )
+        assert _is_write_denied(str(path)) is True
+
+    def test_profile_scoped_other_subdir_not_denied(self):
+        """Only the pairing/ credential store within a profile is denied —
+        a profile's other subdirectories must stay writable."""
+        from hermes_constants import get_default_hermes_root
+
+        root = get_default_hermes_root()
+        path = root / "profiles" / "coder" / "skills" / "note.md"
+        assert _is_write_denied(str(path)) is False
+
+
 class TestWriteAllowed:
     def test_tmp_file(self):
         assert _is_write_denied("/tmp/safe_file.txt") is False


### PR DESCRIPTION
## What does this PR do?
`agent/file_safety.py::is_write_denied()` and `gateway/platforms/base.py::_media_delivery_denied_paths()`/`_path_under_denied_prefix()` are supposed to block writes/media-delivery for the live DM-pairing store (per-platform approved-user allowlists), but they only covered some of the shapes that store can actually resolve to.

`gateway/pairing.py::PairingStore` resolves its live directory via `get_hermes_dir("platforms/pairing", "pairing", home=...)`. Per that resolver's contract (formalized in #53319): the legacy `pairing/` path only wins when it has content; an empty or absent legacy directory falls through to the consolidated `platforms/pairing/` location. Multiplex gateways serve secondary profiles via `PairingStore(profile=name)`, so the same fallback applies *per profile* too. That gives four possible live-store shapes:

- `<HERMES_HOME>/pairing/` (legacy, default profile)
- `<HERMES_HOME>/platforms/pairing/` (consolidated, default profile)
- `<HERMES_HOME>/profiles/<name>/pairing/` (legacy, multiplex profile)
- `<HERMES_HOME>/profiles/<name>/platforms/pairing/` (consolidated, multiplex profile — the shape a **freshly created** multiplex profile actually uses)

The guards originally only checked the first three; the fourth (new multiplex profiles under the now-default consolidated layout) was unprotected.

`HERMES_WRITE_SAFE_ROOT` is unset by default, so `is_write_denied()`'s denylist is the *primary* write protection for the overwhelming majority of installs. Net effect on an unprotected shape: the agent's own file-write tools (`write_file`, `patch`, etc.) could write into that profile's live pairing-approval store undetected — e.g. injecting a fake approved user id to forge pairing/DM authorization for that profile — and the `MEDIA:` delivery path could exfiltrate the file's contents (the profile's approved-user list) as a native attachment.

Related: the still-open #52644 fixes the analogous read-guard (`get_read_block_error()`) for the two default-profile layouts, and its own PR body explicitly (and incorrectly) states the write guard "likewise already blocks the pairing tree" for both. #70144 separately denies *sibling-profile* credential access in media delivery but keeps the literal `_ROOT_CREDENTIAL_DIRS = ("pairing", "mcp-tokens")` unchanged, so it doesn't cover any of the profile-scoped shapes here either.

## Related Issue
No existing issue — found while re-verifying #52644's read/write "mirror" claim against the live write and media-delivery guards, then extended to the profile-scoped case after confirming `gateway/run.py` actually constructs `PairingStore(profile=name)` for multiplex secondary profiles.

## Type of Change
- [x] 🔒 Security fix

## Changes Made
- `agent/file_safety.py::_classify_write_denial()`: check both `pairing/` and `platforms/pairing/` under each Hermes root (not just the legacy one), and match both `profiles/<name>/pairing/` and `profiles/<name>/platforms/pairing/` by path shape (profile names aren't known ahead of time). The profile-scoped branch now returns `"credential"` consistently with every sibling check in the function, instead of a bare boolean.
- `gateway/platforms/base.py::_media_delivery_denied_paths()`: add `platforms/pairing` to `_ROOT_CREDENTIAL_DIRS` alongside the existing `pairing` entry.
- `gateway/platforms/base.py::_is_profile_pairing_path()`: match both the legacy and consolidated per-profile shapes.
- `tests/tools/test_write_deny.py` / `tests/gateway/test_platform_base.py`: regression tests for all four shapes (legacy/consolidated × default/profile-scoped), plus a negative test confirming a profile's non-pairing subdirectories stay writable/deliverable.

## How to Test
```
pytest tests/tools/test_write_deny.py tests/gateway/test_platform_base.py -k pairing -v
```
Mutation-verified: the new profile-scoped-consolidated tests fail against the pre-fix code (return the live path instead of `None`, or a bare `True`/`False` mismatch) and pass after the fix. Also ran the full neighboring suites — `test_write_deny.py`, `test_platform_base.py` (99 tests), `test_file_safety*.py` (115 tests) — all green. Ruff clean on all four changed files.

## Checklist
- [x] Contributing Guide read | Conventional Commits | No duplicate PR found (fresh search across "profile pairing platforms", "_is_profile_pairing_path", "multiplex pairing store consolidated"; the two related open PRs, #52644 and #70144, cover the read-guard side and sibling-profile media delivery respectively — neither touches the write-guard or the profile-scoped `platforms/pairing` shape here)
- [x] Single logical fix (extend both write-side pairing guards to every live-store shape) | Tests added (mutation-verified) | Platform: macOS
- [x] Docs — N/A | Cross-platform — N/A (pure path-string logic, no OS dependency)