### PR TITLE
fix(tools): restore parent runtime after failed delegation

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -41,6 +41,7 @@ Payment / credit exhaustion fallback:
 """
 
 import contextlib
+import contextvars
 import json
 import logging
 import os
@@ -2108,11 +2109,11 @@ def _read_main_model() -> str:
 
     Runtime override: when an AIAgent is active with a CLI/gateway-provided
     model that differs from config.yaml, ``set_runtime_main()`` records the
-    override in a process-local global. This is consulted FIRST so tools
+    override in the current execution context. This is consulted FIRST so tools
     that gate on "the active main model" (e.g. ``vision_analyze``'s native
     fast path) see the live runtime, not the persisted config default.
     """
-    override = _RUNTIME_MAIN_MODEL
+    override = _runtime_main_value("model")
     if isinstance(override, str) and override.strip():
         return override.strip()
     try:
@@ -2139,7 +2140,7 @@ def _read_main_provider() -> str:
     Runtime override: see ``_read_main_model`` — same mechanism for the
     provider half of the runtime tuple.
     """
-    override = _RUNTIME_MAIN_PROVIDER
+    override = _runtime_main_value("provider")
     if isinstance(override, str) and override.strip():
         return override.strip().lower()
     try:
@@ -2159,7 +2160,7 @@ def _read_main_api_key() -> str:
     """Read the user's main model API key from the runtime override or config.
 
     Mirrors ``_read_main_model`` / ``_read_main_provider``: checks the
-    process-local ``_RUNTIME_MAIN_API_KEY`` override first (set by
+    context-local runtime override first (set by
     ``set_runtime_main`` when an AIAgent is active), then falls back to
     ``model.api_key`` in config.yaml.
 
@@ -2168,7 +2169,7 @@ def _read_main_api_key() -> str:
     the main model's credentials instead of falling to ``no-key-required``
     (issue #9318).
     """
-    override = _RUNTIME_MAIN_API_KEY
+    override = _runtime_main_value("api_key")
     if isinstance(override, str) and override.strip():
         return override.strip()
     try:
@@ -2189,7 +2190,7 @@ def _read_main_base_url() -> str:
 
     Same override-then-config pattern as ``_read_main_api_key``.
     """
-    override = _RUNTIME_MAIN_BASE_URL
+    override = _runtime_main_value("base_url")
     if isinstance(override, str) and override.strip():
         return override.strip()
     try:
@@ -2225,13 +2226,80 @@ def _read_main_api_key_if_same_host(aux_base_url: str) -> str:
     return _read_main_api_key()
 
 
-# Process-local override set by AIAgent at session/turn start. Single-threaded
-# per turn — no lock needed. Cleared by ``clear_runtime_main()``.
+# Runtime override set by AIAgent at session/turn start. This is scoped to the
+# current execution context so delegated children running in worker threads
+# cannot overwrite the parent's auxiliary routing after a timeout.
+_RUNTIME_MAIN_CONTEXT: contextvars.ContextVar[Optional[Dict[str, str]]] = contextvars.ContextVar(
+    "hermes_auxiliary_runtime_main",
+    default=None,
+)
+_RUNTIME_MAIN_KEYS = ("provider", "model", "base_url", "api_key", "api_mode")
+
+# Legacy main-thread mirror retained for tests and direct introspection. Runtime
+# routing should read through _runtime_main_snapshot(), not these globals
+# directly.
 _RUNTIME_MAIN_PROVIDER: str = ""
 _RUNTIME_MAIN_MODEL: str = ""
 _RUNTIME_MAIN_BASE_URL: str = ""
 _RUNTIME_MAIN_API_KEY: str = ""
 _RUNTIME_MAIN_API_MODE: str = ""
+
+
+def _runtime_main_payload(
+    provider: str = "",
+    model: str = "",
+    *,
+    base_url: str = "",
+    api_key: str = "",
+    api_mode: str = "",
+) -> Dict[str, str]:
+    return {
+        "provider": (provider or "").strip().lower(),
+        "model": (model or "").strip(),
+        "base_url": (base_url or "").strip(),
+        "api_key": api_key.strip() if isinstance(api_key, str) else "",
+        "api_mode": (api_mode or "").strip(),
+    }
+
+
+def _runtime_main_snapshot() -> Dict[str, str]:
+    runtime = _RUNTIME_MAIN_CONTEXT.get()
+    if isinstance(runtime, dict) and any(
+        isinstance(runtime.get(key), str) and runtime.get(key, "").strip()
+        for key in _RUNTIME_MAIN_KEYS
+    ):
+        return {
+            key: runtime.get(key, "").strip() if isinstance(runtime.get(key), str) else ""
+            for key in _RUNTIME_MAIN_KEYS
+        }
+
+    if threading.current_thread() is threading.main_thread():
+        return {
+            "provider": _RUNTIME_MAIN_PROVIDER,
+            "model": _RUNTIME_MAIN_MODEL,
+            "base_url": _RUNTIME_MAIN_BASE_URL,
+            "api_key": _RUNTIME_MAIN_API_KEY,
+            "api_mode": _RUNTIME_MAIN_API_MODE,
+        }
+
+    return {key: "" for key in _RUNTIME_MAIN_KEYS}
+
+
+def _runtime_main_value(key: str) -> str:
+    return _runtime_main_snapshot().get(key, "")
+
+
+def _mirror_runtime_main_globals(runtime: Dict[str, str]) -> None:
+    if threading.current_thread() is not threading.main_thread():
+        return
+
+    global _RUNTIME_MAIN_PROVIDER, _RUNTIME_MAIN_MODEL
+    global _RUNTIME_MAIN_BASE_URL, _RUNTIME_MAIN_API_KEY, _RUNTIME_MAIN_API_MODE
+    _RUNTIME_MAIN_PROVIDER = runtime.get("provider", "")
+    _RUNTIME_MAIN_MODEL = runtime.get("model", "")
+    _RUNTIME_MAIN_BASE_URL = runtime.get("base_url", "")
+    _RUNTIME_MAIN_API_KEY = runtime.get("api_key", "")
+    _RUNTIME_MAIN_API_MODE = runtime.get("api_mode", "")
 
 
 def set_runtime_main(
@@ -2253,24 +2321,22 @@ def set_runtime_main(
     recorded so that ``_resolve_auto`` can construct a valid client in
     Step 1 instead of falling through to the aggregator chain.
     """
-    global _RUNTIME_MAIN_PROVIDER, _RUNTIME_MAIN_MODEL
-    global _RUNTIME_MAIN_BASE_URL, _RUNTIME_MAIN_API_KEY, _RUNTIME_MAIN_API_MODE
-    _RUNTIME_MAIN_PROVIDER = (provider or "").strip().lower()
-    _RUNTIME_MAIN_MODEL = (model or "").strip()
-    _RUNTIME_MAIN_BASE_URL = (base_url or "").strip()
-    _RUNTIME_MAIN_API_KEY = api_key.strip() if isinstance(api_key, str) else ""
-    _RUNTIME_MAIN_API_MODE = (api_mode or "").strip()
+    runtime = _runtime_main_payload(
+        provider,
+        model,
+        base_url=base_url,
+        api_key=api_key,
+        api_mode=api_mode,
+    )
+    _RUNTIME_MAIN_CONTEXT.set(runtime)
+    _mirror_runtime_main_globals(runtime)
 
 
 def clear_runtime_main() -> None:
     """Clear the runtime override (e.g. on session end)."""
-    global _RUNTIME_MAIN_PROVIDER, _RUNTIME_MAIN_MODEL
-    global _RUNTIME_MAIN_BASE_URL, _RUNTIME_MAIN_API_KEY, _RUNTIME_MAIN_API_MODE
-    _RUNTIME_MAIN_PROVIDER = ""
-    _RUNTIME_MAIN_MODEL = ""
-    _RUNTIME_MAIN_BASE_URL = ""
-    _RUNTIME_MAIN_API_KEY = ""
-    _RUNTIME_MAIN_API_MODE = ""
+    runtime = _runtime_main_payload()
+    _RUNTIME_MAIN_CONTEXT.set(runtime)
+    _mirror_runtime_main_globals(runtime)
 
 
 def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str], Optional[str]]:
@@ -4148,17 +4214,18 @@ def _resolve_auto(
     runtime_api_key = runtime.get("api_key", "")
     runtime_api_mode = str(runtime.get("api_mode") or "")
 
-    # Fall back to process-local globals when main_runtime dict was not
+    # Fall back to the context-local runtime when main_runtime dict was not
     # provided or was incomplete.  ``set_runtime_main()`` now records
     # base_url/api_key/api_mode alongside provider/model, so custom:
     # providers get the full credential surface in Step 1 of the
     # auto-detect chain.
-    if not runtime_base_url and _RUNTIME_MAIN_BASE_URL:
-        runtime_base_url = _RUNTIME_MAIN_BASE_URL
-    if not runtime_api_key and _RUNTIME_MAIN_API_KEY:
-        runtime_api_key = _RUNTIME_MAIN_API_KEY
-    if not runtime_api_mode and _RUNTIME_MAIN_API_MODE:
-        runtime_api_mode = _RUNTIME_MAIN_API_MODE
+    runtime_snapshot = _runtime_main_snapshot()
+    if not runtime_base_url and runtime_snapshot.get("base_url"):
+        runtime_base_url = runtime_snapshot["base_url"]
+    if not runtime_api_key and runtime_snapshot.get("api_key"):
+        runtime_api_key = runtime_snapshot["api_key"]
+    if not runtime_api_mode and runtime_snapshot.get("api_mode"):
+        runtime_api_mode = runtime_snapshot["api_mode"]
 
     # ── Warn once if OPENAI_BASE_URL is set but config.yaml uses a named
     #    provider (not 'custom').  This catches the common "env poisoning"
@@ -5382,10 +5449,11 @@ def resolve_vision_provider_client(
                 rpc_api_key = None
                 rpc_api_mode = resolved_api_mode
                 if main_provider == "custom" or main_provider.startswith("custom:"):
-                    if _RUNTIME_MAIN_BASE_URL:
-                        rpc_base_url = _RUNTIME_MAIN_BASE_URL
-                        rpc_api_key = _RUNTIME_MAIN_API_KEY or None
-                        rpc_api_mode = resolved_api_mode or _RUNTIME_MAIN_API_MODE or None
+                    runtime_snapshot = _runtime_main_snapshot()
+                    if runtime_snapshot.get("base_url"):
+                        rpc_base_url = runtime_snapshot["base_url"]
+                        rpc_api_key = runtime_snapshot.get("api_key") or None
+                        rpc_api_mode = resolved_api_mode or runtime_snapshot.get("api_mode") or None
                     else:
                         # No live runtime recorded (non-gateway caller): fall
                         # back to resolving the configured custom endpoint.

--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -267,9 +267,9 @@ def _resolve_inference_base_url(
 ) -> str:
     """Best-effort base URL for the active inference provider."""
     try:
-        from agent.auxiliary_client import _RUNTIME_MAIN_BASE_URL
+        from agent.auxiliary_client import _read_main_base_url
 
-        runtime = str(_RUNTIME_MAIN_BASE_URL or "").strip()
+        runtime = str(_read_main_base_url() or "").strip()
         if runtime:
             return runtime
     except Exception:

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -501,6 +501,63 @@ class TestToolNamePreservation(unittest.TestCase):
 
         self.assertEqual(model_tools._last_resolved_tool_names, original_tools)
 
+    def test_runtime_main_restored_after_child_failure(self):
+        """A failed delegated child must not leave aux routing on its model."""
+        import agent.auxiliary_client as aux
+
+        self.addCleanup(aux.clear_runtime_main)
+        parent = _make_mock_parent(depth=0)
+        parent.provider = "deepseek"
+        parent.model = "deepseek-v4-pro"
+        parent.base_url = "https://api.deepseek.com/v1"
+        parent.api_key = "parent-key"
+        parent.api_mode = "chat_completions"
+        aux.clear_runtime_main()
+        aux.set_runtime_main(
+            parent.provider,
+            parent.model,
+            base_url=parent.base_url,
+            api_key=parent.api_key,
+            api_mode=parent.api_mode,
+        )
+
+        creds = {
+            "model": "doubao-seed-2-0-lite-260428",
+            "provider": "ark-coding",
+            "base_url": "https://ark.example/v1",
+            "api_key": "child-key",
+            "api_mode": "chat_completions",
+            "request_overrides": None,
+            "max_output_tokens": None,
+        }
+
+        with patch("run_agent.AIAgent") as MockAgent, \
+             patch("tools.delegate_tool._resolve_delegation_credentials", return_value=creds):
+            mock_child = MagicMock()
+            mock_child.get_activity_summary.return_value = {"api_call_count": 0}
+
+            def _fail_after_child_turn_start(*args, **kwargs):
+                aux.set_runtime_main(
+                    creds["provider"],
+                    creds["model"],
+                    base_url=creds["base_url"],
+                    api_key=creds["api_key"],
+                    api_mode=creds["api_mode"],
+                )
+                raise RuntimeError("API call failed after 3 retries: Request timed out")
+
+            mock_child.run_conversation.side_effect = _fail_after_child_turn_start
+            MockAgent.return_value = mock_child
+
+            result = json.loads(delegate_task(goal="trigger timeout", parent_agent=parent))
+
+        self.assertEqual(result["results"][0]["status"], "error")
+        self.assertEqual(aux._RUNTIME_MAIN_PROVIDER, parent.provider)
+        self.assertEqual(aux._RUNTIME_MAIN_MODEL, parent.model)
+        self.assertEqual(aux._RUNTIME_MAIN_BASE_URL, parent.base_url)
+        self.assertEqual(aux._RUNTIME_MAIN_API_KEY, parent.api_key)
+        self.assertEqual(aux._RUNTIME_MAIN_API_MODE, parent.api_mode)
+
     def test_build_child_agent_does_not_raise_name_error(self):
         """Regression: _build_child_agent must not reference _saved_tool_names.
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -558,6 +558,82 @@ class TestToolNamePreservation(unittest.TestCase):
         self.assertEqual(aux._RUNTIME_MAIN_API_KEY, parent.api_key)
         self.assertEqual(aux._RUNTIME_MAIN_API_MODE, parent.api_mode)
 
+    def test_runtime_main_ignores_late_timed_out_child_update(self):
+        """A worker abandoned after timeout must not overwrite parent aux routing."""
+        import agent.auxiliary_client as aux
+
+        self.addCleanup(aux.clear_runtime_main)
+        parent = _make_mock_parent(depth=0)
+        parent.provider = "deepseek"
+        parent.model = "deepseek-v4-pro"
+        parent.base_url = "https://api.deepseek.com/v1"
+        parent.api_key = "parent-key"
+        parent.api_mode = "chat_completions"
+        aux.clear_runtime_main()
+        aux.set_runtime_main(
+            parent.provider,
+            parent.model,
+            base_url=parent.base_url,
+            api_key=parent.api_key,
+            api_mode=parent.api_mode,
+        )
+
+        creds = {
+            "model": "doubao-seed-2-0-lite-260428",
+            "provider": "ark-coding",
+            "base_url": "https://ark.example/v1",
+            "api_key": "child-key",
+            "api_mode": "chat_completions",
+            "request_overrides": None,
+            "max_output_tokens": None,
+        }
+        release_late_write = threading.Event()
+        late_write_done = threading.Event()
+
+        def _timeout_then_late_child_write(*args, **kwargs):
+            release_late_write.wait(timeout=2)
+            aux.set_runtime_main(
+                creds["provider"],
+                creds["model"],
+                base_url=creds["base_url"],
+                api_key=creds["api_key"],
+                api_mode=creds["api_mode"],
+            )
+            late_write_done.set()
+            return {"final_response": "late", "completed": True, "api_calls": 1}
+
+        with patch("run_agent.AIAgent") as MockAgent, \
+             patch("tools.delegate_tool._get_child_timeout", return_value=0.05), \
+             patch("tools.delegate_tool._resolve_delegation_credentials", return_value=creds):
+            mock_child = MagicMock()
+            mock_child.get_activity_summary.return_value = {"api_call_count": 1}
+            mock_child.run_conversation.side_effect = _timeout_then_late_child_write
+            MockAgent.return_value = mock_child
+
+            result = json.loads(delegate_task(goal="trigger timeout", parent_agent=parent))
+
+        self.assertEqual(result["results"][0]["status"], "timeout")
+        self.assertEqual(aux._read_main_provider(), parent.provider)
+        self.assertEqual(aux._read_main_model(), parent.model)
+        self.assertEqual(aux._read_main_base_url(), parent.base_url)
+        self.assertEqual(aux._read_main_api_key(), parent.api_key)
+        self.assertEqual(aux._RUNTIME_MAIN_PROVIDER, parent.provider)
+        self.assertEqual(aux._RUNTIME_MAIN_MODEL, parent.model)
+        self.assertEqual(aux._RUNTIME_MAIN_BASE_URL, parent.base_url)
+        self.assertEqual(aux._RUNTIME_MAIN_API_KEY, parent.api_key)
+
+        release_late_write.set()
+        self.assertTrue(late_write_done.wait(timeout=2))
+
+        self.assertEqual(aux._read_main_provider(), parent.provider)
+        self.assertEqual(aux._read_main_model(), parent.model)
+        self.assertEqual(aux._read_main_base_url(), parent.base_url)
+        self.assertEqual(aux._read_main_api_key(), parent.api_key)
+        self.assertEqual(aux._RUNTIME_MAIN_PROVIDER, parent.provider)
+        self.assertEqual(aux._RUNTIME_MAIN_MODEL, parent.model)
+        self.assertEqual(aux._RUNTIME_MAIN_BASE_URL, parent.base_url)
+        self.assertEqual(aux._RUNTIME_MAIN_API_KEY, parent.api_key)
+
     def test_build_child_agent_does_not_raise_name_error(self):
         """Regression: _build_child_agent must not reference _saved_tool_names.
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -801,6 +801,24 @@ def _emit_parent_console(parent_agent, line: str) -> None:
     print(line)
 
 
+def _restore_parent_aux_runtime(parent_agent) -> None:
+    """Restore auxiliary-client routing to the parent after a child turn."""
+    if parent_agent is None:
+        return
+    try:
+        from agent.auxiliary_client import set_runtime_main
+
+        set_runtime_main(
+            getattr(parent_agent, "provider", "") or "",
+            getattr(parent_agent, "model", "") or "",
+            base_url=getattr(parent_agent, "base_url", "") or "",
+            api_key=getattr(parent_agent, "api_key", "") or "",
+            api_mode=getattr(parent_agent, "api_mode", "") or "",
+        )
+    except Exception as exc:
+        logger.debug("Failed to restore parent auxiliary runtime: %s", exc)
+
+
 def _build_child_progress_callback(
     task_index: int,
     goal: str,
@@ -2318,6 +2336,11 @@ def _run_single_child(
         saved_tool_names = getattr(child, "_delegate_saved_tool_names", None)
         if isinstance(saved_tool_names, list):
             model_tools._last_resolved_tool_names = list(saved_tool_names)
+
+        # Child run_conversation() updates auxiliary_client's process-local
+        # "main runtime" for its own turn. Put it back before the parent
+        # continues, especially on timeout/error exits.
+        _restore_parent_aux_runtime(parent_agent)
 
         # Remove child from active tracking
 


### PR DESCRIPTION
## What does this PR do?

Fixes a delegation state leak where a failed or timed-out `delegate_task` child could leave process-local auxiliary runtime routing pointed at the child delegation model/provider.

`AIAgent.run_conversation()` updates `agent.auxiliary_client`'s runtime globals at turn start. Subagents do this too, but `delegate_task` only restored the parent tool-name global after child completion/failure. This restores the parent auxiliary runtime in the child cleanup path so later parent-side auto/aux/plugin LLM calls keep using the parent session model.

## Related Issue

Fixes #62665

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/delegate_tool.py`
  - Added parent auxiliary runtime restoration after delegated child turns.
  - Restores runtime state in `_run_single_child` cleanup for success, timeout, and error paths.

- `tests/tools/test_delegate.py`
  - Added regression coverage for a child failure that switches aux runtime to the delegation model before raising.

## How to Test

1. Run the focused regression:
   `UV_CACHE_DIR=/private/tmp/hermes-uv-cache uv run --extra dev python -m pytest tests/tools/test_delegate.py::TestToolNamePreservation::test_runtime_main_restored_after_child_failure -q`

2. Run delegate tool coverage:
   `UV_CACHE_DIR=/private/tmp/hermes-uv-cache uv run --extra dev python -m pytest tests/tools/test_delegate.py -q`

3. Run nearby delegation failure/background coverage:
   `UV_CACHE_DIR=/private/tmp/hermes-uv-cache uv run --extra dev python -m pytest tests/tools/test_async_delegation.py tests/tools/test_delegate_subagent_timeout_diagnostic.py -q`

## Screenshots / Logs

Focused and nearby tests pass:
- `tests/tools/test_delegate.py`: 155 passed
- `tests/tools/test_async_delegation.py`: 20 passed
- `tests/tools/test_delegate_subagent_timeout_diagnostic.py`: 7 passed