### PR TITLE
fix(gateway): kanban notifier — honor SendResult(success=False), notify on block_loop_detected, tolerate transient outages

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -48,6 +48,16 @@ class GatewayAuthorizationMixin:
             return None
         profile_name = (profile or "").strip() or None
         if profile_name and profile_name != "default":
+            active_profile = None
+            active_profile_fn = getattr(self, "_active_profile_name", None)
+            if callable(active_profile_fn):
+                try:
+                    active_profile = active_profile_fn()
+                except Exception:
+                    active_profile = None
+            if profile_name == active_profile:
+                adapters = getattr(self, "adapters", None) or {}
+                return adapters.get(platform)
             profile_adapters = getattr(self, "_profile_adapters", None) or {}
             if profile_name in profile_adapters:
                 return profile_adapters[profile_name].get(platform)

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -164,7 +164,7 @@ class GatewayKanbanWatchersMixin:
 
         # "status" covers dashboard drag-drop and `_set_status_direct()`
         # writes — surface those transitions to subscribers too.
-        TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out", "status", "archived", "unblocked")
+        TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out", "status", "archived", "unblocked", "block_loop_detected")
         # Subscriptions are removed only when the task reaches a truly final
         # status (done / archived). We used to also unsub on any terminal
         # event kind (gave_up / crashed / timed_out / blocked), but that
@@ -181,7 +181,13 @@ class GatewayKanbanWatchersMixin:
         # means the chat is dead (deleted, bot kicked, etc.) — after N
         # consecutive send failures the sub is dropped so we don't spin
         # against a dead chat every 5 seconds forever.
-        MAX_SEND_FAILURES = 3
+        # Raised from 3 to 12 (~60s at the 5s tick cadence): now that a
+        # reported SendResult(success=False) also lands here (see the
+        # delivery loop below), a transient Telegram/API outage of a few
+        # ticks must NOT permanently unsubscribe a live review-gate channel.
+        # A genuinely dead chat still drops, just ~60s later — a fine trade
+        # for an unattended gate where a false drop means silent work pileup.
+        MAX_SEND_FAILURES = 12
         sub_fail_counts: dict[tuple, int] = getattr(
             self, "_kanban_sub_fail_counts", {}
         )
@@ -396,6 +402,25 @@ class GatewayKanbanWatchersMixin:
                             if ev.payload and ev.payload.get("status"):
                                 new_status = str(ev.payload["status"])
                             msg = f"🔄 {board_tag}{tag}Kanban {sub['task_id']} → {new_status}"
+                        elif kind == "block_loop_detected":
+                            # A task re-blocked for the same cause past the
+                            # recurrence limit and was routed to `triage` for a
+                            # human decision. This is the ONE transition that
+                            # exists to force human attention, yet it emits no
+                            # `blocked`/`status` event — so before adding it to
+                            # TERMINAL_KINDS it produced zero notification and
+                            # the task stalled in triage silently. Ping loudly.
+                            reason = ""
+                            recurrences = None
+                            if ev.payload:
+                                if ev.payload.get("reason"):
+                                    reason = f": {str(ev.payload['reason'])[:160]}"
+                                recurrences = ev.payload.get("recurrences")
+                            rc = f" (blocked {recurrences}x for the same cause)" if recurrences else ""
+                            msg = (
+                                f"🛑 {board_tag}{tag}Kanban {sub['task_id']} routed to TRIAGE"
+                                f" — needs a human decision{rc}{reason}"
+                            )
                         else:
                             # archived / unblocked are claimed by TERMINAL_KINDS
                             # (so the cursor advances past them and they can't
@@ -413,9 +438,24 @@ class GatewayKanbanWatchersMixin:
                             sub["chat_id"], sub.get("thread_id") or "",
                         )
                         try:
-                            await adapter.send(
+                            send_result = await adapter.send(
                                 sub["chat_id"], msg, metadata=metadata,
                             )
+                            # A returned SendResult(success=False) is a failure
+                            # the adapter chose to REPORT rather than raise (e.g.
+                            # Telegram "Not connected" mid-reconnect after a
+                            # gateway restart, or a degraded send path). The old
+                            # code discarded the return value, so such a failure
+                            # fell through to the success branch: the event was
+                            # marked seen, the cursor stayed advanced, and the
+                            # notification was silently lost forever. Convert it
+                            # into the same failure path a raised exception takes
+                            # so the claim is rewound and retried instead.
+                            if send_result is not None and getattr(
+                                send_result, "success", True
+                            ) is False:
+                                _err = getattr(send_result, "error", None) or "success=False"
+                                raise RuntimeError(f"adapter.send reported failure: {_err}")
                             logger.debug(
                                 "kanban notifier: delivered %s event for %s to %s/%s on board %s",
                                 kind, sub["task_id"], platform_str, sub["chat_id"], board_slug,

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -173,6 +173,45 @@ def test_kanban_notifier_rewinds_claim_on_send_exception(tmp_path, monkeypatch):
     assert [ev.kind for ev in _unseen_terminal_events(tid)] == ["completed"]
 
 
+class ReportedFailureAdapter:
+    """Adapter that REPORTS failure via SendResult(success=False) instead of
+    raising — the exact contract the Telegram adapter uses for 'Not connected'
+    and degraded-send paths."""
+
+    def __init__(self):
+        self.attempts = 0
+
+    async def send(self, chat_id, text, metadata=None):
+        self.attempts += 1
+        from gateway.platforms.base import SendResult
+        return SendResult(success=False, error="Not connected")
+
+
+def test_kanban_notifier_rewinds_claim_on_reported_send_failure(tmp_path, monkeypatch):
+    """A non-raising SendResult(success=False) must NOT advance the cursor.
+
+    Regression for the silent-drop bug: the notifier used to discard send()'s
+    return value, so a reported (not raised) failure — e.g. Telegram mid-
+    reconnect after a gateway restart — fell through to the success branch,
+    marked the event seen, and lost the notification forever. The event must
+    remain unseen for retry, exactly like the raised-exception path.
+    """
+    db_path = tmp_path / "reported-failure.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    tid = _create_completed_subscription()
+
+    adapter = ReportedFailureAdapter()
+    runner = _make_runner(adapter)
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert adapter.attempts >= 1, "send should have been attempted"
+    assert [ev.kind for ev in _unseen_terminal_events(tid)] == ["completed"], (
+        "a reported send failure must rewind the claim, not silently drop the event"
+    )
+
+
 def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
     """A retry cycle (crashed → reclaimed → crashed) notifies the user twice.
 
@@ -233,6 +272,36 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
         f"deliveries (texts: {[d['text'] for d in adapter.sent]})"
     )
     assert "crashed" in adapter.sent[1]["text"].lower()
+
+
+def test_notifier_delivers_subscription_owned_by_active_profile(tmp_path, monkeypatch):
+    """A single-profile gateway stamps active profile but keeps adapters primary."""
+    db_path = tmp_path / "active-profile-owner.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="owned by active profile", assignee="worker")
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="chat-1",
+            notifier_profile="dev",
+        )
+        kb.complete_task(conn, tid, summary="done")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    runner._active_profile_name = lambda: "dev"
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    assert tid in adapter.sent[0]["text"]
 
 
 def test_notifier_owning_profile_adapter_no_default_fallback(tmp_path, monkeypatch):

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -101,6 +101,14 @@ def test_secondary_allowlist_still_authorized(monkeypatch):
     assert runner._is_user_authorized(source) is True
 
 
+def test_active_profile_stamp_resolves_primary_adapter(monkeypatch):
+    """A single-profile gateway stamps its active profile but stores adapters as primary."""
+    runner, default_adapter, _secondary_adapter = _make_multiplex_runner(monkeypatch)
+    runner._active_profile_name = lambda: "dev"
+
+    assert runner._authorization_adapter(Platform.WECOM, profile="dev") is default_adapter
+
+
 def test_adapter_for_source_resolves_secondary_profile_adapter(monkeypatch):
     """Ingress adapter lookup must use the stamped profile's adapter map."""
     runner, default_adapter, secondary_adapter = _make_multiplex_runner(monkeypatch)


### PR DESCRIPTION
### What

Three delivery-reliability fixes to the gateway kanban notifier
(`gateway/kanban_watchers.py`), plus an active-profile adapter routing fix
(`gateway/authz_mixin.py`):

1. **Soft send-failure was a silent drop (addresses the notifier half of #31901).**
   The delivery loop discarded `adapter.send()`'s return value. The cursor is
   claimed *before* send, so an adapter that REPORTS failure via
   `SendResult(success=False)` without raising (e.g. the Telegram adapter's
   "Not connected" mid-reconnect, or a degraded-send path) advanced the
   subscription past the event — the notification was lost forever, no retry, no
   log above DEBUG. Now a reported failure is raised into the existing
   rewind/retry path. Regression test:
   `test_kanban_notifier_rewinds_claim_on_reported_send_failure`.

2. **`block_loop_detected` never notified.** When a task re-blocks for the same
   cause past `BLOCK_RECURRENCE_LIMIT`, `block_task` routes it to `triage` for a
   human decision and emits only a `block_loop_detected` event — a kind absent
   from the notifier's `TERMINAL_KINDS`. So the one transition that exists to
   force human attention produced zero notification and the task stalled in
   triage silently. Added to `TERMINAL_KINDS` with a dedicated message.

3. **A brief outage permanently unsubscribed a live channel.** `MAX_SEND_FAILURES`
   was 3 at a 5s tick — a ~15s Telegram/API blip dropped the subscription for
   good (and, with fix #1, soft failures now reach this counter too). Raised to
   12 (~60s); a genuinely dead chat still drops, just later.

4. **Active-profile routing.** A single-profile gateway stamps
   `notifier_profile=<active>` but registers its adapter as primary;
   `_authorization_adapter` now returns `self.adapters[platform]` when the
   stamped profile equals the active profile. Related to #56802 (that issue
   covers the multi-profile topology; this is the single-profile facet).

### Why

Each is a silent-failure path: the notifier is the only signal a human gets that
unattended work is held or failed. A dropped/blocked notification means work
piles up behind the review gate invisibly.

### Testing

`pytest tests/gateway/test_kanban_notifier.py tests/gateway/test_multiplex_profile_authz.py`
— green (16 passed), including the new regression test that asserts a reported
send failure leaves the event unseen (rewound) rather than silently consumed.

### Not included

Notification-copy/UX wording is intentionally out of scope (reliability only).
The decompose-inheritance half of #31901 (child tasks not inheriting notify
subs) is not addressed here.
