### PR TITLE
fix(hooks): register hooks in profile-isolated Desktop and TUI backends

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12180,6 +12180,22 @@ def cmd_dashboard(args):
     # fail-closed SystemExit unchanged.
     _maybe_setup_dashboard_auth_interactively(args)
 
+    # The Desktop app starts one backend per profile. Register that profile's
+    # hooks only there — the browser dashboard is a multi-profile process and
+    # must not install one profile's hooks process-wide. Auth setup comes first
+    # because it may force plugin rediscovery, which clears registered hooks.
+    if os.environ.get("HERMES_DESKTOP") == "1":
+        try:
+            from hermes_cli.config import load_config
+            from agent.shell_hooks import register_from_config
+
+            register_from_config(load_config(), accept_hooks=False)
+        except Exception:
+            logger.debug(
+                "shell-hook registration failed at Desktop backend startup",
+                exc_info=True,
+            )
+
     # The in-browser Chat tab (the embedded TUI over PTY/WebSocket) is always
     # available — the desktop app and the dashboard's own Chat tab both rely on
     # the `/api/ws` + `/api/pty` sockets, so there is no reason to gate them.

--- a/tests/hermes_cli/test_dashboard_unified_launch.py
+++ b/tests/hermes_cli/test_dashboard_unified_launch.py
@@ -26,6 +26,72 @@ def _args(**kw):
     return types.SimpleNamespace(**defaults)
 
 
+def _stub_dashboard_startup(main_mod, monkeypatch, *, desktop, registration_error=False):
+    """Stub dashboard startup dependencies and return its observable events."""
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name", lambda: "default"
+    )
+    if desktop:
+        monkeypatch.setenv("HERMES_DESKTOP", "1")
+    else:
+        monkeypatch.delenv("HERMES_DESKTOP", raising=False)
+    monkeypatch.delenv("HERMES_WEB_DIST", raising=False)
+    monkeypatch.setattr(main_mod, "_sync_bundled_skills_quietly", lambda: None)
+    monkeypatch.setattr(main_mod, "_build_web_ui", lambda *_a, **_k: True)
+    monkeypatch.setitem(sys.modules, "fastapi", types.SimpleNamespace())
+    monkeypatch.setitem(sys.modules, "uvicorn", types.SimpleNamespace())
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_logging",
+        types.SimpleNamespace(setup_logging=lambda **_k: None),
+    )
+
+    events = []
+    config = {"hooks": {"pre_llm_call": [{"command": "test-hook"}]}}
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(
+            discover_plugins=lambda: events.append("plugin-discovery")
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        types.SimpleNamespace(
+            load_config=lambda: events.append("config-load") or config
+        ),
+    )
+
+    def register_from_config(cfg, *, accept_hooks):
+        events.append(("hook-registration", cfg, accept_hooks))
+        if registration_error:
+            raise RuntimeError("shell-hook registration failed")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.shell_hooks",
+        types.SimpleNamespace(register_from_config=register_from_config),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.mcp_startup.start_background_mcp_discovery",
+        lambda **_k: events.append("mcp-discovery"),
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "_maybe_setup_dashboard_auth_interactively",
+        lambda _args: events.append("auth-setup"),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.web_server",
+        types.SimpleNamespace(
+            start_server=lambda **_kwargs: events.append("server-start")
+        ),
+    )
+    return events, config
+
+
 class TestUnifiedDashboardRouting:
     def test_profile_launch_attaches_to_running_dashboard(self, main_mod, monkeypatch):
         monkeypatch.setattr(
@@ -232,3 +298,71 @@ class TestUnifiedDashboardRouting:
                 "thread_name": "dashboard-mcp-discovery",
             }
         ]
+
+    def test_ordinary_dashboard_does_not_register_shell_hooks(
+        self, main_mod, monkeypatch
+    ):
+        """The multi-profile browser dashboard must not install profile hooks."""
+        events, _config = _stub_dashboard_startup(
+            main_mod, monkeypatch, desktop=False
+        )
+
+        main_mod.cmd_dashboard(_args())
+
+        assert events == [
+            "plugin-discovery",
+            "mcp-discovery",
+            "auth-setup",
+            "server-start",
+        ]
+
+    def test_desktop_registers_shell_hooks_after_auth_immediately_before_server_start(
+        self, main_mod, monkeypatch
+    ):
+        """Auth may rediscover plugins, so Desktop hooks load after auth setup."""
+        events, config = _stub_dashboard_startup(
+            main_mod, monkeypatch, desktop=True
+        )
+
+        main_mod.cmd_dashboard(_args())
+
+        assert events == [
+            "plugin-discovery",
+            "mcp-discovery",
+            "auth-setup",
+            "config-load",
+            ("hook-registration", config, False),
+            "server-start",
+        ]
+
+    def test_desktop_shell_hook_registration_failure_still_starts_server(
+        self, main_mod, monkeypatch
+    ):
+        events, config = _stub_dashboard_startup(
+            main_mod, monkeypatch, desktop=True, registration_error=True
+        )
+
+        main_mod.cmd_dashboard(_args())
+
+        assert events == [
+            "plugin-discovery",
+            "mcp-discovery",
+            "auth-setup",
+            "config-load",
+            ("hook-registration", config, False),
+            "server-start",
+        ]
+
+    def test_dashboard_lifecycle_actions_do_not_register_shell_hooks(
+        self, main_mod, monkeypatch
+    ):
+        events, _config = _stub_dashboard_startup(
+            main_mod, monkeypatch, desktop=True
+        )
+        monkeypatch.setattr(main_mod, "_report_dashboard_status", lambda: 0)
+        with pytest.raises(SystemExit):
+            main_mod.cmd_dashboard(_args(status=True))
+        monkeypatch.setattr(main_mod, "_find_stale_dashboard_pids", lambda: [])
+        with pytest.raises(SystemExit):
+            main_mod.cmd_dashboard(_args(stop=True))
+        assert events == []

--- a/tests/tui_gateway/test_entry_sys_path.py
+++ b/tests/tui_gateway/test_entry_sys_path.py
@@ -12,9 +12,12 @@ failure.
 """
 
 import ast
+import io
 import pathlib
 
 import hermes_bootstrap
+import pytest
+import tui_gateway.entry as entry
 
 
 def _entry_source() -> str:
@@ -51,6 +54,89 @@ def test_entry_calls_shared_harden_guard_before_heavy_imports():
     assert harden_call_line < server_import_line, (
         "harden_import_path() must run before tui_gateway.server is imported"
     )
+
+
+def test_main_registers_configured_shell_hooks_before_gateway_ready(monkeypatch):
+    config = {"hooks": {"pre_tool_call": [{"command": "check-tool"}]}}
+    events = []
+
+    from agent import shell_hooks
+    from hermes_cli import config as config_module
+
+    monkeypatch.setattr(entry, "_install_sidecar_publisher", lambda: None)
+    monkeypatch.setattr(entry, "_log_exit", lambda _reason: None)
+    monkeypatch.setattr(entry, "resolve_skin", lambda: {})
+    monkeypatch.setattr(entry.sys, "stdin", io.StringIO(""))
+    monkeypatch.setattr(config_module, "read_raw_config", lambda: {})
+    monkeypatch.setattr(
+        config_module,
+        "load_config",
+        lambda: events.append("load_config") or config,
+    )
+    monkeypatch.setattr(
+        shell_hooks,
+        "register_from_config",
+        lambda cfg, *, accept_hooks: events.append(
+            ("register_from_config", cfg, accept_hooks)
+        ),
+    )
+    monkeypatch.setattr(
+        entry,
+        "write_json",
+        lambda message: events.append(message["params"]["type"]) or True,
+    )
+
+    entry.main()
+
+    assert events == [
+        "load_config",
+        ("register_from_config", config, False),
+        "gateway.ready",
+    ]
+
+
+@pytest.mark.parametrize("failure_stage", ["load", "register"])
+def test_main_shell_hook_failure_still_emits_gateway_ready(
+    monkeypatch, failure_stage
+):
+    config = {"hooks": {"pre_tool_call": [{"command": "check-tool"}]}}
+    events = []
+
+    from agent import shell_hooks
+    from hermes_cli import config as config_module
+
+    monkeypatch.setattr(entry, "_install_sidecar_publisher", lambda: None)
+    monkeypatch.setattr(entry, "_log_exit", lambda _reason: None)
+    monkeypatch.setattr(entry, "resolve_skin", lambda: {})
+    monkeypatch.setattr(entry.sys, "stdin", io.StringIO(""))
+    monkeypatch.setattr(config_module, "read_raw_config", lambda: {})
+
+    def load_config():
+        events.append("load_config")
+        if failure_stage == "load":
+            raise RuntimeError("config load failed")
+        return config
+
+    def register_from_config(cfg, *, accept_hooks):
+        events.append(("register_from_config", cfg, accept_hooks))
+        if failure_stage == "register":
+            raise RuntimeError("shell-hook registration failed")
+
+    monkeypatch.setattr(config_module, "load_config", load_config)
+    monkeypatch.setattr(shell_hooks, "register_from_config", register_from_config)
+    monkeypatch.setattr(
+        entry,
+        "write_json",
+        lambda message: events.append(message["params"]["type"]) or True,
+    )
+
+    entry.main()
+
+    expected = ["load_config"]
+    if failure_stage == "register":
+        expected.append(("register_from_config", config, False))
+    expected.append("gateway.ready")
+    assert events == expected
 
 
 def test_entry_does_not_reimplement_guard_inline():

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -293,6 +293,17 @@ def join_mcp_discovery(timeout: float | None = None) -> bool:
 def main():
     _install_sidecar_publisher()
 
+    try:
+        from hermes_cli.config import load_config
+        from agent.shell_hooks import register_from_config
+
+        register_from_config(load_config(), accept_hooks=False)
+    except Exception:
+        logger.debug(
+            "shell-hook registration failed at TUI gateway startup",
+            exc_info=True,
+        )
+
     # MCP tool discovery — runs in a background daemon thread so a slow or
     # unreachable MCP server can't freeze TUI startup.  Previously this ran
     # inline before ``gateway.ready``, which meant any configured-but-down


### PR DESCRIPTION
## Problem

Shell hooks configured in `config.yaml` are registered in CLI and messaging-gateway startup, but not in the profile-specific Desktop backend or standalone TUI gateway. The turn loop still invokes hooks, but the process-local registry is empty, so hooks such as `pre_llm_call` and `pre_tool_call` silently do nothing.

This is especially misleading because `hermes hooks doctor` can pass while the active Desktop/TUI process has registered no hooks.

## Fix

- Register configured shell hooks in `cmd_dashboard()` only when `HERMES_DESKTOP=1`.
- Register after interactive auth setup and immediately before `start_server()` because auth setup can force plugin rediscovery and clear registered callbacks.
- Leave the ordinary multi-profile browser dashboard unchanged; it must not install one profile's hooks process-wide.
- Register hooks in standalone `tui_gateway.entry.main()` before `gateway.ready`.
- Keep both startup paths fail-open: registration errors are debug-logged and never prevent Hermes from starting.
- Preserve side-effect-free `--status` and `--stop` lifecycle actions.

## Profile isolation

The `HERMES_DESKTOP=1` guard is intentional. Desktop starts a separate backend process per profile, while the ordinary browser dashboard can serve multiple profiles. Unconditionally registering the launch/default profile's hooks in the browser-dashboard process risks executing them during another profile's turns.

## Ordering

Registration occurs after `_maybe_setup_dashboard_auth_interactively()`. That path may force plugin rediscovery, which clears `PluginManager._hooks`; registering earlier can leave shell-hook deduplication state populated while the actual callbacks have been removed.

## Tests

Added regression coverage for:

- ordinary dashboard does not register profile hooks;
- Desktop registers after auth setup and immediately before server start;
- registration failure still starts the Desktop server;
- `--status` and `--stop` do not register hooks;
- standalone TUI registers before `gateway.ready`;
- TUI config-load and registration failures still emit readiness.

Local verification:

```text
19 focused tests passed
Ruff passed
Python compilation passed
git diff --check passed
Independent review: PASS — no security concerns or logic errors
```

The same patch was also exercised through real isolated Desktop WebSocket and standalone TUI prompt paths with a controlled `pre_llm_call` hook; both produced completed hook invocations.

## Related work

Related issues: #41457, #43823.

This overlaps #53894, #57020 and #61823, but differs in two material ways:

1. it avoids process-global hook registration in the ordinary multi-profile browser dashboard;
2. it registers only after auth/plugin rediscovery, preventing callbacks from being silently cleared during startup.
