### PR TITLE
perf(dashboard): lightweight profile listing — multi-profile session list 10s → ~1.5s

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -874,6 +874,38 @@ def write_profile_meta(
 # CRUD operations
 # ---------------------------------------------------------------------------
 
+def list_profile_homes() -> List[Tuple[str, Path]]:
+    """Return ``(name, HERMES_HOME)`` for all profiles — the LIGHTWEIGHT listing.
+
+    ``list_profiles()`` is built for the Profiles settings page: per profile it
+    parses config.yaml (pure-Python PyYAML over ~17KB files), probes whether a
+    gateway process is running (process-table scans), and rglobs the skills
+    tree. Hot read paths that only need each profile's name + home directory
+    (the session-list aggregator, cron listings) were paying that entire cost
+    on EVERY sidebar refresh — py-spy showed ~70% of a 10s
+    /api/profiles/sessions call inside yaml.safe_load/_check_gateway_running/
+    _count_skills for fields the response never uses. This helper is just the
+    directory scan: default home + each valid profile dir. No YAML, no process
+    probes, no globbing.
+    """
+    homes: List[Tuple[str, Path]] = []
+    default_home = _get_default_hermes_home()
+    if default_home.is_dir():
+        homes.append(("default", default_home))
+    profiles_root = _get_profiles_root()
+    if profiles_root.is_dir():
+        for entry in sorted(profiles_root.iterdir()):
+            if not entry.is_dir():
+                continue
+            name = entry.name
+            if name == "default":
+                continue
+            if not _PROFILE_ID_RE.match(name):
+                continue
+            homes.append((name, entry))
+    return homes
+
+
 def list_profiles() -> List[ProfileInfo]:
     """Return info for all profiles, including the default."""
     profiles = []

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4078,10 +4078,13 @@ def get_profiles_sessions(
         targets.append((name, home))
     else:
         try:
-            infos = profiles_mod.list_profiles()
-            targets = [(info.name, info.path) for info in infos]
+            # Lightweight (name, home) listing — the full list_profiles() parses
+            # every profile's config.yaml + probes gateway PIDs + rglobs skills
+            # on EVERY call, which py-spy measured at ~70% of a 10s sidebar
+            # refresh for fields this endpoint never returns.
+            targets = list(profiles_mod.list_profile_homes())
         except Exception:
-            _log.exception("GET /api/profiles/sessions: list_profiles failed")
+            _log.exception("GET /api/profiles/sessions: list_profile_homes failed")
             targets = []
         if not targets:
             targets.append(("default", profiles_mod.get_profile_dir("default")))
@@ -10204,9 +10207,25 @@ def _call_cron_for_profile(target_profile: Optional[str], func_name: str, *args,
     return result
 
 
+def _cron_profile_names() -> List[str]:
+    """Profile NAMES only, via the lightweight (name, home) listing.
+
+    The cron job aggregators only need names to route _call_cron_for_profile;
+    going through _cron_profile_dicts() -> list_profiles() paid the full
+    config.yaml-parse + gateway-PID-probe + skills-rglob cost per profile on
+    every /api/cron/jobs call (a boot-path RPC — py-spy showed it stacked on
+    top of the session-list refresh on every sidebar load).
+    """
+    from hermes_cli import profiles as profiles_mod
+    try:
+        return [name for name, _home in profiles_mod.list_profile_homes()]
+    except Exception:
+        _log.exception("Failed to list profile homes for cron; falling back to full listing")
+        return [str(p.get("name") or "") for p in _cron_profile_dicts()]
+
+
 def _find_cron_job_profile(job_id: str) -> Optional[str]:
-    for profile in _cron_profile_dicts():
-        name = str(profile.get("name") or "")
+    for name in _cron_profile_names():
         if not name:
             continue
         jobs = _call_cron_for_profile(name, "list_jobs", True)
@@ -10221,8 +10240,7 @@ def _list_cron_jobs_sync(profile: str = "all"):
         return _call_cron_for_profile(requested, "list_jobs", True)
 
     jobs: List[Dict[str, Any]] = []
-    for item in _cron_profile_dicts():
-        name = str(item.get("name") or "")
+    for name in _cron_profile_names():
         if not name:
             continue
         try:

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -26,6 +26,7 @@ from hermes_cli.profiles import (
     create_profile,
     delete_profile,
     list_profiles,
+    list_profile_homes,
     set_active_profile,
     get_active_profile,
     get_active_profile_name,
@@ -703,6 +704,40 @@ class TestListProfiles:
         profiles = list_profiles()
         assert profiles[0].name == "default"
         assert profiles[0].is_default is True
+
+
+class TestListProfileHomes:
+    """Tests for list_profile_homes() — the lightweight (name, home) listing.
+
+    Behavior contract: it must agree with list_profiles() on WHICH profiles
+    exist and WHERE they live (same names, same paths) — it just skips the
+    expensive per-profile metadata (config.yaml parse, gateway probe, skills
+    rglob) that hot read paths like /api/profiles/sessions never use.
+    """
+
+    def test_matches_list_profiles_names_and_paths(self, profile_env):
+        create_profile("alpha", no_alias=True)
+        create_profile("beta", no_alias=True)
+        heavy = {(p.name, str(p.path)) for p in list_profiles()}
+        light = {(name, str(home)) for name, home in list_profile_homes()}
+        assert light == heavy
+
+    def test_includes_default_first(self, profile_env):
+        create_profile("alpha", no_alias=True)
+        homes = list_profile_homes()
+        assert homes[0][0] == "default"
+
+    def test_skips_invalid_profile_dir_names(self, profile_env, tmp_path):
+        create_profile("alpha", no_alias=True)
+        # A junk dir that doesn't match the profile-id pattern must be ignored,
+        # matching list_profiles() behavior.
+        from hermes_cli.profiles import _get_profiles_root
+
+        junk = _get_profiles_root() / "Not A Profile!"
+        junk.mkdir(parents=True, exist_ok=True)
+        names = [name for name, _ in list_profile_homes()]
+        assert "Not A Profile!" not in names
+        assert "alpha" in names
 
 
 # ===================================================================

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -317,18 +317,22 @@ async def test_cron_profile_scan_runs_off_event_loop(isolated_profiles, monkeypa
     event_loop_thread = threading.get_ident()
     profile_scan_threads = SimpleQueue()
     worker_threads = SimpleQueue()
-    original_profile_dicts = web_server._cron_profile_dicts
+    # The list path scans profiles via the lightweight _cron_profile_names()
+    # (name-only listing); the find path still resolves through it too. Spy on
+    # that — the contract under test is unchanged: the profile scan must run
+    # OFF the event loop.
+    original_profile_names = web_server._cron_profile_names
     original_find = web_server._find_cron_job_profile
 
-    def tracking_profile_dicts():
+    def tracking_profile_names():
         profile_scan_threads.put(threading.get_ident())
-        return original_profile_dicts()
+        return original_profile_names()
 
     def tracking_find(job_id):
         worker_threads.put(threading.get_ident())
         return original_find(job_id)
 
-    monkeypatch.setattr(web_server, "_cron_profile_dicts", tracking_profile_dicts)
+    monkeypatch.setattr(web_server, "_cron_profile_names", tracking_profile_names)
     monkeypatch.setattr(web_server, "_find_cron_job_profile", tracking_find)
 
     jobs = await web_server.list_cron_jobs(profile="all")


### PR DESCRIPTION
## Problem
With several profiles, `GET /api/profiles/sessions?profile=all` (fired on every desktop sidebar refresh) and `GET /api/cron/jobs` get slow — on a live install with 7 profiles, **10–12s** per list call. py-spy flamegraph: **~70% of wall time is inside `list_profiles()`** — per profile it parses `config.yaml` with pure-Python PyYAML, probes gateway PIDs via process-table scans, and `rglob`s the skills tree, all for fields (`model`/`provider`/`skill_count`/`gateway_running`) these endpoints never return. The actual per-profile SQL is ~0.6s total.

## Fix
- `profiles.list_profile_homes()`: the lightweight `(name, home)` directory scan — no YAML, no process probes, no globbing (measured 0.2ms vs 474ms for the full call on the same install).
- `/api/profiles/sessions` and the cron aggregators switch to it via a `_cron_profile_names()` seam.
- `list_profiles()` untouched — the Profiles settings page genuinely uses the metadata.

Measured on the same live install after deploy: **10–12s → ~1.5s** (`profile=all`, 50 rows, 4,200 sessions); `/api/cron/jobs` 1.8s → 0.15s. Benefits desktop sidebar, web UI, and TUI.

## Verification
- Parity test: `list_profile_homes()` returns the same names+paths as `list_profiles()` (default-first, invalid-dir skip).
- The existing event-loop-offload spy test retargeted to the new seam (same contract: profile scan runs off the event loop).
- 179 tests pass across the profiles + cron suites on this base.