### PR TITLE
fix(gateway): classify PEER_ID_INVALID and migrated-chat as dead targets

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2520,7 +2520,21 @@ SEND_ERROR_KINDS = frozenset(
 # dead.  ``classify_send_error`` collapses both into ``"not_found"``;
 # ``is_chat_level_not_found`` recovers the distinction for the dead-target path.
 # See gateway.dead_targets.
-_CHAT_LEVEL_NOT_FOUND_SUBSTRINGS = ("chat not found",)
+_CHAT_LEVEL_NOT_FOUND_SUBSTRINGS = (
+    "chat not found",
+    # Telegram-specific chat-level failures: the target chat_id itself is
+    # permanently unusable, not a sub-part of an otherwise-reachable chat.
+    # PEER_ID_INVALID: the bot cannot resolve the chat_id at all (e.g. never
+    # started a DM with that user, or the id references a deleted entity) —
+    # unlike the thread/message-level not_found substrings below, there is no
+    # "sub-chat" reading of this failure. "group chat was migrated to a
+    # supergroup chat": the old chat_id is retired in favor of a new
+    # supergroup id; every future send to the old id fails identically. Both
+    # were previously unclassified ("unknown"), so the dead-target path never
+    # short-circuited retries against them — see #56225.
+    "peer_id_invalid",
+    "group chat was migrated",
+)
 _SUBCHAT_NOT_FOUND_SUBSTRINGS = (
     "message to edit not found",
     "message to reply not found",

--- a/tests/gateway/test_dead_targets.py
+++ b/tests/gateway/test_dead_targets.py
@@ -130,7 +130,39 @@ _SUBCHAT_NOT_FOUND_MESSAGES = [
 ]
 
 
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Bad Request: PEER_ID_INVALID",
+        "Bad Request: group chat was migrated to a supergroup chat",
+    ],
+)
+@pytest.mark.asyncio
+async def test_peer_invalid_and_migrated_chat_mark_target_dead(isolate, message):
+    # Previously unclassified ("unknown"), so the dead-target path never
+    # short-circuited retries against a permanently-unreachable chat_id — #56225.
+    adapter = RaisingAdapter(message)
+    router = DeliveryRouter(GatewayConfig(), adapters={Platform.TELEGRAM: adapter})
+    target = DeliveryTarget.parse("telegram:101")
+
+    res = await router.deliver("hi", [target])
+    assert res["telegram:101"]["success"] is False
+    assert router.dead_targets.is_dead("telegram", "101") is True
+
+
 class TestNotFoundBlastRadius:
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Bad Request: PEER_ID_INVALID",
+            "Bad Request: group chat was migrated to a supergroup chat",
+        ],
+    )
+    def test_is_chat_level_not_found_peer_invalid_and_migrated(self, message):
+        from gateway.platforms.base import is_chat_level_not_found
+
+        assert is_chat_level_not_found(error_text=message) is True
 
     @pytest.mark.parametrize("message", _SUBCHAT_NOT_FOUND_MESSAGES)
     def test_is_chat_level_not_found_subchat(self, message):

--- a/tests/gateway/test_send_error_classification.py
+++ b/tests/gateway/test_send_error_classification.py
@@ -30,6 +30,8 @@ class _FakeBadRequest(Exception):
         ("Forbidden: user is deactivated", "forbidden"),
         ("Bad Request: not enough rights to send text messages", "forbidden"),
         ("Bad Request: chat not found", "not_found"),
+        ("Bad Request: PEER_ID_INVALID", "not_found"),
+        ("Bad Request: group chat was migrated to a supergroup chat", "not_found"),
         ("Bad Request: message to edit not found", "not_found"),
         ("Too Many Requests: retry after 12", "rate_limited"),
         ("Flood control exceeded", "rate_limited"),


### PR DESCRIPTION
## What does this PR do?
`classify_send_error()` (`gateway/platforms/base.py`) has no substring match for two Telegram-specific chat-level failures:
- `PEER_ID_INVALID` — the bot cannot resolve the `chat_id` at all (e.g. it never started a DM with that user, or the id references a deleted entity).
- `"group chat was migrated to a supergroup chat"` — the old `chat_id` is permanently retired in favor of a new supergroup id.

Both fall through to `"unknown"`. `DeadTargetRegistry.is_dead_error_kind()` only treats `"forbidden"`/`"not_found"` as a dead-worthy kind, so an `"unknown"` classification never marks the delivery target dead. Every future send to a migrated or invalid `chat_id` keeps hitting the live Telegram API and failing identically — permanent, silent wasted calls with no self-healing.

This is a self-documented gap from #56225 (1 July): that PR's own review notes call it out explicitly — *"PEER_ID_INVALID / group chat was migrated classify as unknown and are never dead-marked → infinite retries. This is a latent gap on current main, out of scope here; happy to open a separate follow-up if wanted."* Confirmed still live on current `main`.

## Related Issue
No existing issue — the gap was documented in #56225's own PR body but no follow-up issue was filed.

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- `gateway/platforms/base.py`: add `"peer_id_invalid"` and `"group chat was migrated"` to `_CHAT_LEVEL_NOT_FOUND_SUBSTRINGS`. Both are chat-level, not sub-chat — unlike a deleted forum topic or edited-away message, there is no reading of either failure where the parent chat stays reachable, so they belong with `"chat not found"` rather than the thread/message-level bucket. No change to `_SUBCHAT_NOT_FOUND_SUBSTRINGS` or its blast-radius handling.
- `tests/gateway/test_send_error_classification.py`: 2 new parametrized cases — both texts classify as `"not_found"`.
- `tests/gateway/test_dead_targets.py`: end-to-end regression (`DeliveryRouter` + `RaisingAdapter`) proving both failures now mark the target dead, plus unit coverage in `TestNotFoundBlastRadius` for `is_chat_level_not_found`.

## How to Test
```
pytest tests/gateway/test_send_error_classification.py tests/gateway/test_dead_targets.py -v
```
Mutation-verified: all 6 new tests fail against the pre-fix code (classify as `"unknown"` / target stays alive) and pass after the fix. Ran the full neighboring suites (`test_send_error_classification.py`, `test_dead_targets.py`, `test_platform_base.py`) — 229 passed, 2 pre-existing skips. Ruff clean. Confirmed empirically that the existing thread/message-level (sub-chat) `not_found` cases are unaffected — `"message to edit not found"` etc. still classify as `is_chat_level_not_found() == False`.

## Checklist
- [x] Contributing Guide read | Conventional Commits | No duplicate PR found (searched "PEER_ID_INVALID", "group chat was migrated", "_CHAT_LEVEL_NOT_FOUND_SUBSTRINGS"; the one hit, #10166, targets `gateway/platforms/telegram.py` — a file that no longer exists after the platform-plugin restructure — is 2+ months stale with zero activity, and takes a different approach entirely (live retry with the migrated chat_id inside `send()`) that only covers the migration case, not `PEER_ID_INVALID`; not a real competitor)
- [x] Single logical fix | Tests added (mutation-verified) | Platform: macOS
- [x] Docs — N/A | Cross-platform — N/A (pure string classification, no OS dependency)