### PR TITLE
Preserve non-ASCII characters in saved jobs.json

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -875,7 +875,7 @@ def _save_jobs_unlocked(jobs: List[Dict[str, Any]]):
     fd, tmp_path = tempfile.mkstemp(dir=str(jobs_file.parent), suffix='.tmp', prefix='.jobs_')
     try:
         with os.fdopen(fd, 'w', encoding='utf-8') as f:
-            json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2)
+            json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2, ensure_ascii=False)
             f.flush()
             os.fsync(f.fileno())
         atomic_replace(tmp_path, jobs_file)


### PR DESCRIPTION
## Summary

Add `ensure_ascii=False` to the `json.dump` call in `_save_jobs_unlocked()` so non-ASCII characters are written as literal characters instead of `\uXXXX` escape sequences.

## Problem

`_save_jobs_unlocked()` at `cron/jobs.py:878` uses `json.dump(..., indent=2)` without `ensure_ascii=False`. The default `ensure_ascii=True` escapes any non-ASCII character to `\uXXXX` sequences in the stored `jobs.json`.

While the file round-trips correctly through `json.load`, the codebase explicitly supports and documents manual editing of `jobs.json` by users. `\uXXXX` escape sequences make manual editing painful and error-prone — users see `{"name": "\u0905\u092d\u093f\u092e\u092f"}` instead of `{"name": "अभिमय"}`.

## Consistency

Compare with `_save_auth_store` in `hermes_cli/auth.py` which already uses `ensure_ascii=False`. This change brings `_save_jobs_unlocked` in line with the rest of the codebase.

## Validation

- Single-line change
- `json.load` reads both formats identically — no downstream impact
- Manual editing of `jobs.json` now works with native characters
