### PR TITLE
Add thread-safe lazy init for OpenRouter client

### DIFF
--- a/tools/openrouter_client.py
+++ b/tools/openrouter_client.py
@@ -7,8 +7,10 @@ consistently.
 """
 
 import os
+import threading
 
 _client = None
+_client_lock = threading.Lock()
 
 
 def get_async_client():
@@ -20,11 +22,13 @@ def get_async_client():
     """
     global _client
     if _client is None:
-        from agent.auxiliary_client import resolve_provider_client
-        client, _model = resolve_provider_client("openrouter", async_mode=True)
-        if client is None:
-            raise ValueError("OPENROUTER_API_KEY environment variable not set")
-        _client = client
+        with _client_lock:
+            if _client is None:
+                from agent.auxiliary_client import resolve_provider_client
+                client, _model = resolve_provider_client("openrouter", async_mode=True)
+                if client is None:
+                    raise ValueError("OPENROUTER_API_KEY environment variable not set")
+                _client = client
     return _client
 
 


### PR DESCRIPTION
## Summary

Make `get_async_client()` in `tools/openrouter_client.py` thread-safe using double-checked locking.

## Problem

`get_async_client()` uses a bare `if _client is None:` check without any synchronization primitive. When multiple threads call it concurrently (e.g. cron tick thread + gateway thread both initializing at startup), both can enter the init block simultaneously, calling `resolve_provider_client()` twice — wasting an HTTP round-trip and briefly creating a duplicate `AsyncOpenAI` client.

## Fix

- Add `threading.Lock()` guarding the initialization path
- Use the double-checked locking pattern: check `_client is None` outside the lock (fast path for the common case), then re-check inside the lock (ensures only one thread initializes)
- Minimal change: 4 lines added, 0 lines of existing logic changed

## Validation

- Single-threaded behavior: identical to before (lock is only acquired when `_client` is `None`)
- Multi-threaded behavior: second caller waits on the lock, sees non-None `_client` after the first thread releases, and returns immediately
- All existing callers (`cron/scheduler.py`, `tools/`) use `get_async_client()` — no interface change
