### PR TITLE
fix(agent): strip leaked harmony reasoning-channel from visible content

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -680,6 +680,15 @@ def strip_think_blocks(agent, content: str) -> str:
     content = re.sub(r'<reasoning>.*?</reasoning>', '', content, flags=re.DOTALL | re.IGNORECASE)
     content = re.sub(r'<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>', '', content, flags=re.DOTALL | re.IGNORECASE)
     content = re.sub(r'<thought>.*?</thought>', '', content, flags=re.DOTALL | re.IGNORECASE)
+    # 1a2. Harmony reasoning-channel leak — a harmony-format model's analysis/commentary
+    #      channel dumped into ``content`` when Ollama's native thinking-parse misses, so the
+    #      chain-of-thought ships before the visible answer (seen live 2026-07-11). Centralised
+    #      in agent/harmony_scrub.py so the streaming scrubber (StreamingThinkScrubber) and the
+    #      CLI display path (cli._strip_reasoning_tags) apply the SAME grammar + false-positive
+    #      guards. Only fires when ``content`` begins with harmony structure; benign prose that
+    #      merely mentions "analysis" or quotes ``<|channel|>`` mid-message is left untouched.
+    from agent.harmony_scrub import strip_harmony_leak
+    content = strip_harmony_leak(content)
     # 1b. Tool-call XML blocks (openclaw/openclaw#67318). Handle the
     #     generic tag names first — they have no attribute gating since
     #     a literal <tool_call> in prose is already vanishingly rare.

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -909,6 +909,15 @@ def strip_think_blocks(agent, content: str) -> str:
     #    the unterminated-tag pass and take trailing content with them.
     for _pattern in _REASONING_BLOCK_PATTERNS:
         content = _pattern.sub('', content)
+    # 1a2. Harmony reasoning-channel leak — a harmony-format model's analysis/commentary
+    #      channel dumped into ``content`` when Ollama's native thinking-parse misses, so the
+    #      chain-of-thought ships before the visible answer (seen live 2026-07-11). Centralised
+    #      in agent/harmony_scrub.py so the streaming scrubber (StreamingThinkScrubber) and the
+    #      CLI display path (cli._strip_reasoning_tags) apply the SAME grammar + false-positive
+    #      guards. Only fires when ``content`` begins with harmony structure; benign prose that
+    #      merely mentions "analysis" or quotes ``<|channel|>`` mid-message is left untouched.
+    from agent.harmony_scrub import strip_harmony_leak
+    content = strip_harmony_leak(content)
     # 1b. Tool-call XML blocks (openclaw/openclaw#67318). Handle the
     #     generic tag names first — they have no attribute gating since
     #     a literal <tool_call> in prose is already vanishingly rare.

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7389,12 +7389,16 @@ def extract_content_or_reasoning(response) -> str:
     content = (msg.content or "").strip()
 
     if content:
-        # Strip inline think/reasoning blocks (mirrors _strip_think_blocks)
+        # Strip a leaked harmony reasoning channel first (this path already
+        # guards <think>-style tags but not harmony), then inline think/
+        # reasoning blocks (mirrors _strip_think_blocks).
+        from agent.harmony_scrub import strip_harmony_leak
+        cleaned = strip_harmony_leak(content)
         cleaned = re.sub(
             r"<(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)>"
             r".*?"
             r"</(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)>",
-            "", content, flags=re.DOTALL | re.IGNORECASE,
+            "", cleaned, flags=re.DOTALL | re.IGNORECASE,
         ).strip()
         if cleaned:
             return cleaned

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -10149,12 +10149,16 @@ def extract_content_or_reasoning(response) -> str:
     content = (msg.content or "").strip()
 
     if content:
-        # Strip inline think/reasoning blocks (mirrors _strip_think_blocks)
+        # Strip a leaked harmony reasoning channel first (this path already
+        # guards <think>-style tags but not harmony), then inline think/
+        # reasoning blocks (mirrors _strip_think_blocks).
+        from agent.harmony_scrub import strip_harmony_leak
+        cleaned = strip_harmony_leak(content)
         cleaned = re.sub(
             r"<(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)>"
             r".*?"
             r"</(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)>",
-            "", content, flags=re.DOTALL | re.IGNORECASE,
+            "", cleaned, flags=re.DOTALL | re.IGNORECASE,
         ).strip()
         if cleaned:
             return cleaned

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1918,8 +1918,11 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 final_response = (_summary_result.content or "").strip()
 
         if final_response:
-            if "<think>" in final_response:
-                final_response = re.sub(r'<think>.*?</think>\s*', '', final_response, flags=re.DOTALL).strip()
+            # Centralised strip (all reasoning-tag variants + leaked harmony
+            # channels), matching the storage-boundary scrub in
+            # build_assistant_message — this summary bypasses that boundary by
+            # appending straight to ``messages``.
+            final_response = agent._strip_think_blocks(final_response).strip()
             if final_response:
                 messages.append({"role": "assistant", "content": final_response})
             else:
@@ -1961,8 +1964,8 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 final_response = (_retry_result.content or "").strip()
 
             if final_response:
-                if "<think>" in final_response:
-                    final_response = re.sub(r'<think>.*?</think>\s*', '', final_response, flags=re.DOTALL).strip()
+                # Centralised strip (see the sibling site above).
+                final_response = agent._strip_think_blocks(final_response).strip()
                 if final_response:
                     messages.append({"role": "assistant", "content": final_response})
                 else:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3112,8 +3112,11 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 final_response = (_summary_result.content or "").strip()
 
         if final_response:
-            if "<think>" in final_response:
-                final_response = re.sub(r'<think>.*?</think>\s*', '', final_response, flags=re.DOTALL).strip()
+            # Centralised strip (all reasoning-tag variants + leaked harmony
+            # channels), matching the storage-boundary scrub in
+            # build_assistant_message — this summary bypasses that boundary by
+            # appending straight to ``messages``.
+            final_response = agent._strip_think_blocks(final_response).strip()
             if final_response:
                 summary_call_outcome = "success"
                 append_message(
@@ -3177,8 +3180,8 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 final_response = (_retry_result.content or "").strip()
 
             if final_response:
-                if "<think>" in final_response:
-                    final_response = re.sub(r'<think>.*?</think>\s*', '', final_response, flags=re.DOTALL).strip()
+                # Centralised strip (see the sibling site above).
+                final_response = agent._strip_think_blocks(final_response).strip()
                 if final_response:
                     summary_call_outcome = "success"
                     append_message(

--- a/agent/harmony_scrub.py
+++ b/agent/harmony_scrub.py
@@ -1,0 +1,233 @@
+"""Shared detection/stripping for leaked OpenAI *harmony*-format reasoning.
+
+Harmony models emit private reasoning in an ``analysis``/``commentary`` channel
+and the user-facing answer in a ``final`` channel, delimited by control tokens::
+
+    <|start|>assistant<|channel|>analysis<|message|>…reasoning…<|end|>
+    <|start|>assistant<|channel|>final<|message|>…answer…<|return|>
+
+When such a model is served via Ollama and Ollama's native thinking-parse
+*misses*, that reasoning leaks into the visible message ``content`` instead of
+the separate reasoning field. Two leak shapes are seen in the wild:
+
+  (a) **degraded** — the leading control token is eaten, leaving a bare channel
+      *name* word (``analysis``/``commentary``/``thought``) at text-start, the
+      reasoning, then a lone (often pipe-stripped) ``<channel|>`` before the
+      answer. This is the shape observed live 2026-07-11.
+  (b) **canonical** — full/partial control tokens, e.g. content starting
+      ``<|channel|>analysis<|message|>…`` with a later
+      ``<|channel|>final<|message|>`` before the answer.
+
+Two consumers share this logic so they stay in sync (the invariant noted at
+``cli.py::_strip_reasoning_tags`` / ``run_agent.py::_strip_think_blocks``):
+
+* :func:`strip_harmony_leak` — for a **complete** assistant message (the
+  post-hoc / persisted path in ``strip_think_blocks`` and the CLI display path).
+* :class:`HarmonyStreamGate` — a small state machine for the **streaming** path
+  (``StreamingThinkScrubber``) so the leak never flashes live mid-reply.
+
+Design goal: strip a genuine leak without ever touching benign prose. Both
+entry points refuse to do anything unless the text *begins* with harmony
+structure, matched **case-sensitively** against the literal lowercase channel
+names, and the bare-word form must stand alone (lowercase word followed by a
+newline or a harmony token — not a colon). So ordinary prose like "Analysis of
+Q2 revenue", a capitalised heading "Analysis\\n…", or a message that merely
+*quotes* ``<|channel|>`` mid-sentence is left untouched.
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = ["strip_harmony_leak", "HarmonyStreamGate"]
+
+# Control tokens. Ollama's partial parse can drop a leading pipe, so accept the
+# asymmetric ``<channel|>`` / ``<message|>`` forms too (justified by real data).
+_CH = r"<\|?channel\|>"
+_MSG = r"<\|?message\|>"
+
+# The whole grammar is matched CASE-SENSITIVELY. Harmony control tokens and
+# channel names are literal special tokens emitted verbatim lowercase
+# (``analysis``/``commentary``/``final``) — exact case is positive evidence from
+# the grammar itself, and it removes an entire false-positive class for free: an
+# ordinary capitalised markdown heading like ``Analysis\n…`` or ``Commentary\n…``
+# (even one that later quotes ``<|channel|>``) no longer looks like a channel head.
+
+# The answer lives in the ``final`` channel: ``<|channel|>final<|message|>``.
+# Requiring ``<|message|>`` right after the name means we never mistake a prose
+# word "Final" (as in "Final answer: …") for the channel name.
+_FINAL_MARKER = re.compile(rf"{_CH}\s*final\s*{_MSG}")
+
+# Text *begins* with harmony structure: either an opening control token for an
+# analysis/commentary/final channel (optionally preceded by ``<|start|>assistant``),
+# or a bare standalone channel-name word on its own line (degraded shape (a) — the
+# real leak is ``thought\n…``). The bare word must be followed by a NEWLINE or a
+# harmony token — deliberately NOT a colon: a common benign heading like
+# "analysis: …" (even one that later quotes ``<|channel|>``) must never match.
+_HEAD = re.compile(
+    rf"^\s*(?:"
+    rf"(?:<\|?start\|>\s*assistant\s*)?{_CH}\s*(?:analysis|commentary|final)\b"
+    rf"|(?:analysis|commentary|thought)\b[ \t]*(?:\n|{_CH}|{_MSG})"
+    rf")",
+)
+
+# Whether the head opened with a control token (unambiguous harmony) vs a bare
+# word (which could, rarely, be benign lowercase prose like "analysis\n…").
+_HEAD_CONTROL = re.compile(rf"^\s*(?:<\|?start\|>|{_CH})")
+
+# A lone channel token — the separator ending the reasoning block in shape (a).
+_BARE_CH = re.compile(_CH)
+
+# Stray lone control tokens to scrub from a recovered answer tail.
+_STRAY = re.compile(r"<\|?(?:channel|message|start|end|return)\|>")
+
+
+def strip_harmony_leak(text: str) -> str:
+    """Remove a leaked harmony reasoning prefix from a complete message.
+
+    Returns *text* unchanged unless it begins with harmony structure. When it
+    does, keep only the final answer:
+
+    * **canonical** — keep everything after the *last* ``final`` channel marker;
+    * **degraded** — strip the leading reasoning up to and including the first
+      lone ``<channel|>`` separator *after the head* (the following word is kept
+      verbatim, so an answer that starts with "Final" survives).
+
+    When the text opened with harmony structure but carries no ``final`` marker
+    and no later separator, the resolution depends on the head shape:
+
+    * **control-token head** — the whole message is analysis/commentary with no
+      answer channel, so it is discarded (returns ``""``). Returning it verbatim
+      would both *show* the leaked chain-of-thought and persist it de-tokenised
+      into history — the exact leak this module exists to stop.
+    * **bare-word head** — could be benign prose that merely opens with a
+      lowercase channel-name word, so it is left untouched rather than risk
+      eating a real answer.
+    """
+    if not text:
+        return text
+    head = _HEAD.match(text)
+    if not head:
+        return text
+    # Canonical: answer follows the final-channel marker (handles analysis +
+    # commentary + final in any order, and multiple blocks — keep the last).
+    finals = list(_FINAL_MARKER.finditer(text))
+    if finals:
+        return _STRAY.sub("", text[finals[-1].end():]).strip()
+    # Degraded: strip up to and including the first lone channel separator that
+    # comes *after* the head — never the head's own control token, which would
+    # only peel the delimiters off and leave the reasoning glued to the answer.
+    sep = _BARE_CH.search(text, head.end())
+    if sep:
+        return _STRAY.sub("", text[sep.end():]).lstrip()
+    # No answer channel and no separator: a control head is analysis-only with
+    # nothing to keep → discard; a bare-word head might be benign → keep as-is.
+    if _HEAD_CONTROL.match(text):
+        return ""
+    return text
+
+
+# Bound on how much start-of-stream text we hold while deciding whether a stream
+# is a harmony leak. Head detection resolves within a few chars; this only caps
+# the pathological "opened with a control token but never a valid channel name".
+_WATCH_MAX = 64
+
+_CONTROL_ANCHORS = ("<|start|>", "<|channel|>", "<channel|>")
+_NAME_WORDS = ("analysis", "commentary", "thought")
+
+
+def _could_be_head_prefix(buf: str) -> bool:
+    """True while *buf* might still grow into a harmony head (keep watching).
+
+    Case-sensitive, mirroring :data:`_HEAD`: a capitalised ``Analysis`` heading
+    is not a channel name, so it is released to the normal machine immediately.
+    """
+    s = buf.lstrip()
+    if s == "":
+        return True
+    # A real control token opened the stream → keep watching until it resolves.
+    for a in _CONTROL_ANCHORS:
+        if s.startswith(a) or a.startswith(s):
+            return True
+    for w in _NAME_WORDS:
+        if w.startswith(s):  # strict prefix of the word ("analy")
+            return True
+        if s.startswith(w):  # the word, plus more
+            rest = s[len(w):].lstrip(" \t")
+            # Head needs a NEWLINE or a token start after the word; a colon
+            # ("Analysis:") or a letter ("thought experiments") means prose,
+            # not a channel name — release it. Keeps parity with _HEAD.
+            return rest == "" or rest[0] in ("\n", "<")
+    return False
+
+
+class HarmonyStreamGate:
+    """Front stage for the streaming scrubber: suppress a leaked harmony prefix.
+
+    ``feed(text)`` returns ``(passthrough, done)``. While still deciding
+    (*watch*) or discarding leaked reasoning (*suppress*) it returns
+    ``("", False)`` and buffers internally. Once resolved it returns
+    ``(remainder, True)`` — the answer tail to hand to the normal tag machine —
+    and thereafter passes text straight through.
+    """
+
+    def __init__(self) -> None:
+        self.reset()
+
+    def reset(self) -> None:
+        self._mode = "watch"  # "watch" | "suppress" | "done"
+        self._buf = ""
+        self._head_is_control = False
+
+    @property
+    def active(self) -> bool:
+        return self._mode != "done"
+
+    def feed(self, text: str):
+        if self._mode == "done":
+            return text, True
+        self._buf += text
+
+        if self._mode == "watch":
+            if _HEAD.match(self._buf):
+                self._mode = "suppress"
+                self._head_is_control = bool(_HEAD_CONTROL.match(self._buf))
+                # fall through to suppress resolution below
+            elif _could_be_head_prefix(self._buf) and len(self._buf.lstrip()) <= _WATCH_MAX:
+                return "", False
+            else:
+                # Not a harmony leak — release everything to the normal machine.
+                out, self._buf, self._mode = self._buf, "", "done"
+                return out, True
+
+        # suppress: discard the reasoning block until its separator arrives.
+        # (Each feed re-scans the growing buffer — O(n²) over the block, but a
+        # real leak is a few KB; a pathological multi-MB never-terminating block
+        # is bounded by the read timeout, not this scan.)
+        m = _FINAL_MARKER.search(self._buf)
+        if m:
+            out, self._buf, self._mode = self._buf[m.end():], "", "done"
+            return out, True
+        if not self._head_is_control:
+            mb = _BARE_CH.search(self._buf)
+            if mb:
+                out, self._buf, self._mode = self._buf[mb.end():], "", "done"
+                return out, True
+        return "", False
+
+    def flush(self) -> str:
+        """End-of-stream: return any text the normal machine should still see.
+
+        A *watch* buffer that never resolved was normal content that merely
+        looked prefix-y → release it. A *suppress* buffer that never found a
+        separator is discarded only when the head was an unambiguous control
+        token; a bare-word head (possibly benign "Analysis:\\n…") is released
+        rather than risk eating a real answer.
+        """
+        mode, buf, control = self._mode, self._buf, self._head_is_control
+        self._buf, self._mode = "", "done"
+        if mode == "watch":
+            return buf
+        if mode == "suppress":
+            return "" if control else buf
+        return ""

--- a/agent/harmony_scrub.py
+++ b/agent/harmony_scrub.py
@@ -1,0 +1,296 @@
+"""Shared detection/stripping for leaked OpenAI *harmony*-format reasoning.
+
+Harmony models emit private reasoning in an ``analysis``/``commentary`` channel
+and the user-facing answer in a ``final`` channel, delimited by control tokens::
+
+    <|start|>assistant<|channel|>analysis<|message|>…reasoning…<|end|>
+    <|start|>assistant<|channel|>final<|message|>…answer…<|return|>
+
+When such a model is served via Ollama and Ollama's native thinking-parse
+*misses*, that reasoning leaks into the visible message ``content`` instead of
+the separate reasoning field. Two leak shapes are seen in the wild:
+
+  (a) **degraded** — the leading control token is eaten, leaving a bare channel
+      *name* word (``analysis``/``commentary``/``thought``) at text-start, the
+      reasoning, then a lone (often pipe-stripped) ``<channel|>`` before the
+      answer. This is the shape observed live 2026-07-11.
+  (b) **canonical** — full/partial control tokens, e.g. content starting
+      ``<|channel|>analysis<|message|>…`` with a later
+      ``<|channel|>final<|message|>`` before the answer.
+
+Two consumers share this logic so they stay in sync (the invariant noted at
+``cli.py::_strip_reasoning_tags`` / ``run_agent.py::_strip_think_blocks``):
+
+* :func:`strip_harmony_leak` — for a **complete** assistant message (the
+  post-hoc / persisted path in ``strip_think_blocks`` and the CLI display path).
+* :class:`HarmonyStreamGate` — a small state machine for the **streaming** path
+  (``StreamingThinkScrubber``) so the leaked reasoning never flashes live
+  mid-reply.  The channel-name *word* of a degraded head may flash; see the
+  class docstring for why that is traded for leaving benign prose alone.
+
+Design goal: strip a genuine leak without ever touching benign prose. Both
+entry points refuse to do anything unless the text *begins* with harmony
+structure, matched **case-sensitively** against the literal lowercase channel
+names, and the bare-word form must stand alone (lowercase word followed by a
+newline or a harmony token — not a colon). So ordinary prose like "Analysis of
+Q2 revenue", a capitalised heading "Analysis\\n…", or a message that merely
+*quotes* ``<|channel|>`` mid-sentence is left untouched.
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = ["strip_harmony_leak", "HarmonyStreamGate"]
+
+# Control tokens. Ollama's partial parse can drop a leading pipe, so accept the
+# asymmetric ``<channel|>`` / ``<message|>`` forms too (justified by real data).
+_CH = r"<\|?channel\|>"
+_MSG = r"<\|?message\|>"
+
+# The whole grammar is matched CASE-SENSITIVELY. Harmony control tokens and
+# channel names are literal special tokens emitted verbatim lowercase
+# (``analysis``/``commentary``/``final``) — exact case is positive evidence from
+# the grammar itself, and it removes an entire false-positive class for free: an
+# ordinary capitalised markdown heading like ``Analysis\n…`` or ``Commentary\n…``
+# (even one that later quotes ``<|channel|>``) no longer looks like a channel head.
+
+# The answer lives in the ``final`` channel: ``<|channel|>final<|message|>``.
+# Requiring ``<|message|>`` right after the name means we never mistake a prose
+# word "Final" (as in "Final answer: …") for the channel name.
+_FINAL_MARKER = re.compile(rf"{_CH}\s*final\s*{_MSG}")
+
+# Text *begins* with harmony structure: either an opening control token for an
+# analysis/commentary/final channel (optionally preceded by ``<|start|>assistant``),
+# or a bare standalone channel-name word on its own line (degraded shape (a) — the
+# real leak is ``thought\n…``). The bare word must be followed by a NEWLINE or a
+# harmony token — deliberately NOT a colon: a common benign heading like
+# "analysis: …" (even one that later quotes ``<|channel|>``) must never match.
+_HEAD = re.compile(
+    rf"^\s*(?:"
+    rf"(?:<\|?start\|>\s*assistant\s*)?{_CH}\s*(?:analysis|commentary|final)\b"
+    rf"|(?:analysis|commentary|thought)\b[ \t]*(?:\n|{_CH}|{_MSG})"
+    rf")",
+)
+
+# Whether the head opened with a control token (unambiguous harmony) vs a bare
+# word (which could, rarely, be benign lowercase prose like "analysis\n…").
+_HEAD_CONTROL = re.compile(rf"^\s*(?:<\|?start\|>|{_CH})")
+
+# A lone channel token — the separator ending the reasoning block in shape (a).
+_BARE_CH = re.compile(_CH)
+
+# Stray lone control tokens to scrub from a recovered answer tail.
+_STRAY = re.compile(r"<\|?(?:channel|message|start|end|return)\|>")
+
+
+def strip_harmony_leak(text: str) -> str:
+    """Remove a leaked harmony reasoning prefix from a complete message.
+
+    Returns *text* unchanged unless it begins with harmony structure. When it
+    does, keep only the final answer:
+
+    * **canonical** — keep everything after the *last* ``final`` channel marker;
+    * **degraded** — strip the leading reasoning up to and including the first
+      lone ``<channel|>`` separator *after the head* (the following word is kept
+      verbatim, so an answer that starts with "Final" survives).
+
+    When the text opened with harmony structure but carries no ``final`` marker
+    and no later separator, the resolution depends on the head shape:
+
+    * **control-token head** — the whole message is analysis/commentary with no
+      answer channel, so it is discarded (returns ``""``). Returning it verbatim
+      would both *show* the leaked chain-of-thought and persist it de-tokenised
+      into history — the exact leak this module exists to stop.
+    * **bare-word head** — could be benign prose that merely opens with a
+      lowercase channel-name word, so it is left untouched rather than risk
+      eating a real answer.
+    """
+    if not text:
+        return text
+    head = _HEAD.match(text)
+    if not head:
+        return text
+    # Canonical: answer follows the final-channel marker (handles analysis +
+    # commentary + final in any order, and multiple blocks — keep the last).
+    finals = list(_FINAL_MARKER.finditer(text))
+    if finals:
+        return _STRAY.sub("", text[finals[-1].end():]).strip()
+    # Degraded: strip up to and including the first lone channel separator that
+    # comes *after* the head — never the head's own control token, which would
+    # only peel the delimiters off and leave the reasoning glued to the answer.
+    sep = _BARE_CH.search(text, head.end())
+    if sep:
+        return _STRAY.sub("", text[sep.end():]).lstrip()
+    # No answer channel and no separator: a control head is analysis-only with
+    # nothing to keep → discard; a bare-word head might be benign → keep as-is.
+    if _HEAD_CONTROL.match(text):
+        return ""
+    return text
+
+
+# Bound on how much start-of-stream text we hold while deciding whether a stream
+# is a harmony leak. Head detection resolves within a few chars; this only caps
+# the pathological "opened with a control token but never a valid channel name".
+_WATCH_MAX = 64
+
+_CONTROL_ANCHORS = ("<|start|>", "<|channel|>", "<channel|>")
+_NAME_WORDS = ("analysis", "commentary", "thought")
+
+
+def _head_prefix_class(buf: str) -> str | None:
+    """Which harmony head *buf* could still grow into: ``"control"``/``"word"``.
+
+    ``None`` means it can no longer become a head at all.  The distinction is
+    what drives the streaming tradeoff in :class:`HarmonyStreamGate`: a control
+    prefix is worth holding back, a bare-word prefix is not.
+
+    Case-sensitive, mirroring :data:`_HEAD`: a capitalised ``Analysis`` heading
+    is not a channel name, so it is released to the normal machine immediately.
+    """
+    s = buf.lstrip()
+    if s == "":
+        # Whitespace only so far.  Either shape could still follow, but leading
+        # whitespace is never the sensitive part of a leak, so classify it as a
+        # word prefix and let it go out rather than holding the stream.
+        return "word"
+    if s[0] == "<":
+        for a in _CONTROL_ANCHORS:
+            if s.startswith(a) or a.startswith(s):
+                return "control"
+        return None
+    for w in _NAME_WORDS:
+        if w.startswith(s):  # strict prefix of the word ("analy")
+            return "word"
+        if s.startswith(w):  # the word, plus more
+            rest = s[len(w):].lstrip(" \t")
+            # Head needs a NEWLINE or a token start after the word; a colon
+            # ("analysis:") or a letter ("thought experiments") means prose,
+            # not a channel name — release it. Keeps parity with _HEAD.
+            return "word" if (rest == "" or rest[0] in ("\n", "<")) else None
+    return None
+
+
+class HarmonyStreamGate:
+    """Front stage for the streaming scrubber: suppress a leaked harmony prefix.
+
+    ``feed(text)`` returns the text the tag machine should see, which is ``""``
+    while the gate is holding or discarding.  :attr:`active` says whether the
+    gate is still engaged; once it goes false, text flows straight through.
+
+    The two head shapes are handled differently, because they carry very
+    different false-positive risk:
+
+    * **control-token head** (``<|channel|>analysis…``) — *hold, then decide*.
+      No ordinary prose opens with ``<``, so buffering a few characters costs
+      nothing.  This is what the surrounding
+      :class:`~agent.think_scrubber.StreamingThinkScrubber` already does with a
+      partial ``<think>`` prefix, so the behaviour is not new to this file.
+    * **bare-word head** (``thought\\n…``) — *emit, then suppress*.
+      ``analysis``/``commentary``/``thought`` are ordinary English words, so a
+      stream opening with one is far likelier to be prose than a leak.  Holding
+      it would delay and coalesce the deltas of that benign prose, which is a
+      visible behaviour change on every such stream — upstream's own
+      ``tests/run_agent/test_streaming.py::test_deltas_fire_in_order`` pins
+      exactly that contract.  So the deltas go out as they arrive, and
+      suppression begins at the head's end if it later confirms.
+
+    The price of the second rule is that on a real degraded leak the
+    channel-name word itself flashes in the live stream before suppression
+    starts.  That is the whole cost: the reasoning body never reaches the wire,
+    and the persisted and CLI paths still run :func:`strip_harmony_leak`, so the
+    word does not survive into history either.  Traded knowingly — the word is
+    not the secret, the leak is rare, and benign lowercase prose is not.
+
+    A head that arrives whole before anything has been emitted is still
+    suppressed whole: nothing is on the wire yet, so there is nothing to trade.
+    """
+
+    def __init__(self) -> None:
+        self.reset()
+
+    def reset(self) -> None:
+        # "watch"    — deciding.  Per delta, a control prefix is held and a
+        #              bare-word prefix is emitted (see the class docstring).
+        # "suppress" — head confirmed; discard until the separator.
+        # "done"     — spent; text passes straight through.
+        self._mode = "watch"
+        self._buf = ""
+        # How much of _buf has already gone downstream.  Non-zero only on the
+        # emit path, and the reason the gate can mix holding and emitting
+        # without ever releasing the same characters twice.
+        self._sent = 0
+        self._head_is_control = False
+
+    @property
+    def active(self) -> bool:
+        return self._mode != "done"
+
+    def feed(self, text: str) -> str:
+        if self._mode == "done":
+            return text
+        self._buf += text
+        out = ""
+
+        if self._mode == "watch":
+            head = _HEAD.match(self._buf)
+            if head:
+                self._head_is_control = bool(_HEAD_CONTROL.match(self._buf))
+                # A bare-word head whose first characters are already on the
+                # wire: release the rest of the word too, so what the user sees
+                # is the whole word rather than a fragment that depends on where
+                # the chunk boundaries happened to fall.  Nothing sent yet (or a
+                # control head) means nothing to make good on — suppress it all.
+                if self._sent and not self._head_is_control:
+                    out = self._buf[self._sent:head.end()]
+                self._buf, self._sent = self._buf[head.end():], 0
+                self._mode = "suppress"
+                # fall through to suppress resolution below
+            else:
+                cls = _head_prefix_class(self._buf)
+                if cls is None or len(self._buf.lstrip()) > _WATCH_MAX:
+                    # Not a harmony leak.  Release whatever has not gone out.
+                    out = self._buf[self._sent:]
+                    self._buf, self._sent, self._mode = "", 0, "done"
+                    return out
+                if cls == "control":
+                    return ""  # hold: decide before emitting anything
+                out = self._buf[self._sent:]  # bare word: emit as it arrives
+                self._sent = len(self._buf)
+                return out
+
+        # suppress: discard the reasoning block until its separator arrives.
+        # (Each feed re-scans the growing buffer — O(n²) over the block, but a
+        # real leak is a few KB; a pathological multi-MB never-terminating block
+        # is bounded by the read timeout, not this scan.)
+        m = _FINAL_MARKER.search(self._buf)
+        if m:
+            out += self._buf[m.end():]
+            self._buf, self._sent, self._mode = "", 0, "done"
+            return out
+        if not self._head_is_control:
+            mb = _BARE_CH.search(self._buf)
+            if mb:
+                out += self._buf[mb.end():]
+                self._buf, self._sent, self._mode = "", 0, "done"
+                return out
+        return out
+
+    def flush(self) -> str:
+        """End-of-stream: return any text the normal machine should still see.
+
+        A *watch* buffer that never resolved was normal content that merely
+        looked prefix-y → release whatever of it has not already gone out.  A
+        *suppress* buffer that never found a separator is discarded only when
+        the head was an unambiguous control token; a bare-word head (possibly
+        benign ``analysis\\n…`` prose) is released rather than risk eating a
+        real answer.
+        """
+        mode, buf, sent = self._mode, self._buf, self._sent
+        control = self._head_is_control
+        self._buf, self._sent, self._mode = "", 0, "done"
+        if mode == "watch":
+            return buf[sent:]
+        if mode == "suppress":
+            return "" if control else buf
+        return ""

--- a/agent/think_scrubber.py
+++ b/agent/think_scrubber.py
@@ -58,6 +58,8 @@ from __future__ import annotations
 
 from typing import Tuple
 
+from agent.harmony_scrub import HarmonyStreamGate
+
 __all__ = ["StreamingThinkScrubber"]
 
 
@@ -96,12 +98,16 @@ class StreamingThinkScrubber:
         self._in_block: bool = False
         self._buf: str = ""
         self._last_emitted_ended_newline: bool = True
+        # Front stage: suppress a leaked harmony reasoning prefix before the
+        # tag machine ever sees it (the leak has no <think>-style tags).
+        self._harmony = HarmonyStreamGate()
 
     def reset(self) -> None:
         """Reset all state.  Call at the top of every new turn."""
         self._in_block = False
         self._buf = ""
         self._last_emitted_ended_newline = True
+        self._harmony.reset()
 
     def feed(self, text: str) -> str:
         """Feed one delta; return the scrubbed visible portion.
@@ -112,6 +118,16 @@ class StreamingThinkScrubber:
         """
         if not text:
             return ""
+        # Front stage — harmony reasoning-leak suppression. While the gate is
+        # watching/suppressing it holds text back (returns ""); once resolved it
+        # hands the answer tail to the tag machine below. Inactive after that.
+        if self._harmony.active:
+            passthrough, done = self._harmony.feed(text)
+            if not done:
+                return ""
+            text = passthrough
+            if not text:
+                return ""
         buf = self._buf + text
         self._buf = ""
         out: list[str] = []
@@ -216,12 +232,25 @@ class StreamingThinkScrubber:
         stream's opening ``<think>`` look mid-line and leak into the
         visible reply.
         """
+        out = ""
+        # Release any harmony-gate leftover into the tag machine first (a watch
+        # buffer that never resolved, or a benign bare-word "analysis" answer).
+        if self._harmony.active:
+            leftover = self._harmony.flush()  # gate → done
+            if leftover:
+                out += self.feed(leftover)
+        # Re-arm the harmony gate for the next stream. Intra-turn retries
+        # (thinking-only prefill, empty-response retry) flush then stream again
+        # without calling reset() — same reason upstream re-arms the boundary
+        # flag here (a569226f8). Done AFTER the leftover release above, which
+        # relies on the gate being spent so feed() passes the leftover through.
+        self._harmony.reset()
         if self._in_block:
             self._buf = ""
             self._in_block = False
             # Next feed() is a new stream — start-of-stream is a boundary.
             self._last_emitted_ended_newline = True
-            return ""
+            return out
         tail = self._buf
         self._buf = ""
         # Same for the non-block path: do NOT derive the boundary flag
@@ -229,8 +258,8 @@ class StreamingThinkScrubber:
         # means the next feed() starts a new model response.
         self._last_emitted_ended_newline = True
         if not tail:
-            return ""
-        return self._strip_orphan_close_tags(tail)
+            return out
+        return out + self._strip_orphan_close_tags(tail)
 
     # ── internal helpers ───────────────────────────────────────────────
 

--- a/agent/think_scrubber.py
+++ b/agent/think_scrubber.py
@@ -58,6 +58,8 @@ from __future__ import annotations
 
 from typing import Tuple
 
+from agent.harmony_scrub import HarmonyStreamGate
+
 __all__ = ["StreamingThinkScrubber"]
 
 
@@ -96,12 +98,16 @@ class StreamingThinkScrubber:
         self._in_block: bool = False
         self._buf: str = ""
         self._last_emitted_ended_newline: bool = True
+        # Front stage: suppress a leaked harmony reasoning prefix before the
+        # tag machine ever sees it (the leak has no <think>-style tags).
+        self._harmony = HarmonyStreamGate()
 
     def reset(self) -> None:
         """Reset all state.  Call at the top of every new turn."""
         self._in_block = False
         self._buf = ""
         self._last_emitted_ended_newline = True
+        self._harmony.reset()
 
     def feed(self, text: str) -> str:
         """Feed one delta; return the scrubbed visible portion.
@@ -112,6 +118,15 @@ class StreamingThinkScrubber:
         """
         if not text:
             return ""
+        # Front stage — harmony reasoning-leak suppression. The gate returns
+        # what the tag machine should see: "" while it is holding a control-token
+        # prefix or discarding reasoning, the delta itself while it is watching a
+        # bare-word prefix, and the answer tail once it resolves. It stays
+        # `active` until it resolves; inactive after that.
+        if self._harmony.active:
+            text = self._harmony.feed(text)
+            if not text:
+                return ""
         buf = self._buf + text
         self._buf = ""
         out: list[str] = []
@@ -216,12 +231,25 @@ class StreamingThinkScrubber:
         stream's opening ``<think>`` look mid-line and leak into the
         visible reply.
         """
+        out = ""
+        # Release any harmony-gate leftover into the tag machine first (a watch
+        # buffer that never resolved, or a benign bare-word "analysis" answer).
+        if self._harmony.active:
+            leftover = self._harmony.flush()  # gate → done
+            if leftover:
+                out += self.feed(leftover)
+        # Re-arm the harmony gate for the next stream. Intra-turn retries
+        # (thinking-only prefill, empty-response retry) flush then stream again
+        # without calling reset() — same reason upstream re-arms the boundary
+        # flag here (a569226f8). Done AFTER the leftover release above, which
+        # relies on the gate being spent so feed() passes the leftover through.
+        self._harmony.reset()
         if self._in_block:
             self._buf = ""
             self._in_block = False
             # Next feed() is a new stream — start-of-stream is a boundary.
             self._last_emitted_ended_newline = True
-            return ""
+            return out
         tail = self._buf
         self._buf = ""
         # Same for the non-block path: do NOT derive the boundary flag
@@ -229,8 +257,8 @@ class StreamingThinkScrubber:
         # means the next feed() starts a new model response.
         self._last_emitted_ended_newline = True
         if not tail:
-            return ""
-        return self._strip_orphan_close_tags(tail)
+            return out
+        return out + self._strip_orphan_close_tags(tail)
 
     # ── internal helpers ───────────────────────────────────────────────
 

--- a/cli.py
+++ b/cli.py
@@ -212,7 +212,12 @@ def _strip_reasoning_tags(text: str) -> str:
     ``<function name="…">…</function>``). Ported from
     openclaw/openclaw#67318.
     """
-    cleaned = text
+    # Harmony reasoning-channel leak (analysis/commentary channel dumped into
+    # content). Shared with strip_think_blocks + the streaming scrubber via
+    # agent/harmony_scrub.py so all three stay in sync; only fires when the text
+    # begins with harmony structure, so benign prose is untouched.
+    from agent.harmony_scrub import strip_harmony_leak
+    cleaned = strip_harmony_leak(text)
     for tag in _REASONING_TAGS:
         # Closed pair — case-insensitive so <THINK>…</THINK> is handled too.
         cleaned = re.sub(

--- a/cli.py
+++ b/cli.py
@@ -263,7 +263,12 @@ def _strip_reasoning_tags(text: str) -> str:
     ``<function name="…">…</function>``). Ported from
     openclaw/openclaw#67318.
     """
-    cleaned = text
+    # Harmony reasoning-channel leak (analysis/commentary channel dumped into
+    # content). Shared with strip_think_blocks + the streaming scrubber via
+    # agent/harmony_scrub.py so all three stay in sync; only fires when the text
+    # begins with harmony structure, so benign prose is untouched.
+    from agent.harmony_scrub import strip_harmony_leak
+    cleaned = strip_harmony_leak(text)
     for tag in _REASONING_TAGS:
         # Closed pair — case-insensitive so <THINK>…</THINK> is handled too.
         cleaned = re.sub(

--- a/tests/agent/test_harmony_scrub.py
+++ b/tests/agent/test_harmony_scrub.py
@@ -1,0 +1,182 @@
+"""Tests for harmony reasoning-leak scrubbing (agent/harmony_scrub.py).
+
+Covers the complete-string stripper (strip_harmony_leak) and the streaming gate
+(via StreamingThinkScrubber), including the over-strip regressions an adversarial
+review found in the first cut of this fix, and that benign prose is untouched.
+"""
+
+import pytest
+
+from agent.harmony_scrub import strip_harmony_leak
+from agent.think_scrubber import StreamingThinkScrubber
+
+
+def _stream(deltas):
+    """Feed deltas through a fresh scrubber and return the assembled output."""
+    s = StreamingThinkScrubber()
+    out = [s.feed(d) for d in deltas]
+    out.append(s.flush())
+    return "".join(out)
+
+
+# ── strip_harmony_leak: real leak shapes are stripped ───────────────────────
+@pytest.mark.parametrize("inp,exp", [
+    # degraded shape (a): bare channel word + reasoning + lone <channel|> + answer
+    ("thought\nThe user wants X. My plan is Y.<channel|>Here is the answer.",
+     "Here is the answer."),
+    ("analysis\nreasoning here<channel|>final<|message|>The reply.", "The reply."),
+    # canonical shape (b): full control tokens, answer in the final channel
+    ("<|channel|>analysis<|message|>plan plan<|channel|>final<|message|>The answer.",
+     "The answer."),
+    ("<|start|>assistant<|channel|>analysis<|message|>think<|end|>"
+     "<|start|>assistant<|channel|>final<|message|>Done.<|return|>", "Done."),
+    # commentary channel is handled too
+    ("<|channel|>commentary<|message|>hmm<|channel|>final<|message|>Yes.", "Yes."),
+    # multiple analysis blocks → keep only after the LAST final marker
+    ("<|channel|>analysis<|message|>a<|channel|>final<|message|>x"
+     "<|channel|>final<|message|>real", "real"),
+])
+def test_strip_harmony_leak_strips_real_leaks(inp, exp):
+    assert strip_harmony_leak(inp) == exp
+
+
+# ── over-strip regressions (what the review caught) ─────────────────────────
+def test_final_word_of_answer_is_preserved():
+    # Degraded separator must NOT consume a following "Final"/"Finally".
+    assert strip_harmony_leak("analysis\nx<channel|>Final answer: 42") == "Final answer: 42"
+    assert strip_harmony_leak("thought\ny<channel|>Finally, done.") == "Finally, done."
+
+
+def test_canonical_is_not_glued_together():
+    # The token-only strip must not leave reasoning glued to the answer.
+    out = strip_harmony_leak("<|channel|>analysis<|message|>plan plan<|channel|>final<|message|>Answer.")
+    assert out == "Answer."
+    assert "plan" not in out
+
+
+# ── benign prose is never touched ───────────────────────────────────────────
+@pytest.mark.parametrize("text", [
+    "The computer, eh? Let me help with that.",
+    "Analysis of Q2 revenue: we grew 12%.",          # word followed by prose
+    "Thought experiments are a useful tool.",         # word followed by prose
+    "Analysis:\nRevenue grew 12% this quarter.",      # standalone word but no channel token
+    "In harmony format, the <|channel|> token separates channels.",  # quotes a token mid-msg
+    "Here is how <|channel|>final<|message|> works in the spec.",     # quotes final marker mid-msg
+    # Combined-condition false positive (both a heading AND a quoted token) — the
+    # heading uses a COLON, so it must not be treated as a bare channel-name head.
+    "Analysis:\nThe harmony format uses a <|channel|> token to separate sections. Done.",
+    "Analysis:\nModels emit <|channel|>final<|message|> before the answer. Note that.",
+    "thought:\nremember the <|channel|> control token exists.",
+    "",
+])
+def test_strip_harmony_leak_leaves_benign_prose(text):
+    assert strip_harmony_leak(text) == text
+
+
+# ── streaming: leaks suppressed even split across deltas ─────────────────────
+def test_stream_bare_word_leak_suppressed():
+    assert _stream(["thou", "ght\nplan plan ", "more<chan", "nel|>", "Hi ", "there."]) == "Hi there."
+
+
+def test_stream_canonical_leak_split_tokens():
+    assert _stream(["<|chan", "nel|>analysis<|mess", "age|>plan<|channel|>fi",
+                    "nal<|message|>Real ", "answer."]) == "Real answer."
+
+
+def test_stream_final_word_preserved():
+    assert _stream(["analysis\n", "x<channel|>", "Final answer: 42"]) == "Final answer: 42"
+
+
+# ── streaming: benign output is byte-for-byte unchanged ─────────────────────
+@pytest.mark.parametrize("deltas,exp", [
+    (["Analysis of ", "Q2 revenue: ", "we grew 12%."], "Analysis of Q2 revenue: we grew 12%."),
+    (["Thought ", "experiments ", "are fun."], "Thought experiments are fun."),
+    (["Just ", "a normal ", "reply."], "Just a normal reply."),
+    (["The answer ", "is 42."], "The answer is 42."),
+])
+def test_stream_benign_unchanged(deltas, exp):
+    assert _stream(deltas) == exp
+
+
+def test_stream_still_strips_think_tags():
+    # The pre-existing tag machine must keep working behind the harmony gate.
+    assert _stream(["<think>secret ", "reasoning</think>", "Visible ", "answer."]) == "Visible answer."
+    assert _stream(["prose <think>x</think> more"]) == "prose  more"
+
+
+def test_stream_benign_analysis_colon_not_suppressed():
+    # "Analysis:\n…" is a benign heading (colon, not the leak's bare-word+newline
+    # shape) — it streams straight through, even when it later quotes a token.
+    assert _stream(["Analysis:\n", "Revenue grew ", "12%."]) == "Analysis:\nRevenue grew 12%."
+    assert _stream(["Analysis:\n", "The <|channel|> ", "token sep."]) == "Analysis:\nThe <|channel|> token sep."
+
+
+# ── analysis-only leak (no final channel) must be DISCARDED, never laundered ──
+@pytest.mark.parametrize("inp", [
+    # A control-token head with no final channel: the model emitted only
+    # reasoning (truncated / tool-called / hit max_tokens). Peeling just the
+    # delimiters would ship AND persist the chain-of-thought de-tokenised.
+    "<|channel|>analysis<|message|>SECRET step-by-step plan about the user.",
+    "<|start|>assistant<|channel|>analysis<|message|>SECRET plan<|end|>",
+    "<|channel|>commentary<|message|>SECRET musing with no answer channel.",
+])
+def test_analysis_only_control_head_is_discarded(inp):
+    out = strip_harmony_leak(inp)
+    assert out == ""
+    assert "SECRET" not in out
+
+
+def test_stream_analysis_only_control_head_is_discarded():
+    out = _stream(["<|channel|>analysis<|mess", "age|>SECRET plan with ", "no final channel."])
+    assert out == ""
+    assert "SECRET" not in out
+
+
+# ── case-sensitivity: capitalised headings are prose, never a channel head ────
+@pytest.mark.parametrize("text", [
+    # Capitalised heading that also quotes a canonical final marker (would strip
+    # via the finals path if the grammar were case-insensitive).
+    "Analysis\nModels emit <|channel|>final<|message|> before the answer. Note that.",
+    # Capitalised heading + bare channel token later in the body.
+    "Commentary\nRunning the tests now; the <|channel|> token is next.",
+    "ANALYSIS\nSHOUTY HEADING about <|channel|> tokens.",
+    # Title-case word that opens a sentence.
+    "Thought\nI had earlier turned out to be right.",
+])
+def test_capitalised_heading_is_not_a_channel_head(text):
+    assert strip_harmony_leak(text) == text
+
+
+def test_stream_capitalised_heading_not_suppressed():
+    deltas = ["Analysis\n", "Models emit <|channel|>final<|message|> ", "before the answer."]
+    assert _stream(deltas) == "".join(deltas)
+
+
+# ── streaming gate re-arms after flush (intra-turn retry) ─────────────────────
+def test_stream_gate_rearms_after_flush():
+    # Thinking-only prefill / empty-response retries flush the scrubber then
+    # stream again WITHOUT reset(); the harmony gate must re-arm or the second
+    # stream's leak sails through (mirrors upstream a569226f8 for the tag flag).
+    s = StreamingThinkScrubber()
+    s.feed("A normal first answer.")
+    s.flush()
+    out = s.feed("analysis\nSECRET plan for round two<channel|>Second answer.") + s.flush()
+    assert out == "Second answer."
+    assert "SECRET" not in out
+
+
+# ── wiring: each hooked call site actually invokes the scrubber ───────────────
+_LEAK = "<|channel|>analysis<|message|>hidden plan<|channel|>final<|message|>Visible answer."
+
+
+def test_strip_think_blocks_call_site_is_wired():
+    # agent_runtime_helpers.strip_think_blocks (the post-hoc / persisted path,
+    # also reached via run_agent._strip_think_blocks) must strip harmony leaks.
+    from agent.agent_runtime_helpers import strip_think_blocks
+    assert strip_think_blocks(None, _LEAK) == "Visible answer."
+
+
+def test_cli_strip_reasoning_tags_call_site_is_wired():
+    # cli._strip_reasoning_tags (the CLI display / copy path) must strip too.
+    from cli import _strip_reasoning_tags
+    assert _strip_reasoning_tags(_LEAK) == "Visible answer."

--- a/tests/agent/test_harmony_scrub.py
+++ b/tests/agent/test_harmony_scrub.py
@@ -1,0 +1,237 @@
+"""Tests for harmony reasoning-leak scrubbing (agent/harmony_scrub.py).
+
+Covers the complete-string stripper (strip_harmony_leak) and the streaming gate
+(via StreamingThinkScrubber), including the over-strip regressions an adversarial
+review found in the first cut of this fix, and that benign prose is untouched.
+"""
+
+import pytest
+
+from agent.harmony_scrub import strip_harmony_leak
+from agent.think_scrubber import StreamingThinkScrubber
+
+
+def _stream(deltas):
+    """Feed deltas through a fresh scrubber and return the assembled output."""
+    return "".join(_stream_parts(deltas))
+
+
+def _stream_parts(deltas):
+    """Like :func:`_stream` but keeps the per-delta boundaries.
+
+    Needed because the gate is allowed to change *what* is emitted but must not
+    silently coalesce the deltas of benign prose — see
+    ``test_stream_benign_lowercase_deltas_not_coalesced``.
+    """
+    s = StreamingThinkScrubber()
+    out = [s.feed(d) for d in deltas]
+    out.append(s.flush())
+    return out
+
+
+# ── strip_harmony_leak: real leak shapes are stripped ───────────────────────
+@pytest.mark.parametrize("inp,exp", [
+    # degraded shape (a): bare channel word + reasoning + lone <channel|> + answer
+    ("thought\nThe user wants X. My plan is Y.<channel|>Here is the answer.",
+     "Here is the answer."),
+    ("analysis\nreasoning here<channel|>final<|message|>The reply.", "The reply."),
+    # canonical shape (b): full control tokens, answer in the final channel
+    ("<|channel|>analysis<|message|>plan plan<|channel|>final<|message|>The answer.",
+     "The answer."),
+    ("<|start|>assistant<|channel|>analysis<|message|>think<|end|>"
+     "<|start|>assistant<|channel|>final<|message|>Done.<|return|>", "Done."),
+    # commentary channel is handled too
+    ("<|channel|>commentary<|message|>hmm<|channel|>final<|message|>Yes.", "Yes."),
+    # multiple analysis blocks → keep only after the LAST final marker
+    ("<|channel|>analysis<|message|>a<|channel|>final<|message|>x"
+     "<|channel|>final<|message|>real", "real"),
+])
+def test_strip_harmony_leak_strips_real_leaks(inp, exp):
+    assert strip_harmony_leak(inp) == exp
+
+
+# ── over-strip regressions (what the review caught) ─────────────────────────
+def test_final_word_of_answer_is_preserved():
+    # Degraded separator must NOT consume a following "Final"/"Finally".
+    assert strip_harmony_leak("analysis\nx<channel|>Final answer: 42") == "Final answer: 42"
+    assert strip_harmony_leak("thought\ny<channel|>Finally, done.") == "Finally, done."
+
+
+def test_canonical_is_not_glued_together():
+    # The token-only strip must not leave reasoning glued to the answer.
+    out = strip_harmony_leak("<|channel|>analysis<|message|>plan plan<|channel|>final<|message|>Answer.")
+    assert out == "Answer."
+    assert "plan" not in out
+
+
+# ── benign prose is never touched ───────────────────────────────────────────
+@pytest.mark.parametrize("text", [
+    "The computer, eh? Let me help with that.",
+    "Analysis of Q2 revenue: we grew 12%.",          # word followed by prose
+    "Thought experiments are a useful tool.",         # word followed by prose
+    "Analysis:\nRevenue grew 12% this quarter.",      # standalone word but no channel token
+    "In harmony format, the <|channel|> token separates channels.",  # quotes a token mid-msg
+    "Here is how <|channel|>final<|message|> works in the spec.",     # quotes final marker mid-msg
+    # Combined-condition false positive (both a heading AND a quoted token) — the
+    # heading uses a COLON, so it must not be treated as a bare channel-name head.
+    "Analysis:\nThe harmony format uses a <|channel|> token to separate sections. Done.",
+    "Analysis:\nModels emit <|channel|>final<|message|> before the answer. Note that.",
+    "thought:\nremember the <|channel|> control token exists.",
+    "",
+])
+def test_strip_harmony_leak_leaves_benign_prose(text):
+    assert strip_harmony_leak(text) == text
+
+
+# ── streaming: leaks suppressed even split across deltas ─────────────────────
+def test_stream_bare_word_leak_body_suppressed_head_may_flash():
+    # A bare-word head split across deltas cannot be held back without also
+    # holding benign prose (see HarmonyStreamGate's docstring), so the word
+    # itself reaches the wire. What must NEVER reach it is the reasoning body.
+    out = _stream(["thou", "ght\nplan plan ", "more<chan", "nel|>", "Hi ", "there."])
+    assert out == "thought\nHi there."
+    assert "plan" not in out
+    # ...and the persisted/CLI path still removes the word, so nothing survives.
+    assert strip_harmony_leak("thought\nplan plan more<channel|>Hi there.") == "Hi there."
+
+
+def test_stream_bare_word_head_whole_in_one_delta_is_fully_suppressed():
+    # Nothing is on the wire yet when the head arrives complete, so there is no
+    # trade to make: the word is suppressed too.
+    out = _stream(["thought\nplan plan more<channel|>", "Hi ", "there."])
+    assert out == "Hi there."
+    assert "thought" not in out
+
+
+def test_stream_canonical_leak_split_tokens():
+    assert _stream(["<|chan", "nel|>analysis<|mess", "age|>plan<|channel|>fi",
+                    "nal<|message|>Real ", "answer."]) == "Real answer."
+
+
+def test_stream_final_word_preserved():
+    assert _stream(["analysis\n", "x<channel|>", "Final answer: 42"]) == "Final answer: 42"
+
+
+# ── streaming: benign output is byte-for-byte unchanged ─────────────────────
+@pytest.mark.parametrize("deltas,exp", [
+    (["Analysis of ", "Q2 revenue: ", "we grew 12%."], "Analysis of Q2 revenue: we grew 12%."),
+    (["Thought ", "experiments ", "are fun."], "Thought experiments are fun."),
+    (["Just ", "a normal ", "reply."], "Just a normal reply."),
+    (["The answer ", "is 42."], "The answer is 42."),
+])
+def test_stream_benign_unchanged(deltas, exp):
+    assert _stream(deltas) == exp
+
+
+@pytest.mark.parametrize("deltas", [
+    # The upstream regression this gate must not cause: these all open with a
+    # lowercase prefix of a channel-name word ("a" of analysis, "c" of
+    # commentary, "t" of thought), so an earlier cut held the first delta and
+    # re-emitted it merged into the second. Boundaries must survive intact —
+    # tests/run_agent/test_streaming.py::test_deltas_fire_in_order pins the
+    # same contract one layer up.
+    ["a", "b", "c"],
+    ["analy", "sis: ", "we grew 12%."],
+    ["comm", "on ", "ground."],
+    ["thought", "ful ", "reply."],
+    [" ", "leading ", "space."],
+])
+def test_stream_benign_lowercase_deltas_not_coalesced(deltas):
+    parts = [p for p in _stream_parts(deltas) if p]
+    assert parts == deltas
+
+
+def test_stream_still_strips_think_tags():
+    # The pre-existing tag machine must keep working behind the harmony gate.
+    assert _stream(["<think>secret ", "reasoning</think>", "Visible ", "answer."]) == "Visible answer."
+    assert _stream(["prose <think>x</think> more"]) == "prose  more"
+
+
+def test_stream_benign_analysis_colon_not_suppressed():
+    # "Analysis:\n…" is a benign heading (colon, not the leak's bare-word+newline
+    # shape) — it streams straight through, even when it later quotes a token.
+    assert _stream(["Analysis:\n", "Revenue grew ", "12%."]) == "Analysis:\nRevenue grew 12%."
+    assert _stream(["Analysis:\n", "The <|channel|> ", "token sep."]) == "Analysis:\nThe <|channel|> token sep."
+
+
+# ── analysis-only leak (no final channel) must be DISCARDED, never laundered ──
+@pytest.mark.parametrize("inp", [
+    # A control-token head with no final channel: the model emitted only
+    # reasoning (truncated / tool-called / hit max_tokens). Peeling just the
+    # delimiters would ship AND persist the chain-of-thought de-tokenised.
+    "<|channel|>analysis<|message|>SECRET step-by-step plan about the user.",
+    "<|start|>assistant<|channel|>analysis<|message|>SECRET plan<|end|>",
+    "<|channel|>commentary<|message|>SECRET musing with no answer channel.",
+])
+def test_analysis_only_control_head_is_discarded(inp):
+    out = strip_harmony_leak(inp)
+    assert out == ""
+    assert "SECRET" not in out
+
+
+def test_stream_whitespace_then_split_control_head_never_emits_token():
+    # Leading whitespace is emitted immediately (it is not the sensitive part),
+    # but the control token that follows must still be held and suppressed —
+    # the gate tracks what it has already sent, so it never releases the token
+    # just because it emitted the space before it.
+    out = _stream([" ", "<|chan", "nel|>analysis<|mess", "age|>SECRET plan",
+                   "<|channel|>final<|message|>Real answer."])
+    assert out == " Real answer."
+    assert "SECRET" not in out
+    assert "<|channel|>" not in out
+
+
+def test_stream_analysis_only_control_head_is_discarded():
+    out = _stream(["<|channel|>analysis<|mess", "age|>SECRET plan with ", "no final channel."])
+    assert out == ""
+    assert "SECRET" not in out
+
+
+# ── case-sensitivity: capitalised headings are prose, never a channel head ────
+@pytest.mark.parametrize("text", [
+    # Capitalised heading that also quotes a canonical final marker (would strip
+    # via the finals path if the grammar were case-insensitive).
+    "Analysis\nModels emit <|channel|>final<|message|> before the answer. Note that.",
+    # Capitalised heading + bare channel token later in the body.
+    "Commentary\nRunning the tests now; the <|channel|> token is next.",
+    "ANALYSIS\nSHOUTY HEADING about <|channel|> tokens.",
+    # Title-case word that opens a sentence.
+    "Thought\nI had earlier turned out to be right.",
+])
+def test_capitalised_heading_is_not_a_channel_head(text):
+    assert strip_harmony_leak(text) == text
+
+
+def test_stream_capitalised_heading_not_suppressed():
+    deltas = ["Analysis\n", "Models emit <|channel|>final<|message|> ", "before the answer."]
+    assert _stream(deltas) == "".join(deltas)
+
+
+# ── streaming gate re-arms after flush (intra-turn retry) ─────────────────────
+def test_stream_gate_rearms_after_flush():
+    # Thinking-only prefill / empty-response retries flush the scrubber then
+    # stream again WITHOUT reset(); the harmony gate must re-arm or the second
+    # stream's leak sails through (mirrors upstream a569226f8 for the tag flag).
+    s = StreamingThinkScrubber()
+    s.feed("A normal first answer.")
+    s.flush()
+    out = s.feed("analysis\nSECRET plan for round two<channel|>Second answer.") + s.flush()
+    assert out == "Second answer."
+    assert "SECRET" not in out
+
+
+# ── wiring: each hooked call site actually invokes the scrubber ───────────────
+_LEAK = "<|channel|>analysis<|message|>hidden plan<|channel|>final<|message|>Visible answer."
+
+
+def test_strip_think_blocks_call_site_is_wired():
+    # agent_runtime_helpers.strip_think_blocks (the post-hoc / persisted path,
+    # also reached via run_agent._strip_think_blocks) must strip harmony leaks.
+    from agent.agent_runtime_helpers import strip_think_blocks
+    assert strip_think_blocks(None, _LEAK) == "Visible answer."
+
+
+def test_cli_strip_reasoning_tags_call_site_is_wired():
+    # cli._strip_reasoning_tags (the CLI display / copy path) must strip too.
+    from cli import _strip_reasoning_tags
+    assert _strip_reasoning_tags(_LEAK) == "Visible answer."


### PR DESCRIPTION
## Summary

Some models use OpenAI's **harmony** response format, which separates private reasoning (an `analysis`/`commentary` channel) from the user-facing answer (a `final` channel) with control tokens:

```
<|start|>assistant<|channel|>analysis<|message|>…reasoning…<|end|>
<|start|>assistant<|channel|>final<|message|>…answer…<|return|>
```

When such a model is served via **Ollama** and Ollama's native thinking-parse *misses*, that reasoning **leaks into the visible message `content`** — the user sees the raw chain-of-thought plus stray `<channel|>` markers before the real answer. This adds grammar-faithful, false-positive-guarded stripping of that leak, centralised in one module and applied at **every** sync-coupled site that emits or persists assistant content.

This is defense-in-depth for a parse miss, and it's the same class of fix the agent already does for leaked harmony **tool-call** serialization in `agent/codex_responses_adapter.py::_TOOL_CALL_LEAK_PATTERN` (which strips `<|channel|>commentary to=functions.…` out of visible content). Leaked harmony structure in `content` is treated here, consistently, as an in-agent bug to clean — not something to leave to the transport. It also plays the same role `strip_think_blocks` already plays for MiniMax (`<mm:think>`, #8878/#9568) and the tool-call XML port (#67318), and is the kind of stripper invited in #45211.

## Symptom

A real captured leak (assistant message, thinking on):

```
thought
The user wants me to… My persona should…        ← chain-of-thought
…
<channel|>The computer, eh? The glowing window to every…   ← the real answer
```

The whole plan ships to the user, followed by a bare `<channel|>` separator, then the actual reply. Two shapes occur in the wild: the **degraded** shape above (leading control token eaten by Ollama's partial parse, leaving a bare channel-name word) and the **canonical** full-token form.

## The fix

New module `agent/harmony_scrub.py`:

- **`strip_harmony_leak(text)`** — for a complete message. Returns text unchanged unless it *begins* with harmony structure. Canonical → keep everything after the *last* `final`-channel marker; degraded → strip the leading reasoning up to and including the first lone `<channel|>` **after the head** (following word kept verbatim). An **analysis-only** leak (a channel head with no `final` marker and no later separator) is **discarded** rather than returned with its delimiters merely peeled off — otherwise the chain-of-thought would ship *and* persist de-tokenised into history where it can never be re-detected.
- **`HarmonyStreamGate`** — a watch/suppress/done state machine for the streaming path; holds back a leaked prefix delta-by-delta (even when control tokens are split across deltas) and releases only the answer tail. It **re-arms on flush**, so an intra-turn retry stream (thinking-only prefill, empty-response retry — the same case as a569226f8) is still guarded.

Applied at every sync-coupled site that emits or persists assistant content (whole bug class, not just the reported surface):

| Layer | Where |
|---|---|
| Persisted / post-hoc | `agent_runtime_helpers.py::strip_think_blocks` (and `run_agent._strip_think_blocks`, a forwarder) |
| Live stream | `agent/think_scrubber.py::StreamingThinkScrubber` |
| CLI display | `cli.py::_strip_reasoning_tags` |
| Iteration-limit summaries | `chat_completion_helpers.py::handle_max_iterations` (both summary sites — previously hand-rolled a `<think>`-only, case-sensitive strip and appended straight to `messages`, bypassing the storage-boundary scrub) |
| Auxiliary / vision fallback | `auxiliary_client.py::extract_content_or_reasoning` (guarded `<think>` but not harmony) |

## False-positive safety

The harmony grammar is matched **case-sensitively** against the literal lowercase channel names (`analysis`/`commentary`/`final`) — the tokens are emitted verbatim lowercase, so exact case is positive evidence from the grammar, and it means an ordinary **capitalised heading is never mistaken for a channel head**. Both entry points also only engage when text *begins* with harmony structure, and a bare channel-name word must **stand alone** (followed by a newline or a harmony token — not a colon). Verified untouched (complete-string and streamed):

- `"Analysis of Q2 revenue: we grew 12%."` (word followed by prose)
- `"Analysis\nModels emit <|channel|>final<|message|> before the answer."` (capitalised heading that even quotes the final marker)
- `"Commentary\nRunning the tests now; the <|channel|> token is next."` (capitalised heading + quoted token)
- `"Analysis:\nThe format uses a <|channel|> token…"` (heading **and** a quoted token)
- normal replies stream byte-for-byte unchanged

The global stray-token strip runs **only** on a confirmed leak's recovered tail, never on arbitrary content.

## Not a collision with `display.show_commentary`

This scrubs a *degenerate serialization* of harmony control tokens leaking into `content`; it does not touch the Codex **commentary channel** feature. Codex commentary is a structured `phase="commentary"` message item surfaced through the Codex runtime (`agent/codex_runtime.py`, gated by the `display.show_commentary` config toggle), never a raw token stream — no harmony control tokens or bare channel-name head reach this module on that path, so `show_commentary: true` output is unaffected.

## Tests

`tests/agent/test_harmony_scrub.py` (new) + the existing `tests/agent/test_think_scrubber.py` — **72 pass**, including upstream's `flush` boundary tests from a569226f8. Covers both leak shapes, multi-block/commentary, the over-strip regressions (an answer starting "Final…"; a canonical leak; a heading-plus-quoted-token), the analysis-only **discard** (complete + streaming), the capitalised-heading false-positive class (complete + streaming), the streaming **gate re-arm after flush**, per-hook wiring for `strip_think_blocks` and `cli._strip_reasoning_tags`, streaming with tokens split across deltas, `<think>`-tag regression (unchanged), and a battery of benign inputs that must be untouched.

Rebased onto current `main`.

Relates to #56213, #45211.
