### PR TITLE
fix(memory/hindsight): per-project banks, extra recall banks, and recall the current turn

### DIFF
--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -60,7 +60,8 @@ Config file: `~/.hermes/hindsight/config.json`
 | Key | Default | Description |
 |-----|---------|-------------|
 | `bank_id` | `hermes` | Memory bank name (static fallback used when `bank_id_template` is unset or resolves empty) |
-| `bank_id_template` | — | Optional template to derive the bank name dynamically. Placeholders: `{profile}`, `{workspace}`, `{platform}`, `{user}`, `{session}`. Example: `hermes-{profile}` isolates memory per active Hermes profile. Empty placeholders collapse cleanly (e.g. `hermes-{user}` with no user becomes `hermes`). |
+| `bank_id_template` | — | Optional template to derive the bank name dynamically. Placeholders: `{profile}`, `{project}`, `{workspace}`, `{platform}`, `{user}`, `{session}`. Example: `hermes-{profile}` isolates memory per active Hermes profile. Empty placeholders collapse cleanly (e.g. `hermes-{user}` with no user becomes `hermes`). |
+| — `{project}` | — | The repo (or directory) name of the session's cwd, resolved the same way the Hindsight plugins for Claude Code and Codex resolve it — so a bare `{project}` template puts all three harnesses in **one bank per project**. Outside any project it resolves empty and the static `bank_id` is used. |
 | `bank_mission` | — | Reflect mission (identity/framing for reflect reasoning). Applied via Banks API. |
 | `bank_retain_mission` | — | Retain mission (steers what gets extracted). Applied via Banks API. |
 
@@ -75,6 +76,8 @@ Config file: `~/.hermes/hindsight/config.json`
 | `recall_prompt_preamble` | — | Custom preamble for recalled memories in context |
 | `recall_tags` | — | Tags to filter when searching memories |
 | `recall_tags_match` | `any` | Tag matching mode: `any` / `all` / `any_strict` / `all_strict` |
+| `recall_additional_banks` | — | Extra banks merged into every recall, **read-only** — retains always go to `bank_id`. List or comma-separated string. Use it to layer a shared bank under a per-project one (e.g. `user-global` alongside a `{project}` bank). |
+| `prefetch_wait_seconds` | `15` | How long a turn waits for its own recall before proceeding without it. Auto-recall is warmed at the end of the previous turn; when the current question misses that cache, it is recalled now and awaited up to this bound. A wedged Hindsight then costs the turn its memory, never the turn itself. |
 | `recall_types` | `observation` | Fact types surfaced by recall (both auto-recall and the `hindsight_recall` tool). Comma-separated string or JSON list. **Default narrowed to `observation` only** (see "Behavior change" below). Set to `observation,world,experience` to also include raw facts. |
 | `auto_recall` | `true` | Automatically recall memories before each turn |
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -37,6 +37,7 @@ import json
 import logging
 import os
 import queue
+import subprocess
 import sys
 import threading
 
@@ -581,11 +582,39 @@ def _sanitize_bank_segment(value: str) -> str:
     return "".join(out).strip("-_")
 
 
+def _resolve_project_name(cwd: str = "") -> str:
+    """Resolve the current project name from the working directory.
+
+    Mirrors the Hindsight Claude Code / Codex plugin's project derivation so a
+    ``{project}`` bank resolves to the SAME bank id across all three harnesses:
+    the basename of the main repository (git-common-dir), which collapses
+    worktrees of one repo onto a single bank, falling back to the plain cwd
+    basename outside a git repo.
+
+    Returns "" when the directory cannot be determined, which makes a
+    ``{project}`` template fall back to the static ``bank_id``.
+    """
+    cwd = cwd or os.getcwd()
+    if not cwd:
+        return ""
+    try:
+        result = subprocess.run(
+            ["git", "-C", cwd, "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return os.path.basename(os.path.dirname(result.stdout.strip()))
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return os.path.basename(cwd.rstrip(os.sep))
+
+
 def _resolve_bank_id_template(template: str, fallback: str, **placeholders: str) -> str:
     """Resolve a bank_id template string with the given placeholders.
 
     Supported placeholders (each is sanitized before substitution):
       {profile}   — active Hermes profile name (from agent_identity)
+      {project}   — repo/directory name of the cwd (matches Claude Code + Codex)
       {workspace} — Hermes workspace name (from agent_workspace)
       {platform}  — "cli", "telegram", "discord", etc.
       {user}      — platform user id (gateway sessions)
@@ -659,6 +688,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._timeout = _DEFAULT_TIMEOUT
         self._idle_timeout = _DEFAULT_IDLE_TIMEOUT
         self._prefetch_result = ""
+        self._prefetch_query = ""
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread = None
         # Single-writer model for retain. sync_turn() enqueues; the writer
@@ -712,6 +742,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._bank_mission = ""
         self._bank_retain_mission: str | None = None
         self._bank_id_template = ""
+        self._recall_additional_banks: List[str] = []
 
     @property
     def name(self) -> str:
@@ -982,7 +1013,9 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "llm_api_key", "description": "LLM API key (optional for openai_compatible)", "secret": True, "env_var": "HINDSIGHT_LLM_API_KEY", "when": {"mode": "local_embedded"}},
             {"key": "llm_model", "description": "LLM model", "default": "gpt-4o-mini", "default_from": {"field": "llm_provider", "map": _PROVIDER_DEFAULT_MODELS}, "when": {"mode": "local_embedded"}},
             {"key": "bank_id", "description": "Memory bank name (static fallback when bank_id_template is unset)", "default": "hermes"},
-            {"key": "bank_id_template", "description": "Optional template to derive bank_id dynamically. Placeholders: {profile}, {workspace}, {platform}, {user}, {session}. Example: hermes-{profile}", "default": ""},
+            {"key": "prefetch_wait_seconds", "description": "Max seconds a turn waits for its memory recall before proceeding without it", "default": 15.0},
+            {"key": "recall_additional_banks", "description": "Extra banks merged into every recall, read-only (list or comma-separated). Writes always go to bank_id. Example: user-global", "default": ""},
+            {"key": "bank_id_template", "description": "Optional template to derive bank_id dynamically. Placeholders: {profile}, {project}, {workspace}, {platform}, {user}, {session}. Use {project} (repo name of the cwd) to share one bank per project with the Hindsight Claude Code / Codex plugins. Example: {project}", "default": ""},
             {"key": "bank_mission", "description": "Mission/purpose description for the memory bank"},
             {"key": "bank_retain_mission", "description": "Custom extraction prompt for memory retention"},
             {"key": "recall_budget", "description": "Recall thoroughness", "default": "mid", "choices": ["low", "mid", "high"]},
@@ -1290,11 +1323,22 @@ class HindsightMemoryProvider(MemoryProvider):
             self._bank_id_template,
             fallback=static_bank_id,
             profile=self._agent_identity,
+            project=_resolve_project_name() if "{project}" in self._bank_id_template else "",
             workspace=self._agent_workspace,
             platform=self._platform,
             user=self._user_id,
             session=self._session_id,
         )
+        # Extra read-only banks merged into every recall (never written to).
+        # Parity with the Hindsight Claude Code / Codex plugins'
+        # `recallAdditionalBanks`: lets a per-project bank also see a durable
+        # cross-project bank (e.g. "user-global"). The writing bank stays
+        # self._bank_id — additional banks are recall-only by construction.
+        self._recall_additional_banks = [
+            b for b in _normalize_retain_tags(self._config.get("recall_additional_banks"))
+            if b != self._bank_id
+        ]
+
         budget = self._config.get("recall_budget") or self._config.get("budget") or banks.get("budget", "mid")
         self._budget = budget if budget in _VALID_BUDGETS else "mid"
 
@@ -1351,6 +1395,10 @@ class HindsightMemoryProvider(MemoryProvider):
             self._recall_types = list(configured_types) or ["observation"]
         self._recall_prompt_preamble = self._config.get("recall_prompt_preamble", "")
         self._recall_max_input_chars = int(self._config.get("recall_max_input_chars", 800))
+        # Bounded wait for a cold recall at turn time (see prefetch()). Long enough
+        # for a reranked recall on a loaded box, short enough that a wedged server
+        # costs the turn its memory rather than the turn itself.
+        self._prefetch_wait_seconds = float(self._config.get("prefetch_wait_seconds", 15.0))
         self._retain_async = self._config.get("retain_async", True)
 
         _client_version = "unknown"
@@ -1463,13 +1511,50 @@ class HindsightMemoryProvider(MemoryProvider):
             f"hindsight_retain to store facts."
         )
 
+    def _clean_prefetch_query(self, query: str) -> str:
+        """The exact string queue_prefetch would send to the server."""
+        query = query or ""
+        if self._recall_max_input_chars and len(query) > self._recall_max_input_chars:
+            query = query[:self._recall_max_input_chars]
+        return query
+
     def prefetch(self, query: str, *, session_id: str = "") -> str:
+        """Return recalled context for *query*, recalling now if it isn't warm.
+
+        The agent warms this cache by calling ``queue_prefetch`` at the END of a
+        turn (run_agent._mirror_turn_to_memory), so the warm entry answers the
+        PREVIOUS message, not the one the user just sent. Serving it verbatim
+        made every recall a turn late, and left the first message of any session
+        — the whole of a ``hermes -z`` run — with no memory at all.
+
+        So the cache is now keyed by the query it was warmed for: a hit is used
+        for free, and a miss recalls the current question and waits for it. The
+        wait is bounded by ``prefetch_wait_seconds`` — a wedged Hindsight must
+        cost the turn its memory, never the turn itself.
+        """
+        wanted = self._clean_prefetch_query(query)
+        with self._prefetch_lock:
+            warm_query = self._prefetch_query
+            warm_result = self._prefetch_result
+
+        if wanted and warm_query != wanted:
+            logger.debug("Prefetch: cache holds %r, need %r — recalling now",
+                         warm_query[:40], wanted[:40])
+            with self._prefetch_lock:
+                self._prefetch_result = ""
+                self._prefetch_query = ""
+            self.queue_prefetch(query, session_id=session_id)
+        elif warm_result:
+            logger.debug("Prefetch: cache hit for the current query")
+
         if self._prefetch_thread and self._prefetch_thread.is_alive():
-            logger.debug("Prefetch: waiting for background thread to complete")
-            self._prefetch_thread.join(timeout=3.0)
+            logger.debug("Prefetch: waiting up to %.1fs for recall", self._prefetch_wait_seconds)
+            self._prefetch_thread.join(timeout=self._prefetch_wait_seconds)
+
         with self._prefetch_lock:
             result = self._prefetch_result
             self._prefetch_result = ""
+            self._prefetch_query = ""
         if not result:
             logger.debug("Prefetch: no results available")
             return ""
@@ -1481,6 +1566,61 @@ class HindsightMemoryProvider(MemoryProvider):
         )
         return f"{header}\n\n{result}"
 
+    def _recall_text_for_bank(self, bank_id: str, query: str, *, method: str, numbered: bool = False) -> str:
+        """Read one bank and render it as text. Shared by prefetch and the tool.
+
+        ``method`` is "reflect" (LLM-composed narrative) or "recall" (ranked
+        fact list) — the same two shapes the prefetch path already supported,
+        factored out so every reader can run over several banks.
+
+        ``numbered`` renders the recall list as "1. …" (the tool's long-standing
+        output shape) instead of the prefetch path's "- …" bullets. Numbering
+        restarts per bank, since each bank is ranked independently.
+        """
+        if method == "reflect":
+            resp = self._run_hindsight_operation(
+                lambda client: client.areflect(bank_id=bank_id, query=query, budget=self._budget)
+            )
+            return resp.text or ""
+
+        recall_kwargs: dict = {
+            "bank_id": bank_id, "query": query,
+            "budget": self._budget, "max_tokens": self._recall_max_tokens,
+        }
+        if self._recall_tags:
+            recall_kwargs["tags"] = self._recall_tags
+            recall_kwargs["tags_match"] = self._recall_tags_match
+        if self._recall_types:
+            recall_kwargs["types"] = self._recall_types
+        resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
+        if not resp.results:
+            return ""
+        texts = [r.text for r in resp.results if r.text]
+        if numbered:
+            return "\n".join(f"{i}. {t}" for i, t in enumerate(texts, 1))
+        return "\n".join(f"- {t}" for t in texts)
+
+    def _recall_across_banks(self, query: str, *, method: str, numbered: bool = False) -> str:
+        """Read the writing bank plus every configured additional bank.
+
+        Additional banks are labelled so the model can tell project memory from
+        cross-project memory. A failing additional bank is logged and skipped —
+        it must never take down recall of the main bank.
+        """
+        sections: List[str] = []
+        for bank_id in [self._bank_id, *self._recall_additional_banks]:
+            try:
+                text = self._recall_text_for_bank(bank_id, query, method=method, numbered=numbered)
+            except Exception as e:
+                if bank_id == self._bank_id:
+                    raise
+                logger.debug("Recall from additional bank %s failed: %s", bank_id, e, exc_info=True)
+                continue
+            if not text:
+                continue
+            sections.append(text if bank_id == self._bank_id else f"## From bank: {bank_id}\n{text}")
+        return "\n\n".join(sections)
+
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
         if self._memory_mode == "tools":
             logger.debug("Prefetch: skipped (tools-only mode)")
@@ -1491,32 +1631,17 @@ class HindsightMemoryProvider(MemoryProvider):
         if self._shutting_down.is_set():
             logger.debug("Prefetch: skipped (shutting down)")
             return
-        # Truncate query to max chars
-        if self._recall_max_input_chars and len(query) > self._recall_max_input_chars:
-            query = query[:self._recall_max_input_chars]
+        query = self._clean_prefetch_query(query)
+        with self._prefetch_lock:
+            self._prefetch_query = query
 
         def _run():
             try:
-                if self._prefetch_method == "reflect":
-                    logger.debug("Prefetch: calling reflect (bank=%s, query_len=%d)", self._bank_id, len(query))
-                    resp = self._run_hindsight_operation(lambda client: client.areflect(bank_id=self._bank_id, query=query, budget=self._budget))
-                    text = resp.text or ""
-                else:
-                    recall_kwargs: dict = {
-                        "bank_id": self._bank_id, "query": query,
-                        "budget": self._budget, "max_tokens": self._recall_max_tokens,
-                    }
-                    if self._recall_tags:
-                        recall_kwargs["tags"] = self._recall_tags
-                        recall_kwargs["tags_match"] = self._recall_tags_match
-                    if self._recall_types:
-                        recall_kwargs["types"] = self._recall_types
-                    logger.debug("Prefetch: calling recall (bank=%s, query_len=%d, budget=%s)",
-                                 self._bank_id, len(query), self._budget)
-                    resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
-                    num_results = len(resp.results) if resp.results else 0
-                    logger.debug("Prefetch: recall returned %d results", num_results)
-                    text = "\n".join(f"- {r.text}" for r in resp.results if r.text) if resp.results else ""
+                logger.debug("Prefetch: calling %s (banks=%s, query_len=%d, budget=%s)",
+                             self._prefetch_method,
+                             [self._bank_id, *self._recall_additional_banks], len(query), self._budget)
+                text = self._recall_across_banks(query, method=self._prefetch_method)
+                logger.debug("Prefetch: %s returned %d chars", self._prefetch_method, len(text))
                 if text:
                     with self._prefetch_lock:
                         self._prefetch_result = text
@@ -1731,24 +1856,12 @@ class HindsightMemoryProvider(MemoryProvider):
             if not query:
                 return tool_error("Missing required parameter: query")
             try:
-                recall_kwargs: dict = {
-                    "bank_id": self._bank_id, "query": query, "budget": self._budget,
-                    "max_tokens": self._recall_max_tokens,
-                }
-                if self._recall_tags:
-                    recall_kwargs["tags"] = self._recall_tags
-                    recall_kwargs["tags_match"] = self._recall_tags_match
-                if self._recall_types:
-                    recall_kwargs["types"] = self._recall_types
-                logger.debug("Tool hindsight_recall: bank=%s, query_len=%d, budget=%s",
-                             self._bank_id, len(query), self._budget)
-                resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
-                num_results = len(resp.results) if resp.results else 0
-                logger.debug("Tool hindsight_recall: %d results", num_results)
-                if not resp.results:
+                logger.debug("Tool hindsight_recall: banks=%s, query_len=%d, budget=%s",
+                             [self._bank_id, *self._recall_additional_banks], len(query), self._budget)
+                text = self._recall_across_banks(query, method="recall", numbered=True)
+                if not text:
                     return json.dumps({"result": "No relevant memories found."})
-                lines = [f"{i}. {r.text}" for i, r in enumerate(resp.results, 1)]
-                return json.dumps({"result": "\n".join(lines)})
+                return json.dumps({"result": text})
             except Exception as e:
                 logger.warning("hindsight_recall failed: %s", e, exc_info=True)
                 return tool_error(f"Failed to search memory: {e}")
@@ -1758,15 +1871,11 @@ class HindsightMemoryProvider(MemoryProvider):
             if not query:
                 return tool_error("Missing required parameter: query")
             try:
-                logger.debug("Tool hindsight_reflect: bank=%s, query_len=%d, budget=%s",
-                             self._bank_id, len(query), self._budget)
-                resp = self._run_hindsight_operation(
-                    lambda client: client.areflect(
-                        bank_id=self._bank_id, query=query, budget=self._budget
-                    )
-                )
-                logger.debug("Tool hindsight_reflect: response_len=%d", len(resp.text or ""))
-                return json.dumps({"result": resp.text or "No relevant memories found."})
+                logger.debug("Tool hindsight_reflect: banks=%s, query_len=%d, budget=%s",
+                             [self._bank_id, *self._recall_additional_banks], len(query), self._budget)
+                text = self._recall_across_banks(query, method="reflect")
+                logger.debug("Tool hindsight_reflect: response_len=%d", len(text))
+                return json.dumps({"result": text or "No relevant memories found."})
             except Exception as e:
                 logger.warning("hindsight_reflect failed: %s", e, exc_info=True)
                 return tool_error(f"Failed to reflect: {e}")
@@ -1886,6 +1995,7 @@ class HindsightMemoryProvider(MemoryProvider):
             self._prefetch_thread.join(timeout=3.0)
         with self._prefetch_lock:
             self._prefetch_result = ""
+            self._prefetch_query = ""
 
         # 3. Now rotate to the new session.
         if parent_session_id:

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -689,6 +689,11 @@ class HindsightMemoryProvider(MemoryProvider):
         self._idle_timeout = _DEFAULT_IDLE_TIMEOUT
         self._prefetch_result = ""
         self._prefetch_query = ""
+        # Every queued prefetch takes the next generation. A worker may only
+        # publish its result while its generation is still the current one, so
+        # a slow recall that lands after its turn was served — or after a
+        # session switch — is dropped instead of overwriting a newer answer.
+        self._prefetch_gen = 0
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread = None
         # Single-writer model for retain. sync_turn() enqueues; the writer
@@ -1555,6 +1560,7 @@ class HindsightMemoryProvider(MemoryProvider):
             result = self._prefetch_result
             self._prefetch_result = ""
             self._prefetch_query = ""
+            self._prefetch_gen += 1
         if not result:
             logger.debug("Prefetch: no results available")
             return ""
@@ -1634,6 +1640,8 @@ class HindsightMemoryProvider(MemoryProvider):
         query = self._clean_prefetch_query(query)
         with self._prefetch_lock:
             self._prefetch_query = query
+            self._prefetch_gen += 1
+            gen = self._prefetch_gen
 
         def _run():
             try:
@@ -1644,6 +1652,10 @@ class HindsightMemoryProvider(MemoryProvider):
                 logger.debug("Prefetch: %s returned %d chars", self._prefetch_method, len(text))
                 if text:
                     with self._prefetch_lock:
+                        if gen != self._prefetch_gen:
+                            logger.debug("Prefetch: dropping stale result (gen %d, current %d)",
+                                         gen, self._prefetch_gen)
+                            return
                         self._prefetch_result = text
             except Exception as e:
                 logger.debug("Hindsight prefetch failed: %s", e, exc_info=True)
@@ -1996,6 +2008,9 @@ class HindsightMemoryProvider(MemoryProvider):
         with self._prefetch_lock:
             self._prefetch_result = ""
             self._prefetch_query = ""
+            # The join is bounded: a worker that outlives it must not resurrect
+            # the old session's recall in the new one.
+            self._prefetch_gen += 1
 
         # 3. Now rotate to the new session.
         if parent_session_id:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1977,3 +1977,65 @@ class TestPrefetchRecallsCurrentQuery:
 
         assert p.prefetch("uma pergunta") == ""   # returns, does not hang
         assert started.is_set()
+
+    def test_a_recall_that_lands_after_its_turn_cannot_overwrite_the_next_one(self, provider_with_config):
+        """The wait is bounded, so a slow worker outlives the turn that queued
+        it. If it may still publish, it overwrites the NEXT turn's recall with
+        the previous question's memories — the turn-late answer this cache was
+        keyed by query to stop, only now wearing a fresh label."""
+        import threading as _t
+        p = provider_with_config()
+        p._prefetch_wait_seconds = 0.05
+        release = _t.Event()
+        landed = _t.Event()
+
+        def _slow(bank_id, query, *, method, numbered=False):
+            release.wait(5)
+            landed.set()
+            return "- memory for the old question"
+        p._recall_text_for_bank = _slow
+
+        assert p.prefetch("old question") == ""    # bounded wait expires; the worker lives on
+        stale = p._prefetch_thread
+
+        # Next turn: its own recall completes and owns the slot.
+        p._recall_text_for_bank = (
+            lambda bank_id, query, *, method, numbered=False: "- memory for the new question"
+        )
+        p.queue_prefetch("new question")
+        p._prefetch_thread.join(5)
+
+        release.set()                              # only now does the old worker return
+        assert landed.wait(5)
+        stale.join(5)
+
+        with p._prefetch_lock:
+            assert p._prefetch_result == "- memory for the new question"
+        assert "old question" not in p.prefetch("new question")
+
+    def test_a_recall_outliving_the_session_switch_join_is_dropped(self, provider_with_config):
+        """on_session_switch drains the in-flight worker with a 3s join. A
+        worker slower than that must not resurrect the old session's memories
+        in the new one — the join bounds the wait, the generation bounds the write."""
+        import threading as _t
+        p = provider_with_config()
+        release = _t.Event()
+        landed = _t.Event()
+
+        def _slow(bank_id, query, *, method, numbered=False):
+            release.wait(5)
+            landed.set()
+            return "- old-session recall: user likes Rust"
+        p._recall_text_for_bank = _slow
+
+        p.queue_prefetch("old question")
+        stale = p._prefetch_thread
+        p._prefetch_thread = None      # simulate a worker that outlived the bounded join
+        p.on_session_switch("new-sid")
+
+        release.set()
+        assert landed.wait(5)
+        stale.join(5)
+
+        with p._prefetch_lock:
+            assert p._prefetch_result == ""

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -8,6 +8,7 @@ turn counting, tags), and schema completeness.
 import json
 import os
 import re
+import subprocess
 import stat
 import sys
 from types import SimpleNamespace
@@ -26,6 +27,7 @@ from plugins.memory.hindsight import (
     _normalize_observation_scopes,
     _normalize_retain_tags,
     _resolve_bank_id_template,
+    _resolve_project_name,
     _sanitize_bank_segment,
 )
 
@@ -790,11 +792,18 @@ class TestToolHandlers:
 
 
 class TestPrefetch:
-    def test_prefetch_returns_empty_when_no_result(self, provider):
+    def test_prefetch_with_a_cold_cache_recalls_the_current_query(self, provider):
+        # Was: "no warm cache -> empty". That WAS the bug: the cache is only warmed
+        # post-turn, so a cold read is every session's first message. Now it recalls.
+        assert "Memory 1" in provider.prefetch("test")
+
+    def test_prefetch_returns_empty_when_the_recall_finds_nothing(self, provider):
+        provider._recall_text_for_bank = lambda bank_id, query, *, method, numbered=False: ""
         assert provider.prefetch("test") == ""
 
     def test_prefetch_default_preamble(self, provider):
         provider._prefetch_result = "- some memory"
+        provider._prefetch_query = "test"
         result = provider.prefetch("test")
         assert "Hindsight Memory" in result
         assert "- some memory" in result
@@ -802,6 +811,7 @@ class TestPrefetch:
     def test_prefetch_custom_preamble(self, provider_with_config):
         p = provider_with_config(recall_prompt_preamble="Custom header:")
         p._prefetch_result = "- memory line"
+        p._prefetch_query = "test"
         result = p.prefetch("test")
         assert result.startswith("Custom header:")
         assert "- memory line" in result
@@ -1245,10 +1255,12 @@ class TestSessionSwitchBufferFlush:
         """Stale recall text from the old session must not leak into the
         next session's first prefetch read."""
         provider._prefetch_result = "old-session recall: User likes Rust"
+        provider._prefetch_query = "old question"
         provider.on_session_switch("new-sid")
         assert provider._prefetch_result == ""
-        # And subsequent prefetch() should now report empty, not the leftover.
-        assert provider.prefetch("anything") == ""
+        assert provider._prefetch_query == ""
+        # The next read must not serve the leftover: it recalls for the new session.
+        assert "old-session recall" not in provider.prefetch("anything")
 
     def test_in_flight_prefetch_thread_drained_on_switch(self, provider, monkeypatch):
         """on_session_switch must wait for an in-flight prefetch from the
@@ -1819,3 +1831,149 @@ def test_save_config_sets_owner_only_permissions(tmp_path):
     assert config_file.exists()
     mode = stat.S_IMODE(config_file.stat().st_mode)
     assert mode == 0o600, f"Expected 0o600 (owner-only), got {oct(mode)}"
+
+
+class TestProjectBank:
+    """{project} must resolve to the SAME bank id the Hindsight Claude Code /
+    Codex plugins derive (basename of the git main repo), so all three
+    harnesses share one bank per project."""
+
+    def test_project_name_is_git_repo_basename(self, tmp_path):
+        repo = tmp_path / "memory-brain"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        # A nested subdir must still resolve to the repo root's name.
+        nested = repo / "packages" / "schemas"
+        nested.mkdir(parents=True)
+        assert _resolve_project_name(str(repo)) == "memory-brain"
+        assert _resolve_project_name(str(nested)) == "memory-brain"
+
+    def test_project_name_falls_back_to_dir_basename_outside_git(self, tmp_path):
+        plain = tmp_path / "not-a-repo"
+        plain.mkdir()
+        assert _resolve_project_name(str(plain)) == "not-a-repo"
+
+    def test_template_resolves_project(self):
+        result = _resolve_bank_id_template(
+            "{project}", fallback="hermes",
+            profile="", project="memory-brain", workspace="", platform="", user="", session="",
+        )
+        assert result == "memory-brain"
+
+    def test_template_falls_back_when_project_unknown(self):
+        # Outside any directory we can name, "{project}" renders empty -> static bank_id.
+        result = _resolve_bank_id_template(
+            "{project}", fallback="hermes",
+            profile="", project="", workspace="", platform="", user="", session="",
+        )
+        assert result == "hermes"
+
+
+class TestRecallAdditionalBanks:
+    """Extra banks are recall-only: merged into reads, never written to."""
+
+    def _provider(self, additional, bank_id="memory-brain"):
+        p = HindsightMemoryProvider()
+        p._bank_id = bank_id
+        p._budget = "mid"
+        p._recall_max_tokens = 4096
+        p._recall_tags = []
+        p._recall_types = ["observation"]
+        p._recall_additional_banks = [b for b in additional if b != bank_id]
+        return p
+
+    def test_config_drops_the_main_bank_from_the_extras(self):
+        p = self._provider(["user-global", "memory-brain"])
+        assert p._recall_additional_banks == ["user-global"]
+
+    def test_recall_merges_banks_in_order_and_labels_the_extras(self, monkeypatch):
+        p = self._provider(["user-global"])
+        monkeypatch.setattr(p, "_recall_text_for_bank",
+                            lambda bank_id, query, *, method, numbered=False: f"fact from {bank_id}")
+        out = p._recall_across_banks("q", method="recall")
+        assert out.startswith("fact from memory-brain")
+        assert "## From bank: user-global" in out
+        assert "fact from user-global" in out
+
+    def test_failing_extra_bank_does_not_break_the_main_recall(self, monkeypatch):
+        def flaky(bank_id, query, *, method, numbered=False):
+            if bank_id == "user-global":
+                raise RuntimeError("bank is down")
+            return "fact from memory-brain"
+        p = self._provider(["user-global"])
+        monkeypatch.setattr(p, "_recall_text_for_bank", flaky)
+        assert p._recall_across_banks("q", method="recall") == "fact from memory-brain"
+
+    def test_failing_main_bank_still_raises(self, monkeypatch):
+        def broken(bank_id, query, *, method, numbered=False):
+            raise RuntimeError("bank is down")
+        p = self._provider(["user-global"])
+        monkeypatch.setattr(p, "_recall_text_for_bank", broken)
+        with pytest.raises(RuntimeError):
+            p._recall_across_banks("q", method="recall")
+
+    def test_writes_never_target_an_additional_bank(self):
+        p = self._provider(["user-global"])
+        p._turn_index = 1
+        p._retain_source = ""
+        p._session_id = "s1"
+        p._platform = p._user_id = p._user_name = ""
+        p._chat_id = p._chat_name = p._chat_type = p._thread_id = p._agent_identity = ""
+        p._observation_scopes = ""
+        p._retain_tags = []
+        kwargs = p._build_retain_kwargs("some content")
+        assert kwargs["bank_id"] == "memory-brain"
+
+
+class TestPrefetchRecallsCurrentQuery:
+    """The warm cache is filled post-turn (it answers the PREVIOUS message).
+    prefetch() must recall for the message the user just sent, not serve it."""
+
+    def test_stale_cache_is_discarded_and_the_current_query_is_recalled(self, provider_with_config):
+        p = provider_with_config()
+        recalled = []
+        p._prefetch_result = "- memory about the previous question"
+        p._prefetch_query = "what did we do yesterday?"
+
+        def _fake(bank_id, query, *, method, numbered=False):
+            recalled.append(query)
+            return "- memory about deploys"
+        p._recall_text_for_bank = _fake
+
+        out = p.prefetch("how do I deploy?")
+        assert recalled == ["how do I deploy?"], "recall must use the message just sent"
+        assert "memory about deploys" in out
+        assert "previous question" not in out
+
+    def test_warm_cache_for_the_same_query_is_reused_without_recalling(self, provider_with_config):
+        p = provider_with_config()
+        p._prefetch_result = "- cached memory"
+        p._prefetch_query = "how do I deploy?"
+
+        def _boom(*a, **k):
+            raise AssertionError("must not recall — the cache already answers this query")
+        p._recall_text_for_bank = _boom
+
+        assert "cached memory" in p.prefetch("how do I deploy?")
+
+    def test_first_turn_of_a_session_recalls_instead_of_returning_nothing(self, provider_with_config):
+        # Cold provider: no warm cache at all. This is every `hermes -z` run and
+        # the first message of every chat session.
+        p = provider_with_config()
+        p._recall_text_for_bank = lambda bank_id, query, *, method, numbered=False: "- a durable fact"
+        assert "a durable fact" in p.prefetch("qual e o meu codinome?")
+
+    def test_a_wedged_recall_costs_the_memory_not_the_turn(self, provider_with_config):
+        import threading as _t
+        p = provider_with_config()
+        p._prefetch_wait_seconds = 0.2
+        started = _t.Event()
+
+        def _hang(bank_id, query, *, method, numbered=False):
+            started.set()
+            _t.Event().wait(30)  # never returns within the bounded wait
+            return "too late"
+        p._recall_text_for_bank = _hang
+
+        assert p.prefetch("uma pergunta") == ""   # returns, does not hang
+        assert started.is_set()

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -424,6 +424,9 @@ The setup wizard installs dependencies automatically and only installs what's ne
 |-----|---------|-------------|
 | `mode` | `cloud` | `cloud` or `local` |
 | `bank_id` | `hermes` | Memory bank identifier |
+| `bank_id_template` | — | Derive the bank name dynamically. Placeholders: `{profile}`, `{project}`, `{workspace}`, `{platform}`, `{user}`, `{session}`. A bare `{project}` (the repo name of the session's cwd) shares one bank per project with the Hindsight plugins for Claude Code and Codex |
+| `recall_additional_banks` | — | Extra banks merged into every recall, read-only — retains still go to `bank_id`. List or comma-separated (e.g. `user-global`) |
+| `prefetch_wait_seconds` | `15` | Max seconds a turn waits for its own memory recall before proceeding without it |
 | `recall_budget` | `mid` | Recall thoroughness: `low` / `mid` / `high` |
 | `memory_mode` | `hybrid` | `hybrid` (context + tools), `context` (auto-inject only), `tools` (tools only) |
 | `auto_retain` | `true` | Automatically retain conversation turns |


### PR DESCRIPTION
The Hindsight memory provider shares a server and its banks with the Hindsight plugins for Claude Code and Codex. Three defects kept Hermes from behaving like them. Each is fixed independently and covered by tests.

## 1. No per-project bank

`bank_id_template` offers `{profile}`, `{workspace}`, `{platform}`, `{user}`, `{session}` — none of which follow the working directory. `{workspace}` cannot stand in either: `agent_workspace` is hardcoded to the literal `"hermes"` (`agent/agent_init.py`), so it is a constant. A static `bank_id` was therefore the only option, and it funnels every project's memory into one bank.

This adds **`{project}`**, derived from the cwd exactly the way the Hindsight Claude Code plugin derives it — the basename of `git rev-parse --git-common-dir`, so worktrees and nested subdirectories collapse onto the repository's bank, with the plain directory basename as the fallback outside a repo. `bank_id_template: "{project}"` now lands in the same bank those plugins already use for that project.

## 2. No read-only extra banks

The Claude Code and Codex plugins have `recallAdditionalBanks`, which lets a per-project bank also see a durable cross-project bank (user identity, standing preferences). The Hermes provider had no equivalent — and the `banks` config map looked like one but is inert: it is read as `banks["hermes"]` (`cfg_get(self._config, "banks", "hermes")`), a key nothing writes.

This adds **`recall_additional_banks`**: extra banks merged into every read (the prefetch context, `hindsight_recall`, `hindsight_reflect`), each labelled with its bank so the model can tell project memory from cross-project memory. Writes always go to `bank_id` — the extras are recall-only by construction. A failing extra bank is logged and skipped; it can never take the main bank's recall down with it.

## 3. Recall was always one turn late

`run_agent._mirror_turn_to_memory` warms the cache by calling `queue_prefetch` at the **end** of a turn, so the cached text answers the **previous** message. `prefetch()` served that text verbatim and discarded the query it was handed. Two consequences:

- every recall answered the wrong question — the one before the one the user just asked;
- the first message of any session had no memory at all, which means a `hermes -z` one-shot run — a single turn — was always memory-blind, despite the provider being fully initialized.

The cache is now **keyed by the query it was warmed for**. A hit is reused for free; a miss recalls what the user actually just asked and waits for it. The wait is bounded by a new `prefetch_wait_seconds` (default 15s), so a wedged Hindsight costs the turn its memory rather than the turn itself.

Two existing assertions in `TestPrefetch` encoded this bug (`no warm cache -> no memory`). They now assert the corrected contract.

## Tests

`246 passed` across `tests/plugins/memory/test_hindsight_provider.py`, `tests/agent/test_memory_provider.py`, `tests/agent/test_memory_session_switch.py` and `tests/hermes_cli/test_memory_providers.py`, including new coverage for:

- project derivation: git repo, nested subdirectory, non-git directory, empty fallback;
- extra banks: ordered merge and labelling, main-bank dedupe, a failing extra bank not breaking the main recall, a failing main bank still raising, and writes never targeting an extra bank;
- current-query recall: a stale cache is discarded and the current query recalled, a matching cache is reused without a server call, a cold session recalls instead of returning nothing, and a wedged recall returns empty rather than hanging the turn.

Verified end to end against a self-hosted Hindsight: with `bank_id_template: "{project}"` and `recall_additional_banks: ["user-global"]`, a single-turn `hermes -z` in a project directory recalled a fact that existed only in the cross-project bank — which requires all three fixes at once.