### PR TITLE
fix(agent): make output-length continuations text-only

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -453,9 +453,28 @@ def _get_continuation_prompt(is_partial_stub: bool, dropped_tools: Optional[List
     else:
         return (
             "[System: Your previous response was truncated by the output "
-            "length limit. Continue exactly where you left off. Do not "
-            "restart or repeat prior text. Finish the answer directly.]"
+            "length limit. This recovery call is text-only: do not call or "
+            "describe tools. Output only the unfinished sections. Start at "
+            "the next missing heading with no continuation preamble, do not "
+            "restart or repeat any prior heading, table, or paragraph, and "
+            "finish the answer directly.]"
         )
+
+
+def _force_text_only_length_continuation(api_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    """Remove tool surfaces from an output-length continuation request.
+
+    The first response already spent its tool phase and emitted user-visible
+    text.  A synthetic continuation exists only to finish that text.  Leaving
+    the tool schema attached contradicts the prompt and lets a local model
+    reopen investigation, which either executes unwanted work or trips the
+    terminal tool-call guard.  Return a shallow copy so middleware snapshots
+    of the original request remain untouched.
+    """
+    bounded = dict(api_kwargs)
+    for key in ("tools", "tool_choice", "parallel_tool_calls"):
+        bounded.pop(key, None)
+    return bounded
 
 
 # Shared recovery hint appended to every content-policy refusal message. Both
@@ -1172,6 +1191,8 @@ def run_conversation(
                         allow_stream=False,
                         is_github_responses=agent._is_copilot_url(),
                     )
+                if length_continue_retries > 0:
+                    api_kwargs = _force_text_only_length_continuation(api_kwargs)
                 # Copilot x-initiator: the first API call of a user turn is
                 # marked "user" so Copilot bills a premium request; tool-loop
                 # follow-ups keep the default "agent" header (#3040).
@@ -1249,7 +1270,7 @@ def run_conversation(
                             if isinstance(request_messages, list)
                             else [],
                             message_count=len(api_messages),
-                            tool_count=len(agent.tools or []),
+                            tool_count=len(api_kwargs.get("tools") or []),
                             approx_input_tokens=approx_tokens,
                             request_char_count=total_chars,
                             max_tokens=agent.max_tokens,

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -252,6 +252,8 @@ class TestLengthContinuationPromptBranching:
     def test_real_truncation_uses_length_prompt(self):
         prompt = self._simulate_branch("chatcmpl-abc123")
         assert "output length limit" in prompt
+        assert "text-only" in prompt
+        assert "next missing heading" in prompt
         assert "network error" not in prompt
 
     def test_no_id_falls_through_to_length_prompt(self):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4784,8 +4784,13 @@ class TestRunConversation:
         assert result["final_response"] == "Part 1 Part 2"
 
         second_call_messages = agent.client.chat.completions.create.call_args_list[1].kwargs["messages"]
+        second_call_kwargs = agent.client.chat.completions.create.call_args_list[1].kwargs
         assert second_call_messages[-1]["role"] == "user"
         assert "truncated by the output length limit" in second_call_messages[-1]["content"]
+        assert "text-only" in second_call_messages[-1]["content"]
+        assert "tools" not in second_call_kwargs
+        assert "tool_choice" not in second_call_kwargs
+        assert "parallel_tool_calls" not in second_call_kwargs
 
     def test_length_continuation_preserves_large_provider_default_output_cap(self, agent):
         """Continuation retries must not shrink a higher provider default cap."""


### PR DESCRIPTION
## Summary

- make output-length continuation requests text-only
- remove `tools`, `tool_choice`, and `parallel_tool_calls` from only the synthetic continuation request
- strengthen the continuation prompt so the model resumes at the next missing section without reopening investigation
- report the effective tool count after request bounding

## Why

When a response already emitted useful text and ended with `finish_reason=length`, Hermes asks the model to continue. The request still exposed the full tool schema, which contradicted that recovery prompt. Local models could reopen tool work during the continuation, causing duplicated investigation, unwanted tool attempts, or a guarded continuation with no user-visible final text.

This keeps the initial request unchanged. Only the synthetic output-length continuation loses tool surfaces.

## Scope

This is intentionally narrower than the closed #22381: it does not change retry counts, output caps, topic splitting, or truncated tool-call recovery. Partial network stubs and oversized tool-call recovery retain their existing tool behavior.

## Validation

```text
python -m py_compile agent/conversation_loop.py
python -m pytest -q tests/run_agent/test_partial_stream_finish_reason.py tests/run_agent/test_run_agent.py -k 'length or continuation'
19 passed, 410 deselected
```
