### PR TITLE
fix(cron): prevent concurrent duplicate fires

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -7,6 +7,8 @@ Output is saved to ~/.hermes/cron/output/{job_id}/{timestamp}.md
 
 import contextlib
 import copy
+import functools
+import hashlib
 from contextvars import ContextVar
 from dataclasses import dataclass
 import json
@@ -1465,13 +1467,21 @@ def remove_job(job_id: str) -> bool:
     return False
 
 
-def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
-                 delivery_error: Optional[str] = None):
+def mark_job_run(
+    job_id: str,
+    success: bool,
+    error: Optional[str] = None,
+    delivery_error: Optional[str] = None,
+    fire_claim_token: Optional[str] = None,
+    completion_token: Optional[str] = None,
+) -> bool:
     """
     Mark a job as having been run.
     
-    Updates last_run_at, last_status, increments completed count,
-    computes next_run_at, and auto-deletes if repeat limit reached.
+    Updates last_run_at, last_status, increments completed count, computes
+    next_run_at, and auto-deletes if the repeat limit is reached. Tokenized
+    fire claims are completed only by their owner; stale completion attempts
+    return False without mutating the job.
 
     ``delivery_error`` is tracked separately from the agent error — a job
     can succeed (agent produced output) but fail delivery (platform down).
@@ -1480,10 +1490,26 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
         jobs = load_jobs()
         for i, job in enumerate(jobs):
             if job["id"] == job_id:
+                current_claim = job.get("fire_claim")
+                current_token = (
+                    current_claim.get("token")
+                    if isinstance(current_claim, dict)
+                    and isinstance(current_claim.get("token"), str)
+                    else None
+                )
+                if (
+                    current_token is not None or fire_claim_token is not None
+                ) and current_token != fire_claim_token:
+                    logger.info(
+                        "Job '%s': stale completion did not match the active fire claim",
+                        job_id,
+                    )
+                    return False
                 now = _hermes_now().isoformat()
                 job["last_run_at"] = now
                 job["last_status"] = "ok" if success else "error"
                 job["last_error"] = error if not success else None
+                job["last_completion_token"] = completion_token
                 # Track delivery failures separately — cleared on successful delivery
                 job["last_delivery_error"] = delivery_error
                 # Clear any external-fire claim so a re-armed recurring job can
@@ -1520,7 +1546,7 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                         # Remove the job (limit reached)
                         jobs.pop(i)
                         save_jobs(jobs)
-                        return
+                        return True
                 
                 # Compute next run
                 job["next_run_at"] = compute_next_run(job["schedule"], now)
@@ -1555,9 +1581,35 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                     job["state"] = "scheduled"
 
                 save_jobs(jobs)
-                return
+                return True
 
         logger.warning("mark_job_run: job_id %s not found, skipping save", job_id)
+        return False
+
+
+def update_job_run_post_completion(
+    job_id: str,
+    completion_token: str,
+    delivery_error: Optional[str],
+    interrupted_error: Optional[str] = None,
+) -> bool:
+    """CAS-update delivery/interruption state for the run that finalized."""
+    if not completion_token:
+        return False
+    with _jobs_lock():
+        jobs = load_jobs()
+        for job in jobs:
+            if job["id"] != job_id:
+                continue
+            if job.get("last_completion_token") != completion_token:
+                return False
+            job["last_delivery_error"] = delivery_error
+            if interrupted_error is not None:
+                job["last_status"] = "error"
+                job["last_error"] = interrupted_error
+            save_jobs(jobs)
+            return True
+    return False
 
 
 def claim_dispatch(job_id: str) -> bool:
@@ -1701,26 +1753,148 @@ def _machine_id() -> str:
     return f"{host}:{os.getpid()}"
 
 
-def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300) -> bool:
-    """Atomically claim a job for a single external 'fire' (multi-machine
-    at-most-once). Returns True iff THIS caller won the claim.
+FIRE_CLAIM_MAX_LIVE_HOLDER_SECONDS = 4 * 3600
 
-    Used by the external-provider fire path (``CronScheduler.fire_due``) when an
-    external scheduler (Chronos) signals a job is due across N gateway replicas:
-    exactly one wins. Single-machine deployments always win.
+
+@functools.lru_cache(maxsize=1)
+def _local_fire_claim_machine_fingerprint() -> str:
+    """Return a hashed, process-independent identity for this local runtime.
+
+    Linux ``/proc`` facts identify the boot and PID namespace. Other platforms
+    fall back only to deterministic node identities; process-random UUID
+    fallbacks are rejected so unverifiable claims retain TTL-only semantics.
+    """
+    boot_id = ""
+    pid1_start = ""
+    try:
+        boot_id = Path("/proc/sys/kernel/random/boot_id").read_text(encoding="utf-8").strip()
+    except OSError:
+        pass
+    try:
+        pid1_stat = Path("/proc/1/stat").read_text(encoding="utf-8")
+        _, separator, pid1_tail = pid1_stat.rpartition(")")
+        pid1_fields = pid1_tail.split()
+        if separator and len(pid1_fields) > 19:
+            pid1_start = pid1_fields[19]
+    except OSError:
+        pass
+    if boot_id and pid1_start:
+        proc_identity = f"boot:{boot_id}\x1fpid1:{pid1_start}"
+        return hashlib.sha256(proc_identity.encode("utf-8")).hexdigest()
+    components: List[str] = []
+    try:
+        node = uuid.getnode()
+        if not node & (1 << 40):
+            components.append(f"node:{node:012x}")
+    except Exception:
+        pass
+    if not components:
+        return ""
+    return hashlib.sha256("\x1f".join(components).encode("utf-8")).hexdigest()
+
+
+def _fire_claim_holder_provenance() -> Dict[str, Any]:
+    """Build provenance used only for safe same-machine PID liveness checks."""
+    if os.getenv("HERMES_MACHINE_ID", "").strip():
+        return {"kind": "opaque-machine-id-v1"}
+    machine = _local_fire_claim_machine_fingerprint()
+    if not machine:
+        return {"kind": "unverifiable-v1"}
+    return {"kind": "local-process-v1", "machine": machine, "pid": os.getpid()}
+
+
+def _build_fire_claim(now: datetime) -> Dict[str, Any]:
+    return {
+        "at": now.isoformat(),
+        "by": _machine_id(),
+        "token": uuid.uuid4().hex,
+        "holder": _fire_claim_holder_provenance(),
+    }
+
+
+def fire_claim_token(job: Dict[str, Any]) -> Optional[str]:
+    """Return a job's non-empty fire-claim ownership token, if present."""
+    claim = job.get("fire_claim")
+    if not isinstance(claim, dict):
+        return None
+    token = claim.get("token")
+    return token if isinstance(token, str) and token else None
+
+
+def _fire_claim_holder_is_alive(claim: Dict[str, Any]) -> bool:
+    """Return whether a proven same-machine claim has a live local holder.
+
+    Legacy claims, cross-machine claims, and explicit ``HERMES_MACHINE_ID``
+    claims have no unambiguous local provenance and retain TTL-only semantics.
+    """
+    holder = claim.get("holder")
+    if not isinstance(holder, dict) or holder.get("kind") != "local-process-v1":
+        return False
+    machine = _local_fire_claim_machine_fingerprint()
+    if not machine or holder.get("machine") != machine:
+        return False
+    pid_value = holder.get("pid")
+    if isinstance(pid_value, bool) or not isinstance(pid_value, (int, str)):
+        return False
+    try:
+        pid = int(pid_value)
+    except (TypeError, ValueError):
+        return False
+    if pid <= 0:
+        return False
+    from gateway.status import _pid_exists
+
+    return _pid_exists(pid)
+
+
+def _fire_claim_is_active(
+    claim: Any,
+    now: datetime,
+    *,
+    claim_ttl_seconds: int = 300,
+) -> bool:
+    """Return whether a persisted fire claim still owns its execution slot."""
+    if not isinstance(claim, dict):
+        return False
+    try:
+        claimed_at = _ensure_aware(datetime.fromisoformat(claim["at"]))
+        age = (now - claimed_at).total_seconds()
+    except (KeyError, TypeError, ValueError):
+        return False
+    if not 0 <= age < FIRE_CLAIM_MAX_LIVE_HOLDER_SECONDS:
+        return False
+    if age < claim_ttl_seconds:
+        return True
+    return _fire_claim_holder_is_alive(claim)
+
+
+def claim_job_for_fire_snapshot(
+    job_id: str,
+    *,
+    claim_ttl_seconds: int = 300,
+) -> Optional[Dict[str, Any]]:
+    """Atomically claim a job for a single fire (multi-machine
+    at-most-once) and return the persisted claimed snapshot.
+
+    Used by built-in ticks, manual runs, and external-provider fires. When an
+    external scheduler signals a job across N gateway replicas, exactly one
+    wins the shared store claim.
 
     Under the file lock: reject if the job is missing/disabled/paused. If a
-    fresh claim (younger than ``claim_ttl_seconds``) already exists, lose.
-    Otherwise stamp a ``fire_claim`` and, for recurring jobs, advance
+    fresh claim (younger than ``claim_ttl_seconds`` and the absolute hold cap)
+    already exists, lose. Otherwise stamp a ``fire_claim`` and, for recurring
+    jobs, advance
     ``next_run_at`` (mirrors ``advance_next_run``'s at-most-once bump so a stale
     re-delivery for the old time can't re-fire). One-shots keep ``next_run_at``
     but the fresh ``fire_claim`` blocks a duplicate retry for the same fire.
-    ``mark_job_run`` clears the claim on completion so a re-armed recurring job
-    is claimable again next fire.
+    ``mark_job_run`` clears the claim only when the completion token matches,
+    so an older execution cannot erase a replacement claimant's ownership.
 
     The stale-claim TTL means a machine that crashed after claiming but before
     completing doesn't wedge the job forever — after the TTL another fire can
-    reclaim it.
+    reclaim it. A live same-machine holder keeps its claim beyond that TTL so a
+    long-running job cannot be fired twice. The absolute hold limit bounds PID
+    reuse and still guarantees eventual recovery.
     """
     with _jobs_lock():
         jobs = load_jobs()
@@ -1728,32 +1902,100 @@ def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300) -> bool:
             if job["id"] != job_id:
                 continue
             if not job.get("enabled", True) or job.get("state") == "paused":
-                return False
+                return None
             now = _hermes_now()
             existing = job.get("fire_claim")
-            if existing:
-                try:
-                    claimed_at = _ensure_aware(datetime.fromisoformat(existing["at"]))
-                    # Bounded on BOTH sides (#60703): a claim stamped in the
-                    # future (clock/TZ skew across a restart, or a corrupted
-                    # timestamp) would otherwise have a negative age and stay
-                    # "fresh" forever — the job becomes permanently unfireable
-                    # and every manual `cron run` reports "already being
-                    # fired". Treat future-dated claims as stale/overwritable.
-                    _age = (now - claimed_at).total_seconds()
-                    if 0 <= _age < claim_ttl_seconds:
-                        return False  # someone holds a fresh claim
-                except Exception:
-                    pass  # malformed claim → overwrite
-            job["fire_claim"] = {"at": now.isoformat(), "by": _machine_id()}
+            if _fire_claim_is_active(
+                existing,
+                now,
+                claim_ttl_seconds=claim_ttl_seconds,
+            ):
+                return None
+            previous_next_run_at = job.get("next_run_at")
+            job["fire_claim"] = _build_fire_claim(now)
             kind = job.get("schedule", {}).get("kind")
             if kind in {"cron", "interval"}:
                 nxt = compute_next_run(job["schedule"], now.isoformat())
                 if nxt:
                     job["next_run_at"] = nxt
             save_jobs(jobs)
-            return True
+            claimed_job = copy.deepcopy(job)
+            claimed_job["_fire_claim_previous_next_run_at"] = previous_next_run_at
+            return claimed_job
+        return None
+
+
+def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300) -> bool:
+    """Atomically claim a fire, preserving the historical boolean API."""
+    return (
+        claim_job_for_fire_snapshot(
+            job_id,
+            claim_ttl_seconds=claim_ttl_seconds,
+        )
+        is not None
+    )
+
+
+def release_fire_claim(
+    job_id: str,
+    token: str,
+    *,
+    restore_next_run_at: Optional[str] = None,
+    expected_next_run_at: Optional[str] = None,
+    expected_run_claim_owner: Optional[str] = None,
+) -> bool:
+    """Clear only the fire claim owned by *token*.
+
+    A caller that aborts before submitting the claimed run may also restore
+    the pre-claim schedule position. The restore is conditional on the job
+    still carrying the next-run value written by the claim, so a concurrent
+    schedule edit is never overwritten. A pre-submit one-shot ``run_claim``
+    can also be cleared by owner compare-and-set so rejection does not strand
+    the job while preserving any replacement owner's claim.
+    """
+    if not token:
         return False
+    with _jobs_lock():
+        jobs = load_jobs()
+        for job in jobs:
+            if job["id"] != job_id:
+                continue
+            if fire_claim_token(job) != token:
+                return False
+            job["fire_claim"] = None
+            if (
+                restore_next_run_at is not None
+                and job.get("next_run_at") == expected_next_run_at
+            ):
+                job["next_run_at"] = restore_next_run_at
+            run_claim = job.get("run_claim")
+            if (
+                expected_run_claim_owner is not None
+                and isinstance(run_claim, dict)
+                and run_claim.get("by") == expected_run_claim_owner
+            ):
+                job["run_claim"] = None
+            save_jobs(jobs)
+            return True
+    return False
+
+
+def release_run_claim(job_id: str, expected_owner: str) -> bool:
+    """Clear only the due-selection run claim owned by *expected_owner*."""
+    if not expected_owner:
+        return False
+    with _jobs_lock():
+        jobs = load_jobs()
+        for job in jobs:
+            if job["id"] != job_id:
+                continue
+            run_claim = job.get("run_claim")
+            if not isinstance(run_claim, dict) or run_claim.get("by") != expected_owner:
+                return False
+            job["run_claim"] = None
+            save_jobs(jobs)
+            return True
+    return False
 
 
 def get_due_jobs() -> List[Dict[str, Any]]:
@@ -1884,6 +2126,15 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
         # state still reaches save_jobs() below.
         try:
             if not job.get("enabled", True):
+                continue
+
+            # Manual and external-provider fires claim before run_one_job stamps
+            # a finite one-shot's dispatch count. Keep that active record out of
+            # stale one-shot cleanup so its owner can persist the final outcome.
+            if (
+                job.get("schedule", {}).get("kind") == "once"
+                and _fire_claim_is_active(job.get("fire_claim"), now)
+            ):
                 continue
 
             # Cross-process running-claim guard (#59229): if another scheduler

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -10,6 +10,7 @@ runs at a time if multiple processes overlap.
 
 import asyncio
 import atexit
+import copy
 import concurrent.futures
 import contextvars
 import json
@@ -21,6 +22,7 @@ import subprocess
 import sys
 import threading
 import time
+import uuid
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
@@ -238,7 +240,18 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run, claim_dispatch, heartbeat_run_claim
+from cron.jobs import (
+    claim_dispatch,
+    claim_job_for_fire_snapshot,
+    fire_claim_token,
+    get_due_jobs,
+    heartbeat_run_claim,
+    mark_job_run,
+    release_fire_claim,
+    release_run_claim,
+    save_job_output,
+    update_job_run_post_completion,
+)
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
@@ -297,9 +310,13 @@ def _is_cron_silence_response(text: str) -> bool:
 _parallel_pool: Optional[concurrent.futures.ThreadPoolExecutor] = None
 _parallel_pool_max_workers: Optional[int] = None
 _running_job_ids: set = set()
+_running_job_claim_tokens: dict = {}
+_running_job_claim_snapshots: dict = {}
+_running_job_started_tokens: set = set()
 _running_lock = threading.Lock()
+_shutdown_started = False
 
-# Job IDs the gateway shutdown path force-killed the tool subprocess of
+# Job/token pairs whose tool subprocess the gateway shutdown path force-killed
 # while still in ``_running_job_ids`` (see ``mark_running_jobs_interrupted``
 # below). ``run_one_job``'s own completion path checks this set before
 # writing its own ``last_status`` so a cron agent thread that keeps running
@@ -338,7 +355,7 @@ def mark_running_jobs_interrupted(reason: str) -> list:
     same process and may go on to produce a plausible-looking final
     response from the now-truncated tool output.
 
-    Records the job IDs in ``_interrupted_job_ids`` BEFORE writing
+    Records each job's fire-claim incarnation in ``_interrupted_job_ids`` BEFORE writing
     ``last_status`` so ``run_one_job``'s own eventual completion for the
     same job (racing in its own thread) sees the flag and skips its normal
     write instead of clobbering this one — see the check near the end of
@@ -352,20 +369,44 @@ def mark_running_jobs_interrupted(reason: str) -> list:
 
     Returns the list of job IDs marked, for the caller to log.
     """
+    global _shutdown_started
     with _running_lock:
-        job_ids = list(_running_job_ids)
-        _interrupted_job_ids.update(job_ids)
-    marked = []
-    for job_id in job_ids:
+        _shutdown_started = True
+        job_claims = list(_running_job_started_tokens)
+        unstarted_claims = [
+            (key, snapshot)
+            for key, snapshot in _running_job_claim_snapshots.items()
+            if key not in _running_job_started_tokens
+        ]
+        for (job_id, claim_token), _snapshot in unstarted_claims:
+            _running_job_claim_snapshots.pop((job_id, claim_token), None)
+            if _running_job_claim_tokens.get(job_id) == claim_token:
+                _running_job_claim_tokens.pop(job_id, None)
+                _running_job_ids.discard(job_id)
+        _interrupted_job_ids.update(job_claims)
+    for _key, snapshot in unstarted_claims:
         try:
-            mark_job_run(job_id, False, reason)
-            marked.append(job_id)
+            _release_unstarted_claimed_job(snapshot)
+        except Exception as e:
+            logger.warning(
+                "Failed to release unstarted job %s during shutdown: %s",
+                snapshot.get("id"),
+                e,
+            )
+    marked = []
+    for job_id, claim_token in job_claims:
+        try:
+            mark_kwargs = {}
+            if claim_token is not None:
+                mark_kwargs["fire_claim_token"] = claim_token
+            if mark_job_run(job_id, False, reason, **mark_kwargs) is not False:
+                marked.append(job_id)
         except Exception as e:
             logger.warning("Failed to mark job %s interrupted: %s", job_id, e)
     return marked
 
 
-def _is_interrupted(job_id: str) -> bool:
+def _is_interrupted(job_id: str, claim_token: Optional[str] = None) -> bool:
     """Non-destructive peek at whether the shutdown path has marked
     ``job_id`` interrupted (see ``mark_running_jobs_interrupted``).
 
@@ -377,20 +418,20 @@ def _is_interrupted(job_id: str) -> bool:
     flag: the later, authoritative check (right before ``last_status`` is
     written) still needs to see it."""
     with _running_lock:
-        return job_id in _interrupted_job_ids
+        return (job_id, claim_token) in _interrupted_job_ids
 
 
-def _consume_interrupted_flag(job_id: str) -> bool:
+def _consume_interrupted_flag(job_id: str, claim_token: Optional[str] = None) -> bool:
     """Return True and clear the flag if the shutdown path already marked
     ``job_id`` interrupted (see ``mark_running_jobs_interrupted``).
 
     Called by ``run_one_job`` right before it would otherwise write its own
-    ``last_status``. Consuming (discarding) rather than just checking keeps
-    the flag from leaking across a later, unrelated run of the same job ID
-    (recurring jobs reuse their ID every fire)."""
+    ``last_status``. The fire-claim token scopes the flag to one execution so
+    a replacement run with the same recurring job ID cannot consume it."""
+    key = (job_id, claim_token)
     with _running_lock:
-        if job_id in _interrupted_job_ids:
-            _interrupted_job_ids.discard(job_id)
+        if key in _interrupted_job_ids:
+            _interrupted_job_ids.discard(key)
             return True
         return False
 
@@ -3395,26 +3436,27 @@ def _teardown_cron_agent(agent, job_id: str) -> None:
 
 
 def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -> bool:
-    """Run ONE due job end-to-end: execute → save output → deliver → mark.
+    """Run ONE due job end-to-end: execute → save → finalize → deliver.
 
     This is the shared firing body extracted from ``tick``'s per-job closure so
     that BOTH the built-in ticker and an external provider's ``fire_due`` (e.g.
     Chronos) run the identical sequence — no duplicated correctness.
 
     It does NOT decide whether the job is due, claim it, or compute the next
-    run — those are the caller's concern (``tick`` advances ``next_run_at``
-    under the file lock before dispatch; an external provider claims via the
-    store CAS). This function only fires the given job once.
+    run — those are the caller's concern. Built-in, manual, and external paths
+    all claim through the store CAS before calling this function.
 
     Returns True if the job was processed (even if the job itself failed —
     failure is recorded via ``mark_job_run``), False only if processing raised.
     """
+    claim_token = fire_claim_token(job)
+    completion_token = uuid.uuid4().hex
     try:
         # Pre-run dispatch claim (issue #38758): atomically commit a finite
         # one-shot's dispatch BEFORE its side effect runs, so a tick that dies
         # mid-execution (gateway kill, OOM, segfault, hard-timeout) cannot
-        # re-fire the job forever on restart. No-op for recurring jobs (they
-        # use advance_next_run) and infinite/no-repeat jobs. This lives here in
+        # re-fire the job forever on restart. No-op for recurring jobs (their
+        # fire claim advances the schedule) and infinite/no-repeat jobs. This lives here in
         # the shared body so BOTH the built-in ticker and the external provider
         # (Chronos fire_due) get at-most-times semantics.
         if not claim_dispatch(job["id"]):
@@ -3476,67 +3518,244 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             if verbose:
                 logger.info("Output saved to: %s", output_file)
 
-            # If the gateway shutdown killed this job's tool subprocess
-            # mid-flight (#60432), the agent may still have produced a
-            # plausible-looking final_response from the truncated output --
-            # force the failure path so the delivered message is an honest
-            # "this run was interrupted" summary instead of that response.
-            # Peek-only: the flag stays set for the authoritative check
-            # right before mark_job_run below.
-            if success and _is_interrupted(job["id"]):
+            interrupted_error = (
+                "Interrupted by gateway shutdown before the run finished "
+                "(tool subprocess was killed mid-flight)."
+            )
+            if _is_interrupted(job["id"], claim_token):
+                success = False
+                error = interrupted_error
+
+            # Treat empty final_response as a soft failure so last_status is
+            # not "ok" — the agent ran but produced nothing useful (#8585).
+            empty_response = success and not final_response.strip()
+            if empty_response:
                 success = False
                 error = (
-                    "Interrupted by gateway shutdown before the run finished "
-                    "(tool subprocess was killed mid-flight)."
+                    "Agent completed but produced empty response "
+                    "(model error, timeout, or misconfiguration)"
                 )
 
-            # Deliver the final response to the origin/target chat.
-            # If the agent responded with [SILENT], skip delivery (but
-            # output is already saved above).  Failed jobs always deliver.
-            deliver_content = final_response if success else _summarize_cron_failure_for_delivery(job, error)
-            # Treat whitespace-only final responses the same as empty
-            # responses: do not deliver a blank message, and let the
-            # empty-response guard below mark the run as a soft failure.
-            should_deliver = bool(deliver_content.strip())
-            # Cron silence suppression — see _is_cron_silence_response.  Replaces the
-            # old `SILENT_MARKER in ...upper()` substring check, which both leaked
-            # bracketless near-markers ("SILENT" / "NO_REPLY") and wrongly swallowed
-            # a real report that merely quoted "[SILENT]" mid-sentence (#51438,
-            # #46917).  Keeps the intentional bracketed-prefix / trailing-line
-            # tolerance the cron contract relies on.
-            if should_deliver and success and _is_cron_silence_response(deliver_content):
-                logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
+            # Finalize ownership before any user-visible delivery. If a newer
+            # incarnation replaced this token at the absolute cap, its CAS wins
+            # and the stale runner must remain completely silent.
+            mark_kwargs = {
+                "delivery_error": None,
+                "completion_token": completion_token,
+            }
+            if claim_token is not None:
+                mark_kwargs["fire_claim_token"] = claim_token
+            finalized = mark_job_run(job["id"], success, error, **mark_kwargs)
+            if finalized is False:
+                _consume_interrupted_flag(job["id"], claim_token)
+                logger.info(
+                    "Job '%s': stale completion lost ownership — suppressing delivery",
+                    job["id"],
+                )
+                return True
+
+            # A drain can race the completion CAS. If this exact incarnation was
+            # interrupted, correct its finalized status by completion-token CAS
+            # without touching a replacement run, then deliver only the honest
+            # interruption summary.
+            if _consume_interrupted_flag(job["id"], claim_token):
+                success = False
+                error = interrupted_error
+                update_job_run_post_completion(
+                    job["id"],
+                    completion_token,
+                    None,
+                    interrupted_error,
+                )
+
+            # Deliver only after this run has atomically finalized ownership.
+            deliver_content = (
+                final_response
+                if success
+                else _summarize_cron_failure_for_delivery(job, error)
+            )
+            should_deliver = not empty_response and bool(deliver_content.strip())
+            if (
+                should_deliver
+                and success
+                and _is_cron_silence_response(deliver_content)
+            ):
+                logger.info(
+                    "Job '%s': agent returned %s — skipping delivery",
+                    job["id"],
+                    SILENT_MARKER,
+                )
                 should_deliver = False
 
             if should_deliver:
                 try:
-                    delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
+                    delivery_error = _deliver_result(
+                        job,
+                        deliver_content,
+                        adapters=adapters,
+                        loop=loop,
+                    )
                 except Exception as de:
                     delivery_error = str(de)
                     logger.error("Delivery failed for job %s: %s", job["id"], de)
+            try:
+                update_job_run_post_completion(
+                    job["id"],
+                    completion_token,
+                    delivery_error,
+                )
+            except Exception as update_error:
+                logger.warning(
+                    "Job '%s': failed to record delivery outcome: %s",
+                    job["id"],
+                    update_error,
+                )
         finally:
             # Tear down the deferred agent(s) now that save + delivery have run
             # (or raised). Must happen on every path so cron agents never leak
             # their subprocesses/clients (#10200).
             for _deferred_agent in _deferred_agents:
                 _teardown_cron_agent(_deferred_agent, job["id"])
-
-        # Treat empty final_response as a soft failure so last_status
-        # is not "ok" — the agent ran but produced nothing useful.
-        # (issue #8585)
-        if success and not final_response.strip():
-            success = False
-            error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
-
-        if not _consume_interrupted_flag(job["id"]):
-            mark_job_run(job["id"], success, error, delivery_error=delivery_error)
         return True
 
     except Exception as e:
         logger.error("Error processing job %s: %s", job['id'], e)
-        if not _consume_interrupted_flag(job["id"]):
-            mark_job_run(job["id"], False, str(e))
+        if not _consume_interrupted_flag(job["id"], claim_token):
+            mark_kwargs = {"completion_token": completion_token}
+            if claim_token is not None:
+                mark_kwargs["fire_claim_token"] = claim_token
+            mark_job_run(job["id"], False, str(e), **mark_kwargs)
         return False
+
+
+def _claim_job_for_tick(job: dict) -> Optional[dict]:
+    """Acquire the shared fire claim and return its persisted job snapshot."""
+    job_id = job["id"]
+    claimed_job = claim_job_for_fire_snapshot(job_id)
+    if claimed_job is None:
+        return None
+    if fire_claim_token(claimed_job) is None:
+        logger.error(
+            "Job '%s' was claimed without an ownership token",
+            job.get("name", job_id),
+        )
+        return None
+    return claimed_job
+
+
+def _release_unstarted_tick_claim(
+    original_job: dict,
+    claimed_job: Optional[dict],
+    claim_token: str,
+) -> bool:
+    """Release a pre-submit claim without consuming its scheduled fire."""
+    if claimed_job is None:
+        return False
+    return _release_unstarted_claimed_job(
+        claimed_job,
+        restore_next_run_at=original_job.get("next_run_at"),
+    )
+
+
+def _release_unstarted_claimed_job(
+    claimed_job: dict,
+    *,
+    restore_next_run_at: Optional[str] = None,
+) -> bool:
+    """Token-CAS release for a claimed run that never started."""
+    claim_token = fire_claim_token(claimed_job)
+    if claim_token is None:
+        return False
+    if restore_next_run_at is None:
+        restore_next_run_at = claimed_job.get("_fire_claim_previous_next_run_at")
+    run_claim = claimed_job.get("run_claim")
+    run_claim_owner = (
+        run_claim.get("by") if isinstance(run_claim, dict) else None
+    )
+    return release_fire_claim(
+        claimed_job["id"],
+        claim_token,
+        restore_next_run_at=(
+            restore_next_run_at if isinstance(restore_next_run_at, str) else None
+        ),
+        expected_next_run_at=claimed_job.get("next_run_at"),
+        expected_run_claim_owner=(
+            run_claim_owner if isinstance(run_claim_owner, str) else None
+        ),
+    )
+
+
+def _release_due_run_claim(job: dict) -> bool:
+    """Release a one-shot due-selection claim when drain skips dispatch."""
+    run_claim = job.get("run_claim")
+    owner = run_claim.get("by") if isinstance(run_claim, dict) else None
+    if not isinstance(owner, str):
+        return False
+    return release_run_claim(job["id"], owner)
+
+
+def _register_running_claim(
+    job_id: str,
+    claim_token: str,
+    claimed_job: Optional[dict] = None,
+) -> str:
+    """Publish one run incarnation, superseding only a different stale token."""
+    with _running_lock:
+        if _shutdown_started:
+            return "shutdown"
+        previous_token = _running_job_claim_tokens.get(job_id)
+        if previous_token == claim_token:
+            return "duplicate"
+        if previous_token is not None:
+            _interrupted_job_ids.add((job_id, previous_token))
+        _running_job_ids.add(job_id)
+        _running_job_claim_tokens[job_id] = claim_token
+        if claimed_job is not None:
+            _running_job_claim_snapshots[(job_id, claim_token)] = copy.deepcopy(
+                claimed_job
+            )
+        return "published"
+
+
+def _begin_running_claim(job_id: str, claim_token: str) -> bool:
+    """Atomically cross the shutdown boundary before entering the run body."""
+    with _running_lock:
+        if _shutdown_started or _running_job_claim_tokens.get(job_id) != claim_token:
+            return False
+        _running_job_started_tokens.add((job_id, claim_token))
+        return True
+
+
+def _unregister_running_claim(job_id: str, claim_token: str) -> None:
+    """Remove local visibility only when this exact incarnation still owns it."""
+    with _running_lock:
+        _running_job_started_tokens.discard((job_id, claim_token))
+        _running_job_claim_snapshots.pop((job_id, claim_token), None)
+        _interrupted_job_ids.discard((job_id, claim_token))
+        if _running_job_claim_tokens.get(job_id) == claim_token:
+            _running_job_claim_tokens.pop(job_id, None)
+            _running_job_ids.discard(job_id)
+
+
+def run_claimed_job(job: dict, adapters=None, loop=None, verbose: bool = True) -> bool:
+    """Run an already claimed manual/external fire with shutdown visibility."""
+    claim_token = fire_claim_token(job)
+    if claim_token is None:
+        logger.error("Refusing to run claimed job %r without an ownership token", job.get("id"))
+        return False
+    registration = _register_running_claim(job["id"], claim_token, job)
+    if registration == "shutdown":
+        _release_unstarted_claimed_job(job)
+        return False
+    if registration == "duplicate":
+        return False
+    try:
+        if not _begin_running_claim(job["id"], claim_token):
+            _release_unstarted_claimed_job(job)
+            return False
+        return run_one_job(job, adapters=adapters, loop=loop, verbose=verbose)
+    finally:
+        _unregister_running_claim(job["id"], claim_token)
 
 
 def _notify_provider_jobs_changed() -> None:
@@ -3590,6 +3809,13 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
         return 0
 
     try:
+        with _running_lock:
+            if _shutdown_started:
+                logger.info("Tick skipped — gateway shutdown has begun")
+                return 0
+        if _interpreter_shutting_down():
+            logger.warning("Tick skipped — interpreter is shutting down")
+            return 0
         due_jobs = get_due_jobs()
 
         if verbose and not due_jobs:
@@ -3598,14 +3824,6 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
 
         if verbose:
             logger.info("%s - %s job(s) due", _hermes_now().strftime('%H:%M:%S'), len(due_jobs))
-
-        # Advance next_run_at for all recurring jobs FIRST, under the file lock,
-        # before any execution begins.  This preserves at-most-once semantics.
-        # For parallel jobs that are already running, advance_next_run keeps
-        # bumping next_run_at forward so the grace window never expires.
-        # mark_job_run() overwrites next_run_at on completion.
-        for job in due_jobs:
-            advance_next_run(job["id"])
 
         # Resolve max parallel workers: env var > config.yaml > unbounded.
         # Set HERMES_CRON_MAX_PARALLEL=1 to restore old serial behaviour.
@@ -3654,46 +3872,92 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
         _all_futures: list = []
 
         def _submit_with_guard(job: dict, pool: concurrent.futures.ThreadPoolExecutor):
-            """Submit a job fire-and-forget with the in-flight dedup guard.
+            """Claim and submit one job with local and store-level dedup guards.
 
             Returns the future, or None if the job was skipped because a prior
-            tick's run of the same job is still in flight.  The running-set
-            membership is released in the worker's finally block.
+            local or cross-process fire still owns it. The running-set membership
+            is released in the worker's finally block.
             """
             job_id = job["id"]
-            # A tick can race gateway teardown: once the interpreter is
-            # finalizing, ``pool.submit`` raises "cannot schedule new futures
-            # after interpreter shutdown" and crashes the tick. Skip cleanly —
-            # the job stays due and will fire on the next healthy tick
-            # (#58720, #55924).
-            if _interpreter_shutting_down():
-                logger.warning(
-                    "Job '%s' not dispatched — interpreter is shutting down",
+            with _running_lock:
+                drain_started = _shutdown_started
+            if drain_started:
+                _release_due_run_claim(job)
+                logger.info(
+                    "Job '%s' not claimed — gateway shutdown has begun",
                     job.get("name", job_id),
                 )
                 return None
-            with _running_lock:
-                if job_id in _running_job_ids:
-                    logger.info("Job '%s' already running — skipping", job.get("name", job_id))
+            claim_token = None
+            claimed_job = None
+            try:
+                claimed_job = _claim_job_for_tick(job)
+                if claimed_job is None:
+                    logger.info(
+                        "Job '%s' already claimed by another fire — skipping",
+                        job.get("name", job_id),
+                    )
                     return None
-                _running_job_ids.add(job_id)
+                claim_token = fire_claim_token(claimed_job)
+                if claim_token is None:
+                    raise RuntimeError(f"Job {job_id!r} persisted a fire claim without a token")
+                if _interpreter_shutting_down():
+                    _release_unstarted_tick_claim(job, claimed_job, claim_token)
+                    logger.warning(
+                        "Job '%s' not dispatched — interpreter began shutting down",
+                        job.get("name", job_id),
+                    )
+                    return None
+                registration = _register_running_claim(
+                    job_id,
+                    claim_token,
+                    claimed_job,
+                )
+                if registration != "published":
+                    _release_unstarted_tick_claim(job, claimed_job, claim_token)
+                    reason = (
+                        "gateway shutdown began"
+                        if registration == "shutdown"
+                        else "the same local run was already published"
+                    )
+                    logger.info(
+                        "Job '%s' not dispatched — %s during claim acquisition",
+                        job.get("name", job_id),
+                        reason,
+                    )
+                    return None
+            except BaseException:
+                if claim_token is not None:
+                    _unregister_running_claim(job_id, claim_token)
+                if claim_token is not None:
+                    _release_unstarted_tick_claim(job, claimed_job, claim_token)
+                raise
+
             _ctx = contextvars.copy_context()
 
-            def _run_and_release(j=job, ctx=_ctx):
+            def _run_and_release(
+                j=claimed_job,
+                original=job,
+                ctx=_ctx,
+                token=claim_token,
+            ):
                 try:
+                    if not _begin_running_claim(j["id"], token):
+                        _release_unstarted_tick_claim(original, j, token)
+                        return False
                     return ctx.run(_process_job, j)
                 finally:
-                    with _running_lock:
-                        _running_job_ids.discard(j["id"])
+                    _unregister_running_claim(j["id"], token)
 
             try:
                 return pool.submit(_run_and_release)
-            except RuntimeError as submit_err:
-                # Interpreter began finalizing between the guard above and the
-                # submit — release the in-flight claim we just took and skip.
-                if _interpreter_shutting_down(submit_err):
-                    with _running_lock:
-                        _running_job_ids.discard(job_id)
+            except BaseException as submit_err:
+                _unregister_running_claim(job_id, claim_token)
+                if claim_token is not None:
+                    _release_unstarted_tick_claim(job, claimed_job, claim_token)
+                if isinstance(submit_err, RuntimeError) and _interpreter_shutting_down(
+                    submit_err
+                ):
                     logger.warning(
                         "Job '%s' not dispatched — interpreter is shutting down",
                         job.get("name", job_id),

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -94,15 +94,13 @@ class CronScheduler(ABC):
         Returns True if THIS caller claimed and ran the job, False if the claim
         was lost (another machine/retry won it) or the job no longer exists.
         """
-        from cron.jobs import claim_job_for_fire, get_job
-        from cron.scheduler import run_one_job
+        from cron.jobs import claim_job_for_fire_snapshot
+        from cron.scheduler import run_claimed_job
 
-        if not claim_job_for_fire(job_id):
-            return False  # another machine already claimed this fire
-        job = get_job(job_id)
+        job = claim_job_for_fire_snapshot(job_id)
         if job is None:
-            return False  # job removed (e.g. repeat-N exhausted) between arm and fire
-        return run_one_job(job, adapters=adapters, loop=loop)
+            return False  # another machine already claimed this fire
+        return run_claimed_job(job, adapters=adapters, loop=loop)
 
     def reconcile(self) -> None:
         """Converge the external registry toward jobs.json (the desired state):

--- a/tests/cron/test_claim_job_for_fire.py
+++ b/tests/cron/test_claim_job_for_fire.py
@@ -1,21 +1,82 @@
 """Tests for the store-level CAS fire claim (Phase 4C).
 
-`claim_job_for_fire` gives multi-machine at-most-once semantics when an external
-scheduler (Chronos) fires a job: across N gateway replicas, exactly ONE wins the
-claim for a given fire. Single-machine deployments always win (unaffected).
+`claim_job_for_fire` gives built-in, manual, and external scheduler fires one
+shared at-most-once boundary. Across N processes or gateway replicas, exactly
+one caller owns a given fire until completion or safe recovery.
 
 These exercise the real store against a temp HERMES_HOME (no mocks) per the
 E2E-over-mocks discipline for file-touching code.
 """
+import os
+import socket
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
 
 @pytest.fixture
 def temp_home(tmp_path, monkeypatch):
-    """Isolated HERMES_HOME so jobs.json doesn't touch the real store."""
+    """Isolated cron store so jobs.json doesn't touch the real store."""
+    import cron.scheduler as scheduler
+    from cron.jobs import _local_fire_claim_machine_fingerprint
+
+    _local_fire_claim_machine_fingerprint.cache_clear()
+    with scheduler._running_lock:
+        scheduler._running_job_ids.clear()
+        scheduler._running_job_claim_tokens.clear()
+        scheduler._running_job_claim_snapshots.clear()
+        scheduler._running_job_started_tokens.clear()
+        scheduler._interrupted_job_ids.clear()
+        scheduler._shutdown_started = False
+    monkeypatch.delenv("HERMES_MACHINE_ID", raising=False)
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    # cron.jobs caches no home at import; get_hermes_home() reads the env live.
-    yield tmp_path
+    monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+    try:
+        yield tmp_path
+    finally:
+        _local_fire_claim_machine_fingerprint.cache_clear()
+        with scheduler._running_lock:
+            scheduler._running_job_ids.clear()
+            scheduler._running_job_claim_tokens.clear()
+            scheduler._running_job_claim_snapshots.clear()
+            scheduler._running_job_started_tokens.clear()
+            scheduler._interrupted_job_ids.clear()
+            scheduler._shutdown_started = False
+
+
+def _rewrite_claim(job_id, **changes):
+    from cron.jobs import load_jobs, save_jobs
+
+    jobs = load_jobs()
+    for job in jobs:
+        if job["id"] == job_id:
+            job["fire_claim"].update(changes)
+    save_jobs(jobs)
+
+
+def _rewrite_job(job_id, **changes):
+    from cron.jobs import load_jobs, save_jobs
+
+    jobs = load_jobs()
+    for job in jobs:
+        if job["id"] == job_id:
+            job.update(changes)
+    save_jobs(jobs)
+
+
+def _delete_claim_fields(job_id, *fields):
+    from cron.jobs import load_jobs, save_jobs
+
+    jobs = load_jobs()
+    for job in jobs:
+        if job["id"] == job_id:
+            for field in fields:
+                job["fire_claim"].pop(field, None)
+    save_jobs(jobs)
 
 
 def test_claim_succeeds_once_then_blocks(temp_home):
@@ -30,6 +91,101 @@ def test_claim_succeeds_once_then_blocks(temp_home):
     assert claim_job_for_fire(jid) is True
     assert claim_job_for_fire(jid) is False
     assert get_job(jid)["next_run_at"] != before
+
+
+def test_claim_persists_unambiguous_local_holder_provenance(temp_home):
+    """Default claims identify the exact local machine and process separately."""
+    from cron.jobs import create_job, claim_job_for_fire, get_job
+
+    job = create_job(prompt="x", schedule="every 5m", name="provenance")
+    assert claim_job_for_fire(job["id"]) is True
+
+    stored = get_job(job["id"])
+    assert stored is not None
+    holder = stored["fire_claim"]["holder"]
+    assert holder["kind"] == "local-process-v1"
+    assert holder["machine"]
+    assert holder["pid"] == os.getpid()
+
+
+def test_machine_fingerprint_ignores_optional_dependency_availability(temp_home):
+    from cron.jobs import _local_fire_claim_machine_fingerprint
+
+    _local_fire_claim_machine_fingerprint.cache_clear()
+    parent_fingerprint = _local_fire_claim_machine_fingerprint()
+    fake_dependencies = temp_home / "fake-dependencies"
+    fake_dependencies.mkdir()
+    (fake_dependencies / "psutil.py").write_text(
+        "def boot_time():\n    return 123.456\n",
+        encoding="utf-8",
+    )
+    probe = (
+        "from cron.jobs import _local_fire_claim_machine_fingerprint; "
+        "print(_local_fire_claim_machine_fingerprint())"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=os.getcwd(),
+        env={
+            **os.environ,
+            "HERMES_HOME": str(temp_home),
+            "PYTHONPATH": str(fake_dependencies),
+        },
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=True,
+    )
+
+    assert result.stdout.strip() == parent_fingerprint
+
+
+def test_machine_fingerprint_ignores_random_node_when_proc_identity_exists(
+    temp_home, monkeypatch
+):
+    import cron.jobs as jobs_mod
+
+    monkeypatch.setattr(jobs_mod.uuid, "getnode", lambda: 0x010000000001)
+    jobs_mod._local_fire_claim_machine_fingerprint.cache_clear()
+    first = jobs_mod._local_fire_claim_machine_fingerprint()
+
+    monkeypatch.setattr(jobs_mod.uuid, "getnode", lambda: 0x030000000002)
+    jobs_mod._local_fire_claim_machine_fingerprint.cache_clear()
+    second = jobs_mod._local_fire_claim_machine_fingerprint()
+
+    assert first
+    assert second == first
+
+
+def test_machine_fingerprint_rejects_random_node_as_only_identity(
+    temp_home, monkeypatch
+):
+    import cron.jobs as jobs_mod
+
+    def unavailable(*_args, **_kwargs):
+        raise OSError("unavailable")
+
+    monkeypatch.setattr(jobs_mod.Path, "read_text", unavailable)
+    monkeypatch.setattr(jobs_mod.uuid, "getnode", lambda: 0x010000000001)
+    jobs_mod._local_fire_claim_machine_fingerprint.cache_clear()
+
+    assert jobs_mod._local_fire_claim_machine_fingerprint() == ""
+
+
+def test_machine_fingerprint_rejects_partial_proc_identity(temp_home, monkeypatch):
+    """A boot ID without PID-namespace identity is not safe for PID liveness."""
+    import cron.jobs as jobs_mod
+
+    def partial_proc_identity(path, *_args, **_kwargs):
+        if str(path).endswith("/boot_id"):
+            return "shared-host-boot-id"
+        raise OSError("pid namespace identity unavailable")
+
+    monkeypatch.setattr(jobs_mod.Path, "read_text", partial_proc_identity)
+    monkeypatch.setattr(jobs_mod.uuid, "getnode", lambda: 0x010000000001)
+    jobs_mod._local_fire_claim_machine_fingerprint.cache_clear()
+
+    assert jobs_mod._local_fire_claim_machine_fingerprint() == ""
 
 
 def test_claim_oneshot_cannot_be_double_claimed(temp_home):
@@ -56,15 +212,804 @@ def test_claim_paused_job_returns_false(temp_home):
     assert claim_job_for_fire(job["id"]) is False
 
 
-def test_stale_claim_is_reclaimable(temp_home, monkeypatch):
+def test_stale_claim_of_dead_holder_is_reclaimable(temp_home):
     """A claim older than the TTL is overwritten — the fire isn't stuck forever
     if the winning machine crashed before mark_job_run cleared the claim."""
-    from cron.jobs import create_job, claim_job_for_fire
+    from cron.jobs import (
+        _local_fire_claim_machine_fingerprint,
+        claim_job_for_fire,
+        create_job,
+    )
+    from gateway.status import _pid_exists
 
     job = create_job(prompt="x", schedule="every 5m", name="s")
     jid = job["id"]
     assert claim_job_for_fire(jid) is True
-    # With a 0s TTL, the existing claim is always considered stale.
+    exited = subprocess.Popen([sys.executable, "-c", "pass"])
+    dead_pid = exited.pid
+    assert exited.wait(timeout=10) == 0
+    assert _pid_exists(dead_pid) is False
+    _rewrite_claim(
+        jid,
+        by=f"{socket.gethostname()}:{dead_pid}",
+        holder={
+            "kind": "local-process-v1",
+            "machine": _local_fire_claim_machine_fingerprint(),
+            "pid": dead_pid,
+        },
+    )
+    # With a 0s TTL and a dead holder, the claim is stale and reclaimable.
+    assert claim_job_for_fire(jid, claim_ttl_seconds=0) is True
+
+
+def test_live_holder_keeps_claim_past_freshness_ttl(temp_home):
+    """A long-running job must not lose its claim merely because its TTL elapsed."""
+    from cron.jobs import create_job, claim_job_for_fire
+
+    job = create_job(prompt="x", schedule="every 5m", name="live")
+    jid = job["id"]
+
+    assert claim_job_for_fire(jid) is True
+    assert claim_job_for_fire(jid, claim_ttl_seconds=0) is False
+
+
+def test_same_hostname_remote_holder_uses_ttl_only(temp_home):
+    """Remote provenance wins even when hostname and PID collide locally."""
+    from cron.jobs import create_job, claim_job_for_fire
+
+    job = create_job(prompt="x", schedule="every 5m", name="remote-collision")
+    jid = job["id"]
+    assert claim_job_for_fire(jid) is True
+    _rewrite_claim(
+        jid,
+        by=f"{socket.gethostname()}:{os.getpid()}",
+        holder={
+            "kind": "local-process-v1",
+            "machine": "remote-machine",
+            "pid": os.getpid(),
+        },
+    )
+
+    assert claim_job_for_fire(jid, claim_ttl_seconds=0) is True
+
+
+def test_legacy_ambiguous_holder_uses_ttl_only(temp_home):
+    """Pre-provenance host:pid claims remain readable but are never probed."""
+    from cron.jobs import create_job, claim_job_for_fire
+
+    job = create_job(prompt="x", schedule="every 5m", name="legacy")
+    jid = job["id"]
+    assert claim_job_for_fire(jid) is True
+    _delete_claim_fields(jid, "holder")
+
+    assert claim_job_for_fire(jid, claim_ttl_seconds=0) is True
+
+
+def test_live_holder_blocks_competing_process_after_ttl(temp_home):
+    """A ticker process cannot reclaim a still-running manual fire."""
+    from cron.jobs import create_job, claim_job_for_fire
+
+    job = create_job(prompt="x", schedule="every 5m", name="race")
+    jid = job["id"]
+    assert claim_job_for_fire(jid) is True
+
+    probe = (
+        "from cron.jobs import claim_job_for_fire; "
+        f"raise SystemExit(1 if claim_job_for_fire({jid!r}, claim_ttl_seconds=0) else 0)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=os.getcwd(),
+        env={**os.environ, "HERMES_HOME": str(temp_home)},
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_builtin_tick_does_not_dispatch_past_live_manual_claim(temp_home, monkeypatch):
+    """The built-in ticker must arbitrate through the same claim as manual run."""
+    from cron.jobs import claim_job_for_fire, create_job
+    from cron.scheduler import tick
+
+    job = create_job(prompt="x", schedule="every 5m", name="manual-vs-tick")
+    jid = job["id"]
+    assert claim_job_for_fire(jid) is True
+    _rewrite_claim(
+        jid,
+        at=(datetime.now(timezone.utc) - timedelta(minutes=6)).isoformat(),
+    )
+    _rewrite_job(
+        jid,
+        next_run_at=(datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat(),
+    )
+
+    ran = []
+    monkeypatch.setattr(
+        "cron.scheduler.run_one_job",
+        lambda due_job, **kwargs: ran.append(due_job["id"]) or True,
+    )
+
+    assert tick(verbose=False, sync=True) == 0
+    assert ran == []
+
+
+def test_finite_oneshot_fire_claim_prevents_stale_cleanup(temp_home):
+    """A manual/external one-shot fire must keep its record until completion."""
+    from cron.jobs import (
+        claim_dispatch,
+        claim_job_for_fire,
+        create_job,
+        get_due_jobs,
+        get_job,
+    )
+
+    job = create_job(prompt="x", schedule="30m", name="claimed-once", repeat=1)
+    jid = job["id"]
+    _rewrite_job(
+        jid,
+        next_run_at=(datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat(),
+    )
+    assert claim_job_for_fire(jid) is True
+    assert claim_dispatch(jid) is True
+
+    assert get_due_jobs() == []
+    stored = get_job(jid)
+    assert stored is not None
+    assert stored["repeat"]["completed"] == 1
+    assert stored["fire_claim"]["token"]
+
+
+def test_tick_aborts_claim_when_shutdown_starts_during_claim(temp_home, monkeypatch):
+    """A shutdown racing claim acquisition must prevent post-shutdown dispatch."""
+    import cron.scheduler as scheduler
+    from cron.jobs import claim_job_for_fire_snapshot, create_job, get_job
+
+    job = create_job(prompt="x", schedule="every 5m", name="shutdown-race")
+    second = create_job(
+        prompt="y",
+        schedule="30m",
+        name="after-shutdown",
+        repeat=1,
+    )
+    jid = job["id"]
+    due_at = (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat()
+    _rewrite_job(
+        jid,
+        next_run_at=due_at,
+    )
+    _rewrite_job(second["id"], next_run_at=due_at)
+    original_claim = claim_job_for_fire_snapshot
+    ran = []
+    claim_calls = []
+    shutdown_started = False
+
+    def claim_during_shutdown(job_id, **kwargs):
+        nonlocal shutdown_started
+        claim_calls.append(job_id)
+        if not shutdown_started:
+            shutdown_started = True
+            scheduler.mark_running_jobs_interrupted("shutdown during claim")
+        return original_claim(job_id, **kwargs)
+
+    monkeypatch.setattr(
+        scheduler,
+        "claim_job_for_fire_snapshot",
+        claim_during_shutdown,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "run_one_job",
+        lambda claimed_job, **kwargs: ran.append(claimed_job["id"]) or True,
+    )
+
+    assert scheduler.tick(verbose=False, sync=True) == 0
+    assert ran == []
+    assert claim_calls == [jid]
+    stored = get_job(jid)
+    assert stored is not None
+    assert stored.get("fire_claim") is None
+    assert stored["next_run_at"] == due_at
+    second_stored = get_job(second["id"])
+    assert second_stored is not None
+    assert second_stored.get("fire_claim") is None
+    assert second_stored.get("run_claim") is None
+    assert second_stored["next_run_at"] == due_at
+
+
+def test_tick_never_enters_body_when_shutdown_starts_after_registration(
+    temp_home,
+    monkeypatch,
+):
+    """A registered-but-unstarted pool job is released before side effects."""
+    import cron.scheduler as scheduler
+    from cron.jobs import create_job, get_job
+
+    job = create_job(prompt="x", schedule="every 5m", name="registered-tick")
+    due_at = (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat()
+    _rewrite_job(job["id"], next_run_at=due_at)
+    original_register = scheduler._register_running_claim
+    body_entered = []
+
+    def register_then_shutdown(job_id, claim_token, claimed_job=None):
+        result = original_register(job_id, claim_token, claimed_job)
+        if result == "published":
+            scheduler.mark_running_jobs_interrupted("shutdown after registration")
+        return result
+
+    monkeypatch.setattr(scheduler, "_register_running_claim", register_then_shutdown)
+    monkeypatch.setattr(
+        scheduler,
+        "run_one_job",
+        lambda claimed_job, **kwargs: body_entered.append(claimed_job["id"]) or True,
+    )
+
+    assert scheduler.tick(verbose=False, sync=True) == 0
+    assert body_entered == []
+    stored = get_job(job["id"])
+    assert stored is not None
+    assert stored.get("fire_claim") is None
+    assert stored["next_run_at"] == due_at
+
+
+def test_manual_run_never_enters_body_when_shutdown_starts_after_registration(
+    temp_home,
+    monkeypatch,
+):
+    """Manual/provider wrapper has the same registration-to-body barrier."""
+    import cron.scheduler as scheduler
+    from cron.jobs import claim_job_for_fire_snapshot, create_job, get_job
+
+    job = create_job(prompt="x", schedule="every 5m", name="registered-manual")
+    original = get_job(job["id"])
+    assert original is not None
+    before = original["next_run_at"]
+    claimed = claim_job_for_fire_snapshot(job["id"])
+    assert claimed is not None
+    original_register = scheduler._register_running_claim
+    body_entered = []
+
+    def register_then_shutdown(job_id, claim_token, claimed_job=None):
+        result = original_register(job_id, claim_token, claimed_job)
+        if result == "published":
+            scheduler.mark_running_jobs_interrupted("shutdown after registration")
+        return result
+
+    monkeypatch.setattr(scheduler, "_register_running_claim", register_then_shutdown)
+    monkeypatch.setattr(
+        scheduler,
+        "run_one_job",
+        lambda claimed_job, **kwargs: body_entered.append(claimed_job["id"]) or True,
+    )
+
+    assert scheduler.run_claimed_job(claimed, verbose=False) is False
+    assert body_entered == []
+    stored = get_job(job["id"])
+    assert stored is not None
+    assert stored.get("fire_claim") is None
+    assert stored["next_run_at"] == before
+
+
+def test_builtin_tick_executes_with_persisted_claim_token(temp_home, monkeypatch):
+    from cron.jobs import create_job, fire_claim_token, get_job, mark_job_run
+    from cron.scheduler import tick
+
+    job = create_job(prompt="x", schedule="every 5m", name="tick-token")
+    _rewrite_job(
+        job["id"],
+        next_run_at=(datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat(),
+    )
+    seen_tokens = []
+
+    def run_claimed(claimed_job, **kwargs):
+        token = fire_claim_token(claimed_job)
+        assert token is not None
+        seen_tokens.append(token)
+        assert mark_job_run(
+            claimed_job["id"],
+            success=True,
+            fire_claim_token=token,
+        )
+        return True
+
+    monkeypatch.setattr("cron.scheduler.run_one_job", run_claimed)
+
+    assert tick(verbose=False, sync=True) == 1
+    assert len(seen_tokens) == 1
+    completed = get_job(job["id"])
+    assert completed is not None
+    assert completed.get("fire_claim") is None
+
+
+def test_manual_run_executes_with_persisted_claim_token(temp_home, monkeypatch):
+    from cron.jobs import create_job, fire_claim_token, mark_job_run
+    from tools.cronjob_tools import _execute_job_now
+
+    job = create_job(prompt="x", schedule="every 5m", name="manual-token")
+    seen_tokens = []
+
+    def run_claimed(claimed_job, **kwargs):
+        token = fire_claim_token(claimed_job)
+        assert token is not None
+        seen_tokens.append(token)
+        assert mark_job_run(
+            claimed_job["id"],
+            success=True,
+            fire_claim_token=token,
+        )
+        return True
+
+    monkeypatch.setattr("cron.scheduler.run_one_job", run_claimed)
+
+    result = _execute_job_now(job)
+    assert result["claimed"] is True
+    assert result["success"] is True
+    assert len(seen_tokens) == 1
+
+
+def test_builtin_tick_does_not_reread_after_atomic_claim(temp_home, monkeypatch):
+    """A won claim returns its token snapshot without a fallible second read."""
+    import cron.scheduler as scheduler
+    from cron.jobs import create_job, fire_claim_token, mark_job_run
+
+    job = create_job(prompt="x", schedule="every 5m", name="atomic-tick-snapshot")
+    _rewrite_job(
+        job["id"],
+        next_run_at=(datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat(),
+    )
+
+    def forbidden_reread(_job_id):
+        raise OSError("post-claim read failed")
+
+    def run_claimed(claimed_job, **_kwargs):
+        token = fire_claim_token(claimed_job)
+        assert token is not None
+        assert mark_job_run(
+            claimed_job["id"],
+            success=True,
+            fire_claim_token=token,
+        )
+        return True
+
+    monkeypatch.setattr(scheduler, "get_job", forbidden_reread, raising=False)
+    monkeypatch.setattr(scheduler, "run_one_job", run_claimed)
+
+    assert scheduler.tick(verbose=False, sync=True) == 1
+
+
+def test_manual_run_does_not_reread_before_execution(temp_home, monkeypatch):
+    """Manual execution receives the atomic claim snapshot before store rereads."""
+    import tools.cronjob_tools as cron_tools
+    from cron.jobs import create_job, fire_claim_token, get_job, mark_job_run
+
+    job = create_job(prompt="x", schedule="every 5m", name="atomic-manual-snapshot")
+    ran = False
+
+    def get_only_after_run(job_id):
+        if not ran:
+            raise OSError("post-claim read failed")
+        return get_job(job_id)
+
+    def run_claimed(claimed_job, **_kwargs):
+        nonlocal ran
+        import cron.scheduler as scheduler
+
+        token = fire_claim_token(claimed_job)
+        assert token is not None
+        assert scheduler.get_running_job_ids() == frozenset({claimed_job["id"]})
+        assert scheduler._running_job_claim_tokens[claimed_job["id"]] == token
+        ran = True
+        assert mark_job_run(
+            claimed_job["id"],
+            success=True,
+            fire_claim_token=token,
+        )
+        return True
+
+    monkeypatch.setattr(cron_tools, "get_job", get_only_after_run)
+    monkeypatch.setattr("cron.scheduler.run_one_job", run_claimed)
+
+    result = cron_tools._execute_job_now(job)
+    assert result["claimed"] is True
+    assert result["success"] is True
+    assert ran is True
+
+
+def test_tick_releases_its_claim_when_submission_is_rejected(temp_home, monkeypatch):
+    from cron.jobs import create_job, get_job
+    from cron.scheduler import tick
+
+    class RejectingPool:
+        def submit(self, callback):
+            raise RuntimeError("cannot schedule new futures after shutdown")
+
+    job = create_job(prompt="x", schedule="every 5m", name="reject-submit")
+    due_at = (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat()
+    _rewrite_job(
+        job["id"],
+        next_run_at=due_at,
+    )
+    monkeypatch.setattr("cron.scheduler._get_parallel_pool", lambda workers: RejectingPool())
+    monkeypatch.setattr(
+        "cron.scheduler._interpreter_shutting_down",
+        lambda error=None: error is not None,
+    )
+
+    assert tick(verbose=False, sync=True) == 0
+    stored = get_job(job["id"])
+    assert stored is not None
+    assert stored.get("fire_claim") is None
+    assert stored["next_run_at"] == due_at
+
+
+def test_rejected_oneshot_submission_clears_run_and_fire_claims(temp_home, monkeypatch):
+    """A one-shot rejected before execution remains immediately due."""
+    from cron.jobs import create_job, get_due_jobs, get_job
+    from cron.scheduler import tick
+
+    class RejectingPool:
+        def submit(self, callback):
+            raise RuntimeError("cannot schedule new futures after shutdown")
+
+    job = create_job(prompt="x", schedule="30m", name="reject-once", repeat=1)
+    due_at = (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat()
+    _rewrite_job(job["id"], next_run_at=due_at)
+    monkeypatch.setattr("cron.scheduler._get_parallel_pool", lambda workers: RejectingPool())
+    monkeypatch.setattr(
+        "cron.scheduler._interpreter_shutting_down",
+        lambda error=None: error is not None,
+    )
+
+    assert tick(verbose=False, sync=True) == 0
+    stored = get_job(job["id"])
+    assert stored is not None
+    assert stored.get("fire_claim") is None
+    assert stored.get("run_claim") is None
+    assert stored["next_run_at"] == due_at
+    assert [due["id"] for due in get_due_jobs()] == [job["id"]]
+
+
+def test_unstarted_release_cannot_clear_replacement_run_claim(temp_home):
+    """Run-claim cleanup is owner-CAS just like fire-claim cleanup."""
+    from cron.jobs import (
+        claim_job_for_fire_snapshot,
+        create_job,
+        fire_claim_token,
+        get_due_jobs,
+        get_job,
+        release_fire_claim,
+    )
+
+    job = create_job(prompt="x", schedule="30m", name="replacement-run", repeat=1)
+    due_at = (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat()
+    _rewrite_job(job["id"], next_run_at=due_at)
+    due = get_due_jobs()
+    assert len(due) == 1
+    original_owner = due[0]["run_claim"]["by"]
+    claimed = claim_job_for_fire_snapshot(job["id"])
+    assert claimed is not None
+    token = fire_claim_token(claimed)
+    assert token is not None
+    _rewrite_job(
+        job["id"],
+        run_claim={"by": "replacement-owner", "at": datetime.now(timezone.utc).isoformat()},
+    )
+
+    assert release_fire_claim(
+        job["id"],
+        token,
+        restore_next_run_at=due_at,
+        expected_next_run_at=claimed["next_run_at"],
+        expected_run_claim_owner=original_owner,
+    )
+    stored = get_job(job["id"])
+    assert stored is not None
+    assert stored.get("fire_claim") is None
+    assert stored["run_claim"]["by"] == "replacement-owner"
+
+
+def test_live_holder_cannot_keep_claim_forever(temp_home):
+    """A reused live PID must not wedge a crashed job indefinitely."""
+    from cron.jobs import (
+        FIRE_CLAIM_MAX_LIVE_HOLDER_SECONDS,
+        claim_job_for_fire,
+        create_job,
+    )
+
+    job = create_job(prompt="x", schedule="every 5m", name="bounded")
+    jid = job["id"]
+    assert claim_job_for_fire(jid) is True
+    _rewrite_claim(
+        jid,
+        at=(
+            datetime.now(timezone.utc)
+            - timedelta(seconds=FIRE_CLAIM_MAX_LIVE_HOLDER_SECONDS + 1)
+        ).isoformat(),
+    )
+
+    assert (
+        claim_job_for_fire(
+            jid,
+            claim_ttl_seconds=FIRE_CLAIM_MAX_LIVE_HOLDER_SECONDS * 2,
+        )
+        is True
+    )
+
+
+def test_live_holder_is_reclaimable_at_absolute_cap(temp_home, monkeypatch):
+    from cron.jobs import (
+        FIRE_CLAIM_MAX_LIVE_HOLDER_SECONDS,
+        claim_job_for_fire,
+        create_job,
+    )
+
+    now = datetime(2026, 7, 10, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+    job = create_job(prompt="x", schedule="every 5m", name="exact-cap")
+    assert claim_job_for_fire(job["id"]) is True
+    _rewrite_claim(
+        job["id"],
+        at=(now - timedelta(seconds=FIRE_CLAIM_MAX_LIVE_HOLDER_SECONDS)).isoformat(),
+    )
+
+    assert claim_job_for_fire(job["id"]) is True
+
+
+def test_tick_replaces_local_registry_entry_at_absolute_cap(temp_home, monkeypatch):
+    """The local fast guard must not override the persisted claim's absolute cap."""
+    import cron.scheduler as scheduler
+    from cron.jobs import (
+        FIRE_CLAIM_MAX_LIVE_HOLDER_SECONDS,
+        claim_job_for_fire_snapshot,
+        create_job,
+        fire_claim_token,
+        mark_job_run,
+    )
+
+    now = datetime(2026, 7, 10, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+    job = create_job(prompt="x", schedule="every 5m", name="registry-cap")
+    first = claim_job_for_fire_snapshot(job["id"])
+    assert first is not None
+    first_token = fire_claim_token(first)
+    assert first_token is not None
+    _rewrite_claim(
+        job["id"],
+        at=(now - timedelta(seconds=FIRE_CLAIM_MAX_LIVE_HOLDER_SECONDS)).isoformat(),
+    )
+    _rewrite_job(job["id"], next_run_at=(now - timedelta(seconds=1)).isoformat())
+    with scheduler._running_lock:
+        scheduler._running_job_ids.add(job["id"])
+        scheduler._running_job_claim_tokens[job["id"]] = first_token
+
+    replacement_tokens = []
+
+    def run_replacement(claimed_job, **_kwargs):
+        replacement_token = fire_claim_token(claimed_job)
+        assert replacement_token is not None
+        assert replacement_token != first_token
+        replacement_tokens.append(replacement_token)
+        assert scheduler._is_interrupted(job["id"], first_token) is True
+        assert mark_job_run(
+            job["id"],
+            success=True,
+            fire_claim_token=replacement_token,
+        )
+        return True
+
+    monkeypatch.setattr(scheduler, "run_one_job", run_replacement)
+
+    assert scheduler.tick(verbose=False, sync=True) == 1
+    assert len(replacement_tokens) == 1
+    assert scheduler.get_running_job_ids() == frozenset()
+
+
+def test_shutdown_cas_loss_keeps_old_flag_while_replacement_completes(temp_home):
+    """A replacement completes normally while a killed old token stays suppressed."""
+    import cron.scheduler as scheduler
+    from cron.jobs import (
+        FIRE_CLAIM_MAX_LIVE_HOLDER_SECONDS,
+        claim_job_for_fire_snapshot,
+        create_job,
+        fire_claim_token,
+        get_job,
+        mark_job_run,
+    )
+
+    job = create_job(prompt="x", schedule="every 5m", name="shutdown-replacement")
+    old = claim_job_for_fire_snapshot(job["id"])
+    assert old is not None
+    old_token = fire_claim_token(old)
+    assert old_token is not None
+    _rewrite_claim(
+        job["id"],
+        at=(
+            datetime.now(timezone.utc)
+            - timedelta(seconds=FIRE_CLAIM_MAX_LIVE_HOLDER_SECONDS + 1)
+        ).isoformat(),
+    )
+    replacement = claim_job_for_fire_snapshot(job["id"])
+    assert replacement is not None
+    replacement_token = fire_claim_token(replacement)
+    assert replacement_token is not None
+    assert replacement_token != old_token
+    with scheduler._running_lock:
+        scheduler._running_job_ids.add(job["id"])
+        scheduler._running_job_claim_tokens[job["id"]] = old_token
+        scheduler._running_job_started_tokens.add((job["id"], old_token))
+
+    assert scheduler.mark_running_jobs_interrupted("gateway drain") == []
+    assert scheduler._is_interrupted(job["id"], old_token) is True
+    assert scheduler._is_interrupted(job["id"], replacement_token) is False
+    assert mark_job_run(
+        job["id"],
+        success=True,
+        fire_claim_token=replacement_token,
+    )
+    stored = get_job(job["id"])
+    assert stored is not None
+    assert stored["last_status"] == "ok"
+    assert stored.get("fire_claim") is None
+    assert scheduler._consume_interrupted_flag(job["id"], replacement_token) is False
+    assert scheduler._consume_interrupted_flag(job["id"], old_token) is True
+
+
+def test_stale_runner_cannot_deliver_after_replacement_claim(temp_home, monkeypatch):
+    """Completion ownership is finalized before any user-visible delivery."""
+    import cron.scheduler as scheduler
+    from cron.jobs import (
+        FIRE_CLAIM_MAX_LIVE_HOLDER_SECONDS,
+        claim_job_for_fire_snapshot,
+        create_job,
+        fire_claim_token,
+        get_job,
+    )
+
+    job = create_job(prompt="x", schedule="every 5m", name="stale-delivery")
+    old = claim_job_for_fire_snapshot(job["id"])
+    assert old is not None
+    old_token = fire_claim_token(old)
+    assert old_token is not None
+    replacement_token = None
+    delivered = []
+
+    monkeypatch.setattr(
+        scheduler,
+        "run_job",
+        lambda claimed_job, **_kwargs: (True, "output", "OLD RESPONSE", None),
+    )
+
+    def replace_before_completion(job_id, output):
+        nonlocal replacement_token
+        _rewrite_claim(
+            job_id,
+            at=(
+                datetime.now(timezone.utc)
+                - timedelta(seconds=FIRE_CLAIM_MAX_LIVE_HOLDER_SECONDS + 1)
+            ).isoformat(),
+        )
+        replacement = claim_job_for_fire_snapshot(job_id)
+        assert replacement is not None
+        replacement_token = fire_claim_token(replacement)
+        assert replacement_token is not None
+        assert replacement_token != old_token
+        return temp_home / "old-output.md"
+
+    monkeypatch.setattr(scheduler, "save_job_output", replace_before_completion)
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_result",
+        lambda claimed_job, content, **_kwargs: delivered.append(content),
+    )
+
+    assert scheduler.run_one_job(old, verbose=False) is True
+    assert delivered == []
+    stored = get_job(job["id"])
+    assert stored is not None
+    assert stored["fire_claim"]["token"] == replacement_token
+
+
+def test_stale_delivery_result_cannot_overwrite_newer_completion(temp_home):
+    """Post-delivery bookkeeping is completion-token CAS."""
+    from cron.jobs import (
+        claim_job_for_fire_snapshot,
+        create_job,
+        fire_claim_token,
+        get_job,
+        mark_job_run,
+        update_job_run_post_completion,
+    )
+
+    job = create_job(prompt="x", schedule="every 5m", name="delivery-cas")
+    first = claim_job_for_fire_snapshot(job["id"])
+    assert first is not None
+    first_fire_token = fire_claim_token(first)
+    assert first_fire_token is not None
+    assert mark_job_run(
+        job["id"],
+        success=True,
+        fire_claim_token=first_fire_token,
+        completion_token="completion-one",
+    )
+    second = claim_job_for_fire_snapshot(job["id"])
+    assert second is not None
+    second_fire_token = fire_claim_token(second)
+    assert second_fire_token is not None
+    assert mark_job_run(
+        job["id"],
+        success=True,
+        fire_claim_token=second_fire_token,
+        completion_token="completion-two",
+    )
+
+    assert update_job_run_post_completion(
+        job["id"],
+        "completion-one",
+        "stale delivery failure",
+    ) is False
+    assert update_job_run_post_completion(
+        job["id"],
+        "completion-two",
+        "current delivery failure",
+    ) is True
+    stored = get_job(job["id"])
+    assert stored is not None
+    assert stored["last_delivery_error"] == "current delivery failure"
+
+
+def test_stale_completion_cannot_clear_replacement_claim(temp_home):
+    """A capped-out old run cannot erase the newer run's ownership token."""
+    from cron.jobs import (
+        FIRE_CLAIM_MAX_LIVE_HOLDER_SECONDS,
+        claim_job_for_fire,
+        create_job,
+        get_job,
+        mark_job_run,
+    )
+
+    job = create_job(prompt="x", schedule="every 5m", name="claim-token")
+    jid = job["id"]
+    assert claim_job_for_fire(jid) is True
+    first = get_job(jid)
+    assert first is not None
+    first_token = first["fire_claim"]["token"]
+    _rewrite_claim(
+        jid,
+        at=(
+            datetime.now(timezone.utc)
+            - timedelta(seconds=FIRE_CLAIM_MAX_LIVE_HOLDER_SECONDS + 1)
+        ).isoformat(),
+    )
+    assert claim_job_for_fire(jid) is True
+    replacement = get_job(jid)
+    assert replacement is not None
+    replacement_token = replacement["fire_claim"]["token"]
+    assert replacement_token != first_token
+
+    mark_job_run(jid, success=True, fire_claim_token=first_token)
+    after_stale_completion = get_job(jid)
+    assert after_stale_completion is not None
+    assert after_stale_completion["fire_claim"]["token"] == replacement_token
+    assert after_stale_completion.get("last_run_at") is None
+
+    mark_job_run(jid, success=True, fire_claim_token=replacement_token)
+    completed = get_job(jid)
+    assert completed is not None
+    assert completed.get("fire_claim") is None
+
+
+def test_pid_shaped_explicit_machine_id_uses_ttl_only(temp_home, monkeypatch):
+    """An explicit machine ID is opaque even when it resembles host:pid."""
+    from cron.jobs import create_job, claim_job_for_fire
+
+    monkeypatch.setenv("HERMES_MACHINE_ID", f"{socket.gethostname()}:{os.getpid()}")
+    job = create_job(prompt="x", schedule="every 5m", name="explicit-id")
+    jid = job["id"]
+
+    assert claim_job_for_fire(jid) is True
     assert claim_job_for_fire(jid, claim_ttl_seconds=0) is True
 
 
@@ -76,9 +1021,11 @@ def test_mark_job_run_clears_claim(temp_home):
     job = create_job(prompt="x", schedule="every 5m", name="c")
     jid = job["id"]
     assert claim_job_for_fire(jid) is True
-    assert get_job(jid).get("fire_claim") is not None
+    claimed = get_job(jid)
+    assert claimed is not None
+    token = claimed["fire_claim"]["token"]
 
-    mark_job_run(jid, success=True)
+    mark_job_run(jid, success=True, fire_claim_token=token)
     assert get_job(jid).get("fire_claim") is None
     # …and the re-armed recurring job is claimable again.
     assert claim_job_for_fire(jid) is True

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -181,6 +181,7 @@ class TestRunJobScript:
         assert success is True
         assert output == ""
 
+    @pytest.mark.live_system_guard_bypass
     def test_script_timeout(self, cron_env, monkeypatch):
         from cron import scheduler as sched_mod
         from cron.scheduler import _run_job_script

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -213,7 +213,11 @@ class TestTickWorkdirPartition:
         parallel_job = {"id": "c", "name": "C", "workdir": None}
 
         monkeypatch.setattr(sched, "get_due_jobs", lambda: [workdir_a, workdir_b, parallel_job])
-        monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
+        monkeypatch.setattr(
+            sched,
+            "_claim_job_for_tick",
+            lambda job: {**job, "fire_claim": {"token": f"test-{job['id']}"}},
+        )
 
         # Record call order / thread context.
         import threading

--- a/tests/cron/test_parallel_pool.py
+++ b/tests/cron/test_parallel_pool.py
@@ -12,6 +12,15 @@ from unittest.mock import patch
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _stub_tick_fire_claim(monkeypatch):
+    """Pool tests use synthetic due jobs outside the jobs store."""
+    monkeypatch.setattr(
+        "cron.scheduler._claim_job_for_tick",
+        lambda job: {**job, "fire_claim": {"token": f"test-{job['id']}"}},
+    )
+
+
 class TestPersistentPool:
     """_get_parallel_pool returns a persistent ThreadPoolExecutor."""
 
@@ -80,10 +89,10 @@ class TestRunningJobGuard:
 
         # Simulate the job already running.
         sched._running_job_ids.add("guard-job")
+        sched._running_job_claim_tokens["guard-job"] = "test-guard-job"
 
         dispatched = []
         monkeypatch.setattr(sched, "get_due_jobs", lambda: [job])
-        monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
         monkeypatch.setattr(sched, "run_job", lambda j, **_kw: dispatched.append(j["id"]) or (True, "out", "resp", None))
         monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: None)
         monkeypatch.setattr(sched, "mark_job_run", lambda *_a, **_kw: None)
@@ -94,6 +103,7 @@ class TestRunningJobGuard:
         assert dispatched == []
 
         sched._running_job_ids.discard("guard-job")
+        sched._running_job_claim_tokens.pop("guard-job", None)
         sched._shutdown_parallel_pool()
 
 
@@ -116,7 +126,6 @@ class TestSyncMode:
         ]
 
         monkeypatch.setattr(sched, "get_due_jobs", lambda: jobs)
-        monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
         monkeypatch.setattr(sched, "run_job", lambda j, **_kw: (True, "out", "resp", None))
         monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: "/tmp/out")
         monkeypatch.setattr(sched, "mark_job_run", lambda *_a, **_kw: None)
@@ -152,7 +161,6 @@ class TestSyncMode:
             return True, "out", "resp", None
 
         monkeypatch.setattr(sched, "get_due_jobs", lambda: [job])
-        monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
         monkeypatch.setattr(sched, "run_job", slow_run)
         monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: "/tmp/out")
         monkeypatch.setattr(sched, "mark_job_run", lambda *_a, **_kw: None)
@@ -206,7 +214,6 @@ class TestSequentialPool:
             return True, "out", "resp", None
 
         monkeypatch.setattr(sched, "get_due_jobs", lambda: [job])
-        monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
         monkeypatch.setattr(sched, "run_job", slow_run)
         monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: "/tmp/out")
         monkeypatch.setattr(sched, "mark_job_run", lambda *_a, **_kw: None)
@@ -245,10 +252,10 @@ class TestSequentialPool:
 
         # Simulate the job already running.
         sched._running_job_ids.add("guard-seq")
+        sched._running_job_claim_tokens["guard-seq"] = "test-guard-seq"
 
         dispatched = []
         monkeypatch.setattr(sched, "get_due_jobs", lambda: [job])
-        monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
         monkeypatch.setattr(sched, "run_job", lambda j, **_kw: dispatched.append(j["id"]) or (True, "out", "resp", None))
         monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: None)
         monkeypatch.setattr(sched, "mark_job_run", lambda *_a, **_kw: None)
@@ -259,6 +266,7 @@ class TestSequentialPool:
         assert dispatched == []
 
         sched._running_job_ids.discard("guard-seq")
+        sched._running_job_claim_tokens.pop("guard-seq", None)
         sched._shutdown_parallel_pool()
 
     def test_get_sequential_pool_is_persistent(self):

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -1,6 +1,6 @@
 """Characterization + unit tests for the `run_one_job` shared helper (Phase 4A).
 
-`tick`'s per-job body (`_process_job`) is the execute → save → deliver → mark
+`tick`'s per-job body (`_process_job`) is the execute → save → mark → deliver
 sequence that fires ONE due job. Phase 4A extracts it into a module-level
 `run_one_job(job, *, adapters=None, loop=None, verbose=False)` so the external
 Chronos provider's `fire_due` can reuse the IDENTICAL body — no duplicated
@@ -31,39 +31,52 @@ def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final res
         calls.append(("deliver", job["id"]))
         return None
 
-    def fake_mark(jid, ok, err=None, delivery_error=None):
+    def fake_mark(
+        jid,
+        ok,
+        err=None,
+        delivery_error=None,
+        fire_claim_token=None,
+        completion_token=None,
+    ):
         calls.append(("mark", jid, ok))
+        return True
 
     monkeypatch.setattr(s, "run_job", fake_run_job)
     monkeypatch.setattr(s, "save_job_output", fake_save)
     monkeypatch.setattr(s, "_deliver_result", fake_deliver)
     monkeypatch.setattr(s, "mark_job_run", fake_mark)
+    monkeypatch.setattr(s, "update_job_run_post_completion", lambda *args, **kwargs: True)
     return calls
 
 
 def test_tick_process_job_sequence(monkeypatch):
     """Characterization: a single due job driven through tick() runs the
-    sequence run_job → save → deliver → mark, in that order."""
+    sequence run_job → save → mark → deliver, in that order."""
     calls = _patch_pipeline(monkeypatch)
     monkeypatch.setattr(s, "get_due_jobs", lambda: [{"id": "j1", "name": "t"}])
-    monkeypatch.setattr(s, "advance_next_run", lambda jid: True)
+    monkeypatch.setattr(
+        s,
+        "_claim_job_for_tick",
+        lambda job: {**job, "fire_claim": {"token": f"test-{job['id']}"}},
+    )
 
     s.tick(verbose=False, sync=True)
 
-    assert [c[0] for c in calls] == ["run_job", "save", "deliver", "mark"]
-    assert calls[-1] == ("mark", "j1", True)
+    assert [c[0] for c in calls] == ["run_job", "save", "mark", "deliver"]
+    assert calls[-2] == ("mark", "j1", True)
 
 
 def test_run_one_job_success_sequence(monkeypatch):
-    """The extracted helper runs the same execute→save→deliver→mark sequence
+    """The extracted helper runs the same execute→save→mark→deliver sequence
     for a successful job."""
     calls = _patch_pipeline(monkeypatch)
 
     ok = s.run_one_job({"id": "j2", "name": "t"})
 
     assert ok is True
-    assert [c[0] for c in calls] == ["run_job", "save", "deliver", "mark"]
-    assert calls[-1] == ("mark", "j2", True)
+    assert [c[0] for c in calls] == ["run_job", "save", "mark", "deliver"]
+    assert calls[-2] == ("mark", "j2", True)
 
 
 def test_run_one_job_silent_skips_delivery(monkeypatch):
@@ -110,7 +123,7 @@ def test_run_one_job_exception_marks_failure(monkeypatch):
     marks = []
     monkeypatch.setattr(
         s, "mark_job_run",
-        lambda jid, ok, err=None, delivery_error=None: marks.append((jid, ok)),
+        lambda jid, ok, err=None, **kwargs: marks.append((jid, ok)),
     )
 
     ok = s.run_one_job({"id": "j6", "name": "t"})

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -5,13 +5,24 @@ import itertools
 import json
 import logging
 import os
-from unittest.mock import AsyncMock, patch, MagicMock
+from unittest.mock import ANY, AsyncMock, patch, MagicMock
 
 import pytest
 
 from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt, _resolve_cron_enabled_toolsets, _merge_mcp_into_per_job_toolsets
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
+
+
+@pytest.fixture(autouse=True)
+def _stub_tick_fire_claim(monkeypatch):
+    """Scheduler unit tests use synthetic due jobs outside the jobs store."""
+    def claimed(job):
+        claimed_job = dict(job)
+        claimed_job["fire_claim"] = {"token": f"test-{job['id']}"}
+        return claimed_job
+
+    monkeypatch.setattr("cron.scheduler._claim_job_for_tick", claimed)
 
 
 class TestPerJobToolsetMcpMerge:
@@ -1555,7 +1566,6 @@ class TestRunJobSessionPersistence:
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
              patch("cron.scheduler.get_due_jobs", return_value=[job]), \
-             patch("cron.scheduler.advance_next_run"), \
              patch("cron.scheduler.mark_job_run") as mock_mark, \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
@@ -2626,6 +2636,8 @@ class TestSilentDelivery:
             False,
             "Agent completed but produced empty response (model error, timeout, or misconfiguration)",
             delivery_error=None,
+            completion_token=ANY,
+            fire_claim_token="test-monitor-job",
         )
 
 
@@ -3106,7 +3118,6 @@ class TestParallelTick:
         ]
 
         with patch("cron.scheduler.get_due_jobs", return_value=jobs), \
-             patch("cron.scheduler.advance_next_run"), \
              patch("cron.scheduler.run_job", side_effect=mock_run_job), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._deliver_result", return_value=None), \
@@ -3151,7 +3162,6 @@ class TestParallelTick:
         ]
 
         with patch("cron.scheduler.get_due_jobs", return_value=jobs), \
-             patch("cron.scheduler.advance_next_run"), \
              patch("cron.scheduler.run_job", side_effect=mock_run_job), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._deliver_result", return_value=None), \
@@ -3180,7 +3190,6 @@ class TestParallelTick:
         ]
 
         with patch("cron.scheduler.get_due_jobs", return_value=jobs), \
-             patch("cron.scheduler.advance_next_run"), \
              patch("cron.scheduler.run_job", side_effect=mock_run_job), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._deliver_result", return_value=None), \

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -338,12 +338,50 @@ def test_fire_due_default_claims_then_runs(monkeypatch):
     from cron.scheduler_provider import InProcessCronScheduler
 
     ran = []
-    monkeypatch.setattr(jobs, "claim_job_for_fire", lambda jid: True, raising=False)
-    monkeypatch.setattr(jobs, "get_job", lambda jid: {"id": jid, "name": "t"})
+    monkeypatch.setattr(
+        jobs,
+        "claim_job_for_fire_snapshot",
+        lambda jid: {"id": jid, "name": "t", "fire_claim": {"token": "test"}},
+    )
     monkeypatch.setattr(sched, "run_one_job", lambda job, **kw: ran.append(job["id"]) or True)
 
     assert InProcessCronScheduler().fire_due("j1") is True
     assert ran == ["j1"]
+
+
+def test_fire_due_registers_claimed_run_for_shutdown(monkeypatch):
+    """External-provider runs must be visible to shutdown with their claim token."""
+    import cron.jobs as jobs
+    import cron.scheduler as sched
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    claimed = {"id": "j1", "name": "t", "fire_claim": {"token": "external-token"}}
+    with sched._running_lock:
+        sched._running_job_ids.clear()
+        sched._running_job_claim_tokens.clear()
+        sched._running_job_claim_snapshots.clear()
+        sched._running_job_started_tokens.clear()
+        sched._interrupted_job_ids.clear()
+        sched._shutdown_started = False
+        sched._running_job_ids.add("j1")
+        sched._running_job_claim_tokens["j1"] = "superseded-token"
+
+    def run_visible(job, **_kwargs):
+        assert sched.get_running_job_ids() == frozenset({"j1"})
+        assert sched._running_job_claim_tokens["j1"] == "external-token"
+        assert sched._is_interrupted("j1", "superseded-token") is True
+        with patch("cron.scheduler.mark_job_run", return_value=True):
+            assert sched.mark_running_jobs_interrupted("shutdown") == ["j1"]
+        return True
+
+    monkeypatch.setattr(jobs, "claim_job_for_fire_snapshot", lambda jid: dict(claimed))
+    monkeypatch.setattr(sched, "run_one_job", run_visible)
+
+    assert InProcessCronScheduler().fire_due("j1") is True
+    assert sched.get_running_job_ids() == frozenset()
+    assert sched._consume_interrupted_flag("j1", "external-token") is False
+    assert sched._consume_interrupted_flag("j1", "superseded-token") is True
+    sched._shutdown_started = False
 
 
 def test_fire_due_lost_claim_does_not_run(monkeypatch):
@@ -354,7 +392,7 @@ def test_fire_due_lost_claim_does_not_run(monkeypatch):
     from cron.scheduler_provider import InProcessCronScheduler
 
     ran = []
-    monkeypatch.setattr(jobs, "claim_job_for_fire", lambda jid: False, raising=False)
+    monkeypatch.setattr(jobs, "claim_job_for_fire_snapshot", lambda jid: None)
     monkeypatch.setattr(sched, "run_one_job", lambda job, **kw: ran.append(job["id"]) or True)
 
     assert InProcessCronScheduler().fire_due("j1") is False
@@ -369,8 +407,7 @@ def test_fire_due_missing_job_does_not_run(monkeypatch):
     from cron.scheduler_provider import InProcessCronScheduler
 
     ran = []
-    monkeypatch.setattr(jobs, "claim_job_for_fire", lambda jid: True, raising=False)
-    monkeypatch.setattr(jobs, "get_job", lambda jid: None)
+    monkeypatch.setattr(jobs, "claim_job_for_fire_snapshot", lambda jid: None)
     monkeypatch.setattr(sched, "run_one_job", lambda job, **kw: ran.append(job["id"]) or True)
 
     assert InProcessCronScheduler().fire_due("gone") is False

--- a/tests/cron/test_shutdown_interrupt.py
+++ b/tests/cron/test_shutdown_interrupt.py
@@ -23,10 +23,25 @@ def _reset_scheduler_state():
     import cron.scheduler as sched
 
     sched._running_job_ids.clear()
+    sched._running_job_claim_tokens.clear()
+    sched._running_job_claim_snapshots.clear()
+    sched._running_job_started_tokens.clear()
     sched._interrupted_job_ids.clear()
+    sched._shutdown_started = False
     yield
     sched._running_job_ids.clear()
+    sched._running_job_claim_tokens.clear()
+    sched._running_job_claim_snapshots.clear()
+    sched._running_job_started_tokens.clear()
     sched._interrupted_job_ids.clear()
+    sched._shutdown_started = False
+
+
+def _mark_started(sched, job_id, claim_token=None):
+    sched._running_job_ids.add(job_id)
+    if claim_token is not None:
+        sched._running_job_claim_tokens[job_id] = claim_token
+    sched._running_job_started_tokens.add((job_id, claim_token))
 
 
 class TestGetRunningJobIds:
@@ -71,7 +86,8 @@ class TestMarkRunningJobsInterrupted:
     def test_marks_every_in_flight_job(self):
         import cron.scheduler as sched
 
-        sched._running_job_ids.update({"job-1", "job-2"})
+        _mark_started(sched, "job-1")
+        _mark_started(sched, "job-2")
 
         with patch("cron.scheduler.mark_job_run") as mock_mark:
             marked = sched.mark_running_jobs_interrupted("gateway shutdown (final-cleanup)")
@@ -88,12 +104,12 @@ class TestMarkRunningJobsInterrupted:
     def test_sets_interrupted_flag_for_consumption_by_run_one_job(self):
         import cron.scheduler as sched
 
-        sched._running_job_ids.add("job-1")
+        _mark_started(sched, "job-1")
 
         with patch("cron.scheduler.mark_job_run"):
             sched.mark_running_jobs_interrupted("shutdown")
 
-        assert "job-1" in sched._interrupted_job_ids
+        assert ("job-1", None) in sched._interrupted_job_ids
 
     def test_one_job_marking_failure_does_not_block_the_others(self):
         """mark_job_run raising for one job (e.g. a jobs.json write race)
@@ -101,7 +117,8 @@ class TestMarkRunningJobsInterrupted:
         shutdown, there's no retry window."""
         import cron.scheduler as sched
 
-        sched._running_job_ids.update({"job-1", "job-2"})
+        _mark_started(sched, "job-1")
+        _mark_started(sched, "job-2")
 
         def _side_effect(job_id, success, reason, **kwargs):
             if job_id == "job-1":
@@ -111,6 +128,31 @@ class TestMarkRunningJobsInterrupted:
             marked = sched.mark_running_jobs_interrupted("shutdown")
 
         assert marked == ["job-2"]
+
+    def test_rejected_stale_owner_keeps_token_scoped_interruption_flag(self):
+        """A failed CAS keeps the old-run guard without poisoning its replacement."""
+        import cron.scheduler as sched
+
+        _mark_started(sched, "job-1", "old-token")
+
+        with patch("cron.scheduler.mark_job_run", return_value=False):
+            marked = sched.mark_running_jobs_interrupted("shutdown")
+
+        assert marked == []
+        assert sched._consume_interrupted_flag("job-1", "new-token") is False
+        assert sched._consume_interrupted_flag("job-1", "old-token") is True
+
+    def test_interruption_flag_is_scoped_to_fire_claim_token(self):
+        """An interrupted old run must not suppress its replacement's completion."""
+        import cron.scheduler as sched
+
+        _mark_started(sched, "job-1", "old-token")
+
+        with patch("cron.scheduler.mark_job_run", return_value=True):
+            assert sched.mark_running_jobs_interrupted("shutdown") == ["job-1"]
+
+        assert sched._consume_interrupted_flag("job-1", "new-token") is False
+        assert sched._consume_interrupted_flag("job-1", "old-token") is True
 
 
 class TestIsInterrupted:
@@ -125,20 +167,20 @@ class TestIsInterrupted:
     def test_true_when_marked(self):
         import cron.scheduler as sched
 
-        sched._interrupted_job_ids.add("job-1")
+        sched._interrupted_job_ids.add(("job-1", None))
 
         assert sched._is_interrupted("job-1") is True
 
     def test_does_not_clear_the_flag(self):
         import cron.scheduler as sched
 
-        sched._interrupted_job_ids.add("job-1")
+        sched._interrupted_job_ids.add(("job-1", None))
 
         sched._is_interrupted("job-1")
 
         # Still set -- the later, authoritative check before mark_job_run
         # must still see it.
-        assert "job-1" in sched._interrupted_job_ids
+        assert ("job-1", None) in sched._interrupted_job_ids
         assert sched._is_interrupted("job-1") is True
 
 
@@ -151,7 +193,7 @@ class TestConsumeInterruptedFlag:
     def test_true_and_clears_when_marked(self):
         import cron.scheduler as sched
 
-        sched._interrupted_job_ids.add("job-1")
+        sched._interrupted_job_ids.add(("job-1", None))
 
         assert sched._consume_interrupted_flag("job-1") is True
         # Consumed -- a second check (e.g. a later, unrelated fire of the
@@ -166,11 +208,11 @@ class TestRunOneJobHonoursInterruptedFlag:
     def _make_job(self, job_id="job-1"):
         return {"id": job_id, "name": "test job", "prompt": "do work"}
 
-    def test_success_path_skipped_when_interrupted(self):
+    def test_interrupted_run_finalizes_as_failure(self):
         import cron.scheduler as sched
 
         job = self._make_job()
-        sched._interrupted_job_ids.add(job["id"])
+        sched._interrupted_job_ids.add((job["id"], None))
 
         with patch("cron.scheduler.claim_dispatch", return_value=True), \
              patch("agent.secret_scope.set_secret_scope", return_value=None), \
@@ -187,25 +229,18 @@ class TestRunOneJobHonoursInterruptedFlag:
             result = sched.run_one_job(job)
 
         assert result is True
-        # The would-be "success" write must NOT happen -- the shutdown
-        # path already wrote the authoritative interrupted status.
-        mock_mark.assert_not_called()
+        mock_mark.assert_called_once()
+        assert mock_mark.call_args.args[1] is False
         # Flag is consumed so a later, unrelated fire of the same job ID
         # isn't permanently silenced.
-        assert job["id"] not in sched._interrupted_job_ids
+        assert (job["id"], None) not in sched._interrupted_job_ids
 
     def test_interrupted_job_delivers_failure_summary_not_raw_response(self):
-        """The status-write guard alone isn't enough: delivery happens
-        BEFORE mark_job_run in run_one_job's own flow, so a job that kept
-        running post-kill and produced a plausible-looking final_response
-        must not have that response sent to the user just because the
-        eventual status write gets suppressed. Interrupted jobs must route
-        through the same failure-summary delivery path a real failure
-        would."""
+        """An owned interrupted run may deliver only its failure summary."""
         import cron.scheduler as sched
 
         job = self._make_job()
-        sched._interrupted_job_ids.add(job["id"])
+        sched._interrupted_job_ids.add((job["id"], None))
 
         with patch("cron.scheduler.claim_dispatch", return_value=True), \
              patch("agent.secret_scope.set_secret_scope", return_value=None), \
@@ -264,7 +299,7 @@ class TestRunOneJobHonoursInterruptedFlag:
         import cron.scheduler as sched
 
         job = self._make_job()
-        sched._interrupted_job_ids.add(job["id"])
+        sched._interrupted_job_ids.add((job["id"], None))
 
         with patch("cron.scheduler.claim_dispatch", return_value=True), \
              patch("agent.secret_scope.set_secret_scope", return_value=None), \

--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -14,6 +14,7 @@ from tools.cronjob_tools import cronjob, _execute_job_now
 
 _JOB = {"id": "job-run-1", "name": "manual run", "prompt": "hi",
         "schedule": {"kind": "cron", "expr": "0 9 * * *"}}
+_CLAIMED_JOB = {**_JOB, "fire_claim": {"token": "test-claim"}}
 
 
 class TestCronjobRunExecutesImmediately:
@@ -21,7 +22,7 @@ class TestCronjobRunExecutesImmediately:
         """action='run' must claim the job then fire it through run_one_job."""
         ran = {"job": "after-run", "last_status": "ok", "last_error": None}
         with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
-             patch("tools.cronjob_tools.claim_job_for_fire", return_value=True) as m_claim, \
+             patch("tools.cronjob_tools.claim_job_for_fire_snapshot", return_value=dict(_CLAIMED_JOB)) as m_claim, \
              patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
              patch("tools.cronjob_tools.get_job", return_value=ran):
             out = json.loads(cronjob(action="run", job_id="job-run-1"))
@@ -35,7 +36,7 @@ class TestCronjobRunExecutesImmediately:
     def test_run_skips_when_claim_lost(self):
         """If the scheduler already holds the fire claim, do NOT double-run."""
         with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
-             patch("tools.cronjob_tools.claim_job_for_fire", return_value=False), \
+             patch("tools.cronjob_tools.claim_job_for_fire_snapshot", return_value=None), \
              patch("cron.scheduler.run_one_job") as m_run, \
              patch("tools.cronjob_tools.get_job", return_value=dict(_JOB)):
             out = json.loads(cronjob(action="run", job_id="job-run-1"))
@@ -50,7 +51,7 @@ class TestCronjobRunExecutesImmediately:
         """A failed run is reported via the re-read job's last_status/last_error."""
         failed = {"id": "job-run-1", "last_status": "error", "last_error": "provider 500"}
         with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
-             patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+             patch("tools.cronjob_tools.claim_job_for_fire_snapshot", return_value=dict(_CLAIMED_JOB)), \
              patch("cron.scheduler.run_one_job", return_value=True), \
              patch("tools.cronjob_tools.get_job", return_value=failed):
             out = json.loads(cronjob(action="run", job_id="job-run-1"))
@@ -61,7 +62,7 @@ class TestCronjobRunExecutesImmediately:
 
     def test_execute_job_now_bails_without_claim(self):
         """_execute_job_now never calls run_one_job when the claim is lost."""
-        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=False), \
+        with patch("tools.cronjob_tools.claim_job_for_fire_snapshot", return_value=None), \
              patch("cron.scheduler.run_one_job") as m_run:
             res = _execute_job_now(dict(_JOB))
         assert res["claimed"] is False
@@ -70,7 +71,7 @@ class TestCronjobRunExecutesImmediately:
 
     def test_execute_job_now_marks_failure_on_exception(self):
         """An exception during fire is captured, marked failed, not propagated."""
-        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+        with patch("tools.cronjob_tools.claim_job_for_fire_snapshot", return_value=dict(_CLAIMED_JOB)), \
              patch("cron.scheduler.run_one_job", side_effect=RuntimeError("boom")), \
              patch("tools.cronjob_tools.mark_job_run") as m_mark, \
              patch("tools.cronjob_tools.get_job", return_value=dict(_JOB)):

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -21,8 +21,9 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from cron.jobs import (
     AmbiguousJobReference,
-    claim_job_for_fire,
+    claim_job_for_fire_snapshot,
     create_job,
+    fire_claim_token,
     get_job,
     list_jobs,
     mark_job_run,
@@ -610,7 +611,7 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
     blocks a duplicate fire and advances ``next_run_at`` for recurring jobs).
     If the claim is lost (another fire is in flight), this is a no-op.
 
-    The actual firing is delegated to ``run_one_job`` — the single shared
+    The actual firing is delegated to ``run_claimed_job`` — the shared
     execute→save→deliver→mark body the ticker and external providers use — so
     failure delivery, ``[SILENT]`` handling, and live-adapter delivery stay
     identical across paths and can't drift.
@@ -619,12 +620,13 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
     """
     job_id = job["id"]
     try:
-        from cron.scheduler import run_one_job
+        from cron.scheduler import run_claimed_job
 
         # At-most-once claim: bail without running if a tick/other fire owns it.
-        if not claim_job_for_fire(job_id):
-            # claim_job_for_fire returns False for paused/disabled/missing
-            # jobs too — don't mislabel those as "already being fired"
+        claimed_job = claim_job_for_fire_snapshot(job_id)
+        if claimed_job is None:
+            # A missing snapshot also represents paused/disabled/missing jobs —
+            # don't mislabel those as "already being fired"
             # (#60703): that message sends the user chasing a phantom
             # in-flight run when the job simply isn't runnable.
             refreshed = get_job(job_id)
@@ -636,9 +638,11 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
                 reason = "Job is already being fired by the scheduler; not run again."
             return {"claimed": False, "success": False, "error": reason}
 
-        # run_one_job records last_run_at/last_status via mark_job_run (which
-        # also clears the fire claim) and returns True iff it processed the job.
-        processed = run_one_job(job)
+        job = claimed_job
+
+        # run_claimed_job publishes shutdown visibility, then run_one_job records
+        # status via mark_job_run (which also clears the fire claim).
+        processed = run_claimed_job(job)
         refreshed = get_job(job_id) or {}
         ok = refreshed.get("last_status") == "ok"
         return {
@@ -650,7 +654,12 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
     except Exception as e:
         logger.error("Failed to execute cron job %s immediately: %s", job_id, e)
         try:
-            mark_job_run(job_id, False, str(e))
+            mark_job_run(
+                job_id,
+                False,
+                str(e),
+                fire_claim_token=fire_claim_token(job),
+            )
         except Exception:
             pass
         return {"claimed": True, "success": False, "error": str(e)}


### PR DESCRIPTION
## What does this PR do?

Prevents duplicate cron fires by making every dispatch surface acquire the same tokenized, store-level `fire_claim` before execution.

The existing in-process `_running_job_ids` guard cannot coordinate separate gateway processes, manual `cronjob run` calls, or external scheduler callbacks. It also leaves timing windows around pool submission and shutdown. This change makes the persisted claim the authority while retaining the local running set as a fast guard.

The claim includes unambiguous machine/process provenance. A fresh claim blocks all competitors; after the freshness TTL, a proven-live local holder continues to block theft up to a bounded absolute cap. Completion and release use token compare-and-set semantics, so a stale runner cannot clear or overwrite a replacement run.

It also closes the recovery races found during review:

- finite one-shots are not stale-deleted while an active manual/external fire owns them;
- shutdown interruption flags are scoped to `(job_id, fire_claim_token)` rather than only the reusable job ID;
- a latched shutdown racing claim acquisition prevents that job from dispatching and prevents every later due job from even acquiring a fire claim;
- registered-but-unstarted work must atomically cross a body-entry barrier; if drain wins, its exact claim is rolled back before any agent, script, or tool side effect;
- rejected pre-submit claims restore the original due `next_run_at` and clear only the owner-matching one-shot `run_claim`;
- absolute-cap replacements supersede the local token registry without allowing stale cleanup to remove the new incarnation.
- each run finalizes ownership before delivery, so a capped-out stale runner cannot send output after a replacement wins.

## Related Issue

Fixes #51329.

Related existing work: #60946, #51452, and the cron-only portion of #52479. This PR covers those timing concerns with one store-level claim shared by built-in, manual, and external-provider fire paths.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/jobs.py`
  - add tokenized fire-claim acquisition/release/completion CAS;
  - return the persisted claimed snapshot atomically so dispatchers never need a fallible post-claim reread;
  - persist machine/process provenance and bounded live-holder recovery semantics;
  - keep finite one-shots while an active fire claim owns execution;
  - conditionally restore a due schedule when submission never starts.
- `cron/scheduler.py`
  - acquire the persisted claim before publishing local running state;
  - pass claim tokens through completion, failure, and shutdown paths;
  - scope interruption state to the claimed run incarnation;
  - latch shutdown to abort claim/publication races and all later dispatches;
  - register manual/external runs for shutdown visibility and token-safe replacement;
  - distinguish registered/unstarted claims from started runs during shutdown, rolling back only the former;
  - release fire and owner-matching one-shot run claims safely on pre-submit aborts;
  - finalize before delivery and record delivery outcomes with a separate completion-token CAS.
- `cron/scheduler_provider.py`
  - pass the atomic claimed snapshot through the shared running-token registry.
- `tools/cronjob_tools.py`
  - route immediate/manual runs through the same persisted claim and registered execution body.
- `tests/cron/` and `tests/tools/`
  - add cross-process, manual-vs-tick, external-vs-tick, TTL/liveness/cap, stale-owner, one-shot cleanup, shutdown-race, submission-rejection, and token-CAS regressions.

## How to Test

1. Run the cron gate:
   ```bash
   bash scripts/run_tests.sh tests/cron/ -j 4
   ```
2. Run the manual cron tool suites:
   ```bash
   python3 -m pytest tests/tools/test_cronjob_tools.py tests/tools/test_cronjob_run_immediate.py -q
   ```
3. Run lint and portability checks:
   ```bash
   ruff check cron/jobs.py cron/scheduler.py cron/scheduler_provider.py tools/cronjob_tools.py tests/cron/test_claim_job_for_fire.py tests/cron/test_cron_script.py tests/cron/test_cron_workdir.py tests/cron/test_parallel_pool.py tests/cron/test_run_one_job.py tests/cron/test_scheduler.py tests/cron/test_scheduler_provider.py tests/cron/test_shutdown_interrupt.py tests/tools/test_cronjob_run_immediate.py
   python3 scripts/check-windows-footguns.py --all
   git diff --check
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 Ubuntu, Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is internal and the affected docstrings were updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — no new platform-specific synchronization primitives; the portability scan passes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; the existing tool contract is unchanged

## Screenshots / Logs

Verified on current `origin/main`:

- `bash scripts/run_tests.sh tests/cron/ -j 4`: **711 passed, 0 failed**
- `python3 -m pytest tests/tools/test_cronjob_tools.py tests/tools/test_cronjob_run_immediate.py -q`: **82 passed**
- focused claim/lifecycle/provider/tool suite: **192 passed**
- Ruff: passed
- `python3 scripts/check-windows-footguns.py --all`: **756 files scanned, no findings**
- `git diff --check`, `git diff --cached --check`, and `py_compile`: passed

The repository-wide test wrapper was also attempted, but this local environment lacks optional full-suite dependencies such as `prompt_toolkit`; unrelated suites fail during collection. The cron/tool gates above are clean, and GitHub CI remains the authoritative full-suite result.
