### PR TITLE
fix(agent): skip app-server native pre-api compression

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -79,6 +79,51 @@ logger = logging.getLogger(__name__)
 INTERRUPT_WAITING_FOR_MODEL_PREFIX = "Operation interrupted: waiting for model response ("
 
 
+def _codex_app_server_owns_auto_compaction(agent) -> bool:
+    """Return true when Codex app-server should handle automatic compaction."""
+    return (
+        getattr(agent, "api_mode", None) == "codex_app_server"
+        and str(
+            getattr(agent, "codex_app_server_auto_compaction", "native")
+            or "native"
+        ).lower()
+        in {"native", "off"}
+    )
+
+
+def _should_run_pre_api_pressure_compression(
+    agent,
+    messages: List[Dict[str, Any]],
+    compression_attempts: int,
+    request_pressure_tokens: int,
+) -> bool:
+    """Mirror turn-prologue compression guards for tool-loop pressure checks."""
+    if (
+        not getattr(agent, "compression_enabled", False)
+        or len(messages) <= 1
+        or compression_attempts >= 3
+    ):
+        return False
+
+    if _codex_app_server_owns_auto_compaction(agent):
+        return False
+
+    compressor = agent.context_compressor
+    defer_preflight = getattr(
+        compressor, "should_defer_preflight_to_real_usage", lambda _t: False
+    )
+    if defer_preflight(request_pressure_tokens):
+        return False
+
+    compression_cooldown = getattr(
+        compressor, "get_active_compression_failure_cooldown", lambda: None
+    )()
+    if compression_cooldown:
+        return False
+
+    return bool(compressor.should_compress(request_pressure_tokens))
+
+
 def _image_error_max_dimension(error: Exception) -> Optional[int]:
     """Extract a provider-reported image dimension ceiling, if present."""
     parts = []
@@ -1003,19 +1048,11 @@ def run_conversation(
         # LLM cooldown + anti-thrash guards (#11529). compression_attempts is a
         # hard per-turn backstop shared with the overflow error handlers.
         _compressor = agent.context_compressor
-        _defer_preflight = getattr(
-            _compressor, "should_defer_preflight_to_real_usage", lambda _t: False
-        )
-        _compression_cooldown = getattr(
-            _compressor, "get_active_compression_failure_cooldown", lambda: None
-        )()
-        if (
-            agent.compression_enabled
-            and len(messages) > 1
-            and compression_attempts < 3
-            and not _defer_preflight(request_pressure_tokens)
-            and not _compression_cooldown
-            and _compressor.should_compress(request_pressure_tokens)
+        if _should_run_pre_api_pressure_compression(
+            agent,
+            messages,
+            compression_attempts,
+            request_pressure_tokens,
         ):
             compression_attempts += 1
             logger.info(

--- a/tests/run_agent/test_codex_app_server_compaction.py
+++ b/tests/run_agent/test_codex_app_server_compaction.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 from agent.codex_runtime import _record_codex_app_server_compaction
 from agent.conversation_compression import COMPACTION_STATUS, compress_context
+from agent.conversation_loop import _should_run_pre_api_pressure_compression
 from agent.transports.codex_app_server_session import TurnResult
 
 
@@ -58,6 +59,32 @@ class DummyAgent:
         self.events.append((name, payload))
 
 
+class PressureCompressor:
+    threshold_tokens = 10_000
+    context_length = 12_000
+
+    def __init__(self):
+        self.checked_tokens = []
+
+    def should_defer_preflight_to_real_usage(self, _tokens):
+        return False
+
+    def get_active_compression_failure_cooldown(self):
+        return None
+
+    def should_compress(self, tokens):
+        self.checked_tokens.append(tokens)
+        return True
+
+
+class PressureAgent:
+    def __init__(self, *, api_mode="codex_app_server", auto_compaction="native"):
+        self.api_mode = api_mode
+        self.codex_app_server_auto_compaction = auto_compaction
+        self.compression_enabled = True
+        self.context_compressor = PressureCompressor()
+
+
 def test_codex_app_server_native_auto_mode_leaves_thread_compaction_to_codex():
     agent = DummyAgent(
         TurnResult(thread_id="thread-1", turn_id="compact-turn-1")
@@ -77,6 +104,42 @@ def test_codex_app_server_native_auto_mode_leaves_thread_compaction_to_codex():
     assert agent._codex_session.calls == 0
     assert agent.context_compressor.compression_count == 0
     assert agent.events == []
+
+
+def test_codex_app_server_native_auto_skips_tool_loop_pre_api_compression():
+    agent = PressureAgent(auto_compaction="native")
+    messages = [
+        {"role": "user", "content": "make a large artifact"},
+        {"role": "tool", "content": "x" * 100},
+    ]
+
+    should_compress = _should_run_pre_api_pressure_compression(
+        agent,
+        messages,
+        compression_attempts=0,
+        request_pressure_tokens=100_000,
+    )
+
+    assert should_compress is False
+    assert agent.context_compressor.checked_tokens == []
+
+
+def test_codex_app_server_hermes_auto_keeps_tool_loop_pre_api_compression():
+    agent = PressureAgent(auto_compaction="hermes")
+    messages = [
+        {"role": "user", "content": "make a large artifact"},
+        {"role": "tool", "content": "x" * 100},
+    ]
+
+    should_compress = _should_run_pre_api_pressure_compression(
+        agent,
+        messages,
+        compression_attempts=0,
+        request_pressure_tokens=100_000,
+    )
+
+    assert should_compress is True
+    assert agent.context_compressor.checked_tokens == [100_000]
 
 
 def test_codex_app_server_manual_compression_routes_to_codex_thread():


### PR DESCRIPTION
## Summary

This makes the tool-loop pre-API pressure compression path respect Codex app-server native/off auto-compaction mode.

The turn prologue already skips Hermes-initiated preflight compression for `api_mode == "codex_app_server"` when `codex_app_server_auto_compaction` is `native` or `off`, because Codex app-server threads are compacted by the app-server runtime itself. The later tool-loop pre-API pressure check did not have the same guard.

## Why

A single turn can grow after large tool results. The pre-API pressure check correctly catches that case for normal Hermes-managed compression, but for Codex app-server native/off mode it could still call `_compress_context()`.

In native/off mode, `_compress_context_via_codex_app_server()` intentionally returns without compacting unless forced. That means the tool-loop path could burn pre-API compression attempts on a no-op and then continue toward the same oversized request instead of leaving automatic compaction ownership to the app-server runtime.

## Changes

- Add a production helper for the tool-loop pre-API compression decision.
- Skip that pre-API Hermes compression path when Codex app-server owns automatic compaction (`native` / `off`).
- Keep `codex_app_server_auto_compaction="hermes"` behavior unchanged.
- Add regression coverage for both native and Hermes auto-compaction modes.

## Tests

```text
python -m pytest tests\run_agent\test_codex_app_server_compaction.py -q --tb=short -p no:cacheprovider
7 passed in 2.82s

python -m ruff check --no-cache agent\conversation_loop.py tests\run_agent\test_codex_app_server_compaction.py
All checks passed!