### PR TITLE
fix(agent): avoid fuzzy repair for MCP tool names

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3376,7 +3376,7 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
        Claude-style models sometimes tack on (TodoTool_tool ->
        TodoTool -> Todo -> todo). Applied twice so double-tacked
        suffixes like ``TodoTool_tool`` reduce all the way.
-    5. Fuzzy match (difflib, cutoff=0.7).
+    5. Fuzzy match (difflib, cutoff=0.7) for non-MCP tools.
 
     See #14784 for the original reports (TodoTool_tool, Patch_tool,
     BrowserClick_tool were all returning "Unknown tool" before).
@@ -3447,6 +3447,15 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
     for c in cands:
         if c and c in agent.valid_tool_names:
             return c
+
+    # MCP tool names encode both the server and the tool. A fuzzy fallback can
+    # silently change the requested operation inside the same MCP namespace
+    # (for example, a hallucinated ghidra ``disassemble_function`` becoming
+    # ``decompile_function``). That is a semantic substitution, not a safe
+    # spelling repair, so leave unmatched MCP calls invalid and let the normal
+    # unknown-tool correction path show the model the available tools.
+    if normalized.startswith("mcp__"):
+        return None
 
     # Fuzzy match as last resort.
     matches = get_close_matches(lowered, agent.valid_tool_names, n=1, cutoff=0.7)

--- a/tests/run_agent/test_repair_tool_call_name.py
+++ b/tests/run_agent/test_repair_tool_call_name.py
@@ -30,6 +30,12 @@ VALID = {
 }
 
 
+def _bind_repair(valid_tool_names):
+    from run_agent import AIAgent
+    stub = SimpleNamespace(valid_tool_names=set(valid_tool_names))
+    return AIAgent._repair_tool_call.__get__(stub, AIAgent)
+
+
 @pytest.fixture
 def repair():
     """Return a bound _repair_tool_call built on a minimal shell agent.
@@ -39,9 +45,7 @@ def repair():
     reads self.valid_tool_names. A SimpleNamespace stub is enough to
     bind the unbound function.
     """
-    from run_agent import AIAgent
-    stub = SimpleNamespace(valid_tool_names=VALID)
-    return AIAgent._repair_tool_call.__get__(stub, AIAgent)
+    return _bind_repair(VALID)
 
 
 class TestExistingBehaviorStillWorks:
@@ -125,3 +129,34 @@ class TestVolcEngineXmlPollution:
         # rest of the pipeline (fuzzy match at 0.7 cutoff) can still
         # recover the obvious target.
         assert repair('"terminal"') == "terminal"
+
+class TestMcpToolNameRepair:
+    """MCP names are namespaced; fuzzy repair must not swap tool semantics."""
+
+    MCP_VALID = {
+        "mcp__ghidra_mcp__decompile_function",
+        "mcp__ghidra_mcp__rename_function",
+        "mcp__ghidra_mcp__set_function_prototype",
+        "mcp__ghidra_mcp__read_bytes",
+    }
+
+    def test_mcp_tool_names_do_not_fuzzy_match_to_different_operation(self):
+        repair = _bind_repair(self.MCP_VALID)
+
+        assert repair("mcp__ghidra_mcp__disassemble_function") is None
+
+    def test_mcp_exact_normalization_still_works(self):
+        repair = _bind_repair(self.MCP_VALID)
+
+        assert (
+            repair("MCP__GHIDRA_MCP__DECOMPILE_FUNCTION")
+            == "mcp__ghidra_mcp__decompile_function"
+        )
+
+    def test_mcp_tool_suffix_strip_still_allows_exact_match(self):
+        repair = _bind_repair(self.MCP_VALID)
+
+        assert (
+            repair("mcp__ghidra_mcp__read_bytes_tool")
+            == "mcp__ghidra_mcp__read_bytes"
+        )


### PR DESCRIPTION
## Summary
- keep exact/normalization/suffix tool-name repairs intact
- disable the final fuzzy-name fallback for unmatched MCP tool names
- add regression coverage for hallucinated MCP tools such as `mcp__ghidra_mcp__disassemble_function`

## Why
MCP tool names encode both the server and the operation. The generic fuzzy fallback can silently turn a nonexistent MCP tool into a different valid operation inside the same namespace. For example, a model may hallucinate `mcp__ghidra_mcp__disassemble_function`; because Ghidra MCP exposes `decompile_function` but not `disassemble_function`, fuzzy repair can rewrite the call to `mcp__ghidra_mcp__decompile_function` instead of letting the normal unknown-tool correction path run.

That is a semantic substitution, not a safe spelling repair. It is especially risky for analysis tools where disassembly and decompilation are different evidence surfaces.

## Validation
- `python3 -m py_compile agent/agent_runtime_helpers.py tests/run_agent/test_repair_tool_call_name.py`
- `python3 -m pytest tests/run_agent/test_repair_tool_call_name.py -q` → 32 passed
- `git diff --check`

## Notes
Exact MCP matches and deterministic repairs still work:
- case normalization remains allowed
- trailing `_tool` suffix stripping remains allowed when it resolves to an exact registered MCP tool
- only the final fuzzy fallback is skipped for unmatched `mcp__...` names
