### PR TITLE
fix(ui): keep model picker switches session-scoped

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -109,7 +109,7 @@ describe('useModelControls', () => {
     expect($currentProvider.get()).toBe('deepseek')
   })
 
-  it('routes active-session picker changes through config.set with an explicit provider', async () => {
+  it('routes active-session picker changes through config.set with an explicit session-scoped provider', async () => {
     const requestGateway = vi.fn(async () => ({ key: 'model', value: 'claude-sonnet-4.6' }) as never)
     let controls!: Controls
 
@@ -127,9 +127,31 @@ describe('useModelControls', () => {
     expect(requestGateway).toHaveBeenCalledWith('config.set', {
       session_id: 'session-1',
       key: 'model',
-      value: 'claude-sonnet-4.6 --provider anthropic'
+      value: 'claude-sonnet-4.6 --provider anthropic --session'
     })
     expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
+  })
+
+  it('session-scopes MoA preset selections so they cannot persist as the global gateway default', async () => {
+    const requestGateway = vi.fn(async () => ({ key: 'model', value: 'BeastMode' }) as never)
+    let controls!: Controls
+
+    render(
+      <Harness activeSessionId="session-1" onReady={value => (controls = value)} requestGateway={requestGateway} />
+    )
+
+    await expect(
+      controls.selectModel({
+        model: 'BeastMode',
+        provider: 'moa'
+      })
+    ).resolves.toBe(true)
+
+    expect(requestGateway).toHaveBeenCalledWith('config.set', {
+      session_id: 'session-1',
+      key: 'model',
+      value: 'BeastMode --provider moa --session'
+    })
   })
 
   it('stores a no-session pick as UI state with no gateway or global write', async () => {

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -96,7 +96,7 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
         await requestGateway('config.set', {
           session_id: activeSessionId,
           key: 'model',
-          value: `${selection.model} --provider ${selection.provider}`
+          value: `${selection.model} --provider ${selection.provider} --session`
         })
 
         void queryClient.invalidateQueries({ queryKey: ['model-options', activeSessionId] })

--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -61,8 +61,8 @@ describe('ModelMenuPanel MoA presets', () => {
     fireEvent.click(row)
 
     // #54670: must route through the persistent model-switch path
-    // (config.set model="<preset> --provider moa"), i.e. onSelectModel with
-    // provider 'moa', NOT a one-shot command.dispatch that reverts after a turn.
+    // i.e. onSelectModel with provider 'moa' (which session-scopes live-session
+    // switches), NOT a one-shot command.dispatch that reverts after a turn.
     expect(onSelectModel).toHaveBeenCalledWith({ model: 'BeastMode', provider: 'moa' })
   })
 

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -180,8 +180,8 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
   }
 
   // Selecting a MoA preset switches the session to it PERSISTENTLY, using the
-  // same path real provider selections use (config.set model="<preset>
-  // --provider moa" via onSelectModel → the gateway's persistent switch_model).
+  // same path real provider selections use (onSelectModel → config.set with
+  // --session for live sessions → the gateway's persistent switch_model).
   // Previously this dispatched the one-shot `/moa` command, which ran a single
   // turn through MoA and then silently reverted to the prior model (#54670) —
   // the dropdown presented presets like persistent selections but they weren't.

--- a/ui-tui/src/__tests__/activeSessionSwitcher.test.ts
+++ b/ui-tui/src/__tests__/activeSessionSwitcher.test.ts
@@ -86,10 +86,10 @@ describe('session orchestrator helpers', () => {
 
   it('turns model picker values into session-scoped draft model args', () => {
     expect(draftModelArgFromPickerValue('kimi-k2.6 --provider ollama-cloud --tui-session')).toBe(
-      'kimi-k2.6 --provider ollama-cloud'
+      'kimi-k2.6 --provider ollama-cloud --session'
     )
     expect(draftModelArgFromPickerValue('openai/gpt-5.5 --provider openai-codex --global')).toBe(
-      'openai/gpt-5.5 --provider openai-codex'
+      'openai/gpt-5.5 --provider openai-codex --session'
     )
   })
 

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -209,7 +209,7 @@ describe('createSlashHandler', () => {
       confirm_expensive_model: false,
       key: 'model',
       session_id: 'sid-abc',
-      value: 'anthropic/claude-sonnet-4.6 --provider openrouter'
+      value: 'anthropic/claude-sonnet-4.6 --provider openrouter --session'
     })
   })
 

--- a/ui-tui/src/__tests__/orchestratorPromptSession.test.ts
+++ b/ui-tui/src/__tests__/orchestratorPromptSession.test.ts
@@ -32,7 +32,7 @@ describe('startPromptLiveSession', () => {
         'rpc',
         {
           method: 'config.set',
-          params: { key: 'model', session_id: 'abc123', value: 'kimi-k2.6 --provider ollama-cloud' }
+          params: { key: 'model', session_id: 'abc123', value: 'kimi-k2.6 --provider ollama-cloud --session' }
         }
       ],
       ['sys', 'model → kimi-k2.6'],

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -1,5 +1,5 @@
 import { attachedImageNotice, introMsg, toTranscriptMessages } from '../../../domain/messages.js'
-import { TUI_SESSION_MODEL_FLAG } from '../../../domain/slash.js'
+import { sessionScopedModelArg, TUI_SESSION_MODEL_FLAG } from '../../../domain/slash.js'
 import type {
   BackgroundStartResponse,
   ConfigGetValueResponse,
@@ -20,10 +20,6 @@ import { patchUiState } from '../../uiStore.js'
 import type { SlashCommand } from '../types.js'
 
 const TUI_SESSION_MODEL_RE = new RegExp(`(?:^|\\s)${TUI_SESSION_MODEL_FLAG}(?:\\s|$)`)
-const TUI_SESSION_STRIP_RE = new RegExp(`\\s*${TUI_SESSION_MODEL_FLAG}\\b\\s*`, 'g')
-
-const stripTuiSessionFlag = (trimmed: string) => trimmed.replace(TUI_SESSION_STRIP_RE, ' ').replace(/\s+/g, ' ').trim()
-
 const modelValueForConfigSet = (arg: string) => {
   const trimmed = arg.trim()
 
@@ -32,7 +28,7 @@ const modelValueForConfigSet = (arg: string) => {
   }
 
   if (TUI_SESSION_MODEL_RE.test(trimmed)) {
-    return stripTuiSessionFlag(trimmed)
+    return sessionScopedModelArg(trimmed)
   }
 
   return trimmed

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -9,6 +9,7 @@ import { hasLeadGap, prevRenderedMsg } from '../domain/blockLayout.js'
 import { SECTION_NAMES, sectionMode } from '../domain/details.js'
 import { attachedImageNotice, imageTokenMeta } from '../domain/messages.js'
 import { composeTabTitle, fmtCwdBranch, shortCwd } from '../domain/paths.js'
+import { sessionScopedModelArg } from '../domain/slash.js'
 import { type GatewayClient } from '../gatewayClient.js'
 import type {
   ClarifyRespondResponse,
@@ -116,7 +117,7 @@ export async function startPromptLiveSession({
     return null
   }
 
-  const requestedModel = modelArg?.trim()
+  const requestedModel = modelArg ? sessionScopedModelArg(modelArg) : ''
 
   if (requestedModel) {
     const result = await rpc<ConfigSetResponse>('config.set', { key: 'model', session_id: sid, value: requestedModel })

--- a/ui-tui/src/components/activeSessionSwitcher.tsx
+++ b/ui-tui/src/components/activeSessionSwitcher.tsx
@@ -1,7 +1,7 @@
 import { Box, Text, useInput, useStdout } from '@hermes/ink'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-import { TUI_SESSION_MODEL_FLAG } from '../domain/slash.js'
+import { sessionScopedModelArg } from '../domain/slash.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type {
   SessionActiveItem,
@@ -205,18 +205,7 @@ export const closeFallbackAfterClose = (
 }
 
 export const draftModelArgFromPickerValue = (value: string) => {
-  const parts = value.trim().split(/\s+/).filter(Boolean)
-  const kept: string[] = []
-
-  for (const part of parts) {
-    if (part === TUI_SESSION_MODEL_FLAG || part === '--global') {
-      continue
-    }
-
-    kept.push(part)
-  }
-
-  return kept.join(' ')
+  return sessionScopedModelArg(value)
 }
 
 export const draftModelNameFromArg = (value: string) => {

--- a/ui-tui/src/domain/slash.ts
+++ b/ui-tui/src/domain/slash.ts
@@ -1,5 +1,12 @@
-/** Appended to `/model` args from the TUI picker for session scope; stripped in `session` slash before `config.set`. */
+/** Appended by TUI pickers; converted to the backend's `--session` flag before `config.set`. */
 export const TUI_SESSION_MODEL_FLAG = '--tui-session'
+
+export const sessionScopedModelArg = (value: string) => {
+  const parts = value.trim().split(/\s+/).filter(Boolean)
+  const kept = parts.filter(part => part !== TUI_SESSION_MODEL_FLAG && part !== '--global' && part !== '--session')
+
+  return kept.length ? `${kept.join(' ')} --session` : ''
+}
 
 export const looksLikeSlashCommand = (text: string) => /^\/[^\s/]*(?:\s|$)/.test(text)
 


### PR DESCRIPTION
## Summary
Desktop and TUI model-picker selections now stay scoped to the chat that opened the picker instead of rewriting the profile-wide model default.

The UIs already carried a session identifier, but backend persistence is controlled by the parsed `--session` flag. Three picker paths dropped that intent and therefore inherited `model.persist_switch_by_default: true`.

## Changes
- Preserve @izumi0uu's Desktop and MoA fix from #59493.
- Fold in @DatTheMaster's TUI slash-picker direction from #61192.
- Replace duplicated sentinel stripping with one `sessionScopedModelArg()` helper.
- Cover the missed Active Session Switcher/new-live-session path identified during review.

## Validation
| Path | Result |
|---|---|
| Desktop picker + MoA tests | 10 passed |
| TUI slash, active-session, and live-session tests | 85 passed |
| Desktop + TUI TypeScript checks | Passed |
| Real backend flag parser | `--session` → `persist_global=False` for normal and MoA selections |
| `git diff --check` | Passed |

Fixes #56058 and the Desktop-to-global entry point in #59480. Supersedes #59493 and #61192.

## Infographic

![Model choice stays in its chat](https://v3b.fal.media/files/b/0aa1d523/9xCAJXJXk84X3cLAzzlQZ_eNmmqCcg.png)
